### PR TITLE
[FIX] html_editor: cropper test case getting failed

### DIFF
--- a/addons/html_editor/static/tests/media.test.js
+++ b/addons/html_editor/static/tests/media.test.js
@@ -140,6 +140,6 @@ test("cropper should not open for external image", async () => {
     await animationFrame();
 
     await click('.btn[name="image_crop"]');
-    await waitFor(".o_notification_manager .o_notification");
+    await waitFor(".o_notification_manager .o_notification", { timeout: 1000 });
     expect("img.o_we_cropper_img").toHaveCount(0);
 });


### PR DESCRIPTION
After merging this commit [1], the test sometimes non-deterministically fails on runbot. This PR aims to fix the test.

[1]: https://github.com/odoo/odoo/commit/1a2c3c00869fd9702bb9d15e3d38d9c02a3349f5



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
