### PR TITLE
[FIX] hr_holidays : add employee in the allocations search bar

### DIFF
--- a/addons/hr_holidays/views/hr_leave_allocation_views.xml
+++ b/addons/hr_holidays/views/hr_leave_allocation_views.xml
@@ -6,6 +6,7 @@
         <field name="model">hr.leave.allocation</field>
         <field name="arch" type="xml">
             <search string="Search allocations">
+                <field name="employee_id" string='Employee'/>
                 <field name="name"/>
                 <field name="activity_user_id" string="Activities of"/>
                 <field name="activity_type_id" string="Activity type"/>


### PR DESCRIPTION
In Management < Allocations, the first research was Description. The search bar has been adjusted to search allocations by employee firstly.
