### PR TITLE
[FIX] account_qr_code_*, l10n_gr_edi, l10n_id, l10n_jo_edi: quiet mode params

### DIFF
--- a/addons/account_qr_code_emv/models/res_bank.py
+++ b/addons/account_qr_code_emv/models/res_bank.py
@@ -88,7 +88,7 @@ class ResPartnerBank(models.Model):
         if qr_method == 'emv_qr':
             return {
                 'barcode_type': 'QR',
-                'quiet': False,
+                'quiet': 0,
                 'width': 128,
                 'height': 128,
                 'humanreadable': 1,

--- a/addons/account_qr_code_sepa/models/res_bank.py
+++ b/addons/account_qr_code_sepa/models/res_bank.py
@@ -31,7 +31,7 @@ class ResPartnerBank(models.Model):
         if qr_method == 'sct_qr':
             return {
                 'barcode_type': 'QR',
-                'quiet': False,
+                'quiet': 0,
                 'width': 128,
                 'height': 128,
                 'humanreadable': 1,

--- a/addons/l10n_gr_edi/models/account_move.py
+++ b/addons/l10n_gr_edi/models/account_move.py
@@ -307,7 +307,7 @@ class AccountMove(models.Model):
         if document.state in ('invoice_sent', 'bill_sent'):
             barcode_params = urlencode({
                 'barcode_type': 'QR',
-                'quiet': False,
+                'quiet': 0,
                 'value': document.mydata_url,
                 'width': 180,
                 'height': 180,

--- a/addons/l10n_id/models/res_bank.py
+++ b/addons/l10n_id/models/res_bank.py
@@ -124,7 +124,7 @@ class ResPartnerBank(models.Model):
                 return {}
             return {
                 'barcode_type': 'QR',
-                'quiet': False,
+                'quiet': 0,
                 'width': 120,
                 'height': 120,
                 'value': self._get_qr_vals(qr_method, amount, currency, debtor_partner, free_communication, structured_communication),

--- a/addons/l10n_jo_edi/models/account_move.py
+++ b/addons/l10n_jo_edi/models/account_move.py
@@ -98,7 +98,7 @@ class AccountMove(models.Model):
         self.ensure_one()
         encoded_params = url_encode({
             'barcode_type': 'QR',
-            'quiet': False,
+            'quiet': 0,
             'value': self.l10n_jo_edi_qr,
             'width': 200,
             'height': 200,


### PR DESCRIPTION
Use integer for url params and not boolean

Caused by: https://github.com/odoo/odoo/pull/209386