### PR TITLE
[FIX] point_of_sale: fail to load demo data

### DIFF
--- a/addons/point_of_sale/data/point_of_sale_onboarding_main_config.xml
+++ b/addons/point_of_sale/data/point_of_sale_onboarding_main_config.xml
@@ -27,27 +27,27 @@
         <field name="company_id" ref="base.main_company" />
         <field name="name">ClosedDemo/0001</field>
         <field name="state">paid</field>
-        <field name="amount_total">4.81</field>
+        <field name="amount_total">4.5</field>
         <field name="amount_tax">0.0</field>
-        <field name="amount_paid">4.81</field>
+        <field name="amount_paid">4.5</field>
         <field name="amount_return">0.0</field>
         <field name="pos_reference">Order 00000-001-1001</field>
     </record>
 
     <record id="pos_closed_orderline_1_1_1" model="pos.order.line" forcecreate="False">
         <field name="product_id" ref="wall_shelf" />
-        <field name="price_subtotal">1.98</field>
-        <field name="price_subtotal_incl">1.98</field>
-        <field name="price_unit">1.98</field>
+        <field name="price_subtotal">2.5</field>
+        <field name="price_subtotal_incl">2.5</field>
+        <field name="price_unit">2.5</field>
         <field name="order_id" ref="pos_closed_order_1_1" />
         <field name="full_product_name">Wall Shelf</field>
     </record>
 
     <record id="pos_closed_orderline_1_1_2" model="pos.order.line" forcecreate="False">
         <field name="product_id" ref="small_shelf" />
-        <field name="price_subtotal">2.83</field>
-        <field name="price_subtotal_incl">2.83</field>
-        <field name="price_unit">2.83</field>
+        <field name="price_subtotal">2.5</field>
+        <field name="price_subtotal_incl">2.5</field>
+        <field name="price_unit">2.5</field>
         <field name="order_id" ref="pos_closed_order_1_1" />
         <field name="full_product_name">Small Shelf</field>
     </record>
@@ -55,7 +55,7 @@
     <record id="pos_payment_1" model="pos.payment" forcecreate="False">
         <field name="payment_method_id" ref="point_of_sale.payment_method" />
         <field name="pos_order_id" ref="pos_closed_order_1_1" />
-        <field name="amount">4.81</field>
+        <field name="amount">5.0</field>
     </record>
 
     <record id="pos_closed_order_1_2" model="pos.order" forcecreate="False">
@@ -72,9 +72,9 @@
 
     <record id="pos_closed_orderline_1_2_1" model="pos.order.line" forcecreate="False">
         <field name="product_id" ref="product_product_12" />
-        <field name="price_subtotal">120.50</field>
-        <field name="price_subtotal_incl">120.5</field>
-        <field name="price_unit">120.50</field>
+        <field name="price_subtotal">120.0</field>
+        <field name="price_subtotal_incl">120.0</field>
+        <field name="price_unit">120.0</field>
         <field name="order_id" ref="pos_closed_order_1_2" />
         <field name="full_product_name">Office Chair Black</field>
     </record>
@@ -91,10 +91,10 @@
     <record id="pos_payment_2" model="pos.payment" forcecreate="False">
         <field name="payment_method_id" ref="point_of_sale.payment_method" />
         <field name="pos_order_id" ref="pos_closed_order_1_2" />
-        <field name="amount">2220.50</field>
+        <field name="amount">2220.0</field>
     </record>
 
-    <function model="pos.session" name="post_closing_cash_details" eval="[[ref('pos_closed_session_1')], 2225.31]" />
+    <function model="pos.session" name="post_closing_cash_details" eval="[[ref('pos_closed_session_1')], 2225.0]" />
 
     <function model="pos.session" name="update_closing_control_state_session"
         eval="[[ref('pos_closed_session_1')], '']" />


### PR DESCRIPTION
* STEP TO REPRODUCE: create without-demo database and install l10n_vn,
point_of_sale. Note that: currency rounding of l10n_vn (Viet Nam is
1.0).
New session of pos then try load demo data -> Missing error on
pos.session

* Reason: in the demo data at
https://github.com/odoo/odoo/blob/17.0/addons/point_of_sale/data/point_of_sale_onboarding_main_config.xml#L97
the amount is 2225.31 , we have 2 payment at
https://github.com/odoo/odoo/blob/17.0/addons/point_of_sale/data/point_of_sale_onboarding_main_config.xml#L55
and https://github.com/odoo/odoo/blob/17.0/addons/point_of_sale/data/point_of_sale_onboarding_main_config.xml#L91
because of the rounding amount will be round from 4.81 -> 5, 2220.50 ->
2221 , which will make total payment amount is 2226 while the amount
above is 2225.31 (also will be round when create move line is 2225)
therefore causing imbalance when check move balance, lead to the line
https://github.com/odoo/odoo/blob/17.0/addons/point_of_sale/models/pos_session.py#L343
(self.env.cr.rollback) where we rollback full transaction including the
creation of pos.session (because pos.session here create from the xml
data too) -> Missing error when try to self.name or any fields of
pos.session

* Solution : there are 2 solution , 1 is to make the demo data amount an
event number, 2 is use savepoint to make sure we rollback enough stuff
only not rollback the pos.session, this commit implement the first way




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
