### PR TITLE
[IMP] base_geolocalize,* : preserve coordinates and recompute on portal update

### DIFF
--- a/addons/base_geolocalize/models/res_partner.py
+++ b/addons/base_geolocalize/models/res_partner.py
@@ -9,17 +9,6 @@ class ResPartner(models.Model):
 
     date_localization = fields.Date(string='Geolocation Updated On')
 
-    def write(self, vals):
-        # Reset latitude/longitude in case we modify the address without
-        # updating the related geolocation fields
-        if any(field in vals for field in ['street', 'zip', 'city', 'state_id', 'country_id']) \
-                and not all('partner_%s' % field in vals for field in ['latitude', 'longitude']):
-            vals.update({
-                'partner_latitude': 0.0,
-                'partner_longitude': 0.0,
-            })
-        return super().write(vals)
-
     @api.model
     def _geo_localize(self, street='', zip='', city='', state='', country=''):
         geo_obj = self.env['base.geocoder']

--- a/addons/website_crm_partner_assign/models/res_partner.py
+++ b/addons/website_crm_partner_assign/models/res_partner.py
@@ -81,3 +81,20 @@ class ResPartner(models.Model):
                 assign_partner = assign_partner.parent_id
                 partner = partner.parent_id
 
+    def write(self, vals):
+        """Recompute geolocation when a portal user updates their address.
+
+        Portal users cannot manually refresh geolocation. Since geolocation is used
+        for automatic lead assignment, recompute it when a portal user updates their
+        address and the partner is eligible for assignment (graded and previously
+        geolocated).
+        """
+        res = super().write(vals)
+
+        address_fields = {'street', 'zip', 'city', 'state_id', 'country_id'}
+        if self.env.user._is_portal() and address_fields & vals.keys():
+            partners = self.filtered(lambda p: p.grade_id and p.date_localization)
+            if partners:
+                partners.geo_localize()
+
+        return res


### PR DESCRIPTION
*=website_crm_partner_assign

Before:
Updating a partner address reset latitude and longitude to 0.0. This could leave the partner without coordinates, preventing automatic lead assignment.

After:
Coordinates are preserved when the address is modified. Also, when a portal user eligible for automatic lead assignment updates their address, the geolocation is automatically recomputed. Internal users still need to manually refresh the geolocation when updating an address to receive leads from the new location.

Task-4812621