### PR TITLE
[FIX] mail: KeyError when collecting partners from emails

### DIFF
--- a/addons/account/tests/test_account_move_send.py
+++ b/addons/account/tests/test_account_move_send.py
@@ -695,6 +695,25 @@ class TestAccountMoveSend(TestAccountMoveSendCommon):
         self.assertEqual(move_send_batch_wizard.summary_data, {'email': {'count': len(invoices), 'label': 'by Email'}})
         self.assertFalse(move_send_batch_wizard.alerts)
 
+    def test_compute_value_of_send_invoice_batch_with_cc(self):
+        tmpl = self.env.ref("account.email_template_edi_invoice")
+        tmpl.write({
+            "email_cc": "example@ex.net,other@ex.net",
+            "use_default_to": False,
+        })
+
+        invoices = (
+            self.init_invoice("out_invoice", partner=self.partner_a, amounts=[1000], post=True) +
+            self.init_invoice("out_invoice", partner=self.partner_b, amounts=[1000], post=True)
+        )
+
+        move_send_batch_wizard = Form(self.env['account.move.send.batch.wizard'].with_context(
+            active_model='account.move', active_ids=invoices.ids))
+
+        self.assertEqual(move_send_batch_wizard.move_ids.ids, invoices.ids)
+        self.assertEqual(move_send_batch_wizard.summary_data, {'email': {'count': len(invoices), 'label': 'by Email'}})
+        self.assertFalse(move_send_batch_wizard.alerts)
+
     def test_invoice_multi_email_missing(self):
         invoice1 = self.init_invoice("out_invoice", partner=self.partner_a, amounts=[1000], post=True)
         invoice2 = self.init_invoice("out_invoice", partner=self.partner_b, amounts=[1000], post=True)

--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -2010,7 +2010,7 @@ class MailThread(models.AbstractModel):
         if self and len(self) != len(records_emails):
             raise ValueError('Invoke with either self maching records_emails, either on a void recordset.')
         # when invoked through MailThread, ids may come from records_emails (not recommended tool usage)
-        res_ids = self.ids or [record.id for record in records_emails]
+        res_ids = self.ids or [record._origin.id for record in records_emails]
         found_results = dict.fromkeys(res_ids, self.env['res.partner'])
         # email_key is email_normalized, unless email is wrong and cannot be normalized
         # in which case the raw input is used instead, to distinguish various wrong
@@ -2034,7 +2034,7 @@ class MailThread(models.AbstractModel):
             for mail in mails:
                 mail_normalized = email_normalize(mail, strict=False)
                 email_key = mail_normalized or mail
-                emails_key_res_ids[email_key].append(record.id)
+                emails_key_res_ids[email_key].append(record)
                 if record_company and email_key:  # False is not interesting anyway
                     emails_key_company_id[email_key] = record_company.id
                 emails_all.append(mail)
@@ -2081,7 +2081,7 @@ class MailThread(models.AbstractModel):
             mail_key = email_normalize(mail, strict=False) or mail
             for res_id in emails_key_res_ids[mail_key]:
                 # use an "OR" to avoid duplicates in returned recordset
-                found_results[res_id] |= partner
+                found_results[res_id._origin.id] |= partner
         return found_results
 
     def _mail_find_user_for_gateway(self, email_value, alias=None):


### PR DESCRIPTION
When calling `_partner_find_from_emails`, we loop through records associated with each email and attempt to merge the corresponding partners into a result dictionary using: `found_results[res_id] |= partner`

However, if `res_id` is a `NewId`,
this raises a KeyError if the key has not yet been initialized.

Steps to reproduce:
Go to Email Templates
Search fo Invoicing
In Invoicing template go to Email Configuration
Uncheck Default recipients
Add Cc (add any mail)
Back to accountant and try to send more than one Invoice at once.

OPW-4851075
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
