### PR TITLE
[FIX] pos_hr: reset module_pos_hr flag on uninstall

### DIFF
--- a/addons/pos_hr/__init__.py
+++ b/addons/pos_hr/__init__.py
@@ -3,3 +3,9 @@
 from . import models
 from . import report
 from . import wizard
+
+
+def uninstall_hook(env):
+    env.cr.execute("SELECT 1 FROM ir_module_module WHERE name = 'pos_hr' AND state = 'to remove'")
+    if env.cr.rowcount:
+        env.cr.execute("UPDATE pos_config SET module_pos_hr = False WHERE module_pos_hr")

--- a/addons/pos_hr/__manifest__.py
+++ b/addons/pos_hr/__manifest__.py
@@ -25,6 +25,7 @@ The actual till still requires one user but an unlimited number of employees can
     ],
     'installable': True,
     'auto_install': True,
+    'uninstall_hook': 'uninstall_hook',
     'assets': {
         'point_of_sale._assets_pos': [
             'pos_hr/static/src/**/*',


### PR DESCRIPTION
In point_of_sale, when we configure `Log in with Employees` option in pos config it will installed `pos_hr` module.

problem is if customer uninstalled module `pos_hr` from apps option `module_pos_hr` still true in pos config.
without pos_hr installed. Therefore if there is a write during the upgrade in the pos config we get an error.
and that write happen when it's try to load pos_sms module and load pos_config_main data record.

Traceback generated when it's try to install
`pos_sms` module which was introduced in saas~17.3

similar to this issue : ref: https://github.com/odoo/enterprise/pull/59810/commits


Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
