### PR TITLE
FIX] account:Avoid unwanted <p> tag wrapping in tax description import from data

### DIFF
--- a/addons/account/models/account_tax.py
+++ b/addons/account/models/account_tax.py
@@ -593,6 +593,11 @@ class AccountTax(models.Model):
     def _sanitize_vals(self, vals):
         """Normalize the create/write values."""
         sanitized = vals.copy()
+
+        # Wrap plain text in <div> if description has no HTML tags
+        if 'description' in sanitized and not isinstance(sanitized['description'], bool) and not re.search(r'<[^>]+>', sanitized['description']):
+            sanitized['description'] = f"<div>{sanitized['description']}</div>"
+
         # Allow to provide invoice_repartition_line_ids and refund_repartition_line_ids by dispatching them
         # correctly in the repartition_line_ids
         if 'repartition_line_ids' in sanitized and (

--- a/addons/account/tests/test_chart_template.py
+++ b/addons/account/tests/test_chart_template.py
@@ -989,14 +989,14 @@ class TestChartTemplate(AccountTestInvoicingCommon):
             'no_translation.test_chart_template_company_test_free_account_group.name@fr_BE': 'Free Account Group account/FR',  # fallback to account
             'tax_group_taxes.name@en_US': 'Taxes',
             'tax_group_taxes.name@fr_BE': 'Taxes FR',
-            'test_tax_1_template.description@en_US': Markup('<p>Tax 1 Description</p>'),
+            'test_tax_1_template.description@en_US': Markup('Tax 1 Description'),
             'test_tax_1_template.description@fr_BE': Markup('Tax 1 Description translation2/FR'),
             'test_tax_1_template.name@en_US': 'Tax 1',
             'test_tax_1_template.name@fr_BE': 'Tax 1 FR',
             'translation.test_chart_template_company_test_free_account.name@en_US': 'Free Account',
             'translation.test_chart_template_company_test_free_account.name@fr_BE': 'Free Account FR_BE',  # do not use generic lang
-            'translation.test_chart_template_company_test_free_tax.description@en_US': Markup('<p>Free Tax Description</p>'),
-            'translation.test_chart_template_company_test_free_tax.description@fr_BE': Markup('<p>Free Tax Description</p>'),
+            'translation.test_chart_template_company_test_free_tax.description@en_US': Markup('Free Tax Description'),
+            'translation.test_chart_template_company_test_free_tax.description@fr_BE': Markup('Free Tax Description FR'),
             'translation.test_chart_template_company_test_free_tax.name@en_US': 'Free Tax',
             'translation.test_chart_template_company_test_free_tax.name@fr_BE': 'Free Tax FR',
         })


### PR DESCRIPTION
Before this commit, when plain text (e.g., "Some tax") was imported from a CSV
file into the HTML field `description`, the system wrapped it in a `<p>` tag
during normalization via `html_normalize`, since plain text is not valid HTML.

After this commit, we add a check before record creation:
- If the value is plain text without any HTML, we wrap it in a `<div>` to make it
valid HTML.
- If it already contains HTML, we leave it untouched.

This avoids unintended `<p>` wrapping by `html_normalize`.

Note: if content is wrapped in a `<div>`, `html_normalize` will strip it out.
This ensures consistent HTML formatting for the description field during
create/write operations and prevents unexpected automatic wrapping by
the system.

task-4862728

