### PR TITLE
[IMP] orm: speedup setup get_depends

### DIFF
--- a/odoo/orm/registry.py
+++ b/odoo/orm/registry.py
@@ -394,8 +394,8 @@ class Registry(Mapping[str, type["BaseModel"]]):
         self._is_modifying_relations.clear()
         self.registry_invalidated = True
 
-        self.field_depends.clear()
-        self.field_depends_context.clear()
+        # model classes on which to *not* recompute field_depends[_context]
+        models_field_depends_done = set()
 
         if model_names is None:
             self.many2many_relations.clear()
@@ -405,6 +405,9 @@ class Registry(Mapping[str, type["BaseModel"]]):
             for model_cls in self.models.values():
                 model_cls._setup_done__ = False
 
+            self.field_depends.clear()
+            self.field_depends_context.clear()
+
         else:
             # only mark impacted models for setup
             for model_name in self.descendants(model_names, '_inherit', '_inherits'):
@@ -413,7 +416,9 @@ class Registry(Mapping[str, type["BaseModel"]]):
             # recursively mark fields to re-setup
             todo = []
             for model_cls in self.models.values():
-                if not model_cls._setup_done__:
+                if model_cls._setup_done__:
+                    models_field_depends_done.add(model_cls)
+                else:
                     todo.extend(model_cls._fields.values())
 
             done = set()
@@ -434,6 +439,12 @@ class Registry(Mapping[str, type["BaseModel"]]):
                     field.__set_name__(model_cls, name)
                     field._setup_done = False
 
+                    models_field_depends_done.discard(model_cls)
+
+                # partial invalidation of field_depends[_context]
+                self.field_depends.pop(field, None)
+                self.field_depends_context.pop(field, None)
+
                 done.add(field)
                 todo.extend(self.field_setup_dependents.pop(field, ()))
 
@@ -442,7 +453,10 @@ class Registry(Mapping[str, type["BaseModel"]]):
         model_classes.setup_model_classes(env)
 
         # determine field_depends and field_depends_context
-        for model in env.values():
+        for model_cls in self.models.values():
+            if model_cls in models_field_depends_done:
+                continue
+            model = model_cls(env, (), ())
             for field in model._fields.values():
                 depends, depends_context = field.get_depends(model)
                 self.field_depends[field] = tuple(depends)

--- a/odoo/orm/registry.py
+++ b/odoo/orm/registry.py
@@ -411,19 +411,22 @@ class Registry(Mapping[str, type["BaseModel"]]):
                 self[model_name]._setup_done__ = False
 
             # recursively mark fields to re-setup
-            todo = [
-                field
-                for model_cls in self.models.values()
-                if not model_cls._setup_done__
-                for field in model_cls._fields.values()
-            ]
+            todo = []
+            for model_cls in self.models.values():
+                if not model_cls._setup_done__:
+                    todo.extend(model_cls._fields.values())
+
+            done = set()
             for field in todo:
-                if field._setup_done and field._base_fields__:
+                if field in done:
+                    continue
+
+                model_cls = self[field.model_name]
+                if model_cls._setup_done__ and field._base_fields__:
                     # the field has been created by model_classes._setup() as
                     # Field(_base_fields__=...); restore it to force its setup
-                    base_fields = field._base_fields__
-                    model_cls = self[field.model_name]
                     name = field.name
+                    base_fields = field._base_fields__
 
                     field.__dict__.clear()
                     field.__init__(_base_fields__=base_fields)
@@ -431,6 +434,7 @@ class Registry(Mapping[str, type["BaseModel"]]):
                     field.__set_name__(model_cls, name)
                     field._setup_done = False
 
+                done.add(field)
                 todo.extend(self.field_setup_dependents.pop(field, ()))
 
         self.many2one_company_dependents.clear()


### PR DESCRIPTION
This is the second part of speedup introduced  in  #211658

After improving setup_model_classes, get_depends is the next pieces, taking ~1m30 (whole setup is ~2m30)

After this pr, it goes to ~5 seconds, making the whole setup ~60 second 

This pr proposes an alternative solution to avoid resetting the whole depends when setting up the models.

The "depends" of a field should be quite stable, it is possible to add some of them by overriding a compute but in this case, the model will be re setup.

The fix is about `depends_context` for related fields. This value depends on all fields in the path of the related, meaning that a related like `model1_id.model2_id.model3_id` actually depends on all intermediate models. If we re-setup `model2`, we need to recompute the `depends_context` of the related field.