### PR TITLE
[FIX] core: stream Binary fields with non-b64 value

### DIFF
--- a/odoo/addons/test_http/tests/test_static.py
+++ b/odoo/addons/test_http/tests/test_static.py
@@ -396,6 +396,30 @@ class TestHttpStatic(TestHttpStaticCommon):
                     raise AssertionError(e) from exc
                 self.assertEqual(res.content, self.gizeh_data)
 
+    def test_static24_binary_non_base64(self):
+        self.authenticate('admin', 'admin')
+
+        # need a Binary(attachment=False) field
+        # TODO: master, add such a field on test_http.stargate
+        record = self.env['ir.mail_server'].create({
+            'name': 'dummy test_http test_static server',
+            'smtp_host': 'localhost',
+        })
+
+        for name, value, error_msg in [
+            ('raw bad padding', b'()', "binascii.Error: Non-base64 digit found"),
+            ('raw good padding', b'()==', "binascii.Error: Non-base64 digit found"),
+            ('b64 bad padding', b'YB', "binascii.Error: Incorrect padding"),
+        ]:
+            with self.subTest(name=name):
+                record.smtp_ssl_certificate = value
+                with self.assertLogs('odoo.http') as capture:
+                    res = self.url_open(f'/web/content/ir.mail_server/{record.id}/smtp_ssl_certificate')
+                self.assertEqual(res.status_code, 500)
+                self.assertEqual(len(capture.output), 1, capture.output)
+                self.assertIn(error_msg, capture.output[0])
+                self.assertIn("ir.mail_server.smtp_ssl_certificate", capture.output[0])
+
 @tagged('post_install', '-at_install')
 class TestHttpStaticLogo(TestHttpStaticCommon):
     @staticmethod

--- a/odoo/http.py
+++ b/odoo/http.py
@@ -536,7 +536,12 @@ class Stream:
     def from_binary_field(cls, record, field_name):
         """ Create a :class:`~Stream`: from a binary field. """
         data_b64 = record[field_name]
-        data = base64.b64decode(data_b64) if data_b64 else b''
+        try:
+            data = base64.b64decode(data_b64, validate=True) if data_b64 else b''
+        except ValueError as exc:
+            e = ("Expected base64 encoded content, but it looks like "
+                 f"{record._name}.{field_name} contains raw bytes.")
+            raise ValueError(e) from exc
         return cls(
             type='data',
             data=data,


### PR DESCRIPTION
Write some bytes in a `field.Binary(attachment=False)` field. The ORM doesn't encode the bytes in b64, and the value is stored as a binary blob in postgres.

Attempt to download the content via /web/content (actually any route that uses `http.Stream` is affected). It sometimes download something, sometimes fail with an "Incorrect padding" error.

The `http.Stream` class wrongly assumes that reading a binary/image field is always going to return the value base64-encoded, thus it always attemps to decode it. The `b64decode` function silently discard non-b64 characters and only complain if the final thing lacks the b64 `=` padding (to make the length a multiple of 4).

So when it downloaded something, it downloaded crap.

Makes the code actually raise an error should the binary field not contains b64 data.

Fixing the problem by using the data as-is (with no b64 decoding) is not desirable. We use `Binary(attachment=False)` when we need to store sensitive documents, often cryptographic keys, and exporting them is often not desirable.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
