### PR TITLE
[IMP] hw_drivers: add comment explaining Adam support

### DIFF
--- a/addons/hw_drivers/iot_handlers/drivers/SerialScaleDriver.py
+++ b/addons/hw_drivers/iot_handlers/drivers/SerialScaleDriver.py
@@ -275,6 +275,14 @@ class AdamEquipmentDriver(ScaleDriver):
             with serial_connection(device['identifier'], protocol, is_probing=True) as connection:
                 connection.write(protocol.measureCommand + protocol.commandTerminator)
                 # Checking whether writing to the serial port using the Adam protocol raises a timeout exception is about the only thing we can do.
+                #
+                # Explanation:
+                # - The serial connection for the Adam scales only sends data back after receiving the print ('P') command.
+                #   - An attempt to find some other undocumented command (by trying every possible ASCII character) was unsuccessful.
+                # - Sending this command is equivalent to pressing the 'Print' button on the device.
+                # - It will only respond if the weight is non-zero, otherwise there will just be a double beep.
+                # - It will also only give a double beep if the item has already been printed. You have to take the weight off and put it back again to print again.
+                # - Therefore, there is no way for us to detect the scale automatically as it will only respond if a user actively weighs something.
                 return True
         except serial.serialutil.SerialTimeoutException:
             pass


### PR DESCRIPTION
The Adam Scale driver has no way of identifying that the connected Serial device is indeed an Adam Scale. This was previously mentioned briefly in a comment, but it lead to confusion as to exactly why and if there was any other way around the issue.

This commit expands the comment to detail exactly why we can't detect the Adam scales. By giving all the information in the code, it should prevent further time being wasted trying to solve this issue when it is a hard limitation of the Adam Scale.

task-4866092

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
