### PR TITLE
[FIX] mrp: avoid crash when printing BOM with 0-quantity byproducts

### DIFF
--- a/addons/mrp/report/mrp_report_bom_structure.py
+++ b/addons/mrp/report/mrp_report_bom_structure.py
@@ -407,7 +407,7 @@ class ReportBomStructure(models.AbstractModel):
             if byproduct._skip_byproduct_line(product):
                 continue
             line_quantity = (bom_quantity / (bom.product_qty or 1.0)) * byproduct.product_qty
-            cost_share = byproduct.cost_share / 100
+            cost_share = byproduct.cost_share / 100 if byproduct.product_qty > 0 else 0
             byproduct_cost_portion += cost_share
             price = byproduct.product_id.uom_id._compute_price(byproduct.product_id.with_company(company).standard_price, byproduct.product_uom_id) * line_quantity
             byproducts.append({

--- a/addons/mrp/report/mrp_report_bom_structure.xml
+++ b/addons/mrp/report/mrp_report_bom_structure.xml
@@ -69,7 +69,7 @@
                             <td class="text-end" t-esc="data['prod_cost']/data['quantity']" t-options='{"widget": "monetary", "display_currency": currency}'/>
                         </tr>
                         <t t-if="data['show_costs'] and data['byproducts']" t-foreach="data['byproducts']" t-as="byproduct">
-                            <tr>
+                            <tr t-if="byproduct['quantity'] &gt; 0">
                                 <td name="td_mrp_bom_byproducts_f" class="text-end" t-esc="byproduct['name']"/>
                                 <td class="text-end"><strong>Unit Cost</strong></td>
                                 <td class="text-start" groups="uom.group_uom" t-esc="byproduct['uom_name']"/>


### PR DESCRIPTION
**Issue**:
Printing the BOM crashes when one of the byproduct quantity is set to 0

**Steps to reproduce**:
- Open the manufactoring app
- Go to settings and activate by-product settings
- Go to Products > Bills of Materials
- Open a BOM
- Put the quantity of one the by-product by 0
- Click on overview
- Click on the print button

**Cause**:
In the `mrp_report_bom_structure.xml` template, there is this division:
- `<td class="text-end" t-esc="byproduct['bom_cost'] / byproduct['quantity']" t-options='{"widget": "monetary", "display_currency": currency}'/>`

without checking if `byproduct['quantity']` is different than 0.

**Solution**:
Added the check on `byproduct['quantity']` in the foreach

**Additional notes**:
Since it makes no real sense to have a non-zero BoM cost associated with a byproduct whose quantity is zero, the cost is set to 0 when the quantity is 0.

opw-4853525