### PR TITLE
[FIX] html_editor: add direct download checkbox in link popover

### DIFF
--- a/addons/html_editor/static/src/main/link/link_plugin.js
+++ b/addons/html_editor/static/src/main/link/link_plugin.js
@@ -114,14 +114,11 @@ async function fetchAttachmentMetaData(url, ormService) {
     try {
         const urlParsed = new URL(url, window.location.origin);
         const attachementId = parseInt(urlParsed.pathname.split("/").pop());
-        const [{ name, mimetype }] = await ormService.read(
-            "ir.attachment",
-            [attachementId],
-            ["name", "mimetype"]
-        );
-        return { name, mimetype };
+        return (
+            await ormService.read("ir.attachment", [attachementId], ["name", "mimetype", "type"])
+        )[0];
     } catch {
-        return { name: url, mimetype: undefined };
+        return { name: url };
     }
 }
 

--- a/addons/html_editor/static/src/main/link/link_popover.xml
+++ b/addons/html_editor/static/src/main/link/link_popover.xml
@@ -5,7 +5,8 @@
             <div t-if="state.editing" class="container-fluid d-flex vertical-center p-2" t-ref="editing-wrapper">
                 <div t-if="state.isImage" class="col p-2" style="max-width: 250px;">
                     <div class="input-group mb-1">
-                        <input t-ref="url" class="o_we_href_input_link border-dark-subtle form-control form-control-sm" t-model="state.url" title="URL" placeholder="Type your URL" t-on-keydown="onKeydownEnter"/>
+                        <input t-ref="url" class="o_we_href_input_link border-dark-subtle form-control form-control-sm" t-model="state.url" title="URL" placeholder="Type your URL"
+                            t-on-keydown="onKeydownEnter"/>
                         <button class="o_we_apply_link btn btn-sm btn-primary" t-att-class="{'mx-1': state.type ===  ''}" t-on-click="onClickApply">Apply</button>
                     </div>
                 </div>
@@ -26,7 +27,7 @@
                                 title="URL"
                                 placeholder="e.g. https://www.odoo.com"
                                 t-on-keydown="onKeydownEnter"
-                                t-on-input="onChange"/>
+                                t-on-input="this.onChange"/>
                             <span class="ms-1" t-if="props.canUpload and !state.url">
                                 or <button class="btn btn-light btn-sm" t-on-click="uploadFile"><i class="fa fa-upload"/></button>
                             </span>
@@ -85,10 +86,22 @@
                             </div>
                         </t>
                         <t t-if="props.allowTargetBlank">
-                            <div class="d-flex mb-1 target-blank-option">
-                                <input class="me-1" type="checkbox" t-att-checked="state.linkTarget === '_blank'" t-on-change="(ev)=>this.state.linkTarget = ev.target.checked ? '_blank' : ''"/>
-                                <label>Open in new window</label>
-                            </div>
+                            <t t-if="state.isDocument">
+                                <CheckBox
+                                    value="state.directDownload"
+                                    onChange="onClickDirectDownload.bind(this)"
+                                    className="'direct-download-option'">
+                                    Direct download
+                                </CheckBox>
+                            </t>
+                            <t t-if="!state.isDocument || (state.isDocument and !state.directDownload)">
+                                <CheckBox
+                                    value="state.linkTarget === '_blank'"
+                                    onChange="onClickNewWindow.bind(this)"
+                                    className="'target-blank-option'">
+                                    Open in new window
+                                </CheckBox>
+                            </t>
                         </t>
                         <div class="mt-3">
                             <button class="o_we_apply_link btn btn-sm btn-primary" t-att-disabled="!state.url" t-on-click="onClickApply">Apply</button>

--- a/addons/html_editor/static/tests/link/popover.test.js
+++ b/addons/html_editor/static/tests/link/popover.test.js
@@ -1261,6 +1261,29 @@ describe("upload file via link popover", () => {
         );
     });
 
+    test("direct download option works as expected", async () => {
+        const { editor } = await setupEditor("<p>[]<br></p>", {
+            config: { allowTargetBlank: true },
+        });
+        execCommand(editor, "openLinkTools");
+        await contains("input.o_we_href_input_link").fill(
+            "/web/content/1?unique=123&download=true",
+            { confirm: false }
+        );
+        expect(".direct-download-option input").toBeChecked();
+
+        await contains("input.o_we_href_input_link").edit("/web/content/1?unique=123", {
+            confirm: false,
+        });
+        expect(".direct-download-option input").not.toBeChecked();
+
+        await contains(".direct-download-option input").check();
+        expect("input.o_we_href_input_link").toHaveValue("/web/content/1?unique=123&download=true");
+
+        await contains(".direct-download-option input").uncheck();
+        expect("input.o_we_href_input_link").toHaveValue("/web/content/1?unique=123");
+    });
+
     test("label input does not get filled on file upload if it is already filled", async () => {
         const { editor } = await setupEditor("<p>[]<br></p>");
         const mockedUpload = patchUpload(editor);


### PR DESCRIPTION
This fix brings back a feature from before the mysterious-egg refactor.

Steps to reproduce:
1. Go to website builder in edit mode
2. Add a link to the website
3. Click on it and click on the edit icon
4. Empty the URL input
5. Upload a file

Before fix: No option to choose whether this link should, when clicked, download the document or open it in the browser
After fix: A "Direct download" checkbox appears as before the refactor

task-4367641