### PR TITLE
[FIX] point_of_sale: serialize object without uuid

### DIFF
--- a/addons/point_of_sale/static/src/app/models/utils/recursive_serialization.js
+++ b/addons/point_of_sale/static/src/app/models/utils/recursive_serialization.js
@@ -170,7 +170,7 @@ const deepSerialization = (
                         uuidMapping[targetModel][record.uuid][fieldName] = record[fieldName].uuid;
                     }
                 }
-                serialized[relatedModel][record[fieldName].uuid] = record[fieldName];
+                serialized[relatedModel][record[fieldName].uuid] = record[fieldName].uuid;
             }
             if (typeof recordId === "number" && recordId >= 0) {
                 result[fieldName] = record[fieldName].id;

--- a/addons/pos_event/static/tests/tours/pos_event_tour.js
+++ b/addons/pos_event/static/tests/tours/pos_event_tour.js
@@ -40,3 +40,27 @@ registry.category("web_tour.tours").add("SellingEventInPos", {
             ReceiptScreen.clickNextOrder(),
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("test_selling_multiple_ticket_saved", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            ProductScreen.clickDisplayedProduct("My Awesome Event"),
+            EventTourUtils.increaseQuantityOfTicket("Ticket VIP"),
+            EventTourUtils.increaseQuantityOfTicket("Ticket Basic"),
+            Dialog.confirm(),
+            EventTourUtils.answerTicketSelectQuestion("1", "Question1", "Q1-Answer1"),
+            EventTourUtils.answerTicketSelectQuestion("2", "Question1", "Q1-Answer1"),
+            EventTourUtils.answerGlobalSelectQuestion("Question2", "Q2-Answer1"),
+            EventTourUtils.answerGlobalSelectQuestion("Question3", "Q3-Answer1"),
+            Dialog.confirm(),
+            ProductScreen.clickPayButton(),
+            PaymentScreen.clickPaymentMethod("Bank", true, { remaining: "0.00" }),
+            PaymentScreen.clickValidate(),
+            ReceiptScreen.isShown(),
+            EventTourUtils.printTicket("full"),
+            EventTourUtils.printTicket("badge"),
+            ReceiptScreen.clickNextOrder(),
+        ].flat(),
+});

--- a/addons/pos_event/tests/test_frontend.py
+++ b/addons/pos_event/tests/test_frontend.py
@@ -92,3 +92,16 @@ class TestUi(TestPointOfSaleHttpCommon):
         event_answer_name = event_registration.registration_answer_ids.value_answer_id.mapped('name')
         self.assertEqual(len(event_registration.registration_answer_ids), 3)
         self.assertEqual(event_answer_name, ['Q1-Answer1', 'Q2-Answer1', 'Q3-Answer1'])
+
+    def test_selling_multiple_ticket_saved(self):
+        self.pos_user.write({
+            'group_ids': [
+                (4, self.env.ref('event.group_event_user').id),
+            ]
+        })
+        self.main_pos_config.with_user(self.pos_user).open_ui()
+        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'test_selling_multiple_ticket_saved', login="pos_user")
+
+        order = self.env['pos.order'].search([], order='id desc', limit=1)
+        self.assertTrue(order.lines[0].event_registration_ids)
+        self.assertTrue(order.lines[1].event_registration_ids)


### PR DESCRIPTION
When serializing an object, we rely on the uuid to identify it and avoid
serializing it multiple times. Some object (like the event registration)
do not have a uuid, so we need to make sure they are always serialized.

Steps to reproduce:
-------------------
* Install pos_event module
* Open a POS session
* Add the architect event product to the cart
* In the popup add one Ticket Basic and one Ticket VIP
* Validate the order
* Go to the receipt screens
* Print the badge
> Observation: Only one of the badge is being printed

Why the fix:
------------
As the registraion had no uuid, the first one was serialized but the
second one was ignored as it was detected as already serialized. Now if
the object we are serializing does not have a uuid, we generate make
sure it's always serialized, by putting `undefined` instead of a record
in the `serialized` dict.

opw-4863800