### PR TITLE
[FIX] point_of_sale: cancel old orders + print img

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -1067,7 +1067,7 @@ class PosOrder(models.Model):
             if order_is_in_futur:
                 raise UserError(_('The order delivery / pickup date is in the future. You cannot cancel it.'))
 
-        today_orders = self.filtered(lambda order: order.state == 'draft' and (not order.preset_time or order.preset_time.date() == fields.Date.today()))
+        today_orders = self.filtered(lambda order: order.state == 'draft' and (not order.preset_time or order.preset_time.date() <= fields.Date.today()))
         next_days_orders = self.filtered(lambda order: order.preset_time and order.preset_time.date() > fields.Date.today() and order.state == 'draft')
         next_days_orders.session_id = False
         today_orders.write({'state': 'cancel'})

--- a/addons/point_of_sale/static/src/app/services/printer_service.js
+++ b/addons/point_of_sale/static/src/app/services/printer_service.js
@@ -1,4 +1,4 @@
-import { loadAllImages } from "@point_of_sale/utils";
+import { waitImages } from "@point_of_sale/utils";
 
 import { Reactive } from "@web/core/utils/reactive";
 
@@ -22,7 +22,13 @@ export class PrinterService extends Reactive {
         this.device = newDevice;
     }
     printWeb(el) {
-        this.renderer.whenMounted({ el, callback: window.print });
+        this.renderer.whenMounted({
+            el,
+            callback: async (el) => {
+                await waitImages(el);
+                window.print(el);
+            },
+        });
         return true;
     }
     async printHtml(el, { webPrintFallback = false } = {}) {
@@ -47,7 +53,7 @@ export class PrinterService extends Reactive {
         this.state.isPrinting = true;
         const el = await this.renderer.toHtml(component, props);
         try {
-            await loadAllImages(el);
+            await waitImages(el);
         } catch (e) {
             console.error("Images could not be loaded correctly", e);
         }


### PR DESCRIPTION
Before this commit, printing images in receipt with the web print could not show the images if they are not loaded. This is now waiting for the images to be loaded.

Before this commit, if an order preset time was from yesterday, the order could not be cancelled. This is now fixed by changing the condition to accept cancelling orders with a preset time in the past

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
