### PR TITLE
[FIX] hr_contract: Fix menu parent restoration on uninstall

### DIFF
--- a/addons/hr_contract/__init__.py
+++ b/addons/hr_contract/__init__.py
@@ -1,6 +1,19 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+import logging
 
 from . import models
 from . import report
 from . import wizard
+
+_logger = logging.getLogger(__name__)
+
+
+def uninstall_hook(env):
+    try:
+        env.ref('hr.menu_resource_calendar_view').parent_id = env.ref("hr.menu_config_employee")
+        env.ref('hr.menu_view_hr_contract_type').parent_id = env.ref("hr.menu_config_recruitment")
+        env.ref('hr.menu_view_hr_contract_type').active = False
+        env.ref('hr.menu_view_hr_contract_type').sequence = 2
+    except ValueError as e:
+        _logger.warning(e)

--- a/addons/hr_contract/__manifest__.py
+++ b/addons/hr_contract/__manifest__.py
@@ -34,6 +34,7 @@ You can assign several contracts per employee.
     'demo': ['data/hr_contract_demo.xml'],
     'installable': True,
     'application': True,
+    'uninstall_hook': "uninstall_hook",
     'assets': {
         'web.assets_backend': [
             'hr_contract/static/src/**/*',


### PR DESCRIPTION
This PR adds an uninstall_hook to restore the correct parent menus under the hr module that were overridden by this module.

Task: 4818020


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
