### PR TITLE
[FIX] account: Fix 'add_tax_details_in_base_line' py/js parameter

### DIFF
--- a/addons/account/models/account_tax.py
+++ b/addons/account/models/account_tax.py
@@ -1380,12 +1380,13 @@ class AccountTax(models.Model):
         :param company:         The company owning the base line.
         :param rounding_method: The rounding method to be used. If not specified, it will be taken from the company.
         """
+        rounding_method = rounding_method or company.tax_calculation_rounding_method
         price_unit_after_discount = base_line['price_unit'] * (1 - (base_line['discount'] / 100.0))
         taxes_computation = base_line['tax_ids']._get_tax_details(
             price_unit=price_unit_after_discount,
             quantity=base_line['quantity'],
             precision_rounding=base_line['currency_id'].rounding,
-            rounding_method=rounding_method or company.tax_calculation_rounding_method,
+            rounding_method=rounding_method,
             product=base_line['product_id'],
             special_mode=base_line['special_mode'],
             manual_tax_amounts=base_line['manual_tax_amounts'],
@@ -1398,13 +1399,13 @@ class AccountTax(models.Model):
             'raw_total_included': taxes_computation['total_included'] / rate if rate else 0.0,
             'taxes_data': [],
         }
-        if company.tax_calculation_rounding_method == 'round_per_line':
+        if rounding_method == 'round_per_line':
             tax_details['raw_total_excluded'] = company.currency_id.round(tax_details['raw_total_excluded'])
             tax_details['raw_total_included'] = company.currency_id.round(tax_details['raw_total_included'])
         for tax_data in taxes_computation['taxes_data']:
             tax_amount = tax_data['tax_amount'] / rate if rate else 0.0
             base_amount = tax_data['base_amount'] / rate if rate else 0.0
-            if company.tax_calculation_rounding_method == 'round_per_line':
+            if rounding_method == 'round_per_line':
                 tax_amount = company.currency_id.round(tax_amount)
                 base_amount = company.currency_id.round(base_amount)
             tax_details['taxes_data'].append({

--- a/addons/account/models/account_tax.py
+++ b/addons/account/models/account_tax.py
@@ -1229,7 +1229,7 @@ class AccountTax(models.Model):
     # -------------------------------------------------------------------------
 
     @api.model
-    def _get_base_line_field_value_from_record(self, record, field, extra_values, fallback):
+    def _get_base_line_field_value_from_record(self, record, field, extra_values, fallback, from_base_line=False):
         """ Helper to extract a default value for a record or something looking like a record.
 
         Suppose field is 'product_id' and fallback is 'self.env['product.product']'
@@ -1241,12 +1241,14 @@ class AccountTax(models.Model):
         :param field:           The name of the field to extract.
         :param extra_values:    The extra kwargs passed in addition of 'record'.
         :param fallback:        The value to return if not found in record or extra_values.
+        :param from_base_line:  Indicate if the value has to be retrieved automatically from the base_line and not the record.
+                                False by default.
         :return:                The field value corresponding to 'field'.
         """
         need_origin = isinstance(fallback, models.Model)
         if field in extra_values:
             value = extra_values[field] or fallback
-        elif isinstance(record, models.Model) and field in record._fields:
+        elif isinstance(record, models.Model) and field in record._fields and not from_base_line:
             value = record[field]
         elif isinstance(record, dict):
             value = record.get(field, fallback)
@@ -1270,8 +1272,8 @@ class AccountTax(models.Model):
         :param kwargs:  The extra values to override some values that will be taken from the record.
         :return:        A dictionary representing a base line.
         """
