### PR TITLE
[IMP] website, html_editor: add option to toggle aspect-ratio

### DIFF
--- a/addons/html_editor/controllers/main.py
+++ b/addons/html_editor/controllers/main.py
@@ -351,7 +351,7 @@ class HTML_Editor(http.Controller):
     def video_url_data(self, video_url, autoplay=False, loop=False,
                        hide_controls=False, hide_fullscreen=False,
                        hide_dm_logo=False, hide_dm_share=False,
-                       start_from=False):
+                       start_from=False, **kwargs):
         return get_video_url_data(
             video_url, autoplay=autoplay, loop=loop,
             hide_controls=hide_controls, hide_fullscreen=hide_fullscreen,

--- a/addons/html_editor/static/src/main/media/media_dialog/video_selector.xml
+++ b/addons/html_editor/static/src/main/media/media_dialog/video_selector.xml
@@ -55,7 +55,7 @@
             <div class="o_video_preview position-relative border-0 p-3">
                 <div t-if="this.state.src and !this.state.errorMessage" class="o_video_dialog_preview_text mb-2">Preview</div>
                 <div class="media_iframe_video">
-                    <div class="media_iframe_video_size"/>
+                    <div t-att-class="this.state.isVertical ? 'media_iframe_video_size_for_vertical' : 'media_iframe_video_size'"/>
                     <VideoIframe
                         t-if="this.state.src and !this.state.errorMessage"
                         src="this.state.src"/>

--- a/addons/html_editor/static/src/others/embedded_components/backend/video/video.js
+++ b/addons/html_editor/static/src/others/embedded_components/backend/video/video.js
@@ -79,7 +79,10 @@ export class EmbeddedVideoComponent extends ReadonlyEmbeddedVideoComponent {
     }
 
     get url() {
-        return getVideoUrl(this.state.platform, this.state.videoId, this.state.params).toString();
+        const urlParams = Object.fromEntries(
+            Object.entries(this.state.params).filter(([key]) => key !== "isVertical")
+        );
+        return getVideoUrl(this.state.platform, this.state.videoId, urlParams).toString();
     }
 
     /**
@@ -90,6 +93,13 @@ export class EmbeddedVideoComponent extends ReadonlyEmbeddedVideoComponent {
         this.state.videoId = media.videoId;
         this.state.platform = media.platform;
         this.state.params = media.params;
+        const isVertical = media.params.isVertical;
+        if (isVertical) {
+            this.videoBlock.dataset.isVertical = "true";
+        } else {
+            delete this.videoBlock.dataset.isVertical;
+        }
+        this.videoBlock.classList.toggle("media_iframe_video_size_for_vertical", isVertical);
         this.props.focusEditable();
     }
 }

--- a/addons/html_editor/static/src/others/embedded_components/backend/video/video.js
+++ b/addons/html_editor/static/src/others/embedded_components/backend/video/video.js
@@ -82,7 +82,9 @@ export class EmbeddedVideoComponent extends ReadonlyEmbeddedVideoComponent {
         const urlParams = Object.fromEntries(
             Object.entries(this.state.params).filter(([key]) => key !== "isVertical")
         );
-        return getVideoUrl(this.state.platform, this.state.videoId, urlParams).toString();
+        return decodeURIComponent(
+            getVideoUrl(this.state.platform, this.state.videoId, urlParams).toString()
+        );
     }
 
     /**

--- a/addons/html_editor/static/src/others/embedded_components/backend/video/video.scss
+++ b/addons/html_editor/static/src/others/embedded_components/backend/video/video.scss
@@ -13,4 +13,11 @@
         height: 100%;
         min-height: auto !important;
     }
+
+    &.media_iframe_video_size_for_vertical {
+        max-width: 315px;
+        &:has(iframe) {
+            aspect-ratio: 9 / 16;
+        }
+    }
 }

--- a/addons/html_editor/static/src/others/embedded_components/plugins/video_plugin/video_blueprint.xml
+++ b/addons/html_editor/static/src/others/embedded_components/plugins/video_plugin/video_blueprint.xml
@@ -1,6 +1,8 @@
 <templates>
     <t t-name="html_editor.EmbeddedVideoBlueprint">
         <div t-att-data-embedded-props="embeddedProps" data-embedded="video"
-            data-oe-protected="true" contenteditable="false"/>
+            data-oe-protected="true" contenteditable="false"
+            t-att-data-is-vertical="isVertical and 'true'"
+            t-attf-class="{{isVertical ? 'media_iframe_video_size_for_vertical' : ''}}"/>
     </t>
 </templates>

--- a/addons/html_editor/static/src/others/embedded_components/plugins/video_plugin/video_selector_dialog/embedded_video_selector.js
+++ b/addons/html_editor/static/src/others/embedded_components/plugins/video_plugin/video_selector_dialog/embedded_video_selector.js
@@ -11,6 +11,7 @@ export class EmbeddedVideoSelector extends VideoSelector {
                     platform: media.platform,
                     params: media.params || {},
                 }),
+                isVertical: media.params?.isVertical,
             })
         );
     }

--- a/addons/html_editor/static/src/scss/html_editor.common.scss
+++ b/addons/html_editor/static/src/scss/html_editor.common.scss
@@ -342,12 +342,23 @@ div.media_iframe_video {
         height: 0;
     }
 
+    .media_iframe_video_size_for_vertical {
+        padding-bottom: 177.78%; /* 9:16 aspect ratio */
+        position: relative;
+        width: 100%;
+        height: 0;
+    }
+
     .css_editable_mode_display {
         @include o-position-absolute(0,0,0,0);
         width: 100%;
         height: 100%;
         display: none;
         z-index: 2;
+    }
+
+    &:has(.media_iframe_video_size_for_vertical) {
+        max-width: 315px;
     }
 }
 

