### PR TITLE
[FIX] sale:  recompute price on product change

### DIFF
--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -577,15 +577,23 @@ class SaleOrderLine(models.Model):
                 line.price_unit = 0.0
                 line.technical_price_unit = 0.0
             else:
-                line = line.with_company(line.company_id)
-                price = line._get_display_price()
-                product_taxes = line.product_id.taxes_id._filter_taxes_by_company(line.company_id)
-                line.price_unit = line.product_id._get_tax_included_unit_price_from_price(
-                    price,
-                    product_taxes=product_taxes,
-                    fiscal_position=line.order_id.fiscal_position_id,
-                )
-                line.technical_price_unit = line.price_unit
+                line._reset_price_unit()
+
+    def _reset_price_unit(self):
+        self.ensure_one()
+
+        line = self.with_company(self.company_id)
+        price = line._get_display_price()
+        product_taxes = line.product_id.taxes_id._filter_taxes_by_company(line.company_id)
+        price_unit = line.product_id._get_tax_included_unit_price_from_price(
+            price,
+            product_taxes=product_taxes,
+            fiscal_position=line.order_id.fiscal_position_id,
+        )
+        line.update({
+            'price_unit': price_unit,
+            'technical_price_unit': price_unit,
+        })
 
     def _get_order_date(self):
         self.ensure_one()
@@ -1191,6 +1199,12 @@ class SaleOrderLine(models.Model):
                     'message': product.sale_line_warn_msg,
                 }
             }
+
+    @api.onchange('product_id')
+    def _onchange_product_id(self):
+        if not self.product_id:
+            return
+        self._reset_price_unit()
 
     @api.onchange('product_packaging_id')
     def _onchange_product_packaging_id(self):

--- a/addons/sale/tests/test_sale_order.py
+++ b/addons/sale/tests/test_sale_order.py
@@ -772,6 +772,33 @@ class TestSaleOrder(SaleCommon):
         })
         self.assertEqual(new_order.order_line.price_unit, 22.0)
 
+    def test_sale_order_unit_price_recompute_on_product_change(self):
+        """Ensure price_unit is correctly recomputed when the product is
+           changed after manually changing the price.
+        """
+        product2 = self.env['product.product'].create({
+            'name': "Test Product2",
+            'list_price': 0.0,
+        })
+        sol = self.sale_order.order_line[0]
+        # Manually change the product & price on the SO line
+        with Form(sol) as sol_form:
+            sol_form.product_id = product2
+            sol_form.price_unit = 100
+        # Expected price_subtotal = custom unit price * quantity
+        self.assertAlmostEqual(
+            sol.price_subtotal, 100 * sol.product_uom_qty,
+            msg="price_total should be equal to expected_total",
+        )
+        # Unit price should reset after changing the product
+        with Form(sol) as sol_form:
+            sol_form.product_id = self.product
+        # Expected price_subtotal = list price * quantity
+        self.assertAlmostEqual(
+            sol.price_subtotal, self.product.list_price * sol.product_uom_qty,
+            msg="price_total should be equal to expected_total",
+        )
+
 
 @tagged('post_install', '-at_install')
 class TestSaleOrderInvoicing(AccountTestInvoicingCommon, SaleCommon):


### PR DESCRIPTION
step to reproduce
- Create a quotation,
- Select a product
- Update the price manually
- change the product
- The amount stays the same
expectation: with change of product in SO, price should also recompute

issue:
currently,`_compute_price_unit` depends on `technical_price_unit` such that
`price_unit` won't update if `price_unit` and `technical_price_unit` are not same.
 which is the case when price_unit was manually set, regardless of the product

https://github.com/odoo/odoo/blob/12ef230df58122fbdac0b4c1b4781c535b8516ba/addons/sale/models/sale_order_line.py#L567-L570

we should reset to original price with change of product

opw-4813069


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
