### PR TITLE
[FIX] hr_attendance: department employee count in kiosk

### DIFF
--- a/addons/hr_attendance/controllers/main.py
+++ b/addons/hr_attendance/controllers/main.py
@@ -85,13 +85,16 @@ class HrAttendance(http.Controller):
         if not company:
             return request.not_found()
         else:
-            department_list = [{'id': dep["id"],
-                                 'name': dep["name"],
-                                 'count': dep["total_employee"]
-                                 } for dep in request.env['hr.department'].sudo().search_read(domain=[('company_id', '=', company.id)],
-                                                                                              fields=["id",
-                                                                                                      "name",
-                                                                                                      "total_employee"])]
+            department_list = [
+                {"id": dep["id"], "name": dep["name"], "count": dep["total_employee"]}
+                for dep in request.env["hr.department"]
+                .with_context(allowed_company_ids=[company.id])
+                .sudo()
+                .search_read(
+                    domain=[("company_id", "=", company.id)],
+                    fields=["id", "name", "total_employee"],
+                )
+            ]
             has_password = self.has_password()
             if not from_trial_mode and has_password:
                 request.session.logout(keep_db=True)

--- a/addons/hr_attendance/tests/__init__.py
+++ b/addons/hr_attendance/tests/__init__.py
@@ -5,3 +5,4 @@ from . import test_hr_attendance_overtime
 from . import test_hr_attendance_process
 from . import test_hr_attendance_domain_translation
 from . import test_load_scenario
+from . import test_hr_attendance_kiosk

--- a/addons/hr_attendance/tests/test_hr_attendance_kiosk.py
+++ b/addons/hr_attendance/tests/test_hr_attendance_kiosk.py
@@ -1,0 +1,39 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from odoo.tests.common import tagged, HttpCase
+from unittest.mock import patch
+from odoo.http import Request
+
+
+@tagged('post_install', '-at_install', 'hr_attendance_overtime')
+class TestHrAttendanceKiosk(HttpCase):
+    """ Tests for kiosk """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.company_A = cls.env['res.company'].create({'name': 'company_A'})
+        cls.company_B = cls.env['res.company'].create({'name': 'company_B'})
+
+        cls.department_A = cls.env['hr.department'].create({'name': 'department_A', 'company_id': cls.company_B.id})
+
+        cls.employee_A = cls.env['hr.employee'].create({
+            'name': 'employee_A',
+             'company_id': cls.company_B.id,
+             'department_id': cls.department_A.id,
+        })
+        cls.employee_B = cls.env['hr.employee'].create({
+            'name': 'employee_B',
+            'company_id': cls.company_A.id,
+            'department_id': cls.department_A.id,
+        })
+
+    def test_employee_count_kiosk(self):
+        # the mock need to return a None value which can be converted into a Reponse object
+        with patch.object(Request, "render", return_value=None) as render:
+            self.url_open(self.company_B.attendance_kiosk_url)
+
+        render.assert_called_once()
+        _template, kiosk_info = render.call_args[0]
+        kiosk_info = kiosk_info['kiosk_backend_info']
+        self.assertEqual(kiosk_info['company_name'], 'company_B')
+        self.assertEqual(kiosk_info['departments'][0]['count'], 1)


### PR DESCRIPTION
**PROBLEM**
When using the kiosk on a company that's not the default company, the employee count displayed for all department is 0.

**STEP TO REPRODUCE**
1.install the attendance module.
2.select another company.
3.go to the kiosk (attendance/Kiosk Mode).
4.identify manually.
5.notice the department count is incorrectly displayed as 0.

**CAUSE**
When entering the kiosk, the user is disconnected from their session, the user in this context is the public_user who have only access to the default company. The _compute_total_employee filter employees based on the company we have access to, so any employee from the non-default company are not taken into account.

**FIX**
We set the allowed_company_ids to the correct company id in the request context.

opw-4647574