### PR TITLE
[IMP] website: adapt and re-enable tours

### DIFF
--- a/addons/website/static/tests/tours/snippet_popup_display_on_click.js
+++ b/addons/website/static/tests/tours/snippet_popup_display_on_click.js
@@ -2,9 +2,9 @@ import {
     clickOnEditAndWaitEditMode,
     clickOnElement,
     clickOnSave,
-    changeOption,
     insertSnippet,
     registerWebsitePreviewTour,
+    openLinkPopup,
 } from '@website/js/tours/tour_utils';
 import { browser } from "@web/core/browser/browser";
 
@@ -19,10 +19,14 @@ registerWebsitePreviewTour("snippet_popup_display_on_click", {
         trigger: ":iframe .s_popup .s_banner",
         run: "click",
     },
-    changeOption("SnippetPopup", 'we-select[data-attribute-name="display"] we-toggler'),
+    {
+        content: "Click on Display option",
+        trigger: ".o_customize_tab [data-container-title='Popup'] [data-label='Display'] .dropdown-toggle",
+        run: "click",
+    },
     {
         content: "Click on the display 'On Click' option",
-        trigger: "#oe_snippets we-button[data-name='onclick_opt']",
+        trigger: ".o_popover [data-action-id='copyAnchor']",
         async run(helpers) {
             // Patch and ignore write on clipboard in tour as we don't have permissions
             const oldWriteText = browser.navigator.clipboard.writeText;
@@ -44,21 +48,19 @@ registerWebsitePreviewTour("snippet_popup_display_on_click", {
         },
     },
     clickOnElement("button to close the popup", ":iframe .s_popup_close"),
-    clickOnElement("text image snippet button", ":iframe .s_text_image .btn-secondary"),
+    ...openLinkPopup(":iframe .s_text_image a.btn-secondary", "Button", 1),
+    clickOnElement("text image snippet button", ".o-we-linkpopover .o_we_edit_link"),
     {
-        content: "Paste the popup anchor in the URL input",
-        trigger: "#o_link_dialog_url_input",
-        run: "edit #Win-%2420",
+        content: "Add a link to the popup in the URL input",
+        trigger: ".o-we-linkpopover .o_we_href_input_link",
+        run: "edit #Win-%2420"
     },
     ...clickOnSave(),
-    {
-        trigger: "body .o_notification_manager:not(.o_upload_progress_toast):empty:hidden",
-    },
     {
         content: "Wait content of iframe is loaded",
         trigger: ":iframe main:contains(enhance your)",
     },
-    clickOnElement("text image snippet button", ":iframe .s_text_image .btn-secondary"),
+    clickOnElement("text image snippet button", ":iframe .s_text_image .btn-fill-secondary"),
     {
         content: "Verify that the popup opens after clicked the button.",
         trigger: ":iframe .s_popup .modal[id='Win-%2420'].show",
@@ -72,30 +74,23 @@ registerWebsitePreviewTour("snippet_popup_display_on_click", {
     },
     {
         content: "wait for the page to be loaded",
-        trigger: ".o_website_preview[data-view-xmlid='website.contactus']",
+        trigger: ":iframe [data-view-xmlid='website.contactus']",
     },
     ...clickOnEditAndWaitEditMode(),
     ...insertSnippet({id: "s_text_image", name: "Image - Text", groupName: "Content"}),
-    clickOnElement("text image snippet button", ":iframe .s_text_image .btn-secondary"),
+    {
+        content: "Click on the text image snippet to edit it.",
+        trigger: ":iframe .s_text_image",
+        run: "click",
+    },
+    ...openLinkPopup(":iframe .s_text_image a.btn-secondary", "Button", 1),
+    clickOnElement("text image snippet button", ".o-we-linkpopover .o_we_edit_link"),
     {
         content: "Add a link to the homepage in the URL input",
-        trigger: "#o_link_dialog_url_input",
-        run: "edit /",
-    },
-    {
-        content: "Open the page anchor selector",
-        trigger: ".o_link_dialog_page_anchor .dropdown-toggle",
-        run: "click",
-    },
-    {
-        content: "Click on the popup anchor to add it after the homepage link in the URL input",
-        trigger: ".o_link_dialog_page_anchor we-button:contains('#Win-%2420')",
-        run: "click",
+        trigger: ".o-we-linkpopover .o_we_href_input_link",
+        run: "edit /#Win-%2420"
     },
     ...clickOnSave(),
-    {
-        trigger: "body .o_notification_manager:not(.o_upload_progress_toast):empty:hidden",
-    },
     {
         content: "Wait content of iframe is loaded",
         trigger: ":iframe main:contains(enhance your)",
@@ -104,9 +99,9 @@ registerWebsitePreviewTour("snippet_popup_display_on_click", {
         content: "Wait form is patched",
         trigger: ":iframe form#contactus_form input[name=company]:value(yourcompany)",
     },
-    clickOnElement("text image snippet button", ":iframe .s_text_image .btn-secondary"),
+    clickOnElement("text image snippet button", ":iframe .s_text_image .btn-fill-secondary"),
     {
-        trigger: ".o_website_preview[data-view-xmlid='website.homepage']",
+        trigger: ":iframe [data-view-xmlid='website.homepage']",
     },
     {
         content: "Verify that the popup opens when the homepage page loads.",

--- a/addons/website/tests/test_snippets.py
+++ b/addons/website/tests/test_snippets.py
@@ -100,8 +100,6 @@ class TestSnippets(HttpCase):
     def test_10_parallax(self):
         self.start_tour(self.env['website'].get_client_action_url('/'), 'test_parallax', login='admin')
 
-    # TODO master-mysterious-egg fix error
-    @unittest.skip("prepare mysterious-egg for merging")
     def test_11_snippet_popup_display_on_click(self):
         # To make the tour reliable we need to wait a field using data-fill-with
         # to be patched, the step however relies on the company field being


### PR DESCRIPTION
The `snippet_popup_display_on_click` tour was previously broken due to DOM structure changes introduced by the new website builder and was consequently disabled.

This PR updates the tour steps to align with the new DOM and re-enables the associated test.

Page anchor functionality has been removed and is handled by adding directly to link, which is not needed to be tested here.