### PR TITLE
[FIX] im_livechat: do not allow livechat users to remove colleagues

### DIFF
--- a/addons/im_livechat/views/im_livechat_channel_views.xml
+++ b/addons/im_livechat/views/im_livechat_channel_views.xml
@@ -106,7 +106,7 @@
                                                     <main class="ps-1">
                                                         <div class="d-flex justify-content-between align-items-baseline">
                                                             <field name="name" class="fw-bold fs-5"/>
-                                                            <a class="btn p-0 opacity-75 opacity-100-hover" role="button" groups="im_livechat.im_livechat_group_user" type="delete">
+                                                            <a class="btn p-0 opacity-75 opacity-100-hover" role="button" groups="im_livechat.im_livechat_group_manager" type="delete">
                                                                 <i title="Remove operator" class="fa fa-fw fa-lg fa-close"/>
                                                             </a>
                                                         </div>


### PR DESCRIPTION
Current behavior before PR:
 - The remove icon was visible to all users, even those who not have access rights.
 
![image](https://github.com/user-attachments/assets/2d1fe162-e492-4d97-9cc7-06b4ced99a9a)

Desired behavior after PR is merged:
 - Only users with group `im_livechat_group_manager`  could remove a livechat operator.
 
![image](https://github.com/user-attachments/assets/83aa3fa7-5cbe-46ab-bb3d-55cd136a56d3)


task-id:[4781704](https://www.odoo.com/odoo/project/1519/tasks/4781704)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
