### PR TITLE
[FIX] analytic: ensure analytic distribution is saved on 'Save & Close'

### DIFF
--- a/addons/analytic/static/src/components/analytic_distribution/analytic_distribution.js
+++ b/addons/analytic/static/src/components/analytic_distribution/analytic_distribution.js
@@ -607,11 +607,14 @@ export class AnalyticDistribution extends Component {
 
     onWindowClick(ev) {
         /*
-        Dropdown should be closed only if all these condition are true:
+        Dropdown should be closed only if all these conditions are true:
             - dropdown is open
             - click is outside widget element (widgetRef)
-            - there is no active modal containing a list/kanban view (search more modal)
-            - there is no popover (click is not in search modal's search bar menu)
+            - Either:
+                - The click is not inside an active modal with a list/kanban view (search more modal)
+                    and not inside a popover (search bar menu)
+                OR
+                - The widget is inside an active modal
             - click is not targeting document dom element (drag and drop search more modal)
         */
 
@@ -621,7 +624,8 @@ export class AnalyticDistribution extends Component {
         ];
         if (this.isDropdownOpen
             && !this.widgetRef.el.contains(ev.target)
-            && !ev.target.closest(selectors.join(","))
+            && (!ev.target.closest(selectors.join(","))
+                || document.querySelector(".modal:not(.o_inactive_modal)").contains(this.widgetRef.el))
             && !ev.target.isSameNode(document.documentElement)
            ) {
             this.forceCloseEditor();


### PR DESCRIPTION
**Issue**
When creating an expense line, if the user selects an analytic distribution and clicks "Save & Close", the selected distribution is not saved. However, closing the popup with the "X" icon does trigger the save.

**Steps to Reproduce**
1. Go to Expenses > Expense Reports
2. Select an employee (e.g., Ronnie Hart)
3. Add a new expense line
4. Set an Analytic Distribution
5. Click Save & Close
6. Observe that the analytic distribution is not retained

**Root Cause**
The save behavior is triggered by a window click event, but clicks inside modals (like the analytic distribution popup) do not propagate as expected. Because everything within the popup is modal, the click does not satisfy the criteria to trigger saving the data.

**Fix**
Refine the modal detection logic in the `onWindowClick` handler. Specifically, allow modals that contain `this.widgetRef.el` to trigger the closing (and thus saving) behavior, ensuring that selections made in such modals are not lost when clicking Save & Close.

Opw-4765799
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
