### PR TITLE
[FIX] mail: Show main attachment when no attachments

### DIFF
--- a/addons/account/static/tests/account_move_form.test.js
+++ b/addons/account/static/tests/account_move_form.test.js
@@ -2,11 +2,14 @@ import {
     click,
     insertText,
     openFormView,
+    patchUiSize,
+    SIZES,
     start,
     startServer,
     triggerHotkey
 } from "@mail/../tests/mail_test_helpers";
 import { expect, test } from "@odoo/hoot";
+import { waitFor } from "@odoo/hoot-dom";
 import { asyncStep, contains, onRpc, waitForSteps } from "@web/../tests/web_test_helpers";
 import { defineAccountModels } from "./account_test_helpers";
 
@@ -61,4 +64,43 @@ test("Confirmation dialog on delete contains a warning", async () => {
     expect(".o_dialog div.text-danger").toHaveText("This operation will create a gap in the sequence.", {
         message: "warning message has been added in the dialog"
     });
+});
+
+test("Display main_attachment if no attachments", async () => {
+    const pyEnv = await startServer();
+    const pdfId = pyEnv["ir.attachment"].create({
+        mimetype: "application/pdf",
+    });
+    const accountMove = pyEnv["account.move"].create({
+        name: "Rick Astley",
+        message_attachment_count: 0,
+    });
+    pyEnv["mail.message"].create([
+        {
+            body: "Never Gonna Give You Up, Never Gonna Let You Down, Never Gonna Run Around and Desert You.",
+            res_id: accountMove,
+            model: "account.move",
+            attachment_ids: [pdfId],
+        },
+    ]);
+    pyEnv["account.move"].write([accountMove], { message_main_attachment_id: pdfId });
+
+    patchUiSize({ size: SIZES.XXL });
+    await start();
+    await openFormView("account.move", accountMove, {
+        arch: `<form js_class='account_move_form'>
+            <sheet>
+                <notebook>
+                    <page id="invoice_tab" name="invoice_tab" string="Invoice Lines">
+                        <field name="name"/>
+                    </page>
+                    <page id="aml_tab" string="Journal Items" name="aml_tab"></page>
+                </notebook>
+            </sheet>
+            <div class="o_attachment_preview"/>
+            <chatter/>
+        </form>`,
+    });
+    await waitFor(".o_attachment_preview");
+    expect(".o-mail-Attachment > iframe").toBeVisible(); // There should be iframe for PDF viewer
 });

--- a/addons/mail/static/src/chatter/web/form_renderer.js
+++ b/addons/mail/static/src/chatter/web/form_renderer.js
@@ -44,7 +44,7 @@ patch(FormRenderer.prototype, {
             id: this.props.record.resId,
             model: this.props.record.resModel,
         });
-        return this.messagingState.thread.attachmentsInWebClientView.length > 0;
+        return this.messagingState.thread.hasFile;
     },
     mailLayout(hasAttachmentContainer) {
         const xxl = this.uiService.size >= SIZES.XXL;

--- a/addons/mail/static/src/core/common/attachment_view.xml
+++ b/addons/mail/static/src/core/common/attachment_view.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
     <t t-name="mail.AttachmentView">
-        <div t-if="state.thread.attachmentsInWebClientView.length > 0" class="o-mail-Attachment">
+        <div t-if="state.thread.hasFile" class="o-mail-Attachment">
             <div class="o_attachment_control popout d-print-none cursor-pointer"
                  t-on-click="onClickPopout"
                  data-tooltip="Open preview in a separate window."

--- a/addons/mail/static/src/core/common/thread_model.js
+++ b/addons/mail/static/src/core/common/thread_model.js
@@ -881,6 +881,13 @@ export class Thread extends Record {
     }
 
     /**
+     * @returns {boolean}
+     */
+    get hasFile() {
+        return this.attachmentsInWebClientView.length > 0 || this.message_main_attachment_id;
+    }
+
+    /**
      * Following a load more or load around, listing of messages contains persistent messages.
      * Transient messages are missing, so this function puts known transient messages at the
      * right place in message list of thread.


### PR DESCRIPTION
When opening a form view if there is a main attachment but there is no attachment, the main attachment would not be displayed. This is happenning because we are setting attachment_ids and not attachment directly which are not added into attachmentsInWebClientView.

The solution here was to display the files if we either have some attachments or the main attachment with a small refactoring to have the condition to display those file in one place.

task-4784283

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
