### PR TITLE
[FIX] website: strengthen sitemap test

### DIFF
--- a/addons/website/tests/test_sitemap.py
+++ b/addons/website/tests/test_sitemap.py
@@ -28,18 +28,21 @@ class TestWebsiteSitemap(TransactionCase):
                 "UPDATE ir_ui_view SET write_date = %s WHERE id = %s",
                 (view_date, page.view_id.id)
             )
-            Page.invalidate_model()
-            View.invalidate_model()
+            Page.invalidate_model(['write_date'])
+            View.invalidate_model(['write_date'])
+            self.assertEqual(str(page.write_date), page_date)
+            self.assertEqual(str(page.view_id.write_date), view_date)
 
         def get_sitemap_lastmod():
             pages = website._enumerate_pages()
             return next(p['lastmod'] for p in pages if p['loc'] == page_url)
 
         old_date = "2002-05-06 12:00:00"
-        new_date = "2014-05-15 12:00:00"
 
+        new_date = "2014-05-15 12:00:00"
         set_write_dates(new_date, old_date)
         self.assertEqual(str(get_sitemap_lastmod()), new_date[:10])
 
-        set_write_dates(old_date, new_date)
-        self.assertEqual(str(get_sitemap_lastmod()), new_date[:10])
+        new_date2 = "2015-10-01 12:00:00"
+        set_write_dates(old_date, new_date2)
+        self.assertEqual(str(get_sitemap_lastmod()), new_date2[:10])


### PR DESCRIPTION
Follow-up of [1].

- Using `invalidate_model` without giving the related field seems to be causing issues in the master version. Let's just mention what we need only to be sure.

- Check the proper update of write_date.s (note that this was already done in some forward-ported versions of [1]).

- Use two distinct "new dates" so that potential cache features do not make the test pass by chance, and ease debugging of the test.

[1]: https://github.com/odoo/odoo/commit/4df533196d3cfdee34beb2ae604f569e67cf4f93
