### PR TITLE
[IMP] hr: add smartbuttons on employee public

### DIFF
--- a/addons/hr/models/hr_employee_public.py
+++ b/addons/hr/models/hr_employee_public.py
@@ -58,6 +58,7 @@ class HrEmployeePublic(models.Model):
 
     # Manager-only fields
     is_manager = fields.Boolean(compute='_compute_is_manager')
+    is_user = fields.Boolean(compute='_compute_is_user')
 
     employee_id = fields.Many2one('hr.employee', 'Employee', compute="_compute_employee_id", search="_search_employee_id", compute_sudo=True)
     # hr.employee.public specific fields
@@ -115,6 +116,12 @@ class HrEmployeePublic(models.Model):
         all_reports = self.env['hr.employee.public'].search([('id', 'child_of', self.env.user.employee_id.id)]).ids
         for employee in self:
             employee.is_manager = employee.id in all_reports
+
+    @api.depends_context('uid')
+    def _compute_is_user(self):
+        user_employee_id = self.env.user.employee_id.id
+        for employee in self:
+            employee.is_user = employee.id == user_employee_id
 
     def _compute_presence_state(self):
         self._compute_from_employee('hr_presence_state')

--- a/addons/hr_attendance/__manifest__.py
+++ b/addons/hr_attendance/__manifest__.py
@@ -24,6 +24,7 @@ actions(Check in/Check out) performed by them.
         'views/hr_attendance_overtime_view.xml',
         'views/hr_department_view.xml',
         'views/hr_employee_view.xml',
+        'views/hr_employee_public_views.xml',
         'views/res_config_settings_views.xml',
         'views/hr_attendance_kiosk_templates.xml'
     ],

--- a/addons/hr_attendance/models/hr_employee.py
+++ b/addons/hr_attendance/models/hr_employee.py
@@ -32,8 +32,7 @@ class HrEmployee(models.Model):
         string="Attendance Status", compute='_compute_attendance_state',
         selection=[('checked_out', "Checked out"), ('checked_in', "Checked in")],
         groups="hr_attendance.group_hr_attendance_officer,hr.group_hr_user")
-    hours_last_month = fields.Float(
-        compute='_compute_hours_last_month', groups="hr_attendance.group_hr_attendance_officer,hr.group_hr_user")
+    hours_last_month = fields.Float(compute='_compute_hours_last_month')
     hours_today = fields.Float(
         compute='_compute_hours_today',
         groups="hr_attendance.group_hr_attendance_officer,hr.group_hr_user")
@@ -47,8 +46,7 @@ class HrEmployee(models.Model):
         compute='_compute_hours_last_month', groups="hr.group_hr_user")
     overtime_ids = fields.One2many(
         'hr.attendance.overtime', 'employee_id', groups="hr_attendance.group_hr_attendance_officer,hr.group_hr_user")
-    total_overtime = fields.Float(
-        compute='_compute_total_overtime', compute_sudo=True, groups="hr_attendance.group_hr_attendance_officer,hr.group_hr_user")
+    total_overtime = fields.Float(compute='_compute_total_overtime', compute_sudo=True)
 
     @api.model_create_multi
     def create(self, vals_list):

--- a/addons/hr_attendance/models/hr_employee_public.py
+++ b/addons/hr_attendance/models/hr_employee_public.py
@@ -12,13 +12,24 @@ class HrEmployeePublic(models.Model):
         groups="hr_attendance.group_hr_attendance_officer")
     hours_today = fields.Float(related='employee_id.hours_today', readonly=True,
         groups="hr_attendance.group_hr_attendance_officer")
+    hours_last_month = fields.Float(related='employee_id.hours_last_month')
     last_attendance_id = fields.Many2one(related='employee_id.last_attendance_id', readonly=True,
         groups="hr_attendance.group_hr_attendance_officer")
-    total_overtime = fields.Float(related='employee_id.total_overtime', readonly=True,
-        groups="hr_attendance.group_hr_attendance_officer")
+    total_overtime = fields.Float(related='employee_id.total_overtime', readonly=True)
     attendance_manager_id = fields.Many2one(related='employee_id.attendance_manager_id',
         groups="hr_attendance.group_hr_attendance_officer")
     last_check_in = fields.Datetime(related='employee_id.last_check_in',
         groups="hr_attendance.group_hr_attendance_officer")
     last_check_out = fields.Datetime(related='employee_id.last_check_out',
         groups="hr_attendance.group_hr_attendance_officer")
