### PR TITLE
[IMP] account_accountant: improve matching of reconciliation rules

### DIFF
--- a/addons/account/models/account_reconcile_model.py
+++ b/addons/account/models/account_reconcile_model.py
@@ -120,9 +120,9 @@ class AccountReconcileModel(models.Model):
         check_company=True,
         help='The reconciliation model will only be available from the selected journals.')
     match_amount = fields.Selection(selection=[
-        ('lower', 'Is Lower Than'),
-        ('greater', 'Is Greater Than'),
-        ('between', 'Is Between'),
+        ('lower', 'Is lower than or equal to'),
+        ('greater', 'Is greater than or equal to'),
+        ('between', 'Is between'),
     ], string='Amount', tracking=True,
         help='The reconciliation model will only be applied when the amount being lower than, greater than or between specified amount(s).')
     match_amount_min = fields.Float(string='Amount Min Parameter', tracking=True)


### PR DESCRIPTION
Matching amounts for reco rules now have `or equal to` for the `greater than` and `lower than` selections. This makes more sense for users trying to have "In between" values.

task-4863744
