### PR TITLE
[ADD] auth_timeout: re-ask for authentication on user inactivity

### DIFF
--- a/addons/auth_timeout/__init__.py
+++ b/addons/auth_timeout/__init__.py
@@ -1,0 +1,2 @@
+from . import controllers
+from . import models

--- a/addons/auth_timeout/__manifest__.py
+++ b/addons/auth_timeout/__manifest__.py
@@ -1,0 +1,24 @@
+{
+    "name": "Auth Timeout",
+    "summary": "Ask for authentication after user inactivity",
+    "category": "Hidden/Tools",
+    "depends": ["auth_totp", "auth_totp_mail", "auth_passkey", "bus"],
+    "data": [
+        "views/login_templates.xml",
+        "views/res_groups_views.xml",
+    ],
+    "assets": {
+        "web.assets_backend": [
+            "auth_timeout/static/src/services/check_identity/*",
+        ],
+        "web.assets_frontend": [
+            "auth_timeout/static/src/services/check_identity/*",
+            "auth_timeout/static/src/scss/auth_timeout.scss",
+        ],
+        "web.assets_tests": [
+            "auth_timeout/static/tests/tours/**/*",
+        ],
+    },
+    "author": "Odoo S.A.",
+    "license": "LGPL-3",
+}

--- a/addons/auth_timeout/controllers/__init__.py
+++ b/addons/auth_timeout/controllers/__init__.py
@@ -1,0 +1,3 @@
+from . import main
+from . import web_home
+from . import auth_passkey_webauthn

--- a/addons/auth_timeout/controllers/auth_passkey_webauthn.py
+++ b/addons/auth_timeout/controllers/auth_passkey_webauthn.py
@@ -1,0 +1,11 @@
+from odoo import http
+from odoo.addons.auth_passkey.controllers import main as auth_passkey_main
+
+
+class WebauthnController(auth_passkey_main.WebauthnController):
+    # `/auth/passkey/start-auth` must be `check_identity=False`
+    # because it's used to start an authentication upon authentication with a passkey,
+    # which is used when the user needs to check its identity using a passkey
+    @http.route(check_identity=False)
+    def json_start_authentication(self):
+        return super().json_start_authentication()

--- a/addons/auth_timeout/controllers/main.py
+++ b/addons/auth_timeout/controllers/main.py
@@ -1,0 +1,23 @@
+from odoo import http
+from odoo.http import request
+
+
+class AuthTimeOutController(http.Controller):
+    @http.route(
+        "/auth-timeout/check-identity", type="http", auth="user", website=True, sitemap=False, check_identity=False
+    )
+    def check_identity(self, redirect=None):
+        """Display the authentication form in a page. Used when an HTTP call raises a `CheckIdentityException`."""
+        return request.render("auth_timeout.check_identity", {"redirect": redirect})
+
+    # Cannot be readonly because checking the identity can lead to some data being written
+    # e.g. totp rate limit during a totp by mail
+    @http.route("/auth-timeout/session/check-identity", type="jsonrpc", auth="user", check_identity=False)
+    def check_identity_session(self, **kwargs):
+        """JSON route used to receive the authentication form sent by the user."""
+        return request.env["ir.http"]._check_identity(kwargs)
+
+    @http.route("/auth-timeout/send-totp-mail-code", type="jsonrpc", auth="user", check_identity=False)
+    def send_totp_mail_code(self):
+        """JSON route to trigger the sending of the TOTP code by email when requested by the user in the interface."""
+        self.env.user._send_totp_mail_code()

--- a/addons/auth_timeout/controllers/web_home.py
+++ b/addons/auth_timeout/controllers/web_home.py
@@ -1,0 +1,14 @@
+from odoo import http
+
+from odoo.addons.web.controllers import home as web_home
+
+
+class Home(web_home.Home):
+    # `/web/webclient/load_menus` must be `check_identity=False`
+    # because it is called in Javascript using a simple `fetch` rather than a `rpc(...)`
+    # within a QWeb template (see `web.webclient_bootstrap` in `webclient_templates.xml`).
+    # Only `rpc` is overriden to catch `CheckIdentityException` to display the screen lock dialog.
+    # `fetch` isn't and therefore raises an error upon receiving a `CheckIdentityException`.
+    @http.route(check_identity=False)
+    def web_load_menus(self, lang=None):
+        return super().web_load_menus(lang)

--- a/addons/auth_timeout/models/__init__.py
+++ b/addons/auth_timeout/models/__init__.py
@@ -1,0 +1,5 @@
+from . import auth_totp_device
+from . import ir_http
+from . import ir_websocket
+from . import res_groups
+from . import res_users

--- a/addons/auth_timeout/models/auth_totp_device.py
+++ b/addons/auth_timeout/models/auth_totp_device.py
@@ -1,0 +1,14 @@
+from odoo import models
+
+
+class AuthTotpDevice(models.Model):
+    _inherit = "auth_totp.device"
+
+    def _get_trusted_device_age(self):
+        age = super()._get_trusted_device_age()
+        user_lock_timeout_mfa = [
+            threshold for threshold, mfa in self.env.user._get_lock_timeouts().get("lock_timeout") if mfa
+        ]
+        if user_lock_timeout_mfa:
+            return min(age, *user_lock_timeout_mfa)
+        return age

