### PR TITLE
[IMP] hr_holidays: add dashboard banner in kanban

### DIFF
--- a/addons/hr_holidays/models/hr_employee.py
+++ b/addons/hr_holidays/models/hr_employee.py
@@ -32,9 +32,11 @@ class HrEmployee(models.Model):
     def action_time_off_dashboard(self):
         action = self.env['ir.actions.act_window']._for_xml_id('hr_holidays.hr_leave_action_action_approve_department')
         action['context'] = dict(literal_eval(action['context']))
-        action['context']['search_default_employee_id'] = self.ids
+        action['context']['show_dashboard'] = True
         action['context'].pop('search_default_waiting_for_me', False)
         action['context'].pop('search_default_waiting_for_me_manager', False)
+        action['context']['default_employee_id'] = self.id
+        action['domain'] = [('employee_id', 'in', self.ids)]
         return action
 
     def _is_leave_user(self):

--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -602,9 +602,10 @@ class HrLeave(models.Model):
         for leave in self:
             virtual_remaining_leaves = 0
             max_leaves = 0
-            for allocation_dict in employee_days_per_allocation[leave.employee_id][leave.holiday_status_id].values():
-                max_leaves += allocation_dict['max_leaves']
-                virtual_remaining_leaves += allocation_dict['virtual_remaining_leaves']
+            for allocation, allocation_dict in employee_days_per_allocation[leave.employee_id][leave.holiday_status_id].items():
+                if allocation and (not allocation.date_to or allocation.date_to >= date_from):
+                    max_leaves += allocation_dict['max_leaves']
+                    virtual_remaining_leaves += allocation_dict['virtual_remaining_leaves']
             leave.virtual_remaining_leaves = virtual_remaining_leaves
             leave.max_leaves = max_leaves
 

--- a/addons/hr_holidays/static/src/views/kanban/kanban_controller.js
+++ b/addons/hr_holidays/static/src/views/kanban/kanban_controller.js
@@ -1,0 +1,16 @@
+import { KanbanController } from "@web/views/kanban/kanban_controller";
+import { EventBus, useSubEnv } from "@odoo/owl";
+
+export class TimeOffKanbanController extends KanbanController {
+    setup() {
+        super.setup();
+        useSubEnv({
+            timeOffBus: new EventBus(),
+        });
+    }
+
+    afterExecuteActionButton(clickParams) {
+        super.afterExecuteActionButton(clickParams);
+        this.env.timeOffBus.trigger("update_dashboard");
+    }
+}

--- a/addons/hr_holidays/static/src/views/kanban/kanban_renderer.js
+++ b/addons/hr_holidays/static/src/views/kanban/kanban_renderer.js
@@ -1,0 +1,17 @@
+import { KanbanRenderer } from '@web/views/kanban/kanban_renderer';
+import { TimeOffDashboard } from '../../dashboard/time_off_dashboard';
+
+export class TimeOffKanbanRenderer extends KanbanRenderer {
+    static template = "hr_holidays.KanbanRenderer";
+    static components = {
+        ...TimeOffKanbanRenderer.components,
+        TimeOffDashboard,
+    };
+    get employeeId() {
+        return this.env.model.config.context.active_id || null;
+    }
+
+    get showDashboard() {
+        return this.env.model.config.context.show_dashboard || false;
+    }
+}

--- a/addons/hr_holidays/static/src/views/kanban/kanban_renderer.xml
+++ b/addons/hr_holidays/static/src/views/kanban/kanban_renderer.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+    <t t-name="hr_holidays.KanbanRenderer">
+        <div class="o_timeoff_calendar d-flex flex-column">
+            <TimeOffDashboard t-if="showDashboard" employeeId="employeeId"/>
+            <t t-call="web.KanbanRenderer"/>
+        </div>
+    </t>
+</templates>

--- a/addons/hr_holidays/static/src/views/kanban/kanban_view.js
+++ b/addons/hr_holidays/static/src/views/kanban/kanban_view.js
@@ -1,0 +1,12 @@
+import { kanbanView } from '@web/views/kanban/kanban_view';
+import { registry } from '@web/core/registry';
+import { TimeOffKanbanRenderer } from './kanban_renderer';
+import { TimeOffKanbanController } from './kanban_controller';
+
+const TimeOffKanbanView = {
+    ...kanbanView,
+    Renderer: TimeOffKanbanRenderer,
+    Controller: TimeOffKanbanController
+}
+
+registry.category('views').add('time_off_kanban_dashboard', TimeOffKanbanView);

--- a/addons/hr_holidays/views/hr_leave_views.xml
+++ b/addons/hr_holidays/views/hr_leave_views.xml
@@ -490,9 +490,9 @@
                 <attribute name="invisible">0</attribute>
             </xpath>
             <xpath expr="//field[@name='holiday_status_id']" position="before">
-                <field name="employee_id" groups="hr_holidays.group_hr_holidays_user" readonly="state in ['cancel', 'refuse', 'validate', 'validate1']" widget="many2one_avatar_employee"/>
+                <field name="employee_id" groups="hr_holidays.group_hr_holidays_responsible" readonly="state in ['cancel', 'refuse', 'validate', 'validate1']" widget="many2one_avatar_employee"/>
                 <field name="company_id" groups="base.group_multi_company"/>
-                <field name="department_id" groups="hr_holidays.group_hr_holidays_user" readonly="1"/>
+                <field name="department_id" groups="hr_holidays.group_hr_holidays_responsible" readonly="1"/>
             </xpath>
         </field>
     </record>

--- a/addons/hr_holidays/views/hr_leave_views.xml
+++ b/addons/hr_holidays/views/hr_leave_views.xml
@@ -91,7 +91,7 @@
         <field name="name">hr.leave.view.kanban</field>
         <field name="model">hr.leave</field>
         <field name="arch" type="xml">
-            <kanban sample="1" class="o_holidays_view_kanban">
+            <kanban sample="1" class="o_holidays_view_kanban" js_class="time_off_kanban_dashboard">
                 <header>
                     <button type="action"
                         name="%(hr_holidays.action_hr_leave_generate_multi_wizard)d"


### PR DESCRIPTION
When coming from the time off smartbutton on the employee, having a small banner indicating the number of leaves remaining is useful.
This PR adds this banner, the same as in the time off dashboard.

The PR also fixes two bugs: 
- When an employee is a time off manager of another employee, he has access to the time off management menu. There, he can create new time offs for all subordinates employees. The field employee_id had the group hr_holiday_user, which is wrong as the time off managers don't necessarilly have this group. Removing the group allows the time off managers to select the correct employee, and the domain on the employee field ensures that the manager can only select subordinates employees.
- In hr_leave kanban cards, the time off balance for that time off type is shown. The amount were incorrectly computed. This PR fixes the issue by filtering out the expired leave allocations.