### PR TITLE
[FIX] html_editor: apply font size correctly when different size already exists

### DIFF
--- a/addons/html_editor/static/src/core/format_plugin.js
+++ b/addons/html_editor/static/src/core/format_plugin.js
@@ -191,7 +191,7 @@ export class FormatPlugin extends Plugin {
     hasSelectionFormat(format, targetedNodes = this.dependencies.selection.getTargetedNodes()) {
         const targetedTextNodes = targetedNodes.filter(isTextNode);
         const isFormatted = formatsSpecs[format].isFormatted;
-        return targetedTextNodes.some((n) => isFormatted(n, this.editable));
+        return targetedTextNodes.some((n) => isFormatted(n, { editable: this.editable }));
     }
     /**
      * Return true if the current selection on the editable appears as the given
@@ -209,7 +209,9 @@ export class FormatPlugin extends Plugin {
             targetedTextNodes.length &&
             targetedTextNodes.every(
                 (node) =>
-                    isZwnbsp(node) || isEmptyTextNode(node) || isFormatted(node, this.editable)
+                    isZwnbsp(node) ||
+                    isEmptyTextNode(node) ||
+                    isFormatted(node, { editable: this.editable })
             )
         );
     }

--- a/addons/html_editor/static/src/utils/formatting.js
+++ b/addons/html_editor/static/src/utils/formatting.js
@@ -93,7 +93,10 @@ export const formatsSpecs = {
         removeStyle: (node) => removeStyle(node, "font-family"),
     },
     fontSize: {
-        isFormatted: (node) => closestElement(node)?.style["font-size"],
+        isFormatted: (node, props) => {
+            const fontSize = closestElement(node)?.style["font-size"];
+            return props?.size ? fontSize === props.size : fontSize;
+        },
         hasStyle: (node) => node.style && node.style["font-size"],
         addStyle: (node, props) => {
             node.style["font-size"] = props.size;
@@ -102,8 +105,11 @@ export const formatsSpecs = {
         removeStyle: (node) => removeStyle(node, "font-size"),
     },
     setFontSizeClassName: {
-        isFormatted: (node) =>
-            FONT_SIZE_CLASSES.find((cls) => closestElement(node)?.classList?.contains(cls)),
+        isFormatted: (node, props) =>
+            props?.className
+                ? FONT_SIZE_CLASSES.includes(props.className) &&
+                  closestElement(node)?.classList.contains(props.className)
+                : FONT_SIZE_CLASSES.find((cls) => closestElement(node)?.classList?.contains(cls)),
         hasStyle: (node, props) => FONT_SIZE_CLASSES.find((cls) => node.classList.contains(cls)),
         addStyle: (node, props) => {
             node.style.removeProperty("font-size");
@@ -112,7 +118,7 @@ export const formatsSpecs = {
         removeStyle: (node) => removeClass(node, ...FONT_SIZE_CLASSES, ...TEXT_STYLE_CLASSES),
     },
     switchDirection: {
-        isFormatted: isDirectionSwitched,
+        isFormatted: (node, props) => isDirectionSwitched(node, props.editable),
     },
 };
 

--- a/addons/html_editor/static/tests/_helpers/user_actions.js
+++ b/addons/html_editor/static/tests/_helpers/user_actions.js
@@ -158,6 +158,9 @@ export function strikeThrough(editor) {
 export function setFontSize(size) {
     return (editor) => execCommand(editor, "formatFontSize", { size });
 }
+export function setFontSizeClassName(className) {
+    return (editor) => execCommand(editor, "formatFontSizeClassName", { className });
+}
 export function setFontFamily(fontFamily) {
     return (editor) => {
         editor.shared.format.formatSelection("fontFamily", {

--- a/addons/html_editor/static/tests/format/font_size.test.js
+++ b/addons/html_editor/static/tests/format/font_size.test.js
@@ -2,7 +2,7 @@ import { test, expect } from "@odoo/hoot";
 import { setupEditor, testEditor } from "../_helpers/editor";
 import { unformat } from "../_helpers/format";
 import { strong } from "../_helpers/tags";
-import { setFontSize, tripleClick } from "../_helpers/user_actions";
+import { setFontSize, setFontSizeClassName, tripleClick } from "../_helpers/user_actions";
 import { Plugin } from "@html_editor/plugin";
 import { MAIN_PLUGINS } from "@html_editor/plugin_sets";
 import { animationFrame } from "@odoo/hoot-mock";
@@ -209,6 +209,15 @@ test("should add style to br except line-break br", async () => {
     expect(getContent(el)).toBe(`<p><span style="font-size: 36px;">[abc]</span><br><br></p>`);
 });
 
+test("should update the font size currectly if already has one", async () => {
+    await testEditor({
+        contentBefore: '<h2 style="font-size: 14px;">[abcdefg]</h2>',
+        stepFunction: setFontSize("18px"),
+        contentAfter:
+            '<h2 style="font-size: 14px;"><span style="font-size: 18px;">[abcdefg]</span></h2>',
+    });
+});
+
 test("should add style to br except line-break br (2)", async () => {
     const { editor, el } = await setupEditor("<p>[]abc<br><br><br></p>");
     await press(["ctrl", "a"]);
@@ -216,4 +225,12 @@ test("should add style to br except line-break br (2)", async () => {
     expect(getContent(el)).toBe(
         `<p><span style="font-size: 36px;">[abc</span><br><span style="font-size: 36px;"><br>]</span><br></p>`
     );
+});
+
+test("should update the font class if the parent already has one", async () => {
+    await testEditor({
+        contentBefore: '<h2 class="h4-fs">[abcdefg]</h2>',
+        stepFunction: setFontSizeClassName("h3-fs"),
+        contentAfter: '<h2 class="h4-fs"><span class="h3-fs">[abcdefg]</span></h2>',
+    });
 });


### PR DESCRIPTION
Description of the issue this PR addresses:

- Snippet templates include structure like `<h2 class="h3-fs">Some Text</h2>`.
- When trying to change the font size of selected text inside such elements, the editor falsely detected the correct size and skipped applying the new one.

Current behavior before PR:

- The editor only checked if any known font size class was present on the closest block element.
- As a result, users could not apply a new font size if a different font size class already existed.

Desired behavior after PR is merged:

- The editor now checks whether the exact font size class being applied is already present.
- This ensures that applying a new font size works as expected, even when other font size classes are present on ancestor elements.

task-4855154

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