+    display_extra_hours = fields.Boolean(related='company_id.hr_attendance_display_overtime')
+
+    def action_open_last_month_attendances(self):
+        self.ensure_one()
+        if self.is_user:
+            return self.employee_id.action_open_last_month_attendances()
+
+    def action_open_last_month_overtime(self):
+        self.ensure_one()
+        if self.is_user:
+            return self.employee_id.action_open_last_month_overtime()

--- a/addons/hr_attendance/views/hr_employee_public_views.xml
+++ b/addons/hr_attendance/views/hr_employee_public_views.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="hr_employee_public_view_form" model="ir.ui.view">
+        <field name="name">hr.employee.public.form.inherit.attendance</field>
+        <field name="model">hr.employee.public</field>
+        <field name="inherit_id" ref="hr.hr_employee_public_view_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//div[@name='button_box']" position="inside">
+                <button name="action_open_last_month_attendances"
+                        class="oe_stat_button"
+                        icon="fa-calendar"
+                        type="object"
+                        groups="base.group_user"
+                        help="Worked hours this month"
+                        invisible="not is_user">
+                    <div class="o_field_widget o_stat_info">
+                        <span class="o_stat_value">
+                            <field name="hours_last_month" widget="float_time"/> Hours
+                        </span>
+                        <span class="o_stat_text">
+                            This Month
+                        </span>
+                    </div>
+                </button>
+                <field name="display_extra_hours" invisible="1"/>
+                <button name="action_open_last_month_overtime"
+                        class="oe_stat_button"
+                        icon="fa-history"
+                        type="object"
+                        invisible="not is_user or total_overtime == 0.0 or not display_extra_hours"
+                        help="Amount of extra hours">
+                    <div class="o_stat_info">
+                        <span class="o_stat_value text-success" invisible="total_overtime &lt; 0">
+                            <field name="total_overtime" widget="float_time"/>
+                        </span>
+                        <span class="o_stat_value text-danger" invisible="total_overtime &gt;= 0">
+                            <field name="total_overtime" widget="float_time"/>
+                        </span>
+                        <span class="o_stat_text">Extra Hours</span>
+                    </div>
+                </button>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/addons/hr_holidays/models/hr_employee.py
+++ b/addons/hr_holidays/models/hr_employee.py
@@ -40,8 +40,7 @@ class HrEmployee(models.Model):
     show_leaves = fields.Boolean('Able to see Remaining Time Off', compute='_compute_show_leaves')
     is_absent = fields.Boolean('Absent Today', compute='_compute_leave_status', search='_search_absent_employee')
     allocation_display = fields.Char(compute='_compute_allocation_remaining_display')
-    allocation_remaining_display = fields.Char(compute='_compute_allocation_remaining_display',
-                                               groups="hr.group_hr_user")
+    allocation_remaining_display = fields.Char(compute='_compute_allocation_remaining_display')
     hr_icon_display = fields.Selection(selection_add=[
         ('presence_holiday_absent', 'On leave'),
         ('presence_holiday_present', 'Present but on leave')])

--- a/addons/hr_holidays/models/hr_employee_public.py
+++ b/addons/hr_holidays/models/hr_employee_public.py
@@ -21,6 +21,7 @@ class HrEmployeePublic(models.Model):
         ('presence_holiday_absent', 'On leave'),
         ('presence_holiday_present', 'Present but on leave')])
     allocation_display = fields.Char(compute='_compute_allocation_display')
+    allocation_remaining_display = fields.Char(related='employee_id.allocation_remaining_display')
 
     def _compute_show_leaves(self):
         self._compute_from_employee('show_leaves')
@@ -48,3 +49,8 @@ class HrEmployeePublic(models.Model):
 
     def _compute_allocation_display(self):
         self._compute_from_employee('allocation_display')
+
+    def action_time_off_dashboard(self):
+        self.ensure_one()
+        if self.is_user:
+            return self.employee_id.action_time_off_dashboard()

--- a/addons/hr_holidays/views/hr_views.xml
+++ b/addons/hr_holidays/views/hr_views.xml
@@ -159,6 +159,33 @@
         </field>
     </record>
 
+    <record id="hr_employee_public_form_view_inherit" model="ir.ui.view">
+        <field name="name">hr.employee.public.leave.form.inherit</field>
+        <field name="model">hr.employee.public</field>
+        <field name="inherit_id" ref="hr.hr_employee_public_view_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//div[@name='button_box']" position="inside">
+                <field name="show_leaves" invisible="1"/>
+                <button name="%(hr_leave_action_new_request)d"
+                        type="action"
+                        class="oe_stat_button"
+                        icon="fa-calendar"
+                        invisible="not is_user or not show_leaves"
+                        groups="base.group_user"
+                        help="Remaining leaves">
+                    <div class="o_field_widget o_stat_info">
+                        <span class="o_stat_value">
+                            <field name="allocation_remaining_display"/>/<field name="allocation_display"/> Days
+                        </span>
+                        <span class="o_stat_text">
+                            Time Off
+                        </span>
+                    </div>
+                </button>
+            </xpath>
+        </field>
+    </record>
+
     <record id="res_users_view_form" model="ir.ui.view">
         <field name="name">hr.user.preferences.view.form.leave.inherit</field>
         <field name="model">res.users</field>

