### PR TITLE
[FIX] account: fix transfer wizard reconciled error message

### DIFF
--- a/addons/account/wizard/account_automatic_entry_wizard.py
+++ b/addons/account/wizard/account_automatic_entry_wizard.py
@@ -147,7 +147,7 @@ class AccountAutomaticEntryWizard(models.TransientModel):
         if any(move.state != 'posted' for move in move_line_ids.mapped('move_id')):
             raise UserError(_("Oops! You can only change the period or account for posted entries! Other ones aren't up for an adventure like that!"))
         if any(move_line.reconciled for move_line in move_line_ids):
-            raise UserError(_("Oops! You can only change the period or account for posted entries! Other ones aren't up for an adventure like that!"))
+            raise UserError(_("Oops! You can only change the period or account for items that are not yet reconciled! Other ones aren't up for an adventure like that!"))
         if any(line.company_id.root_id != move_line_ids[0].company_id.root_id for line in move_line_ids):
             raise UserError(_('You cannot use this wizard on journal entries belonging to different companies.'))
         res['company_id'] = move_line_ids[0].company_id.root_id.id


### PR DESCRIPTION
In commit 9cbd351a124e00f8695b407c8a6f086902bc51df an error message in the Transfer Journal Items wizard (`account.automatic.entry.wizard`) was broken.

This commit fixes that error message.

task-None