### PR TITLE
[IMP] im_livechat: improve message returned in chatbot script

### DIFF
--- a/addons/im_livechat/models/chatbot_script_step.py
+++ b/addons/im_livechat/models/chatbot_script_step.py
@@ -349,6 +349,6 @@ class ChatbotScriptStep(models.Model):
         return [
             Store.Many("answer_ids"),
             Store.Attr("is_last", lambda step: step._is_last_step()),
-            Store.Attr("message", lambda s: plaintext2html(s.message) if s.message else False),
+            "message",
             "step_type",
         ]

--- a/addons/im_livechat/static/src/core/common/chatbot_model.js
+++ b/addons/im_livechat/static/src/core/common/chatbot_model.js
@@ -3,6 +3,7 @@ import { rpc } from "@web/core/network/rpc";
 import { browser } from "@web/core/browser/browser";
 import { debounce } from "@web/core/utils/timing";
 import { expirableStorage } from "@im_livechat/core/common/expirable_storage";
+import { prettifyMessageContent } from "@mail/utils/common/format";
 
 export class Chatbot extends Record {
     static id = AND("script", "thread");
@@ -122,7 +123,10 @@ export class Chatbot extends Record {
             this.currentStep.message = this.store["mail.message"].insert({
                 id: this.store.getNextTemporaryId(),
                 author_id: this.script.operator_partner_id,
-                body: this.currentStep.scriptStep.message,
+                body: await prettifyMessageContent(this.currentStep.scriptStep.message, {
+                    allowEmojiLoading: false,
+                    withParagraph: true,
+                }),
                 thread: this.thread,
             });
         }

--- a/addons/mail/static/src/utils/common/format.js
+++ b/addons/mail/static/src/utils/common/format.js
@@ -28,7 +28,7 @@ const messageUrlRegExp = new RegExp(`^${escapeRegExp(getOrigin())}/mail/message/
  */
 export async function prettifyMessageContent(
     rawBody,
-    { validMentions = [], allowEmojiLoading = true } = {}
+    { validMentions = [], allowEmojiLoading = true, withParagraph = false } = {}
 ) {
     let body = htmlTrim(rawBody);
     body = htmlReplace(body, /(\r|\n){2,}/g, () => markup`<br/><br/>`);
@@ -42,6 +42,10 @@ export async function prettifyMessageContent(
     // as text internally and only make html enrichment at display time but
     // the current design makes this quite hard to do.
     body = generateMentionsLinks(body, validMentions);
+    if (withParagraph) {
+        body = htmlReplace(body, /([<]\s*br\s*\/?[>]){2,}/gi, () => markup`</p><p>`);
+        body = markup`<p>${body}</p>`;
+    }
     if (allowEmojiLoading || odoo.loader.modules.get("@web/core/emoji_picker/emoji_data")) {
         body = await _generateEmojisOnHtml(body);
     }

--- a/addons/mail/static/tests/utils/prettify_message.test.js
+++ b/addons/mail/static/tests/utils/prettify_message.test.js
@@ -1,0 +1,26 @@
+import { expect, test } from "@odoo/hoot";
+import { markup } from "@odoo/owl";
+
+import { prettifyMessageContent } from "@mail/utils/common/format";
+const Markup = markup().constructor;
+
+test("prettifyMessageContent follows the same behaviour as plaintext2html with with_paragraph", async () => {
+    const result = await prettifyMessageContent(
+        "this is a test😇<i>false italic</i>\nnew line\n\ndouble line\n\n\ntriple line",
+        { withParagraph: true }
+    );
+    expect(result).toBeInstanceOf(Markup);
+    expect(result.toString()).toEqual(
+        "<p>this is a test😇&lt;i&gt;false italic&lt;/i&gt;<br>new line</p><p>double line</p><p>triple line</p>"
+    );
+});
+
+test("prettifyMessageContent keeps up to 2 new lines by default", async () => {
+    const result = await prettifyMessageContent(
+        "this is a test😇<i>false italic</i>\nnew line\n\ndouble line\n\n\ntriple line"
+    );
+    expect(result).toBeInstanceOf(Markup);
+    expect(result.toString()).toEqual(
+        "this is a test😇&lt;i&gt;false italic&lt;/i&gt;<br>new line<br><br>double line<br><br>triple line"
+    );
+});


### PR DESCRIPTION
The goal of this commit is to improve the caching and speed of the messages of chatbots.

It is achieved by storing the html version directly in the database and is to be returned as the message if requested.

task-4676004

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
