### PR TITLE
[FIX] web_editor: avoid traceback when video thumbnail is missing

### DIFF
--- a/addons/web_editor/static/src/components/media_dialog/video_selector.js
+++ b/addons/web_editor/static/src/components/media_dialog/video_selector.js
@@ -224,12 +224,16 @@ export class VideoSelector extends Component {
      */
     async prepareVimeoPreviews() {
         return Promise.all(this.props.vimeoPreviewIds.map(async (videoId) => {
-            const { thumbnail_url: thumbnailSrc } = await this.http.get(`https://vimeo.com/api/oembed.json?url=http%3A//vimeo.com/${encodeURIComponent(videoId)}`);
-            this.state.vimeoPreviews.push({
-                id: videoId,
-                thumbnailSrc,
-                src: `https://player.vimeo.com/video/${encodeURIComponent(videoId)}`
-            });
+            try {
+                const { thumbnail_url: thumbnailSrc } = await this.http.get(`https://vimeo.com/api/oembed.json?url=http%3A//vimeo.com/${encodeURIComponent(videoId)}`);
+                this.state.vimeoPreviews.push({
+                    id: videoId,
+                    thumbnailSrc,
+                    src: `https://player.vimeo.com/video/${encodeURIComponent(videoId)}`
+                });
+            } catch (error) {
+                console.warn(`Error loading thumbnail for video id ${videoId}`, error);
+            }
         }));
     }
 }


### PR DESCRIPTION
Problem:
When loading a thumbnail for a video, if the thumbnail does not exist, a traceback occurs. This breaks the user experience when attempting to add or preview background videos.

Solution:
Add a check for the existence of the thumbnail. If it does not exist, safely skip rendering the video and log a warning instead of raising an exception.

Steps to reproduce:
1. Go to Website.
2. Add a text block.
3. Add a background video.
4. When the video selector opens and no thumbnail is available, a traceback appears.

opw-4859192

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
