### PR TITLE
[FIX] mail: prevent action buttons from showing in chatter on unsaved forms

### DIFF
--- a/addons/mail/static/src/chatter/web_portal/chatter.js
+++ b/addons/mail/static/src/chatter/web_portal/chatter.js
@@ -32,6 +32,7 @@ export class Chatter extends Component {
             /** @type {import("models").Thread} */
             thread: undefined,
             aside: false,
+            disabled: !this.props.threadId,
         });
         this.rootRef = useRef("root");
         this.onScrollDebounced = useThrottleForAnimation(this.onScroll);
@@ -40,6 +41,7 @@ export class Chatter extends Component {
 
         onMounted(this._onMounted);
         onWillUpdateProps((nextProps) => {
+            this.state.disabled = !nextProps.threadId;
             if (
                 this.props.threadId !== nextProps.threadId ||
                 this.props.threadModel !== nextProps.threadModel

--- a/addons/mail/static/src/chatter/web_portal/chatter.scss
+++ b/addons/mail/static/src/chatter/web_portal/chatter.scss
@@ -2,10 +2,6 @@
     display: none;
 }
 
-.o-chatter-disabled .o-mail-Message-actions {
-    display: none;
-}
-
 .o-mail-Chatter-top {
     z-index: $o-mail-NavigableList-zIndex - 2;
     background-color: $o-webclient-background-color;

--- a/addons/mail/static/src/core/common/message.xml
+++ b/addons/mail/static/src/core/common/message.xml
@@ -157,7 +157,7 @@
 </t>
 
 <t t-name="mail.Message.actions">
-    <div t-if="props.hasActions and message.hasActions and !state.isEditing" class="o-mail-Message-actions d-print-none d-flex align-items-start"
+    <div t-if="props.hasActions and message.hasActions and !state.isEditing and !env.inChatter?.disabled" class="o-mail-Message-actions d-print-none d-flex align-items-start"
         t-att-class="{
             'start-0': isAlignedRight,
             'mx-1': !isMobileOS,

--- a/addons/mail/static/tests/chatter/web/chatter.test.js
+++ b/addons/mail/static/tests/chatter/web/chatter.test.js
@@ -318,7 +318,6 @@ test("base rendering when chatter has no record", async () => {
     await contains(".o-mail-Message-author", { text: "Mitchell Admin" });
     await contains(".o-mail-Message-body", { text: "Creating a new record..." });
     await contains("button", { count: 0, text: "Load More" });
-    await contains(".o-mail-Message-actions");
 });
 
 test("base rendering when chatter has attachments", async () => {
@@ -575,6 +574,18 @@ test("chatter updating", async () => {
     });
     await click(".o_pager_next");
     await contains(".o-mail-Message");
+});
+
+test("chatter message actions appear only after saving the form", async () => {
+    await start();
+    await openFormView("res.partner");
+    await contains(".o-mail-Message");
+    await contains(".o-mail-Message-actions", { count: 0 });
+    await click(".o_form_button_save");
+    await click("button", { text: "Send message" });
+    await insertText(".o-mail-Composer-input", "hey");
+    await click(".o-mail-Composer-send");
+    await contains(".o-mail-Message-actions");
 });
 
 test("post message on draft record", async () => {


### PR DESCRIPTION
Currently, an error occurs due to message action buttons being visible on unsaved forms.

Steps to replicate:
- Open any module with chatter (eg. `sale_management`).
- Click on `Mark as todo` (star icon) without saving (hover near to user's name in chatter).

Error:
`TypeError: 'float' object is not iterable`

The error occurs due to a recent [commit](https://github.com/odoo/odoo/pull/211362/files#diff-0fc14194d473213159537bf41f421dcbaf940dfd81ac87d263b196e914d40af3R160) that added the d-flex class to the `<div>` [1] containing the message actions. The core issue lies in the use of `d-flex`, which overrides any conditional visibility logic [2] applied to its child elements. As a result, the message action buttons become visible even before the form is saved.

This commit resolves the issue by making the visibility logic important so it doesnt get overridden by `d-flex`. This ensures that the conditional visibility logic is respected, preventing the action buttons to appear before the form is saved.

[1] - https://github.com/odoo/odoo/blob/e7cbe74f388ed1177d4c5c6fbe54988a1dc18217/addons/mail/static/src/core/common/message.xml#L160

[2] - https://github.com/odoo/odoo/blob/e7cbe74f388ed1177d4c5c6fbe54988a1dc18217/addons/mail/static/src/chatter/web_portal/chatter.scss#L5-L7

https://github.com/user-attachments/assets/4a4d168d-961e-4b49-be84-c95b0d899b7b

sentry-6657359767
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
