### PR TITLE
[15.0][IMP] mrp: Reduce time to set values for new columns with big tables

### DIFF
--- a/addons/mrp/__init__.py
+++ b/addons/mrp/__init__.py
@@ -16,12 +16,14 @@ def _pre_init_mrp(cr):
           stock_move.unit_factor is terribly slow with the ORM and leads to "Out of
           Memory" crashes
     """
-    cr.execute("""ALTER TABLE "stock_move" ADD COLUMN "is_done" bool;""")
+    cr.execute("""ALTER TABLE "stock_move" ADD COLUMN "is_done" bool DEFAULT TRUE;""")
     cr.execute("""UPDATE stock_move
-                     SET is_done=COALESCE(state in ('done', 'cancel'), FALSE);""")
-    cr.execute("""ALTER TABLE "stock_move" ADD COLUMN "unit_factor" double precision;""")
-    cr.execute("""UPDATE stock_move
-                     SET unit_factor=1;""")
+                    SET is_done = FALSE
+                  WHERE state NOT IN ('done', 'cancel');""")
+    cr.execute("""ALTER TABLE stock_move ALTER COLUMN is_done DROP DEFAULT;""")
+    cr.execute("""ALTER TABLE "stock_move"
+                    ADD COLUMN "unit_factor" double precision DEFAULT 1;""")
+    cr.execute("""ALTER TABLE stock_move ALTER COLUMN unit_factor DROP DEFAULT;""")
 
 def _create_warehouse_data(cr, registry):
     """ This hook is used to add a default manufacture_pull_id, manufacture


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**

When installing mrp on databases with many records in the stock move table, the time it takes to set the initial values is excessive, resulting in deadlocks.

**Current behavior before PR:**

Excessive time and crashes when installing mrp on a database with many records in stock move

**Desired behavior after PR is merged:**

That the installation of the module is immediate and does not cause blockages.


**Additional comments:**

This enhancement is applicable to versions 15.0, 16.0, 17.0 and 18.0.

I also believe that this approach should be considered for setting any default value when adding a new column, at least in tables that are likely to have millions of records.


@Tecnativa

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
