### PR TITLE
[FIX] account: reconciliation between different partners

### DIFF
--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -1593,8 +1593,8 @@ class AccountMoveLine(models.Model):
                     aggregates=['id:recordset']
                 )) if matching2lines is None and line.matching_number else matching2lines
                 if (
-                    # allow changing the partner or/and the account on all the lines of a reconciliation together
-                    changing_fields - {'partner_id', 'account_id'}
+                    # allow changing the account on all the lines of a reconciliation together
+                    changing_fields - {'account_id'}
                     or line.matching_number and not all(reconciled_line in self for reconciled_line in matching2lines[line.matching_number])
                 ):
                     line._check_reconciliation()
@@ -3367,7 +3367,7 @@ class AccountMoveLine(models.Model):
         """
         tax_fnames = ['balance', 'tax_line_id', 'tax_ids', 'tax_tag_ids']
         fiscal_fnames = tax_fnames + ['account_id', 'journal_id', 'amount_currency', 'currency_id', 'partner_id']
-        reconciliation_fnames = ['account_id', 'date', 'balance', 'amount_currency', 'currency_id', 'partner_id']
+        reconciliation_fnames = ['account_id', 'date', 'balance', 'amount_currency', 'currency_id']
         return {
             'tax': tax_fnames,
             'fiscal': fiscal_fnames,


### PR DESCRIPTION
This has been allowed since saas-12.5, https://github.com/odoo/odoo/commit/6b8acd025758b042cca39508bc8994a1307d1ccd, and is still currently allowed when making a new reconciliation: you can indeed select 2 aml with different partners. But for some reason, in https://github.com/odoo/odoo/commit/1b30777ab63998d1c0b64b655e717d74b3648bcf, we added a restriction to disallow changing that afterwards.

All things considered, the change of partner on reconciled entries should be allowed since it's a non-relevant point when reconciling items together.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
