### PR TITLE
[IMP] point_of_sale: child contact's orders should display on parent contact

### DIFF
--- a/addons/point_of_sale/models/res_partner.py
+++ b/addons/point_of_sale/models/res_partner.py
@@ -107,10 +107,8 @@ class ResPartner(models.Model):
         This function returns an action that displays the pos orders from partner.
         '''
         action = self.env['ir.actions.act_window']._for_xml_id('point_of_sale.action_pos_pos_form')
-        if self.is_company:
-            action['domain'] = [('partner_id.commercial_partner_id', '=', self.id)]
-        else:
-            action['domain'] = [('partner_id', '=', self.id)]
+        # If the partner has any children (including grandchildren)
+        action['domain'] = [('partner_id', 'child_of', self.id)]
         return action
 
     def open_commercial_entity(self):


### PR DESCRIPTION
Steps: 
====
- Create a contact (e.g., Parent Partner). (contact type should be Person)
- Add a child contact under Parent Partner (e.g., Child Partner).
- Create one POS order each for the Parent Partner and the Child Partner.
- Go to the backend and check the order counts for Parent Partner it is showing 2, but the actual orders using the smart button are showing 1 record only.

Issue :
====
- The child partner's pos orders are not showing on the parent partner's form view when the partner type is person.

Improvement:
====
- This commit ensures that the smart button action includes orders from child partners using the child_of domain, regardless of partner type.

task-4854766