### PR TITLE
[FIX] web: Prevent updating position when element is not loaded

### DIFF
--- a/addons/web/static/src/core/position_hook.js
+++ b/addons/web/static/src/core/position_hook.js
@@ -325,7 +325,7 @@ export function usePosition(refName, getTarget, options = {}) {
 
     let executingUpdate = false;
     const batchedUpdate = async () => {
-        if (!executingUpdate) {
+        if (!executingUpdate && ref.el) {
             executingUpdate = true;
             update();
             await Promise.resolve();


### PR DESCRIPTION
Exemple of steps:
- Install `crm`
- Open crm with pivot view
- Click on '+' on a stage, exemple: "Proposition"

There is a dropdown with other sub-dropdown,
If we go to a sub-dropdown for the first time it is displayed correctly but the second time it is displayed with a wrong position (on the parent dropdown).

The problem occurs because the `batchedUpdate` function doesn't wait for the element to be displayed before updating its position. In our case, the dropdown didn't have time to have its position adjusted because the batch was called too early.
opw-4493236