### PR TITLE
[FIX] hr_holidays: fix wrong usage of integer widget

### DIFF
--- a/addons/hr_holidays/views/hr_leave_allocation_views.xml
+++ b/addons/hr_holidays/views/hr_leave_allocation_views.xml
@@ -425,9 +425,9 @@
                                             </div>
                                             <div class="col-3 o_hr_holidays_card">
                                                 <div class="fw-bold d-flex gap-1 me-1">
-                                                    <field name="virtual_remaining_leaves" widget="integer" options="{'type': 'number'}"/>
+                                                    <field name="virtual_remaining_leaves" widget="float" digits="[3,2]"/>
                                                     /
-                                                    <field name="max_leaves" widget="integer" options="{'type': 'number'}"/>
+                                                    <field name="max_leaves" widget="float" digits="[3,2]"/>
                                                 </div>
                                                 <span>
                                                     Current balance

--- a/addons/hr_holidays/views/hr_leave_views.xml
+++ b/addons/hr_holidays/views/hr_leave_views.xml
@@ -159,9 +159,9 @@
                                             <div class="col-3 o_hr_holidays_card">
                                                 <div t-if="record.holiday_status_requires_allocation.raw_value"> <!-- To keep the same space-->
                                                     <div class="fw-bold d-flex gap-1 me-1">
-                                                        <field name="virtual_remaining_leaves"/>
+                                                        <field name="virtual_remaining_leaves" widget="float" digits="[3,2]"/>
                                                         /
-                                                        <field name="max_leaves"/>
+                                                        <field name="max_leaves" widget="float" digits="[3,2]"/>
                                                     </div>
                                                     <span>
                                                         Current balance


### PR DESCRIPTION
Before this commit, the widget integer was used for a float and was raised as an error. This commit fix it.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
