### PR TITLE
[FIX] web: only reload when closing dialog if requested

### DIFF
--- a/addons/web/static/src/views/form/form_controller.js
+++ b/addons/web/static/src/views/form/form_controller.js
@@ -346,8 +346,12 @@ export class FormController extends Component {
             isDomainSelected: this.model.root.isDomainSelected,
             resModel: this.model.root.resModel,
             domain: this.props.domain,
-            onActionExecuted: () =>
-                this.model.load({ resId: this.model.root.resId, resIds: this.model.root.resIds }),
+            onActionExecuted: ({ noReload } = {}) => {
+                if (!noReload) {
+                    const { resId, resIds } = this.model.root;
+                    return this.model.load({ resId: resId, resIds: resIds });
+                }
+            },
             shouldExecuteAction: this.shouldExecuteAction.bind(this),
         };
     }

--- a/addons/web/static/src/views/list/list_controller.js
+++ b/addons/web/static/src/views/list/list_controller.js
@@ -240,7 +240,11 @@ export class ListController extends Component {
             items: this.actionMenuItems,
             isDomainSelected: this.model.root.isDomainSelected,
             resModel: this.model.root.resModel,
-            onActionExecuted: () => this.model.load(),
+            onActionExecuted: ({ noReload } = {}) => {
+                if (!noReload) {
+                    return this.model.load();
+                }
+            },
         };
     }
 

