### PR TITLE
[FIX] web: tree editor: hide special options if allowExpressions = False

### DIFF
--- a/addons/web/static/src/core/domain_selector/domain_selector.xml
+++ b/addons/web/static/src/core/domain_selector/domain_selector.xml
@@ -9,6 +9,7 @@
                     update.bind="update"
                     readonly="props.readonly"
                     isDebugMode="props.isDebugMode"
+                    allowExpressions="props.allowExpressions"
                     defaultConnector="props.defaultConnector"
                     getDefaultCondition.bind="getDefaultCondition"
                     getOperatorEditorInfo.bind="getOperatorEditorInfo"

--- a/addons/web/static/src/core/tree_editor/tree_editor.js
+++ b/addons/web/static/src/core/tree_editor/tree_editor.js
@@ -42,8 +42,10 @@ export class TreeEditor extends Component {
         isDebugMode: { type: Boolean, optional: true },
         defaultConnector: { type: [{ value: "&" }, { value: "|" }], optional: true },
         isSubTree: { type: Boolean, optional: true },
+        allowExpressions: { type: Boolean, optional: true },
     };
     static defaultProps = {
+        allowExpressions: true,
         defaultConnector: "&",
         readonly: false,
         isSubTree: false,
@@ -191,7 +193,9 @@ export class TreeEditor extends Component {
 
     getValueEditorInfo(node) {
         const fieldDef = this.getFieldDef(node.path);
-        return getValueEditorInfo(fieldDef, node.operator);
+        return getValueEditorInfo(fieldDef, node.operator, {
+            allowExpressions: this.props.allowExpressions,
+        });
     }
 
     async _updatePath(node, path) {

--- a/addons/web/static/src/core/tree_editor/tree_editor_value_editors.js
+++ b/addons/web/static/src/core/tree_editor/tree_editor_value_editors.js
@@ -166,8 +166,9 @@ function getPartialValueEditorInfo(fieldDef, operator, params = {}) {
             return STRING_EDITOR;
         case "is_not_between":
         case "between": {
-            const editorInfo = getValueEditorInfo(fieldDef, "=");
+            const editorInfo = getValueEditorInfo(fieldDef, "=", params);
             const { defaultValue } = getValueEditorInfo(fieldDef, "=", {
+                ...params,
                 forBetween: true,
             });
             return {
@@ -196,7 +197,7 @@ function getPartialValueEditorInfo(fieldDef, operator, params = {}) {
                     value,
                     update,
                     amountEditorInfo: {
-                        ...getValueEditorInfo({ type: "integer" }, "="),
+                        ...getValueEditorInfo({ type: "integer" }, "=", params),
                         isSupported: (value) => Number.isInteger(value) && value >= 0,
                         message: _t("Positive integer expected"),
                     },
@@ -222,6 +223,7 @@ function getPartialValueEditorInfo(fieldDef, operator, params = {}) {
                     return makeAutoCompleteEditor(fieldDef);
                 default: {
                     const editorInfo = getValueEditorInfo(fieldDef, "=", {
+                        ...params,
                         addBlankOption: true,
                         startEmpty: true,
                     });
@@ -384,7 +386,7 @@ function getPartialValueEditorInfo(fieldDef, operator, params = {}) {
         case "date_option":
         case "datetime_option":
         case "time_option": {
-            if (fieldDef.name in OPTIONS_WITH_SELECT) {
+            if (OPTIONS_WITH_SELECT.has(fieldDef.name)) {
                 return getEditorInfoForOptionsWithSelect(fieldDef.name, params);
             } else if (fieldDef.name === "__time") {
                 return {

--- a/addons/web/static/src/core/tree_editor/utils.js
+++ b/addons/web/static/src/core/tree_editor/utils.js
@@ -14,7 +14,10 @@ import {
     normalizeValue,
     splitPath,
 } from "@web/core/tree_editor/condition_tree";
-import { OPTIONS_WITH_SELECT } from "@web/core/tree_editor/tree_editor_datetime_options";
+import {
+    getOptionsFor,
+    OPTIONS_WITH_SELECT,
+} from "@web/core/tree_editor/tree_editor_datetime_options";
 import { getOperatorLabel } from "@web/core/tree_editor/tree_editor_operator_editor";
 import { unique, zip } from "@web/core/utils/arrays";
 import { useService } from "@web/core/utils/hooks";
@@ -30,10 +33,10 @@ import { Within } from "./tree_editor_components";
 function formatValue(val, disambiguate, fieldDef, displayNames) {
     if (
         fieldDef?.type === "date_option" &&
-        fieldDef.name in OPTIONS_WITH_SELECT &&
+        OPTIONS_WITH_SELECT.has(fieldDef.name) &&
         typeof val !== "string"
     ) {
-        const options = OPTIONS_WITH_SELECT[fieldDef.name];
+        const options = getOptionsFor(fieldDef.name, true);
         const valToCompare = val instanceof Expression ? val._expr : val;
         const [, label] = (options || []).find(([v]) => v === valToCompare) || [];
         if (label !== undefined) {

--- a/addons/web/static/tests/core/domain_selector/domain_selector.test.js
+++ b/addons/web/static/tests/core/domain_selector/domain_selector.test.js
@@ -3280,6 +3280,35 @@ test("hide today, next, last operators when allowExpressions = False", async () 
     ]);
 });
 
+test(`hide "This day"/"This month" when allowExpressions = False`, async () => {
+    await makeDomainSelector({
+        domain: `[("datetime.day_of_month", "=", 1), ("datetime.month_number", "=", 1) ]`,
+        allowExpressions: false,
+        update(domain) {
+            expect.step(domain);
+        },
+    });
+    const range = [];
+    for (let i = 1; i <= 31; i++) {
+        range.push(String(i));
+    }
+    expect(getValueOptions()).toEqual(range);
+    expect(getValueOptions(1)).toEqual([
+        "January",
+        "February",
+        "March",
+        "April",
+        "May",
+        "June",
+        "July",
+        "August",
+        "September",
+        "October",
+        "November",
+        "December",
+    ]);
+});
+
 test("many2one: placeholders for in operator", async () => {
     await makeDomainSelector({
         domain: `[("product_id", "in", [])]`,


### PR DESCRIPTION
The domain selector passes a new prop allowExpressions to the tree editor. If that prop is false (default true), the value
"This day" ("This month") will not proposed for selection for "day_of_month" (resp. "month_number"). This is done to prevent users to introduce expressions in their domains when they are not supported.