### PR TITLE
Community PR: replace `date` with `create_date` in stock picking

### DIFF
--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -1038,11 +1038,11 @@ class PosSession(models.Model):
                         if move._is_in():
                             signed_product_qty *= -1
                         amount = signed_product_qty * move.product_id._compute_average_price(0, move.quantity, move)
-                        stock_expense[exp_key] = self._update_amounts(stock_expense[exp_key], {'amount': amount}, move.picking_id.date, force_company_currency=True)
+                        stock_expense[exp_key] = self._update_amounts(stock_expense[exp_key], {'amount': amount}, move.picking_id.create_date, force_company_currency=True)
                         if move._is_in():
-                            stock_return[out_key] = self._update_amounts(stock_return[out_key], {'amount': amount}, move.picking_id.date, force_company_currency=True)
+                            stock_return[out_key] = self._update_amounts(stock_return[out_key], {'amount': amount}, move.picking_id.create_date, force_company_currency=True)
                         else:
-                            stock_output[out_key] = self._update_amounts(stock_output[out_key], {'amount': amount}, move.picking_id.date, force_company_currency=True)
+                            stock_output[out_key] = self._update_amounts(stock_output[out_key], {'amount': amount}, move.picking_id.create_date, force_company_currency=True)
         MoveLine = self.env['account.move.line'].with_context(check_move_validity=False, skip_invoice_sync=True)
 
         data.update({

--- a/addons/purchase_stock/models/purchase_order.py
+++ b/addons/purchase_stock/models/purchase_order.py
@@ -323,7 +323,6 @@ class PurchaseOrder(models.Model):
             'picking_type_id': self.picking_type_id.id,
             'partner_id': self.partner_id.id,
             'user_id': False,
-            'date': self.date_order,
             'origin': self.name,
             'location_dest_id': self._get_destination_location(),
             'location_id': self.partner_id.property_stock_supplier.id,

--- a/addons/sale_stock/views/sale_stock_portal_template.xml
+++ b/addons/sale_stock/views/sale_stock_portal_template.xml
@@ -19,7 +19,7 @@
 
         <div id="sale_invoices" position="after">
             <t t-set="delivery_orders" t-value="sale_order.picking_ids.filtered(lambda picking: picking.picking_type_id.code == 'outgoing')"/>
-            <t t-set="latest_delivery_orders" t-value="delivery_orders.sorted('date', reverse=True)[:3]"/>
+            <t t-set="latest_delivery_orders" t-value="delivery_orders.sorted('create_date', reverse=True)[:3]"/>
             <div t-if="delivery_orders" class="col-12 col-lg-6 mb-4">
                 <h5 class="mb-1">Last Delivery Orders</h5>
                 <hr class="mt-1 mb-2"/>

--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -607,10 +607,6 @@ class StockPicking(models.Model):
     has_deadline_issue = fields.Boolean(
         "Is late", compute='_compute_has_deadline_issue', store=True, default=False,
         help="Is late or will be late depending on the deadline and scheduled date")
-    date = fields.Datetime(
-        'Creation Date',
-        default=fields.Datetime.now, tracking=True, copy=False,
-        help="Creation Date, usually the time of the order")
     date_done = fields.Datetime('Date of Transfer', copy=False, readonly=True, help="Date at which the transfer has been processed or cancelled.")
     delay_alert_date = fields.Datetime('Delay Alert Date', compute='_compute_delay_alert_date', search='_search_delay_alert_date')
     json_popover = fields.Char('JSON data for the popover widget', compute='_compute_json_popover')


### PR DESCRIPTION
This change was suggested by a contributor, but it requires an upgrade
script, so a set of 3 new PRs was created. The original purpose was to
improve the stock picking filtering in `simulate_period` test helper
method. While working on this, it became apparent that the `date` field
in stock picking is useless and it should be replaced by `create_date`.

Related:
https://github.com/odoo/odoo/pull/213949
https://github.com/odoo/enterprise/pull/87494
https://github.com/odoo/upgrade/pull/7852

Original community PRs:
https://github.com/odoo/odoo/pull/171895
https://github.com/odoo/enterprise/pull/66084

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
