### PR TITLE
[IMP] html_editor: select text using drag hook

### DIFF
--- a/addons/html_editor/static/src/main/signature_plugin.js
+++ b/addons/html_editor/static/src/main/signature_plugin.js
@@ -35,6 +35,7 @@ export class SignaturePlugin extends Plugin {
         is_empty_predicates: this.isEmpty.bind(this),
         unsplittable_node_predicates: (host) =>
             host.nodeType === Node.ELEMENT_NODE && host.matches(`.${SIGNATURE_CLASS}`),
+        move_node_whitelist_selectors: `.${SIGNATURE_CLASS}`,
     };
 
     cleanSignatures({ rootClone }) {

--- a/addons/html_editor/static/src/others/embedded_components/plugins/caption_plugin/caption_plugin.js
+++ b/addons/html_editor/static/src/others/embedded_components/plugins/caption_plugin/caption_plugin.js
@@ -49,6 +49,7 @@ export class CaptionPlugin extends Plugin {
         ],
         image_name_predicates: [this.getImageName.bind(this)],
         link_compatible_selection_predicates: [this.isLinkAllowedOnSelection.bind(this)],
+        move_node_whitelist_selectors: "figure",
     };
 
     setup() {

--- a/addons/html_editor/static/tests/movenode.test.js
+++ b/addons/html_editor/static/tests/movenode.test.js
@@ -2,8 +2,9 @@ import { describe, expect, getFixture, test } from "@odoo/hoot";
 import { hover } from "@odoo/hoot-dom";
 import { animationFrame, tick } from "@odoo/hoot-mock";
 import { contains } from "@web/../tests/web_test_helpers";
-import { setupEditor } from "./_helpers/editor";
+import { base64Img, setupEditor } from "./_helpers/editor";
 import { getContent } from "./_helpers/selection";
+import { EMBEDDED_COMPONENT_PLUGINS, MAIN_PLUGINS } from "@html_editor/plugin_sets";
 
 describe.current.tags("desktop");
 
@@ -31,6 +32,30 @@ test("should show the hook when hovering the second P", async () => {
     await hover(el.querySelector("p:last-child"));
     expect(".oe-sidewidget-move").toHaveCount(1);
     expect(".oe-sidewidget-move").toHaveRect({ top: 37, left: 5 });
+});
+test("should show the hook when hovering a signature", async () => {
+    const { el } = await setupEditor(
+        `<p>ab</p><div class="o-signature-container"><h1>Hello[]</h1></div><p>cd</p>`,
+        { styleContent: styles }
+    );
+    await hover(el.querySelector(".o-signature-container"));
+    expect(".oe-sidewidget-move").toHaveCount(1);
+});
+test("should show the hook when hovering a figure element", async () => {
+    const { el } = await setupEditor(
+        `<figure>
+            <img class="img-fluid test-image" src="${base64Img}">
+            <figcaption>Hello</figcaption>
+        </figure>`,
+        {
+            config: {
+                Plugins: [...MAIN_PLUGINS, ...EMBEDDED_COMPONENT_PLUGINS],
+            },
+            styleContent: styles,
+        }
+    );
+    await hover(el.querySelector("figure"));
+    expect(".oe-sidewidget-move").toHaveCount(1);
 });
 test("should not show the hook when hovering a DIV which is not a baseContainer", async () => {
     const { el } = await setupEditor(`<p>a[]</p><div class="oe_unbreakable"><br></div><p>b</p>`, {


### PR DESCRIPTION
Description of the feature this PR addresses:

I. This PR allows users to select the current block by clicking on the drag hook.
II. Also makes move node handler available for signatures and image with captions elements.

task-4851871

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
