### PR TITLE
[IMP] base: make some tools lazy-loaded to speedup initialization

### DIFF
--- a/addons/base_geolocalize/models/base_geocoder.py
+++ b/addons/base_geolocalize/models/base_geocoder.py
@@ -1,6 +1,4 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
-import requests
 import logging
 
 from odoo import api, fields, models, modules, tools, _
@@ -86,6 +84,7 @@ class BaseGeocoder(models.AbstractModel):
         if not addr:
             _logger.info('invalid address given')
             return None
+        import requests  # noqa: PLC0415
         url = 'https://nominatim.openstreetmap.org/search'
         try:
             headers = {'User-Agent': 'Odoo (http://www.odoo.com/contactus)'}
@@ -113,6 +112,7 @@ class BaseGeocoder(models.AbstractModel):
             return None
         if tools.config['test_enable'] or modules.module.current_test:
             raise UserError(_("OpenStreetMap calls disabled in testing environment."))
+        import requests  # noqa: PLC0415
         try:
             headers = {"User-Agent": "Odoo (http://www.odoo.com/contactus)"}
             response = requests.get(
@@ -148,6 +148,7 @@ class BaseGeocoder(models.AbstractModel):
         params = {'sensor': 'false', 'address': addr, 'key': apikey}
         if kw.get('force_country'):
             params['components'] = 'country:%s' % kw['force_country']
+        import requests  # noqa: PLC0415
         try:
             result = requests.get(url, params).json()
         except Exception as e:

--- a/addons/base_import/models/base_import.py
+++ b/addons/base_import/models/base_import.py
@@ -19,7 +19,6 @@ from collections.abc import Sequence
 
 import chardet
 import psycopg2
-import requests
 from PIL import Image
 
 from odoo import api, fields, models
@@ -28,7 +27,6 @@ from odoo.tools import (
     DEFAULT_SERVER_DATE_FORMAT,
     DEFAULT_SERVER_DATETIME_FORMAT,
     config,
-    parse_version,
 )
 from odoo.tools.mimetypes import guess_mimetype
 from odoo.tools.translate import _
@@ -1271,6 +1269,7 @@ class Base_ImportImport(models.TransientModel):
             elif field['type'] == 'binary' and field.get('attachment') and any(f in name for f in IMAGE_FIELDS) and name in import_fields:
                 index = import_fields.index(name)
 
+                import requests  # noqa: PLC0415
                 with requests.Session() as session:
                     session.stream = True
 

--- a/addons/base_import_module/models/ir_module.py
+++ b/addons/base_import_module/models/ir_module.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import ast
 import base64
 import json
@@ -6,7 +5,6 @@ import logging
 import lxml
 import os
 import pathlib
-import requests
 import sys
 import zipfile
 from collections import defaultdict
@@ -391,6 +389,7 @@ class IrModuleModule(models.Model):
                 'offset': offset,
             }
         }
+        import requests  # noqa: PLC0415
         try:
             resp = self._call_apps(json.dumps(payload))
             resp.raise_for_status()
@@ -420,6 +419,7 @@ class IrModuleModule(models.Model):
     @ormcache('payload')
     def _call_apps(self, payload):
         headers = {'Content-type': 'application/json', 'Accept': 'text/plain'}
+        import requests  # noqa: PLC0415
         return requests.post(
                 f"{APPS_URL}/loempia/listdatamodules",
                 data=payload,
@@ -430,6 +430,7 @@ class IrModuleModule(models.Model):
     @api.model
     @ormcache()
     def _get_industry_categories_from_apps(self):
+        import requests  # noqa: PLC0415
         try:
             resp = requests.post(
                 f"{APPS_URL}/loempia/listindustrycategory",
@@ -447,6 +448,7 @@ class IrModuleModule(models.Model):
         if not self.env.is_admin():
             raise AccessDenied()
         module_name = self.env.context.get('module_name')
+        import requests  # noqa: PLC0415
         try:
             resp = requests.get(
                 f"{APPS_URL}/loempia/download/data_app/{module_name}/{major_version}",

--- a/addons/base_vat/models/res_partner.py
+++ b/addons/base_vat/models/res_partner.py
@@ -9,7 +9,7 @@ from stdnum.exceptions import InvalidComponent, InvalidChecksum, InvalidFormat
 from stdnum.util import clean
 
 from odoo import api, models, fields
-from odoo.tools import _, zeep, LazyTranslate
+from odoo.tools import _, LazyTranslate
 from odoo.exceptions import ValidationError
 from odoo.addons.base.models.res_partner import EU_EXTRA_VAT_CODES
 
@@ -183,6 +183,7 @@ class ResPartner(models.Model):
             if partner.parent_id and partner.parent_id.vat == partner.vat:
                 partner.vies_valid = partner.parent_id.vies_valid
                 continue
+            from odoo.tools import zeep  # noqa: PLC0415
             try:
                 vies_valid = check_vies(partner.vat, timeout=10)
                 partner.vies_valid = vies_valid['valid']

--- a/odoo/addons/base/models/ir_actions.py
+++ b/odoo/addons/base/models/ir_actions.py
@@ -9,7 +9,6 @@ from collections import defaultdict
 from functools import reduce
 from operator import getitem
 
-import requests
 from pytz import timezone
 
 from odoo import api, fields, models, tools
@@ -951,6 +950,7 @@ class IrActionsServer(models.Model):
         json_values = json.dumps(vals, sort_keys=True, default=str)
         _logger.info("Webhook call to %s", url)
         _logger.debug("POST JSON data for webhook call: %s", json_values)
+        import requests  # noqa: PLC0415
         try:
             # 'send and forget' strategy, and avoid locking the user if the webhook
             # is slow or non-functional (we still allow for a 1s timeout so that

--- a/odoo/addons/base/models/res_partner.py
+++ b/odoo/addons/base/models/res_partner.py
@@ -1,15 +1,11 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 from __future__ import annotations
 
 import base64
 import collections
 import datetime
-import hashlib
 import pytz
-import re
 
-import requests
 from collections import defaultdict
 from random import randint
 from werkzeug import urls

--- a/odoo/tools/xml_utils.py
+++ b/odoo/tools/xml_utils.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Utilities for generating, parsing and checking XML/XSD files on top of the lxml.etree module."""
 
 import base64
@@ -8,7 +7,6 @@ import re
 import zipfile
 from io import BytesIO
 
-import requests
 from lxml import etree
 
 from odoo.exceptions import UserError
@@ -232,6 +230,7 @@ def load_xsd_files_from_url(env, url, file_name=None, force_reload=False,
     :rtype: odoo.api.ir.attachment | bool
     :return: every XSD attachment created/fetched or False if an error occurred (see warning logs)
     """
+    import requests  # noqa: PLC0415
     try:
         _logger.info("Fetching file/archive from given URL: %s", url)
         response = requests.get(url, timeout=request_max_timeout)


### PR DESCRIPTION
Lazy import of some modules to speedup startup of base module.

- requests: 73ms (including 36ms for urllib3)
- zeep: 20ms + import of requests (or httpx)
- checking binary for wkhtmltopdf: 28ms (because it starts sub-processes)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
