### PR TITLE
[IMP] account,purchase,sale: prioritize already invoiced products for current vendor/customer

### DIFF
--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -1144,6 +1144,12 @@
                                         <field name="product_id"
                                                optional="conditional"
                                                widget="product_label_section_and_note_field"
+                                               context="{
+                                                'partner_id': parent.partner_id,
+                                                'prioritize_for': (context.get('default_move_type') in ('out_invoice', 'out_refund', 'out_receipt') and 'sale') or
+                                                                  (context.get('default_move_type') in ('in_invoice', 'in_refund', 'in_receipt') and 'purchase') or
+                                                                  False,
+                                               }"
                                                domain="
                                                     context.get('default_move_type') in ('out_invoice', 'out_refund', 'out_receipt')
                                                     and [('sale_ok', '=', True)]

--- a/addons/product/views/product_views.xml
+++ b/addons/product/views/product_views.xml
@@ -670,7 +670,7 @@ action = {
                     <t t-name="card" class="p-0">
                     <!-- TODO : not getting border when select record -->
                         <div class="d-flex flex-grow-1 m-2">
-                            <div class="ps-2 d-flex flex-column m-0"
+                            <div name="product_fields" class="ps-2 d-flex flex-column m-0"
                                     t-attf-id="product-{{record.id.raw_value}}">
                                 <div class="d-flex">
                                     <field name="name" class="fw-bold fs-4 text-reset mb-1 me-2"/>

--- a/addons/purchase/views/purchase_views.xml
+++ b/addons/purchase/views/purchase_views.xml
@@ -264,7 +264,12 @@
                                         widget="product_label_section_and_note_field"
                                         readonly="state in ('purchase', 'to approve', 'cancel') or is_downpayment"
                                         required="not display_type and not is_downpayment"
-                                        context="{'partner_id':parent.partner_id, 'quantity':product_qty, 'company_id': parent.company_id}"
+                                        context="{
+                                            'company_id': parent.company_id,
+                                            'prioritize_for': 'purchase',
+                                            'partner_id':parent.partner_id,
+                                            'quantity':product_qty,
+                                        }"
                                         options="{'show_label_warning': True}"
                                         force_save="1" domain="[('purchase_ok', '=', True), '|', ('company_id', '=', False), ('company_id', 'parent_of', parent.company_id)]"/>
                                     <field name="name" widget="section_and_note_text" optional="show"/>

--- a/addons/purchase_product_matrix/views/purchase_views.xml
+++ b/addons/purchase_product_matrix/views/purchase_views.xml
@@ -14,7 +14,10 @@
                     string="Product"
                     readonly="state in ('purchase', 'to approve', 'cancel')"
                     required="not display_type"
-                    context="{'partner_id': parent.partner_id}"
+                    context="{
+                        'partner_id': parent.partner_id,
+                        'prioritize_for': 'purchase',
+                    }"
                     options="{'show_label_warning': True}"
                     widget="pol_product_many2one"/>
                 <field name="product_template_attribute_value_ids" column_invisible="1"/>

--- a/addons/sale/models/product_product.py
+++ b/addons/sale/models/product_product.py
@@ -37,13 +37,7 @@ class ProductProduct(models.Model):
         for product in self:
             if product.last_invoice_date:
                 days_count = (today - product.last_invoice_date).days
