### PR TITLE
[IMP] mail, *: allow user to create personal outgoing mail server

### DIFF
--- a/addons/auth_totp_mail/views/res_users_views.xml
+++ b/addons/auth_totp_mail/views/res_users_views.xml
@@ -26,11 +26,6 @@
             </form>
             <h1 position="replace"/>
             <xpath expr="//field[@name='image_1920']" position="replace"/>
-            <notebook position="replace">
-                <header>
-                </header>
-                <sheet>$0</sheet>
-            </notebook>
             <notebook position="before">
                 <field name="image_1920" widget="image" class="oe_avatar" options="{'zoom': true, 'preview_image':'image_128'}"/>
                     <div class="oe_title">

--- a/addons/google_gmail/__manifest__.py
+++ b/addons/google_gmail/__manifest__.py
@@ -13,6 +13,7 @@
         "views/fetchmail_server_views.xml",
         "views/ir_mail_server_views.xml",
         "views/res_config_settings_views.xml",
+        "views/templates.xml",
     ],
     "auto_install": True,
     "author": "Odoo S.A.",

--- a/addons/google_gmail/models/__init__.py
+++ b/addons/google_gmail/models/__init__.py
@@ -6,3 +6,4 @@ from . import google_gmail_mixin
 from . import fetchmail_server
 from . import ir_mail_server
 from . import res_config_settings
+from . import res_users

--- a/addons/google_gmail/models/google_gmail_mixin.py
+++ b/addons/google_gmail/models/google_gmail_mixin.py
@@ -26,7 +26,9 @@ class GoogleGmailMixin(models.AbstractModel):
 
     _description = 'Google Gmail Mixin'
 
-    _SERVICE_SCOPE = 'https://mail.google.com/'
+    _SERVICE_SCOPE = 'https://mail.google.com/ https://www.googleapis.com/auth/userinfo.email'
+
+    active = fields.Boolean(default=True)
 
     google_gmail_authorization_code = fields.Char(string='Authorization Code', groups='base.group_system', copy=False)
     google_gmail_refresh_token = fields.Char(string='Refresh Token', groups='base.group_system', copy=False)
