### PR TITLE
Master import delay xmo

### DIFF
--- a/odoo/_monkeypatches/PIL.py
+++ b/odoo/_monkeypatches/PIL.py
@@ -1,0 +1,11 @@
+from PIL import Image, ImageFile
+
+def patch_module():
+    ImageFile.LOAD_TRUNCATED_IMAGES = True
+    # Preload PIL with the minimal subset of image formats we need
+    Image.preinit()
+    # Not part of the preinit set but should be safe enough for us
+    from PIL import IcoImagePlugin  # noqa: PLC0415
+    # Allow saving PDF streams in images
+    from PIL import PdfImagePlugin  # noqa: PLC0415
+    Image._initialized = 2

--- a/odoo/addons/base/models/ir_actions.py
+++ b/odoo/addons/base/models/ir_actions.py
@@ -9,7 +9,6 @@ from collections import defaultdict
 from functools import reduce
 from operator import getitem
 
-import requests
 from pytz import timezone
 
 from odoo import api, fields, models, tools
@@ -951,6 +950,7 @@ class IrActionsServer(models.Model):
         json_values = json.dumps(vals, sort_keys=True, default=str)
         _logger.info("Webhook call to %s", url)
         _logger.debug("POST JSON data for webhook call: %s", json_values)
+        import requests  # noqa: PLC0415
         try:
             # 'send and forget' strategy, and avoid locking the user if the webhook
             # is slow or non-functional (we still allow for a 1s timeout so that

--- a/odoo/addons/base/models/ir_actions_report.py
+++ b/odoo/addons/base/models/ir_actions_report.py
@@ -14,7 +14,6 @@ from itertools import islice
 from urllib.parse import urlparse
 
 import lxml.html
-from PIL import Image, ImageFile
 from lxml import etree
 from markupsafe import Markup
 
@@ -28,9 +27,6 @@ from odoo.tools.barcode import check_barcode_encoding, createBarcodeDrawing, get
 from odoo.tools.misc import find_in_path
 from odoo.tools.pdf import PdfFileReader, PdfFileWriter, PdfReadError
 from odoo.tools.safe_eval import safe_eval, time
-
-# Allow truncated images
-ImageFile.LOAD_TRUNCATED_IMAGES = True
 
 _logger = logging.getLogger(__name__)
 
@@ -800,6 +796,7 @@ class IrActionsReport(models.Model):
 
                         # Ensure the stream can be saved in Image.
                         if attachment.mimetype.startswith('image'):
+                            from PIL import Image  # noqa: PLC0415
                             img = Image.open(stream)
                             new_stream = io.BytesIO()
                             img.convert("RGB").save(new_stream, format="pdf")

--- a/odoo/addons/base/models/ir_attachment.py
+++ b/odoo/addons/base/models/ir_attachment.py
@@ -18,7 +18,7 @@ from odoo import api, fields, models, _
 from odoo.exceptions import AccessError, ValidationError, UserError
 from odoo.fields import Domain
 from odoo.http import Stream, root, request
-from odoo.tools import config, consteq, human_size, image, split_every, str2bool
+from odoo.tools import config, consteq, human_size, split_every, str2bool
 from odoo.tools.mimetypes import guess_mimetype, fix_filename_extension
 from odoo.tools.misc import limited_field_access_token
 
@@ -330,6 +330,7 @@ class IrAttachment(models.Model):
             # Can be set to 0 to skip the resize
             max_resolution = ICP('base.image_autoresize_max_px', '1920x1920')
             if str2bool(max_resolution, True):
+                from odoo.tools import image
                 try:
                     if is_raw:
                         img = image.ImageProcess(values['raw'], verify_resolution=False)

--- a/odoo/addons/base/models/ir_binary.py
+++ b/odoo/addons/base/models/ir_binary.py
@@ -7,7 +7,6 @@ from odoo import models
 from odoo.exceptions import AccessError, MissingError, UserError
 from odoo.http import Stream, request
 from odoo.tools import file_open, replace_exceptions
