### PR TITLE
[FIX] account: computation of move_name for CABA entries

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -5542,6 +5542,11 @@ class AccountMove(models.Model):
     # HELPER METHODS
     # -------------------------------------------------------------------------
 
+    def _get_fnames_to_flush_for_locked_increment(self):
+        fnames = super()._get_fnames_to_flush_for_locked_increment()
+        fnames.extend(['made_sequence_gap', 'posted_before'])
+        return fnames
+
     @api.model
     def get_invoice_types(self, include_receipts=False):
         return self.get_sale_types(include_receipts) + self.get_purchase_types(include_receipts)

--- a/addons/account/models/sequence_mixin.py
+++ b/addons/account/models/sequence_mixin.py
@@ -349,6 +349,9 @@ class SequenceMixin(models.AbstractModel):
         )
         return format, format_values
 
+    def _get_fnames_to_flush_for_locked_increment(self):
+        return [self._sequence_field]
+
     def _locked_increment(self, format_string, format_values):
         """Increment the sequence for the given format, returning the new value.
 
@@ -374,7 +377,7 @@ class SequenceMixin(models.AbstractModel):
             cache[cache_key] += 1
             return format_string.format(**format_values, seq=cache[cache_key])
 
-        self.flush_recordset()
+        self.flush_recordset(self._get_fnames_to_flush_for_locked_increment())
         with self.env.cr.savepoint(flush=False) as sp:
             # By updating a row covered by the sequence's UNIQUE constraint,
             # the transaction acquires an exclusive lock on the corresponding


### PR DESCRIPTION
The name field of `account.move` became protected, which prevents the correct computation of the `move_name` field on `account.move.line`. As a result, move_name is not set for cash basis (CABA) journal items.

The problem stems from flushing of whole recordset in the `_locked_increment` of sequence_mixin. This **PR** modifies the flush and allows only required fields to be flushed.

Steps to reproduce (Runbot, v18):

1. Post an invoice that creates a CABA entry
2. Open the journal items list view
3. Number (move_name) is empty for the CABA-related lines

**opw**-4747878