### PR TITLE
[IMP] website: adapt and re-enable 'text_animations' tour

### DIFF
--- a/addons/website/static/src/js/tours/tour_utils.js
+++ b/addons/website/static/src/js/tours/tour_utils.js
@@ -672,3 +672,31 @@ export function selectFullText(elementName, selector) {
         },
     };
 }
+
+/**
+ * Click button from the toolbar, if expand is true, it will
+ * first expand the toolbar.
+ * @param {string} elementName
+ * @param {string} selector
+ * @param {string} button
+ * @param {boolean} expand - Whether to expand the toolbar for more buttons.
+ * @returns {Array} The steps to click the toolbar button.
+ */
+export function clickToolbarButton(elementName, selector, button, expand = false) {
+    const steps = [
+        selectFullText(`${elementName}`, selector),
+        {
+            content: `Click on the ${button} from toolbar`,
+            trigger: `.o-we-toolbar button[title="${button}"]`,
+            run: "click",
+        },
+    ];
+    if (expand) {
+        steps.splice(1, 0, {
+            content: "Expand the toolbar for more buttons",
+            trigger: ".o-we-toolbar button[name='expand_toolbar']",
+            run: "click",
+        });
+    }
+    return steps;
+}

--- a/addons/website/static/tests/tours/edit_megamenu.js
+++ b/addons/website/static/tests/tours/edit_megamenu.js
@@ -4,7 +4,7 @@ import {
     clickOnSave,
     openLinkPopup,
     registerWebsitePreviewTour,
-    selectFullText,
+    clickToolbarButton,
 } from "@website/js/tours/tour_utils";
 
 const toggleMegaMenu = (stepOptions) => Object.assign({}, {
@@ -255,15 +255,11 @@ registerWebsitePreviewTour('edit_megamenu_big_icons_subtitles', {
         trigger: '[data-select-label="Big Icons Subtitles"]',
         run: "click",
     },
-    selectFullText(
+    ...clickToolbarButton(
         "h4 of first menu link of the first column",
-        ".s_mega_menu_big_icons_subtitles .row > div:first-child .nav > :first-child h4"
+        ".s_mega_menu_big_icons_subtitles .row > div:first-child .nav > :first-child h4",
+        "Toggle bold"
     ),
-    {
-        content: "Convert it to Bold",
-        trigger: '#oe_snippets #toolbar #bold',
-        run: "click",
-    },
     ...clickOnSave(),
     clickOnExtraMenuItem({}, true),
     toggleMegaMenu(),

--- a/addons/website/static/tests/tours/text_animations.js
+++ b/addons/website/static/tests/tours/text_animations.js
@@ -1,54 +1,61 @@
 import {
     insertSnippet,
     registerWebsitePreviewTour,
-    selectFullText,
-} from '@website/js/tours/tour_utils';
+    clickToolbarButton,
+} from "@website/js/tours/tour_utils";
 
-registerWebsitePreviewTour("text_animations", {
-    url: "/",
-    edition: true,
-}, () => [
-    ...insertSnippet({
-        id: "s_cover",
-        name: "Cover",
-        groupName: "Intro",
-    }),
-    selectFullText("snippet title", ".s_cover h1"),
+function setTextAnimation(trigger, value) {
+    return [
+        ...clickToolbarButton("snippet title", ".s_cover h1", "Animate Text", true),
+        {
+            content: "Open Effect options in the popover",
+            trigger: ".o_popover [data-label='Effect'] button.dropdown-toggle",
+            run: "click",
+        },
+        {
+            content: "Select the text animation",
+            trigger: `.o_popover [data-action-value="${value}"]`,
+            run: "click",
+        },
+        {
+            content: "Click away to close the popover",
+            trigger: `${trigger}:not(.o_popover)`,
+            run: "click",
+        },
+    ];
+}
+
+registerWebsitePreviewTour(
+    "text_animations",
     {
-        content: "Click on the 'Animate Text' button to activate the option",
-        trigger: "div.o_we_animate_text",
-        run: "click",
+        url: "/",
+        edition: true,
     },
-    {
-        content: "Check that the animation was applied",
-        trigger: ":iframe .s_cover h1 span.o_animated_text",
-    },
-    {
-        content: "Click on the 'Animate Text' button",
-        trigger: "div.o_we_animate_text",
-        run: "click",
-    },
-    {
-        content: "Check that the animation was disabled for the title",
-        trigger: ":iframe .s_cover:not(:has(.o_animated_text))",
-    },
-    {
-        content: "Open the text background color colorpicker",
-        trigger: "button#oe-fore-color",
-        run: "click",
-    },
-    {
-        content: "Add a background color on the selected text",
-        trigger: ".o_colorpicker_section [data-color='black']",
-        run: "click",
-    },
-    {
-        content: "Try to apply the text animation again",
-        trigger: "div.o_we_animate_text",
-        run: "click",
-    },
-    {
-        content: "Check that the animation was applied and that the <font> element is inside the o_animated_text element",
-        trigger: ":iframe .s_cover:has(span.o_animated_text > font.bg-black)",
-    },
-]);
+    () => [
+        ...insertSnippet({
+            id: "s_cover",
+            name: "Cover",
+            groupName: "Intro",
+        }),
+        ...setTextAnimation(":iframe .s_cover h1", "o_anim_slide_in"),
+        {
+            content: "Check that the animation was applied",
+            trigger: ":iframe .s_cover .o_animated_text",
+        },
+        ...clickToolbarButton("snippet title", ".s_cover h1", "Animate Text", true),
+        {
+            content: "Reset the text animation",
+            trigger: ".o_popover button[title='Reset']",
+            run: "click",
+        },
+        {
+            content: "Check that the animation was disabled for the title",
+            trigger: ":iframe .s_cover:not(:has(.o_animated_text))",
+        },
+        ...setTextAnimation(":iframe .s_cover h1", "o_anim_slide_in"),
+        {
+            content: "Check that the animation was applied",
+            trigger: ":iframe .s_cover:has(span.o_animated_text)",
+        },
+    ]
+);

--- a/addons/website/static/tests/tours/text_highlights.js
+++ b/addons/website/static/tests/tours/text_highlights.js
@@ -2,7 +2,7 @@ import {
     insertSnippet,
     registerWebsitePreviewTour,
     selectElementInWeSelectWidget,
-    selectFullText,
+    clickToolbarButton,
 } from '@website/js/tours/tour_utils';
 
 registerWebsitePreviewTour("text_highlights", {
@@ -14,12 +14,7 @@ registerWebsitePreviewTour("text_highlights", {
         name: "Cover",
         groupName: "Intro",
     }),
-    selectFullText("snippet title", ".s_cover h1"),
-    {
-        content: "Click on the 'Highlight Effects' button to activate the option",
-        trigger: "div.o_we_text_highlight",
-        run: "click",
-    },
+    ...clickToolbarButton("snippet title", ".s_cover h1", "Apply highlight", true),
     {
         content: "Check that the highlight was applied",
         trigger: ":iframe .s_cover h1 span.o_text_highlight > .o_text_highlight_item > svg:has(.o_text_highlight_path_underline)",

--- a/addons/website/static/tests/tours/translate_text_options.js
+++ b/addons/website/static/tests/tours/translate_text_options.js
@@ -4,6 +4,7 @@ import {
     registerWebsitePreviewTour,
     selectElementInWeSelectWidget,
     selectFullText,
+    clickToolbarButton,
 } from "@website/js/tours/tour_utils";
 
 registerWebsitePreviewTour(
@@ -18,18 +19,18 @@ registerWebsitePreviewTour(
             name: "Text",
             groupName: "Text",
         }),
-        selectFullText("first text block in the snippet", "#wrap .s_text_block p"),
-        {
-            content: "Click on the 'Animate Text' button to activate the option",
-            trigger: "div.o_we_animate_text",
-            run: "click",
-        },
-        selectFullText("second text block in the snippe", "#wrap .s_text_block p:last"),
-        {
-            content: "Click on the 'Highlight Effects' button to activate the option",
-            trigger: "div.o_we_text_highlight",
-            run: "click",
-        },
+        ...clickToolbarButton(
+            "first text block in the snippet",
+            "#wrap .s_text_block p",
+            "Animate Text",
+            true
+        ),
+        ...clickToolbarButton(
+            "second text block in the snippet",
+            "#wrap .s_text_block p:last",
+            "Apply highlight",
+            true
+        ),
         ...clickOnSave(),
         {
             content: "Change the language to French",

--- a/addons/website/static/tests/tours/website_text_edition.js
+++ b/addons/website/static/tests/tours/website_text_edition.js
@@ -3,7 +3,7 @@ import {
     goBackToBlocks,
     goToTheme,
     registerWebsitePreviewTour,
-    selectFullText,
+    clickToolbarButton,
 } from "@website/js/tours/tour_utils";
 import { rgbToHex } from "@web/core/utils/colors";
 
@@ -31,17 +31,12 @@ registerWebsitePreviewTour("website_text_edition", {
     },
     goBackToBlocks(),
     ...insertSnippet({id: "s_text_block", name: "Text", groupName: "Text"}),
-    selectFullText("text block first paragraph", ".s_text_block p"),
-    {
-        content: "Expand toolbar to see the color picker",
-        trigger: ".o-we-toolbar button[name='expand_toolbar']",
-        run: "click",
-    },
-    {
-        content: "Select the color picker",
-        trigger: ".o-we-toolbar button.o-select-color-foreground",
-        run: "click",
-    },
+    ...clickToolbarButton(
+        "text block first paragraph",
+        ".s_text_block p",
+        "Apply Font Color",
+        true
+    ),
     {
         content: "Open solid section in color picker",
         trigger: ".o_font_color_selector button:contains('Custom')",

--- a/addons/website/static/tests/tours/website_text_font_size.js
+++ b/addons/website/static/tests/tours/website_text_font_size.js
@@ -2,7 +2,7 @@ import {
     insertSnippet,
     goToTheme,
     registerWebsitePreviewTour,
-    selectFullText,
+    clickToolbarButton,
 } from '@website/js/tours/tour_utils';
 import {FONT_SIZE_CLASSES} from '@web_editor/js/editor/odoo-editor/src/utils/utils';
 
@@ -40,12 +40,12 @@ function checkComputedFontSize(fontSizeClass, stage) {
 function getFontSizeTestSteps(fontSizeClass) {
     return [
         ...insertSnippet({id: "s_text_block", name: "Text", groupName: "Text"}),
-        selectFullText(`text block first paragraph [${fontSizeClass}]`, ".s_text_block p"),
+        ...clickToolbarButton(
+            `text block first paragraph [${fontSizeClass}]`,
+            ".s_text_block p",
+            "Select font size"
+        ),
         {
-            content: `Open the font size dropdown to select ${fontSizeClass}`,
-            trigger: ".o-we-toolbar :iframe [name='font-size-input']",
-            run: "click",
-        }, {
             content: `Select ${fontSizeClass} in the dropdown`,
             trigger: `.o_font_size_selector_menu span:contains(${classNameInfo.get(fontSizeClass).start})`,
             run: "click",

--- a/addons/website/tests/test_ui.py
+++ b/addons/website/tests/test_ui.py
@@ -551,8 +551,6 @@ class TestUi(HttpCaseWithWebsiteUser):
         self.assertFalse(menu_root.action, 'The top menu should not have an action (or the test/tour will not test anything).')
         self.start_tour('/', 'website_backend_menus_redirect', login='admin')
 
-    # TODO master-mysterious-egg fix error
-    @unittest.skip("prepare mysterious-egg for merging")
     def test_30_website_text_animations(self):
         self.start_tour("/", 'text_animations', login='admin')
 


### PR DESCRIPTION
Due to structural changes in the DOM from the updated website builder, the 'text_animations' tour was broken and skipped in tests.

This improvement introduces `pickFromFloatingToolbar()*` and `setTextAnimation()` helpers to adapt the tour logic, ensuring compatibility and reactivating the tour test.

*`pickFromFloatingToolbar()` is a new utility function that selects a specific option from the floating toolbar, which is now used in the tour to set text animations can be later used to pick other tools available in toolbar as well.