### PR TITLE
[PERF] core: gc.freeze()

### DIFF
--- a/odoo/tools/gc.py
+++ b/odoo/tools/gc.py
@@ -39,14 +39,14 @@ def _timing_gc_callback(event, info):
     gen = info['generation']
     if event == 'start':
         _gc_start = _gc_time()
-        if gen == 2 and _logger.isEnabledFor(logging.DEBUG):
-            _logger.debug("info %s, starting collection of gen2", gc_info())
+        if gen == 2:
+            _logger.info("info %s, starting collection of gen2", gc_info())
     else:
         timing = _gc_time() - _gc_start
         _gc_timings[gen] += timing
         _gc_start = 0
         if gen > 0:
-            _logger.debug("collected %s in %.2fms", info, _to_ms(timing))
+            _logger.info("collected %s in %.2fms", info, _to_ms(timing))
 
 
 def gc_set_timing(*, enable: bool):
@@ -84,6 +84,7 @@ def gc_info():
         'time': times if _timing_gc_callback in gc.callbacks else (),
         'count': stats,
         'thresholds': (gc.get_count(), gc.get_threshold()),
+        'frozen count': (gc.get_freeze_count(), len(gc.get_objects())),
     }
 
 

--- a/odoo/tools/gc.py
+++ b/odoo/tools/gc.py
@@ -87,6 +87,15 @@ def gc_info():
     }
 
 
+def gc_freeze():
+    """Freeze all allocated objects now.
+
+    This allows the GC to skip checking them when performing full collections.
+    """
+    gc.freeze()
+    _logger.debug("frozen %d objects", gc.get_freeze_count())
+
+
 @contextlib.contextmanager
 def disabling_gc():
     """Disable gc in the context manager."""


### PR DESCRIPTION
Performance of `gc.collect()` (collection 2) is about 1ms for every 2k objects on my machine. Once Odoo is loaded, we have thousands of objects that will stay in memory during the whole execution of the program. With just base module, we have 150k objects and with 300 modules, we have 350k objects.
Therefore, GC takes 100-200ms when doing a collection. This pauses the interpreter during that time and can happen in the middle of a request. By tweaking the thresholds, we reduce the number of collections, but they still happen.

If we `gc.freeze()` these objects, collecting objects will take a few milliseconds.

I did not find much difference in memory usage after forking. I think this is due to reference counting.

task-4856492



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
