### PR TITLE
[IMP] hr_recruitment: homepage (job position) UI/X

### DIFF
--- a/addons/hr_recruitment/static/src/scss/hr_applicant.scss
+++ b/addons/hr_recruitment/static/src/scss/hr_applicant.scss
@@ -20,3 +20,8 @@
     }
 }
 
+.o_hr_applicant_view_activity {
+    .o_m2o_avatar {
+        margin-right: 0px !important;
+    }
+}

--- a/addons/hr_recruitment/static/src/scss/hr_job.scss
+++ b/addons/hr_recruitment/static/src/scss/hr_job.scss
@@ -63,6 +63,20 @@
     margin: 0px;
 }
 
+.o_hr_recruitment_kanban_card_mobile_screen {
+    min-height: 0px !important;
+}
+
+.o_hr_recruitment_kanban {
+    .o_m2o_avatar {
+        margin-right: 0px !important;
+    }
+}
+
+.activity_badge {
+    --badge-padding-x: .55em;
+}
+
 .o_hr_recruitment_kanban_card {
     border: 0px;
 }

--- a/addons/hr_recruitment/views/hr_applicant_views.xml
+++ b/addons/hr_recruitment/views/hr_applicant_views.xml
@@ -422,9 +422,9 @@
         <field name="arch" type="xml">
             <activity string="Applicants">
                 <templates>
-                    <div t-name="activity-box">
+                    <div t-name="activity-box" class="o_hr_applicant_view_activity">
                         <field name="user_id" widget="many2one_avatar_user"/>
-                        <div class="flex-grow-1">
+                        <div class="flex-grow-1 ms-1">
                             <field name="partner_name" muted="1" display="full" class="o_text_block"/>
                         </div>
                     </div>

--- a/addons/hr_recruitment/views/hr_job_views.xml
+++ b/addons/hr_recruitment/views/hr_job_views.xml
@@ -72,7 +72,98 @@
                     <t t-name="card">
                         <div class="o_hr_recruitment_kanban_card_large_screen">
                             <main>
-                                <div class="o_hr_recruitment_kanban_card_main_content d-flex flex-column">
+                                <div class="o_hr_recruitment_kanban_card_main_content d-flex flex-row align-content-center ms-1">
+                                    <div class="col-3 mb-2 d-flex flex-column">
+                                        <div class="d-flex flex-row mb-2">
+                                            <div class="d-flex fw-bold fs-3">
+                                                <field name="is_favorite" widget="boolean_favorite" nolabel="1"/>
+                                                <field class="fs-2" name="name"/>
+                                            </div>
+                                            <div t-if="record.alias_email.value" class="d-flex flex-wrap">
+                                                <field name="alias_id"/>
+                                            </div>
+                                        </div>
+                                        <div class="d-flex flex-row">
+                                            <div class="col">
+                                                <div groups="!base.group_multi_company">
+                                                    <field name="user_id" widget="many2one_avatar_user"
+                                                        options="{'display_avatar_name': True}"/>
+                                                </div>
+                                                <div groups="base.group_multi_company">
+                                                    <t t-if="record.company_id.raw_value != 0">
+                                                        <div class="d-flex flex-row align-items-center">
+                                                            <field name="user_id" widget="many2one_avatar_user"
+                                                                options="{'display_avatar_name': False}"/>
+                                                            <field class="ms-1" name="company_id"/>
+                                                        </div>
+                                                    </t>
+                                                    <t t-else="">
+                                                        <field name="user_id" widget="many2one_avatar_user"
+                                                            options="{'display_avatar_name': True}"/>
+                                                    </t>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div class="col align-content-center">
+                                        <div class="d-flex justify-content-center">
+                                            <field name="no_of_recruitment" class="number fs-1"/>
+                                            <div class="number_description fs-4">
+                                                <span>to</span>
+                                                <span>recruit</span>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div class="col align-content-center">
+                                        <div class="d-flex justify-content-center">
+                                            <field name="new_application_count" class="number fs-1"/>
+                                            <div class="number_description text-body-secondary fs-4">
+                                                <span>new</span>
+                                                <span>applications</span>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div class="col align-content-center">
+                                        <div class="d-flex justify-content-center">
+                                            <field name="old_application_count" class="number fs-1"/>
+                                            <div class="number_description text-body-secondary fs-4">
+                                                <span>in</span>
+                                                <span>progress</span>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div class="col align-content-center">
+                                        <div class="d-flex flex-row justify-content-center mt-1">
+                                            <div class="position-relative">
+                                                <button name="action_open_activities" type="object" class="ps-1 pe-1 pt-0 pb-0">
+                                                    <i class="fa fa-2x fa-clock-o" role="img" aria-label="Activities"></i>
+                                                    <span class="activity_badge position-absolute top-0 start-100 translate-middle badge rounded-pill bg-danger text-light">
+                                                        <field name="activity_count"/>
+                                                    </span> 
+                                                </button>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div class="col align-content-center">
+                                        <div class="d-flex justify-content-center">
+                                            <button class="btn btn-primary" name="%(action_hr_job_applications)d" type="action">
+                                                Job Page
+                                            </button>
+                                        </div>
+                                    </div>
+                                    <div class="col align-content-center">
+                                        <div class="d-flex justify-content-center">
+                                            <button class="btn btn-secondary" type="open">
+                                                Configure
+                                            </button>
+                                        </div>
+                                    </div>
+                                </div>
+                            </main>
+                        </div>
+                        <div class="o_hr_recruitment_kanban_card_mobile_screen">
+                            <main>
+                                <div class="o_hr_recruitment_kanban_card_main_content d-flex flex-column gap-1 mb-1">
                                     <div class="mb-2">
                                         <div class="d-flex fw-bold fs-3">
                                             <field name="is_favorite" widget="boolean_favorite" nolabel="1"/>
