### PR TITLE
[FIX] account: Do not record entries in the branch journal when creating automatic entries

### DIFF
--- a/addons/account/wizard/account_automatic_entry_wizard.py
+++ b/addons/account/wizard/account_automatic_entry_wizard.py
@@ -144,7 +144,7 @@ class AutomaticEntryWizard(models.TransientModel):
             raise UserError(_('You can only change the period/account for items that are not yet reconciled.'))
         if any(line.company_id.root_id != move_line_ids[0].company_id.root_id for line in move_line_ids):
             raise UserError(_('You cannot use this wizard on journal entries belonging to different companies.'))
-        res['company_id'] = move_line_ids[0].company_id.root_id.id
+        res['company_id'] = move_line_ids[0].company_id._accessible_branches()[:1].id
 
         allowed_actions = set(dict(self._fields['action'].selection))
         if self.env.context.get('default_action'):


### PR DESCRIPTION
**Steps to Reproduce**

1. Create a journal in the branch company.
2. Create Automatic Entries for transactions originating from the branch.
3. In the wizard, the branch's journal cannot be selected.

**Cause**:  
The company field in the wizard is always changed to the root company, making it impossible to select the branch's journal.

**Solution**:  
The goal was to enable the management of automatic entries for multiple entries coming from different branches.




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
