### PR TITLE
[FIX] base: merge partner without access to banks

### DIFF
--- a/addons/account/models/res_partner_bank.py
+++ b/addons/account/models/res_partner_bank.py
@@ -293,7 +293,7 @@ class ResPartnerBank(models.Model):
             should_allow_changes = True  # If we were on a non-trusted account, we will allow to change (setting/... one last time before trusting)
         else:
             # If we were on a trusted account, we only allow changes if the account is moving to untrusted.
-            should_allow_changes = ('allow_out_payment' in vals and vals['allow_out_payment'] is False)
+            should_allow_changes = self.env.su or ('allow_out_payment' in vals and vals['allow_out_payment'] is False)
 
         if ('acc_number' in vals or 'partner_id' in vals) and not should_allow_changes:
             raise UserError(_("You cannot modify the account number or partner of an account that has been trusted."))

--- a/odoo/addons/base/wizard/base_partner_merge.py
+++ b/odoo/addons/base/wizard/base_partner_merge.py
@@ -405,9 +405,9 @@ class BasePartnerMergeAutomaticWizard(models.TransientModel):
             if duplicate_account:
                 self._update_foreign_keys_generic('res.partner.bank', src_account, duplicate_account)
                 self._update_reference_fields_generic('res.partner.bank', src_account, duplicate_account)
-                src_account.unlink()
+                src_account.sudo().unlink()
             else:
-                src_account.write({'partner_id': dst_partner.id})
+                src_account.sudo().write({'partner_id': dst_partner.id})
 
     def _merge(self, partner_ids, dst_partner=None, extra_checks=True):
         """ private implementation of merge partner
@@ -470,7 +470,7 @@ class BasePartnerMergeAutomaticWizard(models.TransientModel):
         self._log_merge_operation(src_partners, dst_partner)
 
         # delete source partner, since they are merged
-        src_partners.unlink()
+        src_partners.sudo().unlink()
 
     def _log_merge_operation(self, src_partners, dst_partner):
         _logger.info('(uid = %s) merged the partners %r with %s', self._uid, src_partners.ids, dst_partner.id)


### PR DESCRIPTION
Previous code was trying to unlink or write on res.partner.bank, but the user might not has enough credentials to do that. In the context of merging partners, it makes sense to do those operations in sudo to avoid raising access rights errors





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
