### PR TITLE
[IMP] l10n_sa_edi: add parent company information in CSR file for bra…

### DIFF
--- a/addons/l10n_sa_edi/i18n/ar.po
+++ b/addons/l10n_sa_edi/i18n/ar.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 15.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-06-26 10:46+0000\n"
+"POT-Creation-Date: 2025-07-09 12:44+0000\n"
 "PO-Revision-Date: 2025-06-26 14:58+0400\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -23,12 +23,9 @@ msgstr ""
 #, python-format
 msgid ""
 "\n"
-"Building Number: %s, Plot Identification: %s \n"
+"Building Number: %s, Plot Identification: %s\n"
 "Neighborhood: %s"
 msgstr ""
-"\n"
-"رقم المبنى: %s ، تعريف قطعة الأرض: %s\n"
-"الحي: %s"
 
 #. module: l10n_sa_edi
 #. odoo-python
@@ -135,15 +132,6 @@ msgid "<span class=\"fw-bold\">VAT Amount</span>"
 msgstr ""
 
 #. module: l10n_sa_edi
-#: model_terms:ir.ui.view,arch_db:l10n_sa_edi.res_config_settings_view_form
-msgid ""
-"<span class=\"o_form_label\">ZATCA API Integration</span>\n"
-"                            <span class=\"fa fa-lg fa-building-o\" title=\"Values set here are company-specific.\" aria-label=\"Values set here are company-specific.\" groups=\"base.group_multi_company\" role=\"img\"/>"
-msgstr ""
-"<span class=\"o_form_label\">دمج الواجهة البرمجية لزاتكا</span>\n"
-"                            <span class=\"fa fa-lg fa-building-o\" title=\"Values set here are company-specific.\" aria-label=\"Values set here are company-specific.\" groups=\"base.group_multi_company\" role=\"img\"/>"
-
-#. module: l10n_sa_edi
 #: model_terms:ir.ui.view,arch_db:l10n_sa_edi.arabic_english_invoice
 msgid "<strong>الإجمالي الفرعي بالريال السعودي</strong>"
 msgstr ""
@@ -172,6 +160,11 @@ msgstr "وضع الواجهة البرمجية للتطلبيق"
 #: model:ir.model,name:l10n_sa_edi.model_account_move_reversal
 msgid "Account Move Reversal"
 msgstr "عكس حركة الحساب "
+
+#. module: l10n_sa_edi
+#: model:ir.model,name:l10n_sa_edi.model_account_move_send
+msgid "Account Move Send"
+msgstr ""
 
 #. module: l10n_sa_edi
 #: model:ir.model,name:l10n_sa_edi.model_account_debit_note
@@ -295,7 +288,7 @@ msgstr "الشركات "
 #: model_terms:ir.ui.view,arch_db:l10n_sa_edi.view_account_journal_form
 msgid ""
 "Complete the Compliance Checks\n"
-"                                    <i class=\"fa fa-check text-success ms-1\" attrs=\"{'invisible': [('l10n_sa_compliance_checks_passed', '=', False)]}\"/>"
+"                                    <i class=\"fa fa-check text-success ms-1\" invisible=\"not l10n_sa_compliance_checks_passed\"/>"
 msgstr ""
 
 #. module: l10n_sa_edi
@@ -391,7 +384,6 @@ msgstr "العميل"
 
 #. module: l10n_sa_edi
 #: model:ir.model.fields,help:l10n_sa_edi.field_account_tax__l10n_sa_is_retention
-#: model:ir.model.fields,help:l10n_sa_edi.field_account_tax_template__l10n_sa_is_retention
 msgid "Determines whether or not a tax counts as a Withholding Tax"
 msgstr "يحدد ما إذا كانت الضريبة تُحسب كضريبة احتجاز أم لا"
 
@@ -421,7 +413,6 @@ msgstr "الأخطاء:"
 
 #. module: l10n_sa_edi
 #: model:ir.model.fields,field_description:l10n_sa_edi.field_account_tax__l10n_sa_exemption_reason_code
-#: model:ir.model.fields,field_description:l10n_sa_edi.field_account_tax_template__l10n_sa_exemption_reason_code
 msgid "Exemption Reason Code"
 msgstr "كود سبب الإعفاء"
 
@@ -450,6 +441,8 @@ msgid "Hash of the latest submitted invoice to be used as the Previous Invoice H
 msgstr "تشفير آخر فاتورة مرسلة ليتم إرساله كتشفير الفاتورة السابقة (KSA-13)"
 
 #. module: l10n_sa_edi
+#: model_terms:ir.ui.view,arch_db:l10n_sa_edi.ubl_21_CreditNoteType_zatca
+#: model_terms:ir.ui.view,arch_db:l10n_sa_edi.ubl_21_DebitNoteType_zatca
 #: model_terms:ir.ui.view,arch_db:l10n_sa_edi.ubl_21_InvoiceType_zatca
 msgid "ICV"
 msgstr "ICV"
@@ -485,22 +478,18 @@ msgstr "تم إرسال الفاتورة بنجاح إلى زاتكا"
 #: code:addons/l10n_sa_edi/models/account_edi_format.py:0
 #, python-format
 msgid ""
-"Invoice could not be cleared: \r\n"
-" %s "
+"Invoice could not be cleared:\n"
+"%s"
 msgstr ""
-"تعذر مسح الفاتورة: \n"
-" %s "
 
 #. module: l10n_sa_edi
 #. odoo-python
 #: code:addons/l10n_sa_edi/models/account_edi_format.py:0
 #, python-format
 msgid ""
-"Invoice could not be reported: \r\n"
-" %s "
+"Invoice could not be reported:\n"
+"%s"
 msgstr ""
-"تعذر إعداد تقرير عن الفاتورة: \n"
-" %s "
 
 #. module: l10n_sa_edi
 #: model:ir.model.fields,help:l10n_sa_edi.field_account_bank_statement_line__l10n_sa_chain_index
@@ -537,7 +526,6 @@ msgstr "رقم إقامة "
 
 #. module: l10n_sa_edi
 #: model:ir.model.fields,field_description:l10n_sa_edi.field_account_tax__l10n_sa_is_retention
-#: model:ir.model.fields,field_description:l10n_sa_edi.field_account_tax_template__l10n_sa_is_retention
 msgid "Is Retention"
 msgstr "احتفاظ"
 
@@ -612,11 +600,6 @@ msgid "L10N Sa Edi Plot Identification"
 msgstr "L10N Sa Edi تعريف قطعة الأرض"
 
 #. module: l10n_sa_edi
-#: model:ir.model.fields,field_description:l10n_sa_edi.field_l10n_sa_edi_otp_wizard____last_update
-msgid "Last Modified on"
-msgstr "آخر تعديل في"
-
-#. module: l10n_sa_edi
 #: model:ir.model.fields,field_description:l10n_sa_edi.field_l10n_sa_edi_otp_wizard__write_uid
 msgid "Last Updated by"
 msgstr "آخر تحديث بواسطة"
@@ -642,6 +625,8 @@ msgid "Momra License"
 msgstr "رخصة وزارة الشؤون البلدية و القروية والإسكان"
 
 #. module: l10n_sa_edi
+#: model_terms:ir.ui.view,arch_db:l10n_sa_edi.ubl_21_CreditNoteType_zatca
+#: model_terms:ir.ui.view,arch_db:l10n_sa_edi.ubl_21_DebitNoteType_zatca
 #: model_terms:ir.ui.view,arch_db:l10n_sa_edi.ubl_21_InvoiceType_zatca
 msgid "N/A"
 msgstr "غير منطبق"
@@ -699,12 +684,9 @@ msgstr "أخطاء التجهيز"
 #: model_terms:ir.ui.view,arch_db:l10n_sa_edi.res_config_settings_view_form
 msgid ""
 "Once you change the submission mode to <strong>Production</strong>, you cannot change it anymore.\n"
-"                                Be very careful, as any invoice submitted to ZATCA in Production mode will be accounted for\n"
-"                                and might lead to <strong>Fines &amp; Penalties</strong>."
+"                            Be very careful, as any invoice submitted to ZATCA in Production mode will be accounted for\n"
+"                            and might lead to <strong>Fines &amp; Penalties</strong>."
 msgstr ""
-"بمجرد أن تقوم بتغيير وضع الإرسال إلى <strong>الإنتاج</strong>، لن يكون بمقدورك تغييره بعد الآن.\n"
-"                                توخ الحذر، حيث إن أي فاتورة يتم إرسالها إلى زاتكا في وضع الإنتاج سيتم اعتبارها\n"
-"                                وقد تؤدي إلى <strong>الغرامات &amp; العقوبات</strong>."
 
 #. module: l10n_sa_edi
 #. odoo-python
@@ -734,6 +716,8 @@ msgid "PCSID Renewal"
 msgstr "تجديد PCSID"
 
 #. module: l10n_sa_edi
+#: model_terms:ir.ui.view,arch_db:l10n_sa_edi.ubl_21_CreditNoteType_zatca
+#: model_terms:ir.ui.view,arch_db:l10n_sa_edi.ubl_21_DebitNoteType_zatca
 #: model_terms:ir.ui.view,arch_db:l10n_sa_edi.ubl_21_InvoiceType_zatca
 msgid "PIH"
 msgstr "PIH"
@@ -749,6 +733,13 @@ msgstr "معرف جواز السفر"
 #, python-format
 msgid "Please Re-Onboard the Journal for a new serial number"
 msgstr "يرجى إعادة تجهيز دفتر اليومية للحصول على رقم تسلسلي جديد."
+
+#. module: l10n_sa_edi
+#. odoo-python
+#: code:addons/l10n_sa_edi/models/account_move.py:0
+#, python-format
+msgid "Please make sure that the invoice company matches the journal company on all invoices you wish to confirm"
+msgstr "يرجى التأكد من أن الشركة المرتبطة بالفاتورة تطابق الشركة المرتبطة بالدفتر المحاسبي في جميع الفواتير التي ترغب في تأكيدها."
 
 #. module: l10n_sa_edi
 #. odoo-python
@@ -814,6 +805,8 @@ msgid "Production certificate has expired, please renew the PCSID before proceed
 msgstr "لقد انتهت مدة صلاحية شهادة الإنتاج. يرجى تجديد PCSID قبل الاستمرار"
 
 #. module: l10n_sa_edi
+#: model_terms:ir.ui.view,arch_db:l10n_sa_edi.ubl_21_CreditNoteType_zatca
+#: model_terms:ir.ui.view,arch_db:l10n_sa_edi.ubl_21_DebitNoteType_zatca
 #: model_terms:ir.ui.view,arch_db:l10n_sa_edi.ubl_21_InvoiceType_zatca
 msgid "QR"
 msgstr "QR"
@@ -852,14 +845,14 @@ msgstr "طلب CSID"
 #: model_terms:ir.ui.view,arch_db:l10n_sa_edi.view_account_journal_form
 msgid ""
 "Request a Compliance Certificate (CCSID)\n"
-"                                    <i class=\"fa fa-check text-success ms-1\" groups=\"base.group_system\" attrs=\"{'invisible': [('l10n_sa_compliance_csid_json', '=', False)]}\"/>"
+"                                    <i class=\"fa fa-check text-success ms-1\" groups=\"base.group_system\" invisible=\"not l10n_sa_compliance_csid_json\"/>"
 msgstr ""
 
 #. module: l10n_sa_edi
 #: model_terms:ir.ui.view,arch_db:l10n_sa_edi.view_account_journal_form
 msgid ""
 "Request a Production Certificate (PCSID)\n"
-"                                    <i class=\"fa fa-check text-success ms-1\" groups=\"base.group_system\" attrs=\"{'invisible': [('l10n_sa_production_csid_json', '=', False)]}\"/>"
+"                                    <i class=\"fa fa-check text-success ms-1\" groups=\"base.group_system\" invisible=\"not l10n_sa_production_csid_json\"/>"
 msgstr ""
 
 #. module: l10n_sa_edi
@@ -882,13 +875,6 @@ msgstr "الرقم التسلسلي"
 #: code:addons/l10n_sa_edi/models/account_journal.py:0
 #, python-format
 msgid "Server returned an unexpected error: %(error)s"
-msgstr ""
-
-#. module: l10n_sa_edi
-#: model_terms:ir.ui.view,arch_db:l10n_sa_edi.view_account_journal_form
-msgid ""
-"Set a Serial Number for your device\n"
-"                                    <i class=\"fa fa-check text-success ms-1\" attrs=\"{'invisible': [('l10n_sa_serial_number', '=', False)]}\"/>"
 msgstr ""
 
 #. module: l10n_sa_edi
@@ -948,7 +934,6 @@ msgstr "الضريبة"
 
 #. module: l10n_sa_edi
 #: model:ir.model.fields,help:l10n_sa_edi.field_account_tax__l10n_sa_exemption_reason_code
-#: model:ir.model.fields,help:l10n_sa_edi.field_account_tax_template__l10n_sa_exemption_reason_code
 msgid "Tax Exemption Reason Code (ZATCA)"
 msgstr "كود سبب الإعفاء (زاتكا)"
 
@@ -961,11 +946,6 @@ msgstr "رقم التعريف الضريبي"
 #: model_terms:ir.ui.view,arch_db:l10n_sa_edi.arabic_english_invoice
 msgid "Tax Invoice"
 msgstr "فاتورة الضريبة"
-
-#. module: l10n_sa_edi
-#: model:ir.model,name:l10n_sa_edi.model_account_tax_template
-msgid "Templates for Taxes"
-msgstr "قوالب الضرائب"
 
 #. module: l10n_sa_edi
 #: model:ir.model.fields,help:l10n_sa_edi.field_account_journal__l10n_sa_csr
@@ -1046,37 +1026,31 @@ msgstr "ضريبة القيمة المضافة مطلوبة عندما يتم إ
 
 #. module: l10n_sa_edi
 #: model:ir.model.fields.selection,name:l10n_sa_edi.selection__account_tax__l10n_sa_exemption_reason_code__vatex-sa-29
-#: model:ir.model.fields.selection,name:l10n_sa_edi.selection__account_tax_template__l10n_sa_exemption_reason_code__vatex-sa-29
 msgid "VATEX-SA-29 Financial services mentioned in Article 29 of the VAT Regulations."
 msgstr "VATEX-SA-29 الخدمات المالية المذكورة في القانون 29 في لوائح ضريبة القيمة المضافة."
 
 #. module: l10n_sa_edi
 #: model:ir.model.fields.selection,name:l10n_sa_edi.selection__account_tax__l10n_sa_exemption_reason_code__vatex-sa-29-7
-#: model:ir.model.fields.selection,name:l10n_sa_edi.selection__account_tax_template__l10n_sa_exemption_reason_code__vatex-sa-29-7
 msgid "VATEX-SA-29-7 Life insurance services mentioned in Article 29 of the VAT."
 msgstr "VATEX-SA-29-7 خدمات التأمين على الحياة المذكورة في القانون 29 لضريبة القيمة المضافة."
 
 #. module: l10n_sa_edi
 #: model:ir.model.fields.selection,name:l10n_sa_edi.selection__account_tax__l10n_sa_exemption_reason_code__vatex-sa-30
-#: model:ir.model.fields.selection,name:l10n_sa_edi.selection__account_tax_template__l10n_sa_exemption_reason_code__vatex-sa-30
 msgid "VATEX-SA-30 Real estate transactions mentioned in Article 30 of the VAT Regulations."
 msgstr "VATEX-SA-30 المعاملات العقارية المذكورة في القانون 30 في لوائح ضريبة القيمة المضافة."
 
 #. module: l10n_sa_edi
 #: model:ir.model.fields.selection,name:l10n_sa_edi.selection__account_tax__l10n_sa_exemption_reason_code__vatex-sa-32
-#: model:ir.model.fields.selection,name:l10n_sa_edi.selection__account_tax_template__l10n_sa_exemption_reason_code__vatex-sa-32
 msgid "VATEX-SA-32 Export of goods."
 msgstr "VATEX-SA-32 تصدير البضائع."
 
 #. module: l10n_sa_edi
 #: model:ir.model.fields.selection,name:l10n_sa_edi.selection__account_tax__l10n_sa_exemption_reason_code__vatex-sa-33
-#: model:ir.model.fields.selection,name:l10n_sa_edi.selection__account_tax_template__l10n_sa_exemption_reason_code__vatex-sa-33
 msgid "VATEX-SA-33 Export of Services."
 msgstr "VATEX-SA-33 تصدير الخدمات."
 
 #. module: l10n_sa_edi
 #: model:ir.model.fields.selection,name:l10n_sa_edi.selection__account_tax__l10n_sa_exemption_reason_code__vatex-sa-34-1
-#: model:ir.model.fields.selection,name:l10n_sa_edi.selection__account_tax_template__l10n_sa_exemption_reason_code__vatex-sa-34-1
 msgid "VATEX-SA-34-1 The international transport of Goods."
 msgstr "VATEX-SA-34-1 الشحن الدولي للبضائع."
 
@@ -1088,49 +1062,41 @@ msgstr "VATEX-SA-34-2 المواصلات الدولية للركاب."
 
 #. module: l10n_sa_edi
 #: model:ir.model.fields.selection,name:l10n_sa_edi.selection__account_tax__l10n_sa_exemption_reason_code__vatex-sa-34-3
-#: model:ir.model.fields.selection,name:l10n_sa_edi.selection__account_tax_template__l10n_sa_exemption_reason_code__vatex-sa-34-3
 msgid "VATEX-SA-34-3 Services directly connected and incidental to a Supply of international passenger transport."
 msgstr "VATEX-SA-34-3 الخدمات المتصلة مباشرة وعرضاً بوسيلة مواصلات الركاب الدولية."
 
 #. module: l10n_sa_edi
 #: model:ir.model.fields.selection,name:l10n_sa_edi.selection__account_tax__l10n_sa_exemption_reason_code__vatex-sa-34-4
-#: model:ir.model.fields.selection,name:l10n_sa_edi.selection__account_tax_template__l10n_sa_exemption_reason_code__vatex-sa-34-4
 msgid "VATEX-SA-34-4 Supply of a qualifying means of transport."
 msgstr "VATEX-SA-34-4 التزويد بوسائل نقل مؤهلة."
 
 #. module: l10n_sa_edi
 #: model:ir.model.fields.selection,name:l10n_sa_edi.selection__account_tax__l10n_sa_exemption_reason_code__vatex-sa-34-5
-#: model:ir.model.fields.selection,name:l10n_sa_edi.selection__account_tax_template__l10n_sa_exemption_reason_code__vatex-sa-34-5
 msgid "VATEX-SA-34-5 Any services relating to Goods or passenger transportation, as defined in article twenty five of these Regulations."
 msgstr "VATEX-SA-34-5 أي خدمة متعلقة بنقل الركاب أو البضائع، كما هو محدد في القانون خمسة وعشرين في تلك اللوائح."
 
 #. module: l10n_sa_edi
 #: model:ir.model.fields.selection,name:l10n_sa_edi.selection__account_tax__l10n_sa_exemption_reason_code__vatex-sa-35
-#: model:ir.model.fields.selection,name:l10n_sa_edi.selection__account_tax_template__l10n_sa_exemption_reason_code__vatex-sa-35
 msgid "VATEX-SA-35 Medicines and medical equipment."
 msgstr "VATEX-SA-35 الأدوية والمعدات الطبية."
 
 #. module: l10n_sa_edi
 #: model:ir.model.fields.selection,name:l10n_sa_edi.selection__account_tax__l10n_sa_exemption_reason_code__vatex-sa-36
-#: model:ir.model.fields.selection,name:l10n_sa_edi.selection__account_tax_template__l10n_sa_exemption_reason_code__vatex-sa-36
 msgid "VATEX-SA-36 Qualifying metals."
 msgstr "VATEX-SA-36 المعادن المؤهلة."
 
 #. module: l10n_sa_edi
 #: model:ir.model.fields.selection,name:l10n_sa_edi.selection__account_tax__l10n_sa_exemption_reason_code__vatex-sa-edu
-#: model:ir.model.fields.selection,name:l10n_sa_edi.selection__account_tax_template__l10n_sa_exemption_reason_code__vatex-sa-edu
 msgid "VATEX-SA-EDU Private education to citizen."
 msgstr "VATEX-SA-EDU تعليم خاص للمواطن."
 
 #. module: l10n_sa_edi
 #: model:ir.model.fields.selection,name:l10n_sa_edi.selection__account_tax__l10n_sa_exemption_reason_code__vatex-sa-hea
-#: model:ir.model.fields.selection,name:l10n_sa_edi.selection__account_tax_template__l10n_sa_exemption_reason_code__vatex-sa-hea
 msgid "VATEX-SA-HEA Private healthcare to citizen."
 msgstr "VATEX-SA-HEA رعاية صحية خاصة للمواطن."
 
 #. module: l10n_sa_edi
 #: model:ir.model.fields.selection,name:l10n_sa_edi.selection__account_tax__l10n_sa_exemption_reason_code__vatex-sa-oos
-#: model:ir.model.fields.selection,name:l10n_sa_edi.selection__account_tax_template__l10n_sa_exemption_reason_code__vatex-sa-oos
 msgid "VATEX-SA-OOS Not subject to VAT."
 msgstr ""
 
@@ -1145,10 +1111,8 @@ msgstr "التحذيرات:"
 #: model_terms:ir.ui.view,arch_db:l10n_sa_edi.res_config_settings_view_form
 msgid ""
 "You can select the API used for submissions down below. There are three modes available: Sandbox, Pre-Production and Production.\n"
-"                                Once you have selected the correct API, you can start the Onboarding process by going to the Journals and checking the options under the ZATCA tab."
+"                            Once you have selected the correct API, you can start the Onboarding process by going to the Journals and checking the options under the ZATCA tab."
 msgstr ""
-"يمكنك تحديد الواجهة البرمجية المستخدمة لعمليات الإرسال أدناه. توجد ثلاثة أوضاع متاحة: Sandbox، ما قبل الإنتاج، والإنتاج.\n"
-"                                بمجرد أن تقوم بتحديد الواجهة البرمجية الصحيحة، يمكنك بدء عملية التجهيز عن طريق الذهاب إلى دفاتر اليومية وتحديد الخيارات تحت علامة تبويب زاتكا."
 
 #. module: l10n_sa_edi
 #. odoo-python
@@ -1179,6 +1143,7 @@ msgid "You need to request the CCSID first before you can proceed"
 msgstr "عليك طلب CCSID أولاً قبل الاستمرار"
 
 #. module: l10n_sa_edi
+#: model:ir.model.fields,field_description:l10n_sa_edi.field_account_move_send__l10n_sa_edi_enable_zatca
 #: model_terms:ir.ui.view,arch_db:l10n_sa_edi.view_account_journal_form
 msgid "ZATCA"
 msgstr "زاتكا"
@@ -1206,6 +1171,11 @@ msgid "ZATCA chain index"
 msgstr "مؤشر سلسلة زاتكا"
 
 #. module: l10n_sa_edi
+#: model_terms:ir.ui.view,arch_db:l10n_sa_edi.res_config_settings_view_form
+msgid "ZATCA specific settings for Saudi eInvoicing"
+msgstr ""
+
+#. module: l10n_sa_edi
 #: model_terms:ir.ui.view,arch_db:l10n_sa_edi.sa_partner_address_form
 msgid "ZIP"
 msgstr "ZIP"
@@ -1227,6 +1197,8 @@ msgstr "not(//ancestor-or-self::ext:UBLExtensions)"
 
 #. module: l10n_sa_edi
 #: model_terms:ir.ui.view,arch_db:l10n_sa_edi.export_sa_zatca_ubl_extensions
+#: model_terms:ir.ui.view,arch_db:l10n_sa_edi.ubl_21_CreditNoteType_zatca
+#: model_terms:ir.ui.view,arch_db:l10n_sa_edi.ubl_21_DebitNoteType_zatca
 #: model_terms:ir.ui.view,arch_db:l10n_sa_edi.ubl_21_InvoiceType_zatca
 msgid "urn:oasis:names:specification:ubl:dsig:enveloped:xades"
 msgstr "urn:oasis:names:specification:ubl:dsig:enveloped:xades"
@@ -1238,6 +1210,8 @@ msgstr "urn:oasis:names:specification:ubl:signature:1"
 
 #. module: l10n_sa_edi
 #: model_terms:ir.ui.view,arch_db:l10n_sa_edi.export_sa_zatca_ubl_extensions
+#: model_terms:ir.ui.view,arch_db:l10n_sa_edi.ubl_21_CreditNoteType_zatca
+#: model_terms:ir.ui.view,arch_db:l10n_sa_edi.ubl_21_DebitNoteType_zatca
 #: model_terms:ir.ui.view,arch_db:l10n_sa_edi.ubl_21_InvoiceType_zatca
 msgid "urn:oasis:names:specification:ubl:signature:Invoice"
 msgstr "urn:oasis:names:specification:ubl:signature:Invoice"

--- a/addons/l10n_sa_edi/i18n/l10n_sa_edi.pot
+++ b/addons/l10n_sa_edi/i18n/l10n_sa_edi.pot
@@ -4,10 +4,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 16.0+e\n"
+"Project-Id-Version: Odoo Server 17.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-06-26 10:46+0000\n"
-"PO-Revision-Date: 2025-06-26 10:46+0000\n"
+"POT-Creation-Date: 2025-07-09 12:44+0000\n"
+"PO-Revision-Date: 2025-07-09 12:44+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -21,7 +21,7 @@ msgstr ""
 #, python-format
 msgid ""
 "\n"
-"Building Number: %s, Plot Identification: %s \n"
+"Building Number: %s, Plot Identification: %s\n"
 "Neighborhood: %s"
 msgstr ""
 
@@ -140,13 +140,6 @@ msgid "<span class=\"fw-bold\">VAT Amount</span>"
 msgstr ""
 
 #. module: l10n_sa_edi
-#: model_terms:ir.ui.view,arch_db:l10n_sa_edi.res_config_settings_view_form
-msgid ""
-"<span class=\"o_form_label\">ZATCA API Integration</span>\n"
-"                            <span class=\"fa fa-lg fa-building-o\" title=\"Values set here are company-specific.\" aria-label=\"Values set here are company-specific.\" groups=\"base.group_multi_company\" role=\"img\"/>"
-msgstr ""
-
-#. module: l10n_sa_edi
 #: model_terms:ir.ui.view,arch_db:l10n_sa_edi.arabic_english_invoice
 msgid "<strong>الإجمالي الفرعي بالريال السعودي</strong>"
 msgstr ""
@@ -174,6 +167,11 @@ msgstr ""
 #. module: l10n_sa_edi
 #: model:ir.model,name:l10n_sa_edi.model_account_move_reversal
 msgid "Account Move Reversal"
+msgstr ""
+
+#. module: l10n_sa_edi
+#: model:ir.model,name:l10n_sa_edi.model_account_move_send
+msgid "Account Move Send"
 msgstr ""
 
 #. module: l10n_sa_edi
@@ -304,7 +302,7 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:l10n_sa_edi.view_account_journal_form
 msgid ""
 "Complete the Compliance Checks\n"
-"                                    <i class=\"fa fa-check text-success ms-1\" attrs=\"{'invisible': [('l10n_sa_compliance_checks_passed', '=', False)]}\"/>"
+"                                    <i class=\"fa fa-check text-success ms-1\" invisible=\"not l10n_sa_compliance_checks_passed\"/>"
 msgstr ""
 
 #. module: l10n_sa_edi
@@ -403,7 +401,6 @@ msgstr ""
 
 #. module: l10n_sa_edi
 #: model:ir.model.fields,help:l10n_sa_edi.field_account_tax__l10n_sa_is_retention
-#: model:ir.model.fields,help:l10n_sa_edi.field_account_tax_template__l10n_sa_is_retention
 msgid "Determines whether or not a tax counts as a Withholding Tax"
 msgstr ""
 
@@ -433,7 +430,6 @@ msgstr ""
 
 #. module: l10n_sa_edi
 #: model:ir.model.fields,field_description:l10n_sa_edi.field_account_tax__l10n_sa_exemption_reason_code
-#: model:ir.model.fields,field_description:l10n_sa_edi.field_account_tax_template__l10n_sa_exemption_reason_code
 msgid "Exemption Reason Code"
 msgstr ""
 
@@ -465,6 +461,8 @@ msgid ""
 msgstr ""
 
 #. module: l10n_sa_edi
+#: model_terms:ir.ui.view,arch_db:l10n_sa_edi.ubl_21_CreditNoteType_zatca
+#: model_terms:ir.ui.view,arch_db:l10n_sa_edi.ubl_21_DebitNoteType_zatca
 #: model_terms:ir.ui.view,arch_db:l10n_sa_edi.ubl_21_InvoiceType_zatca
 msgid "ICV"
 msgstr ""
@@ -500,8 +498,8 @@ msgstr ""
 #: code:addons/l10n_sa_edi/models/account_edi_format.py:0
 #, python-format
 msgid ""
-"Invoice could not be cleared: \r\n"
-" %s "
+"Invoice could not be cleared:\n"
+"%s"
 msgstr ""
 
 #. module: l10n_sa_edi
@@ -509,8 +507,8 @@ msgstr ""
 #: code:addons/l10n_sa_edi/models/account_edi_format.py:0
 #, python-format
 msgid ""
-"Invoice could not be reported: \r\n"
-" %s "
+"Invoice could not be reported:\n"
+"%s"
 msgstr ""
 
 #. module: l10n_sa_edi
@@ -550,7 +548,6 @@ msgstr ""
 
 #. module: l10n_sa_edi
 #: model:ir.model.fields,field_description:l10n_sa_edi.field_account_tax__l10n_sa_is_retention
-#: model:ir.model.fields,field_description:l10n_sa_edi.field_account_tax_template__l10n_sa_is_retention
 msgid "Is Retention"
 msgstr ""
 
@@ -627,11 +624,6 @@ msgid "L10N Sa Edi Plot Identification"
 msgstr ""
 
 #. module: l10n_sa_edi
-#: model:ir.model.fields,field_description:l10n_sa_edi.field_l10n_sa_edi_otp_wizard____last_update
-msgid "Last Modified on"
-msgstr ""
-
-#. module: l10n_sa_edi
 #: model:ir.model.fields,field_description:l10n_sa_edi.field_l10n_sa_edi_otp_wizard__write_uid
 msgid "Last Updated by"
 msgstr ""
@@ -657,6 +649,8 @@ msgid "Momra License"
 msgstr ""
 
 #. module: l10n_sa_edi
+#: model_terms:ir.ui.view,arch_db:l10n_sa_edi.ubl_21_CreditNoteType_zatca
+#: model_terms:ir.ui.view,arch_db:l10n_sa_edi.ubl_21_DebitNoteType_zatca
 #: model_terms:ir.ui.view,arch_db:l10n_sa_edi.ubl_21_InvoiceType_zatca
 msgid "N/A"
 msgstr ""
@@ -716,8 +710,8 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:l10n_sa_edi.res_config_settings_view_form
 msgid ""
 "Once you change the submission mode to <strong>Production</strong>, you cannot change it anymore.\n"
-"                                Be very careful, as any invoice submitted to ZATCA in Production mode will be accounted for\n"
-"                                and might lead to <strong>Fines &amp; Penalties</strong>."
+"                            Be very careful, as any invoice submitted to ZATCA in Production mode will be accounted for\n"
+"                            and might lead to <strong>Fines &amp; Penalties</strong>."
 msgstr ""
 
 #. module: l10n_sa_edi
@@ -750,6 +744,8 @@ msgid "PCSID Renewal"
 msgstr ""
 
 #. module: l10n_sa_edi
+#: model_terms:ir.ui.view,arch_db:l10n_sa_edi.ubl_21_CreditNoteType_zatca
+#: model_terms:ir.ui.view,arch_db:l10n_sa_edi.ubl_21_DebitNoteType_zatca
 #: model_terms:ir.ui.view,arch_db:l10n_sa_edi.ubl_21_InvoiceType_zatca
 msgid "PIH"
 msgstr ""
@@ -764,6 +760,15 @@ msgstr ""
 #: code:addons/l10n_sa_edi/migrations/0.2/post-migrate.py:0
 #, python-format
 msgid "Please Re-Onboard the Journal for a new serial number"
+msgstr ""
+
+#. module: l10n_sa_edi
+#. odoo-python
+#: code:addons/l10n_sa_edi/models/account_move.py:0
+#, python-format
+msgid ""
+"Please make sure that the invoice company matches the journal company on all"
+" invoices you wish to confirm"
 msgstr ""
 
 #. module: l10n_sa_edi
@@ -839,6 +844,8 @@ msgid ""
 msgstr ""
 
 #. module: l10n_sa_edi
+#: model_terms:ir.ui.view,arch_db:l10n_sa_edi.ubl_21_CreditNoteType_zatca
+#: model_terms:ir.ui.view,arch_db:l10n_sa_edi.ubl_21_DebitNoteType_zatca
 #: model_terms:ir.ui.view,arch_db:l10n_sa_edi.ubl_21_InvoiceType_zatca
 msgid "QR"
 msgstr ""
@@ -877,14 +884,14 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:l10n_sa_edi.view_account_journal_form
 msgid ""
 "Request a Compliance Certificate (CCSID)\n"
-"                                    <i class=\"fa fa-check text-success ms-1\" groups=\"base.group_system\" attrs=\"{'invisible': [('l10n_sa_compliance_csid_json', '=', False)]}\"/>"
+"                                    <i class=\"fa fa-check text-success ms-1\" groups=\"base.group_system\" invisible=\"not l10n_sa_compliance_csid_json\"/>"
 msgstr ""
 
 #. module: l10n_sa_edi
 #: model_terms:ir.ui.view,arch_db:l10n_sa_edi.view_account_journal_form
 msgid ""
 "Request a Production Certificate (PCSID)\n"
-"                                    <i class=\"fa fa-check text-success ms-1\" groups=\"base.group_system\" attrs=\"{'invisible': [('l10n_sa_production_csid_json', '=', False)]}\"/>"
+"                                    <i class=\"fa fa-check text-success ms-1\" groups=\"base.group_system\" invisible=\"not l10n_sa_production_csid_json\"/>"
 msgstr ""
 
 #. module: l10n_sa_edi
@@ -907,13 +914,6 @@ msgstr ""
 #: code:addons/l10n_sa_edi/models/account_journal.py:0
 #, python-format
 msgid "Server returned an unexpected error: %(error)s"
-msgstr ""
-
-#. module: l10n_sa_edi
-#: model_terms:ir.ui.view,arch_db:l10n_sa_edi.view_account_journal_form
-msgid ""
-"Set a Serial Number for your device\n"
-"                                    <i class=\"fa fa-check text-success ms-1\" attrs=\"{'invisible': [('l10n_sa_serial_number', '=', False)]}\"/>"
 msgstr ""
 
 #. module: l10n_sa_edi
@@ -973,7 +973,6 @@ msgstr ""
 
 #. module: l10n_sa_edi
 #: model:ir.model.fields,help:l10n_sa_edi.field_account_tax__l10n_sa_exemption_reason_code
-#: model:ir.model.fields,help:l10n_sa_edi.field_account_tax_template__l10n_sa_exemption_reason_code
 msgid "Tax Exemption Reason Code (ZATCA)"
 msgstr ""
 
@@ -985,11 +984,6 @@ msgstr ""
 #. module: l10n_sa_edi
 #: model_terms:ir.ui.view,arch_db:l10n_sa_edi.arabic_english_invoice
 msgid "Tax Invoice"
-msgstr ""
-
-#. module: l10n_sa_edi
-#: model:ir.model,name:l10n_sa_edi.model_account_tax_template
-msgid "Templates for Taxes"
 msgstr ""
 
 #. module: l10n_sa_edi
@@ -1081,7 +1075,6 @@ msgstr ""
 
 #. module: l10n_sa_edi
 #: model:ir.model.fields.selection,name:l10n_sa_edi.selection__account_tax__l10n_sa_exemption_reason_code__vatex-sa-29
