### PR TITLE
[IMP] website_sale: dropped shipping address setting

### DIFF
--- a/addons/website_sale/models/res_config_settings.py
+++ b/addons/website_sale/models/res_config_settings.py
@@ -9,11 +9,6 @@ class ResConfigSettings(models.TransientModel):
     _inherit = 'res.config.settings'
 
     # Groups
-    group_delivery_invoice_address = fields.Boolean(
-        string="Shipping Address",
-        implied_group='account.group_delivery_invoice_address',
-        group='base.group_portal,base.group_user,base.group_public',
-    )
     group_show_uom_price = fields.Boolean(
         string="Base Unit Price",
         default=False,

--- a/addons/website_sale/security/res_groups.xml
+++ b/addons/website_sale/security/res_groups.xml
@@ -11,18 +11,6 @@
     </record>
 
     <!-- Security groups -->
-    <record id="base.group_public" model="res.groups">
-        <field name="implied_ids" eval="[
-            Command.link(ref('account.group_delivery_invoice_address')),
-        ]"/>
-    </record>
-
-    <record id="base.group_portal" model="res.groups">
-        <field name="implied_ids" eval="[
-            Command.link(ref('account.group_delivery_invoice_address')),
-        ]"/>
-    </record>
-
     <record id="base.group_user" model="res.groups">
         <field name="implied_ids" eval="[
             Command.link(ref('account.group_delivery_invoice_address')),

--- a/addons/website_sale/views/res_config_settings_views.xml
+++ b/addons/website_sale/views/res_config_settings_views.xml
@@ -132,9 +132,6 @@
                 </block>
 
                 <block title="Delivery" id="sale_shipping_settings">
-                    <setting id="shipping_address_setting" help="Let the customer enter a delivery address">
-                        <field name="group_delivery_invoice_address"/>
-                    </setting>
                     <setting id="delivery_method_setting" string="Shipping Costs" help="Compute shipping costs on orders"
                              documentation="/applications/inventory_and_mrp/inventory/shipping/setup/third_party_shipper.html">
                         <div class="content-group">

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -2725,11 +2725,7 @@
             <t t-set="redirect" t-valuef="/shop/checkout"/>
             <t t-set="same_shipping" t-value="bool(order.partner_shipping_id==order.partner_invoice_id or only_services)" />
             <div id="shop_checkout">
-                <!-- When delivery address is enabled. -->
-                <t
-                    t-if="order._has_deliverable_products()"
-                    groups="account.group_delivery_invoice_address"
-                >
+                <t t-if="order._has_deliverable_products()">
                     <t t-call="website_sale.delivery_address_row">
                         <t t-set="addresses" t-value="delivery_addresses"/>
                     </t>
@@ -2739,13 +2735,6 @@
                 </t>
                 <t t-call="website_sale.billing_address_row">
                     <t t-set="addresses" t-value="billing_addresses"/>
-                </t>
-                <!-- When delivery address is disabled. -->
-                <t
-                    groups="!account.group_delivery_invoice_address"
-                    t-call="website_sale.delivery_form"
-                >
-                    <t t-set="selected_dm_id" t-value="order.carrier_id.id"/>
                 </t>
             </div>
         </t>
@@ -2764,40 +2753,23 @@
 
     <template id="billing_address_row">
         <div id="billing_address_row" class="mb-3">
-            <p
-                t-attf-class="{{only_services and 'h4 mb-3' or 'h5'}}"
-                groups="account.group_delivery_invoice_address"
-            >
+            <p t-attf-class="{{only_services and 'h4 mb-3' or 'h5'}}">
                 Billing address
             </p>
-            <h4 groups="!account.group_delivery_invoice_address">Your address</h4>
-            <t groups="account.group_delivery_invoice_address">
-                <t t-set="has_delivery" t-value="order._has_deliverable_products()"/>
-                <div t-if="has_delivery" class="form-check form-switch mt-2 mb-3">
-                    <label id="use_delivery_as_billing_label">
-                        <input
-                            type="checkbox"
-                            id="use_delivery_as_billing"
-                            class="form-check-input"
-                            t-att-checked="use_delivery_as_billing"
-                        /> Same as delivery address
-                    </label>
-                </div>
-            </t>
-            <t
-                t-set="delivery_address_disabled"
-                groups="!account.group_delivery_invoice_address"
-                t-value="True"
-            />
-            <t
-                t-set="delivery_address_disabled"
-                groups="account.group_delivery_invoice_address"
-                t-value="False"
-            />
+            <t t-set="has_delivery" t-value="order._has_deliverable_products()"/>
+            <div t-if="has_delivery" class="form-check form-switch mt-2 mb-3">
+                <label id="use_delivery_as_billing_label">
+                    <input
+                        type="checkbox"
+                        id="use_delivery_as_billing"
+                        class="form-check-input"
+                        t-att-checked="use_delivery_as_billing"
+                    /> Same as delivery address
+                </label>
+            </div>
             <div
                 id="billing_container"
                 t-attf-class="{{'d-none' if use_delivery_as_billing and has_delivery else ''}}"
-                t-att-data-delivery-address-disabled="delivery_address_disabled"
             >
                 <t t-call="website_sale.address_row">
                     <t t-set="address_type" t-value="'billing'"/>
@@ -2854,7 +2826,6 @@
                         t-if="use_delivery_as_billing and not only_services and partner_sudo"
                         class="alert alert-warning"
                         role="alert"
-                        groups="account.group_delivery_invoice_address"
                     >
                         <p class="mb-0">
                             You are editing your <b>delivery and billing</b> addresses
@@ -2930,7 +2901,6 @@
                     <div
                         t-if="not use_delivery_as_billing and order._has_deliverable_products()"
                         t-attf-class="{{not use_delivery_as_billing and not only_services and 'col-md-6 ps-1'}}"
-                        groups="account.group_delivery_invoice_address"
                     >
                         <t t-if="order.pickup_location_data">
                             <b>Deliver to pickup point</b>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

- Dropping shipping address setting and all groups related to it.

Current behavior before PR:

- Separate shipping address option shown based on group_delivery_invoice_address.
- Views contain group-based conditional logic.

Desired behavior after PR is merged:

- Unified address form for billing and delivery.
- All group-based conditions removed.
- Simpler, cleaner checkout flow with no extra config.

Task_ID:[4746668](https://www.odoo.com/odoo/project/4106/tasks/4746668)

Related PR:
Upgrade PR: https://github.com/odoo/upgrade/pull/7705

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
