### PR TITLE
[IMP] pos_self_order: auto-refresh kiosk /self on product availability change

### DIFF
--- a/addons/pos_self_order/__manifest__.py
+++ b/addons/pos_self_order/__manifest__.py
@@ -93,6 +93,8 @@
             ("include", "point_of_sale.base_tests"),
             "pos_self_order/static/tests/tours/**/*",
             "point_of_sale/static/tests/generic_helpers/numpad_util.js",
+            "point_of_sale/static/tests/generic_helpers/dialog_util.js",
+            "point_of_sale/static/tests/generic_helpers/utils.js",
         ],
     },
     "author": "Odoo S.A.",

--- a/addons/pos_self_order/models/product_product.py
+++ b/addons/pos_self_order/models/product_product.py
@@ -126,9 +126,13 @@ class ProductProduct(models.Model):
         config_self = self.env['pos.config'].sudo().search([('self_ordering_mode', '!=', 'nothing')])
         for config in config_self:
             if config.current_session_id and config.access_token:
-                config._notify('PRODUCT_CHANGED', {
-                    'product.product': self.read(self._load_pos_self_data_fields(config.id), load=False)
-                })
+                records = self.env["product.template"].load_product_from_pos(config.id, [('id', '=', self.product_tmpl_id.id)])
+                payload = {}
+                self_models = self.env["pos.config"]._load_self_data_models()
+                for model in records:
+                    if model in self_models:
+                        payload[model] = records[model]
+                config._notify('PRODUCT_CHANGED', payload)
 
     def _can_return_content(self, field_name=None, access_token=None):
         if field_name == "image_512" and self.sudo().self_order_available:

--- a/addons/pos_self_order/static/src/app/components/unavailable_product_dialog/unavailable_product_dialog.js
+++ b/addons/pos_self_order/static/src/app/components/unavailable_product_dialog/unavailable_product_dialog.js
@@ -1,0 +1,17 @@
+import { Component } from "@odoo/owl";
+import { Dialog } from "@web/core/dialog/dialog";
+
+export class UnavailableProductsDialog extends Component {
+    static template = "pos_self_order.UnavailableProductsDialog";
+    static components = { Dialog };
+    static props = {
+        productNames: { type: Array },
+        onClose: { type: Function, optional: true },
+        close: { type: Function, optional: true },
+    };
+
+    onConfirm() {
+        this.props.onClose();
+        this.props.close();
+    }
+}

--- a/addons/pos_self_order/static/src/app/components/unavailable_product_dialog/unavailable_product_dialog.xml
+++ b/addons/pos_self_order/static/src/app/components/unavailable_product_dialog/unavailable_product_dialog.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+    <t t-name="pos_self_order.UnavailableProductsDialog">
+        <Dialog>
+            <t t-set-slot="header">
+                <h4 class="modal-title">Oops...</h4>
+            </t>
+            <div class="modal-body">
+                <p>
+                    It seems that 
+                    <strong class="text-danger">
+                        <t t-esc="props.productNames.join(', ')"/>
+                    </strong> 
+                    <t t-if="props.productNames.length > 1"> are</t>
+                    <t t-else=""> is</t>
+                    no longer available. Please go back and edit your order.
+                </p>
+            </div>
+            <t t-set-slot="footer">
+                <button class="btn btn-primary" t-on-click="onConfirm">OK</button>
+            </t>
+        </Dialog>
+    </t>
+</templates>

--- a/addons/pos_self_order/static/tests/tours/self_order_kiosk_tour.js
+++ b/addons/pos_self_order/static/tests/tours/self_order_kiosk_tour.js
@@ -5,6 +5,7 @@ import * as ConfirmationPage from "@pos_self_order/../tests/tours/utils/confirma
 import * as LandingPage from "@pos_self_order/../tests/tours/utils/landing_page_util";
 import * as ProductPage from "@pos_self_order/../tests/tours/utils/product_page_util";
 import * as Numpad from "@point_of_sale/../tests/generic_helpers/numpad_util";
