### PR TITLE
[FIX] html_builder: make the snippet keys available in the DOM again + [FIX] html_builder: make drag and drop promise resolver always available

### DIFF
--- a/addons/html_builder/static/src/core/drag_and_drop_plugin.js
+++ b/addons/html_builder/static/src/core/drag_and_drop_plugin.js
@@ -131,12 +131,12 @@ export class DragAndDropPlugin extends Plugin {
                 return draggedEl;
             },
             onDragStart: ({ x, y }) => {
-                this.dependencies.operation.next(
-                    async () => {
-                        await new Promise((resolve) => (dragAndDropResolve = () => resolve()));
-                    },
-                    { withLoadingEffect: false }
+                const dragAndDropProm = new Promise(
+                    (resolve) => (dragAndDropResolve = () => resolve())
                 );
+                this.dependencies.operation.next(async () => await dragAndDropProm, {
+                    withLoadingEffect: false,
+                });
                 const restoreDragSavePoint = this.dependencies.history.makeSavePoint();
                 this.cancelDragAndDrop = () => {
                     // Undo the changes needed to ease the drag and drop.

--- a/addons/html_builder/static/src/sidebar/block_tab.js
+++ b/addons/html_builder/static/src/sidebar/block_tab.js
@@ -219,12 +219,12 @@ export class BlockTab extends Component {
                 return draggedEl;
             },
             onDragStart: ({ element }) => {
-                this.shared.operation.next(
-                    async () => {
-                        await new Promise((resolve) => (dragAndDropResolve = () => resolve()));
-                    },
-                    { withLoadingEffect: false }
+                const dragAndDropProm = new Promise(
+                    (resolve) => (dragAndDropResolve = () => resolve())
                 );
+                this.shared.operation.next(async () => await dragAndDropProm, {
+                    withLoadingEffect: false,
+                });
                 const restoreDragSavePoint = this.shared.history.makeSavePoint();
                 this.cancelDragAndDrop = () => {
                     // Undo the changes needed to ease the drag and drop.

--- a/addons/html_builder/static/src/sidebar/custom_inner_snippet.xml
+++ b/addons/html_builder/static/src/sidebar/custom_inner_snippet.xml
@@ -8,7 +8,7 @@
         t-att-name="snippet.title"
         t-att-data-id="snippet.id"
         t-att-data-tooltip="snippet.isDisabled and props.disabledTooltip">
-        <div class="o_snippet_thumbnail">
+        <div class="o_snippet_thumbnail" t-att-data-snippet="snippet.name">
             <button t-if="!snippet.isInstallable" class="o_snippet_thumbnail_area" t-on-click="props.onClickHandler" title="Insert snippet"/>
             <Img t-if="snippet.isDisabled" src="'/html_builder/static/img/snippet_disabled.svg'" class="'o_snippet_undroppable'"/>
             <div class="o_snippet_thumbnail_img" t-attf-style="background-image: url({{snippet.thumbnailSrc}});"/>

--- a/addons/html_builder/static/src/sidebar/snippet.xml
+++ b/addons/html_builder/static/src/sidebar/snippet.xml
@@ -10,7 +10,7 @@
          t-att-data-tooltip="snippet.isDisabled and props.disabledTooltip"
          t-on-mouseover="onInstallableHover"
          t-on-mouseout="onInstallableHover">
-        <div class="o_snippet_thumbnail">
+        <div class="o_snippet_thumbnail" t-att-data-snippet="snippet.name">
             <button t-if="!snippet.isInstallable" class="o_snippet_thumbnail_area" t-on-click="props.onClickHandler" title="Insert snippet"/>
             <Img t-if="snippet.isDisabled" src="'/html_builder/static/img/snippet_disabled.svg'" class="'o_snippet_undroppable'"/>
             <div class="o_snippet_thumbnail_img" t-attf-style="background-image: url({{snippet.thumbnailSrc}});"/>


### PR DESCRIPTION
[FIX] html_builder: make the snippet keys available in the DOM again

During the refactoring, in order to simplify the DOM of the BLOCKS tab,
only the minimum needed information was added on the snippets. Now that
the tests are being reenabled, the omitted snippet keys are needed again
for the `snippets_all_drag_and_drop` tour.

This commit adds back these keys on the snippets, as the `data-snippet`
attribute on the `o_snippet_thumbnail` elements, like before.

task-4367641

---
[FIX] html_builder: make drag and drop promise resolver always available

This commit declares the drag and drop promise (for which the mutex
should wait) before calling the mutex, instead of in the mutex, allowing
`dragAndDropResolve` to always have a value during the drag and drop.

This is needed for tours like the `snippets_all_drag_and_drop` one,
which are failing because they happen too quickly, so before the mutex
could run, making the resolver unavailable and so the call to it fail.

task-4367641