### PR TITLE
[FIX] sale: sum credit to invoice only once

### DIFF
--- a/addons/sale/models/res_partner.py
+++ b/addons/sale/models/res_partner.py
@@ -73,11 +73,13 @@ class ResPartner(models.Model):
     def _compute_credit_to_invoice(self):
         # EXTENDS 'account'
         super()._compute_credit_to_invoice()
+        if not (commercial_partners := self.commercial_partner_id & self):
+            return  # nothing to compute
         company = self.env.company
         domain = [
             ('company_id', '=', company.id),
             ('partner_invoice_id', 'any', [
-                ('commercial_partner_id', 'in', self.commercial_partner_id.ids),
+                ('commercial_partner_id', 'in', commercial_partners.ids),
             ]),
             ('amount_to_invoice', '>', 0),
             ('state', '=', 'sale')

--- a/addons/sale/tests/test_credit_limit.py
+++ b/addons/sale/tests/test_credit_limit.py
@@ -371,23 +371,36 @@ class TestSaleOrderCreditLimit(TestSaleCommon):
             'name': "Company A",
             'is_company': True,
             'credit_limit': 10000.0,
+            'child_ids': [
+                Command.link(self.partner_a.id),
+                Command.create({
+                    'name': "Company A Invoice",
+                    'type': 'invoice',
+                }),
+            ],
         })
-        self.partner_a.commercial_partner_id = company_a
+        invoice_partner = company_a.child_ids.filtered(lambda p: p.type == 'invoice')
 
         order = self.empty_order
         order.write({
             'order_line': [Command.create({
                 'product_id': self.company_data['product_order_no'].id,
-                'price_unit': 1200.0,
+                'price_unit': 600.0,
                 'tax_id': False,
             })],
         })
-        order.action_confirm()
+        orders = order + order.copy({'partner_invoice_id': invoice_partner.id})
+        orders.action_confirm()
+
+        self.assertFalse(
+            self.partner_a.credit_to_invoice,
+            "Credit should only apply to the commercial entity",
+        )
         self.assertFalse(company_a.credit)
         self.assertEqual(company_a.credit_to_invoice, 1200.0)
 
-        invoice = order._create_invoices()
-        invoice.action_post()
+        invoices = orders._create_invoices()
+        invoices.action_post()
         company_a.invalidate_recordset()
         self.assertFalse(company_a.credit_to_invoice)
         self.assertEqual(company_a.credit, 1200.0)


### PR DESCRIPTION
Versions
--------
- 17.0+

Steps
-----
1. Have a partner with a `commercial_partner_id`;
2. for the `commercial_partner_id`, create an partner of type `invoice`;
3. create & confirm a sale order invoiced to the initial partner;
4. create & confirm a sale order invoiced to the invoice partner;
5. check the `credit_to_invoice` of the partner;
6. check the `credit_to_invoice` of the `commercial_partner_id`.

Issue
-----
The credit to invoice is twice what it should be.

Cause
-----
The `_compute_credit_to_invoice` method sums up the `credit_to_invoice` on a partner's `commercial_partner_id`. By first checking the partner's credit to invoice, it searched all sale orders credited to the commercial entity. Before it can sum these, it first has to compute the `credit_to_invoice` of the `commercial_partner_id`, which retrieves the same sale orders, and hence get summed up twice.

Solution
--------
Only compute the `credit_to_invoice` on commercial partners by taking the intersection of `self` & `self.commercial_partner_id`.

opw-4855507