### PR TITLE
[IMP] website_sale: adpat and re-enable tours

### DIFF
--- a/addons/website_sale/static/tests/tours/website_sale_remove_product_image.js
+++ b/addons/website_sale/static/tests/tours/website_sale_remove_product_image.js
@@ -13,7 +13,7 @@ const clickOnImgAndWaitForLoad = [
     },
     {
         content: "Check that the snippet editor of the clicked image has been loaded",
-        trigger: "we-customizeblock-options:has(we-title:contains('Re-order'))",
+        trigger: ".o_customize_tab [data-container-title='Image']",
     },
 ];
 const enterEditModeOfTestProduct = () => [
@@ -23,20 +23,24 @@ const enterEditModeOfTestProduct = () => [
         trigger: ":iframe a:contains('Test Remove Image')",
         run: "click",
     },
+    {
+        content: "Check that the product page is loaded",
+        trigger: ":iframe .o_wsale_product_page",
+    },
     ...clickOnEditAndWaitEditMode(),
 ];
 
 const removeImg = [
     {
         content: "Click on Remove",
-        trigger: "we-customizeblock-options:has(we-title:contains('Image')) we-button[data-name='media_wsale_remove']",
+        trigger: ".o_customize_tab [data-container-title='Image'] button[data-action-id='removeMedia']",
         run: "click",
     },
     // If the snippet editor is not visible, the remove process is considered as
     // finished.
     {
         content: "Check that the snippet editor is not visible",
-        trigger: ".o_we_customize_panel:not(:has(we-customizeblock-options:has(we-title:contains('Re-order'))))",
+        trigger: ".o_customize_tab:not(:has([data-container-title='Image']))",
     },
 ];
 

--- a/addons/website_sale/tests/test_website_sale_image.py
+++ b/addons/website_sale/tests/test_website_sale_image.py
@@ -399,8 +399,6 @@ class TestWebsiteSaleRemoveImage(HttpCase):
         self.assertFalse(self.template.image_1920)
         self.assertFalse(self.product.image_1920)
 
-    # TODO master-mysterious-egg fix error
-    @unittest.skip("prepare mysterious-egg for merging")
     def test_website_sale_remove_main_product_image_with_variant(self):
         # Set the color attribute and values on the template.
         self.env['product.template.attribute.line'].create([{


### PR DESCRIPTION
The `website_sale_remove_product_image` tour was previously broken due to DOM structure changes introduced by the new website builder and was consequently disabled.

This PR updates the tour steps to align with the new DOM and re-enables the associated test.