--- a/addons/auth_timeout/models/ir_http.py
+++ b/addons/auth_timeout/models/ir_http.py
@@ -1,0 +1,245 @@
+import logging
+import re
+import time
+
+from odoo import api, models
+from odoo.http import request, root, SessionExpiredException
+
+
+class CheckIdentityException(SessionExpiredException):
+    """Exception raised when a user is requested to re-authenticate."""
+
+    # To log only with debug level in odoo/http.py Application.__call__
+    loglevel = logging.DEBUG
+
+
+class IrHttp(models.AbstractModel):
+    _inherit = "ir.http"
+
+    @classmethod
+    def _must_check_identity(cls):
+        """
+        Determine whether the current user session requires identity confirmation.
+
+        This method checks two timeout conditions:
+        - `lock_timeout`: maximum allowed session duration before re-authentication is required,
+        regardless of user activity.
+        - `lock_timeout_inactivity`: period of inactivity after which re-authentication is required.
+
+        It compares the current time to session timestamps and evaluates whether the thresholds have been exceeded:
+        - `lock_timeout` compares with the session timestamp `create_time`
+        - `lock_timeout_inactivity` compares with the session timestamp `identity-check-next`
+
+        :return: A dictionary describing the re-authentication requirement, or None if no check is needed.
+
+            Possible keys:
+            - "logout": True if a full logout is required
+            - "check_identity": True if an identity check is required
+            - "mfa": True if multi-factor authentication is required
+            - "1fa": previously used auth method, to avoid reuse as second factor
+
+        :rtype: dict or None
+        """
+        session = request.session
+        env = request.env(user=request.session.uid)
+        timeouts = env.user._get_lock_timeouts()
+        for timeout_type, reauth_type, session_key, session_key_default, first_timeout in [
+            ("lock_timeout", "logout", "create_time", 0, 0),
+            (
+                "lock_timeout_inactivity",
+                "check_identity",
+                "identity-check-next",
+                None,
+                timeouts["lock_timeout_inactivity"][0][0] if timeouts.get("lock_timeout_inactivity") else 0,
+            ),
+        ]:
+            for timeout, mfa in reversed(timeouts[timeout_type]):
+                threshold = time.time() - timeout
+                timestamp = session.get(session_key, session_key_default)
+                # Only the lowest inactivity timeout will set `identity-check-next` in the session
+                # Hence, an inactivity timeout with a greater timeout must reduce its timeout with the first timeout
+                # to get if its timeout is reached according to when `identity-check-next` was set at the lowest timeout
+                # It doesn't apply for `create_time`, which is set as soon as the session is created
+                if timestamp is not None and timestamp - first_timeout <= threshold:
+                    res = {reauth_type: True, "mfa": mfa}
+                    if mfa:
+                        first_fa = session.get("identity-check-1fa")
+                        if first_fa:
+                            timestamp_1fa, auth_method_1fa = first_fa
+                            if timestamp_1fa > threshold:
+                                res["1fa"] = auth_method_1fa
+                    return res
+
+    @classmethod
+    def _check_identity(cls, credential):
+        """
+        Verify the user's identity using the given credentials.
+
+        Handles both single and multi-factor authentication flows depending on the
+        current session state and configured timeout rules.
+
+        :param dict credential: A dictionary containing authentication data. Must include
+            a "type" key (e.g., "password", "totp", "webauthn"). If empty, the method
+            returns the list of available authentication methods.
+
+        :return: A dictionary indicating the outcome of the identity check:
+
+            - {"auth_methods": [...]} if no credential is provided,
+            - {"mfa": True, "auth_methods": [...]} if a second factor is required,
+            - None if re-authentication is complete.
+
+        :rtype: dict or None
+        """
+        check_identity = cls._must_check_identity() or {}
+        first_fa = check_identity.get("1fa")
+        user = request.env.user
+        auth_methods = user._get_auth_methods()
+        if not credential:
+            if first_fa and first_fa in auth_methods:
+                auth_methods.remove(first_fa)
+            return {"user_id": user.id, "login": user.login, "auth_methods": auth_methods}
+
+        if credential.get("type") in ("totp", "totp_mail"):
+            credential["token"] = int(re.sub(r"\s", "", credential["token"]))
+
+        auth = user._check_credentials(credential, {"interactive": True})
+
+        if first_fa and first_fa != auth["auth_method"]:
+            request.session.pop("identity-check-1fa")
+        elif auth["mfa"] != "skip" and len(auth_methods) > 1 and check_identity.get("mfa"):
+            request.session["identity-check-1fa"] = (time.time(), credential["type"])
+            auth_methods.remove(credential["type"])
+            return {"mfa": True, "auth_methods": auth_methods}
+
+        request.session.pop("identity-check-next", None)
+        request.session["identity-check-last"] = time.time()
+
+    def _set_session_inactivity(self, session, inactivity_period=0, force=False):
+        """
+        Set or clear the session's inactivity timeout flag.
+
+        This method is used to track user inactivity and determine when a session
+        should trigger re-authentication. It is called when presence data is received
+        through the websocket, either:
+
+        - because the web client, in Javascript, sent an event that the user is inactive
+        - because the websocket connection was closed (e.g., the user closed the browser,
+          the last tab to Odoo was closed, internet disconnection, ...)
+
+        :param Session session: The user's HTTP session object.
+        :param float inactivity_period: Duration of user inactivity in milliseconds.
+        :param bool force: If True, forcibly mark the session as inactive regardless of duration.
+            This is typically used when the WebSocket connection is closed (e.g., the user closes
+            their last browser tab), signaling that the user has gone away. The inactivity timeout
+            still applies in this case. If the user becomes active again (e.g., reopens the tab)
+            before the threshold is reached, the session will be considered active again,
+            and re-authentication will not be required.
+
+        :return: None
+        """
+        # inactivity_period sent by the js is in milliseconds
+        inactivity_period = inactivity_period / 1000
+        timeout = self.env.user._get_lock_timeout_inactivity()
+        inactive = timeout and (force or inactivity_period >= timeout)
+        if inactive:
+            next_check = time.time() + timeout - inactivity_period
+            if not session.get("identity-check-next") or next_check < session["identity-check-next"]:
+                session["identity-check-next"] = next_check
+                # Save manually, websocket requests do not save the session automatically
+                root.session_store.save(session)
+        elif not inactive and (timestamp := session.get("identity-check-next")) and timestamp > time.time():
+            session.pop("identity-check-next")
+            # Save manually, websocket requests do not save the session automatically
+            root.session_store.save(session)
+
+    @classmethod
+    def _authenticate(cls, endpoint):
+        """
+        Extend the standard `_authenticate` to enforce identity re-confirmation.
+
+        This method checks whether the current session requires identity confirmation due to timeout or inactivity.
+        If a logout is required, a `SessionExpiredException` is raised, which the client handles by redirecting
+        to the login page.
+        If a check identity is required, a `CheckIdentityException` is raised, which the client handles by showing the
+        re-authentication dialog.
+
+        :param endpoint: The HTTP route endpoint being accessed.
+        :type endpoint: werkzeug.routing.Rule
+
+        :raises CheckIdentityException: If the session requires identity re-confirmation.
+        :raises SessionExpiredException: If the session requires a full login.
+        :return: None
+        """
+        super()._authenticate(endpoint)
+        if endpoint.routing["auth"] == "user" and request.session.uid is not None:
+            if must_check_identity := cls._must_check_identity():
+                if must_check_identity.get("logout"):
+                    raise SessionExpiredException(f"User {request.session.uid} needs to login again")
+                elif endpoint.routing.get("check_identity", True) and must_check_identity.get("check_identity"):
+                    raise CheckIdentityException(f"User {request.session.uid} needs to confirm his identity")
+
+    @classmethod
+    def _handle_error(cls, exception):
+        """
+        Handle exceptions raised during request processing.
+
+        If the exception is a `CheckIdentityException` and the route is HTTP-based,
+        the user is redirected to the identity confirmation page. This ensures that
+        re-authentication can be completed before redirecting to the original request.
+
+        All other exceptions, e.g. `JSONRPC` calls, are handled by displaying the authentication form in a dialog
+        rather than a page.
+
+        :param Exception exception: The exception raised during request dispatch.
+        :return: An HTTP response for identity confirmation, or the default error response.
+        :rtype: werkzeug.wrappers.Response
+        """
+        if request.dispatcher.routing_type == "http" and isinstance(exception, CheckIdentityException):
+            response = request.redirect_query(
+                "/auth-timeout/check-identity", {"redirect": request.httprequest.full_path}
+            )
+            return response
+        return super()._handle_error(exception)
+
+    def _session_info_common_auth_timeout(self, session_info):
+        """
+        Add inactivity timeout metadata to the session info dictionary.
+
+        This method is used to include the user's applicable inactivity timeout
+        (in seconds) in the session information returned to the frontend. The
+        timeout is only added for authenticated (non-public) users.
+
+        :param dict session_info: The original session information dictionary.
+        :return: The updated session information with inactivity timeout (if applicable).
+        :rtype: dict
+        """
+        if not self.env.user._is_public() and (timeout := self.env.user._get_lock_timeout_inactivity()):
+            session_info["lock_timeout_inactivity"] = timeout
+        return session_info
+
+    def session_info(self):
+        """
+        Extend the backend session info with inactivity timeout metadata.
+
+        Adds the user's inactivity timeout (if applicable) to the session info
+        returned to the backend web client.
+
+        :return: The updated session information dictionary.
+        :rtype: dict
+        """
+        session_info = super().session_info()
+        return self._session_info_common_auth_timeout(session_info)
+
+    @api.model
+    def get_frontend_session_info(self):
+        """
+        Extend the frontend session info with inactivity timeout and user login.
+
+        dds the user's inactivity timeout (if applicable) to the session info
+        returned to the frontend web client.
+
+        :return: The updated session information dictionary.
+        :rtype: dict
+        """
+        session_info = super().get_frontend_session_info()
+        return self._session_info_common_auth_timeout(session_info)

--- a/addons/auth_timeout/models/ir_websocket.py
+++ b/addons/auth_timeout/models/ir_websocket.py
@@ -1,0 +1,39 @@
+from odoo import models
+from odoo.http import root
+from odoo.addons.bus.websocket import wsrequest
+
+
+class IrWebsocket(models.AbstractModel):
+    _inherit = "ir.websocket"
+
+    def _update_mail_presence(self, inactivity_period):
+        """
+        Override to track user inactivity via WebSocket presence updates.
+
+        This method extends the base `_update_mail_presence` to update the session's
+        inactivity state using the provided inactivity duration from the frontend.
+
+        :param float inactivity_period: Duration of user inactivity in milliseconds.
+        :return: None
+        """
+        self.env["ir.http"]._set_session_inactivity(wsrequest.session, inactivity_period)
+        super()._update_mail_presence(inactivity_period)
+
+    def _on_websocket_closed(self, cookies):
+        """
+        Override to mark the session as inactive when the WebSocket connection closes.
+
+        This ensures that the session is flagged for re-authentication if the user
+        closes their last tab, by forcing inactivity tracking when the connection is lost.
+
+        :param dict cookies: A dictionary containing the user's session ID cookie.
+        :return: None
+        """
+        if self.env.user:
+            session = root.session_store.get(cookies["session_id"])
+            if not session.is_new:
+                # `is_new` is a mitigation to avoid calls with arbitrary `session_id`
+                # which would create a new session file in the session filestore with an arbitrary name
+                # e.g. `env['ir.websocket']._on_websocket_closed({'session_id': 'A'*84})`
+                self.env["ir.http"]._set_session_inactivity(session, force=True)
+        super()._on_websocket_closed(cookies)