-#: model:ir.model.fields.selection,name:l10n_sa_edi.selection__account_tax_template__l10n_sa_exemption_reason_code__vatex-sa-29
 msgid ""
 "VATEX-SA-29 Financial services mentioned in Article 29 of the VAT "
 "Regulations."
@@ -1089,14 +1082,12 @@ msgstr ""
 
 #. module: l10n_sa_edi
 #: model:ir.model.fields.selection,name:l10n_sa_edi.selection__account_tax__l10n_sa_exemption_reason_code__vatex-sa-29-7
-#: model:ir.model.fields.selection,name:l10n_sa_edi.selection__account_tax_template__l10n_sa_exemption_reason_code__vatex-sa-29-7
 msgid ""
 "VATEX-SA-29-7 Life insurance services mentioned in Article 29 of the VAT."
 msgstr ""
 
 #. module: l10n_sa_edi
 #: model:ir.model.fields.selection,name:l10n_sa_edi.selection__account_tax__l10n_sa_exemption_reason_code__vatex-sa-30
-#: model:ir.model.fields.selection,name:l10n_sa_edi.selection__account_tax_template__l10n_sa_exemption_reason_code__vatex-sa-30
 msgid ""
 "VATEX-SA-30 Real estate transactions mentioned in Article 30 of the VAT "
 "Regulations."
@@ -1104,19 +1095,16 @@ msgstr ""
 
 #. module: l10n_sa_edi
 #: model:ir.model.fields.selection,name:l10n_sa_edi.selection__account_tax__l10n_sa_exemption_reason_code__vatex-sa-32
-#: model:ir.model.fields.selection,name:l10n_sa_edi.selection__account_tax_template__l10n_sa_exemption_reason_code__vatex-sa-32
 msgid "VATEX-SA-32 Export of goods."
 msgstr ""
 
 #. module: l10n_sa_edi
 #: model:ir.model.fields.selection,name:l10n_sa_edi.selection__account_tax__l10n_sa_exemption_reason_code__vatex-sa-33
-#: model:ir.model.fields.selection,name:l10n_sa_edi.selection__account_tax_template__l10n_sa_exemption_reason_code__vatex-sa-33
 msgid "VATEX-SA-33 Export of Services."
 msgstr ""
 
 #. module: l10n_sa_edi
 #: model:ir.model.fields.selection,name:l10n_sa_edi.selection__account_tax__l10n_sa_exemption_reason_code__vatex-sa-34-1
-#: model:ir.model.fields.selection,name:l10n_sa_edi.selection__account_tax_template__l10n_sa_exemption_reason_code__vatex-sa-34-1
 msgid "VATEX-SA-34-1 The international transport of Goods."
 msgstr ""
 
@@ -1128,7 +1116,6 @@ msgstr ""
 
 #. module: l10n_sa_edi
 #: model:ir.model.fields.selection,name:l10n_sa_edi.selection__account_tax__l10n_sa_exemption_reason_code__vatex-sa-34-3
-#: model:ir.model.fields.selection,name:l10n_sa_edi.selection__account_tax_template__l10n_sa_exemption_reason_code__vatex-sa-34-3
 msgid ""
 "VATEX-SA-34-3 Services directly connected and incidental to a Supply of "
 "international passenger transport."
@@ -1136,13 +1123,11 @@ msgstr ""
 
 #. module: l10n_sa_edi
 #: model:ir.model.fields.selection,name:l10n_sa_edi.selection__account_tax__l10n_sa_exemption_reason_code__vatex-sa-34-4
-#: model:ir.model.fields.selection,name:l10n_sa_edi.selection__account_tax_template__l10n_sa_exemption_reason_code__vatex-sa-34-4
 msgid "VATEX-SA-34-4 Supply of a qualifying means of transport."
 msgstr ""
 
 #. module: l10n_sa_edi
 #: model:ir.model.fields.selection,name:l10n_sa_edi.selection__account_tax__l10n_sa_exemption_reason_code__vatex-sa-34-5
-#: model:ir.model.fields.selection,name:l10n_sa_edi.selection__account_tax_template__l10n_sa_exemption_reason_code__vatex-sa-34-5
 msgid ""
 "VATEX-SA-34-5 Any services relating to Goods or passenger transportation, as"
 " defined in article twenty five of these Regulations."
@@ -1150,31 +1135,26 @@ msgstr ""
 
 #. module: l10n_sa_edi
 #: model:ir.model.fields.selection,name:l10n_sa_edi.selection__account_tax__l10n_sa_exemption_reason_code__vatex-sa-35
-#: model:ir.model.fields.selection,name:l10n_sa_edi.selection__account_tax_template__l10n_sa_exemption_reason_code__vatex-sa-35
 msgid "VATEX-SA-35 Medicines and medical equipment."
 msgstr ""
 
 #. module: l10n_sa_edi
 #: model:ir.model.fields.selection,name:l10n_sa_edi.selection__account_tax__l10n_sa_exemption_reason_code__vatex-sa-36
-#: model:ir.model.fields.selection,name:l10n_sa_edi.selection__account_tax_template__l10n_sa_exemption_reason_code__vatex-sa-36
 msgid "VATEX-SA-36 Qualifying metals."
 msgstr ""
 
 #. module: l10n_sa_edi
 #: model:ir.model.fields.selection,name:l10n_sa_edi.selection__account_tax__l10n_sa_exemption_reason_code__vatex-sa-edu
-#: model:ir.model.fields.selection,name:l10n_sa_edi.selection__account_tax_template__l10n_sa_exemption_reason_code__vatex-sa-edu
 msgid "VATEX-SA-EDU Private education to citizen."
 msgstr ""
 
 #. module: l10n_sa_edi
 #: model:ir.model.fields.selection,name:l10n_sa_edi.selection__account_tax__l10n_sa_exemption_reason_code__vatex-sa-hea
-#: model:ir.model.fields.selection,name:l10n_sa_edi.selection__account_tax_template__l10n_sa_exemption_reason_code__vatex-sa-hea
 msgid "VATEX-SA-HEA Private healthcare to citizen."
 msgstr ""
 
 #. module: l10n_sa_edi
 #: model:ir.model.fields.selection,name:l10n_sa_edi.selection__account_tax__l10n_sa_exemption_reason_code__vatex-sa-oos
-#: model:ir.model.fields.selection,name:l10n_sa_edi.selection__account_tax_template__l10n_sa_exemption_reason_code__vatex-sa-oos
 msgid "VATEX-SA-OOS Not subject to VAT."
 msgstr ""
 
@@ -1189,7 +1169,7 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:l10n_sa_edi.res_config_settings_view_form
 msgid ""
 "You can select the API used for submissions down below. There are three modes available: Sandbox, Pre-Production and Production.\n"
-"                                Once you have selected the correct API, you can start the Onboarding process by going to the Journals and checking the options under the ZATCA tab."
+"                            Once you have selected the correct API, you can start the Onboarding process by going to the Journals and checking the options under the ZATCA tab."
 msgstr ""
 
 #. module: l10n_sa_edi
@@ -1225,6 +1205,7 @@ msgid "You need to request the CCSID first before you can proceed"
 msgstr ""
 
 #. module: l10n_sa_edi
+#: model:ir.model.fields,field_description:l10n_sa_edi.field_account_move_send__l10n_sa_edi_enable_zatca
 #: model_terms:ir.ui.view,arch_db:l10n_sa_edi.view_account_journal_form
 msgid "ZATCA"
 msgstr ""
@@ -1252,6 +1233,11 @@ msgid "ZATCA chain index"
 msgstr ""
 
 #. module: l10n_sa_edi
+#: model_terms:ir.ui.view,arch_db:l10n_sa_edi.res_config_settings_view_form
+msgid "ZATCA specific settings for Saudi eInvoicing"
+msgstr ""
+
+#. module: l10n_sa_edi
 #: model_terms:ir.ui.view,arch_db:l10n_sa_edi.sa_partner_address_form
 msgid "ZIP"
 msgstr ""
@@ -1273,6 +1259,8 @@ msgstr ""
 
 #. module: l10n_sa_edi
 #: model_terms:ir.ui.view,arch_db:l10n_sa_edi.export_sa_zatca_ubl_extensions
+#: model_terms:ir.ui.view,arch_db:l10n_sa_edi.ubl_21_CreditNoteType_zatca
+#: model_terms:ir.ui.view,arch_db:l10n_sa_edi.ubl_21_DebitNoteType_zatca
 #: model_terms:ir.ui.view,arch_db:l10n_sa_edi.ubl_21_InvoiceType_zatca
 msgid "urn:oasis:names:specification:ubl:dsig:enveloped:xades"
 msgstr ""
@@ -1284,6 +1272,8 @@ msgstr ""
 
 #. module: l10n_sa_edi
 #: model_terms:ir.ui.view,arch_db:l10n_sa_edi.export_sa_zatca_ubl_extensions
+#: model_terms:ir.ui.view,arch_db:l10n_sa_edi.ubl_21_CreditNoteType_zatca
+#: model_terms:ir.ui.view,arch_db:l10n_sa_edi.ubl_21_DebitNoteType_zatca
 #: model_terms:ir.ui.view,arch_db:l10n_sa_edi.ubl_21_InvoiceType_zatca
 msgid "urn:oasis:names:specification:ubl:signature:Invoice"
 msgstr ""

--- a/addons/l10n_sa_edi/models/account_move.py
+++ b/addons/l10n_sa_edi/models/account_move.py
@@ -9,6 +9,7 @@ from lxml import etree
 from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
 from cryptography.hazmat.backends import default_backend
 from cryptography.x509 import load_der_x509_certificate
+from odoo.exceptions import UserError
 
 
 class AccountMove(models.Model):
@@ -269,6 +270,11 @@ class AccountMove(models.Model):
             'total_amount': invoice_vals['vals']['monetary_total_vals']['tax_inclusive_amount'],
             'total_tax': invoice_vals['vals']['tax_total_vals'][-1]['tax_amount'],
         }
+
+    def action_post(self):
+        if self.filtered(lambda move: move.country_code == "SA" and move.move_type in ('out_invoice', 'out_refund') and move.company_id != move.journal_id.company_id):
+            raise UserError(_("Please make sure that the invoice company matches the journal company on all invoices you wish to confirm"))
+        return super().action_post()
 
 
 class AccountMoveLine(models.Model):

--- a/addons/l10n_sa_edi/tests/__init__.py
+++ b/addons/l10n_sa_edi/tests/__init__.py
@@ -3,3 +3,4 @@
 
 from . import common
 from . import test_edi_zatca
+from . import test_account_move

--- a/addons/l10n_sa_edi/tests/compliance/simplified/credit.xml
+++ b/addons/l10n_sa_edi/tests/compliance/simplified/credit.xml
@@ -53,7 +53,7 @@
         <cbc:CityName>&#1575;&#1604;&#1605;&#1583;&#1610;&#1606;&#1577; &#1575;&#1604;&#1605;&#1606;&#1608;&#1585;&#1577;</cbc:CityName>
         <cbc:PostalZone>42317</cbc:PostalZone>
         <cbc:CountrySubentity>Riyadh</cbc:CountrySubentity>
-        <cbc:CountrySubentityCode>RYA</cbc:CountrySubentityCode>
+        <cbc:CountrySubentityCode>RUH</cbc:CountrySubentityCode>
         <cac:Country>
           <cbc:IdentificationCode>SA</cbc:IdentificationCode>
           <cbc:Name>Saudi Arabia</cbc:Name>
@@ -70,7 +70,7 @@
           <cbc:CityName>&#1575;&#1604;&#1605;&#1583;&#1610;&#1606;&#1577; &#1575;&#1604;&#1605;&#1606;&#1608;&#1585;&#1577;</cbc:CityName>
           <cbc:PostalZone>42317</cbc:PostalZone>
           <cbc:CountrySubentity>Riyadh</cbc:CountrySubentity>
-          <cbc:CountrySubentityCode>RYA</cbc:CountrySubentityCode>
+          <cbc:CountrySubentityCode>RUH</cbc:CountrySubentityCode>
           <cac:Country>
             <cbc:IdentificationCode>SA</cbc:IdentificationCode>
             <cbc:Name>Saudi Arabia</cbc:Name>
@@ -91,7 +91,7 @@
           <cbc:CityName>&#1575;&#1604;&#1605;&#1583;&#1610;&#1606;&#1577; &#1575;&#1604;&#1605;&#1606;&#1608;&#1585;&#1577;</cbc:CityName>
           <cbc:PostalZone>42317</cbc:PostalZone>
           <cbc:CountrySubentity>Riyadh</cbc:CountrySubentity>
-          <cbc:CountrySubentityCode>RYA</cbc:CountrySubentityCode>
+          <cbc:CountrySubentityCode>RUH</cbc:CountrySubentityCode>
           <cac:Country>
             <cbc:IdentificationCode>SA</cbc:IdentificationCode>
             <cbc:Name>Saudi Arabia</cbc:Name>
@@ -116,7 +116,7 @@
       </cac:PartyName>
       <cac:PostalAddress>
         <cbc:CountrySubentity>Riyadh</cbc:CountrySubentity>
-        <cbc:CountrySubentityCode>RYA</cbc:CountrySubentityCode>
+        <cbc:CountrySubentityCode>RUH</cbc:CountrySubentityCode>
         <cac:Country>
           <cbc:IdentificationCode>SA</cbc:IdentificationCode>
           <cbc:Name>Saudi Arabia</cbc:Name>
@@ -126,7 +126,7 @@
         <cbc:RegistrationName>Mohammed Ali</cbc:RegistrationName>
         <cac:RegistrationAddress>
           <cbc:CountrySubentity>Riyadh</cbc:CountrySubentity>
-          <cbc:CountrySubentityCode>RYA</cbc:CountrySubentityCode>
+          <cbc:CountrySubentityCode>RUH</cbc:CountrySubentityCode>
           <cac:Country>
             <cbc:IdentificationCode>SA</cbc:IdentificationCode>
             <cbc:Name>Saudi Arabia</cbc:Name>
@@ -140,7 +140,7 @@
         <cbc:RegistrationName>Mohammed Ali</cbc:RegistrationName>
         <cac:RegistrationAddress>
           <cbc:CountrySubentity>Riyadh</cbc:CountrySubentity>
-          <cbc:CountrySubentityCode>RYA</cbc:CountrySubentityCode>
+          <cbc:CountrySubentityCode>RUH</cbc:CountrySubentityCode>
           <cac:Country>
             <cbc:IdentificationCode>SA</cbc:IdentificationCode>
             <cbc:Name>Saudi Arabia</cbc:Name>

--- a/addons/l10n_sa_edi/tests/compliance/simplified/debit.xml
+++ b/addons/l10n_sa_edi/tests/compliance/simplified/debit.xml
@@ -53,7 +53,7 @@
         <cbc:CityName>&#1575;&#1604;&#1605;&#1583;&#1610;&#1606;&#1577; &#1575;&#1604;&#1605;&#1606;&#1608;&#1585;&#1577;</cbc:CityName>
         <cbc:PostalZone>42317</cbc:PostalZone>
         <cbc:CountrySubentity>Riyadh</cbc:CountrySubentity>
-        <cbc:CountrySubentityCode>RYA</cbc:CountrySubentityCode>
+        <cbc:CountrySubentityCode>RUH</cbc:CountrySubentityCode>
         <cac:Country>
           <cbc:IdentificationCode>SA</cbc:IdentificationCode>
           <cbc:Name>Saudi Arabia</cbc:Name>
@@ -70,7 +70,7 @@
           <cbc:CityName>&#1575;&#1604;&#1605;&#1583;&#1610;&#1606;&#1577; &#1575;&#1604;&#1605;&#1606;&#1608;&#1585;&#1577;</cbc:CityName>
           <cbc:PostalZone>42317</cbc:PostalZone>
           <cbc:CountrySubentity>Riyadh</cbc:CountrySubentity>
-          <cbc:CountrySubentityCode>RYA</cbc:CountrySubentityCode>
+          <cbc:CountrySubentityCode>RUH</cbc:CountrySubentityCode>
           <cac:Country>
             <cbc:IdentificationCode>SA</cbc:IdentificationCode>
             <cbc:Name>Saudi Arabia</cbc:Name>
@@ -91,7 +91,7 @@
           <cbc:CityName>&#1575;&#1604;&#1605;&#1583;&#1610;&#1606;&#1577; &#1575;&#1604;&#1605;&#1606;&#1608;&#1585;&#1577;</cbc:CityName>
           <cbc:PostalZone>42317</cbc:PostalZone>
           <cbc:CountrySubentity>Riyadh</cbc:CountrySubentity>
-          <cbc:CountrySubentityCode>RYA</cbc:CountrySubentityCode>
+          <cbc:CountrySubentityCode>RUH</cbc:CountrySubentityCode>
           <cac:Country>
             <cbc:IdentificationCode>SA</cbc:IdentificationCode>
             <cbc:Name>Saudi Arabia</cbc:Name>
@@ -116,7 +116,7 @@
       </cac:PartyName>
       <cac:PostalAddress>
         <cbc:CountrySubentity>Riyadh</cbc:CountrySubentity>
-        <cbc:CountrySubentityCode>RYA</cbc:CountrySubentityCode>
+        <cbc:CountrySubentityCode>RUH</cbc:CountrySubentityCode>
         <cac:Country>
           <cbc:IdentificationCode>SA</cbc:IdentificationCode>
           <cbc:Name>Saudi Arabia</cbc:Name>
@@ -126,7 +126,7 @@
         <cbc:RegistrationName>Mohammed Ali</cbc:RegistrationName>
         <cac:RegistrationAddress>
           <cbc:CountrySubentity>Riyadh</cbc:CountrySubentity>
-          <cbc:CountrySubentityCode>RYA</cbc:CountrySubentityCode>
+          <cbc:CountrySubentityCode>RUH</cbc:CountrySubentityCode>
           <cac:Country>
             <cbc:IdentificationCode>SA</cbc:IdentificationCode>
             <cbc:Name>Saudi Arabia</cbc:Name>
@@ -140,7 +140,7 @@
         <cbc:RegistrationName>Mohammed Ali</cbc:RegistrationName>
         <cac:RegistrationAddress>
           <cbc:CountrySubentity>Riyadh</cbc:CountrySubentity>
