### PR TITLE
[FIX] html_editor, website: clean duplicate assets impported

### DIFF
--- a/addons/html_editor/__manifest__.py
+++ b/addons/html_editor/__manifest__.py
@@ -21,7 +21,6 @@ This addon provides an extensible, maintainable editor.
         'web.assets_backend': [
             'html_editor/static/src/**/*',
             ('include', 'html_editor.assets_media_dialog'),
-            ('include', 'html_editor.assets_link_popover'),
             ('remove', 'html_editor/static/src/components/history_dialog/history_dialog.dark.scss'),
             ('remove', 'html_editor/static/src/main/toolbar/toolbar.dark.scss'),
         ],
@@ -41,11 +40,6 @@ This addon provides an extensible, maintainable editor.
         'html_editor.assets_image_cropper': [
             'html_editor/static/lib/cropperjs/cropper.css',
             'html_editor/static/lib/cropperjs/cropper.js',
-        ],
-        'html_editor.assets_link_popover': [
-            'html_editor/static/src/main/link/link_popover.js',
-            'html_editor/static/src/main/link/link_popover.xml',
-            'html_editor/static/src/main/link/utils.js',
         ],
     },
     'license': 'LGPL-3'

--- a/addons/website/__manifest__.py
+++ b/addons/website/__manifest__.py
@@ -250,6 +250,7 @@
         ],
         'web.assets_backend': [
             ('include', 'website.assets_editor'),
+            ('include', 'html_editor.assets_link_popover'),
             'website/static/src/scss/color_palettes.scss',
             'website/static/src/scss/view_hierarchy.scss',
             'website/static/src/scss/website.backend.scss',


### PR DESCRIPTION
We have duplicate assets imported from the pr: https://github.com/odoo/odoo/pull/187091 up to saas-18.2, this pr is to clean the duplicate introduced


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
