### PR TITLE
[FIX] hr_work_entry: show work_entry_source once having multiple options

### DIFF
--- a/addons/hr_work_entry/views/hr_employee_views.xml
+++ b/addons/hr_work_entry/views/hr_employee_views.xml
@@ -17,6 +17,9 @@
                         </div>
                 </button>
             </div>
+            <group name="contract" position="inside">
+                <field name="work_entry_source" invisible="1"/>
+            </group>
         </field>
     </record>
 </odoo>


### PR DESCRIPTION
Bug / current behavior: The field work_entry_source was added to the employee form view only when installing hr_work_entry_planning (a dependency of the Planning app).

Required behavior: The field work_entry_source should be shown upon installing hr_work_entry_attendance (a dependency of the Attendance app) as well. Both modules add a new selection to the field. Thus, when either module is installed, the field should be added to the form view to allow the user to choose.

Fix: Add the field work_entry_source as invisible to the form view in the base module hr_work_entry. Make it visible once you install any of the planning or attendance modules.

task-4866002
Enterprise PR: https://github.com/odoo/enterprise/pull/87507


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
