### PR TITLE
[FIX] html_builder, *: apply new color palette to theme colorpickers

### DIFF
--- a/addons/html_builder/static/src/builder.js
+++ b/addons/html_builder/static/src/builder.js
@@ -21,8 +21,8 @@ import { InvisibleElementsPanel } from "@html_builder/sidebar/invisible_elements
 import { BlockTab } from "@html_builder/sidebar/block_tab";
 import { CustomizeTab } from "@html_builder/sidebar/customize_tab";
 import {
-    EDITOR_COLOR_CSS_VARIABLES,
-    getCSSVariableValue,
+    setBuilderCSSVariables,
+    setEditableDocument,
     setEditableWindow,
 } from "@html_builder/utils/utils_css";
 import { withSequence } from "@html_editor/utils/resource";
@@ -153,6 +153,7 @@ export class Builder extends Component {
             const iframeEl = await this.props.iframeLoaded;
             this.editableEl = iframeEl.contentDocument.body.querySelector("#wrapwrap");
             setEditableWindow(iframeEl.contentWindow);
+            setEditableDocument(iframeEl.contentDocument);
 
             // Prevent image dragging in the website builder. Not via css because
             // if one of the image ancestor has a dragstart listener, the dragstart handler
@@ -188,7 +189,7 @@ export class Builder extends Component {
 
         onMounted(() => {
             this.editor.document.body.classList.add("editor_enable");
-            this.setCSSVariables();
+            setBuilderCSSVariables();
             // TODO: onload editor
             this.updateInvisibleEls();
         });
@@ -203,18 +204,6 @@ export class Builder extends Component {
 
     get displayOnlyCustomizeTab() {
         return !!this.props.config.customizeTab;
-    }
-
-    setCSSVariables() {
-        const el = this.builder_sidebarRef.el;
-        for (const style of EDITOR_COLOR_CSS_VARIABLES) {
-            let value = getCSSVariableValue(style);
-            if (value.startsWith("'") && value.endsWith("'")) {
-                // Gradient values are recovered within a string.
-                value = value.substring(1, value.length - 1);
-            }
-            el.style.setProperty(`--we-cp-${style}`, value);
-        }
     }
 
     discard() {

--- a/addons/html_builder/static/src/utils/utils_css.js
+++ b/addons/html_builder/static/src/utils/utils_css.js
@@ -1,3 +1,4 @@
+import { EDITOR_COLOR_CSS_VARIABLES } from "@html_editor/utils/color";
 import { backgroundImageCssToParts, getBgImageURLFromURL } from "@html_editor/utils/image";
 import { normalizeCSSColor, isCSSColor, isColorGradient } from "@web/core/utils/colors";
 
@@ -6,48 +7,6 @@ export const setEditableWindow = (ew) => (editableWindow = ew);
 let editableDocument = document;
 export const setEditableDocument = (ed) => (editableDocument = ed);
 
-export const COLOR_PALETTE_COMPATIBILITY_COLOR_NAMES = [
-    "primary",
-    "secondary",
-    "alpha",
-    "beta",
-    "gamma",
-    "delta",
-    "epsilon",
-    "success",
-    "info",
-    "warning",
-    "danger",
-];
-
-/**
- * These constants are colors that can be edited by the user when using
- * web_editor in a website context. We keep track of them so that color
- * palettes and their preview elements can always have the right colors
- * displayed even if website has redefined the colors during an editing
- * session.
- *
- * @type {string[]}
- */
-export const EDITOR_COLOR_CSS_VARIABLES = [...COLOR_PALETTE_COMPATIBILITY_COLOR_NAMES];
-// o-cc and o-colors
-for (let i = 1; i <= 5; i++) {
-    EDITOR_COLOR_CSS_VARIABLES.push(`o-color-${i}`);
-    EDITOR_COLOR_CSS_VARIABLES.push(`o-cc${i}-bg`);
-    EDITOR_COLOR_CSS_VARIABLES.push(`o-cc${i}-bg-gradient`);
-    EDITOR_COLOR_CSS_VARIABLES.push(`o-cc${i}-headings`);
-    EDITOR_COLOR_CSS_VARIABLES.push(`o-cc${i}-text`);
-    EDITOR_COLOR_CSS_VARIABLES.push(`o-cc${i}-btn-primary`);
-    EDITOR_COLOR_CSS_VARIABLES.push(`o-cc${i}-btn-primary-text`);
-    EDITOR_COLOR_CSS_VARIABLES.push(`o-cc${i}-btn-secondary`);
-    EDITOR_COLOR_CSS_VARIABLES.push(`o-cc${i}-btn-secondary-text`);
-    EDITOR_COLOR_CSS_VARIABLES.push(`o-cc${i}-btn-primary-border`);
-    EDITOR_COLOR_CSS_VARIABLES.push(`o-cc${i}-btn-secondary-border`);
-}
-// Grays
-for (let i = 100; i <= 900; i += 100) {
-    EDITOR_COLOR_CSS_VARIABLES.push(`${i}`);
-}
 /**
  * window.getComputedStyle cannot work properly with CSS shortcuts (like
  * 'border-width' which is a shortcut for the top + right + bottom + left border
@@ -346,7 +305,7 @@ export function computeColorClasses(colorNames, prefix = "bg-") {
  */
 export function getCSSVariableValue(key, htmlStyle) {
     if (htmlStyle === undefined) {
-        htmlStyle = editableWindow.getComputedStyle(editableWindow.document.documentElement);
+        htmlStyle = editableWindow.getComputedStyle(editableDocument.documentElement);
     }
     // Get trimmed value from the HTML element
     let value = htmlStyle.getPropertyValue(`--${key}`).trim();
@@ -550,4 +509,16 @@ export function applyNeededCss(
         return true;
     }
     return false;
+}
+
+export function setBuilderCSSVariables() {
+    for (const style of EDITOR_COLOR_CSS_VARIABLES) {
+        let value = getCSSVariableValue(style);
+        if (value.startsWith("'") && value.endsWith("'")) {
+            // Gradient values are recovered within a string.
+            value = value.substring(1, value.length - 1);
+        }
+        const builderEl = editableWindow.top.document.querySelector(".o-snippets-menu");
+        builderEl.style.setProperty(`--hb-cp-${style}`, value);
+    }
 }

--- a/addons/web/static/src/core/color_picker/color_picker.scss
+++ b/addons/web/static/src/core/color_picker/color_picker.scss
@@ -1,12 +1,13 @@
+// TODO: move this with the theme tab to html_builder. It shouldn't be in web.
 @mixin preview-outline-button($type, $ccIndex) {
     .btn-#{$type} {
         background-color: transparent;
-        color: var(--o-cc#{$ccIndex}-btn-#{$type});
-        border-color: var(--o-cc#{$ccIndex}-btn-#{$type});
+        color: var(--hb-cp-o-cc#{$ccIndex}-btn-#{$type});
+        border-color: var(--hb-cp-o-cc#{$ccIndex}-btn-#{$type});
     }
     .btn-#{$type}:hover {
-        background-color: var(--o-cc#{$ccIndex}-btn-#{$type});
-        color: var(--o-cc#{$ccIndex}-btn-#{$type}-text);
+        background-color: var(--hb-cp-o-cc#{$ccIndex}-btn-#{$type});
+        color: var(--hb-cp-o-cc#{$ccIndex}-btn-#{$type}-text);
     }
 }
 
@@ -159,24 +160,25 @@
     @include text-emphasis-variant(".text-#{$-color-name}", $-color);
 }
 
+// TODO: move this with the theme tab to html_builder. It shouldn't be in web.
 .o_cc_preview_wrapper {
     @for $index from 1 through 5 {
         .o_cc#{$index} {
-            background-color: var(--o-cc#{$index}-bg);
-            background-image: var(--o-cc#{$index}-bg-gradient), url('/web/static/img/transparent.png');
-            color: var(--o-cc#{$index}-text);
+            background-color: var(--hb-cp-o-cc#{$index}-bg);
+            background-image: var(--hb-cp-o-cc#{$index}-bg-gradient), url('/web/static/img/transparent.png');
+            color: var(--hb-cp-o-cc#{$index}-text);
             h1 {
-                color: var(--o-cc#{$index}-headings);
+                color: var(--hb-cp-o-cc#{$index}-headings);
             }
             .btn-primary {
-                background-color: var(--o-cc#{$index}-btn-primary);
-                color: var(--o-cc#{$index}-btn-primary-text);
-                border-color: var(--o-cc#{$index}-btn-primary-border);
+                background-color: var(--hb-cp-o-cc#{$index}-btn-primary);
+                color: var(--hb-cp-o-cc#{$index}-btn-primary-text);
+                border-color: var(--hb-cp-o-cc#{$index}-btn-primary-border);
             }
             .btn-secondary {
-                background-color: var(--o-cc#{$index}-btn-secondary);
-                color: var(--o-cc#{$index}-btn-secondary-text);
-                border-color: var(--o-cc#{$index}-btn-secondary-border);
+                background-color: var(--hb-cp-o-cc#{$index}-btn-secondary);
+                color: var(--hb-cp-o-cc#{$index}-btn-secondary-text);
+                border-color: var(--hb-cp-o-cc#{$index}-btn-secondary-border);
             }
         }
     }

--- a/addons/web/static/src/core/color_picker/color_picker.xml
+++ b/addons/web/static/src/core/color_picker/color_picker.xml
@@ -31,6 +31,7 @@
                     t-on-focusin="onColorFocusin"
                     t-on-focusout="onColorHoverOut"/>
         </div>
+        <!-- TODO: move the theme tab to html_builder. It shouldn't be in web. -->
         <t t-if="state.activeTab==='theme'">
             <div class="pt-2 px-2 pb-3 d-flex flex-column gap-1 o_cc_preview_wrapper"
                 t-on-click="onColorApply"
@@ -46,7 +47,7 @@
                     <t t-set="activeClass" t-value="this.props.state.selectedColorCombination === className ? 'selected' : ''"/>
                     <button
                             type="button"
-                            class="w-100 p-0 border-0 bg-transparent color-combination-button"
+                            class="w-100 p-0 border-0 color-combination-button"
                             t-att-class="[className, activeClass].join(' ')"
                             t-att-data-color="className"
                             t-attf-title="Preset {{number}}">

--- a/addons/website/static/src/builder/plugins/customize_website_plugin.js
+++ b/addons/website/static/src/builder/plugins/customize_website_plugin.js
@@ -1,4 +1,8 @@
-import { getCSSVariableValue, isCSSVariable } from "@html_builder/utils/utils_css";
+import {
+    getCSSVariableValue,
+    isCSSVariable,
+    setBuilderCSSVariables,
+} from "@html_builder/utils/utils_css";
 import { Plugin } from "@html_editor/plugin";
 import { parseHTML } from "@html_editor/utils/html";
 import { ConfirmationDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
@@ -760,6 +764,7 @@ class CustomizeWebsiteColorAction extends BuilderAction {
                 { colorType, combinationColor, nullValue }
             );
         }
+        setBuilderCSSVariables();
     }
 }
 

--- a/addons/website/static/src/builder/plugins/theme/theme_colors_option.xml
+++ b/addons/website/static/src/builder/plugins/theme/theme_colors_option.xml
@@ -73,40 +73,22 @@
                 <t t-set-slot="collapse">
                     <t t-foreach="state.presets" t-as="preset" t-key="preset.id">
                         <BuilderRow t-slot-scope="row">
-                            <div t-on-click="row.toggleCollapseContent"
-                                t-attf-class="
-                                    w-100 p-2 d-flex justify-content-between
-                                    align-items-center ms-3"
-                                t-attf-style="
-                                    background-color: {{preset.background}};
-                                    background-image: {{preset.backgroundGradient}};
-                                    color: {{preset.text}}">
-                                <h3
-                                    class="m-0"
-                                    t-attf-style="color: {{preset.headings}}">
-                                    Title
-                                </h3>
-                                <p class="my-0 ms-3 me-auto">
-                                    Text
-                                </p>
-                                <button
-                                    tabindex="-1"
-                                    class="btn btn-sm me-2"
-                                    t-attf-style="
-                                        background-color: {{preset.primaryBtn}};
-                                        color: {{preset.primaryBtnText}};
-                                        border: 1px solid {{preset.primaryBtnBorder}}">
-                                    Button
-                                </button>
-                                <button
-                                    tabindex="-1"
-                                    class="btn btn-sm"
-                                    t-attf-style="
-                                        background-color: {{preset.secondaryBtn}};
-                                        color: {{preset.secondaryBtnText}};
-                                        border: 1px solid {{preset.secondaryBtnBorder}}">
-                                    Button
-                                </button>
+                            <div class="o_cc_preview_wrapper" t-on-click="row.toggleCollapseContent">
+                                <div inert="" t-att-class="`o_cc${preset.id}`"
+                                     class="w-100 p-2 d-flex justify-content-between align-items-center ms-3">
+                                    <h3 class="m-0">
+                                        Title
+                                    </h3>
+                                    <p class="my-0 ms-3 me-auto">
+                                        Text
+                                    </p>
+                                    <button class="btn btn-primary btn-sm me-2">
+                                        Button
+                                    </button>
+                                    <button class="btn btn-secondary btn-sm">
+                                        Button
+                                    </button>
+                                </div>
                             </div>
                             <t t-set-slot="collapse">
                                 <BuilderRow label.translate="Background">

--- a/addons/website/static/src/builder/plugins/theme/theme_tab_plugin.js
+++ b/addons/website/static/src/builder/plugins/theme/theme_tab_plugin.js
@@ -3,7 +3,7 @@ import { Plugin } from "@html_editor/plugin";
 import { withSequence } from "@html_editor/utils/resource";
 import { ThemeColorsOption } from "./theme_colors_option";
 import { ThemeAdvancedOption } from "./theme_advanced_option";
-import { getCSSVariableValue } from "@html_builder/utils/utils_css";
+import { getCSSVariableValue, setBuilderCSSVariables } from "@html_builder/utils/utils_css";
 import { ConfirmationDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
 import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
@@ -278,6 +278,7 @@ class ChangeColorPaletteAction extends CustomizeWebsiteVariableAction {
             return;
         }
         await super.apply(context);
+        setBuilderCSSVariables();
     }
 }
 

--- a/addons/website/static/src/builder/plugins/theme/theme_tab_plugin.js
+++ b/addons/website/static/src/builder/plugins/theme/theme_tab_plugin.js
@@ -263,9 +263,12 @@ class CustomizeGrayAction extends BuilderAction {
 class ChangeColorPaletteAction extends CustomizeWebsiteVariableAction {
     static id = "changeColorPalette";
     static dependencies = ["customizeWebsite"];
-    setup() {}
-    async apply(context) {
-        const confirmed = await new Promise((resolve) => {
+    setup() {
+        this.preview = false;
+        this.dependencies.customizeWebsite.withCustomHistory(this);
+    }
+    async load() {
+        return new Promise((resolve) => {
             this.services.dialog.add(ConfirmationDialog, {
                 body: _t(
                     "Changing the color palette will reset all your color customizations, are you sure you want to proceed?"
@@ -274,7 +277,9 @@ class ChangeColorPaletteAction extends CustomizeWebsiteVariableAction {
                 cancel: () => resolve(false),
             });
         });
-        if (!confirmed) {
+    }
+    async apply(context) {
+        if (!context.loadResult) {
             return;
         }
         await super.apply(context);

--- a/addons/website/static/tests/builder/website_builder/background_option.test.js
+++ b/addons/website/static/tests/builder/website_builder/background_option.test.js
@@ -80,7 +80,7 @@ test("toggle Show/Hide on mobile of the shape background", async () => {
 
 test("Check if an element with a background image has necessary classes", async () => {
     await setupWebsiteBuilder(`
-        <section class="s_banner overflow-hidden" style="background-color:(0, 0, 0, 0); 
+        <section class="s_banner overflow-hidden" style="background-color:(0, 0, 0, 0);
                 background-image: url(&quot;/website_slides/static/src/img/banner_default.svg&quot;); height: 300px" data-snippet="s_banner">
             AAA
         </section>`);


### PR DESCRIPTION
*: web, website
    
Before the refactoring to html_builder, to replicate the `--o-ccX-...`
variables available within the iframe, the website wysiwyg used CSS
custom properties (prefixed with `--we-cp-`) set on the main document.
This was lost during the refactoring, causing the "Theme" tab of the
builder colorpickers never to be updated after modifying the theme
colors.

This commit reapplies those variables, prefixing them with `--hb-cp-`
(for "html_builder copy").