### PR TITLE
[FIX] l10n_pt: missing portuguese accounting types

### DIFF
--- a/addons/account/i18n/pt.po
+++ b/addons/account/i18n/pt.po
@@ -3481,7 +3481,6 @@ msgstr "A percentagem de saldo não pode ser 0"
 
 #. module: account
 #. odoo-python
-#: code:addons/account/models/chart_template.py:0
 #: model:account.account,name:account.1_bank_journal_default_account_45
 #: model:account.journal,name:account.1_bank
 #: model:ir.model.fields,field_description:account.field_account_journal__bank_id
@@ -3495,6 +3494,12 @@ msgstr "A percentagem de saldo não pode ser 0"
 #: model_terms:ir.ui.view,arch_db:account.view_account_move_line_filter
 msgid "Bank"
 msgstr "Banco"
+
+#. module: account
+#. odoo-python
+#: code:addons/account/models/chart_template.py:0
+msgid "Bank"
+msgstr "Depósitos à ordem"
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.res_config_settings_view_form
@@ -4146,7 +4151,6 @@ msgstr "Passar para"
 
 #. module: account
 #. odoo-python
-#: code:addons/account/models/chart_template.py:0
 #: model:account.account,name:account.1_cash_journal_default_account_46
 #: model:account.journal,name:account.1_cash
 #: model:ir.model.fields.selection,name:account.selection__account_journal__type__cash
@@ -4154,6 +4158,12 @@ msgstr "Passar para"
 #: model_terms:ir.ui.view,arch_db:account.view_account_move_line_filter
 msgid "Cash"
 msgstr "Numerário"
+
+#. module: account
+#. odoo-python
+#: code:addons/account/models/chart_template.py:0
+msgid "Cash"
+msgstr "Caixa"
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.view_account_journal_form


### PR DESCRIPTION
The account type `Caixa` (Cash) and `Depósitos à Ordem` (Demand deposits) were missing from the Portuguese localization. Changed translations in pt.po for the template_chart.py context.

Steps to reproduce:
- install the accountant and l10n_pt module.
- select a Portuguese company.
- in the Chart of Accounts, notice there is no account named `Caixa` and `Depósitos à ordem`.

Ticket [link](https://www.odoo.com/odoo/project/967/tasks/4829413)
opw-4829413
