### PR TITLE
[IMP] website: highlight: add delete button & improve edit behavior

### DIFF
--- a/addons/html_editor/static/src/main/table/table_plugin.js
+++ b/addons/html_editor/static/src/main/table/table_plugin.js
@@ -119,6 +119,8 @@ export class TablePlugin extends Plugin {
         fully_selected_node_predicates: (node) => !!closestElement(node, ".o_selected_td"),
         targeted_nodes_processors: this.adjustTargetedNodes.bind(this),
         move_node_whitelist_selectors: "table",
+        collapsed_selection_toolbar_predicate: (selectionData) =>
+            !!closestElement(selectionData.editableSelection.anchorNode, "td.o_selected_td"),
     };
 
     setup() {

--- a/addons/html_editor/static/src/main/toolbar/toolbar_plugin.js
+++ b/addons/html_editor/static/src/main/toolbar/toolbar_plugin.js
@@ -7,7 +7,6 @@ import { registry } from "@web/core/registry";
 import { ToolbarMobile } from "./mobile_toolbar";
 import { debounce } from "@web/core/utils/timing";
 import { omit } from "@web/core/utils/objects";
-import { closestElement } from "@html_editor/utils/dom_traversal";
 import { withSequence } from "@html_editor/utils/resource";
 import { _t } from "@web/core/l10n/translation";
 
@@ -356,7 +355,9 @@ export class ToolbarPlugin extends Plugin {
         }
         const isCollapsed = selectionData.editableSelection.isCollapsed;
         if (isCollapsed) {
-            return !!closestElement(selectionData.editableSelection.anchorNode, "td.o_selected_td");
+            return this.getResource("collapsed_selection_toolbar_predicate").some((fn) =>
+                fn(selectionData)
+            );
         }
         return !!this.getFilteredTargetedNodes().length;
     }

--- a/addons/website/static/src/builder/plugins/highlight/highlight_configurator.js
+++ b/addons/website/static/src/builder/plugins/highlight/highlight_configurator.js
@@ -33,8 +33,8 @@ export class HighlightConfigurator extends Component {
     static props = {
         applyHighlight: Function,
         applyHighlightStyle: Function,
+        deleteHighlight: Function,
         getHighlightState: Function,
-        getSelection: Function,
         previewHighlight: Function,
         previewHighlightStyle: Function,
         revertHighlight: Function,
@@ -96,6 +96,11 @@ export class HighlightConfigurator extends Component {
     selectHighlightColor(color) {
         this.props.componentStack.pop();
         this.props.applyHighlightStyle("--text-highlight-color", normalizeColor(color));
+    }
+
+    deleteHighlight() {
+        this.props.deleteHighlight();
+        this.openHighlightPicker(false);
     }
 
     onThicknessChange(ev) {

--- a/addons/website/static/src/builder/plugins/highlight/highlight_configurator.xml
+++ b/addons/website/static/src/builder/plugins/highlight/highlight_configurator.xml
@@ -8,6 +8,7 @@
             <button id="highlightPicker" title="highlightPicker" class="btn btn-secondary" t-on-click="openHighlightPicker">
                 <t t-out="this.highlightIdToName[this.state.highlightId]"/>
             </button>
+            <button class="btn btn-sm btn-light fa fa-trash" title="Reset" t-on-click="deleteHighlight"/>
         </div>
 
         <div class="d-flex align-items-center mb-3">

--- a/addons/website/static/tests/builder/website_builder/highlight.test.js
+++ b/addons/website/static/tests/builder/website_builder/highlight.test.js
@@ -67,3 +67,39 @@ test("Changing highlight keep the color and the width", async () => {
         "--text-highlight-width": "2px",
     });
 });
+
+test("Selecting partially a highlight select all the highlight", async () => {
+    const { editor } = await setupEditor(
+        ` 
+        <p>
+            <span class="o_text_highlight o_text_highlight_freehand_2" style="--text-highlight-color: #E79C9C; --text-highlight-width: 2px;">h[i]ghlight</span>
+        </p>`,
+        { config: { Plugins: [...MAIN_PLUGINS, HighlightPlugin] } }
+    );
+    await expandToolbar();
+    expect(".o-select-highlight").toHaveCount(1);
+    let selectionData = editor.shared.selection.getEditableSelection();
+    expect(selectionData.anchorOffset).toBe(1);
+    expect(selectionData.focusOffset).toBe(2);
+    await click(".o-we-toolbar .o-select-highlight");
+    selectionData = editor.shared.selection.getEditableSelection();
+    expect(selectionData.anchorOffset).toBe(0);
+    expect(selectionData.focusOffset).toBe(9);
+});
+
+test("Can remove an highlight with the trash button", async () => {
+    await setupEditor(
+        ` 
+        <p>
+            <span class="o_text_highlight o_text_highlight_freehand_2" style="--text-highlight-color: #E79C9C; --text-highlight-width: 2px;">h[i]ghlight</span>
+        </p>`,
+        { config: { Plugins: [...MAIN_PLUGINS, HighlightPlugin] } }
+    );
+    await expandToolbar();
+    expect(".o-select-highlight").toHaveCount(1);
+    expect(".o_text_highlight").toHaveCount(1);
+    await click(".o-we-toolbar .o-select-highlight");
+    await waitFor("button[title='Reset']");
+    await click("button[title='Reset']");
+    expect(".o_text_highlight").toHaveCount(0);
+});


### PR DESCRIPTION
[IMP] website: highlight: add delete button & improve edit behavior

Context:
It is possible to highlight text in the website builder.
To do so, go to the website builder, select some text, and click the highlight button in the toolbar.

With this commit, editing an existing highlight is more intuitive:
- When partially selecting a highlight, the entire highlight is now modified.
- Clicking on a highlight opens the toolbar, allowing the user to modify the existing highlight.
- A “trash” button is now available to completely remove the highlight.
- To avoid confusion, it is no longer possible to edit multiple highlights at the same time.