### PR TITLE
[IMP] account_edi_proxy_client: add timeout argument to _make_request

### DIFF
--- a/addons/account_edi_proxy_client/models/account_edi_proxy_user.py
+++ b/addons/account_edi_proxy_client/models/account_edi_proxy_user.py
@@ -101,7 +101,7 @@ class AccountEdiProxyClientUser(models.Model):
         '''
         return False
 
-    def _make_request(self, url, params=False):
+    def _make_request(self, url, params=False, request_timeout=False):
         ''' Make a request to proxy and handle the generic elements of the reponse (errors, new refresh token).
         '''
         payload = {
@@ -110,7 +110,7 @@ class AccountEdiProxyClientUser(models.Model):
             'params': params or {},
             'id': uuid.uuid4().hex,
         }
-
+        timeout = request_timeout or TIMEOUT
         # Last barrier : in case the demo mode is not handled by the caller, we block access.
         if self.edi_mode == 'demo':
             raise AccountEdiProxyError("block_demo_mode", "Can't access the proxy in demo mode")
@@ -119,7 +119,7 @@ class AccountEdiProxyClientUser(models.Model):
             response = requests.post(
                 url,
                 json=payload,
-                timeout=TIMEOUT,
+                timeout=timeout,
                 headers={'content-type': 'application/json'},
                 auth=OdooEdiProxyAuth(user=self)).json()
         except (ValueError, requests.exceptions.ConnectionError, requests.exceptions.MissingSchema, requests.exceptions.Timeout, requests.exceptions.HTTPError):

--- a/addons/l10n_au/__manifest__.py
+++ b/addons/l10n_au/__manifest__.py
@@ -31,6 +31,7 @@ Also:
     ],
     'demo': [
         'demo/demo_company.xml',
+        'demo/res_bank.xml',
     ],
     'license': 'LGPL-3',
 }

--- a/addons/l10n_au/demo/res_bank.xml
+++ b/addons/l10n_au/demo/res_bank.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record model="res.bank" id="bank_au_cba">
+        <field name="name">Commonwealth Bank of Australia</field>
+        <field name="bic">CTBAAU2S</field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
Some requests may require a longer timeout than the default 30 seconds when pinging the IAP server as they may need several external API calls.

This commit adds a `request_timeout` argument to the `_make_request` method to allow specifying a custom timeout value for the request.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
