### PR TITLE
[FIX] html_editor, website: add `transformImage` command

### DIFF
--- a/addons/html_editor/static/src/main/media/image_transform_button.js
+++ b/addons/html_editor/static/src/main/media/image_transform_button.js
@@ -1,110 +1,22 @@
-import { Component, useExternalListener, useState } from "@odoo/owl";
+import { Component, useState } from "@odoo/owl";
 import { toolbarButtonProps } from "@html_editor/main/toolbar/toolbar";
-import { registry } from "@web/core/registry";
-import { ImageTransformation } from "./image_transformation";
-
 export class ImageTransformButton extends Component {
     static template = "html_editor.ImageTransformButton";
     static props = {
         id: String,
         icon: String,
         title: String,
-        getTargetedImage: Function,
-        resetImageTransformation: Function,
-        addStep: Function,
-        document: { validate: (p) => p.nodeType === Node.DOCUMENT_NODE },
-        editable: { validate: (p) => p.nodeType === Node.ELEMENT_NODE },
         ...toolbarButtonProps,
         activeTitle: String,
+        getTransformState: Function,
+        handleImageTransformation: Function,
     };
 
     setup() {
-        this.state = useState({ active: false });
-        this.pointerDownInsideTransform = false;
-        // We close the image transform when we click outside any element not
-        // related to it. When the pointerdown of the click is inside the image
-        // transform and pointerup is outside while resizing or rotating the
-        // image it will consider the click as being done outside image
-        // transform. So we need to keep track if the pointerdown is inside or
-        // outside to know if we want to close the image transform component or
-        // not.
-        useExternalListener(this.props.document, "pointerdown", (ev) => {
-            if (this.isNodeInsideTransform(ev.target)) {
-                this.pointerDownInsideTransform = true;
-            } else {
-                this.closeImageTransformation();
-                this.pointerDownInsideTransform = false;
-            }
-        });
-        useExternalListener(this.props.document, "click", (ev) => {
-            if (!this.isNodeInsideTransform(ev.target) && !this.pointerDownInsideTransform) {
-                this.closeImageTransformation();
-            }
-            this.pointerDownInsideTransform = false;
-        });
-        // When we click on any character the image is deleted and we need to close the image transform
-        // We handle this by selectionchange
-        useExternalListener(this.props.document, "selectionchange", (ev) => {
-            this.closeImageTransformation();
-        });
-    }
-
-    isNodeInsideTransform(node) {
-        if (!node) {
-            return false;
-        }
-        if (node.nodeType === Node.TEXT_NODE) {
-            node = node.parentElement;
-        }
-        if (node.matches('[name="image_transform"], [name="image_transform"] *')) {
-            return true;
-        }
-        if (
-            this.isImageTransformationOpen() &&
-            node.matches(
-                ".transfo-container, .transfo-container div, .transfo-container i, .transfo-container span"
-            )
-        ) {
-            return true;
-        }
-        return false;
+        this.state = useState(this.props.getTransformState());
     }
 
     onButtonClick() {
-        this.handleImageTransformation(this.props.getTargetedImage());
-    }
-
-    handleImageTransformation(image) {
-        if (this.isImageTransformationOpen()) {
-            this.props.resetImageTransformation(image);
-            this.closeImageTransformation();
-        } else {
-            this.openImageTransformation(image);
-        }
-    }
-
-    openImageTransformation(image) {
-        this.state.active = true;
-        registry.category("main_components").add("ImageTransformation", {
-            Component: ImageTransformation,
-            props: {
-                image,
-                document: this.props.document,
-                editable: this.props.editable,
-                destroy: () => this.closeImageTransformation(),
-                onChange: () => this.props.addStep(),
-            },
-        });
-    }
-
-    isImageTransformationOpen() {
-        return registry.category("main_components").contains("ImageTransformation");
-    }
-
-    closeImageTransformation() {
-        this.state.active = false;
-        if (this.isImageTransformationOpen()) {
-            registry.category("main_components").remove("ImageTransformation");
-        }
+        this.props.handleImageTransformation();
     }
 }

--- a/addons/website/static/src/builder/plugins/image/image_tool_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/image/image_tool_option_plugin.js
@@ -177,8 +177,8 @@ class TransformImageAction extends BuilderAction {
     isApplied({ editingElement }) {
         return editingElement.matches(`[style*="transform"]`);
     }
-    apply() {
-        return this.dependencies.userCommand.getCommand("transformImage").run();
+    apply({ editingElement }) {
+        return this.dependencies.userCommand.getCommand("transformImage").run(editingElement);
     }
 }
 class ResetTransformImageAction extends BuilderAction {


### PR DESCRIPTION
Problem:
When attempting to transform an image on the website editor, a traceback occurs.

Cause:
The `transformImage` command is missing from the `userCommand` plugin. The logic to open the transformation overlay was placed in `image_transform_button`.

Solution:
Move the overlay logic to the `image_plugin` and properly define the `transformImage` command to avoid the error.

Steps to reproduce:
1. Open the Website Editor.
2. Click on any image.
3. Click the "Transform" option. → A traceback appears.

opw-4863928

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
