### PR TITLE
[PERF] crm: Add index on default order

### DIFF
--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -255,6 +255,7 @@ class CrmLead(models.Model):
     )
     _user_id_team_id_type_index = models.Index("(user_id, team_id, type)")
     _create_date_team_id_idx = models.Index("(create_date, team_id)")
+    _default_order_idx = models.Index('(priority DESC, id DESC) WHERE active IS TRUE')
 
     @api.constrains('probability', 'stage_id')
     def _check_won_validity(self):


### PR DESCRIPTION
This commit adds a default index on the order of `crm.lead`. It will support the `web_search_read` that are done in the kanban view.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
