### PR TITLE
[FIX] account_edi_ubl_cii: party identification conflict

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_bis3.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_bis3.py
@@ -124,13 +124,11 @@ class AccountEdiXmlUBLBIS3(models.AbstractModel):
 
     def _get_partner_party_identification_vals_list(self, partner):
         # EXTENDS account.edi.xml.ubl_21
-        vals = super()._get_partner_party_identification_vals_list(partner)
-
         if partner.country_code == 'NL':
-            vals.append({
+            return [{
                 'id': partner.peppol_endpoint,
-            })
-        return vals
+            }]
+        return super()._get_partner_party_identification_vals_list(partner)
 
     def _get_delivery_vals_list(self, invoice):
         # EXTENDS account.edi.xml.ubl_21

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/nlcius_out_invoice.xml
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/nlcius_out_invoice.xml
@@ -22,9 +22,6 @@
     <cac:Party>
       <cbc:EndpointID schemeID="0106">77777677</cbc:EndpointID>
       <cac:PartyIdentification>
-        <cbc:ID>ref_partner_1</cbc:ID>
-      </cac:PartyIdentification>
-      <cac:PartyIdentification>
         <cbc:ID>77777677</cbc:ID>
       </cac:PartyIdentification>
       <cac:PartyName>
@@ -58,9 +55,6 @@
   <cac:AccountingCustomerParty>
     <cac:Party>
       <cbc:EndpointID schemeID="9944">NL41452B11</cbc:EndpointID>
-      <cac:PartyIdentification>
-        <cbc:ID>ref_partner_2</cbc:ID>
-      </cac:PartyIdentification>
       <cac:PartyIdentification>
         <cbc:ID>NL41452B11</cbc:ID>
       </cac:PartyIdentification>

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/nlcius_out_refund.xml
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/nlcius_out_refund.xml
@@ -26,9 +26,6 @@
     <cac:Party>
       <cbc:EndpointID schemeID="0106">77777677</cbc:EndpointID>
       <cac:PartyIdentification>
-        <cbc:ID>ref_partner_1</cbc:ID>
-      </cac:PartyIdentification>
-      <cac:PartyIdentification>
         <cbc:ID>77777677</cbc:ID>
       </cac:PartyIdentification>
       <cac:PartyName>
@@ -62,9 +59,6 @@
   <cac:AccountingCustomerParty>
     <cac:Party>
       <cbc:EndpointID schemeID="9944">NL41452B11</cbc:EndpointID>
-      <cac:PartyIdentification>
-        <cbc:ID>ref_partner_2</cbc:ID>
-      </cac:PartyIdentification>
       <cac:PartyIdentification>
         <cbc:ID>NL41452B11</cbc:ID>
       </cac:PartyIdentification>

--- a/addons/l10n_rs_edi/models/account_edi_xml_ubl_21_rs.py
+++ b/addons/l10n_rs_edi/models/account_edi_xml_ubl_21_rs.py
@@ -73,9 +73,9 @@ class AccountEdiXmlUBL21RS(models.AbstractModel):
         return vals_list
 
     def _get_partner_party_identification_vals_list(self, partner):
-        vals_list = super()._get_partner_party_identification_vals_list(partner)
+        # EXTENDS account.edi.xml.ubl_21
         if partner.country_code == 'RS' and partner.l10n_rs_edi_public_funds:
-            vals_list.append({
+            return [{
                 'id': f'JBKJS: {partner.l10n_rs_edi_public_funds}',
-            })
-        return vals_list
+            }]
+        return super()._get_partner_party_identification_vals_list(partner)

--- a/addons/l10n_tr_nilvera_einvoice/models/account_edi_xml_ubl_tr.py
+++ b/addons/l10n_tr_nilvera_einvoice/models/account_edi_xml_ubl_tr.py
@@ -55,17 +55,18 @@ class AccountEdiXmlUblTr(models.AbstractModel):
 
     def _get_partner_party_identification_vals_list(self, partner):
         # EXTENDS account.edi.xml.ubl_21
-        vals = super()._get_partner_party_identification_vals_list(partner)
         # Nilvera will reject any <ID> without a <schemeID>, so remove all items not
         # having the following structure : {'id': '...', 'id_attrs': {'schemeID': '...'}}
-        vals = [v for v in vals if v.get('id') and v.get('id_attrs', {}).get('schemeID')]
-        vals.append({
-            'id_attrs': {
-                'schemeID': 'VKN' if partner.is_company else 'TCKN',
-            },
-            'id': partner.vat,
-        })
-        return vals
+        if partner.country_code == 'TR':
+            return [{
+                'id_attrs': {
+                    'schemeID': 'VKN' if partner.is_company else 'TCKN',
+                },
+                'id': partner.vat,
+            }]
+        else:
+            vals = super()._get_partner_party_identification_vals_list(partner)
+            return [v for v in vals if v.get('id') and v.get('id_attrs', {}).get('schemeID')]
 
     def _get_partner_address_vals(self, partner):
         # EXTENDS account.edi.xml.ubl_21


### PR DESCRIPTION
odoo/odoo#206655 added the partner ref in the party identification nodes, but most rule sets don't accept multiple ids for a single partner party identification. Commit 4e22e6b already fixed the issue for malaysian edi.

so instead of calling super and extending, we do full overriding with no delegation for `_get_partner_party_identification_vals_list`.

enterprise: https://github.com/odoo/enterprise/pull/87298

no-task