### PR TITLE
[PERF] core: gc set_threshold()

### DIFF
--- a/odoo/init.py
+++ b/odoo/init.py
@@ -3,9 +3,18 @@
 
 """ Odoo initialization. """
 
+import gc
 import sys
 from .release import MIN_PY_VERSION
 assert sys.version_info > MIN_PY_VERSION, f"Outdated python version detected, Odoo requires Python >= {'.'.join(map(str, MIN_PY_VERSION))} to run."
+
+# ----------------------------------------------------------
+# Set gc thresolds if they are default, see `odoo.tools.gc`.
+# ----------------------------------------------------------
+if gc.get_threshold()[0] == 700:
+    # Handling requests can sometimes allocate over 5k new objects, let leave
+    # some space before starting any collection.
+    gc.set_threshold(12_000, 20, 25)
 
 # ----------------------------------------------------------
 # Import tools to patch code and libraries


### PR DESCRIPTION
Details in the commit message.

## Performance

Memory checks:
- memray stats are similar
- htop indicates same RES memory in workers (they vary because of ormcache)
- invalidated registries are collected correctly

In terms of timing, we can see already differences when starting odoo. Most of detailed tests were performed on runbot by logging GC info before a full collect. How to read:
- cum_time (time spent by GC in ms): this is the main measure to optimize
- time[*].pct it is quite good for time to be split evenly, but if need to choose, collect more objects in early generations to avoid moving them later
- count[2].collections: should remain low, it can be quite costly
- count[2].collected / count[2].collections: should be high, otherwise, we run GC for not much to collect

