### PR TITLE
[FIX] mail: do not show hidden chat bubbles in discuss app

### DIFF
--- a/addons/mail/static/src/core/common/chat_hub.xml
+++ b/addons/mail/static/src/core/common/chat_hub.xml
@@ -26,7 +26,7 @@
                         <ChatBubble t-if="cw.canShow" chatWindow="cw"/>
                     </t>
                     <div class="o-mail-ChatHub-extraActions"/>
-                    <t t-if="chatHub.folded.length > chatHub.maxFolded" t-call="mail.ChatHub.hiddenButton"/>
+                    <t t-if="chatHub.showConversations and chatHub.folded.length > chatHub.maxFolded" t-call="mail.ChatHub.hiddenButton"/>
                 </t>
             </div>
         </div>

--- a/addons/mail/static/tests/chat_bubble/chat_bubble.test.js
+++ b/addons/mail/static/tests/chat_bubble/chat_bubble.test.js
@@ -9,6 +9,7 @@ import {
     hover,
     insertText,
     onRpcBefore,
+    openDiscuss,
     openFormView,
     setupChatHub,
     start,
@@ -18,6 +19,7 @@ import {
 } from "../mail_test_helpers";
 
 import { rpc } from "@web/core/network/rpc";
+import { range } from "@web/core/utils/numbers";
 
 describe.current.tags("desktop");
 defineMailModels();
@@ -309,6 +311,19 @@ test("Can close all chat windows at once", async () => {
     await click(".o-dropdown-item", { text: "Close all conversations" });
     await contains(".o-mail-ChatBubble", { count: 0 });
     assertChatHub({});
+});
+
+test("Don't show chat hub in discuss app", async () => {
+    const pyEnv = await startServer();
+    const channelIds = pyEnv["discuss.channel"].create(
+        range(0, 20).map((i) => ({ name: String(i) }))
+    );
+    setupChatHub({ folded: channelIds.reverse() });
+    await start();
+    await contains(".o-mail-ChatBubble", { count: 8 }); // max reached
+    await contains(".o-mail-ChatBubble", { text: "+13" });
+    await openDiscuss();
+    await contains(".o-mail-ChatBubble", { count: 0 });
 });
 
 test("Can compact chat hub", async () => {


### PR DESCRIPTION
Before this commit, hidden chat bubble were shown in discuss app.

Steps to reproduce:
1. have at least 8 chat bubbles, so it shows "+X" chat bubble at the bottom
2. open discuss app => Discuss app has the "+X" chat bubble in the bottom-right.

This happens because chat hub is intended to be hidden when discuss app is open with only one exception: AI chat windows that are actively being used in discuss app.

ChatHub component was changed to take this new feature into account, but the "+X" chat bubble was not properly managed in its visibility.

Before / After
![Screenshot 2025-06-10 at 15 02 18](https://github.com/user-attachments/assets/5558ae2f-0638-4f60-aa2b-5ed96a61c586) ![Screenshot 2025-06-10 at 15 03 10](https://github.com/user-attachments/assets/b210f7ac-e809-4319-a5cd-b5b9f13b7574)

