### PR TITLE
[FIX] hr: fix chatter not working

### DIFF
--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -1021,6 +1021,7 @@ class HrEmployee(models.Model):
         # Only one write call for all the fields from hr.version
         new_vals = vals.copy()
         version_vals = {val: new_vals.pop(val) for val in vals if val in self._fields and self._fields[val].inherited}
+        res = super().write(new_vals)
         if version_vals:
             version_vals['last_modified_date'] = fields.Datetime.now()
             version_vals['last_modified_uid'] = self.env.uid
@@ -1028,7 +1029,6 @@ class HrEmployee(models.Model):
 
             for employee in self:
                 employee._track_set_log_message(Markup("<b>Modified on the Version '%s'</b>") % employee.version_id.display_name)
-        res = super().write(new_vals)
         if res and 'resource_calendar_id' in vals:
             resources_per_calendar_id = defaultdict(lambda: self.env['resource.resource'])
             for employee in self:

--- a/addons/hr/models/hr_version.py
+++ b/addons/hr/models/hr_version.py
@@ -60,16 +60,16 @@ class HrVersion(models.Model):
         ('other', 'Other'),
     ], groups="hr.group_hr_user", tracking=True, help="This is the legal sex recognized by the state.")
 
-    private_street = fields.Char(string="Private Street", groups="hr.group_hr_user")
-    private_street2 = fields.Char(string="Private Street2", groups="hr.group_hr_user")
-    private_city = fields.Char(string="Private City", groups="hr.group_hr_user")
+    private_street = fields.Char(string="Private Street", groups="hr.group_hr_user", tracking=True)
+    private_street2 = fields.Char(string="Private Street2", groups="hr.group_hr_user", tracking=True)
+    private_city = fields.Char(string="Private City", groups="hr.group_hr_user", tracking=True)
     private_state_id = fields.Many2one(
         "res.country.state", string="Private State",
         domain="[('country_id', '=?', private_country_id)]",
-        groups="hr.group_hr_user")
-    private_zip = fields.Char(string="Private Zip", groups="hr.group_hr_user")
+        groups="hr.group_hr_user", tracking=True)
+    private_zip = fields.Char(string="Private Zip", groups="hr.group_hr_user", tracking=True)
     private_country_id = fields.Many2one("res.country", string="Private Country",
-                                         groups="hr.group_hr_user")
+                                         groups="hr.group_hr_user", tracking=True)
 
     distance_home_work = fields.Integer(string="Home-Work Distance", groups="hr.group_hr_user", tracking=True)
     km_home_work = fields.Integer(string="Home-Work Distance in Km", groups="hr.group_hr_user",
@@ -98,26 +98,27 @@ class HrVersion(models.Model):
             ('trainee', 'Trainee'),
             ('contractor', 'Contractor'),
             ('freelance', 'Freelancer'),
-        ], string='Employee Type', default='employee', required=True, groups="hr.group_hr_user")
+        ], string='Employee Type', default='employee', required=True, groups="hr.group_hr_user", tracking=True)
     department_id = fields.Many2one('hr.department', check_company=True, tracking=True)
     member_of_department = fields.Boolean("Member of department", compute='_compute_part_of_department', search='_search_part_of_department',
         help="Whether the employee is a member of the active user's department or one of it's child department.")
     job_id = fields.Many2one('hr.job', check_company=True, tracking=True)
-    job_title = fields.Char(related='job_id.name', readonly=False, string="Job Title", groups="hr.group_hr_user")
+    job_title = fields.Char(related='job_id.name', readonly=False, string="Job Title", groups="hr.group_hr_user", tracking=True)
     address_id = fields.Many2one(
         'res.partner',
         string='Work Address',
         default=_get_default_address_id,
         store=True,
         readonly=False,
-        check_company=True)
+        check_company=True,
+        tracking=True)
     work_location_id = fields.Many2one('hr.work.location', 'Work Location',
-                                       domain="[('address_id', '=', address_id)]")
+                                       domain="[('address_id', '=', address_id)]", tracking=True)
     work_location_name = fields.Char("Work Location Name", compute="_compute_work_location_name_type")
     work_location_type = fields.Selection([
         ("home", "Home"),
         ("office", "Office"),
-        ("other", "Other")], compute="_compute_work_location_name_type", groups="hr.group_hr_user")
+        ("other", "Other")], compute="_compute_work_location_name_type", groups="hr.group_hr_user", tracking=True)
 
     departure_reason_id = fields.Many2one("hr.departure.reason", string="Departure Reason",
                                           groups="hr.group_hr_user", copy=False, ondelete='restrict', tracking=True)
@@ -145,7 +146,7 @@ class HrVersion(models.Model):
 
     contract_template_id = fields.Many2one(
         'hr.version', string="Contract Template", groups="hr.group_hr_user",
-        domain="[('company_id', '=', company_id), ('employee_id', '=', False)]",
+        domain="[('company_id', '=', company_id), ('employee_id', '=', False)]", tracking=True,
         help="Select a contract template to auto-fill the contract form with predefined values. You can still edit the fields as needed after applying the template.")
     structure_type_id = fields.Many2one('hr.payroll.structure.type', string="Salary Structure Type",
                                         compute="_compute_structure_type_id", readonly=False, store=True, tracking=True,


### PR DESCRIPTION
In the employee form view, modifying version fields should show a message in the
 chatter for the tracked values with the date of the version in which it was
 modified.

This didn't work anymore because we were writing on the versions before writing
  on super. But since mail.thread compares values to previous values, the
  previous values were already the new ones so no changes were detected.

Reversing the order of the writes allow the mail.thread to detect the changes and print the message in the chatter.

Task: 4865411