### PR TITLE
[FIX] resource: fully-flexible attendance hours

### DIFF
--- a/addons/resource/models/resource_calendar.py
+++ b/addons/resource/models/resource_calendar.py
@@ -372,11 +372,13 @@ class ResourceCalendar(models.Model):
             for resource in resources:
                 if resource and resource._is_fully_flexible():
                     # If the resource is fully flexible, return the whole period from start_dt to end_dt with a dummy attendance
+                    hours = (end_dt - start_dt).total_seconds() / 3600
+                    days = hours / 24
                     dummy_attendance = self.env['resource.calendar.attendance'].new({
-                        'duration_hours': (end - start).total_seconds() / 3600,
-                        'duration_days': (end - start).days + 1,
+                        'duration_hours': hours,
+                        'duration_days': days,
                     })
-                    result_per_resource_id[resource.id] = WorkIntervals([(start, end, dummy_attendance)])
+                    result_per_resource_id[resource.id] = WorkIntervals([(start_dt, end_dt, dummy_attendance)])
                 elif resource and resource.calendar_id.flexible_hours:
                     # For flexible Calendars, we create intervals to fill in the weekly intervals with the average daily hours
                     # until the full time required hours are met. This gives us the most correct approximation when looking at a daily

--- a/addons/resource/tests/__init__.py
+++ b/addons/resource/tests/__init__.py
@@ -2,3 +2,4 @@
 # -*- coding: utf-8 -*-
 
 from . import test_utils
+from . import test_resource_calendar

--- a/addons/resource/tests/test_resource_calendar.py
+++ b/addons/resource/tests/test_resource_calendar.py
@@ -1,0 +1,45 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+import pytz
+from datetime import datetime
+
+from odoo.tests.common import TransactionCase
+
+
+class TestResourceCalendar(TransactionCase):
+
+    def test_fully_flexible_attendance_interval_duration(self):
+        """
+        Test that the duration of a fully flexible attendance interval is correctly computed.
+        """
+        calendar = self.env['resource.calendar'].create({
+            'name': 'Standard Calendar',
+            'two_weeks_calendar': False,
+        })
+        resource = self.env['resource.resource'].create({
+            'name': 'Wade Wilson',
+            'calendar_id': False,  # Fully-flexible because no calendar is set
+            'tz': 'America/New_York',  # -04:00 UTC offset in the summer
+        })
+        self.env['resource.calendar.attendance'].create({
+            'name': 'TEMP',
+            'calendar_id': calendar.id,
+            'dayofweek': '2',  # Wednesday
+            'hour_from': 14,   # 18:00 UTC
+            'hour_to': 17,     # 21:00 UTC
+            'date_from': datetime(2025, 6, 4, 0, 0, 0).date(),
+        })
+        UTC = pytz.timezone('UTC')
+        start_dt = datetime(2025, 6, 4, 18, 0, 0).astimezone(UTC)
+        end_dt = datetime(2025, 6, 4, 21, 0, 0).astimezone(UTC)
+        result_per_resource_id = calendar._attendance_intervals_batch(
+            start_dt, end_dt, resource
+        )
+        start, end, attendance = result_per_resource_id[resource.id]._items[0]
+        # For a flexible resource, we expect the output times to match the
+        # input times exactly, since the resource has no fixed calendar.
+        # Further, the dummy attendance that is created should have a duration
+        # equal to the difference between the start and end times.
+        self.assertEqual(start, start_dt, "Output start time should match the input start time")
+        self.assertEqual(end, end_dt, "Output end time should match the input end time")
+        self.assertEqual(attendance.duration_hours, 3.0, "Attendance duration should be 3 hours")
+        self.assertEqual(attendance.duration_days, 0.125, "Attendance duration should be 0.125 days (3 hours)")


### PR DESCRIPTION
This commit fixes the calculation of the duration of an attendance record for an employee on a fully flexible working schedule.

Previously, we were using the adjusted start and end times, which were adjusted from their original values to be the outer bounds of the interval made up of the original times and the UTC-converted times. This resulted in a duration that was too
long.

Now, we use the original start and end times to calculate the duration of the attendance because this value is timezone-agnostic.
