### PR TITLE
[FIX] hr: correctly update job title

### DIFF
--- a/addons/hr/models/hr_version.py
+++ b/addons/hr/models/hr_version.py
@@ -106,7 +106,7 @@ class HrVersion(models.Model):
     job_id = fields.Many2one('hr.job', check_company=True, tracking=True)
     job_title = fields.Char(compute="_compute_job_title", inverse="_inverse_job_title", store=True, readonly=False,
         string="Job Title", tracking=True)
-    is_custom_job_title = fields.Boolean(default=False, groups="hr.group_hr_user")
+    is_custom_job_title = fields.Boolean(compute='_compute_is_custom_job_title', store=True, default=False, groups="hr.group_hr_user")
     address_id = fields.Many2one(
         'res.partner',
         string='Work Address',
@@ -198,6 +198,12 @@ class HrVersion(models.Model):
     def _inverse_job_title(self):
         for version in self:
             version.is_custom_job_title = version.job_title != version.job_id.name
+
+    @api.depends('job_id')
+    def _compute_is_custom_job_title(self):
+        for version in self.filtered('job_id'):
+            if version._origin.job_id != version.job_id:
+                version.is_custom_job_title = False
 
     @api.constrains('employee_id', 'contract_date_start', 'contract_date_end')
     def _check_dates(self):

--- a/addons/hr/tests/test_hr_employee.py
+++ b/addons/hr/tests/test_hr_employee.py
@@ -529,6 +529,31 @@ class TestHrEmployee(TestHrCommon):
         self.assertEqual(self.employee.resource_calendar_id, old_calendar)
         self.assertEqual(self.employee.resource_id.calendar_id, old_calendar)
 
+    def test_job_title(self):
+        first_job = self.env['hr.job'].create({'name': "first job"})
+        second_job = self.env['hr.job'].create({'name': "second job"})
+
+        with Form(self.employee_without_image) as employee_form:
+            # Assign first job to employee, job title should be job name
+            employee_form.job_id = first_job
+            self.assertEqual(employee_form.job_title, first_job.name)
+
+            # Change job title, job name should not change
+            employee_form.job_title = "custom job title"
+            self.assertEqual(first_job.name, "first job")
+
+            # Change the name of the first job, job title should not be updated
+            first_job.name = "first job modified"
+            self.assertEqual(employee_form.job_title, "custom job title")
+            employee_form.save()
+
+            # Assign second job to employee, job title should be second job name
+            employee_form.job_id = second_job
+            self.assertEqual(employee_form.job_title, second_job.name)
+
+            # Switch back to first job, job title should be first job name
+            employee_form.job_id = first_job
+            self.assertEqual(employee_form.job_title, first_job.name)
 
 @tagged('-at_install', 'post_install')
 class TestHrEmployeeWebJson(HttpCase):


### PR DESCRIPTION
Steps to reproduce the bug:
- Select a job position for the employee, the job title should be the same
- Change the job title (let's call it A)
- Change the job position's name, the job title should remain as before
- Change the job position, the job title updates correctly
- Without saving, change the job position to A
- The job title is not correctly updated

This commit fixes the issue by correctly computing the technical field is_custom_job_title.

task-4860251