### PR TITLE
[FIX] crm: prefill lead partner and company in form view

### DIFF
--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -414,7 +414,7 @@ class CrmLead(models.Model):
     @api.onchange('commercial_partner_id')
     def _onchange_commercial_partner_id(self):
         for lead in self:
-            if lead.partner_id and lead.commercial_partner_id != lead.partner_id.commercial_partner_id:
+            if lead.partner_id and lead.commercial_partner_id and lead.commercial_partner_id != lead.partner_id.commercial_partner_id:
                 # writing to partner will invalidate and recompute
                 # re-write the original value to keep user selection
                 commercial_partner = lead.commercial_partner_id

--- a/addons/sales_team/views/crm_team_views.xml
+++ b/addons/sales_team/views/crm_team_views.xml
@@ -163,8 +163,8 @@
                         </div>
                     </t>
                     <t t-name="card" class="flex-column justify-content-between">
-                        <div>
-                            <field name="name" class="fw-bold text-truncate fs-2 ms-2"/>
+                        <div class="ms-2 me-3">
+                            <field name="name" class="fw-bold fs-2"/>
                         </div>
                         <div class="crm_team_kanban_bottom d-flex align-items-center mt-5">
                             <field name="company_id" invisible="1"/>


### PR DESCRIPTION
Since odoo/odoo@68667ad5d42d2a7cd25b2433cafa776d2bb87b4b
we can select separately the company and the partner in
the kanban view quick create form.

In order to be consistent between the company_partner_id
(being moslty the company of the partner, if it is not a
company) and the partner_id, an onchange was added, which
everytime the company_partner_id sets the partner to null
if their company_partner_id is different. Moslty, when
changing to company B and partner P of company A is set,
then sets partner to False.

ISSUE
=====

However, this has a side-effect that is resolved here:
1. Go to the form view of a contact that is either a
company without parent company, or an individual without
company [1]
2. Press the stat button for opportunities
3. Either in the kanban view quick create, or in the form
view opened on using the 'new' button of the list view...
4. The lead is not pre-filled with partner data (name,
phone, email...)

It seems that the context is not working properly as
default values are not propagated.

FIX
===

Actually, the context works fine. The issue is that the
onchange will set partner (and data) to False in the two
cases [1] As we have a default partner_id value, but no
commercial_partner_id in those cases (as its compute will
set it to False then), then we compare the partner_id value
to False, and as they differ, we set partner_id to False

-> check that self.commercial_partner_id is set to trigger
the onchange. This prevents the issue described above.

TEST
====

Add a few test cases for the default_partner_id in existing
test_kanban_quick_create_partner_inherited_details

OTHER FIX
=========

In kanban cards, team name was going over the card when
too long. Make it jump to next line instead.

Task-4863922
