### PR TITLE
[FIX] html_editor: list marker hidden with large font in nested list

### DIFF
--- a/addons/html_editor/static/src/main/list/list_plugin.js
+++ b/addons/html_editor/static/src/main/list/list_plugin.js
@@ -1060,7 +1060,10 @@ export class ListPlugin extends Plugin {
                 li.parentElement.nodeName === "UL" ? markerWidth * 2 : markerWidth;
             // For smaller font sizes, doubling the width of the dot marker is still lower than the
             // default. The default is kept in that case.
-            return Math.max(defaultPadding, paddingForMarker);
+            // Fallback to default if marker is missing (e.g., in li.oe-nested).
+            return isNaN(paddingForMarker)
+                ? defaultPadding
+                : Math.max(defaultPadding, paddingForMarker);
         });
         const largestPadding = Math.max(...requiredPaddings);
         if (largestPadding > defaultPadding) {

--- a/addons/html_editor/static/src/main/list/list_plugin.js
+++ b/addons/html_editor/static/src/main/list/list_plugin.js
@@ -787,6 +787,12 @@ export class ListPlugin extends Plugin {
         if (listItems.length || navListItems.length) {
             this.indentListNodes(listItems);
             this.dependencies.tabulation.indentBlocks(nonListItems);
+            const listsToAdjustPadding = new Set(
+                listItems.map((li) => closestElement(li, "ul, ol")).filter(Boolean)
+            );
+            for (const list of listsToAdjustPadding) {
+                this.adjustListPadding(list);
+            }
             // Do nothing to nav-items.
             this.dependencies.history.addStep();
             return true;

--- a/addons/html_editor/static/tests/list/indent.test.js
+++ b/addons/html_editor/static/tests/list/indent.test.js
@@ -691,6 +691,28 @@ describe("with selection collapsed", () => {
             contentAfter: '<ul><li class="nav-item">a[]</li></ul>',
         });
     });
+    test("should adjust list padding on tab", async () => {
+        await testEditor({
+            styleContent: ":root { font: 14px Roboto }",
+            contentBefore: unformat(`
+                <ol style="padding-inline-start: 58px;">
+                    <li style="font-size: 56px;">abc</li>
+                    <li style="font-size: 56px;">def[]</li>
+                </ol>
+            `),
+            stepFunction: keydownTab,
+            contentAfter: unformat(`
+                <ol style="padding-inline-start: 58px;">
+                    <li style="font-size: 56px;">abc</li>
+                    <li class="oe-nested">
+                        <ol style="padding-inline-start: 59px;">
+                            <li style="font-size: 56px;">def[]</li>
+                        </ol>
+                    </li>
+                </ol>
+            `),
+        });
+    });
 });
 
 describe("with selection", () => {

--- a/addons/html_editor/static/tests/list/list_font_size.test.js
+++ b/addons/html_editor/static/tests/list/list_font_size.test.js
@@ -7,6 +7,7 @@ import {
     toggleUnorderedList,
 } from "../_helpers/user_actions";
 import { execCommand } from "../_helpers/userCommands";
+import { unformat } from "../_helpers/format";
 
 before(() => {
     return document.fonts.add(new FontFace(
@@ -21,6 +22,32 @@ test("should apply font-size to completely selected list item", async () => {
         contentBefore: "<ol><li>[abc]</li><li>def</li></ol>",
         stepFunction: setFontSize("56px"),
         contentAfter: `<ol style="padding-inline-start: 60px;"><li style="font-size: 56px;">[abc]</li><li>def</li></ol>`,
+    });
+    await testEditor({
+        styleContent: ":root { font: 14px Roboto }",
+        contentBefore: unformat(`
+            <ol>
+                <li>[abc</li>
+                <li class="oe-nested">
+                    <ol>
+                        <li>def</li>
+                    </ol>
+                </li>
+                <li>ghi]</li>
+            </ol>
+        `),
+        stepFunction: setFontSize("64px"),
+        contentAfter: unformat(`
+            <ol style="padding-inline-start: 68px;">
+                <li style="font-size: 64px;">[abc</li>
+                <li class="oe-nested">
+                    <ol style="padding-inline-start: 67px;">
+                        <li style="font-size: 64px;">def</li>
+                    </ol>
+                </li>
+                <li style="font-size: 64px;">ghi]</li>
+            </ol>
+        `),
     });
 });
 


### PR DESCRIPTION
### Steps to reproduce:

**Issue 1:**

- Go to To-do
- Create a numbered list with a nested sub list.
- Select all and increase the font size to 80.
- Observe that ::marker in the primary list is hidden.

**Issue 2:**

- Create a numbered list and type something.
- Press Enter, then press tab.
- Write something and press backspace.
- Observe that the nested list move from its place.

### Description of the issue/feature this PR addresses:

- `li.oe-nested` elements do not have a marker, causing `markerWidth` to be `NaN`, and `Math.max(NaN, value)` also returned `NaN`, so no padding-inline-start was applied.
- The nested list could shift unexpectedly because we did not adjust the list's padding when indenting with the Tab key.

### Desired behavior after PR is merged:

- Fallback to default padding is applied when marker width is invalid, ensuring list marker remains visible and properly aligned.
- On indenting, the list padding is properly adjusted.

task-4854704

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
