### PR TITLE
[FIX] web: onchange warning from within a formViewDialog

### DIFF
--- a/addons/web/static/tests/views/view_dialogs/form_view_dialog_tests.js
+++ b/addons/web/static/tests/views/view_dialogs/form_view_dialog_tests.js
@@ -8,6 +8,7 @@ import {
     patchWithCleanup,
     triggerHotkey,
 } from "@web/../tests/helpers/utils";
+import { contains } from "@web/../tests/utils";
 import { makeView } from "@web/../tests/views/helpers";
 import { createWebClient } from "@web/../tests/webclient/helpers";
 import { FormViewDialog } from "@web/views/view_dialogs/form_view_dialog";
@@ -376,4 +377,49 @@ QUnit.module("ViewDialogs", (hooks) => {
             assert.containsNone(target, ".modal", "modal should be closed");
         }
     );
+
+    QUnit.test("display a dialog if onchange result is a warning from within a dialog", async function (assert) {
+        serverData.views = {
+            "instrument,false,form": `<form><field name="display_name" /></form>`
+        };
+        await makeView({
+            type: "form",
+            resModel: "partner",
+            serverData,
+            arch: `<form><field name="instrument"/></form>`,
+            resId: 2,
+            mockRPC(route, args) {
+                if (args.method === "onchange" && args.model === "instrument") {
+                    assert.step("onchange warning")
+                    return Promise.resolve({
+                        warning: {
+                            title: "Warning",
+                            message: "You must first select a partner",
+                            type: "dialog",
+                        },
+                    });
+                }
+            },
+        });
+
+        await editInput(target, ".o_field_widget[name=instrument] input", "tralala");
+        await contains(".o_m2o_dropdown_option_create_edit a");
+
+        await click(target.querySelector(".o_m2o_dropdown_option_create_edit a"));
+        await contains(".modal.o_inactive_modal");
+        assert.containsN(document.body, ".modal", 2);
+        assert.strictEqual(
+            document.body.querySelector(".modal:not(.o_inactive_modal) .modal-body").textContent,
+            "You must first select a partner"
+        );
+
+        await click(document.body.querySelector(".modal:not(.o_inactive_modal) button"))
+        assert.containsOnce(target, ".modal");
+        assert.strictEqual(
+            document.body.querySelector(".modal:not(.o_inactive_modal) .modal-title").textContent,
+            "Create Instruments"
+        );
+
+        assert.verifySteps(["onchange warning"])
+    });
 });

--- a/addons/web/static/tests/webclient/actions/window_action_tests.js
+++ b/addons/web/static/tests/webclient/actions/window_action_tests.js
@@ -20,6 +20,7 @@ import {
     patchWithCleanup,
     clickSave,
 } from "../../helpers/utils";
+import { contains } from "@web/../tests/utils";
 import { createWebClient, doAction, getActionManagerServerData, loadState } from "./../helpers";
 import { errorService } from "../../../src/core/errors/error_service";
 import { RPCError } from "@web/core/network/rpc_service";
@@ -2196,11 +2197,7 @@ QUnit.module("ActionManager", (hooks) => {
             await doAction(webClient, 3);
 
             await click(target.querySelector(".o_list_button_add"));
-            assert.containsOnce(
-                document.body,
-                ".modal.o_technical_modal",
-                "Warning modal should be opened"
-            );
+            await contains(".modal.o_technical_modal");
 
             await click(document.querySelector(".modal.o_technical_modal button.btn-close"));
             assert.containsNone(


### PR DESCRIPTION
Have a model that returns a warning onchange during the first call to onchange. On another model that has a many2one to the first model, Create And Edit a record via the many2one field on the form view.

Before this commit, there was an endless loop because on dialog was triggering the opening of a second one *during* its willStart lifecycle period, so none of them end up mounted, instead, the formViewDialog was constantly reinstanciated because the dialog container constantly received requests to re-render.

After this commit, we only open those dialog onMounted of the main component, and this issue doesn't occur anymore.

opw-4783459

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
