### PR TITLE
[FIX] base: correctly guess xlsx mimetype

### DIFF
--- a/odoo/addons/base/models/ir_attachment.py
+++ b/odoo/addons/base/models/ir_attachment.py
@@ -762,13 +762,12 @@ class IrAttachment(models.Model):
               file extension at the end of the filename unless the
               filename already had a valid extension.
         """
+        raw = file.read()  # load the entire file in memory :(
         if mimetype == 'TRUST':
             mimetype = file.content_type
             filename = file.filename
         elif mimetype == 'GUESS':
-            head = file.read(1024)
-            file.seek(-len(head), 1)  # rewind
-            mimetype = guess_mimetype(head)
+            mimetype = guess_mimetype(raw)
             filename = fix_filename_extension(file.filename, mimetype)
         elif all(mimetype.partition('/')):
             filename = fix_filename_extension(file.filename, mimetype)
@@ -778,7 +777,7 @@ class IrAttachment(models.Model):
         return self.create({
             'name': filename,
             'type': 'binary',
-            'raw': file.read(),  # load the entire file in memory :(
+            'raw': raw,
             'mimetype': mimetype,
             **vals,
         })

--- a/odoo/addons/test_mimetypes/tests/__init__.py
+++ b/odoo/addons/test_mimetypes/tests/__init__.py
@@ -1,2 +1,3 @@
 # -*- coding: utf-8 -*-
 from . import test_guess_mimetypes
+from . import test_ir_attachment

--- a/odoo/addons/test_mimetypes/tests/test_ir_attachment.py
+++ b/odoo/addons/test_mimetypes/tests/test_ir_attachment.py
@@ -1,0 +1,50 @@
+from odoo.tests.common import TransactionCase
+from odoo.tools.misc import file_open
+
+
+class TestIrAttachmentMimeGuessing(TransactionCase):
+    def create_ir_attachment(self, extension):
+        filename = f'case.{extension}'
+        path = f'test_mimetypes/tests/testfiles/{filename}'
+        with file_open(path, 'rb') as f:
+            f.filename = filename
+            attachment = self.env['ir.attachment']._from_request_file(
+                f,
+                mimetype='GUESS',
+            )
+            return attachment
+
+    def test_ir_attachment_xls(self):
+        attachment = self.create_ir_attachment('xls')
+        self.assertEqual(
+            attachment.mimetype,
+            'application/vnd.ms-excel'
+        )
+
+    def test_ir_attachment_xlsx(self):
+        attachment = self.create_ir_attachment('xlsx')
+        self.assertEqual(
+            attachment.mimetype,
+            'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
+        )
+
+    def test_ir_attachment_docx(self):
+        attachment = self.create_ir_attachment('docx')
+        self.assertEqual(
+            attachment.mimetype,
+            'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
+        )
+
+    def test_ir_attachment_odt(self):
+        attachment = self.create_ir_attachment('odt')
+        self.assertEqual(
+            attachment.mimetype,
+            'application/vnd.oasis.opendocument.text'
+        )
+
+    def test_ir_attachment_ods(self):
+        attachment = self.create_ir_attachment('ods')
+        self.assertEqual(
+            attachment.mimetype,
+            'application/vnd.oasis.opendocument.spreadsheet'
+        )


### PR DESCRIPTION
Issue: .xlsx files shared by portal users being converted into .zip files.

https://drive.google.com/file/d/1MgHOrCW4QOVWmlYES-qWUQwEBH2M5gjk/view

https://www.odoo.com/odoo/action-4043/4607156
https://www.odoo.com/odoo/my-support-tasks/4753670

How to reproduce:
1. Share a Documents workspace with a portal user.
2. Ensure the portal user has "edit" rights on the workspace. (so that he/she can share documents.)
3. Log in to the portal as the portal user.
4. Navigate to the shared workspace.
5. Upload an Excel (.xlsx) or Word (.docx) file.
6. Issue: The files are now .zip files.

Background:

In commit [9a1dec8](https://github.com/odoo/odoo/commit/9a1dec8eea5eae3a3e801dd2210fefa8a05ae485), the _from_request_file() method was introduced to guess a file's mimetype by analyzing only its first 1024 bytes. 
https://github.com/odoo/odoo/blob/2d7bb960b00bfeae3e6ab8c0367237f3b08271cb/odoo/addons/base/models/ir_attachment.py#L769-L771
The guessing process ultimately calls zipfile.ZipFile(), which requires the entire file content to correctly parse OOXML formats.
https://github.com/odoo/odoo/blob/2d7bb960b00bfeae3e6ab8c0367237f3b08271cb/odoo/tools/mimetypes.py#L28-L42
Because we only provided the initial chunk, zipfile could not detect the file as `.zip` file, raising Error. 
```
2025-06-10 14:49:54,049 61227 WARNING odoo_18_empty2 odoo.tools.mimetypes.guess_mimetype: Sub-checker '_check_open_container_format' of type 'application/zip' failed 
Traceback (most recent call last):
  File "/Users/sujuodoo/odoo18/odoo/odoo/tools/mimetypes.py", line 159, in _odoo_guess_mimetype
    guess = discriminant(bin_data)
            ^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/sujuodoo/odoo18/odoo/odoo/tools/mimetypes.py", line 59, in _check_open_container_format
    with io.BytesIO(data) as f, zipfile.ZipFile(f) as z:
                                ^^^^^^^^^^^^^^^^^^
  File "/Users/sujuodoo/.pyenv/versions/3.11.6/lib/python3.11/zipfile.py", line 1302, in __init__
    self._RealGetContents()
  File "/Users/sujuodoo/.pyenv/versions/3.11.6/lib/python3.11/zipfile.py", line 1369, in _RealGetContents
    raise BadZipFile("File is not a zip file")
zipfile.BadZipFile: File is not a zip file
``` 
(Handled by Line 158 -167 below, where `discriminant()` = `_check_ooxml()`)
Consequently, it fell back to the generic application/zip mimetype. ( Line 168-170 below) 

https://github.com/odoo/odoo/blob/2d7bb960b00bfeae3e6ab8c0367237f3b08271cb/odoo/tools/mimetypes.py#L154-L170
https://github.com/odoo/odoo/blob/2d7bb960b00bfeae3e6ab8c0367237f3b08271cb/odoo/tools/mimetypes.py#L122-L144

We already load the entire file in memory to `self.create()`, so I'm assuming it is fine to do so earlier in the code and pass it to the `guess_mimetype` -> `_odoo_guess_mimetype`, but at the same time I guess this might me a technical limitation. 
https://github.com/odoo/odoo/blob/2d7bb960b00bfeae3e6ab8c0367237f3b08271cb/odoo/addons/base/models/ir_attachment.py#L778-L784

I'm curious how you guys think about this. 


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr