### PR TITLE
[FIX] mail: discuss sidebar actions style more readable

### DIFF
--- a/addons/mail/static/src/core/common/chat_window.xml
+++ b/addons/mail/static/src/core/common/chat_window.xml
@@ -158,7 +158,7 @@
 </t>
 
 <t t-name="mail.ThreadActionsAsDropdownContent.action">
-    <DropdownItem class="'btn d-flex align-items-baseline m-0 ' + (env.inChatWindow ? 'o-mail-ChatWindow-command rounded-0 p-2' : ('rounded-3 px-2 py-1 bg-200 smaller ' + (!action_first ? 'rounded-top-0' : !action_last ? 'rounded-bottom-0' : '')))" onSelected="() => action.onSelect()">
+    <DropdownItem class="'btn d-flex align-items-baseline m-0 ' + (env.inChatWindow ? 'o-mail-ChatWindow-command rounded-0 p-2' : ('rounded-3 px-2 py-1 bg-200 ' + (!action_first ? 'rounded-top-0' : !action_last ? 'rounded-bottom-0' : '')))" onSelected="() => action.onSelect()">
         <i t-att-class="action.icon"/>
         <span t-att-class="{ 'mx-2': env.inChatWindow, 'mx-1': !env.inChatWindow }" t-attf-class="{{ action.nameClass }}" t-out="action.name"/>
     </DropdownItem>

--- a/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.xml
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.xml
@@ -70,7 +70,7 @@
             <div class="o-mail-DiscussSidebarCategory-actions" t-att-class="{ 'd-flex flex-column align-items-start pt-1': store.discuss.isSidebarCompact, 'btn-group btn-group-sm ms-1 o-gap-0_5': !store.discuss.isSidebarCompact }">
                 <t name="action-group">
                     <t t-foreach="actions" t-as="action" t-key="action_index">
-                        <button class="btn w-100 opacity-50 opacity-100-hover" t-on-click="() => action.onSelect()" t-att-class="{ 'd-flex align-items-center px-1 py-0 gap-1 text-start smaller btn-secondary shadow-sm': store.discuss.isSidebarCompact, 'btn-light bg-transparent rounded-3 p-0 border-transparent': !store.discuss.isSidebarCompact }" t-attf-class="#{action.class}" t-att-title="store.discuss.isSidebarCompact ? '' : action.label" t-att-data-hotkey="action.hotkey">
+                        <button class="btn w-100 opacity-75 opacity-100-hover rounded-3" t-on-click="() => action.onSelect()" t-att-class="{ 'd-flex align-items-center px-1 py-0 gap-1 text-start small btn-secondary shadow-sm': store.discuss.isSidebarCompact, 'btn-light bg-transparent p-0 border-transparent': !store.discuss.isSidebarCompact }" t-attf-class="#{action.class}" t-att-title="store.discuss.isSidebarCompact ? '' : action.label" t-att-data-hotkey="action.hotkey">
                             <i role="img" class="fa-fw fa-lg" t-att-class="action.icon"/>
                             <span t-if="store.discuss.isSidebarCompact" class="text-muted" t-esc="action.label"/>
                         </button>

--- a/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_channel_actions.scss
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_channel_actions.scss
@@ -1,6 +1,6 @@
 .o-mail-DiscussSidebarChannelActions {
     .o-dropdown-item {
-        opacity: 65%;
+        opacity: 85%;
         &.focus {
             opacity: 100%;
             outline: 1px solid $gray-300;


### PR DESCRIPTION
Before this commit, discuss sidebar actions were hard to read.

This comes from small text size and low opacity when not hovered.

This commit fixes by increasing text and having opacity increased when not hovered. Discuss sidebar category actions still use an older style but they have been tweaked in a similar way.

Before / After
![Screenshot 2025-06-10 at 14 47 49](https://github.com/user-attachments/assets/51f4ebfc-e086-451a-814c-796ce639230e) ![Screenshot 2025-06-10 at 14 47 25](https://github.com/user-attachments/assets/68c88387-ca92-4320-a5d5-1f71d08aec08)
