### PR TITLE
[FIX] portal: properly display invalid-feedback.s in input-group.s

### DIFF
--- a/addons/portal/static/src/scss/portal.scss
+++ b/addons/portal/static/src/scss/portal.scss
@@ -162,9 +162,13 @@ li > p {
 [class^="col-lg-"] {
     min-height: 24px;
 }
-.input-group {
+// TODO this was added a compatibility layer for old layouts when we switched
+// to Bootstrap 4. It should be removed at some point, to not have to support
+// invalid-feedback with that awful :where selector.
+.input-group:where(:not(:has(.was-validated :invalid ~ .invalid-feedback, .is-invalid ~ .invalid-feedback))) {
     flex-flow: row nowrap;
 }
+
 .list-group-item:not([class*="list-group-item-"]):not(.active) {
     color: color-contrast($list-group-bg);
 }


### PR DESCRIPTION
Commit [1] added a compatibility layer when we switched to Bootstrap 4. That compatibility layer actually still exists in master, even though we are now using Bootstrap 5. A specific rule was forcing input-group elements on one row... which conflicts with the fact that invalid feedbacks are supposed to wrap on the next row.

This commit fixes that by re-enabling the wrap, when such a feedback is displayed only. In master, the rule should probably be removed, hoping outdated layouts were updated to Bootstrap 4+ correctly at this point (not even sure what exactly is broken by not forcing the input-group on one row).

Steps to reproduce:
- Add a form in your website page
- Add a date field (this is an input-group)
- Make it required
- Save
- Open the HTML editor(*) and add an invalid-feedback in that field
- Save
- Send your form without filling it => the input-group is broken

(*) starting from 18.4, there is a standard use case on the /my/security
    page. There might be unknown usecases between 16.0 and 18.4.

[1]: https://github.com/odoo/odoo/commit/7aa473e09944bc5c1aba2dbcd611097dd36db6c5

Related to task-3959739
