### PR TITLE
[IMP] point_of_sale: use more space for category names

### DIFF
--- a/addons/point_of_sale/static/src/app/components/category_selector/category_selector.xml
+++ b/addons/point_of_sale/static/src/app/components/category_selector/category_selector.xml
@@ -11,7 +11,9 @@
                         class="category-img-thumb h-100 rounded-3 object-fit-cover"
                         alt="Category"
                     />
-                    <span t-if="category.name" t-attf-class="{{category.imgSrc ? 'px-2' : 'px-3'}} text-center text-wrap-categ fs-5" t-esc="category.name" />
+                    <span t-if="category.name"
+                          t-att-class="{'px-2': category.imgSrc, 'px-3': !category.imgSrc and this.pos.config.show_category_images}"
+                          class="text-center text-wrap-categ fs-5" t-esc="category.name" />
                 </button>
             </t>
         </div>


### PR DESCRIPTION
This commit reduces padding so that long category names can occupy more available space.

task-4865740

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
