### PR TITLE
[FIX] html_editor:  close image cropper when image is removed

### DIFF
--- a/addons/html_editor/static/src/main/media/image_crop.js
+++ b/addons/html_editor/static/src/main/media/image_crop.js
@@ -54,6 +54,16 @@ export class ImageCrop extends Component {
         useExternalListener(this.document, "keydown", this.onDocumentKeydown, {
             capture: true,
         });
+        useExternalListener(
+            this.document,
+            "selectionchange",
+            () => {
+                if (!this.props.media.isConnected) {
+                    this.closeCropper();
+                }
+            },
+            { capture: true }
+        );
 
         onMounted(() => {
             this.hasModifiedImageClass = this.media.classList.contains("o_modified_image_to_save");

--- a/addons/html_editor/static/src/main/media/image_transform_button.js
+++ b/addons/html_editor/static/src/main/media/image_transform_button.js
@@ -31,12 +31,17 @@ export class ImageTransformButton extends Component {
                 this.mouseDownInsideTransform = false;
             }
         });
-        useExternalListener(this.props.document, "click", (ev) => {
-            if (!this.isNodeInsideTransform(ev.target) && !this.mouseDownInsideTransform) {
-                this.closeImageTransformation();
-            }
-            this.mouseDownInsideTransform = false;
-        });
+        useExternalListener(
+            this.props.document,
+            "click",
+            (ev) => {
+                if (!this.isNodeInsideTransform(ev.target) && !this.mouseDownInsideTransform) {
+                    this.closeImageTransformation();
+                }
+                this.mouseDownInsideTransform = false;
+            },
+            { capture: true }
+        );
     }
 
     isNodeInsideTransform(node) {


### PR DESCRIPTION
### Steps to reproduce:

**Issue 1:**
- Add an image in the editor.
- Apply image transformation (e.g., shrink it).
- Open the image cropper tools.
- Press the Backspace key.
- Observe that cropper still visible.

**Issue 2:**
- Go to To-Do and insert an image.
- Click on Image Transform, then on Image Crop — observe that
Image Crop opens correctly.
- Click the Discard button in the Image Crop UI.
- Again select the image, click Image Transform, then Image Crop.
- Notice that Image Crop no longer opens.

### Description of the issue/feature this PR addresses:

- Pressing Backspace removes the image from the editor.
- However, the cropper remains open, and focus returns to editable area, allowing to type with the cropper still visible.
- Clicking Image Crop while Image Transform was active could destroy both due to async loadBundle() timing. On subsequent attempts, ImageCrop was added before ImageTransform was removed, causing Owl to destroy both in the same frame.

### Desired behavior after PR is merged:

- When the image is removed, the associated cropper is also closed.
- Clicking Image Crop button while Image Transform is active now works.

task-4859869

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr


