### PR TITLE
[FIX] base: prevent set state to 'uninstalled' when module is already installed

### DIFF
--- a/odoo/addons/base/models/ir_module.py
+++ b/odoo/addons/base/models/ir_module.py
@@ -465,7 +465,7 @@ class IrModuleModule(models.Model):
 
     @assert_log_admin_access
     def button_install_cancel(self):
-        self.write({'state': 'uninstalled', 'demo': False})
+        self.filtered(lambda m: m.state == 'to install').write({'state': 'uninstalled', 'demo': False})
         return True
 
     @assert_log_admin_access
@@ -641,7 +641,7 @@ class IrModuleModule(models.Model):
         }
 
     def button_uninstall_cancel(self):
-        self.write({'state': 'installed'})
+        self.filtered(lambda m: m.state == 'to remove').write({'state': 'installed'})
         return True
 
     @assert_log_admin_access


### PR DESCRIPTION
Currently a missing dependency error is generated when the user clicks the
`Cancel Install` button on an already installed module.

This issue may occur due to the below reason:
- When the user installs multiple modules at once, the user may click
 `Cancel Install` on laready installed module
- In the duplicate tab scenario, the user module is installed from one tab, and
  the user clicks  `Cancel Install` on another tab.

Error :
`Some modules are not loaded, some dependencies or manifest may be missing...`

This commit will fix the above issue by writing state as 'uninstalled` when the
module state is `to install`. Also, the same for `Cancel Uninstall` write the
module's state as `installed` when its state is 'to remove'

sentry-3928883995
