### PR TITLE
[IMP] html_editor: add button shape option in link popover

### DIFF
--- a/addons/html_editor/static/src/main/link/link_popover.js
+++ b/addons/html_editor/static/src/main/link/link_popover.js
@@ -62,6 +62,15 @@ export class LinkPopover extends Component {
         { style: "dotted", label: "┄┄┄" },
         { style: "double", label: "═══" },
     ];
+    buttonShapeData = [
+        { shape: "", label: "Default" },
+        { shape: "rounded-circle", label: "Default + Rounded" },
+        { shape: "outline", label: "Outline" },
+        { shape: "outline rounded-circle", label: "Outline + Rounded" },
+        { shape: "fill", label: "Fill" },
+        { shape: "fill rounded-circle", label: "Fill + Rounded" },
+        { shape: "flat", label: "Flat" },
+    ];
     setup() {
         this.ui = useService("ui");
         this.notificationService = useService("notification");
@@ -98,6 +107,7 @@ export class LinkPopover extends Component {
             directDownload: true,
             isDocument: false,
             buttonSize: this.props.linkElement.className.match(/btn-(sm|lg)/)?.[1] || "",
+            buttonShape: this.getButtonShape(),
             customBorderSize: computedStyle.borderWidth.replace("px", "") || "1",
             customBorderStyle: computedStyle.borderStyle || "solid",
             isImage: this.props.isImage,
@@ -347,6 +357,34 @@ export class LinkPopover extends Component {
             return deduceURLfromText(text, this.props.linkElement) || "";
         }
     }
+    getButtonShape() {
+        const shapeToRegex = (shape) => {
+            const parts = shape.trim().split(/\s+/);
+            const regexParts = parts.map((cls) => {
+                if (["outline", "fill"].includes(cls)) {
+                    cls = `btn-${cls}`;
+                }
+                return `(?=.*\\b${cls}\\b)`;
+            });
+            return { regex: new RegExp(regexParts.join("")), nbParts: parts.length };
+        };
+        // If multiple shapes match, prefer the one with more specificity.
+        let shapeMatched = "";
+        let matchScore = 0;
+        for (const { shape } of this.buttonShapeData) {
+            if (!shape) {
+                continue;
+            }
+            const { regex, nbParts } = shapeToRegex(shape);
+            if (regex.test(this.props.linkElement.className)) {
+                if (matchScore < nbParts) {
+                    matchScore = nbParts;
+                    shapeMatched = shape;
+                }
+            }
+        }
+        return shapeMatched;
+    }
     /**
      * link preview in the popover
      */
@@ -461,17 +499,25 @@ export class LinkPopover extends Component {
 
     get classes() {
         let classes = [...this.props.linkElement.classList]
-            .filter((value) => !value.match(/btn(-[a-z0-9]+)*/))
+            .filter((value) => !value.match(/^(btn.*|rounded-circle|flat)$/))
             .join(" ");
 
+        let stylePrefix = "";
+        if (this.state.type === "custom") {
+            if (this.state.buttonSize) {
+                classes += ` btn-${this.state.buttonSize}`;
+            }
+            if (this.state.buttonShape) {
+                const buttonShape = this.state.buttonShape.split(" ");
+                if (["outline", "fill"].includes(buttonShape[0])) {
+                    stylePrefix = `${buttonShape[0]}-`;
+                }
+                classes += ` ${buttonShape.slice(stylePrefix ? 1 : 0).join(" ")}`;
+            }
+        }
         if (this.state.type) {
-            classes += ` btn btn-fill-${this.state.type}`;
+            classes += ` btn btn-${stylePrefix}${this.state.type}`;
         }
-
-        if (this.state.buttonSize) {
-            classes += ` btn-${this.state.buttonSize}`;
-        }
-
         return classes.trim();
     }
 

--- a/addons/html_editor/static/src/main/link/link_popover.xml
+++ b/addons/html_editor/static/src/main/link/link_popover.xml
@@ -85,6 +85,16 @@
                                     </t>
                                 </select>
                             </div>
+                            <div class="input-group mb-1">
+                                <label>Shape</label>
+                                <select name="link_style_shape" class="form-select form-select-sm link-style" t-model="state.buttonShape" t-on-change="onChange">
+                                    <t t-foreach="this.buttonShapeData" t-as="buttonShapeData" t-key="buttonShapeData.shape">
+                                        <option t-att-value="buttonShapeData.shape" t-att-selected="state.buttonShape === buttonShapeData.shape">
+                                            <span t-out="buttonShapeData.label"/>
+                                        </option>
+                                    </t>
+                                </select>
+                            </div>
                         </t>
                         <t t-if="props.allowTargetBlank">
                             <t t-if="state.isDocument">

--- a/addons/html_editor/static/tests/link/button.test.js
+++ b/addons/html_editor/static/tests/link/button.test.js
@@ -151,14 +151,14 @@ describe("Custom button style", () => {
         await animationFrame();
 
         expect(cleanLinkArtifacts(getContent(el))).toBe(
-            '<p><a href="http://test.test/" class="btn btn-fill-custom" style="color: #FF0000; background-color: #00FF00; border-width: 6px; border-color: #0000FF; border-style: dotted; ">Hello</a></p>'
+            '<p><a href="http://test.test/" class="btn btn-custom" style="color: #FF0000; background-color: #00FF00; border-width: 6px; border-color: #0000FF; border-style: dotted; ">Hello</a></p>'
         );
 
         await click(".o_we_apply_link");
         await animationFrame();
 
         expect(cleanLinkArtifacts(getContent(el))).toBe(
-            '<p><a href="http://test.test/" class="btn btn-fill-custom" style="color: #FF0000; background-color: #00FF00; border-width: 6px; border-color: #0000FF; border-style: dotted; ">Hello[]</a></p>'
+            '<p><a href="http://test.test/" class="btn btn-custom" style="color: #FF0000; background-color: #00FF00; border-width: 6px; border-color: #0000FF; border-style: dotted; ">Hello[]</a></p>'
         );
     });
 
@@ -177,6 +177,41 @@ describe("Custom button style", () => {
 
         expect(cleanLinkArtifacts(getContent(el))).toBe(
             '<p><a href="http://test.test/" target="_blank">Hello[]</a></p>'
+        );
+    });
+
+    test("Editor allow custom shape if config is active", async () => {
+        const { el } = await setupEditor(
+            '<p><a href="https://test.com/">link[]Label</a></p>',
+            allowCustomOpt
+        );
+        await waitFor(".o-we-linkpopover");
+        await click(".o_we_edit_link");
+        await animationFrame();
+        await click('select[name="link_type"]');
+        await select("custom");
+        await animationFrame();
+
+        // test outline
+        await click('select[name="link_style_shape"]');
+        await select("outline");
+        await animationFrame();
+        expect(cleanLinkArtifacts(getContent(el))).toBe(
+            '<p><a href="https://test.com/" class="btn btn-outline-custom" style="color: rgb(0, 0, 0); background-color: rgb(166, 227, 226); border-width: 1px; border-color: rgb(0, 143, 140); border-style: dashed; ">linkLabel</a></p>'
+        );
+
+        // test fill + rounded
+        await click('select[name="link_style_shape"]');
+        await select("fill rounded-circle");
+        await animationFrame();
+        expect(cleanLinkArtifacts(getContent(el))).toBe(
+            '<p><a href="https://test.com/" class="rounded-circle btn btn-fill-custom" style="color: rgb(0, 0, 0); background-color: rgb(166, 227, 226); border-width: 1px; border-color: rgb(0, 143, 140); border-style: dashed; ">linkLabel</a></p>'
+        );
+
+        await click(".o_we_apply_link");
+        await animationFrame();
+        expect(cleanLinkArtifacts(getContent(el))).toBe(
+            '<p><a href="https://test.com/" class="rounded-circle btn btn-fill-custom" style="color: rgb(0, 0, 0); background-color: rgb(166, 227, 226); border-width: 1px; border-color: rgb(0, 143, 140); border-style: dashed; ">link[]Label</a></p>'
         );
     });
 });

