### PR TITLE
[FIX] html_editor: avoid extra base containers on list toggle

### DIFF
--- a/addons/html_editor/static/src/main/list/list_plugin.js
+++ b/addons/html_editor/static/src/main/list/list_plugin.js
@@ -9,6 +9,7 @@ import {
     isParagraphRelatedElement,
     isProtected,
     isProtecting,
+    isShrunkBlock,
     listElementSelector,
 } from "@html_editor/utils/dom_info";
 import {
@@ -622,14 +623,16 @@ export class ListPlugin extends Plugin {
         const ul = li.parentNode;
         const dir = ul.getAttribute("dir");
         const textAlign = ul.style.getPropertyValue("text-align");
-        wrapInlinesInBlocks(li, {
-            baseContainerNodeName: this.dependencies.baseContainer.getDefaultNodeName(),
-            cursors,
-        });
-        if (!li.hasChildNodes()) {
-            // Outdenting an empty LI produces an empty baseContainer
+        const children = childNodes(li);
+        if (!children.every(isBlock)) {
             const baseContainer = this.dependencies.baseContainer.createBaseContainer();
-            baseContainer.append(this.document.createElement("br"));
+            for (const child of children) {
+                cursors.update(callbacksForCursorUpdate.append(baseContainer, child));
+                baseContainer.append(child);
+            }
+            if (isShrunkBlock(baseContainer)) {
+                baseContainer.append(this.document.createElement("br"));
+            }
             li.append(baseContainer);
             cursors.remapNode(li, baseContainer);
         }

--- a/addons/html_editor/static/tests/list/toggle_cl.test.js
+++ b/addons/html_editor/static/tests/list/toggle_cl.test.js
@@ -407,6 +407,20 @@ describe("Range collapsed", () => {
                 `),
             });
         });
+
+        test("should convert list item with line breaks into a single paragraph", async () => {
+            await testEditor({
+                contentBefore: '<ul class="o_checklist"><li>ab<br>cd<br>ef[]</li></ul>',
+                stepFunction: toggleCheckList,
+                contentAfter: "<p>ab<br>cd<br>ef[]</p>",
+            });
+            await testEditor({
+                contentBefore:
+                    '<ul class="o_checklist"><li>ab<br><b>cd</b><br><i>ef[]</i></li></ul>',
+                stepFunction: toggleCheckList,
+                contentAfter: "<p>ab<br><b>cd</b><br><i>ef[]</i></p>",
+            });
+        });
     });
 });
 

--- a/addons/html_editor/static/tests/list/toggle_ol.test.js
+++ b/addons/html_editor/static/tests/list/toggle_ol.test.js
@@ -248,6 +248,19 @@ describe("Range collapsed", () => {
                 `),
             });
         });
+
+        test("should convert list item with line breaks into a single paragraph", async () => {
+            await testEditor({
+                contentBefore: "<ol><li>ab<br>cd<br>ef[]</li></ol>",
+                stepFunction: toggleOrderedList,
+                contentAfter: "<p>ab<br>cd<br>ef[]</p>",
+            });
+            await testEditor({
+                contentBefore: "<ol><li>ab<br><b>cd</b><br><i>ef[]</i></li></ol>",
+                stepFunction: toggleOrderedList,
+                contentAfter: "<p>ab<br><b>cd</b><br><i>ef[]</i></p>",
+            });
+        });
     });
 });
 

--- a/addons/html_editor/static/tests/list/toggle_ul.test.js
+++ b/addons/html_editor/static/tests/list/toggle_ul.test.js
@@ -295,6 +295,19 @@ describe("Range collapsed", () => {
                 `),
             });
         });
+
+        test("should convert list item with line breaks into a single paragraph", async () => {
+            await testEditor({
+                contentBefore: "<ul><li>ab<br>cd<br>ef[]</li></ul>",
+                stepFunction: toggleUnorderedList,
+                contentAfter: "<p>ab<br>cd<br>ef[]</p>",
+            });
+            await testEditor({
+                contentBefore: "<ul><li>ab<br><b>cd</b><br><i>ef[]</i></li></ul>",
+                stepFunction: toggleUnorderedList,
+                contentAfter: "<p>ab<br><b>cd</b><br><i>ef[]</i></p>",
+            });
+        });
     });
     describe("Transform", () => {
         test("should turn an empty ordered list into an unordered list", async () => {


### PR DESCRIPTION
**Current behavior before PR:**

- When a list contains content separated by **Shift+Enter** toggling the list would break these lines and create a separate base container for each segment separated by `<br>`.

**Desired behavior after PR is merged:**

- Only a single base container is created when toggling a list that contains **Shift+Enter** contents.

task:4854372
