### PR TITLE
[FIX] product: select correct seller with decimal precision

### DIFF
--- a/addons/product/models/product_product.py
+++ b/addons/product/models/product_product.py
@@ -687,7 +687,13 @@ class ProductProduct(models.Model):
 
         def sort_function(record):
             vals = {
-                'price_discounted': record.currency_id._convert(record.price_discounted, record.env.company.currency_id, record.env.company, date or fields.Date.context_today(self))
+                'price_discounted': record.currency_id._convert(
+                    record.price_discounted,
+                    record.env.company.currency_id,
+                    record.env.company,
+                    date or fields.Date.context_today(self),
+                    round=False,
+                ),
             }
             return [vals.get(key, record[key]) for key in sort_key]
         sellers = self._get_filtered_sellers(partner_id=partner_id, quantity=quantity, date=date, uom_id=uom_id, params=params)

--- a/addons/product/tests/test_seller.py
+++ b/addons/product/tests/test_seller.py
@@ -116,6 +116,21 @@ class TestSeller(TransactionCase):
         msg = "Wrong cost price: LCD Monitor if more than 3 Unit.should be 785 instead of %s" % price
         self.assertEqual(float_compare(price, 785, precision_digits=2), 0, msg)
 
+    def test_31_select_seller(self):
+        """Check that the right seller is selected, even when the decimal precision of
+        Product Price is higher than the precision of the currency.
+        """
+        self.env.ref('product.decimal_price').digits = 3
+        partner = self.asustec
+        product = self.product_consu
+        self.env['product.supplierinfo'].create([{
+            'partner_id': partner.id,
+            'product_tmpl_id': product.product_tmpl_id.id,
+            'price': price,
+        } for price in (0.025, 0.022, 0.020)])
+        price = product._select_seller(partner_id=partner, quantity=201).price
+        self.assertAlmostEqual(price, 0.02, places=3, msg="Lowest price should be returned")
+
     def test_40_seller_min_qty_precision(self):
         """Test that the min_qty has the precision of Product UoM."""
         # Arrange: Change precision digits


### PR DESCRIPTION
**Problem:**
when the decimal precision of Product Price is higher than the precision of the currency used, the seller is not correctly selected based on their prices

**Steps to reproduce:**
- Open Settings/Technical/Database Structure/Decimal Accuracy
- For Product Price set a decimal accuracy of 3
- Create a new product
- In the purchase tab add 3 lines for a vendor the same vendor
- First line with a price of 0.025 and a qty of 1
- Second line with a price of 0.022 and a qty of 2
- Third line with a price of 0.020 and a qty of 3
- Create a new request for quotation for this product with this vendor
- set a quantity of 3

**Current behavior:**
The unit price is 0.022

**Expected behavior:**
It should be 0.020

**Cause of the issue:**
When sorting the set of product.supplierinfo, rounding should not be applied because the rounding will be the one of the currency and the Product Price could allow more decimal than the currency.
If we allow vendors price to be more precise the the currency, the sorting should take into account this precision when choosing a vendor.

opw-4823919