### PR TITLE
[FIX] l10n_latam_check: Third-party check status corrected when canceling origin payment

### DIFF
--- a/addons/l10n_latam_check/models/account_payment.py
+++ b/addons/l10n_latam_check/models/account_payment.py
@@ -225,7 +225,7 @@ class AccountPayment(models.Model):
                         ('bank_id', '=', check.bank_id.id),
                         ('issuer_vat', '=', check.issuer_vat),
                         ('name', '=', check.name),
-                        ('payment_id.state', '!=', 'draft'),
+                        ('payment_id.state', 'not in', ['draft', 'canceled']),
                         ('id', '!=', check._origin.id)], limit=1)
                 if same_checks:
                     msgs.append(

--- a/addons/l10n_latam_check/models/l10n_latam_check.py
+++ b/addons/l10n_latam_check/models/l10n_latam_check.py
@@ -129,7 +129,7 @@ class l10nLatamAccountPaymentCheck(models.Model):
     def _get_last_operation(self):
         self.ensure_one()
         return (self.payment_id + self.operation_ids).filtered(
-                lambda x: x.state != 'draft').sorted(key=lambda payment: (payment.date, payment._origin.id))[-1:]
+                lambda x: x.state not in ['draft', 'canceled']).sorted(key=lambda payment: (payment.date, payment._origin.id))[-1:]
 
     @api.depends('payment_id.state', 'operation_ids.state')
     def _compute_current_journal(self):
@@ -152,7 +152,7 @@ class l10nLatamAccountPaymentCheck(models.Model):
         :return:    An action on account.move.
         '''
         self.ensure_one()
-        operations = ((self.operation_ids + self.payment_id).filtered(lambda x: x.state != 'draft'))
+        operations = ((self.operation_ids + self.payment_id).filtered(lambda x: x.state not in ['draft', 'canceled']))
         action = {
             'name': _("Check Operations"),
             'type': 'ir.actions.act_window',

--- a/addons/l10n_latam_check/wizards/l10n_latam_payment_mass_transfer.py
+++ b/addons/l10n_latam_check/wizards/l10n_latam_payment_mass_transfer.py
@@ -54,7 +54,7 @@ class L10nLatamPaymentMassTransfer(models.TransientModel):
             checks = self.env['l10n_latam.check'].browse(self._context.get('active_ids', []))
             if checks.filtered(lambda x: x.payment_method_line_id.code != 'new_third_party_checks'):
                 raise 'You have select some payments that are not checks. Please call this action from the Third Party Checks menu'
-            elif not all(check.payment_id.state != 'draft' for check in checks):
+            elif not all(check.payment_id.state not in ['draft', 'canceled'] for check in checks):
                 raise UserError(_("All the selected checks must be posted"))
             currency_ids = checks.mapped('currency_id')
             if any(x != currency_ids[0] for x in currency_ids):


### PR DESCRIPTION
Fixed an issue where, when canceling a payment that originated the third-party check, the check remained in "In Hand" status when it shouldn't. 
Now, when the payment is canceled, the check status is properly updated to reflect its cancellation, ensuring consistency in the workflow.


**Description of the issue/feature this PR addresses:**

This PR addresses an issue where a third-party check remains in the "In Hand" status even after the origin payment is canceled.

**Current behavior before PR:**

A customer payment is created with a third-party check.

The payment is confirmed, then moved to draft and canceled.

After cancellation, the third-party check remains in the "In Hand" status in the third-party checks menu, even though the origin payment has been canceled.

**Desired behavior after PR is merged:**

When the payment is canceled, the check will no longer remain in "In Hand" status in the third-party checks menu after the payment is canceled.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
