### PR TITLE
[IMP] l10n_us: add US tax report variant

### DIFF
--- a/addons/l10n_us_account/__manifest__.py
+++ b/addons/l10n_us_account/__manifest__.py
@@ -12,6 +12,7 @@
     'depends': ['l10n_us', 'account'],
     'data': [
         'views/res_bank_views.xml',
+        'data/tax_report.xml',
         'data/uom_data.xml',
     ],
     'installable': True,

--- a/addons/l10n_us_account/data/tax_report.xml
+++ b/addons/l10n_us_account/data/tax_report.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="tax_report" model="account.report">
+        <field name="name">Tax Report</field>
+        <field name="root_report_id" ref="account.generic_tax_report"/>
+        <field name="country_id" ref="base.us"/>
+        <field name="availability_condition">country</field>
+        <field name="column_ids">
+            <record id="column_net" model="account.report.column">
+                <field name="name">Net</field>
+                <field name="expression_label">net</field>
+                <field name="figure_type">monetary</field>
+            </record>
+            <record id="column_tax" model="account.report.column">
+                <field name="name">Tax</field>
+                <field name="expression_label">tax</field>
+                <field name="figure_type">monetary</field>
+            </record>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Before this PR, the Generic Tax Report had always been considered as the only report necessary to handle the US taxes. The problem is that, if a company needs to submit tax reports in multiple countries (because it has a VAT number in them; what we call multivat in the Odoo jargon), the Generic Tax Report would then show the taxes from every company, not only the US ones, hence becoming a bit messy. This also causes issues with the tax returns, which need to know the country they belong to in order to properly set the tax lock date.

We solve that by introducing a new US tax report. It does the same as the Generic Tax Report, but shows only the US taxes.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
