### PR TITLE
[FIX] html_editor, website: fix login page on edit

### DIFF
--- a/addons/html_editor/static/src/main/toolbar/toolbar_plugin.js
+++ b/addons/html_editor/static/src/main/toolbar/toolbar_plugin.js
@@ -234,13 +234,16 @@ export class ToolbarPlugin extends Plugin {
             // keyup. Opening is debounced to avoid open/close between
             // sequential keystrokes.
             this.addDomListener(this.editable, "keydown", (ev) => {
-                if (ev.key.startsWith("Arrow")) {
+                // reason for "key?":
+                // On Chrome, if there is a password saved for a login page,
+                // a mouse click trigger a keydown event without any key 
+                if (ev.key?.startsWith("Arrow")) {
                     this.closeToolbar();
                     this.onSelectionChangeActive = false;
                 }
             });
             this.addDomListener(this.editable, "keyup", (ev) => {
-                if (ev.key.startsWith("Arrow")) {
+                if (ev.key?.startsWith("Arrow")) {
                     this.onSelectionChangeActive = true;
                     this.debouncedUpdateToolbar();
                 }

--- a/addons/website/__manifest__.py
+++ b/addons/website/__manifest__.py
@@ -257,6 +257,7 @@
             'website/static/src/js/text_processing.js',
             'website/static/src/js/highlight_utils.js',
             'website/static/src/client_actions/website_preview/website_builder_action.editor.scss',
+            'website/static/src/components/user_switch.js',
         ],
         'web.assets_frontend_minimal': [
             'website/static/src/utils/misc.js',

--- a/addons/website/static/src/components/user_switch.js
+++ b/addons/website/static/src/components/user_switch.js
@@ -1,0 +1,12 @@
+import { UserSwitch } from "@web/core/user_switch/user_switch";
+import { patch } from "@web/core/utils/patch";
+
+patch(UserSwitch.prototype, {
+    toggleFormDisplay() {
+        if (document.body.classList.contains("editor_enable")) {
+            return;
+        }
+        super.toggleFormDisplay();
+    },
+});
+


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
- Fix traceback when the user click with the mouse on the login page
- Prevent changing page by clicking on one of the buttons of the login form while the Editor is open
- Prevent clicking "Login" while being in the Editor app, fixing a traceback

Desired behavior after PR is merged:
- The login page should not crash when the user click with the mouse
- The user shouldn't be able to leave the login page while he is editing the login page
- The user shouldn't be able to click login while being in the Editor app

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
