### PR TITLE
[FIX] hr_employee: Fixing missing edit properties action in hr_employ…

### DIFF
--- a/addons/hr/views/hr_employee_views.xml
+++ b/addons/hr/views/hr_employee_views.xml
@@ -150,6 +150,7 @@
                                 <field name="company_id" groups="base.group_multi_company"/>
                             </group>
                         </group>
+                        <field name="employee_properties" columns="2"/>
                         <notebook>
                             <page name="global_information" string="Global Information" groups="hr.group_hr_user">
                                 <group>


### PR DESCRIPTION
In this PR, we re-introduced the missing edit properties action in hr_employee form view. the new added properties will be displayed on the top (as before).
Description of the issue/feature this PR addresses:

Current behavior before PR:
![image](https://github.com/user-attachments/assets/82e8098e-c802-4fbf-b22d-f18486703776)

Desired behavior after PR is merged:
![image](https://github.com/user-attachments/assets/a9e26565-7fd1-4fd4-af77-4a99a1e735ff)

Task: 4868118.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
