### PR TITLE
[IMP] website_payment: introducing a new donation form in editor

### DIFF
--- a/addons/website/static/src/builder/plugins/content_width_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/content_width_option_plugin.js
@@ -9,7 +9,7 @@ export class ContentWidthOption extends BaseOptionComponent {
     static template = "website.ContentWidthOption";
     static selector = "section, .s_carousel .carousel-item, .s_carousel_intro_item";
     static exclude =
-        "[data-snippet] :not(.oe_structure) > [data-snippet],#footer > *,#o_wblog_post_content *, .s_bento_banner section[data-name='Card'],.s_floating_blocks .s_floating_blocks_block, .s_bento_block_card";
+        "[data-snippet] :not(.oe_structure) > [data-snippet],#footer > *,#o_wblog_post_content *, .s_bento_banner section[data-name='Card'],.s_floating_blocks .s_floating_blocks_block, .s_bento_block_card, .o_no_content_width_option";
     static applyTo = ":scope > .container, :scope > .container-fluid, :scope > .o_container_small";
 }
 

--- a/addons/website/static/src/builder/plugins/form/form_option.js
+++ b/addons/website/static/src/builder/plugins/form/form_option.js
@@ -49,8 +49,8 @@ export class FormOption extends BaseOptionComponent {
         this.showEndMessage = false;
         // Get the email_to value from the data-for attribute if it exists. We
         // use it if there is no value on the email_to input.
-        const formId = el.id;
-        const dataForValues = getParsedDataFor(formId, el.ownerDocument);
+        this.formId = el.id;
+        const dataForValues = getParsedDataFor(this.formId, el.ownerDocument);
         if (dataForValues) {
             this.dataForEmailTo = dataForValues["email_to"];
         }

--- a/addons/website/static/src/builder/plugins/options/scroll_button_option.js
+++ b/addons/website/static/src/builder/plugins/options/scroll_button_option.js
@@ -5,7 +5,7 @@ export class ScrollButtonOption extends BaseOptionComponent {
     static template = "website.ScrollButtonOption";
     static selector = "section";
     static exclude =
-        "[data-snippet] :not(.oe_structure) > [data-snippet], .s_instagram_page, .o_facebook_page, .o_mega_menu > section, .s_appointments .s_dynamic_snippet_content, .s_bento_banner section[data-name='Card'], .s_floating_blocks, .s_floating_blocks .s_floating_blocks_block, .s_bento_block_card, .s_dynamic_category, .s_dynamic_category .s_dynamic_snippet_title, .s_announcement_scroll";
+        "[data-snippet] :not(.oe_structure) > [data-snippet], .s_instagram_page, .o_facebook_page, .o_mega_menu > section, .s_appointments .s_dynamic_snippet_content, .s_bento_banner section[data-name='Card'], .s_floating_blocks, .s_floating_blocks .s_floating_blocks_block, .s_bento_block_card, .s_dynamic_category, .s_dynamic_category .s_dynamic_snippet_title, .s_announcement_scroll, .o_no_scroll_button";
 
     setup() {
         super.setup();

--- a/addons/website/static/src/builder/plugins/options/website_background_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/website_background_option_plugin.js
@@ -22,7 +22,7 @@ export class WebsiteBackgroundCarouselOption extends BaseWebsiteBackgroundOption
 export class WebsiteBackgroundBGColorImageOption extends BaseWebsiteBackgroundOption {
     static selector =
         "section, .carousel-item, .s_masonry_block .row > div, .s_color_blocks_2 .row > div, .parallax, .s_text_cover .row > .o_not_editable, .s_website_form_cover .row > .o_not_editable, .s_split_intro .row > .o_not_editable, .s_bento_grid .row > div, .s_banner_categories .row > div, .s_ecomm_categories_showcase_block, .s_bento_grid_avatars .row > div";
-    static exclude = `${BASE_ONLY_BG_IMAGE_SELECTOR}, .s_carousel_wrapper, .s_image_gallery .carousel-item, .s_google_map, .s_map, [data-snippet] :not(.oe_structure) > [data-snippet], .s_masonry_block .s_col_no_resize, .s_quotes_carousel_wrapper, .s_carousel_intro_wrapper, .s_carousel_cards_item, .s_dynamic_snippet_category .s_dynamic_snippet_title`;
+    static exclude = `${BASE_ONLY_BG_IMAGE_SELECTOR}, .s_carousel_wrapper, .s_image_gallery .carousel-item, .s_google_map, .s_map, [data-snippet] :not(.oe_structure) > [data-snippet], .s_masonry_block .s_col_no_resize, .s_quotes_carousel_wrapper, .s_carousel_intro_wrapper, .s_carousel_cards_item, .s_dynamic_snippet_category .s_dynamic_snippet_title, .o_no_background_option`;
     static defaultProps = {
         withColors: true,
         withImages: true,

--- a/addons/website_payment/__manifest__.py
+++ b/addons/website_payment/__manifest__.py
@@ -32,6 +32,7 @@ This is a bridge module that adds multi-website support for payment providers.
         ],
         'web.assets_tests': [
             'website_payment/static/tests/tours/donation.js',
+            'website_payment/static/tests/tours/donation_form_custom_fields.js',
         ],
         'web.assets_unit_tests': [
             'website_payment/static/tests/builder/**/*',

--- a/addons/website_payment/models/payment_transaction.py
+++ b/addons/website_payment/models/payment_transaction.py
@@ -1,7 +1,5 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from markupsafe import Markup
-
 from odoo import _, fields, models
 
 
@@ -9,20 +7,14 @@ class PaymentTransaction(models.Model):
     _inherit = "payment.transaction"
 
     is_donation = fields.Boolean(string="Is donation")
+    donation_log_message = fields.Html(string="Donation Log Message")
 
     def _post_process(self):
         super()._post_process()
         for donation_tx in self.filtered(lambda tx: tx.state == 'done' and tx.is_donation):
             donation_tx._send_donation_email()
-            msg = [_('Payment received from donation with following details:')]
-            for field in ['company_id', 'partner_id', 'partner_name', 'partner_country_id', 'partner_email']:
-                field_name = donation_tx._fields[field].string
-                value = donation_tx[field]
-                if value:
-                    if hasattr(value, 'name'):
-                        value = value.name
-                    msg.append(Markup('<br/>- %s: %s') % (field_name, value))
-            donation_tx.payment_id._message_log(body=Markup().join(msg))
+            # Log the donation message to the payment record's message history
+            donation_tx.payment_id._message_log(body=donation_tx.donation_log_message)
 
     def _send_donation_email(self, is_internal_notification=False, comment=None, recipient_email=None):
         self.ensure_one()

--- a/addons/website_payment/static/src/interactions/payment_form.js
+++ b/addons/website_payment/static/src/interactions/payment_form.js
@@ -88,16 +88,36 @@ patch(PaymentForm.prototype, {
     async _initiatePaymentFlow(providerCode, paymentOptionId, paymentMethodCode, flow) {
         if (document.querySelector('.o_donation_payment_form')) {
             const mandatoryFields = {
-                'name': _t('Name'),
-                'email': _t('Email'),
-                'country_id': _t('Country'),
+                partner_name: _t("Name"),
+                partner_email: _t("Email"),
+                partner_country_id: _t("Country"),
             };
+            const donationFormEl = document.querySelector("#o_donation_field_form");
+
+            // This code is added here because setting a custom field as
+            // required in the form does not work. So, we are manually checking
+            // if the field is mandatory.
+            donationFormEl
+                .querySelectorAll(".s_website_form_required .s_website_form_label")
+                .forEach((fieldEl) => {
+                    mandatoryFields[fieldEl.getAttribute("for")] = fieldEl.textContent.trim();
+                });
 
             let firstInvalidFieldEl;
             for (const id in mandatoryFields) {
-                const fieldEl = this.el.querySelector(`input[name="${id}"],select[name="${id}"]`);
-                const isInvalid =
-                    !fieldEl.value.trim() || (id === "email" && !fieldEl.checkValidity());
+                const fieldEl = donationFormEl.querySelector(
+                    `.s_website_form_required .s_website_form_input[id^=${id}], .s_website_form_model_required .s_website_form_input#${id}`
+                );
+                let isInvalid;
+                if (fieldEl.type === "radio" || fieldEl.type === "checkbox") {
+                    const checkedEl = donationFormEl.querySelector(
+                        `.s_website_form_input[id^=${id}]:checked`
+                    );
+                    isInvalid = !checkedEl || !checkedEl.value.trim();
+                } else {
+                    isInvalid =
+                        !fieldEl.value.trim() || (id === "email" && !fieldEl.checkValidity());
+                }
                 fieldEl.classList.toggle("is-invalid", isInvalid);
                 if (isInvalid && !firstInvalidFieldEl) {
                     firstInvalidFieldEl = fieldEl;
@@ -128,6 +148,59 @@ patch(PaymentForm.prototype, {
      */
     _prepareTransactionRouteParams() {
         const transactionRouteParams = super._prepareTransactionRouteParams(...arguments);
+
+        const getFormData = (formSelector) => {
+            const formEl = document.querySelector(formSelector);
+            if (!formEl) {
+                return {};
+            }
+            const formData = new FormData(formEl);
+            const partnerDetails = {};
+            formData.forEach((value, key) => {
+                // Retrieve all form elements that share the same name attribute
+                // This is necessary for handling cases where multiple inputs
+                // exist for a single key (e.g., checkbox groups).
+                const fieldEls = formEl.querySelectorAll(`[name="${CSS.escape(key)}"]`);
+                const fieldEl = [...fieldEls].find((el) => el.value == value);
+
+                const fieldWrapperEl = fieldEl.closest(".s_website_form_field");
+                const labelText = fieldWrapperEl
+                    .querySelector(".s_website_form_label_content")
+                    ?.innerText.trim();
+                // Check whether the field belongs to a required model wrapper.
+                // If it does, we need to use the element ID as the key to match
+                // the field name with the transaction field. Otherwise, we can
+                // use the form field name as the key.
+                const modelRequiredEl = fieldEl.closest(".s_website_form_model_required");
+                const targetKey = modelRequiredEl ? fieldEl.id : labelText || key;
+
+                if (
+                    !modelRequiredEl &&
+                    !fieldWrapperEl.classList.contains("s_website_form_custom")
+                ) {
+                    // Since the form uses a separate model, the existing fields
+                    // don’t match the element IDs. To handle this, we need to
+                    // check whether the field is a select or a checkbox so we
+                    // can retrieve the correct value to display in the logs.
+                    if (fieldEl.tagName === "SELECT") {
+                        value = fieldEl.options[fieldEl.selectedIndex]?.text.trim();
+                    } else if (
+                        ["checkbox", "radio"].includes(fieldEl.type) &&
+                        fieldEls.length > 1
+                    ) {
+                        value = formEl
+                            .querySelector(`label[for="${fieldEl.id}"]`)
+                            ?.innerText.trim();
+                    }
+                }
+                partnerDetails[targetKey] = partnerDetails[targetKey]
+                    ? [].concat(partnerDetails[targetKey], value)
+                    : value;
+            });
+            return partnerDetails;
+        };
+        const partnerDetails = getFormData("#o_donation_field_form");
+
         return document.querySelector('.o_donation_payment_form')
             ? {
             ...transactionRouteParams,
@@ -135,11 +208,7 @@ patch(PaymentForm.prototype, {
             currency_id: this.paymentContext['currencyId']
                     ? parseInt(this.paymentContext['currencyId']) : null,
             reference_prefix:this.paymentContext['referencePrefix']?.toString(),
-            partner_details: {
-                name: this.el.querySelector('input[name="name"]').value,
-                email: this.el.querySelector('input[name="email"]').value,
-                country_id: this.el.querySelector('select[name="country_id"]').value,
-            },
+            partner_details: partnerDetails,
             donation_comment: this.el.querySelector('#donation_comment').value,
             donation_recipient_email: this.el.querySelector(
                 'input[name="donation_recipient_email"]'

--- a/addons/website_payment/static/src/website_builder/donation_form_option.xml
+++ b/addons/website_payment/static/src/website_builder/donation_form_option.xml
@@ -1,0 +1,9 @@
+<templates>
+
+    <t t-inherit="website.s_website_form_form_option" t-inherit-mode="extension">
+        <xpath expr="//BuilderRow[@label.translate=&quot;On Success&quot;]" position="attributes">
+            <attribute name="t-if">this.formId !== 'o_donation_field_form'</attribute>
+        </xpath>
+    </t>
+
+</templates>

--- a/addons/website_payment/static/tests/tours/donation.js
+++ b/addons/website_payment/static/tests/tours/donation.js
@@ -150,6 +150,15 @@ registry.category("web_tour.tours").add("donation_snippet_use_2", {
             expectUnloadPage: true,
         },
         {
+            // At this point, we are about to submit the donation form. However,
+            // the pre-filled fields such as name and email are still empty,
+            // which would cause an `is-invalid` error on the email field during
+            // submission. Since pre-filling values will take additional time to
+            // implement.
+            content: "Wait until the partner name field is pre-filled, then submit the form",
+            trigger: "input#partner_name:not(:empty)"
+        },
+        {
             content: "Click on the 'Amount to donate' input field",
             trigger: "input#other_amount_value",
             run: "click",

--- a/addons/website_payment/static/tests/tours/donation_form_custom_fields.js
+++ b/addons/website_payment/static/tests/tours/donation_form_custom_fields.js
@@ -1,0 +1,82 @@
+import { registry } from "@web/core/registry";
+import {
+    clickOnSave,
+    registerWebsitePreviewTour,
+    changeOptionInPopover,
+} from "@website/js/tours/tour_utils";
+
+function addNewField() {
+    return [
+        {
+            content: "Click the 'Field' button to add a new field",
+            trigger: "div[data-container-title='Field'] button.btn-success",
+            run: "click",
+        },
+        {
+            content: "Wait until the new field type options are displayed",
+            trigger: "[data-label='Type'] button:contains('text')",
+        },
+    ];
+}
+
+function fillInputField(selector, value) {
+    return [
+        {
+            content: `Fill input field with value ${value}`,
+            trigger: `${selector}`,
+            run: `edit ${value}`,
+        },
+    ];
+}
+
+registerWebsitePreviewTour(
+    "donation_form_custom_field_create",
+    {
+        url: "/donation/pay",
+        edition: true,
+    },
+    () => [
+        {
+            content: "Select the 'Email' field to proceed",
+            trigger: ":iframe #div_email",
+            run: "click",
+        },
+        ...addNewField(),
+        ...changeOptionInPopover("Field", "Type", "[data-action-value='city']"),
+        ...addNewField(),
+        ...changeOptionInPopover("Field", "Type", "[data-action-value='zip']"),
+        ...addNewField(),
+        {
+            content: "Set the label of the new field to 'field_1'",
+            trigger: "[data-action-id='setLabelText'] input",
+            run: "edit field_1",
+        },
+        ...clickOnSave(),
+    ]
+);
+
+registry.category("web_tour.tours").add("donation_form_custom_field_submit", {
+    url: "/donation/pay",
+    steps: () => [
+        {
+            content: "Verify that the donation form is displayed",
+            trigger: "#o_donation_field_form",
+        },
+        ...fillInputField("input#partner_name", "odoo_bot"),
+        ...fillInputField("input#partner_email", "odoo_bot@odoo.com"),
+        {
+            content: "Select the country from the dropdown",
+            trigger: "select#partner_country_id",
+            run: "selectByLabel India",
+        },
+        ...fillInputField("input[name='city']", "Gandhinagar"),
+        ...fillInputField("input[name='zip']", "384241"),
+        ...fillInputField("input[name='field_1']", "this_is_the_text_of_field_1"),
+        {
+            content: "Submit the donation form",
+            trigger: "button[name='o_payment_submit_button']",
+            run: "click",
+            expectUnloadPage: true,
+        },
+    ],
+});

--- a/addons/website_payment/tests/test_snippets.py
+++ b/addons/website_payment/tests/test_snippets.py
@@ -5,7 +5,9 @@ from odoo.addons.base.tests.common import HttpCaseWithUserPortal
 @tagged('post_install', '-at_install')
 class TestSnippets(HttpCaseWithUserPortal):
 
-    def test_01_donation(self):
+    def setUp(self):
+        super().setUp()
+
         payment_demo = self.env['ir.module.module']._get('payment_demo')
         if payment_demo.state != 'installed':
             self.skipTest("payment_demo module is not installed")
@@ -25,7 +27,12 @@ class TestSnippets(HttpCaseWithUserPortal):
 
         self.user_portal.country_id = belgium.id
 
+    def test_01_donation(self):
         self.start_tour("/?enable_editor=1", "donation_snippet_edition", login='admin')
         self.start_tour("/", "donation_snippet_use", login="portal")
         self.start_tour("/?enable_editor=1", "donation_snippet_edition_2", login='admin')
         self.start_tour("/", "donation_snippet_use_2", login="portal")
+
+    def test_02_donation_form_custom_field(self):
+        self.start_tour("/donation/pay", "donation_form_custom_field_create", login="admin")
+        self.start_tour("/donation/pay", "donation_form_custom_field_submit", login="portal")

--- a/addons/website_payment/views/payment_form_templates.xml
+++ b/addons/website_payment/views/payment_form_templates.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
 
-    <!-- Insert the donation form inside the payment form's <form/> element. -->
     <template id="website_payment.payment_form" inherit_id="payment.form">
         <xpath expr="//div[@id='o_payment_form_options']" position="before">
             <div class="mb-3" t-if="is_donation">
@@ -10,8 +9,58 @@
         </xpath>
     </template>
 
-    <!-- Display of /donation/pay -->
-    <template id="website_payment.donation_pay" name="Donation payment">
+    <template id="website_payment.website_payment_donation_form">
+        <div class="container-fluid">
+            <form id="o_donation_field_form" class="o_mark_required" data-model_name="res.partner"
+                hide-change-model="true" data-mark="*">
+                <div class="s_website_form_rows row w-100 s_col_no_bgcolor">
+                    <div data-name="Field"
+                        t-attf-class="s_website_form_field s_website_form_model_required mb-3 #{error.get('name') and 'o_has_error' or ''} col-lg-12 div_name"
+                        data-type="char">
+                        <label class="s_website_form_label" for="name">
+                            <span class="s_website_form_label_content">Name</span>
+                            <span class="s_website_form_mark"> *</span>
+                        </label>
+                        <input id="partner_name" type="text" name="name" data-fill-with="name"
+                            t-attf-class="form-control s_website_form_input #{error.get('name') and 'is-invalid' or ''}" />
+                        <div class="invalid-feedback">
+                            Please provide a name.
+                        </div>
+                    </div>
+                    <div data-name="Field"
+                        t-attf-class="s_website_form_field s_website_form_model_required mb-3 #{error.get('email') and 'o_has_error' or ''} col-lg-6"
+                        id="div_email" data-type="char">
+                        <label class="s_website_form_label" for="email">
+                            <span class="s_website_form_label_content">Email</span>
+                            <span class="s_website_form_mark"> *</span>
+                        </label>
+                        <input id="partner_email" type="email" name="email" data-fill-with="email"
+                            t-attf-class="form-control s_website_form_input #{error.get('email') and 'is-invalid' or ''}" />
+                        <div class="invalid-feedback">
+                            Please enter a valid email address.
+                        </div>
+                    </div>
+                    <t t-set="country_id" t-value="partner_details.get('country_id')" />
+                    <div data-name="Field"
+                        t-attf-class="s_website_form_field s_website_form_model_required mb-3 #{error.get('country_id') and 'o_has_error' or ''} col-lg-6 div_country"
+                        data-type="many2one">
+                        <label class="s_website_form_label" for="country_id">
+                            <span class="s_website_form_label_content">Country</span>
+                            <span class="s_website_form_mark"> *</span>
+                        </label>
+                        <select id="partner_country_id" name="country_id"
+                            t-attf-class="form-select s_website_form_input #{error.get('country_id') and 'is-invalid' or ''}"
+                            required="1">
+                            <option t-foreach="countries" t-as="c" t-att-value="c.id" t-out="c.name"
+                                t-att-selected="c.id == (country_id or -1)" />
+                        </select>
+                    </div>
+                </div>
+            </form>
+        </div>
+    </template>
+
+    <template id="website_payment.donation_page_layout" name="Donation page layout">
         <t t-set="page_title">Donation</t>
         <t t-set="additional_title"><t t-out="page_title"/></t>
         <t t-call="portal.frontend_layout" page_title="page_title" additional_title="additional_title">
@@ -29,7 +78,12 @@
                             <div t-elif="not currency" class="alert alert-warning">
                                 <strong>Warning</strong> The currency is missing or incorrect.
                             </div>
-                            <t t-else="" t-call="payment.form"/>
+                            <div t-else="">
+                                <t t-if="is_donation">
+                                    <h1 class="o_page_header mt16 mb4 h3-fs">Donation</h1>
+                                </t>
+                                <t t-call="payment.form"/>
+                            </div>
                         </div>
                     </div>
                 </div>
@@ -38,46 +92,30 @@
         </t>
     </template>
 
+    <!--
+        Display of /donation/pay
+
+        Donation payment page extension.
+        This template exists as a separate inherited template to make the
+        donation form section editable in the website editor.
+
+        The donation form section uses `t-ignore="true"`, which only works
+        correctly when applied from an inherited template. Defining this
+        logic directly in the base layout would prevent the section from
+        being properly editable and manageable in the website builder.
+    -->
+    <template id="website_payment.donation_pay" inherit_id="website_payment.donation_page_layout" name="Donation payment">
+        <xpath expr="//t[@t-if='is_donation']//h1" position="after">
+            <div class="mb-3" t-ignore="true">
+                <section class="s_website_form mb-3 oe_unmovable oe_unremovable o_no_save o_no_content_width_option o_no_scroll_button o_no_background_option" data-vcss="001" data-snippet="s_website_form" data-name="Form">
+                    <t t-call="website_payment.website_payment_donation_form"/>
+                </section>
+            </div>
+        </xpath>
+    </template>
+
     <template id="website_payment.donation_information" name="Donation Information">
-        <h1 class="o_page_header mt16 mb4 h3-fs">Donation</h1>
         <div class="row">
-            <div t-attf-class="mb-3 #{error.get('name') and 'o_has_error' or ''} col-lg-12 div_name">
-                <label class="col-form-label fw-bold" for="name">Name
-                    <span class="s_website_form_mark"> *</span>
-                </label>
-                <input t-att-readonly="'1' if 'name' in partner_details and partner_id else None" type="text" name="name" t-attf-class="form-control #{error.get('name') and 'is-invalid' or ''}" t-att-value="partner_details.get('name')" required="1"/>
-                <div class="invalid-feedback">
-                    Please provide a name.
-                </div>
-            </div>
-            <div class="w-100"/>
-            <div t-attf-class="mb-3 #{error.get('email') and 'o_has_error' or ''} col-lg-6" id="div_email">
-                <label class="col-form-label fw-bold" for="email">Email
-                    <span class="s_website_form_mark"> *</span>
-                </label>
-                <input t-att-readonly="'1' if 'email' in partner_details and partner_id else None" type="email" name="email" t-attf-class="form-control #{error.get('email') and 'is-invalid' or ''}" t-att-value="partner_details.get('email')" required="1"/>
-                <div class="invalid-feedback">
-                    Please enter a valid email address.
-                </div>
-            </div>
-            <t t-set="country_id" t-value="partner_details.get('country_id')"/>
-            <div t-attf-class="mb-3 #{error.get('country_id') and 'o_has_error' or ''} col-lg-6 div_country">
-                <label class="col-form-label fw-bold" for="country_id">Country
-                    <span class="s_website_form_mark"> *</span>
-                </label>
-                <select t-att-disabled="'1' if country_id and partner_id else None" id="country_id" name="country_id" t-attf-class="form-select #{error.get('country_id') and 'is-invalid' or ''}" required="1">
-                    <option value="">Country...</option>
-                    <t t-foreach="countries" t-as="c">
-                        <option t-att-value="c.id" t-att-selected="c.id == (country_id or -1)">
-                            <t t-out="c.name" />
-                        </option>
-                    </t>
-                </select>
-                <div class="invalid-feedback">
-                    Please select a country.
-                </div>
-            </div>
-            <div class="w-100"/>
             <div class="mb-3 col-lg-12 o_donation_payment_form">
                 <div class="col-lg-6 px-0">
                     <label class="col-form-label fw-bold">Amount (<t t-out="currency.symbol"/>)</label>


### PR DESCRIPTION
*: website, payment

The donation form is now editable, letting users add custom fields easily. Both existing fields and custom fields are logged in the chatter of `payment.transaction`, enhancing traceability and customization.

Key changes:
1. Allow adding both custom and existing fields.
2. Enable field position changes and duplication for custom fields.
3. Treat `Name`, `Email`, and `Country` as technical fields—these are restricted and cannot be deleted.
4. Introduce a new `donation_form` action.
5. Log custom fields as comments in the `payment.transaction` model.
6. Hide the On Success button and URL input from the form.

task-3114722