@@ -83,105 +174,37 @@
                                         </div>
                                     </div>
                                     <div class="d-flex flex-row">
-                                        <div class="col align-content-center">
-                                            <field name="user_id" widget="many2one_avatar_user"
-                                                options="{'display_avatar_name': True}"/>
-                                        </div>
-                                        <div class="col">
-                                            <span
-                                                name="edit_job"
-                                                type="open"
-                                                t-attf-class="{{ record.no_of_recruitment.raw_value == 0 ? 'text-secondary' : '' }}"
-                                            >
-                                                <div class="d-flex">
-                                                    <field name="no_of_recruitment" class="number"/>
-                                                    <div class="number_description">
-                                                        <span>Open</span>
-                                                        <span>
-                                                            <t t-if="record.no_of_recruitment.raw_value == 1">Slot</t>
-                                                            <t t-else="">Slots</t>
-                                                        </span>
-                                                    </div>
-                                                </div>
-                                            </span>
-                                        </div>
-                                        <div class="col">
-                                            <div class="d-flex">
-                                                <field name="application_count" class="number"/>
-                                                <div class="number_description">
-                                                <span>Open</span>
-                                                    <t t-if="record.application_count.raw_value == 1">Application</t>
-                                                    <t t-else="">Applications</t>
-                                                </div>
-                                            </div>
-                                        </div>
-                                        <div t-if="record.company_id.raw_value" class="col align-content-center" groups="base.group_multi_company">
-                                            <i class="fa fa-building-o" role="img" aria-label="Company" title="Company"></i> <field name="company_id"/>
-                                        </div>
-                                        <div class="col align-content-center">
-                                            <button class="btn btn-primary" name="%(action_hr_job_applications)d" type="action">
-                                                Job Page
-                                            </button>
-                                        </div>
-                                    </div>
-                                </div>
-                                <div name="activities" class="text-end">
-                                    <div class="d-inline-block me-4" invisible="not activities_today and not activities_overdue">
-                                        <a t-if="record.activities_overdue.raw_value > 0" name="action_open_late_activities" type="object" class="text-danger"><field name="activities_overdue"/> Late Activities</a>
-                                        <br t-if="record.activities_today.raw_value > 0 and record.activities_overdue.raw_value > 0"/>
-                                        <a t-if="record.activities_today.raw_value > 0" name="action_open_today_activities" type="object" class="text-warning"><field name="activities_today"/> Activities Today</a>
-                                    </div>
-                                </div>
-                            </main>
-                        </div>
-                        <div class="o_hr_recruitment_kanban_card_mobile_screen">
-                            <main>
-                                <div class="o_hr_recruitment_kanban_card_main_content d-flex flex-column">
-                                    <div class="mb-2">
-                                        <div class="d-flex fw-bold fs-3">
-                                            <field name="is_favorite" widget="boolean_favorite" nolabel="1"/>
-                                            <field name="name"/>
-                                        </div>
-                                        <div t-if="record.alias_email.value" class="d-flex flex-wrap">
-                                            <field name="alias_id"/>
-                                        </div>
-                                    </div>
-                                    <div class="d-flex">
-                                        <div class="col-6 d-flex align-items-center justify-content-center">
-                                            <button class="btn btn-primary" name="%(action_hr_job_applications)d" type="action">
-                                                Job Page
-                                            </button>
-                                        </div>
-                                        <div class="col-6 d-flex">
-                                            <div class="d-flex flex-column text-end me-2">
+                                        <div class="col-1 align-content-end me-1">
+                                            <div class="d-flex flex-row justify-content-center">
                                                 <field name="user_id" widget="many2one_avatar_user"
                                                     options="{'display_avatar_name': False}"/>
