### PR TITLE
[IMP] point_of_sale: prevent double weighing

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/scale_screen/scale_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/scale_screen/scale_screen.js
@@ -20,7 +20,7 @@ export class ScaleScreen extends Component {
     }
 
     confirm() {
-        this.props.getPayload(this.scale.netWeight);
+        this.props.getPayload(this.scale.confirmWeight());
         this.props.close();
     }
 

--- a/addons/point_of_sale/static/src/app/screens/scale_screen/scale_screen.xml
+++ b/addons/point_of_sale/static/src/app/screens/scale_screen/scale_screen.xml
@@ -44,7 +44,7 @@
                     <i t-if="scale.loading and !scale.tareRequested" class="fa fa-spinner fa-spin"/>
                     <t t-else="">Get Weight</t>
                 </button>
-                <button class="buy-product btn btn-lg btn-primary d-flex align-items-center justify-content-center mx-2 mb-2 cursor-pointer w-100" t-on-click="confirm">
+                <button class="buy-product btn btn-lg btn-primary d-flex align-items-center justify-content-center mx-2 mb-2 cursor-pointer w-100" t-on-click="confirm" t-att-disabled="!scale.isWeightValid">
                     Order
                     <i class="fa fa-angle-double-right ms-2"/>
                 </button>


### PR DESCRIPTION
In order to satisfy certification requirements from the LNE, we implement the following:
- A product is weighed at e.g. 200g and added to the order
- Another product is weighed. The weight must change from 200g before the user is allowed to add the item.
- This should also happen even if another non-weighed product is added in-between.

task-4859589

Enterprise PR: https://github.com/odoo/enterprise/pull/87296

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
