### PR TITLE
[FIX] industry: prevent upgrade if major changed

### DIFF
--- a/addons/base_import_module/models/base_import_module.py
+++ b/addons/base_import_module/models/base_import_module.py
@@ -1,7 +1,10 @@
 # -*- coding: utf-8 -*-
 import base64
+import zipfile
 from io import BytesIO
-from odoo import api, fields, models
+from odoo import fields, models, _
+from odoo.exceptions import AccessError, RedirectWarning, UserError
+from odoo.modules.module import MANIFEST_NAMES
 
 
 class BaseImportModule(models.TransientModel):
@@ -16,18 +19,49 @@ class BaseImportModule(models.TransientModel):
     with_demo = fields.Boolean(string='Import demo data of module')
     modules_dependencies = fields.Text()
 
+    def _get_module_names(self, module_file):
+        if not self.env.is_admin():
+            raise AccessError(_("Only administrators can install data modules."))
+        if not module_file:
+            raise Exception(_("No file sent."))
+        if not zipfile.is_zipfile(module_file):
+            raise UserError(_('Only zip files are supported.'))
+
+        module_names = []
+        for file in zipfile.ZipFile(module_file, "r").filelist:
+            file_dirs = file.filename.split('/')
+            if len(file_dirs) == 2 and file_dirs[1] in MANIFEST_NAMES:
+                module_names.append(file_dirs[0])
+        return module_names
+
     def import_module(self):
         self.ensure_one()
         IrModule = self.env['ir.module.module']
         zip_data = base64.decodebytes(self.module_file)
         fp = BytesIO()
         fp.write(zip_data)
-        res = IrModule._import_zipfile(fp, force=self.force, with_demo=self.with_demo)
-        return {
+        module_names = self._get_module_names(fp)
+        installed_major_versions = {
+            module.id: int(module.installed_version.split('.')[2])
+            for module in IrModule.search([('name', 'in', module_names)])
+        }
+        IrModule._import_zipfile(fp, force=self.force, with_demo=self.with_demo)
+        latest_major_versions = {
+            module.id: int(module.latest_version.split('.')[2])
+            for module in IrModule.search([('name', 'in', module_names)])
+        }
+        IMPORT_ACTION = {
             'type': 'ir.actions.act_url',
             'target': 'self',
             'url': '/odoo',
         }
+        if any(installed_major_versions[id] < latest_major_versions[id] for id in installed_major_versions):
+            raise RedirectWarning(
+                _("A new version is available!\n\nHowever upgrade script is not yet available to upgrade to new version.\nProceeding may break some data in your modules."),
+                IMPORT_ACTION,
+                _('Upgrade')
+            )
+        return IMPORT_ACTION
 
     def get_dependencies_to_install_names(self):
         module_ids, _not_found = self.env['ir.module.module']._get_missing_dependencies_modules(base64.decodebytes(self.module_file))

--- a/addons/base_import_module/views/ir_module_views.xml
+++ b/addons/base_import_module/views/ir_module_views.xml
@@ -11,7 +11,7 @@
                 </xpath>
                 <xpath expr="//button[@name='button_immediate_install']" position="after">
                     <button type="object" class="btn btn-primary btn-sm" name="button_immediate_install_app" invisible="state != 'uninstalled' or module_type in ('official', False)" groups="base.group_system" context="{'module_name':name}">Activate</button>
-                    <button type="object" class="btn btn-primary btn-sm" name="button_immediate_install_app" invisible="state == 'uninstalled' or module_type in ('official', False)" groups="base.group_system" context="{'module_name':name}">Upgrade</button>
+                    <button type="object" class="btn btn-primary btn-sm" name="button_immediate_install_app" invisible="state == 'uninstalled' or module_type in ('official', False)" groups="base.group_system" context="{'module_name':name}">Reset</button>
                 </xpath>
                 <xpath expr="//button[@name='button_immediate_install']" position="attributes">
                     <attribute name="invisible">state != 'uninstalled' or (module_type and module_type != 'official')</attribute>
@@ -52,7 +52,7 @@
                 </xpath>
                 <xpath expr="//button[@name='button_immediate_install']" position="after">
                     <button type="object" class="btn btn-primary me-1" name="button_immediate_install_app" invisible="state != 'uninstalled' or module_type in ('official', False)" groups="base.group_system">Activate</button>
-                    <button type="object" class="btn btn-primary me-1" name="button_immediate_install_app" invisible="state == 'uninstalled' or module_type in ('official', False)" groups="base.group_system">Upgrade</button>
+                    <button type="object" class="btn btn-primary me-1" name="button_immediate_install_app" invisible="state == 'uninstalled' or module_type in ('official', False)" groups="base.group_system">Reset</button>
                 </xpath>
                 <xpath expr="//button[@name='button_immediate_install']" position="attributes">
                     <attribute name="invisible">to_buy or state != 'uninstalled' or (module_type and module_type != 'official')</attribute>


### PR DESCRIPTION
### Before this commit:
 Activated industry apps had an "Upgrade" button with was slightly misleading, since the button was actually reseting the module regardless if there is a new version or not.

### After this commit:
 The "Upgrade" button has been named "Reset" for better clarity. Additionally in case of a major change in module version a warning will be raised to signal to users potential record breakage in case of upgrade.

- Lines flagged by ci/security should be safe because it only reads zip imported file paths and extracts module names if they exist.

task-4752273