### PR TITLE
[FIX] website: no x scrolling on mobile animation


### DIFF
--- a/addons/website/static/src/scss/website.scss
+++ b/addons/website/static/src/scss/website.scss
@@ -2135,9 +2135,10 @@ input[value*="data-oe-translation-source-sha"] {
     visibility: visible;
 }
 .o_wanim_overflow_xy_hidden {
-    // "overflow-x: clip" is added to the "body" and not to "html" because if
-    // it's added to "html", when a popup opens, the page scrolls to the top.
-    > body {
+    // "overflow-x: clip" is added to the "#wrapwrap" and not to "html" because
+    // if it's added to "html", when a popup opens, the page scrolls to the top.
+    // It's not added on body because mobile browser ignore overflow-x on it.
+    #wrapwrap {
         // We use clip instead of hidden to prevent scroll animations to an
         // anchor from stopping working.
         overflow-x: clip !important;
@@ -2145,9 +2146,6 @@ input[value*="data-oe-translation-source-sha"] {
         @supports not (overflow-x: clip) {
             overflow-x: hidden !important;
         }
-        // Create a new formatting context. Without this, elements inside <body>
-        // may still overflow (e.g. animated elements in Firefox).
-        display: flow-root;
     }
     &.o_rtl, .o_rtl {
         // Fix for Chrome and Edge bug: resolves slow/stuck scrolling during


### PR DESCRIPTION
Scenario:

- add a 2 columns content widget
- set the right column text to "On Scroll" animation with "Slide" effect
  and "From Right" direction so the content may be out of the page
- save and reload the page on mobile
- scroll down get in middle of animation with some content out of page
- try to scroll to the right

Result: we can scroll to the right and see the overflowing animated
content outside of the expected page limit.

History:

During an animation, a fix prevent the horizontal scrollbar by setting
"overflow-x: hidden" (or crop depending on version) on a given element:

- in odoo/design-themes@51abb093c77993363b170b12be134c95b3009895
  (14.0: 2021) it was added to $().getScrollingElement()
- in 189a7c96e6e26825dc05c0c6466576fe63aa091e (18.0: 2022) the main page
  scroll was moved from #wrapwrap to html
- in fece9cb85761e6cb3fe3642f947661464402363b (18.0: 2024) the
  "overflow-x: hidden" was moved to the body element

Cause: the "overflow-x: hidden" is ignored by mobile browser on html and
body tags ([example of report]), so in 18.0 and over the possible
horizontal scrollbar caused by an animation is not hidden.

Fix: apply the "overflow-x: clip/hidden" on #wrapwrap element.

[example of report]: https://stackoverflow.com/questions/14270084

opw-4575726