### PR TITLE
[FIX] product: check company constraint on combo items

### DIFF
--- a/addons/product/models/product_combo.py
+++ b/addons/product/models/product_combo.py
@@ -76,3 +76,4 @@ class ProductCombo(models.Model):
     def _check_company_id(self):
         templates = self.env['product.template'].sudo().search([('combo_ids', 'in', self.ids)])
         templates._check_company(fnames=['combo_ids'])
+        self.combo_item_ids._check_company(fnames=['product_id'])

--- a/addons/product/tests/test_product_combo.py
+++ b/addons/product/tests/test_product_combo.py
@@ -141,3 +141,8 @@ class TestProductCombo(ProductCommon):
             type='combo',
             combo_ids=[Command.link(combo_in_company_a.id)],
         )
+        # Raise if we try to update a combo product in company A with a combo without company.
+        with self.assertRaises(UserError):
+            combo_in_company_a.write({
+                'company_id': False,
+            })


### PR DESCRIPTION
to_reproduce:
---
1. Create a combo product (no company set)
2. Create a combo choice (no company set)
3. Add a product with company restrictions
4. Multi-company error appears: "Incompatible companies on records"
5. Set company on combo choice and product template - error resolves
6. Remove company from both combo choice and combo product template
7. Save succeeds despite invalid company configuration

problem:
---
- During combo choice updates, only the modified combo items are included in vals['combo_item_ids'], while existing unchanged combo items are not added to the validation scope.
 https://github.com/odoo/odoo/blob/b13c686dbd6a887a251143efca1c18e7a4fb631a/addons/web/models/models.py#L68
- The company validation logic only checks items present in the vals,  missing the existing combo items that should also be validated for company consistency.
https://github.com/odoo/odoo/blob/b13c686dbd6a887a251143efca1c18e7a4fb631a/addons/web/models/models.py#L1092

solution:
---
- Add another check on combo items

opw-4844678

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
