### PR TITLE
[FIX] html_editor: remove HTML comments to avoid traceback on delete

### DIFF
--- a/addons/html_editor/static/src/core/comment_plugin.js
+++ b/addons/html_editor/static/src/core/comment_plugin.js
@@ -12,7 +12,6 @@ export class CommentPlugin extends Plugin {
         for (const el of [node, ...descendants(node)]) {
             if (el.nodeType === Node.COMMENT_NODE && !isProtected(el)) {
                 el.remove();
-                return;
             }
         }
     }

--- a/addons/html_editor/static/tests/comment.test.js
+++ b/addons/html_editor/static/tests/comment.test.js
@@ -6,4 +6,8 @@ test("should remove comment node inside editable content during sanitize", async
         contentBefore: "<p>ab<!-- comment -->cd</p>",
         contentAfter: "<p>abcd</p>",
     });
+    await testEditor({
+        contentBefore: "<p>ab<!-- comment -->cd<!-- Another comment --></p>",
+        contentAfter: "<p>abcd</p>",
+    });
 });


### PR DESCRIPTION
Problem:
When content containing HTML comments is added to the editor, a traceback occur when deleting the commente element.

Solution:
Remove HTML comments from the content when it's inserted into the editor. These comments are added by `convert_inline` and will be re-applied on save if needed.

Steps to reproduce:
- Create a new email template
- Add an image
- Save
- Delete the image using backspace
- Traceback occurs

opw-4863747

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
