### PR TITLE
[FIX] website_event_* : enhance menu field spacing 

### DIFF
--- a/addons/website_event/views/event_event_views.xml
+++ b/addons/website_event/views/event_event_views.xml
@@ -37,14 +37,14 @@
             </div>
             <xpath expr="//div[hasclass('oe_title')]" position="after">
                 <div name="event_menu_configuration" groups="base.group_no_one">
-                    <label for="website_menu" string="Website Submenu"/>
-                    <field name="website_menu"/>
+                    <label for="website_menu" string="Website Submenu" class="me-1"/>
+                    <field name="website_menu" class="me-3"/>
                     <!-- hidden sub-menus, they are triggered all at once based on "website_menu" -->
                     <field name="introduction_menu" invisible="1"/>
                     <field name="location_menu" invisible="1"/>
                     <field name="register_menu" invisible="1"/>
-                    <label for="community_menu" string="Community" invisible="1"/>
-                    <field name="community_menu" invisible="1"/>
+                    <label for="community_menu" string="Community" invisible="1" class="me-1"/>
+                    <field name="community_menu" invisible="1" class="me-3"/>
                 </div>
             </xpath>
             <field name="tag_ids" position="attributes">

--- a/addons/website_event/views/event_type_views.xml
+++ b/addons/website_event/views/event_type_views.xml
@@ -8,12 +8,12 @@
         <field name="arch" type="xml">
             <xpath expr="//div[hasclass('oe_title')]" position="after">
                     <span name="website_menu">
-                        <label for="website_menu" string="Website Submenu"/>
-                        <field name="website_menu"/>
+                        <label for="website_menu" string="Website Submenu" class="me-1"/>
+                        <field name="website_menu" class="me-3"/>
                     </span>
                     <span name="community_menu" invisible="1">
-                        <label for="community_menu" string="Community"/>
-                        <field name="community_menu"/>
+                        <label for="community_menu" string="Community" class="me-1"/>
+                        <field name="community_menu" class="me-3"/>
                     </span>
             </xpath>
         </field>

--- a/addons/website_event_booth/views/event_event_views.xml
+++ b/addons/website_event_booth/views/event_event_views.xml
@@ -10,8 +10,8 @@
                 <field name="exhibition_map"/>
             </field>
             <field name="website_menu" position="after">
-                <label for="booth_menu"/>
-                <field name="booth_menu"/>
+                <label for="booth_menu" class="me-1"/>
+                <field name="booth_menu" class="me-3"/>
             </field>
         </field>
     </record>

--- a/addons/website_event_booth/views/event_type_views.xml
+++ b/addons/website_event_booth/views/event_type_views.xml
@@ -8,8 +8,8 @@
         <field name="arch" type="xml">
             <xpath expr="//span[@name='website_menu']" position='after'>
                 <span>
-                    <label for="booth_menu" string="Booth Menu Item"/>
-                    <field name="booth_menu"/>
+                    <label for="booth_menu" string="Booth Menu Item" class="me-1"/>
+                    <field name="booth_menu" class="me-3"/>
                 </span>
             </xpath>
         </field>

--- a/addons/website_event_exhibitor/views/event_event_views.xml
+++ b/addons/website_event_exhibitor/views/event_event_views.xml
@@ -16,8 +16,8 @@
                 </button>
             </field>
             <xpath expr="//label[@for='community_menu']" position="before">
-                <label for="exhibitor_menu"/>
-                <field name="exhibitor_menu"/>
+                <label for="exhibitor_menu" class="me-1"/>
+                <field name="exhibitor_menu" class="me-3"/>
             </xpath>
         </field>
     </record>

--- a/addons/website_event_exhibitor/views/event_type_views.xml
+++ b/addons/website_event_exhibitor/views/event_type_views.xml
@@ -7,8 +7,8 @@
         <field name="arch" type="xml">
                 <xpath expr="//span[@name='community_menu']" position='before'>
                 <span name="exhibitor_menu">
-                    <label for="exhibitor_menu" string="Exhibitors Menu Item"/>
-                    <field name="exhibitor_menu"/>
+                    <label for="exhibitor_menu" string="Exhibitors Menu Item" class="me-1"/>
+                    <field name="exhibitor_menu" class="me-3"/>
                 </span>
             </xpath>
         </field>

--- a/addons/website_event_track/views/event_event_views.xml
+++ b/addons/website_event_track/views/event_event_views.xml
@@ -16,10 +16,10 @@
                 </button>
             </xpath>
             <xpath expr="//field[@name='website_menu']" position="after">
-                <label for="website_track" string="Showcase Tracks"/>
-                <field name="website_track"/>
-                <label for="website_track_proposal" string="Allow Track Proposals"/>
-                <field name="website_track_proposal"/>
+                <label for="website_track" string="Showcase Tracks" class="me-1"/>
+                <field name="website_track" class="me-3"/>
+                <label for="website_track_proposal" string="Allow Track Proposals" class="me-1"/>
+                <field name="website_track_proposal" class="me-3"/>
             </xpath>
         </field>
     </record>

--- a/addons/website_event_track/views/event_type_views.xml
+++ b/addons/website_event_track/views/event_type_views.xml
@@ -8,12 +8,12 @@
         <field name="arch" type="xml">
                 <xpath expr="//span[@name='website_menu']" position='after'>
                 <span>
-                    <label for="website_track" string="Tracks Menu Item"/>
-                    <field name="website_track"/>
+                    <label for="website_track" string="Tracks Menu Item" class="me-1"/>
+                    <field name="website_track" class="me-3"/>
                 </span>
                 <span name="website_track_proposal">
-                    <label for="website_track_proposal" string="Track Proposals Menu Item"/>
-                    <field name="website_track_proposal"/>
+                    <label for="website_track_proposal" string="Track Proposals Menu Item" class="me-1"/>
+                    <field name="website_track_proposal" class="me-3"/>
                 </span>
             </xpath>
         </field>


### PR DESCRIPTION
The PR fixes the display of the fields displayed when the debug mode is activated and used to show buttons in the menu of event website pages. Previously, it was difficult to determine what were the labels of the fields. To make it clearer, the spaces between the label-field couples have been increased. 

Task-4750239