### PR TITLE
[FIX] website_slides: fix new content ribbon

### DIFF
--- a/addons/website_slides/static/src/scss/website_slides.scss
+++ b/addons/website_slides/static/src/scss/website_slides.scss
@@ -51,31 +51,8 @@ $line-height-truncate: 1.25em;
 
 .o_wslides_arrow {
     position: absolute;
-    height: 24px;
-    margin-left: -5px;
-    margin-top: 10px;
-    line-height: 1.8em;
-    padding-left: 8px;
-    padding-right: 5px;
-    background: #17A2B8;
-    color: white;
-    box-shadow: 0px 0px 3px  gray;
-    z-index: 1;
-
-    text-decoration: none;
-
-    &:after {
-        // the triangle
-        content: "";
-        position: absolute;
-        height: 0px;
-        width: 0px;
-        right: 0;
-        margin-right: -15px;
-        border-left: 15px solid #17A2B8;
-        border-bottom: 12px solid transparent;
-        border-top: 12px solid transparent;
-    }
+    top: 0;
+    right: 0;
 }
 
 // Color tags according to assigned background color.

--- a/addons/website_slides/views/website_slides_templates_homepage.xml
+++ b/addons/website_slides/views/website_slides_templates_homepage.xml
@@ -338,6 +338,7 @@
             <div t-else="" class="o_wslides_background_image">
                 <img t-att-src="channel.website_background_image_url" class=" img img-fluid"/>
             </div>
+            <t t-if="channel.image_1920 and channel.partner_has_new_content" t-call="website_slides.course_card_information"/>
         </a>
         <div class="card-body p-3">
             <a class="card-title h5 mb-2 o_wslides_desc_truncate_2" t-attf-href="/slides/#{slug(channel)}" t-esc="channel.name"/>
@@ -381,7 +382,7 @@
 <template id="course_card_information_arrow" inherit_id="website_slides.course_card_information"
     active="True" name='New Content Ribbon'>
     <xpath expr="//t[@id='course_card_information_content']" position="inside">
-        <span class="o_wslides_arrow">New Content</span>
+        <span class="o_wslides_arrow badge bg-primary mt-2 me-2">New Content</span>
     </xpath>
 </template>
 


### PR DESCRIPTION
Fix the new content ribbon which (if the option is activated) should be displayed on the course cards when a new published content has been added during the last 7 days.

Task-4852463

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
