### PR TITLE
[IMP] hr_holidays: remove scrollbar from timeoff request popup in the overview menu

### DIFF
--- a/addons/hr_holidays/report/hr_leave_report_calendar.xml
+++ b/addons/hr_holidays/report/hr_leave_report_calendar.xml
@@ -28,11 +28,11 @@
         <field name="model">hr.leave.report.calendar</field>
         <field name="arch" type="xml">
             <form string="Time Off">
-                <sheet class="py-0 pe-0 overflow-hidden">
+                <sheet >
                     <widget name="web_ribbon" title="Cancelled" bg_color="text-bg-danger" invisible="state != 'cancel'"/>
                     <widget name="web_ribbon" title="Refused" bg_color="bg-danger" invisible="state != 'refuse'"/>
                     <widget name="web_ribbon" title="Approved" bg_color="bg-success" invisible="state != 'validate'"/>
-                    <group>
+                    <group class="py-0 pe-0 overflow-hidden">
                         <field name="name"/>
                         <field name="start_datetime"/>
                         <field name="stop_datetime"/>


### PR DESCRIPTION
When logged in as a simple user (e.g., demo user), opening the Time Off Request popup from the Overview menu shows a scrollbar, even when there's no overflow content. 
The layout of the popup menu has been adjusted to fit the content within the popup.

