### PR TITLE
[FIX] pos_{ , event }: preserve ticket price for event orderlines in PoS

### DIFF
--- a/addons/point_of_sale/static/src/app/models/pos_order.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order.js
@@ -457,11 +457,7 @@ export class PosOrder extends Base {
     setPricelist(pricelist) {
         this.pricelist_id = pricelist ? pricelist : false;
 
-        const lines_to_recompute = this.lines.filter(
-            (line) =>
-                line.price_type === "original" &&
-                !(line.combo_line_ids?.length || line.combo_parent_id)
-        );
+        const lines_to_recompute = this.getLinesToCompute();
 
         for (const line of lines_to_recompute) {
             const newPrice = line.product_id.getPrice(
@@ -1097,6 +1093,14 @@ export class PosOrder extends Base {
 
     get showChange() {
         return !floatIsZero(this.orderChange, this.currency.decimal_places) && this.finalized;
+    }
+
+    getLinesToCompute() {
+        return this.lines.filter(
+            (line) =>
+                line.price_type === "original" &&
+                !(line.combo_line_ids?.length || line.combo_parent_id)
+        );
     }
 }
 

--- a/addons/pos_event/static/src/app/models/pos_order.js
+++ b/addons/pos_event/static/src/app/models/pos_order.js
@@ -6,4 +6,8 @@ patch(PosOrder.prototype, {
     get eventRegistrations() {
         return this.lines.flatMap((line) => line.event_registration_ids);
     },
+    getLinesToCompute() {
+        // Override to ensure orderline price of event tickets are not recomputed
+        return super.getLinesToCompute().filter((line) => !line.event_ticket_id);
+    },
 });

--- a/addons/pos_event/static/tests/tours/pos_event_tour.js
+++ b/addons/pos_event/static/tests/tours/pos_event_tour.js
@@ -64,3 +64,30 @@ registry.category("web_tour.tours").add("test_selling_multiple_ticket_saved", {
             ReceiptScreen.clickNextOrder(),
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("test_orderline_price_remain_same_as_ticket_price", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+
+            ProductScreen.clickDisplayedProduct("My Awesome Event"),
+            EventTourUtils.increaseQuantityOfTicket("Ticket VIP"),
+            Dialog.confirm(),
+            EventTourUtils.answerTicketSelectQuestion("1", "Question1", "Q1-Answer1"),
+            EventTourUtils.answerGlobalSelectQuestion("Question2", "Q2-Answer1"),
+            EventTourUtils.answerGlobalSelectQuestion("Question3", "Q3-Answer1"),
+            Dialog.confirm(),
+            ProductScreen.totalAmountIs("200.00"),
+            ProductScreen.clickPartnerButton(),
+            ProductScreen.clickCustomer("Partner Test 1"),
+            ProductScreen.totalAmountIs("200.00"),
+            ProductScreen.clickPayButton(),
+            PaymentScreen.clickPaymentMethod("Bank", true, { remaining: "0.00" }),
+            PaymentScreen.clickValidate(),
+            ReceiptScreen.isShown(),
+            EventTourUtils.printTicket("full"),
+            EventTourUtils.printTicket("badge"),
+            ReceiptScreen.clickNextOrder(),
+        ].flat(),
+});


### PR DESCRIPTION
Before this commit:
==========
- When selling event tickets through the Point of Sale (PoS), if an orderline was created with the ticket-specific price (higher than the base product price), the price would reset to the base product price when a customer (partner) was added or the pricelist was changed.

After this commit:
==========
- The event ticket orderline now retains its original ticket price even after a partner is selected or the pricelist is updated. This ensures pricing consistency and prevents unintended overrides for event-specific products.

task-4862687
