### PR TITLE
[FIX] web: show currency only for monetary aggregates

### DIFF
--- a/addons/web/static/src/views/list/list_renderer.js
+++ b/addons/web/static/src/views/list/list_renderer.js
@@ -731,7 +731,7 @@ export class ListRenderer extends Component {
             digits: attrs.digits ? JSON.parse(attrs.digits) : field.digits,
             escape: true,
         };
-        if (field.type === "monetary" || widget === "monetary") {
+        if (field.type === "monetary") {
             formatOptions.currencyId = group.aggregates[field.currency_field][0];
         }
         return {

--- a/addons/web/static/tests/views/list/list_view.test.js
+++ b/addons/web/static/tests/views/list/list_view.test.js
@@ -4512,7 +4512,8 @@ test(`monetary aggregates in grouped list`, async () => {
         arch: `
             <list>
                 <field name="foo"/>
-                <field name="amount" widget="monetary" sum="Sum"/>
+                <field name="amount" sum="Sum"/>
+                <field name="qux" widget="monetary" sum="Sum"/>
                 <field name="currency_id"/>
             </list>
         `,
@@ -4521,8 +4522,10 @@ test(`monetary aggregates in grouped list`, async () => {
     expect(`.o_group_header`).toHaveCount(2);
     await contains(`.o_group_header:first`).click();
     await contains(`.o_group_header:last`).click();
-    expect(`.o_group_header:first`).toHaveText("USD (3)\n $ 800.00");
-    expect(`.o_group_header:last`).toHaveText("EUR (1)\n 1,200.00 €");
+    // Don't handle currencies in aggregates for non monetary fields even with the widget:
+    // it is bad practice and the server won't send the information anyway
+    expect(`.o_group_header:first`).toHaveText("USD (3)\n $ 800.00 19.00");
+    expect(`.o_group_header:last`).toHaveText("EUR (1)\n 1,200.00 € 0.40");
     expect(`.o_list_footer .o_list_number span`).toHaveText("—");
     expect(`.o_list_footer .o_list_number span`).toHaveAttribute(
         "data-tooltip",


### PR DESCRIPTION
This commit removes the display of currency symbols in group aggregates for field types other than monetary which use the moneatary widget (e.g., float or integer). Since the server does not provide currency information for non-monetary fields, attempting to display it would always lead to a traceback.

task-4865433