### PR TITLE
[FIX] l10n_es: fix error when removing currency from an invoice

### DIFF
--- a/addons/l10n_es/models/account_move.py
+++ b/addons/l10n_es/models/account_move.py
@@ -15,12 +15,13 @@ class AccountMove(models.Model):
     def _compute_l10n_es_is_simplified(self):
         simplified_partner = self.env.ref('l10n_es.partner_simplified', raise_if_not_found=False)
         for move in self:
+            currency_id = move.currency_id or move.company_id.currency_id
             move.l10n_es_is_simplified = (move.country_code == 'ES') and (
                 (not move.partner_id and move.move_type in ('in_receipt', 'out_receipt'))
                 or (simplified_partner and move.partner_id == simplified_partner)
                 or (move.move_type in ('out_invoice', 'out_refund')
                     and not move.commercial_partner_id.vat
-                    and move.currency_id.compare_amounts(abs(move.amount_total_signed), 400) <= 0  # standard simplified invoice limit
+                    and currency_id.compare_amounts(abs(move.amount_total_signed), 400) <= 0  # standard simplified invoice limit
                     and move.commercial_partner_id.country_id in self.env.ref('base.europe').country_ids
                 )
             )


### PR DESCRIPTION
When User removes the currency from an invoice,
A traceback will appear.

Steps to reproduce the error:
- Install ``l10n_es`` module and switch to ``ES Company``
- Enable Multiple currency
- Create an invoice > Set customer > save
- Now, Remove currency and customer from an invoice

Traceback:
```
ValueError: Expected singleton: res.currency()
```

https://github.com/odoo/odoo/blob/51fcbd211d2b1abf4b93becedbcbb9e03002cdd6/addons/l10n_es/models/account_move.py#L23
This line causes a traceback with an empty currency
when the user removes the currency from the invoice.

sentry-6670501631

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
