### PR TITLE
[FIX] stock: store qty_to_order_computed

### DIFF
--- a/addons/purchase_stock/models/stock.py
+++ b/addons/purchase_stock/models/stock.py
@@ -121,9 +121,11 @@ class StockWarehouseOrderpoint(models.Model):
     product_supplier_id = fields.Many2one('res.partner', compute='_compute_product_supplier_id', store=True, string='Product Supplier')
 
     @api.depends('product_id.purchase_order_line_ids.product_qty', 'product_id.purchase_order_line_ids.state')
-    def _compute_qty(self):
-        """ Extend to add more depends values """
-        return super()._compute_qty()
+    def _compute_qty_to_order_computed(self):
+        """ Extend to add more depends values
+        TODO: Probably performance costly due to x2many in depends
+        """
+        return super()._compute_qty_to_order_computed()
 
     @api.depends('supplier_id')
     def _compute_lead_days(self):

--- a/addons/purchase_stock/tests/test_purchase_lead_time.py
+++ b/addons/purchase_stock/tests/test_purchase_lead_time.py
@@ -258,12 +258,12 @@ class TestPurchaseLeadTime(PurchaseTestCommon):
         orderpoint_form.product_id = product
         orderpoint_form.product_min_qty = 0.0
         orderpoint_form.visibility_days = 1.0
-        orderpoint = orderpoint_form.save()
+        orderpoint_form.save()
 
         orderpoint_form = Form(self.env['stock.warehouse.orderpoint'].with_company(company2))
         orderpoint_form.product_id = product
         orderpoint_form.product_min_qty = 0.0
-        orderpoint = orderpoint_form.save()
+        orderpoint_form.save()
 
         delivery_moves = self.env['stock.move']
         for i in range(0, 6):
@@ -284,11 +284,9 @@ class TestPurchaseLeadTime(PurchaseTestCommon):
         self.assertEqual(len(po_line), 1)
         self.assertEqual(po_line.product_uom_qty, 25.0)
         self.assertEqual(len(po_line.order_id), 1)
-        orderpoint_form = Form(orderpoint)
-        orderpoint_form.save()
 
         self.mock_date.today.return_value = fields.Date.today() + timedelta(days=2)
-        orderpoint._compute_qty()
+        self.env.invalidate_all()
         self.env['procurement.group'].run_scheduler()
         po_line02 = self.env['purchase.order.line'].search([('product_id', '=', product.id)])
         self.assertEqual(po_line02, po_line, 'The orderpoint execution should not create a new POL')

--- a/addons/stock/models/stock_rule.py
+++ b/addons/stock/models/stock_rule.py
@@ -696,6 +696,7 @@ class ProcurementGroup(models.Model):
         # Minimum stock rules
         domain = self._get_orderpoint_domain(company_id=company_id)
         orderpoints = self.env['stock.warehouse.orderpoint'].search(domain)
+        orderpoints.sudo()._compute_qty_to_order_computed()
         orderpoints.sudo()._procure_orderpoint_confirm(use_new_cursor=use_new_cursor, company_id=company_id, raise_user_error=False)
 
         if use_new_cursor:

--- a/addons/stock/views/stock_orderpoint_views.xml
+++ b/addons/stock/views/stock_orderpoint_views.xml
@@ -204,6 +204,7 @@
         <field name="path">replenishment</field>
         <field name="code">
             action = model.with_context(
+                search_default_filter_to_reorder=True,
                 search_default_filter_not_snoozed=True,
                 default_trigger='manual',
                 searchpanel_default_trigger='manual'

--- a/odoo/addons/test_main_flows/static/tests/tours/main_flow.js
+++ b/odoo/addons/test_main_flows/static/tests/tours/main_flow.js
@@ -906,14 +906,12 @@ stepUtils.autoExpandMoreButtons(),
     run: "click",
 },
 {
-    // FIXME WOWL: remove first part of selector when legacy view is dropped
-    trigger: "input.o_field_widget[name=product_min_qty], .o_field_widget[name=product_min_qty] input",
+    trigger: ".o_field_widget[name=product_min_qty] input",
     content: _t("Set the minimum product quantity"),
     tooltipPosition: "right",
     run: "edit 1",
 }, {
-    // FIXME WOWL: remove first part of selector when legacy view is dropped
-    trigger: "input.o_field_widget[name=product_max_qty], .o_field_widget[name=product_max_qty] input",
+    trigger: ".o_field_widget[name=product_max_qty] input",
     content: _t("Set the maximum product quantity"),
     tooltipPosition: "right",
     run: "edit 10",


### PR DESCRIPTION
There is an issue with the `to replenish` filter.
Once added, every request will add the domain `qty_to_order` greater than 0. However `qty_to_order` and `qty_to_order_computed` are not store. It implies that the server has to recompute everything at each request. The base computation already require a lot of computation and could be slow on huge db.

In order to fix it we store the base computation. The drawback:
- It has to be update everyday in order to be correct (since the qty_to_order depends on the qty_forecast which is base today + lead times)
- Perf issue on move validation since it will recompute the qty_to_order_computed. We add an orm "speedup" to only recompute the orderpoints related to the move. (Since the depends are too wide, `product_id.stock_move_id...`)

See PR #164300
This reverts commit 99a5a1fdc341416ad873034190ebf3129abc54ca.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
