### PR TITLE
[FIX] website_sale_wishlist: disable wishlist button animation

### DIFF
--- a/addons/website_sale_comparison/views/website_sale_comparison_template.xml
+++ b/addons/website_sale_comparison/views/website_sale_comparison_template.xml
@@ -15,7 +15,7 @@
                 t-att-data-product-product-id="product_variant_id"
                 data-action="o_comparelist"
             >
-                <span class="fa fa-exchange"/>
+                <span class="fa fa-exchange o_not-animable"/>
             </button>
         </xpath>
     </template>

--- a/addons/website_sale_wishlist/views/website_sale_wishlist_template.xml
+++ b/addons/website_sale_wishlist/views/website_sale_wishlist_template.xml
@@ -16,7 +16,7 @@
                 data-action="o_wishlist"
                 title="Add to Wishlist"
             >
-                <span class="fa fa-heart" role="img" aria-label="Add to wishlist"/>
+                <span class="fa fa-heart o_not-animable" role="img" aria-label="Add to wishlist"/>
             </button>
         </xpath>
     </template>
@@ -275,7 +275,7 @@
                                             <input name="product_id" t-att-value="wish.product_id.id" type="hidden"/>
                                             <a t-if="combination_info['prevent_zero_price_sale']" t-att-href="website.contact_us_button_url" class="btn btn-primary btn_cta">Contact Us</a>
                                             <button id="add_to_cart_button" t-else="" type="button" role="button" class="btn btn-secondary btn-block o_wish_add mb4" >
-                                                <span class="fa fa-fw fa-shopping-cart"/>
+                                                <span class="fa fa-fw fa-shopping-cart o_not-animable"/>
                                                 <span class="d-none d-md-inline">Add</span>
                                             </button>
                                         </td>


### PR DESCRIPTION
## Version
18.0+

## Issue
When an animation is set on wishlist button icon, only one product appears per eCommerce page.
Same behavior for compare and add-to-cart buttons.

## Steps to reproduce
- Enable wishlists from `Settings` App;
- Go to shop frontend view in edit mode:
  - Select a wishlist button icon on any product by clicking on it;
  - From editor's view, move to `Icon` section:
    - Add an animation (e.g. `On Appearance`).
  - Save and refresh;
  - Move to any shop page and see only 1 product.

> [!important]
> Not reproducible in FireFox or Safari.

opw-4784323