--- a/addons/html_editor/static/src/utils/url.js
+++ b/addons/html_editor/static/src/utils/url.js
@@ -57,6 +57,10 @@ export function getVideoUrl(platform, videoId, params) {
         case "youku":
             url = new URL(`https://player.youku.com/embed/${videoId}`);
             break;
+        case "facebook":
+            url = new URL(`https://www.facebook.com/plugins/video.php`);
+            params.href = `https://www.facebook.com/facebook/videos/${videoId}/`;
+            break;
         default:
             throw new Error(`Unsupported platform: ${platform}`);
     }

--- a/addons/html_editor/static/tests/paste.test.js
+++ b/addons/html_editor/static/tests/paste.test.js
@@ -3404,9 +3404,12 @@ describe("youtube video", () => {
             await press("Enter");
             // Wait for the getYoutubeVideoElement promise to resolve.
             await tick();
-            expect(getContent(el)).toBe(
-                `<p>ab</p><div data-oe-expression="${videoUrl}" class="media_iframe_video" contenteditable="false"><div class="css_editable_mode_display"></div><div class="media_iframe_video_size" contenteditable="false"></div><iframe frameborder="0" contenteditable="false" allowfullscreen="allowfullscreen" src="${videoUrl}"></iframe></div><p>[]cd</p>`
-            );
+            const expected = `<p>ab</p><div data-oe-expression="${videoUrl}" class="media_iframe_video" contenteditable="false">
+                <div class="css_editable_mode_display"></div>
+                <div class="media_iframe_video_size" contenteditable="false"></div>
+                <iframe loading="lazy" frameborder="0" contenteditable="false" allowfullscreen="allowfullscreen" src="${videoUrl}"></iframe>
+            </div><p>[]cd</p>`;
+            expect(getContent(el)).toBe(expected);
         });
 
         test("should paste and transform a youtube URL in a span (1)", async () => {
@@ -3420,9 +3423,12 @@ describe("youtube video", () => {
             await press("Enter");
             // Wait for the getYoutubeVideoElement promise to resolve.
             await tick();
-            expect(getContent(el)).toBe(
-                '<p>a<span class="a">b</span></p><div data-oe-expression="https://youtu.be/dQw4w9WgXcQ" class="media_iframe_video" contenteditable="false"><div class="css_editable_mode_display"></div><div class="media_iframe_video_size" contenteditable="false"></div><iframe frameborder="0" contenteditable="false" allowfullscreen="allowfullscreen" src="https://youtu.be/dQw4w9WgXcQ"></iframe></div><p><span class="a">[]c</span>d</p>'
-            );
+            const expected = `<p>a<span class="a">b</span></p><div data-oe-expression="https://youtu.be/dQw4w9WgXcQ" class="media_iframe_video" contenteditable="false">
+                <div class="css_editable_mode_display"></div>
+                <div class="media_iframe_video_size" contenteditable="false"></div>
+                <iframe loading="lazy" frameborder="0" contenteditable="false" allowfullscreen="allowfullscreen" src="https://youtu.be/dQw4w9WgXcQ"></iframe>
+            </div><p><span class="a">[]c</span>d</p>`;
+            expect(getContent(el)).toBe(expected);
         });
 
         test("should paste and not transform a youtube URL in a existing link", async () => {
@@ -3485,9 +3491,12 @@ describe("youtube video", () => {
             await press("Enter");
             // Wait for the getYoutubeVideoElement promise to resolve.
             await tick();
-            expect(getContent(el)).toBe(
-                '<p>ab</p><div data-oe-expression="https://youtu.be/dQw4w9WgXcQ" class="media_iframe_video" contenteditable="false"><div class="css_editable_mode_display"></div><div class="media_iframe_video_size" contenteditable="false"></div><iframe frameborder="0" contenteditable="false" allowfullscreen="allowfullscreen" src="https://youtu.be/dQw4w9WgXcQ"></iframe></div><p>[]cd</p>'
-            );
+            const expected = `<p>ab</p><div data-oe-expression="https://youtu.be/dQw4w9WgXcQ" class="media_iframe_video" contenteditable="false">
+                <div class="css_editable_mode_display"></div>
+                <div class="media_iframe_video_size" contenteditable="false"></div>
+                <iframe loading="lazy" frameborder="0" contenteditable="false" allowfullscreen="allowfullscreen" src="https://youtu.be/dQw4w9WgXcQ"></iframe>
+            </div><p>[]cd</p>`;
+            expect(getContent(el)).toBe(expected);
         });
 
         test("should paste and transform a youtube URL in a span (2)", async () => {
@@ -3502,9 +3511,12 @@ describe("youtube video", () => {
             await press("Enter");
             // Wait for the getYoutubeVideoElement promise to resolve.
             await tick();
-            expect(getContent(el)).toBe(
-                `<p>a<span class="a">b</span></p><div data-oe-expression="${videoUrl}" class="media_iframe_video" contenteditable="false"><div class="css_editable_mode_display"></div><div class="media_iframe_video_size" contenteditable="false"></div><iframe frameborder="0" contenteditable="false" allowfullscreen="allowfullscreen" src="${videoUrl}"></iframe></div><p><span class="a">[]c</span>d</p>`
-            );
+            const expected = `<p>a<span class="a">b</span></p><div data-oe-expression="${videoUrl}" class="media_iframe_video" contenteditable="false">
+                <div class="css_editable_mode_display"></div>
+                <div class="media_iframe_video_size" contenteditable="false"></div>
+                <iframe loading="lazy" frameborder="0" contenteditable="false" allowfullscreen="allowfullscreen" src="${videoUrl}"></iframe>
+            </div><p><span class="a">[]c</span>d</p>`;
+            expect(getContent(el)).toBe(expected);
         });
 
         test("should paste and not transform a youtube URL in a existing link", async () => {

--- a/addons/html_editor/tools.py
+++ b/addons/html_editor/tools.py
@@ -24,7 +24,7 @@ player_regexes = {
     'youtube': r'^(?:(?:https?:)?//)?(?:www\.|m\.)?(?:youtu\.be/|youtube(-nocookie)?\.com/(?:embed/|v/|shorts/|live/|watch\?v=|watch\?.+&v=))((?:\w|-){11})\S*$',
     'vimeo': r'//(player.)?vimeo.com/([a-z]*/)?(?P<id>[^/\?]+)(?:/(?P<hash>[^/\?]+))?(?:\?(?P<params>[^\s]+))?$',
     'dailymotion': r'(https?:\/\/)(www\.)?(dailymotion\.com\/(embed\/video\/|embed\/|video\/|hub\/.*#video=)|geo\.dailymotion\.com\/player\.html\?video=|dai\.ly\/)(?P<id>[A-Za-z0-9]{6,7})',
-    'instagram': r'(?:(.*)instagram.com|instagr\.am)/p/(.[a-zA-Z0-9-_\.]*)',
+    'instagram': r'(?:(.*)instagram\.com|instagr\.am)/(?:p|reel)/([a-zA-Z0-9\-_\.]+)',
     'youku': r'(?:(https?:\/\/)?(v\.youku\.com/v_show/id_|player\.youku\.com/player\.php/sid/|player\.youku\.com/embed/|cloud\.youku\.com/services/sharev\?vid=|video\.tudou\.com/v/)|youku:)(?P<id>[A-Za-z0-9]+)(?:\.html|/v\.swf|)',
     "facebook": r'^(?:(?:https?:)?//)?(?:www\.)?facebook\.com(?:/(?:[^/]+/)?videos/|/watch/?\?v=|/reel/|/plugins/video\.php\?[^ ]*?href=.*?(?:videos|reel)%2[Ff])(?P<id>\d+)',
 }

--- a/addons/website/static/tests/builder/videos.test.js
+++ b/addons/website/static/tests/builder/videos.test.js
@@ -1,6 +1,7 @@
 import { expect, test } from "@odoo/hoot";
-import { animationFrame, dblclick } from "@odoo/hoot-dom";
+import { animationFrame, dblclick, waitFor, queryOne } from "@odoo/hoot-dom";
 import { defineWebsiteModels, setupWebsiteBuilder } from "./website_helpers";
+import { onRpc } from "@web/../tests/web_test_helpers";
 
 defineWebsiteModels();
 
@@ -18,4 +19,44 @@ test("double click on video", async () => {
     await dblclick(":iframe iframe");
     await animationFrame();
     expect(".modal-content:contains(Select a media) .o_video_dialog_form").toHaveCount(1);
+});
+
+test("vertical toggle of video options", async () => {
+    onRpc("/html_editor/video_url/data", () => ({
+        platform: "youtube",
+        embed_url: "//www.youtube.com/embed/G8b4UZIcTfg?rel=0&autoplay=0",
+        video_id: "G8b4UZIcTfg",
+        params: { rel: "0", autoplay: "0" },
+    }));
+    await setupWebsiteBuilder(`
+        <div>
+            <div data-oe-expression="//www.youtube.com/embed/wf9gPmNc2sc?rel=0&autoplay=0"
+                 class="media_iframe_video o_snippet_drop_in_only">
+                <div class="css_editable_mode_display"></div>
+                <div class="media_iframe_video_size"></div>
+                <iframe frameborder="0" allowfullscreen="allowfullscreen" aria-label="Video"></iframe>
+            </div>
+        </div>
+    `);
+
+    expect(".modal-content").toHaveCount(0);
+    await dblclick(":iframe iframe");
+    await animationFrame();
+    expect(".modal-content:contains(Select a media) .o_video_dialog_form").toHaveCount(1);
+    expect(".modal-content:contains(Select a media) .media_iframe_video .media_iframe_video_size").toHaveCount(1);
+    // Wait for options to be rendered before interaction
+    await waitFor(".modal-content:contains(Select a media) .o_video_dialog_form .o_video_dialog_options");
+    // Toggle the “Vertical” option
+    const verticalToggle = queryOne('.modal-content:contains("Select a media") .o_video_dialog_form .o_video_dialog_options label:contains(Vertical) input');
+    verticalToggle.click();
+
+    // Confirm vertical class is applied in the preview area
+    await waitFor(".modal-content:contains(Select a media) .media_iframe_video .media_iframe_video_size_for_vertical");
+    queryOne('.modal-content:contains(Select a media) footer button:contains(Add)').click();
+    await animationFrame();
+    // Verify the vertical class persists in the website preview
+    expect(":iframe .media_iframe_video .media_iframe_video_size_for_vertical").toHaveCount(1);
+    // Reopen configurator and ensure the vertical setting is still active
+    await dblclick(":iframe iframe");
+    await waitFor(".modal-content:contains(Select a media) .media_iframe_video .media_iframe_video_size_for_vertical");
 });


### PR DESCRIPTION
Specification:
- Introduced a "Vertical" toggle button in the media dialog to switch
between horizontal and vertical view for Instagram, YouTube, Facebook.

After this commit:
- The media dialog includes a "Vertical" toggle button for switching
video types.
- When the "Vertical" toggle is ON, the vertical video selector
is displayed.
- When the "Vertical" toggle is OFF, the regular horizontal selector
is shown.
- The "Vertical" toggle is hidden when the media dialog is opened for
selecting a background video.
- New url for Instagram works well which has reel in it.
example: [https://www.instagram.com/reel/{video_id}/](https://www.instagram.com/reel/%7Bvideo_id%7D/)

task-4645422

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
