### PR TITLE
[PERF] point_of_sale: excluding attributes values

### DIFF
--- a/addons/point_of_sale/models/product_attribute.py
+++ b/addons/point_of_sale/models/product_attribute.py
@@ -69,4 +69,4 @@ class ProductTemplateAttributeExclusion(models.Model):
 
     @api.model
     def _load_pos_data_fields(self, config_id):
-        return ['value_ids']
+        return ['value_ids', 'product_template_attribute_value_id']

--- a/addons/point_of_sale/static/src/app/components/popups/product_configurator_popup/product_configurator_popup.js
+++ b/addons/point_of_sale/static/src/app/components/popups/product_configurator_popup/product_configurator_popup.js
@@ -14,6 +14,11 @@ export class BaseProductAttribute extends Component {
         "allSelectedValues",
     ];
 
+    setup() {
+        super.setup(...arguments);
+        this.pos = usePos();
+    }
+
     getFormatPriceExtra(val) {
         const sign = val < 0 ? "- " : "+ ";
         return sign + this.env.utils.formatCurrency(Math.abs(val));
@@ -46,6 +51,7 @@ export class MultiProductAttribute extends BaseProductAttribute {
     static template = "point_of_sale.MultiProductAttribute";
 
     setup() {
+        super.setup(...arguments);
         this.state = useState({
             is_value_selected: this.props.attribute.values().reduce((acc, value) => {
                 acc[value.id] = false;
@@ -124,7 +130,7 @@ export class ProductConfiguratorPopup extends Component {
 
         let combination;
         while ((combination = getNext()) !== null) {
-            if (!combination.some((value) => value.doHaveConflictWith(combination))) {
+            if (!combination.some((value) => this.pos.doHaveConflictWith(value, combination))) {
                 combination.forEach((value) => {
                     this.state.attributes[value.attribute_id.id].selected = value;
                 });

--- a/addons/point_of_sale/static/src/app/components/popups/product_configurator_popup/product_configurator_popup.xml
+++ b/addons/point_of_sale/static/src/app/components/popups/product_configurator_popup/product_configurator_popup.xml
@@ -10,13 +10,13 @@
                             type="radio"
                             t-att-checked="value.id === props.selected.id"
                             t-on-change="() => props.setSelected(value)"
-                            t-att-disabled="value.doHaveConflictWith(props.allSelectedValues)" 
+                            t-att-disabled="pos.doHaveConflictWith(value, props.allSelectedValues)" 
                             t-att-name="value.attribute_id.id"
                             t-attf-id="{{ value.attribute_id.id }}_{{ value.id }}"
                             class="form-check-input radio-check"
                         />
                         <label t-attf-for="{{ value.attribute_id.id }}_{{ value.id }}">
-                            <span t-att-class="{ 'text-muted': value.doHaveConflictWith(props.allSelectedValues) }" t-esc="value.name"/>
+                            <span t-att-class="{ 'text-muted': pos.doHaveConflictWith(value, props.allSelectedValues) }" t-esc="value.name"/>
                             <div t-if="value.price_extra" class="price-extra-cell d-inline-block ms-2">
                                 <span class="price_extra px-2 py-1 rounded-pill text-bg-info">
                                     <t t-esc="getFormatPriceExtra(value.price_extra)"/>
@@ -49,7 +49,7 @@
                             t-attf-class="btn btn-secondary btn-lg lh-lg d-flex {{ value.id == props.selected.id ? 'active' : '' }}"
                             t-att-name="value.name"
                             t-attf-for="{{ value.attribute_id.id }}_{{ value.id }}">
-                            <span t-att-class="{ 'text-muted': value.doHaveConflictWith(props.allSelectedValues) }" t-esc="value.name"/>
+                            <span t-att-class="{ 'text-muted': pos.doHaveConflictWith(value, props.allSelectedValues) }" t-esc="value.name"/>
                             <div t-if="value.price_extra" class="price-extra-cell d-inline-block ms-2">
                                 <span class="price_extra px-2 py-1 rounded-pill text-bg-info">
                                     <t t-esc="getFormatPriceExtra(value.price_extra)"/>
@@ -71,7 +71,7 @@
 
             <select class="configurator_select form-select form-select-md" t-on-change="(e) => this.onChange(e)">
                 <t t-foreach="props.attribute.values()" t-as="value" t-key="value.id">
-                    <option t-att-value="value.id" t-att-disabled="value.doHaveConflictWith(props.allSelectedValues)"  t-att-class="{'ptav-not-available': value.excluded}">
+                    <option t-att-value="value.id" t-att-disabled="pos.doHaveConflictWith(value, props.allSelectedValues)"  t-att-class="{'ptav-not-available': value.excluded}">
                         <t t-set="is_custom" t-value="is_custom || (value.is_custom and value.id == props.selected.id)"/>
                         <t t-esc="value.name"/>
                         <t t-if="value.price_extra">
@@ -103,7 +103,7 @@
                                 t-att-checked="value.id === props.selected.id"
                                 t-on-change="() => props.setSelected(value)"
                                 t-att-name="value.attribute_id.id"
-                                t-att-disabled="value.doHaveConflictWith(props.allSelectedValues)" 
+                                t-att-disabled="pos.doHaveConflictWith(value, props.allSelectedValues)" 
                                 t-attf-id="{{ value.attribute_id.id }}_{{ value.id }}"
                                 class="m-2 opacity-0" 
                             />
@@ -135,7 +135,7 @@
                     t-attf-class="form-check-label btn btn-secondary btn-lg lh-lg d-flex {{ this.state.is_value_selected[value.id] === true ? 'active' : '' }}"
                     t-attf-name="multi-{{value.id}}"
                     t-attf-for="multi-{{value.id}}">
-                    <span t-att-class="{ 'text-muted': value.doHaveConflictWith(props.allSelectedValues) }" t-esc="value.name"/>
+                    <span t-att-class="{ 'text-muted': pos.doHaveConflictWith(value, props.allSelectedValues) }" t-esc="value.name"/>
                     <div t-if="value.price_extra" class="price-extra-cell d-inline-block ms-2">
                         <span class="price_extra px-2 py-1 rounded-pill text-bg-info">
                             <t t-esc="getFormatPriceExtra(value.price_extra)"/>

--- a/addons/point_of_sale/static/src/app/models/product_template_attribute_value.js
+++ b/addons/point_of_sale/static/src/app/models/product_template_attribute_value.js
@@ -3,23 +3,6 @@ import { Base } from "./related_models";
 
 export class ProductTemplateAttributeValue extends Base {
     static pythonModel = "product.template.attribute.value";
-
-    setup() {
-        super.setup(...arguments);
-    }
-
-    get exclusions() {
-        const values = this.models["product.template.attribute.value"].filter((value) =>
-            value.exclude_for.some(({ value_ids }) => value_ids.some(({ id }) => id === this.id))
-        );
-
-        return [...this.exclude_for.flatMap(({ value_ids }) => value_ids), ...values];
-    }
-
-    doHaveConflictWith(values) {
-        const excludedIds = values.map(({ id }) => id);
-        return this.exclusions.some(({ id }) => excludedIds.includes(id));
-    }
 }
 
 registry

--- a/addons/point_of_sale/static/tests/pos/tours/product_configurator_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/product_configurator_tour.js
@@ -113,3 +113,17 @@ registry.category("web_tour.tours").add("test_attribute_order", {
             ),
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("test_exclusion_attribute_values", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            ProductScreen.clickDisplayedProduct("Configurable Chair"),
+            ProductConfigurator.pickColor("Red"),
+            ProductConfigurator.pickSelect("Metal"),
+            ProductConfigurator.isUnavailable("Other"),
+            ProductConfigurator.isUnavailable("Wool"),
+            Chrome.endTour(),
+        ].flat(),
+});

--- a/addons/point_of_sale/static/tests/pos/tours/utils/product_configurator_util.js
+++ b/addons/point_of_sale/static/tests/pos/tours/utils/product_configurator_util.js
@@ -57,3 +57,12 @@ export function isOptionShown(option) {
         },
     ];
 }
+
+export function isUnavailable(option) {
+    return [
+        {
+            content: `option ${option} is unavailable`,
+            trigger: `.modal .attribute span.text-muted:contains('${option}')`,
+        },
+    ];
+}

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -212,25 +212,25 @@ class TestPointOfSaleHttpCommon(AccountTestInvoicingHttpCommon):
         })
         line.product_template_value_ids[0].price_extra = 2
 
-        chair_color_attribute = env['product.attribute'].create({
+        cls.chair_color_attribute = env['product.attribute'].create({
             'name': 'Color',
             'display_type': 'color',
             'create_variant': 'no_variant',
         })
-        chair_color_red = env['product.attribute.value'].create({
+        cls.chair_color_red = env['product.attribute.value'].create({
             'name': 'Red',
-            'attribute_id': chair_color_attribute.id,
+            'attribute_id': cls.chair_color_attribute.id,
             'html_color': '#ff0000',
         })
         chair_color_blue = env['product.attribute.value'].create({
             'name': 'Blue',
-            'attribute_id': chair_color_attribute.id,
+            'attribute_id': cls.chair_color_attribute.id,
             'html_color': '#0000ff',
         })
         chair_color_line = env['product.template.attribute.line'].create({
             'product_tmpl_id': cls.configurable_chair.id,
-            'attribute_id': chair_color_attribute.id,
-            'value_ids': [(6, 0, [chair_color_red.id, chair_color_blue.id])]
+            'attribute_id': cls.chair_color_attribute.id,
+            'value_ids': [(6, 0, [cls.chair_color_red.id, chair_color_blue.id])]
         })
         chair_color_line.product_template_value_ids[0].price_extra = 1
 
@@ -253,28 +253,28 @@ class TestPointOfSaleHttpCommon(AccountTestInvoicingHttpCommon):
             'value_ids': [(6, 0, [chair_legs_metal.id, chair_legs_wood.id])]
         })
 
-        chair_fabrics_attribute = env['product.attribute'].create({
+        cls.chair_fabrics_attribute = env['product.attribute'].create({
             'name': 'Fabrics',
             'display_type': 'radio',
             'create_variant': 'no_variant',
         })
         chair_fabrics_leather = env['product.attribute.value'].create({
             'name': 'Leather',
-            'attribute_id': chair_fabrics_attribute.id,
+            'attribute_id': cls.chair_fabrics_attribute.id,
         })
-        chair_fabrics_wool = env['product.attribute.value'].create({
+        cls.chair_fabrics_wool = env['product.attribute.value'].create({
             'name': 'wool',
-            'attribute_id': chair_fabrics_attribute.id,
+            'attribute_id': cls.chair_fabrics_attribute.id,
         })
-        chair_fabrics_other = env['product.attribute.value'].create({
+        cls.chair_fabrics_other = env['product.attribute.value'].create({
             'name': 'Other',
-            'attribute_id': chair_fabrics_attribute.id,
+            'attribute_id': cls.chair_fabrics_attribute.id,
             'is_custom': True,
         })
         env['product.template.attribute.line'].create({
             'product_tmpl_id': cls.configurable_chair.id,
-            'attribute_id': chair_fabrics_attribute.id,
-            'value_ids': [(6, 0, [chair_fabrics_leather.id, chair_fabrics_wool.id, chair_fabrics_other.id])]
+            'attribute_id': cls.chair_fabrics_attribute.id,
+            'value_ids': [(6, 0, [chair_fabrics_leather.id, cls.chair_fabrics_wool.id, cls.chair_fabrics_other.id])]
         })
         chair_color_line.product_template_value_ids[1].is_custom = True
 
@@ -2128,6 +2128,28 @@ class TestUi(TestPointOfSaleHttpCommon):
             'resource_calendar_id': resource_calendar
         })
         self.start_pos_tour('test_preset_timing_retail')
+
+    def test_exclusion_attribute_values(self):
+        chair_fabrics_other_ptav = self.configurable_chair.attribute_line_ids.filtered(lambda l: l.attribute_id.id == self.chair_fabrics_attribute.id).product_template_value_ids.filtered(lambda v: v.product_attribute_value_id.id == self.chair_fabrics_other.id)
+        chair_fabrics_wool_ptav = self.configurable_chair.attribute_line_ids.filtered(lambda l: l.attribute_id.id == self.chair_fabrics_attribute.id).product_template_value_ids.filtered(lambda v: v.product_attribute_value_id.id == self.chair_fabrics_wool.id)
+        chair_color_red_ptav = self.configurable_chair.attribute_line_ids.filtered(lambda l: l.attribute_id.id == self.chair_color_attribute.id).product_template_value_ids.filtered(lambda v: v.product_attribute_value_id.id == self.chair_color_red.id)
+
+        # Test the exclusion of attribute values
+        self.env['product.template.attribute.exclusion'].create({
+            'product_tmpl_id': self.configurable_chair.id,
+            'product_template_attribute_value_id': chair_color_red_ptav.id,
+            'value_ids': [Command.set([chair_fabrics_other_ptav.id])],
+        })
+
+        # # Test the exclusion of attribute values in the opposite direction
+        self.env['product.template.attribute.exclusion'].create({
+            'product_tmpl_id': self.configurable_chair.id,
+            'product_template_attribute_value_id': chair_fabrics_wool_ptav.id,
+            'value_ids': [Command.set([chair_color_red_ptav.id])],
+        })
+
+        self.main_pos_config.with_user(self.pos_user).open_ui()
+        self.start_pos_tour('test_exclusion_attribute_values')
 
 
 # This class just runs the same tests as above but with mobile emulation


### PR DESCRIPTION
Before this commit, the computation of the exclusion of some attributes based on other selected was going through every attribute to determine if it was excluded or not. This is now done once at the loading of the pos.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
