### PR TITLE
[IMP] mail: add feedback on activity

### DIFF
--- a/addons/mail/models/mail_activity.py
+++ b/addons/mail/models/mail_activity.py
@@ -73,6 +73,7 @@ class MailActivity(models.Model):
     note = fields.Html('Note', sanitize_style=True)
     date_deadline = fields.Date('Due Date', index=True, required=True, default=fields.Date.context_today)
     date_done = fields.Date('Done Date', compute='_compute_date_done', store=True)
+    feedback = fields.Text('Feedback')
     automated = fields.Boolean(
         'Automated activity', readonly=True,
         help='Indicates this activity has been created automatically and not by any user.')
@@ -557,6 +558,8 @@ class MailActivity(models.Model):
 
         # once done, archive to keep history without keeping them alive
         self.action_archive()
+        if feedback:
+            self.feedback = feedback
         return messages, next_activities
 
     @api.readonly

--- a/addons/mail/views/mail_activity_views.xml
+++ b/addons/mail/views/mail_activity_views.xml
@@ -288,6 +288,7 @@
                 <field name="res_name" string="Linked to"/>
                 <field name="date_deadline" widget="remaining_days"/>
                 <field name="date_done" string="Done Date" optional="hide"/>
+                <field name="feedback" optional="hide"/>
                 <button name="action_done" type="object" string="Done" icon="fa-check" invisible="active == False"/>
                 <button name="unlink" type="object" string="Cancel" icon="fa-times" class="text-danger" invisible="active == False"/>
                 <widget name="activity_list_reschedule_dropdown"/>

--- a/addons/test_mail/tests/test_mail_activity.py
+++ b/addons/test_mail/tests/test_mail_activity.py
@@ -196,7 +196,7 @@ class TestActivityFlow(TestActivityCommon):
             self.assertEqual(test_record.activity_ids, self.env['mail.activity'])
 
             # employee record an activity and check the deadline
-            self.env['mail.activity'].create({
+            activity = self.env['mail.activity'].create({
                 'summary': 'Test Activity',
                 'date_deadline': date.today() + relativedelta(days=1),
                 'activity_type_id': self.env.ref('mail.mail_activity_data_email').id,
@@ -213,7 +213,8 @@ class TestActivityFlow(TestActivityCommon):
             self.assertEqual(test_record.activity_state, 'today')
 
             # activity is done
-            test_record.activity_ids.action_feedback(feedback='So much feedback')
+            activity.action_feedback(feedback='So much feedback')
+            self.assertEqual(activity.feedback, 'So much feedback')
             self.assertEqual(test_record.activity_ids, self.env['mail.activity'])
             self.assertEqual(test_record.message_ids[0].subtype_id, self.env.ref('mail.mt_activities'))
 


### PR DESCRIPTION
- Earlier feedback given when closing the activity was not stored in the
  activity model was there only in the logged message.
- This PR introduces a `feedback` field in the mail.activity model to save
  feedback directly on the activity, ensuring a complete and self-contained
  activity view.

Task-4757151