### PR TITLE
[FIX][17.0] stock: Add missing group for button

### DIFF
--- a/addons/stock/views/stock_quant_views.xml
+++ b/addons/stock/views/stock_quant_views.xml
@@ -419,7 +419,7 @@ in this location. That leads to a negative stock.
                             class="btn-primary ms-1"
                             display="always"/>
                     <button name="stock.action_stock_inventory_adjustement_name" groups="stock.group_stock_manager" type="action" string="Apply"/>
-                    <button name="action_reset" type="object" string="Clear"/>
+                    <button name="action_reset" type="object" string="Clear" groups="stock.group_stock_manager"/>
                     <button name="stock.action_stock_request_count" groups="stock.group_stock_manager" type="action" string="Request a Count"/>
                     <button name="action_stock_quant_relocate" string="Relocate" type="object" groups="stock.group_stock_manager" invisible="context.get('hide_location', False)" context="{'action_ref': 'stock.action_view_inventory_tree'}"/>
                 </header>


### PR DESCRIPTION
- The "Clear" button is only accessible by "group_stock_manager" but without a group attached, "stock_user" can still see it and operate it, resulting in an unnecessary permission error, confusing the user.


Current behavior before PR:

![Screenshot 2025-06-10 at 1 07 41 PM](https://github.com/user-attachments/assets/26922c7f-ff81-430e-af51-a5badeafcbec)

![Screenshot 2025-06-10 at 1 09 01 PM](https://github.com/user-attachments/assets/93b3dee2-e9d0-448e-b26b-9353e4120877)








---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
