### PR TITLE
[FIX] mrp_subcontracting: validate correct amount on backorder

### DIFF
--- a/addons/mrp_subcontracting/models/stock_move.py
+++ b/addons/mrp_subcontracting/models/stock_move.py
@@ -305,6 +305,9 @@ class StockMove(models.Model):
             return True
         return should_bypass_reservation
 
+    def _get_available_move_lines(self, assigned_moves_ids, partially_available_moves_ids):
+        return super(StockMove, self.filtered(lambda m: not m.is_subcontract))._get_available_move_lines(assigned_moves_ids, partially_available_moves_ids)
+
     def _update_subcontract_order_qty(self, new_quantity):
         for move in self:
             quantity_to_remove = move.product_uom_qty - new_quantity

--- a/addons/mrp_subcontracting/tests/test_subcontracting.py
+++ b/addons/mrp_subcontracting/tests/test_subcontracting.py
@@ -1869,3 +1869,59 @@ class TestSubcontractingSerialMassReceipt(TransactionCase):
         })
         report_values = self.env['report.mrp.report_bom_structure']._get_report_data(bom_id=bom.id, searchVariant=False)
         self.assertTrue(report_values)
+
+    def test_subcontracting_multiple_backorders(self):
+        """
+        Check that processing multiple backorders in a raw for a
+        subcontracted prodcut is well behaved.
+        """
+        subcontracted_produt = self.env['product.product'].create({
+            'name': 'Lovely product',
+            'is_storable': True,
+        })
+        self.env['mrp.bom'].create({
+            'product_tmpl_id': subcontracted_produt.product_tmpl_id.id,
+            'type': 'subcontract',
+            'subcontractor_ids': [Command.set(self.subcontractor.ids)],
+        })
+        warehouse = self.env['stock.warehouse'].search([('company_id', '=', self.env.company.id)], limit=1)
+        warehouse.in_type_id.create_backorder = 'always'
+        receipt = self.env['stock.picking'].create({
+            'picking_type_id': warehouse.in_type_id.id,
+            'partner_id': self.subcontractor.id,
+            'location_id': self.ref('stock.stock_location_suppliers'),
+            'location_dest_id': warehouse.lot_stock_id.id,
+            'move_ids': [Command.create({
+                'name': subcontracted_produt.name,
+                'product_id': subcontracted_produt.id,
+                'product_uom_qty': 100,
+                'product_uom': subcontracted_produt.uom_id.id,
+                'location_id': self.ref('stock.stock_location_suppliers'),
+                'location_dest_id': warehouse.lot_stock_id.id,
+            })],
+        })
+        receipt.action_confirm()
+        with Form(receipt) as picking_form:
+            with picking_form.move_ids_without_package.edit(0) as move:
+                move.quantity = 5.0
+        self.assertRecordValues(receipt.move_line_ids, [
+            {'quantity': 5.0, 'state': 'partially_available', 'picked': True}
+        ])
+        receipt.button_validate()
+        backorder = receipt.backorder_ids
+        with Form(backorder) as picking_form:
+            with picking_form.move_ids_without_package.edit(0) as move:
+                move.quantity = 3.0
+        self.assertRecordValues(backorder.move_line_ids, [
+            {'quantity': 3.0, 'state': 'partially_available', 'picked': True}
+        ])
+        backorder.button_validate()
+        backorder_backorder = backorder.backorder_ids
+        with Form(backorder_backorder) as picking_form:
+            with picking_form.move_ids_without_package.edit(0) as move:
+                move.quantity = 1.0
+        self.assertRecordValues(backorder_backorder.move_line_ids, [
+            {'quantity': 1.0, 'state': 'partially_available', 'picked': True}
+        ])
+        backorder_backorder.button_validate()
+        self.assertEqual(subcontracted_produt.qty_available, 9.0)


### PR DESCRIPTION
### Steps to reproduce:

- Create a storable product P with a vendor and a subcontracting bom for that vendor.
- Create a purchase order for 100 units with that vendor.
- Validate the receipt R1 for 5 units and backorder
- Validate the backorder R2 for 3 units and backorder
- Validate the backorder of the backorder R3 for 1 units and backorder
#### > The on hand qty of the product is at 99 even thought you registered only 9 units.

