### PR TITLE
[FIX] account: reconciliation between different partners

### DIFF
--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -1561,8 +1561,8 @@ class AccountMoveLine(models.Model):
                     aggregates=['id:recordset'],
                 )) if matching2lines is None else matching2lines
                 if (
-                    # allow changing the partner or/and the account on all the lines of a reconciliation together
-                    changing_fields - {'partner_id', 'account_id'}
+                    # allow changing the account on all the lines of a reconciliation together
+                    changing_fields - {'account_id'}
                     or not all(reconciled_line in self for reconciled_line in matching2lines[line.matching_number])
                 ):
                     lines_to_unreconcile += line
@@ -3339,7 +3339,7 @@ class AccountMoveLine(models.Model):
         """
         tax_fnames = ['balance', 'tax_line_id', 'tax_ids', 'tax_tag_ids']
         fiscal_fnames = tax_fnames + ['account_id', 'journal_id', 'amount_currency', 'currency_id', 'partner_id']
-        reconciliation_fnames = ['account_id', 'date', 'balance', 'amount_currency', 'currency_id', 'partner_id']
+        reconciliation_fnames = ['account_id', 'date', 'balance', 'amount_currency', 'currency_id']
         return {
             'tax': tax_fnames,
             'fiscal': fiscal_fnames,

--- a/addons/account/tests/test_account_move_reconcile.py
+++ b/addons/account/tests/test_account_move_reconcile.py
@@ -5785,7 +5785,6 @@ class TestAccountMoveReconcile(AccountTestInvoicingCommon):
         """ bank move doesn't have partner_id set on the account.move, but has it only on account.move.line"""
         inv = self.env['account.move'].create([{
             'move_type': 'entry',
-            'partner_id': self.partner_a.id,
             'line_ids': [
                 Command.create({
                     'debit': 0.0,


### PR DESCRIPTION
This has been allowed since saas-12.5, 6b8acd025758b042cca39508bc8994a1307d1ccd, and is still currently allowed when making a new reconciliation: you can indeed select 2 aml with different partners. But for some reason, in 1b30777ab63998d1c0b64b655e717d74b3648bcf, we added a restriction to disallow changing that afterwards. This took yet another turn with 404fbaeeeb16a65900c60f47967d6d79373c6213, that was allowing the reconciliation on draft entries, but where we explicitly break the reconciliation in case the partner would change...

All things considered, the change of partner on draft entries shouldn't break the reconcilation since it's a non-relevant point when reconciling items together.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
