### PR TITLE
[FIX] html_editor: add top margin to headings inside the editor

### DIFF
--- a/addons/html_editor/static/src/main/font/font_plugin.scss
+++ b/addons/html_editor/static/src/main/font/font_plugin.scss
@@ -24,3 +24,7 @@ blockquote {
         padding: $padding-blockquote;
     }
 }
+
+.odoo-editor-editable :is(h1, h2, h3, h4, h5, h6):not(:first-child) {
+    margin-top: 0.5rem;
+}


### PR DESCRIPTION
Current behavior before PR:

- Due to the default use of `div.o-paragraph` instead of `<p>`, there was no spacing between heading elements and the base container when headings appeared directly below it.

Desired behavior after PR is merged:

- All heading elements inside the editor, except the first one, now have a top margin applied. This ensures proper spacing between the base container and any following heading elements.

task: 4863821