### PR TITLE
[IMP] tools: add `FrozenDict`

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -3,6 +3,7 @@
 import ast
 import calendar
 from collections import Counter, defaultdict
+from collections.abc import Mapping
 from contextlib import ExitStack, contextmanager
 from datetime import date, timedelta
 from dateutil.relativedelta import relativedelta
@@ -4460,7 +4461,7 @@ class AccountMove(models.Model):
             for grouping_key, values in aggregated_values.items():
                 if not grouping_key:
                     continue
-                if isinstance(grouping_key, dict):
+                if isinstance(grouping_key, Mapping):
                     values.update(grouping_key)
                 tax_details[grouping_key] = values
 
@@ -4469,7 +4470,7 @@ class AccountMove(models.Model):
         for grouping_key, values in values_per_grouping_key.items():
             if not grouping_key:
                 continue
-            if isinstance(grouping_key, dict):
+            if isinstance(grouping_key, Mapping):
                 values.update(grouping_key)
             tax_details[grouping_key] = values
 

--- a/addons/account/wizard/account_automatic_entry_wizard.py
+++ b/addons/account/wizard/account_automatic_entry_wizard.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from odoo import api, fields, models, _
 from odoo.exceptions import UserError, ValidationError
+from odoo.tools.json import json_default
 from odoo.tools.misc import format_date, formatLang
 from odoo.tools.float_utils import float_repr
 from odoo.tools import groupby
@@ -365,9 +366,9 @@ class AccountAutomaticEntryWizard(models.TransientModel):
                 if any(line.account_id.account_type != record.move_line_ids[0].account_id.account_type for line in record.move_line_ids):
                     raise UserError(_('All accounts on the lines must be of the same type.'))
             if record.action == 'change_period':
-                record.move_data = json.dumps(record._get_move_dict_vals_change_period())
+                record.move_data = json.dumps(record._get_move_dict_vals_change_period(), default=json_default)
             elif record.action == 'change_account':
-                record.move_data = json.dumps(record._get_move_dict_vals_change_account())
+                record.move_data = json.dumps(record._get_move_dict_vals_change_account(), default=json_default)
 
     @api.depends('move_data')
     def _compute_preview_move_data(self):

--- a/addons/rpc/controllers.py
+++ b/addons/rpc/controllers.py
@@ -4,12 +4,12 @@ import xmlrpc.client
 from datetime import date, datetime
 from collections import defaultdict
 from markupsafe import Markup
+from types import MappingProxyType
 
 import odoo.exceptions
 from odoo.http import Controller, route, dispatch_rpc, request, Response
 from odoo.fields import Date, Datetime, Command
 from odoo.tools import lazy
-from odoo.tools.misc import frozendict
 
 # ==========================================================
 # XML-RPC helpers
@@ -97,7 +97,7 @@ class OdooMarshaller(xmlrpc.client.Marshaller):
         # XML 1.0 disallows control characters, remove them otherwise they break clients
         return super().dump_unicode(value.translate(CONTROL_CHARACTERS), write)
 
-    dispatch[frozendict] = dump_frozen_dict
+    dispatch[MappingProxyType] = dump_frozen_dict
     dispatch[bytes] = dump_bytes
     dispatch[datetime] = dump_datetime
     dispatch[date] = dump_date

--- a/odoo/addons/base/models/res_lang.py
+++ b/odoo/addons/base/models/res_lang.py
@@ -6,12 +6,12 @@ import json
 import locale
 import logging
 import re
+from collections.abc import Mapping
 from typing import Any, Literal
 
 from odoo import api, fields, models, tools, _
 from odoo.exceptions import UserError, ValidationError
 from odoo.tools import OrderedSet
-from odoo.tools.misc import ReadonlyDict
 
 _logger = logging.getLogger(__name__)
 
@@ -21,12 +21,27 @@ DEFAULT_TIME_FORMAT = '%H:%M:%S'
 DEFAULT_SHORT_TIME_FORMAT = '%H:%M'
 
 
