### PR TITLE
[FIX] point_of_sale: correctly handle restricted categories with combo

### DIFF
--- a/addons/point_of_sale/models/product_template.py
+++ b/addons/point_of_sale/models/product_template.py
@@ -99,11 +99,12 @@ class ProductTemplate(models.Model):
             )
             product_tmpl_ids = [r[0] for r in self.env.execute_query(sql)]
             products = self._load_product_with_domain([('id', 'in', product_tmpl_ids)])
-            product_combo = products.filtered(lambda p: p['type'] == 'combo')
-            products += product_combo.combo_ids.combo_item_ids.product_id.product_tmpl_id
         else:
             domain = self._load_pos_data_domain(data)
             products = self._load_product_with_domain(domain)
+
+        product_combo = products.filtered(lambda p: p['type'] == 'combo')
+        products += product_combo.combo_ids.combo_item_ids.product_id.product_tmpl_id
 
         data['pos.config'][0]['_product_default_values'] = \
             self.env['account.tax']._eval_taxes_computation_prepare_product_default_values(product_fields)

--- a/addons/point_of_sale/static/src/app/models/utils/order_change.js
+++ b/addons/point_of_sale/static/src/app/models/utils/order_change.js
@@ -45,7 +45,10 @@ export const getOrderChanges = (order, orderPreparationCategories) => {
         const product = orderline.getProduct();
         const note = orderline.getNote();
         const lineKey = orderline.uuid;
-        const productCategoryIds = product.parentPosCategIds.filter((id) =>
+        const baseProduct = orderline.combo_parent_id
+            ? orderline.combo_parent_id.product_id
+            : product;
+        const productCategoryIds = baseProduct.parentPosCategIds.filter((id) =>
             prepaCategoryIds.has(id)
         );
 

--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -1756,6 +1756,9 @@ export class PosStore extends WithLazyGetterTrap {
             const product = this.models["product.product"].get(change["product_id"]);
             const categoryIds = product.parentPosCategIds;
 
+            if (change.isCombo) {
+                return true;
+            }
             for (const categoryId of categoryIds) {
                 if (categories.includes(categoryId)) {
                     return true;
@@ -2290,36 +2293,38 @@ export class PosStore extends WithLazyGetterTrap {
             return [];
         }
 
-        const excludedProductIds = [
-            this.config.tip_product_id?.product_tmpl_id?.id,
-            ...this.session._pos_special_products_ids.map(
-                (id) => this.models["product.product"].get(id)?.product_tmpl_id?.id
-            ),
-        ].filter(Boolean);
+        const excludedProductIds = new Set(
+            [
+                this.config.tip_product_id?.product_tmpl_id?.id,
+                ...this.session._pos_special_products_ids.map(
+                    (id) => this.models["product.product"].get(id)?.product_tmpl_id?.id
+                ),
+            ].filter(Boolean)
+        );
+        const filteredList = [];
+        const availableCateg = new Set(
+            (this.config.iface_available_categ_ids || []).map((c) => c.id)
+        );
 
-        list = list
-            .filter((product) => !excludedProductIds.includes(product.id) && product.canBeDisplayed)
-            .sort((a, b) => {
-                // Sort in the same order as what we receive (look _load_product_with_domain)
-                if (a.sequence !== b.sequence) {
-                    return a.sequence - b.sequence;
-                }
-                if (a.default_code !== b.default_code) {
-                    if (!b.default_code) {
-                        return -1;
-                    }
-                    if (!a.default_code) {
-                        return 1;
-                    }
-                    return a.default_code.localeCompare(b.default_code);
-                }
-                return a.name.localeCompare(b.name);
-            })
-            .slice(0, 100);
+        for (const p of list) {
+            if (filteredList.length >= 100) {
+                break;
+            }
+
+            if (excludedProductIds.has(p.id) || !p.canBeDisplayed) {
+                continue;
+            }
+
+            if (availableCateg.size && !p.pos_categ_ids.some((c) => availableCateg.has(c.id))) {
+                continue;
+            }
+
+            filteredList.push(p);
+        }
 
         return searchWord !== ""
-            ? list.sort((a, b) => b.is_favorite - a.is_favorite)
-            : list.sort((a, b) => {
+            ? filteredList.sort((a, b) => b.is_favorite - a.is_favorite)
+            : filteredList.sort((a, b) => {
                   if (b.is_favorite !== a.is_favorite) {
                       return b.is_favorite - a.is_favorite;
                   }

--- a/addons/point_of_sale/static/tests/pos/tours/product_screen_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/product_screen_tour.js
@@ -15,6 +15,8 @@ import * as OfflineUtil from "@point_of_sale/../tests/generic_helpers/offline_ut
 import * as TicketScreen from "@point_of_sale/../tests/pos/tours/utils/ticket_screen_util";
 import * as Utils from "@point_of_sale/../tests/pos/tours/utils/common";
 import * as BackendUtils from "@point_of_sale/../tests/pos/tours/utils/backend_utils";
+import * as combo from "@point_of_sale/../tests/pos/tours/utils/combo_popup_util";
+import { generatePreparationReceiptElement } from "@point_of_sale/../tests/pos/tours/utils/preparation_receipt_util";
 
 registry.category("web_tour.tours").add("ProductScreenTour", {
     steps: () =>
@@ -292,6 +294,34 @@ registry.category("web_tour.tours").add("limitedProductPricelistLoading", {
             ProductScreen.selectedOrderlineHas("Test Product 1", "2", "160.0"),
 
             scan_barcode("0100300"),
+            Chrome.endTour(),
+        ].flat(),
+});
+
+registry.category("web_tour.tours").add("test_restricted_categories_combo_product", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            ProductScreen.productIsDisplayed("Office Combo"),
+            ProductScreen.productIsDisplayed("Combo Product 4"),
+            ProductScreen.productIsDisplayed("Combo Product 5").map(negateStep),
+            ProductScreen.clickDisplayedProduct("Office Combo"),
+            combo.select("Combo Product 5"),
+            Dialog.confirm(),
+            {
+                content: "Check if order preparation has product correctly ordered",
+                trigger: "body",
+                run: async () => {
+                    const rendered = generatePreparationReceiptElement();
+                    if (!rendered.innerHTML.includes("Office Combo")) {
+                        throw new Error("Office Combo not found in preparation receipt");
+                    }
+                    if (!rendered.innerHTML.includes("Combo Product 5")) {
+                        throw new Error("Combo Product 5 not found in preparation receipt");
+                    }
+                },
+            },
             Chrome.endTour(),
         ].flat(),
 });

--- a/addons/point_of_sale/static/tests/pos/tours/utils/preparation_receipt_util.js
+++ b/addons/point_of_sale/static/tests/pos/tours/utils/preparation_receipt_util.js
@@ -1,0 +1,28 @@
+/* global posmodel */
+
+import { renderToElement } from "@web/core/utils/render";
+
+export function generatePreparationReceiptElement() {
+    const order = posmodel.getOrder();
+    const orderChange = posmodel.changesToOrder(
+        order,
+        posmodel.config.preparationCategories,
+        false
+    );
+
+    const { orderData, changes } = posmodel.generateOrderChange(
+        order,
+        orderChange,
+        Array.from(posmodel.config.preparationCategories),
+        false
+    );
+
+    orderData.changes = {
+        title: "new",
+        data: changes.new,
+    };
+
+    return renderToElement("point_of_sale.OrderChangeReceipt", {
+        data: orderData,
+    });
+}

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -1261,6 +1261,41 @@ class TestUi(TestPointOfSaleHttpCommon):
         self.main_pos_config.with_user(self.pos_user).open_ui()
         self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'limitedProductPricelistLoading', login="pos_user")
 
+    def test_restricted_categories_combo_product(self):
+        """
+        Ensure combo choices product are always loaded if parent is in allowed categories, even when restricted categories are configured:
+        - These combo choices should be visible when configuring the parent combo product but not be visible as product that we can directly sell inside POS
+        - These combo choices should appear on the preparation ticket changes
+        """
+        pos_restricted_categ = self.env["pos.category"].create({
+            "name": "Restricted product",
+        })
+        pos_other_categ = self.env["pos.category"].create({
+            "name": "Other products",
+        })
+        self.env['pos.printer'].create({
+            'name': 'Printer',
+            'printer_type': 'epson_epos',
+            'epson_printer_ip': '0.0.0.0',
+            'product_categories_ids': [Command.set(self.env['pos.category'].search([]).ids)],
+        })
+
+        self.main_pos_config.write({
+            'is_order_printer': True,
+            'printer_ids': [Command.set(self.env['pos.printer'].search([]).ids)],
+        })
+        self.main_pos_config.write({
+            "limit_categories": True,
+            "iface_available_categ_ids": [(6, 0, [pos_restricted_categ.id])],
+        })
+        setup_product_combo_items(self)
+        self.office_combo.pos_categ_ids = [(6, 0, [pos_restricted_categ.id])]
+        self.office_combo.combo_ids = [(6, 0, [self.desks_combo.id])]
+        self.desks_combo.combo_item_ids[0].product_id.pos_categ_ids = [(6, 0, [pos_restricted_categ.id])]
+        self.desks_combo.combo_item_ids[1].product_id.pos_categ_ids = [(6, 0, [pos_other_categ.id])]
+        self.main_pos_config.with_user(self.pos_user).open_ui()
+        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'test_restricted_categories_combo_product', login="pos_user")
+
     def test_multi_product_options(self):
         self.pos_user.write({
             'group_ids': [

--- a/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
@@ -1,5 +1,3 @@
-/* global posmodel */
-
 import * as PaymentScreen from "@point_of_sale/../tests/pos/tours/utils/payment_screen_util";
 import * as Dialog from "@point_of_sale/../tests/generic_helpers/dialog_util";
 import * as ReceiptScreen from "@point_of_sale/../tests/pos/tours/utils/receipt_screen_util";
@@ -15,9 +13,9 @@ import * as combo from "@point_of_sale/../tests/pos/tours/utils/combo_popup_util
 import { inLeftSide } from "@point_of_sale/../tests/pos/tours/utils/common";
 import { registry } from "@web/core/registry";
 import * as Numpad from "@point_of_sale/../tests/generic_helpers/numpad_util";
-import { renderToElement } from "@web/core/utils/render";
 import { delay } from "@odoo/hoot-dom";
 import * as TextInputPopup from "@point_of_sale/../tests/generic_helpers/text_input_popup_util";
+import { generatePreparationReceiptElement } from "@point_of_sale/../tests/pos/tours/utils/preparation_receipt_util";
 
 const ProductScreen = { ...ProductScreenPos, ...ProductScreenResto };
 
@@ -400,27 +398,7 @@ registry.category("web_tour.tours").add("PreparationPrinterContent", {
                 content: "Check if order preparation contains always Variant",
                 trigger: "body",
                 run: async () => {
-                    const order = posmodel.getOrder();
-                    const orderChange = posmodel.changesToOrder(
-                        order,
-                        posmodel.config.preparationCategories,
-                        false
-                    );
-                    const { orderData, changes } = posmodel.generateOrderChange(
-                        order,
-                        orderChange,
-                        Array.from(posmodel.config.preparationCategories),
-                        false
-                    );
-
-                    orderData.changes = {
-                        title: "new",
-                        data: changes.new,
-                    };
-
-                    const rendered = renderToElement("point_of_sale.OrderChangeReceipt", {
-                        data: orderData,
-                    });
+                    const rendered = generatePreparationReceiptElement();
 
                     if (!rendered.innerHTML.includes("Value 1")) {
                         throw new Error("Value 1 not found in printed receipt");
@@ -456,27 +434,7 @@ registry.category("web_tour.tours").add("test_combo_preparation_receipt", {
                 content: "Check if order preparation has product correctly ordered",
                 trigger: "body",
                 run: async () => {
-                    const order = posmodel.getOrder();
-                    const orderChange = posmodel.changesToOrder(
-                        order,
-                        posmodel.config.preparationCategories,
-                        false
-                    );
-                    const { orderData, changes } = posmodel.generateOrderChange(
-                        order,
-                        orderChange,
-                        Array.from(posmodel.config.preparationCategories),
-                        false
-                    );
-
-                    orderData.changes = {
-                        title: "new",
-                        data: changes.new,
-                    };
-
-                    const rendered = renderToElement("point_of_sale.OrderChangeReceipt", {
-                        data: orderData,
-                    });
+                    const rendered = generatePreparationReceiptElement();
                     const orderLines = [...rendered.querySelectorAll(".orderline")];
                     const orderLinesInnerText = orderLines.map((orderLine) => orderLine.innerText);
                     const expectedOrderLines = [
@@ -623,28 +581,9 @@ registry.category("web_tour.tours").add("test_combo_preparation_receipt_layout",
             {
                 trigger: "body",
                 run: async () => {
-                    const order = posmodel.getOrder();
-                    const orderChange = posmodel.changesToOrder(
-                        order,
-                        posmodel.config.preparationCategories,
-                        false
-                    );
-                    const { orderData, changes } = posmodel.generateOrderChange(
-                        order,
-                        orderChange,
-                        Array.from(posmodel.config.preparationCategories),
-                        false
-                    );
+                    const rendered = generatePreparationReceiptElement();
 
-                    orderData.changes = {
-                        title: "new",
-                        data: changes.new,
-                    };
-
-                    const printed = renderToElement("point_of_sale.OrderChangeReceipt", {
-                        data: orderData,
-                    });
-                    const comboItemLines = [...printed.querySelectorAll(".orderline.ms-5")].map(
+                    const comboItemLines = [...rendered.querySelectorAll(".orderline.ms-5")].map(
                         (el) => el.innerText
                     );
                     const expectedComboItemLines = [

--- a/addons/pos_self_order/static/src/app/services/self_order_service.js
+++ b/addons/pos_self_order/static/src/app/services/self_order_service.js
@@ -464,7 +464,7 @@ export class SelfOrder extends Reactive {
             (p) => p.pos_categ_ids.length === 0 && !isSpecialProduct(p)
         );
 
-        if (productWoCat.length) {
+        if (productWoCat.length && !this.config.iface_available_categ_ids.length) {
             this.productCategories.push({
                 id: 0,
                 hour_after: 0,
@@ -499,14 +499,17 @@ export class SelfOrder extends Reactive {
     }
 
     _getKioskPrintingCategoriesChanges(order, categories) {
-        return order.lines.filter((orderline) =>
-            categories.some((category) =>
+        return order.lines.filter((orderline) => {
+            const baseProductId = orderline.combo_parent_id
+                ? orderline.combo_parent_id.product_id.id
+                : orderline.product_id.id;
+            return categories.some((category) =>
                 this.models["product.product"]
-                    .get(orderline.product_id.id)
+                    .get(baseProductId)
                     .pos_categ_ids.map((categ) => categ.id)
                     .includes(category.id)
-            )
-        );
+            );
+        });
     }
 
     async printKioskChanges(access_token = "") {

--- a/addons/pos_self_order/static/src/app/store/order_change_receipt_template.xml
+++ b/addons/pos_self_order/static/src/app/store/order_change_receipt_template.xml
@@ -23,8 +23,8 @@
             </div>
             <br />
             <t t-foreach="changes.new" t-as="change" t-key="change_index">
-                <div class="product-details d-flex">
-                    <span class="product-quantity me-5 mb-1" t-esc="change.qty"/>
+                <div class="product-details d-flex" t-att-class="{'ms-5': change.combo_parent_id}">
+                    <span class="product-quantity me-3 mb-1" t-esc="change.qty"/>
                     <span class="product-name" t-esc="change.full_product_name"/>
                 </div>
                 <t t-if="change.customer_note">


### PR DESCRIPTION
- Backport of : https://github.com/odoo/odoo/pull/211030 into `18.2`:
- Ensure combo choices product are always loaded if parent is in allowed categories,even when restricted categories are configured. Also send this combo choices to preparation printer.
- Prevent display of combo choice products outside restricted categories in POS UI. Also fix Kiosk/Self-Order to avoid showing 'Uncategorized' when restrictions are active.
- Add a margin start for combo choice product for preparation receipt coming from Kiosk.
- Extract tour preparation receipt util to check the content of preparation receipt.

task-id: 4809444


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