-                if days_count > 365:
-                    day_value_str = self.env._('%(years_count)sy', years_count=(days_count // 365))
-                elif days_count > 30:
-                    day_value_str = self.env._('%(months_count)smo', months_count=(days_count // 30))
-                else:
-                    day_value_str = self.env._('%(days_count)sd', days_count=days_count)
-                product.last_invoice_since = day_value_str
+                product.last_invoice_since = self.env['product.template']._get_last_invoice_since(days_count)
 
     def _compute_sales_count(self):
         r = {}

--- a/addons/sale/models/product_product.py
+++ b/addons/sale/models/product_product.py
@@ -1,22 +1,60 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from collections import defaultdict
 from datetime import timedelta
 
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError
-from odoo.tools import float_round
 
 
 class ProductProduct(models.Model):
     _inherit = 'product.product'
 
     sales_count = fields.Float(compute='_compute_sales_count', string='Sold', digits='Product Unit')
+    last_invoice_date = fields.Date(compute='_compute_last_invoice_date')
 
     # Catalog related fields
     product_catalog_product_is_in_sale_order = fields.Boolean(
         compute='_compute_product_is_in_sale_order',
         search='_search_product_is_in_sale_order',
     )
+
+    @api.depends_context('partner_id')
+    def _compute_last_invoice_date(self):
+        self.last_invoice_date = False
+        partner_id = self.env.context.get('partner_id')
+        if not partner_id:
+            return
+
+        today = fields.Date.today()
+        prioritized_product_and_time = self.env['product.template']._get_products_and_most_recent_invoice_date(partner_id, 'sale', self.ids)
+        dates_by_product = defaultdict(lambda: False)
+        for data in prioritized_product_and_time:
+            date = data['invoice_date']
+            product = self.browse(data['product_id'])
+            if not dates_by_product[product] or date > dates_by_product[product]:
+                dates_by_product[product] = date if date <= today else today
+        for (product, date) in dates_by_product.items():
+            product.last_invoice_date = date
+
+    @api.depends_context('formatted_display_name', 'partner_id', 'prioritize_for')
+    def _compute_display_name(self):
+        super()._compute_display_name()
+
+        # Add last invoiced date beside the product's name.
+        if self.env.context.get('formatted_display_name') and\
+            self.env['product.template']._must_prioritize_invoiced_product():
+            today = fields.Date.today()
+            for product in self:
+                if product.last_invoice_date:
+                    days_count = (today - product.last_invoice_date).days
+                    if days_count > 365:
+                        day_value_str = self.env._('%(years_count)sy', years_count=(days_count // 365))
+                    elif days_count > 30:
+                        day_value_str = self.env._('%(months_count)smo', months_count=(days_count // 30))
+                    else:
+                        day_value_str = self.env._('%(days_count)sd', days_count=days_count)
+                    product.display_name += f'\t`{day_value_str}`'
 
     def _compute_sales_count(self):
         r = {}
@@ -113,7 +151,7 @@ class ProductProduct(models.Model):
             so_lines.product_uom_id = to_uom_id
         return super()._update_uom(to_uom_id)
 
-    def _trigger_uom_warning(self):        
+    def _trigger_uom_warning(self):
         res = super()._trigger_uom_warning()
         if res:
             return res

--- a/addons/sale/models/product_template.py
+++ b/addons/sale/models/product_template.py
@@ -75,13 +75,7 @@ class ProductTemplate(models.Model):
         for product in self:
             if product.last_invoice_date:
                 days_count = (today - product.last_invoice_date).days
-                if days_count > 365:
-                    day_value_str = self.env._('%(years_count)sy', years_count=(days_count // 365))
-                elif days_count > 30:
-                    day_value_str = self.env._('%(months_count)smo', months_count=(days_count // 30))
-                else:
-                    day_value_str = self.env._('%(days_count)sd', days_count=days_count)
-                product.last_invoice_since = day_value_str
+                product.last_invoice_since = self._get_last_invoice_since(days_count)
 
     @api.depends('invoice_policy', 'sale_ok', 'service_tracking')
     def _compute_product_tooltip(self):
@@ -257,11 +251,19 @@ class ProductTemplate(models.Model):
         """
         return ['no']
 
+    @api.model
+    def _get_last_invoice_since(self, days_count):
+        if days_count > 365:
+            return self.env._('%(years_count)sy', years_count=(days_count // 365))
+        elif days_count > 30:
+            return self.env._('%(months_count)smo', months_count=(days_count // 30))
+        else:
+            return self.env._('%(days_count)sd', days_count=days_count)
+
     ####################################
     # Product/combo configurator hooks #
     ####################################
 
-    @api.model
     def _get_configurator_display_price(
         self, product_or_template, quantity, date, currency, pricelist, **kwargs
     ):

--- a/addons/sale/models/product_template.py
+++ b/addons/sale/models/product_template.py
@@ -4,7 +4,6 @@ from collections import defaultdict
 
 from odoo import _, api, fields, models
 from odoo.exceptions import ValidationError
-from odoo.tools import float_round
 
 
 class ProductTemplate(models.Model):

--- a/addons/sale/models/product_template.py
+++ b/addons/sale/models/product_template.py
@@ -54,6 +54,43 @@ class ProductTemplate(models.Model):
              "whenever the customer hits *Add to Cart* (cross-sell strategy, "
              "e.g. for computers: warranty, software, etc.).",
         check_company=True)
+    last_invoice_date = fields.Date(compute='_compute_last_invoice_date')
+
+    @api.depends_context('partner_id')
+    def _compute_last_invoice_date(self):
+        self.last_invoice_date = False
+        partner_id = self.env.context.get('partner_id')
+        if not partner_id:
+            return
+
+        today = fields.Date.today()
+        prioritized_product_and_time = self._get_products_and_most_recent_invoice_date(partner_id, 'sale', self.product_variant_ids.ids)
+        dates_by_product_template = defaultdict(lambda: False)
+        for data in prioritized_product_and_time:
+            date = data['invoice_date']
+            product_tmpl = self.browse(data['product_tmpl_id'])
+            if not dates_by_product_template[product_tmpl] or date > dates_by_product_template[product_tmpl]:
+                dates_by_product_template[product_tmpl] = date if date <= today else today
+        for (product_tmpl, date) in dates_by_product_template.items():
+            product_tmpl.last_invoice_date = date
+
+    @api.depends_context('formatted_display_name', 'partner_id', 'prioritize_for')
+    def _compute_display_name(self):
+        super()._compute_display_name()
+
+        # Add last invoiced date beside the product's name.
+        if self.env.context.get('formatted_display_name') and self._must_prioritize_invoiced_product():
+            today = fields.Date.today()
+            for product in self:
+                if product.last_invoice_date:
+                    days_count = (today - product.last_invoice_date).days
+                    if days_count > 365:
+                        day_value_str = self.env._('%(years_count)sy', years_count=(days_count // 365))
+                    elif days_count > 30:
+                        day_value_str = self.env._('%(months_count)smo', months_count=(days_count // 30))
+                    else:
+                        day_value_str = self.env._('%(days_count)sd', days_count=days_count)
+                    product.display_name += f'\t`{day_value_str}`'
 
     @api.depends('invoice_policy', 'sale_ok', 'service_tracking')
     def _compute_product_tooltip(self):

--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -1323,6 +1323,8 @@ class SaleOrder(models.Model):
             **super()._get_action_add_from_catalog_extra_context(),
             'product_catalog_currency_id': self.currency_id.id,
             'product_catalog_digits': self.order_line._fields['price_unit'].get_digits(self.env),
+            'partner_id': self.partner_id.id,
+            'prioritize_for': 'sale',
         }
 
     def _get_product_catalog_domain(self):

--- a/addons/sale/tests/test_sale_order.py
+++ b/addons/sale/tests/test_sale_order.py
@@ -340,16 +340,16 @@ class TestSaleOrder(SaleCommon):
         ])
         # Check their last invoice date and displayed name are correctly computed.
         self.assertRecordValues(product_tmpl.product_variant_ids.with_context(display_context), [
-            {'display_name': 'Test Product (A)\t--15d--', 'last_invoice_date': two_weeks_ago},
-            {'display_name': 'Test Product (B)\t--3mo--', 'last_invoice_date': three_months_ago},
-            {'display_name': 'Test Product (C)\t--1y--', 'last_invoice_date': one_and_half_year_ago},
+            {'display_name': '`15d` **Test Product (A)**', 'last_invoice_date': two_weeks_ago},
+            {'display_name': '`3mo` **Test Product (B)**', 'last_invoice_date': three_months_ago},
+            {'display_name': '`1y` **Test Product (C)**', 'last_invoice_date': one_and_half_year_ago},
         ])
         # Do the same check for the product template (it should take the most recent date from all variants.)
         self.assertRecordValues(product_tmpl, [
             {'display_name': 'Test Product', 'last_invoice_date': False},
         ])
         self.assertRecordValues(product_tmpl.with_context(display_context), [
-            {'display_name': 'Test Product\t--15d--', 'last_invoice_date': two_weeks_ago},
+            {'display_name': '`15d` **Test Product**', 'last_invoice_date': two_weeks_ago},
         ])
 
     def test_state_changes(self):

--- a/addons/sale/views/product_views.xml
+++ b/addons/sale/views/product_views.xml
@@ -117,6 +117,11 @@
             <xpath expr="//t[@t-name='menu']" position="attributes">
                 <attribute name="groups">sales_team.group_sale_manager</attribute>
             </xpath>
+            <xpath expr="//div[@name='product_fields']" position="inside">
+                <div name="last_invoice_since" invisible="not last_invoice_date" class="text-muted">
+                    <field name="last_invoice_since"/> ago
+                </div>
+            </xpath>
         </field>
     </record>
 

--- a/addons/sale/views/sale_order_views.xml
+++ b/addons/sale/views/sale_order_views.xml
@@ -626,6 +626,8 @@
                                     context="{
                                         'default_lst_price': price_unit,
                                         'default_uom_id': product_uom_id,
+                                        'prioritize_for': 'sale',
+                                        'partner_id': parent.partner_id,
                                     }"
                                     options="{
                                         'show_label_warning': True
@@ -639,6 +641,8 @@
                                     context="{
                                         'default_list_price': price_unit,
                                         'default_uom_id': product_uom_id,
+                                        'prioritize_for': 'sale',
+                                        'partner_id': parent.partner_id,
                                     }"
                                     options="{
                                         'show_label_warning': True


### PR DESCRIPTION
## Prioritize already invoiced products
This PR adds a query to search products while giving priority to the last invoiced ones.
So, when creating a purchase order or a sale order, the user will see on the top of the name search previous purchased/sold products for the order's vendor/customer.

It relies on context keys to add on the product field in the view:
- `partner_id` (int): the ID of the current partner;
- `move_type` (str) for a invoice;
- `is_purchase` (bool) for a purchase order;
- `is_sale` (bool) for a sale order.
 
If `partner_id` or `move_type`/`is_purchase`/`is_sale` key is missing, the search for the priority won't be done, so, if for a reason or another, the user doesn't want this filter, the context key can be removed from the view.

## Adds duration since last invoice product
#### Add `product.product` `last_invoiced_date` compute field
This field gets the last time the product was invoiced for a given partner (get in the context.)
If the `partner_id` is not in the context, the compute is skip.
#### Add last invoiced time period beside the product's name
In a Sale Order, when selecting a SO line's product, the time period between today and the last invoice for the SO partner will be displayed beside the product's name.

For example, let say we have a product named "Tool Box":
- If the last invoice was done 2 weeks ago, the product's display name
  will be "Tool Box    14d";
- If the last invoice was done 18 months ago, the product's display name
  will be "Tool Box    1y".

### TODO:
- [ ] Adds some tests in `account` alongside `purchase`;
- [ ] Adapt tests to check system parameter works as expected.

task-4423839