### PR TITLE
[IMP] l10n_id: add country in migration script

### DIFF
--- a/addons/l10n_id/migrations/1.2/end-migrate_update_taxes.py
+++ b/addons/l10n_id/migrations/1.2/end-migrate_update_taxes.py
@@ -18,7 +18,7 @@ def migrate(cr, version):
                 "name": xmlid,
                 "module": "l10n_id",
                 "model": "account.tax.group",
-                "res_id": env['account.tax.group'].create({'name': name}).id,
+                "res_id": env['account.tax.group'].create({'name': name, 'country_id': env.ref('base.id').id}).id,
                 'noupdate': True
             })
 


### PR DESCRIPTION
Adding `country_id` to the newly introduced tax groups

4485693

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
