### PR TITLE
[FIX] account: Prevent autopost from infinitely calling itself

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -5449,6 +5449,7 @@ class AccountMove(models.Model):
                         move._post()
                 except UserError as e:
                     move.checked = False
+                    move.auto_post = 'no'
                     msg = _('The move could not be posted for the following reason: %(error_message)s', error_message=e)
                     move.message_post(body=msg, message_type='comment')
 

--- a/addons/account/tests/__init__.py
+++ b/addons/account/tests/__init__.py
@@ -56,3 +56,4 @@ from . import test_mail_tracking_value
 from . import test_res_partner_merge
 from . import test_account_merge_wizard
 from . import test_account_move_attachment
+from . import test_account_move_auto_post

--- a/addons/account/tests/test_account_move_auto_post.py
+++ b/addons/account/tests/test_account_move_auto_post.py
@@ -1,0 +1,52 @@
+from odoo import fields
+from odoo.tests import tagged
+
+from odoo.addons.account.tests.common import AccountTestInvoicingCommon
+from odoo.addons.base.tests.test_ir_cron import CronMixinCase
+
+
+@tagged('post_install', '-at_install')
+class TestAccountMoveAutoPost(AccountTestInvoicingCommon, CronMixinCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+    def test_auto_post_infinite_loop(self):
+        """ The scheduled action 'account.ir_cron_auto_post_draft_entry' can fall into an infinite
+        loop in certain conditions """
+
+        auto_post_journal = self.env['account.journal'].create({
+            "type": "sale",
+            "name": "Test journal",
+            "code": "TEST",
+            "company_id": self.company_data["company"].id,
+        })
+
+        # creating 100 invalid invoices (missing partner)
+        self.env['account.move'].create([{
+            'move_type': 'out_invoice',
+            'invoice_date': fields.Date.today(),
+            'date': fields.Date.today(),
+            'invoice_line_ids': [(0, 0, {
+                'name': 'test line',
+                'price_unit': 10,
+                'quantity': 1,
+                'account_id': self.company_data['default_account_revenue'].id,
+            })],
+            'journal_id': auto_post_journal.id,
+            'auto_post': 'at_date',
+            'checked': True
+        } for _ in range(100)])
+
+        cron = self.env.ref('account.ir_cron_auto_post_draft_entry')
+
+        with self.capture_triggers('account.ir_cron_auto_post_draft_entry') as captured_triggers:
+            # Calling method_direct_trigger the first time to fetch all 100 invoices.
+            # A trigger would be captured here since it tries to trigger itself again.
+            cron.method_direct_trigger()
+            # Calling method_direct_trigger a second time.
+            # No triggers should be captured here, since no invoices should be fetched.
+            cron.method_direct_trigger()
+
+        self.assertEqual(len(captured_triggers.records), 1)


### PR DESCRIPTION
**Steps to reproduce:**
- For simplicity, create a new account.
- Create a new journal entry, with one line on the newly created account.
- Set the date to today or older.
- Set auto-post to "At date".
- Make sure the journal has autocheck_on_post set to True.
- Keep the journal entry in draft, and duplicate it until you have 100 copies. (Make sure auto-post is set to "At date" on all of the copies aswell)
- Set the newly created account to 'Deprecated'.
- Manually execute the scheduled action "Account: Post draft entries with auto_post enabled and accounting date up to today"

**Issue:**
The scheduled action fails and then falls into an infinte loop, and logs an error on the chatter every minute, which could lead to thousands of mail_message records beign created.

**Cause:**
If the autopost scheduled action fails on a certain move, it marks it as 'move.checked = False'. So that when it is calls itself again (if the number of moves to post is greater than or equal to 100), it won't fetch the same move and fail again.
But having 'journal_id.autocheck_on_post = True' in the search domain allows autopost to fetch the same move it marked before (if the journal allows it), which leads to an infinite loop.

**Solution:**
If autopost fails on a move, set 'auto_post' to 'no' so it won't be fetched again.

opw-4815790

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
