### PR TITLE
[FIX] mail: disable chatter features according to user access rights

### DIFF
--- a/addons/mail/static/src/chatter/web/chatter.xml
+++ b/addons/mail/static/src/chatter/web/chatter.xml
@@ -14,17 +14,17 @@
                         'btn-secondary': state.composerType === 'note',
                         'active': state.composerType === 'message',
                         'my-2': !props.compactHeight
-                    }" t-att-disabled="!state.thread.hasWriteAccess and !(state.thread.hasReadAccess and state.thread.canPostOnReadonly) and props.threadId" data-hotkey="m" t-on-click="() => this.toggleComposer('message')">
+                    }" t-att-disabled="isChatterMessagingDisabled" data-hotkey="m" t-on-click="() => this.toggleComposer('message')">
                         Send message
                     </button>
                     <button class="o-mail-Chatter-logNote btn text-nowrap me-1" t-att-class="{
                         'btn-primary active': state.composerType === 'note',
                         'btn-secondary': state.composerType !== 'note',
                         'my-2': !props.compactHeight
-                    }" t-att-disabled="!state.thread.hasWriteAccess and !(state.thread.hasReadAccess and state.thread.canPostOnReadonly) and props.threadId" data-hotkey="shift+m" t-on-click="() => this.toggleComposer('note')">
+                    }" t-att-disabled="isChatterMessagingDisabled" data-hotkey="shift+m" t-on-click="() => this.toggleComposer('note')">
                         Log note
                     </button>
-                    <button t-if="props.has_activities" class="o-mail-Chatter-activity btn btn-secondary text-nowrap" t-att-class="{ 'my-2': !props.compactHeight }" data-hotkey="shift+a" t-on-click="scheduleActivity">
+                    <button t-if="props.has_activities" class="o-mail-Chatter-activity btn btn-secondary text-nowrap" t-att-class="{ 'my-2': !props.compactHeight }" t-att-disabled="isChatterMessagingDisabled" data-hotkey="shift+a" t-on-click="scheduleActivity">
                         <span>Activity</span>
                     </button>
                     <span class="o-mail-Chatter-topbarGrow flex-grow-1 pe-2"/>

