### PR TITLE
[FIX] mail: scroll to message scroll to top of message

### DIFF
--- a/addons/mail/static/src/core/common/message.xml
+++ b/addons/mail/static/src/core/common/message.xml
@@ -13,6 +13,7 @@
                 t-ref="root"
                 t-if="message.exists()"
             >
+                <div class="o-mail-Message-jumpTarget position-absolute top-0 pe-none"/>
                 <div t-if="props.asCard and isMobileOS" class="position-absolute end-0 z-1"><t t-call="mail.Message.actions"/></div>
                 <div class="o-mail-Message-core position-relative d-flex flex-shrink-0 bg-inherit">
                     <div class="o-mail-Message-sidebar d-flex flex-shrink-0 align-items-center flex-column bg-inherit" t-att-class="{ 'align-items-start': !isAlignedRight, 'o-inChatWindow': env.inChatWindow }">

--- a/addons/mail/static/src/core/common/notification_message.xml
+++ b/addons/mail/static/src/core/common/notification_message.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <templates xml:space="preserve">
     <t t-name="mail.NotificationMessage">
-        <div class="o-mail-NotificationMessage text-break mx-auto px-3 text-center smaller" t-on-click="onClickNotificationMessage" t-ref="root">
+        <div class="o-mail-NotificationMessage text-break mx-auto px-3 text-center smaller position-relative" t-on-click="onClickNotificationMessage" t-ref="root">
+            <div class="o-mail-Message-jumpTarget position-absolute top-0 pe-none"/>
             <i t-if="message.notificationIcon" t-attf-class="{{ message.notificationIcon }} me-1 text-muted opacity-50"/>
             <t t-if="message.notificationType === 'call'">
                 <span class="text-muted opacity-50" t-esc="callInformation"/>

--- a/addons/mail/static/src/core/common/thread.js
+++ b/addons/mail/static/src/core/common/thread.js
@@ -224,7 +224,10 @@ export class Thread extends Component {
                     this.props.thread.selfMember.new_message_separator_ui - 1
                 )?.el;
                 if (el) {
-                    el.scrollIntoView({ behavior: "instant", block: "center" });
+                    el.querySelector(".o-mail-Message-jumpTarget").scrollIntoView({
+                        behavior: "instant",
+                        block: "center",
+                    });
                 }
             },
             () => [this.props.jumpToNewMessage]
@@ -610,7 +613,9 @@ export class Thread extends Component {
         const el = this.refByMessageId.get(this.messageHighlight.highlightedMessageId)?.el;
         if (el) {
             this.scrollingToHighlight = true;
-            this.messageHighlight.scrollTo(el).then(() => (this.scrollingToHighlight = false));
+            this.messageHighlight
+                .scrollTo(el.querySelector(".o-mail-Message-jumpTarget"))
+                .then(() => (this.scrollingToHighlight = false));
         }
     }
 

--- a/addons/mail/static/tests/thread/message_highlight.test.js
+++ b/addons/mail/static/tests/thread/message_highlight.test.js
@@ -8,7 +8,7 @@ import {
 } from "@mail/../tests/mail_test_helpers";
 import { Thread } from "@mail/core/common/thread";
 import { describe, test } from "@odoo/hoot";
-import { advanceTime, Deferred, tick } from "@odoo/hoot-dom";
+import { advanceTime, Deferred, tick, waitFor } from "@odoo/hoot-dom";
 import { disableAnimations } from "@odoo/hoot-mock";
 import { patchWithCleanup } from "@web/../tests/web_test_helpers";
 
@@ -72,4 +72,34 @@ test("can highlight message (slow ref registration)", async () => {
     await advanceTime(1000);
     slowRegisterMessageDef.resolve();
     await isInViewportOf(".o-mail-Message:contains(message 100)", ".o-mail-Thread");
+});
+
+test("highlight scrolls to beginning of long message", async () => {
+    disableAnimations();
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({ name: "general" });
+    const [messageId1] = pyEnv["mail.message"].create([
+        {
+            body: `long message `.repeat(500),
+            model: "discuss.channel",
+            res_id: channelId,
+        },
+        {
+            body: `short message`,
+            model: "discuss.channel",
+            res_id: channelId,
+        },
+    ]);
+    await pyEnv["discuss.channel"].set_message_pin(channelId, messageId1, true);
+    await start();
+    await openDiscuss(channelId);
+    await waitFor(".o-mail-Message:contains('short message')");
+    await isInViewportOf(".o-mail-Message:contains('short message')", ".o-mail-Thread");
+    await click("a[data-oe-type='highlight']");
+    await advanceTime(1000);
+    await isInViewportOf(".o-mail-Message:contains('long message')", ".o-mail-Thread");
+    await isInViewportOf(
+        ".o-mail-Message:contains('long message') .o-mail-Message-avatar", // avatar is at beginning of message
+        ".o-mail-Thread"
+    );
 });


### PR DESCRIPTION
Before this commit, when jumping to a message like from message reply-to or "jump" in pinned or searched messages, it was smooth scrolling to the middle of message.

This is a problem on big messages, because we have to manually scroll to top message which is not great.

This happens because the programmatic scroll is made with `.scrollIntoView({ block: "center" })` on the whole message. The `block: "center"` centers the message on the scrollable which is good, but it also scrolls in the middle of element, hence the issue.

This commit fixes the issue by keeping `block: "center"` for nice scroll in middle of screen, but instead of using whole message element it uses a small invisible and click-through element `div.o-mail-Message-jumpTarget` that is used as the target for highlight and jump. This hidden element is at the very top of message, so `scrollIntoView({ block: "center" })` will scroll to top of message and put it in middle of scrollable.

Task-4688158