@@ -72,7 +74,7 @@ class GoogleGmailMixin(models.AbstractModel):
         """
         self.ensure_one()
 
-        if not self.env.user.has_group('base.group_system'):
+        if not self.env.is_admin():
             raise AccessError(_('Only the administrator can link a Gmail mail server.'))
 
         if not self.google_gmail_uri:
@@ -81,6 +83,7 @@ class GoogleGmailMixin(models.AbstractModel):
         return {
             'type': 'ir.actions.act_url',
             'url': self.google_gmail_uri,
+            'target': 'self',
         }
 
     def _fetch_gmail_refresh_token(self, authorization_code):

--- a/addons/google_gmail/models/res_users.py
+++ b/addons/google_gmail/models/res_users.py
@@ -1,0 +1,34 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import api, fields, models
+
+
+class ResUsers(models.Model):
+    _inherit = "res.users"
+
+    outgoing_mail_server_type = fields.Selection(
+        selection_add=[("gmail", "Gmail")],
+        ondelete={"gmail": "set default"},
+    )
+
+    @api.model
+    def _get_personal_server_type(self, smtp_server):
+        if smtp_server.smtp_authentication == "gmail":
+            return "gmail"
+        return super()._get_personal_server_type(smtp_server)
+
+    @api.model
+    def _get_mail_server_values(self, server_type):
+        values = super()._get_mail_server_values(server_type)
+        if server_type == "gmail":
+            values |= {
+                "smtp_host": "smtp.gmail.com",
+                "smtp_authentication": "gmail",
+            }
+        return values
+
+    @api.model
+    def _get_mail_server_setup_end_action(self, smtp_server):
+        if smtp_server.smtp_authentication == "gmail":
+            return smtp_server.sudo().open_google_gmail_uri()
+        return super()._get_mail_server_setup_end_action(smtp_server)

--- a/addons/google_gmail/views/ir_mail_server_views.xml
+++ b/addons/google_gmail/views/ir_mail_server_views.xml
@@ -5,9 +5,10 @@
         <field name="model">ir.mail_server</field>
         <field name="inherit_id" ref="base.ir_mail_server_form"/>
         <field name="arch" type="xml">
-            <field name="smtp_user" position="after">
+            <field name="smtp_ssl_private_key" position="after">
                 <div invisible="smtp_authentication != 'gmail'"
-                    class="d-flex flex-row align-items-center" colspan="8"
+                    class="d-flex flex-row align-items-center"
+                    colspan="2"
                     groups="base.group_system">
                     <span invisible="smtp_authentication != 'gmail' or not google_gmail_refresh_token"
                         class="badge text-bg-success">

--- a/addons/google_gmail/views/templates.xml
+++ b/addons/google_gmail/views/templates.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <odoo>
-    <template id="microsoft_outlook_oauth_error">
+    <template id="google_gmail_oauth_error">
         <t t-call-assets="web.assets_frontend" t-js="false"/>
         <div class="py-5">
             <div class="alert alert-warning w-50 mx-auto" role="alert">

--- a/addons/hr/views/res_users.xml
+++ b/addons/hr/views/res_users.xml
@@ -50,13 +50,8 @@
                     <attribute name="delete">false</attribute>
                     <attribute name="js_class">hr_employee_profile_form</attribute>
                 </form>
-                <notebook position="replace">
-                        <field name="hr_presence_state" invisible="1"/>
-                        <header>
-                        </header>
-                        <sheet>$0</sheet>
-                </notebook>
                 <notebook position="before">
+                    <field name="hr_presence_state" invisible="1"/>
                     <div class="oe_button_box" name="button_box">
                         <button
                             id="hr_presence_button"

--- a/addons/mail/__manifest__.py
+++ b/addons/mail/__manifest__.py
@@ -71,6 +71,7 @@ For more specific needs, you may also assign custom-defined actions
         'views/fetchmail_views.xml',
         'views/ir_cron_views.xml',
         'views/ir_filters_views.xml',
+        'views/ir_mail_server_views.xml',
         'views/mail_message_subtype_views.xml',
         'views/mail_tracking_value_views.xml',
         'views/mail_notification_views.xml',

--- a/addons/mail/models/fetchmail.py
+++ b/addons/mail/models/fetchmail.py
@@ -91,6 +91,7 @@ class FetchmailServer(models.Model):
     _name = 'fetchmail.server'
     _description = 'Incoming Mail Server'
     _order = 'priority'
+    _email_field = 'user'
 
     name = fields.Char('Name', required=True)
     active = fields.Boolean('Active', default=True)

--- a/addons/mail/models/ir_mail_server.py
+++ b/addons/mail/models/ir_mail_server.py
@@ -1,17 +1,27 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import api, fields, models
+from odoo import _, api, fields, models
+from odoo.exceptions import UserError
+from odoo.tools import email_normalize
 
 
 class IrMail_Server(models.Model):
     _inherit = 'ir.mail_server'
+    _email_field = 'smtp_user'
 
     mail_template_ids = fields.One2many(
         comodel_name='mail.template',
         inverse_name='mail_server_id',
         string='Mail template using this mail server',
         readonly=True)
+
+    owner_user_id = fields.Many2one('res.users', 'Owner')
+
+    _unique_owner_user_id = models.Constraint(
+        "UNIQUE(owner_user_id)",
+        "owner_user_id must be unique",
+    )
 
     def _active_usages_compute(self):
         usages_super = super()._active_usages_compute()
@@ -58,3 +68,18 @@ class IrMail_Server(models.Model):
         # no from_filter or from_filter is configured for a domain different that
         # the default_from of company's alias_domain -> fallback
         return super()._get_test_email_from()
+
+    @api.model
+    def _filter_mail_servers_fallback(self, servers):
+        return servers.filtered(lambda s: not s.owner_user_id)
+
+    def _check_forced_mail_server(self, mail_server, allow_archived, smtp_from):
+        super()._check_forced_mail_server(mail_server, allow_archived, smtp_from)
+
+        if mail_server.owner_user_id:
+            if email_normalize(smtp_from) != mail_server.from_filter:
+                raise UserError(_('The server "%s" cannot be forced as it belongs to a user.', mail_server.display_name))
+            if not mail_server.active:
+                raise UserError(_('The server "%s" cannot be forced as it belongs to a user and is archived.', mail_server.display_name))
+            if mail_server.owner_user_id.outgoing_mail_server_id != mail_server:
+                raise UserError(_('The server "%s" cannot be forced as the owner does not use it anymore.', mail_server.display_name))

--- a/addons/mail/models/ir_mail_server.py
+++ b/addons/mail/models/ir_mail_server.py
@@ -3,6 +3,7 @@
 
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError
+from odoo.fields import Domain
 from odoo.tools import email_normalize
 
 
@@ -72,6 +73,12 @@ class IrMail_Server(models.Model):
     @api.model
     def _filter_mail_servers_fallback(self, servers):
         return servers.filtered(lambda s: not s.owner_user_id)
+
+    def _find_mail_server_allowed_domain(self):
+        """Restrict search to 'public' servers."""
+        domain = super()._find_mail_server_allowed_domain()
+        domain &= Domain('owner_user_id', '=', False)
+        return domain
 
     def _check_forced_mail_server(self, mail_server, allow_archived, smtp_from):
         super()._check_forced_mail_server(mail_server, allow_archived, smtp_from)

--- a/addons/mail/static/src/views/fields/mail_server_configurator_selection/mail_server_configurator_selection.js
+++ b/addons/mail/static/src/views/fields/mail_server_configurator_selection/mail_server_configurator_selection.js
@@ -1,0 +1,74 @@
+import { _t } from "@web/core/l10n/translation";
+import { registry } from "@web/core/registry";
+import { SelectionField, selectionField } from "@web/views/fields/selection/selection_field";
+import { user } from "@web/core/user";
+import { useService } from "@web/core/utils/hooks";
+import { useState } from "@odoo/owl";
+
+export class MailServerConfiguratorSelection extends SelectionField {
+    static template = "mail.MailServerConfiguratorSelection";
+
+    setup() {
+        super.setup();
+        this.action = useService("action");
+        this.orm = useService("orm");
+        this.notification = useService("notification");
+        this.state = useState({
+            value: null,
+            connectionFailed: false,
+        });
+    }
+
+    /**
+     * Allow to change the value displayed without making the field dirty.
+     */
+    get value() {
+        return this.state.value || super.value;
+    }
+
+    get readonly() {
+        return this.props.record.resId !== user.userId;
+    }
+
+    get isServerConfigured() {
+        return !!this.props.record.data.outgoing_mail_server_id;
+    }
+
+    async onOptionChange(value) {
+        const oldValue = this.value;
+        this.state.value = value;
+        await this.props.record.model.root.save();
+        try {
+            const action = await this.orm.call("res.users", "action_setup_outgoing_mail_server", [
+                value,
+            ]);
+            if (action) {
+                this.action.doAction(action);
+            }
+        } catch (error) {
+            this.state.value = oldValue;
+            this.notification.add(error.data.message, {
+                type: "danger",
+            });
+        }
+    }
+
+    async onTestConnection() {
+        await this.props.record.model.root.save();
+        try {
+            const action = await this.orm.call("res.users", "action_test_outgoing_mail_server");
+            this.state.connectionFailed = false;
+            this.action.doAction(action);
+        } catch (error) {
+            this.notification.add(_t("Connection failed: %s", error.data.message), {
+                type: "danger",
+            });
+            this.state.connectionFailed = true;
+        }
+    }
+}
+
+registry.category("fields").add("mail_server_configurator_selection", {
+    ...selectionField,
+    component: MailServerConfiguratorSelection,
+});

--- a/addons/mail/static/src/views/fields/mail_server_configurator_selection/mail_server_configurator_selection.scss
+++ b/addons/mail/static/src/views/fields/mail_server_configurator_selection/mail_server_configurator_selection.scss
@@ -1,0 +1,9 @@
+.o_mail_server_configurator_selection_test_connection {
+    // Change the text content when hovering
+    &:hover div:nth-child(1) {
+        display: none !important;
+    }
+    &:not(:hover) div:nth-child(2) {
+        display: none !important;
+    }
+}

--- a/addons/mail/static/src/views/fields/mail_server_configurator_selection/mail_server_configurator_selection.xml
+++ b/addons/mail/static/src/views/fields/mail_server_configurator_selection/mail_server_configurator_selection.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates>
+    <div t-name="mail.MailServerConfiguratorSelection" class="d-flex flex-row">
+        <t t-if="readonly">
+            <span t-esc="string" t-att-raw-value="value" />
+        </t>
+        <t t-else="">
+            <select
+                class="o_input pe-3 me-3"
+                t-att-class="{'w-auto': value !== 'default'}"
+                t-on-change="(event) => this.onOptionChange(event.target.value)">
+                <option
+                    t-foreach="options" t-as="option" t-key="option[0]"
+                    class="text-black"
+                    t-att-selected="option[0] === value"
+                    t-att-value="option[0]"
+                    t-out="option[1]"
+                />
+            </select>
+            <button t-if="value !== 'default' and isServerConfigured"
+                class="btn btn-link o_mail_server_configurator_selection_test_connection py-0"
+                t-on-click="() => this.onTestConnection()">
+                <div t-if="!this.state.connectionFailed">
+                    <i class="fa fa-check"/> Emails sent via <t t-out="string"/>
+                </div>
+                <div t-else="" class="text-danger">
+                    Connection failed
+                </div>
+                <div>
+                    <i class="fa fa-plug"/> Test Connection
+                </div>
+            </button>
+        </t>
+    </div>
+</templates>

--- a/addons/mail/views/fetchmail_views.xml
+++ b/addons/mail/views/fetchmail_views.xml
@@ -114,6 +114,13 @@
             <field name="view_mode">list,form</field>
             <field name="view_id" ref="view_email_server_tree"/>
             <field name="search_view_id" ref="view_email_server_search"/>
+            <field name="help" type="html">
+                <div>
+                    <b class="o_view_nocontent_smiling_face">
+                        No Incoming Servers yet
+                    </b>
+                </div>
+            </field>
         </record>
 
 </odoo>

--- a/addons/mail/views/ir_mail_server_views.xml
+++ b/addons/mail/views/ir_mail_server_views.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" ?>
+<odoo>
+    <record id="ir_mail_server_view_form" model="ir.ui.view">
+        <field name="name">ir.mail_server.view.form.inherit.mail</field>
+        <field name="model">ir.mail_server</field>
+        <field name="inherit_id" ref="base.ir_mail_server_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//label[@for='smtp_user']" position="attributes">
+                <attribute name="invisible" add="owner_user_id" separator="or"/>
+            </xpath>
+            <xpath expr="//label[@for='smtp_user']" position="after">
+                <label for="smtp_user" string="User email"
+                    invisible="smtp_authentication == 'certificate' or not owner_user_id"/>
+            </xpath>
+            <xpath expr="//field[@name='smtp_pass']" position="after">
+                <field name="owner_user_id"
+                    placeholder="Restrict usage to a user"
+                    groups="base.group_no_one"
+                    widget="many2one_avatar_user"/>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/addons/mail/views/res_users_views.xml
+++ b/addons/mail/views/res_users_views.xml
@@ -1,6 +1,19 @@
 <?xml version="1.0"?>
 <odoo>
     <data>
+        <record id="action_res_users_my_fullpage" model="ir.actions.act_window">
+            <!-- Like action_res_users_my, but in full page -->
+            <field name="name">Change My Preferences</field>
+            <field name="res_model">res.users</field>
+            <field name="view_mode">form</field>
+            <field name="path">my-preferences</field>
+        </record>
+        <record id="action_res_users_my_fullpage_view" model="ir.actions.act_window.view">
+            <field eval="50" name="sequence"/>
+            <field name="view_mode">form</field>
+            <field name="view_id" ref="base.view_users_form_simple_modif"/>
+            <field name="act_window_id" ref="mail.action_res_users_my_fullpage"/>
+        </record>
 
         <!-- Update Preferences form !-->
         <record id="view_users_form_simple_modif_mail" model="ir.ui.view">
@@ -12,6 +25,13 @@
                     <xpath expr="//group[@name='signature']|//field[@name='signature']" position="before">
                         <group string="Discuss" name="discuss">
                             <field name="notification_type" widget="radio" readonly="0"/>
+                            <field name="outgoing_mail_server_id" invisible="1"/> <!-- Used by the mail_server_configurator_selection widget -->
+                            <span class="o_form_label" invisible="not has_external_mail_server">Outgoing Mail Server</span>
+                            <field name="outgoing_mail_server_type"
+                                nolabel="1"
+                                string="Outgoing Mail Server"
+                                widget="mail_server_configurator_selection"
+                                invisible="not has_external_mail_server"/>
                             <field name="role_ids" widget="many2many_tags" readonly="not can_edit_role"/>
                         </group>
                     </xpath>
@@ -32,6 +52,13 @@
                     <xpath expr="//group[@name='messaging']|//field[@name='signature']" position="before">
                         <group string="Discuss" name="discuss">
                             <field name="notification_type" widget="radio" invisible="share"/>
+                            <field name="outgoing_mail_server_id" invisible="1"/> <!-- Used by the mail_server_configurator_selection widget -->
+                            <span class="o_form_label" invisible="not has_external_mail_server">Outgoing Mail Server</span>
+                            <field name="outgoing_mail_server_type"
+                                nolabel="1"
+                                string="Outgoing Mail Server"
+                                widget="mail_server_configurator_selection"
+                                invisible="not has_external_mail_server"/>
                             <field name="role_ids" widget="many2many_tags" readonly="not can_edit_role"/>
                         </group>
                     </xpath>

--- a/addons/microsoft_outlook/__manifest__.py
+++ b/addons/microsoft_outlook/__manifest__.py
@@ -15,6 +15,7 @@
         "views/res_config_settings_views.xml",
         "views/templates.xml",
     ],
+    "auto_install": True,
     "author": "Odoo S.A.",
     "license": "LGPL-3",
 }

--- a/addons/microsoft_outlook/models/__init__.py
+++ b/addons/microsoft_outlook/models/__init__.py
@@ -6,3 +6,4 @@ from . import microsoft_outlook_mixin
 from . import fetchmail_server
 from . import ir_mail_server
 from . import res_config_settings
+from . import res_users

--- a/addons/microsoft_outlook/models/fetchmail_server.py
+++ b/addons/microsoft_outlook/models/fetchmail_server.py
@@ -46,7 +46,7 @@ class FetchmailServer(models.Model):
             self.microsoft_outlook_refresh_token = False
             self.microsoft_outlook_access_token = False
             self.microsoft_outlook_access_token_expiration = False
-            super(FetchmailServer, self).onchange_server_type()
+            super().onchange_server_type()
 
     def _imap_login__(self, connection):  # noqa: PLW3201
         """Authenticate the IMAP connection.

