### PR TITLE
[16.0][IMP] web: Export allowedFns to enable adding other contexts.

### DIFF
--- a/addons/web/static/src/core/py_js/py_interpreter.js
+++ b/addons/web/static/src/core/py_js/py_interpreter.js
@@ -269,7 +269,7 @@ function methods(_class) {
     return Object.getOwnPropertyNames(_class.prototype).map((prop) => _class.prototype[prop]);
 }
 
-const allowedFns = new Set([
+export const allowedFns = new Set([
     BUILTINS.time.strftime,
     BUILTINS.bool,
     BUILTINS.context_today,


### PR DESCRIPTION

Description of the issue/feature this PR addresses:
allowedFns is used to validate functions permitted for use in evaluate. However, it is not currently exported, so other modules cannot create new functions.

Current behavior before PR:
Other modules can inherit and add new functions.

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
