### PR TITLE
[FIX] im_livechat: hide button rule ignored

### DIFF
--- a/addons/im_livechat/controllers/webclient.py
+++ b/addons/im_livechat/controllers/webclient.py
@@ -52,6 +52,6 @@ class WebClient(WebclientController):
                 )
                 store.add_global_values(livechat_rule=Store.One(matching_rule))
             store.add_global_values(
-                livechat_available=bool(matching_rule.chatbot_script_id
-                or channel.available_operator_ids)
+                livechat_available=matching_rule.action != "hide_button"
+                and bool(matching_rule.chatbot_script_id or channel.available_operator_ids)
             )

--- a/addons/website_livechat/tests/test_livechat_basic_flow.py
+++ b/addons/website_livechat/tests/test_livechat_basic_flow.py
@@ -337,6 +337,32 @@ class TestLivechatBasicFlowHttpCase(HttpCaseWithUserDemo, TestLivechatCommon):
             ),
         )
 
+    def test_livechat_not_available_with_hide_button_rule(self):
+        self.env["im_livechat.channel.rule"].create([
+            {
+                "channel_id": self.livechat_channel.id,
+                "regex_url": "/show",
+                "action": "display_button",
+            },
+            {
+                "channel_id": self.livechat_channel.id,
+                "action": "hide_button",
+                "regex_url": "/hide",
+            },
+        ])
+        result = self.make_jsonrpc_request(
+            "/mail/action",
+            {"fetch_params": [["init_livechat", self.livechat_channel.id]]},
+            headers={"Referer": "/show"},
+        )
+        self.assertEqual(result["Store"]["livechat_available"], True)
+        result = self.make_jsonrpc_request(
+            "/mail/action",
+            {"fetch_params": [["init_livechat", self.livechat_channel.id]]},
+            headers={"Referer": "/hide"},
+        )
+        self.assertEqual(result["Store"]["livechat_available"], False)
+
 
 @tests.tagged('post_install', '-at_install')
 class TestLivechatBasicFlowHttpCaseMobile(HttpCaseWithUserDemo, TestLivechatCommon):


### PR DESCRIPTION
Before this commit, the live chat button would show even
when a rule asked to hide it This commit fixes the issue.
This condition was lost when refactoring "/livechat/init"
route to use "/mail/action" in [1].

[1]: https://github.com/odoo/odoo/pull/194399