### PR TITLE
[FIX] website: fix border-radius of image in card snippet

### DIFF
--- a/addons/website/static/src/snippets/s_card/000.scss
+++ b/addons/website/static/src/snippets/s_card/000.scss
@@ -19,6 +19,16 @@
         &[data-shape] {
             object-fit: contain;
         }
+
+        &.rounded-start {
+            border-bottom-left-radius: var(--card-inner-border-radius) !important;
+            border-top-left-radius: var(--card-inner-border-radius) !important;
+        }
+
+        &.rounded-end {
+            border-top-right-radius: var(--card-inner-border-radius) !important;
+            border-bottom-right-radius: var(--card-inner-border-radius) !important;
+        }
     }
 
     .o_card_img_wrapper.ratio {


### PR DESCRIPTION
Specification:
- Border radius on the image in the card snippet was not being
applied correctly.
- Border radius should be consistent with the card's border radius.

After this commit:
- The image inside the card snippet will now correctly inherit the
border radius from the card.
- This change ensures that the image appears rounded in the same
way as the card itself.

task-4848288

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
