### PR TITLE
[FIX] calendar: don't resort attendees

### DIFF
--- a/addons/calendar/models/calendar_event.py
+++ b/addons/calendar/models/calendar_event.py
@@ -1425,7 +1425,7 @@ class CalendarEvent(models.Model):
     def find_partner_customer(self):
         self.ensure_one()
         return next(
-            (attendee.partner_id for attendee in self.attendee_ids.sorted('create_date')
+            (attendee.partner_id for attendee in self.attendee_ids
              if attendee.partner_id != self.user_id.partner_id),
             self.env['calendar.attendee']
         )


### PR DESCRIPTION
Now that mail templates are validated when updated, this function is called when the `appointment` module is updated.
This sort fail[^1] when are attendees without a create_date.

Moreover, this sort is useless as this is the default order.

[^1]: TypeError: '<' not supported between instances of 'bool' and 'datetime.datetime'