| What | Baseline | This PR |
| ---- | ---- | ---- |
| logs | https://runbot.odoo.com/runbot/build/82118650 | https://runbot.odoo.com/runbot/build/82117208 |
| at install - 70 minutes | {'cum_time': 397460.41, 'time': [{'avg_time': 142987, 'time': 35554.78, 'pct': 0.089}, {'avg_time': 1797411, 'time': 40630.49, 'pct': 0.102}, {'avg_time': 332239034, 'time': 321275.15, 'pct': 0.808}], 'count': [{'collections': 248739, 'collected': 14213352, 'uncollectable': 0}, {'collections': 22612, 'collected': 3641720, 'uncollectable': 0}, {'collections': 967, 'collected': 48078051, 'uncollectable': 0}], 'thresholds': ((52, 7, 50), (700, 10, 10))} | {'cum_time': 111117.55, 'time': [{'avg_time': 4913728, 'time': 54837.21, 'pct': 0.494}, {'avg_time': 76133011, 'time': 40426.63, 'pct': 0.364}, {'avg_time': 792685970, 'time': 15853.72, 'pct': 0.143}], 'count': [{'collections': 11181, 'collected': 18849369, 'uncollectable': 0}, {'collections': 532, 'collected': 32276456, 'uncollectable': 0}, {'collections': 20, 'collected': 9621481, 'uncollectable': 0}], 'thresholds': ((11061, 19, 12), (12000, 20, 25))} |
| at install - just export profiling |  {'cum_time': 609.95, 'time': [{'avg_time': 122957, 'time': 102.18, 'pct': 0.168}, {'avg_time': 1257655, 'time': 95.58, 'pct': 0.157}, {'avg_time': 68698691, 'time': 412.19, 'pct': 0.676}], 'count': [{'collections': 913, 'collected': 19946, 'uncollectable': 0}, {'collections': 83, 'collected': 2617, 'uncollectable': 0}, {'collections': 6, 'collected': 143, 'uncollectable': 0}], 'thresholds': ((702, 0, 15), (700, 10, 10))} | {'cum_time': 194.06, 'time': [{'avg_time': 38811933, 'time': 194.06, 'pct': 1.0}, {'avg_time': 0, 'time': 0.0, 'pct': 0.0}, {'avg_time': 0, 'time': 0.0, 'pct': 0.0}], 'count': [{'collections': 26, 'collected': 22815, 'uncollectable': 0}, {'collections': 1, 'collected': 6, 'uncollectable': 0}, {'collections': 0, 'collected': 0, 'uncollectable': 0}], 'thresholds': ((1316, 15, 1), (12000, 20, 25))} |
| testing post_install from account to account_asset_fleet - 27 minutes | {'cum_time': 45050.15, 'time': [{'avg_time': 111466, 'time': 6705.26, 'pct': 0.149}, {'avg_time': 869194, 'time': 4753.63, 'pct': 0.106}, {'avg_time': 273099659, 'time': 33591.26, 'pct': 0.746}], 'count': [{'collections': 60237, 'collected': 3505264, 'uncollectable': 0}, {'collections': 5476, 'collected': 1051238, 'uncollectable': 0}, {'collections': 123, 'collected': 7195598, 'uncollectable': 0}], 'thresholds': ((0, 1, 130), (700, 10, 10))} | {'cum_time': 17886.49, 'time': [{'avg_time': 4526719, 'time': 8464.97, 'pct': 0.473}, {'avg_time': 75926405, 'time': 6757.45, 'pct': 0.378}, {'avg_time': 888024243, 'time': 2664.07, 'pct': 0.149}], 'count': [{'collections': 1891, 'collected': 4600229, 'uncollectable': 0}, {'collections': 90, 'collected': 4813306, 'uncollectable': 0}, {'collections': 3, 'collected': 1776124, 'uncollectable': 0}], 'thresholds': ((6160, 11, 12), (12000, 20, 25))} |
| testing post_install from web to web_unsplash - 64 minutes | {'cum_time': 69102.04, 'time': [{'avg_time': 109583, 'time': 5912.03, 'pct': 0.086}, {'avg_time': 1240230, 'time': 6083.33, 'pct': 0.088}, {'avg_time': 399347394, 'time': 57106.68, 'pct': 0.826}], 'count': [{'collections': 54032, 'collected': 1405220, 'uncollectable': 0}, {'collections': 4912, 'collected': 1313330, 'uncollectable': 0}, {'collections': 143, 'collected': 16600155, 'uncollectable': 0}], 'thresholds': ((0, 0, 10), (700, 10, 10))} | {'cum_time': 25984.11, 'time': [{'avg_time': 3055229, 'time': 8209.4, 'pct': 0.316}, {'avg_time': 88704753, 'time': 11354.21, 'pct': 0.437}, {'avg_time': 1605125679, 'time': 6420.5, 'pct': 0.247}], 'count': [{'collections': 2708, 'collected': 3037357, 'uncollectable': 0}, {'collections': 129, 'collected': 8961948, 'uncollectable': 0}, {'collections': 4, 'collected': 5582190, 'uncollectable': 0}], 'thresholds': ((1264, 9, 25), (12000, 20, 25))} |
| testing post_install from sale to stock_barcode_mrp - 70 minutes | {'cum_time': 158560.75, 'time': [{'avg_time': 134031, 'time': 20092.38, 'pct': 0.127}, {'avg_time': 1182518, 'time': 16115.36, 'pct': 0.102}, {'avg_time': 352602335, 'time': 122353.01, 'pct': 0.772}], 'count': [{'collections': 149990, 'collected': 6362613, 'uncollectable': 0}, {'collections': 13635, 'collected': 2419403, 'uncollectable': 0}, {'collections': 347, 'collected': 28025735, 'uncollectable': 0}], 'thresholds': ((0, 5, 26), (700, 10, 10))} | {'cum_time': 55009.59, 'time': [{'avg_time': 3859096, 'time': 22533.26, 'pct': 0.41}, {'avg_time': 75868085, 'time': 21091.33, 'pct': 0.383}, {'avg_time': 1138499935, 'time': 11385.0, 'pct': 0.207}], 'count': [{'collections': 5860, 'collected': 9285019, 'uncollectable': 0}, {'collections': 279, 'collected': 16932807, 'uncollectable': 0}, {'collections': 10, 'collected': 8608501, 'uncollectable': 0}], 'thresholds': ((0, 11, 19), (12000, 20, 25))} |

We can see that most of the time, we save ~65% of GC time. Which improves the overall performance by a little over 1% on all workloads and 5% in the at install tests.
If we look at the efficiency of calling the GC in the last test: collection 0 removes 1500 objects per call instead of 42, collection 1 removes 60k instead of 170 objects and collection 2 removes 860k instead of 80k objects.
We still spend around the same in collections 0 and 1. We prioritize the first collections and avoid doing (costly) full GC.

Disabling the GC when loading the registry already contains some benchmarks for thresholds: #213465

task-4856492
Merge after #213465

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
