### PR TITLE
[IMP] mail: fallback for tracking records without display name

### DIFF
--- a/addons/mail/models/mail_tracking_value.py
+++ b/addons/mail/models/mail_tracking_value.py
@@ -119,9 +119,10 @@ class MailTracking(models.Model):
                 'new_value_char': new_value.display_name if new_value else ''
             })
         elif col_info['type'] in {'one2many', 'many2many'}:
+            model_name = self.env['ir.model']._get(field.relation).display_name
             values.update({
-                'old_value_char': ', '.join(initial_value.mapped('display_name')) if initial_value else '',
-                'new_value_char': ', '.join(new_value.mapped('display_name')) if new_value else '',
+                'old_value_char': ', '.join(value.display_name or self.env._('Unnamed %(record_model_name)s (%(record_id)s)', record_model_name=model_name, record_id=value.id) for value in initial_value) if initial_value else '',
+                'new_value_char': ', '.join(value.display_name or self.env._('Unnamed %(record_model_name)s (%(record_id)s)', record_model_name=model_name, record_id=value.id) for value in new_value) if new_value else '',
             })
         else:
             raise NotImplementedError(f'Unsupported tracking on field {field.name} (type {col_info["type"]}')

--- a/addons/test_mail/tests/test_message_track.py
+++ b/addons/test_mail/tests/test_message_track.py
@@ -498,15 +498,17 @@ class TestTrackingInternals(MailCommon):
                 (0, 0, {'name': 'Child1'}),
                 (0, 0, {'name': 'Child2'}),
                 (0, 0, {'name': 'Child3'}),
+                (0, 0, {'name': False}),
             ],
         })
+        child4_tracking = f'Unnamed Sub-model: pseudo tags for tracking ({test_record.one2many_field[3].id})'
         self.flush_tracking()
         last_message = test_record.message_ids[0]
         self.assertTracking(
             last_message,
             [
                 ('many2many_field', 'many2many', ', '.join(test_tags[:2].mapped('name')), ', '.join((test_tags[1] + test_tags[2]).mapped('name'))),
-                ('one2many_field', 'one2many', '', ', '.join(('Child1', 'Child2', 'Child3'))),
+                ('one2many_field', 'one2many', '', f'Child1, Child2, Child3, {child4_tracking}'),
             ]
         )
 
@@ -516,7 +518,7 @@ class TestTrackingInternals(MailCommon):
         last_message = test_record.message_ids[0]
         self.assertTracking(
             last_message,
-            [('one2many_field', 'one2many', ', '.join(('Child1', 'Child2', 'Child3')), ', '.join(('Child2', 'Child3')))]
+            [('one2many_field', 'one2many', f'Child1, Child2, Child3, {child4_tracking}', f'Child2, Child3, {child4_tracking}')]
         )
 
     @users('employee')


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Addresses: https://github.com/odoo/odoo/issues/178883
Same issue is also in 18.0. Is there a separate PR necessary or will this be ported forward?

Current behavior before PR:
An error is displayed when tracking is activated on one2many and many2many with records without display_name.

Desired behavior after PR is merged:
Should not crash and use fallback like in other cases.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
