### PR TITLE
[FIX] hr: correctly remove m2o link between user and employee

### DIFF
--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -423,7 +423,7 @@ class HrEmployeePrivate(models.Model):
             employee_fields_to_empty = self._get_employee_m2o_to_empty_on_archived_employees()
             user_fields_to_empty = self._get_user_m2o_to_empty_on_archived_employees()
             employee_domain = [[(field, 'in', archived_employees.ids)] for field in employee_fields_to_empty]
-            user_domain = [[(field, 'in', archived_employees.user_id.ids) for field in user_fields_to_empty]]
+            user_domain = [[(field, 'in', archived_employees.user_id.ids)] for field in user_fields_to_empty]
             employees = self.env['hr.employee'].search(expression.OR(employee_domain + user_domain))
             for employee in employees:
                 for field in employee_fields_to_empty:


### PR DESCRIPTION
Currently, a user needs to be time off, expense and timesheet approver of an employee for those links to be removed by the departure wizard. If not all the approver fields are the same user, that link will not be removed.

Steps to reproduce:
- Set Marc Demo as only Time Off approver on an employee.
- Archive Marc Demo's employee (This does not remove time off approver from the previous employee)

To rectify this issue, we correctly group the `user_domain` so that their contents are properly OR'd.