-        def load(field, fallback):
-            return self._get_base_line_field_value_from_record(record, field, kwargs, fallback)
+        def load(field, fallback, from_base_line=False):
+            return self._get_base_line_field_value_from_record(record, field, kwargs, fallback, from_base_line=from_base_line)
 
         currency = (
             load('currency_id', None)
@@ -1298,13 +1300,13 @@ class AccountTax(models.Model):
             # - False for the normal behavior.
             # - total_included to force all taxes to be price included.
             # - total_excluded to force all taxes to be price excluded.
-            'special_mode': kwargs.get('special_mode', False),
+            'special_mode': load('special_mode', False, from_base_line=True),
 
             # A special typing of base line for some custom behavior:
             # - False for the normal behavior.
             # - early_payment if the base line represent an early payment in mixed mode.
             # - cash_rounding if the base line is a delta to round the business object for the cash rounding feature.
-            'special_type': kwargs.get('special_type', False),
+            'special_type': load('special_type', False, from_base_line=True),
 
             # All computation are managing the foreign currency and the local one.
             # This is the rate to be applied when generating the tax details (see '_add_tax_details_in_base_line').
@@ -1312,7 +1314,7 @@ class AccountTax(models.Model):
 
             # For all computation that are inferring a base amount in order to reach a total you know in advance, you have to force some
             # base/tax amounts for the computation (E.g. down payment, combo products, global discounts etc).
-            'manual_tax_amounts': kwargs.get('manual_tax_amounts', None),
+            'manual_tax_amounts': load('manual_tax_amounts', None, from_base_line=True),
 
             # ===== Accounting stuff =====
 

--- a/addons/account/models/account_tax.py
+++ b/addons/account/models/account_tax.py
@@ -778,13 +778,14 @@ class AccountTax(models.Model):
                 sorted_taxes |= tax
         return sorted_taxes, group_per_tax
 
-    def _batch_for_taxes_computation(self, special_mode=False):
+    def _batch_for_taxes_computation(self, special_mode=False, filter_tax_function=None):
         """ Group the current taxes all together like price-included percent taxes or division taxes.
 
         [!] Mirror of the same method in account_tax.js.
         PLZ KEEP BOTH METHODS CONSISTENT WITH EACH OTHERS.
 
-        :param special_mode: The special mode of the taxes computation: False, 'total_excluded' or 'total_included'.
+        :param special_mode:        The special mode of the taxes computation: False, 'total_excluded' or 'total_included'.
+        :param filter_tax_function: Optional function to filter out some taxes from the computation.
         :return: A dictionary containing:
             * batch_per_tax: A mapping of each tax to its batch.
             * group_per_tax: A mapping of each tax retrieved from a group of taxes.
@@ -794,6 +795,9 @@ class AccountTax(models.Model):
                             [G, B([A, D, F]), E, C] will be computed as [A, D, F, C, E, G]
         """
         sorted_taxes, group_per_tax = self._flatten_taxes_and_sort_them()
+        if filter_tax_function:
+            sorted_taxes = sorted_taxes.filtered(filter_tax_function)
+
         results = {
             'batch_per_tax': {},
             'group_per_tax': group_per_tax,
@@ -996,6 +1000,7 @@ class AccountTax(models.Model):
         product=None,
         special_mode=False,
         manual_tax_amounts=None,
+        filter_tax_function=None,
     ):
         """ Compute the tax/base amounts for the current taxes.
 
@@ -1017,6 +1022,7 @@ class AccountTax(models.Model):
                             Note: You can only expect accurate symmetrical taxes computation with not rounded price_unit
                             as input and 'round_globally' computation. Otherwise, it's not guaranteed.
         :param manual_tax_amounts:  A dictionary mapping a tax_id to a custom tax/base amount.
+        :param filter_tax_function: Optional function to filter out some taxes from the computation.
         :return: A dict containing:
             'evaluation_context':       The evaluation_context parameter.
             'taxes_data':               A list of dictionaries, one per tax containing:
@@ -1065,8 +1071,8 @@ class AccountTax(models.Model):
                 'extra_base_for_base': 0.0,
             }
 
-        # Flatten the taxes and order them.
-        batching_results = self._batch_for_taxes_computation(special_mode=special_mode)
+        # Flatten the taxes, order them and filter them if necessary.
+        batching_results = self._batch_for_taxes_computation(special_mode=special_mode, filter_tax_function=filter_tax_function)
         sorted_taxes = batching_results['sorted_taxes']
         taxes_data = {}
         reverse_charge_taxes_data = {}
@@ -1316,6 +1322,10 @@ class AccountTax(models.Model):
             # base/tax amounts for the computation (E.g. down payment, combo products, global discounts etc).
             'manual_tax_amounts': load('manual_tax_amounts', None, from_base_line=True),
 
+            # Add a function allowing to filter out some taxes during the evaluation. Those taxes can't be removed from the base_line
+            # when dealing with group of taxes to maintain a correct link between the child tax and its parent.
+            'filter_tax_function': load('filter_tax_function', None, from_base_line=True),
+
             # ===== Accounting stuff =====
 
             # The sign of the business object regarding its accounting balance.
@@ -1409,6 +1419,7 @@ class AccountTax(models.Model):
             product=base_line['product_id'],
             special_mode=base_line['special_mode'],
             manual_tax_amounts=base_line['manual_tax_amounts'],
+            filter_tax_function=base_line['filter_tax_function'],
         )
         rate = base_line['rate']
         tax_details = base_line['tax_details'] = {

--- a/addons/account/models/account_tax.py
+++ b/addons/account/models/account_tax.py
@@ -750,6 +750,34 @@ class AccountTax(models.Model):
             product=product,
         )
 
+    def _flatten_taxes_and_sort_them(self):
+        """ Flattens the taxes contained in this recordset, returning all the
+        children at the bottom of the hierarchy, in a recordset, ordered by sequence.
+          Eg. considering letters as taxes and alphabetic order as sequence :
+          [G, B([A, D, F]), E, C] will be computed as [A, D, F, C, E, G]
+
+        [!] Mirror of the same method in account_tax.js.
+        PLZ KEEP BOTH METHODS CONSISTENT WITH EACH OTHERS.
+
+        :return: A tuple <sorted_taxes, group_per_tax> where:
+            - sorted_taxes is a recordset of taxes.
+            - group_per_tax maps each tax to its parent group of taxes if exists.
+        """
+        def sort_key(tax):
+            return tax.sequence, tax.id or None
+
+        group_per_tax = {}
+        sorted_taxes = self.env['account.tax']
+        for tax in self.sorted(key=sort_key):
+            if tax.amount_type == 'group':
+                children = tax.children_tax_ids.sorted(key=sort_key)
+                sorted_taxes |= children
+                for child in children:
+                    group_per_tax[child.id] = tax
+            else:
+                sorted_taxes |= tax
+        return sorted_taxes, group_per_tax
+
     def _batch_for_taxes_computation(self, special_mode=False):
         """ Group the current taxes all together like price-included percent taxes or division taxes.
 
@@ -765,24 +793,12 @@ class AccountTax(models.Model):
                             Eg. considering letters as taxes and alphabetic order as sequence :
                             [G, B([A, D, F]), E, C] will be computed as [A, D, F, C, E, G]
         """
-        def sort_key(tax):
-            return tax.sequence, tax.id
-
+        sorted_taxes, group_per_tax = self._flatten_taxes_and_sort_them()
         results = {
             'batch_per_tax': {},
-            'group_per_tax': {},
-            'sorted_taxes': self.env['account.tax'],
+            'group_per_tax': group_per_tax,
+            'sorted_taxes': sorted_taxes,
         }
-
-        # Flatten the taxes.
-        for tax in self.sorted(key=sort_key):
-            if tax.amount_type == 'group':
-                children = tax.children_tax_ids.sorted(key=sort_key)
-                results['sorted_taxes'] |= children
-                for child in children:
-                    results['group_per_tax'][child.id] = tax
-            else:
-                results['sorted_taxes'] |= tax
 
         # Group them per batch.
         batch = self.env['account.tax']
@@ -1107,8 +1123,9 @@ class AccountTax(models.Model):
                 continue
 
             # Base amount.
-            if manual_tax_amounts and 'base_amount_currency' in manual_tax_amounts.get(str(tax.id), {}):
-                base = manual_tax_amounts[str(tax.id)]['base_amount_currency']
+            tax_id_str = str(tax.id)
+            if manual_tax_amounts and 'base_amount_currency' in manual_tax_amounts.get(tax_id_str, {}):
+                base = manual_tax_amounts[tax_id_str]['base_amount_currency']
             else:
                 total_tax_amount = sum(taxes_data[other_tax.id]['tax_amount'] for other_tax in tax_data['batch'])
                 total_tax_amount += sum(
@@ -2556,19 +2573,7 @@ class AccountTax(models.Model):
     # -------------------------------------------------------------------------
 
     def flatten_taxes_hierarchy(self):
-        # Flattens the taxes contained in this recordset, returning all the
-        # children at the bottom of the hierarchy, in a recordset, ordered by sequence.
-        #   Eg. considering letters as taxes and alphabetic order as sequence :
-        #   [G, B([A, D, F]), E, C] will be computed as [A, D, F, C, E, G]
-        # If create_map is True, an additional value is returned, a dictionary
-        # mapping each child tax to its parent group
-        all_taxes = self.env['account.tax']
-        for tax in self.sorted(key=lambda r: r.sequence):
-            if tax.amount_type == 'group':
-                all_taxes += tax.children_tax_ids.flatten_taxes_hierarchy()
-            else:
-                all_taxes += tax
-        return all_taxes
+        return self._flatten_taxes_and_sort_them()[0]
 
     def get_tax_tags(self, is_refund, repartition_type):
         document_type = 'refund' if is_refund else 'invoice'

--- a/addons/account/static/src/components/tests_shared_js_python/tests_shared_js_python.js
+++ b/addons/account/static/src/components/tests_shared_js_python/tests_shared_js_python.js
@@ -21,10 +21,16 @@ export class TestsSharedJsPython extends Component {
 
     processTest(params) {
         if (params.test === "taxes_computation") {
+            let filter_tax_function = null;
+            if (params.excluded_tax_ids && params.excluded_tax_ids.length) {
+                filter_tax_function = (tax) => !params.excluded_tax_ids.includes(tax.id);
+            }
+
             const kwargs = {
                 product: params.product,
                 precision_rounding: params.precision_rounding,
                 rounding_method: params.rounding_method,
+                filter_tax_function: filter_tax_function,
             };
             const results = {
                 results: accountTaxHelpers.get_tax_details(

--- a/addons/account/static/src/helpers/account_tax.js
+++ b/addons/account/static/src/helpers/account_tax.js
@@ -498,7 +498,8 @@ export const accountTaxHelpers = {
         }
     },
 
-    add_tax_details_in_base_line(base_line, company) {
+    add_tax_details_in_base_line(base_line, company, { rounding_method = null } = {}) {
+        rounding_method = rounding_method || company.tax_calculation_rounding_method;
         const price_unit_after_discount = base_line.price_unit * (1 - (base_line.discount / 100.0));
         const currency_pd = base_line.currency_id.rounding;
         const company_currency_pd = company.currency_id.rounding;
@@ -508,7 +509,7 @@ export const accountTaxHelpers = {
             base_line.quantity,
             {
                 precision_rounding: currency_pd,
-                rounding_method: company.tax_calculation_rounding_method,
+                rounding_method: rounding_method,
                 product: base_line.product_id,
                 special_mode: base_line.special_mode,
                 manual_tax_amounts: base_line.manual_tax_amounts
@@ -524,7 +525,7 @@ export const accountTaxHelpers = {
             taxes_data: []
         };
 
-        if (company.tax_calculation_rounding_method === 'round_per_line') {
+        if (rounding_method === "round_per_line") {
             tax_details.raw_total_excluded = roundPrecision(tax_details.raw_total_excluded, currency_pd);
             tax_details.raw_total_included = roundPrecision(tax_details.raw_total_included, currency_pd);
         }
@@ -533,7 +534,7 @@ export const accountTaxHelpers = {
             let tax_amount = rate ? tax_data.tax_amount / rate : 0.0;
             let base_amount = rate ? tax_data.base_amount / rate : 0.0;
 
-            if (company.tax_calculation_rounding_method === 'round_per_line') {
+            if (rounding_method === "round_per_line") {
                 tax_amount = roundPrecision(tax_amount, company_currency_pd);
                 base_amount = roundPrecision(base_amount, company_currency_pd);
             }

--- a/addons/account/static/src/helpers/account_tax.js
+++ b/addons/account/static/src/helpers/account_tax.js
@@ -51,8 +51,12 @@ export const accountTaxHelpers = {
      * [!] Mirror of the same method in account_tax.py.
      * PLZ KEEP BOTH METHODS CONSISTENT WITH EACH OTHERS.
      */
-    batch_for_taxes_computation(taxes, { special_mode = null } = {}) {
-        const { sorted_taxes, group_per_tax } = this.flatten_taxes_and_sort_them(taxes);
+    batch_for_taxes_computation(taxes, { special_mode = null, filter_tax_function = null } = {}) {
+        let { sorted_taxes, group_per_tax } = this.flatten_taxes_and_sort_them(taxes);
+        if (filter_tax_function) {
+            sorted_taxes = sorted_taxes.filter(filter_tax_function);
+        }
+
         const results = {
             batch_per_tax: {},
             group_per_tax: group_per_tax,
@@ -238,6 +242,7 @@ export const accountTaxHelpers = {
             product = null,
             special_mode = null,
             manual_tax_amounts = null,
+            filter_tax_function = null,
         } = {}
     ) {
         const self = this;
@@ -281,7 +286,7 @@ export const accountTaxHelpers = {
             }
         }
 
-        // Flatten the taxes and order them.
+        // Flatten the taxes, order them and filter them if necessary.
 
         function prepare_tax_extra_data(tax, kwargs = {}) {
             let price_include;
@@ -303,8 +308,9 @@ export const accountTaxHelpers = {
 
         const batching_results = this.batch_for_taxes_computation(taxes, {
             special_mode: special_mode,
+            filter_tax_function: filter_tax_function,
         });
-        const sorted_taxes = batching_results.sorted_taxes;
+        let sorted_taxes = batching_results.sorted_taxes;
         const taxes_data = {};
         const reverse_charge_taxes_data = {};
         for (const tax of sorted_taxes) {
@@ -504,7 +510,8 @@ export const accountTaxHelpers = {
             special_mode: load('special_mode', null),
             special_type: load('special_type', null),
             rate: load("rate", 1.0),
-            manual_tax_amounts: load('manual_tax_amounts', null),
+            manual_tax_amounts: load("manual_tax_amounts", null),
+            filter_tax_function: load("filter_tax_function", null),
         }
     },
 
@@ -522,7 +529,8 @@ export const accountTaxHelpers = {
                 rounding_method: rounding_method,
                 product: base_line.product_id,
                 special_mode: base_line.special_mode,
-                manual_tax_amounts: base_line.manual_tax_amounts
+                manual_tax_amounts: base_line.manual_tax_amounts,
+                filter_tax_function: base_line.filter_tax_function
             }
         );
 

--- a/addons/account/static/src/helpers/account_tax.js
+++ b/addons/account/static/src/helpers/account_tax.js
@@ -473,7 +473,7 @@ export const accountTaxHelpers = {
         if (field in extra_values) {
             return extra_values[field] || fallback;
         }
-        if (field in record) {
+        if (record && field in record) {
             return record[field] || fallback;
         }
         return fallback;
@@ -501,10 +501,10 @@ export const accountTaxHelpers = {
             discount: load('discount', 0.0),
             currency_id: currency,
             sign: load('sign', 1.0),
-            special_mode: kwargs.special_mode || null,
-            special_type: kwargs.special_type || null,
+            special_mode: load('special_mode', null),
+            special_type: load('special_type', null),
             rate: load("rate", 1.0),
-            manual_tax_amounts: kwargs.manual_tax_amounts || null,
+            manual_tax_amounts: load('manual_tax_amounts', null),
         }
     },
 

--- a/addons/account/tests/common.py
+++ b/addons/account/tests/common.py
@@ -1109,11 +1109,12 @@ class TestTaxCommon(AccountTestInvoicingHttpCommon):
                     float_round(results['price_unit'], precision_rounding=rounding),
                 )
 
-    def _create_py_sub_test_taxes_computation(self, taxes, price_unit, quantity, product, precision_rounding, rounding_method):
+    def _create_py_sub_test_taxes_computation(self, taxes, price_unit, quantity, product, precision_rounding, rounding_method, excluded_tax_ids):
         kwargs = {
             'product': product,
             'precision_rounding': precision_rounding,
             'rounding_method': rounding_method,
+            'filter_tax_function': (lambda tax: tax.id not in excluded_tax_ids) if excluded_tax_ids else None,
         }
         results = {'results': taxes._get_tax_details(price_unit, quantity, **kwargs)}
         if rounding_method == 'round_globally':
@@ -1131,7 +1132,7 @@ class TestTaxCommon(AccountTestInvoicingHttpCommon):
             )
         return results
 
-    def _create_js_sub_test_taxes_computation(self, taxes, price_unit, quantity, product, precision_rounding, rounding_method):
+    def _create_js_sub_test_taxes_computation(self, taxes, price_unit, quantity, product, precision_rounding, rounding_method, excluded_tax_ids):
         return {
             'test': 'taxes_computation',
             'taxes': [self._jsonify_tax(tax) for tax in taxes],
@@ -1140,6 +1141,7 @@ class TestTaxCommon(AccountTestInvoicingHttpCommon):
             'product': self._jsonify_product(product, taxes),
             'precision_rounding': precision_rounding,
             'rounding_method': rounding_method,
+            'excluded_tax_ids': excluded_tax_ids,
         }
 
     def assert_taxes_computation(
@@ -1152,6 +1154,7 @@ class TestTaxCommon(AccountTestInvoicingHttpCommon):
         precision_rounding=0.01,
         rounding_method='round_per_line',
         excluded_special_modes=None,
+        excluded_tax_ids=None,
     ):
         def extra_function(results):
             results['excluded_special_modes'] = excluded_special_modes
@@ -1170,6 +1173,7 @@ class TestTaxCommon(AccountTestInvoicingHttpCommon):
             product,
             precision_rounding,
             rounding_method,
+            excluded_tax_ids,
             extra_function=extra_function,
         )
 

--- a/addons/account/tests/test_taxes_computation.py
+++ b/addons/account/tests/test_taxes_computation.py
@@ -43,6 +43,23 @@ class TestTaxesComputation(TestTaxCommon):
         )
         self._run_js_tests()
 
+    def test_taxes_filtering(self):
+        tax_percent_1 = self.percent_tax(10.0)
+        tax_percent_2 = self.percent_tax(20.0)
+        self.assert_taxes_computation(
+            tax_percent_1 | tax_percent_2,
+            100.0,
+            {
+                'total_included': 110.0,
+                'total_excluded': 100.0,
+                'taxes_data': (
+                    (100.0, 10.0),
+                ),
+            },
+            excluded_tax_ids=tax_percent_2.ids,
+        )
+        self._run_js_tests()
+
     def test_random_case_1(self):
         tax_percent_8_price_included = self.percent_tax(8.0, price_include_override='tax_included')
         tax_percent_0_price_included = self.percent_tax(0.0, price_include_override='tax_included')

--- a/addons/sale/tests/test_sale_order_down_payment.py
+++ b/addons/sale/tests/test_sale_order_down_payment.py
@@ -363,11 +363,13 @@ class TestSaleOrderDownPayment(TestSaleCommon):
         self._assert_invoice_lines_values(invoice.line_ids, expected)
 
     def test_tax_fixed_amount_breakdown(self):
-        tax_10_fix_a = self.create_tax(10, {'amount_type': 'fixed', 'include_base_amount': True})
-        tax_10_fix_b = self.create_tax(10, {'amount_type': 'fixed', 'include_base_amount': True})
-        tax_10_fix_c = self.create_tax(10, {'amount_type': 'fixed'})
+        tax_10_fix_a = self.create_tax(10, {'amount_type': 'fixed', 'include_base_amount': True, 'sequence': 1})
+        tax_10_fix_b = self.create_tax(10, {'amount_type': 'fixed', 'include_base_amount': True, 'sequence': 3})
+        tax_10_fix_c = self.create_tax(10, {'amount_type': 'fixed', 'sequence': 5})
         tax_10_a = self.tax_10
+        tax_10_a.sequence = 2
         tax_10_b = self.create_tax(10)
+        tax_10_b.sequence = 4
         tax_group_1 = self.env['account.tax'].create({
             'name': "Tax Group",
             'amount_type': 'group',
@@ -508,11 +510,13 @@ class TestSaleOrderDownPayment(TestSaleCommon):
         analytic_plan = self.env['account.analytic.plan'].create({'name': 'Plan Test'})
         an_acc_01 = str(self.env['account.analytic.account'].create({'name': 'Account 01', 'plan_id': analytic_plan.id}).id)
         an_acc_02 = str(self.env['account.analytic.account'].create({'name': 'Account 02', 'plan_id': analytic_plan.id}).id)
-        tax_10_fix_a = self.create_tax(10, {'amount_type': 'fixed', 'include_base_amount': True})
-        tax_10_fix_b = self.create_tax(10, {'amount_type': 'fixed', 'include_base_amount': True})
-        tax_10_fix_c = self.create_tax(10, {'amount_type': 'fixed'})
+        tax_10_fix_a = self.create_tax(10, {'amount_type': 'fixed', 'include_base_amount': True, 'sequence': 1})
+        tax_10_fix_b = self.create_tax(10, {'amount_type': 'fixed', 'include_base_amount': True, 'sequence': 3})
+        tax_10_fix_c = self.create_tax(10, {'amount_type': 'fixed', 'sequence': 4})
         tax_10_a = self.tax_10
+        tax_10_a.sequence = 2
         tax_10_b = self.create_tax(10)
+        tax_10_b.sequence = 5
         tax_group_1 = self.env['account.tax'].create({
             'name': "Tax Group",
             'amount_type': 'group',


### PR DESCRIPTION
- rounding_method is there on the python code but not js-side.
- rounding_method is passed to the taxes computation but not used after to decide if the total_excluded has to be rounded or not.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
