### PR TITLE
[IMP] base: add session existence check mechanism

### DIFF
--- a/addons/rpc/tests/test_xmlrpc.py
+++ b/addons/rpc/tests/test_xmlrpc.py
@@ -67,7 +67,7 @@ class TestXMLRPC(common.HttpCase):
         now = datetime.datetime.now()
         ids = self.xmlrpc(
             'res.device.log', 'create',
-            {'session_identifier': "abc", 'first_activity': now}
+            {'session_identifier': "abc", 'first_activity': now, 'revoked': False}
         )
         [r] = self.xmlrpc(
             'res.device.log', 'read',

--- a/odoo/addons/test_http/utils.py
+++ b/odoo/addons/test_http/utils.py
@@ -71,6 +71,9 @@ class MemorySessionStore(SessionStore):
         for sid in sid_to_remove:
             self.store.pop(sid)
 
+    def get_missing_session_identifiers(self, identifiers):
+        return set(identifiers).difference(self.store)
+
     def rotate(self, session, env):
         FilesystemSessionStore.rotate(self, session, env)
 

--- a/odoo/http.py
+++ b/odoo/http.py
@@ -986,6 +986,43 @@ class FilesystemSessionStore(sessions.FilesystemSessionStore):
     def is_valid_key(self, key):
         return _base64_urlsafe_re.match(key) is not None
 
+    def get_missing_session_identifiers(self, identifiers):
+        """
+            :param identifiers: session identifiers whose file existence must be checked
+                                identifiers are a part session sid (first 42 chars)
+            :type identifiers: iterable
+            :return: the identifiers which are not present on the filesystem
+            :rtype: set
+
+            Note 1:
+            Working with identifiers 42 characters long means that
+            we don't have to work with the entire sid session,
+            while maintaining sufficient entropy to avoid collisions.
+            See details in ``generate_key``.
+
+            Note 2:
+            Scans the session store for inactive (GC'd) sessions.
+            Works even if GC is done externally (not via ``vacuum()``).
+            Performance is acceptable for an infrequent background job:
+                - listing ``directories``: 1-5s on SSD
+                - iterating sessions:
+                    - 25k on standard SSD: ~1.5 min
+                    - 2M on RAID10 SSD: ~25s
+        """
+        # There are a lot of session files.
+        # Use the param ``identifiers`` to select the necessary directories.
+        # In the worst case, we have 4096 directories (64^2).
+        identifiers = set(identifiers)
+        directories = {
+            os.path.normpath(os.path.join(self.path, identifier[:2]))
+            for identifier in identifiers
+        }
+        # Remove the identifiers for which a file is present on the filesystem.
+        for directory in directories:
+            with contextlib.suppress(OSError), os.scandir(directory) as session_files:
+                identifiers.difference_update(sf.name[:42] for sf in session_files)
+        return identifiers
+
     def delete_from_identifiers(self, identifiers):
         files_to_unlink = []
         for identifier in identifiers:


### PR DESCRIPTION
Before this commit, all the devices that had been logged in at a given time were listed in the "Devices" tab of the user's profile. This generates a lot of devices and is not practical.

This commit only displays devices whose session exists on the filesystem (which makes sense from a business point of view, but also from a security point of view).

task-4848398