### PR TITLE
[FIX] stock_landed_costs: refund move negative valuation adjustment

### DIFF
--- a/addons/stock_landed_costs/models/stock_landed_cost.py
+++ b/addons/stock_landed_costs/models/stock_landed_cost.py
@@ -385,7 +385,10 @@ class AdjustmentLines(models.Model):
     @api.depends('former_cost', 'additional_landed_cost')
     def _compute_final_cost(self):
         for line in self:
-            line.final_cost = line.former_cost + line.additional_landed_cost
+            if line.cost_id.vendor_bill_id.move_type == 'in_refund':
+                line.final_cost = line.former_cost - line.additional_landed_cost
+            else:
+                line.final_cost = line.former_cost + line.additional_landed_cost
 
     def _create_accounting_entries(self, move, qty_out):
         # TDE CLEANME: product chosen for computation ?


### PR DESCRIPTION
**Current behavior:**
Creating a credit note (refund move type) for a landed cost line from a vendor bill with a credit instead of debit will increase the `AdjustmentLines` `final_cost` field.

**Expected behavior:**
The `final_cost` should be negatively impacted in this situation.

**Steps to reproduce:**
1. Create a non-standard costing product, create a landed cost service product

2. Create a purchase order with the product and LC, confirm and receive the product

3. Create the vendor bill, confirm, create the landed cost & validate it

4. Create a credit note ("Reverse" on wizard), delete the non-LC invoice line and change the price unit of the LC line to a negative value

5. Switch the move type from the action menu 2x in order to correctly adapt the sign of the monetary fields

6. Confirm the credit note, create the landed cost and validate it -> look at the generated LC's valuation adjustment lines

**Cause of the issue:**
No logic to support a negative impact on the `final_cost` field.

**Fix:**
Check the LC's `vendor_bill_id` move type while calculating the final cost, if it's a refund type then adjust the calculation of the final cost accordingly (subtract the additional landed cost).

opw-4369715