### PR TITLE
[IMP] html_builder: keep customize options on tab switch

### DIFF
--- a/addons/html_builder/static/src/builder.js
+++ b/addons/html_builder/static/src/builder.js
@@ -245,10 +245,6 @@ export class Builder extends Component {
      */
     onTabClick(tab) {
         this.setTab(tab);
-        // Deactivate the options when clicking on the "BLOCKS" or "THEME" tabs.
-        if (tab === "theme" || tab === "blocks") {
-            this.editor.shared["builderOptions"].deactivateContainers();
-        }
     }
 
     setTab(tab) {

--- a/addons/website/static/src/builder/plugins/options/cookies_bar_option.js
+++ b/addons/website/static/src/builder/plugins/options/cookies_bar_option.js
@@ -11,6 +11,7 @@ class CookiesBarOptionPlugin extends Plugin {
                 template: "website.CookiesBarOption",
                 selector: "#website_cookies_bar",
                 applyTo: ".modal",
+                reloadTarget: true,
             },
         ],
         builder_actions: {

--- a/addons/website/static/src/builder/plugins/options/footer_copyright_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/footer_copyright_option_plugin.js
@@ -12,6 +12,7 @@ class FooterCopyrightOptionPlugin extends Plugin {
                 selector: ".o_footer_copyright",
                 editableOnly: false,
                 groups: ["website.group_website_designer"],
+                reloadTarget: true,
             },
         ],
     };

--- a/addons/website/static/src/builder/plugins/options/navbar_logo_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/navbar_logo_option_plugin.js
@@ -14,6 +14,7 @@ class NavbarLogoOptionPlugin extends Plugin {
                 title: _t("Navbar Logo"),
                 editableOnly: false,
                 groups: ["website.group_website_designer"],
+                reloadTarget: true,
             }),
         ],
     };

--- a/addons/website/static/src/builder/plugins/switchable_views_plugin.js
+++ b/addons/website/static/src/builder/plugins/switchable_views_plugin.js
@@ -16,6 +16,7 @@ export class SwitchableViewsPlugin extends Plugin {
             },
             groups: ["website.group_website_designer"],
             editableOnly: false,
+            reloadTarget: true, // TODO: make sure that needed
         },
     };
 

--- a/addons/website_sale/static/src/website_builder/product_image_option_plugin.js
+++ b/addons/website_sale/static/src/website_builder/product_image_option_plugin.js
@@ -43,8 +43,8 @@ export class ProductImageOptionPlugin extends Plugin {
 }
 
 /*
-* Change sequence of product page images
-*/
+ * Change sequence of product page images
+ */
 export class SetPositionAction extends BuilderAction {
     static id = "setPosition";
     setup() {

--- a/addons/website_sale/static/src/website_builder/website_sale_show_empty_option_plugin.js
+++ b/addons/website_sale/static/src/website_builder/website_sale_show_empty_option_plugin.js
@@ -12,6 +12,7 @@ class WebsiteSaleShowEmptyOptionPlugin extends Plugin {
                 selector: "#wrapwrap > header",
                 editableOnly: false,
                 groups: ["website.group_website_designer"],
+                reloadTarget: true,
             }),
         ],
     };


### PR DESCRIPTION
This PR introduces two changes.

1. In the website builder, when the user clicks on some element of the website, it opens several customize options in the "Customize" tab of the sidebar. Previously, if the user switched to either the "Block" tab or the "Theme" tab, once he would come back to the "Customize" tab, all the options would be gone. This commit changes this behavior by keeping the options enabled.

This allows to avoid to have to reselect snippets in order to see the desired customize options after switching to another tab.

2. Some actions are automatically saved and trigger a reload of the builder. When this happens, we want to keep as many options as possible open in the "Customize Tab". This can only be done with option containers associated with a selector only matching one element on the page.
TODO: remaining selectors to check:
-   .o_record_cover_container
-   .o_facebook_page
-   .listing_layout_switcher
-   .o_mega_menu
-   .o_wblog_post_page_cover[data-res-model='blog.post']
-   .o_wcrm_filters_top
-   .o_wsale_product_images

task-3103768
