### PR TITLE
[FIX] point_of_sale: show access denied popup on POS sample data loading

### DIFF
--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -1926,6 +1926,14 @@ export class PosStore extends WithLazyGetterTrap {
         );
     }
     async loadSampleData() {
+        const isPosManager = await user.hasGroup("point_of_sale.group_pos_manager");
+        if (!isPosManager) {
+            this.dialog.add(AlertDialog, {
+                title: _t("Access Denied"),
+                body: _t("It seems like you don't have enough rights to load data."),
+            });
+            return;
+        }
         await this.data.call("pos.config", "load_demo_data", [[this.config.id]]);
         await this.reloadData(true);
     }

--- a/addons/point_of_sale/static/tests/pos/tours/product_screen_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/product_screen_tour.js
@@ -843,3 +843,41 @@ registry.category("web_tour.tours").add("test_delete_line", {
             Chrome.endTour(),
         ].flat(),
 });
+
+function clickLoadSampleButton() {
+    return [
+        {
+            trigger:
+                '.o_view_nocontent .o_nocontent_help button.btn-primary:contains("Load Sample")',
+            content: "Click on Load Sample button",
+            run: "click",
+        },
+    ].flat();
+}
+
+registry.category("web_tour.tours").add("test_load_pos_demo_data_by_pos_user", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            clickLoadSampleButton(),
+            {
+                trigger:
+                    '.modal-content:has(.modal-title:contains("Access Denied")) .modal-footer .btn.btn-primary:contains("Ok")',
+                content: "Click Ok on the Access Denied dialog box",
+                run: "click",
+            },
+            Chrome.endTour(),
+        ].flat(),
+});
+
+registry.category("web_tour.tours").add("test_load_pos_demo_data_by_pos_admin", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            clickLoadSampleButton(),
+            ProductScreen.isShown(),
+            ProductScreen.clickDisplayedProduct("Small Shelf"),
+            Chrome.endTour(),
+        ].flat(),
+});


### PR DESCRIPTION
Currently, an error is encountered when trying to load sample data in POS session if the **Administrator** is assigned the **User role** for the Point of Sale app.

**Steps to reproduce:**
- Install the `point_of_sale` module (without demo data).
- Create a new POS session (from list view).
- Change the POS rights of the **Administrator** user from _Administrator_ to _User_.
- Open the pos sessions and on the product screen, click **Load Sample**.

**Error:**
```
while parsing /home/odoo/src/odoo/saas-18.3/addons/point_of_sale/data/scenarios/furniture_category_data.xml:5, somewhere inside
<record id="pos_category_miscellaneous" model="pos.category">
            <field name="name">Misc</field>
            <field name="image_128" type="base64" file="point_of_sale/static/img/misc_category.png"/>
            <field name="sequence">1</field>
        </record>
```

This commit will prevent the error by displaying an **Access Denied** pop-up for users without admin rights, when attempting to load the POS sample data.

Sentry - 6672207110