### PR TITLE
[FIX] payment: fix broken provider installed after creating company

### DIFF
--- a/addons/account_payment/models/payment_provider.py
+++ b/addons/account_payment/models/payment_provider.py
@@ -103,9 +103,9 @@ class PaymentProvider(models.Model):
     #=== BUSINESS METHODS ===#
 
     @api.model
-    def _setup_provider(self, code):
+    def _setup_provider(self, code, **kwargs):
         """ Override of `payment` to create the payment method of the provider. """
-        super()._setup_provider(code)
+        super()._setup_provider(code, **kwargs)
         self._setup_payment_method(code)
 
     @api.model

--- a/addons/delivery/__init__.py
+++ b/addons/delivery/__init__.py
@@ -4,7 +4,11 @@ from . import controllers
 from . import models
 from . import wizard
 
-from odoo.addons.payment import reset_payment_provider
+from odoo.addons.payment import reset_payment_provider, setup_provider
+
+
+def post_init_hook(env):
+    setup_provider(env, 'custom', custom_mode='cash_on_delivery')
 
 
 def uninstall_hook(env):

--- a/addons/delivery/__manifest__.py
+++ b/addons/delivery/__manifest__.py
@@ -38,6 +38,7 @@ The system is able to add and compute the shipping line.
             'delivery/static/src/**/*',
         ],
     },
+    'post_init_hook': 'post_init_hook',
     'uninstall_hook': 'uninstall_hook',
     'installable': True,
     'author': 'Odoo S.A.',

--- a/addons/payment/__init__.py
+++ b/addons/payment/__init__.py
@@ -6,8 +6,8 @@ from . import utils
 from . import wizards
 
 
-def setup_provider(env, code):
-    env['payment.provider']._setup_provider(code)
+def setup_provider(env, code, **kwargs):
+    env['payment.provider']._setup_provider(code, **kwargs)
 
 
 def reset_payment_provider(env, code, **kwargs):

--- a/addons/payment/models/res_company.py
+++ b/addons/payment/models/res_company.py
@@ -19,9 +19,9 @@ class ResCompany(models.Model):
     def create(self, vals_list):
         companies = super().create(vals_list)
 
-        # Duplicate providers in the new companies.
+        # Duplicate installed providers in the new companies.
         providers_sudo = self.env['payment.provider'].sudo().search(
-            [('company_id', '=', self.env.user.company_id.id)]
+            [('company_id', '=', self.env.user.company_id.id), ('module_state', '=', 'installed')]
         )
         for company in companies:
             if company.parent_id:  # The company is a branch.

--- a/addons/payment/tests/test_multicompany_flows.py
+++ b/addons/payment/tests/test_multicompany_flows.py
@@ -35,10 +35,7 @@ class TestMultiCompanyFlows(PaymentHttpCommon):
             'group_ids': [Command.link(cls.group_user.id)],
         })
 
-        cls.provider = cls.env['payment.provider'].search(
-            [('company_id', '=', cls.company_b.id), ('name', '=', 'Dummy Provider')],
-            limit=1,
-        )
+        cls.provider = cls.dummy_provider.copy({'company_id': cls.company_b.id})
         cls.provider.state = 'test'
 
     def test_pay_logged_in_another_company(self):

--- a/addons/payment/tests/test_res_company.py
+++ b/addons/payment/tests/test_res_company.py
@@ -7,16 +7,18 @@ from odoo.addons.payment.tests.common import PaymentCommon
 class TestResCompany(PaymentCommon):
 
     def test_creating_company_duplicates_providers(self):
-        """Ensure that payment providers of an existing company are correctly duplicated
+        """Ensure that installed payment providers of an existing company are correctly duplicated
         when a new company is created."""
         main_company = self.env.company
-        main_company_providers_count = self.env['payment.provider'].search_count(
-            [('company_id', '=', main_company.id)]
-        )
+        main_company_providers_count = self.env['payment.provider'].search_count([
+            ('company_id', '=', main_company.id),
+            ('module_state', '=', 'installed'),
+        ])
 
         new_company = self.env['res.company'].create({'name': 'New Company'})
-        new_company_providers_count = self.env['payment.provider'].search_count(
-            [('company_id', '=', new_company.id)]
-        )
+        new_company_providers_count = self.env['payment.provider'].search_count([
+            ('company_id', '=', new_company.id),
+            ('module_state', '=', 'installed'),
+        ])
 
         self.assertEqual(new_company_providers_count, main_company_providers_count)

--- a/addons/payment/views/payment_provider_views.xml
+++ b/addons/payment/views/payment_provider_views.xml
@@ -226,8 +226,7 @@
             <p class="fw-bold">To add a provider to the current company:</p>
             <ol class="text-start d-inline-block">
                 <li>Toggle the main company in the company switcher.</li>
-                <li>Duplicate the provider you want to add.</li>
-                <li>Set the current company as the company of the provider.</li>
+                <li>Install the provider you want to add.</li>
             </ol>
         </field>
     </record>

--- a/addons/payment_custom/models/payment_provider.py
+++ b/addons/payment_custom/models/payment_provider.py
@@ -51,8 +51,8 @@ class PaymentProvider(models.Model):
                     f'</div>'
 
     @api.model
-    def _get_removal_domain(self, provider_code, *, custom_mode='', **kwargs):
-        res = super()._get_removal_domain(provider_code, custom_mode=custom_mode, **kwargs)
+    def _get_provider_domain(self, provider_code, *, custom_mode='', **kwargs):
+        res = super()._get_provider_domain(provider_code, custom_mode=custom_mode, **kwargs)
         if provider_code == 'custom' and custom_mode:
             return AND([res, [('custom_mode', '=', custom_mode)]])
         return res

--- a/addons/website_sale_collect/__init__.py
+++ b/addons/website_sale_collect/__init__.py
@@ -4,7 +4,11 @@ from . import models
 from . import controllers
 from . import utils
 
-from odoo.addons.payment import reset_payment_provider
+from odoo.addons.payment import reset_payment_provider, setup_provider
+
+
+def post_init_hook(env):
+    setup_provider(env, 'custom', custom_mode='on_site')
 
 
 def uninstall_hook(env):

--- a/addons/website_sale_collect/__manifest__.py
+++ b/addons/website_sale_collect/__manifest__.py
@@ -29,6 +29,7 @@ Allows customers to check in-store stock, pay on site, and pick up their orders 
             'website_sale_collect/static/src/**/*',
         ],
     },
+    'post_init_hook': 'post_init_hook',
     'uninstall_hook': 'uninstall_hook',
     'author': 'Odoo S.A.',
     'license': 'LGPL-3',


### PR DESCRIPTION
Since https://github.com/odoo/odoo/commit/0d3228e10d04a01c87fbef1e0e78b37c462c9ea5, payment providers are automatically duplicated for newly created companies. However, if a provider module is installed after creating a new company it does not work.

Steps to reproduce:
- Create a new company without installing any payment provider.
- Install a payment provider module after the company is created.
- You’ll notice that the `code` field is not set on the provider records copied to each company, which makes the provider unusable.

Issue:
- Copied provider records are missing critical fields like `code`.
- Without these fields, it’s impossible to configure or use the provider.

Cause:
- The data file `provider_data.xml` in each `payment_*` module only populates the base provider record defined in `payment/payment_provider_data.xml`.
- As a result, copied records lack necessary fields and become non-functional.

Solution:
- Change flow to copy only installed provider in new companies and new providers will copied after installation.
- Adjust the `post_init_hook` to copy provider after install.
- This ensures all required fields are properly initialized.

affected version-master
opw-4857980




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
