### PR TITLE
[IMP] product: Filter operations on packaging barcode

### DIFF
--- a/addons/product/models/uom_uom.py
+++ b/addons/product/models/uom_uom.py
@@ -2,12 +2,21 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import models, fields, _
+from odoo.fields import Domain
 
 
 class UomUom(models.Model):
     _inherit = 'uom.uom'
 
-    product_uom_ids = fields.One2many('product.uom', 'uom_id', string='Barcodes', domain=lambda self: ['|', ('product_id', '=', self.env.context.get('product_id')), ('product_id', 'in', self.env.context.get('product_ids', []))])
+    def _domain_product_uoms(self):
+        domain = []
+        if self.env.context.get("product_id"):
+            domain.append(Domain('product_id', '=', self.env.context['product_id']))
+        if self.env.context.get("product_ids"):
+            domain.append(Domain('product_id', 'in', self.env.context['product_ids']))
+        return Domain.OR(domain) if domain else Domain.TRUE
+
+    product_uom_ids = fields.One2many('product.uom', 'uom_id', string='Barcodes', domain=_domain_product_uoms)
 
     def action_open_packaging_barcodes(self):
         self.ensure_one()


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

As an operator with a lot of transfer/operations to do, being able to filter based on a product barcode you have can save a lot of time but sometimes you only have access to the packaging barcode and you don't want to open the packaging to have access to the product barcode. 

Current behavior before PR:

When iterating through pickings move and move_lines, the product_uom field is empty as there areno product_id or product_ids in context (making it hard to filter on packaging).

Desired behavior after PR is merged:

The product_uom field on move and move_line now returns all barcodes linked to a packaging if product id or product_ids are not in context, making filtering operations on packaging barcode easier (ie. Domain.TRUE)

task: 4729518
enterprise PR: https://github.com/odoo/enterprise/pull/87450

I confirm I have signed the CLA and read the PR guidelines at [www.odoo.com/submit-pr](http://www.odoo.com/submit-pr)
