### PR TITLE
[IMP] im_livechat: remove Ratings menu item from channel kanban card

### DIFF
--- a/addons/im_livechat/views/im_livechat_channel_views.xml
+++ b/addons/im_livechat/views/im_livechat_channel_views.xml
@@ -27,7 +27,6 @@
                     <field name="rating_count"/>
                     <templates>
                         <t t-name="menu">
-                            <a type="object" name="action_view_rating" class="dropdown-item" role="menuitem">Ratings</a>
                             <a type="open" class="dropdown-item" role="menuitem">
                                 <span groups="im_livechat.im_livechat_group_manager">Configure Channel</span>
                                 <span groups="!im_livechat.im_livechat_group_manager">View Channel</span>


### PR DESCRIPTION
Current behavior before PR:
- burger menu in the live chat channel kanban card displayed a menu item "Ratings"

Desired behavior after PR is merged:
- Removed the "Ratings" menu item as it was redundant with the action when clicked on the kanban card

task-id:[4795432](https://www.odoo.com/odoo/my-tasks/4795432)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
