### PR TITLE
[FIX] mail: thread naming for deleted message

### DIFF
--- a/addons/mail/models/discuss/discuss_channel.py
+++ b/addons/mail/models/discuss/discuss_channel.py
@@ -1289,7 +1289,7 @@ class DiscussChannel(models.Model):
             {
                 "channel_type": self.channel_type,
                 "from_message_id": message.id,
-                "name": name or (message.body.striptags()[:30] if message.body else _("New Thread")),
+                "name": name or (message.body.striptags()[:30] if message.body and not tools.is_html_empty(message.body) else _("New Thread")),
                 "parent_channel_id": self.id,
             }
         )


### PR DESCRIPTION
Current behavior before PR:
 - When creating a thread from a deleted message, the thread has no name.
![image](https://github.com/user-attachments/assets/8ef4ce74-3a19-4d91-b60e-9f2fa7910775)

Desired behavior after PR is merged:
 - Threads created from deleted messages automatically get "New Thread" as the fallback name
![image](https://github.com/user-attachments/assets/ef0588e1-5b56-4302-8441-02b22b2b0757)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
