### PR TITLE
[IMP] pos_restaurant: skip 'send to kitchen' prompt if no items need preparation

### DIFF
--- a/addons/pos_restaurant/static/src/app/utils/order_payment_validation.js
+++ b/addons/pos_restaurant/static/src/app/utils/order_payment_validation.js
@@ -29,7 +29,11 @@ patch(OrderPaymentValidation.prototype, {
         return await super.afterOrderValidation(...arguments);
     },
     async askBeforeValidation() {
-        if (this.pos.config.module_pos_restaurant && this.order.hasChange && !this.order.isRefund) {
+        if (
+            this.pos.config.module_pos_restaurant &&
+            this.pos.categoryCount.length &&
+            !this.order.isRefund
+        ) {
             const confirmed = await ask(this.pos.dialog, {
                 title: _t("Warning !"),
                 body: _t(

--- a/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
@@ -2,6 +2,7 @@ import * as PaymentScreen from "@point_of_sale/../tests/pos/tours/utils/payment_
 import * as Dialog from "@point_of_sale/../tests/generic_helpers/dialog_util";
 import * as ReceiptScreen from "@point_of_sale/../tests/pos/tours/utils/receipt_screen_util";
 import * as ChromePos from "@point_of_sale/../tests/pos/tours/utils/chrome_util";
+import * as PartnerList from "@point_of_sale/../tests/pos/tours/utils/partner_list_util";
 import * as ChromeRestaurant from "@pos_restaurant/../tests/tours/utils/chrome";
 const Chrome = { ...ChromePos, ...ChromeRestaurant };
 import * as FloorScreen from "@pos_restaurant/../tests/tours/utils/floor_screen_util";
@@ -598,6 +599,12 @@ registry.category("web_tour.tours").add("test_multiple_preparation_printer_diffe
             Dialog.bodyIs("Printer 1: The printer is not reachable."),
             Dialog.bodyIs("Printer 2: The printer is not reachable."),
             Dialog.confirm(),
+            // OrderWarningDialog should not be shown as order already send for preparation
+            FloorScreen.clickTable("5"),
+            ProductScreen.clickPayButton(),
+            PaymentScreen.clickPaymentMethod("Bank"),
+            PaymentScreen.clickValidate(),
+            ReceiptScreen.clickNextOrder(),
         ].flat(),
 });
 
@@ -668,6 +675,31 @@ registry.category("web_tour.tours").add("test_customer_alone_saved", {
             Chrome.clickOrders(),
             Chrome.clickRegister(),
             ProductScreen.customerIsSelected("Deco Addict"),
+        ].flat(),
+});
+
+registry.category("web_tour.tours").add("test_no_kitchen_confirmation_for_deposit_money", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            FloorScreen.clickTable("5"),
+            ProductScreen.clickPartnerButton(),
+            PartnerList.clickPartnerOptions("A powerful PoS man!"),
+            PartnerList.clickDropDownItemText("Deposit money"),
+            {
+                content: "select payment method for deposit money",
+                trigger: ".o_dialog .selection-item:contains('bank')",
+                run: "click",
+            },
+            PaymentScreen.clickNumpad("+10"),
+            PaymentScreen.fillPaymentLineAmountMobile("bank", "10.0"),
+            PaymentScreen.changeIs("0"),
+            PaymentScreen.clickValidate(),
+            Dialog.is("The order is empty"),
+            Dialog.confirm("Yes"),
+            ReceiptScreen.clickNextOrder(),
+            Chrome.endTour(),
         ].flat(),
 });
 

--- a/addons/pos_restaurant/tests/test_frontend.py
+++ b/addons/pos_restaurant/tests/test_frontend.py
@@ -637,6 +637,18 @@ class TestFrontend(TestFrontendCommon):
         """
         self.start_tour(f"/pos/ui?config_id={self.main_pos_config.id}", 'test_customer_alone_saved', login="pos_user")
 
+    def test_no_kitchen_confirmation_for_deposit_money(self):
+        if not self.env["ir.module.module"].search([("name", "=", "pos_settle_due"), ("state", "=", "installed")]):
+            self.skipTest("pos_settle_due module is required for this test")
+
+        self.customer_account_payment_method = self.env['pos.payment.method'].create({
+            'name': 'Customer Account',
+            'split_transactions': True,
+        })
+        self.pos_config.write({'payment_method_ids': [(4, self.customer_account_payment_method.id)]})
+        self.pos_config.with_user(self.pos_admin).open_ui()
+        self.start_pos_tour('test_no_kitchen_confirmation_for_deposit_money', login="pos_admin")
+
     def test_open_default_register_screen_config(self):
         """
         Tests that the default register screen is opened when the config is set to do so


### PR DESCRIPTION
## After this commit:
- On the payment screen, the `confirmation dialog` to send items to the kitchen shows only if there are **unsent kitchen items** in the order.
- A test is added to make sure this message doesn't show when placing a `deposit money` order.
   
Task: 4851891