### PR TITLE
[FIX] core: handle WS closed in web proxy

### DIFF
--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -1270,12 +1270,16 @@ class ChromeBrowser:
 
     def _handle_request_paused(self, **params):
         url = params['request']['url']
+        if url.startswith(f'http://{HOST}'):
+            cmd = 'Fetch.continueRequest'
+            response = {}
+        else:
+            cmd = 'Fetch.fulfillRequest'
+            response = module.current_test.fetch_proxy(url)
         try:
-            if url.startswith(f'http://{HOST}'):
-                self._websocket_send('Fetch.continueRequest', params={'requestId': params['requestId']})
-            else:
-                response = module.current_test.fetch_proxy(url)
-                self._websocket_send('Fetch.fulfillRequest', params={'requestId': params['requestId'], **response})
+            self._websocket_send(cmd, params={'requestId': params['requestId'], **response})
+        except websocket.WebSocketConnectionClosedException:
+            pass
         except (BrokenPipeError, ConnectionResetError):
             # this can happen if the browser is closed. Just ignore it.
             _logger.info("Websocket error while handling request %s", params['request']['url'])


### PR DESCRIPTION
If the browser triggers a request just as a tour is finishing up (e.g. navigation to a new page triggering a font fetch), the harness can close the websocket connection while the request is in the `requestPaused` proxy, causing the reply to fail and trigger an error.

We can just ignore the error in that case. An alternative would be to enqueue a future into `_responses` when we receive the query, but that would still have a race as depending on scheduling decisions the browser could have already shut down by the time we reach the handler, so we'd need to enqueue a future, check if `ws` is still open, and bail if not.

And even then that's still got a hole as there is some time between the `wait(_responses.values())` and the `ws.close()`.

https://runbot.odoo.com/odoo/error/186309
