### PR TITLE
[FIX] mail: message bubble width issue after deleting message via edit

### DIFF
--- a/addons/mail/static/src/core/common/message_model.js
+++ b/addons/mail/static/src/core/common/message_model.js
@@ -581,6 +581,7 @@ export class Message extends Record {
         });
         this.body = "";
         this.attachment_ids = [];
+        this.composer = undefined;
     }
 
     async setDone() {


### PR DESCRIPTION
This commit fixes a UI bug where editing a message and clearing its content results in the message bubble expanding to full width.

**Current behavior before PR:**
![image](https://github.com/user-attachments/assets/4af7f748-1d15-4344-8c30-0a33d334adb6)
**Desired behavior after PR is merged:**
![image](https://github.com/user-attachments/assets/ea3d13eb-138d-46c9-a41f-0c7c2dffdc77)
