### PR TITLE
[FIX] website: fix visibility condition chaining in forms

### DIFF
--- a/addons/website/static/src/snippets/s_website_form/form.js
+++ b/addons/website/static/src/snippets/s_website_form/form.js
@@ -750,12 +750,25 @@ export class Form extends Interaction {
                 return false;
             }
 
-            const formData = new FormData(this.el);
+            const formData = this.getFormDataIncludingDisabledFields(this.el);
             const currentValueOfDependency = ["contains", "!contains"].includes(comparator)
                 ? formData.getAll(dependencyName).join()
                 : formData.get(dependencyName);
             return this.compareTo(comparator, currentValueOfDependency, visibilityCondition, between);
         };
+    }
+
+    /**
+     * @param {HTMLElement} formEl the form from which we want to retrieve
+     *      the FormData, including the disabled fields.
+     * @returns {FormData} a FormData object containing also disabled fields
+     */
+    getFormDataIncludingDisabledFields(formEl) {
+        const formCopy = formEl.cloneNode(true);
+        formCopy.querySelectorAll("input, select, textarea").forEach((element) => {
+            element.removeAttribute("disabled");
+        });
+        return new FormData(formCopy);
     }
 
     isFieldVisible(fieldEl) {

--- a/addons/website/static/tests/interactions/snippets/form.test.js
+++ b/addons/website/static/tests/interactions/snippets/form.test.js
@@ -1,7 +1,7 @@
 import { setupInteractionWhiteList, startInteractions } from "@web/../tests/public/helpers";
 
 import { describe, expect, test } from "@odoo/hoot";
-import { click, fill, queryOne } from "@odoo/hoot-dom";
+import { clear, click, fill, queryOne } from "@odoo/hoot-dom";
 import { advanceTime, Deferred } from "@odoo/hoot-mock";
 
 import { onRpc } from "@web/../tests/web_test_helpers";
@@ -87,6 +87,86 @@ const formTemplate = `
                         </div>
                         <div class="mb-0 py-2 col-12 s_website_form_submit text-end s_website_form_no_submit_label" data-name="Submit Button">
                             <div style="width: 200px;" class="s_website_form_label"/>
+                            <span id="s_website_form_result"></span>
+                            <a href="#" role="button" class="btn btn-primary s_website_form_send">Submit</a>
+                        </div>
+                    </div>
+                </form>
+            </div>
+        </section>
+    </div>
+`;
+
+const formWithVisibilityRulesTemplate = `
+    <div id="wrapwrap">
+        <section class="s_website_form pt16 pb16" data-vcss="001" data-snippet="s_website_form" data-name="Form">
+            <div class="container-fluid">
+                <form action="/website/form/" method="post" enctype="multipart/form-data" class="o_mark_required" data-mark="*" data-pre-fill="true" data-model_name="mail.mail" data-success-mode="redirect" data-success-page="/contactus-thank-you">
+                    <div class="s_website_form_rows row s_col_no_bgcolor">
+                        <div data-name="Field" class="s_website_form_field mb-3 col-12 s_website_form_dnone">
+                            <div class="row s_col_no_resize s_col_no_bgcolor">
+                                <label class="col-form-label col-sm-auto s_website_form_label" style="width: 200px">
+                                    <span class="s_website_form_label_content"></span>
+                                </label>
+                                <div class="col-sm">
+                                    <input type="hidden" class="form-control s_website_form_input" name="email_to" value="info@yourcompany.example.com">
+                                <input type="hidden" value="1239f1d1c0d16680501b9974762f153fa21f4fb29aeb982c9b888f22d49cb56e" class="form-control s_website_form_input s_website_form_custom" name="website_form_signature"></div>
+                            </div>
+                        </div>
+                        <div data-name="Field" class="s_website_form_field mb-3 col-12 s_website_form_model_required" data-type="email">
+                            <div class="row s_col_no_resize s_col_no_bgcolor">
+                                <label class="col-form-label col-sm-auto s_website_form_label" style="width: 200px" for="oub62hlfgjwf">
+                                    <span class="s_website_form_label_content">Your Email</span>
+                                    <span class="s_website_form_mark"> *</span>
+                                </label>
+                                <div class="col-sm">
+                                    <input class="form-control s_website_form_input" type="email" name="email_from" required="" data-fill-with="email" id="oub62hlfgjwf">
+                                </div>
+                            </div>
+                        </div>
+                        <div data-name="Field" class="s_website_form_field mb-3 col-12 s_website_form_model_required" data-type="char">
+                            <div class="row s_col_no_resize s_col_no_bgcolor">
+                                <label class="col-form-label col-sm-auto s_website_form_label" style="width: 200px" for="oqsf4m51acj">
+                                    <span class="s_website_form_label_content">Subject</span>
+                                    <span class="s_website_form_mark"> *</span>
+                                </label>
+                                <div class="col-sm">
+                                    <input class="form-control s_website_form_input" type="text" name="subject" required="" id="oqsf4m51acj">
+                                </div>
+                            </div>
+                        </div>
+                        <div data-name="Field" class="s_website_form_field mb-3 col-12 s_website_form_custom" data-type="char">
+                            <div class="row s_col_no_resize s_col_no_bgcolor">
+                                <label class="col-form-label col-sm-auto s_website_form_label" style="width: 200px" for="oea48nwznnp">
+                                    <span class="s_website_form_label_content">FieldA</span>
+                                </label>
+                                <div class="col-sm">
+                                    <input class="form-control s_website_form_input" type="text" name="FieldA" id="oea48nwznnp">
+                                </div>
+                            </div>
+                        </div>
+                        <div data-name="Field" class="s_website_form_field mb-3 col-12 s_website_form_custom s_website_form_field_hidden_if d-none" data-type="char" data-visibility-dependency="FieldA" data-visibility-comparator="equal" data-visibility-condition="foo">
+                            <div class="row s_col_no_resize s_col_no_bgcolor">
+                                <label class="col-form-label col-sm-auto s_website_form_label" style="width: 200px" for="o42sfafdr6r9">
+                                    <span class="s_website_form_label_content">FieldB</span>
+                                </label>
+                                <div class="col-sm">
+                                    <input class="form-control s_website_form_input" type="text" name="FieldB" id="o42sfafdr6r9" disabled="disabled">
+                                </div>
+                            </div>
+                        </div>
+                        <div data-name="Field" class="s_website_form_field mb-3 col-12 s_website_form_custom s_website_form_field_hidden_if d-none" data-type="char" data-visibility-dependency="FieldB" data-visibility-comparator="equal" data-visibility-condition="foo">
+                            <div class="row s_col_no_resize s_col_no_bgcolor">
+                                <label class="col-form-label col-sm-auto s_website_form_label" style="width: 200px" for="onhykjagdxb">
+                                    <span class="s_website_form_label_content">FieldC</span>
+                                </label>
+                                <div class="col-sm">
+                                    <input class="form-control s_website_form_input" type="text" name="FieldC" id="onhykjagdxb" disabled="disabled">
+                                </div>
+                            </div>
+                        </div>
+                        <div class="mb-0 py-2 col-12 s_website_form_submit text-end s_website_form_no_submit_label" data-name="Submit Button">
+                            <div style="width: 200px;" class="s_website_form_label"></div>
                             <span id="s_website_form_result"></span>
                             <a href="#" role="button" class="btn btn-primary s_website_form_send">Submit</a>
                         </div>
@@ -344,4 +424,33 @@ test("form prefilled conditional", async () => {
     expect(core.interactions).toHaveLength(1);
     expect(queryOne("form input[name=name]")).toHaveValue("Mitchell Admin");
     expect(queryOne("form input[name=phone]")).toHaveValue("+1-555-5555");
+});
+
+test("form elements chained conditional visibility", async () => {
+    await startInteractions(formWithVisibilityRulesTemplate);
+    const fieldA = queryOne("input[name=FieldA]");
+    const fieldB = queryOne("input[name=FieldB]");
+    const fieldC = queryOne("input[name=FieldC]");
+    checkField(fieldB, false, false);
+    checkField(fieldC, false, false);
+    await click(fieldA);
+    await fill("foo");
+    await advanceTime(400); // Debounce delay.
+    checkField(fieldB, true, false);
+    checkField(fieldC, false, false);
+    await click(fieldB);
+    await fill("foo");
+    await advanceTime(400); // Debounce delay.
+    checkField(fieldB, true, false);
+    checkField(fieldC, true, false);
+    await click(fieldA);
+    await clear();
+    await advanceTime(400); // Debounce delay.
+    checkField(fieldB, false, false);
+    checkField(fieldC, false, false);
+    await click(fieldA);
+    await fill("foo");
+    await advanceTime(400); // Debounce delay.
+    checkField(fieldB, true, false);
+    checkField(fieldC, true, false);
 });


### PR DESCRIPTION
**Problem**
Given a form with three elements, A, B, and C, where C visibility depends on the content of B, and B visibility depends on the content of A, when form element B becomes visible, even if its content should trigger the visibility of C, C remains hidden.
Since [1], the check of visibility condition for C fails because it is based on a FormData object created before removing the attribute disabled from B. This doesn't work because FormData does not contain information from disabled elements.

**How to reproduce**
1. Add a form snippet on the page
2. Add three new fields to the form
3. Label the fields `fieldA`, `fieldB` and `fieldC`
4. Set `fieldB` to be `visible only if` `fieldA` `Is equal to` `test`
5. Set `fieldC` to be `visible only if` `fieldB` `Is equal to` `test`
6. Save
7. Type `test` in `fieldA` -> `fieldB` becomes visible
8. Type `test` in `fieldB` -> `fieldC` becomes visible
9. Delete `test` from `fieldA` -> both `fieldB` and `fieldC` disappear
10. Type `test` in `fieldA`
11. BUG: `fieldB` appears, contains `test`, but `fieldC` is hidden

**Solution**
A new function `getFormDataIncludingDisabledFields` is added, which generates a `FormData`-like object that includes disabled elements.

[1] odoo@b9b3a60

task-4367641
