### PR TITLE
[FIX] account: fix the incorrect base on tax report with analytic

### DIFF
--- a/addons/account/models/account_move_line_tax_details.py
+++ b/addons/account/models/account_move_line_tax_details.py
@@ -398,6 +398,7 @@ class AccountMoveLine(models.Model):
                     tax_line.tax_line_id AS tax_id,
                     tax_line.group_tax_id,
                     tax_line.tax_repartition_line_id,
+                    tax_line.analytic_distribution,
 
                     tax_line.company_id,
                     tax_line.display_type AS display_type,
@@ -468,6 +469,7 @@ class AccountMoveLine(models.Model):
                 sub.tax_line_id,
                 sub.display_type,
                 sub.src_line_id,
+                sub.analytic_distribution,
 
                 sub.tax_id,
                 sub.group_tax_id,


### PR DESCRIPTION
### Issue:
When having two lines on an invoice with the same tax and different analytic distribution, the base value is doubled on the tax report.

### Steps to reproduce:
- Create a new tax on sales (eg 10%)
- Make sure the option "Analytic Accounting" is ticked in the settings
- Create an invoice with two lines (eg both at $100), add the tax on both
- Change the analytic distribution on both lines to different values
- Confirm the invoice
- Go to the tax report
- Select the report "Group By: Account > Tax"
- On the report the "Net" amount is doubled ($400), the tax amount is correct ($20)

### Cause:
On the invoice we can see in "Journal Items" that two tax lines are created instead of one (one for each analytic distribution).

The "Group By" reports are generated by [this query](https://github.com/odoo/odoo/blob/51fcbd211d2b1abf4b93becedbcbb9e03002cdd6/addons/account/models/account_move_line_tax_details.py#L92).  At the [creation of the second subtable](https://github.com/odoo/odoo/blob/51fcbd211d2b1abf4b93becedbcbb9e03002cdd6/addons/account/models/account_move_line_tax_details.py#L164-L198) the move lines are linked together based among other things on the tax id. The [filter on analytic distribution](https://github.com/odoo/odoo/blob/51fcbd211d2b1abf4b93becedbcbb9e03002cdd6/addons/account/models/account_move_line_tax_details.py#L187-L191) does not apply here as `tax.analytic = False`. The result is that each tax line is linked with both base lines. The second subtable have 4 lines in this case, with each base line doubled.

The result of the query have the base amount doubled.

### Solution:
We cannot fix the query as there is no link to find the tax line origin among the base lines.

The method `_read_generic_tax_report_amounts` in `account_reports` is made to fix the base values in report in case of duplicate. Until now, it did not include the duplication caused by analytic distribution but duplication because of repartition lines for example.

The fix is to use this method also for analytic distribution. So we add `tdr.analytic_distribution` in the `GROUP BY`. This value must be returned by the query in `account` so we add it.

opw-4753676