### PR TITLE
[FIX] mail: no flicker on opening discuss conversation

### DIFF
--- a/addons/mail/static/src/core/common/thread.js
+++ b/addons/mail/static/src/core/common/thread.js
@@ -628,8 +628,8 @@ export class Thread extends Component {
 
     get showStartMessage() {
         return (
-            ["channel", "group"].includes(this.props.thread.channel_type) ||
-            this.props.thread.channel_type === "chat"
+            this.state.mountedAndLoaded &&
+            ["channel", "group", "chat"].includes(this.props.thread.channel_type)
         );
     }
 


### PR DESCRIPTION
Before this commit, when opening a conversation in chat window, it always show a small flicker at opening.

This happens because there's a template part to show start message text `"Welcome to #channel"` at the very beginning of conversation. This must be shown only at the very beginning, but when opening a conversation in a chat window, there's a short period of time when the component is not fully loaded and mounted. This `"Welcome to #channel"` start message text was not conditionally awaiting mounted and loaded thread component.

Before / After
![before](https://github.com/user-attachments/assets/4b9e5f88-c949-4af2-95ba-cafba0398e32) ![after](https://github.com/user-attachments/assets/e9af6238-ce5f-4d09-80d5-1bb0691fb564)

