### PR TITLE
[FIX] purchase_stock, *: include visibility_days in qty_forecast compute

### DIFF
--- a/addons/purchase_stock/tests/test_reordering_rule.py
+++ b/addons/purchase_stock/tests/test_reordering_rule.py
@@ -1078,7 +1078,7 @@ class TestReorderingRule(TransactionCase):
             'date': dt.today() + td(days=6),
         })
         move._action_confirm()
-        self.assertEqual(op.qty_to_order, 0, 'sale order is ignored')
+        self.assertEqual(op.qty_to_order, 1, 'out move is ignored')
         # out move today to force the forecast to be negative
         move = self.env['stock.move'].create({
             'name': 'Test move',

--- a/addons/stock/models/stock_orderpoint.py
+++ b/addons/stock/models/stock_orderpoint.py
@@ -265,7 +265,7 @@ class StockWarehouseOrderpoint(models.Model):
         return self.action_replenish()
 
     @api.depends('product_id', 'location_id', 'product_id.stock_move_ids', 'product_id.stock_move_ids.state',
-                 'product_id.stock_move_ids.date', 'product_id.stock_move_ids.product_uom_qty', 'product_id.seller_ids.delay')
+                 'product_id.stock_move_ids.date', 'product_id.stock_move_ids.product_uom_qty', 'product_id.seller_ids.delay', 'visibility_days')
     def _compute_qty(self):
         orderpoints_contexts = defaultdict(lambda: self.env['stock.warehouse.orderpoint'])
         for orderpoint in self:
@@ -273,7 +273,7 @@ class StockWarehouseOrderpoint(models.Model):
                 orderpoint.qty_on_hand = False
                 orderpoint.qty_forecast = False
                 continue
-            orderpoint_context = orderpoint._get_product_context()
+            orderpoint_context = orderpoint._get_product_context(orderpoint.visibility_days)
             product_context = frozendict({**orderpoint_context})
             orderpoints_contexts[product_context] |= orderpoint
         for orderpoint_context, orderpoints_by_context in orderpoints_contexts.items():


### PR DESCRIPTION
*: stock

The visibility_days field defines how many days into the future the
forecast should be considered for product replenishment:
```
Consider product forecast these many days in the future upon product
replenishment ...
```
However, the method computing qty_forecast did not depend on the
visibility_days value, leading to incorrect replenishment behavior.

This commit fixes the issue by ensuring visibility_days is taken into
account during forecast computation.