### PR TITLE
[FIX] project: fix subtask access in private projects

### DIFF
--- a/addons/project/models/project_task.py
+++ b/addons/project/models/project_task.py
@@ -358,7 +358,7 @@ class Task(models.Model):
     @api.depends('project_id', 'parent_id')
     def _compute_show_display_in_project(self):
         for task in self:
-            task.show_display_in_project = bool(task.parent_id) and task.project_id == task.parent_id.project_id
+            task.show_display_in_project = bool(task.parent_id) and task.project_id == task.parent_id.sudo().project_id
 
     @api.depends('stage_id', 'depend_on_ids.state')
     def _compute_state(self):


### PR DESCRIPTION
To reproduce:
=============
- Create a private project and a task in it
- Create a subtask in this task and assign it to Demo
- Log in as Demo and go to "My Tasks"
- the subtask is listed but opening it gives an access error

Problem:
========
the computation of the field `show_display_in_project` requires reading `project_id` from the parent task, which is not allowed for Demo

Solution:
=========
read through `sudo`

opw-4850408

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