+import * as Dialog from "@point_of_sale/../tests/generic_helpers/dialog_util";
 
 registry.category("web_tour.tours").add("self_kiosk_each_table_takeaway_in", {
     steps: () => [
@@ -205,5 +206,44 @@ registry.category("web_tour.tours").add("test_self_order_pricelist", {
         Utils.clickBtn("Order"),
         Utils.clickBtn("Close"),
         Utils.checkIsNoBtn("My Order"),
+    ],
+});
+
+registry.category("web_tour.tours").add("test_self_order_kiosk_product_availability", {
+    steps: () => [
+        Utils.clickBtn("Order Now"),
+        LandingPage.selectLocation("Test-In"),
+        ProductPage.clickCategory("Category 2"),
+        // Mark 'Combo Product 5' as unavailable and verify it shows as out of stock
+        Utils.setProductAvailability("Combo Product 5", false),
+        ProductPage.checkProductOutOfStock("Combo Product 5"),
+        ProductPage.clickProduct("Office Combo"),
+        ProductPage.clickComboProduct("Combo Product 4"),
+        Utils.clickBtn("Add to cart"),
+        // Make 'Office Combo' unavailable and attempt payment
+        // Expect a dialog stating the product is no longer available and user is redirected to product page
+        Utils.clickBtn("Checkout"),
+        Utils.setProductAvailability("Office Combo", false),
+        Utils.clickBtn("Order"),
+        Dialog.bodyIs(
+            "It seems that Office Combo is no longer available. Please go back and edit your order."
+        ),
+        Dialog.confirm("OK"),
+        // Add 'Combo Product 4' again and mark 'Combo Product 5' available, then unavailable after adding to cart
+        // Expect unavailable product dialog and user should remain on cart page to process remaining items
+        ProductPage.clickProduct("Combo Product 4"),
+        Utils.setProductAvailability("Combo Product 5", true),
+        ProductPage.clickProduct("Combo Product 5"),
+        Utils.clickBtn("Checkout"),
+        Utils.setProductAvailability("Combo Product 5", false),
+        Utils.clickBtn("Order"),
+        Dialog.bodyIs(
+            "It seems that Combo Product 5 is no longer available. Please go back and edit your order."
+        ),
+        Dialog.confirm("OK"),
+        Utils.clickBtn("Order"),
+        Numpad.click("3"),
+        Utils.clickBtn("Order"),
+        Utils.clickBtn("Close"),
     ],
 });

--- a/addons/pos_self_order/static/tests/tours/self_order_mobile_tour.js
+++ b/addons/pos_self_order/static/tests/tours/self_order_mobile_tour.js
@@ -4,6 +4,7 @@ import * as CartPage from "@pos_self_order/../tests/tours/utils/cart_page_util";
 import * as LandingPage from "@pos_self_order/../tests/tours/utils/landing_page_util";
 import * as ProductPage from "@pos_self_order/../tests/tours/utils/product_page_util";
 import * as ConfirmationPage from "@pos_self_order/../tests/tours/utils/confirmation_page_util";
+import * as Dialog from "@point_of_sale/../tests/generic_helpers/dialog_util";
 
 registry.category("web_tour.tours").add("self_mobile_each_table_takeaway_in", {
     steps: () => [
@@ -296,6 +297,44 @@ registry.category("web_tour.tours").add("self_mobile_auto_table_selection_takeaw
         ConfirmationPage.isShown(),
         Utils.clickBtn("Ok"),
         Utils.checkIsNoBtn("Order Now"),
+    ],
+});
+
+registry.category("web_tour.tours").add("test_self_order_product_availability", {
+    steps: () => [
+        Utils.checkIsNoBtn("My Order"),
+        Utils.clickBtn("Order Now"),
+        LandingPage.selectLocation("Test-In"),
+        // Mark 'Combo Product 5' as unavailable and verify it shows as out of stock
+        Utils.setProductAvailability("Combo Product 5", false),
+        ProductPage.checkProductOutOfStock("Combo Product 5"),
+        ProductPage.clickProduct("Office Combo"),
+        ProductPage.clickComboProduct("Combo Product 4"),
+        Utils.clickBtn("Add to cart"),
+        // Make 'Office Combo' unavailable and attempt payment
+        // Expect a dialog stating the product is no longer available and user is redirected to product page
+        Utils.clickBtn("Checkout"),
+        Utils.setProductAvailability("Office Combo", false),
+        Utils.clickBtn("Order"),
+        Dialog.bodyIs(
+            "It seems that Office Combo is no longer available. Please go back and edit your order."
+        ),
+        Dialog.confirm("OK"),
+        // Add 'Combo Product 4' again and mark 'Combo Product 5' available, then unavailable after adding to cart
+        // Expect unavailable product dialog and user should remain on cart page to process remaining items
+        ProductPage.clickProduct("Combo Product 4"),
+        Utils.setProductAvailability("Combo Product 5", true),
+        ProductPage.clickProduct("Combo Product 5"),
+        Utils.clickBtn("Checkout"),
+        Utils.setProductAvailability("Combo Product 5", false),
+        Utils.clickBtn("Order"),
+        Dialog.bodyIs(
+            "It seems that Combo Product 5 is no longer available. Please go back and edit your order."
+        ),
+        Dialog.confirm("OK"),
+        Utils.clickBtn("Order"),
+        ...CartPage.selectTable("1"),
+        Utils.clickBtn("Ok"),
     ],
 });
 

--- a/addons/pos_self_order/static/tests/tours/utils/common.js
+++ b/addons/pos_self_order/static/tests/tours/utils/common.js
@@ -1,3 +1,5 @@
+/* global posmodel */
+
 export function clickBtn(buttonName) {
     return {
         content: `Click on button '${buttonName}'`,
@@ -104,4 +106,20 @@ export function increaseComboItemQty(productName, qty) {
     }
 
     return steps;
+}
+
+export function setProductAvailability(productName, value) {
+    return {
+        content: `Set 'self_order_available' of product '${productName}' to ${value}`,
+        trigger: "body",
+        run: async function () {
+            const product = posmodel.data.models["product.template"].find(
+                (p) => p.name === productName
+            );
+            if (!product) {
+                throw new Error(`Product '${productName}' not found.`);
+            }
+            product.self_order_available = value;
+        },
+    };
 }

--- a/addons/pos_self_order/static/tests/tours/utils/product_page_util.js
+++ b/addons/pos_self_order/static/tests/tours/utils/product_page_util.js
@@ -151,3 +151,10 @@ export function setupCombo(products, addToCart = true) {
 
     return steps;
 }
+
+export function checkProductOutOfStock(productName) {
+    return {
+        content: `Check if '${productName}' is marked as out of stock`,
+        trigger: `.o_self_product_box:has(span:contains('${productName}')):has(div:contains('Out of stock'))`,
+    };
+}

--- a/addons/pos_self_order/tests/test_self_order_common.py
+++ b/addons/pos_self_order/tests/test_self_order_common.py
@@ -3,7 +3,7 @@
 import odoo.tests
 from odoo.addons.point_of_sale.tests.common_setup_methods import setup_product_combo_items
 from odoo.addons.pos_self_order.tests.self_order_common_test import SelfOrderCommonTest
-
+from odoo import Command
 from odoo.exceptions import UserError
 
 
@@ -131,3 +131,32 @@ class TestSelfOrderCommon(SelfOrderCommonTest):
         })
 
         self.assertTrue(product.self_order_visible, "the field should be visible when the pos config has no limit categories")
+
+    def test_self_order_product_availability(self):
+        """Test product visibility and cart behavior for kiosk and mobile self-ordering modes."""
+        setup_product_combo_items(self)
+
+        # Remove all combo items except desks_combo
+        self.office_combo.write({
+            "combo_ids": [
+                Command.unlink(c.id)
+                for c in self.office_combo.combo_ids
+                if c.id != self.desks_combo.id
+            ],
+        })
+
+        # --- Kiosk Mode Tour ---
+        self.pos_config.write({
+            'self_ordering_mode': 'kiosk',
+            'self_ordering_pay_after': 'each',
+            'self_ordering_service_mode': 'table',
+        })
+        self.pos_config.with_user(self.pos_user).open_ui()
+        self.pos_config.current_session_id.set_opening_control(0, "")
+        self.start_tour(self.pos_config._get_self_order_route(), "test_self_order_kiosk_product_availability")
+
+        # --- Mobile Mode Tour ---
+        self.pos_config.write({
+            'self_ordering_mode': 'mobile',
+        })
+        self.start_tour(self.pos_config._get_self_order_route(), "test_self_order_product_availability")


### PR DESCRIPTION
Before this commit:
---------------------------
- Product availability changes were not reflected in the kiosk or self-order 
 screens.
- Users could select and proceed to payment for products that were already 
 out of stock.
- No automatic UI update; a manual page reload was required to reflect stock 
 changes.

After this commit:
------------------------------------
- Product availability changes now automatically refresh the kiosk and 
  self-order interfaces.
- Unavailable products are blocked from being selected or paid for.
- The UI reflects real-time stock status, ensuring a consistent and reliable  
  experience.

Task-4830424