### PR TITLE
[FIX] web_editor: prevent error when 'data-oe-type' is missing in embedded field

### DIFF
--- a/addons/web_editor/models/ir_ui_view.py
+++ b/addons/web_editor/models/ir_ui_view.py
@@ -64,7 +64,10 @@ class IrUiView(models.Model):
         Model = self.env[el.get('data-oe-model')]
         field = el.get('data-oe-field')
 
-        model = 'ir.qweb.field.' + el.get('data-oe-type')
+        data_oe_type = el.get('data-oe-type')
+        if not data_oe_type:
+            raise ValidationError(_("Missing 'data-oe-type' attribute in embedded field."))
+        model = 'ir.qweb.field.' + data_oe_type
         converter = self.env[model] if model in self.env else self.env['ir.qweb.field']
 
         try:


### PR DESCRIPTION
Currently, an error occurs when saving a website page that contains an embedded
field missing the `'data-oe-type'` attribute.

**Steps to produce:**

- Install the `website` module.
- Open the `Website` app and click `Edit`.
- Drag an `Embed Code` block and add the following content:
  `<span data-oe-field='name' data-oe-model='res.partner' />`.
- Try to `Save` it.

**Error:**
`TypeError: can only concatenate str (not 'NoneType') to str`

**Root Cause:**
At [1], the value of `data-oe-type` is `None`, causes an `Error`.

[1]
https://github.com/odoo/odoo/blob/f0d49213ab919bb507e88d1ac725aed92401590b/addons/web_editor/models/ir_ui_view.py#L67

This commit ensures an error message is raised, when `data-oe-type` is missing
from the embedded element.

Sentry – 6675421840
