### PR TITLE
[FIX] core: search related context

### DIFF
--- a/odoo/addons/test_orm/models/test_orm.py
+++ b/odoo/addons/test_orm/models/test_orm.py
@@ -1,8 +1,9 @@
 import datetime
 import logging
 
-from odoo import Command, api, fields, models
+from odoo import api, fields, models
 from odoo.exceptions import AccessError, ValidationError
+from odoo.fields import Command
 from odoo.tools import SQL
 from odoo.tools.float_utils import float_round
 from odoo.tools.translate import html_translate
@@ -473,6 +474,7 @@ class TestOrmRelated_Foo(models.Model):
     name = fields.Char()
     bar_id = fields.Many2one('test_orm.related_bar')
     bar_name = fields.Char('bar_name', related='bar_id.name', related_sudo=False)
+    bar_alias = fields.Many2one(related='bar_id', string='bar_alias')
 
 
 class TestOrmRelated_Bar(models.Model):
@@ -480,6 +482,7 @@ class TestOrmRelated_Bar(models.Model):
     _description = 'test_orm.related_bar'
 
     name = fields.Char()
+    active = fields.Boolean(default=True)
 
 
 class TestOrmRelated_Inherits(models.Model):

--- a/odoo/addons/test_orm/tests/test_fields.py
+++ b/odoo/addons/test_orm/tests/test_fields.py
@@ -1444,6 +1444,20 @@ class TestFields(TransactionCaseWithUserDemo, TransactionExpressionCase):
         self.assertEqual(bar.foo, oof)
         self.assertIn(bar, bar.search([('foo', 'in', oof.ids)]))
 
+    def test_25_related_many2one(self):
+        bar = self.env['test_orm.related_bar'].create({'name': 'A'})
+        foo = self.env['test_orm.related_foo'].create({'name': 'A', 'bar_id': bar.id})
+        self.assertEqual(foo.bar_id, bar)
+        self.assertEqual(foo.bar_alias, foo.bar_id)
+
+        # After deactivating the foo record, the search should be executed with
+        # context depending on searching a many2one field: active_test=False.
+        for active in (True, False):
+            with self.subTest(active=active):
+                bar.active = active
+                self.assertEqual(foo.search([('id', 'in', foo.ids), ('bar_id', 'ilike', 'A')]), foo)
+                self.assertEqual(foo.search([('id', 'in', foo.ids), ('bar_alias', 'ilike', 'A')]), foo)
+
     def test_25_one2many_inverse_related(self):
         left = self.env['test_orm.trigger.left'].create({})
         right = self.env['test_orm.trigger.right'].create({})

--- a/odoo/orm/fields.py
+++ b/odoo/orm/fields.py
@@ -769,7 +769,12 @@ class Field(typing.Generic[T]):
         # if the value is a domain, resolve it using records' environment
         if isinstance(value, Domain):
             field, comodel = path_fields[-1]
-            value = comodel.with_env(records.env)._search(value)
+            user_comodel = comodel.with_env(records.env)
+            if field.type == 'many2one':
+                user_comodel = user_comodel.with_context(active_test=False)
+            elif field.type in ('one2many', 'many2many'):
+                user_comodel = user_comodel.with_context(**field.context)
+            value = user_comodel._search(value)
 
         # build the domain backwards with the any operator
         field, comodel = path_fields[-1]


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
When searching on a related field which points to a relational field, the relation should be searched with the the context modified as in other searches (active_test=False for many2one, context from the field for x2many).

```
partner_id = fields.Many2one(related='something.partner_id')

partner_domain = [...]
self.search([('partner_id', 'any', partner_domain)])
  # the partner_domain is executed on
  # env['res.partner'].with_context(active_test=False)
```

Current behavior before PR:
Context is not updated when using a domain to search relational fields `('relational_field_id', 'any', [...])`.

Desired behavior after PR is merged:
Use the context as defined for each field type: many2one is active_test=False and x2many use the context from the field.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