--- a/addons/microsoft_outlook/models/res_users.py
+++ b/addons/microsoft_outlook/models/res_users.py
@@ -1,0 +1,34 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import api, fields, models
+
+
+class ResUsers(models.Model):
+    _inherit = "res.users"
+
+    outgoing_mail_server_type = fields.Selection(
+        selection_add=[("outlook", "Outlook")],
+        ondelete={"outlook": "set default"},
+    )
+
+    @api.model
+    def _get_personal_server_type(self, smtp_server):
+        if smtp_server.smtp_authentication == 'outlook':
+            return 'outlook'
+        return super()._get_personal_server_type(smtp_server)
+
+    @api.model
+    def _get_mail_server_values(self, server_type):
+        values = super()._get_mail_server_values(server_type)
+        if server_type == "outlook":
+            values |= {
+                "smtp_host": "smtp-mail.outlook.com",
+                "smtp_authentication": "outlook",
+            }
+        return values
+
+    @api.model
+    def _get_mail_server_setup_end_action(self, smtp_server):
+        if smtp_server.smtp_authentication == 'outlook':
+            return smtp_server.sudo().open_microsoft_outlook_uri()
+        return super()._get_mail_server_setup_end_action(smtp_server)

--- a/addons/microsoft_outlook/views/ir_mail_server_views.xml
+++ b/addons/microsoft_outlook/views/ir_mail_server_views.xml
@@ -5,9 +5,10 @@
         <field name="model">ir.mail_server</field>
         <field name="inherit_id" ref="base.ir_mail_server_form"/>
         <field name="arch" type="xml">
