### PR TITLE
[FIX] mail: thread Leave/Unpin action not in discuss header

### DIFF
--- a/addons/mail/static/src/core/common/thread_actions.js
+++ b/addons/mail/static/src/core/common/thread_actions.js
@@ -186,7 +186,17 @@ function transformAction(component, id, action) {
          * - In action definition: indicate whether the action is elligible as partition actions. @see useThreadActions::partition
          * - While action is being used: indicate that the action is being used as a partitioned action.
          */
-        partition: action.partition ?? true,
+        get partition() {
+            if (action._partition) {
+                return action._partition;
+            }
+            return typeof action.partition === "function"
+                ? action.partition(component)
+                : action.partition ?? true;
+        },
+        set partition(partition) {
+            action._partition = partition;
+        },
         /** Determines whether this is a popover linked to this action. */
         popover: null,
         /** Determines the order of this action (smaller first). */

--- a/addons/mail/static/src/core/public_web/thread_actions.js
+++ b/addons/mail/static/src/core/public_web/thread_actions.js
@@ -4,9 +4,7 @@ import { _t } from "@web/core/l10n/translation";
 import { useService } from "@web/core/utils/hooks";
 
 threadActionsRegistry.add("leave", {
-    condition: (component) =>
-        !(component.env.inChatWindow && !component.ui.isSmall) &&
-        (component.thread?.canLeave || component.thread?.canUnpin),
+    condition: (component) => component.thread?.canLeave || component.thread?.canUnpin,
     icon: "fa fa-fw fa-sign-out text-danger",
     iconLarge: "fa fa-fw fa-lg fa-sign-out text-danger",
     name: (component) =>
@@ -14,6 +12,7 @@ threadActionsRegistry.add("leave", {
     nameClass: "text-danger",
     open: (component) =>
         component.thread.canLeave ? component.thread.leaveChannel() : component.thread.unpin(),
+    partition: (component) => component.env.inChatWindow,
     sequence: 10,
     sequenceGroup: 40,
     setup() {

--- a/addons/mail/static/tests/chat_window/chat_window.test.js
+++ b/addons/mail/static/tests/chat_window/chat_window.test.js
@@ -186,7 +186,7 @@ test("chat window: basic rendering", async () => {
     // dropdown requires an extra delay before click (because handler is registered in useEffect)
     await contains("[title='Open Actions Menu']");
     await click("[title='Open Actions Menu']");
-    await contains(".o-mail-ChatWindow-command", { count: 15 });
+    await contains(".o-mail-ChatWindow-command", { count: 16 });
     await contains(".o-dropdown-item", { text: "Open in Discuss" });
     await contains(".o-dropdown-item", { text: "Attachments" });
     await contains(".o-dropdown-item", { text: "Pinned Messages" });
@@ -197,6 +197,7 @@ test("chat window: basic rendering", async () => {
     await contains(".o-dropdown-item", { text: "Rename Thread" });
     await contains(".o-dropdown-item", { text: "Notification Settings" });
     await contains(".o-dropdown-item", { text: "Call Settings" });
+    await contains(".o-dropdown-item", { text: "Leave Channel" });
 });
 
 test.skip("Fold state of chat window is sync among browser tabs", async () => {

--- a/addons/mail/static/tests/discuss_app/discuss.test.js
+++ b/addons/mail/static/tests/discuss_app/discuss.test.js
@@ -659,8 +659,17 @@ test("basic top bar rendering", async () => {
     await contains("button:disabled", { text: "Unstar all" });
     await contains(".o-mail-Discuss-threadName", { value: "Starred" });
     await click(".o-mail-DiscussSidebarChannel", { text: "General" });
-    await contains(".o-mail-Discuss-header button[title='Invite People']");
     await contains(".o-mail-Discuss-threadName", { value: "General" });
+    await contains(".o-mail-Discuss-header button", { count: 9 });
+    await contains(".o-mail-Discuss-header button[title='Start Video Call']");
+    await contains(".o-mail-Discuss-header button[title='Start Call']");
+    await contains(".o-mail-Discuss-header button[title='Notification Settings']");
+    await contains(".o-mail-Discuss-header button[title='Invite People']");
+    await contains(".o-mail-Discuss-header button[title='Search Messages']");
+    await contains(".o-mail-Discuss-header button[title='Threads']");
+    await contains(".o-mail-Discuss-header button[title='Attachments']");
+    await contains(".o-mail-Discuss-header button[title='Pinned Messages']");
+    await contains(".o-mail-Discuss-header button[title='Members']");
 });
 
 test("rendering of inbox message", async () => {


### PR DESCRIPTION
Before this commit, the "Unpin/Leave" thread action was shown in the discuss header.

This was added by mistake from a recent improvement to show discuss sidebar actions on conversation. In the sidebar, the "Leave/Unpin" action should be displayed, but the header we don't.

Thread actions are elligible for chat window and discuss header in "partitioned" actions. Actions are elligible for discuss sidebar in "sidebar" actions. The "Leave/Unpin" should not be displayed in discuss header, but in chat window on small screen it must be shown because there's no access to discuss sidebar.

This commit fixes the issue by adding more customisation for showing in "partition" actions. The "Leave/Unpin" is shown in partitioned action only in chat window.

Note that while this action was limited to small screen, but there's no reason to not have it in all screen size for all chat windows. This commit makes this improvement too.

Before / After
![Screenshot 2025-06-10 at 15 56 39](https://github.com/user-attachments/assets/beea963b-e856-492d-ae15-cb2d3c9f9dc5)
![Screenshot 2025-06-10 at 15 59 17](https://github.com/user-attachments/assets/30ea4b04-d4c0-4177-90bc-2a9b93b710ec)