-class LangData(ReadonlyDict):
+class LangData(Mapping):
     """ A ``dict``-like class which can access field value like a ``res.lang`` record.
     Note: This data class cannot store data for fields with the same name as
     ``dict`` methods, like ``dict.keys``.
     """
-    __slots__ = ()
+    __slots__ = ('__data',)
+
+    def __init__(self, data):
+        self.__data = dict(data)
+
+    def __getitem__(self, key):
+        return self.__data[key]
+
+    def __len__(self):
+        return len(self.__data)
+
+    def __iter__(self):
+        return iter(self.__data)
+
+    def __contains__(self, key):
+        return key in self.__data
 
     def __bool__(self) -> bool:
         return bool(self.id)
@@ -38,18 +53,30 @@ class LangData(ReadonlyDict):
             raise AttributeError
 
 
-class LangDataDict(ReadonlyDict):
+class LangDataDict(Mapping):
     """ A ``dict`` of :class:`LangData` objects indexed by some key, which returns
     a special dummy :class:`LangData` for missing keys.
     """
-    __slots__ = ()
+    __slots__ = ('__data',)
 
-    def __getitem__(self, key: Any) -> LangData:
+    def __init__(self, data):
+        self.__data = dict(data)
+
+    def __getitem__(self, key) -> LangData:
         try:
-            return self._data__[key]
+            return self.__data[key]
         except KeyError:
             some_lang = next(iter(self.values()))  # should have at least one active language
             return LangData(dict.fromkeys(some_lang, False))
+
+    def __len__(self):
+        return len(self.__data)
+
+    def __iter__(self):
+        return iter(self.__data)
+
+    def __contains__(self, key):
+        return key in self.__data
 
 
 class ResLang(models.Model):

--- a/odoo/orm/models.py
+++ b/odoo/orm/models.py
@@ -78,6 +78,7 @@ from .utils import (
 
 if typing.TYPE_CHECKING:
     from collections.abc import Collection, Iterable, Iterator, Reversible, Sequence
+    from types import MappingProxyType
     from .table_objects import TableObject
     from .environments import Environment
     from .registry import Registry, TriggerTree
@@ -357,7 +358,9 @@ class BaseModel(metaclass=MetaModel):
     pool: Registry  # all registry classes have a registry on the class
     # TODO replace most usages with self.env.registry; pool is reserved for class instance
 
-    _fields: dict[str, Field]
+    _fields__: dict[str, Field]
+    _fields: MappingProxyType[str, Field]
+
     _auto: bool = False
     """Whether a database table should be created.
     If set to ``False``, override :meth:`~odoo.models.BaseModel.init`

--- a/odoo/tools/json.py
+++ b/odoo/tools/json.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
 from datetime import date, datetime
+from types import MappingProxyType
 import json as json_
 import re
 
 import markupsafe
 from .func import lazy
-from .misc import ReadonlyDict
 
 JSON_SCRIPTSAFE_MAPPER = {
     '&': r'\u0026',
@@ -54,6 +54,8 @@ class JSON:
 
         Cf https://code.djangoproject.com/ticket/17419#comment:27
         """
+        if 'default' not in kwargs:
+            kwargs['default'] = json_default
         return _ScriptSafe(json_.dumps(*args, **kwargs))
 scriptsafe = JSON()
 
@@ -66,7 +68,7 @@ def json_default(obj):
         return fields.Date.to_string(obj)
     if isinstance(obj, lazy):
         return obj._value
-    if isinstance(obj, ReadonlyDict):
+    if isinstance(obj, MappingProxyType):
         return dict(obj)
     if isinstance(obj, bytes):
         return obj.decode()


### PR DESCRIPTION
Before this commit, Odoo had two implementations for creating an immutable dictionary. These two implementations have different behaviours and coexist for backward compatibility reasons.

The purpose of this commit is to leave only one implementation for the immutable dictionary, called `FrozenDict`.

This implementation enables us to obtain the behaviour of a proxy, i.e. only the methods that cannot modify the exposed dictionary.

In addition, by default, we don't override internal methods of the dictionary which improves performance (despite the cost during creation).

task-4808836