### PR TITLE
[IMP] sale_project: link project created from sale order

### DIFF
--- a/addons/sale_project/models/project_project.py
+++ b/addons/sale_project/models/project_project.py
@@ -178,11 +178,12 @@ class ProjectProject(models.Model):
     @api.model_create_multi
     def create(self, vals_list):
         projects = super().create(vals_list)
-        sol_ids = {
-            vals['sale_line_id']
-            for vals in vals_list
-            if vals.get('sale_line_id')
-        }
+        sol_ids = set()
+        for project, vals in zip(projects, vals_list):
+            if (vals.get('sale_line_id')):
+                sol_ids.add(vals['sale_line_id'])
+            if project.sale_order_id and not project.sale_order_id.project_id:
+                project.sale_order_id.project_id = project.id
         if sol_ids:
             projects._ensure_sale_order_linked(list(sol_ids))
         return projects

--- a/addons/sale_project/tests/test_sale_project.py
+++ b/addons/sale_project/tests/test_sale_project.py
@@ -1635,3 +1635,17 @@ class TestSaleProject(TestSaleProjectCommon):
         order.action_confirm()
         self.assertEqual(order.tasks_count, 1, "1 task should be created")
         self.assertEqual(order.tasks_ids.allocated_hours, 0, "Task should get 0 hrs (manual policy)")
+
+    def test_create_project_from_sale_order(self):
+        """Test that a project created from a sale order is linked to that sale order."""
+        sale_order = self.env['sale.order'].create({
+            'partner_id': self.partner.id,
+            'order_line': [Command.create({'product_id': self.product_order_service1.id})],
+        })
+        sale_order.action_confirm()
+        action = sale_order.action_create_project()
+        project = self.env['project.project'].with_context(action['context']).create({
+            'name': 'Test Project',
+            'allow_billable': True,
+        })
+        self.assertEqual(sale_order.project_id, project, "The created project should be linked to this sale order")


### PR DESCRIPTION
Ensure that a project created via the sale order action is linked to the related sale order.

task-4797391