### PR TITLE
[FIX] mail: show display_name for contact without name and email

### DIFF
--- a/addons/crm/tests/test_crm_lead_notification.py
+++ b/addons/crm/tests/test_crm_lead_notification.py
@@ -123,6 +123,7 @@ class NewLeadNotification(TestCrmCommon):
                         'email': 'philip.j.fry@test.example.com',
                         'lang': self.contact_1.lang,
                         'reason': 'Customer',
+                        'display_name': 'Planet Express, Philip J Fry',
                         'create_values': {}
                   }],
                 [{
@@ -130,6 +131,7 @@ class NewLeadNotification(TestCrmCommon):
                   'name': 'Test Partner',
                   'lang': partner_no_email.lang,
                   'reason': 'Customer',
+                  'display_name': 'Test Partner',
                   'create_values': {}
                   }],
                 [
@@ -144,6 +146,7 @@ class NewLeadNotification(TestCrmCommon):
                       'partner_id': partner_no_email.id,
                       'name': 'Test Partner',
                       'lang': partner_no_email.lang,
+                      'display_name': 'Test Partner',
                       'reason': 'Customer',
                       'create_values':{}
                     }

--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -1887,9 +1887,22 @@ class MailThread(models.AbstractModel):
             return result
         if partner and partner.email:  # complete profile: id, name <email>
             email_normalized = ','.join(email_normalize_all(partner.email))
-            recipient_data.update({'partner_id': partner.id, 'name': partner.name or '', 'email': email_normalized})
+            recipient_data.update(
+                {
+                    "partner_id": partner.id,
+                    "name": partner.name or "",
+                    "email": email_normalized,
+                    "display_name": partner.display_name,
+                }
+            )
         elif partner:  # incomplete profile: id, name
-            recipient_data.update({'partner_id': partner.id, 'name': partner.name})
+            recipient_data.update(
+                {
+                    "partner_id": partner.id,
+                    "name": partner.name,
+                    "display_name": partner.display_name,
+                }
+            )
         else:  # unknown partner, we are probably managing an email address
             _, parsed_email_normalized = parse_contact_from_email(email)
             partner_create_values = self._get_customer_information().get(parsed_email_normalized, {})

--- a/addons/mail/static/src/core/common/follower_model.js
+++ b/addons/mail/static/src/core/common/follower_model.js
@@ -20,6 +20,10 @@ export class Follower extends Record {
     is_active;
     partner = Record.one("Persona");
 
+    get displayName() {
+        return this.partner.name || this.display_name;
+    }
+
     /** @returns {boolean} */
     get isEditable() {
         const hasWriteAccess = this.thread ? this.thread.hasWriteAccess : false;

--- a/addons/mail/static/src/core/web/base_recipients_list.js
+++ b/addons/mail/static/src/core/web/base_recipients_list.js
@@ -21,8 +21,8 @@ export class BaseRecipientsList extends Component {
     /** @returns {Markup} */
     getRecipientListToHTML() {
         const recipients = this.props.thread.recipients.slice(0, 5).map((
-            { partner }) => {
-                const text = partner.email ? partner.emailWithoutDomain : partner.name;
+            { partner, displayName }) => {
+                const text = (partner.email && partner.emailWithoutDomain) || displayName;
                 return `<span class="text-muted" title="${escape(
                     partner.email || _t("no email address")
                 )}">${escape(text)}</span>`;

--- a/addons/mail/static/src/core/web/follower_list.xml
+++ b/addons/mail/static/src/core/web/follower_list.xml
@@ -31,7 +31,7 @@
     <div class="dropdown-item o-mail-Follower d-flex justify-content-between p-0">
         <a class="o-mail-Follower-details d-flex align-items-center flex-grow-1 px-3 o-min-width-0" t-att-class="{ 'o-inactive fst-italic opacity-25': !follower.is_active }" href="#" role="menuitem" t-on-click.prevent="(ev) => this.onClickDetails(ev, follower)">
             <img class="o-mail-Follower-avatar me-2 rounded o_object_fit_cover" t-att-src="follower.partner.avatarUrl" alt=""/>
-            <span class="flex-shrink text-truncate" t-esc="follower.partner.name"/>
+            <span class="flex-shrink text-truncate" t-esc="follower.displayName"/>
         </a>
         <t t-if="follower.isEditable">
             <button class="o-mail-Follower-action btn btn-icon rounded-0" title="Edit subscription" aria-label="Edit subscription" t-on-click="(ev) => this.onClickEdit(ev, follower)">

--- a/addons/mail/static/src/core/web/recipient_list.js
+++ b/addons/mail/static/src/core/web/recipient_list.js
@@ -27,7 +27,7 @@ export class RecipientList extends Component {
     getRecipientText(recipient) {
         return (
             recipient.partner.email ||
-            sprintf(_t("[%(name)s] (no email address)"), { name: recipient.partner.name })
+            sprintf(_t("[%(name)s] (no email address)"), { name: recipient.displayName })
         );
     }
 }

--- a/addons/mail/static/src/core/web/suggested_recipient.js
+++ b/addons/mail/static/src/core/web/suggested_recipient.js
@@ -20,6 +20,10 @@ export class SuggestedRecipient extends Component {
         this.dialogService = useService("dialog");
     }
 
+    get name() {
+        return this.props.recipient.name || this.props.recipient.display_name;
+    }
+
     get titleText() {
         return _t("Add as recipient and follower (reason: %s)", this.props.recipient.reason);
     }

--- a/addons/mail/static/src/core/web/suggested_recipient.xml
+++ b/addons/mail/static/src/core/web/suggested_recipient.xml
@@ -5,7 +5,7 @@
             <div class="form-check">
                 <input t-attf-id="{{ props.recipient.id }}_checkbox" class="form-check-input" type="checkbox" t-att-checked="props.recipient.checked" t-on-change="onChangeCheckbox"/>
                 <label class="form-check-label" t-attf-for="{{ props.recipient.id }}_checkbox">
-                    <t t-if="props.recipient.name" t-esc="props.recipient.name"/>
+                    <t t-if="name" t-esc="name"/>
                     <t t-if="props.recipient.email and props.recipient.email !== props.recipient.name">
                         (<t t-esc="props.recipient.email"/>)
                     </t>

--- a/addons/mail/static/tests/chatter/web/follower_list_menu.test.js
+++ b/addons/mail/static/tests/chatter/web/follower_list_menu.test.js
@@ -221,12 +221,15 @@ test("Load 100 recipients at once", async () => {
     await contains(".o-mail-RecipientList span", { count: 0, text: "Load more" });
 });
 
-test("Load recipient without email", async () => {
+test("Load recipient without email and/or name", async () => {
     const pyEnv = await startServer();
-    const [partnerId_1, partnerId_2] = pyEnv["res.partner"].create([
+    const [partnerId_1, partnerId_2, partnerId_3] = pyEnv["res.partner"].create([
         { name: "Luigi" },
         { name: "Mario" },
+        // Recipient without name and email
+        { type: "invoice" },
     ]);
+    pyEnv["res.partner"].write([partnerId_3], { parent_id: partnerId_1 });
     pyEnv["mail.followers"].create([
         {
             is_active: true,
@@ -240,6 +243,12 @@ test("Load recipient without email", async () => {
             res_id: partnerId_1,
             res_model: "res.partner",
         },
+        {
+            is_active: true,
+            partner_id: partnerId_3,
+            res_id: partnerId_1,
+            res_model: "res.partner",
+        },
     ]);
     await start();
     await openFormView("res.partner", partnerId_1);
@@ -247,6 +256,9 @@ test("Load recipient without email", async () => {
     await contains("span[title='no email address']", { text: "Mario" });
     await click("button[title='Show all recipients']");
     await contains(".o-mail-RecipientList li", { text: "[Mario] (no email address)" });
+    await contains(".o-mail-RecipientList li", {
+        text: "[Luigi, Invoice Address] (no email address)",
+    });
 });
 
 test('Show "Add follower" and subtypes edition/removal buttons on all followers if user has write access', async () => {

--- a/addons/mail/static/tests/composer/composer.test.js
+++ b/addons/mail/static/tests/composer/composer.test.js
@@ -768,6 +768,27 @@ test("Show 'No recipient found.' with 0 followers.", async () => {
     await contains(".o-mail-Chatter-top", { text: "To: No recipient" });
 });
 
+test("Show display_name of recipients without name in the recipient list.", async () => {
+    const pyEnv = await startServer();
+    const [parentPartner, partner] = pyEnv["res.partner"].create([
+        { name: "Test Partner", email: "test1@odoo.com" },
+        { type: "invoice" },
+    ]);
+    pyEnv["res.partner"].write(partner, { parent_id: parentPartner });
+    pyEnv["mail.followers"].create({
+        is_active: true,
+        partner_id: partner,
+        res_id: parentPartner,
+        res_model: "res.partner",
+    });
+    await start();
+    await openFormView("res.partner", parentPartner);
+    await click("button", { text: "Send message" });
+    await contains(".o-mail-Chatter span.text-muted", {
+        text: "Test Partner, Invoice Address",
+    });
+});
+
 test("Uploading multiple files in the composer create multiple temporary attachments", async () => {
     const pyEnv = await startServer();
     const channelId = pyEnv["discuss.channel"].create({ name: "test" });

--- a/addons/mail/static/tests/composer/suggested_recipients.test.js
+++ b/addons/mail/static/tests/composer/suggested_recipients.test.js
@@ -319,3 +319,23 @@ test("suggested recipients should be added as follower when posting a message", 
     await contains(".o-mail-Message");
     await contains(".o-mail-Followers-counter", { text: "1" });
 });
+
+test("suggested recipients without name should show display_name instead", async () => {
+    const pyEnv = await startServer();
+    const [partner1, partner2] = pyEnv["res.partner"].create([
+        { name: "Test Partner" },
+        // Partner without name
+        { type: "invoice" },
+    ]);
+
+    pyEnv["res.partner"].write([partner2], { parent_id: partner1 });
+    const fakeId = pyEnv["res.fake"].create({ partner_ids: [partner2] });
+    registerArchs(archs);
+    await start();
+    await openFormView("res.fake", fakeId);
+    await click("button", { text: "Send message" });
+    await contains(".o-mail-SuggestedRecipient", {
+        text: "Test Partner, Invoice Address",
+        contains: ["input[type=checkbox]:checked"],
+    });
+});

--- a/addons/mail/static/tests/mock_server/mock_models/mail_followers.js
+++ b/addons/mail/static/tests/mock_server/mock_models/mail_followers.js
@@ -5,6 +5,14 @@ import { getKwArgs, makeKwArgs, models } from "@web/../tests/web_test_helpers";
 export class MailFollowers extends models.ServerModel {
     _name = "mail.followers";
 
+    /* override */
+    _compute_display_name() {
+        for (const record of this) {
+            const [partner] = this.env["res.partner"].browse(record.partner_id);
+            record.display_name = partner.display_name;
+        }
+    }
+
     _to_store(ids, store, fields) {
         const kwargs = getKwArgs(arguments, "ids", "store", "fields");
         fields = kwargs.fields;

--- a/addons/mail/static/tests/mock_server/mock_models/res_partner.js
+++ b/addons/mail/static/tests/mock_server/mock_models/res_partner.js
@@ -24,6 +24,18 @@ export class ResPartner extends webModels.ResPartner {
             </form>`,
     };
 
+    /* override */
+    _compute_display_name() {
+        super._compute_display_name();
+        for (const record of this) {
+            if (record.parent_id && !record.name) {
+                const [parent] = this.env["res.partner"].browse(record.parent_id);
+                const type = this._fields.type.selection.find((item) => item[0] === record.type);
+                record.display_name = `${parent.name}, ${type[1]}`;
+            }
+        }
+    }
+
     /**
      * @param {string} [search]
      * @param {number} [limit]

--- a/addons/test_mail/tests/test_mail_flow.py
+++ b/addons/test_mail/tests/test_mail_flow.py
@@ -176,6 +176,7 @@ class TestMailFlow(MailCommon, TestRecipients):
                 'email': 'portal@zboing.com',
                 'lang': None,
                 'name': 'Portal Zboing',
+                'display_name': 'Portal Zboing',
                 'reason': 'CC Email',
                 'partner_id': self.customer_portal_zboing.id,
             },

--- a/addons/website_slides/tests/test_mail.py
+++ b/addons/website_slides/tests/test_mail.py
@@ -45,6 +45,7 @@ class TestSlidesMail(SlidesCase):
         self.assertDictEqual(
             suggested_recipient,
             {
+                'display_name': user_id.partner_id.display_name,
                 'lang': None, 'email': user_id.email, 'name': user_id.name,
                 'partner_id': user_id.partner_id.id, 'reason': 'Responsible'
             }


### PR DESCRIPTION
Steps to reproduce
===============
1. Create a contact of type invoice address without name and email.
2. Go to any app with chatter.
3. Add this user to the recipient ----> Only the blue tick will be visible (recipient name will be empty)

After this commit, we will use the display_name as a fallback to show in the chatter.
