### PR TITLE
[FIX] point_of_sale: info popup correct taxes

### DIFF
--- a/addons/point_of_sale/models/product.py
+++ b/addons/point_of_sale/models/product.py
@@ -115,7 +115,13 @@ class ProductProduct(models.Model):
         config = self.env['pos.config'].browse(pos_config_id)
 
         # Tax related
-        taxes = self.taxes_id.compute_all(price, config.currency_id, quantity, self)
+        tax_to_use = None
+        company = config.company_id
+        while not tax_to_use and company:
+            tax_to_use = self.taxes_id.filtered(lambda tax: tax.company_id.id == company.id)
+            if not tax_to_use:
+                company = company.parent_id
+        taxes = tax_to_use.compute_all(price, config.currency_id, quantity, self)
         grouped_taxes = {}
         for tax in taxes['taxes']:
             if tax['id'] in grouped_taxes:

--- a/addons/point_of_sale/tests/test_pos_products_with_tax.py
+++ b/addons/point_of_sale/tests/test_pos_products_with_tax.py
@@ -682,6 +682,14 @@ class TestPoSProductsWithTax(TestPoSCommon):
             []
         )
 
+        def get_taxes_name_popup(product):
+            return [tax['name'] for tax in product.get_product_info_pos(product_all_taxes.lst_price, 1, xx_config.id)['all_prices']['tax_details']]
+
+        self.assertEqual(get_taxes_name_popup(product_all_taxes), ["Tax XX"])
+        self.assertEqual(get_taxes_name_popup(product_no_xx_tax), ["Tax X"])
+        self.assertEqual(get_taxes_name_popup(product_no_branch_tax), ["Tax A", "Tax B"])
+        self.assertEqual(get_taxes_name_popup(product_no_tax), [])
+
     def test_combo_product_variant_error(self):
         """This tests make sure that product containing variants cannot change type to combo"""
 


### PR DESCRIPTION
The taxes used in the info popup of the product list should be the taxes of the company that owns the PoS. At the moment, it uses the all the taxes defined on the product regardless of the company.

Steps to reproduce:
-------------------
* Create a branch for your main company
* Define a tax in the main company, and one in the branch
* Create a product and assign the two taxes to it
* Open the PoS in the branch
* Open the product info popup
> Observation: Both tax are shown on the popup, even the one defined in
  the main company.

Why the fix:
------------
As it is done in `_pos_data_process` we should take the taxes of the company that owns the PoS, and if no tax is found. We should use the taxe of the parent company if there is any. If no tax is found it means no tax should be used.

opw-4647704