### PR TITLE
[FIX] mail: send button visibility while editing message in chatter

### DIFF
--- a/addons/mail/static/src/core/common/composer.js
+++ b/addons/mail/static/src/core/common/composer.js
@@ -93,6 +93,7 @@ export class Composer extends Component {
         this.isMobileOS = isMobileOS();
         this.isIosPwa = isIOS() && isDisplayStandalone();
         this.composerActions = useComposerActions();
+        this.EDIT_CLICK_TYPE = EDIT_CLICK_TYPE;
         this.OR_PRESS_SEND_KEYBIND = _t("or press %(send_keybind)s", {
             send_keybind: markup(
                 this.sendKeybinds.map((key) => `<samp>${escape(key)}</samp>`).join(" + ")
@@ -263,50 +264,27 @@ export class Composer extends Component {
     }
 
     get CANCEL_OR_SAVE_EDIT_TEXT() {
-        if (this.ui.isSmall) {
-            return _t(
-                "%(open_button)s%(icon)s%(open_em)sDiscard editing%(close_em)s%(close_button)s",
-                {
-                    open_button: markup(
-                        `<button class='btn px-1 py-0' data-type="${escape(
-                            EDIT_CLICK_TYPE.CANCEL
-                        )}">`
-                    ),
-                    close_button: markup("</button>"),
-                    icon: markup(
-                        `<i class='fa fa-times-circle pe-1' data-type="${escape(
-                            EDIT_CLICK_TYPE.CANCEL
-                        )}"></i>`
-                    ),
-                    open_em: markup(`<em data-type="${escape(EDIT_CLICK_TYPE.CANCEL)}">`),
-                    close_em: markup("</em>"),
-                }
-            );
-        } else {
-            const tags = {
-                open_samp: markup("<samp>"),
-                close_samp: markup("</samp>"),
-                open_em: markup("<em>"),
-                close_em: markup("</em>"),
-                open_cancel: markup(
-                    `<a role="button" href="#" data-type="${escape(EDIT_CLICK_TYPE.CANCEL)}">`
-                ),
-                close_cancel: markup("</a>"),
-                open_save: markup(
-                    `<a role="button" href="#" data-type="${escape(EDIT_CLICK_TYPE.SAVE)}">`
-                ),
-                close_save: markup("</a>"),
-            };
-            return this.env.inChatter
-                ? _t(
-                      "%(open_samp)sEscape%(close_samp)s %(open_em)sto %(open_cancel)scancel%(close_cancel)s%(close_em)s, %(open_samp)sCTRL-Enter%(close_samp)s %(open_em)sto %(open_save)ssave%(close_save)s%(close_em)s",
-                      tags
-                  )
-                : _t(
-                      "%(open_samp)sEscape%(close_samp)s %(open_em)sto %(open_cancel)scancel%(close_cancel)s%(close_em)s, %(open_samp)sEnter%(close_samp)s %(open_em)sto %(open_save)ssave%(close_save)s%(close_em)s",
-                      tags
-                  );
-        }
+        const tags = {
+            open_samp: markup`<samp>`,
+            close_samp: markup`</samp>`,
+            open_em: markup`<em>`,
+            close_em: markup`</em>`,
+            open_cancel: markup`
+                <a role="button" href="#" data-type="${EDIT_CLICK_TYPE.CANCEL}">`,
+            close_cancel: markup`</a>`,
+            open_save: markup`
+                <a role="button" href="#" data-type="${EDIT_CLICK_TYPE.SAVE}">`,
+            close_save: markup`</a>`,
+        };
+        return this.env.inChatter
+            ? _t(
+                  "%(open_samp)sEscape%(close_samp)s %(open_em)sto %(open_cancel)scancel%(close_cancel)s%(close_em)s, %(open_samp)sCTRL-Enter%(close_samp)s %(open_em)sto %(open_save)ssave%(close_save)s%(close_em)s",
+                  tags
+              )
+            : _t(
+                  "%(open_samp)sEscape%(close_samp)s %(open_em)sto %(open_cancel)scancel%(close_cancel)s%(close_em)s, %(open_samp)sEnter%(close_samp)s %(open_em)sto %(open_save)ssave%(close_save)s%(close_em)s",
+                  tags
+              );
     }
 
     get SEND_TEXT() {

--- a/addons/mail/static/src/core/common/composer.xml
+++ b/addons/mail/static/src/core/common/composer.xml
@@ -32,14 +32,22 @@
             <div t-if="showComposerAvatar" class="o-mail-Composer-sidebarMain flex-shrink-0 d-flex">
                 <img class="o-mail-Composer-avatar mx-auto o_avatar rounded-3" t-att-src="(thread?.effectiveSelf or message.effectiveSelf).avatarUrl" alt="Avatar of user"/>
             </div>
-            <div class="o-mail-Composer-coreHeader text-truncate small p-2" t-if="props.composer.replyToMessage">
-                <span class="cursor-pointer" t-on-click="() => env.messageHighlight?.highlightMessage(props.composer.replyToMessage, props.composer.thread)">
-                    Replying to <b t-esc="props.composer.replyToMessage.authorName"/>
+            <div class="o-mail-Composer-coreHeader">
+                <div t-if="props.composer.replyToMessage" class="text-truncate small p-2">
+                    <span class="cursor-pointer" t-on-click="() => env.messageHighlight?.highlightMessage(props.composer.replyToMessage, props.composer.thread)">
+                        Replying to <b t-esc="props.composer.replyToMessage.authorName"/>
+                    </span>
+                    <span t-if="props.composer.replyToMessage.thread?.notEq(props.composer.thread)">
+                        on: <b><t t-esc="props.composer.replyToMessage.thread.displayName"/></b>
+                    </span>
+                    <i class="fa fa-lg fa-times-circle rounded-circle p-0 ms-1 cursor-pointer" title="Stop replying" t-on-click="() => (props.composer.replyToMessage = undefined)"/>
+                </div>
+                <span t-if="props.composer.message and ui.isSmall" class="px-1" t-on-click="onClickCancelOrSaveEditText">
+                    <button class="btn btn-sm btn-secondary rounded-pill border border-secondary ps-1 pe-2 py-0 mb-1" t-att-data-type="EDIT_CLICK_TYPE.CANCEL">
+                        <i class="oi oi-close pe-2" t-att-data-type="EDIT_CLICK_TYPE.CANCEL"></i>
+                        Discard editing
+                    </button>
                 </span>
-                <span t-if="props.composer.replyToMessage.thread?.notEq(props.composer.thread)">
-                    on: <b><t t-esc="props.composer.replyToMessage.thread.displayName"/></b>
-                </span>
-                <i class="fa fa-lg fa-times-circle rounded-circle p-0 ms-1 cursor-pointer" title="Stop replying" t-on-click="() => (props.composer.replyToMessage = undefined)"/>
             </div>
             <div class="o-mail-Composer-coreMain d-flex flex-nowrap align-items-start flex-grow-1" t-att-class="{ 'flex-column' : extended or props.composer.message }">
                 <div class="o-mail-Composer-inputContainer o-mail-Composer-bg d-flex flex-grow-1 border border-secondary shadow-sm"
@@ -111,8 +119,8 @@
                 </div>
                 <div t-else="" class="d-flex align-items-center gap-1 w-100 pe-2">
                     <div class="pt-1" t-att-class="{ 'mt-2': !props.composer.message }">
-                        <span t-if="props.composer.message" class="text-muted px-1 small" t-out="CANCEL_OR_SAVE_EDIT_TEXT" t-on-click="onClickCancelOrSaveEditText"/>
-                        <t t-else="">
+                        <span t-if="props.composer.message and !ui.isSmall" class="text-muted px-1 small" t-out="CANCEL_OR_SAVE_EDIT_TEXT" t-on-click="onClickCancelOrSaveEditText" />
+                        <t t-elif="!props.composer.message">
                             <t t-call="mail.Composer.sendButton"/>
                             <span t-if="!isSendButtonDisabled and !isMobileOS" class="text-muted small ms-1" t-out="OR_PRESS_SEND_KEYBIND"/>
                         </t>

--- a/addons/mail/static/src/core/common/composer_actions.js
+++ b/addons/mail/static/src/core/common/composer_actions.js
@@ -46,7 +46,8 @@ composerActionsRegistry
             return "";
         },
         condition: (component) =>
-            !component.env.inChatter && (!component.props.composer.message || component.ui.isSmall),
+            (component.ui.isSmall && component.props.composer.message) ||
+            (!component.env.inChatter && !component.props.composer.message),
         disabledCondition: (component) => component.isSendButtonDisabled,
         icon: "fa fa-paper-plane-o",
         name(component) {

--- a/addons/mail/static/tests/message/message.test.js
+++ b/addons/mail/static/tests/message/message.test.js
@@ -213,26 +213,6 @@ test("Can edit message comment in chatter", async () => {
     await contains(".o-mail-Message-content", { text: "edited again (edited)" });
 });
 
-test.skip("Can edit message comment in chatter (mobile)", async () => {
-    const pyEnv = await startServer();
-    const partnerId = pyEnv["res.partner"].create({ name: "TestPartner" });
-    pyEnv["mail.message"].create({
-        author_id: serverState.partnerId,
-        body: "original message",
-        message_type: "comment",
-        model: "res.partner",
-        res_id: partnerId,
-    });
-    await start();
-    await openFormView("res.partner", partnerId);
-    await click(".o-mail-Message [title='Expand']");
-    await click("button:contains('Edit')");
-    await contains("button", { text: "Discard editing" });
-    await insertText(".o-mail-Message .o-mail-Composer-input", "edited message", { replace: true });
-    await click("button[title='Save editing']");
-    await contains(".o-mail-Message-content", { text: "edited message (edited)" });
-});
-
 test("Cursor is at end of composer input on edit", async () => {
     const pyEnv = await startServer();
     const channelId = pyEnv["discuss.channel"].create({


### PR DESCRIPTION
**Purpose of this PR:**

This PR addresses UI issues in the mobile view of the chatter during message editing.

- Ensures the send button is properly displayed while editing messages on mobile.
- Moves the "Discard Editing" action above the composer.

**Before this PR:**
![image](https://github.com/user-attachments/assets/fa4b0813-8596-4a25-986a-5ed65eb1a5c2)

**After this PR:**
<img width="446" height="132" alt="image" src="https://github.com/user-attachments/assets/1842f341-268a-40e3-8915-dc08fb9162b3" />

task-[4780731](https://www.odoo.com/odoo/project/1519/tasks/4780731)
