### PR TITLE
[FIX] im_livechat: correct livechat_member_type for logged in users

### DIFF
--- a/addons/im_livechat/models/im_livechat_channel.py
+++ b/addons/im_livechat/models/im_livechat_channel.py
@@ -216,7 +216,7 @@ class Im_LivechatChannel(models.Model):
     def _get_livechat_discuss_channel_vals(
         self, anonymous_name, previous_operator_id=None, chatbot_script=None, user_id=None, country_id=None, lang=None
     ):
-        user_operator = False
+        user_operator = self.env["res.users"]
         if chatbot_script:
             if chatbot_script.id not in self.browse(self.ids).mapped('rule_ids.chatbot_script_id.id'):
                 return False
@@ -238,10 +238,16 @@ class Im_LivechatChannel(models.Model):
             )
         ]
         visitor_user = False
-        if user_id:
-            visitor_user = self.env['res.users'].browse(user_id)
-            if visitor_user and visitor_user.active and user_operator and visitor_user != user_operator:  # valid session user (not public)
-                members_to_add.append(Command.create({"livechat_member_type": "visitor", 'partner_id': visitor_user.partner_id.id}))
+        if user_id and user_id != user_operator.id:
+            visitor_user = self.env["res.users"].browse(user_id)
+            members_to_add.append(
+                Command.create(
+                    {
+                        "livechat_member_type": "visitor",
+                        "partner_id": visitor_user.partner_id.id,
+                    },
+                ),
+            )
 
         if chatbot_script:
             name = chatbot_script.title

--- a/addons/im_livechat/tests/test_chatbot_internals.py
+++ b/addons/im_livechat/tests/test_chatbot_internals.py
@@ -528,3 +528,20 @@ class ChatbotCase(MailCommon, chatbot_common.ChatbotCase):
                 self.chatbot_script if expected_result else self.env["chatbot.script"],
                 f"Condition: {condition}, Operator available: {operator_available}, Expected result: {expected_result}",
             )
+
+    def test_chatbot_member_type(self):
+        """Ensure livechat_member_type are correctly set when using chatbot with a logged in user."""
+        self.authenticate(self.user_employee.login, self.user_employee.login)
+        data = self.make_jsonrpc_request(
+            "/im_livechat/get_session",
+            {
+                "anonymous_name": "Test Visitor",
+                "chatbot_script_id": self.chatbot_script.id,
+                "channel_id": self.livechat_channel.id,
+            },
+        )
+        discuss_channel = self.env["discuss.channel"].browse(data["channel_id"])
+        self.assertEqual(
+            discuss_channel.channel_member_ids.mapped("livechat_member_type"),
+            ["bot", "visitor"],
+        )

--- a/addons/im_livechat/tools/misc.py
+++ b/addons/im_livechat/tools/misc.py
@@ -7,6 +7,7 @@ def downgrade_to_public_user():
     """Replace the request user by the public one. All the cookies are removed
     in order to ensure that the no user-specific data is kept in the request."""
     public_user = request.env.ref("base.public_user")
+    request.session.uid = None
     request.update_env(user=public_user)
     request.cookies = {}
 


### PR DESCRIPTION
Even if there is no user_operator (which is the case when using chatbot), the livechat_member_type should be set to "visitor".