### PR TITLE
[FIX] website: fix body color below if page bigger than viewport


### DIFF
--- a/addons/website/static/src/scss/website.scss
+++ b/addons/website/static/src/scss/website.scss
@@ -17,12 +17,14 @@ $-seen-urls: ();
     }
 }
 
+$real-body-bg: $body-bg;
 :root {
     // The color behind the boxed layout is forced by Odoo. The box background
     // color uses the `$body-bg` variable.
     // grep: BOXED_BODY_BG_ODOO
     @if o-website-value('layout') != 'full' {
         $-boxed-layout-body-bg: o-color('body');
+        $real-body-bg: $-boxed-layout-body-bg !global;
         --#{$variable-prefix}body-bg-rgb: #{to-rgb($-boxed-layout-body-bg)};
         --#{$variable-prefix}body-bg: #{$-boxed-layout-body-bg};
     }
@@ -175,13 +177,15 @@ $-seen-urls: ();
         $custom-colors: append($custom-colors, $key);
     }
     @include print-variable('custom-colors', $custom-colors);
+}
 
-    // A background color is set on <html> to prevent the fallback iframe used
-    // for navigation in the backend to be visible once the top iframe is loaded
-    // (see /website/iframefallback). Indeed, if the website <body> uses a
-    // transparent background color, the fallback iframe would be visible on
-    // some browsers (e.g. Chrome).
-    background-color: white;
+body {
+    // Remove the transparency of the background color to prevent the fallback
+    // iframe used for navigation in the backend to be visible once the top
+    // iframe is loaded (see /website/iframefallback). Indeed, if the website
+    // <body> uses a transparent background color, the fallback iframe would be
+    // visible on some // browsers (e.g. Chrome).
+    background-color: mix(change-color($real-body-bg, $alpha: 1), white, percentage(alpha($real-body-bg)));
 }
 
 @mixin body-image-bg-style() {


### PR DESCRIPTION
This reverts the fix of commit 2597d6f4c33fe2ae8a60e11059c2630ac8aff58c
and flatten the background color of the body element instead.

Scenario:
- set a color to the body different than white
- add snippets to have a height higher than the viewport
- go down in the page

Result: the background color is only set up to the viewport height.

Cause:

Before 18.0, the body takes 100% of the page height because we are scrolling
over the #wrapwrap element.

In 18.0 with 189a7c96e6e26825dc05c0c6466576fe63aa091e, we are scrolling
over the body element, that combined with the body having a height of
100%  makes the body element being positionned from 0 to viewport height,
and it's not present below that.

Also to set background of the whole page, the browser uses the body
background if there is no background on the html element, so even if the
body didn't cover the whole page, we were getting the body color on the
whole page.

So the change in 2597d6f4c33fe2ae8a60e11059c2630ac8aff58c that set the
html element to white, causes the background color to only be applied to
up to the viewport height, with the background being blank below that.

Fix: set the body background color to the flattened rgb color.

opw-4863179
opw-4863724