### PR TITLE
[FIX] tools: prevent error when xpath expression is missing

### DIFF
--- a/odoo/tools/template_inheritance.py
+++ b/odoo/tools/template_inheritance.py
@@ -74,6 +74,8 @@ def locate_node(arch, spec):
     """
     if spec.tag == 'xpath':
         expr = spec.get('expr')
+        if not expr:
+            raise ValidationError(_("Missing 'expr' attribute in <xpath> element."))
         try:
             xPath = etree.ETXPath(expr)
         except etree.XPathSyntaxError as e:


### PR DESCRIPTION
Currently, an error occurs when creating a `view` with a `<xpath>` node that is missing the `'expr'` attribute.

**Steps to produce:**

- Navigate to: `Settings > Technical > User Interface > Views`.
- Create a `New view` and select any `Inherited View`.
- set `Architecture` to `'<xpath></xpath>'` and try to `save` it.

**Error:**
`TypeError: Argument must be bytes or unicode, got 'NoneType' `

**Root Cause:**
at [1], the `expr` is `None`, and passing it to `ETXPath()` causes an `Error`.

[1]
https://github.com/odoo/odoo/blob/5201fb02145532e7311986068655e12eaf1ae3ce/odoo/tools/template_inheritance.py#L87

This commit ensures an error message is raised, when the `expr` attribute is missing from a `<xpath>` node.

Sentry – 6669873478