### PR TITLE
[FIX] web: fix focus on tab in colorpicker

### DIFF
--- a/addons/html_editor/static/tests/color_selector.test.js
+++ b/addons/html_editor/static/tests/color_selector.test.js
@@ -883,4 +883,28 @@ describe("color preview", () => {
         `);
         await expectElementCount(".o-we-toolbar", 1);
     });
+
+    test("should preview selected text color when tabbing", async () => {
+        await setupEditor(
+            `<p>
+                This is a <font style="color: rgb(255, 0, 0);">[test]</font>.
+            </p>`
+        );
+
+        await expandToolbar();
+        await animationFrame();
+        expect("i.fa-font").toHaveStyle({ borderBottomColor: "rgb(255, 0, 0)" });
+        await click(".o-select-color-foreground");
+        await animationFrame();
+        await press("Tab"); // Tab to Custom
+        await animationFrame();
+        await press("Tab"); // Tab to Gradient
+        await animationFrame();
+        await press("Tab"); // Tab to Trash
+        await animationFrame();
+        expect(queryAll("font")).toHaveLength(0); // The color was deleted
+        await press("Tab"); // Tab to 1st color
+        await animationFrame();
+        expect("font").toHaveStyle({ color: "rgb(113, 75, 103)" });
+    });
 });

--- a/addons/web/static/src/core/color_picker/color_picker.xml
+++ b/addons/web/static/src/core/color_picker/color_picker.xml
@@ -29,7 +29,7 @@
                     t-on-mouseover="onColorHover"
                     t-on-mouseout="onColorHoverOut"
                     t-on-focusin="onColorFocusin"
-                    t-on-focusout="onColorHoverOut"/>
+                    t-on-focusout="onColorFocusout"/>
         </div>
         <!-- TODO: move the theme tab to html_builder. It shouldn't be in web. -->
         <t t-if="state.activeTab==='theme'">
@@ -38,8 +38,8 @@
                 t-on-mouseover="onColorHover"
                 t-on-mouseout="onColorHoverOut"
                 t-on-mouseleave="() => this.props.applyColorResetPreview()"
-                t-on-focusin="onColorHover"
-                t-on-focusout="onColorHoverOut"
+                t-on-focusin="onColorFocusin"
+                t-on-focusout="onColorFocusout"
                 >
                 <!-- List all Presets -->
                 <t t-foreach="[1, 2, 3, 4, 5]" t-as="number" t-key="number">
@@ -69,7 +69,7 @@
                 t-ref="solidTabRef"
                 t-on-keydown="colorPickerNavigation"
                 t-on-focusin="onColorFocusin"
-                t-on-focusout="onColorHoverOut">
+                t-on-focusout="onColorFocusout">
                 <div class="o_colorpicker_section">
                     <button data-color="o-color-1" t-attf-style="background-color: var(--o-color-1)" class="btn o_color_button"/>
                     <button data-color="o-color-3" t-attf-style="background-color: var(--o-color-3)" class="btn o_color_button"/>


### PR DESCRIPTION
Following [1], which introduced the preview when focusing color buttons
inside a colorpicker (and revert when focusing out of them), tabbing on
the color selector within html_editor stopped working as expected:
1. the reset button doesn't trigger a preview
2. For instance in the To-Do app:
- Select a single word
- Open the "Apply Font Color" picker and use tab to navigate
=> The color of the whole line is changed.

[1]: https://github.com/odoo/odoo/commit/9fe45e2b7ddbbfd0445ffe25a859e67a316d02b2