--- a/addons/auth_timeout/models/res_groups.py
+++ b/addons/auth_timeout/models/res_groups.py
@@ -1,0 +1,236 @@
+from odoo import api, fields, models
+from odoo.tools import ormcache
+
+CACHE_INVALIDATE_FIELDS = ("lock_timeout", "lock_timeout_mfa", "lock_timeout_inactivity", "lock_timeout_inactivity_mfa")
+
+
+def human_readable_delay(minutes):
+    if not minutes:
+        return minutes, "minutes"
+    if minutes % 1440 == 0:
+        return minutes // 1440, "days"
+    elif minutes % 60 == 0:
+        return minutes // 60, "hours"
+    else:
+        return minutes, "minutes"
+
+
+def human_readable_delay_to_minutes(delay, unit):
+    if unit == "days":
+        return delay * 1440
+    elif unit == "hours":
+        return delay * 60
+    else:
+        return delay
+
+
+DELAY_UNITS = [
+    ("minutes", "minutes"),
+    ("hours", "hours"),
+    ("days", "days"),
+]
+
+
+class ResGroups(models.Model):
+    _inherit = "res.groups"
+
+    lock_timeout = fields.Integer(
+        string="Session timeout",
+        help="Time interval (in minutes) after which re-authentication is required, regardless of inactivity.",
+    )
+
+    lock_timeout_mfa = fields.Boolean(
+        string="Require MFA on session timeout",
+        help="Enable two-factor authentication when the session timeout is reached.",
+    )
+
+    lock_timeout_inactivity = fields.Integer(
+        string="Inactivity timeout",
+        help="Time (in minutes) of user inactivity after which re-authentication is required.",
+    )
+
+    lock_timeout_inactivity_mfa = fields.Boolean(
+        string="Require MFA on inactivity timeout",
+        help="Enable two-factor authentication when the inactivity timeout is reached.",
+    )
+
+    # Technical fields for the user interface
+    has_lock_timeout = fields.Boolean(
+        help="Requires re-authentication after the user's last connection",
+        compute="_compute_has_lock_timeout",
+        readonly=False,
+    )
+    lock_timeout_delay_unit = fields.Selection(DELAY_UNITS, compute="_compute_lock_timeout_delay_unit", readonly=False)
+    lock_timeout_delay_in_unit = fields.Integer(compute="_compute_lock_timeout_delay_unit", readonly=False)
+    lock_timeout_2fa_selection = fields.Selection(
+        [("without_2fa", "Logout"), ("with_2fa", "Logout with two-factor authentication")],
+        compute="_compute_lock_timeout_2fa_selection",
+        inverse="_inverse_lock_timeout_2fa_selection",
+    )
+
+    has_lock_timeout_inactivity = fields.Boolean(
+        help="Requires re-authentication after a period of user inactivity",
+        compute="_compute_lock_timeout_inactivity_bool",
+        readonly=False,
+    )
+    lock_timeout_inactivity_delay_unit = fields.Selection(
+        DELAY_UNITS,
+        compute="_compute_lock_timeout_inactivity_delay_unit",
+        readonly=False,
+    )
+    lock_timeout_inactivity_delay_in_unit = fields.Integer(
+        compute="_compute_lock_timeout_inactivity_delay_unit",
+        readonly=False,
+    )
+    lock_timeout_inactivity_2fa_selection = fields.Selection(
+        [("without_2fa", "Screen lock"), ("with_2fa", "Screen lock with two-factor authentication")],
+        compute="_compute_lock_timeout_inactivity_2fa_selection",
+        inverse="_inverse_lock_timeout_inactivity_2fa_selection",
+    )
+
+    @api.depends("lock_timeout")
+    def _compute_has_lock_timeout(self):
+        for group in self:
+            group.has_lock_timeout = bool(group.lock_timeout)
+
+    @api.depends("lock_timeout")
+    def _compute_lock_timeout_delay_unit(self):
+        for group in self:
+            (
+                group.lock_timeout_delay_in_unit,
+                group.lock_timeout_delay_unit,
+            ) = human_readable_delay(group.lock_timeout)
+
+    @api.depends("lock_timeout_mfa")
+    def _compute_lock_timeout_2fa_selection(self):
+        for group in self:
+            group.lock_timeout_2fa_selection = "with_2fa" if group.lock_timeout_mfa else "without_2fa"
+
+    def _inverse_lock_timeout_2fa_selection(self):
+        for group in self:
+            group.lock_timeout_mfa = group.lock_timeout_2fa_selection == "with_2fa"
+
+    @api.depends("lock_timeout_inactivity")
+    def _compute_lock_timeout_inactivity_bool(self):
+        for group in self:
+            group.has_lock_timeout_inactivity = bool(group.lock_timeout_inactivity)
+
+    @api.depends("lock_timeout_inactivity")
+    def _compute_lock_timeout_inactivity_delay_unit(self):
+        for group in self:
+            (
+                group.lock_timeout_inactivity_delay_in_unit,
+                group.lock_timeout_inactivity_delay_unit,
+            ) = human_readable_delay(group.lock_timeout_inactivity)
+
+    @api.depends("lock_timeout_inactivity_mfa")
+    def _compute_lock_timeout_inactivity_2fa_selection(self):
+        for group in self:
+            group.lock_timeout_inactivity_2fa_selection = (
+                "with_2fa" if group.lock_timeout_inactivity_mfa else "without_2fa"
+            )
+
+    def _inverse_lock_timeout_inactivity_2fa_selection(self):
+        for group in self:
+            group.lock_timeout_inactivity_mfa = group.lock_timeout_inactivity_2fa_selection == "with_2fa"
+
+    @api.onchange("has_lock_timeout")
+    def _onchange_has_lock_timeout(self):
+        for group in self:
+            if not group.has_lock_timeout:
+                group.lock_timeout = False
+                group.lock_timeout_mfa = False
+            else:
+                group.lock_timeout = 1440  # 1 day by default
+                group.lock_timeout_mfa = True  # Require 2FA by default
+
+    @api.onchange("lock_timeout_delay_unit", "lock_timeout_delay_in_unit")
+    def _onchange_lock_timeout_delay_unit(self):
+        for group in self:
+            group.lock_timeout = human_readable_delay_to_minutes(
+                group.lock_timeout_delay_in_unit,
+                group.lock_timeout_delay_unit,
+            )
+
+    @api.onchange("has_lock_timeout_inactivity")
+    def _onchange_has_lock_timeout_inactivity(self):
+        for group in self:
+            if not group.has_lock_timeout_inactivity:
+                group.lock_timeout_inactivity = False
+                group.lock_timeout_inactivity_mfa = False
+            else:
+                group.lock_timeout_inactivity = 15  # 15 minutes by default
+                group.lock_timeout_inactivity_mfa = False  # Do not Require 2FA by default
+
+    @api.onchange("lock_timeout_inactivity_delay_unit", "lock_timeout_inactivity_delay_in_unit")
+    def _onchange_lock_timeout_inactivity_delay_unit(self):
+        for group in self:
+            group.lock_timeout_inactivity = human_readable_delay_to_minutes(
+                group.lock_timeout_inactivity_delay_in_unit,
+                group.lock_timeout_inactivity_delay_unit,
+            )
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        """Override to invalidate `_get_lock_timeouts` cache if timeout fields are set on creation."""
+        if any(field in vals for vals in vals_list for field in CACHE_INVALIDATE_FIELDS):
+            self.env.registry.clear_cache()
+        return super().create(vals_list)
+
+    def write(self, vals):
+        """Override to invalidate `_get_lock_timeouts` cache if timeout fields are updated."""
+        if any(field in vals for field in CACHE_INVALIDATE_FIELDS):
+            self.env.registry.clear_cache()
+        return super().write(vals)
+
+    def unlink(self):
+        """Override to invalidate `_get_lock_timeouts` cache if timeout fields exist on deleted records."""
+        if self.filtered(lambda r: any(r[field] for field in CACHE_INVALIDATE_FIELDS)):
+            self.env.registry.clear_cache()
+        return super().unlink()
+
+    @ormcache("self._ids")
+    def _get_lock_timeouts(self):
+        """
+        Compute the session and inactivity timeout settings for the user.
+
+        This method returns the shortest configured timeouts (in seconds) across all groups
+        implied by the user's group membership. For each type of timeout, it distinguishes
+        between those that require MFA and those that do not.
+
+        :return: A dictionary with timeout types as keys and a list of tuples as values.
+            Each tuple is of the form (timeout_in_seconds, requires_mfa), ordered from shortest to longest.
+
+            Example::
+
+                {
+                    'lock_timeout': [(43200, False), (86400, True)],
+                    'lock_timeout_inactivity': [(900, False)]
+                }
+
+        :rtype: dict
+        """
+        result = {}
+
+        for key, mfa_key in [
+            ("lock_timeout", "lock_timeout_mfa"),
+            ("lock_timeout_inactivity", "lock_timeout_inactivity_mfa"),
+        ]:
+            # `with_context({})` because
+            # - Same reasons than https://github.com/odoo/odoo/commit/7a0255665714f2c0129d04d4a3f14a3137c159f1
+            # - As this method is decorated with `@ormcache('self._ids')`, it cannot depend on the context
+            values = [(g[key], g[mfa_key]) for g in self.with_context({}).all_implied_ids if g[key]]
+            min_non_mfa = min((timeout for timeout, mfa in values if not mfa), default=None)
+            min_mfa = min((timeout for timeout, mfa in values if mfa), default=None)
+
+            result[key] = []
+
+            if min_mfa:
+                result[key].append((min_mfa * 60, True))
+            if min_non_mfa and (not min_mfa or min_non_mfa < min_mfa):
+                result[key].append((min_non_mfa * 60, False))
+
+            # Sort from lowest timeout to highest
+            result[key].sort()
+
+        return result

--- a/addons/auth_timeout/models/res_users.py
+++ b/addons/auth_timeout/models/res_users.py
@@ -1,0 +1,51 @@
+from odoo import models
+
+
+class ResUsers(models.Model):
+    _inherit = "res.users"
+
+    def _get_auth_methods(self):
+        """
+        Return the list of authentication methods available to the user.
+
+        This includes passkeys (WebAuthn), TOTP (app or mail), and password,
+        depending on the user's configured credentials and MFA policy.
+
+        :return: A list of enabled authentication method types (e.g., ["webauthn", "totp", "password"]).
+        :rtype: list[str]
+        """
+        self.ensure_one()
+        auth_methods = []
+        if self.auth_passkey_key_ids:
+            auth_methods.append("webauthn")
+        if mfa_type := self._mfa_type():
+            auth_methods.append(mfa_type)
+        auth_methods.append("password")
+        return auth_methods
+
+    def _get_lock_timeouts(self):
+        """
+        Return the user's configured session and inactivity timeouts.
+
+        Delegates to the group-level `_get_lock_timeouts`, using the user's group membership
+        to determine applicable timeout settings.
+
+        :return: A dictionary of timeout types and values, as defined by `_get_lock_timeouts` on groups.
+        :rtype: dict
+        """
+        self.ensure_one()
+        # Take advantage of the ormcache of `self._get_group_ids()` to get the user groups and avoid queries
+        return self.env["res.groups"].browse(self._get_group_ids())._get_lock_timeouts()
+
+    def _get_lock_timeout_inactivity(self):
+        """
+        Return the shortest applicable inactivity timeout for the user.
+
+        Extracts the first (i.e., shortest) timeout from the "lock_timeout_inactivity"
+        entry in the user's timeout configuration, if present.
+
+        :return: Inactivity timeout in seconds, or None if not configured.
+        :rtype: float or None
+        """
+        timeouts = self._get_lock_timeouts()
+        return timeouts.get("lock_timeout_inactivity")[0][0] if timeouts.get("lock_timeout_inactivity") else None

--- a/addons/auth_timeout/static/src/scss/auth_timeout.scss
+++ b/addons/auth_timeout/static/src/scss/auth_timeout.scss
@@ -1,0 +1,5 @@
+.oe_check_identity_form {
+    max-width: 600px;
+    position: relative;
+    margin: 50px auto;
+}