-            <field name="smtp_user" position="after">
+            <field name="smtp_ssl_private_key" position="after">
                 <div invisible="smtp_authentication != 'outlook'"
-                    class="d-flex flex-row align-items-center" colspan="8"
+                    class="d-flex flex-row align-items-center"
+                    colspan="2"
                     groups="base.group_system">
                     <span invisible="smtp_authentication != 'outlook' or not microsoft_outlook_refresh_token"
                         class="badge text-bg-success">

--- a/addons/test_mail_full/tests/__init__.py
+++ b/addons/test_mail_full/tests/__init__.py
@@ -4,6 +4,7 @@ from . import test_controller_attachment
 from . import test_controller_reaction
 from . import test_controller_update
 from . import test_controller_thread
+from . import test_ir_mail_server
 from . import test_mail_bot
 from . import test_mail_performance
 from . import test_mail_thread_internals

--- a/addons/test_mail_full/tests/test_ir_mail_server.py
+++ b/addons/test_mail_full/tests/test_ir_mail_server.py
@@ -1,0 +1,148 @@
+from contextlib import contextmanager
+from unittest.mock import patch
+
+from odoo.addons.mail.tests.common import MailCommon
+from odoo.tests import tagged, users
+
+from odoo.addons.base.models.ir_mail_server import IrMail_Server
+from odoo.exceptions import UserError, ValidationError
+
+
+@tagged('mail_server')
+class TestIrMailServerPersonal(MailCommon):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env['ir.config_parameter'].sudo().set_param('mail.disable_personal_mail_servers', False)
+        cls.user_admin.email = 'admin@test.lan'
+        cls.user_employee.email = 'employee@test.lan'
+        cls.user_employee.group_ids += cls.env.ref('mass_mailing.group_mass_mailing_user')
+        cls.test_partner = cls.env['res.partner'].create({
+            'name': 'test partner', 'email': 'test.partner@test.lan'
+        })
+        cls.mail_server_user.write({
+            'from_filter': cls.user_employee.email,
+            'owner_user_id': cls.user_employee,
+            'smtp_user': cls.user_employee.email,
+        })
+        cls.user_employee.invalidate_recordset(['outgoing_mail_server_id'])
+
+    @contextmanager
+    def mock_mail_connect(self):
+        original_connect = IrMail_Server._connect__
+        self.connected_server_ids = []
+
+        def patched_connect(mail_server, *args, **kwargs):
+            self.connected_server_ids.append(kwargs.get('mail_server_id'))
+            original_connect(mail_server, *args, **kwargs)
+
+        with patch.object(IrMail_Server, '_connect__', autospec=True, wraps=IrMail_Server, side_effect=patched_connect):
+            yield
+
+    @users('admin', 'employee')
+    def test_personal_mail_server_allowed_mailing(self):
+        """Check a mailing can be sent with a personal server, only if the mailing was created by the owner."""
+        mailing_values = {
+            'subject': 'Hello from Personal Server',
+            'mailing_model_id': self.env['ir.model']._get_id('res.partner'),
+            'mailing_domain': repr([('id', '=', self.test_partner.id)]),
+            'email_from': self.user_employee.email_formatted
+        }
+        employee_mailing = self.env['mailing.mailing'].with_user(self.user_employee).create(mailing_values)
+        with self.mock_mail_connect():
+            employee_mailing.action_send_mail()
+
+        self.assertEqual(len(self.connected_server_ids), 1)
+        self.assertEqual(self.connected_server_ids[0], self.mail_server_user.id)
+
+        employee_impersonate_mailing = self.env['mailing.mailing'].create(mailing_values)
+        with self.mock_mail_connect():
+            employee_impersonate_mailing.action_send_mail()
+
+        self.assertEqual(len(self.connected_server_ids), 1)
+        if self.env.user == self.mail_server_user.owner_user_id:
+            self.assertEqual(self.connected_server_ids[0], self.mail_server_user.id)
+        else:
+            self.assertNotEqual(self.connected_server_ids[0], self.mail_server_user.id)
+
+    @users('admin', 'employee')
+    def test_personal_mail_server_allowed_post(self):
+        """Check that only the owner of the mail server can create mails that will be sent from it."""
+        test_record = self.test_partner.with_user(self.env.user)
+        with self.mock_mail_connect():
+            test_record.message_post(
+                body='hello',
+                author_id=self.user_employee.partner_id.id, email_from=self.user_employee.email,
+                partner_ids=test_record.ids,
+            )
+
+        self.assertEqual(len(self.connected_server_ids), 1)
+        if self.env.user == self.mail_server_user.owner_user_id:
+            self.assertEqual(self.connected_server_ids[0], self.mail_server_user.id)
+        else:
+            self.assertNotEqual(self.connected_server_ids[0], self.mail_server_user.id)
+
+        # check disallowed exceptions
+        if self.env.user != self.mail_server_user.owner_user_id:
+            # check raise on invalid server at create
+            with self.assertRaises(ValidationError):
+                test_record.message_post(
+                    body='hello',
+                    author_id=self.user_employee.partner_id.id, email_from=self.user_employee.email,
+                    mail_server_id=self.mail_server_user.id,
+                    partner_ids=test_record.ids,
+                )
+
+            # check raise on invalid server at send (should not happen in normal flow)
+            mail = self.env['mail.mail'].sudo().create({
+                'body_html': 'hello',
+                'email_from': self.user_employee.email,
+                'author_id': self.user_employee.partner_id.id,
+                'partner_ids': test_record.ids,
+            })
+            with self.mock_mail_gateway(), self.assertRaisesRegex(UserError, "Unauthorized server for some of the sending mails."):
+                mail._send(self, mail_server=self.mail_server_user)
+
+    def test_personal_mail_server_find_mail_server(self):
+        """Check that _find_mail_server only finds 'public' servers unless otherwise allowed."""
+        IrMailServer = self.env['ir.mail_server']
+        all_servers = IrMailServer.search([])
+        test_cases = [
+            (None, False),
+            (all_servers, True),
+        ]
+        for mail_servers, should_find_personal in test_cases:
+            with self.subTest(mail_servers=mail_servers):
+                found_server, found_email_from = IrMailServer._find_mail_server(self.user_employee.email, mail_servers=mail_servers)
+                if should_find_personal:
+                    self.assertEqual(
+                        (found_server, found_email_from), (self.mail_server_user, self.user_employee.email),
+                        'Passing in a server that is owned should allow finding it.'
+                    )
+                else:
+                    self.assertNotEqual(
+                        found_server, self.mail_server_user,
+                        'Finding a server for an email_from without specifying a list of servers should not find owned servers.'
+                    )
+
+    @users('employee')
+    def test_immutable_create_uid(self):
+        """Make sure create_uid is not writable, as it's a security assumption for these tests."""
+        message = self.test_partner.with_user(self.env.user).message_post(
+            body='hello',
+            author_id=self.user_employee.partner_id.id, email_from=self.user_employee.email,
+            partner_ids=self.test_partner.ids,
+        )
+
+        self.assertEqual(message.create_uid, self.user_employee)
+        message.create_uid = self.user_admin
+        self.assertEqual(message.create_uid, self.user_employee)
+
+    def test_personal_mail_server_mail_for_existing_message(self):
+        """Crons should be able to send a mail from a personal server for an existing message."""
+        message = self.test_partner.with_user(self.user_employee).message_post(body='hello')
+        message.partner_ids += self.test_partner
+        with self.mock_mail_connect():
+            self.test_partner.with_user(self.env.ref('base.user_root'))._notify_thread(message)
+        self.assertEqual(self.connected_server_ids, [self.mail_server_user.id], "Should have used message creator's server.")

