### PR TITLE
[FIX] website: add step in history when adding a new form field

### DIFF
--- a/addons/website/static/src/builder/plugins/form/form_option.xml
+++ b/addons/website/static/src/builder/plugins/form/form_option.xml
@@ -74,7 +74,7 @@
 <t t-name="website.s_website_form_form_option_add_field_button">
     <button type="button" class="btn o_we_bg_brand_primary"
         t-att-title="props.tooltip"
-        t-on-click="() => props.addField(domState.el)"
+        t-on-click="() => this.addField()"
     >
         + Field
     </button>

--- a/addons/website/static/src/builder/plugins/form/form_option_add_field_button.js
+++ b/addons/website/static/src/builder/plugins/form/form_option_add_field_button.js
@@ -1,16 +1,20 @@
-import { BaseOptionComponent, useDomState } from "@html_builder/core/utils";
+import { useOperation } from "@html_builder/core/operation_plugin";
+import { BaseOptionComponent } from "@html_builder/core/utils";
 
 export class FormOptionAddFieldButton extends BaseOptionComponent {
-    // TODO create +Field template
     static template = "website.s_website_form_form_option_add_field_button";
     static props = {
         addField: Function,
         tooltip: String,
     };
+
     setup() {
-        super.setup();
-        this.domState = useDomState((el) => ({
-            el,
-        }));
+        this.callOperation = useOperation();
+    }
+
+    addField() {
+        this.callOperation(() => {
+            this.props.addField(this.env.getEditingElement());
+        });
     }
 }


### PR DESCRIPTION
This commit ensures that adding a new field to a form correctly updates the history.

Steps to reproduce:
- Drop a form snippet
- Click on `+ Field`
- A new field is added
- Clicking on undo should only remove the field

Previously, clicking undo would remove the entire form snippet.