### PR TITLE
[FIX] web: support x2many search defaults in search model

### DIFF
--- a/addons/web/static/src/search/search_arch_parser.js
+++ b/addons/web/static/src/search/search_arch_parser.js
@@ -136,8 +136,8 @@ export class SearchArchParser {
             preField.fieldType = fieldType;
             if (fieldType !== "properties" && name in this.searchDefaults) {
                 preField.isDefault = true;
-                let value = this.searchDefaults[name];
-                value = Array.isArray(value) ? value[0] : value;
+                const val = this.searchDefaults[name];
+                const value = Array.isArray(val) ? val[0] : val;
                 let operator = preField.operator;
                 if (!operator) {
                     let type = fieldType;
@@ -169,6 +169,22 @@ export class SearchArchParser {
                             .then((results) => {
                                 preField.defaultAutocompleteValue.label =
                                     results[0]["display_name"];
+                            })
+                    );
+                } else if (
+                    ["many2many", "one2many"].includes(fieldType) &&
+                    Array.isArray(val) &&
+                    val.every((v) => Number.isInteger(v) && v > 0)
+                ) {
+                    preField.defaultAutocompleteValue.operator = "in";
+                    preField.defaultAutocompleteValue.value = val;
+                    this.labels.push((orm) =>
+                        orm
+                            .call(relation, "read", [val, ["display_name"]], { context })
+                            .then((results) => {
+                                preField.defaultAutocompleteValue.label = `${results
+                                    .map((r) => r["display_name"])
+                                    .join(" or ")}`;
                             })
                     );
                 }

--- a/addons/web/static/tests/search/search_bar.test.js
+++ b/addons/web/static/tests/search/search_bar.test.js
@@ -854,7 +854,7 @@ test("check kwargs of a rpc call with a domain", async () => {
     expect(searchBar.env.searchModel.domain).toEqual([["company", "=", 5]]);
 });
 
-test("should wait label promises for one2many search defaults", async () => {
+test("should wait label promises for many2one search defaults", async () => {
     const def = new Deferred();
     onRpc("read", () => def);
 
@@ -871,6 +871,31 @@ test("should wait label promises for one2many search defaults", async () => {
     await animationFrame();
     expect(`.o_cp_searchview`).toHaveCount(1);
     expect(getFacetTexts()[0].replace("\n", "")).toBe("CompanyFirst record");
+});
+
+test("should wait label promises for many2many search defaults", async () => {
+    Partner._fields.m2m = fields.Many2many({ relation: "partner" });
+    const def = new Deferred();
+    onRpc("read", () => def);
+
+    mountWithSearch(SearchBar, {
+        resModel: "partner",
+        searchMenuTypes: [],
+        searchViewId: false,
+        searchViewArch: `
+            <search>
+                <field name="m2m"/>
+            </search>
+        `,
+        context: { search_default_m2m: [1, 2] },
+    });
+    await animationFrame();
+    expect(`.o_cp_searchview`).toHaveCount(0);
+
+    def.resolve();
+    await animationFrame();
+    expect(`.o_cp_searchview`).toHaveCount(1);
+    expect(getFacetTexts()[0].replace("\n", "")).toBe("M2mFirst record or Second record");
 });
 
 test("globalContext keys in name_search", async () => {


### PR DESCRIPTION
This commit adds support for x2many field defaults in the search_arch_parser, which previously did not handle these field types correctly when used as search defaults.
Based on https://github.com/odoo/odoo/pull/177716
