### PR TITLE
[IMP] mrp: estimate cost of operation

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -1498,6 +1498,7 @@ class MrpProduction(models.Model):
         move_raws_to_adjust._adjust_procure_method()
         moves_to_confirm._action_confirm(merge=False)
         workorder_to_confirm._action_confirm()
+        workorder_to_confirm._set_cost_mode()
         # run scheduler for moves forecasted to not have enough in stock
         ignored_mo_ids = self.env.context.get('ignore_mo_ids', [])
         self.move_raw_ids.with_context(ignore_mo_ids=ignored_mo_ids + self.ids)._trigger_scheduler()

--- a/addons/mrp/models/mrp_routing.py
+++ b/addons/mrp/models/mrp_routing.py
@@ -57,6 +57,11 @@ class MrpRoutingWorkcenter(models.Model):
     cycle_number = fields.Integer("Repetitions", compute="_compute_time_cycle")
     time_total = fields.Float('Total Duration', compute="_compute_time_cycle")
     show_time_total = fields.Boolean('Show Total Duration?', compute="_compute_time_cycle")
+    cost_mode = fields.Selection([('actual', 'Based on Actual resources'), ('estimated', 'Based on Estimated resources')],
+                                 string='Cost Computation', default='actual', tracking=True,
+                                 help="Determines the way Odoo calculates the cost of the operation:\n"
+                                 "- Based on Actual resources: the cost will be calculated based on tracked time and real employee costs.\n"
+                                 "- Based on Estimated resources: the cost will be calculated based on estimated time and costs.")
     cost = fields.Float('Cost', compute="_compute_cost")
 
     @api.depends('time_mode', 'time_mode_batch')

--- a/addons/mrp/views/mrp_routing_views.xml
+++ b/addons/mrp/views/mrp_routing_views.xml
@@ -96,6 +96,7 @@
                                 <field name="workcenter_id" context="{'default_company_id': company_id}"/>
                                 <field name="possible_bom_product_template_attribute_value_ids" invisible="1"/>
                                 <field name="bom_product_template_attribute_value_ids" widget="many2many_tags" options="{'no_create': True}" groups="product.group_product_variant"/>
+                                <field name="cost_mode" widget="radio"/>
                                 <field name="allow_operation_dependencies" invisible="1"/>
                                 <field name="blocked_by_operation_ids" widget="many2many_tags" context="{'default_bom_id':bom_id}" invisible="not allow_operation_dependencies"/>
                             </group><group name="workorder">


### PR DESCRIPTION
The cost of operation is currently based on the actual time. In the case a worker worked 3 hours but only logged in Odoo to register a serial number, the actual time would only be a few seconds.

For this reason, we are adding the possibility to compute the cost based on the manual or tracked time of an operation.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
