### PR TITLE
[FIX] pos_loyalty: prevent adding points again when settling order

### DIFF
--- a/addons/pos_loyalty/static/src/app/models/pos_order_line.js
+++ b/addons/pos_loyalty/static/src/app/models/pos_order_line.js
@@ -59,8 +59,9 @@ patch(PosOrderline.prototype, {
     },
     ignoreLoyaltyPoints({ program }) {
         return (
-            ["gift_card", "ewallet"].includes(program.program_type) &&
-            this._e_wallet_program_id?.id !== program.id
+            (["gift_card", "ewallet"].includes(program.program_type) &&
+                this._e_wallet_program_id?.id !== program.id) ||
+            this.settled_order_id
         );
     },
     isGiftCardOrEWalletReward() {

--- a/addons/pos_loyalty/static/tests/tours/pos_loyalty_tour.js
+++ b/addons/pos_loyalty/static/tests/tours/pos_loyalty_tour.js
@@ -2,6 +2,7 @@ import * as PosLoyalty from "@pos_loyalty/../tests/tours/utils/pos_loyalty_util"
 import * as ProductScreen from "@point_of_sale/../tests/pos/tours/utils/product_screen_util";
 import * as TicketScreen from "@point_of_sale/../tests/pos/tours/utils/ticket_screen_util";
 import * as SelectionPopup from "@point_of_sale/../tests/generic_helpers/selection_popup_util";
+import * as PartnerList from "@point_of_sale/../tests/pos/tours/utils/partner_list_util";
 import * as Dialog from "@point_of_sale/../tests/generic_helpers/dialog_util";
 import * as Chrome from "@point_of_sale/../tests/pos/tours/utils/chrome_util";
 import * as Notification from "@point_of_sale/../tests/generic_helpers/notification_util";
@@ -589,5 +590,18 @@ registry.category("web_tour.tours").add("test_two_variant_same_discount", {
             Dialog.confirm("Open Register"),
             ProductScreen.clickDisplayedProduct("Sofa"),
             Chrome.clickBtn("Add"),
+        ].flat(),
+});
+
+registry.category("web_tour.tours").add("test_settle_dont_give_points_again", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            ProductScreen.clickPartnerButton(),
+            PartnerList.clickPartnerOptions("AAA Partner"),
+            PartnerList.clickDropDownItemText("Settle due accounts"),
+            PartnerList.clickSettleOrderName("Shop/"),
+            ProductScreen.totalAmountIs("10.00"),
         ].flat(),
 });

--- a/addons/pos_loyalty/tests/test_frontend.py
+++ b/addons/pos_loyalty/tests/test_frontend.py
@@ -2787,3 +2787,62 @@ class TestUi(TestPointOfSaleHttpCommon):
             "test_buy_x_get_y_reward_qty",
             login="pos_user"
         )
+
+    def test_settle_dont_give_points_again(self):
+        """
+        Tests that when settling an order that has been partially paid, it does not give the loyalty
+        points again. All of them should be given during the first transaction.
+        """
+        if self.main_pos_config.current_session_id:
+            self.main_pos_config.current_session_id.action_pos_session_closing_control()
+        LoyaltyProgram = self.env['loyalty.program']
+        (LoyaltyProgram.search([])).write({'pos_ok': False})
+        self.loyalty_program = self.env['loyalty.program'].create({
+            'name': 'Loyalty Program Test',
+            'program_type': 'promotion',
+            'pos_ok': True,
+            'pos_config_ids': [Command.link(self.main_pos_config.id)],
+            'rule_ids': [Command.create({
+                'reward_point_mode': 'money',
+                'reward_point_amount': 1,
+                'minimum_qty': 0,
+            })],
+            'reward_ids': [Command.create({
+                'reward_type': 'discount',
+                'discount': 1,
+                'discount_mode': 'per_point',
+            })],
+        })
+        partner_aaa = self.env['res.partner'].create({'name': 'AAA Partner'})
+        self.customer_account_payment_method = self.env['pos.payment.method'].create({
+            'name': 'Customer Account',
+            'split_transactions': True,
+        })
+        self.main_pos_config.write({
+            'payment_method_ids': [(4, self.customer_account_payment_method.id, 0)],
+        })
+        self.main_pos_config.open_ui()
+        order = self.env['pos.order'].create({
+            'company_id': self.company.id,
+            'session_id': self.main_pos_config.current_session_id.id,
+            'partner_id': partner_aaa.id,
+            'lines': [Command.create({
+                'product_id': self.wall_shelf.product_variant_id.id,
+                'price_unit': 10,
+                'discount': 0,
+                'qty': 1,
+                'price_subtotal': 10,
+                'price_subtotal_incl': 10,
+            })],
+            'amount_paid': 10.0,
+            'amount_total': 10.0,
+            'amount_tax': 0.0,
+            'amount_return': 0.0,
+            'to_invoice': True,
+        })
+        payment_context = {"active_id": order.id, "active_ids": order.ids}
+        self.env['pos.make.payment'].with_context(**payment_context).create({
+            'amount': 10.0,
+            'payment_method_id': self.customer_account_payment_method.id,
+        }).check()
+        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'test_settle_dont_give_points_again', login="accountman")


### PR DESCRIPTION
**Problem:**
When settling an order that has been paid with a customer account or that has an amount due for that customer, the loyalty points will be awarded again depending on the amount paid. This means that the customer will receive the points in full when making the order, and one more time when settling said order.

**Steps to reproduce:**
- Make a purchase with Customer Account as payment method
- The points are awarded in full
- Go to the customer tab and click settle due accounts
- Select your order and pay for it
- The points are awarded once again depending on how much was left to pay

**Why the fix:**
The points should just be awarded once when the order is confirmed, even
if it has not been paid for yet. We now ignore the line if it's about
a settled order, as those points have already been awarded.

opw-4770142