--- a/addons/mail/static/src/chatter/web/chatter_patch.js
+++ b/addons/mail/static/src/chatter/web/chatter_patch.js
@@ -289,6 +289,15 @@ patch(Chatter.prototype, {
         return _t("Unfollow");
     },
 
+    get isChatterMessagingDisabled() {
+        const thread = this.state.thread;
+        return (
+            !thread.hasWriteAccess &&
+            !(thread.hasReadAccess && thread.canPostOnReadonly) &&
+            this.props.threadId
+        );
+    },
+
     changeThread(threadModel, threadId) {
         super.changeThread(...arguments);
         this.attachmentUploader.thread = this.state.thread;

--- a/addons/test_mail/models/test_mail_corner_case_models.py
+++ b/addons/test_mail/models/test_mail_corner_case_models.py
@@ -247,6 +247,18 @@ class MailTestMultiCompanyWithActivity(models.Model):
     company_id = fields.Many2one("res.company")
 
 
+class MailTestMultiCompanyWithActivityRead(models.Model):
+    """ This model can be used in multi company tests with activity
+    and supporting posting even if the user has no write access. """
+    _name = "mail.test.multi.company.with.activity.read"
+    _description = "Test Multi Company Mail With Activity"
+    _inherit = ["mail.thread", "mail.activity.mixin"]
+    _mail_post_access = 'read'
+
+    name = fields.Char()
+    company_id = fields.Many2one("res.company")
+
+
 class MailTestNothread(models.Model):
     """ Models not inheriting from mail.thread but using some cross models
     capabilities of mail. """

--- a/addons/test_mail/security/ir.model.access.csv
+++ b/addons/test_mail/security/ir.model.access.csv
@@ -59,6 +59,8 @@ access_mail_test_multi_company_read_user,mail.test.multi.company.read.user,model
 access_mail_test_multi_company_read_portal,mail.test.multi.company.read.portal,model_mail_test_multi_company_read,base.group_portal,1,0,0,0
 access_mail_test_multi_company_with_activity_user,mail.test.multi.company.with.activity.user,model_mail_test_multi_company_with_activity,base.group_user,1,1,1,1
 access_mail_test_multi_company_with_activity_portal,mail.test.multi.company.with.activity.portal,model_mail_test_multi_company_with_activity,base.group_portal,1,0,0,0
+access_mail_test_multi_company_with_activity_read_user,mail.test.multi.company.with.activity.read.user,model_mail_test_multi_company_with_activity_read,base.group_user,1,1,1,1
+access_mail_test_multi_company_with_activity_read_portal,mail.test.multi.company.with.activity.read.portal,model_mail_test_multi_company_with_activity_read,base.group_portal,1,0,0,0
 access_mail_test_nothread_user,mail.test.nothread.user,model_mail_test_nothread,base.group_user,1,1,1,1
 access_mail_test_nothread_portal,mail.test.nothread.portal,model_mail_test_nothread,base.group_portal,1,0,0,0
 access_mail_test_recipients_user,mail.test.recipients.user,model_mail_test_recipients,base.group_user,1,1,1,1

--- a/addons/test_mail/static/tests/mock_server/models/mail_test_multi_company_with_activity.js
+++ b/addons/test_mail/static/tests/mock_server/models/mail_test_multi_company_with_activity.js
@@ -1,0 +1,5 @@
+import { models } from "@web/../tests/web_test_helpers";
+
+export class MailTestMultiCompanyWithActivity extends models.ServerModel {
+    _name = "mail.test.multi.company.with.activity";
+}

--- a/addons/test_mail/static/tests/mock_server/models/mail_test_multi_company_with_activity_read.js
+++ b/addons/test_mail/static/tests/mock_server/models/mail_test_multi_company_with_activity_read.js
@@ -1,0 +1,6 @@
+import { models } from "@web/../tests/web_test_helpers";
+
+export class MailTestMultiCompanyWithActivityRead extends models.ServerModel {
+    _name = "mail.test.multi.company.with.activity.read";
+    _mail_post_access = "read";
+}

--- a/addons/test_mail/static/tests/test_mail_test_helpers.js
+++ b/addons/test_mail/static/tests/test_mail_test_helpers.js
@@ -2,6 +2,8 @@ import { contains, mailModels } from "@mail/../tests/mail_test_helpers";
 import { MailTestActivity } from "@test_mail/../tests/mock_server/models/mail_test_activity";
 import { MailTestMultiCompany } from "@test_mail/../tests/mock_server/models/mail_test_multi_company";
 import { MailTestMultiCompanyRead } from "@test_mail/../tests/mock_server/models/mail_test_multi_company_read";
+import { MailTestMultiCompanyWithActivity } from "@test_mail/../tests/mock_server/models/mail_test_multi_company_with_activity";
+import { MailTestMultiCompanyWithActivityRead } from "@test_mail/../tests/mock_server/models/mail_test_multi_company_with_activity_read";
 import { MailTestProperties } from "@test_mail/../tests/mock_server/models/mail_test_properties";
 import { MailTestSimpleMainAttachment } from "./mock_server/models/mail_test_simple_main_attachment";
 import { MailTestSimple } from "@test_mail/../tests/mock_server/models/mail_test_simple";
@@ -13,6 +15,8 @@ export const testMailModels = {
     MailTestActivity,
     MailTestMultiCompany,
     MailTestMultiCompanyRead,
+    MailTestMultiCompanyWithActivity,
+    MailTestMultiCompanyWithActivityRead,
     MailTestProperties,
     MailTestSimpleMainAttachment,
     MailTestSimple,


### PR DESCRIPTION
**Steps to reproduce:**
- Install Contact app
- Remove the Contact Creation right from a user in the Extra Rights section
- Try to create an activity on any contact using the chatter
- Access Error is raised

**Issue:**
Current `res.partner` inherits from `mail.thread`, which defines `_mail_post_access = 'write'`. This means that if a user doesn't have the access rights needed to create a contact, he is unable to create any activity related to a contact.

**Fix:**
As we can't change the mail rights on partners, we disable the chatter
buttons (log notes / activity) when the user does not have sufficient
permissions.

opw-4721335
