### PR TITLE
[FIX] portal, *: vat and company name editable

### DIFF
--- a/addons/point_of_sale/static/tests/pos/tours/pos_self_invoicing_portal_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/pos_self_invoicing_portal_tour.js
@@ -35,6 +35,26 @@ registry.category("web_tour.tours").add("invoicePoSOrderWithSelfInvocing", {
             run: "edit test@test.com",
         },
         {
+            trigger: ".o_portal_wrap input[name='company_name']",
+            run: function () {
+                const companyNameInput = document.querySelector("input[name='company_name']");
+                if (companyNameInput.hasAttribute("readonly")) {
+                    throw new Error("The company name input must not be readonly.");
+                }
+                companyNameInput.value = "TEST COMPANY NAME";
+            },
+        },
+        {
+            trigger: ".o_portal_wrap input[name='vat']",
+            run: function () {
+                const vatInput = document.querySelector("input[name='vat']");
+                if (vatInput.hasAttribute("readonly")) {
+                    throw new Error("The vat input must not be readonly.");
+                }
+                vatInput.value = "1234567890";
+            },
+        },
+        {
             trigger: ".o_portal_wrap input[name='street']",
             run: "edit 131, Satyamcity society",
         },

--- a/addons/portal/models/res_partner.py
+++ b/addons/portal/models/res_partner.py
@@ -43,6 +43,8 @@ class ResPartner(models.Model):
     @api.model
     def _get_current_partner(self, **kwargs):
         """ Get main partner of the current user base on logged in user and kwargs. """
+        if self.env.user._is_public():
+            return self.env['res.partner']
         return self.env.user.partner_id
 
     def _get_delivery_address_domain(self):


### PR DESCRIPTION
modules: portal, point_of_sale

This commit is about the self-invoicing: the 'vat' and 'company name' were not editable when you request an invoice as an unlogged user. Steps to reproduce :
- Open a pos session and create an order, pay it (and print the ticket)
- Close the pos session
- Open a new private window and go to <url>/pos/ticket
- Enter the ticket number, the date and the unique code and press "Request invoice"
- A form is displayed and the two fields "company name" and "vat" can now be edited

Related to task-4777131
Runbot: https://runbot.odoo.com/runbot/bundle/saas-18-2-portal-vat-editable-roto-376921