--- a/addons/auth_timeout/static/src/services/check_identity/check_identity.js
+++ b/addons/auth_timeout/static/src/services/check_identity/check_identity.js
@@ -1,0 +1,290 @@
+import { Component, EventBus, onWillDestroy, onWillStart, useState } from "@odoo/owl";
+import { Dialog } from "@web/core/dialog/dialog";
+import { rpc, RPCError } from "@web/core/network/rpc";
+import { registry } from "@web/core/registry";
+import { useService } from "@web/core/utils/hooks";
+import { redirect } from "@web/core/utils/urls";
+import { session } from "@web/session";
+
+import * as passkeyLib from "@auth_passkey/../lib/simplewebauthn";
+
+/**
+ * CheckIdentityForm component
+ *
+ * Displays a re-authentication form based on the user's available authentication methods.
+ * Handles form submission, errors, switching methods, and passkey (WebAuthn) flows.
+ *
+ * @class
+ * @extends Component
+ * @param {Object} props
+ * @param {string} [props.redirect] Optional redirect URL after successful re-authentication
+ * @param {Function} [props.close] Callback when the dialog is closed
+ */
+export class CheckIdentityForm extends Component {
+    static template = "auth_timeout.CheckIdentityForm";
+    static props = {
+        redirect: { type: String, optional: true },
+        close: { type: Function, optional: true },
+    };
+    static authMethodTemplates = {
+        password: {
+            form: "auth_timeout.CheckIdentityFormPassword",
+            linkString: "auth_timeout.CheckIdentityLinkStringPassword",
+        },
+        totp: {
+            form: "auth_timeout.CheckIdentityFormTOTP",
+            linkString: "auth_timeout.CheckIdentityLinkStringTOTP",
+        },
+        totp_mail: {
+            form: "auth_timeout.CheckIdentityFormTOTPMail",
+            linkString: "auth_timeout.CheckIdentityLinkStringTOTPMail",
+        },
+        webauthn: {
+            form: "auth_timeout.CheckIdentityFormWebAuthN",
+            linkString: "auth_timeout.CheckIdentityLinkStringWebAuthN",
+        },
+    };
+
+    async setup() {
+        this.checkIdentity = useService("check_identity");
+        this.checkIdentity.bus.trigger("start");
+        this.state = useState({
+            error: false,
+            authMethod: null,
+        });
+        onWillStart(async () => {
+            const data = await this.checkIdentity.getInitData();
+            this.user = {
+                userId: data.user_id,
+                name: data.login,
+            };
+            this.setAuthMethods(data.auth_methods);
+        });
+        onWillDestroy(() => {
+            this.checkIdentity.bus.trigger("stop");
+        });
+        this.checkIdentity.bus.addEventListener("identityChecked", () => {
+            this.close();
+        });
+    }
+
+    setAuthMethods(authMethods) {
+        this.authMethods = authMethods;
+        this.state.authMethod = this.authMethods[0];
+    }
+
+    getAuthMethodFormTemplate(authMethod) {
+        return CheckIdentityForm.authMethodTemplates[authMethod].form;
+    }
+
+    getAuthMethodLinkStringTemplate(authMethod) {
+        return CheckIdentityForm.authMethodTemplates[authMethod].linkString;
+    }
+
+    async onSubmit(ev) {
+        const form = ev.target;
+        if (form.querySelector('input[name="type"]').value === "webauthn") {
+            const serverOptions = await rpc("/auth/passkey/start-auth");
+            const auth = await passkeyLib.startAuthentication(serverOptions).catch((e) => console.log(e));
+            if (!auth) {
+                return false;
+            }
+            form.querySelector('input[name="webauthn_response"]').value = JSON.stringify(auth);
+        }
+        const formData = new FormData(form);
+        const formValues = Object.fromEntries(formData.entries());
+        try {
+            const result = await this.checkIdentity.check(formValues);
+            if (result?.mfa) {
+                this.setAuthMethods(result.auth_methods);
+            }
+        } catch (error) {
+            if (error.data) {
+                this.state.error = error.data.message;
+            } else {
+                this.state.error = "Your identity could not be confirmed";
+            }
+        }
+    }
+
+    close() {
+        if (this.props.close) {
+            this.props.close();
+        }
+        if (this.props.redirect) {
+            redirect(this.props.redirect);
+        }
+    }
+
+    async onChangeAuthMethod(ev) {
+        this.state.authMethod = ev.target.dataset.authMethod;
+        this.state.error = false;
+        if (this.state.authMethod == "totp_mail") {
+            try {
+                await rpc("/auth-timeout/send-totp-mail-code");
+            } catch (error) {
+                if (error.data) {
+                    this.state.error = error.data.message;
+                } else {
+                    this.state.error = "The code could not be sent by email";
+                }
+            }
+        }
+    }
+}
+
+/**
+ * CheckIdentityDialog component
+ *
+ * Wraps CheckIdentityForm in a modal dialog, used by the check_identity service.
+ *
+ * @class
+ * @extends Component
+ * @param {Object} props
+ * @param {Function} props.close Callback passed by the Dialog service to close the modal
+ */
+export class CheckIdentityDialog extends Component {
+    static template = "auth_timeout.CheckIdentityDialog";
+    static components = { Dialog, CheckIdentityForm };
+    static props = {
+        close: Function, // prop added by the Dialog service
+    };
+
+    setup() {
+        this.formProps = {
+            close: this.props.close,
+        };
+        this.env.dialogData.dismiss = () => {
+            redirect("/web/session/logout");
+        };
+    }
+}
+
+/**
+ * Check Identity Service
+ *
+ * Manages global identity check logic:
+ * - Listens for inactivity via presence service
+ * - Listens for `CheckIdentityException` errors from RPC
+ * - Displays dialog and synchronizes re-auth state across tabs
+ *
+ * @type {Object}
+ * @property {string[]} dependencies Services this one relies on: ["bus_service", "dialog", "presence"]
+ * @method start
+ * @param {Object} env OWL environment
+ * @param {Object} deps Injected services: bus_service, dialog, presence
+ * @returns {Object} Service interface with {channel, bus, run}
+ */
+export const checkIdentityService = {
+    dependencies: ["bus_service", "dialog", "presence"],
+    eventBus: new EventBus(),
+    /**
+     * Runs the identity check dialog if not already shown.
+     *
+     * Used by patched RPC calls and inactivity timers to ensure
+     * identity confirmation is enforced only once at a time.
+     *
+     * @returns {Promise<void>} Resolves when the user completes the check.
+     */
+    start(env, { bus_service, dialog, presence }) {
+        const channel = new BroadcastChannel("check_identity");
+        const bus = this.eventBus;
+        let started = false;
+        let inactivityTimer;
+
+        const check = async (credential) => {
+            const result = await rpc("/auth-timeout/session/check-identity", credential);
+            if (result?.mfa) {
+                return { success: false, mfa: result.mfa, auth_methods: result.auth_methods };
+            }
+            bus.trigger("identityChecked");
+            channel.postMessage("identityChecked");
+        };
+
+        const run = async () => {
+            if (!started) {
+                dialog.add(CheckIdentityDialog);
+            }
+            // Empty the current view, to not let any confidential data displayed
+            // not even inspecting the dom or through the console using Javascript.
+            env.services.action && env.bus.trigger("ACTION_MANAGER:UPDATE", {});
+            await new Promise((resolve) => {
+                checkIdentityService.eventBus.addEventListener("identityChecked", resolve, { once: true });
+            });
+            // Reload the view to display back the data that was displayed before.
+            env.services.action && env.services.action.doAction("soft_reload");
+        };
+
+        const getInitData = async () => {
+            return await rpc("/auth-timeout/session/check-identity");
+        };
+
+        bus.addEventListener("start", () => {
+            started = true;
+        });
+
+        bus.addEventListener("stop", () => {
+            started = false;
+        });
+
+        channel.addEventListener("message", (event) => {
+            if (event.data === "identityChecked") {
+                bus.trigger("identityChecked");
+            }
+        });
+
+        // Inactivity: Set a timer after which the check identity automatically appear.
+        if (session.lock_timeout_inactivity) {
+            // Start the bus to be able to send inactivities / presences
+            bus_service.start();
+            const updatePresence = () => {
+                bus_service.send("update_presence", { inactivity_period: presence.getInactivityPeriod() });
+            };
+            // Immediately send a presence on bus connect
+            bus_service.addEventListener("connect", () => updatePresence(), { once: true });
+            const startInactivityTimer = () => {
+                inactivityTimer = setTimeout(
+                    async () => {
+                        if (presence.getInactivityPeriod() >= session.lock_timeout_inactivity * 1000) {
+                            // Send the fact the user is away to the server.
+                            updatePresence();
+                            // Display the check identity dialog
+                            await run();
+                        }
+                        startInactivityTimer();
+                    },
+                    session.lock_timeout_inactivity * 1000 - presence.getInactivityPeriod(),
+                );
+            };
+
+            presence.bus.addEventListener("presence", () => {
+                if (!started) {
+                    clearTimeout(inactivityTimer);
+                    startInactivityTimer();
+                }
+            });
+
+            startInactivityTimer();
+        }
+
+        return {
+            bus,
+            check,
+            getInitData,
+            run,
+        };
+    },
+};
+
+const checkIdentityErrorHandler = (env, error, originalError) => {
+    if (originalError instanceof RPCError) {
+        if (originalError.data.name === "odoo.addons.auth_timeout.models.ir_http.CheckIdentityException") {
+            useService("check_identity").run();
+            return true;
+        }
+    }
+};
+
+registry.category("public_components").add("auth_timeout.check_identity_form", CheckIdentityForm);
+registry.category("services").add("check_identity", checkIdentityService);
+registry.category("error_handlers").add("checkIdentityErrorHandler", checkIdentityErrorHandler);