--- a/addons/hr_maintenance/models/__init__.py
+++ b/addons/hr_maintenance/models/__init__.py
@@ -1,4 +1,5 @@
-# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import equipment
 from . import res_users
+from . import hr_employee_public

--- a/addons/hr_maintenance/models/hr_employee_public.py
+++ b/addons/hr_maintenance/models/hr_employee_public.py
@@ -1,0 +1,9 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import fields, models
+
+
+class HrEmployeePublic(models.Model):
+    _inherit = 'hr.employee.public'
+
+    equipment_count = fields.Integer(related='employee_id.equipment_count')

--- a/addons/hr_maintenance/models/res_users.py
+++ b/addons/hr_maintenance/models/res_users.py
@@ -16,7 +16,7 @@ class HrEmployee(models.Model):
     _inherit = 'hr.employee'
 
     equipment_ids = fields.One2many('maintenance.equipment', 'employee_id', groups="hr.group_hr_user")
-    equipment_count = fields.Integer('Equipment Count', compute='_compute_equipment_count', groups="hr.group_hr_user")
+    equipment_count = fields.Integer('Equipment Count', compute='_compute_equipment_count')
 
     @api.depends('equipment_ids')
     def _compute_equipment_count(self):

--- a/addons/hr_maintenance/views/hr_views.xml
+++ b/addons/hr_maintenance/views/hr_views.xml
@@ -19,6 +19,25 @@
         </field>
     </record>
 
+    <record id="hr_employee_public_view_form" model="ir.ui.view">
+        <field name="name">hr.employee.public.form.inherit.maintenance</field>
+        <field name="model">hr.employee.public</field>
+        <field name="inherit_id" ref="hr.hr_employee_public_view_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//div[@name='button_box']" position="inside">
+                <field name="employee_id" invisible="1"/>
+                <button name="%(maintenance.hr_equipment_action)d"
+                    context="{'search_default_employee_id': employee_id, 'default_employee_id': employee_id}"
+                    class="o_stat_button"
+                    icon="fa-cubes"
+                    type="action"
+                    invisible="not is_user">
+                    <field name="equipment_count" widget="statinfo"/>
+                </button>
+            </xpath>
+        </field>
+    </record>
+
     <!-- user preferences -->
     <record id="res_users_view_form_preference" model="ir.ui.view">
         <field name="name">res.users.view.form.inherit.maintenance</field>

--- a/addons/hr_skills_slides/__manifest__.py
+++ b/addons/hr_skills_slides/__manifest__.py
@@ -15,6 +15,7 @@ This module add completed courses to resume for employees.
     'depends': ['hr_skills', 'website_slides'],
     'data': [
         'views/hr_employee_views.xml',
+        'views/hr_employee_public_views.xml',
         'views/hr_templates.xml',
         'data/hr_resume_data.xml',
     ],

--- a/addons/hr_skills_slides/models/__init__.py
+++ b/addons/hr_skills_slides/models/__init__.py
@@ -1,6 +1,6 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import hr_employee
+from . import hr_employee_public
 from . import hr_resume_line
 from . import slide_channel

--- a/addons/hr_skills_slides/models/hr_employee.py
+++ b/addons/hr_skills_slides/models/hr_employee.py
@@ -8,8 +8,8 @@ class HrEmployee(models.Model):
     _inherit = 'hr.employee'
 
     subscribed_courses = fields.Many2many('slide.channel', related='user_partner_id.slide_channel_ids')
-    has_subscribed_courses = fields.Boolean(compute='_compute_courses_completion_text', groups="hr.group_hr_user,base.group_system")
-    courses_completion_text = fields.Char(compute="_compute_courses_completion_text", groups="hr.group_hr_user")
+    has_subscribed_courses = fields.Boolean(compute='_compute_courses_completion_text')
+    courses_completion_text = fields.Char(compute="_compute_courses_completion_text")
 
     @api.depends_context('lang')
     @api.depends('subscribed_courses', 'user_partner_id.slide_channel_completed_ids')

