### PR TITLE
[FIX] website_sale: allow carousel image zoom

### DIFF
--- a/addons/website_sale/static/src/scss/website_sale_frontend.scss
+++ b/addons/website_sale/static/src/scss/website_sale_frontend.scss
@@ -11,6 +11,7 @@
 
     .o_wsale_image_viewer_image {
         .o_wsale_image_viewer_void {
+            z-index: 1;
             padding-top: 64px;
             padding-bottom: 156px;
         }


### PR DESCRIPTION
## Version
18.0+

## Issue
Carousel images are not zoomable on product's website view

## Steps to reproduce
- Select any product and move to `Sales` tab:
  - Add 1 image under `ECOMMERCE MEDIA` section.
  - Click `Go to website` and open edit mode:
    - Select the main image in the view;
    - In the editor, change the `Image Zoom` value for `Pop-up on Click`;
    - Save and close the editor.
  - Click on the main image to display the carousel:
    - Hover the current image and try to zoom in or out *(using the mouse wheel or equivalent action on trackpad)*

opw-4831912