### PR TITLE
[FIX] website: image resized for ios parralax

### DIFF
--- a/addons/website/static/src/scss/website.scss
+++ b/addons/website/static/src/scss/website.scss
@@ -1327,8 +1327,14 @@ $-o-carousel-controllers-size: map-get($spacers, 5);
     > .s_parallax_bg {
         @extend %o-we-background-layer;
     }
-    &.s_parallax_is_fixed > .s_parallax_bg {
-        background-attachment: fixed;
+    @include media-breakpoint-up(xl) {
+        // Fixed backgrounds are disabled when using a mobile/tablet device,
+        // which is not a big deal but, on some of them (iOS...), defining the
+        // background as fixed breaks the background-size/position props.
+        // So we enable this only for >= XL devices.
+        &.s_parallax_is_fixed > .s_parallax_bg {
+            background-attachment: fixed;
+        }
     }
 }
 // Keeps parallax snippet element selectable when Height = auto.


### PR DESCRIPTION
This reverts commit 0b9859f693d4f23d17b0644e8e0b0ad0bb08c843.

Scenario: insert the Parallax snippet, open the page in iPhone (tested
on safari 14.0 up to 18.5).

Result: the image is zoomed highly and doesn't respect
background-size:cover property.

Issue: having "background-attachment:fixed" in iOS breaks
background-size property, and the image is not resized to fit.

Fix: restoring 412117c2a789a24191cda040614d01fe290e77cc by reverting
0b9859f693d4f23d17b0644e8e0b0ad0bb08c843 since the fix was still
necessary. This has the drawback that parallax that were working on
non-iOS device will now scroll, but this will be consistent.

opw-4848881

__pr note:__ I rebased on 18.1 since it was the revert original version.