### PR TITLE
[FIX] account: add display alias fields and update related views

### DIFF
--- a/addons/account/models/account_journal.py
+++ b/addons/account/models/account_journal.py
@@ -220,9 +220,14 @@ class AccountJournal(models.Model):
     )
     accounting_date = fields.Date(compute='_compute_accounting_date')
 
+    display_alias_fields = fields.Boolean(compute='_compute_display_alias_fields')
+
     _sql_constraints = [
         ('code_company_uniq', 'unique (company_id, code)', 'Journal codes must be unique per company.'),
     ]
+
+    def _compute_display_alias_fields(self):
+        self.display_alias_fields = self.env['mail.alias.domain'].search_count([], limit=1)
 
     @api.depends('type', 'company_id')
     def _compute_code(self):

--- a/addons/account/views/account_journal_views.xml
+++ b/addons/account/views/account_journal_views.xml
@@ -147,8 +147,9 @@
                                            string="Create Invoices upon Emails" invisible="type not in ('sale', 'purchase')">
                                        <field name="alias_id"/>
                                     </group>
+                                    <field name="display_alias_fields" invisible="1"/>
                                     <group name="group_alias_no_domain" string="Create Invoices upon Emails"
-                                           invisible="type not in ('sale', 'purchase') or alias_domain_id">
+                                           invisible="type not in ('sale', 'purchase') or display_alias_fields">
                                         <div class="content-group" colspan="2">
                                             <a type='action' name='%(action_open_settings)d' class="btn btn-link" role="button">
                                                 <i class="oi oi-fw o_button_icon oi-arrow-right"/> Choose or Configure Email Servers
@@ -156,7 +157,7 @@
                                         </div>
                                     </group>
                                     <group class="oe_edit_only" name="group_alias_edit" string="Create Invoices upon Emails"
-                                           invisible="type not in ('sale', 'purchase') or not alias_domain_id">
+                                           invisible="type not in ('sale', 'purchase') or not display_alias_fields">
                                         <label string="Email Alias" for="alias_name"/>
                                         <div class="oe_inline" name="edit_alias" style="display: inline;" dir="ltr" >
                                             <field name="alias_name" class="oe_inline"/>@


### PR DESCRIPTION
**Description**

For new journals created, no domain is defined on the alias by default, and having no domain defined will just make the field go hidden entirely. ---

**Steps to Reproduce**

1. Add an alias domain if not already existing through : General Settings -> Discuss -> Alias Domain
2. Accounting -> Configuration -> Accounting -> Journals
3. Create new Journal , save it and go to the advanced settings page.
4. notice that you cannot define a domain on the journal settings
---

**Before**
- Having no domain defined will just make the field go hidden entirely. ---

**After**
- No domain will still not be defined, but you can easily define it on the journal. ---

---

- This fix reuses the necessary part of an IMP commit from version 18.0 which resolve the issue
commit : https://github.com/odoo/odoo/commit/c0f82707f8da95d6f193171d856b9627106403f9

---
opw-4827730