### PR TITLE
[FIX] spreadsheet: group by property field

### DIFF
--- a/addons/spreadsheet/static/tests/pivots/model/pivot_plugin.test.js
+++ b/addons/spreadsheet/static/tests/pivots/model/pivot_plugin.test.js
@@ -40,6 +40,7 @@ import { THIS_YEAR_GLOBAL_FILTER } from "@spreadsheet/../tests/helpers/global_fi
 
 import * as spreadsheet from "@odoo/o-spreadsheet";
 import { waitForDataLoaded } from "@spreadsheet/helpers/model";
+import { Partner, Product } from "../../helpers/data";
 const { toZone } = spreadsheet.helpers;
 
 describe.current.tags("headless");
@@ -2085,4 +2086,54 @@ test("Can change display type of a measure", async function () {
         A4: "Yes",    B4: "",             C4: "706.67%",      D4: "773.33%",
         A5: "Total",  B5: "",             C5: "",             D5: "",
     });
+});
+
+test("can group by property", async () => {
+    Product._records = [
+        {
+            id: 1,
+            properties_definitions: [{ name: "dbfc", type: "char", string: "prop 1" }],
+        },
+    ];
+    Partner._records = [
+        {
+            product_id: 1,
+            partner_properties: {
+                dbfc: "hello",
+            },
+        },
+    ];
+    onRpc("partner", "get_property_definition", () => ({
+        name: "dbfc",
+        type: "char",
+        string: "prop 1",
+    }));
+    onRpc("partner", "read_group", ({ kwargs }) => {
+        // the generic mock server doesn't support group by properties
+        if (kwargs.groupby?.includes("partner_properties.dbfc")) {
+            return [
+                {
+                    "partner_properties.dbfc": "hello",
+                    __domain: [["partner_properties.dbfc", "=", "hello"]],
+                    __count: 1,
+                },
+            ];
+        }
+    });
+    const { model } = await createSpreadsheetWithPivot();
+    const pivotId = model.getters.getPivotIds()[0];
+    updatePivot(model, pivotId, {
+        rows: [],
+        columns: [{ fieldName: "partner_properties.dbfc" }],
+        measures: [{ id: "__count:sum", fieldName: "__count" }],
+    });
+    setCellContent(model, "A1", '=PIVOT.HEADER(1, "partner_properties.dbfc", "hello")');
+    setCellContent(
+        model,
+        "A2",
+        '=PIVOT.VALUE(1, "__count:sum", "partner_properties.dbfc", "hello")'
+    );
+    await waitForDataLoaded(model);
+    expect(getEvaluatedCell(model, "A1").value).toBe("hello");
+    expect(getEvaluatedCell(model, "A2").value).toBe(1);
 });


### PR DESCRIPTION
Steps to reproduce:
- add a property on Tasks
- open a pivot view
- group by this property
- insert in spreadsheet

=> boom

The pivot cannot be loaded because the property is not a real field. Hence it's not loaded by `fields_get` and we are missing the property metadata (type)
We need to load the definition independently and we push it to the fields. It's a hack but it seems to work.

opw-4858129


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