--- a/addons/hr_skills_slides/models/hr_employee_public.py
+++ b/addons/hr_skills_slides/models/hr_employee_public.py
@@ -1,0 +1,15 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import fields, models
+
+
+class HrEmployeePublic(models.Model):
+    _inherit = 'hr.employee.public'
+
+    has_subscribed_courses = fields.Boolean(related='employee_id.has_subscribed_courses')
+    courses_completion_text = fields.Char(related='employee_id.courses_completion_text')
+
+    def action_open_courses(self):
+        self.ensure_one()
+        if self.is_user:
+            return self.employee_id.action_open_courses()

--- a/addons/hr_skills_slides/views/hr_employee_public_views.xml
+++ b/addons/hr_skills_slides/views/hr_employee_public_views.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="hr_employee_public_view_form" model="ir.ui.view">
+        <field name="name">hr.employee.public.form.inherit.skills.slides</field>
+        <field name="model">hr.employee.public</field>
+        <field name="inherit_id" ref="hr.hr_employee_public_view_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//div[@name='button_box']" position="inside">
+               <field name="has_subscribed_courses" invisible="1" groups="website_slides.group_website_slides_officer"/>
+                <button name="action_open_courses"
+                    class="oe_stat_button"
+                    groups="website_slides.group_website_slides_officer"
+                    icon="fa-graduation-cap"
+                    type="object"
+                    invisible="not is_user or not user_id or not has_subscribed_courses">
+                    <field name="courses_completion_text" widget="statinfo" string="Courses"/>
+                </button>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/addons/hr_timesheet/__manifest__.py
+++ b/addons/hr_timesheet/__manifest__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 
@@ -37,6 +36,7 @@ up a management by affair.
         'report/report_timesheet_templates.xml',
         'views/hr_department_views.xml',
         'views/hr_employee_views.xml',
+        'views/hr_employee_public_views.xml',
         'data/hr_timesheet_data.xml',
         'views/project_task_sharing_views.xml',
         'views/project_update_views.xml',

--- a/addons/hr_timesheet/models/__init__.py
+++ b/addons/hr_timesheet/models/__init__.py
@@ -1,9 +1,9 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import account_analytic_line_calendar_employee
 from . import analytic_applicability
 from . import hr_employee
+from . import hr_employee_public
 from . import hr_timesheet
 from . import ir_http
 from . import ir_ui_menu

--- a/addons/hr_timesheet/models/hr_employee.py
+++ b/addons/hr_timesheet/models/hr_employee.py
@@ -10,7 +10,7 @@ from odoo.tools import SQL
 class HrEmployee(models.Model):
     _inherit = 'hr.employee'
 
-    has_timesheet = fields.Boolean(compute='_compute_has_timesheet', groups="hr.group_hr_user,base.group_system", export_string_translation=False)
+    has_timesheet = fields.Boolean(compute='_compute_has_timesheet', export_string_translation=False)
 
     def _compute_has_timesheet(self):
         if self.ids:

--- a/addons/hr_timesheet/models/hr_employee_public.py
+++ b/addons/hr_timesheet/models/hr_employee_public.py
@@ -1,0 +1,14 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import fields, models
+
+
+class HrEmployeePublic(models.Model):
+    _inherit = 'hr.employee.public'
+
+    has_timesheet = fields.Boolean(related='employee_id.has_timesheet')
+
+    def action_timesheet_from_employee(self):
+        self.ensure_one()
+        if self.is_user:
+            return self.employee_id.action_timesheet_from_employee()

--- a/addons/hr_timesheet/views/hr_employee_public_views.xml
+++ b/addons/hr_timesheet/views/hr_employee_public_views.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="hr_employee_public_view_form" model="ir.ui.view">
+        <field name="name">hr.employee.public.form.inherit.timesheet</field>
+        <field name="model">hr.employee.public</field>
+        <field name="inherit_id" ref="hr.hr_employee_public_view_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//div[@name='button_box']" position="inside">
+               <field name="has_timesheet" groups="hr_timesheet.group_hr_timesheet_user" invisible="1"/>
+                <button invisible="not is_user or not has_timesheet" class="oe_stat_button" type="object" name="action_timesheet_from_employee" icon="fa-calendar" groups="hr_timesheet.group_hr_timesheet_user">
+                    <div class="o_stat_info">
+                        <span class="o_stat_text">Timesheets</span>
+                    </div>
+                </button>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
With this commit, if a user has no HR rights and is looking at his own public employee record, he should see some smartbuttons linking multiple apps.
The following smartbuttons have been added:
- Attendances and overtime (if display overtime setting is activated)
- Time off (Remaning leaves)
- Maintenance (Equipment)
- eLearning courses
- Timesheets

task-4840326