### PR TITLE
[FIX] html_builder: prevent excluded elements from updating containers

### DIFF
--- a/addons/html_builder/static/src/core/builder_options_plugin.js
+++ b/addons/html_builder/static/src/core/builder_options_plugin.js
@@ -72,6 +72,20 @@ export class BuilderOptionsPlugin extends Plugin {
             const el = this.editable.querySelector(this.config.initialTarget);
             this.updateContainers(el);
         }
+
+        // Selector of elements that should not update/have containers when they
+        // are clicked.
+        this.notActivableElementsSelector = [
+            "#web_editor-top-edit",
+            "#oe_manipulators",
+            ".oe_drop_zone",
+            ".o_notification_manager",
+            ".o_we_no_overlay",
+            ".ui-autocomplete",
+            ".modal .btn-close",
+            ".transfo-container",
+            ".o_datetime_picker",
+        ].join(", ");
     }
 
     destroy() {
@@ -112,6 +126,9 @@ export class BuilderOptionsPlugin extends Plugin {
             return;
         }
         if (target) {
+            if (target.closest(this.notActivableElementsSelector)) {
+                return;
+            }
             this.target = target;
         }
         if (!this.target || !this.target.isConnected) {

--- a/addons/website/static/src/interactions/carousel.edit.js
+++ b/addons/website/static/src/interactions/carousel.edit.js
@@ -27,6 +27,9 @@ export class CarouselEdit extends Interaction {
      * @param {Event} ev
      */
     async onControlClick(ev) {
+        // Activate the active slide.
+        this.el.querySelector(".carousel-item.active").click();
+
         // Compute to which slide the carousel will slide.
         const controlEl = ev.currentTarget;
         let direction;

--- a/addons/website/static/tests/builder/builder_option.test.js
+++ b/addons/website/static/tests/builder/builder_option.test.js
@@ -166,3 +166,27 @@ test("Containers fallback to a valid ancestor if the target disappears and resto
     expect(".options-container[data-container-title='Ancestor']").toHaveCount(1);
     expect(".options-container[data-container-title='Target 1']").toHaveCount(1);
 });
+
+test("Do not activate/update containers if the element clicked is excluded", async () => {
+    addOption({
+        selector: ".test-options-target",
+        template: xml`<BuilderButton classAction="'test'">Test</BuilderButton>`,
+    });
+    await setupWebsiteBuilder(`
+        <div data-name="Target 1" class="test-options-target target1 o_we_no_overlay">
+            Homepage
+        </div>
+        <div data-name="Target 2" class="test-options-target target2">
+            Homepage2
+        </div>
+
+    `);
+
+    await contains(":iframe .target1").click();
+    expect(".options-container").toHaveCount(0);
+    await contains(":iframe .target2").click();
+    expect(".options-container").toHaveAttribute("data-container-title", "Target 2");
+    expect(".options-container [data-class-action='test']").toHaveCount(1);
+    await contains(":iframe .target1").click();
+    expect(".options-container").toHaveAttribute("data-container-title", "Target 2");
+});


### PR DESCRIPTION
[FIX] html_builder: prevent excluded elements from updating containers

This commit adds back the fact that some elements should not have
options/update the containers when clicking on them. These elements are
the ones matching the classes stored in `notActivableElementsSelector`.

Note that this selectors list has been reviewed compared to before.
Indeed, only the clicks in the editable are listened to, so the elements
outside of it do not need to be considered anymore. This list should
still be updated again, when everything will be more stabilized.

task-4367641

---
[FIX] website: activate active slide when clicking on a carousel control

This commit restores a forgotten `CarouselEdit` interaction behavior
when clicking on a carousel control. Indeed, before sliding, the active
slide options should be activated first, so the containers are
consistent. This is especially needed when undoing/redoing a slide, in
order for the carousel to always fallback on the right slide.

task-4367641