### PR TITLE
[FIX] purchase_stock: fix uom field not found on form error

### DIFF
--- a/addons/purchase_stock/tests/test_reordering_rule.py
+++ b/addons/purchase_stock/tests/test_reordering_rule.py
@@ -23,6 +23,7 @@ class TestReorderingRule(TransactionCase):
         cls.partner = cls.env['res.partner'].create({
             'name': 'Smith'
         })
+        cls.env.user.group_ids += cls.env.ref('uom.group_uom')
 
         # create product and set the vendor
         product_form = Form(cls.env['product.product'])


### PR DESCRIPTION
This commit makes sure that the test user has the `group_uom` group before setting `product_uom_id` field on the seller in the product form. Otherwise, an error is thrown stating that the field is not found on the view.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
