### PR TITLE
[FIX] website_sale: enable qweb image tools for products

### DIFF
--- a/addons/website_sale/static/tests/tours/website_sale_remove_product_image.js
+++ b/addons/website_sale/static/tests/tours/website_sale_remove_product_image.js
@@ -42,6 +42,27 @@ const removeImg = [
     },
 ];
 
+const resizeImage = [
+    {
+        content: "Check that image tools are available for modification",
+        trigger: "we-customizeblock-options:has(we-title:contains('Format'))", // Check that the image tool is available to the user
+    },
+    {
+        content: "Open the Format selector",
+        trigger: "[data-name='format_select_opt']:has(we-toggler) we-toggler",
+        run: "click",
+    },
+    {
+        content: "Select the 512px webp format",
+        trigger: "we-selection-items we-button[data-select-format='512 image/webp']",
+        run: "click",
+    },
+    {
+        content: "Verify that the image was resized to 512",
+        trigger: ":iframe #o-carousel-product img.o_modified_image_to_save[data-resize-width='512']",
+    }
+];
+
 registerWebsitePreviewTour("add_and_remove_main_product_image_no_variant", {
     url: "/shop?search=Test Remove Image",
 }, () => [
@@ -71,4 +92,13 @@ registerWebsitePreviewTour("remove_main_product_image_with_variant", {
     ...clickOnEditAndWaitEditMode(),
     ...clickOnImgAndWaitForLoad,
     ...removeImg,
+]);
+
+registerWebsitePreviewTour("product_image_tool_enabled", {
+    url: "/shop?search=Test Remove Image",
+}, () => [
+    ...enterEditModeOfTestProduct(),
+    ...clickOnImgAndWaitForLoad,
+    ...resizeImage,
+    ...clickOnSave(),
 ]);

--- a/addons/website_sale/tests/test_website_sale_image.py
+++ b/addons/website_sale/tests/test_website_sale_image.py
@@ -408,3 +408,17 @@ class TestWebsiteSaleRemoveImage(HttpCase):
         self.start_tour(self.env['website'].get_client_action_url('/'), 'remove_main_product_image_with_variant', login='admin')
         self.assertFalse(self.template.image_1920)
         self.assertFalse(self.product.image_1920)
+
+    def test_website_sale_modify_main_product_image(self):
+        # Attachment needed to be able to fallback to the original for resizing
+        self.env['ir.attachment'].create({
+            'datas': self.template.image_1920,
+            'name': 'blue.jpg',
+        })
+        self.product = self.env['product.product'].create({
+            'product_tmpl_id': self.template.id,
+        })
+        data_length = len(self.product.image_1920)
+        url = self.env['website'].get_client_action_url('/')
+        self.start_tour(url, 'product_image_tool_enabled', login='admin')
+        self.assertLess(len(self.product.image_1920), data_length)


### PR DESCRIPTION
**Steps to reproduce:**
- Install eCommerce app
- Go to the shop of the website
- Activate the editor
- Click on 'New' in the top right
- Create new product with image
- Image is automatically converted to 1920x1920 (unless given in webp format)
- Try to edit the product image later on
- The ImageTools editor options are not available

**Issue:**
When using the `New` -> `Product` flow of the website editor, the user can't modify the given image, and as the image tools are disabled it can't manually do it when the product is saved.

**Fix:**
Added necessary fields to the html element of the product image when computing `'ir.qweb.field.image'` so that it can be processed like the other images created with building blocks. To achieve this, the original image file related to the current product image needs to be fetched.

opw-4561958

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
