### PR TITLE
[FIX] stock_account: raise an error when editing a move without adding lots

### DIFF
--- a/addons/stock_account/i18n/stock_account.pot
+++ b/addons/stock_account/i18n/stock_account.pot
@@ -4,10 +4,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 18.0\n"
+"Project-Id-Version: Odoo Server 18.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-05-07 20:36+0000\n"
-"PO-Revision-Date: 2025-05-07 20:36+0000\n"
+"POT-Creation-Date: 2025-08-01 07:25+0000\n"
+"PO-Revision-Date: 2025-08-01 07:25+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -925,6 +925,14 @@ msgstr ""
 msgid ""
 "This product is valuated by lot/serial number. Changing the cost will update"
 " the cost of every lot/serial number in stock."
+msgstr ""
+
+#. module: stock_account
+#. odoo-python
+#: code:addons/stock_account/models/stock_move_line.py:0
+msgid ""
+"This product is valuated by lot: an explicit Lot/Serial number is required "
+"when adding quantity"
 msgstr ""
 
 #. module: stock_account

--- a/addons/stock_account/models/stock_move_line.py
+++ b/addons/stock_account/models/stock_move_line.py
@@ -77,6 +77,8 @@ class StockMoveLine(models.Model):
         self.ensure_one()
         if self.state != 'done':
             return
+        if self.product_id.lot_valuated and not self.lot_id:
+            raise UserError(_('This product is valuated by lot: an explicit Lot/Serial number is required when adding quantity'))
         product_uom = self.product_id.uom_id
         added_uom_qty = self.product_uom_id._compute_quantity(added_qty, product_uom, rounding_method='HALF-UP')
         if float_is_zero(added_uom_qty, precision_rounding=product_uom.rounding):

--- a/addons/stock_account/tests/test_lot_valuation.py
+++ b/addons/stock_account/tests/test_lot_valuation.py
@@ -798,3 +798,16 @@ class TestLotValuation(TestStockValuationCommon):
         self.assertRecordValues(delivery.move_ids, [
             {'quantity': 5.0, 'state': 'done', 'lot_ids': self.lot1.ids}
         ])
+
+    def test_adjustment_post_validation(self):
+        """
+        On a picking order test the behavior of changing the quantity on a stock.move
+        """
+        in_move = self._make_in_move(self.product1, 2, 2, create_picking=True, lot_ids=[self.lot1])
+        picking = in_move.picking_id
+        picking.action_toggle_is_locked()
+        with self.assertRaises(UserError):
+            with Form(picking) as picking_form:
+                with picking_form.move_ids_without_package.edit(0) as mv:
+                    mv.quantity = 5.0
+        self.assertEqual(in_move.quantity, 2)


### PR DESCRIPTION
Steps to reproduce:
1) Create a product tracked by lot and with valuation by lot. 
2) Create a Purchase Order with this product and Confirm it.
3) Go to Receipt
4) Add a Lot number and validate
3) Unlock the receipt and modify the `quantity`.

Current behavior
- Get a traceback.

Expected behavior:
- If there is only one lot:
  - update the lot quantity
- Else :
  - raise an error

The fix should be applied before the `web_save` call to prevent the creation of a new `stock.move.line`. Therefore it's done on the `onchange` call.

opw-4841162

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
