### PR TITLE
[FIX] l10n_lu: tax report: make sure to empty subformula on aggregation

### DIFF
--- a/addons/l10n_lu/data/tax_report/section_2.xml
+++ b/addons/l10n_lu/data/tax_report/section_2.xml
@@ -1724,6 +1724,7 @@
                                 <field name="label">balance</field>
                                 <field name="engine">aggregation</field>
                                 <field name="formula">LUTAX_046.balance + LUTAX_056.balance + LUTAX_407.balance + LUTAX_410.balance + LUTAX_768.balance + LUTAX_227.balance</field>
+                                <field name="subformula" eval="False"/>
                             </record>
                         </field>
                     </record>


### PR DESCRIPTION
This aggregation expression used to have 'cross_report' as subformula. Though, it was useless (since the aggregation only uses term from the same report), and the subformula was removed from the data file without explicitly resetting it to False. This became a problem in 18.3, because the cross_report syntax changes. Because of that, a migrated report failed to open, since it still was using the old syntax on that expression. We fix that by explicitly emptying the subformula.
