### PR TITLE
[IMP] sms: use a separate button to "insert field"

### DIFF
--- a/addons/mail/static/src/views/web/fields/emojis_text_field/emoji_text_field.scss
+++ b/addons/mail/static/src/views/web/fields/emojis_text_field/emoji_text_field.scss
@@ -1,0 +1,3 @@
+.o_field_text_emojis textarea.o_input {
+ padding-right: 2rem;   
+}

--- a/addons/sms/static/src/components/sms_widget/fields_sms_widget.xml
+++ b/addons/sms/static/src/components/sms_widget/fields_sms_widget.xml
@@ -2,13 +2,19 @@
 
 <templates xml:space="preserve">
     <t t-name="sms.SmsWidget" t-inherit="mail.EmojisTextField" t-inherit-mode="primary">
+        <xpath expr="//div[hasclass('o_field_input_buttons')]/button[hasclass('fa-magic')]" position="replace"/>
         <xpath expr="/*[last()]/*[last()]" position="after">
             <div class="o_sms_container mt-3">
-                <span class="text-muted o_sms_count" t-if="nbrChar > 0">
+                <span class="text-muted o_sms_count me-1">
                     <t t-out="nbrChar"/>/<t t-out="160 * nbrSMS" /> <t t-out="nbrCharExplanation" /> | <t t-out="nbrSMS"/> SMS (<t t-out="encoding"/>)
                     <a href="https://iap-services.odoo.com/iap/sms/pricing" target="_blank"
-                        title="SMS Pricing" aria-label="SMS Pricing" class="fa fa-lg fa-info-circle"/>
+                        title="SMS Pricing" aria-label="SMS Pricing" class="fa fa-lg fa-info-circle align-middle"/>
                 </span>
+                <button t-if="props.dynamicPlaceholder"
+                    class="btn btn-link py-0 border-0"
+                    title="Insert Field"
+                    t-on-click="onDynamicPlaceholderOpen"
+                ><span class="fa fa-magic me-1"/><span>Insert Field</span></button>
             </div>
         </xpath>
     </t>

--- a/addons/web/static/src/core/utils/autoresize.js
+++ b/addons/web/static/src/core/utils/autoresize.js
@@ -99,9 +99,7 @@ export function resizeTextArea(textarea, options = {}) {
         borderTopWidth: 0,
         borderBottomWidth: 0,
         paddingTop: 0,
-        paddingRight: style.paddingRight,
         paddingBottom: 0,
-        paddingLeft: style.paddingLeft,
     });
     textarea.style.height = "auto";
     const height = Math.max(minimumHeight, textarea.scrollHeight + heightOffset);


### PR DESCRIPTION
The "insert field" button from standard emoji text fields goes over the text in the SMS composer.

As we already extend the text widget with a character counter under it, we will also pull the button out of the text area and into a specific button that's more explicit.

task-4619648