-          <cbc:CountrySubentityCode>RYA</cbc:CountrySubentityCode>
+          <cbc:CountrySubentityCode>RUH</cbc:CountrySubentityCode>
           <cac:Country>
             <cbc:IdentificationCode>SA</cbc:IdentificationCode>
             <cbc:Name>Saudi Arabia</cbc:Name>

--- a/addons/l10n_sa_edi/tests/compliance/simplified/invoice.xml
+++ b/addons/l10n_sa_edi/tests/compliance/simplified/invoice.xml
@@ -48,7 +48,7 @@
         <cbc:CityName>&#1575;&#1604;&#1605;&#1583;&#1610;&#1606;&#1577; &#1575;&#1604;&#1605;&#1606;&#1608;&#1585;&#1577;</cbc:CityName>
         <cbc:PostalZone>42317</cbc:PostalZone>
         <cbc:CountrySubentity>Riyadh</cbc:CountrySubentity>
-        <cbc:CountrySubentityCode>RYA</cbc:CountrySubentityCode>
+        <cbc:CountrySubentityCode>RUH</cbc:CountrySubentityCode>
         <cac:Country>
           <cbc:IdentificationCode>SA</cbc:IdentificationCode>
           <cbc:Name>Saudi Arabia</cbc:Name>
@@ -65,7 +65,7 @@
           <cbc:CityName>&#1575;&#1604;&#1605;&#1583;&#1610;&#1606;&#1577; &#1575;&#1604;&#1605;&#1606;&#1608;&#1585;&#1577;</cbc:CityName>
           <cbc:PostalZone>42317</cbc:PostalZone>
           <cbc:CountrySubentity>Riyadh</cbc:CountrySubentity>
-          <cbc:CountrySubentityCode>RYA</cbc:CountrySubentityCode>
+          <cbc:CountrySubentityCode>RUH</cbc:CountrySubentityCode>
           <cac:Country>
             <cbc:IdentificationCode>SA</cbc:IdentificationCode>
             <cbc:Name>Saudi Arabia</cbc:Name>
@@ -86,7 +86,7 @@
           <cbc:CityName>&#1575;&#1604;&#1605;&#1583;&#1610;&#1606;&#1577; &#1575;&#1604;&#1605;&#1606;&#1608;&#1585;&#1577;</cbc:CityName>
           <cbc:PostalZone>42317</cbc:PostalZone>
           <cbc:CountrySubentity>Riyadh</cbc:CountrySubentity>
-          <cbc:CountrySubentityCode>RYA</cbc:CountrySubentityCode>
+          <cbc:CountrySubentityCode>RUH</cbc:CountrySubentityCode>
           <cac:Country>
             <cbc:IdentificationCode>SA</cbc:IdentificationCode>
             <cbc:Name>Saudi Arabia</cbc:Name>
@@ -111,7 +111,7 @@
       </cac:PartyName>
       <cac:PostalAddress>
         <cbc:CountrySubentity>Riyadh</cbc:CountrySubentity>
-        <cbc:CountrySubentityCode>RYA</cbc:CountrySubentityCode>
+        <cbc:CountrySubentityCode>RUH</cbc:CountrySubentityCode>
         <cac:Country>
           <cbc:IdentificationCode>SA</cbc:IdentificationCode>
           <cbc:Name>Saudi Arabia</cbc:Name>
@@ -121,7 +121,7 @@
         <cbc:RegistrationName>Mohammed Ali</cbc:RegistrationName>
         <cac:RegistrationAddress>
           <cbc:CountrySubentity>Riyadh</cbc:CountrySubentity>
-          <cbc:CountrySubentityCode>RYA</cbc:CountrySubentityCode>
+          <cbc:CountrySubentityCode>RUH</cbc:CountrySubentityCode>
           <cac:Country>
             <cbc:IdentificationCode>SA</cbc:IdentificationCode>
             <cbc:Name>Saudi Arabia</cbc:Name>
@@ -135,7 +135,7 @@
         <cbc:RegistrationName>Mohammed Ali</cbc:RegistrationName>
         <cac:RegistrationAddress>
           <cbc:CountrySubentity>Riyadh</cbc:CountrySubentity>
-          <cbc:CountrySubentityCode>RYA</cbc:CountrySubentityCode>
+          <cbc:CountrySubentityCode>RUH</cbc:CountrySubentityCode>
           <cac:Country>
             <cbc:IdentificationCode>SA</cbc:IdentificationCode>
             <cbc:Name>Saudi Arabia</cbc:Name>

--- a/addons/l10n_sa_edi/tests/compliance/standard/credit.xml
+++ b/addons/l10n_sa_edi/tests/compliance/standard/credit.xml
@@ -8,10 +8,10 @@
     <cbc:UUID>6c49b8e0-2ce5-11ed-b6c7-c54ae37ec60b</cbc:UUID>
     <cbc:IssueDate>2022-09-05</cbc:IssueDate>
     <cbc:IssueTime>09:39:15</cbc:IssueTime>
-    <cbc:InvoiceTypeCode name="0100100">381</cbc:InvoiceTypeCode>
+    <cbc:InvoiceTypeCode name="0100000">381</cbc:InvoiceTypeCode>
     <cbc:DocumentCurrencyCode>SAR</cbc:DocumentCurrencyCode>
     <cbc:TaxCurrencyCode>SAR</cbc:TaxCurrencyCode>
-    <cbc:BuyerReference>Azure Interior</cbc:BuyerReference>
+    <cbc:BuyerReference>Saudi Aramco</cbc:BuyerReference>
     <cac:OrderReference>
         <cbc:ID>test</cbc:ID>
     </cac:OrderReference>
@@ -47,7 +47,7 @@
                 <cbc:CityName>&#1575;&#1604;&#1605;&#1583;&#1610;&#1606;&#1577; &#1575;&#1604;&#1605;&#1606;&#1608;&#1585;&#1577;</cbc:CityName>
                 <cbc:PostalZone>42317</cbc:PostalZone>
                 <cbc:CountrySubentity>Riyadh</cbc:CountrySubentity>
-                <cbc:CountrySubentityCode>RYA</cbc:CountrySubentityCode>
+                <cbc:CountrySubentityCode>RUH</cbc:CountrySubentityCode>
                 <cac:Country>
                     <cbc:IdentificationCode>SA</cbc:IdentificationCode>
                     <cbc:Name>Saudi Arabia</cbc:Name>
@@ -64,7 +64,7 @@
                     <cbc:CityName>&#1575;&#1604;&#1605;&#1583;&#1610;&#1606;&#1577; &#1575;&#1604;&#1605;&#1606;&#1608;&#1585;&#1577;</cbc:CityName>
                     <cbc:PostalZone>42317</cbc:PostalZone>
                     <cbc:CountrySubentity>Riyadh</cbc:CountrySubentity>
-                    <cbc:CountrySubentityCode>RYA</cbc:CountrySubentityCode>
+                    <cbc:CountrySubentityCode>RUH</cbc:CountrySubentityCode>
                     <cac:Country>
                         <cbc:IdentificationCode>SA</cbc:IdentificationCode>
                         <cbc:Name>Saudi Arabia</cbc:Name>
@@ -85,7 +85,7 @@
                     <cbc:CityName>&#1575;&#1604;&#1605;&#1583;&#1610;&#1606;&#1577; &#1575;&#1604;&#1605;&#1606;&#1608;&#1585;&#1577;</cbc:CityName>
                     <cbc:PostalZone>42317</cbc:PostalZone>
                     <cbc:CountrySubentity>Riyadh</cbc:CountrySubentity>
-                    <cbc:CountrySubentityCode>RYA</cbc:CountrySubentityCode>
+                    <cbc:CountrySubentityCode>RUH</cbc:CountrySubentityCode>
                     <cac:Country>
                         <cbc:IdentificationCode>SA</cbc:IdentificationCode>
                         <cbc:Name>Saudi Arabia</cbc:Name>
@@ -102,45 +102,70 @@
     </cac:AccountingSupplierParty>
     <cac:AccountingCustomerParty>
         <cac:Party>
+            <cac:PartyIdentification>
+                <cbc:ID schemeID="CRN">353535353535353</cbc:ID>
+            </cac:PartyIdentification>
             <cac:PartyName>
-                <cbc:Name>Chichi Lboukla</cbc:Name>
+                <cbc:Name>Saud Ahmed</cbc:Name>
             </cac:PartyName>
             <cac:PostalAddress>
-                <cbc:StreetName>4557 De Silva St</cbc:StreetName>
+                <cbc:StreetName>4557 King Salman St</cbc:StreetName>
                 <cbc:BuildingNumber>12300</cbc:BuildingNumber>
                 <cbc:PlotIdentification>2323</cbc:PlotIdentification>
                 <cbc:CitySubdivisionName>Neighbor!</cbc:CitySubdivisionName>
-                <cbc:CityName>Fremont</cbc:CityName>
+                <cbc:CityName>Riyadh</cbc:CityName>
                 <cbc:PostalZone>94538</cbc:PostalZone>
-                <cbc:CountrySubentity>California</cbc:CountrySubentity>
-                <cbc:CountrySubentityCode>CA</cbc:CountrySubentityCode>
+                <cbc:CountrySubentity>Riyadh</cbc:CountrySubentity>
+                <cbc:CountrySubentityCode>RUH</cbc:CountrySubentityCode>
                 <cac:Country>
-                    <cbc:IdentificationCode>US</cbc:IdentificationCode>
-                    <cbc:Name>United States</cbc:Name>
+                    <cbc:IdentificationCode>SA</cbc:IdentificationCode>
+                    <cbc:Name>Saudi Arabia</cbc:Name>
                 </cac:Country>
             </cac:PostalAddress>
-            <cac:PartyLegalEntity>
-                <cbc:RegistrationName>Chichi Lboukla</cbc:RegistrationName>
+            <cac:PartyTaxScheme>
+                <cbc:RegistrationName>Saud Ahmed</cbc:RegistrationName>
+                <cbc:CompanyID>311111111111113</cbc:CompanyID>
                 <cac:RegistrationAddress>
-                    <cbc:StreetName>4557 De Silva St</cbc:StreetName>
+                    <cbc:StreetName>4557 King Salman St</cbc:StreetName>
                     <cbc:BuildingNumber>12300</cbc:BuildingNumber>
                     <cbc:PlotIdentification>2323</cbc:PlotIdentification>
                     <cbc:CitySubdivisionName>Neighbor!</cbc:CitySubdivisionName>
-                    <cbc:CityName>Fremont</cbc:CityName>
+                    <cbc:CityName>Riyadh</cbc:CityName>
                     <cbc:PostalZone>94538</cbc:PostalZone>
-                    <cbc:CountrySubentity>California</cbc:CountrySubentity>
-                    <cbc:CountrySubentityCode>CA</cbc:CountrySubentityCode>
+                    <cbc:CountrySubentity>Riyadh</cbc:CountrySubentity>
+                    <cbc:CountrySubentityCode>RUH</cbc:CountrySubentityCode>
                     <cac:Country>
-                        <cbc:IdentificationCode>US</cbc:IdentificationCode>
-                        <cbc:Name>United States</cbc:Name>
+                        <cbc:IdentificationCode>SA</cbc:IdentificationCode>
+                        <cbc:Name>Saudi Arabia</cbc:Name>
                     </cac:Country>
+                </cac:RegistrationAddress>
+                <cac:TaxScheme>
+                    <cbc:ID>VAT</cbc:ID>
+                </cac:TaxScheme>
+            </cac:PartyTaxScheme>
+            <cac:PartyLegalEntity>
+                <cbc:RegistrationName>Saud Ahmed</cbc:RegistrationName>
+                <cbc:CompanyID>311111111111113</cbc:CompanyID>
+                <cac:RegistrationAddress>
+                <cbc:StreetName>4557 King Salman St</cbc:StreetName>
+                <cbc:BuildingNumber>12300</cbc:BuildingNumber>
+                <cbc:PlotIdentification>2323</cbc:PlotIdentification>
+                <cbc:CitySubdivisionName>Neighbor!</cbc:CitySubdivisionName>
+                <cbc:CityName>Riyadh</cbc:CityName>
+                <cbc:PostalZone>94538</cbc:PostalZone>
+                <cbc:CountrySubentity>Riyadh</cbc:CountrySubentity>
+                <cbc:CountrySubentityCode>RUH</cbc:CountrySubentityCode>
+                <cac:Country>
+                    <cbc:IdentificationCode>SA</cbc:IdentificationCode>
+                    <cbc:Name>Saudi Arabia</cbc:Name>
+                </cac:Country>
                 </cac:RegistrationAddress>
             </cac:PartyLegalEntity>
             <cac:Contact>
                 <cbc:ID>340</cbc:ID>
-                <cbc:Name>Chichi Lboukla</cbc:Name>
-                <cbc:Telephone>+18709310505</cbc:Telephone>
-                <cbc:ElectronicMail>azure.Interior24@example.com</cbc:ElectronicMail>
+                <cbc:Name>Saud Ahmed</cbc:Name>
+                <cbc:Telephone>+966556666666</cbc:Telephone>
+                <cbc:ElectronicMail>saudi.aramco@example.com</cbc:ElectronicMail>
             </cac:Contact>
         </cac:Party>
     </cac:AccountingCustomerParty>

--- a/addons/l10n_sa_edi/tests/compliance/standard/debit.xml
+++ b/addons/l10n_sa_edi/tests/compliance/standard/debit.xml
@@ -8,10 +8,10 @@
     <cbc:UUID>4dfa4796-2ce6-11ed-b6c7-c54ae37ec60b</cbc:UUID>
     <cbc:IssueDate>2022-09-05</cbc:IssueDate>
     <cbc:IssueTime>09:45:27</cbc:IssueTime>
-    <cbc:InvoiceTypeCode name="0100100">383</cbc:InvoiceTypeCode>
+    <cbc:InvoiceTypeCode name="0100000">383</cbc:InvoiceTypeCode>
     <cbc:DocumentCurrencyCode>SAR</cbc:DocumentCurrencyCode>
     <cbc:TaxCurrencyCode>SAR</cbc:TaxCurrencyCode>
-    <cbc:BuyerReference>Azure Interior</cbc:BuyerReference>
+    <cbc:BuyerReference>Saudi Aramco</cbc:BuyerReference>
     <cac:OrderReference>
         <cbc:ID>INV/2022/00014, Totes forgot</cbc:ID>
     </cac:OrderReference>
@@ -47,7 +47,7 @@
                 <cbc:CityName>&#1575;&#1604;&#1605;&#1583;&#1610;&#1606;&#1577; &#1575;&#1604;&#1605;&#1606;&#1608;&#1585;&#1577;</cbc:CityName>
                 <cbc:PostalZone>42317</cbc:PostalZone>
                 <cbc:CountrySubentity>Riyadh</cbc:CountrySubentity>
-                <cbc:CountrySubentityCode>RYA</cbc:CountrySubentityCode>
+                <cbc:CountrySubentityCode>RUH</cbc:CountrySubentityCode>
                 <cac:Country>
                     <cbc:IdentificationCode>SA</cbc:IdentificationCode>
                     <cbc:Name>Saudi Arabia</cbc:Name>
@@ -64,7 +64,7 @@
                 <cbc:CityName>&#1575;&#1604;&#1605;&#1583;&#1610;&#1606;&#1577; &#1575;&#1604;&#1605;&#1606;&#1608;&#1585;&#1577;</cbc:CityName>
                 <cbc:PostalZone>42317</cbc:PostalZone>
                 <cbc:CountrySubentity>Riyadh</cbc:CountrySubentity>
-                <cbc:CountrySubentityCode>RYA</cbc:CountrySubentityCode>
+                <cbc:CountrySubentityCode>RUH</cbc:CountrySubentityCode>
                 <cac:Country>
                     <cbc:IdentificationCode>SA</cbc:IdentificationCode>
                     <cbc:Name>Saudi Arabia</cbc:Name>
@@ -85,7 +85,7 @@
                 <cbc:CityName>&#1575;&#1604;&#1605;&#1583;&#1610;&#1606;&#1577; &#1575;&#1604;&#1605;&#1606;&#1608;&#1585;&#1577;</cbc:CityName>
                 <cbc:PostalZone>42317</cbc:PostalZone>
                 <cbc:CountrySubentity>Riyadh</cbc:CountrySubentity>
-                <cbc:CountrySubentityCode>RYA</cbc:CountrySubentityCode>
+                <cbc:CountrySubentityCode>RUH</cbc:CountrySubentityCode>
                 <cac:Country>
                     <cbc:IdentificationCode>SA</cbc:IdentificationCode>
                     <cbc:Name>Saudi Arabia</cbc:Name>
@@ -102,45 +102,70 @@
     </cac:AccountingSupplierParty>
     <cac:AccountingCustomerParty>
         <cac:Party>
+            <cac:PartyIdentification>
+                <cbc:ID schemeID="CRN">353535353535353</cbc:ID>
+            </cac:PartyIdentification>
             <cac:PartyName>
-                <cbc:Name>Chichi Lboukla</cbc:Name>
+                <cbc:Name>Saud Ahmed</cbc:Name>
             </cac:PartyName>
             <cac:PostalAddress>
-                <cbc:StreetName>4557 De Silva St</cbc:StreetName>
+                <cbc:StreetName>4557 King Salman St</cbc:StreetName>
                 <cbc:BuildingNumber>12300</cbc:BuildingNumber>
                 <cbc:PlotIdentification>2323</cbc:PlotIdentification>
                 <cbc:CitySubdivisionName>Neighbor!</cbc:CitySubdivisionName>
-                <cbc:CityName>Fremont</cbc:CityName>
+                <cbc:CityName>Riyadh</cbc:CityName>
                 <cbc:PostalZone>94538</cbc:PostalZone>
-                <cbc:CountrySubentity>California</cbc:CountrySubentity>
-                <cbc:CountrySubentityCode>CA</cbc:CountrySubentityCode>
+                <cbc:CountrySubentity>Riyadh</cbc:CountrySubentity>
+                <cbc:CountrySubentityCode>RUH</cbc:CountrySubentityCode>
                 <cac:Country>
