### PR TITLE
[IMP] analytic: hierarchy groupby

### DIFF
--- a/addons/analytic/__manifest__.py
+++ b/addons/analytic/__manifest__.py
@@ -30,6 +30,13 @@ that have no counterpart in the general financial accounts.
         'web.assets_backend': [
             'analytic/static/src/components/**/*',
             'analytic/static/src/services/**/*',
+            'analytic/static/src/views/**/*',
+            ('remove', 'analytic/static/src/views/graph/**'),
+            ('remove', 'analytic/static/src/views/pivot/**'),
+        ],
+        'web.assets_backend_lazy': [
+            'analytic/static/src/views/graph/**',
+            'analytic/static/src/views/pivot/**',
         ],
         'web.assets_unit_tests': [
             'analytic/static/tests/**/*',

--- a/addons/analytic/models/analytic_line.py
+++ b/addons/analytic/models/analytic_line.py
@@ -121,7 +121,7 @@ class AnalyticPlanFields(models.AbstractModel):
                 account_node.set('domain', repr(self._get_plan_domain(project_plan)))
 
             # If there is a main node, append the ones for other plans
-            if account_node is not None or account_filter_node is not None:
+            if account_node is not None:
                 account_node.set('context', repr(self._get_account_node_context(project_plan)))
                 for plan in other_plans[::-1]:
                     fname = plan._column_name()
@@ -133,8 +133,16 @@ class AnalyticPlanFields(models.AbstractModel):
                             'domain': repr(self._get_plan_domain(plan)),
                             'context': repr(self._get_account_node_context(plan)),
                         }))
-                    if account_filter_node is not None:
+            if account_filter_node is not None:
+                for plan in other_plans[::-1] + project_plan:
+                    fname = plan._column_name()
+                    if plan != project_plan:
                         account_filter_node.addnext(E.filter(name=fname, context=f"{{'group_by': '{fname}'}}"))
+                    current = plan
+                    while current := current.children_ids:
+                        _depth, subfname = current[0]._hierarchy_name()
+                        if subfname in self._fields:
+                            account_filter_node.addnext(E.filter(name=subfname, context=f"{{'group_by': '{subfname}'}}"))
         return arch, view
 
 

--- a/addons/analytic/models/analytic_plan.py
+++ b/addons/analytic/models/analytic_plan.py
@@ -1,10 +1,14 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
+import re
+
 from random import randint
 
 from odoo import api, fields, models, _
 from odoo.exceptions import UserError
 from odoo.tools import ormcache, make_index_name, create_index
+
+from odoo.addons.base.models.ir_model import MODULE_UNINSTALL_FLAG
 
 
 class AccountAnalyticPlan(models.Model):
