### PR TITLE
[FIX] mail, web_unsplash: powerbox tests uses expectElementCount helper

### DIFF
--- a/addons/mail/static/tests/inline/html_mail_field.test.js
+++ b/addons/mail/static/tests/inline/html_mail_field.test.js
@@ -1,5 +1,6 @@
 import { setSelection } from "@html_editor/../tests/_helpers/selection";
 import { insertText } from "@html_editor/../tests/_helpers/user_actions";
+import { expectElementCount } from "@html_editor/../tests/_helpers/ui_expectations";
 import { HtmlMailField } from "@mail/views/web/fields/html_mail_field/html_mail_field";
 import { after, before, beforeEach, expect, test } from "@odoo/hoot";
 import { press, queryOne } from "@odoo/hoot-dom";
@@ -109,11 +110,11 @@ test("HtmlMail don't have access to column commands", async function () {
     setSelectionInHtmlField();
     await insertText(htmlEditor, "/");
     await animationFrame();
-    expect(".o-we-powerbox").toHaveCount(1);
+    await expectElementCount(".o-we-powerbox", 1);
 
     await insertText(htmlEditor, "column");
     await animationFrame();
-    expect(".o-we-powerbox").toHaveCount(0);
+    await expectElementCount(".o-we-powerbox", 0);
 });
 
 test("HtmlMail add icon and save inline html", async function () {

--- a/addons/web_unsplash/static/tests/unsplash.test.js
+++ b/addons/web_unsplash/static/tests/unsplash.test.js
@@ -1,5 +1,6 @@
 import { setupEditor } from "@html_editor/../tests/_helpers/editor";
 import { insertText } from "@html_editor/../tests/_helpers/user_actions";
+import { expectElementCount } from "@html_editor/../tests/_helpers/ui_expectations";
 import { expect, test } from "@odoo/hoot";
 import { animationFrame, click, Deferred, press, waitFor } from "@odoo/hoot-dom";
 import { contains, makeMockEnv, onRpc } from "@web/../tests/web_test_helpers";
@@ -48,10 +49,10 @@ test("Unsplash is inserted in the Media Dialog", async () => {
     });
     const env = await makeMockEnv();
     const { editor } = await setupEditor(`<p>[]</p>`, { env });
-    expect(".o-we-powerbox").toHaveCount(0);
+    await expectElementCount(".o-we-powerbox", 0);
     await insertText(editor, "/image");
     await animationFrame();
-    expect(".o-we-powerbox").toHaveCount(1);
+    await expectElementCount(".o-we-powerbox", 1);
     await click(".o-we-command");
     await animationFrame();
     expect(".o_select_media_dialog").toHaveCount(1);
@@ -85,10 +86,10 @@ test("Unsplash error is displayed when there is no key", async () => {
     });
     const env = await makeMockEnv();
     const { editor } = await setupEditor(`<p>[]</p>`, { env });
-    expect(".o-we-powerbox").toHaveCount(0);
+    await expectElementCount(".o-we-powerbox", 0);
     await insertText(editor, "/image");
     await animationFrame();
-    expect(".o-we-powerbox").toHaveCount(1);
+    await expectElementCount(".o-we-powerbox", 1);
     await click(".o-we-command");
     await animationFrame();
     expect(".o_select_media_dialog").toHaveCount(1);


### PR DESCRIPTION
Purpose of this PR:

- Update powerbox test cases to use `expectElementCount` helper, which waits for elements to appear before checking their count.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