-                    <cbc:IdentificationCode>US</cbc:IdentificationCode>
-                    <cbc:Name>United States</cbc:Name>
+                    <cbc:IdentificationCode>SA</cbc:IdentificationCode>
+                    <cbc:Name>Saudi Arabia</cbc:Name>
                 </cac:Country>
             </cac:PostalAddress>
-            <cac:PartyLegalEntity>
-                <cbc:RegistrationName>Chichi Lboukla</cbc:RegistrationName>
+            <cac:PartyTaxScheme>
+                <cbc:RegistrationName>Saud Ahmed</cbc:RegistrationName>
+                <cbc:CompanyID>311111111111113</cbc:CompanyID>
                 <cac:RegistrationAddress>
-                    <cbc:StreetName>4557 De Silva St</cbc:StreetName>
+                    <cbc:StreetName>4557 King Salman St</cbc:StreetName>
                     <cbc:BuildingNumber>12300</cbc:BuildingNumber>
                     <cbc:PlotIdentification>2323</cbc:PlotIdentification>
                     <cbc:CitySubdivisionName>Neighbor!</cbc:CitySubdivisionName>
-                    <cbc:CityName>Fremont</cbc:CityName>
+                    <cbc:CityName>Riyadh</cbc:CityName>
                     <cbc:PostalZone>94538</cbc:PostalZone>
-                    <cbc:CountrySubentity>California</cbc:CountrySubentity>
-                    <cbc:CountrySubentityCode>CA</cbc:CountrySubentityCode>
+                    <cbc:CountrySubentity>Riyadh</cbc:CountrySubentity>
+                    <cbc:CountrySubentityCode>RUH</cbc:CountrySubentityCode>
                     <cac:Country>
-                        <cbc:IdentificationCode>US</cbc:IdentificationCode>
-                        <cbc:Name>United States</cbc:Name>
+                        <cbc:IdentificationCode>SA</cbc:IdentificationCode>
+                        <cbc:Name>Saudi Arabia</cbc:Name>
                     </cac:Country>
+                </cac:RegistrationAddress>
+                <cac:TaxScheme>
+                    <cbc:ID>VAT</cbc:ID>
+                </cac:TaxScheme>
+            </cac:PartyTaxScheme>
+            <cac:PartyLegalEntity>
+                <cbc:RegistrationName>Saud Ahmed</cbc:RegistrationName>
+                <cbc:CompanyID>311111111111113</cbc:CompanyID>
+                <cac:RegistrationAddress>
+                <cbc:StreetName>4557 King Salman St</cbc:StreetName>
+                <cbc:BuildingNumber>12300</cbc:BuildingNumber>
+                <cbc:PlotIdentification>2323</cbc:PlotIdentification>
+                <cbc:CitySubdivisionName>Neighbor!</cbc:CitySubdivisionName>
+                <cbc:CityName>Riyadh</cbc:CityName>
+                <cbc:PostalZone>94538</cbc:PostalZone>
+                <cbc:CountrySubentity>Riyadh</cbc:CountrySubentity>
+                <cbc:CountrySubentityCode>RUH</cbc:CountrySubentityCode>
+                <cac:Country>
+                    <cbc:IdentificationCode>SA</cbc:IdentificationCode>
+                    <cbc:Name>Saudi Arabia</cbc:Name>
+                </cac:Country>
                 </cac:RegistrationAddress>
             </cac:PartyLegalEntity>
             <cac:Contact>
                 <cbc:ID>550</cbc:ID>
-                <cbc:Name>Chichi Lboukla</cbc:Name>
-                <cbc:Telephone>+18709310505</cbc:Telephone>
-                <cbc:ElectronicMail>azure.Interior24@example.com</cbc:ElectronicMail>
+                <cbc:Name>Saud Ahmed</cbc:Name>
+                <cbc:Telephone>+966556666666</cbc:Telephone>
+                <cbc:ElectronicMail>saudi.aramco@example.com</cbc:ElectronicMail>
             </cac:Contact>
         </cac:Party>
     </cac:AccountingCustomerParty>

--- a/addons/l10n_sa_edi/tests/compliance/standard/invoice.xml
+++ b/addons/l10n_sa_edi/tests/compliance/standard/invoice.xml
@@ -8,10 +8,10 @@
     <cbc:UUID>ff608a28-096e-44a1-a896-cbb52212a8a3</cbc:UUID>
     <cbc:IssueDate>2022-09-05</cbc:IssueDate>
     <cbc:IssueTime>08:20:02</cbc:IssueTime>
-    <cbc:InvoiceTypeCode name="0100100">388</cbc:InvoiceTypeCode>
+    <cbc:InvoiceTypeCode name="0100000">388</cbc:InvoiceTypeCode>
     <cbc:DocumentCurrencyCode>SAR</cbc:DocumentCurrencyCode>
     <cbc:TaxCurrencyCode>SAR</cbc:TaxCurrencyCode>
-    <cbc:BuyerReference>Azure Interior</cbc:BuyerReference>
+    <cbc:BuyerReference>Saudi Aramco</cbc:BuyerReference>
     <cac:OrderReference>
         <cbc:ID>INV/2022/00014</cbc:ID>
     </cac:OrderReference>
@@ -41,7 +41,7 @@
                 <cbc:CityName>&#1575;&#1604;&#1605;&#1583;&#1610;&#1606;&#1577; &#1575;&#1604;&#1605;&#1606;&#1608;&#1585;&#1577;</cbc:CityName>
                 <cbc:PostalZone>42317</cbc:PostalZone>
                 <cbc:CountrySubentity>Riyadh</cbc:CountrySubentity>
-                <cbc:CountrySubentityCode>RYA</cbc:CountrySubentityCode>
+                <cbc:CountrySubentityCode>RUH</cbc:CountrySubentityCode>
                 <cac:Country>
                     <cbc:IdentificationCode>SA</cbc:IdentificationCode>
                     <cbc:Name>Saudi Arabia</cbc:Name>
@@ -58,7 +58,7 @@
                     <cbc:CityName>&#1575;&#1604;&#1605;&#1583;&#1610;&#1606;&#1577; &#1575;&#1604;&#1605;&#1606;&#1608;&#1585;&#1577;</cbc:CityName>
                     <cbc:PostalZone>42317</cbc:PostalZone>
                     <cbc:CountrySubentity>Riyadh</cbc:CountrySubentity>
-                    <cbc:CountrySubentityCode>RYA</cbc:CountrySubentityCode>
+                    <cbc:CountrySubentityCode>RUH</cbc:CountrySubentityCode>
                     <cac:Country>
                         <cbc:IdentificationCode>SA</cbc:IdentificationCode>
                         <cbc:Name>Saudi Arabia</cbc:Name>
@@ -79,7 +79,7 @@
                     <cbc:CityName>&#1575;&#1604;&#1605;&#1583;&#1610;&#1606;&#1577; &#1575;&#1604;&#1605;&#1606;&#1608;&#1585;&#1577;</cbc:CityName>
                     <cbc:PostalZone>42317</cbc:PostalZone>
                     <cbc:CountrySubentity>Riyadh</cbc:CountrySubentity>
-                    <cbc:CountrySubentityCode>RYA</cbc:CountrySubentityCode>
+                    <cbc:CountrySubentityCode>RUH</cbc:CountrySubentityCode>
                     <cac:Country>
                         <cbc:IdentificationCode>SA</cbc:IdentificationCode>
                         <cbc:Name>Saudi Arabia</cbc:Name>
@@ -97,47 +97,69 @@
     <cac:AccountingCustomerParty>
         <cac:Party>
             <cac:PartyIdentification>
-                <cbc:ID schemeID="CRN">US12345677</cbc:ID>
+                <cbc:ID schemeID="CRN">353535353535353</cbc:ID>
             </cac:PartyIdentification>
             <cac:PartyName>
-                <cbc:Name>Chichi Lboukla</cbc:Name>
+                <cbc:Name>Saud Ahmed</cbc:Name>
             </cac:PartyName>
             <cac:PostalAddress>
-                <cbc:StreetName>4557 De Silva St</cbc:StreetName>
+                <cbc:StreetName>4557 King Salman St</cbc:StreetName>
                 <cbc:BuildingNumber>12300</cbc:BuildingNumber>
                 <cbc:PlotIdentification>2323</cbc:PlotIdentification>
                 <cbc:CitySubdivisionName>Neighbor!</cbc:CitySubdivisionName>
-                <cbc:CityName>Fremont</cbc:CityName>
+                <cbc:CityName>Riyadh</cbc:CityName>
                 <cbc:PostalZone>94538</cbc:PostalZone>
-                <cbc:CountrySubentity>California</cbc:CountrySubentity>
-                <cbc:CountrySubentityCode>CA</cbc:CountrySubentityCode>
+                <cbc:CountrySubentity>Riyadh</cbc:CountrySubentity>
+                <cbc:CountrySubentityCode>RUH</cbc:CountrySubentityCode>
                 <cac:Country>
-                    <cbc:IdentificationCode>US</cbc:IdentificationCode>
-                    <cbc:Name>United States</cbc:Name>
+                    <cbc:IdentificationCode>SA</cbc:IdentificationCode>
+                    <cbc:Name>Saudi Arabia</cbc:Name>
                 </cac:Country>
             </cac:PostalAddress>
-            <cac:PartyLegalEntity>
-                <cbc:RegistrationName>Chichi Lboukla</cbc:RegistrationName>
+            <cac:PartyTaxScheme>
+                <cbc:RegistrationName>Saud Ahmed</cbc:RegistrationName>
+                <cbc:CompanyID>311111111111113</cbc:CompanyID>
                 <cac:RegistrationAddress>
-                    <cbc:StreetName>4557 De Silva St</cbc:StreetName>
+                    <cbc:StreetName>4557 King Salman St</cbc:StreetName>
                     <cbc:BuildingNumber>12300</cbc:BuildingNumber>
                     <cbc:PlotIdentification>2323</cbc:PlotIdentification>
                     <cbc:CitySubdivisionName>Neighbor!</cbc:CitySubdivisionName>
-                    <cbc:CityName>Fremont</cbc:CityName>
+                    <cbc:CityName>Riyadh</cbc:CityName>
                     <cbc:PostalZone>94538</cbc:PostalZone>
-                    <cbc:CountrySubentity>California</cbc:CountrySubentity>
-                    <cbc:CountrySubentityCode>CA</cbc:CountrySubentityCode>
+                    <cbc:CountrySubentity>Riyadh</cbc:CountrySubentity>
+                    <cbc:CountrySubentityCode>RUH</cbc:CountrySubentityCode>
                     <cac:Country>
-                        <cbc:IdentificationCode>US</cbc:IdentificationCode>
-                        <cbc:Name>United States</cbc:Name>
+                        <cbc:IdentificationCode>SA</cbc:IdentificationCode>
+                        <cbc:Name>Saudi Arabia</cbc:Name>
+                    </cac:Country>
+                </cac:RegistrationAddress>
+                <cac:TaxScheme>
+                    <cbc:ID>VAT</cbc:ID>
+                </cac:TaxScheme>
+            </cac:PartyTaxScheme>
+            <cac:PartyLegalEntity>
+                <cbc:RegistrationName>Saud Ahmed</cbc:RegistrationName>
+                <cbc:CompanyID>311111111111113</cbc:CompanyID>
+                <cac:RegistrationAddress>
+                    <cbc:StreetName>4557 King Salman St</cbc:StreetName>
+                    <cbc:BuildingNumber>12300</cbc:BuildingNumber>
+                    <cbc:PlotIdentification>2323</cbc:PlotIdentification>
+                    <cbc:CitySubdivisionName>Neighbor!</cbc:CitySubdivisionName>
+                    <cbc:CityName>Riyadh</cbc:CityName>
+                    <cbc:PostalZone>94538</cbc:PostalZone>
+                    <cbc:CountrySubentity>Riyadh</cbc:CountrySubentity>
+                    <cbc:CountrySubentityCode>RUH</cbc:CountrySubentityCode>
+                    <cac:Country>
+                        <cbc:IdentificationCode>SA</cbc:IdentificationCode>
+                        <cbc:Name>Saudi Arabia</cbc:Name>
                     </cac:Country>
                 </cac:RegistrationAddress>
             </cac:PartyLegalEntity>
             <cac:Contact>
                 <cbc:ID>42</cbc:ID>
-                <cbc:Name>Chichi Lboukla</cbc:Name>
-                <cbc:Telephone>+18709310505</cbc:Telephone>
-                <cbc:ElectronicMail>azure.Interior24@example.com</cbc:ElectronicMail>
+                <cbc:Name>Saud Ahmed</cbc:Name>
+                <cbc:Telephone>+966556666666</cbc:Telephone>
+                <cbc:ElectronicMail>saudi.aramco@example.com</cbc:ElectronicMail>
             </cac:Contact>
         </cac:Party>
     </cac:AccountingCustomerParty>

--- a/addons/l10n_sa_edi/tests/test_account_move.py
+++ b/addons/l10n_sa_edi/tests/test_account_move.py
@@ -1,0 +1,47 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+import logging
+
+from odoo.exceptions import UserError
+from odoo.tests import tagged
+
+from .common import TestSaEdiCommon
+
+_logger = logging.getLogger(__name__)
+
+
+@tagged('post_install_l10n', '-at_install', 'post_install')
+class TestSAEdiAccountMove(TestSaEdiCommon):
+
+    @classmethod
+    def setUpClass(cls, chart_template_ref='sa', edi_format_ref='l10n_sa_edi.edi_sa_zatca'):
+        super().setUpClass(chart_template_ref=chart_template_ref, edi_format_ref=edi_format_ref)
+
+        cls._setup_branches()
+
+    @classmethod
+    def _setup_branches(cls):
+        cls.sa_branch = cls.env['res.company'].create({
+            'name': 'SA Branch',
+            'parent_id': cls.company.id,
+            'country_id': cls.company.country_id.id,
+        })
+
+    def test_invoice_with_mismatched_companies(self):
+        move_data = {
+            'name': 'INV/2025/00012',
+            'invoice_date': '2025-07-05',
+            'invoice_date_due': '2025-07-12',
+            'partner_id': self.partner_sa,
+            'invoice_line_ids': [{
+                'product_id': self.product_a.id,
+                'price_unit': self.product_a.standard_price,
+                'quantity': 1,
+                'tax_ids': self.tax_15.ids,
+            }]
+        }
+
+        invoice = self._create_invoice(**move_data)
+        invoice.company_id = self.sa_branch
+
+        with self.assertRaises(UserError, msg="A UserError is expected when the company on the invoice doesn't match the company on the journal."):
+            invoice.action_post()

--- a/addons/l10n_sa_edi/tests/test_edi_zatca.py
+++ b/addons/l10n_sa_edi/tests/test_edi_zatca.py
@@ -5,6 +5,7 @@ import logging
 from pytz import timezone
 
 from odoo import Command
+from odoo.exceptions import ValidationError
 from odoo.tests import tagged
 from odoo.tools import misc
 
@@ -15,61 +16,214 @@ _logger = logging.getLogger(__name__)
 
 @tagged('post_install_l10n', '-at_install', 'post_install')
 class TestEdiZatca(TestSaEdiCommon):
+    # """Test ZATCA EDI compliance for Saudi Arabia."""
 
-    def testInvoiceStandard(self):
+    def _test_document_generation(self, test_file_path, expected_xpath, freeze_time_at, additional_xpath='', document_type=False, move=False, move_data=False):
+        """
+        Common helper to test document generation against expected XML.
+        """
+        with freeze_time(freeze_time_at):
+            # Load expected XML
+            expected_xml = misc.file_open(test_file_path, 'rb').read()
+            expected_tree = self.get_xml_tree_from_string(expected_xml)
+            expected_tree = self.with_applied_xpath(expected_tree, expected_xpath)
 
-        with freeze_time(datetime(year=2022, month=9, day=5, hour=8, minute=20, second=2, tzinfo=timezone('Etc/GMT-3'))):
-            standard_invoice = misc.file_open('l10n_sa_edi/tests/compliance/standard/invoice.xml', 'rb').read()
-            expected_tree = self.get_xml_tree_from_string(standard_invoice)
-            expected_tree = self.with_applied_xpath(expected_tree, self.invoice_applied_xpath)
+            creation_handlers = {
+                "invoice": self._create_invoice,
+                "credit_note": self._create_credit_note,
+                "debit_note": self._create_debit_note,
+            }
 
-            self.partner_us.vat = 'US12345677'
-            move = self._create_invoice(name='INV/2022/00014', date='2022-09-05', date_due='2022-09-22', partner_id=self.partner_us,
-                                        product_id=self.product_a, price=320.0)
-            move._l10n_sa_generate_unsigned_data()
-            generated_file = self.env['account.edi.format']._l10n_sa_generate_zatca_template(move)
+            if additional_xpath:
+                expected_tree = self.with_applied_xpath(expected_tree, additional_xpath)
+
+            if move:
+                final_move = move
+            elif move_data and document_type in creation_handlers:
+                final_move = creation_handlers[document_type](**move_data)
+            else:
+                raise ValidationError("Either move or document_type + move_data need to be given")
+
+            # Generate ZATCA XML
+            if final_move.state != 'posted':
+                final_move.action_post()
+
+            final_move._l10n_sa_generate_unsigned_data()
+            generated_file = self.env['account.edi.format']._l10n_sa_generate_zatca_template(final_move)
             current_tree = self.get_xml_tree_from_string(generated_file)
             current_tree = self.with_applied_xpath(current_tree, self.remove_ubl_extensions_xpath)
 
+            # Assert
             self.assertXmlTreeEqual(current_tree, expected_tree)
 
-    def testInvoiceWithDownpayment(self):
+    def testCreditNoteSimplified(self):
+        """Test simplified credit note generation."""
+        move_data = {
+            'name': 'INV/2023/00034',
+            'invoice_date': '2023-03-10',
+            'invoice_date_due': '2023-03-10',
+            'partner_id': self.partner_sa_simplified,
+            'invoice_line_ids': [{
+                'product_id': self.product_burger.id,
+                'price_unit': self.product_burger.standard_price,
+                'quantity': 3,
+                'tax_ids': self.tax_15.ids,
+            }]
+        }
 