### Cause of the issue:

Currently, the above flow associate with the last receipt move with a qty of 1 both a move line for 1 unit and a move line for 90 units. As both will be picked at validation time, the receipt for 1 unit will effectively be treated as a receipt of 91 units. Here are the details:

Updating the quantity of the move of R1 to 5 will in turn update the quantity of the move line to 5 and pick it by the "_set_quantity":
https://github.com/odoo/odoo/blob/d7daf7dc075896ec4707f912acd41fb1249d5959/addons/mrp_subcontracting/models/stock_move.py#L78-L82 https://github.com/odoo/odoo/blob/d7daf7dc075896ec4707f912acd41fb1249d5959/addons/mrp_subcontracting/models/mrp_production.py#L139-L143
Then, the first validation (of R1) for 5 units instead of 100 is well processed: it creates a backorder with a receipt move for 95 units and assign it with a single move line of 95.

Similarily, setting the quantity on R2 will set the move line to 3 picked units. However, at validation, the situation will be quite different when assigning its backorder since the move of R2 now has an `move_orig_ids`. This will result in R3 to be assigned by 2 move lines:
- one for 2 units
- one for 90 units instead of one for 92 units.

Indeed, during the action_assign of R3 (triggered by the `_create_backorder` of R2), we try to determine the qty available from done move lines related to our move_orig_ids and its `move_dest_ids` in order to see if there is already an available quantity (bacause more was processed in than out for instance). We will then first create a move line for that available quantity:
https://github.com/odoo/odoo/blob/d7daf7dc075896ec4707f912acd41fb1249d5959/addons/stock/models/stock_move.py#L1873-L1886 and finish the assignment with the `missing_reserved_quantity`: https://github.com/odoo/odoo/blob/d7daf7dc075896ec4707f912acd41fb1249d5959/addons/stock/models/stock_move.py#L1907 The issue is that in our case, we should not find any available quantity to assign and the method responsible for this computation `_get_available_move_lines` will still find a discrepency between the available_move_lines_in qty and the available_move_lines_out qty for 5 - 3 that is 2 units
-> We will end up with one move line for 2 units and one for 90.

The discrepency is due to the fact that the
`_get_available_move_lines_in` finds one in move line **done** for 5 units of R1. But that the `_get_available_move_lines_out` first finds the move line **done** for 5 units related to R1:
https://github.com/odoo/odoo/blob/d7daf7dc075896ec4707f912acd41fb1249d5959/addons/stock/models/stock_move.py#L1817-L1821 But then erase the values by the demand of 3 provided by the **partially_available** move line of R2 that we are currently validating and that we should not have considered in the present flow: https://github.com/odoo/odoo/blob/d7daf7dc075896ec4707f912acd41fb1249d5959/addons/stock/models/stock_move.py#L1822-L1823

In particular, we end with a picking R3 for 92 units and 2 move lines. Now, setting the quantity of R3 to 1 will update the quantity of the first move line to 1 and set it as picked without altering the second one as the update of the quantity can totally be handled by the first move line. We therefore end up with a move with a move with a quantity of 1 and 2 move lines: 1 picked unit and 90 unpicked unit: https://github.com/odoo/odoo/blob/d7daf7dc075896ec4707f912acd41fb1249d5959/addons/mrp_subcontracting/models/mrp_production.py#L124-L143 Now, this would be fine if the second move line was not automatically picked as it would be ignored by the action done. However, since the move it self was not picked since subcontracted moves are never automatically recomputed as picked from their move lines: https://github.com/odoo/odoo/blob/d7daf7dc075896ec4707f912acd41fb1249d5959/addons/mrp_subcontracting/models/stock_move.py#L61-L63 the _pre_action_done_hook of the picking validation will pick the entire move and hence set the other move line as picked: https://github.com/odoo/odoo/blob/d7daf7dc075896ec4707f912acd41fb1249d5959/addons/stock/models/stock_picking.py#L1486-L1487 In particular both move lines will be validated and update the related stock quants.

### Fix:

Since in the case where there is no done move line we still find the outgoing partially reserved quantity that we are currently validating we should add the values of both **done** and **reserved** outgoing qties for the behavior on backorders to be the same as on the first picking validation.

opw-4822646
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
