### PR TITLE
[FIX] mail: show jump present button more eagerly

### DIFF
--- a/addons/mail/static/src/core/common/thread.xml
+++ b/addons/mail/static/src/core/common/thread.xml
@@ -70,7 +70,7 @@
 </t>
 
 <t t-name="mail.Thread.jumpPresent">
-    <button t-if="props.showJumpPresent and state.showJumpPresent" class="o-mail-Thread-jumpPresent position-fixed p-2 rounded-circle lh-1 m-n3 user-select-none btn btn-light shadow-sm border border-secondary" t-ref="jump-present" t-on-click="() => this.jumpToPresent()" title="Jump to Present"><i class="oi text-muted" t-att-class="{ 'oi-chevron-down': props.order === 'asc', 'oi-chevron-up': props.order !== 'asc' }"/></button>
+    <button t-if="props.showJumpPresent and state.showJumpPresent" class="o-mail-Thread-jumpPresent position-fixed p-2 rounded-circle lh-1 m-n3 user-select-none btn btn-light shadow-sm border border-secondary" t-att-class="{ 'bottom-0': env.inChatter and !env.inChatter.aside }" t-ref="jump-present" t-on-click="() => this.jumpToPresent()" title="Jump to Present"><i class="oi text-muted" t-att-class="{ 'oi-chevron-down': props.order === 'asc', 'oi-chevron-up': props.order !== 'asc' }"/></button>
 </t>
 
 <t t-name="mail.Thread.loadOlder">

--- a/addons/mail/static/src/utils/common/hooks.js
+++ b/addons/mail/static/src/utils/common/hooks.js
@@ -233,7 +233,7 @@ export function useOnBottomScrolled(refName, callback, threshold = 1) {
 
 /**
  * @param {string} refName
- * @param {function} cb
+ * @param {function} [cb]
  */
 export function useVisible(refName, cb, { ready = true } = {}) {
     const ref = useRef(refName);
@@ -243,7 +243,7 @@ export function useVisible(refName, cb, { ready = true } = {}) {
     });
     function setValue(value) {
         state.isVisible = value;
-        cb(state.isVisible);
+        cb?.(state.isVisible);
     }
     const observer = new IntersectionObserver((entries) => {
         setValue(entries.at(-1).isIntersecting);

--- a/addons/mail/static/tests/mail_test_helpers.js
+++ b/addons/mail/static/tests/mail_test_helpers.js
@@ -618,6 +618,7 @@ export function observeRenders() {
  */
 export async function isInViewportOf(childSelector, parentSelector) {
     await contains(parentSelector);
+    await contains(childSelector);
     const inViewportDeferred = new Deferred();
     const failTimeout = setTimeout(() => check({ crashOnFail: true }), 3000);
     const check = ({ crashOnFail = false } = {}) => {


### PR DESCRIPTION
Before this commit, the "jump present" button when scrolling to older messages was displayed when going quite far in older messages.

This happens because condition was: greater distance of either 3 times the view port client height and 10 times the height of most recent messages.

When most recent messages are very big, this can be long until to see the jump to present.
Also when there are lots of messages, 3 times the scroll client height can be a bit too much.

In the past the "jump to present" UI was a banner so we were tempted to show when user was likely to want to jump to present. This is a small button now so we can be much more eager to its showing.

This commit removes the condition to recent message height and just uses the height of scroll client height for the showing of jump to present.

Before / After
![before](https://github.com/user-attachments/assets/2ced4066-f7d7-4cd3-aec8-3f3dcaa16867) ![after](https://github.com/user-attachments/assets/e12ca32c-9fe0-4714-9151-a04c4379c0a3)