--- a/addons/auth_timeout/static/src/services/check_identity/check_identity.xml
+++ b/addons/auth_timeout/static/src/services/check_identity/check_identity.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+
+    <t t-name="auth_timeout.CheckIdentityDialog">
+        <Dialog title.translate="Confirm access" size="'md'" contentClass="'o_error_dialog'" footer="false">
+            <CheckIdentityForm t-props="formProps"/>
+        </Dialog>
+    </t>
+
+    <t t-name="auth_timeout.CheckIdentityForm">
+        <p role="alert" class="alert alert-danger" t-if="state.error" t-esc="state.error"/>
+        <div class="text-center border rounded mb-3 p-3">
+            <img t-attf-src="/web/image/res.users/{{user.userId}}/avatar_128" class="o_avatar rounded me-1"/>
+            Signed in as <strong t-out="user.name"/>
+        </div>
+        <div class="border rounded mb-3 p-3 bg-light">
+            <form t-att-id="state.authMethod" t-on-submit.prevent="onSubmit" class="o_check_identity_form">
+                <input type="hidden" name="type" t-att-value="state.authMethod"/>
+                <t t-call="{{ getAuthMethodFormTemplate(state.authMethod) }}"/>
+            </form>
+        </div>
+        <div t-if="authMethods.length > 1" class="border rounded mb-3 p-3">
+            <h6>Having problems ?</h6>
+            <ul>
+                <t t-foreach="authMethods" t-as="authMethod" t-key="authMethod_index">
+                    <li t-if="state.authMethod !== authMethod">
+                        <a href="#" t-on-click="onChangeAuthMethod" t-att-data-auth-method="authMethod">
+                            <t t-call="{{ getAuthMethodLinkStringTemplate(authMethod) }}"/>
+                        </a>
+                    </li>
+                </t>
+            </ul>
+        </div>
+    </t>
+
+    <!-- Password -->
+    <t t-name="auth_timeout.CheckIdentityFormPassword">
+        <input name="password" type="password" class="form-control" placeholder="Password"/>
+        <div class="text-end mb-3">
+            <a href="/web/reset_password">Forgot password?</a>
+        </div>
+        <div class="text-center d-grid">
+            <button type="submit" class="btn btn-primary">Confirm</button>
+        </div>
+    </t>
+    <t t-name="auth_timeout.CheckIdentityLinkStringPassword">Use your password</t>
+
+    <!-- TOTP Mail -->
+    <t t-name="auth_timeout.CheckIdentityFormTOTPMail">
+        <div class="text-center">
+            <i class="fa fa-3x fa-envelope" aria-hidden="true"/>
+            <h3>Authentication code via email</h3>
+        </div>
+        <div>
+            Enter below the six-digit authentication code just sent to your email
+        </div>
+        <input name="token" inputmode="numeric" pattern="[0-9]+" class="form-control" placeholder="XXXXXX"/>
+        <div class="text-center gap-1 d-grid mb-1 pt-3">
+            <button type="submit" class="btn btn-primary">Verify</button>
+        </div>
+    </t>
+    <t t-name="auth_timeout.CheckIdentityLinkStringTOTPMail">Use an authentication code sent by email</t>
+
+    <!-- TOTP App -->
+    <t t-name="auth_timeout.CheckIdentityFormTOTP">
+        <div class="text-center">
+            <i class="fa fa-3x fa-mobile" aria-hidden="true"/>
+            <h3>Authentication code</h3>
+        </div>
+        <input name="token" inputmode="numeric" pattern="[0-9]+" class="form-control" placeholder="XXXXXX"/>
+        <div class="text-center gap-1 d-grid mb-1 pt-3">
+            <button type="submit" class="btn btn-primary">Verify</button>
+        </div>
+        <div>
+            Open your two-factor authenticator (TOTP) app or browser extension to view your authentication code.
+        </div>
+    </t>
+    <t t-name="auth_timeout.CheckIdentityLinkStringTOTP">Use your authenticator app</t>
+
+    <!-- Passkey -->
+    <t t-name="auth_timeout.CheckIdentityFormWebAuthN">
+        <input type="hidden" name="webauthn_response"/>
+        <div class="text-center">
+            <i class="fa fa-3x fa-shield" aria-hidden="true"/>
+            <h3>Passkey</h3>
+        </div>
+        <div>
+            When you are ready, authenticate using the button below.
+        </div>
+        <div class="text-center gap-1 d-grid mb-1 pt-3">
+            <button type="submit" class="btn btn-primary">Use passkey</button>
+        </div>
+    </t>
+    <t t-name="auth_timeout.CheckIdentityLinkStringWebAuthN">Use your passkey</t>
+
+</templates>

--- a/addons/auth_timeout/static/tests/tours/auth_timeout_tour.js
+++ b/addons/auth_timeout/static/tests/tours/auth_timeout_tour.js
@@ -1,0 +1,210 @@
+import { registry } from "@web/core/registry";
+import { patch } from "@web/core/utils/patch";
+
+import * as passkeyLib from "@auth_passkey/../lib/simplewebauthn";
+
+async function testRPC() {
+    const response = await fetch("/web/session/check", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        credentials: "include",
+        body: JSON.stringify({ params: {} }),
+    });
+    return response.json();
+}
+
+let unpatchPasskeyMethod;
+const patchPasskey = {
+    trigger: "body",
+    run: function () {
+        unpatchPasskeyMethod = patch(passkeyLib, {
+            async startRegistration() {
+                return { id: "foo" };
+            },
+            async startAuthentication() {
+                return { id: "Zm9v" }; // bytes_to_base64url(b"foo") == "Zm9v"
+            },
+        });
+    },
+};
+const unpatchPasskey = {
+    trigger: "body",
+    run: function () {
+        unpatchPasskeyMethod();
+    },
+};
+
+async function retryUntil(predicate, errorMessage = "Condition not met after retries") {
+    for (let attempt = 0; attempt < 5; attempt++) {
+        const result = await testRPC();
+        if (predicate(result)) {
+            return;
+        }
+        await new Promise((r) => setTimeout(r, 1000));
+    }
+    throw new Error(errorMessage);
+}
+
+const assertCheckIdentityForm = {
+    content: "Asserts the check identity form is displayed",
+    trigger: "form.o_check_identity_form",
+};
+
+const assertRPC = {
+    content: "Asserts RPC is allowed",
+    trigger: "body",
+    run: async function () {
+        // Multiple attempts because the inactivity is sent through the websocket and there might be a slight delay
+        // between the moment the identity check form is displayed and the session is marked as inactive
+        // through the websocket.
+        await retryUntil((result) => !result?.error, "RPC was prevented unexpectedly");
+    },
+};
+
+const assertNoRPC = {
+    content: "Asserts RPC is prevented",
+    trigger: "body",
+    run: async function () {
+        await retryUntil(
+            (result) => result?.error?.data?.name === "odoo.addons.auth_timeout.models.ir_http.CheckIdentityException",
+            "RPC was allowed unexpectedly",
+        );
+    },
+};
+
+registry.category("web_tour.tours").add("auth_timeout_tour_lock_timeout_inactivity", {
+    url: "/odoo",
+    steps: () => [
+        // Check identity using a password
+        assertCheckIdentityForm,
+        assertNoRPC,
+        {
+            content: "Switch to password authentication",
+            trigger: 'a[data-auth-method="password"]',
+            run: "click",
+        },
+        {
+            content: "Enter the password",
+            trigger: "form#password input",
+            run: "edit foobarbaz",
+        },
+        {
+            content: "Confirm",
+            trigger: "form#password button",
+            run: "click",
+        },
+        assertRPC,
+
+        // Check identity using a TOTP by app
+        assertCheckIdentityForm,
+        assertNoRPC,
+        {
+            content: "Switch to TOTP authentication",
+            trigger: 'a[data-auth-method="totp"]',
+            run: "click",
+        },
+        {
+            content: "Enter the TOTP from authenticator app",
+            trigger: "form#totp input",
+            run: "edit 111111",
+        },
+        {
+            content: "Confirm",
+            trigger: "form#totp button",
+            run: "click",
+        },
+        assertRPC,
+
+        // Check identity using a passkey
+        assertCheckIdentityForm,
+        assertNoRPC,
+        patchPasskey,
+        {
+            content: "Click Use passkey",
+            trigger: "form#webauthn button",
+            run: "click",
+        },
+        unpatchPasskey,
+        assertRPC,
+    ],
+});
+
+registry.category("web_tour.tours").add("auth_timeout_tour_lock_timeout_inactivity_2fa", {
+    url: "/odoo",
+    steps: () => [
+        // Check identity using a passkey, which is 2FA by itself, and check an RPC call works
+        assertCheckIdentityForm,
+        assertNoRPC,
+        patchPasskey,
+        {
+            content: "Click Use passkey",
+            trigger: "form#webauthn button",
+            run: "click",
+        },
+        unpatchPasskey,
+        assertRPC,
+
+        // Check identity using a password + TOTP for 2FA
+        assertCheckIdentityForm,
+        assertNoRPC,
+        {
+            content: "Switch to password authentication",
+            trigger: 'a[data-auth-method="password"]',
+            run: "click",
+        },
+        {
+            content: "Fill the password",
+            trigger: "form#password input",
+            run: "edit foobarbaz",
+        },
+        {
+            content: "Confirm",
+            trigger: "form#password button",
+            run: "click",
+        },
+        assertNoRPC,
+        assertCheckIdentityForm,
+        {
+            content: "The default authentication, passkey, should be displayed following entering the password",
+            trigger: "form#webauthn button",
+        },
+        {
+            content: "Password should not be suggested as 2FA because it was used as first authentication factor",
+            trigger: ':not(a[data-auth-method="password"])',
+        },
+        {
+            content: "Switch to totp authentication",
+            trigger: 'a[data-auth-method="totp"]',
+            run: "click",
+        },
+        {
+            content: "Fill the TOTP code",
+            trigger: "form#totp input",
+            run: "edit 111111",
+        },
+        {
+            content: "Confirm",
+            trigger: "form#totp button",
+            run: "click",
+        },
+        assertRPC,
+    ],
+});
+
+registry.category("web_tour.tours").add("auth_timeout_tour_lock_timeout", {
+    url: "/odoo",
+    steps: () => [
+        {
+            content: "Wait 1 second, to reach the session timeout set to 1 second",
+            trigger: "body",
+            run: async function () {
+                await new Promise((r) => setTimeout(r, 1000));
+                await testRPC();
+            },
+        },
+        {
+            content: "The session expired dialog should appear, click the close button to be redirected to the login",
+            trigger: ".modal-dialog:has(.modal-title:contains('Session Expired')) footer .btn:contains('Close')",
+        },
+    ],
+});

