### PR TITLE
[FIX] sale: pass only first sale_line_ids's analytic distribution

### DIFF
--- a/addons/sale/models/account_move_line.py
+++ b/addons/sale/models/account_move_line.py
@@ -24,7 +24,7 @@ class AccountMoveLine(models.Model):
         # EXTENDS 'account'
         vals = super()._related_analytic_distribution()
         if self.sale_line_ids and not self.analytic_distribution:
-            vals |= self.sale_line_ids.analytic_distribution or {}
+            vals |= self.sale_line_ids[0].analytic_distribution or {}
         return vals
 
     def _prepare_analytic_lines(self):


### PR DESCRIPTION
In odoo/odoo#199763, `_related_analytic_distribution()` was introduced to pass the existing analytic distribution in a sale order line to an invoice line. However, sale_line_ids is a Many2Many field, so to avoid singleton errors in the case of multiple SOLs, only the analytic distribution of the first sale order line is passed.

no-task

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
