### PR TITLE
[FIX] website_slides: fix new content option

### DIFF
--- a/addons/website_slides/static/src/scss/website_slides.scss
+++ b/addons/website_slides/static/src/scss/website_slides.scss
@@ -51,31 +51,7 @@ $line-height-truncate: 1.5em;
 
 .o_wslides_arrow {
     position: absolute;
-    height: 24px;
-    margin-left: -5px;
-    margin-top: 10px;
-    line-height: 1.8em;
-    padding-left: 8px;
-    padding-right: 5px;
-    background: #17A2B8;
-    color: white;
-    box-shadow: 0px 0px 3px  gray;
-    z-index: 1;
-
-    text-decoration: none;
-
-    &:after {
-        // the triangle
-        content: "";
-        position: absolute;
-        height: 0px;
-        width: 0px;
-        right: 0;
-        margin-right: -15px;
-        border-left: 15px solid #17A2B8;
-        border-bottom: 12px solid transparent;
-        border-top: 12px solid transparent;
-    }
+    top: 0;
 }
 
 

--- a/addons/website_slides/views/website_slides_templates_homepage.xml
+++ b/addons/website_slides/views/website_slides_templates_homepage.xml
@@ -342,6 +342,8 @@
             <div t-field="channel.image_1920" t-options="{'widget': 'image', 'preview_image': 'image_512'}" class="o_wslides_background_image h-100">
                 <t t-if="channel.partner_has_new_content" t-call="website_slides.course_card_information"/>
             </div>
+            <!-- Previous t-call (in the t-field) does not work. Removing it in master-->
+            <t t-if="channel.partner_has_new_content" t-call="website_slides.course_card_information"/>
         </a>
         <div class="card-body p-3">
             <a class="card-title h5 mb-2 o_wslides_desc_truncate_2" t-attf-href="/slides/#{slug(channel)}" t-field="channel.name"/>
@@ -387,7 +389,7 @@
 <template id="course_card_information_arrow" inherit_id="website_slides.course_card_information"
     active="True" name='New Content Ribbon'>
     <xpath expr="//t[@id='course_card_information_content']" position="inside">
-        <span class="o_wslides_arrow">New Content</span>
+        <span class="o_wslides_arrow badge bg-secondary mt-2 ms-2">New Content</span>
     </xpath>
 </template>
 


### PR DESCRIPTION
Restore the "New Content" ribbon (activated via page options) which
should be displayed on the course card when a new published content
has been added during the last 7 days.

The ribbon isn't displayed because it's declared in a "t-field" element
which replaces its content to display the field at rendering.

Task-4852463

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