-from odoo.tools.image import image_process, image_guess_size_from_field_name
 from odoo.tools.mimetypes import guess_mimetype, get_extension
 from odoo.tools.misc import verify_limited_field_access_token
 
@@ -216,6 +215,7 @@ class IrBinary(models.AbstractModel):
             stream.mimetype = 'application/octet-stream'
 
         if (width, height) == (0, 0):
+            from odoo.tools.image import image_guess_size_from_field_name  # noqa: PLC0415
             width, height = image_guess_size_from_field_name(field_name)
 
         if isinstance(stream.etag, str):
@@ -229,6 +229,7 @@ class IrBinary(models.AbstractModel):
         )
 
         if modified and (width or height or crop):
+            from odoo.tools.image import image_process  # noqa: PLC0415
             if stream.type == 'path':
                 with open(stream.path, 'rb') as file:
                     stream.type = 'data'

--- a/odoo/addons/base/models/ir_module.py
+++ b/odoo/addons/base/models/ir_module.py
@@ -1,5 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 import base64
+import contextlib
 import logging
 import os
 import shutil
@@ -19,7 +20,7 @@ from odoo.addons.base.models.ir_model import MODULE_UNINSTALL_FLAG
 from odoo.exceptions import AccessDenied, UserError, ValidationError
 from odoo.fields import Domain
 from odoo.tools.parse_version import parse_version
-from odoo.tools.misc import topological_sort, get_flag
+from odoo.tools.misc import topological_sort, get_flag, file_path
 from odoo.tools.translate import TranslationImporter, get_po_paths, get_datafile_translation_path
 from odoo.http import request
 from odoo.modules import get_module_path
@@ -837,11 +838,6 @@ class IrModuleModule(models.Model):
         }
         mod_names = topological_sort(mod_dict)
         self.env['ir.module.module']._load_module_terms(mod_names, filter_lang, overwrite)
