### PR TITLE
[FIX] mail: crash when hovering unknown reaction

### DIFF
--- a/addons/mail/static/src/core/common/message_reaction_list.js
+++ b/addons/mail/static/src/core/common/message_reaction_list.js
@@ -31,7 +31,8 @@ export class MessageReactionList extends Component {
         const personNames = reaction.personas
             .slice(0, 3)
             .map((persona) => this.props.message.getPersonaName(persona));
-        const shortcode = this.store.emojiLoader.loaded?.emojiValueToShortcodes?.[emoji][0] ?? "?";
+        const shortcode =
+            this.store.emojiLoader.loaded?.emojiValueToShortcodes?.[emoji]?.[0] ?? "?";
         switch (count) {
             case 1:
                 return _t("%(emoji)s reacted by %(person)s", {


### PR DESCRIPTION
When an unknown reaction is hovered (old emojis not present in emoji data anymore for example), shortcode can not be found and a crash occur. This commit fixes the issue.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
