### PR TITLE
[IMP] account_payment: Default outstanding account to online payment methods

### DIFF
--- a/addons/account/models/chart_template.py
+++ b/addons/account/models/chart_template.py
@@ -839,8 +839,7 @@ class AccountChartTemplate(models.AbstractModel):
                 company[company_attr_name] = account
 
         # No fields on company
-        is_accounting_installed_next = self.env["ir.module.module"].search([('name', '=', 'accountant')]).state in ('to install', 'installed')
-        if not company.parent_id and not is_accounting_installed_next:
+        if not company.parent_id:
             accounts_data_no_fields = {
                 'account_journal_payment_debit_account_id': {
                     'name': _("Outstanding Receipts"),

--- a/addons/account/tests/common.py
+++ b/addons/account/tests/common.py
@@ -165,18 +165,8 @@ class AccountTestInvoicingCommon(ProductCommon):
 
         # ==== Payment methods ====
         bank_journal = cls.company_data['default_journal_bank']
-        in_outstanding_account = cls.env['account.account'].create({
-            'name': "Outstanding Receipts",
-            'code': 'OSTR00',
-            'reconcile': True,
-            'account_type': 'asset_current'
-        })
-        out_outstanding_account = cls.env['account.account'].create({
-            'name': "Outstanding Payments",
-            'code': 'OSTP00',
-            'reconcile': True,
-            'account_type': 'asset_current'
-        })
+        in_outstanding_account = cls.env['account.chart.template'].ref('account_journal_payment_debit_account_id')
+        out_outstanding_account = cls.env['account.chart.template'].ref('account_journal_payment_credit_account_id')
         cls.inbound_payment_method_line = bank_journal.inbound_payment_method_line_ids[0]
         cls.inbound_payment_method_line.payment_account_id = in_outstanding_account
         cls.outbound_payment_method_line = bank_journal.outbound_payment_method_line_ids[0]

--- a/addons/account/tests/test_account_account.py
+++ b/addons/account/tests/test_account_account.py
@@ -915,6 +915,7 @@ class TestAccountAccount(TestAccountMergeCommon):
 
             account_form.name = "My Test Account"
             account_form.code = 'test1'
+            account_form.account_type = 'asset_current'
             with account_form.code_mapping_ids.edit(1) as code_mapping_form:
                 code_mapping_form.code = 'test2'
             with account_form.code_mapping_ids.edit(2) as code_mapping_form:


### PR DESCRIPTION
In this PR:
- When activating an Online Payment provider that creates a payment.method.line in a journal, automatically assign an Outstanding account to the payment method.

- Uses the existing Outstanding Account resolution method from Invoicing module to ensure consistency across the system.

- Applied to all Online Payment Providers that rely on provider integration, excluding manual payment providers without external integrations.

task-4826385
