### PR TITLE
[FIX] web: user menu text overlapping checkbox

### DIFF
--- a/addons/web/static/src/webclient/user_menu/user_menu.xml
+++ b/addons/web/static/src/webclient/user_menu/user_menu.xml
@@ -20,15 +20,16 @@
                         dataset="{ menu: element.id }"
                         onSelected="element.callback"
                     >
+                    <div class="d-flex justify-content-between p-0 w-100">
+                        <t t-out="element.description"/>
                         <CheckBox
                             t-if="element.type == 'switch'"
                             value="element.isChecked"
-                            className="'form-switch d-flex flex-row-reverse justify-content-between p-0 w-100'"
+                            className="'form-switch ms-2'"
                             onChange="element.callback"
                         >
-                            <t t-out="element.description"/>
                         </CheckBox>
-                        <t t-else="" t-out="element.description"/>
+                    </div>
                     </DropdownItem>
                     <div t-if="element.type == 'separator'" role="separator" class="dropdown-divider"/>
                 </t>

--- a/addons/web/static/src/webclient/user_menu/user_menu_items.js
+++ b/addons/web/static/src/webclient/user_menu/user_menu_items.js
@@ -52,7 +52,7 @@ function shortCutsItem(env) {
         id: "shortcuts",
         hide: env.isSmall,
         description: markup(
-            `<div class="d-flex align-items-center justify-content-between">
+            `<div class="d-flex align-items-center justify-content-between p-0 w-100">
                 <span>${escape(translatedText)}</span>
                 <span class="fw-bold">${isMacOS() ? "CMD" : "CTRL"}+K</span>
             </div>`


### PR DESCRIPTION
**PROBLEM**
In the user menu, the text of dropdown item sometimes overlap with the checkbox next to it when it's too long.

**STEP TO REPRODUCE**
(happened with the italian localization of the onboarding module, but it's no longer the case because the text was shortened)
1. In `enterprise/web_enterprise/i18n/it.po`, for the msgid "Dark Mode" set the translation to something long.
2. click on the user menu and notice the text for the dark mode dropdown item is overlapping with the checkbox next to it.

**CAUSE**
The checkbox in the user_menu.xml template use d-flex and flex-row-reverse, which doesn't work well with the class form-switch. form-switch add a negative left-margin of -2.5em to the <input> inside the checkbox template.

**FIX**
Put the description text before the checkbox in a flex div, and remove the flex-row-reverse on the checkbox.

opw-4654405

