### PR TITLE
[IMP] stock: activate MTO route with a setting

### DIFF
--- a/addons/purchase_stock/views/res_config_settings_views.xml
+++ b/addons/purchase_stock/views/res_config_settings_views.xml
@@ -14,6 +14,11 @@
 							 documentation="/applications/inventory_and_mrp/inventory/shipping/operation/dropshipping.html">
 						<field name="module_stock_dropshipping"/>
 					</setting>
+					<setting title="This adds a Replenish On Order (MTO) route to apply on products in order to generate on-demand replenishment linked to your sales orders (for example) as soon as they are confirmed, with a direct link. Purchase orders, manufacturing orders, etc. are triggered based on what way to replenish is set on the product (Buy or Manufacture route)."
+							 help="Allow Make to Order, or automate PO, when a product is sold and get direct links between documents."
+                             				 documentation="/applications/inventory_and_mrp/inventory/warehouses_storage/replenishment/mto.html">
+                        			<field name="replenish_on_order"/>
+                    			</setting>
 				</block>
 			</xpath>
 		</field>

--- a/addons/stock/data/stock_data.xml
+++ b/addons/stock/data/stock_data.xml
@@ -63,6 +63,7 @@
             <field name="company_id"></field>
             <field name="active">False</field>
             <field name="sequence">5</field>
+            <field name="product_categ_selectable" eval="True"/>
         </record>
 
         <!-- Properties -->

--- a/addons/stock/models/res_config_settings.py
+++ b/addons/stock/models/res_config_settings.py
@@ -53,6 +53,17 @@ class ResConfigSettings(models.TransientModel):
         "Separator", config_parameter='stock.barcode_separator',
         help="Character(s) used to separate data contained within an aggregate barcode (i.e. a barcode containing multiple barcode encodings)")
     module_stock_fleet = fields.Boolean("Dispatch Management System")
+    replenish_on_order = fields.Boolean("Replenish on Order (MTO)", compute='_compute_replenish_on_order', inverse='_inverse_replenish_on_order')
+
+    def _compute_replenish_on_order(self):
+        route = self.env.ref('stock.route_warehouse0_mto')
+        if route:
+            self.replenish_on_order = route.active
+
+    def _inverse_replenish_on_order(self):
+        route = self.env.ref('stock.route_warehouse0_mto')
+        if route:
+            route.active = self.replenish_on_order
 
     @api.onchange('group_stock_multi_locations')
     def _onchange_group_stock_multi_locations(self):

--- a/addons/stock/views/res_config_settings_views.xml
+++ b/addons/stock/views/res_config_settings_views.xml
@@ -181,6 +181,10 @@
                             documentation="/applications/inventory_and_mrp/inventory/management/delivery/dropshipping.html">
                                 <field name="module_stock_dropshipping"/>
                             </setting>
+                            <setting title="This adds a Replenish On Order (MTO) route to apply on products in order to generate on-demand replenishment linked to your sales orders (for example) as soon as they are confirmed, with a direct link. Purchase orders, manufacturing orders, etc. are triggered based on what way to replenish is set on the product (Buy or Manufacture route)." help="Allow Make to Order, or automate PO, when a product is sold and get direct links between documents."
+                            documentation="/applications/inventory_and_mrp/inventory/warehouses_storage/replenishment/mto.html">
+                                <field name="replenish_on_order"/>
+                            </setting>
                         </block>
                     </app>
                 </xpath>


### PR DESCRIPTION
**Desired behavior after PR is merged:**
- Added replenish_on_order field to settings.
- Made Replenish on Order (MTO) selectable in the product Category when its unarchived.
- Made the replenish_on_order field consistent with the MTO route, so even when it directly un/archived from the route page the change will be reflected in the new MTO settings as well.
- Replenish On Order route now doesn't depend on multi-step routes settings.

Task:4789927




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
