### PR TITLE
[IMP] website: allow empty default value for select form field

### DIFF
--- a/addons/website/static/src/builder/plugins/form/form_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/form/form_option_plugin.js
@@ -1155,13 +1155,32 @@ export class SetFormCustomFieldValueListAction extends BuilderAction {
     static dependencies = ["websiteFormOption"];
     apply({ editingElement: fieldEl, value }) {
         const fields = [];
+        let valueList = JSON.parse(value);
+        if (getSelect(fieldEl)) {
+            valueList = valueList.filter((value) => value.id !== "" || value.display_name !== "");
+            const hasDefault = valueList.some((value) => value.selected);
+            if (valueList.length && !hasDefault) {
+                valueList.unshift({
+                    id: "",
+                    display_name: "",
+                    selected: true,
+                });
+            }
+        }
         const field = getActiveField(fieldEl, { fields });
-        field.records = JSON.parse(value);
+        field.records = valueList;
         this.dependencies.websiteFormOption.replaceField(fieldEl, field, fields);
     }
     getValue({ editingElement: fieldEl }) {
         const fields = [];
         const field = getActiveField(fieldEl, { fields });
+        if (
+            field.records.length &&
+            field.records[0].display_name === "" &&
+            field.records[0].selected === true
+        ) {
+            field.records.shift();
+        }
         return JSON.stringify(field.records);
     }
 }

--- a/addons/website/static/tests/builder/website_builder/form_option.test.js
+++ b/addons/website/static/tests/builder/website_builder/form_option.test.js
@@ -114,3 +114,35 @@ test("undo redo add form field", async () => {
     undo(editor);
     expect(":iframe span.s_website_form_label_content").toHaveCount(0);
 });
+
+test("empty placeholder selection input for selection field", async () => {
+    onRpc("get_authorized_fields", () => ({}));
+    const { getEditor } = await setupWebsiteBuilder(
+        `<section class="s_website_form"><form data-model_name="mail.mail">
+            <div data-name="Field" class="s_website_form_field mb-3 col-12 s_website_form_custom" data-type="many2one">
+                <div class="row s_col_no_resize s_col_no_bgcolor">
+                    <label class="col-form-label col-sm-auto s_website_form_label" for="ozp7022vqhe">
+                        <span class="s_website_form_label_content">Selection Field</span>
+                    </label>
+                    <div class="col-sm">
+                        <select class="form-select s_website_form_input" name="Phone Number" id="ozp7022vqhe">
+                            <option id="ozp7022vqhe0" value="Option 1">Option 1</option>
+                            <option id="ozp7022vqhe1" value="Option 2">Option 2</option>
+                            <option id="ozp7022vqhe2" value="Option 3">Option 3</option>
+                        </select>
+                    </div>
+                </div>
+            </div>
+            <div class="s_website_form_submit">
+                <div class="s_website_form_label"/>
+                <a>Submit</a>
+            </div>
+        </form></section>`
+    );
+    getEditor();
+    expect(":iframe select option").toHaveCount(3);
+    await contains(":iframe .s_website_form_field[data-type='many2one'").click();
+    await contains(".o_we_table_wrapper input[type='checkbox']").click();
+    expect(":iframe select option").toHaveCount(4);
+    expect(":iframe select option:eq(0)").toHaveText("");
+});


### PR DESCRIPTION
Before this commit, users did not have an option to leave the selection
field blank in the website form even though it's not set to required.
The feature was introduced in commit [1] but was lost when introducing
`html_builder`.

In this commit, we reintroduce the feature that allows users to choose
whether they want the selection field to be required or not.

[1]: https://github.com/odoo/odoo/commit/34ddd5dd6a036792c44b865cb7a4671f4ca033cf

task-4367641