### PR TITLE
[FIX] web: Add the `link` role to KanbanRecord

### DIFF
--- a/addons/web/static/src/views/kanban/kanban_record.xml
+++ b/addons/web/static/src/views/kanban/kanban_record.xml
@@ -3,6 +3,7 @@
 
     <t t-name="web.KanbanRecord">
         <article
+            role="link"
             t-att-class="getRecordClasses()"
             t-att-data-id="props.record.id"
             t-att-tabindex="props.record.model.useSampleModel ? -1 : 0"


### PR DESCRIPTION
Accessibile links must have a `role="link"` if they are not `a` tags.

Reference:
https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/link_role

This fix adds the role to the record, so that accessibility tools can recognize it and make it clickable without a mouse.

Tool: [Vimium](https://vimium.github.io/)
<details><summary>Screenshots</summary>
<p>

Before:
![image](https://github.com/user-attachments/assets/1a23b50a-de41-482b-ad3e-d0416bf05895)

After:
![image](https://github.com/user-attachments/assets/d75f6d74-aa1f-45b2-803b-005d3e7dda2b)

</p>
</details> 

