### PR TITLE
[FIX] account: payment amounts sign

### DIFF
--- a/addons/account/models/account_payment.py
+++ b/addons/account/models/account_payment.py
@@ -490,7 +490,7 @@ class AccountPayment(models.Model):
                 payment.amount_company_currency_signed = sum(liquidity_lines.mapped('balance'))
             else:
                 payment.amount_company_currency_signed = payment.currency_id._convert(
-                    from_amount=payment.amount,
+                    from_amount=payment.amount_signed,
                     to_currency=payment.company_currency_id,
                     company=payment.company_id,
                     date=payment.date,

--- a/addons/account/tests/test_account_payment.py
+++ b/addons/account/tests/test_account_payment.py
@@ -813,3 +813,23 @@ class TestAccountPayment(AccountTestInvoicingCommon):
             .create({'payment_method_line_id': payment_method_line.id})\
             ._create_payments()
         self.assertEqual(invoice.state, "posted")
+
+    def test_payment_amount_without_move(self):
+        bank_journal_2 = self.company_data['default_journal_bank'].copy()
+
+        payment = self.env['account.payment'].create({
+            'amount': 100,
+            'payment_type': 'outbound',
+            'partner_type': 'supplier',
+            'partner_id': self.partner_a.id,
+            'currency_id': self.other_currency.id,
+            'journal_id': bank_journal_2.id,
+        })
+
+        payment.action_post()
+
+        self.assertRecordValues(payment, [{
+            'amount': 100,
+            'amount_signed': -100,
+            'amount_company_currency_signed': -50,
+        }])


### PR DESCRIPTION
Issue: field `amount_company_currency_signed` does not have the correct sign when the payment is created without an associated move

It occurs because we convert the `amount` but we should use the `amount_signed`

opw-4656807

