### PR TITLE
[IMP] hr_gamification: Improving Grant Badge UI in Employee view.

### DIFF
--- a/addons/hr_gamification/static/src/scss/hr_gamification.scss
+++ b/addons/hr_gamification/static/src/scss/hr_gamification.scss
@@ -28,3 +28,8 @@
   box-shadow: 0 12px 24px rgba(0, 0, 0, 0.25);
   border-radius: 4px;
 }
+
+.grant_badge_btn {
+    border-radius: 0.5rem !important;
+    width: 18rem;
+}

--- a/addons/hr_gamification/views/hr_employee_views.xml
+++ b/addons/hr_gamification/views/hr_employee_views.xml
@@ -10,7 +10,6 @@
             <xpath expr="//page[@name='hr_settings']" position="before">
                 <page string="Badges" name="received_badges" invisible="not user_id">
                     <field name="has_badges" invisible="1"/>
-                    <button string="Grant a Badge" type="action" name="%(action_reward_wizard)d" invisible="not has_badges"/>
                     <div class="o_field_nocontent" invisible="has_badges">
                         <div class="o_nocontent_help">
                             <p class="o_view_nocontent_neutral_face"></p>
@@ -22,13 +21,12 @@
                     </div>
                     <div class="mt-2">
                         <field name="badge_ids" mode="kanban" />
-                    </div>
-                    <div class="d-flex justify-content-center mt-3" invisible="has_badges">
-                        <button string="Grant a Badge" type="action" name="%(action_reward_wizard)d"/>
+                        <div class="d-flex justify-content-center">
+                            <button class="mt-2 grant_badge_btn o_kanban_renderer o_kanban_record o-kanban-button-new btn btn-link py-3" string="Grant a Badge" type="action" name="%(action_reward_wizard)d"/>
+                        </div>
                     </div>
                 </page>
             </xpath>
-
         </field>
     </record>
 
@@ -41,7 +39,6 @@
             <page name="resume" position="after">
                 <page string="Badges" name="received_badges" invisible="not user_id">
                     <field name="has_badges" invisible="1"/>
-                    <button string="Grant a Badge" type="action" name="%(action_reward_wizard)d" invisible="not has_badges"/>
                     <div class="o_field_nocontent" invisible="has_badges">
                         <div class="o_nocontent_help">
                             <p class="o_view_nocontent_neutral_face"></p>
@@ -53,9 +50,9 @@
                     </div>
                     <div class="mt-2">
                         <field name="badge_ids" mode="kanban" widget="many2many"/>
-                    </div>
-                    <div class="d-flex justify-content-center mt-3" invisible="has_badges">
-                        <button string="Grant a Badge" type="action" name="%(action_reward_wizard)d"/>
+                        <div class="d-flex justify-content-center">
+                            <button class=" mt-2 grant_badge_btn o_kanban_renderer o_kanban_record o-kanban-button-new btn btn-link py-3" string="Grant a Badge" type="action" name="%(action_reward_wizard)d"/>
+                        </div>
                     </div>
                 </page>
             </page>


### PR DESCRIPTION
This PR improves the UI of the "Grant Badge" button in the Employee view by aligning its appearance with the "Add Contact" button in the Contacts section. Specifically, we applied the same CSS styling used for the Contacts button to the Grant Badge button for a consistent look and feel.

### Technical Note
We did not place the "Grant Badge" button inside the grid layout (as is done with the "Add Contact" button in Contacts) due to technical limitations related to how badges are implemented:
The badge_ids field is computed (not stored), whereas Contacts is a stored field.
Both badges and contacts are displayed using kanban view.
In the Contacts section, the "Add Contact" button is automatically injected into the grid by the framework because it operates on a stored field.
For badges, since the field is computed, we must explicitly render the "Grant Badge" button, and we cannot leverage the same automatic injection mechanism.
As a result, the button is styled similarly but positioned outside the grid layout.

Related task: 4815637.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
