### PR TITLE
[FIX] website_sale: erase from cart archived product.

### DIFF
--- a/addons/website_sale/models/product_product.py
+++ b/addons/website_sale/models/product_product.py
@@ -147,3 +147,13 @@ class Product(models.Model):
             self.website_published = True
         else:
             self.website_published = False
+
+    def write(self, vals):
+        if 'active' in vals and not vals['active']:
+            # unlink draft lines containing the archived product
+            self.env['sale.order.line'].sudo().search([
+                ('state', '=', 'draft'),
+                ('product_id', 'in', self.ids),
+                ('order_id', 'any', [('website_id', '!=', False)]),
+            ]).unlink()
+        return super().write(vals)

--- a/addons/website_sale/tests/test_website_sale_product_template.py
+++ b/addons/website_sale/tests/test_website_sale_product_template.py
@@ -45,3 +45,16 @@ class TestWebsiteSaleProductTemplate(WebsiteSaleCommon):
 
         self.assertEqual(configurator_data['category_name'], "Test category")
         self.assertEqual(configurator_data['currency_name'], 'EUR')
+
+    def test_remove_archived_products_from_cart(self):
+        """Archived products shouldn't appear in carts"""
+        self.product.action_archive()
+        self.assertNotIn(
+            self.product, self.cart.order_line.product_id,
+            "Archived product should be deleted from the cart.",
+        )
+        self.service_product.product_tmpl_id.action_archive()
+        self.assertNotIn(
+            self.service_product, self.cart.order_line.product_id,
+            "All products from archived product templates should be removed from the cart.",
+        )


### PR DESCRIPTION
Fix issue where customers could complete purchases of products that where archived or unpublished after being added to cart but before checkout completion.

=> Step to reproduce bug :
	- Install website_sale.
	- Add a product to the cart.
	- (In an other window) archive the product.
	- finish the buy from the cart. (don't reload the cart or the product will be gone)

=> Cause:

The bug originate from:
https://github.com/odoo/odoo/blob/2d7bb960b00bfeae3e6ab8c0367237f3b08271cb/addons/website_sale/controllers/main.py#L1781-L1793 There is no check up during the last part of the transaction to verify if the product is still available.

=> Fix:

Erase from the product from all cart when it's archived

opw-4829872
