### PR TITLE
[FIX] account_peppol: fix a function signature

### DIFF
--- a/addons/account_peppol/models/account_move.py
+++ b/addons/account_peppol/models/account_move.py
@@ -72,8 +72,12 @@ class AccountMove(models.Model):
             else:
                 move.peppol_move_state = move.peppol_move_state
 
-    def _notify_by_email_prepare_rendering_context(self, message, **kwargs):
-        render_context = super()._notify_by_email_prepare_rendering_context(message, **kwargs)
+    def _notify_by_email_prepare_rendering_context(self, message, msg_vals=False, model_description=False,
+                                                   force_email_company=False, force_email_lang=False):
+        render_context = super()._notify_by_email_prepare_rendering_context(
+            message, msg_vals=msg_vals, model_description=model_description,
+            force_email_company=force_email_company, force_email_lang=force_email_lang
+        )
         invoice = render_context['record']
         invoice_country = invoice.commercial_partner_id.country_code
         company_country = invoice.company_id.country_code


### PR DESCRIPTION
Currently the signature of function `_notify_by_email_prepare_rendering_context` in `account_peppol` is not compatible with all ways to call the super function. This can lead to code breaking when `account_peppol` is installed (although it works fine without).

This is fixed in this commit.

Detail:

In module `mail` the (super) function has signature
```python
    def _notify_by_email_prepare_rendering_context(self, message, msg_vals=False,
                                                   model_description=False,
                                                   force_email_company=False,
                                                   force_email_lang=False):
```

Currently in `acccount_peppol` the signature is
```python
    def _notify_by_email_prepare_rendering_context(self, message, **kwargs):
```

The super function can be called as follows while the function in `account_peppol` can not.
```python
    _notify_by_email_prepare_rendering_context(self, message, msg_vals)
```

opw-4846106
