### PR TITLE
[IMP] mail: stop raising on missing email

### DIFF
--- a/addons/mail/models/discuss/discuss_channel.py
+++ b/addons/mail/models/discuss/discuss_channel.py
@@ -892,9 +892,6 @@ class DiscussChannel(models.Model):
                 self._action_unfollow(p)
         return super()._message_receive_bounce(email, partner)
 
-    def _message_compute_author(self, author_id=None, email_from=None, raise_on_email=True):
-        return super()._message_compute_author(author_id=author_id, email_from=email_from, raise_on_email=False)
-
     def _message_compute_parent_id(self, parent_id):
         # super() unravels the chain of parents to set parent_id as the first
         # ancestor. We don't want that in channel.

--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -79,7 +79,7 @@ class MailMessage(models.Model):
         missing_author = 'author_id' in fields and 'author_id' not in res
         missing_email_from = 'email_from' in fields and 'email_from' not in res
         if missing_author or missing_email_from:
-            author_id, email_from = self.env['mail.thread']._message_compute_author(res.get('author_id'), res.get('email_from'), raise_on_email=False)
+            author_id, email_from = self.env['mail.thread']._message_compute_author(res.get('author_id'), res.get('email_from'))
             if missing_email_from:
                 res['email_from'] = email_from
             if missing_author:
@@ -664,7 +664,7 @@ class MailMessage(models.Model):
         tracking_values_list = []
         for values in vals_list:
             if 'email_from' not in values:  # needed to compute reply_to
-                _author_id, email_from = self.env['mail.thread']._message_compute_author(values.get('author_id'), email_from=None, raise_on_email=False)
+                _author_id, email_from = self.env['mail.thread']._message_compute_author(values.get('author_id'), email_from=None)
                 values['email_from'] = email_from
             if not values.get('message_id'):
                 values['message_id'] = self._get_message_id(values)

--- a/addons/mail/wizard/mail_compose_message.py
+++ b/addons/mail/wizard/mail_compose_message.py
@@ -347,7 +347,7 @@ class MailComposeMessage(models.TransientModel):
             # When changing template in raw mode or resetting also fallback.
             if composer.email_from and rendering_mode and not updated_author_id:
                 updated_author_id, _ = Thread._message_compute_author(
-                    None, composer.email_from, raise_on_email=False,
+                    None, composer.email_from,
                 )
                 if not updated_author_id:
                     updated_author_id = self.env.user.partner_id.id

--- a/addons/mail_group/models/mail_group.py
+++ b/addons/mail_group/models/mail_group.py
@@ -294,7 +294,7 @@ class MailGroup(models.Model):
         # First create the <mail.message>
         Mailthread = self.env['mail.thread']
         values = dict((key, val) for key, val in kwargs.items() if key in self.env['mail.message']._fields)
-        author_id, email_from = Mailthread._message_compute_author(author_id, email_from, raise_on_email=True)
+        author_id, email_from = Mailthread._message_compute_author(author_id, email_from)
 
         values.update({
             'author_id': author_id,


### PR DESCRIPTION
We currently raise an exception if not sender email can be found
when trying to send a message.

However as "sending a message" is part of many business flows
it can mean blocking users from performing completely unrelated
actions.

As the email will fail with a clear reason, and generate a failure
notification in the chatter and/or notification tray, there is no
need to specifically raise in this case. The email could very
well fail for any other number of reasons, none of which would
raise an exception, so this behavior is inconsistent.

Under realistic circumstances, every user will have an email
if only for login for login purposes. This change is mostly
useful for testing on new empty databases. In addition to removing
now useless logic.

task-4863442