### PR TITLE
[FIX] mail: fix crash when receiving new message out of focus

### DIFF
--- a/addons/mail/static/src/core/common/store_service.js
+++ b/addons/mail/static/src/core/common/store_service.js
@@ -396,7 +396,7 @@ export class Store extends BaseStore {
                     // assumes tab not focused: parent.document from iframe triggers CORS error
                 }
                 if (isTabFocused && thread?.isDisplayed) {
-                    navigator.serviceWorker.controller.postMessage({
+                    navigator.serviceWorker.controller?.postMessage({
                         type: "notification-display-response",
                         payload: { correlationId },
                     });


### PR DESCRIPTION
In order not to send push notifications when message is already seen, the service worker asks to every tab whether he already read the message. Tab answer using `navigator.serviceWorker.controller` which can be `null`. This case was not handled leading to crashes. This PR fixes the issue.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
