### PR TITLE
[FIX] web_editor: Fix text highlight disruption on paste

### DIFF
--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
@@ -5218,6 +5218,12 @@ export class OdooEditor extends EventTarget {
             // Instantiate DOMPurify with the correct window.
             this.DOMPurify ??= DOMPurify(this.document.defaultView);
             this.DOMPurify.sanitize(fragment, { IN_PLACE: true });
+            const selection = this.document.getSelection();
+            if (selection?.anchorNode && closestElement(selection.anchorNode, ".o_text_highlight")) {
+                for (const textHighlight of fragment.querySelectorAll(".o_text_highlight")) {
+                    unwrapContents(textHighlight);
+                }
+            }
             if (fragment.hasChildNodes()) {
                 this._applyCommand('insert', fragment);
             }


### PR DESCRIPTION
Problem:
When pasting highlighted content, the text highlight gets disturbed and is not properly maintained in the target location.

Solution:
Unwrap the `o_text_highlight` wrapper from pasted content before insertion. This allows the highlight to be correctly reapplied when the DOM mutation observer processes the change.

Steps to reproduce:
- Open website editor
- Create content with text highlighting applied
- Copy a portion of the highlighted text
- Paste it within another highlighted text section
- Observe that the text formatting becomes corrupted

opw-4438171

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
