### PR TITLE
[FIX] website: display website navbar

### DIFF
--- a/addons/website/static/src/client_actions/website_preview/website_builder_action.js
+++ b/addons/website/static/src/client_actions/website_preview/website_builder_action.js
@@ -189,30 +189,14 @@ export class WebsiteBuilder extends Component {
         };
     }
 
-    isSystrayDisplayed() {
-        // TODO: improve this. These are the minimal requirements for at least
-        // one systray item to be displayed, but it duplicates logic from the
-        // WebsiteSystrayItem component.
-        const websiteMetadata = this.websiteService.currentWebsite?.metadata;
-        return (
-            this.websiteService.websites.length > 1 ||
-            this.websiteService.isRestrictedEditor ||
-            (this.websiteService.currentWebsite && websiteMetadata &&
-                (websiteMetadata.canPublish || websiteMetadata.editableInBackend))
-        );
-    }
-
     addSystrayItems() {
-        if (
-            !websiteSystrayRegistry.contains("website.WebsiteSystrayItem") &&
-            this.isSystrayDisplayed()
-        ) {
+        if (!websiteSystrayRegistry.contains("website.WebsiteSystrayItem")) {
             websiteSystrayRegistry.add(
                 "website.WebsiteSystrayItem",
                 {
                     Component: WebsiteSystrayItem,
                     props: this.systrayProps,
-                    isDisplayed: this.isSystrayDisplayed.bind(this),
+                    isDisplayed: () => true,
                 },
                 { sequence: -100 }
             );


### PR DESCRIPTION
The tour `test_04_not_reditor_salesman` failed due to the "Publish" systray not appearing. This happened because the systray container needed the website service to be started in order to be displayed, but at that point the data was not yet loaded.

We now display the container by default, each systray item will be shown depending on the container's state, which allows more flexibility.

runbot-226530