### PR TITLE
[FIX] project: preserve active users when copying multiple tasks

### DIFF
--- a/addons/project/models/project_task.py
+++ b/addons/project/models/project_task.py
@@ -853,8 +853,8 @@ class ProjectTask(models.Model):
                 child_ids = current_task.child_ids
                 vals['child_ids'] = [Command.create(child_id.copy_data(default)[0]) for child_id in child_ids]
             if not has_default_users and vals['user_ids']:
-                active_users = task.user_ids & active_users
-                vals['user_ids'] = [Command.set(active_users.ids)]
+                task_active_users = task.user_ids & active_users
+                vals['user_ids'] = [Command.set(task_active_users.ids)]
             if task.is_template and not self.env.context.get('copy_from_template'):
                 vals['is_template'] = True
             if self.env.context.get('copy_from_template'):


### PR DESCRIPTION
Issue:
--------
  When copying multiple tasks, even active users are removed from the copied tasks.

Cause:
------
   The `active_users` variable was being unintentionally overridden during the copy process.

Fix:
------
  Prevented the override of `active_users` to ensure only archived users are excluded, not active ones.

Steps to reproduce:
--------
  1. Create a new active project user.
  2. Create three tasks:
     - Task 1: No users assigned.
     - Task 2: Assigned to two active users.
     - Task 3: Assigned to one active and one soon-to-be-archived user.
  3. Archive one of the users.
  4. Copy all tasks.
  5. Validate `user_ids` on the copied tasks:
     - Task 1 → Expect no users.
     - Task 2 → Expect both active users to remain.
     - Task 3 → Expect only the active user (`self.user_projectuser`) to remain.

task: 4419770