-                                                <field name="no_of_recruitment"/>
-                                                <field name="application_count"/>
                                             </div>
-                                            <div class="d-flex flex-column">
+                                        </div>
+                                        <div class="col align-content-end">
+                                            <div groups="base.group_multi_company">
+                                                <t t-if="record.company_id.raw_value != 0">
+                                                    <field name="company_id"/>
+                                                </t>
+                                                <t t-else="">
+                                                    <field name="user_id"/>
+                                                </t>
+                                            </div>
+                                            <div groups="!base.group_multi_company">
                                                 <field name="user_id"/>
-                                                <a
-                                                    name="edit_job"
-                                                    type="open"
-                                                    t-attf-class="{{ record.no_of_recruitment.raw_value == 0 ? 'text-secondary' : '' }}"
-                                                    groups="hr_recruitment.group_hr_recruitment_user"
-                                                >
-                                                    <t t-if="record.no_of_recruitment.raw_value == 1">Open Slot</t>
-                                                    <t t-else="">Open Slots</t>
-                                                </a>
-                                                <span
-                                                    name="edit_job"
-                                                    type="open"
-                                                    t-attf-class="{{ record.no_of_recruitment.raw_value == 0 ? 'text-secondary' : '' }}"
-                                                    groups="!hr_recruitment.group_hr_recruitment_user"
-                                                >
-                                                    <t t-if="record.no_of_recruitment.raw_value == 1">Open Slot</t>
-                                                    <t t-else="">Open Slots</t>
-                                                </span>
-                                                <t t-if="record.application_count.raw_value == 1">Open Application</t>
-                                                <t t-else="">Open Applications</t>
                                             </div>
+                                        </div>
+                                    </div>
+                                    <div class="d-flex flex-row">
+                                        <div class="col-1 align-content-end me-1">
+                                            <div class="d-flex flex-row justify-content-center">
+                                                <i class="fa fa-user fa-2x" title="new_applications_icon"/>
+                                            </div>
+                                        </div>
+                                        <div class="col align-content-end">
+                                            <span>
+                                                <field name="application_count"/>
+                                                <span > new applications</span>
+                                            </span>
                                         </div>
                                     </div>
                                 </div>

--- a/addons/mail/static/src/views/web/activity/activity_cell.xml
+++ b/addons/mail/static/src/views/web/activity/activity_cell.xml
@@ -9,7 +9,7 @@
             <div class="d-flex justify-content-between align-items-center mt-4 px-2">
                 <div class="o-mail-ActivityCell-deadline" t-out="reportingDateFormatted"/>
                 <div class="d-flex justify-content-end">
-                    <div t-if="props.userAssignedIds" class="d-flex justify-content-start">
+                    <div t-if="props.userAssignedIds" class="d-flex justify-content-center">
                         <Avatar t-if="props.userAssignedIds.length > 0"
                                 resModel="'res.users'" resId="props.userAssignedIds[0]"
                                 displayName="''" noSpacing="true"/>

--- a/addons/mail/static/src/views/web/fields/avatar/avatar.xml
+++ b/addons/mail/static/src/views/web/fields/avatar/avatar.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
     <t t-name="mail.Avatar">
-        <div class="o-mail-Avatar o_avatar d-flex align-items-center" t-att-class="props.cssClass">
+        <div class="o-mail-Avatar o_avatar d-flex justify-content-center align-items-center" t-att-class="props.cssClass">
             <img t-attf-class="rounded {{props.noSpacing ? '' : 'me-2'}}"
                 t-attf-src="/web/image/{{props.resModel}}/{{props.resId}}/avatar_128"
                 t-on-click.stop.prevent="onClickAvatar"


### PR DESCRIPTION
Making a cleaner recruitment job positions view:
- Adding activity and configure button directly in the view to avoid losing time clicking o_kanban_card_manage_settings -> Activities/Configuration
- Renaming
	- open slots -> new applications
	- open applications -> new applications
- Adding "in progress" (more convenient)
- Displaying company name when it's possible instead of the user_id (more convenient)

Cleaner recruitment job position for mobile:
- Displaying only usefull infos
- Displaying company name when it's possible instead of the user_id (more convenient)

On job position activities view:
- Adjusting spacing right to the assignee avatar

[IMP] #4762193
