### PR TITLE
[FIX] sale: fix saleman unable to confirm SO with template confirm email

### DIFF
--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -1228,7 +1228,7 @@ class SaleOrder(models.Model):
 
         async_send = str2bool(self.env['ir.config_parameter'].sudo().get_param('sale.async_emails'))
         cron = self.env.ref('sale.send_pending_emails_cron', raise_if_not_found=False)
-        cron_enabled = cron and cron.active
+        cron_enabled = cron and cron.sudo().active
         if async_send and cron_enabled and allow_deferred_sending:
             # Schedule the email to be sent asynchronously.
             self.pending_email_template_id = mail_template


### PR DESCRIPTION
To reproduce (on runbot):

- as admin user:
  * create or update a quotation template and set a confirmation email

- as demo user:
  * create a new quotation
  * select the quotation template of previous step
  * click on 'Confirm' button

As AccessError is raised saying that user don't have access to `ir.cron`.

Following introducing on async email in odoo/odoo@156bc1b1ab5b, we need to check if cron is active as superuser because normal user don't have access to schedule actions (`ir.cron`).


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
