### PR TITLE
[FIX] base: format invoice PDF - update partner display_name formatting

### DIFF
--- a/odoo/addons/base/models/res_partner.py
+++ b/odoo/addons/base/models/res_partner.py
@@ -1014,6 +1014,8 @@ class ResPartner(models.Model):
                     else:
                         name = f"{name} - {partner.vat}"
 
+            # Remove extra empty lines
+            name = re.sub(r'\s+\n', '\n', name)
             partner.display_name = name.strip()
 
     @api.model

--- a/odoo/addons/base/tests/test_format_address_mixin.py
+++ b/odoo/addons/base/tests/test_format_address_mixin.py
@@ -60,3 +60,23 @@ class TestPartnerFormatAddress(FormatAddressCase):
     def test_address_view(self):
         self.env.company.country_id = self.env.ref('base.us')
         self.assertAddressView('res.partner')
+
+    def test_display_name_address_formatting(self):
+        france = self.env.ref('base.fr')
+
+        partner = self.env['res.partner'].create({
+            'name': 'John Doe',
+            'street': '123 Main Street',
+            'street2': '',
+            'city': 'Paris',
+            'country_id': france.id,
+        })
+
+        # Default display_name without context
+        self.assertIn('John Doe', partner.display_name)
+
+        # display_name with show_address context
+        display_name = partner.with_context(show_address=True).display_name
+        self.assertIn('123 Main Street', display_name)
+        self.assertIn('Paris', display_name)
+        self.assertNotIn('\n\n', display_name)


### PR DESCRIPTION
To Reproduce:
=============
- add contact with empty street2
- create invoice
- generate pdf from invoice --> blank line

Problem:
=========
-The _compute_display_name method concatenates address fields using newline characters (\n).
-When some address components (like street2) are empty, this results in multiple consecutive newlines (\n\n), producing blank lines in the rendered display name and PDF reports.
https://github.com/odoo/odoo/blob/saas-18.3/odoo/addons/base/models/res_partner.py#L990

Solution:
==========
filtering out empty or whitespace-only lines,
and joining them back properly.

opw-4820829
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