+        self._test_document_generation(
+            document_type='credit_note',
+            test_file_path='l10n_sa_edi/tests/compliance/simplified/credit.xml',
+            expected_xpath=self.credit_note_applied_xpath,
+            move_data=move_data,
+            freeze_time_at=datetime(2023, 3, 10, 14, 59, 38, tzinfo=timezone('Etc/GMT-3'))
+        )
+
+    def testCreditNoteStandard(self):
+        """Test standard credit note generation."""
+        move_data = {
+            'name': 'INV/2022/00014',
+            'invoice_date': '2022-09-05',
+            'invoice_date_due': '2022-09-22',
+            'partner_id': self.partner_sa,
+            'invoice_line_ids': [{
+                'product_id': self.product_a.id,
+                'price_unit': self.product_a.standard_price,
+                'quantity': 1,
+                'tax_ids': self.tax_15.ids,
+            }]
+        }
+
+        additional_xpath = '''
+            <xpath expr="(//*[local-name()='AdditionalDocumentReference']/*[local-name()='UUID'])[1]" position="replace">
+                <UUID>___ignore___</UUID>
+            </xpath>
+        '''
+
+        self._test_document_generation(
+            document_type='credit_note',
+            test_file_path='l10n_sa_edi/tests/compliance/standard/credit.xml',
+            expected_xpath=self.credit_note_applied_xpath,
+            move_data=move_data,
+            freeze_time_at=datetime(2022, 9, 5, 9, 39, 15, tzinfo=timezone('Etc/GMT-3')),
+            additional_xpath=additional_xpath
+        )
+
+    def testDebitNoteSimplified(self):
+        """Test simplified debit note generation."""
+        move_data = {
+            'name': 'INV/2023/00034',
+            'invoice_date': '2023-03-10',
+            'invoice_date_due': '2023-03-10',
+            'partner_id': self.partner_sa_simplified,
+            'invoice_line_ids': [{
+                'product_id': self.product_burger.id,
+                'price_unit': self.product_burger.standard_price,
+                'quantity': 2,
+                'tax_ids': self.tax_15.ids,
+            }]
+        }
+
+        self._test_document_generation(
+            document_type='debit_note',
+            test_file_path='l10n_sa_edi/tests/compliance/simplified/debit.xml',
+            expected_xpath=self.debit_note_applied_xpath,
+            move_data=move_data,
+            freeze_time_at=datetime(2023, 3, 10, 15, 1, 46, tzinfo=timezone('Etc/GMT-3'))
+        )
+
+    def testDebitNoteStandard(self):
+        """Test standard debit note generation."""
+        move_data = {
+            'name': 'INV/2022/00001',
+            'invoice_date': '2022-09-05',
+            'invoice_date_due': '2022-09-22',
+            'partner_id': self.partner_sa,
+            'invoice_line_ids': [{
+                'product_id': self.product_b.id,
+                'price_unit': self.product_b.standard_price,
+                'quantity': 1,
+                'tax_ids': self.tax_15.ids,
+            }]
+        }
+
+        additional_xpath = '''
+            <xpath expr="(//*[local-name()='AdditionalDocumentReference']/*[local-name()='UUID'])[1]" position="replace">
+                <UUID>___ignore___</UUID>
+            </xpath>
+        '''
+
+        self._test_document_generation(
+            document_type='debit_note',
+            test_file_path='l10n_sa_edi/tests/compliance/standard/debit.xml',
+            expected_xpath=self.debit_note_applied_xpath,
+            move_data=move_data,
+            freeze_time_at=datetime(2022, 9, 5, 9, 45, 27, tzinfo=timezone('Etc/GMT-3')),
+            additional_xpath=additional_xpath
+        )
+
+    def testInvoiceSimplified(self):
+        """Test simplified invoice generation."""
+        move_data = {
+            'name': 'INV/2023/00034',
+            'invoice_date': '2023-03-10',
+            'invoice_date_due': '2023-03-10',
+            'partner_id': self.partner_sa_simplified,
+            'invoice_line_ids': [{
+                'product_id': self.product_burger.id,
+                'price_unit': self.product_burger.standard_price,
+                'quantity': 3,
+                'tax_ids': self.tax_15.ids,
+            }]
+        }
+
+        self._test_document_generation(
+            document_type='invoice',
+            test_file_path='l10n_sa_edi/tests/compliance/simplified/invoice.xml',
+            expected_xpath=self.invoice_applied_xpath,
+            move_data=move_data,
+            freeze_time_at=datetime(2023, 3, 10, 14, 56, 55, tzinfo=timezone('Etc/GMT-3'))
+        )
+
+    def testInvoiceStandard(self):
+        """Test standard invoice generation."""
+        move_data = {
+            'name': 'INV/2022/00014',
+            'invoice_date': '2022-09-05',
+            'invoice_date_due': '2022-09-22',
+            'partner_id': self.partner_sa,
+            'invoice_line_ids': [{
+                'product_id': self.product_a.id,
+                'price_unit': self.product_a.standard_price,
+                'quantity': 1,
+                'tax_ids': self.tax_15.ids,
+            }]
+        }
+
+        self._test_document_generation(
+            document_type='invoice',
+            test_file_path='l10n_sa_edi/tests/compliance/standard/invoice.xml',
+            expected_xpath=self.invoice_applied_xpath,
+            move_data=move_data,
+            freeze_time_at=datetime(2022, 9, 5, 8, 20, 2, tzinfo=timezone('Etc/GMT-3'))
+        )
+
+    def testInvoiceWithDownpayment(self):
+        """Test invoice generation with downpayment scenarios."""
         if 'sale' not in self.env["ir.module.module"]._installed():
             self.skipTest("Sale module is not installed")
 
-        def test_generated_file(move, test_file, xpath_to_apply):
-            move.write({
-                'invoice_date': '2022-09-05',
-                'invoice_date_due': '2022-09-22',
-                'state': 'posted',
-                'l10n_sa_confirmation_datetime': datetime.now(),
-            })
-            move._l10n_sa_generate_unsigned_data()
-            generated_file = self.env['account.edi.format']._l10n_sa_generate_zatca_template(move)
-            current_tree = self.get_xml_tree_from_string(generated_file)
-            current_tree = self.with_applied_xpath(current_tree, self.remove_ubl_extensions_xpath)
+        freeze = datetime(2022, 9, 5, 8, 20, 2, tzinfo=timezone('Etc/GMT-3'))
 
-            expected_file = misc.file_open(f'l10n_sa_edi/tests/test_files/{test_file}.xml', 'rb').read()
-            expected_tree = self.get_xml_tree_from_string(expected_file)
-            expected_tree = self.with_applied_xpath(expected_tree, xpath_to_apply)
-
-            self.assertXmlTreeEqual(current_tree, expected_tree)
-
-        retention_tax = self.env['account.tax'].create({
-            'l10n_sa_is_retention': True,
-            'name': 'Retention Tax',
-            'amount_type': 'percent',
-            'amount': -5.0,
+        # Helper to test generated files
+        saudi_pricelist = self.env['product.pricelist'].create({
+            'name': 'SAR',
+            'currency_id': self.env.ref('base.SAR').id
         })
-
-        with freeze_time(datetime(year=2022, month=9, day=5, hour=8, minute=20, second=2, tzinfo=timezone('Etc/GMT-3'))):
-            self.partner_us.vat = 'US12345677'
-
-            pricelist = self.env['product.pricelist'].create({'name': 'SAR', 'currency_id': self.env.ref('base.SAR').id})
+        with freeze_time(freeze):
             sale_order = self.env['sale.order'].create({
-                'partner_id': self.partner_us.id,
-                'pricelist_id': pricelist.id,
+                'partner_id': self.partner_sa.id,
+                'pricelist_id': saudi_pricelist.id,
                 'order_line': [
                     Command.create({
                         'product_id': self.product_a.id,
@@ -81,133 +235,93 @@ class TestEdiZatca(TestSaEdiCommon):
             })
             sale_order.action_confirm()
 
+            # Context for wizards
             context = {
                 'active_model': 'sale.order',
                 'active_ids': [sale_order.id],
                 'active_id': sale_order.id,
-                'default_journal_id': self.company_data['default_journal_sale'].id,
+                'default_journal_id': self.customer_invoice_journal.id,
             }
-            downpayment = self.env['sale.advance.payment.inv'].with_context(context).create({
+
+            # Create downpayment invoice
+            downpayment_wizard = self.env['sale.advance.payment.inv'].with_context(context).create({
                 'advance_payment_method': 'fixed',
                 'fixed_amount': 115,
                 'deposit_taxes_id': [Command.set(self.tax_15.ids)],
-            })._create_invoices(sale_order)
+            })
+            downpayment = downpayment_wizard._create_invoices(sale_order)
+            downpayment.invoice_date_due = '2022-09-22'
 
-            final = self.env['sale.advance.payment.inv'].with_context(context).create({})._create_invoices(sale_order)
-            final.invoice_line_ids.filtered(lambda l: l.product_id == self.product_a).tax_ids = [(Command.link(retention_tax.id))]
+            # Create final invoice
+            final_wizard = self.env['sale.advance.payment.inv'].with_context(context).create({})
+            final = final_wizard._create_invoices(sale_order)
+            final.invoice_date_due = '2022-09-22'
 
-            for move, test_file in (
-                (downpayment, "downpayment_invoice"),
-                (final, "final_invoice")
-            ):
-                with self.subTest(move=move, test_file=test_file):
-                    test_generated_file(move, test_file, self.invoice_applied_xpath)
+        # Test invoices
+        for move, test_file in [
+            (downpayment, "downpayment_invoice"),
+            (final, "final_invoice")
+        ]:
+            with self.subTest(move=move, test_file=test_file):
+                self._test_document_generation(
+                    test_file_path=f'l10n_sa_edi/tests/test_files/{test_file}.xml',
+                    expected_xpath=self.invoice_applied_xpath,
+                    freeze_time_at=freeze,
+                    move=move,
+                )
 
-            for move, test_file in (
-                (downpayment, "downpayment_credit_note"),
-                (final, "final_credit_note")
-            ):
-                with self.subTest(move=move, test_file=test_file):
-                    wiz_context = {
-                        'active_model': 'account.move',
-                        'active_ids': [move.id],
-                        'default_journal_id': move.journal_id.id,
-                    }
-                    refund_invoice_wiz = self.env['account.move.reversal'].with_context(wiz_context).create({
-                        'reason': 'please reverse :c',
-                        'date': '2022-09-05',
-                    })
-                    refund_invoice = self.env['account.move'].browse(refund_invoice_wiz.reverse_moves()['res_id'])
-                    test_generated_file(refund_invoice, test_file, self.credit_note_applied_xpath)
+        # Test credit notes
+        for move, test_file in [
+            (downpayment, "downpayment_credit_note"),
+            (final, "final_credit_note")
+        ]:
+            with self.subTest(move=move, test_file=test_file):
+                # Create refund
+                wiz_context = {
+                    'active_model': 'account.move',
+                    'active_ids': [move.id],
+                    'default_journal_id': move.journal_id.id,
+                }
+                refund_wizard = self.env['account.move.reversal'].with_context(wiz_context).create({
+                    'reason': 'please reverse :c',
+                    'date': '2022-09-05',
+                })
+                refund_invoice = self.env['account.move'].browse(refund_wizard.reverse_moves()['res_id'])
+                refund_invoice.invoice_date_due = '2022-09-22'
+                self._test_document_generation(
+                    test_file_path=f'l10n_sa_edi/tests/test_files/{test_file}.xml',
+                    expected_xpath=self.credit_note_applied_xpath,
+                    freeze_time_at=freeze,
+                    move=refund_invoice,
+                )
 
-    def testCreditNoteStandard(self):
+    def testInvoiceWithRetention(self):
+        """Test standard invoice generation."""
 
-        with freeze_time(datetime(year=2022, month=9, day=5, hour=9, minute=39, second=15, tzinfo=timezone('Etc/GMT-3'))):
-            applied_xpath = self.credit_note_applied_xpath + \
-            '''
-                <xpath expr="(//*[local-name()='AdditionalDocumentReference']/*[local-name()='UUID'])[1]" position="replace">
-                    <UUID>___ignore___</UUID>
-                </xpath>
-            '''
+        retention_tax = self.env['account.tax'].create({
+            'l10n_sa_is_retention': True,
+            'name': 'Retention Tax',
+            'amount_type': 'percent',
+            'amount': -10.0,
+        })
 
-            standard_credit_note = misc.file_open('l10n_sa_edi/tests/compliance/standard/credit.xml', 'rb').read()
-            expected_tree = self.get_xml_tree_from_string(standard_credit_note)
-            expected_tree = self.with_applied_xpath(expected_tree, applied_xpath)
+        move_data = {
+            'name': 'INV/2022/00014',
+            'invoice_date': '2022-09-05',
+            'invoice_date_due': '2022-09-22',
+            'partner_id': self.partner_sa,
+            'invoice_line_ids': [{
+                'product_id': self.product_a.id,
+                'price_unit': self.product_a.standard_price,
+                'quantity': 1,
+                'tax_ids': self.tax_15.ids + retention_tax.ids,
+            }]
+        }
 
-            credit_note = self._create_credit_note(name='INV/2022/00014', date='2022-09-05', date_due='2022-09-22',
-                                                   partner_id=self.partner_us, product_id=self.product_a, price=320.0)
-            credit_note._l10n_sa_generate_unsigned_data()
-            generated_file = self.env['account.edi.format']._l10n_sa_generate_zatca_template(credit_note)
-            current_tree = self.get_xml_tree_from_string(generated_file)
-            current_tree = self.with_applied_xpath(current_tree, self.remove_ubl_extensions_xpath)
-
-            self.assertXmlTreeEqual(current_tree, expected_tree)
-
-    def testDebitNoteStandard(self):
-        with freeze_time(datetime(year=2022, month=9, day=5, hour=9, minute=45, second=27, tzinfo=timezone('Etc/GMT-3'))):
-            applied_xpath = self.debit_note_applied_xpath + \
-            '''
-                <xpath expr="(//*[local-name()='AdditionalDocumentReference']/*[local-name()='UUID'])[1]" position="replace">
-                    <UUID>___ignore___</UUID>
-                </xpath>
-            '''
-
-            standard_debit_note = misc.file_open('l10n_sa_edi/tests/compliance/standard/debit.xml', 'rb').read()
-            expected_tree = self.get_xml_tree_from_string(standard_debit_note)
-            expected_tree = self.with_applied_xpath(expected_tree, applied_xpath)
-
-            debit_note = self._create_debit_note(name='INV/2022/00001', date='2022-09-05', date_due='2022-09-22',
-                                                 partner_id=self.partner_us, product_id=self.product_b, price=15.80)
-            debit_note._l10n_sa_generate_unsigned_data()
-            generated_file = self.env['account.edi.format']._l10n_sa_generate_zatca_template(debit_note)
-            current_tree = self.get_xml_tree_from_string(generated_file)
-            current_tree = self.with_applied_xpath(current_tree, self.remove_ubl_extensions_xpath)
-
-            self.assertXmlTreeEqual(current_tree, expected_tree)
-
-    def testInvoiceSimplified(self):
-        with freeze_time(datetime(year=2023, month=3, day=10, hour=14, minute=56, second=55, tzinfo=timezone('Etc/GMT-3'))):
-            simplified_invoice = misc.file_open('l10n_sa_edi/tests/compliance/simplified/invoice.xml', 'rb').read()
-            expected_tree = self.get_xml_tree_from_string(simplified_invoice)
-            expected_tree = self.with_applied_xpath(expected_tree, self.invoice_applied_xpath)
-
-            move = self._create_invoice(name='INV/2023/00034', date='2023-03-10', date_due='2023-03-10', partner_id=self.partner_sa_simplified,
-                                        product_id=self.product_burger, price=265.00, quantity=3.0)
-            move._l10n_sa_generate_unsigned_data()
-            generated_file = self.env['account.edi.format']._l10n_sa_generate_zatca_template(move)
-            current_tree = self.get_xml_tree_from_string(generated_file)
-            current_tree = self.with_applied_xpath(current_tree, self.remove_ubl_extensions_xpath)
-
-            self.assertXmlTreeEqual(current_tree, expected_tree)
-
-    def testCreditNoteSimplified(self):
-        with freeze_time(datetime(year=2023, month=3, day=10, hour=14, minute=59, second=38, tzinfo=timezone('Etc/GMT-3'))):
-            simplified_credit_note = misc.file_open('l10n_sa_edi/tests/compliance/simplified/credit.xml', 'rb').read()
-            expected_tree = self.get_xml_tree_from_string(simplified_credit_note)
-            expected_tree = self.with_applied_xpath(expected_tree, self.credit_note_applied_xpath)
-
-            move = self._create_credit_note(name='INV/2023/00034', date='2023-03-10', date_due='2023-03-10',
-                                            partner_id=self.partner_sa_simplified, product_id=self.product_burger,
-                                            price=265.00, quantity=3.0)
-            move._l10n_sa_generate_unsigned_data()
-            generated_file = self.env['account.edi.format']._l10n_sa_generate_zatca_template(move)
-            current_tree = self.get_xml_tree_from_string(generated_file)
-            current_tree = self.with_applied_xpath(current_tree, self.remove_ubl_extensions_xpath)
-
-            self.assertXmlTreeEqual(current_tree, expected_tree)
-
-    def testDebitNoteSimplified(self):
-        with freeze_time(datetime(year=2023, month=3, day=10, hour=15, minute=1, second=46, tzinfo=timezone('Etc/GMT-3'))):
-            simplified_credit_note = misc.file_open('l10n_sa_edi/tests/compliance/simplified/debit.xml', 'rb').read()
-            expected_tree = self.get_xml_tree_from_string(simplified_credit_note)
-            expected_tree = self.with_applied_xpath(expected_tree, self.debit_note_applied_xpath)
-
-            move = self._create_debit_note(name='INV/2023/00034', date='2023-03-10', date_due='2023-03-10',
-                                           partner_id=self.partner_sa_simplified, product_id=self.product_burger,
-                                           price=265.00, quantity=2.0)
-            move._l10n_sa_generate_unsigned_data()
-            generated_file = self.env['account.edi.format']._l10n_sa_generate_zatca_template(move)
-            current_tree = self.get_xml_tree_from_string(generated_file)
-            current_tree = self.with_applied_xpath(current_tree, self.remove_ubl_extensions_xpath)
-
-            self.assertXmlTreeEqual(current_tree, expected_tree)
+        self._test_document_generation(
+            document_type='invoice',
+            test_file_path='l10n_sa_edi/tests/compliance/standard/invoice.xml',
+            expected_xpath=self.invoice_applied_xpath,
+            move_data=move_data,
+            freeze_time_at=datetime(2022, 9, 5, 8, 20, 2, tzinfo=timezone('Etc/GMT-3'))
+        )

--- a/addons/l10n_sa_edi/tests/test_files/downpayment_credit_note.xml
+++ b/addons/l10n_sa_edi/tests/test_files/downpayment_credit_note.xml
@@ -5,10 +5,10 @@
   <cbc:UUID>ea8e1ab4-6b4e-4cb2-8efc-f8e229622774</cbc:UUID>
   <cbc:IssueDate>2022-09-05</cbc:IssueDate>
   <cbc:IssueTime>08:20:02</cbc:IssueTime>
-  <cbc:InvoiceTypeCode name="0100100">381</cbc:InvoiceTypeCode>
+  <cbc:InvoiceTypeCode name="0100000">381</cbc:InvoiceTypeCode>
   <cbc:DocumentCurrencyCode>SAR</cbc:DocumentCurrencyCode>
   <cbc:TaxCurrencyCode>SAR</cbc:TaxCurrencyCode>
-  <cbc:BuyerReference>Azure Interior</cbc:BuyerReference>
+  <cbc:BuyerReference>Saudi Aramco</cbc:BuyerReference>
   <cac:OrderReference>
     <cbc:ID>Reversal of: INV/2022/00001, please reverse :c</cbc:ID>
   </cac:OrderReference>
@@ -43,7 +43,7 @@
         <cbc:CityName>&#1575;&#1604;&#1605;&#1583;&#1610;&#1606;&#1577; &#1575;&#1604;&#1605;&#1606;&#1608;&#1585;&#1577;</cbc:CityName>
         <cbc:PostalZone>42317</cbc:PostalZone>
         <cbc:CountrySubentity>Riyadh</cbc:CountrySubentity>
-        <cbc:CountrySubentityCode>RYA</cbc:CountrySubentityCode>
+        <cbc:CountrySubentityCode>RUH</cbc:CountrySubentityCode>
         <cac:Country>
           <cbc:IdentificationCode>SA</cbc:IdentificationCode>
           <cbc:Name>Saudi Arabia</cbc:Name>
@@ -60,7 +60,7 @@
           <cbc:CityName>&#1575;&#1604;&#1605;&#1583;&#1610;&#1606;&#1577; &#1575;&#1604;&#1605;&#1606;&#1608;&#1585;&#1577;</cbc:CityName>
           <cbc:PostalZone>42317</cbc:PostalZone>
           <cbc:CountrySubentity>Riyadh</cbc:CountrySubentity>
-          <cbc:CountrySubentityCode>RYA</cbc:CountrySubentityCode>
+          <cbc:CountrySubentityCode>RUH</cbc:CountrySubentityCode>
           <cac:Country>
             <cbc:IdentificationCode>SA</cbc:IdentificationCode>
             <cbc:Name>Saudi Arabia</cbc:Name>
@@ -81,7 +81,7 @@
           <cbc:CityName>&#1575;&#1604;&#1605;&#1583;&#1610;&#1606;&#1577; &#1575;&#1604;&#1605;&#1606;&#1608;&#1585;&#1577;</cbc:CityName>
           <cbc:PostalZone>42317</cbc:PostalZone>
           <cbc:CountrySubentity>Riyadh</cbc:CountrySubentity>
-          <cbc:CountrySubentityCode>RYA</cbc:CountrySubentityCode>
+          <cbc:CountrySubentityCode>RUH</cbc:CountrySubentityCode>
           <cac:Country>
             <cbc:IdentificationCode>SA</cbc:IdentificationCode>
             <cbc:Name>Saudi Arabia</cbc:Name>
@@ -99,47 +99,69 @@
   <cac:AccountingCustomerParty>
     <cac:Party>
       <cac:PartyIdentification>
-        <cbc:ID schemeID="CRN">US12345677</cbc:ID>
+        <cbc:ID schemeID="CRN">353535353535353</cbc:ID>
       </cac:PartyIdentification>
       <cac:PartyName>
-        <cbc:Name>Chichi Lboukla</cbc:Name>
+        <cbc:Name>Saud Ahmed</cbc:Name>
       </cac:PartyName>
       <cac:PostalAddress>
-        <cbc:StreetName>4557 De Silva St</cbc:StreetName>
+        <cbc:StreetName>4557 King Salman St</cbc:StreetName>
         <cbc:BuildingNumber>12300</cbc:BuildingNumber>
         <cbc:PlotIdentification>2323</cbc:PlotIdentification>
         <cbc:CitySubdivisionName>Neighbor!</cbc:CitySubdivisionName>
-        <cbc:CityName>Fremont</cbc:CityName>
+        <cbc:CityName>Riyadh</cbc:CityName>
         <cbc:PostalZone>94538</cbc:PostalZone>
-        <cbc:CountrySubentity>California</cbc:CountrySubentity>
-        <cbc:CountrySubentityCode>CA</cbc:CountrySubentityCode>
+        <cbc:CountrySubentity>Riyadh</cbc:CountrySubentity>
+        <cbc:CountrySubentityCode>RUH</cbc:CountrySubentityCode>
         <cac:Country>
-          <cbc:IdentificationCode>US</cbc:IdentificationCode>
-          <cbc:Name>United States</cbc:Name>
+          <cbc:IdentificationCode>SA</cbc:IdentificationCode>
+          <cbc:Name>Saudi Arabia</cbc:Name>
         </cac:Country>
       </cac:PostalAddress>
+      <cac:PartyTaxScheme>
+          <cbc:RegistrationName>Saud Ahmed</cbc:RegistrationName>
+          <cbc:CompanyID>311111111111113</cbc:CompanyID>
+          <cac:RegistrationAddress>
+              <cbc:StreetName>4557 King Salman St</cbc:StreetName>
+              <cbc:BuildingNumber>12300</cbc:BuildingNumber>
+              <cbc:PlotIdentification>2323</cbc:PlotIdentification>
+              <cbc:CitySubdivisionName>Neighbor!</cbc:CitySubdivisionName>
+              <cbc:CityName>Riyadh</cbc:CityName>
+              <cbc:PostalZone>94538</cbc:PostalZone>
+              <cbc:CountrySubentity>Riyadh</cbc:CountrySubentity>
+              <cbc:CountrySubentityCode>RUH</cbc:CountrySubentityCode>
+              <cac:Country>
+                  <cbc:IdentificationCode>SA</cbc:IdentificationCode>
+                  <cbc:Name>Saudi Arabia</cbc:Name>
+              </cac:Country>
+          </cac:RegistrationAddress>
+          <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+          </cac:TaxScheme>
+      </cac:PartyTaxScheme>
       <cac:PartyLegalEntity>
-        <cbc:RegistrationName>Chichi Lboukla</cbc:RegistrationName>
+        <cbc:RegistrationName>Saud Ahmed</cbc:RegistrationName>
+        <cbc:CompanyID>311111111111113</cbc:CompanyID>
         <cac:RegistrationAddress>
-          <cbc:StreetName>4557 De Silva St</cbc:StreetName>
+          <cbc:StreetName>4557 King Salman St</cbc:StreetName>
           <cbc:BuildingNumber>12300</cbc:BuildingNumber>
           <cbc:PlotIdentification>2323</cbc:PlotIdentification>
           <cbc:CitySubdivisionName>Neighbor!</cbc:CitySubdivisionName>
-          <cbc:CityName>Fremont</cbc:CityName>
+          <cbc:CityName>Riyadh</cbc:CityName>
           <cbc:PostalZone>94538</cbc:PostalZone>
-          <cbc:CountrySubentity>California</cbc:CountrySubentity>
-          <cbc:CountrySubentityCode>CA</cbc:CountrySubentityCode>
+          <cbc:CountrySubentity>Riyadh</cbc:CountrySubentity>
+          <cbc:CountrySubentityCode>RUH</cbc:CountrySubentityCode>
           <cac:Country>
-            <cbc:IdentificationCode>US</cbc:IdentificationCode>
-            <cbc:Name>United States</cbc:Name>
+            <cbc:IdentificationCode>SA</cbc:IdentificationCode>
+            <cbc:Name>Saudi Arabia</cbc:Name>
           </cac:Country>
         </cac:RegistrationAddress>
       </cac:PartyLegalEntity>
       <cac:Contact>
         <cbc:ID>350</cbc:ID>
-        <cbc:Name>Chichi Lboukla</cbc:Name>
-        <cbc:Telephone>+18709310505</cbc:Telephone>
-        <cbc:ElectronicMail>azure.Interior24@example.com</cbc:ElectronicMail>
+        <cbc:Name>Saud Ahmed</cbc:Name>
+        <cbc:Telephone>+966556666666</cbc:Telephone>
+        <cbc:ElectronicMail>saudi.aramco@example.com</cbc:ElectronicMail>
       </cac:Contact>
     </cac:Party>
   </cac:AccountingCustomerParty>

--- a/addons/l10n_sa_edi/tests/test_files/downpayment_invoice.xml
+++ b/addons/l10n_sa_edi/tests/test_files/downpayment_invoice.xml
@@ -5,10 +5,10 @@
   <cbc:UUID>7a06f916-5f83-4519-9355-89d778d246bd</cbc:UUID>
   <cbc:IssueDate>2022-09-05</cbc:IssueDate>
   <cbc:IssueTime>08:20:02</cbc:IssueTime>
-  <cbc:InvoiceTypeCode name="0100100">386</cbc:InvoiceTypeCode>
+  <cbc:InvoiceTypeCode name="0100000">386</cbc:InvoiceTypeCode>
   <cbc:DocumentCurrencyCode>SAR</cbc:DocumentCurrencyCode>
   <cbc:TaxCurrencyCode>SAR</cbc:TaxCurrencyCode>
-  <cbc:BuyerReference>Azure Interior</cbc:BuyerReference>
+  <cbc:BuyerReference>Saudi Aramco</cbc:BuyerReference>
   <cac:OrderReference>
     <cbc:ID>INV/2022/00001</cbc:ID>
   </cac:OrderReference>
@@ -38,7 +38,7 @@
         <cbc:CityName>&#1575;&#1604;&#1605;&#1583;&#1610;&#1606;&#1577; &#1575;&#1604;&#1605;&#1606;&#1608;&#1585;&#1577;</cbc:CityName>
         <cbc:PostalZone>42317</cbc:PostalZone>
         <cbc:CountrySubentity>Riyadh</cbc:CountrySubentity>
-        <cbc:CountrySubentityCode>RYA</cbc:CountrySubentityCode>
+        <cbc:CountrySubentityCode>RUH</cbc:CountrySubentityCode>
         <cac:Country>
           <cbc:IdentificationCode>SA</cbc:IdentificationCode>
           <cbc:Name>Saudi Arabia</cbc:Name>
@@ -55,7 +55,7 @@
           <cbc:CityName>&#1575;&#1604;&#1605;&#1583;&#1610;&#1606;&#1577; &#1575;&#1604;&#1605;&#1606;&#1608;&#1585;&#1577;</cbc:CityName>
           <cbc:PostalZone>42317</cbc:PostalZone>
           <cbc:CountrySubentity>Riyadh</cbc:CountrySubentity>
-          <cbc:CountrySubentityCode>RYA</cbc:CountrySubentityCode>
+          <cbc:CountrySubentityCode>RUH</cbc:CountrySubentityCode>
           <cac:Country>
             <cbc:IdentificationCode>SA</cbc:IdentificationCode>
             <cbc:Name>Saudi Arabia</cbc:Name>
@@ -76,7 +76,7 @@
           <cbc:CityName>&#1575;&#1604;&#1605;&#1583;&#1610;&#1606;&#1577; &#1575;&#1604;&#1605;&#1606;&#1608;&#1585;&#1577;</cbc:CityName>
           <cbc:PostalZone>42317</cbc:PostalZone>
           <cbc:CountrySubentity>Riyadh</cbc:CountrySubentity>
-          <cbc:CountrySubentityCode>RYA</cbc:CountrySubentityCode>
+          <cbc:CountrySubentityCode>RUH</cbc:CountrySubentityCode>
           <cac:Country>
             <cbc:IdentificationCode>SA</cbc:IdentificationCode>
             <cbc:Name>Saudi Arabia</cbc:Name>
@@ -94,47 +94,69 @@
   <cac:AccountingCustomerParty>
     <cac:Party>
       <cac:PartyIdentification>
-        <cbc:ID schemeID="CRN">US12345677</cbc:ID>
+        <cbc:ID schemeID="CRN">353535353535353</cbc:ID>
       </cac:PartyIdentification>
       <cac:PartyName>
-        <cbc:Name>Chichi Lboukla</cbc:Name>
+        <cbc:Name>Saud Ahmed</cbc:Name>
       </cac:PartyName>
       <cac:PostalAddress>
-        <cbc:StreetName>4557 De Silva St</cbc:StreetName>
+        <cbc:StreetName>4557 King Salman St</cbc:StreetName>
         <cbc:BuildingNumber>12300</cbc:BuildingNumber>
         <cbc:PlotIdentification>2323</cbc:PlotIdentification>
         <cbc:CitySubdivisionName>Neighbor!</cbc:CitySubdivisionName>
-        <cbc:CityName>Fremont</cbc:CityName>
+        <cbc:CityName>Riyadh</cbc:CityName>
         <cbc:PostalZone>94538</cbc:PostalZone>
-        <cbc:CountrySubentity>California</cbc:CountrySubentity>
-        <cbc:CountrySubentityCode>CA</cbc:CountrySubentityCode>
+        <cbc:CountrySubentity>Riyadh</cbc:CountrySubentity>
+        <cbc:CountrySubentityCode>RUH</cbc:CountrySubentityCode>
         <cac:Country>
-          <cbc:IdentificationCode>US</cbc:IdentificationCode>
-          <cbc:Name>United States</cbc:Name>
+          <cbc:IdentificationCode>SA</cbc:IdentificationCode>
+          <cbc:Name>Saudi Arabia</cbc:Name>
         </cac:Country>
       </cac:PostalAddress>
+      <cac:PartyTaxScheme>
+          <cbc:RegistrationName>Saud Ahmed</cbc:RegistrationName>
+          <cbc:CompanyID>311111111111113</cbc:CompanyID>
+          <cac:RegistrationAddress>
+              <cbc:StreetName>4557 King Salman St</cbc:StreetName>
+              <cbc:BuildingNumber>12300</cbc:BuildingNumber>
+              <cbc:PlotIdentification>2323</cbc:PlotIdentification>
+              <cbc:CitySubdivisionName>Neighbor!</cbc:CitySubdivisionName>
+              <cbc:CityName>Riyadh</cbc:CityName>
+              <cbc:PostalZone>94538</cbc:PostalZone>
+              <cbc:CountrySubentity>Riyadh</cbc:CountrySubentity>
+              <cbc:CountrySubentityCode>RUH</cbc:CountrySubentityCode>
+              <cac:Country>
+                  <cbc:IdentificationCode>SA</cbc:IdentificationCode>
+                  <cbc:Name>Saudi Arabia</cbc:Name>
+              </cac:Country>
+          </cac:RegistrationAddress>
+          <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+          </cac:TaxScheme>
+      </cac:PartyTaxScheme>
       <cac:PartyLegalEntity>
-        <cbc:RegistrationName>Chichi Lboukla</cbc:RegistrationName>
+        <cbc:RegistrationName>Saud Ahmed</cbc:RegistrationName>
+        <cbc:CompanyID>311111111111113</cbc:CompanyID>
         <cac:RegistrationAddress>
-          <cbc:StreetName>4557 De Silva St</cbc:StreetName>
+          <cbc:StreetName>4557 King Salman St</cbc:StreetName>
           <cbc:BuildingNumber>12300</cbc:BuildingNumber>
           <cbc:PlotIdentification>2323</cbc:PlotIdentification>
           <cbc:CitySubdivisionName>Neighbor!</cbc:CitySubdivisionName>
-          <cbc:CityName>Fremont</cbc:CityName>
+          <cbc:CityName>Riyadh</cbc:CityName>
           <cbc:PostalZone>94538</cbc:PostalZone>
-          <cbc:CountrySubentity>California</cbc:CountrySubentity>
-          <cbc:CountrySubentityCode>CA</cbc:CountrySubentityCode>
+          <cbc:CountrySubentity>Riyadh</cbc:CountrySubentity>
+          <cbc:CountrySubentityCode>RUH</cbc:CountrySubentityCode>
           <cac:Country>
-            <cbc:IdentificationCode>US</cbc:IdentificationCode>
-            <cbc:Name>United States</cbc:Name>
+            <cbc:IdentificationCode>SA</cbc:IdentificationCode>
+            <cbc:Name>Saudi Arabia</cbc:Name>
           </cac:Country>
         </cac:RegistrationAddress>
       </cac:PartyLegalEntity>
       <cac:Contact>
         <cbc:ID>411</cbc:ID>
-        <cbc:Name>Chichi Lboukla</cbc:Name>
-        <cbc:Telephone>+18709310505</cbc:Telephone>
-        <cbc:ElectronicMail>azure.Interior24@example.com</cbc:ElectronicMail>
+        <cbc:Name>Saud Ahmed</cbc:Name>
+        <cbc:Telephone>+966556666666</cbc:Telephone>
+        <cbc:ElectronicMail>saudi.aramco@example.com</cbc:ElectronicMail>
       </cac:Contact>
     </cac:Party>
   </cac:AccountingCustomerParty>

--- a/addons/l10n_sa_edi/tests/test_files/final_credit_note.xml
+++ b/addons/l10n_sa_edi/tests/test_files/final_credit_note.xml
@@ -5,10 +5,10 @@
   <cbc:UUID>e2ab7427-4f07-4f3b-b874-9ca03da4880a</cbc:UUID>
   <cbc:IssueDate>2022-09-05</cbc:IssueDate>
   <cbc:IssueTime>08:20:02</cbc:IssueTime>
-  <cbc:InvoiceTypeCode name="0100100">381</cbc:InvoiceTypeCode>
+  <cbc:InvoiceTypeCode name="0100000">381</cbc:InvoiceTypeCode>
   <cbc:DocumentCurrencyCode>SAR</cbc:DocumentCurrencyCode>
   <cbc:TaxCurrencyCode>SAR</cbc:TaxCurrencyCode>
-  <cbc:BuyerReference>Azure Interior</cbc:BuyerReference>
+  <cbc:BuyerReference>Saudi Aramco</cbc:BuyerReference>
   <cac:OrderReference>
     <cbc:ID>Reversal of: INV/2022/00002, please reverse :c</cbc:ID>
   </cac:OrderReference>
@@ -43,7 +43,7 @@
         <cbc:CityName>&#1575;&#1604;&#1605;&#1583;&#1610;&#1606;&#1577; &#1575;&#1604;&#1605;&#1606;&#1608;&#1585;&#1577;</cbc:CityName>
         <cbc:PostalZone>42317</cbc:PostalZone>
         <cbc:CountrySubentity>Riyadh</cbc:CountrySubentity>
-        <cbc:CountrySubentityCode>RYA</cbc:CountrySubentityCode>
+        <cbc:CountrySubentityCode>RUH</cbc:CountrySubentityCode>
         <cac:Country>
           <cbc:IdentificationCode>SA</cbc:IdentificationCode>
           <cbc:Name>Saudi Arabia</cbc:Name>
@@ -60,7 +60,7 @@
           <cbc:CityName>&#1575;&#1604;&#1605;&#1583;&#1610;&#1606;&#1577; &#1575;&#1604;&#1605;&#1606;&#1608;&#1585;&#1577;</cbc:CityName>
           <cbc:PostalZone>42317</cbc:PostalZone>
           <cbc:CountrySubentity>Riyadh</cbc:CountrySubentity>
-          <cbc:CountrySubentityCode>RYA</cbc:CountrySubentityCode>
+          <cbc:CountrySubentityCode>RUH</cbc:CountrySubentityCode>
           <cac:Country>
             <cbc:IdentificationCode>SA</cbc:IdentificationCode>
             <cbc:Name>Saudi Arabia</cbc:Name>
@@ -81,7 +81,7 @@
           <cbc:CityName>&#1575;&#1604;&#1605;&#1583;&#1610;&#1606;&#1577; &#1575;&#1604;&#1605;&#1606;&#1608;&#1585;&#1577;</cbc:CityName>
           <cbc:PostalZone>42317</cbc:PostalZone>
           <cbc:CountrySubentity>Riyadh</cbc:CountrySubentity>
-          <cbc:CountrySubentityCode>RYA</cbc:CountrySubentityCode>
+          <cbc:CountrySubentityCode>RUH</cbc:CountrySubentityCode>
           <cac:Country>
             <cbc:IdentificationCode>SA</cbc:IdentificationCode>
             <cbc:Name>Saudi Arabia</cbc:Name>
@@ -99,47 +99,69 @@
   <cac:AccountingCustomerParty>
     <cac:Party>
       <cac:PartyIdentification>
-        <cbc:ID schemeID="CRN">US12345677</cbc:ID>
+        <cbc:ID schemeID="CRN">353535353535353</cbc:ID>
       </cac:PartyIdentification>
       <cac:PartyName>
-        <cbc:Name>Chichi Lboukla</cbc:Name>
+        <cbc:Name>Saud Ahmed</cbc:Name>
       </cac:PartyName>
       <cac:PostalAddress>
-        <cbc:StreetName>4557 De Silva St</cbc:StreetName>
+        <cbc:StreetName>4557 King Salman St</cbc:StreetName>
         <cbc:BuildingNumber>12300</cbc:BuildingNumber>
         <cbc:PlotIdentification>2323</cbc:PlotIdentification>
         <cbc:CitySubdivisionName>Neighbor!</cbc:CitySubdivisionName>
-        <cbc:CityName>Fremont</cbc:CityName>
+        <cbc:CityName>Riyadh</cbc:CityName>
         <cbc:PostalZone>94538</cbc:PostalZone>
-        <cbc:CountrySubentity>California</cbc:CountrySubentity>
-        <cbc:CountrySubentityCode>CA</cbc:CountrySubentityCode>
+        <cbc:CountrySubentity>Riyadh</cbc:CountrySubentity>
+        <cbc:CountrySubentityCode>RUH</cbc:CountrySubentityCode>
         <cac:Country>
-          <cbc:IdentificationCode>US</cbc:IdentificationCode>
-          <cbc:Name>United States</cbc:Name>
+          <cbc:IdentificationCode>SA</cbc:IdentificationCode>
+          <cbc:Name>Saudi Arabia</cbc:Name>
         </cac:Country>
       </cac:PostalAddress>
+      <cac:PartyTaxScheme>
+          <cbc:RegistrationName>Saud Ahmed</cbc:RegistrationName>
+          <cbc:CompanyID>311111111111113</cbc:CompanyID>
+          <cac:RegistrationAddress>
+              <cbc:StreetName>4557 King Salman St</cbc:StreetName>
+              <cbc:BuildingNumber>12300</cbc:BuildingNumber>
+              <cbc:PlotIdentification>2323</cbc:PlotIdentification>
+              <cbc:CitySubdivisionName>Neighbor!</cbc:CitySubdivisionName>
+              <cbc:CityName>Riyadh</cbc:CityName>
+              <cbc:PostalZone>94538</cbc:PostalZone>
+              <cbc:CountrySubentity>Riyadh</cbc:CountrySubentity>
+              <cbc:CountrySubentityCode>RUH</cbc:CountrySubentityCode>
+              <cac:Country>
+                  <cbc:IdentificationCode>SA</cbc:IdentificationCode>
+                  <cbc:Name>Saudi Arabia</cbc:Name>
+              </cac:Country>
+          </cac:RegistrationAddress>
+          <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+          </cac:TaxScheme>
+      </cac:PartyTaxScheme>
       <cac:PartyLegalEntity>
-        <cbc:RegistrationName>Chichi Lboukla</cbc:RegistrationName>
+        <cbc:RegistrationName>Saud Ahmed</cbc:RegistrationName>
+        <cbc:CompanyID>311111111111113</cbc:CompanyID>
         <cac:RegistrationAddress>
-          <cbc:StreetName>4557 De Silva St</cbc:StreetName>
+          <cbc:StreetName>4557 King Salman St</cbc:StreetName>
           <cbc:BuildingNumber>12300</cbc:BuildingNumber>
           <cbc:PlotIdentification>2323</cbc:PlotIdentification>
           <cbc:CitySubdivisionName>Neighbor!</cbc:CitySubdivisionName>
-          <cbc:CityName>Fremont</cbc:CityName>
+          <cbc:CityName>Riyadh</cbc:CityName>
           <cbc:PostalZone>94538</cbc:PostalZone>
-          <cbc:CountrySubentity>California</cbc:CountrySubentity>
-          <cbc:CountrySubentityCode>CA</cbc:CountrySubentityCode>
+          <cbc:CountrySubentity>Riyadh</cbc:CountrySubentity>
+          <cbc:CountrySubentityCode>RUH</cbc:CountrySubentityCode>
           <cac:Country>
-            <cbc:IdentificationCode>US</cbc:IdentificationCode>
-            <cbc:Name>United States</cbc:Name>
+            <cbc:IdentificationCode>SA</cbc:IdentificationCode>
+            <cbc:Name>Saudi Arabia</cbc:Name>
           </cac:Country>
         </cac:RegistrationAddress>
       </cac:PartyLegalEntity>
       <cac:Contact>
         <cbc:ID>370</cbc:ID>
-        <cbc:Name>Chichi Lboukla</cbc:Name>
-        <cbc:Telephone>+18709310505</cbc:Telephone>
-        <cbc:ElectronicMail>azure.Interior24@example.com</cbc:ElectronicMail>
+        <cbc:Name>Saud Ahmed</cbc:Name>
+        <cbc:Telephone>+966556666666</cbc:Telephone>
+        <cbc:ElectronicMail>saudi.aramco@example.com</cbc:ElectronicMail>
       </cac:Contact>
     </cac:Party>
   </cac:AccountingCustomerParty>

--- a/addons/l10n_sa_edi/tests/test_files/final_invoice.xml
+++ b/addons/l10n_sa_edi/tests/test_files/final_invoice.xml
@@ -5,10 +5,10 @@
   <cbc:UUID>f60b0627-777e-4374-b8a3-ea071d9220cc</cbc:UUID>
   <cbc:IssueDate>2022-09-05</cbc:IssueDate>
   <cbc:IssueTime>08:20:02</cbc:IssueTime>
-  <cbc:InvoiceTypeCode name="0100100">388</cbc:InvoiceTypeCode>
+  <cbc:InvoiceTypeCode name="0100000">388</cbc:InvoiceTypeCode>
   <cbc:DocumentCurrencyCode>SAR</cbc:DocumentCurrencyCode>
   <cbc:TaxCurrencyCode>SAR</cbc:TaxCurrencyCode>
-  <cbc:BuyerReference>Azure Interior</cbc:BuyerReference>
+  <cbc:BuyerReference>Saudi Aramco</cbc:BuyerReference>
   <cac:OrderReference>
     <cbc:ID>INV/2022/00002</cbc:ID>
   </cac:OrderReference>
@@ -38,7 +38,7 @@
         <cbc:CityName>&#1575;&#1604;&#1605;&#1583;&#1610;&#1606;&#1577; &#1575;&#1604;&#1605;&#1606;&#1608;&#1585;&#1577;</cbc:CityName>
         <cbc:PostalZone>42317</cbc:PostalZone>
         <cbc:CountrySubentity>Riyadh</cbc:CountrySubentity>
-        <cbc:CountrySubentityCode>RYA</cbc:CountrySubentityCode>
+        <cbc:CountrySubentityCode>RUH</cbc:CountrySubentityCode>
         <cac:Country>
           <cbc:IdentificationCode>SA</cbc:IdentificationCode>
           <cbc:Name>Saudi Arabia</cbc:Name>
@@ -55,7 +55,7 @@
           <cbc:CityName>&#1575;&#1604;&#1605;&#1583;&#1610;&#1606;&#1577; &#1575;&#1604;&#1605;&#1606;&#1608;&#1585;&#1577;</cbc:CityName>
           <cbc:PostalZone>42317</cbc:PostalZone>
           <cbc:CountrySubentity>Riyadh</cbc:CountrySubentity>
-          <cbc:CountrySubentityCode>RYA</cbc:CountrySubentityCode>
+          <cbc:CountrySubentityCode>RUH</cbc:CountrySubentityCode>
           <cac:Country>
             <cbc:IdentificationCode>SA</cbc:IdentificationCode>
             <cbc:Name>Saudi Arabia</cbc:Name>
@@ -76,7 +76,7 @@
           <cbc:CityName>&#1575;&#1604;&#1605;&#1583;&#1610;&#1606;&#1577; &#1575;&#1604;&#1605;&#1606;&#1608;&#1585;&#1577;</cbc:CityName>
           <cbc:PostalZone>42317</cbc:PostalZone>
           <cbc:CountrySubentity>Riyadh</cbc:CountrySubentity>
-          <cbc:CountrySubentityCode>RYA</cbc:CountrySubentityCode>
+          <cbc:CountrySubentityCode>RUH</cbc:CountrySubentityCode>
           <cac:Country>
             <cbc:IdentificationCode>SA</cbc:IdentificationCode>
             <cbc:Name>Saudi Arabia</cbc:Name>
@@ -94,47 +94,69 @@
   <cac:AccountingCustomerParty>
     <cac:Party>
       <cac:PartyIdentification>
-        <cbc:ID schemeID="CRN">US12345677</cbc:ID>
+        <cbc:ID schemeID="CRN">353535353535353</cbc:ID>
       </cac:PartyIdentification>
       <cac:PartyName>
-        <cbc:Name>Chichi Lboukla</cbc:Name>
+        <cbc:Name>Saud Ahmed</cbc:Name>
       </cac:PartyName>
       <cac:PostalAddress>
-        <cbc:StreetName>4557 De Silva St</cbc:StreetName>
+        <cbc:StreetName>4557 King Salman St</cbc:StreetName>
         <cbc:BuildingNumber>12300</cbc:BuildingNumber>
         <cbc:PlotIdentification>2323</cbc:PlotIdentification>
         <cbc:CitySubdivisionName>Neighbor!</cbc:CitySubdivisionName>
-        <cbc:CityName>Fremont</cbc:CityName>
+        <cbc:CityName>Riyadh</cbc:CityName>
         <cbc:PostalZone>94538</cbc:PostalZone>
-        <cbc:CountrySubentity>California</cbc:CountrySubentity>
-        <cbc:CountrySubentityCode>CA</cbc:CountrySubentityCode>
+        <cbc:CountrySubentity>Riyadh</cbc:CountrySubentity>
+        <cbc:CountrySubentityCode>RUH</cbc:CountrySubentityCode>
         <cac:Country>
-          <cbc:IdentificationCode>US</cbc:IdentificationCode>
-          <cbc:Name>United States</cbc:Name>
+          <cbc:IdentificationCode>SA</cbc:IdentificationCode>
+          <cbc:Name>Saudi Arabia</cbc:Name>
         </cac:Country>
       </cac:PostalAddress>
+      <cac:PartyTaxScheme>
+          <cbc:RegistrationName>Saud Ahmed</cbc:RegistrationName>
+          <cbc:CompanyID>311111111111113</cbc:CompanyID>
+          <cac:RegistrationAddress>
+              <cbc:StreetName>4557 King Salman St</cbc:StreetName>
+              <cbc:BuildingNumber>12300</cbc:BuildingNumber>
+              <cbc:PlotIdentification>2323</cbc:PlotIdentification>
+              <cbc:CitySubdivisionName>Neighbor!</cbc:CitySubdivisionName>
+              <cbc:CityName>Riyadh</cbc:CityName>
+              <cbc:PostalZone>94538</cbc:PostalZone>
+              <cbc:CountrySubentity>Riyadh</cbc:CountrySubentity>
+              <cbc:CountrySubentityCode>RUH</cbc:CountrySubentityCode>
+              <cac:Country>
+                  <cbc:IdentificationCode>SA</cbc:IdentificationCode>
+                  <cbc:Name>Saudi Arabia</cbc:Name>
+              </cac:Country>
+          </cac:RegistrationAddress>
+          <cac:TaxScheme>
+              <cbc:ID>VAT</cbc:ID>
+          </cac:TaxScheme>
+      </cac:PartyTaxScheme>
       <cac:PartyLegalEntity>
-        <cbc:RegistrationName>Chichi Lboukla</cbc:RegistrationName>
+        <cbc:RegistrationName>Saud Ahmed</cbc:RegistrationName>
+        <cbc:CompanyID>311111111111113</cbc:CompanyID>
         <cac:RegistrationAddress>
-          <cbc:StreetName>4557 De Silva St</cbc:StreetName>
+          <cbc:StreetName>4557 King Salman St</cbc:StreetName>
           <cbc:BuildingNumber>12300</cbc:BuildingNumber>
           <cbc:PlotIdentification>2323</cbc:PlotIdentification>
           <cbc:CitySubdivisionName>Neighbor!</cbc:CitySubdivisionName>
-          <cbc:CityName>Fremont</cbc:CityName>
+          <cbc:CityName>Riyadh</cbc:CityName>
           <cbc:PostalZone>94538</cbc:PostalZone>
-          <cbc:CountrySubentity>California</cbc:CountrySubentity>
-          <cbc:CountrySubentityCode>CA</cbc:CountrySubentityCode>
+          <cbc:CountrySubentity>Riyadh</cbc:CountrySubentity>
+          <cbc:CountrySubentityCode>RUH</cbc:CountrySubentityCode>
           <cac:Country>
-            <cbc:IdentificationCode>US</cbc:IdentificationCode>
-            <cbc:Name>United States</cbc:Name>
+            <cbc:IdentificationCode>SA</cbc:IdentificationCode>
+            <cbc:Name>Saudi Arabia</cbc:Name>
           </cac:Country>
         </cac:RegistrationAddress>
       </cac:PartyLegalEntity>
       <cac:Contact>
         <cbc:ID>320</cbc:ID>
-        <cbc:Name>Chichi Lboukla</cbc:Name>
-        <cbc:Telephone>+18709310505</cbc:Telephone>
-        <cbc:ElectronicMail>azure.Interior24@example.com</cbc:ElectronicMail>
+        <cbc:Name>Saud Ahmed</cbc:Name>
+        <cbc:Telephone>+966556666666</cbc:Telephone>
+        <cbc:ElectronicMail>saudi.aramco@example.com</cbc:ElectronicMail>
       </cac:Contact>
     </cac:Party>
   </cac:AccountingCustomerParty>


### PR DESCRIPTION
…nches

Description of the issue/feature this PR addresses:
The current implementation of generating CSR files for EDI doesn't differnetiate between parent companies and branches. ZATCA, however, expects slightly different information depending on whether the company is a branch or a parent.

This also includes a refactor of the tests for l10n_sa_edi.

Current behavior before PR:
The Organization Name, Organization Unit Name, and Organization Identifier of whichever company on the journal were being sent to ZATCA.
You could also Onboard/Re-Onboard a journal in different company.

The unit tests for EDI document generation were primarily using a partner based in the US, which meant that the b2b invoicing main flow was not being properly tested

Desired behavior after PR is merged:

Parent/Standalone Company:
- Organization Name: The name of the company
- Organization Unit Name: First 10 characters of the VAT
- Organization Identifier: The VAT of the company

Branch:
- Organization Name: The name of the parent
- Organization Unit Name: The name of the branch
- Organization Identifier: The VAT of the parent
- Prevent users from posting invoices, credit notes, or debit notes whose invoice company doesn't match the journal company
- The tests are easier to read and they test the b2b flow correctly

opw-4794842

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
