### PR TITLE
[18.0][IMP] web: Allow extending metadata dialog

### DIFF
--- a/addons/web/static/src/views/debug_items.js
+++ b/addons/web/static/src/views/debug_items.js
@@ -97,7 +97,7 @@ debugRegistry.category("view").add("editSearchView", editSearchView);
 // View Metadata
 // -----------------------------------------------------------------------------
 
-class GetMetadataDialog extends Component {
+export class GetMetadataDialog extends Component {
     static template = "web.DebugMenu.GetMetadataDialog";
     static components = { Dialog };
     static props = {


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Simply add the export keyword on the GetMetadataDialog class to allow third-party modules to extend its functionalities

Current behavior before PR:

GetMetadataDialog class is not exported and so could not be extended 

Desired behavior after PR is merged:

GetMetadataDialog could be easily improved/edited using the `extend` keyword


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