-
-    def _check(self):
-        for module in self:
-            if not module.description_html:
-                _logger.warning('module %s: description is empty!', module.name)
 
     def _get(self, name):
         """ Return the (sudoed) `ir.module.module` record with the given name.

--- a/odoo/addons/base/models/ir_qweb.py
+++ b/odoo/addons/base/models/ir_qweb.py
@@ -389,13 +389,12 @@ from pathlib import Path
 from odoo import api, models, tools
 from odoo.modules import get_module_path
 from odoo.modules.registry import _REGISTRY_CACHES
-from odoo.tools import config, safe_eval, pycompat
+from odoo.tools import config, safe_eval
 from odoo.tools.constants import SUPPORTED_DEBUGGER, EXTERNAL_ASSET
 from odoo.tools.safe_eval import assert_valid_codeobj, _BUILTINS, to_opcodes, _EXPR_OPCODES, _BLACKLIST
 from odoo.tools.json import scriptsafe
 from odoo.tools.lru import LRU
 from odoo.tools.misc import str2bool, file_open, file_path
-from odoo.tools.image import image_data_uri, FILETYPE_BASE64_MAGICWORD
 from odoo.tools.translate import FORMAT_REGEX
 from odoo.http import request
 from odoo.tools.profiler import QwebTracker
@@ -897,6 +896,7 @@ class IrQweb(models.AbstractModel):
     # values for running time
 
     def _get_converted_image_data_uri(self, base64_source):
+        from odoo.tools.image import image_data_uri, FILETYPE_BASE64_MAGICWORD  # noqa: PLC0415
         if self.env.context.get('webp_as_jpg'):
             mimetype = FILETYPE_BASE64_MAGICWORD.get(base64_source[:1], 'png')
             if 'webp' in mimetype:

--- a/odoo/addons/base/models/ir_qweb_fields.py
+++ b/odoo/addons/base/models/ir_qweb_fields.py
@@ -9,7 +9,6 @@ from io import BytesIO
 import babel
 import babel.dates
 from markupsafe import Markup, escape, escape_silent
-from PIL import Image
 from lxml import etree, html
 
 from odoo import api, fields, models, tools
@@ -436,6 +435,7 @@ class IrQwebFieldImage(models.AbstractModel):
         if img_b64 and guess_mimetype(img_b64, '') == 'image/webp':
             return self.env["ir.qweb"]._get_converted_image_data_uri(value)
 
+        from PIL import Image  # noqa: PLC0415
         try:
             image = Image.open(BytesIO(img_b64))
             image.verify()
@@ -444,7 +444,7 @@ class IrQwebFieldImage(models.AbstractModel):
         except: # image.verify() throws "suitable exceptions", I have no idea what they are
             raise ValueError("Invalid image content") from None
 
-        return "data:%s;base64,%s" % (Image.MIME[image.format], value.decode('ascii'))
+        return f"data:{Image.MIME[image.format]};base64,{value.decode('ascii')}"
 
     @api.model
     def value_to_html(self, value, options):

--- a/odoo/addons/base/models/res_company.py
+++ b/odoo/addons/base/models/res_company.py
@@ -8,7 +8,6 @@ from odoo.api import SUPERUSER_ID
 from odoo.exceptions import ValidationError, UserError
 from odoo.fields import Command, Domain
 from odoo.tools import html2plaintext, file_open, ormcache
-from odoo.tools.image import image_process
 
 _logger = logging.getLogger(__name__)
 
@@ -152,6 +151,7 @@ class ResCompany(models.Model):
 
     @api.depends('partner_id.image_1920')
     def _compute_logo_web(self):
+        from odoo.tools.image import image_process  # noqa: PLC0415
         for company in self:
             img = company.partner_id.image_1920
             company.logo_web = img and base64.b64encode(image_process(base64.b64decode(img), size=(180, 0)))

--- a/odoo/addons/base/models/res_partner.py
+++ b/odoo/addons/base/models/res_partner.py
@@ -5,11 +5,8 @@ from __future__ import annotations
 import base64
 import collections
 import datetime
-import hashlib
 import pytz
-import re
 
-import requests
 from collections import defaultdict
 from random import randint
 from werkzeug import urls

--- a/odoo/modules/loading.py
+++ b/odoo/modules/loading.py
@@ -212,7 +212,6 @@ def load_module_graph(
             # Can't put this line out of the loop: ir.module.module will be
             # registered by init_models() above.
             module = env['ir.module.module'].browse(module_id)
-            module._check()
 
             idref: dict = {}
 

--- a/odoo/tools/image.py
+++ b/odoo/tools/image.py
@@ -6,8 +6,6 @@ import io
 from typing import Tuple, Union
 
 from PIL import Image, ImageOps
-# We can preload Ico too because it is considered safe
-from PIL import IcoImagePlugin
 try:
     from PIL.Image import Transpose, Palette, Resampling
 except ImportError:
@@ -23,9 +21,6 @@ from odoo.tools.translate import LazyTranslate
 __all__ = ["image_process"]
 _lt = LazyTranslate('base')
 
-# Preload PIL with the minimal subset of image formats we need
-Image.preinit()
-Image._initialized = 2
 
 # Maps only the 6 first bits of the base64 data, accurate enough
 # for our purpose and faster than decoding the full blob first

--- a/odoo/tools/pdf/__init__.py
+++ b/odoo/tools/pdf/__init__.py
@@ -3,13 +3,10 @@ import importlib
 import io
 import re
 import unicodedata
-import sys
 from datetime import datetime
 from hashlib import md5
 from logging import getLogger
 from zlib import compress, decompress, decompressobj
-
-from PIL import Image, PdfImagePlugin
 
 from odoo.tools.arabic_reshaper import reshape
 from odoo.tools.parse_version import parse_version
@@ -89,10 +86,6 @@ _logger = getLogger(__name__)
 DEFAULT_PDF_DATETIME_FORMAT = "D:%Y%m%d%H%M%S+00'00'"
 REGEX_SUBTYPE_UNFORMATED = re.compile(r'^\w+/[\w-]+$')
 REGEX_SUBTYPE_FORMATED = re.compile(r'^/\w+#2F[\w-]+$')
-
-
-# Disable linter warning: this import is needed to make sure a PDF stream can be saved in Image.
-PdfImagePlugin.__name__
 
 
 # make sure values are unwrapped by calling the specialized __getitem__
@@ -211,6 +204,7 @@ def to_pdf_stream(attachment) -> io.BytesIO:
     if attachment.mimetype == 'application/pdf':
         return stream
     elif attachment.mimetype.startswith('image'):
+        from PIL import Image  # noqa: PLC0415
         output_stream = io.BytesIO()
         Image.open(stream).convert("RGB").save(output_stream, format="pdf")
         return output_stream
@@ -226,6 +220,7 @@ def add_banner(pdf_stream, text=None, logo=False, thickness=SENTINEL):
     :param thickness (float):       The thickness of the banner in pixels (default: 2cm).
     :return (BytesIO):              The modified PDF stream.
     """
