### PR TITLE
[IMP] website: adapt and re-enable tours

### DIFF
--- a/addons/website/static/tests/tours/snippet_visibility_option.js
+++ b/addons/website/static/tests/tours/snippet_visibility_option.js
@@ -21,7 +21,7 @@ registerWebsitePreviewTour("snippet_visibility_option", {
     },
     {
         content: "Click the 'No Desktop' visibility option.",
-        trigger: ".snippet-option-DeviceVisibility we-button[data-toggle-device-visibility='no_desktop']",
+        trigger: "[data-container-title='Column'] [data-action-param='no_desktop']",
         run: "click"
     },
     {
@@ -31,7 +31,7 @@ registerWebsitePreviewTour("snippet_visibility_option", {
     },
     {
         content: "Click the 'No Desktop' visibility option.",
-        trigger: "we-button[data-toggle-device-visibility='no_desktop']",
+        trigger: "[data-container-title='Block'] [data-action-param='no_desktop']",
         run: "click"
     },
     {

--- a/addons/website/static/tests/tours/website_form_editor.js
+++ b/addons/website/static/tests/tours/website_form_editor.js
@@ -1038,10 +1038,10 @@ registerWebsitePreviewTour("website_form_editable_content", {
     edition: true,
 }, () => [
     {
-        trigger: ".o_website_preview.editor_enable.editor_has_snippets",
+        trigger: ".o-snippets-menu div.o_snippet",
     },
     {
-        trigger: `#oe_snippets .oe_snippet[name="Form"].o_we_draggable .oe_snippet_thumbnail:not(.o_we_ongoing_insertion)`,
+        trigger: `.o-snippets-menu .o_block_tab:not(.o_we_ongoing_insertion) .o_snippet[name="Form"].o_draggable .o_snippet_thumbnail`,
         run: "drag_and_drop :iframe #wrap",
     },
     {
@@ -1056,11 +1056,7 @@ registerWebsitePreviewTour("website_form_editable_content", {
             }
         },
     },
-    {
-        content: "Go back to blocks",
-        trigger: ".o_we_add_snippet_btn",
-        run: "click",
-    },
+    goBackToBlocks(),
     ...insertSnippet({id: "s_three_columns", name: "Columns", groupName: "Columns"}),
     {
         content: "Select the first column",
@@ -1069,7 +1065,7 @@ registerWebsitePreviewTour("website_form_editable_content", {
     },
     {
         content: "Drag and drop the selected column inside the form",
-        trigger: ":iframe .o_overlay_move_options .o_move_handle",
+        trigger: ".o_overlay_options .o_move_handle",
         run: "drag_and_drop :iframe section.s_website_form",
     },
     {
@@ -1092,7 +1088,7 @@ registerWebsitePreviewTour("website_form_editable_content", {
     },
     {
         content: "Remove the dropped column",
-        trigger: ":iframe .oe_overlay.oe_active .oe_snippet_remove:not(:visible)",
+        trigger: ".o_overlay_options .oe_snippet_remove:not(:visible)",
         run: "click",
     },
     ...clickOnSave(),

--- a/addons/website/tests/test_ui.py
+++ b/addons/website/tests/test_ui.py
@@ -714,7 +714,6 @@ class TestUi(HttpCaseWithWebsiteUser):
     def test_media_iframe_video(self):
         self.start_tour("/", "website_media_iframe_video", login="admin")
 
-    @unittest.skip
     def test_snippet_visibility_option(self):
         self.start_tour("/", "snippet_visibility_option", login="admin")
 

--- a/addons/website/tests/test_website_form_editor.py
+++ b/addons/website/tests/test_website_form_editor.py
@@ -57,7 +57,6 @@ class TestWebsiteFormEditor(HttpCaseWithUserPortal):
         self.env.company.email = 'after.change@mail.com'
         self.start_tour('/contactus', 'website_form_contactus_check_changed_email', login="portal")
 
-    @unittest.skip
     def test_website_form_editable_content(self):
         self.start_tour('/', 'website_form_editable_content', login="admin")
 


### PR DESCRIPTION
The `test_snippet_visibility_option`, `test_website_form_editable_content` tours were previously broken due to DOM structure changes introduced by the new website builder and were consequently disabled.

This PR updates the tour steps to align with the new DOM and re-enables the associated test.