--- a/odoo/addons/base/models/ir_mail_server.py
+++ b/odoo/addons/base/models/ir_mail_server.py
@@ -838,6 +838,10 @@ class IrMail_Server(models.Model):
             raise MailDeliveryException(_("Mail Delivery Failed"), msg)
         return message_id
 
+    def _find_mail_server_allowed_domain(self):
+        """Overridable domain getter for all mail servers that may be used as default."""
+        return fields.Domain.TRUE
+
     def _find_mail_server(self, email_from, mail_servers=None):
         """Find the appropriate mail server for the given email address.
 
@@ -854,7 +858,7 @@ class IrMail_Server(models.Model):
         notifications_domain = email_domain_extract(notifications_email)
 
         if mail_servers is None:
-            mail_servers = self.sudo().search([], order='sequence')
+            mail_servers = self.sudo().search(self._find_mail_server_allowed_domain(), order='sequence')
         # 0. Archived mail server should never be used
         mail_servers = mail_servers.filtered('active')
 

--- a/odoo/addons/base/views/ir_mail_server_views.xml
+++ b/odoo/addons/base/views/ir_mail_server_views.xml
@@ -56,7 +56,8 @@
                                             required="smtp_authentication != 'cli'"/>
                                     </group>
                                     <group>
-                                        <field name="smtp_user" invisible="smtp_authentication == 'certificate'" force_save="1"/>
+                                        <label for="smtp_user" string="Username" invisible="smtp_authentication == 'certificate'"/>
+                                        <field name="smtp_user" invisible="smtp_authentication == 'certificate'" force_save="1" nolabel="1"/>
                                         <field name="smtp_pass" invisible="smtp_authentication != 'login'" password="True" force_save="1"/>
                                         <field name="smtp_ssl_certificate" invisible="smtp_authentication != 'certificate'" force_save="1"/>
                                         <field name="smtp_ssl_private_key" invisible="smtp_authentication != 'certificate'" force_save="1"/>
@@ -107,6 +108,13 @@
             <field name="view_mode">list,form</field>
             <field name="view_id" ref="ir_mail_server_list" />
             <field name="search_view_id" ref="view_ir_mail_server_search"/>
+            <field name="help" type="html">
+                <div>
+                    <b class="o_view_nocontent_smiling_face">
+                        No Outgoing Servers yet
+                    </b>
+                </div>
+            </field>
         </record>
 
         <menuitem id="menu_mail_servers" parent="menu_email" action="action_ir_mail_server_list" sequence="5" groups="base.group_no_one"/>

--- a/odoo/addons/base/views/res_users_views.xml
+++ b/odoo/addons/base/views/res_users_views.xml
@@ -353,85 +353,88 @@
             <field eval="18" name="priority"/>
             <field name="arch" type="xml">
                 <form string="Users" edit="1">
-                    <widget name="notification_alert"/>
-                    <field name="image_1920" readonly="0" widget='image' class="oe_avatar" options='{"preview_image": "avatar_128"}'/>
-                    <h1>
-                        <field name="name" readonly="1" class="oe_inline"/>
-                    </h1>
-                    <notebook>
-                        <page string="Preferences" name="preferences_page">
-                            <group name="preferences">
-                                <group>
-                                    <field name="email" widget="email" readonly="0"/>
-                                    <field name="phone"/>
+                    <header></header>
+                    <sheet>
+                        <widget name="notification_alert"/>
+                        <field name="image_1920" readonly="0" widget='image' class="oe_avatar" options='{"preview_image": "avatar_128"}'/>
+                        <h1>
+                            <field name="name" readonly="1" class="oe_inline"/>
+                        </h1>
+                        <notebook>
+                            <page string="Preferences" name="preferences_page">
+                                <group name="preferences">
+                                    <group>
+                                        <field name="email" widget="email" readonly="0"/>
+                                        <field name="phone"/>
+                                    </group>
+                                    <group>
+                                        <label for="lang"/>
+                                        <div class="o_row">
+                                            <field name="lang" required="1" readonly="0"/>
+                                            <button
+                                                type="action"
+                                                name="%(base.action_view_base_language_install)d"
+                                                class="oe_edit_only btn-sm btn-link mb4 fa fa-globe"
+                                                aria-label="Add a language"
+                                                groups="base.group_system"
+                                                title="Add a language"
+                                            />
+                                        </div>
+                                        <field name="tz" widget="timezone_mismatch" options="{'tz_offset_field': 'tz_offset'}" readonly="0"/>
+                                        <field name="tz_offset" invisible="1"/> <!-- needed for the timezone_mismatch widget -->
+                                    </group>
                                 </group>
-                                <group>
-                                    <label for="lang"/>
-                                    <div class="o_row">
-                                        <field name="lang" required="1" readonly="0"/>
-                                        <button
-                                            type="action"
-                                            name="%(base.action_view_base_language_install)d"
-                                            class="oe_edit_only btn-sm btn-link mb4 fa fa-globe"
-                                            aria-label="Add a language"
-                                            groups="base.group_system"
-                                            title="Add a language"
-                                        />
+                                <group name="signature">
+                                    <field name="signature" readonly="0" options="{'codeview': true}"/>
+                                </group>
+                                <group name="status" string="Status" invisible="1">
+                                    <field name="company_id" options="{'no_create': True}" readonly="0"
+                                        groups="base.group_multi_company"/>
+                                </group>
+                                <group name="preference_contact"></group>
+                            </page>
+                            <page string="Account Security" name="page_account_security">
+                                <group name="auth" string="Password Management">
+                                    <div colspan="2">
+                                        <button name="preference_change_password" type="object" string="Change password" class="btn btn-secondary"/>
                                     </div>
-                                    <field name="tz" widget="timezone_mismatch" options="{'tz_offset_field': 'tz_offset'}" readonly="0"/>
-                                    <field name="tz_offset" invisible="1"/> <!-- needed for the timezone_mismatch widget -->
                                 </group>
-                            </group>
-                            <group name="signature">
-                                <field name="signature" readonly="0" options="{'codeview': true}"/>
-                            </group>
-                            <group name="status" string="Status" invisible="1">
-                                <field name="company_id" options="{'no_create': True}" readonly="0"
-                                    groups="base.group_multi_company"/>
-                            </group>
-                            <group name="preference_contact"></group>
-                        </page>
-                        <page string="Account Security" name="page_account_security">
-                            <group name="auth" string="Password Management">
-                                <div colspan="2">
-                                    <button name="preference_change_password" type="object" string="Change password" class="btn btn-secondary"/>
-                                </div>
-                            </group>
-                            <group name="access" string="Other Devices">
-                                <div colspan="2">
-                                    <button name="action_revoke_all_devices" type="object" string="Log out from all devices" class="btn btn-secondary"/>
-                                </div>
-                            </group>
-                            <group string="API Keys">
-                                <div class="text-muted" colspan="2">
-                                    API Keys are used to connect to Odoo from external tools without the need for a password or Two-factor Authentication.
-                                    <widget name="documentation_link" path="/developer/misc/api/external_api.html#api-keys" lable="Learn more" icon="fa-fw o_button_icon fa-info-circle"/>
-                                </div>
-                                <div colspan="2" invisible="not api_key_ids">
-                                    <field name="api_key_ids" nolabel="1" colspan="4" readonly="0">
-                                        <list editable="bottom" create="false" delete="false">
-                                            <field name="name"/>
-                                            <field name="scope"/>
-                                            <field name="create_date"/>
-                                            <field name="expiration_date"/>
-                                            <button type="object" name="remove"
-                                                    string="Delete API key." icon="fa-trash"/>
-                                        </list>
-                                    </field>
-                                </div>
-                                <div colspan="2">
-                                    <button name="api_key_wizard" string="New API Key" type="object" class="btn btn-secondary"/>
-                                </div>
-                            </group>
-                        </page>
-                        <page string="Devices" name="page_devices">
-                            <field name="device_ids" mode="kanban"/>
-                        </page>
-                    </notebook>
-                    <footer>
-                        <button name="preference_save" type="object" string="Save" class="btn-primary" data-hotkey="q"/>
-                        <button name="preference_cancel" string="Cancel" special="cancel" data-hotkey="x" class="btn-secondary"/>
-                    </footer>
+                                <group name="access" string="Other Devices">
+                                    <div colspan="2">
+                                        <button name="action_revoke_all_devices" type="object" string="Log out from all devices" class="btn btn-secondary"/>
+                                    </div>
+                                </group>
+                                <group string="API Keys">
+                                    <div class="text-muted" colspan="2">
+                                        API Keys are used to connect to Odoo from external tools without the need for a password or Two-factor Authentication.
+                                        <widget name="documentation_link" path="/developer/misc/api/external_api.html#api-keys" lable="Learn more" icon="fa-fw o_button_icon fa-info-circle"/>
+                                    </div>
+                                    <div colspan="2" invisible="not api_key_ids">
+                                        <field name="api_key_ids" nolabel="1" colspan="4" readonly="0">
+                                            <list editable="bottom" create="false" delete="false">
+                                                <field name="name"/>
+                                                <field name="scope"/>
+                                                <field name="create_date"/>
+                                                <field name="expiration_date"/>
+                                                <button type="object" name="remove"
+                                                        string="Delete API key." icon="fa-trash"/>
+                                            </list>
+                                        </field>
+                                    </div>
+                                    <div colspan="2">
+                                        <button name="api_key_wizard" string="New API Key" type="object" class="btn btn-secondary"/>
+                                    </div>
+                                </group>
+                            </page>
+                            <page string="Devices" name="page_devices">
+                                <field name="device_ids" mode="kanban"/>
+                            </page>
+                        </notebook>
+                        <footer>
+                            <button name="preference_save" type="object" string="Save" class="btn-primary" data-hotkey="q"/>
+                            <button name="preference_cancel" string="Cancel" special="cancel" data-hotkey="x" class="btn-secondary"/>
+                        </footer>
+                    </sheet>
                 </form>
             </field>
         </record>


### PR DESCRIPTION
### Purpose

Allow to internal user to create gmail / outlook personal mail
server, in order to not use the default email address when they
send emails.

### Security

As personal email servers are very sensitive, some checks are
put in place to prevent these servers from being selected by
anyone who isn't the owner of the server. Only the servers of
the creator of the associated message or mailing will be 
selectable, regardless of access rights. 

### Limitations

The main expected use case is for users who may want to
use their personal mail account to send messages.
Although there is no technical issue with this on our side
users may face issues if they try to use their private account
in an app such as email marketing, which might try to send
thousands of emails at once, triggering API limitations
fairly quickly.

Users should be particularly careful to specify the email_from
in such "mass" settings.

### Other

Outlook calendar is now installed by default for consistency.


Task-3061856