--- a/addons/web/static/tests/views/form/form_view.test.js
+++ b/addons/web/static/tests/views/form/form_view.test.js
@@ -51,6 +51,7 @@ import {
     onRpc,
     patchWithCleanup,
     serverState,
+    stepAllNetworkCalls,
     toggleActionMenu,
     toggleMenuItem,
     toggleSearchBarMenu,
@@ -3125,6 +3126,81 @@ test(`form views in dialogs do not have class o_xxl_form_view`, async () => {
     await getService("action").doAction(1);
     expect(`.o_dialog .o_form_view`).toHaveCount(1);
     expect(`.o_dialog .o_form_view`).not.toHaveClass("o_xxl_form_view");
+});
+
+test(`form with custom cog action that has a confirmation target="new" action`, async () => {
+    PartnerType._views = {
+        form: `
+            <form>
+                Are you sure blablabla
+                <footer>
+                    <button name="my_action" type="action" string="Do it"/>
+                </footer>
+            </form>`,
+    };
+    const contextualAction = {
+        id: 80,
+        name: "Sort of confirmation dialog",
+        res_model: "partner.type",
+        context: "{}",
+        views: [[false, "form"]],
+        type: "ir.actions.act_window",
+        target: "new",
+    };
+    Partner._toolbar = {
+        action: [contextualAction],
+        print: [],
+    };
+    Partner._views = {
+        form: `<form><field name="foo"/></form>`,
+    };
+    defineActions([
+        {
+            id: 1,
+            name: "Partner",
+            res_model: "partner",
+            views: [[false, "form"]],
+            res_id: 1,
+        },
+        {
+            id: 2,
+            name: "Partner",
+            res_model: "partner",
+            views: [[false, "list"]],
+            xml_id: "my_action",
+        },
+        contextualAction,
+    ]);
+
+    stepAllNetworkCalls();
+    await mountWithCleanup(WebClient);
+    await getService("action").doAction(1);
+    expect(".o_form_view").toHaveCount(1);
+
+    await contains(`.o_cp_action_menus button:has(.fa-cog)`).click();
+    await contains(`.o-dropdown-item:contains(Sort of confirmation dialog)`).click();
+    expect(".o_dialog").toHaveCount(1);
+
+    await contains(".o_dialog footer button:contains(Do it)").click();
+    expect(".o_dialog").toHaveCount(0);
+    expect(".o_list_view").toHaveCount(1);
+
+    // should not reload the first form view when confirming with Do it
+    expect.verifySteps([
+        "/web/webclient/translations",
+        "/web/webclient/load_menus",
+        "/web/action/load",
+        "get_views",
+        "web_read",
+        "/web/action/load",
+        "get_views",
+        "onchange",
+        "web_save",
+        "/web/action/load",
+        "get_views",
+        "web_search_read",
+        "has_group",
+    ]);
 });
 
 test.tags("desktop");

--- a/addons/web/static/tests/views/list/list_view.test.js
+++ b/addons/web/static/tests/views/list/list_view.test.js
@@ -18003,3 +18003,77 @@ test(`hide pager in the list view with sample data`, async () => {
     expect(".o_content").toHaveClass("o_view_sample_data");
     expect(".o_cp_pager").not.toBeVisible();
 });
+
+test(`list with custom cog action that has a confirmation target="new" action`, async () => {
+    const contextualAction = {
+        id: 80,
+        name: "Sort of confirmation dialog",
+        res_model: "foo",
+        context: "{}",
+        views: [[false, "form"]],
+        type: "ir.actions.act_window",
+        target: "new",
+    };
+    Foo._toolbar = {
+        action: [contextualAction],
+        print: [],
+    };
+    Foo._views = {
+        list: `<list><field name="foo"/></list>`,
+        form: `
+            <form>
+                Are you sure blablabla
+                <footer>
+                    <button name="my_action" type="action" string="Do it"/>
+                </footer>
+            </form>`,
+    };
+    defineActions([
+        {
+            id: 1,
+            name: "Foo",
+            res_model: "foo",
+            views: [[false, "list"]],
+        },
+        {
+            id: 2,
+            name: "Foo",
+            res_model: "foo",
+            views: [[false, "form"]],
+            res_id: 1,
+            xml_id: "my_action",
+        },
+        contextualAction,
+    ]);
+
+    stepAllNetworkCalls();
+    await mountWithCleanup(WebClient);
+    await getService("action").doAction(1);
+    expect(".o_list_view").toHaveCount(1);
+
+    await selectAllRecords();
+    await contains(`.o_cp_action_menus button:has(.fa-cog)`).click();
+    await contains(`.o-dropdown-item:contains(Sort of confirmation dialog)`).click();
+    expect(".o_dialog").toHaveCount(1);
+
+    await contains(".o_dialog footer button:contains(Do it)").click();
+    expect(".o_dialog").toHaveCount(0);
+    expect(".o_form_view").toHaveCount(1);
+
+    // should not reload the list view when confirming with Do it
+    expect.verifySteps([
+        "/web/webclient/translations",
+        "/web/webclient/load_menus",
+        "/web/action/load",
+        "get_views",
+        "web_search_read",
+        "has_group",
+        "/web/action/load",
+        "get_views",
+        "onchange",
+        "web_save",
+        "/web/action/load",
+        "get_views",
+        "web_read",
+    ]);
+});


### PR DESCRIPTION
In form and list views, the callback given to the CogMenu to reload the view when the clicked cog menu action was done, didn't check the `noReload` flag. Typically, this flag is set to true when we're leaving to another action.

However, since [1], and especially [2], this caused an issue as the reloaded view was destroyed while it was being reloaded, so the reload promise was never resolved. As a consequence, we didn't reach the code that actually closes the dialog [3], as `await onClose?.(closeParams)` never resolved.

The faulty behavior could be observed in Employee, open Audrey Peterson, click on the Delete cog menu action, and in the dialog, click on See Timesheets. That dialog was then never closed, and trying to close it manually triggered the "Component is destroyed" error, as it always tried to execute the reload callback.

[1] https://github.com/odoo/odoo/pull/202512
[2] https://github.com/odoo/odoo/pull/202512/commits/d606be75c44fccf0b1ddf5216892f1d4b7162686
[3] https://github.com/odoo/odoo/pull/202512/commits/d606be75c44fccf0b1ddf5216892f1d4b7162686#diff-552aefb62246b1f4fe6a2607ec8f0a01773e53de2d68293266b38bc99c5cb56dR318

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