--- a/addons/auth_timeout/tests/__init__.py
+++ b/addons/auth_timeout/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_auth_timeout

--- a/addons/auth_timeout/tests/test_auth_timeout.py
+++ b/addons/auth_timeout/tests/test_auth_timeout.py
@@ -1,0 +1,568 @@
+import json
+import lxml.html
+import time
+
+import odoo.http
+
+from datetime import datetime, timedelta
+from unittest.mock import patch
+
+from odoo.tests import HttpCase, new_test_user, tagged, TransactionCase
+from odoo.tests.common import HOST
+
+from odoo.addons.auth_totp.models.totp import TOTP
+from odoo.addons.auth_totp.controllers.home import TRUSTED_DEVICE_COOKIE
+
+
+class TestAuthTimeout(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.user = new_test_user(cls.env, "foo", groups="base.group_user,base.group_erp_manager,base.group_system")
+
+    def test_user_auth_methods(self):
+        # By default the only authentication method of the user is the password
+        self.assertEqual(self.user._get_auth_methods(), ["password"])
+
+        # Enforce TOTP by mail, it adds TOTP by email as possible authentication method
+        config = self.env["res.config.settings"].create({})
+        config.auth_totp_enforce = True
+        config.auth_totp_policy = "employee_required"
+        config.execute()
+        self.assertEqual(self.user._get_auth_methods(), ["totp_mail", "password"])
+
+        # Set a TOTP secret, it replaces TOTP by email to TOTP by app
+        self.user.totp_secret = "foo"
+        self.assertEqual(self.user._get_auth_methods(), ["totp", "password"])
+
+        # Set a passkey, it adds WebAuthN as possible authentication method
+        self.env["auth.passkey.key"].create(
+            {
+                "name": "foo",
+                "credential_identifier": "foo",
+                "public_key": "foo",
+                "create_uid": self.user.id,
+            }
+        )
+        self.assertEqual(self.user._get_auth_methods(), ["webauthn", "totp", "password"])
+
+    def test_user_lock_timeouts(self):
+        group1, group2, group3 = self.user.group_ids[:3]
+
+        # Set
+        # - 15 mins session inactivity timeout,
+        # - 24 hours re-authenticate interval, with required MFA
+        group1.lock_timeout_inactivity = 15
+        group1.lock_timeout = 24 * 60
+        group1.lock_timeout_mfa = True
+        self.assertEqual(
+            self.user._get_lock_timeouts(),
+            {
+                "lock_timeout": [(86400, True)],
+                "lock_timeout_inactivity": [(900, False)],
+            },
+        )
+
+        # Adding a higher inactivity timeout on another group: No change, the lowest inactivity timeout stays 15 mins
+        group2.lock_timeout_inactivity = 60  # 1h
+        self.assertEqual(
+            self.user._get_lock_timeouts(),
+            {
+                "lock_timeout": [(86400, True)],
+                "lock_timeout_inactivity": [(900, False)],
+            },
+        )
+
+        # But then require MFA after 1 hour of inactivity
+        # Then, the lowest inactivity timeout without MFA stays 15 mins, but with MFA becomes 1h
+        group2.lock_timeout_inactivity_mfa = True
+        self.assertEqual(
+            self.user._get_lock_timeouts(),
+            {
+                "lock_timeout": [(86400, True)],
+                "lock_timeout_inactivity": [(900, False), (3600, True)],
+            },
+        )
+
+        # Then make it shorter than the 15 mins inactivity timeout
+        # No need to specify the 15 mins timeout without MFA as now there is one shorter requiring MFA
+        group2.lock_timeout_inactivity = 6
+        self.assertEqual(
+            self.user._get_lock_timeouts(),
+            {
+                "lock_timeout": [(86400, True)],
+                "lock_timeout_inactivity": [(360, True)],
+            },
+        )
+
+        # Adding a higher re-authenticate interval on another group: No change, the lowest stays 1 hour
+        group2.lock_timeout = 48 * 60
+        group2.lock_timeout_mfa = True
+        self.assertEqual(
+            self.user._get_lock_timeouts(),
+            {
+                "lock_timeout": [(86400, True)],
+                "lock_timeout_inactivity": [(360, True)],
+            },
+        )
+
+        # Make it shorter, 12 hours instead of the other group with 24 hours
+        # Then the lowest lock timeout becomes 12
+        group2.lock_timeout = 12 * 60
+        self.assertEqual(
+            self.user._get_lock_timeouts(),
+            {
+                "lock_timeout": [(43200, True)],
+                "lock_timeout_inactivity": [(360, True)],
+            },
+        )
+
+        # Do not ask for MFA for this group.
+        # Then the lowest lock timeout without MFA is 12 and with MFA is 24 hours
+        group2.lock_timeout_mfa = False
+        self.assertEqual(
+            self.user._get_lock_timeouts(),
+            {
+                "lock_timeout": [(43200, False), (86400, True)],
+                "lock_timeout_inactivity": [(360, True)],
+            },
+        )
+
+        # For the sake, more tests with a 3rd group
+        # Set a lock timeout after 18 hours without MFA,
+        # which is between the one at 12 hours without MFA and the one at 24 hours with MFA.
+        # No change, as it's without MFA and higher than the one set for 12 hours without MFA.
+        group3.lock_timeout = 18 * 60
+        self.assertEqual(
+            self.user._get_lock_timeouts(),
+            {
+                "lock_timeout": [(43200, False), (86400, True)],
+                "lock_timeout_inactivity": [(360, True)],
+            },
+        )
+
+        # Require MFA for this 18 hours lock timeout
+        # Change: The minimum lock timeout with MFA becomes 18 hours instead of 24 hours
+        group3.lock_timeout_mfa = True
+        self.assertEqual(
+            self.user._get_lock_timeouts(),
+            {
+                "lock_timeout": [(43200, False), (64800, True)],
+                "lock_timeout_inactivity": [(360, True)],
+            },
+        )
+
+        # Make it even shorter than the 12 hours without MFA, let's say 6 hours
+        # Change: As the lowest lock timeout now becomes 6 hours, and require MFA, no need to specify the others
+        group3.lock_timeout = 6 * 60
+        self.assertEqual(
+            self.user._get_lock_timeouts(),
+            {
+                "lock_timeout": [(21600, True)],
+                "lock_timeout_inactivity": [(360, True)],
+            },
+        )
+
+        # Set an inactivity timeout shorter than the one at 6 minutes
+        # Change: The lowest inactivity timeout without MFA becomes 180 seconds
+        group3.lock_timeout_inactivity = 3
+        self.assertEqual(
+            self.user._get_lock_timeouts(),
+            {
+                "lock_timeout": [(21600, True)],
+                "lock_timeout_inactivity": [(180, False), (360, True)],
+            },
+        )
+
+        # Require MFA for this 180 seconds inactivity timeout
+        # Change: The lowest inactivity timeout becomes 180, with or without MFA
+        group3.lock_timeout_inactivity_mfa = True
+        self.assertEqual(
+            self.user._get_lock_timeouts(),
+            {
+                "lock_timeout": [(21600, True)],
+                "lock_timeout_inactivity": [(180, True)],
+            },
+        )
+
+
+@tagged("post_install", "-at_install")
+class TestAuthTimeoutHttp(HttpCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.user = new_test_user(
+            cls.env, "foobarbaz", groups="base.group_user,base.group_erp_manager,base.group_system"
+        )
+
+        # Mock TOTP.match to make the code 111111 always valid.
+        # It will be used during the tour for authentication using TOTP by email and TOTP by app.
+        cls.totp_code = 111111
+        cls.totp_counter = 0
+        origin_totp_match = TOTP.match
+
+        def match(self, code, *args, **kwargs):
+            if code == cls.totp_code:
+                cls.totp_counter += 1
+                return cls.totp_counter
+            return origin_totp_match(self, code, *args, **kwargs)
+
+        cls.classPatch(TOTP, "match", match)
+
+        # Mock auth.passkey.key._verify_registration_options to accept the hard-coded registration during the tour
+        cls.passkey_credential_id = "foo"
+        cls.passkey_credential_id_base64url = "Zm9v"  # bytes_to_base64url(b"foo") == "Zm9v"
+        PasskeyClass = cls.env.registry["auth.passkey.key"]
+        origin_passkey_verify_registration_options = PasskeyClass._verify_registration_options
+
+        def _verify_registration_options(self, registration):
+            if registration.get("id") == cls.passkey_credential_id:
+                return {
+                    "credential_id": cls.passkey_credential_id.encode(),
+                    "credential_public_key": cls.passkey_credential_id.encode(),
+                }
+            return origin_passkey_verify_registration_options(self, registration)
+
+        cls.classPatch(PasskeyClass, "_verify_registration_options", _verify_registration_options)
+
+        # Mock auth.passkey.key._verify_auth to accept the hard-coded authentication during the tour
+        origin_passkey_verify_auth = PasskeyClass._verify_auth
+
+        def _verify_auth(self, auth, public_key, sign_count):
+            if auth.get("id") == cls.passkey_credential_id_base64url:  # bytes_to_base64url(b"foo") == "Zm9v"
+                return 1
+            return origin_passkey_verify_auth(self, auth, public_key, sign_count)
+
+        cls.classPatch(PasskeyClass, "_verify_auth", _verify_auth)
+
+    def rpc(self, model, method, *args, **kwargs):
+        return self.url_open(
+            "/web/dataset/call_kw", json={"params": {"model": model, "method": method, "args": args, "kwargs": kwargs}}
+        ).json()
+
+    def set_session_create_time(self, session_id, timestamp):
+        session = odoo.http.root.session_store.get(session_id)
+        session["create_time"] = timestamp
+        odoo.http.root.session_store.save(session)
+
+    def set_session_last_check_identity(self, session_id, timestamp):
+        session = odoo.http.root.session_store.get(session_id)
+        session["identity-check-last"] = timestamp
+        odoo.http.root.session_store.save(session)
+
+    def set_session_next_check_identity(self, session_id, timestamp):
+        session = odoo.http.root.session_store.get(session_id)
+        session["identity-check-next"] = timestamp
+        odoo.http.root.session_store.save(session)
+
+    def set_auth_totp_mail(self):
+        config = self.env["res.config.settings"].create({})
+        config.auth_totp_enforce = True
+        config.auth_totp_policy = "employee_required"
+        config.execute()
+
+    def set_auth_totp(self):
+        action = self.rpc("res.users", "action_totp_enable_wizard", [self.user.id])["result"]
+        self.rpc(action["res_model"], "enable", [action["res_id"]], context={"code": str(self.totp_code)})
+
+    def set_auth_passkey(self):
+        wizard_id = self.rpc("auth.passkey.key.create", "create", {"name": "foo"})["result"]
+        self.rpc("auth.passkey.key.create", "make_key", wizard_id, {"id": self.passkey_credential_id})
+
+    def check_identity(self, credentials):
+        return self.url_open("/auth-timeout/session/check-identity", json={"params": credentials})
+
+    def assertMustCheckIdentity(self):
+        result = self.rpc("res.users", "read", [self.user.id], ["login"])
+        self.assertEqual(
+            result.get("error", {}).get("data", {}).get("name"),
+            "odoo.addons.auth_timeout.models.ir_http.CheckIdentityException",
+        )
+
+    def assertSessionExpired(self):
+        result = self.rpc("res.users", "read", [self.user.id], ["login"])
+        self.assertEqual(result.get("error", {}).get("data", {}).get("name"), "odoo.http.SessionExpiredException")
+
+    def assertMustNotCheckIdentity(self):
+        result = self.rpc("res.users", "read", [self.user.id], ["login"])
+        self.assertTrue(result.get("result"))
+
+    def test_check_identity_exception(self):
+        group = self.user.group_ids[0]
+        session_id = self.authenticate(self.user.login, self.user.login).sid
+
+        # Set an activity timeout and simulate an inactivity in the session
+        group.lock_timeout_inactivity = 15  # 15 mins
+        self.set_session_next_check_identity(session_id, time.time())
+
+        # Check identity must be checked
+        self.assertMustCheckIdentity()
+
+        # Check the identity
+        self.check_identity({"type": "password", "password": self.user.login})
+
+        # Check identity must no longer be checked
+        self.assertMustNotCheckIdentity()
+
+        # Set a lock timeout and simulate the user did not authenticate for 24+ hours
+        group.lock_timeout = 24 * 60
+        self.set_session_create_time(session_id, time.time() - 25 * 60 * 60)  # 25 hours
+
+        # Check a full login is required
+        self.assertSessionExpired()
+
+    def test_authentication_methods(self):
+        group = self.user.group_ids[0]
+        group.lock_timeout_inactivity = 15  # 15 mins
+
+        session_id = self.authenticate(self.user.login, self.user.login).sid
+        # To avoid the check identity wizard during the configuration of TOTP, ...
+        self.set_session_last_check_identity(session_id, time.time())
+
+        # 1. Password authentication
+        self.set_session_next_check_identity(session_id, time.time() - 16 * 60)
+        self.assertMustCheckIdentity()
+        self.check_identity({"type": "password", "password": self.user.login})
+        self.assertMustNotCheckIdentity()
+
+        # 2. TOTP by email
+        # 2.1 Enable TOTP by mail
+        self.set_auth_totp_mail()
+        # 2.2 Identify using TOTP by email
+        self.set_session_next_check_identity(session_id, time.time() - 16 * 60)
+        self.assertMustCheckIdentity()
+        self.check_identity({"type": "totp_mail", "token": str(self.totp_code)})
+        self.assertMustNotCheckIdentity()
+
+        # 3. TOTP by app
+        self.set_auth_totp()
+        # 3.2 Identify using TOTP by code
+        self.set_session_next_check_identity(session_id, time.time() - 16 * 60)
+        self.assertMustCheckIdentity()
+        self.check_identity({"type": "totp", "token": str(self.totp_code)})
+        self.assertMustNotCheckIdentity()
+
+        # 4. Passkey
+        # 4.1 Registration of the passkey
+        self.set_auth_passkey()
+
+        # 4.2 Identify using a passkey
+        self.set_session_next_check_identity(session_id, time.time() - 16 * 60)
+        self.assertMustCheckIdentity()
+        self.check_identity(
+            {"type": "webauthn", "webauthn_response": json.dumps({"id": self.passkey_credential_id_base64url})}
+        )
+        self.assertMustNotCheckIdentity()
+
+    def test_multiple_lock_timeouts_mfa(self):
+        group1, group2 = self.user.group_ids[:2]
+
+        # Set 2 lock timeouts, one at 15 mins without MFA and one at 60 mins with MFA
+        group1.lock_timeout_inactivity = 15
+        group1.lock_timeout_inactivity_mfa = False
+        group2.lock_timeout_inactivity = 60
+        group2.lock_timeout_inactivity_mfa = True
+
+        # Enforce TOTP by mail so the user has a 2FA
+        config = self.env["res.config.settings"].create({})
+        config.auth_totp_enforce = True
+        config.auth_totp_policy = "employee_required"
+        config.execute()
+
+        session_id = self.authenticate(self.user.login, self.user.login).sid
+
+        # Simulate the session did not authenticate for 30 minutes
+        # Which falls between the 15 mins lock timeout without MFA
+        # and the 60 mins lock timeout with MFA
+        self.set_session_next_check_identity(session_id, time.time() - 30 * 60)
+
+        # Assert the check identity exception is raised
+        self.assertMustCheckIdentity()
+
+        # Check the identity
+        self.check_identity({"type": "password", "password": self.user.login})
+
+        # Check identity must no longer be checked
+        self.assertMustNotCheckIdentity()
+
+        # Simulate the session did not authenticate for 90 mins
+        # Which is greather than the 60 mins lock timeout with MFA
+        self.set_session_next_check_identity(session_id, time.time() - 90 * 60)
+
+        # Assert the check identity exception is raised
+        self.assertMustCheckIdentity()
+
+        # Check the identity with password
+        self.check_identity({"type": "password", "password": self.user.login})
+
+        # Assert the check identity exception is raised as it requires 2FA in addition to just password
+        self.assertMustCheckIdentity()
+
+        # Try to use password again to check identity,
+        # which must not work as password cannot be used as 2FA when it was used as 1st authentication
+        self.check_identity({"type": "password", "password": self.user.login})
+
+        # Assert identity check is still raised because it requires 2FA
+        self.assertMustCheckIdentity()
+
+        # Check the identity with TOTP code as 2FA
+        self.check_identity({"type": "totp_mail", "token": self.user._get_totp_mail_code()[0]})
+
+        # Check identity must no longer be checked
+        self.assertMustNotCheckIdentity()
+
+    def test_multiple_inactivity_timeouts_mfa(self):
+        group1, group2 = self.user.group_ids[:2]
+
+        # Set 2 inactivity timeouts, one at 15 mins without MFA and one at 30 mins with MFA
+        group1.lock_timeout_inactivity = 15  # 15 mins
+        group1.lock_timeout_inactivity_mfa = False
+        group2.lock_timeout_inactivity = 30  # 30 mins
+        group2.lock_timeout_inactivity_mfa = True
+
+        # Enforce TOTP by mail so the user has a 2FA
+        config = self.env["res.config.settings"].create({})
+        config.auth_totp_enforce = True
+        config.auth_totp_policy = "employee_required"
+        config.execute()
+
+        session_id = self.authenticate(self.user.login, self.user.login).sid
+
+        # Simulate the session as inactive for 25 mins.
+        # `identity-check-next` is set to `now` only when the first inactivity timeout is reached.
+        # By setting to `identity-check-next` to 10 mins in the past,
+        # it means the session is inactive for the first inactivity timeout + 10 mins
+        # As the lowest inactivity timeout is configured to 15 mins above in this test
+        # Setting `identity-check-next` to `now` - 10 mins means the session is inactive for 25 mins
+        # Which falls between the timeout without mfa of 15 mins and the timeout with mfa of 30 mins
+        self.set_session_next_check_identity(session_id, time.time() - 10 * 60)
+
+        # Assert the check identity exception is raised
+        self.assertMustCheckIdentity()
+
+        # Check the identity
+        self.check_identity({"type": "password", "password": self.user.login})
+
+        # Check identity must no longer be checked
+        self.assertMustNotCheckIdentity()
+
+        # Now, simulate the session inactive for more than 31 minutes,
+        # by setting to `identity-check-next` to 16 mins in the past:
+        # 15 mins (lowest inactivity timeout configured above) + 16 mins = 31 mins of inactivity.
+        # As it's greater than the 30 mins inactivity tiemout requiring MFA, MFA is required to check the identity
+        self.set_session_next_check_identity(session_id, time.time() - 16 * 60)
+
+        # Assert the check identity exception is raised
+        self.assertMustCheckIdentity()
+
+        # Check the identity with password first
+        self.check_identity({"type": "password", "password": self.user.login})
+
+        # Assert identity check is still raised because it requires 2FA
+        self.assertMustCheckIdentity()
+
+        # Try to use password again to check identity,
+        # which must not work as password cannot be used as 2FA when it was used as 1st authentication
+        self.check_identity({"type": "password", "password": self.user.login})
+
+        # Assert identity check is still raised because it requires 2FA
+        self.assertMustCheckIdentity()
+
+        # Check the identity with TOTP code as 2FA
+        self.check_identity({"type": "totp_mail", "token": self.user._get_totp_mail_code()[0]})
+
+        # Check identity must no longer be checked
+        self.assertMustNotCheckIdentity()
+
+    def test_remember_device(self):
+        # 1. Set a session timeout with MFA lower than the default device age
+        group = self.user.group_ids[0]
+        group.lock_timeout = 24 * 60
+        group.lock_timeout_mfa = True
+
+        # 2. Connect and set a TOTP for the user
+        session_id = self.authenticate(self.user.login, self.user.login).sid
+        self.set_session_last_check_identity(session_id, time.time())
+        self.set_auth_totp()
+
+        # 3. Disconnect
+        self.opener.cookies.clear()
+        del self.session
+
+        # 4. Login again with totp
+        csrf_token = (
+            lxml.html.fromstring(self.url_open("/web/login").content).xpath('//input[@name="csrf_token"]')[0].get("value")
+        )
+        res = self.url_open(
+            "/web/login",
+            data={
+                "login": self.user.login,
+                "password": self.user.login,
+                "csrf_token": csrf_token,
+            },
+        )
+        self.assertIn("/web/login/totp", res.url)
+        csrf_token = lxml.html.fromstring(res.content).xpath('//input[@name="csrf_token"]')[0].get("value")
+        res = self.url_open(
+            "/web/login/totp",
+            data={
+                "totp_token": self.totp_code,
+                "remember": True,
+                "csrf_token": csrf_token,
+            },
+            headers={
+                "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/121.0.0.0 Safari/537.36"
+            },
+        )
+
+        # 5. Assert the expiration date of the cookie
+        expires = datetime.fromtimestamp(self.opener.cookies._cookies[HOST]["/"][TRUSTED_DEVICE_COOKIE].expires)
+        # Expiration date in less than 1 day
+        self.assertLessEqual(expires, datetime.now() + timedelta(seconds=group.lock_timeout * 60))
+        # Expiration date in more than 1 day - 1 minute
+        self.assertGreater(expires, datetime.now() + timedelta(seconds=group.lock_timeout * 60 - 60))
+
+        # 6. Assert the expiration date of the device in database
+        device = self.env["auth_totp.device"].search([("user_id", "=", self.user.id)], order="id DESC", limit=1)
+        self.assertLessEqual(device.expiration_date, datetime.now() + timedelta(seconds=group.lock_timeout * 60))
+        self.assertGreater(device.expiration_date, datetime.now() + timedelta(seconds=group.lock_timeout * 60 - 60))
+
+    def test_auth_timeout_tour(self):
+        session_id = self.authenticate(self.user.login, self.user.login).sid
+        # To avoid the check identity wizard during the configuration of TOTP, ...
+        self.set_session_last_check_identity(session_id, time.time())
+        self.set_auth_totp_mail()
+        self.set_auth_totp()
+        self.set_auth_passkey()
+
+        # Set a 1 second inactivity timeout, with a mock patch because the field `lock_timeout` is in minutes.
+        with patch.object(
+            self.env.registry["res.groups"],
+            "_get_lock_timeouts",
+            return_value={
+                "lock_timeout": [],
+                "lock_timeout_inactivity": [(1, False)],  # 1 second inactivity without MFA
+            },
+        ):
+            self.start_tour("/odoo", "auth_timeout_tour_lock_timeout_inactivity", login=self.user.login)
+
+        # Set a 1 second inactivity timeout with 2fa, with a mock patch because the field `lock_timeout` is in minutes.
+        with patch.object(
+            self.env.registry["res.groups"],
+            "_get_lock_timeouts",
+            return_value={
+                "lock_timeout": [],
+                "lock_timeout_inactivity": [(1, True)],  # 1 second inactivity with MFA
+            },
+        ):
+            self.start_tour("/odoo", "auth_timeout_tour_lock_timeout_inactivity_2fa", login=self.user.login)
+
+        with patch.object(
+            self.env.registry["res.groups"],
+            "_get_lock_timeouts",
+            return_value={
+                "lock_timeout": [(1, True)],  # 1 second session timeout
+                "lock_timeout_inactivity": [],
+            },
+        ):
+            self.start_tour("/odoo", "auth_timeout_tour_lock_timeout", login=self.user.login)

--- a/addons/auth_timeout/views/login_templates.xml
+++ b/addons/auth_timeout/views/login_templates.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <template id="check_identity" name="Check Identity">
+        <t t-call="web.login_layout">
+            <div class="oe_check_identity_form">
+                <div class="text-center">
+                    <img t-attf-src="/logo.png?company={{ request.env.company.id }}" style="padding: 0px; margin: 0px; height: auto; height: 48px;" t-att-alt="request.env.company.name"/>
+                    <h3>Confirm access</h3>
+                </div>
+                <owl-component name="auth_timeout.check_identity_form" t-att-props="json.dumps({'redirect': redirect})"/>
+            </div>
+        </t>
+    </template>
+</odoo>

--- a/addons/auth_timeout/views/res_groups_views.xml
+++ b/addons/auth_timeout/views/res_groups_views.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record model="ir.ui.view" id="auth_passkey_groups_form">
+        <field name="name">auth.passkey.groups.form</field>
+        <field name="model">res.groups</field>
+        <field name="inherit_id" ref="base.view_groups_form"/>
+        <field name="arch" type="xml">
+            <notebook position="inside">
+                <page string="Timeouts">
+                    <group>
+                    <label for="has_lock_timeout_inactivity" string="Inactivity"/>
+                        <div class="d-flex flex-row gap-2">
+                            <field name="has_lock_timeout_inactivity"/>
+                            <div invisible="not has_lock_timeout_inactivity">
+                                <field name="lock_timeout_inactivity" invisible="True"/><!-- for onchanges `_onchange_has_lock_timeout_inactivity`, `_onchange_lock_timeout_inactivity_delay_unit` -->
+                                <field name="lock_timeout_inactivity_2fa_selection" class="oe_inline"/>
+                                after
+                                <field name="lock_timeout_inactivity_delay_in_unit" class="oe_inline o_input_4ch"/>
+                                <field name="lock_timeout_inactivity_delay_unit" class="oe_inline"/>
+                                of inactivity
+                            </div>
+                        </div>
+                        <label for="has_lock_timeout" string="Session"/>
+                        <div class="d-flex flex-row gap-2">
+                            <field name="has_lock_timeout"/>
+                            <div invisible="not has_lock_timeout">
+                                <field name="lock_timeout" invisible="True"/><!-- for onchanges `_onchange_has_lock_timeout`, `_onchange_lock_timeout_delay_unit` -->
+                                <field name="lock_timeout_2fa_selection" class="oe_inline"/>
+                                every
+                                <field name="lock_timeout_delay_in_unit" class="oe_inline o_input_4ch"/>
+                                <field name="lock_timeout_delay_unit" class="oe_inline"/>
+                            </div>
+                        </div>
+                    </group>
+                </page>
+            </notebook>
+        </field>
+    </record>
+</odoo>

--- a/odoo/addons/base/models/res_users.py
+++ b/odoo/addons/base/models/res_users.py
@@ -1088,7 +1088,9 @@ class ResUsers(models.Model):
     def _get_group_ids(self):
         """ Return ``self``'s group ids (as a tuple)."""
         self.ensure_one()
-        return self.all_group_ids._ids
+        # `with_context({})` because this method is decorated with `@ormcache('self._ids')`,
+        # it cannot depend on the context (e.g. `active_test`, `lang`, ...)
+        return self.with_context({}).all_group_ids._ids
 
     def _action_show(self):
         """If self is a singleton, directly access the form view. If it is a recordset, open a list view"""

--- a/odoo/http.py
+++ b/odoo/http.py
@@ -239,6 +239,7 @@ def get_default_session():
         'uid': None,
         'session_token': None,
         '_trace': [],
+        'create_time': time.time(),
     }
 
 DEFAULT_MAX_CONTENT_LENGTH = 128 * 1024 * 1024  # 128MiB
@@ -2389,7 +2390,7 @@ class HttpDispatcher(Dispatcher):
             response = self.request.redirect_query('/web/login', {'redirect': self.request.httprequest.full_path})
             if was_connected:
                 root.session_store.rotate(session, self.request.env)
-                response.set_cookie('session_id', session.sid, max_age=get_session_max_inactivity(self.env), httponly=True)
+                response.set_cookie('session_id', session.sid, max_age=get_session_max_inactivity(self.request.env), httponly=True)
             return response
 
         if isinstance(exc, HTTPException):


### PR DESCRIPTION
A module to introduce:
- Screen lock after 15 minutes,
- Logout after 24 hours

To be compliant with the [Australian Taxation Office regulation](https://softwaredevelopers.ato.gov.au/operational_framework/further-guidance-requirements):
> - remember me on this device must be limited to 24 hours
> - inactive session time-out occurs after a maximum 30 minutes (15 minutes is preferred). This is a screen lock process where full MFA is not required to unlock.

task-4154452