@@ -34,6 +38,7 @@ class AccountAnalyticPlan(models.Model):
     root_id = fields.Many2one(
         'account.analytic.plan',
         compute='_compute_root_id',
+        search='_search_root_id',
     )
     children_ids = fields.One2many(
         'account.analytic.plan',
@@ -125,6 +130,11 @@ class AccountAnalyticPlan(models.Model):
     def _compute_root_id(self):
         for plan in self.sudo():
             plan.root_id = int(plan.parent_path[:-1].split('/')[0]) if plan.parent_path else plan
+
+    def _search_root_id(self, operator, value):
+        if operator != '=':
+            return NotImplemented
+        return [('parent_path', '=like', f'{value}/%')]
 
     @api.depends('name', 'parent_id.complete_name')
     def _compute_complete_name(self):
@@ -249,10 +259,42 @@ class AccountAnalyticPlan(models.Model):
     def unlink(self):
         # Remove the dynamic field created with the plan (see `_inverse_name`)
         self._find_plan_column().unlink()
-        return super().unlink()
+        related_fields = self._find_related_field()
+        res = super().unlink()
+        related_fields.filtered(lambda f: not self._is_subplan_field_used(f)).unlink()
+        self.env.registry.clear_cache()
+        return res
+
+    def _hierarchy_name(self):
+        depth = self.parent_path.count('/') - 1
+        fname = f"{self._column_name()}_{depth}"
+        if fname.startswith('account_id'):
+            fname = f'x_{fname}'
+        return depth, fname
+
+    def _is_subplan_field_used(self, field):
+        """Return `True` if there are analytic plans still on the same hierarchy level as what the field was created for.
+
+        :param field: the recordset of a field created to group by sub plan
+        :rtype: bool
+        """
+        assert '_id_' in field.name
+        root_name, depth = field.name.rsplit('_', maxsplit=1)
+        plan_id_match = re.search(r'\d+', root_name)
+        plan_id = int(plan_id_match.group() if plan_id_match else next(self._get_all_plans()))
+        return bool(self.env['account.analytic.plan'].search([
+            ('root_id', '=', plan_id),
+            ('parent_path', 'like', '%'.join('/' * (int(depth) + 1))),
+        ]))
 
     def _find_plan_column(self, model=False):
         domain = [('name', 'in', [plan._strict_column_name() for plan in self])]
+        if model:
+            domain.append(('model', '=', model))
+        return self.env['ir.model.fields'].sudo().search(domain)
+
+    def _find_related_field(self, model=False):
+        domain = [('name', 'in', [plan._hierarchy_name()[1] for plan in self])]
         if model:
             domain.append(('model', '=', model))
         return self.env['ir.model.fields'].sudo().search(domain)
@@ -265,30 +307,58 @@ class AccountAnalyticPlan(models.Model):
     def _sync_plan_column(self, model):
         # Create/delete a new field/column on related models for this plan, and keep the name in sync.
         for plan in self:
-            prev = plan._find_plan_column(model)
-            if plan.parent_id and prev:
-                prev.unlink()
-            elif prev:
-                prev.field_description = plan.name
-            elif not plan.parent_id:
-                column = plan._strict_column_name()
-                field = self.env['ir.model.fields'].with_context(update_custom_fields=True).sudo().create({
-                    'name': column,
-                    'field_description': plan.name,
-                    'state': 'manual',
-                    'model': model,
-                    'model_id': self.env['ir.model']._get_id(model),
-                    'ttype': 'many2one',
-                    'relation': 'account.analytic.account',
-                    'copied': True,
-                    'on_delete': 'restrict',
-                })
-                Model = self.env[model]
-                if Model._auto:
-                    tablename = Model._table
-                    indexname = make_index_name(tablename, column)
-                    create_index(self.env.cr, indexname, tablename, [column], 'btree', f'{column} IS NOT NULL')
-                    field['index'] = True
+            prev_stored = plan._find_plan_column(model)
+            depth, name_related = plan._hierarchy_name()
+            prev_related = plan._find_related_field(model)
+            if plan.parent_id:
+                # If there is a parent, we just need to make sure there is a field to group by the hierarchy level
+                # of this plan, allowing to group by sub plan
+                if prev_stored:
+                    prev_stored.with_context({MODULE_UNINSTALL_FLAG: True}).unlink()
+                description = f"{plan.root_id.name} ({depth})"
+                if not prev_related:
+                    self.env['ir.model.fields'].with_context(update_custom_fields=True).sudo().create({
+                        'name': name_related,
+                        'field_description': description,
+                        'state': 'manual',
+                        'model': model,
+                        'model_id': self.env['ir.model']._get_id(model),
+                        'ttype': 'many2one',
+                        'relation': 'account.analytic.plan',
+                        'related': plan._column_name() + '.plan_id' + '.parent_id' * (depth - 1),
+                        'store': False,
+                        'readonly': True,
+                    })
+                else:
+                    prev_related.field_description = description
+            else:
+                # If there is no parent, then we need to create a new stored field as this is the root plan
+                if prev_related:
+                    prev_related.with_context({MODULE_UNINSTALL_FLAG: True}).unlink()
+                description = plan.name
+                if not prev_stored:
+                    column = plan._strict_column_name()
+                    field = self.env['ir.model.fields'].with_context(update_custom_fields=True).sudo().create({
+                        'name': column,
+                        'field_description': description,
+                        'state': 'manual',
+                        'model': model,
+                        'model_id': self.env['ir.model']._get_id(model),
+                        'ttype': 'many2one',
+                        'relation': 'account.analytic.account',
+                        'copied': True,
+                        'on_delete': 'restrict',
+                    })
+                    Model = self.env[model]
+                    if Model._auto:
+                        tablename = Model._table
+                        indexname = make_index_name(tablename, column)
+                        create_index(self.env.cr, indexname, tablename, [column], 'btree', f'{column} IS NOT NULL')
+                        field['index'] = True
+                else:
+                    prev_stored.field_description = description
+        if self.children_ids:
+            self.children_ids._sync_plan_column(model)
 
     def write(self, vals):
         new_parent = self.env['account.analytic.plan'].browse(vals.get('parent_id'))

--- a/addons/analytic/static/src/views/analytic_search_model.js
+++ b/addons/analytic/static/src/views/analytic_search_model.js
@@ -1,0 +1,30 @@
+import { SearchModel } from "@web/search/search_model";
+
+const PLAN_REGEX = /^(?:x_)?(x_plan\d+_id|account_id)(_\d+)?$/;
+
+export class AnalyticSearchModel extends SearchModel {
+    getSearchItems(predicate) {
+        let searchItems = super.getSearchItems(predicate);
+        const mapped = Map.groupBy(
+            searchItems.filter((f) => f.fieldName?.match(PLAN_REGEX)),
+            (f) => f.fieldName.match(PLAN_REGEX)[1],
+        );
+        searchItems = searchItems.filter(
+            (f) => !f.fieldName?.match(PLAN_REGEX) || mapped.has(f.fieldName)
+        );
+        searchItems.forEach((f) => {
+            if (f.fieldName && mapped.has(f.fieldName) && mapped.get(f.fieldName).length > 1) {
+                f.options = mapped.get(f.fieldName);
+            }
+        });
+        return searchItems;
+    }
+
+    toggleDateGroupBy(searchItemId, intervalId) {
+        if (typeof(intervalId) === "number") {
+            this.toggleSearchItem(intervalId);
+        } else {
+            super.toggleDateGroupBy(searchItemId, intervalId);
+        }
+    }
+}

--- a/addons/analytic/static/src/views/graph/graph_view.js
+++ b/addons/analytic/static/src/views/graph/graph_view.js
@@ -1,0 +1,10 @@
+import { registry } from "@web/core/registry";
+import { graphView } from "@web/views/graph/graph_view";
+import { AnalyticSearchModel } from "@analytic/views/analytic_search_model";
+
+export const analyticGraphView = {
+    ...graphView,
+    SearchModel: AnalyticSearchModel,
+};
+
+registry.category("views").add("analytic_graph", analyticGraphView);

--- a/addons/analytic/static/src/views/kanban/kanban_view.js
+++ b/addons/analytic/static/src/views/kanban/kanban_view.js
@@ -1,0 +1,10 @@
+import { registry } from "@web/core/registry";
+import { kanbanView } from "@web/views/kanban/kanban_view";
+import { AnalyticSearchModel } from "@analytic/views/analytic_search_model";
+
+export const analyticKanbanView = {
+    ...kanbanView,
+    SearchModel: AnalyticSearchModel,
+};
+
+registry.category("views").add("analytic_kanban", analyticKanbanView);

--- a/addons/analytic/static/src/views/list/list_view.js
+++ b/addons/analytic/static/src/views/list/list_view.js
@@ -1,0 +1,10 @@
+import { registry } from "@web/core/registry";
+import { listView } from "@web/views/list/list_view";
+import { AnalyticSearchModel } from "@analytic/views/analytic_search_model";
+
+export const analyticListView = {
+    ...listView,
+    SearchModel: AnalyticSearchModel,
+};
+
+registry.category("views").add("analytic_list", analyticListView);

--- a/addons/analytic/static/src/views/pivot/pivot_renderer.js
+++ b/addons/analytic/static/src/views/pivot/pivot_renderer.js
@@ -1,0 +1,21 @@
+import { PivotRenderer } from "@web/views/pivot/pivot_renderer";
+
+
+export class AnalyticPivotRenderer extends PivotRenderer {
+
+    /*
+     * Override to avoid using incomplete groupByItems
+     */
+    onGroupBySelected(type, payload) {
+        if (typeof(payload.optionId) === "number") {
+            let searchItems = this.env.searchModel.getSearchItems(
+                (searchItem) =>
+                    ["groupBy", "dateGroupBy"].includes(searchItem.type) && !searchItem.custom
+            )
+            searchItems = [...searchItems, ...searchItems.flatMap((f) => f.options).filter((f) => typeof(f?.id) === "number")]
+            const { fieldName } = searchItems.find(({ id }) => id === payload.optionId);
+            payload.fieldName = fieldName;
+        }
+        super.onGroupBySelected(type, payload);
+    }
+}

--- a/addons/analytic/static/src/views/pivot/pivot_view.js
+++ b/addons/analytic/static/src/views/pivot/pivot_view.js
@@ -1,0 +1,12 @@
+import { registry } from "@web/core/registry";
+import { pivotView } from "@web/views/pivot/pivot_view";
+import { AnalyticSearchModel } from "@analytic/views/analytic_search_model";
+import { AnalyticPivotRenderer } from "@analytic/views/pivot/pivot_renderer";
+
+export const analyticPivotView = {
+    ...pivotView,
+    Renderer: AnalyticPivotRenderer,
+    SearchModel: AnalyticSearchModel,
+};
+
+registry.category("views").add("analytic_pivot", analyticPivotView);

--- a/addons/analytic/static/tests/analytic_test_helpers.js
+++ b/addons/analytic/static/tests/analytic_test_helpers.js
@@ -1,0 +1,15 @@
+import { AccountAnalyticAccount } from "@analytic/../tests/mock_server/mock_models/account_analytic_account";
+import { AccountAnalyticLine } from "@analytic/../tests/mock_server/mock_models/account_analytic_line";
+import { AccountAnalyticPlan } from "@analytic/../tests/mock_server/mock_models/account_analytic_plan";
+import { mailModels } from "@mail/../tests/mail_test_helpers";
+import { defineModels } from "@web/../tests/web_test_helpers";
+
+export const analyticModels = {
+    AccountAnalyticAccount,
+    AccountAnalyticLine,
+    AccountAnalyticPlan,
+};
+
+export function defineAnalyticModels() {
+    return defineModels({ ...mailModels, ...analyticModels });
+}

--- a/addons/analytic/static/tests/analytic_views.test.js
+++ b/addons/analytic/static/tests/analytic_views.test.js
@@ -1,0 +1,121 @@
+import { beforeEach, expect, test } from "@odoo/hoot";
+import { contains, makeMockServer, mountView } from "@web/../tests/web_test_helpers";
+import { defineAnalyticModels } from "./analytic_test_helpers";
+
+defineAnalyticModels()
+const searchViewArch = `
+    <search>
+        <filter name="account_id" context="{'group_by': 'account_id'}"/>
+        <filter name="x_plan122_id" context="{'group_by': 'x_plan122_id'}"/>
+        <filter name="x_plan122_id_1" context="{'group_by': 'x_plan122_id_1'}"/>
+        <filter name="x_plan122_id_2" context="{'group_by': 'x_plan122_id_2'}"/>
+    </search>
+`
+
+beforeEach(async () => {
+    const { env } = await makeMockServer();
+    const root = env['account.analytic.plan'].create({ name: "State" });
+    const eu = env['account.analytic.plan'].create({ name: "Europe", parent_id: root });
+    const be = env['account.analytic.plan'].create({ name: "Belgium", parent_id: eu });
+    const fr = env['account.analytic.plan'].create({ name: "France", parent_id: eu });
+    const am = env['account.analytic.plan'].create({ name: "America", parent_id: root });
+    const us = env['account.analytic.plan'].create({ name: "USA", parent_id: am });
+    const accounts = env['account.analytic.account'].create([
+        { plan_id: be, name: "Brussels" },
+        { plan_id: be, name: "Antwerpen" },
+        { plan_id: fr, name: "Paris" },
+        { plan_id: fr, name: "Marseille" },
+        { plan_id: us, name: "New York" },
+        { plan_id: us, name: "Los Angeles" },
+    ])
+    env["account.analytic.line"].create([
+        { x_plan122_id: accounts[0], x_plan122_id_1: eu, x_plan122_id_2: be, amount: 1 },
+        { x_plan122_id: accounts[1], x_plan122_id_1: eu, x_plan122_id_2: be, amount: 10 },
+        { x_plan122_id: accounts[2], x_plan122_id_1: eu, x_plan122_id_2: fr, amount: 100 },
+        { x_plan122_id: accounts[3], x_plan122_id_1: eu, x_plan122_id_2: fr, amount: 1000 },
+        { x_plan122_id: accounts[4], x_plan122_id_1: am, x_plan122_id_2: us, amount: 10000 },
+        { x_plan122_id: accounts[5], x_plan122_id_1: am, x_plan122_id_2: us, amount: 100000 },
+    ]);
+});
+
+test.tags("desktop");
+test("Analytic hierachy in list view", async () => {
+    await mountView({
+        type: "list",
+        resModel: "account.analytic.line",
+        arch: `<list js_class="analytic_list"><field name="account_id"/></list>`,
+        searchViewId: false,
+        searchViewArch: searchViewArch,
+    });
+    await contains(".o_searchview_dropdown_toggler").click()
+    await contains(".o_group_by_menu .o_accordion_toggle").click();
+    expect(".o_group_by_menu .o_accordion_values .o-dropdown-item").toHaveCount(3);
+    await contains(".o_group_by_menu .o_accordion_values .o-dropdown-item:last").click();
+    expect(".o_facet_value").toHaveText("Country")
+    expect(".o_list_table tbody .o_group_name").toHaveCount(3);
+});
+
+test.tags("desktop");
+test("Analytic hierachy in kanban view", async () => {
+    await mountView({
+        type: "kanban",
+        resModel: "account.analytic.line",
+        arch: `
+            <kanban js_class="analytic_kanban">
+                <templates>
+                    <t t-name="card">
+                        <field class="text-muted" name="account_id"/>
+                    </t>
+                </templates>
+            </kanban>`,
+        searchViewId: false,
+        searchViewArch: searchViewArch,
+    });
+    await contains(".o_searchview_dropdown_toggler").click()
+    await contains(".o_group_by_menu .o_accordion_toggle").click();
+    expect(".o_group_by_menu .o_accordion_values .o-dropdown-item").toHaveCount(3);
+    await contains(".o_group_by_menu .o_accordion_values .o-dropdown-item:last").click();
+    expect(".o_facet_value").toHaveText("Country")
+    expect(".o_kanban_renderer .o_kanban_group").toHaveCount(3);
+});
+
+test.tags("desktop");
+test("Analytic hierachy in pivot view", async () => {
+    await mountView({
+        type: "pivot",
+        resModel: "account.analytic.line",
+        arch: `
+            <pivot js_class="analytic_pivot">
+                <field name="amount" type="measure"/>
+            </pivot>`,
+        searchViewId: false,
+        searchViewArch: searchViewArch,
+    });
+    await contains(".o_searchview_dropdown_toggler").click()
+    await contains(".o_group_by_menu .o_accordion_toggle").click();
+    expect(".o_group_by_menu .o_accordion_values .o-dropdown-item").toHaveCount(3);
+    await contains(".o_group_by_menu .o_accordion_values .o-dropdown-item:last").click();
+    expect(".o_facet_value").toHaveText("Country");
+    expect(".o_pivot tbody .o_value").toHaveCount(4); // 3 groups + 1 total
+
+    // Also check the pivot cell choices
+    await contains(".o_pivot tbody .o_pivot_header_cell_closed").click()
+    await contains(".o_popover .o-dropdown-caret").hover()
+    expect(".o_popover.o-dropdown--menu-submenu span.o-dropdown-item").toHaveCount(3);
+});
+
+test.tags("desktop");
+test("Analytic hierachy in graph view", async () => {
+    await mountView({
+        type: "graph",
+        resModel: "account.analytic.line",
+        arch: `<graph js_class="analytic_graph"><field name="account_id"/></graph>`,
+        searchViewId: false,
+        searchViewArch: searchViewArch,
+    });
+    await contains(".o_searchview_dropdown_toggler").click()
+    await contains(".o_group_by_menu .o_accordion_toggle").click();
+    expect(".o_group_by_menu .o_accordion_values .o-dropdown-item").toHaveCount(3);
+    await contains(".o_group_by_menu .o_accordion_values .o-dropdown-item:last").click();
+    expect(".o_facet_value").toHaveText("Country")
+});

--- a/addons/analytic/static/tests/mock_server/mock_models/account_analytic_account.js
+++ b/addons/analytic/static/tests/mock_server/mock_models/account_analytic_account.js
@@ -1,0 +1,8 @@
+import { models, fields } from "@web/../tests/web_test_helpers";
+
+export class AccountAnalyticAccount extends models.ServerModel {
+    _name = "account.analytic.account";
+
+    name = fields.Char()
+    plan_id = fields.Many2one({ relation: 'account.analytic.plan' })
+}

--- a/addons/analytic/static/tests/mock_server/mock_models/account_analytic_line.js
+++ b/addons/analytic/static/tests/mock_server/mock_models/account_analytic_line.js
@@ -1,5 +1,11 @@
-import { models } from "@web/../tests/web_test_helpers";
+import { models, fields } from "@web/../tests/web_test_helpers";
 
 export class AccountAnalyticLine extends models.ServerModel {
     _name = "account.analytic.line";
+
+    amount = fields.Float()
+    account_id = fields.Many2one({ relation: "account.analytic.account" })
+    x_plan122_id = fields.Many2one({ string: "State", relation: "account.analytic.account" })
+    x_plan122_id_1 = fields.Many2one({ string: "Continent", relation: "account.analytic.plan" })
+    x_plan122_id_2 = fields.Many2one({ string: "Country ", relation: "account.analytic.plan" })
 }

--- a/addons/analytic/static/tests/mock_server/mock_models/account_analytic_plan.js
+++ b/addons/analytic/static/tests/mock_server/mock_models/account_analytic_plan.js
@@ -1,0 +1,8 @@
+import { models, fields } from "@web/../tests/web_test_helpers";
+
+export class AccountAnalyticPlan extends models.ServerModel {
+    _name = "account.analytic.plan";
+
+    name = fields.Char()
+    parent_id = fields.Many2one({ relation: "account.analytic.plan" })
+}

--- a/addons/analytic/views/analytic_line_views.xml
+++ b/addons/analytic/views/analytic_line_views.xml
@@ -4,7 +4,7 @@
         <field name="name">account.analytic.line.list</field>
         <field name="model">account.analytic.line</field>
         <field name="arch" type="xml">
-            <list string="Analytic Items" multi_edit="1">
+            <list string="Analytic Items" multi_edit="1" js_class="analytic_list">
                 <field name="company_id" column_invisible="True"/>
                 <field name="product_uom_category_id" column_invisible="True"/>
                 <field name="date" optional="show"/>
@@ -96,7 +96,7 @@
         <field name="name">account.analytic.line.graph</field>
         <field name="model">account.analytic.line</field>
         <field name="arch" type="xml">
-            <graph string="Analytic Items" sample="1">
+            <graph string="Analytic Items" sample="1" js_class="analytic_graph">
                 <field name="account_id"/>
                 <field name="unit_amount" type="measure" widget="float_time"/>
                 <field name="amount" type="measure"/>
@@ -108,7 +108,7 @@
         <field name="name">account.analytic.line.pivot</field>
         <field name="model">account.analytic.line</field>
         <field name="arch" type="xml">
-            <pivot string="Analytic Items" sample="1">
+            <pivot string="Analytic Items" sample="1" js_class="analytic_pivot">
                 <field name="account_id"/>
                 <field name="date" interval="month" type="col"/>
                 <field name="amount" type="measure"/>
@@ -120,7 +120,7 @@
         <field name="name">account.analytic.line.kanban</field>
         <field name="model">account.analytic.line</field>
         <field name="arch" type="xml">
-            <kanban class="o_kanban_mobile">
+            <kanban class="o_kanban_mobile" js_class="analytic_kanban">
                 <field name="account_id"/>
                 <field name="currency_id"/>
                 <templates>

--- a/addons/sale_timesheet/static/tests/sale_timesheet_test_helpers.js
+++ b/addons/sale_timesheet/static/tests/sale_timesheet_test_helpers.js
@@ -1,15 +1,14 @@
-import { AccountAnalyticLine } from "@analytic/../tests/mock_server/mock_models/account_analytic_line";
+import { analyticModels } from "@analytic/../tests/analytic_test_helpers";
 import { mailModels } from "@mail/../tests/mail_test_helpers";
 import { ProjectTask } from "@project/../tests/mock_server/mock_models/project_task";
 import { SaleOrderLine } from "@sale/../tests/mock_server/mock_models/sale_order_line";
 import { defineModels } from "@web/../tests/web_test_helpers";
 
 export const saleTimesheetModels = {
-    AccountAnalyticLine,
     ProjectTask,
     SaleOrderLine,
 };
 
 export function defineSaleTimesheetModels() {
-    return defineModels({ ...mailModels, ...saleTimesheetModels });
+    return defineModels({ ...mailModels, ...analyticModels, ...saleTimesheetModels });
 }

--- a/addons/web/static/src/views/pivot/pivot_header.js
+++ b/addons/web/static/src/views/pivot/pivot_header.js
@@ -81,9 +81,8 @@ export class PivotHeader extends Component {
             description: item.description || item.string,
             isActive: false,
             options:
-                item.options || ["date", "datetime"].includes(item.type)
-                    ? getIntervalOptions()
-                    : undefined,
+                item.options ||
+                (["date", "datetime"].includes(item.type) ? getIntervalOptions() : undefined),
         }));
     }
 
@@ -106,11 +105,7 @@ export class PivotHeader extends Component {
      */
     validateField(fieldName, field) {
         const { groupable, type } = field;
-        return (
-            groupable &&
-            fieldName !== "id" &&
-            GROUPABLE_TYPES.includes(type)
-        );
+        return groupable && fieldName !== "id" && GROUPABLE_TYPES.includes(type);
     }
 
     /**


### PR DESCRIPTION
Help the users by creating filters automatically depending on the hierarchy of analytic plans.
This allows to open any standard view (list/pivot/graph) by level of hierarchies.

One usecase is, for a plan about localisation:
* Main plan: City (i.e. Brussels, New York, Los Angeles)
* Level 1 sub plan: Country (i.e. Belgium, USA)
* Level 2 sub plan: Continent (i.e. Europe, America)

This will generate (or delete) automatically new fields depending on the various levels in the hierarchy being created or deleted.

When the feature is in use, the group by widget becomes a drop-down similar to the groupby selector of dates, allowing to select either the year/month/...

task-4763892
