### PR TITLE
[FIX] mrp_subcontracting: fallback supplierinfo for BoM line valuation

### DIFF
--- a/addons/mrp_subcontracting/report/mrp_report_bom_structure.py
+++ b/addons/mrp_subcontracting/report/mrp_report_bom_structure.py
@@ -28,6 +28,10 @@ class ReportBomStructure(models.AbstractModel):
                 seller = bom.product_tmpl_id.seller_ids.filtered(lambda s: s.partner_id in bom.subcontractor_ids)[:1]
             else:
                 seller = res['product']._select_seller(quantity=res['quantity'], uom_id=bom.product_uom_id, params={'subcontractor_ids': bom.subcontractor_ids})
+                if not seller:
+                    # If no vendor found for the right quantity, still display
+                    # a vendor to ensure the subcontracting price is shown
+                    seller = res['product']._select_seller(quantity=None, uom_id=bom.product_uom_id, params={'subcontractor_ids': bom.subcontractor_ids})
             if seller:
                 res['subcontracting'] = self._get_subcontracting_line(bom, seller, level + 1, res['quantity'])
                 if not self.env.context.get('minimized', False):

--- a/addons/mrp_subcontracting_account/models/product_product.py
+++ b/addons/mrp_subcontracting_account/models/product_product.py
@@ -12,6 +12,10 @@ class ProductProduct(models.Model):
         price = super()._compute_bom_price(bom, boms_to_recompute, byproduct_bom)
         if bom and bom.type == 'subcontract':
             seller = self._select_seller(quantity=bom.product_qty, uom_id=bom.product_uom_id, params={'subcontractor_ids': bom.subcontractor_ids})
+            if not seller:
+                # Ensure the subcontracting price is always displayed even if no
+                # vendor matches the quantity
+                seller = self._select_seller(quantity=None, uom_id=bom.product_uom_id, params={'subcontractor_ids': bom.subcontractor_ids})
             if seller:
                 seller_price = seller.currency_id._convert(seller.price, self.env.company.currency_id, (bom.company_id or self.env.company), fields.Date.today())
                 price += seller.product_uom._compute_price(seller_price, self.uom_id)


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

When visualizing the structure of a BOM with subcontracted components, the subcontracting cost is omitted if no supplierinfo record exists with a `min_qty` less than or equal to the requested quantity.

This leads to an inconsistent experience compared to regular components, which still show a price by selecting the closest lower `min_qty`. For subcontracted components, if the requested quantity does not match any valid `supplierinfo`, the cost line silently disappears from the report.

Current behavior before PR:

The subcontracting cost is not shown in the BOM cost structure if no `supplierinfo` matches the requested quantity (i.e., `min_qty > quantity`).

Desired behavior after PR is merged:

If no matching supplier is found for the requested quantity, the fallback logic uses any available supplierinfo (as already done in `_format_route_info`), ensuring a price is shown for subcontracted lines. This guarantees the BOM cost structure always includes the subcontracting cost, making the report complete and coherent.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr