### PR TITLE
[IMP] l10n_es/in/ro/* : change many2one ir.attachment to binary 

### DIFF
--- a/addons/l10n_es_edi_facturae/models/account_move.py
+++ b/addons/l10n_es_edi_facturae/models/account_move.py
@@ -54,12 +54,6 @@ REVERSED_COUNTRY_CODE = {v: k for k, v in COUNTRY_CODE_MAP.items()}
 class AccountMove(models.Model):
     _inherit = 'account.move'
 
-    l10n_es_edi_facturae_xml_id = fields.Many2one(
-        comodel_name='ir.attachment',
-        string="Facturae Attachment",
-        compute=lambda self: self._compute_linked_attachment_id('l10n_es_edi_facturae_xml_id', 'l10n_es_edi_facturae_xml_file'),
-        depends=['l10n_es_edi_facturae_xml_file']
-    )
     l10n_es_edi_facturae_xml_file = fields.Binary(
         attachment=True,
         string="Facturae File",
@@ -124,7 +118,7 @@ class AccountMove(models.Model):
     def _l10n_es_edi_facturae_get_default_enable(self):
         self.ensure_one()
         return not self.invoice_pdf_report_id \
-            and not self.l10n_es_edi_facturae_xml_id \
+            and not self.l10n_es_edi_facturae_xml_file \
             and not self.l10n_es_is_simplified \
             and self.is_invoice(include_receipts=True) \
             and (self.partner_id.is_company or self.partner_id.vat) \

--- a/addons/l10n_es_edi_facturae/models/account_move_send.py
+++ b/addons/l10n_es_edi_facturae/models/account_move_send.py
@@ -15,7 +15,12 @@ class AccountMoveSend(models.AbstractModel):
 
     def _get_invoice_extra_attachments(self, move):
         # EXTENDS 'account'
-        return super()._get_invoice_extra_attachments(move) + move.l10n_es_edi_facturae_xml_id
+        l10n_es_edi_facturae_xml_id = self.env['ir.attachment'].search([
+            ('res_model', '=', move._name),
+            ('res_id', 'in', move._origin.ids),
+            ('res_field', '=', 'l10n_es_edi_facturae_xml_file')
+        ])
+        return super()._get_invoice_extra_attachments(move) + l10n_es_edi_facturae_xml_id
 
     def _get_placeholder_mail_attachments_data(self, move, invoice_edi_format=None, extra_edis=None):
         # EXTENDS 'account'
@@ -79,4 +84,4 @@ class AccountMoveSend(models.AbstractModel):
         if attachments_vals:
             attachments = self.env['ir.attachment'].with_user(SUPERUSER_ID).create(attachments_vals)
             res_ids = attachments.mapped('res_id')
-            self.env['account.move'].browse(res_ids).invalidate_recordset(fnames=['l10n_es_edi_facturae_xml_id', 'l10n_es_edi_facturae_xml_file'])
+            self.env['account.move'].browse(res_ids).invalidate_recordset(fnames=['l10n_es_edi_facturae_xml_file'])

--- a/addons/l10n_es_edi_facturae/tests/test_edi_xml.py
+++ b/addons/l10n_es_edi_facturae/tests/test_edi_xml.py
@@ -202,7 +202,7 @@ class TestEdiFacturaeXmls(AccountTestInvoicingCommon):
         invoice.action_post()
         wizard = self.create_send_and_print(invoice)
         wizard.action_send_and_print()
-        self.assertFalse(invoice.l10n_es_edi_facturae_xml_id)
+        self.assertFalse(invoice.l10n_es_edi_facturae_xml_file)
 
     def test_tax_withheld(self):
         with freeze_time(self.frozen_today), \

--- a/addons/l10n_es_edi_tbai/data/template_invoice.xml
+++ b/addons/l10n_es_edi_tbai/data/template_invoice.xml
@@ -103,7 +103,7 @@
                             <t t-set="seq_and_num" t-value="refunded_doc._get_tbai_sequence_and_number()"/>
                             <SerieFactura t-out="seq_and_num[0]"/>
                             <NumFactura t-out="seq_and_num[1]"/>
-                            <FechaExpedicionFactura t-out="format_date(refunded_doc.xml_attachment_id and refunded_doc._get_tbai_signature_and_date()[1] or refunded_doc_invoice_date)"/>
+                            <FechaExpedicionFactura t-out="format_date(refunded_doc._get_xml_attachment_id() and refunded_doc._get_tbai_signature_and_date()[1] or refunded_doc_invoice_date)"/>
                         </IDFacturaRectificadaSustituida>
                     </FacturasRectificadasSustituidas>
                 </t>

--- a/addons/l10n_es_edi_tbai/models/account_move.py
+++ b/addons/l10n_es_edi_tbai/models/account_move.py
@@ -47,19 +47,19 @@ class AccountMove(models.Model):
 
     l10n_es_tbai_post_file = fields.Binary(
         string="TicketBAI Post File",
-        related='l10n_es_tbai_post_document_id.xml_attachment_id.datas',
+        related='l10n_es_tbai_post_document_id.xml_attachment_bin',
     )
     l10n_es_tbai_post_file_name = fields.Char(
         string="TicketBAI Post Attachment Name",
-        related="l10n_es_tbai_post_document_id.xml_attachment_id.name",
+        related="l10n_es_tbai_post_document_id.xml_attachment_bin_filename",
     )
     l10n_es_tbai_cancel_file = fields.Binary(
         string="TicketBAI Cancel File",
-        related='l10n_es_tbai_cancel_document_id.xml_attachment_id.datas',
+        related='l10n_es_tbai_cancel_document_id.xml_attachment_bin',
     )
     l10n_es_tbai_cancel_file_name = fields.Char(
         string="TicketBAI Cancel File Name",
-        related='l10n_es_tbai_cancel_document_id.xml_attachment_id.name',
+        related='l10n_es_tbai_cancel_document_id.xml_attachment_bin_filename',
     )
 
     l10n_es_tbai_is_required = fields.Boolean(
@@ -170,7 +170,7 @@ class AccountMove(models.Model):
                 test_suffix=test_suffix,
                 message=message,
             ),
-            attachment_ids=[self.l10n_es_tbai_post_document_id.xml_attachment_id.id] if not cancel else [self.l10n_es_tbai_cancel_document_id.xml_attachment_id.id],
+            attachment_ids=[(self.l10n_es_tbai_post_document_id if not cancel else self.l10n_es_tbai_cancel_document_id)._get_xml_attachment_id().id]
         )
 
     def _l10n_es_tbai_lock_move(self):

--- a/addons/l10n_es_edi_tbai/models/account_move_send.py
+++ b/addons/l10n_es_edi_tbai/models/account_move_send.py
@@ -20,14 +20,14 @@ class AccountMoveSend(models.AbstractModel):
 
     def _get_invoice_extra_attachments(self, move):
         # EXTENDS 'account'
-        return super()._get_invoice_extra_attachments(move) + move.l10n_es_tbai_post_document_id.xml_attachment_id
+        return super()._get_invoice_extra_attachments(move) + move.l10n_es_tbai_post_document_id._get_xml_attachment_id()
 
     def _get_placeholder_mail_attachments_data(self, move, invoice_edi_format=None, extra_edis=None):
         # EXTENDS 'account'
         results = super()._get_placeholder_mail_attachments_data(move, invoice_edi_format=invoice_edi_format, extra_edis=extra_edis)
 
         if (
-            not move.l10n_es_tbai_post_document_id.xml_attachment_id
+            not move.l10n_es_tbai_post_document_id.xml_attachment_bin
             and 'es_tbai' in extra_edis
         ):
             filename = move._l10n_es_tbai_get_attachment_name()

--- a/addons/l10n_es_edi_tbai/tests/test_edi_tbai_send_bill_bizkaia.py
+++ b/addons/l10n_es_edi_tbai/tests/test_edi_tbai_send_bill_bizkaia.py
@@ -14,7 +14,7 @@ class TestSendBillEdiBizkaia(TestEsEdiTbaiCommonBizkaia):
 
         self.assertEqual(bill.l10n_es_tbai_state, 'to_send')
         self.assertFalse(bill.l10n_es_tbai_chain_index)
-        self.assertFalse(bill.l10n_es_tbai_post_document_id.xml_attachment_id)
+        self.assertFalse(bill.l10n_es_tbai_post_document_id.xml_attachment_bin)
 
         with patch(
             'odoo.addons.l10n_es_edi_tbai.models.l10n_es_edi_tbai_document.requests.Session.request',
@@ -25,10 +25,10 @@ class TestSendBillEdiBizkaia(TestEsEdiTbaiCommonBizkaia):
         self.assertEqual(bill.l10n_es_tbai_state, 'sent')
         # No chain index for vendor bills
         self.assertFalse(bill.l10n_es_tbai_chain_index)
-        self.assertTrue(bill.l10n_es_tbai_post_document_id.xml_attachment_id)
+        self.assertTrue(bill.l10n_es_tbai_post_document_id.xml_attachment_bin)
 
         self.assertEqual(bill.state, 'posted')
-        self.assertFalse(bill.l10n_es_tbai_cancel_document_id.xml_attachment_id)
+        self.assertFalse(bill.l10n_es_tbai_cancel_document_id.xml_attachment_bin)
 
         with patch(
             'odoo.addons.l10n_es_edi_tbai.models.l10n_es_edi_tbai_document.requests.Session.request',
@@ -38,7 +38,7 @@ class TestSendBillEdiBizkaia(TestEsEdiTbaiCommonBizkaia):
 
         self.assertEqual(bill.l10n_es_tbai_state, 'cancelled')
         self.assertEqual(bill.state, 'cancel')
-        self.assertTrue(bill.l10n_es_tbai_cancel_document_id.xml_attachment_id)
+        self.assertTrue(bill.l10n_es_tbai_cancel_document_id.xml_attachment_bin)
 
     def test_post_bill_tbai_failure(self):
         bill = self._create_posted_bill()

--- a/addons/l10n_es_edi_tbai/tests/test_edi_tbai_send_invoice.py
+++ b/addons/l10n_es_edi_tbai/tests/test_edi_tbai_send_invoice.py
@@ -15,7 +15,7 @@ class TestSendAndPrintEdiGipuzkoa(TestEsEdiTbaiCommonGipuzkoa):
 
         self.assertEqual(invoice.l10n_es_tbai_state, 'to_send')
         self.assertFalse(invoice.l10n_es_tbai_chain_index)
-        self.assertFalse(invoice.l10n_es_tbai_post_document_id.xml_attachment_id)
+        self.assertFalse(invoice.l10n_es_tbai_post_document_id.xml_attachment_bin)
 
         # Post with success
         with patch(
@@ -27,10 +27,10 @@ class TestSendAndPrintEdiGipuzkoa(TestEsEdiTbaiCommonGipuzkoa):
         self.assertEqual(invoice.l10n_es_tbai_state, 'sent')
         self.assertTrue(invoice.l10n_es_tbai_chain_index)
         self.assertEqual(invoice.l10n_es_tbai_post_document_id.state, 'accepted')
-        self.assertTrue(invoice.l10n_es_tbai_post_document_id.xml_attachment_id)
+        self.assertTrue(invoice.l10n_es_tbai_post_document_id.xml_attachment_bin)
 
         self.assertEqual(invoice.state, 'posted')
-        self.assertFalse(invoice.l10n_es_tbai_cancel_document_id.xml_attachment_id)
+        self.assertFalse(invoice.l10n_es_tbai_cancel_document_id.xml_attachment_bin)
 
         # Cancel with success
         with patch(
@@ -41,7 +41,7 @@ class TestSendAndPrintEdiGipuzkoa(TestEsEdiTbaiCommonGipuzkoa):
 
         self.assertEqual(invoice.l10n_es_tbai_state, 'cancelled')
         self.assertEqual(invoice.l10n_es_tbai_cancel_document_id.state, 'accepted')
-        self.assertTrue(invoice.l10n_es_tbai_cancel_document_id.xml_attachment_id)
+        self.assertTrue(invoice.l10n_es_tbai_cancel_document_id.xml_attachment_bin)
 
         self.assertEqual(invoice.state, 'cancel')
 
@@ -64,7 +64,7 @@ class TestSendAndPrintEdiGipuzkoa(TestEsEdiTbaiCommonGipuzkoa):
             self.assertEqual(invoice.l10n_es_tbai_state, 'to_send')
             self.assertFalse(invoice.l10n_es_tbai_chain_index)
             self.assertEqual(invoice.l10n_es_tbai_post_document_id.state, 'rejected')
-            self.assertTrue(invoice.l10n_es_tbai_post_document_id.xml_attachment_id)
+            self.assertTrue(invoice.l10n_es_tbai_post_document_id.xml_attachment_bin)
 
         failed_document_id = invoice.l10n_es_tbai_post_document_id.id
 
@@ -80,7 +80,7 @@ class TestSendAndPrintEdiGipuzkoa(TestEsEdiTbaiCommonGipuzkoa):
         self.assertEqual(invoice.l10n_es_tbai_state, 'sent')
         self.assertTrue(invoice.l10n_es_tbai_chain_index)
         self.assertEqual(invoice.l10n_es_tbai_post_document_id.state, 'accepted')
-        self.assertTrue(invoice.l10n_es_tbai_post_document_id.xml_attachment_id)
+        self.assertTrue(invoice.l10n_es_tbai_post_document_id.xml_attachment_bin)
 
     def test_cancel_invoice_tbai_failure(self):
         invoice = self._create_posted_invoice()
@@ -105,7 +105,7 @@ class TestSendAndPrintEdiGipuzkoa(TestEsEdiTbaiCommonGipuzkoa):
         except UserError:
             self.assertEqual(invoice.l10n_es_tbai_state, 'sent')
             self.assertEqual(invoice.l10n_es_tbai_cancel_document_id.state, 'rejected')
-            self.assertTrue(invoice.l10n_es_tbai_cancel_document_id.xml_attachment_id)
+            self.assertTrue(invoice.l10n_es_tbai_cancel_document_id.xml_attachment_bin)
 
         failed_document_id = invoice.l10n_es_tbai_cancel_document_id.id
 
@@ -120,7 +120,7 @@ class TestSendAndPrintEdiGipuzkoa(TestEsEdiTbaiCommonGipuzkoa):
 
         self.assertEqual(invoice.l10n_es_tbai_state, 'cancelled')
         self.assertEqual(invoice.l10n_es_tbai_cancel_document_id.state, 'accepted')
-        self.assertTrue(invoice.l10n_es_tbai_cancel_document_id.xml_attachment_id)
+        self.assertTrue(invoice.l10n_es_tbai_cancel_document_id.xml_attachment_bin)
 
     def test_post_invoice_tbai_request_error(self):
         invoice = self._create_posted_invoice()
@@ -139,7 +139,7 @@ class TestSendAndPrintEdiGipuzkoa(TestEsEdiTbaiCommonGipuzkoa):
             self.assertEqual(invoice.l10n_es_tbai_state, 'to_send')
             self.assertTrue(invoice.l10n_es_tbai_chain_index)
             self.assertEqual(invoice.l10n_es_tbai_post_document_id.state, 'to_send')
-            self.assertTrue(invoice.l10n_es_tbai_post_document_id.xml_attachment_id)
+            self.assertTrue(invoice.l10n_es_tbai_post_document_id.xml_attachment_bin)
 
         pending_document_id = invoice.l10n_es_tbai_post_document_id.id
         chain_index = invoice.l10n_es_tbai_chain_index
@@ -156,7 +156,7 @@ class TestSendAndPrintEdiGipuzkoa(TestEsEdiTbaiCommonGipuzkoa):
 
         self.assertEqual(invoice.l10n_es_tbai_state, 'sent')
         self.assertEqual(invoice.l10n_es_tbai_post_document_id.state, 'accepted')
-        self.assertTrue(invoice.l10n_es_tbai_post_document_id.xml_attachment_id)
+        self.assertTrue(invoice.l10n_es_tbai_post_document_id.xml_attachment_bin)
 
     def test_cancel_invoice_request_error(self):
         invoice = self._create_posted_invoice()
@@ -181,7 +181,7 @@ class TestSendAndPrintEdiGipuzkoa(TestEsEdiTbaiCommonGipuzkoa):
         except UserError:
             self.assertEqual(invoice.l10n_es_tbai_state, 'sent')
             self.assertEqual(invoice.l10n_es_tbai_cancel_document_id.state, 'to_send')
-            self.assertTrue(invoice.l10n_es_tbai_cancel_document_id.xml_attachment_id)
+            self.assertTrue(invoice.l10n_es_tbai_cancel_document_id.xml_attachment_bin)
 
         pending_document_id = invoice.l10n_es_tbai_cancel_document_id.id
 
@@ -196,4 +196,4 @@ class TestSendAndPrintEdiGipuzkoa(TestEsEdiTbaiCommonGipuzkoa):
 
         self.assertEqual(invoice.l10n_es_tbai_state, 'cancelled')
         self.assertEqual(invoice.l10n_es_tbai_cancel_document_id.state, 'accepted')
-        self.assertTrue(invoice.l10n_es_tbai_cancel_document_id.xml_attachment_id)
+        self.assertTrue(invoice.l10n_es_tbai_cancel_document_id.xml_attachment_bin)

--- a/addons/l10n_es_edi_tbai/tests/test_edi_web_services.py
+++ b/addons/l10n_es_edi_tbai/tests/test_edi_web_services.py
@@ -58,8 +58,8 @@ class TestEdiTbaiWebServices(TestEsEdiTbaiCommon):
 
         self._get_invoice_send_wizard(self.out_invoice).action_send_and_print()
         self.assertEqual(self.out_invoice.l10n_es_tbai_state, 'sent')
-        self.assertTrue(self.out_invoice.l10n_es_tbai_post_document_id.xml_attachment_id)
+        self.assertTrue(self.out_invoice.l10n_es_tbai_post_document_id.xml_attachment_bin)
 
         self.in_invoice.l10n_es_tbai_send_bill()
         self.assertEqual(self.in_invoice.l10n_es_tbai_state, 'sent')
-        self.assertTrue(self.in_invoice.l10n_es_tbai_post_document_id.xml_attachment_id)
+        self.assertTrue(self.in_invoice.l10n_es_tbai_post_document_id.xml_attachment_bin)

--- a/addons/l10n_es_edi_tbai/tests/test_edi_xml.py
+++ b/addons/l10n_es_edi_tbai/tests/test_edi_xml.py
@@ -289,7 +289,7 @@ class TestEdiTbaiXmls(TestEsEdiTbaiCommon):
             'res_id': self.out_invoice.id,
             'res_field': 'xml_attachment_id',
         })
-        post_edi_document.xml_attachment_id = post_xml_attachment
+        post_edi_document.xml_attachment_bin = post_xml_attachment.datas
         self.out_invoice.l10n_es_tbai_post_document_id = post_edi_document
         cancel_edi_document = self.out_invoice._l10n_es_tbai_create_edi_document(cancel=True)
         cancel_edi_document._generate_xml(self.out_invoice._l10n_es_tbai_get_values(cancel=True))

--- a/addons/l10n_es_edi_tbai_pos/models/pos_order.py
+++ b/addons/l10n_es_edi_tbai_pos/models/pos_order.py
@@ -26,11 +26,11 @@ class PosOrder(models.Model):
 
     l10n_es_tbai_post_file = fields.Binary(
         string="TicketBAI Post File",
-        related='l10n_es_tbai_post_document_id.xml_attachment_id.datas',
+        related='l10n_es_tbai_post_document_id.xml_attachment_bin',
     )
     l10n_es_tbai_post_file_name = fields.Char(
         string="TicketBAI Post Attachment Name",
-        related="l10n_es_tbai_post_document_id.xml_attachment_id.name",
+        related="l10n_es_tbai_post_document_id.xml_attachment_bin_filename",
     )
 
     l10n_es_tbai_is_required = fields.Boolean(

--- a/addons/l10n_in_edi/models/account_move.py
+++ b/addons/l10n_in_edi/models/account_move.py
@@ -36,15 +36,6 @@ class AccountMove(models.Model):
         tracking=True,
         readonly=True,
     )
-    l10n_in_edi_attachment_id = fields.Many2one(
-        comodel_name='ir.attachment',
-        string="E-Invoice(IN) Attachment",
-        compute=lambda self: self._compute_linked_attachment_id(
-            'l10n_in_edi_attachment_id',
-            'l10n_in_edi_attachment_file'
-        ),
-        depends=['l10n_in_edi_attachment_file']
-    )
     l10n_in_edi_attachment_file = fields.Binary(
         string="E-Invoice(IN) File",
         attachment=True,
@@ -160,8 +151,8 @@ class AccountMove(models.Model):
 
     def _get_l10n_in_edi_response_json(self):
         self.ensure_one()
-        if self.l10n_in_edi_attachment_id:
-            return json.loads(self.l10n_in_edi_attachment_id.sudo().raw.decode("utf-8"))
+        if self.l10n_in_edi_attachment_file:
+            return json.loads(base64.b64decode(self.l10n_in_edi_attachment_file).decode("utf-8"))
         return {}
 
     def _l10n_in_lock_invoice(self):

--- a/addons/l10n_in_edi/models/account_move_send.py
+++ b/addons/l10n_in_edi/models/account_move_send.py
@@ -44,7 +44,15 @@ class AccountMoveSend(models.AbstractModel):
 
     def _get_invoice_extra_attachments(self, invoice):
         # EXTENDS 'account'
-        return super()._get_invoice_extra_attachments(invoice) + invoice.l10n_in_edi_attachment_id
+        # Fetch all EDI attachments(eInvoice) related to the invoice.
+        attachemnt = self.env['ir.attachment'].search([
+            ('res_model', '=', invoice._name),
+            ('res_field', '=', 'l10n_in_edi_attachment_file'),
+            ('res_id', 'in', invoice._origin.ids)
+        ])
+        # If the number of attachments is odd, return the first one (newest eInvoice file created).
+        # If even, return nothing (new eInvoice file not yet created).
+        return super()._get_invoice_extra_attachments(invoice) + (attachemnt[0] if len(attachemnt) % 2 == 1 else attachemnt.browse())
 
     def _call_web_service_before_invoice_pdf_render(self, invoices_data):
         # EXTENDS 'account'

--- a/addons/l10n_in_ewaybill_irn/tests/test_ewaybill_irn.py
+++ b/addons/l10n_in_ewaybill_irn/tests/test_ewaybill_irn.py
@@ -37,21 +37,21 @@ class TestEwaybillJson(L10nInTestInvoicingCommon):
             'name': 'einvoice_a.json',
             'res_model': 'account.move',
             'res_id': cls.invoice_a.id,
+            'res_field': 'l10n_in_edi_attachment_file',
             'raw': b'{"Irn": "1234567890"}',
         })
         attachment_b = cls.env['ir.attachment'].create({
             'name': 'einvoice_b.json',
             'res_model': 'account.move',
             'res_id': cls.invoice_b.id,
+            'res_field': 'l10n_in_edi_attachment_file',
             'raw': b'{"Irn": "1234567890"}',
         })
         cls.invoice_a.write({
             "l10n_in_edi_status": "sent",
-            "l10n_in_edi_attachment_id": attachment_a.id,
         })
         cls.invoice_b.write({
             "l10n_in_edi_status": "sent",
-            "l10n_in_edi_attachment_id": attachment_b.id,
         })
         cls.invoice_b.l10n_in_gst_treatment = 'overseas'
 


### PR DESCRIPTION
This is part of a general change for all the many2one ir.attachment fields to
binary in order to avoid security issues as the former would allow access to all
ir.attachment records.

task-4771679


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
