### PR TITLE
[FIX] website_sale: show empty option

### DIFF
--- a/addons/website_sale/static/src/website_builder/website_sale_show_empty_option.xml
+++ b/addons/website_sale/static/src/website_builder/website_sale_show_empty_option.xml
@@ -4,7 +4,7 @@
     <t t-name="website_sale.ShowEmptyOption">
         <BuilderContext action="'websiteConfig'">
             <BuilderRow label.translate="Show Empty" id="'show_empty_opt'">
-                <BuilderButton title.translate="Show/hide shopping cart" className="'o_btn_show_empty_cart fa fa-shopping-cart d-flex justify-content-center flex-grow-1'" actionParam="{views: ['website_sale.header_hide_empty_cart_link']}" />
+                <BuilderButton title.translate="Show/hide shopping cart" className="'o_btn_show_empty_cart fa fa-shopping-cart d-flex justify-content-center flex-grow-1'" actionParam="{views: ['!website_sale.header_hide_empty_cart_link']}" />
             </BuilderRow>
         </BuilderContext>
     </t>


### PR DESCRIPTION
Previously, the "Show Empty" option  would hide the cart instead of showing it (reversed behaviour of the button). To reproduce the problem:
1. Open website (with website_sale installed)
2. Start editing
3. Click on the header
4. Click on the cart of the "Show empty" option

->Problem
This commit follows [the html_builder refactoring].

[the html_builder refactoring]: odoo/odoo@9fe45e2b7ddb 
Related to task-4367641