### PR TITLE
[IMP] stock_maintenance: fix serial no action in the equipment form view

### DIFF
--- a/addons/stock_maintenance/models/maintenance.py
+++ b/addons/stock_maintenance/models/maintenance.py
@@ -29,5 +29,16 @@ class MaintenanceEquipment(models.Model):
         if not action:
             return True
         action_dict = action._get_action_dict()
-        action_dict['context'] = {'search_default_name': self.serial_no}
+        matching_serials = self.env['stock.lot'].search([('name', '=', self.serial_no)])
+        if len(matching_serials) == 1:
+            action_dict.update({
+                'views': [(False, 'form')],
+                'res_id': matching_serials.id,
+            })
+        else:
+            action_dict.update({
+                'context': {},
+                'views': [(False, 'list'), (False, 'form')],
+                'domain': [('id', 'in', matching_serials.ids)],
+            })
         return action_dict


### PR DESCRIPTION
When the 'Serial Number' button is clicked in the
`maintenance.equipment` form view, it leads to a list view of `stock.lot` that contains all superstrings of the equipment's serial number. To wit, an equipment with a serial number of '12' will match '212' and '01222', which is undesirable behaviour for values that require precision such as serial numbers.

The new behaviour is directly leading to the form view of the `stock.lot` whose name exactly matches the serial number of the given `maintenance.equipment`, which covers 99% of the use cases. For the remaining 1% where there exists more than matching one serial number, the action leads to a list view of all matching `stock.lot`s.

Task ID: [4849953](https://www.odoo.com/odoo/my-tasks/4849953)