### PR TITLE
[FIX] hr_holidays: Adding multiple search option on allocations search bar

### DIFF
--- a/addons/hr_holidays/views/hr_leave_allocation_views.xml
+++ b/addons/hr_holidays/views/hr_leave_allocation_views.xml
@@ -7,10 +7,13 @@
         <field name="arch" type="xml">
             <search string="Search allocations">
                 <field name="employee_id" string='Employee'/>
-                <field name="name"/>
+                <field name="name" string="Title"/>
+                <field name="department_id"/>
+                <field name="holiday_status_id"/>
+                <field name="allocation_type"/>
+                <field name="accrual_plan_id"/>
                 <field name="activity_user_id" string="Activities of"/>
                 <field name="activity_type_id" string="Activity type"/>
-                <field name="holiday_status_id"/>
                 <filter domain="[
                         ('state','in',['confirm']),
                         '|',
@@ -56,7 +59,6 @@
                 <filter string="My Allocations" name="my_leaves" domain="[('employee_id.user_id', '=', uid)]"/>
                 <filter string="Validity Start" name="validity_start" date="date_from" start_month="0" end_month="2" start_year="-1" end_year="1"/>
                 <separator/>
-                <field name="holiday_status_id"/>
                 <filter invisible="1" string="My Activities" name="filter_activities_my"
                     domain="[('activity_user_id', '=', uid)]"/>
                 <separator invisible="1"/>


### PR DESCRIPTION
In Management < Allocations change/add some search filter options which includes
- accrual plan
- allocation type
- time off type sequence change
- department_id
- description(name) renamed as title

Task-4866173

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
