### PR TITLE
[IMP] website: enable and adapt website_image_quality tour

### DIFF
--- a/addons/website/static/tests/tours/snippet_image_quality.js
+++ b/addons/website/static/tests/tours/snippet_image_quality.js
@@ -16,7 +16,7 @@ registerWebsitePreviewTour('website_image_quality', {
     },
     {
         content: "Set low quality",
-        trigger: 'we-customizeblock-options:has(we-title:contains("Image")) we-range[data-set-quality] input',
+        trigger: ".o_customize_tab div[data-container-title='Image'] div[data-action-id='setImageQuality'] input",
         run: 'range 5',
     },
     {
@@ -27,7 +27,7 @@ registerWebsitePreviewTour('website_image_quality', {
         content: "Check image size",
         // Reached size cannot be hardcoded because it changes with
         // different versions of Chrome.
-        trigger: 'we-customizeblock-options:has(we-title:contains("Image")) .o_we_image_weight:contains(" kb"):not(:contains("42.9 kb"))',
+        trigger: ".o_customize_tab [data-container-title='Image'] span[title='Size']:contains(' kb'):not(:contains('42.9 kb'))",
         run() {
             // Make sure the reached size is smaller than the original one.
             if (parseFloat(this.anchor.innerText) >= 42.9) {
@@ -37,7 +37,7 @@ registerWebsitePreviewTour('website_image_quality', {
     },
     {
         content: "Set high quality",
-        trigger: 'we-customizeblock-options:has(we-title:contains("Image")) we-range[data-set-quality] input',
+        trigger: ".o_customize_tab div[data-container-title='Image'] div[data-action-id='setImageQuality'] input",
         run: 'range 99',
     },
     {
@@ -46,6 +46,6 @@ registerWebsitePreviewTour('website_image_quality', {
     },
     {
         content: "Check image size",
-        trigger: 'we-customizeblock-options:has(we-title:contains("Image")) .o_we_image_weight:contains("42.9")',
+        trigger: ".o_customize_tab [data-container-title='Image'] span[title='Size']:contains('42.9')",
     },
 ]);

--- a/addons/website/tests/test_attachment.py
+++ b/addons/website/tests/test_attachment.py
@@ -1,6 +1,5 @@
 import odoo.tests
 from ..tools import create_image_attachment
-import unittest
 
 
 @odoo.tests.common.tagged('post_install', '-at_install')
@@ -37,8 +36,6 @@ class TestWebsiteAttachment(odoo.tests.HttpCase):
         req = self.url_open(base + '/web/image/test.an_image_redirect_301', allow_redirects=True)
         self.assertEqual(req.status_code, 200)
 
-    # TODO master-mysterious-egg fix error
-    @unittest.skip("prepare mysterious-egg for merging")
     def test_02_image_quality(self):
         self.start_tour(self.env['website'].get_client_action_url('/'), 'website_image_quality', login="admin")
 


### PR DESCRIPTION
`website_image_quality` tour was previously broken due to DOM structure changes introduced by the new website builder and was consequently disabled.

This commit updates the tour steps to align with the new DOM and re-enables the associated test.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
