### PR TITLE
[FIX] web: restrict filter operators for binary fields

### DIFF
--- a/addons/web/static/src/core/domain_selector/domain_selector_operator_editor.js
+++ b/addons/web/static/src/core/domain_selector/domain_selector_operator_editor.js
@@ -51,6 +51,7 @@ export function getDomainDisplayedOperators(fieldDef) {
             return ["in", "not in", "=", "!=", "ilike", "not ilike", "set", "not_set"];
         case "json":
             return ["=", "!=", "ilike", "not ilike", "set", "not_set"];
+        case "binary":
         case "properties":
             return ["set", "not_set"];
         case undefined:

--- a/addons/web/static/tests/core/domain_selector_tests.js
+++ b/addons/web/static/tests/core/domain_selector_tests.js
@@ -266,6 +266,35 @@ QUnit.module("Components", (hooks) => {
         );
     });
 
+    QUnit.test("creating domain for binary field", async (assert) => {
+        // Add a binary field to the server data
+        serverData.models.partner.fields.image = {
+            string: "Image",
+            type: "binary",
+            searchable: true,
+        }
+
+        await makeDomainSelector({
+            isDebugMode: true,
+        });
+
+        // Add new rule to select field
+        await addNewRule(target);
+        await openModelFieldSelectorPopover(target);
+
+        // Find and select the binary field
+        const binaryFieldItem = [...document.querySelectorAll(".o_model_field_selector_popover_item_name")]
+            .find(el => el.textContent.trim() === "Imageimage (binary)");
+        assert.ok(binaryFieldItem, "binary field should be available in field selector");
+
+        await click(binaryFieldItem);
+
+        // Check that the operator options are limited to 'set' and 'not_set'
+        const operators = getOperatorOptions(target).map(opt => opt?.textContent?.trim?.() ?? opt?.trim?.() ?? "");
+        assert.deepEqual(operators, ["is set", "is not set"], "binary field should only allow set and not_set");
+
+    });
+
     QUnit.test("building a domain with a datetime", async (assert) => {
         assert.expect(4);
         await makeDomainSelector({


### PR DESCRIPTION
The system encountered an error when users attempted to apply invalid filters on `binary fields` (e.g., `image_1024`). The error occurs when operators like 'is in' with empty string values ('') are used, as binary fields are stored As attachments only support existence checks.

**Steps to produce:-**
1. Add a filter like `[('image_1024', 'in', [])]` in the custom filter where the image exists(eg, Products) and save.
2. Error triggered.

**Error:-**

`Binary field 'Image 1024' stored in attachment: ignore image_1024 in [''] .`

**Solution:-**

- The `web` client's filter operator selection logic has been updated to restrict options for `binary` field types. Now, for binary fields, only the `is set` (`!= False`) and `is not set` (`= False`) operators will be available in the custom filter builder.

**Sentry - 6236134077**

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