+    from PIL import Image  # noqa: PLC0415
     from reportlab.lib import colors  # noqa: PLC0415
     from reportlab.lib.utils import ImageReader  # noqa: PLC0415
     from reportlab.pdfgen import canvas  # noqa: PLC0415

--- a/odoo/tools/pdf/__init__.py
+++ b/odoo/tools/pdf/__init__.py
@@ -211,14 +211,14 @@ def to_pdf_stream(attachment) -> io.BytesIO:
     _logger.warning("mimetype (%s) not recognized for %s", attachment.mimetype, attachment)
 
 
-def add_banner(pdf_stream, text=None, logo=False, thickness=SENTINEL):
+def add_banner(pdf_stream: io.BytesIO, text: str=None, logo: bool=False, thickness: float=SENTINEL) -> io.BytesIO:
     """ Add a banner on a PDF in the upper right corner, with Odoo's logo (optionally).
 
-    :param pdf_stream (BytesIO):    The PDF stream where the banner will be applied.
-    :param text (str):              The text to be displayed.
-    :param logo (bool):             Whether to display Odoo's logo in the banner.
-    :param thickness (float):       The thickness of the banner in pixels (default: 2cm).
-    :return (BytesIO):              The modified PDF stream.
+    :param pdf_stream:    The PDF stream where the banner will be applied.
+    :param text:              The text to be displayed.
+    :param logo:             Whether to display Odoo's logo in the banner.
+    :param thickness:       The thickness of the banner in pixels (default: 2cm).
+    :return:              The modified PDF stream.
     """
     from PIL import Image  # noqa: PLC0415
     from reportlab.lib import colors  # noqa: PLC0415

--- a/odoo/tools/xml_utils.py
+++ b/odoo/tools/xml_utils.py
@@ -8,7 +8,6 @@ import re
 import zipfile
 from io import BytesIO
 
-import requests
 from lxml import etree
 
 from odoo.exceptions import UserError
@@ -232,6 +231,7 @@ def load_xsd_files_from_url(env, url, file_name=None, force_reload=False,
     :rtype: odoo.api.ir.attachment | bool
     :return: every XSD attachment created/fetched or False if an error occurred (see warning logs)
     """
+    import requests
     try:
         _logger.info("Fetching file/archive from given URL: %s", url)
         response = requests.get(url, timeout=request_max_timeout)


### PR DESCRIPTION
All in all these changes reduce the memory use of importing odoo core & base by ~30% (14.7MB + 16.1MB to 11.0MB + 9.6MB). This is on Python 3.10, according to [memray](https://github.com/bloomberg/memray).

This saves memory if no module needing the actual feature is ever loaded.

Although in absolute terms the savings are not exactly massive: installing a db peaks above 60MB.

[before](https://github.com/user-attachments/files/20666981/before.html.gz)
[after](https://github.com/user-attachments/files/20666986/after.html.gz)
