### PR TITLE
[FIX] html_editor: close the link popover for image link after deleting

### DIFF
--- a/addons/html_editor/static/src/main/media/image_plugin.js
+++ b/addons/html_editor/static/src/main/media/image_plugin.js
@@ -256,6 +256,9 @@ export class ImagePlugin extends Plugin {
     deleteImage() {
         const selectedImg = this.getSelectedImage();
         if (selectedImg) {
+            if (this.delegateTo("delete_image_overrides", selectedImg)) {
+                return;
+            }
             const anchorNode = selectedImg.parentElement;
             let anchorOffset = childNodeIndex(selectedImg);
             selectedImg.remove();

--- a/addons/html_editor/static/tests/link/popover.test.js
+++ b/addons/html_editor/static/tests/link/popover.test.js
@@ -951,6 +951,17 @@ describe("links with inline image", () => {
             `<p>ab<a href="#">c</a>]d<img src="${base64Img}">exxf<img src="${base64Img}">g[<a href="#">h</a>i</p>`
         );
     });
+    test("link elelment should be removed and popover should close when image is deleted from a image link ", async () => {
+        const { el } = await setupEditor(`<p>ab<a href="#"><img src="${base64Img}">[]</a>c</p>`);
+        await click("img");
+        await waitFor(".o-we-toolbar");
+        await waitFor(".o-we-linkpopover");
+
+        await click("button[name='image_delete']");
+        await waitForNone(".o-we-linkpopover", { timeout: 1500 });
+
+        expect(cleanLinkArtifacts(getContent(el))).toBe(`<p>ab[]c</p>`);
+    });
 });
 
 describe("readonly mode", () => {

--- a/addons/html_editor/static/tests/media.test.js
+++ b/addons/html_editor/static/tests/media.test.js
@@ -35,6 +35,36 @@ test("Can replace an image", async () => {
     expect("img[src='/web/static/img/logo2.png']").toHaveCount(1);
 });
 
+test("Replace an image with link by a document should remove the link", async () => {
+    onRpc("/web/dataset/call_kw/ir.attachment/search_read", () => [
+        {
+            id: 1,
+            name: "file.txt",
+            mimetype: "text/plain",
+            public: true,
+            image_src: "",
+        },
+    ]);
+    const env = await makeMockEnv();
+    await setupEditor(
+        `<p><a href="http://test.com"><img class="img-fluid" src="/web/static/img/logo.png"></a></p>`,
+        { env }
+    );
+    expect("img[src='/web/static/img/logo.png']").toHaveCount(1);
+    await click("img");
+    await tick(); // selectionchange
+    await waitFor(".o-we-toolbar");
+    expect("button[name='replace_image']").toHaveCount(1);
+    await click("button[name='replace_image']");
+    await animationFrame();
+    await click(".nav-link:contains('Documents')");
+    await animationFrame();
+    await click(".o_we_attachment_highlight");
+    expect(".odoo-editor-editable .o_file_box a:contains('file.txt')").toHaveCount(1);
+    expect("img[src='/web/static/img/logo.png']").toHaveCount(0);
+    expect("p a[href='http://test.com']").toHaveCount(0);
+});
+
 test.tags("focus required");
 test("Selection is collapsed after the image after replacing it", async () => {
     onRpc("/web/dataset/call_kw/ir.attachment/search_read", () => {


### PR DESCRIPTION
Before this commit:
1. Insert an image and add a link to it.
2. Click on the image and remove it by clicking the remove button in the toolbar.
3. The link popover remains open and only disappears after clicking away.

This occurs because the default behavior of a link with text preserves the link
element to allow the possibility of completely changing the label of the link
directly in the editing area.

After this commit: The link popover is properly closed when an image link is
removed, and the link element is removed when the link element associated with
the image is empty.

task-4805029

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
