### PR TITLE
[FIX] web: datetimepicker: correctly save time after closing popover

### DIFF
--- a/addons/web/static/src/core/datetime/datetimepicker_service.js
+++ b/addons/web/static/src/core/datetime/datetimepicker_service.js
@@ -443,6 +443,11 @@ export const datetimePickerService = {
                     )) {
                         if (el) {
                             updateInput(el, value);
+                            // Apply changes immediately if the popover is already closed.
+                            // Otherwise ´apply()´ will be called later on close.
+                            if (!popover.isOpen) {
+                                apply();
+                            }
                         }
                     }
 

--- a/addons/web/static/tests/views/fields/datetime_field.test.js
+++ b/addons/web/static/tests/views/fields/datetime_field.test.js
@@ -141,6 +141,45 @@ test("DatetimeField only triggers fieldChange when a day is picked and when an h
     expect.verifySteps(["onchange"]);
 });
 
+test("DatetimeField edit hour/minute and click away", async () => {
+    mockTimeZone(0);
+
+    onRpc("web_save", ({ args }) => {
+        expect(args[1].datetime).toBe("2017-02-08 08:30:00", {
+            message: "the correct value should be saved",
+        });
+    });
+
+    await mountView({
+        type: "form",
+        resModel: "partner",
+        resId: 1,
+        arch: /* xml */ '<form><field name="datetime"/></form>',
+    });
+
+    // Open the datepicker
+    await click(".o_field_datetime input");
+    await animationFrame();
+    expect(".o_datetime_picker").toHaveCount(1);
+
+    // Manually change the time without { confirm: "enter" }
+    await click(`.o_time_picker_input:eq(0)`);
+    await animationFrame();
+    await edit("8:30");
+    await animationFrame();
+    expect(".o_field_datetime input").toHaveValue("02/08/2017 10:00", {
+        message: "Input value shouldn't be updated yet",
+    });
+
+    // Close the datepicker
+    await click(document.body);
+    await animationFrame();
+    expect(".o_datetime_picker").toHaveCount(0);
+
+    expect(".o_field_datetime input").toHaveValue("02/08/2017 08:30");
+    await clickSave();
+});
+
 test("DatetimeField with datetime formatted without second", async () => {
     mockTimeZone(0);
 


### PR DESCRIPTION
The datetime picker has been designed to only trigger field changes when the popover is closed.
Although the form view input value is synchronized during changes the user makes in the picker, it is only when the window is closed that the changes are actually applied.

But since we introduced the timepicker dropdown, there is an issue with this; If you manually edit the time without pressing enter, no changes are sent. Which is ok as we don't know if the user is still editing the value or not. But if right after that the popover is closed, the ´apply()´ method is not aware of the change.
Closing the datetime picker then causes an "onChange" updating the field value but too late for the changes to be applied.

One possibility was to wait for any late datepicker events during the closure the popover but we had issues with this because of the delay added. So now, we simply check if the datetime picker popover is closed and we force the ´apply()´ method after updating the input value.

Steps to reproduce:
- Open any record having a datetime field
- Edit the time by using the keyboard
- Click-out to validate the time change
- Click on "Save" => It does not work

task-4835354

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