--- a/addons/html_editor/static/tests/link/popover.test.js
+++ b/addons/html_editor/static/tests/link/popover.test.js
@@ -379,7 +379,7 @@ describe("Link creation", () => {
                 "http://test.test/"
             );
             expect(cleanLinkArtifacts(getContent(el))).toBe(
-                '<p><a href="http://test.test/" class="btn btn-fill-primary">http://test.test/[]</a></p>'
+                '<p><a href="http://test.test/" class="btn btn-primary">http://test.test/[]</a></p>'
             );
         });
         test("Should keep http protocol on valid http url", async () => {
@@ -748,7 +748,7 @@ describe("Link formatting in the popover", () => {
         await click('select[name="link_type"');
         await select("primary");
         expect(cleanLinkArtifacts(getContent(el))).toBe(
-            '<p><a href="http://test.com/" class="btn btn-fill-primary">link2</a></p>'
+            '<p><a href="http://test.com/" class="btn btn-primary">link2</a></p>'
         );
     });
     test("after changing the link format, the link should be updated (2)", async () => {
@@ -764,7 +764,7 @@ describe("Link formatting in the popover", () => {
         await click('select[name="link_type"');
         await select("primary");
         expect(cleanLinkArtifacts(getContent(el))).toBe(
-            '<p><a href="http://test.com/" class="btn btn-fill-primary">link2</a></p>'
+            '<p><a href="http://test.com/" class="btn btn-primary">link2</a></p>'
         );
     });
     test("after changing the link format, the link should be updated (3)", async () => {
@@ -780,7 +780,7 @@ describe("Link formatting in the popover", () => {
         await click('select[name="link_type"');
         await select("primary");
         expect(cleanLinkArtifacts(getContent(el))).toBe(
-            '<p><a href="http://test.com/" class="random-css-class text-muted btn btn-fill-primary">link2</a></p>'
+            '<p><a href="http://test.com/" class="random-css-class text-muted btn btn-primary">link2</a></p>'
         );
     });
     test("after applying the link format, the link's format should be updated", async () => {
@@ -795,7 +795,7 @@ describe("Link formatting in the popover", () => {
 
         await click(".o_we_apply_link");
         expect(cleanLinkArtifacts(getContent(el))).toBe(
-            '<p><a href="http://test.com/" class="btn btn-fill-secondary">link2[]</a></p>'
+            '<p><a href="http://test.com/" class="btn btn-secondary">link2[]</a></p>'
         );
     });
     test("clicking the discard button should revert the link format", async () => {
@@ -806,7 +806,7 @@ describe("Link formatting in the popover", () => {
         await click('select[name="link_type"]');
         await select("secondary");
         expect(cleanLinkArtifacts(getContent(el))).toBe(
-            '<p><a href="http://test.com/" class="btn btn-fill-secondary">link2</a></p>'
+            '<p><a href="http://test.com/" class="btn btn-secondary">link2</a></p>'
         );
         await click(".o_we_discard_link");
         expect(cleanLinkArtifacts(getContent(el))).toBe(
@@ -839,7 +839,7 @@ describe("Link formatting in the popover", () => {
         await click('select[name="link_type"]');
         await select("secondary");
         expect(cleanLinkArtifacts(getContent(el))).toBe(
-            '<p><a href="#" class="btn btn-fill-secondary">link1</a></p>'
+            '<p><a href="#" class="btn btn-secondary">link1</a></p>'
         );
         await click(".o_we_discard_link");
         expect(cleanLinkArtifacts(getContent(el))).toBe("<p>[link1]</p>");

--- a/addons/website/static/tests/tours/snippet_popup_display_on_click.js
+++ b/addons/website/static/tests/tours/snippet_popup_display_on_click.js
@@ -60,7 +60,7 @@ registerWebsitePreviewTour("snippet_popup_display_on_click", {
         content: "Wait content of iframe is loaded",
         trigger: ":iframe main:contains(enhance your)",
     },
-    clickOnElement("text image snippet button", ":iframe .s_text_image .btn-fill-secondary"),
+    clickOnElement("text image snippet button", ":iframe .s_text_image .btn-secondary"),
     {
         content: "Verify that the popup opens after clicked the button.",
         trigger: ":iframe .s_popup .modal[id='Win-%2420'].show",
@@ -99,7 +99,7 @@ registerWebsitePreviewTour("snippet_popup_display_on_click", {
         content: "Wait form is patched",
         trigger: ":iframe form#contactus_form input[name=company]:value(yourcompany)",
     },
-    clickOnElement("text image snippet button", ":iframe .s_text_image .btn-fill-secondary"),
+    clickOnElement("text image snippet button", ":iframe .s_text_image .btn-secondary"),
     {
         trigger: ":iframe [data-view-xmlid='website.homepage']",
     },


### PR DESCRIPTION
> 55. [CHDH] When clicking the submit button in the form snippet(s_title_form), the 'shape' option is missing.

This commit reintroduces the `shape` option for the custom button &
link that was previously available before version 18.3. The feature was
unintentionally removed during the website refactoring in which sidebar
link options moved to the link popover.

[1]: https://github.com/odoo/odoo/commit/9fe45e2b7ddbbfd0445ffe25a859e67a316d02b2

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
