### PR TITLE
[FIX] stock_dropshipping,stock_account: Fix invalid COGS on dropship

### DIFF
--- a/addons/stock_account/models/product.py
+++ b/addons/stock_account/models/product.py
@@ -792,10 +792,12 @@ class ProductProduct(models.Model):
         if not qty_to_invoice:
             return 0
 
-        candidates = stock_moves\
-            .sudo()\
-            .filtered(lambda m: is_returned == bool(m.origin_returned_move_id and sum(m.stock_valuation_layer_ids.mapped('quantity')) >= 0))\
-            .mapped('stock_valuation_layer_ids')
+        candidates = self.env['stock.valuation.layer'].sudo()
+        for move in stock_moves.sudo():
+            move_candidates = move._get_layer_candidates()
+            if is_returned != bool(move.origin_returned_move_id and sum(move_candidates.mapped('quantity')) >= 0):
+                continue
+            candidates |= move_candidates
 
         if self.env.context.get('candidates_prefetch_ids'):
             candidates = candidates.with_prefetch(self.env.context.get('candidates_prefetch_ids'))

--- a/addons/stock_account/models/stock_move.py
+++ b/addons/stock_account/models/stock_move.py
@@ -638,3 +638,7 @@ class StockMove(models.Model):
 
     def _get_all_related_sm(self, product):
         return self.filtered(lambda m: m.product_id == product)
+
+    def _get_layer_candidates(self):
+        self.ensure_one()
+        return self.stock_valuation_layer_ids

--- a/addons/stock_dropshipping/models/stock.py
+++ b/addons/stock_dropshipping/models/stock.py
@@ -84,3 +84,15 @@ class StockLot(models.Model):
             ('location_dest_id.usage', '=', 'customer'),
             ('location_id.usage', '=', 'supplier'),
         ]])
+
+
+class StockMove(models.Model):
+    _inherit = 'stock.move'
+
+    def _get_layer_candidates(self):
+        layer_candidates = super()._get_layer_candidates()
+        if self._is_dropshipped():
+            layer_candidates = layer_candidates.filtered(lambda svl: svl.quantity < 0)
+        elif self._is_dropshipped_returned():
+            layer_candidates = layer_candidates.filtered(lambda svl: svl.quantity > 0)
+        return layer_candidates


### PR DESCRIPTION
If you have 2 invoices and 2 dropship picking linked to 1 Dropship Sale Order, and the two dropship have different SVL cost: The 2nd invoice will have incorrect COGS

https://github.com/user-attachments/assets/79f15933-0449-4081-aff0-daa5709889bf

## To reproduce
- Create Product P-DROP:
    * category: AVCO automated
    * Routes: Buy & Dropship
    * Purchase Vendors: Azure Interior @ $10
- Create Sale Order for 1 unit of P-Drop ⇾ Confirm
- Go to Purchase Order ⇾ ensure unit price is $10 ⇾ Confirm
- Receive products ⇾ ensure **valuation is $10**
- Create Vendor Bill (optional) ⇾ Confirm
- Create Invoice ⇾ Confirm
    * **COGS value is $10**  (ok)
- In Sale Order, set ordered quantity to 2 units
    * New draft PO should have been created
- Go to New Purchase Order ⇾ set price to $20 ⇾ Confirm
- Receive products ⇾ ensure **valuation is $20**
- Create Vendor Bill (optional) ⇾ Confirm
- Create Invoice ⇾ Confirm
    * COGS should be $20, but they are actually **$16.67** (KO)

---

## Test result without fix
```
2025-06-11 11:25:32,230 29041 ERROR oes_test_17 odoo.addons.stock_dropshipping.tests.test_stockvaluation: FAIL: TestStockValuation.test_dropship_cogs_multiple_invoices
Traceback (most recent call last):
  File "/home/odoo/projects/odoo-src/multiverse/src/17.0/odoo/addons/stock_dropshipping/tests/test_stockvaluation.py", line 382, in test_dropship_cogs_multiple_invoices
    self.assertEqual(dropship2_cogs_line.balance, -16)
AssertionError: -13.33 != -16
 ```

OPW-4665635

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
