### PR TITLE
[17.0][IMP] mrp: Reduce time to set values for new columns with big tables

### DIFF
--- a/addons/mrp/__init__.py
+++ b/addons/mrp/__init__.py
@@ -14,12 +14,14 @@ def _pre_init_mrp(env):
           stock_move.unit_factor is terribly slow with the ORM and leads to "Out of
           Memory" crashes
     """
-    env.cr.execute("""ALTER TABLE "stock_move" ADD COLUMN "is_done" bool;""")
+    env.cr.execute("""ALTER TABLE "stock_move" ADD COLUMN "is_done" bool DEFAULT TRUE;""")
     env.cr.execute("""UPDATE stock_move
-                     SET is_done=COALESCE(state in ('done', 'cancel'), FALSE);""")
-    env.cr.execute("""ALTER TABLE "stock_move" ADD COLUMN "unit_factor" double precision;""")
-    env.cr.execute("""UPDATE stock_move
-                     SET unit_factor=1;""")
+                    SET is_done = FALSE
+                  WHERE state NOT IN ('done', 'cancel');""")
+    env.cr.execute("""ALTER TABLE stock_move ALTER COLUMN is_done DROP DEFAULT;""")
+    env.cr.execute("""ALTER TABLE "stock_move"
+                    ADD COLUMN "unit_factor" double precision DEFAULT 1;""")
+    env.cr.execute("""ALTER TABLE stock_move ALTER COLUMN unit_factor DROP DEFAULT;""")
 
 def _create_warehouse_data(env):
     """ This hook is used to add a default manufacture_pull_id, manufacture


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**

When installing mrp on databases with many records in the stock move table, the time it takes to set the initial values is excessive, resulting in deadlocks.

This PR sets at database level the default value and then removes that default value in order not to modify the table structure.
What is achieved with these changes is that when the new column is created, it already has the value that all (or the vast majority) of records must have, so that the records do not have to be updated later (or only a small part of them are updated).


**Current behavior before PR:**

Excessive time and crashes when installing mrp on a database with many records in stock move

**Desired behavior after PR is merged:**

That the installation of the module is immediate and does not cause blockages.


**Additional comments:**

This enhancement is applicable to versions 15.0, 16.0, 17.0 and 18.0.

I also believe that this approach should be considered for setting any default value when adding a new column, at least in tables that are likely to have millions of records.


Use this to check that values is keep after DROP DEFAULT:
```
DROP TABLE IF EXISTS demo_default;
CREATE TABLE demo_default (
    id INTEGER PRIMARY KEY
);
INSERT INTO demo_default (id) VALUES (1), (2), (3);

SELECT ctid, xmin::text AS xmin, id FROM demo_default ORDER BY id;

ALTER TABLE demo_default ADD COLUMN flag BOOLEAN DEFAULT TRUE;

ALTER TABLE demo_default ALTER COLUMN flag DROP DEFAULT;

SELECT ctid, xmin::text AS xmin, id, flag FROM demo_default ORDER BY id;
```


@Tecnativa

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr