### PR TITLE
[FIX] sale: show default payment terms if none set

### DIFF
--- a/addons/sale/views/sale_portal_templates.xml
+++ b/addons/sale/views/sale_portal_templates.xml
@@ -661,7 +661,8 @@
             <section t-if="sale_order.payment_term_id" class="mt-4">
                 <h4 class="">Payment terms</h4>
                 <hr class="mt-0 mb-1"/>
-                <span t-field="sale_order.payment_term_id.note"/>
+                <span t-if="sale_order.payment_term_id.note.striptags()" t-field="sale_order.payment_term_id.note"/>
+                <span t-else="" t-field="sale_order.payment_term_id.example_preview"/>
             </section>
         </div>
     </template>


### PR DESCRIPTION
## Version
17.0+

## Issue
Default payment terms are not displayed on quotes/sale orders as it is on invoices.

## Steps to reproduce
*Requires `account` module*
- Create a new payment term in `Accounting` app:
  - Set it up as wanted but leave the `Description on invoice (e.g. Payment terms: 30 days after invoice date)` line empty under the `PREVIEW` section.
- Create a Sale Order using the newly created payment term;
- Preview the SO and move down to the `Payment terms` section which is empty

opw-4793113