### PR TITLE
[REF] web_tour: declare when tour will unload

### DIFF
--- a/addons/auth_totp/static/tests/totp_flow.js
+++ b/addons/auth_totp/static/tests/totp_flow.js
@@ -10,7 +10,8 @@ function openRoot() {
         run() {
             document.querySelector("body").classList.add("wait");
             window.location = '/odoo';
-        }
+        },
+        willUnload: true,
     }, {
         content: "wait for client reload",
         trigger: 'body:not(.wait)',
@@ -141,6 +142,7 @@ registry.category("web_tour.tours").add('totp_login_enabled', {
     content: "check that we're on the login page or go to it",
     trigger: 'input#login, a:contains(Sign in)',
     run: "click",
+    willUnload: true,
 }, {
     content: "input login",
     trigger: 'input#login',
@@ -153,6 +155,7 @@ registry.category("web_tour.tours").add('totp_login_enabled', {
     content: "click da button",
     trigger: 'button:contains("Log in")',
     run: "click",
+    willUnload: true,
 }, {
     content: "expect totp screen",
     trigger: 'label:contains(Authentication Code)',
@@ -168,6 +171,7 @@ registry.category("web_tour.tours").add('totp_login_enabled', {
 }, {
     trigger: `button:contains("Log in")`,
     run: "click",
+    willUnload: true,
 }, {
     content: "using an incorrect token should fail",
     trigger: "p.alert.alert-danger:contains(Verification failed, please double-check the 6-digit code)",
@@ -182,6 +186,7 @@ registry.category("web_tour.tours").add('totp_login_enabled', {
 }, {
     trigger: `button:contains("Log in")`,
     run: "click",
+    willUnload: true,
 }, {
     content: "reusing the same token should fail",
     trigger: "p.alert.alert-danger:contains(Verification failed, please use the latest 6-digit code)",
@@ -196,6 +201,7 @@ registry.category("web_tour.tours").add('totp_login_enabled', {
 {
     trigger: `button:contains("Log in")`,
     run: "click",
+    willUnload: true,
 }, {
     content: "check we're logged in",
     trigger: ".o_user_menu .dropdown-toggle",
@@ -207,6 +213,7 @@ registry.category("web_tour.tours").add('totp_login_device', {
     content: "check that we're on the login page or go to it",
     trigger: 'input#login, a:contains(Sign in)',
     run: "click",
+    willUnload: true,
 }, {
     content: "input login",
     trigger: 'input#login',
@@ -219,6 +226,7 @@ registry.category("web_tour.tours").add('totp_login_device', {
     content: "click da button",
     trigger: 'button:contains("Log in")',
     run: "click",
+    willUnload: true,
 }, {
     content: "expect totp screen",
     trigger: 'label:contains(Authentication Code)',
@@ -238,6 +246,7 @@ registry.category("web_tour.tours").add('totp_login_device', {
 {
     trigger: "button:contains(Log in)",
     run: "click",
+    willUnload: true,
 },
 {
     content: "check we're logged in",
@@ -247,6 +256,7 @@ registry.category("web_tour.tours").add('totp_login_device', {
     content: "click the Log out button",
     trigger: '.dropdown-item[data-menu=logout]',
     run: "click",
+    willUnload: true,
 }, {
     content: "check that we're back on the login page or go to it",
     trigger: 'input#login, a:contains(Log in)',
@@ -263,6 +273,7 @@ registry.category("web_tour.tours").add('totp_login_device', {
     content: "click da button again",
     trigger: 'button:contains("Log in")',
     run: "click",
+    willUnload: true,
 },  {
     content: "check we're logged in without 2FA",
     trigger: ".o_user_menu .dropdown-toggle",
@@ -273,12 +284,11 @@ registry.category("web_tour.tours").add('totp_login_device', {
 ...openUserProfileAtSecurityTab(),
 {
     content: "Open totp wizard",
-    //TODO: remove when PIPU macro PR is merged: https://github.com/odoo/odoo/pull/194508
     trigger: 'a[role=tab]:contains("Account Security").active',
-    async run(actions) {
-        const el = await waitFor('button[name=action_totp_disable]', { timeout: 5000 });
-        await actions.click(el);
-    }
+},
+{
+    trigger: "button[name=action_totp_disable]",
+    run: "click",
 },
 {
     trigger: ".modal div:contains(entering your password)",
@@ -309,6 +319,7 @@ registry.category("web_tour.tours").add('totp_login_disabled', {
     content: "check that we're on the login page or go to it",
     trigger: 'input#login, a:contains(Sign in)',
     run: "click",
+    willUnload: true,
 }, {
     content: "input login",
     trigger: 'input#login',
@@ -321,6 +332,7 @@ registry.category("web_tour.tours").add('totp_login_disabled', {
     content: "click da button",
     trigger: 'button:contains("Log in")',
     run: "click",
+    willUnload: true,
 },
 // normally we'd end the tour here as it's all we care about but there are a
 // bunch of ongoing queries from the loading of the web client which cause

--- a/addons/auth_totp_portal/static/tests/totp_portal.js
+++ b/addons/auth_totp_portal/static/tests/totp_portal.js
@@ -24,17 +24,21 @@ registry.category("web_tour.tours").add('totportal_tour_setup', {
 }, {
     content: "Get secret from collapsed div",
     trigger: 'a:contains("Cannot scan it?")',
-    run: async function(helpers) {
-        const secret = this.anchor
-            .closest("div")
-            .querySelector('span[name="secret"]').textContent;
+},
+{
+    trigger: `span[name="secret"]:hidden`,
+    async run(helpers) {
+        const secret = this.anchor.textContent;
         const token = await rpc("/totphook", {
             secret,
             offset: 0,
         });
         await helpers.edit(token, 'input[name="code"]');
-        await helpers.click("button.btn-primary:contains(Activate)");
     }
+}, {
+    trigger: "button.btn-primary:contains(Activate)",
+    run: "click",
+    willUnload: true,
 }, {
     content: "Check that the button has changed",
     trigger: 'button:contains(Disable two-factor authentication)',
@@ -46,6 +50,7 @@ registry.category("web_tour.tours").add('totportal_login_enabled', {
     content: "check that we're on the login page or go to it",
     trigger: 'input#login, a:contains(Sign in)',
     run: "click",
+    willUnload: true,
 }, {
     content: "input login",
     trigger: 'input#login',
@@ -58,6 +63,7 @@ registry.category("web_tour.tours").add('totportal_login_enabled', {
     content: "click da button",
     trigger: 'button:contains("Log in")',
     run: "click",
+    willUnload: true,
 }, {
     content: "expect totp screen",
     trigger: 'label:contains(Authentication Code)',
@@ -68,10 +74,11 @@ registry.category("web_tour.tours").add('totportal_login_enabled', {
     run: async function (helpers) {
         const token = await rpc('/totphook', { offset: 1 });
         await helpers.edit(token);
-        // FIXME: is there a way to put the button as its own step trigger without
-        //        the tour straight blowing through and not waiting for this?
-        await helpers.click('button:contains("Log in")');
     }
+}, {
+    trigger: "button:contains(Log in)",
+    run: "click",
+    willUnload: true,
 }, {
     content: "check we're logged in",
     trigger: "h3:contains(My account)",
@@ -79,6 +86,7 @@ registry.category("web_tour.tours").add('totportal_login_enabled', {
     content: "go back to security",
     trigger: "a:contains(Security)",
     run: "click",
+    willUnload: true,
 },{
     content: "Open totp wizard",
     trigger: 'button#auth_totp_portal_disable',
@@ -89,11 +97,12 @@ registry.category("web_tour.tours").add('totportal_login_enabled', {
 }, {
     content: "Input password",
     trigger: '[name=password]',
-    run: "edit portal", // FIXME: better way to do this?
+    run: "edit portal",
 }, {
     content: "Confirm",
     trigger: "button:contains(Confirm Password)",
     run: "click",
+    willUnload: true,
 }, {
     content: "Check that the button has changed",
     trigger: 'button:contains(Enable two-factor authentication)',
@@ -105,6 +114,7 @@ registry.category("web_tour.tours").add('totportal_login_disabled', {
     content: "check that we're on the login page or go to it",
     trigger: 'input#login, a:contains(Sign in)',
     run: "click",
+    willUnload: true,
 }, {
     content: "input login",
     trigger: 'input#login',
@@ -117,6 +127,7 @@ registry.category("web_tour.tours").add('totportal_login_disabled', {
     content: "click da button",
     trigger: 'button:contains("Log in")',
     run: "click",
+    willUnload: true,
 }, {
     content: "check we're logged in",
     trigger: "h3:contains(My account)",

--- a/addons/hr_holidays/static/src/tours/hr_leave_type_tour.js
+++ b/addons/hr_holidays/static/src/tours/hr_leave_type_tour.js
@@ -122,6 +122,7 @@ registry.category("web_tour.tours").add("hr_leave_type_tour", {
             content: "Confirm the company selection",
             tooltipPosition: "bottom",
             run: "click",
+            willUnload: true,
         },
         {
             trigger: "button.o_form_button_create",

--- a/addons/l10n_be_pos_sale/static/tests/tours/l10n_be_pos_sale_tour.js
+++ b/addons/l10n_be_pos_sale/static/tests/tours/l10n_be_pos_sale_tour.js
@@ -22,7 +22,7 @@ registry.category("web_tour.tours").add("PosSettleOrderIsInvoice", {
             Dialog.confirm(),
             PaymentScreen.isInvoiceButtonChecked(),
             PaymentScreen.clickPaymentMethod("Cash"),
-            PaymentScreen.clickValidate(),
+            PaymentScreen.clickValidate({ willUnload: "continue" }),
             ReceiptScreen.isShown(),
             ReceiptScreen.clickNextOrder(),
 
@@ -54,7 +54,7 @@ registry.category("web_tour.tours").add("test_pos_branch_company_access", {
             ProductScreen.clickDisplayedProduct("Product A"),
             ProductScreen.clickPayButton(),
             PaymentScreen.clickPaymentMethod("Bank"),
-            PaymentScreen.clickValidate(),
+            PaymentScreen.clickValidate({ willUnload: "continue" }),
             ReceiptScreen.isShown(),
         ].flat(),
 });

--- a/addons/l10n_ec_website_sale/static/tests/tours/website_sale_checkout_address.js
+++ b/addons/l10n_ec_website_sale/static/tests/tours/website_sale_checkout_address.js
@@ -4,12 +4,13 @@ import * as tourUtils from "@website_sale/js/tours/tour_utils";
 registry.category("web_tour.tours").add("shop_checkout_address_ec", {
     url: "/shop",
     steps: () => [
-        ...tourUtils.addToCart({ productName: "Test Product" }),
+        ...tourUtils.addToCart({ productName: "Test Product", willUnload: true }),
         tourUtils.goToCart({ quantity: 1 }),
         {
             content: "Go to checkout",
             trigger: "a:contains('Checkout')",
             run: "click",
+            willUnload: true,
         },
         {
             content: "Check that VAT field is present",

--- a/addons/l10n_es_pos/static/tests/tours/spanish_pos_tour.js
+++ b/addons/l10n_es_pos/static/tests/tours/spanish_pos_tour.js
@@ -30,13 +30,13 @@ registry.category("web_tour.tours").add("spanish_pos_tour", {
             Dialog.confirm(),
 
             PaymentScreen.clickInvoiceButton(),
-            PaymentScreen.clickValidate(),
+            PaymentScreen.clickValidate({ willUnload: "continue" }),
             // verify that the pos requires the selection of a partner
             Dialog.confirm(),
             PartnerList.clickPartner(""),
 
             PaymentScreen.isInvoiceOptionSelected(),
-            PaymentScreen.clickValidate(),
+            PaymentScreen.clickValidate({ willUnload: "continue" }),
             {
                 content:
                     "verify that the simplified invoice number does not appear on the receipt, because this order is invoiced, so it does not have a simplified invoice number",
@@ -51,7 +51,7 @@ registry.category("web_tour.tours").add("spanish_pos_tour", {
             ProductScreen.addOrderline("Desk Pad", "1"),
             ProductScreen.clickPayButton(),
             PaymentScreen.clickPaymentMethod("Customer Account"),
-            PaymentScreen.clickValidate(),
+            PaymentScreen.clickValidate({ willUnload: "continue" }),
             Dialog.is({ title: "Customer Required" }),
         ].flat(),
 });

--- a/addons/l10n_it_edi/static/tests/tours/l10n_it_edi_address_codice_fiscale.js
+++ b/addons/l10n_it_edi/static/tests/tours/l10n_it_edi_address_codice_fiscale.js
@@ -1,5 +1,4 @@
 import { registry } from "@web/core/registry";
-import { queryValue } from "@odoo/hoot-dom";
 
 registry.category("web_tour.tours").add("portal_compute_codice_fiscale", {
     url: "/my",
@@ -8,6 +7,7 @@ registry.category("web_tour.tours").add("portal_compute_codice_fiscale", {
             content: "Check portal is loaded",
             trigger: 'a[href*="/my/account"]:contains("Edit"):first',
             run: "click",
+            willUnload: true,
         },
         {
             content: "Load my account details",
@@ -16,30 +16,25 @@ registry.category("web_tour.tours").add("portal_compute_codice_fiscale", {
         },
         {
             content: "Fill address form with VAT",
-            trigger: 'form.address_autoformat',
+            trigger: "form.address_autoformat",
             run: function () {
-                $('input[name="phone"]').val('99999999');
-                $('input[name="email"]').val('abc@odoo.com');
-                $('input[name="vat"]').val('IT12345670017');
-                $('input[name="street"]').val('SO1 Billing Street, 33');
-                $('input[name="city"]').val('SO1BillingCity');
-                $('input[name="zip"]').val('10000');
+                $('input[name="phone"]').val("99999999");
+                $('input[name="email"]').val("abc@odoo.com");
+                $('input[name="vat"]').val("IT12345670017");
+                $('input[name="street"]').val("SO1 Billing Street, 33");
+                $('input[name="city"]').val("SO1BillingCity");
+                $('input[name="zip"]').val("10000");
             },
         },
         {
-            id: 'o_country_id',
+            id: "o_country_id",
             content: "Select country with code 'IT' to trigger compute of Codice Fiscale",
             trigger: 'select[name="country_id"]',
             run: `selectByLabel Italy`,
         },
         {
             content: "Check if the Codice Fiscale value matches",
-            trigger: "input[name='l10n_it_codice_fiscale']",
-            run: () => {
-                if (queryValue("input[name='l10n_it_codice_fiscale']") !== "12345670017") {
-                    console.error('Expected "12345670017" for Codice Fiscale.');
-                }
-            }
+            trigger: "input[name='l10n_it_codice_fiscale']:value(12345670017)",
         },
         {
             content: "Add state",
@@ -47,12 +42,14 @@ registry.category("web_tour.tours").add("portal_compute_codice_fiscale", {
             run: "selectByIndex 2",
         },
         {
-             content: "Submit the form",
-             trigger: 'button[id=save_address]',
-             run: "click",
-         },
-         {
-             content: "Check that we are back on the portal",
-             trigger: 'a[href*="/my/account"]:contains("Edit"):first',
-         }
-]});
+            content: "Submit the form",
+            trigger: "button[id=save_address]",
+            run: "click",
+            willUnload: true,
+        },
+        {
+            content: "Check that we are back on the portal",
+            trigger: 'a[href*="/my/account"]:contains("Edit"):first',
+        },
+    ],
+});

--- a/addons/mail/static/tests/tours/discuss_channel_public_tour.js
+++ b/addons/mail/static/tests/tours/discuss_channel_public_tour.js
@@ -129,6 +129,7 @@ registry.category("web_tour.tours").add("discuss_channel_public_tour.js", {
             run() {
                 location.reload();
             },
+            willUnload: true,
         },
         {
             content: "Remove reaction",
@@ -141,6 +142,7 @@ registry.category("web_tour.tours").add("discuss_channel_public_tour.js", {
             run() {
                 location.reload();
             },
+            willUnload: true,
         },
         {
             trigger: ".o-mail-Message:not(:has(.o-mail-MessageReaction))",
@@ -174,11 +176,13 @@ registry.category("web_tour.tours").add("discuss_channel_public_tour.js", {
             },
         },
         {
-            trigger: ".o-mail-Message .o-mail-Composer .o-mail-AttachmentContainer:not(.o-isUploading)", // waiting the attachment to be uploaded
+            trigger:
+                ".o-mail-Message .o-mail-Composer .o-mail-AttachmentContainer:not(.o-isUploading)", // waiting the attachment to be uploaded
         },
         {
             content: "Check the earlier provided extra attachment is listed",
-            trigger: '.o-mail-Message .o-mail-Composer .o-mail-AttachmentContainer[title="extra.txt"]',
+            trigger:
+                '.o-mail-Message .o-mail-Composer .o-mail-AttachmentContainer[title="extra.txt"]',
         },
         {
             content: "Save edited message",

--- a/addons/mrp_subcontracting/static/tests/tours/subcontracting_portal_tour.js
+++ b/addons/mrp_subcontracting/static/tests/tours/subcontracting_portal_tour.js
@@ -7,6 +7,7 @@ registry.category("web_tour.tours").add('subcontracting_portal_tour', {
             trigger: 'table > tbody > tr a:has(span:contains(WH/IN/00))',
             content: 'Select the picking to open the backend view.',
             run: 'click',
+            willUnload: true,
         },{
             trigger: ':iframe .o_subcontracting_portal',
             content: 'Wait the subcontracting portal to be loaded.',

--- a/addons/point_of_sale/static/tests/generic_helpers/utils.js
+++ b/addons/point_of_sale/static/tests/generic_helpers/utils.js
@@ -5,8 +5,8 @@ import { simulateBarCode } from "@barcodes/../tests/legacy/helpers";
 export function negate(selector, parent = "body") {
     return `${parent}:not(:has(${selector}))`;
 }
-export function run(run, content = "run function") {
-    return { content, trigger: "body", run };
+export function run(run, content = "run function", willUnload = false) {
+    return { content, trigger: "body", run, willUnload };
 }
 export function scan_barcode(barcode) {
     return [
@@ -27,24 +27,28 @@ export function negateStep(step) {
     };
 }
 export function refresh() {
-    return run(async () => {
-        await new Promise((resolve) => {
-            const checkTransaction = () => {
-                const activeTransactions = posmodel.data.indexedDB.activeTransactions;
-                if (activeTransactions <= 0) {
-                    window.location.reload();
-                    resolve();
-                } else {
-                    setTimeout(checkTransaction, 100);
-                }
-            };
+    return run(
+        async () => {
+            await new Promise((resolve) => {
+                const checkTransaction = () => {
+                    const activeTransactions = posmodel.data.indexedDB.activeTransactions;
+                    if (activeTransactions <= 0) {
+                        window.location.reload();
+                        resolve();
+                    } else {
+                        setTimeout(checkTransaction, 100);
+                    }
+                };
 
-            checkTransaction();
-            setTimeout(() => {
-                throw new Error("Timeout waiting indexedDB for transactions to finish");
-            }, 2000);
-        });
-    }, "refresh page");
+                checkTransaction();
+                setTimeout(() => {
+                    throw new Error("Timeout waiting indexedDB for transactions to finish");
+                }, 2000);
+            });
+        },
+        "refresh page",
+        true
+    );
 }
 export function elementDoesNotExist(selector) {
     return {

--- a/addons/point_of_sale/static/tests/pos/tours/chrome_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/chrome_tour.js
@@ -91,7 +91,7 @@ registry.category("web_tour.tours").add("ChromeTour", {
 
             // click next screen on order 3
             // then delete the new empty order
-            ReceiptScreen.clickNextOrder(),
+            ReceiptScreen.clickNextOrder({ willUnload: "continue" }),
             ProductScreen.orderIsEmpty(),
             Chrome.clickOrders(),
             TicketScreen.deleteOrder("004"),
@@ -114,7 +114,7 @@ registry.category("web_tour.tours").add("ChromeTour", {
             ReceiptScreen.isShown(),
 
             // Cancelling a floating order should remove it from the floating orders list.
-            ReceiptScreen.clickNextOrder(),
+            ReceiptScreen.clickNextOrder({ willUnload: "continue" }),
             Chrome.hasFloatingOrder("006"),
             ProductScreen.clickReview(),
             ProductScreen.clickControlButton("Cancel Order"),
@@ -156,7 +156,12 @@ registry.category("web_tour.tours").add("test_tracking_number_closing_session", 
             ReceiptScreen.clickNextOrder(),
             ProductScreen.isShown(),
             Chrome.clickMenuOption("Close Register"),
-            Utils.selectButton("Close Register"),
+            {
+                content: `Select button close register`,
+                trigger: `button:contains(close register)`,
+                run: "click",
+                willUnload: true,
+            },
             Chrome.startPoS(),
             Dialog.confirm("Open Register"),
             ProductScreen.clickDisplayedProduct("Desk Pad", true, "1.0"),

--- a/addons/point_of_sale/static/tests/pos/tours/pos_cash_rounding_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/pos_cash_rounding_tour.js
@@ -26,7 +26,7 @@ registry
                 PaymentScreen.clickPaymentMethod("Cash"),
                 PaymentScreen.remainingIs("0.0"),
                 PaymentScreen.clickInvoiceButton(),
-                PaymentScreen.clickValidate(),
+                PaymentScreen.clickValidate({ willUnload: "continue" }),
 
                 ReceiptScreen.receiptAmountTotalIs("15.72"),
                 ReceiptScreen.receiptRoundingAmountIs("-0.02"),
@@ -52,7 +52,7 @@ registry
                 PaymentScreen.totalIs("-15.72"),
                 PaymentScreen.clickPaymentMethod("Cash"),
                 PaymentScreen.remainingIs("0.0"),
-                PaymentScreen.clickValidate(),
+                PaymentScreen.clickValidate({ willUnload: "continue" }),
 
                 ReceiptScreen.receiptAmountTotalIs("-15.72"),
                 ReceiptScreen.receiptRoundingAmountIs("0.02"),
@@ -88,7 +88,7 @@ registry
                     PaymentScreen.clickPaymentMethod("Cash"),
                     PaymentScreen.remainingIs("0.0"),
                     PaymentScreen.clickInvoiceButton(),
-                    PaymentScreen.clickValidate(),
+                    PaymentScreen.clickValidate({ willUnload: "continue" }),
 
                     ReceiptScreen.receiptAmountTotalIs("15.72"),
                     ReceiptScreen.receiptRoundingAmountIs("0.01"),
@@ -117,7 +117,7 @@ registry
                     PaymentScreen.remainingIs("-15.04"),
                     PaymentScreen.clickPaymentMethod("Cash"),
                     PaymentScreen.remainingIs("0.0"),
-                    PaymentScreen.clickValidate(),
+                    PaymentScreen.clickValidate({ willUnload: "continue" }),
 
                     ReceiptScreen.receiptAmountTotalIs("-15.72"),
                     ReceiptScreen.receiptRoundingAmountIs("-0.01"),
@@ -152,7 +152,7 @@ registry
                 PaymentScreen.clickPaymentMethod("Cash"),
                 PaymentScreen.remainingIs("0.0"),
                 PaymentScreen.clickInvoiceButton(),
-                PaymentScreen.clickValidate(),
+                PaymentScreen.clickValidate({ willUnload: "continue" }),
 
                 ReceiptScreen.receiptAmountTotalIs("15.72"),
                 ReceiptScreen.receiptRoundingAmountIsNotThere(),
@@ -182,7 +182,7 @@ registry
                 PaymentScreen.remainingIs("-15.05"),
                 PaymentScreen.clickPaymentMethod("Cash"),
                 PaymentScreen.remainingIs("0.0"),
-                PaymentScreen.clickValidate(),
+                PaymentScreen.clickValidate({ willUnload: "continue" }),
 
                 ReceiptScreen.receiptAmountTotalIs("-15.72"),
                 ReceiptScreen.receiptRoundingAmountIsNotThere(),
@@ -218,7 +218,7 @@ registry
                     PaymentScreen.clickPaymentMethod("Cash"),
                     PaymentScreen.remainingIs("0.0"),
                     PaymentScreen.clickInvoiceButton(),
-                    PaymentScreen.clickValidate(),
+                    PaymentScreen.clickValidate({ willUnload: "continue" }),
 
                     ReceiptScreen.receiptAmountTotalIs("15.72"),
                     ReceiptScreen.receiptRoundingAmountIs("-0.04"),
@@ -247,7 +247,7 @@ registry
                     PaymentScreen.remainingIs("-15.04"),
                     PaymentScreen.clickPaymentMethod("Cash"),
                     PaymentScreen.remainingIs("0.0"),
-                    PaymentScreen.clickValidate(),
+                    PaymentScreen.clickValidate({ willUnload: "continue" }),
 
                     ReceiptScreen.receiptAmountTotalIs("-15.72"),
                     ReceiptScreen.receiptRoundingAmountIs("0.04"),
@@ -282,7 +282,7 @@ registry
                 PaymentScreen.clickPaymentMethod("Cash"),
                 PaymentScreen.remainingIs("0.0"),
                 PaymentScreen.clickInvoiceButton(),
-                PaymentScreen.clickValidate(),
+                PaymentScreen.clickValidate({ willUnload: "continue" }),
 
                 ReceiptScreen.receiptAmountTotalIs("15.72"),
                 ReceiptScreen.receiptRoundingAmountIs("0.02"),
@@ -311,7 +311,7 @@ registry
                 PaymentScreen.remainingIs("-15.08"),
                 PaymentScreen.clickPaymentMethod("Cash"),
                 PaymentScreen.remainingIs("0.0"),
-                PaymentScreen.clickValidate(),
+                PaymentScreen.clickValidate({ willUnload: "continue" }),
 
                 ReceiptScreen.receiptAmountTotalIs("-15.72"),
                 ReceiptScreen.receiptRoundingAmountIs("-0.02"),
@@ -342,7 +342,7 @@ registry
                 PaymentScreen.clickPaymentMethod("Cash"),
                 PaymentScreen.remainingIs("0.0"),
                 PaymentScreen.clickInvoiceButton(),
-                PaymentScreen.clickValidate(),
+                PaymentScreen.clickValidate({ willUnload: "continue" }),
 
                 ReceiptScreen.receiptAmountTotalIs("15.72"),
                 ReceiptScreen.receiptRoundingAmountIs("-0.02"),
@@ -368,7 +368,7 @@ registry
                 PaymentScreen.totalIs("-15.72"),
                 PaymentScreen.clickPaymentMethod("Cash"),
                 PaymentScreen.remainingIs("0.0"),
-                PaymentScreen.clickValidate(),
+                PaymentScreen.clickValidate({ willUnload: "continue" }),
 
                 ReceiptScreen.receiptAmountTotalIs("-15.72"),
                 ReceiptScreen.receiptRoundingAmountIs("0.02"),
@@ -403,7 +403,7 @@ registry
                 PaymentScreen.clickPaymentMethod("Cash"),
                 PaymentScreen.remainingIs("0.0"),
                 PaymentScreen.clickInvoiceButton(),
-                PaymentScreen.clickValidate(),
+                PaymentScreen.clickValidate({ willUnload: "continue" }),
 
                 ReceiptScreen.receiptAmountTotalIs("15.72"),
                 ReceiptScreen.receiptRoundingAmountIs("0.01"),
@@ -433,7 +433,7 @@ registry
                 PaymentScreen.remainingIs("-15.04"),
                 PaymentScreen.clickPaymentMethod("Cash"),
                 PaymentScreen.remainingIs("0.0"),
-                PaymentScreen.clickValidate(),
+                PaymentScreen.clickValidate({ willUnload: "continue" }),
 
                 ReceiptScreen.receiptAmountTotalIs("-15.72"),
                 ReceiptScreen.receiptRoundingAmountIs("-0.01"),
@@ -464,7 +464,7 @@ registry
                 PaymentScreen.clickPaymentMethod("Cash"),
                 PaymentScreen.remainingIs("0.0"),
                 PaymentScreen.clickInvoiceButton(),
-                PaymentScreen.clickValidate(),
+                PaymentScreen.clickValidate({ willUnload: "continue" }),
 
                 ReceiptScreen.receiptAmountTotalIs("15.70"),
                 ReceiptScreen.receiptToPayAmountIsNotThere(),
@@ -489,7 +489,7 @@ registry
                 PaymentScreen.totalIs("-15.70"),
                 PaymentScreen.clickPaymentMethod("Cash"),
                 PaymentScreen.remainingIs("0.0"),
-                PaymentScreen.clickValidate(),
+                PaymentScreen.clickValidate({ willUnload: "continue" }),
 
                 ReceiptScreen.receiptAmountTotalIs("-15.70"),
                 ReceiptScreen.receiptToPayAmountIsNotThere(),
@@ -523,7 +523,7 @@ registry
                 PaymentScreen.clickPaymentMethod("Cash"),
                 PaymentScreen.remainingIs("0.0"),
                 PaymentScreen.clickInvoiceButton(),
-                PaymentScreen.clickValidate(),
+                PaymentScreen.clickValidate({ willUnload: "continue" }),
 
                 ReceiptScreen.receiptAmountTotalIs("15.70"),
                 ReceiptScreen.receiptRoundingAmountIs("0.02"),
@@ -553,7 +553,7 @@ registry
                 PaymentScreen.remainingIs("-15.03"),
                 PaymentScreen.clickPaymentMethod("Cash"),
                 PaymentScreen.remainingIs("0.0"),
-                PaymentScreen.clickValidate(),
+                PaymentScreen.clickValidate({ willUnload: "continue" }),
 
                 ReceiptScreen.receiptAmountTotalIs("-15.70"),
                 ReceiptScreen.receiptRoundingAmountIs("-0.02"),
@@ -584,7 +584,7 @@ registry
                 PaymentScreen.clickPaymentMethod("Cash"),
                 PaymentScreen.remainingIs("0.0"),
                 PaymentScreen.clickInvoiceButton(),
-                PaymentScreen.clickValidate(),
+                PaymentScreen.clickValidate({ willUnload: "continue" }),
 
                 ReceiptScreen.receiptAmountTotalIs("15.72"),
                 ReceiptScreen.receiptRoundingAmountIs("-0.02"),
@@ -610,7 +610,7 @@ registry
                 PaymentScreen.totalIs("-15.72"),
                 PaymentScreen.clickPaymentMethod("Cash"),
                 PaymentScreen.remainingIs("0.0"),
-                PaymentScreen.clickValidate(),
+                PaymentScreen.clickValidate({ willUnload: "continue" }),
 
                 ReceiptScreen.receiptAmountTotalIs("-15.72"),
                 ReceiptScreen.receiptRoundingAmountIs("0.02"),
@@ -645,7 +645,7 @@ registry
                 PaymentScreen.clickPaymentMethod("Cash"),
                 PaymentScreen.remainingIs("0.0"),
                 PaymentScreen.clickInvoiceButton(),
-                PaymentScreen.clickValidate(),
+                PaymentScreen.clickValidate({ willUnload: "continue" }),
 
                 ReceiptScreen.receiptAmountTotalIs("15.72"),
                 ReceiptScreen.receiptRoundingAmountIs("0.01"),
@@ -675,7 +675,7 @@ registry
                 PaymentScreen.remainingIs("-15.04"),
                 PaymentScreen.clickPaymentMethod("Cash"),
                 PaymentScreen.remainingIs("0.0"),
-                PaymentScreen.clickValidate(),
+                PaymentScreen.clickValidate({ willUnload: "continue" }),
 
                 ReceiptScreen.receiptAmountTotalIs("-15.72"),
                 ReceiptScreen.receiptRoundingAmountIs("-0.01"),
@@ -704,7 +704,7 @@ registry.category("web_tour.tours").add("test_cash_rounding_with_change", {
             PaymentScreen.fillPaymentLineAmountMobile("Bank", "20.00"),
             PaymentScreen.changeIs("4.30"),
             PaymentScreen.clickInvoiceButton(),
-            PaymentScreen.clickValidate(),
+            PaymentScreen.clickValidate({ willUnload: "continue" }),
 
             ReceiptScreen.receiptAmountTotalIs("15.72"),
             ReceiptScreen.receiptRoundingAmountIs("-0.02"),
@@ -751,7 +751,7 @@ registry.category("web_tour.tours").add("test_cash_rounding_only_cash_method_wit
             PaymentScreen.changeIs("4.30"),
 
             PaymentScreen.clickInvoiceButton(),
-            PaymentScreen.clickValidate(),
+            PaymentScreen.clickValidate({ willUnload: "continue" }),
 
             ReceiptScreen.receiptAmountTotalIs("15.72"),
             ReceiptScreen.receiptRoundingAmountIs("-0.02"),

--- a/addons/point_of_sale/static/tests/pos/tours/pos_self_invoicing_portal_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/pos_self_invoicing_portal_tour.js
@@ -21,6 +21,7 @@ registry.category("web_tour.tours").add("invoicePoSOrderWithSelfInvocing", {
         {
             trigger: ".o_portal_wrap button:contains('Request Invoice')",
             run: "click",
+            willUnload: true,
         },
         {
             trigger: ".o_portal_wrap input[name='name']",
@@ -93,6 +94,7 @@ registry.category("web_tour.tours").add("invoicePoSOrderWithSelfInvocing", {
         {
             trigger: ".o_portal_wrap button:contains('Get my invoice')",
             run: "click",
+            willUnload: true,
         },
         {
             trigger: ".rounded.text-bg-success.fw-normal.badge",

--- a/addons/point_of_sale/static/tests/pos/tours/product_screen_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/product_screen_tour.js
@@ -252,8 +252,20 @@ registry.category("web_tour.tours").add("CashClosingDetails", {
             ProductScreen.closeWithCashAmount("50.0"),
             ProductScreen.cashDifferenceIs("-1.00"),
             Dialog.confirm("Close Register"),
-            Dialog.confirm("Proceed Anyway", ".btn-primary"),
-            Chrome.clickBtn("Backend"),
+            {
+                trigger: ".modal .btn-primary:contains(Proceed Anyway)",
+                run: "click",
+                willUnload: true,
+            },
+            {
+                trigger: "button:contains(backend)",
+                run: "click",
+                willUnload: true,
+            },
+            {
+                trigger: "body",
+                willUnload: true,
+            },
             ProductScreen.lastClosingCashIs("50.00"),
         ].flat(),
 });

--- a/addons/point_of_sale/static/tests/pos/tours/receipt_screen_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/receipt_screen_tour.js
@@ -176,7 +176,15 @@ registry.category("web_tour.tours").add("OrderPaidInCash", {
             ProductScreen.closeWithCashAmount("25"),
             ProductScreen.cashDifferenceIs("0.00"),
             Dialog.confirm("Close Register"),
-            Chrome.clickBtn("Backend"),
+            {
+                trigger: "button:contains(backend)",
+                run: "click",
+                willUnload: true,
+            },
+            {
+                trigger: "body",
+                willUnload: true,
+            },
             ProductScreen.lastClosingCashIs("25.00"),
         ].flat(),
 });

--- a/addons/point_of_sale/static/tests/pos/tours/ticket_screen_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/ticket_screen_tour.js
@@ -99,7 +99,7 @@ registry.category("web_tour.tours").add("TicketScreenTour", {
             inLeftSide(Order.hasLine()),
             TicketScreen.clickControlButton("Invoice"),
             Dialog.confirm(),
-            PartnerList.clickPartner("Partner Test 3"),
+            PartnerList.clickPartner("Partner Test 3", { willUnload: "continue" }),
             TicketScreen.invoicePrinted(),
             TicketScreen.back(),
             // When going back, the ticket screen should be in its previous state.

--- a/addons/point_of_sale/static/tests/pos/tours/utils/backend_utils.js
+++ b/addons/point_of_sale/static/tests/pos/tours/utils/backend_utils.js
@@ -3,6 +3,7 @@ export function editShopConfiguration(shop) {
         {
             trigger: ".o_main_navbar span:contains('Configuration')",
             run: "click",
+            willUnload: "continue",
         },
         {
             trigger: ".dropdown-item:contains('Point of Sales')",

--- a/addons/point_of_sale/static/tests/pos/tours/utils/chrome_util.js
+++ b/addons/point_of_sale/static/tests/pos/tours/utils/chrome_util.js
@@ -13,14 +13,15 @@ export function clickMenuButton() {
         run: "click",
     };
 }
-export function clickMenuOption(name) {
-    return [clickMenuButton(), clickMenuDropdownOption(name)];
+export function clickMenuOption(name, options) {
+    return [clickMenuButton(), clickMenuDropdownOption(name, options)];
 }
-export function clickMenuDropdownOption(name) {
+export function clickMenuDropdownOption(name, { willUnload = false } = {}) {
     return {
         content: `click on something in the burger menu`,
         trigger: `span.dropdown-item:contains(${name})`,
         run: "click",
+        willUnload,
     };
 }
 export function isCashMoveButtonHidden() {
@@ -68,11 +69,12 @@ export function startPoS() {
         },
     ];
 }
-export function clickBtn(name) {
+export function clickBtn(name, { willUnload = false } = {}) {
     return {
         content: `Click on ${name}`,
         trigger: `body button:contains(${name})`,
         run: "click",
+        willUnload,
     };
 }
 export function fillTextArea(target, value) {

--- a/addons/point_of_sale/static/tests/pos/tours/utils/partner_list_util.js
+++ b/addons/point_of_sale/static/tests/pos/tours/utils/partner_list_util.js
@@ -1,8 +1,9 @@
-export function clickPartner(name = "") {
+export function clickPartner(name = "", { willUnload = false } = {}) {
     return {
         content: `click partner '${name}' from partner list screen`,
         trigger: `.modal .partner-list b:contains(${name})`,
         run: "click",
+        willUnload,
     };
 }
 export function clickPartnerOptions(name) {
@@ -100,10 +101,11 @@ export function searchCustomerValue(val, pressEnter = false) {
         steps.push({
             content: `Press Enter to trigger "search more"`,
             trigger: `.modal-dialog .input-group input`,
-            run: () =>
+            run: function () {
                 document
                     .querySelector(".modal-dialog .input-group input")
-                    .dispatchEvent(new KeyboardEvent("keydown", { bubbles: true, key: "Enter" })),
+                    .dispatchEvent(new KeyboardEvent("keydown", { bubbles: true, key: "Enter" }));
+            },
         });
     }
     steps.push(checkCustomerShown(val));

--- a/addons/point_of_sale/static/tests/pos/tours/utils/payment_screen_util.js
+++ b/addons/point_of_sale/static/tests/pos/tours/utils/payment_screen_util.js
@@ -86,19 +86,21 @@ export function clickInvoiceButton() {
         },
     ];
 }
-export function clickValidate() {
+export function clickValidate({ willUnload = false } = {}) {
     return [
         {
             isActive: ["desktop"],
             content: "validate payment",
             trigger: `.payment-screen .button.next.highlight`,
             run: "click",
+            willUnload,
         },
         {
             isActive: ["mobile"],
             content: "validate payment",
             trigger: `.payment-screen .btn-switchpane:contains('Validate')`,
             run: "click",
+            willUnload,
         },
     ];
 }

--- a/addons/point_of_sale/static/tests/pos/tours/utils/product_screen_util.js
+++ b/addons/point_of_sale/static/tests/pos/tours/utils/product_screen_util.js
@@ -6,6 +6,7 @@ import * as TextInputPopup from "@point_of_sale/../tests/generic_helpers/text_in
 import * as Dialog from "@point_of_sale/../tests/generic_helpers/dialog_util";
 import * as Chrome from "@point_of_sale/../tests/pos/tours/utils/chrome_util";
 import { LONG_PRESS_DURATION } from "@point_of_sale/utils";
+import { clickValidate } from "./payment_screen_util";
 
 export function firstProductIsFavorite(name) {
     return [
@@ -143,19 +144,21 @@ export function clickSubcategory(name) {
 export function clickNumpad(...keys) {
     return inLeftSide(keys.map(Numpad.click));
 }
-export function clickPayButton(shouldCheck = true) {
+export function clickPayButton({ shouldCheck = true, willUnload = false } = {}) {
     const steps = [
         {
             isActive: ["desktop"],
             content: "click pay button",
             trigger: ".product-screen .pay-order-button",
             run: "click",
+            willUnload,
         },
         {
             isActive: ["mobile"],
             content: "click pay button",
             trigger: ".btn-switchpane:contains('Pay')",
             run: "click",
+            willUnload,
         },
     ];
     if (shouldCheck) {
@@ -702,18 +705,7 @@ export function closePos() {
 
 export function finishOrder() {
     return [
-        {
-            isActive: ["desktop"],
-            content: "validate the order",
-            trigger: ".payment-screen .button.next.highlight:visible",
-            run: "click",
-        },
-        {
-            isActive: ["mobile"],
-            content: "validate the order",
-            trigger: ".payment-screen .btn-switchpane:contains('Validate')",
-            run: "click",
-        },
+        ...clickValidate({ willUnload: "continue" }),
         Chrome.isSyncStatusConnected(),
         {
             isActive: ["desktop"],

--- a/addons/point_of_sale/static/tests/pos/tours/utils/receipt_screen_util.js
+++ b/addons/point_of_sale/static/tests/pos/tours/utils/receipt_screen_util.js
@@ -1,18 +1,20 @@
 import * as Dialog from "@point_of_sale/../tests/generic_helpers/dialog_util";
 
-export function clickNextOrder() {
+export function clickNextOrder({ willUnload = false } = {}) {
     return [
         {
             isActive: ["desktop"],
             content: "go to next screen",
             trigger: ".receipt-screen .button.next.highlight[name='done']",
             run: "click",
+            willUnload,
         },
         {
             isActive: ["mobile"],
             content: "go to next screen",
             trigger: ".receipt-screen .btn-switchpane.validation-button.highlight[name='done']",
             run: "click",
+            willUnload,
         },
     ];
 }

--- a/addons/portal/static/tests/tours/portal.js
+++ b/addons/portal/static/tests/tours/portal.js
@@ -1,12 +1,13 @@
 import { registry } from "@web/core/registry";
 
-registry.category("web_tour.tours").add('portal_load_homepage', {
-    url: '/my',
+registry.category("web_tour.tours").add("portal_load_homepage", {
+    url: "/my",
     steps: () => [
         {
             content: "Check portal is loaded",
             trigger: 'a[href*="/my/account"]:contains("Edit"):first',
             run: "click",
+            willUnload: true,
         },
         {
             content: "Load my account details",
@@ -14,18 +15,19 @@ registry.category("web_tour.tours").add('portal_load_homepage', {
             run: "click",
         },
         {
-            content: 'type a different phone number',
+            content: "type a different phone number",
             trigger: 'input[name="phone"]',
             run: "edit +1 555 666 7788",
         },
         {
             content: "Submit the form",
-            trigger: 'button[id=save_address]',
+            trigger: "button[id=save_address]",
             run: "click",
+            willUnload: true,
         },
         {
             content: "Check that we are back on the portal",
             trigger: 'a[href*="/my/account"]:contains("Edit"):first',
-        }
-    ]
+        },
+    ],
 });

--- a/addons/pos_discount/static/tests/tours/test_taxes_global_discount.js
+++ b/addons/pos_discount/static/tests/tours/test_taxes_global_discount.js
@@ -45,7 +45,7 @@ export function payAndInvoice(totalAmount) {
         PaymentScreen.remainingIs("0.0"),
 
         PaymentScreen.clickInvoiceButton(),
-        PaymentScreen.clickValidate(),
+        PaymentScreen.clickValidate({ willUnload: "continue" }),
 
         ReceiptScreen.receiptAmountTotalIs(totalAmount),
         ReceiptScreen.clickNextOrder(),

--- a/addons/pos_hr/static/tests/tours/pos_hr_tour.js
+++ b/addons/pos_hr/static/tests/tours/pos_hr_tour.js
@@ -159,7 +159,7 @@ registry.category("web_tour.tours").add("test_change_on_rights_reflected_directl
             PosHr.clickLoginButton(),
             SelectionPopup.has("Mitchell Admin", { run: "click" }),
             Dialog.confirm("Open Register"),
-            Chrome.clickMenuOption("Backend"),
+            Chrome.clickMenuOption("Backend", { willUnload: true }),
             BackendUtils.editShopConfiguration("Shop"),
             {
                 trigger: ".o_tag:contains('Pos Employee1') .o_delete",

--- a/addons/pos_hr/static/tests/tours/utils/pos_hr_helpers.js
+++ b/addons/pos_hr/static/tests/tours/utils/pos_hr_helpers.js
@@ -54,6 +54,7 @@ export function refreshPage() {
             run: () => {
                 window.location.reload();
             },
+            willUnload: true,
         },
     ];
 }

--- a/addons/pos_loyalty/static/tests/tours/e_wallet_program_tour.js
+++ b/addons/pos_loyalty/static/tests/tours/e_wallet_program_tour.js
@@ -16,7 +16,7 @@ registry.category("web_tour.tours").add("EWalletProgramTour1", {
             // Topup 50$ for partner_aaa
             ProductScreen.clickDisplayedProduct("Top-up eWallet"),
             PosLoyalty.orderTotalIs("50.00"),
-            ProductScreen.clickPayButton(false),
+            ProductScreen.clickPayButton({ shouldCheck: false }),
             // If there's no partner, we asked to redirect to the partner list screen.
             Dialog.confirm(),
             PartnerList.clickPartner("AAAAAAA"),

--- a/addons/pos_loyalty/static/tests/tours/gift_card_program_tour.js
+++ b/addons/pos_loyalty/static/tests/tours/gift_card_program_tour.js
@@ -142,7 +142,7 @@ registry.category("web_tour.tours").add("GiftCardProgramInvoice", {
             ProductScreen.clickPayButton(),
             PaymentScreen.clickPaymentMethod("Bank"),
             PaymentScreen.clickInvoiceButton(),
-            PaymentScreen.clickValidate(),
+            PaymentScreen.clickValidate({ willUnload: "continue" }),
             ReceiptScreen.isShown(),
         ].flat(),
 });
@@ -172,7 +172,7 @@ registry.category("web_tour.tours").add("test_physical_gift_card_invoiced", {
             ProductScreen.clickPayButton(),
             PaymentScreen.clickPaymentMethod("Bank"),
             PaymentScreen.clickInvoiceButton(),
-            PaymentScreen.clickValidate(),
+            PaymentScreen.clickValidate({ willUnload: "continue" }),
             ReceiptScreen.isShown(),
         ].flat(),
 });

--- a/addons/pos_restaurant/static/tests/tours/split_bill_screen_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/split_bill_screen_tour.js
@@ -143,7 +143,7 @@ registry.category("web_tour.tours").add("SplitBillScreenTour3", {
             // Check if there is still water in the order
             ProductScreen.isShown(),
             ProductScreen.orderLineHas("Water", "1.0"),
-            ProductScreen.clickPayButton(true),
+            ProductScreen.clickPayButton(),
             PaymentScreen.clickPaymentMethod("Bank"),
             PaymentScreen.clickValidate(),
             ReceiptScreen.discardOrderWarningDialog(),

--- a/addons/pos_sale/static/tests/tours/pos_sale_tour.js
+++ b/addons/pos_sale/static/tests/tours/pos_sale_tour.js
@@ -238,7 +238,7 @@ registry.category("web_tour.tours").add("PoSDownPaymentLinesPerTax", {
             ProductScreen.clickPayButton(),
             PaymentScreen.clickPaymentMethod("Bank"),
             PaymentScreen.clickInvoiceButton(),
-            PaymentScreen.clickValidate(),
+            PaymentScreen.clickValidate({ willUnload: "continue" }),
             ReceiptScreen.isShown(),
         ].flat(),
 });
@@ -321,7 +321,7 @@ registry.category("web_tour.tours").add("PosSettleOrder4", {
             PaymentScreen.clickPaymentMethod("Bank"),
             PaymentScreen.remainingIs("0.0"),
             PaymentScreen.clickShipLaterButton(),
-            PaymentScreen.clickValidate(),
+            PaymentScreen.clickValidate({ willUnload: "continue" }),
             ReceiptScreen.isShown(),
         ].flat(),
 });
@@ -358,7 +358,7 @@ registry.category("web_tour.tours").add("PosSettleOrder5", {
             Dialog.confirm("Open Register"),
             PosSale.settleNthOrder(1),
             ProductScreen.selectedOrderlineHas("Product A", 1),
-            Chrome.clickMenuOption("Backend"),
+            Chrome.clickMenuOption("Backend", { willUnload: true }),
         ].flat(),
 });
 
@@ -426,7 +426,7 @@ registry.category("web_tour.tours").add("POSSalePaymentScreenInvoiceOrder", {
 
             PaymentScreen.clickPaymentMethod("Bank"),
             PaymentScreen.clickInvoiceButton(),
-            PaymentScreen.clickValidate(),
+            PaymentScreen.clickValidate({ willUnload: "continue" }),
             ReceiptScreen.receiptIsThere(),
         ].flat(),
 });

--- a/addons/pos_sale/static/tests/tours/test_taxes_downpayment.js
+++ b/addons/pos_sale/static/tests/tours/test_taxes_downpayment.js
@@ -56,7 +56,7 @@ export function payAndInvoice(totalAmount) {
         PaymentScreen.remainingIs("0.0"),
 
         PaymentScreen.clickInvoiceButton(),
-        PaymentScreen.clickValidate(),
+        PaymentScreen.clickValidate({ willUnload: "continue" }),
 
         ReceiptScreen.receiptAmountTotalIs(totalAmount),
         ReceiptScreen.clickNextOrder(),

--- a/addons/pos_self_order/static/tests/tours/utils/common.js
+++ b/addons/pos_self_order/static/tests/tours/utils/common.js
@@ -57,6 +57,7 @@ export function changeKioskLanguage(language) {
             content: `Check that the language is available`,
             trigger: `.self_order_language_popup .btn:contains(${language})`,
             run: "click",
+            willUnload: true,
         },
         {
             content: `Check that the language changed`,

--- a/addons/project/static/tests/tours/project_sharing_tour.js
+++ b/addons/project/static/tests/tours/project_sharing_tour.js
@@ -39,11 +39,13 @@ const projectSharingSteps = [...stepUtils.goToAppSteps("project.menu_main_pm", '
     run: function () {
         window.location.href = window.location.origin + '/my/projects';
     },
+    willUnload: true,
 }, {
     id: 'project_sharing_feature',
     trigger: 'table > tbody > tr a:has(span:contains(Project Sharing))',
     content: 'Select "Project Sharing" project to go to project sharing feature for this project.',
     run: "click",
+    willUnload: true,
 }, {
     trigger: '.o_project_sharing .o_kanban_renderer',
     content: 'Wait the project sharing feature be loaded',
@@ -148,6 +150,7 @@ registry.category("web_tour.tours").add("project_sharing_with_blocked_task_tour"
         trigger: 'table > tbody > tr a:has(span:contains("Project Sharing"))',
         content: 'Click on the portal project.',
         run: "click",
+        willUnload: true,
     }, {
         trigger: 'article.o_kanban_record',
         content: 'Click on the task',
@@ -171,6 +174,7 @@ registry.category("web_tour.tours").add("portal_project_sharing_tour_with_disall
             content:
                 'Select "Project Sharing" project to go to project sharing feature for this project.',
             run: "click",
+            willUnload: true,
         },
         {
             trigger: ".o_project_sharing",
@@ -211,7 +215,11 @@ registry.category("web_tour.tours").add("portal_project_sharing_tour_with_disall
 registry.category("web_tour.tours").add("test_04_project_sharing_chatter_message_reactions", {
     url: "/my/projects",
     steps: () => [
-        { trigger: "table > tbody > tr a:has(span:contains(Project Sharing))", run: "click" },
+        {
+            trigger: "table > tbody > tr a:has(span:contains(Project Sharing))",
+            run: "click",
+            willUnload: true,
+        },
         { trigger: ".o_project_sharing" },
         { trigger: ".o_kanban_record:contains('Test Task with messages')", run: "click" },
         { trigger: ".o-mail-Message" },
@@ -222,7 +230,11 @@ registry.category("web_tour.tours").add("test_04_project_sharing_chatter_message
 registry.category("web_tour.tours").add("portal_project_sharing_chatter_mention_users", {
     url: "/my/projects",
     steps: () => [
-        { trigger: "table > tbody > tr a:has(span:contains(Project Sharing))", run: "click" },
+        {
+            trigger: "table > tbody > tr a:has(span:contains(Project Sharing))",
+            run: "click",
+            willUnload: true,
+        },
         { trigger: ".o_project_sharing" },
         { trigger: ".o_kanban_record:contains('Test Task')", run: "click" },
         { trigger: ".o-mail-Composer-input", run: "edit @xxx" },

--- a/addons/project_todo/static/tests/tours/project_todo_main_functions.js
+++ b/addons/project_todo/static/tests/tours/project_todo_main_functions.js
@@ -163,6 +163,7 @@ registry.category("web_tour.tours").add('project_todo_main_functions', {
     trigger: 'button[name="action_convert_to_task"]',
     content: 'Convert the todo to a task',
     run: "click",
+    willUnload: true,
 }, {
     trigger: ".o_form_view .breadcrumb-item:last-child",
     content: markup("Let's go back to the <b>kanban view</b> to have an overview of tasks linked to project chosen."),

--- a/addons/sale/static/src/js/tours/product_configurator_tour_utils.js
+++ b/addons/sale/static/src/js/tours/product_configurator_tour_utils.js
@@ -1,4 +1,4 @@
-import { queryAttribute } from '@odoo/hoot-dom';
+import { queryAttribute } from "@odoo/hoot-dom";
 
 function productSelector(productName) {
     return `

--- a/addons/sale/static/tests/tours/sale_signature.js
+++ b/addons/sale/static/tests/tours/sale_signature.js
@@ -9,6 +9,7 @@ registry.category("web_tour.tours").add('sale_signature', {
         content: "open the test SO",
         trigger: 'a:contains(/^test SO$/)',
         run: "click",
+        willUnload: true,
     },
     {
         content: "click sign",
@@ -36,6 +37,7 @@ registry.category("web_tour.tours").add('sale_signature', {
         content: "click submit",
         trigger: '.modal .o_portal_sign_submit:enabled',
         run: "click",
+        willUnload: true,
     },
     {
         content: "check it's confirmed",
@@ -46,6 +48,7 @@ registry.category("web_tour.tours").add('sale_signature', {
         run: function () {
             redirect("/odoo");
         },  // Avoid race condition at the end of the tour by returning to the home page.
+        willUnload: true,
     },
     {
         trigger: 'nav',

--- a/addons/survey/static/tests/tours/certification_failure.js
+++ b/addons/survey/static/tests/tours/certification_failure.js
@@ -111,13 +111,14 @@ var failSteps = [{ // Page-1
     run: "click",
 }, {
     content: "Click on Submit",
-    trigger: 'button.btn-primary:contains("Submit")',
+    trigger: '.modal button.btn-primary:contains("Submit")',
     run: "click",
 }];
 
 var retrySteps = [{
     trigger: 'a:contains("Retry")',
     run: "click",
+    willUnload: true,
 }];
 
 var lastSteps = [{

--- a/addons/survey/static/tests/tours/survey.js
+++ b/addons/survey/static/tests/tours/survey.js
@@ -107,6 +107,7 @@ registry.category("web_tour.tours").add("test_survey_multilang", {
                     langSelect.value = "fr_BE";
                     langSelect.dispatchEvent(new Event("change", { bubbles: true }));
                 },
+                willUnload: true,
             },
             {
                 content: "Check French translation",
@@ -120,6 +121,7 @@ registry.category("web_tour.tours").add("test_survey_multilang", {
                     langSelect.value = "fr_BE";
                     langSelect.dispatchEvent(new Event("change", { bubbles: true }));
                 },
+                willUnload: true,
             },
             {
                 content: "Check French translation",

--- a/addons/test_event_full/static/src/js/tours/wevent_performance_tour.js
+++ b/addons/test_event_full/static/src/js/tours/wevent_performance_tour.js
@@ -54,6 +54,7 @@ var registerSteps = [{
     content: "Validate attendees details",
     trigger: 'button[type=submit]',
     run: 'click',
+    willUnload: true,
 },
 wsTourUtils.fillAdressForm({
     name: "Raoulette Poiluchette",

--- a/addons/test_event_full/static/src/js/tours/wevent_register_tour.js
+++ b/addons/test_event_full/static/src/js/tours/wevent_register_tour.js
@@ -51,6 +51,7 @@ const discoverTalkSteps = function (talkName, fromList, checkToggleReminder, rem
             content: 'Go on "' + talkName + '" talk in List',
             trigger: 'a:contains("' + talkName + '")',
             run: "click",
+            willUnload: true,
         }];
     }
     else {
@@ -58,6 +59,7 @@ const discoverTalkSteps = function (talkName, fromList, checkToggleReminder, rem
             content: 'Click on Live Track',
             trigger: 'article span:contains("' + talkName + '")',
             run: 'click',
+            willUnload: true,
         }];
     }
     steps = steps.concat([{
@@ -137,11 +139,13 @@ const registerSteps = [
         content: "Validate attendees details",
         trigger: ".modal button[type=submit]:enabled",
         run: "click",
+        willUnload: true,
     },
     {
         content: "Click on 'register favorites talks' button",
         trigger: "a:contains(register to your favorites talks now)",
         run: "click",
+        willUnload: true,
     },
     {
         trigger: "h5:contains(Book your talks)",
@@ -157,6 +161,7 @@ var initTourSteps = function (eventName) {
         content: 'Go on "' + eventName + '" page',
         trigger: 'a[href*="/event"]:contains("' + eventName + '"):first',
         run: "click",
+        willUnload: true,
     }];
 };
 
@@ -168,6 +173,7 @@ var browseTalksSteps = [{
     content: 'Browse Talks Submenu',
     trigger: 'a.dropdown-item span:contains("Talks")',
     run: "click",
+    willUnload: true,
 }, {
     content: 'Check we are on the talk list page',
     trigger: 'h5:contains("Book your talks")',
@@ -177,6 +183,7 @@ var browseBackSteps = [{
     content: 'Browse Back',
     trigger: 'a:contains("All Talks")',
     run: "click",
+    willUnload: true,
 }, {
     content: 'Check we are back on the talk list page',
     trigger: 'h5:contains("Book your talks")',

--- a/addons/test_website/static/tests/tours/error_views.js
+++ b/addons/test_website/static/tests/tours/error_views.js
@@ -84,6 +84,7 @@ registry.category("web_tour.tours").add('test_error_website', {
         run: function () {
             window.location.href = window.location.origin + '/test_user_error_http?debug=0';
         },
+        willUnload: true,
     },
     {
         trigger: 'h1:contains("Something went wrong.")',
@@ -94,6 +95,7 @@ registry.category("web_tour.tours").add('test_error_website', {
         run: function () {
                 window.location.href = window.location.origin + '/test_user_error_http?debug=1';
         },
+        willUnload: true,
     },
     {
         trigger: 'h1:contains("Something went wrong.")',
@@ -107,6 +109,7 @@ registry.category("web_tour.tours").add('test_error_website', {
         run: function () {
                 window.location.href = window.location.origin + '/test_validation_error_http?debug=0';
         },
+        willUnload: true,
     },
     {
         trigger: 'h1:contains("Something went wrong.")',
@@ -117,6 +120,7 @@ registry.category("web_tour.tours").add('test_error_website', {
         run: function () {
                 window.location.href = window.location.origin + '/test_validation_error_http?debug=1';
         },
+        willUnload: true,
     },
     {
         trigger: 'h1:contains("Something went wrong.")',
@@ -130,6 +134,7 @@ registry.category("web_tour.tours").add('test_error_website', {
         run: function () {
                 window.location.href = window.location.origin + '/test_access_error_http?debug=0';
         },
+        willUnload: true,
     },
     {
         trigger: 'h1:contains("403: Forbidden")',
@@ -140,6 +145,7 @@ registry.category("web_tour.tours").add('test_error_website', {
         run: function () {
                 window.location.href = window.location.origin + '/test_access_error_http?debug=1';
         },
+        willUnload: true,
     },
     {
         trigger: 'h1:contains("403: Forbidden")',
@@ -153,18 +159,21 @@ registry.category("web_tour.tours").add('test_error_website', {
         run: function () {
                 window.location.href = window.location.origin + '/test_missing_error_http?debug=0';
         },
+        willUnload: true,
     },
     {
         trigger: 'h1:contains("Error 404")',
         run: function () {
                 window.location.href = window.location.origin + '/test_missing_error_http?debug=1';
         },
+        willUnload: true,
     },
     {
         trigger: 'h1:contains("Error 404")',
         run: function () {
             window.location.href = window.location.origin + '/test_access_denied_http?debug=1';
         },
+        willUnload: true,
     },
     {
         trigger: 'h1:contains("403: Forbidden")',
@@ -176,6 +185,7 @@ registry.category("web_tour.tours").add('test_error_website', {
         run: function () {
             window.location.href = window.location.origin + '/test_access_denied_http?debug=1';
         },
+        willUnload: true,
     },
     {
         trigger: 'h1:contains("403: Forbidden")',

--- a/addons/test_website/static/tests/tours/json_auth.js
+++ b/addons/test_website/static/tests/tours/json_auth.js
@@ -14,6 +14,7 @@ registry.category("web_tour.tours").add('test_json_auth', {
         });
         window.location.href = window.location.origin;
     },
+    willUnload: true,
 }, {
     trigger: 'span:contains(Mitchell Admin), span:contains(Administrator)',
 }

--- a/addons/test_website_modules/static/tests/tours/configurator_flow.js
+++ b/addons/test_website_modules/static/tests/tours/configurator_flow.js
@@ -18,6 +18,7 @@ registry.category("web_tour.tours").add("configurator_flow", {
             content: "validate the website creation modal",
             trigger: 'button.btn-primary:contains("Create")',
             run: "click",
+            willUnload: true,
         },
         // Configurator first screen
         {

--- a/addons/test_website_slides_full/static/tests/tours/slides_certification_member.js
+++ b/addons/test_website_slides_full/static/tests/tours/slides_certification_member.js
@@ -25,6 +25,7 @@ var startCertificationSurvey = [{
     content: 'eLearning: go to certification course',
     trigger: 'a:contains("DIY Furniture - TEST")',
     run: "click",
+    willUnload: true,
 }, {
     content: 'eLearning: user should be enrolled',
     trigger: '.o_wslides_js_course_join:contains("You\'re enrolled")',
@@ -32,6 +33,7 @@ var startCertificationSurvey = [{
     content: 'eLearning: start course',
     trigger: '.o_wslides_js_slides_list_slide_link',
     run: "click",
+    willUnload: true,
 }];
 
 var failCertificationSteps = [{
@@ -64,6 +66,7 @@ var retrySteps = [{
     content: 'Survey: retry certification',
     trigger: 'a:contains("Retry")',
     run: "click",
+    willUnload: true,
 }];
 
 var succeedCertificationSteps = [{
@@ -117,6 +120,7 @@ var certificationCompletionSteps = [{
     content: 'Survey: back to course home page',
     trigger: 'a:contains("Go back to course")',
     run: "click",
+    willUnload: true,
 }, {
     content: 'eLearning: course should be completed',
     trigger: '.o_wslides_channel_completion_completed',
@@ -126,10 +130,12 @@ var profileSteps = [{
     content: 'eLearning: back to e-learning home page',
     trigger: 'a:contains("Courses")',
     run: "click",
+    willUnload: true,
 }, {
     content: 'eLearning: access user profile',
     trigger: '.o_wslides_home_aside_loggedin a:contains("View")',
     run: "click",
+    willUnload: true,
 }, {
     content: 'eLearning: check that the user profile certifications include the new certification',
     trigger: '.o_wprofile_slides_course_card_body:contains("Furniture Creation Certification")',

--- a/addons/web/static/tests/tours/user_switch_tour.js
+++ b/addons/web/static/tests/tours/user_switch_tour.js
@@ -11,6 +11,7 @@ function logout() {
             content: "click the Log out button",
             trigger: ".dropdown-item[data-menu=logout]",
             run: "click",
+            willUnload: true,
         },
         {
             // Wait and check we are logged out
@@ -67,6 +68,7 @@ registry.category("web_tour.tours").add("test_user_switch", {
             content: "click on login button",
             trigger: 'button:contains("Log in")',
             run: "click",
+            willUnload: true,
         },
         ...logout(),
         {

--- a/addons/web_tour/static/src/tour_service/tour_automatic.js
+++ b/addons/web_tour/static/src/tour_service/tour_automatic.js
@@ -55,6 +55,7 @@ export class TourAutomatic {
                 },
                 {
                     trigger: step.trigger ? () => step.findTrigger() : null,
+                    willUnload: step.willUnload,
                     timeout:
                         step.pause && this.debugMode
                             ? 9999999
@@ -64,6 +65,7 @@ export class TourAutomatic {
                             await step.checkForUndeterminisms(trigger, delayToCheckUndeterminisms);
                         }
                         const result = await step.doAction();
+                        tourState.setCurrentIndex(step.index + 1);
                         if (this.debugMode) {
                             console.log(trigger);
                             if (step.skipped) {
@@ -76,7 +78,6 @@ export class TourAutomatic {
                                 await this.pause();
                             }
                         }
-                        tourState.setCurrentIndex(step.index + 1);
                         return result;
                     },
                 },

--- a/addons/web_tour/static/src/tour_service/tour_helpers.js
+++ b/addons/web_tour/static/src/tour_service/tour_helpers.js
@@ -1,6 +1,4 @@
 import * as hoot from "@odoo/hoot-dom";
-import { waitForStable } from "@web/core/macro";
-
 export class TourHelpers {
     /**
      * @typedef {string|Node} Selector
@@ -300,8 +298,6 @@ export class TourHelpers {
     async goToUrl(url) {
         const linkEl = document.createElement("a");
         linkEl.href = url;
-        //We want DOM is stable before quit it.
-        await waitForStable();
         await hoot.click(linkEl);
     }
 

--- a/addons/web_tour/static/src/tour_service/tour_service.js
+++ b/addons/web_tour/static/src/tour_service/tour_service.js
@@ -56,6 +56,13 @@ const StepSchema = {
         },
     },
     trigger: { type: String },
+    willUnload: {
+        type: [Boolean, String],
+        optional: true,
+        validate(value) {
+            return [true, false, "continue"].includes(value);
+        },
+    },
     //ONLY IN DEBUG MODE
     pause: { type: Boolean, optional: true },
     break: { type: Boolean, optional: true },

--- a/addons/web_tour/static/src/tour_service/tour_step.js
+++ b/addons/web_tour/static/src/tour_service/tour_step.js
@@ -78,7 +78,16 @@ export class TourStep {
     get stringify() {
         return (
             JSON.stringify(
-                pick(this, "isActive", "content", "trigger", "run", "tooltipPosition", "timeout"),
+                pick(
+                    this,
+                    "isActive",
+                    "content",
+                    "trigger",
+                    "run",
+                    "tooltipPosition",
+                    "timeout",
+                    "willUnload"
+                ),
                 (_key, value) => {
                     if (typeof value === "function") {
                         return "[function]";

--- a/addons/web_tour/static/src/tour_service/tour_step_automatic.js
+++ b/addons/web_tour/static/src/tour_service/tour_step_automatic.js
@@ -1,6 +1,6 @@
 import { tourState } from "./tour_state";
 import * as hoot from "@odoo/hoot-dom";
-import { callWithUnloadCheck, serializeChanges, serializeMutation } from "./tour_utils";
+import { serializeChanges, serializeMutation } from "./tour_utils";
 import { TourHelpers } from "./tour_helpers";
 import { TourStep } from "./tour_step";
 import { getTag } from "@web/core/utils/xml";
@@ -86,19 +86,19 @@ export class TourStepAutomatic extends TourStep {
         if (this.skipped) {
             return false;
         }
-        return await callWithUnloadCheck(async () => {
-            const actionHelper = new TourHelpers(this.element);
-            if (typeof this.run === "function") {
-                await this.run.call({ anchor: this.element }, actionHelper);
-            } else if (typeof this.run === "string") {
-                for (const todo of this.run.split("&&")) {
-                    const m = String(todo)
-                        .trim()
-                        .match(/^(?<action>\w*) *\(? *(?<arguments>.*?)\)?$/);
-                    await actionHelper[m.groups?.action](m.groups?.arguments);
-                }
+        const actionHelper = new TourHelpers(this.element);
+        if (typeof this.run === "function") {
+            return await this.run.call({ anchor: this.element }, actionHelper);
+        } else if (typeof this.run === "string") {
+            let lastResult = null;
+            for (const todo of this.run.split("&&")) {
+                const m = String(todo)
+                    .trim()
+                    .match(/^(?<action>\w*) *\(? *(?<arguments>.*?)\)?$/);
+                lastResult = await actionHelper[m.groups?.action](m.groups?.arguments);
             }
-        });
+            return lastResult;
+        }
     }
 
     /**

--- a/addons/web_tour/static/src/tour_service/tour_utils.js
+++ b/addons/web_tour/static/src/tour_service/tour_utils.js
@@ -317,6 +317,7 @@ export const stepUtils = {
             content: `Navigate to ${url}`,
             trigger: "body",
             run: `goToUrl ${url}`,
+            willUnload: true,
         };
     },
 };

--- a/addons/website/static/tests/tours/client_action_redirect.js
+++ b/addons/website/static/tests/tours/client_action_redirect.js
@@ -1,6 +1,5 @@
 /** @odoo-module */
 
-import { delay } from "@odoo/hoot-dom";
 import { registry } from "@web/core/registry";
 
 const testUrl = '/test_client_action_redirect';
@@ -9,9 +8,9 @@ const goToBackendSteps = [{
     content: "Go to the backend",
     trigger: 'body',
     async run() {
-        await delay(2000);
         window.location.assign(`/@${testUrl}`);
-    }
+    },
+    willUnload: true,
 }, {
     content: "Check we are in the backend",
     trigger: ".o_website_preview :iframe main:has(#test_contact_BE):has(#test_contact_FE)",

--- a/addons/website/static/tests/tours/edit_translated_page.js
+++ b/addons/website/static/tests/tours/edit_translated_page.js
@@ -8,6 +8,7 @@ registry.category("web_tour.tours").add('edit_translated_page_redirect', {
         content: "Enter backend",
         trigger: 'a.o_frontend_to_backend_edit_btn',
         run: "click",
+        willUnload: true,
     },
     {
         content: "Check the data-for attribute",
@@ -23,11 +24,13 @@ registry.category("web_tour.tours").add('edit_translated_page_redirect', {
             // case (there is no trailing slash), so we test it separately.
             location.href = '/nl';
         },
+        willUnload: true,
     },
     {
         content: "Enter backend",
         trigger: 'a.o_frontend_to_backend_edit_btn',
         run: "click",
+        willUnload: true,
     },
     ...clickOnEditAndWaitEditModeInTranslatedPage(),
 ]});

--- a/addons/website/static/tests/tours/page_manager.js
+++ b/addons/website/static/tests/tours/page_manager.js
@@ -94,7 +94,10 @@ const homePage = 'tr:contains("Home")';
 const refreshPage = [
     {
         trigger: "body",
-        run() {window.location.reload();},
+        run() {
+            window.location.reload();
+        },
+        willUnload: true,
     },
 ];
 const duplicateSinglePage = [

--- a/addons/website/static/tests/tours/reset_password.js
+++ b/addons/website/static/tests/tours/reset_password.js
@@ -16,6 +16,7 @@ registry.category("web_tour.tours").add('website_reset_password', {
         content: "submit reset password form",
         trigger: '.oe_reset_password_form button[type="submit"]',
         run: "click",
+        willUnload: true,
     },
     {
         content: "check that we're logged in",

--- a/addons/website/static/tests/tours/skip_website_configurator.js
+++ b/addons/website/static/tests/tours/skip_website_configurator.js
@@ -17,6 +17,7 @@ registry.category("web_tour.tours").add('skip_website_configurator', {
         content: "validate the website creation modal",
         trigger: '.modal button.btn-primary',
         run: "click",
+        willUnload: true,
     },
     {
         content: "skip configurator",

--- a/addons/website/static/tests/tours/website_form_editor_frontend.js
+++ b/addons/website/static/tests/tours/website_form_editor_frontend.js
@@ -234,6 +234,7 @@ registry.category("web_tour.tours").add('website_form_contactus_submit', {
         content: 'Send the form',
         trigger: '.s_website_form_send',
         run: "click",
+        willUnload: true,
     },
     {
         content: 'Check form is submitted without errors',

--- a/addons/website_blog/static/tests/tours/blog_search_with_date.js
+++ b/addons/website_blog/static/tests/tours/blog_search_with_date.js
@@ -9,6 +9,7 @@ registry.category("web_tour.tours").add("blog_autocomplete_with_date", {
     content: "Select first month",
     trigger: 'select[name=archive]',
     run: "selectByIndex 1",
+    willUnload: true,
 },
 {
     trigger: '#o_wblog_posts_loop span:has(i.fa-calendar-o):has(a[href="/blog"])',
@@ -25,6 +26,7 @@ registry.category("web_tour.tours").add("blog_autocomplete_with_date", {
     content: "Wait for suggestions then click on search icon",
     trigger: '.o_searchbar_form button:has(i.oi-search)',
     run: "click",
+    willUnload: true,
 }, {
     content: "Ensure both filters are applied",
     trigger: `#o_wblog_posts_loop:has(span a[href="/blog?search=a"]):has(span i.fa-calendar-o):has(span a[href^="/blog?date_begin"]):has(span i.fa-search)`,

--- a/addons/website_crm/static/tests/tours/website_crm.js
+++ b/addons/website_crm/static/tests/tours/website_crm.js
@@ -60,6 +60,7 @@ registry.category("web_tour.tours").add('website_crm_tour', {
     content: "Send the form",
     trigger: ".s_website_form_send",
     run: "click",
+    willUnload: true,
 }, {
     content: "Check we were redirected to the success page",
     trigger: "#wrap:has(h1:contains('Thank You!'))",
@@ -84,6 +85,7 @@ registry.category("web_tour.tours").add('website_crm_catch_logged_partner_info_t
     content: "Send the form",
     trigger: ".s_website_form_send",
     run: "click",
+    willUnload: true,
 }, {
     content: "Check we were redirected to the success page",
     trigger: "#wrap:has(h1:contains('Thank You!'))",

--- a/addons/website_event_booth_exhibitor/static/tests/tours/website_event_booth_exhibitor.js
+++ b/addons/website_event_booth_exhibitor/static/tests/tours/website_event_booth_exhibitor.js
@@ -8,10 +8,12 @@
         content: 'Go on "Online Reveal" page',
         trigger: 'a[href*="/event"]:contains("Online Reveal"):first',
         run: "click",
+        willUnload: true,
     }, {
         content: 'Browse Booths',
         trigger: 'a:contains("Become exhibitor")',
         run: "click",
+        willUnload: true,
     }, {
         content: 'Wait for the first item to be properly selected before proceeding',
         trigger: 'label.d-block:has(input:checked) h5[name=booth_category_name]',
@@ -27,6 +29,7 @@
         content: "Validate attendees details",
         trigger: 'button:enabled:contains("Book my Booth(s)")',
         run: 'click',
+        willUnload: true,
     }, {
         content: "Fill booth details",
         trigger: 'form[id="o_wbooth_contact_details_form"]',

--- a/addons/website_event_booth_sale/static/tests/tours/helpers/WebsiteEventBoothSaleTourMethods.js
+++ b/addons/website_event_booth_sale/static/tests/tours/helpers/WebsiteEventBoothSaleTourMethods.js
@@ -6,16 +6,19 @@
                 content: "Go to page Event",
                 trigger: '.nav-link:contains("Event")',
                 run: "click",
+                willUnload: true,
             },
             {
                 content: 'Open "Test Event Booths" event',
                 trigger: `h5.card-title span:contains(${eventName})`,
                 run: "click",
+                willUnload: true,
             },
             {
                 content: 'Go to "Booth" page',
                 trigger: 'a:contains("Become exhibitor")',
                 run: "click",
+                willUnload: true,
             },
             {
                 content: 'Select the booth',

--- a/addons/website_event_booth_sale/static/tests/tours/website_event_booth.js
+++ b/addons/website_event_booth_sale/static/tests/tours/website_event_booth.js
@@ -9,10 +9,12 @@ registry.category("web_tour.tours").add('website_event_booth_tour', {
     content: 'Open "Test Event Booths" event',
     trigger: 'h5.card-title span:contains("Test Event Booths")',
     run: "click",
+    willUnload: true,
 }, {
     content: 'Go to "Booth" page',
     trigger: 'a:contains("Become exhibitor")',
     run: "click",
+    willUnload: true,
 }, {
     content: 'Select the first two booths',
     trigger: ".o_wbooth_booths input[name=event_booth_ids]:not(:visible)",
@@ -24,6 +26,7 @@ registry.category("web_tour.tours").add('website_event_booth_tour', {
     content: 'Confirm the booths by clicking the submit button',
     trigger: 'button.o_wbooth_registration_submit',
     run: "click",
+    willUnload: true,
 }, {
     content: 'Fill in your contact information',
     trigger: 'input[name="contact_name"]',
@@ -35,6 +38,7 @@ registry.category("web_tour.tours").add('website_event_booth_tour', {
     content: 'Submit your informations',
     trigger: 'button[type="submit"]',
     run: "click",
+    willUnload: true,
 },
 ...wsTourUtils.assertCartAmounts({
     taxes: '20.00',

--- a/addons/website_event_booth_sale/static/tests/tours/website_event_booth_sale_pricelists.js
+++ b/addons/website_event_booth_sale/static/tests/tours/website_event_booth_sale_pricelists.js
@@ -10,11 +10,13 @@ registry.category("web_tour.tours").add('event_booth_sale_pricelists_different_c
         content: 'Open "Test Event Booths" event',
         trigger: 'h5.card-title span:contains("Test Event Booths")',
         run: "click",
+        willUnload: true,
     },
     {
         content: 'Go to "Become exhibitor" page',
         trigger: 'a:contains("Become exhibitor")',
         run: "click",
+        willUnload: true,
     },
     {
         content: 'Select the booth',
@@ -25,6 +27,7 @@ registry.category("web_tour.tours").add('event_booth_sale_pricelists_different_c
         content: 'Confirm the booth by clicking the submit button',
         trigger: 'button.o_wbooth_registration_submit',
         run: "click",
+        willUnload: true,
     },
     {
         content: 'Fill in your contact information',
@@ -38,6 +41,7 @@ registry.category("web_tour.tours").add('event_booth_sale_pricelists_different_c
         content: 'Submit your informations',
         trigger: 'button[type="submit"]',
         run: "click",
+        willUnload: true,
     },
     wsTourUtils.goToCheckout(),
     ...getPriceListChecksSteps({

--- a/addons/website_event_sale/static/tests/tours/helpers/WebsiteEventSaleTourMethods.js
+++ b/addons/website_event_sale/static/tests/tours/helpers/WebsiteEventSaleTourMethods.js
@@ -12,6 +12,7 @@ export function changePricelist(pricelistName) {
             content: "Go to page Shop",
             trigger: '.nav-link:contains("Shop")',
             run: "click",
+            willUnload: true,
         },
         {
             content: "Toggle Pricelist",
@@ -22,6 +23,7 @@ export function changePricelist(pricelistName) {
             content: `Activate Pricelist ${pricelistName}`,
             trigger: `.dropdown-item:contains(${pricelistName})`,
             run: 'click',
+            willUnload: true,
         },
         {
             content: 'Wait for pricelist to load',
@@ -35,11 +37,13 @@ function checkPriceEvent(eventName, price, close = true) {
             content: "Go to page Event",
             trigger: '.nav-link:contains("Event")',
             run: "click",
+            willUnload: true,
         },
         {
             content: "Open the Pycon event",
             trigger: `.o_wevent_events_list a:contains(${eventName})`,
             run: "click",
+            willUnload: true,
         },
         {
             content: "Open the ticket picking modal",

--- a/addons/website_event_sale/static/tests/tours/website_event_sale.js
+++ b/addons/website_event_sale/static/tests/tours/website_event_sale.js
@@ -8,6 +8,7 @@ registry.category("web_tour.tours").add("event_buy_tickets", {
             content: "Go to the `Events` page",
             trigger: 'a[href*="/event"]:contains("Conference for Architects TEST"):first',
             run: "click",
+            willUnload: true,
         },
         {
             content: "Open the register modal",
@@ -89,12 +90,16 @@ registry.category("web_tour.tours").add("event_buy_tickets", {
             content: "Validate attendees details",
             trigger: ".modal#modal_attendees_registration button[type=submit]",
             run: "click",
+            willUnload: true,
+        },
+        {
+            trigger: ".oe_cart:contains(payment method)",
         },
         wsTourUtils.goToCart({ quantity: 3 }),
         wsTourUtils.goToCheckout(),
         ...wsTourUtils.assertCartAmounts({
             untaxed: "4,000.00",
         }),
-        ...wsTourUtils.payWithTransfer(),
+        ...wsTourUtils.payWithTransfer({ willUnload: true, waitFinalizeYourPayment: true }),
     ],
 });

--- a/addons/website_event_sale/static/tests/tours/website_event_sale_last_ticket.js
+++ b/addons/website_event_sale/static/tests/tours/website_event_sale_last_ticket.js
@@ -7,6 +7,7 @@ registry.category("web_tour.tours").add('event_buy_last_ticket', {
         content: "Open the Last ticket test event page",
         trigger: '.o_wevent_events_list a:contains("Last ticket test")',
         run: "click",
+        willUnload: true,
     },
     {
         content: "Open Registration Modal",
@@ -53,7 +54,8 @@ registry.category("web_tour.tours").add('event_buy_last_ticket', {
         content: "Validate attendees details",
         trigger: ".modal:contains(Attendees) button[type=submit]:contains(Go to Payment)",
         run: "click",
+        willUnload: true,
     },
-    ...wsTourUtils.payWithTransfer(true),
+    ...wsTourUtils.payWithTransfer({ redirect: true }),
     ],
 });

--- a/addons/website_event_sale/static/tests/tours/website_event_sale_pricelists.js
+++ b/addons/website_event_sale/static/tests/tours/website_event_sale_pricelists.js
@@ -9,6 +9,7 @@ registry.category("web_tour.tours").add("event_sale_pricelists_different_currenc
             content: "Open the Pycon event",
             trigger: '.o_wevent_events_list a:contains("Pycon")',
             run: "click",
+            willUnload: true,
         },
         {
             content: "Open the register modal",
@@ -51,6 +52,7 @@ registry.category("web_tour.tours").add("event_sale_pricelists_different_currenc
             trigger:
                 ".modal#modal_attendees_registration:not(.o_inactive_modal) button[type=submit]",
             run: "click",
+            willUnload: true,
         },
         {
             trigger: "body:not(:has(.modal#modal_attendees_registration))",

--- a/addons/website_forum/static/src/js/tours/website_forum.js
+++ b/addons/website_forum/static/src/js/tours/website_forum.js
@@ -10,6 +10,7 @@ registerBackendAndFrontendTour("question", {
     tooltipPosition: "left",
     content: _t("Create a new post in this forum by clicking on the button."),
     run: "click",
+    willUnload: true,
 }, {
     trigger: "input[name=post_name]",
     tooltipPosition: "top",
@@ -56,6 +57,7 @@ registerBackendAndFrontendTour("question", {
     content: _t("Click to post your question."),
     tooltipPosition: "bottom",
     run: "click",
+    willUnload: true,
 },
 {
     trigger: ".o_wforum_content_wrapper h3:contains(test)",
@@ -85,6 +87,7 @@ registerBackendAndFrontendTour("question", {
     content: _t("Click to post your answer."),
     tooltipPosition: "bottom",
     run: "click",
+    willUnload: true,
 }, 
 {
     trigger: ".o_wforum_content_wrapper h3:contains(test)",

--- a/addons/website_forum/static/tests/tours/website_forum_question.js
+++ b/addons/website_forum/static/tests/tours/website_forum_question.js
@@ -7,6 +7,7 @@ registry.category("web_tour.tours").add('forum_question', {
         content: "Ask the question in this forum by clicking on the button.",
         trigger: '.o_wforum_ask_btn',
         run: "click",
+        willUnload: true,
     }, {
         content: "Give your question content.",
         trigger: 'input[name=post_name]',
@@ -39,6 +40,7 @@ registry.category("web_tour.tours").add('forum_question', {
         content: "Click to post your question.",
         trigger: 'button:contains("Post")',
         run: "click",
+        willUnload: true,
     }, {
         content: "This page contain new created question.",
         trigger: '#wrap:has(.fa-star)',
@@ -64,6 +66,7 @@ registry.category("web_tour.tours").add('forum_question', {
         content: "Click on edit",
         trigger: '.o_wforum_question button:contains("Edit")',
         run: "click",
+        willUnload: true,
     },
     {
         content: "Check that the content is the same",
@@ -73,6 +76,7 @@ registry.category("web_tour.tours").add('forum_question', {
         content: "Save changes",
         trigger: 'button:contains("Save Changes")',
         run: "click",
+        willUnload: true,
     },
     {
         trigger: "a:contains(\"Reply\").collapsed",
@@ -92,6 +96,7 @@ registry.category("web_tour.tours").add('forum_question', {
         content: "Click to post your answer.",
         trigger: 'button:contains("Post Answer")',
         run: "click",
+        willUnload: true,
     },
     {
         content: "Close modal once modal animation is done.",

--- a/addons/website_hr_recruitment/static/tests/tours/website_hr_recruitment.js
+++ b/addons/website_hr_recruitment/static/tests/tours/website_hr_recruitment.js
@@ -11,10 +11,12 @@ function applyForAJob(jobName, application) {
         content: "Select Job",
         trigger: `.oe_website_jobs h3:contains(${jobName})`,
         run: "click",
+        willUnload: true,
     }, {
         content: "Apply",
         trigger: ".js_hr_recruitment a:contains('Apply')",
         run: "click",
+        willUnload: true,
     }, {
         content: "Complete name",
         trigger: "input[name=partner_name]",
@@ -39,6 +41,7 @@ function applyForAJob(jobName, application) {
         content: "Send the form",
         trigger: ".s_website_form_send",
         run: "click",
+        willUnload: true,
     }, {
         content: "Check the form is submitted without errors",
         trigger: "#jobs_thankyou h1:contains('Congratulations')",
@@ -60,6 +63,7 @@ registry.category("web_tour.tours").add('website_hr_recruitment_tour', {
         run: () => {
             window.location.href = '/jobs';
         },
+        willUnload: true,
     },
     ...applyForAJob('Internship', {
         name: 'Jack Doe',

--- a/addons/website_links/static/tests/tours/website_links.js
+++ b/addons/website_links/static/tests/tours/website_links.js
@@ -97,6 +97,7 @@ registry.category("web_tour.tours").add('website_links_tour', {
             run: function () {
                 window.location.href = $('#generated_tracked_link .o_website_links_short_url').text();
             },
+            willUnload: true,
         },
         {
             content: "check that we landed on correct page with correct query strings",
@@ -109,6 +110,7 @@ registry.category("web_tour.tours").add('website_links_tour', {
                 }
                 window.location.href = '/r';
             },
+            willUnload: true,
         },
         // 3. Check that counter got incremented and charts are correctly displayed
         {
@@ -125,6 +127,7 @@ registry.category("web_tour.tours").add('website_links_tour', {
             content: "visit link stats page",
             trigger: ".o_website_links_card",
             run: "click",
+            willUnload: true,
         },
         {
             trigger: '.website_links_click_chart .title:contains("1 clicks")',

--- a/addons/website_livechat/static/tests/tours/website_livechat_chatbot_after_reload.js
+++ b/addons/website_livechat/static/tests/tours/website_livechat_chatbot_after_reload.js
@@ -12,6 +12,7 @@ registry.category("web_tour.tours").add("website_livechat_chatbot_after_reload_t
             content: "Reload the page",
             trigger: messagesContain("How can I help you?"),
             run: () => location.reload(),
+            willUnload: true,
         },
         {
             trigger: ".o-livechat-root:shadow .o-livechat-LivechatButton",

--- a/addons/website_livechat/static/tests/tours/website_livechat_chatbot_redirect.js
+++ b/addons/website_livechat/static/tests/tours/website_livechat_chatbot_redirect.js
@@ -35,6 +35,7 @@ registry.category("web_tour.tours").add("website_livechat.chatbot_redirect", {
         {
             trigger: ".o-livechat-root:shadow button:contains(Go to the /chatbot-redirect page)",
             run: "click",
+            willUnload: true,
         },
         {
             trigger:

--- a/addons/website_livechat/static/tests/tours/website_livechat_chatbot_test_page_tour.js
+++ b/addons/website_livechat/static/tests/tours/website_livechat_chatbot_test_page_tour.js
@@ -33,6 +33,7 @@ registry.category("web_tour.tours").add("website_livechat_chatbot_test_page_tour
             run() {
                 window.location.reload();
             },
+            willUnload: true,
         },
         {
             trigger: messagesContain("Hello! I'm a bot!"),

--- a/addons/website_livechat/static/tests/tours/website_livechat_no_new_session_with_hide_rule.js
+++ b/addons/website_livechat/static/tests/tours/website_livechat_no_new_session_with_hide_rule.js
@@ -47,6 +47,7 @@ registry.category("web_tour.tours").add("website_livechat_no_session_with_hide_r
         {
             trigger: "body",
             run: () => (window.location = "/"),
+            willUnload: true,
         },
         {
             trigger: ".o-livechat-root:shadow [title='Close Chat Window (ESC)']",

--- a/addons/website_livechat/static/tests/tours/website_livechat_session_user_changes.js
+++ b/addons/website_livechat/static/tests/tours/website_livechat_session_user_changes.js
@@ -27,6 +27,7 @@ registry.category("web_tour.tours").add("website_livechat_logout_after_chat_star
         {
             trigger: "a:contains(Logout)",
             run: "click",
+            willUnload: true,
         },
         {
             content:

--- a/addons/website_livechat/static/tests/tours/website_livechat_user_known_after_reload.js
+++ b/addons/website_livechat/static/tests/tours/website_livechat_user_known_after_reload.js
@@ -20,6 +20,7 @@ registry.category("web_tour.tours").add("website_livechat_user_known_after_reloa
             run() {
                 window.location.reload();
             },
+            willUnload: true,
         },
         {
             trigger:

--- a/addons/website_payment/static/tests/tours/donation.js
+++ b/addons/website_payment/static/tests/tours/donation.js
@@ -50,6 +50,7 @@ registry.category('web_tour.tours').add('donation_snippet_use', {
             content: "Donate with custom amount set",
             trigger: ".s_donation_donate_btn",
             run: "click",
+            willUnload: true,
         },
         {
             content: "Check if custom amount radio input is selected",
@@ -144,6 +145,7 @@ registry.category('web_tour.tours').add('donation_snippet_use_2', {
             content: "Donate using the selected amount",
             trigger: ".s_donation_donate_btn",
             run: "click",
+            willUnload: true,
         },
         {
             content: "Click on the 'Amount to donate' input field",
@@ -164,6 +166,7 @@ registry.category('web_tour.tours').add('donation_snippet_use_2', {
             content: "Submit the donation form",
             trigger: "button[name='o_payment_submit_button']",
             run: "click",
+            willUnload: true,
         },
         {
             trigger: "body:contains(Your payment has been processed.)",
@@ -171,6 +174,7 @@ registry.category('web_tour.tours').add('donation_snippet_use_2', {
         {
             content: "Verify that the amount displayed is 67",
             trigger: 'span.oe_currency_value:contains("67.00")',
+            willUnload: true,
         },
         {
             trigger: "[name=o_payment_status_alert]:contains(thank you!)",

--- a/addons/website_profile/static/tests/tours/tour_website_profile_description.js
+++ b/addons/website_profile/static/tests/tours/tour_website_profile_description.js
@@ -6,10 +6,12 @@ registry.category("web_tour.tours").add('website_profile_description', {
         content: "Click on one user profile card",
         trigger: "div[onclick]:contains(\"test_user\")",
         run: "click",
+        willUnload: true,
     }, {
         content: "Edit profile",
         trigger: "a:contains('EDIT PROFILE')",
         run: "click",
+        willUnload: true,
     }, {
         content: "Add some content",
         trigger: ".odoo-editor-editable p",
@@ -18,6 +20,7 @@ registry.category("web_tour.tours").add('website_profile_description', {
         content: "Save changes",
         trigger: "button:contains('Update')",
         run: "click",
+        willUnload: true,
     }, {
         content: "Check the content is saved",
         trigger: "span[data-oe-field='website_description']:contains('content <p>code here</p>')",

--- a/addons/website_sale/static/src/js/tours/tour_utils.js
+++ b/addons/website_sale/static/src/js/tours/tour_utils.js
@@ -1,13 +1,27 @@
 import { _t } from "@web/core/l10n/translation";
 import { clickOnElement } from '@website/js/tours/tour_utils';
 
-export function addToCart({productName, search = true, productHasVariants = false}) {
+export function addToCart({
+    productName,
+    search = true,
+    productHasVariants = false,
+    willUnload = false,
+} = {}) {
     const steps = [];
     if (search) {
         steps.push(...searchProduct(productName));
     }
-    steps.push(clickOnElement(productName, `a:contains(${productName})`));
-    steps.push(clickOnElement('Add to cart', '#add_to_cart'));
+    steps.push({
+        content: productName,
+        trigger: `a:contains(${productName})`,
+        run: "click",
+        willUnload,
+    });
+    steps.push({
+        content: "Add to cart",
+        trigger: "#add_to_cart",
+        run: "click",
+    });
     if (productHasVariants) {
         steps.push(clickOnElement('Continue Shopping', 'button:contains("Continue Shopping")'));
     }
@@ -73,7 +87,8 @@ export function fillAdressForm(
         street: "1 rue de la paix",
         city: "Paris",
         zip: "75000",
-    }
+    },
+    willUnload = false
 ) {
     const steps = [];
     steps.push({
@@ -91,16 +106,23 @@ export function fillAdressForm(
         content: "Continue checkout",
         trigger: "a[name='website_sale_main_button']",
         run: "click",
+        willUnload,
     });
     return steps;
 }
 
-export function goToCart({quantity = 1, position = "bottom", backend = false} = {}) {
+export function goToCart({
+    quantity = 1,
+    position = "bottom",
+    backend = false,
+    willUnload = true,
+} = {}) {
     return {
         content: _t("Go to cart"),
         trigger: `${backend ? ":iframe" : ""} a sup.my_cart_quantity:contains(/^${quantity}$/)`,
         tooltipPosition: position,
         run: "click",
+        willUnload,
     };
 }
 
@@ -109,6 +131,7 @@ export function goToCheckout() {
         content: 'Checkout your order',
         trigger: 'a[href^="/shop/checkout"]',
         run: 'click',
+        willUnload: true,
     };
 }
 
@@ -117,16 +140,27 @@ export function confirmOrder() {
         content: 'Confirm',
         trigger: 'a[href^="/shop/confirm_order"]',
         run: 'click',
+        willUnload: true,
     };
 }
 
-export function pay() {
-    return {
-        content: 'Pay',
-        //Either there are multiple payment methods, and one is checked, either there is only one, and therefore there are no radio inputs
-        trigger: 'button[name="o_payment_submit_button"]:visible:not(:disabled)',
-        run: "click",
-    };
+export function pay({ willUnload = false, waitFinalizeYourPayment = false } = {}) {
+    const steps = [
+        {
+            content: 'Pay',
+            //Either there are multiple payment methods, and one is checked, either there is only one, and therefore there are no radio inputs
+            trigger: 'button[name="o_payment_submit_button"]',
+            run: "click",
+            willUnload,
+        },
+    ];
+    if (waitFinalizeYourPayment) {
+        steps.push({
+            trigger: "h1:contains(finalize your payment)",
+            willUnload: true,
+        });
+    }
+    return steps;
 }
 
 export function payWithDemo() {
@@ -139,14 +173,18 @@ export function payWithDemo() {
         trigger: 'input[name="customer_input"]',
         run: "edit 4242424242424242",
     },
-    pay(),
+    ...pay(),
     {
         content: 'eCommerce: check that the payment is successful',
         trigger: '.oe_website_sale_tx_status:contains("Your payment has been processed.")',
     }]
 }
 
-export function payWithTransfer(redirect=false) {
+export function payWithTransfer({
+    redirect = false,
+    willUnload = false,
+    waitFinalizeYourPayment = false,
+} = {}) {
     const first_step = {
         content: "Select `Wire Transfer` payment method",
         trigger: 'input[name="o_payment_radio"][data-payment-method-code="wire_transfer"]',
@@ -154,41 +192,60 @@ export function payWithTransfer(redirect=false) {
     }
     if (!redirect) {
         return [
-        first_step,
-        pay(),
-        {
-            content: "Last step",
-            trigger: '.oe_website_sale_tx_status:contains("Please use the following transfer details")',
-            timeout: 30000,
-        }]
+            first_step,
+            ...pay({ willUnload, waitFinalizeYourPayment }),
+            {
+                content: "Last step",
+                trigger:
+                    '.oe_website_sale_tx_status:contains("Please use the following transfer details")',
+                timeout: 30000,
+            },
+        ];
     } else {
         return [
             first_step,
-            pay(),
+            ...pay({ willUnload, waitFinalizeYourPayment }),
             {
                 content: "Last step",
-                trigger: '.oe_website_sale_tx_status:contains("Please use the following transfer details")',
+                trigger:
+                    '.oe_website_sale_tx_status:contains("Please use the following transfer details")',
                 timeout: 30000,
                 run() {
                     window.location.href = '/contactus'; // Redirect in JS to avoid the RPC loop (20x1sec)
                 },
-            }, {
+                willUnload: true,
+            },
+            {
                 content: "wait page loaded",
                 trigger: 'h1:contains("Contact us")',
-            }
-        ]
+            },
+        ];
     }
 }
 
-export function searchProduct(productName) {
-    return [
+export function searchProduct(productName, { select = false } = {}) {
+    const steps = [
         {
             content: "Search for the product",
             trigger: 'form input[name="search"]',
             run: `edit ${productName}`,
         },
-        clickOnElement('Search', 'form:has(input[name="search"]) .oe_search_button'),
+        {
+            content: `Search ${productName}`,
+            trigger: `form:has(input[name="search"]) .oe_search_button`,
+            run: "click",
+            willUnload: true,
+        },
     ];
+    if (select) {
+        steps.push({
+            content: `Select ${productName}`,
+            trigger: `.oe_product_cart:first a:contains(/^${productName}$/i)`,
+            run: "click",
+            willUnload: true,
+        });
+    }
+    return steps;
 }
 
 /**
@@ -205,6 +262,7 @@ export function selectPriceList(pricelist) {
             content: "Click on pricelist",
             trigger: `span:contains(${pricelist})`,
             run: "click",
+            willUnload: true,
         },
     ];
 }

--- a/addons/website_sale/static/tests/tours/website_free_delivery.js
+++ b/addons/website_sale/static/tests/tours/website_free_delivery.js
@@ -5,7 +5,7 @@ registry.category("web_tour.tours").add("check_free_delivery", {
     url: "/shop",
     steps: () => [
         // Part 1: Check free delivery
-        ...tourUtils.addToCart({ productName: "Office Chair Black TEST" }),
+        ...tourUtils.addToCart({ productName: "Office Chair Black TEST", willUnload: true }),
         tourUtils.goToCart({ quantity: 1 }),
         tourUtils.goToCheckout(),
         {
@@ -31,7 +31,7 @@ registry.category("web_tour.tours").add("check_free_delivery", {
             trigger: 'input[name="o_payment_radio"][data-payment-method-code="wire_transfer"]',
             run: "click",
         },
-        tourUtils.pay(),
+        ...tourUtils.pay({ willUnload: true, waitFinalizeYourPayment: true }),
         {
             content: "Confirmation page should be shown",
             trigger: "#oe_structure_website_sale_confirmation_1:not(:visible)",

--- a/addons/website_sale/static/tests/tours/website_sale_buy.js
+++ b/addons/website_sale/static/tests/tours/website_sale_buy.js
@@ -4,12 +4,7 @@ import * as tourUtils from "@website_sale/js/tours/tour_utils";
 registry.category("web_tour.tours").add('shop_buy_product', {
     url: '/shop',
     steps: () => [
-        ...tourUtils.searchProduct("Storage Box"),
-        {
-            content: "select Storage Box",
-            trigger: '.oe_product_cart:first a:contains("Storage Box")',
-            run: "click",
-        },
+        ...tourUtils.searchProduct("Storage Box", { select: true }),
         {
             content: "click on add to cart",
             trigger: '#product_detail form #add_to_cart',
@@ -18,6 +13,6 @@ registry.category("web_tour.tours").add('shop_buy_product', {
         tourUtils.goToCart(),
         tourUtils.goToCheckout(),
         tourUtils.confirmOrder(),
-        ...tourUtils.payWithTransfer(true),
+        ...tourUtils.payWithTransfer({ redirect: true }),
     ]
 });

--- a/addons/website_sale/static/tests/tours/website_sale_cart_notification.js
+++ b/addons/website_sale/static/tests/tours/website_sale_cart_notification.js
@@ -4,7 +4,10 @@ import * as tourUtils from "@website_sale/js/tours/tour_utils";
 registry.category("web_tour.tours").add("website_sale_cart_notification", {
     url: "/shop",
     steps: () => [
-        ...tourUtils.addToCart({ productName: "website_sale_cart_notification_product_1" }),
+        ...tourUtils.addToCart({
+            productName: "website_sale_cart_notification_product_1",
+            willUnload: true,
+        }),
         {
             content: "check that 1 website_sale_cart_notification_product_1 was added",
             trigger: '.toast-body span:contains("1 x website_sale_cart_notification_product_1")',
@@ -27,13 +30,7 @@ registry.category("web_tour.tours").add("website_sale_cart_notification", {
                 }
             },
         },
-        ...tourUtils.searchProduct("website_sale_cart_notification_product_2"),
-        {
-            content: "select website_sale_cart_notification_product_2",
-            trigger:
-                '.oe_product_cart:first a:contains("website_sale_cart_notification_product_2")',
-            run: "click",
-        },
+        ...tourUtils.searchProduct("website_sale_cart_notification_product_2", { select: true }),
         {
             trigger: "#product_detail",
         },
@@ -63,6 +60,7 @@ registry.category("web_tour.tours").add("website_sale_cart_notification", {
             content: "Go To Cart",
             trigger: '.toast-body a:contains("View cart")',
             run: "click",
+            willUnload: true,
         },
         tourUtils.assertCartContains({
             productName: "website_sale_cart_notification_product_1",

--- a/addons/website_sale/static/tests/tours/website_sale_category_page_and_products_snippet.js
+++ b/addons/website_sale/static/tests/tours/website_sale_category_page_and_products_snippet.js
@@ -56,6 +56,7 @@ registry.category("web_tour.tours").add('category_page_and_products_snippet_use'
         content: "Navigate to category",
         trigger: '.o_wsale_filmstip > li:contains("Test Category") > a',
         run: "click",
+        willUnload: true,
     },
     {
         content: "Check that the snippet displays the right products",

--- a/addons/website_sale/static/tests/tours/website_sale_combo_configurator.js
+++ b/addons/website_sale/static/tests/tours/website_sale_combo_configurator.js
@@ -8,7 +8,7 @@ registry
     .add('website_sale_combo_configurator', {
         url: '/shop?search=Combo product',
         steps: () => [
-            ...wsTourUtils.addToCart({ productName: "Combo product", search: false }),
+            ...wsTourUtils.addToCart({ productName: "Combo product", search: false , willUnload: true}),
             // Assert that the combo configurator behaves as expected.
             comboConfiguratorTourUtils.assertFooterButtonsDisabled(),
             comboConfiguratorTourUtils.setQuantity(3),
@@ -24,6 +24,7 @@ registry
                 content: "Proceed to checkout",
                 trigger: 'button:contains(Proceed to Checkout)',
                 run: 'click',
+                willUnload: true,
             },
             wsTourUtils.assertCartContains({ productName: "Combo product" }),
             wsTourUtils.assertCartContains({ productName: "3 x Product A1" }),

--- a/addons/website_sale/static/tests/tours/website_sale_combo_configurator_single_configurable_item.js
+++ b/addons/website_sale/static/tests/tours/website_sale_combo_configurator_single_configurable_item.js
@@ -6,7 +6,7 @@ registry
     .add('website_sale_combo_configurator_single_configurable_item', {
         url: '/shop?search=Combo product',
         steps: () => [
-            ...wsTourUtils.addToCart({ productName: "Combo product", search: false }),
+            ...wsTourUtils.addToCart({ productName: "Combo product", search: false, willUnload: true }),
             {
                 content: "Assert that the combo configurator is shown",
                 trigger: '.sale-combo-configurator-dialog',

--- a/addons/website_sale/static/tests/tours/website_sale_combo_configurator_single_configuration.js
+++ b/addons/website_sale/static/tests/tours/website_sale_combo_configurator_single_configuration.js
@@ -6,7 +6,7 @@ registry
     .add('website_sale_combo_configurator_single_configuration', {
         url: '/shop?search=Combo product',
         steps: () => [
-            ...wsTourUtils.addToCart({ productName: "Combo product", search: false }),
+            ...wsTourUtils.addToCart({ productName: "Combo product", search: false, willUnload: true }),
             wsTourUtils.goToCart(),
             // Assert that the combo configurator wasn't shown.
             wsTourUtils.assertCartContains({ productName: "Combo product" }),

--- a/addons/website_sale/static/tests/tours/website_sale_complete_flow.js
+++ b/addons/website_sale/static/tests/tours/website_sale_complete_flow.js
@@ -1,6 +1,7 @@
 import { rpc } from "@web/core/network/rpc";
 import { registry } from "@web/core/registry";
 import * as tourUtils from "@website_sale/js/tours/tour_utils";
+import { pay } from "@website_sale/js/tours/tour_utils";
 
     registry.category("web_tour.tours").add('website_sale_tour_1', {
         url: '/shop?search=Storage Box Test',
@@ -10,6 +11,7 @@ import * as tourUtils from "@website_sale/js/tours/tour_utils";
         content: "Open product page",
         trigger: '.oe_product_cart a:contains("Storage Box Test")',
         run: "click",
+        willUnload: true,
     },
     {
         content: "Add one more storage box",
@@ -36,11 +38,7 @@ import * as tourUtils from "@website_sale/js/tours/tour_utils";
         untaxed: '158.00',
         total: '181.70',
     }),
-    {
-        content: "Proceed to checkout",
-        trigger: 'a[href*="/shop/checkout"]',
-        run: "click",
-    },
+        tourUtils.goToCheckout(),
     {
         content: "Fulfill delivery address form",
         trigger: 'select[name="country_id"]',
@@ -74,6 +72,7 @@ import * as tourUtils from "@website_sale/js/tours/tour_utils";
         content: "Click on Confirm button",
         trigger: 'a[name="website_sale_main_button"]',
         run: "click",
+        willUnload: true,
     },
     {
         content: "Billing address is not same as delivery address",
@@ -84,6 +83,7 @@ import * as tourUtils from "@website_sale/js/tours/tour_utils";
         content: "Add a billing address",
         trigger: '.o_portal_address_row a[href^="/shop/address?address_type=billing"]:contains("Add address")',
         run: "click",
+        willUnload: true,
     },
     {
         trigger: 'h4:contains("New address")',
@@ -121,6 +121,7 @@ import * as tourUtils from "@website_sale/js/tours/tour_utils";
         content: "Click on Confirm button to save the address",
         trigger: 'a[name="website_sale_main_button"]',
         run: "click",
+        willUnload: true,
     },
     {
         content: "Check selected delivery address is same as typed in previous step",
@@ -134,6 +135,7 @@ import * as tourUtils from "@website_sale/js/tours/tour_utils";
         content: "Click for edit billing address",
         trigger: '#billing_container .o_portal_address_row a[href^="/shop/address?address_type=billing"].js_edit_address:first',
         run: "click",
+        willUnload: true,
     },
     {
         trigger: 'h4:contains("Edit address")',
@@ -162,6 +164,7 @@ import * as tourUtils from "@website_sale/js/tours/tour_utils";
         content: "Click on Confirm button to save the address",
         trigger: 'a[name="website_sale_main_button"]',
         run: "click",
+        willUnload: true,
     },
         tourUtils.confirmOrder(),
     {
@@ -181,11 +184,13 @@ import * as tourUtils from "@website_sale/js/tours/tour_utils";
         content: "Pay Now",
         trigger: 'button[name="o_payment_submit_button"]:not(:disabled)',
         run: "click",
+        willUnload: true,
     },
     {
         content: "Sign up",
         trigger: '.oe_cart a:contains("Sign Up")',
         run: "click",
+        willUnload: true,
     },
     {
         trigger: `.oe_signup_form input[name="password"]`,
@@ -199,11 +204,13 @@ import * as tourUtils from "@website_sale/js/tours/tour_utils";
         content: "Submit login",
         trigger: `.oe_signup_form button[type="submit"]`,
         run: "click",
+        willUnload: true,
     },
     {
         content: "See Quotations",
         trigger: '.o_portal_docs a:contains("Quotations to review")',
         run: "click",
+        willUnload: true,
     },
     // Sign in as admin change config auth_signup -> b2b, sale_show_tax -> total and Logout
     {
@@ -218,11 +225,13 @@ import * as tourUtils from "@website_sale/js/tours/tour_utils";
         content: "Logout",
         trigger: '#o_logout:contains("Logout")',
         run: "click",
+        willUnload: true,
     },
     {
         content: "Sign in as admin",
         trigger: 'header a[href="/web/login"]',
         run: "click",
+        willUnload: true,
     },
     {
         trigger: `.oe_login_form input[name="login"]`,
@@ -241,7 +250,8 @@ import * as tourUtils from "@website_sale/js/tours/tour_utils";
     {
         content: "Submit login",
         trigger: `.oe_login_form button[type="submit"]`,
-        run: "click"
+        run: "click",
+        willUnload: true,
     },
     {
         trigger: ".o_frontend_to_backend_nav", // Check if the user is connected
@@ -271,12 +281,14 @@ import * as tourUtils from "@website_sale/js/tours/tour_utils";
                 window.location.href = '/web/session/logout?redirect=/shop?search=Storage Box Test';
             });
         },
+        willUnload: true,
     },
     // Testing b2b with Tax-Included Prices
     {
         content: "Open product page",
         trigger: '.oe_product_cart a:contains("Storage Box Test")',
         run: "click",
+        willUnload: true,
     },
     {
         content: "Add one more Storage Box Test",
@@ -307,11 +319,13 @@ import * as tourUtils from "@website_sale/js/tours/tour_utils";
             content: "Proceed to checkout",
             trigger: 'a[href*="/shop/checkout"]',
             run: "click",
+            willUnload: true,
         },
     {
         content: "Click on Sign in Button",
         trigger: `.oe_cart a:contains(Sign in)`,
         run: "click",
+        willUnload: true,
     },
     {
         trigger: `.oe_login_form input[name="login"]`,
@@ -325,11 +339,13 @@ import * as tourUtils from "@website_sale/js/tours/tour_utils";
         content: "Submit login",
         trigger: `.oe_login_form button[type="submit"]`,
         run: "click",
+        willUnload: true,
     },
     {
         content: "Add new delivery address",
         trigger: '#delivery_address_row a[href^="/shop/address"]:contains("Add address")',
         run: "click",
+        willUnload: true,
     },
     {
         content: "Fulfill delivery address form",
@@ -374,11 +390,7 @@ import * as tourUtils from "@website_sale/js/tours/tour_utils";
     {
         trigger: 'input[name="o_payment_radio"][data-payment-method-code="wire_transfer"]:checked',
     },
-    {
-        content: "Pay Now",
-        trigger: 'button[name="o_payment_submit_button"]:not(:disabled)',
-        run: "click",
-    },
+        ...pay({ willUnload: true, waitFinalizeYourPayment: true }),
     {
         trigger: '.oe_cart .oe_website_sale_tx_status',
     },
@@ -394,6 +406,7 @@ import * as tourUtils from "@website_sale/js/tours/tour_utils";
         content: "My account",
         trigger: 'header#top .dropdown-menu a[href="/my/home"]:visible',
         run: "click",
+        willUnload: true,
     },
 
     // enable extra step on website checkout and check extra step on checkout process
@@ -409,11 +422,13 @@ import * as tourUtils from "@website_sale/js/tours/tour_utils";
         content: "Logout",
         trigger: '#o_logout:contains("Logout")',
         run: "click",
+        willUnload: true,
     },
     {
         content: "Sign in as admin",
         trigger: 'header a[href="/web/login"]',
         run: "click",
+        willUnload: true,
     },
     {
         trigger: `.oe_login_form input[name="login"]`,
@@ -433,6 +448,7 @@ import * as tourUtils from "@website_sale/js/tours/tour_utils";
         content: "Submit login",
         trigger: `.oe_login_form button[type="submit"]`,
         run: "click",
+        willUnload: true,
     }]});
 
     registry.category("web_tour.tours").add('website_sale_tour_2', {
@@ -450,11 +466,13 @@ import * as tourUtils from "@website_sale/js/tours/tour_utils";
         content: "Logout",
         trigger: '#o_logout:contains("Logout")',
         run: "click",
+        willUnload: true,
     },
     {
         content: "Sign in as abc",
         trigger: 'header a[href="/web/login"]',
         run: "click",
+        willUnload: true,
     },
     {
         trigger: `.oe_login_form input[name="login"]`,
@@ -474,11 +492,13 @@ import * as tourUtils from "@website_sale/js/tours/tour_utils";
         content: "Submit login",
         trigger: `.oe_login_form button[type="submit"]`,
         run: "click",
+        willUnload: true,
     },
     {
         content: "Open product page",
         trigger: '.oe_product_cart a:contains("Storage Box Test")',
         run: "click",
+        willUnload: true,
     },
     {
         content: "Click on add to cart",
@@ -491,13 +511,15 @@ import * as tourUtils from "@website_sale/js/tours/tour_utils";
         content: "Click on 'Confirm' button (redirect to the 'extra info' form)",
         trigger: 'a[href^="/shop/extra_info"]',
         run: "click",
+        willUnload: true,
     },
     {
         content: "Click on 'Continue checkout' button",
         trigger: '.oe_cart .btn:contains("Continue checkout")',
         run: "click",
+        willUnload: true,
     },
-    ...tourUtils.payWithTransfer(),
+    ...tourUtils.payWithTransfer({ willUnload: true, waitFinalizeYourPayment: true }),
     {
         content: "Check payment status confirmation window",
         trigger: ".oe_website_sale_tx_status[data-order-tracking-info]",

--- a/addons/website_sale/static/tests/tours/website_sale_fiscal_position_tour.js
+++ b/addons/website_sale/static/tests/tours/website_sale_fiscal_position_tour.js
@@ -21,6 +21,7 @@ registry.category("web_tour.tours").add('website_sale_fiscal_position_public_tou
             content: "Change Pricelist",
             trigger: ".dropdown-item:contains('EUROPE EUR')",
             run: 'click',
+            willUnload: true,
         },
         {
             content: "Check price",

--- a/addons/website_sale/static/tests/tours/website_sale_google_analytics.js
+++ b/addons/website_sale/static/tests/tours/website_sale_google_analytics.js
@@ -27,6 +27,7 @@ registry.category("web_tour.tours").add('google_analytics_view_item', {
         content: "select Colored T-Shirt",
         trigger: '.oe_product_cart a:contains("Colored T-Shirt")',
         run: "click",
+        willUnload: true,
     },
     {
         content: "wait until `_getCombinationInfo()` rpc is done",
@@ -53,7 +54,7 @@ registry.category("web_tour.tours").add('google_analytics_view_item', {
 registry.category("web_tour.tours").add('google_analytics_add_to_cart', {
     url: '/shop?search=Basic Shirt',
     steps: () => [
-    ...tourUtils.addToCart({productName: 'Basic Shirt', search: false}),
+    ...tourUtils.addToCart({productName: 'Basic Shirt', search: false, willUnload: true}),
     {
         trigger: "body[cart-event-id]",
     },

--- a/addons/website_sale/static/tests/tours/website_sale_product_configurator_strikethrough_price.js
+++ b/addons/website_sale/static/tests/tours/website_sale_product_configurator_strikethrough_price.js
@@ -8,7 +8,7 @@ registry
     .add('website_sale_product_configurator_strikethrough_price', {
         url: '/shop?search=Main product',
         steps: () => [
-            ...wsTourUtils.addToCart({ productName: "Main product", search: false }),
+            ...wsTourUtils.addToCart({ productName: "Main product", search: false, willUnload: true }),
             configuratorTourUtils.assertProductPrice("Main product", '55.00'),
             websiteConfiguratorTourUtils.assertProductStrikethroughPrice("Main product", '110.00'),
             configuratorTourUtils.assertOptionalProductPrice("Optional product", '5.50'),

--- a/addons/website_sale/static/tests/tours/website_sale_product_configurator_zero_priced.js
+++ b/addons/website_sale/static/tests/tours/website_sale_product_configurator_zero_priced.js
@@ -8,7 +8,7 @@ registry
     .add('website_sale_product_configurator_zero_priced', {
         url: '/shop?search=Main product',
         steps: () => [
-            ...wsTourUtils.addToCart({ productName: "Main product", search: false }),
+            ...wsTourUtils.addToCart({ productName: "Main product", search: false, willUnload: true }),
             // Assert that the "Zero-priced" variant of the optional product can't be sold.
             ...websiteConfiguratorTourUtils.assertOptionalProductZeroPriced(
                 "Optional product (Zero-priced)"

--- a/addons/website_sale/static/tests/tours/website_sale_product_reviews_reactions_public.js
+++ b/addons/website_sale/static/tests/tours/website_sale_product_reviews_reactions_public.js
@@ -8,6 +8,7 @@ registry
             {
                 trigger: '.oe_product_cart a:contains("Storage Box Test")',
                 run: "click",
+                willUnload: true,
             },
             {
                 trigger: '.o_product_page_reviews_title',

--- a/addons/website_sale/static/tests/tours/website_sale_reorder_from_portal.js
+++ b/addons/website_sale/static/tests/tours/website_sale_reorder_from_portal.js
@@ -10,9 +10,15 @@ registry.category("web_tour.tours").add('website_sale_reorder_from_portal', {
             content: 'Select first order',
             trigger: '.o_portal_my_doc_table a:first',
             run: "click",
+            willUnload: true,
         },
         clickOnElement('Reorder Again', '.o_wsale_reorder_button'),
-        clickOnElement('Confirm', '.o_wsale_reorder_confirm'),
+        {
+            content: "Confirm",
+            trigger: ".o_wsale_reorder_confirm",
+            run: "click",
+            willUnload: true,
+        },
         assertCartContains({productName: 'Reorder Product 1'}),
         assertCartContains({productName: 'Reorder Product 2'}),
         {
@@ -26,16 +32,27 @@ registry.category("web_tour.tours").add('website_sale_reorder_from_portal', {
             trigger: "body",
             run() {
                 window.location = "/my/orders";
-            }
+            },
+            willUnload: true,
         },
         {
             content: 'Select first order',
             trigger: '.o_portal_my_doc_table a:first',
             run: "click",
+            willUnload: true,
         },
         clickOnElement('Reorder Again', '.o_wsale_reorder_button'),
-        clickOnElement('Confirm', '.o_wsale_reorder_confirm'),
-        clickOnElement('No', 'button:contains(No)'),
+        {
+            content: "Confirm",
+            trigger: ".modal .o_wsale_reorder_confirm",
+            run: "click",
+        },
+        {
+            content: "No",
+            trigger: ".modal button:contains(No)",
+            run: "click",
+            willUnload: true,
+        },
         assertCartContains({productName: 'Reorder Product 1'}),
         assertCartContains({productName: 'Reorder Product 2'}),
         {
@@ -49,16 +66,27 @@ registry.category("web_tour.tours").add('website_sale_reorder_from_portal', {
             trigger: "body",
             run() {
                 window.location = "/my/orders";
-            }
+            },
+            willUnload: true,
         },
         {
             content: 'Select first order',
             trigger: '.o_portal_my_doc_table a:first',
             run: "click",
+            willUnload: true,
         },
         clickOnElement('Reorder Again', '.o_wsale_reorder_button'),
-        clickOnElement('Confirm', '.o_wsale_reorder_confirm'),
-        clickOnElement('Yes', 'button:contains(Yes)'),
+        {
+            content: "Confirm",
+            trigger: ".o_wsale_reorder_confirm",
+            run: "click",
+        },
+        {
+            content: "Yes",
+            trigger: ".modal button:contains(Yes)",
+            run: "click",
+            willUnload: true,
+        },
         assertCartContains({productName: 'Reorder Product 1'}),
         assertCartContains({productName: 'Reorder Product 2'}),
         {
@@ -68,32 +96,58 @@ registry.category("web_tour.tours").add('website_sale_reorder_from_portal', {
         // Fourth reorder making sure confirmation dialog doesn't pop up unnecessary
         {
             content: "Deleting All products from cart",
-            trigger: 'div.js_cart_lines',
-            run: async () => {
-                $('a.js_delete_product:first').click();
-                await new Promise((r) => setTimeout(r, 1000));
-                $('a.js_delete_product:first').click();
-                await new Promise((r) => setTimeout(r, 1000));
-                $('a.js_delete_product:first').click();
-                await new Promise((r) => setTimeout(r, 1000));
-                $('a.js_delete_product:first').click();
-                await new Promise((r) => setTimeout(r, 1000));
-            }
+            trigger: "div.js_cart_lines",
+        },
+        {
+            trigger: "#cart_products:has(.o_cart_product:eq(3)):not(:has(.o_cart_product:eq(4)))",
+        },
+        {
+            trigger: `a.js_delete_product:first`,
+            run: "click",
+        },
+        {
+            trigger: "#cart_products:has(.o_cart_product:eq(2)):not(:has(.o_cart_product:eq(3)))",
+        },
+        {
+            trigger: `a.js_delete_product:first`,
+            run: "click",
+        },
+        {
+            trigger: "#cart_products:has(.o_cart_product:eq(1)):not(:has(.o_cart_product:eq(2)))",
+        },
+        {
+            trigger: `a.js_delete_product:first`,
+            run: "click",
+        },
+        {
+            trigger: "#cart_products:has(.o_cart_product:eq(0)):not(:has(.o_cart_product:eq(1)))",
+        },
+        {
+            trigger: `a.js_delete_product:first`,
+            run: "click",
+            willUnload: true,
         },
         {
             content: "Go to my orders",
             trigger: 'body',
             run: () => {
                 window.location = '/my/orders';
-            }
+            },
+            willUnload: true,
         },
         {
             content: "Select first order",
             trigger: '.o_portal_my_doc_table a:first',
             run: "click",
+            willUnload: true,
         },
         clickOnElement('Reorder Again', '.o_wsale_reorder_button'),
-        clickOnElement('Confirm', '.o_wsale_reorder_confirm'),
+        {
+            content: "Confirm",
+            trigger: ".o_wsale_reorder_confirm",
+            run: "click",
+            willUnload: true,
+        },
         assertCartContains({productName: 'Reorder Product 1'}),
         {
             content: "Check that quantity is 1",

--- a/addons/website_sale/static/tests/tours/website_sale_shop_archived_variant_multi.js
+++ b/addons/website_sale/static/tests/tours/website_sale_shop_archived_variant_multi.js
@@ -18,6 +18,7 @@ registry.category("web_tour.tours").add('tour_shop_archived_variant_multi', {
         content: "select Test Product",
         trigger: ".oe_product_cart a:contains(/^Test Product 2$/)",
         run: "click",
+        willUnload: true,
     },
     {
         content: 'click on the first variant',
@@ -68,6 +69,7 @@ registry.category("web_tour.tours").add('test_09_pills_variant', {
         content: "select Test Product",
         trigger: ".oe_product_cart a:contains(/^Test Product 2$/)",
         run: "click",
+        willUnload: true,
     },
     {
         content: "check there are two radio boxes, both hidden",

--- a/addons/website_sale/static/tests/tours/website_sale_shop_cart_recovery.js
+++ b/addons/website_sale/static/tests/tours/website_sale_shop_cart_recovery.js
@@ -9,7 +9,7 @@ var recoveryLinkKey = 'website_sale.tour_shop_cart_recovery.recoveryLink';
 registry.category("web_tour.tours").add('shop_cart_recovery', {
     url: '/shop',
     steps: () => [
-        ...tourUtils.addToCart({productName: "Acoustic Bloc Screens"}),
+        ...tourUtils.addToCart({ productName: "Acoustic Bloc Screens", willUnload: true }),
         tourUtils.goToCart(),
     {
         content: "check product is in cart, get cart id, logout, go to login",
@@ -19,6 +19,7 @@ registry.category("web_tour.tours").add('shop_cart_recovery', {
             browser.localStorage.setItem(orderIdKey, orderId);
             window.location.href = "/web/session/logout?redirect=/web/login";
         },
+        willUnload: true,
     },
     {
         content: "edit login input",
@@ -43,6 +44,7 @@ registry.category("web_tour.tours").add('shop_cart_recovery', {
         content: "login as admin and go to the SO (backend)",
         trigger: ".oe_login_form .oe_login_buttons button:contains(log in)",
         run: "click",
+        willUnload: true,
     },
     {
         content: "click action",
@@ -80,7 +82,8 @@ registry.category("web_tour.tours").add('shop_cart_recovery', {
             var link = queryOne('.o-mail-Message-body a:contains("Resume order")').getAttribute('href');
             browser.localStorage.setItem(recoveryLinkKey, link);
             window.location.href = "/web/session/logout?redirect=/";
-        }
+        },
+        willUnload: true,
     },
     {
         content: "go to the recovery link",
@@ -89,6 +92,7 @@ registry.category("web_tour.tours").add('shop_cart_recovery', {
             const localStorage = browser.localStorage;
             window.location.href = localStorage.getItem(recoveryLinkKey);
         },
+        willUnload: true,
     },
     {
         trigger: 'p:contains("This is your current cart")',
@@ -97,6 +101,7 @@ registry.category("web_tour.tours").add('shop_cart_recovery', {
         content: "check the page is working, click on restore",
         trigger: 'p:contains("restore") a:contains("Click here")',
         run: "click",
+        willUnload: true,
     },
     {
         content: "check product is in restored cart",

--- a/addons/website_sale/static/tests/tours/website_sale_shop_custom_attribute_value.js
+++ b/addons/website_sale/static/tests/tours/website_sale_shop_custom_attribute_value.js
@@ -6,6 +6,7 @@
         content: "click on Customizable Desk",
         trigger: '.oe_product_cart a:contains("Customizable Desk (TEST)")',
         run: "click",
+        willUnload: true,
     },
     {
         trigger: "li.js_attribute_value",
@@ -24,6 +25,7 @@
     {
         trigger: 'button:contains(Proceed to Checkout)',
         run: 'click',
+        willUnload: true,
     },
     {
         trigger: "#cart_products",

--- a/addons/website_sale/static/tests/tours/website_sale_shop_custom_attributes_value.js
+++ b/addons/website_sale/static/tests/tours/website_sale_shop_custom_attributes_value.js
@@ -10,6 +10,7 @@ registry.category("web_tour.tours").add("a_shop_custom_attribute_value", {
         content: "click on Customizable Desk",
         trigger: '.oe_product_cart a:contains("Customizable Desk (TEST)")',
         run: "click",
+        willUnload: true,
 }, {
     trigger: 'a.js_add_cart_json:has(i.fa-plus)',
     run: 'click',
@@ -45,6 +46,7 @@ configuratorTourUtils.assertPriceTotal("1,228.50"),
 {
     trigger: 'button:contains(Proceed to Checkout)',
     run: 'click',
+    willUnload: true,
 },
 tourUtils.assertCartContains({
     productName: "Customizable Desk (TEST)",

--- a/addons/website_sale/static/tests/tours/website_sale_shop_deleted_archived_variants.js
+++ b/addons/website_sale/static/tests/tours/website_sale_shop_deleted_archived_variants.js
@@ -13,6 +13,7 @@ registry.category("web_tour.tours").add('tour_shop_deleted_archived_variants', {
         content: "select Test Product 2",
         trigger: ".oe_product_cart a:contains(/^Test Product 2$/)",
         run: "click",
+        willUnload: true,
     },
     {
         content: "check price (3rd variant)",

--- a/addons/website_sale/static/tests/tours/website_sale_shop_dynamic_variants.js
+++ b/addons/website_sale/static/tests/tours/website_sale_shop_dynamic_variants.js
@@ -9,6 +9,7 @@ registry.category("web_tour.tours").add('tour_shop_dynamic_variants', {
         content: "select Dynamic Product",
         trigger: ".oe_product_cart a:contains(/^Dynamic Product$/)",
         run: "click",
+        willUnload: true,
     },
     {
         content: "click on the second variant",

--- a/addons/website_sale/static/tests/tours/website_sale_shop_mail.js
+++ b/addons/website_sale/static/tests/tours/website_sale_shop_mail.js
@@ -5,7 +5,7 @@ import * as tourUtils from "@website_sale/js/tours/tour_utils";
 registry.category("web_tour.tours").add('shop_mail', {
     url: '/shop?search=Acoustic Bloc Screens',
     steps: () => [
-        ...tourUtils.addToCart({productName: 'Acoustic Bloc Screens', search: false}),
+        ...tourUtils.addToCart({productName: 'Acoustic Bloc Screens', search: false, willUnload: true}),
         tourUtils.goToCart(),
     {
         content: "check product is in cart, get cart id, go to backend",
@@ -14,6 +14,7 @@ registry.category("web_tour.tours").add('shop_mail', {
             const orderId = document.querySelector(".my_cart_quantity").dataset["orderId"];
             redirect("/odoo/action-sale.action_orders/" + orderId);
         },
+        willUnload: true,
     },
     {
         content: "click confirm",

--- a/addons/website_sale/static/tests/tours/website_sale_shop_multi_checkbox.js
+++ b/addons/website_sale/static/tests/tours/website_sale_shop_multi_checkbox.js
@@ -9,6 +9,7 @@ registry.category("web_tour.tours").add('tour_shop_multi_checkbox', {
         content: "select Product",
         trigger: ".oe_product_cart a:contains(/^Product Multi$/)",
         run: "click",
+        willUnload: true,
     },
     {
         content: "check price",
@@ -67,6 +68,7 @@ registry.category("web_tour.tours").add('tour_shop_multi_checkbox_single_value',
         content: "select Product",
         trigger: '.oe_product_cart a:contains(/^Burger$/)',
         run: "click",
+        willUnload: true,
     },
     {
         content: "check price",

--- a/addons/website_sale/static/tests/tours/website_sale_shop_no_variant_attribute.js
+++ b/addons/website_sale/static/tests/tours/website_sale_shop_no_variant_attribute.js
@@ -9,6 +9,7 @@ registry.category("web_tour.tours").add('tour_shop_no_variant_attribute', {
         content: "select Test Product 3",
         trigger: ".oe_product_cart a:contains(/^Test Product 3$/)",
         run: "click",
+        willUnload: true,
     },
     {
         content: "check price",

--- a/addons/website_sale/static/tests/tours/website_sale_shop_pricelist_tour.js
+++ b/addons/website_sale/static/tests/tours/website_sale_shop_pricelist_tour.js
@@ -13,6 +13,7 @@ registry.category("web_tour.tours").add(
                 content: "Go to login page",
                 trigger: "a:contains('Sign in')",
                 run: "click",
+                willUnload: true,
             },
             {
                 content: "Submit login",
@@ -22,7 +23,8 @@ registry.category("web_tour.tours").add(
                     document.querySelector('.oe_login_form input[name="password"]').value = "long_enough_password";
                     document.querySelector('.oe_login_form input[name="redirect"]').value = "/shop";
                     document.querySelector('.oe_login_form').submit();
-                }
+                },
+                willUnload: true,
             },
             {
                 content: "Check pricelist",

--- a/addons/website_sale/static/tests/tours/website_sale_shop_zoom.js
+++ b/addons/website_sale/static/tests/tours/website_sale_shop_zoom.js
@@ -12,6 +12,7 @@ registry.category("web_tour.tours").add('shop_zoom', {
         content: "select " + imageName,
         trigger: `.oe_product_cart a:contains(/^${imageName}$/)`,
         run: "click",
+        willUnload: true,
     },
     {
         content: "click on the image",

--- a/addons/website_sale/static/tests/tours/website_sale_snippet_products.js
+++ b/addons/website_sale/static/tests/tours/website_sale_snippet_products.js
@@ -54,7 +54,7 @@ registerWebsitePreviewTour('website_sale.snippet_products', {
             trigger: ":iframe .s_dynamic_snippet_products .o_carousel_product_card_body .js_add_cart",
             run: 'click',
         },
-        goToCart({backend: true}),
+        goToCart({ backend: true, willUnload: false }),
     ]
 });
 

--- a/addons/website_sale/static/tests/tours/website_sale_update_address.js
+++ b/addons/website_sale/static/tests/tours/website_sale_update_address.js
@@ -4,7 +4,7 @@ import * as tourUtils from "@website_sale/js/tours/tour_utils";
 registry.category("web_tour.tours").add('update_billing_shipping_address', {
     url: '/shop',
     steps: () => [
-        ...tourUtils.addToCart({productName: "Office Chair Black TEST"}),
+        ...tourUtils.addToCart({ productName: "Office Chair Black TEST", willUnload: true }),
         tourUtils.goToCart({quantity: 1}),
         tourUtils.goToCheckout(),
         tourUtils.confirmOrder(),
@@ -12,11 +12,13 @@ registry.category("web_tour.tours").add('update_billing_shipping_address', {
             content: "Edit Address",
             trigger: '#delivery_and_billing a:contains("Edit")',
             run: "click",
+            willUnload: true,
         },
         {
             content: "Edit  billing address which is shipping address too",
             trigger: 'a.js_edit_address',
             run: "click",
+            willUnload: true,
         },
         {
             content: "Empty the phone field",

--- a/addons/website_sale/static/tests/tours/website_sale_update_cart.js
+++ b/addons/website_sale/static/tests/tours/website_sale_update_cart.js
@@ -4,12 +4,7 @@ import * as tourUtils from '@website_sale/js/tours/tour_utils';
 registry.category('web_tour.tours').add('shop_update_cart', {
     url: '/shop',
     steps: () => [
-        ...tourUtils.searchProduct("conference chair"),
-        {
-            content: "select conference chair",
-            trigger: '.oe_product_cart:first a:contains("Conference Chair")',
-            run: "click",
-        },
+        ...tourUtils.searchProduct("conference chair", { select: true }),
         {
             trigger: "#product_detail",
         },
@@ -38,11 +33,13 @@ registry.category('web_tour.tours').add('shop_update_cart', {
             content: "click in modal on 'Proceed to checkout' button",
             trigger: 'button:contains("Proceed to Checkout")',
             run: "click",
+            willUnload: true,
         },
         {
             content: "add suggested",
             trigger: '.js_cart_lines:has(a:contains("Storage Box")) button:contains("Add to cart")',
             run: "click",
+            willUnload: true,
         },
         {
             trigger: '#cart_products a[name="o_cart_line_product_link"]>h6:contains("Storage Box")',

--- a/addons/website_sale/static/tests/tours/website_sale_variants_modal_window.js
+++ b/addons/website_sale/static/tests/tours/website_sale_variants_modal_window.js
@@ -8,6 +8,7 @@
             content: "Select the Short (TEST) product",
             trigger: `.oe_product_cart a:contains(/^Short \\(TEST\\)$/)`,
             run: "click",
+            willUnload: true,
         },
         {
             content: "Click on the always variant",
@@ -46,6 +47,7 @@
             content: "Go through the modal window of the product configurator",
             trigger: ".modal:contains(configure your product) button:contains(Proceed to Checkout)",
             run: "click",
+            willUnload: true,
         },
         {
             content: "Check the product is in the cart",

--- a/addons/website_sale_autocomplete/static/tests/autocomplete_tour.js
+++ b/addons/website_sale_autocomplete/static/tests/autocomplete_tour.js
@@ -6,7 +6,7 @@ import * as tourUtils from '@website_sale/js/tours/tour_utils';
 registry.category("web_tour.tours").add('autocomplete_tour', {
     url: '/shop', // /shop/address is redirected if no sales order
     steps: () => [
-    ...tourUtils.addToCart({productName: "A test product"}),
+        ...tourUtils.addToCart({ productName: "A test product", willUnload: true }),
     tourUtils.goToCart(),
     tourUtils.goToCheckout(),
 { // Actual test

--- a/addons/website_sale_collect/static/src/tests/tours/buy_with_click_and_collect.js
+++ b/addons/website_sale_collect/static/src/tests/tours/buy_with_click_and_collect.js
@@ -5,8 +5,7 @@ import * as tourUtils from '@website_sale/js/tours/tour_utils';
 registry.category('web_tour.tours').add('website_sale_collect_buy_product', {
     url: '/shop',
     steps: () => [
-        ...tourUtils.searchProduct("Test CAC Product"),
-        clickOnElement("Test Product", 'a:contains("Test CAC Product")'),
+        ...tourUtils.searchProduct("Test CAC Product", { select: true }),
         clickOnElement("Open Location selector", '[name="click_and_collect_availability"]'),
         clickOnElement("Choose location", '#submit_location_large'),
         clickOnElement('Add to cart', '#add_to_cart'),
@@ -60,7 +59,7 @@ registry.category('web_tour.tours').add('website_sale_collect_buy_product', {
             trigger: 'input[name="o_payment_radio"][data-payment-method-code="pay_on_site"]',
             run: 'click',
         },
-        tourUtils.pay(),
+        ...tourUtils.pay({ willUnload: true, waitFinalizeYourPayment: true }),
         {
             content: "Check payment status confirmation window",
             trigger: '.oe_website_sale_tx_status[data-order-tracking-info]',

--- a/addons/website_sale_comparison/static/tests/tours/website_sale_comparison.js
+++ b/addons/website_sale_comparison/static/tests/tours/website_sale_comparison.js
@@ -44,6 +44,7 @@ import * as tourUtils from "@website_sale/js/tours/tour_utils";
         content: "go to product page of Color Shoes (with variants)",
         trigger: '.oe_product_cart a:contains("Color Shoes")',
         run: "click",
+        willUnload: true,
     },
     {
         content: "check compare button is still there and contains 2 products",
@@ -113,6 +114,7 @@ import * as tourUtils from "@website_sale/js/tours/tour_utils";
         content: "click on compare button",
         trigger: '.o_comparelist_button a',
         run: "click",
+        willUnload: true,
     },
     // test on compare page
     {
@@ -135,6 +137,7 @@ import * as tourUtils from "@website_sale/js/tours/tour_utils";
         content: "remove Color Shoes (Pink) from compare table",
         trigger: '#o_comparelist_table .o_comparelist_remove:eq(2)',
         run: "click",
+        willUnload: true,
     },
     {
         content: "check color shoes with pink variant is removed",
@@ -157,6 +160,7 @@ import * as tourUtils from "@website_sale/js/tours/tour_utils";
         content: "click on compare button to reload",
         trigger: '.o_comparelist_button a',
         run: "click",
+        willUnload: true,
     },
     {
         content: "check product 'Color T-Shirt' is removed",

--- a/addons/website_sale_loyalty/static/tests/tours/test_apply_discount_code.js
+++ b/addons/website_sale_loyalty/static/tests/tours/test_apply_discount_code.js
@@ -11,6 +11,7 @@ registry.category("web_tour.tours").add('apply_discount_code_program_multi_rewar
             content: 'select Super Chair',
             trigger: '.oe_product_cart a:contains("Super Chair")',
             run: "click",
+            willUnload: true,
         },
         {
             content: 'Add Super Chair into cart',
@@ -33,6 +34,7 @@ registry.category("web_tour.tours").add('apply_discount_code_program_multi_rewar
             content: 'validate the promo code',
             trigger: 'form[name="coupon_code"] .a-submit',
             run: "click",
+            willUnload: true,
         },
         {
             content: 'check reward',
@@ -42,6 +44,7 @@ registry.category("web_tour.tours").add('apply_discount_code_program_multi_rewar
             content: 'claim reward',
             trigger: '.alert:contains("10% on Super Chair") .btn:contains("Claim")',
             run: "click",
+            willUnload: true,
         },
         {
             content: "check claimed reward",
@@ -61,6 +64,7 @@ registry.category("web_tour.tours").add('apply_discount_code_program_multi_rewar
             content: 'validate the promo code',
             trigger: 'form[name="coupon_code"] .a-submit',
             run: "click",
+            willUnload: true,
         },
         {
             content: 'check refused message',

--- a/addons/website_sale_loyalty/static/tests/tours/test_ewallet_tour.js
+++ b/addons/website_sale_loyalty/static/tests/tours/test_ewallet_tour.js
@@ -1,46 +1,49 @@
 import { registry } from "@web/core/registry";
-import { TourError } from "@web_tour/tour_service/tour_utils";
 import * as wsTourUtils from "@website_sale/js/tours/tour_utils";
 
-
-registry.category("web_tour.tours").add('shop_sale_ewallet', {
-    url: '/shop',
+registry.category("web_tour.tours").add("shop_sale_ewallet", {
+    url: "/shop",
     steps: () => [
         // Add a $50 gift card to the order
-        ...wsTourUtils.addToCart({productName: "TEST - Gift Card"}),
+        ...wsTourUtils.addToCart({ productName: "TEST - Gift Card", willUnload: true }),
         wsTourUtils.goToCart(),
         {
             trigger: 'a[name="o_loyalty_claim"]:contains("Use")',
-            run() {
+            async run(helpers) {
                 const rewards = document.querySelectorAll('form[name="claim_reward"]');
                 if (rewards.length === 1) {
-                    this.anchor.click();
+                    await helpers.click();
                 } else {
-                    throw new TourError(`Expected 1 claimable reward, got: ${rewards.length}`);
+                    console.error(`Expected 1 claimable reward, got: ${rewards.length}`);
                 }
             },
+            willUnload: true,
         },
         {
-            content: 'Checkout',
+            content: "Checkout",
             trigger: 'a[name="website_sale_main_button"]',
             run: "click",
+            willUnload: true,
         },
         {
-            content: 'Confirm Order',
+            content: "Confirm Order",
             trigger: 'button[name="o_payment_submit_button"]',
             run: "click",
+            willUnload: true,
         },
         {
-            trigger: 'div[id="introduction"] h2:contains("Sales Order")'
+            trigger: 'div[id="introduction"] h2:contains("Sales Order")',
         },
         {
             trigger: 'a[href="/shop/cart"]',
-            run: function() {
-                const cartQuantity = document.querySelector('.my_cart_quantity');
-                if (cartQuantity.textContent !== '0'){
-                    throw new TourError('cart should be empty and reset after an order is paid using ewallet')
+            run: function () {
+                const cartQuantity = document.querySelector(".my_cart_quantity");
+                if (cartQuantity.textContent !== "0") {
+                    console.error(
+                        "cart should be empty and reset after an order is paid using ewallet"
+                    );
                 }
-            }
+            },
         },
     ],
 });

--- a/addons/website_sale_loyalty/static/tests/tours/test_gift_card_tour.js
+++ b/addons/website_sale_loyalty/static/tests/tours/test_gift_card_tour.js
@@ -5,7 +5,7 @@ registry.category("web_tour.tours").add('shop_sale_gift_card', {
     url: '/shop',
     steps: () => [
         // Add a small drawer to the order (50$)
-        ...tourUtils.addToCart({productName: "TEST - Small Drawer"}),
+        ...tourUtils.addToCart({ productName: "TEST - Small Drawer", willUnload: true }),
         tourUtils.goToCart(),
         {
             content: 'insert gift card code',
@@ -16,6 +16,7 @@ registry.category("web_tour.tours").add('shop_sale_gift_card', {
             content: 'validate the gift card',
             trigger: 'form[name="coupon_code"] .a-submit',
             run: "click",
+            willUnload: true,
         },
         {
             content: 'check gift card line',
@@ -30,6 +31,7 @@ registry.category("web_tour.tours").add('shop_sale_gift_card', {
             content: "Validate the promo",
             trigger: 'form[name="coupon_code"] .a-submit',
             run: "click",
+            willUnload: true,
         },
         {
             content: "Check promo",
@@ -39,8 +41,9 @@ registry.category("web_tour.tours").add('shop_sale_gift_card', {
             content: "Click on Continue Shopping",
             trigger: "div.card-body a:contains(Continue shopping)",
             run: "click",
+            willUnload: true,
         },
-        ...tourUtils.addToCart({productName: "TEST - Gift Card"}),
+        ...tourUtils.addToCart({ productName: "TEST - Gift Card", willUnload: true }),
         tourUtils.goToCart({quantity: 2}),
     ],
 });

--- a/addons/website_sale_loyalty/static/tests/tours/test_promo_main_tour.js
+++ b/addons/website_sale_loyalty/static/tests/tours/test_promo_main_tour.js
@@ -13,6 +13,7 @@ registry.category("web_tour.tours").add('shop_sale_loyalty', {
             content: "select Small Cabinet",
             trigger: '.oe_product_cart a:contains("Small Cabinet")',
             run: "click",
+            willUnload: true,
         },
         {
             content: "add 2 Small Cabinet into cart",
@@ -37,6 +38,7 @@ registry.category("web_tour.tours").add('shop_sale_loyalty', {
             content: "validate the coupon",
             trigger: 'form[name="coupon_code"] .a-submit',
             run: "click",
+            willUnload: true,
         },
         {
             content: "check reward product",
@@ -75,8 +77,9 @@ registry.category("web_tour.tours").add('shop_sale_loyalty', {
                     });
                 });
             },
+            willUnload: true,
         },
-            ...tourUtils.addToCart({productName: "Taxed Product"}),
+        ...tourUtils.addToCart({ productName: "Taxed Product", willUnload: true }),
             tourUtils.goToCart({quantity: 3}),
         {
             trigger: ".oe_currency_value:contains(/74.00/):not(div[name='o_cart_total'])",
@@ -118,6 +121,7 @@ registry.category("web_tour.tours").add('shop_sale_loyalty', {
             content: "go to checkout",
             trigger: 'a[href="/shop/checkout?try_skip_step=true"]',
             run: "click",
+            willUnload: true,
         },
         ...tourUtils.assertCartAmounts({
             total: '967.50',

--- a/addons/website_sale_loyalty/static/tests/tours/test_website_sale_free_shipping_discount_line.js
+++ b/addons/website_sale_loyalty/static/tests/tours/test_website_sale_free_shipping_discount_line.js
@@ -38,6 +38,7 @@ webTours.add("check_shipping_discount", {
             content: "select Plumbus",
             trigger: '.oe_product a:contains("Plumbus")',
             run: "click",
+            willUnload: true,
         },
         {
             content: "add 3 Plumbus into cart",
@@ -61,6 +62,7 @@ webTours.add("check_shipping_discount", {
             content: "pay with eWallet",
             trigger: "form[name=claim_reward] a[name='o_loyalty_claim']:contains('Use')",
             run: "click",
+            willUnload: true,
         },
         ...assertRewardAmounts({ discount: "- 304.00" }),
         selectDelivery("delivery1"),
@@ -70,20 +72,22 @@ webTours.add("check_shipping_discount", {
             content: "confirm shipping method",
             trigger: ".o_total_card a[name=website_sale_main_button]",
             run: "click",
+            willUnload: true,
         },
-        pay(),
+        ...pay({ willUnload: true }),
     ],
 });
 
 webTours.add("update_shipping_after_discount", {
     url: "/shop",
     steps: () => [
-        ...addToCart({ productName: "Plumbus" }),
+        ...addToCart({ productName: "Plumbus", willUnload: true }),
         goToCart(),
         {
             content: "use eWallet to check it doesn't impact `free_over` shipping",
             trigger: "a[name='o_loyalty_claim']:contains('Use')",
             run: "click",
+            willUnload: true,
         },
         {
             content: "Check pay with eWallet is applied",
@@ -106,6 +110,7 @@ webTours.add("update_shipping_after_discount", {
             content: "apply discount code",
             trigger: "form[name=coupon_code] .a-submit",
             run: "click",
+            willUnload: true,
         },
         ...assertCartAmounts({
             total: "0.00", // $50 total is covered by eWallet

--- a/addons/website_sale_loyalty/static/tests/tours/website_sale_delivery_gift_card.js
+++ b/addons/website_sale_loyalty/static/tests/tours/website_sale_delivery_gift_card.js
@@ -4,7 +4,7 @@ import * as wsTourUtils from "@website_sale/js/tours/tour_utils";
 registry.category("web_tour.tours").add('shop_sale_loyalty_delivery', {
     url: '/shop',
     steps: () => [
-        ...wsTourUtils.addToCart({productName: "Plumbus"}),
+        ...wsTourUtils.addToCart({ productName: "Plumbus", willUnload: true }),
         wsTourUtils.goToCart(1),
         wsTourUtils.goToCheckout(),
         {
@@ -21,6 +21,7 @@ registry.category("web_tour.tours").add('shop_sale_loyalty_delivery', {
             content: "click on 'Apply'",
             trigger: "a[role='button'].a-submit:contains(Apply)",
             run: "click",
+            willUnload: true,
         },
         wsTourUtils.confirmOrder(),
         ...wsTourUtils.assertCartAmounts({

--- a/addons/website_sale_stock/static/src/js/tours/website_sale_stock_reorder_from_portal.js
+++ b/addons/website_sale_stock/static/src/js/tours/website_sale_stock_reorder_from_portal.js
@@ -8,6 +8,7 @@ registry.category("web_tour.tours").add('website_sale_stock_reorder_from_portal'
             content: 'Select first order',
             trigger: '.o_portal_my_doc_table a:first',
             run: "click",
+            willUnload: true,
         },
         clickOnElement('Reorder Again', '.o_wsale_reorder_button'),
         {

--- a/addons/website_sale_stock/static/tests/tours/website_sale_stock_message_after_close_configurator_modal.js
+++ b/addons/website_sale_stock/static/tests/tours/website_sale_stock_message_after_close_configurator_modal.js
@@ -7,6 +7,7 @@ registry.category("web_tour.tours").add('website_sale_stock_message_after_close_
         content: "Select Customizable Desk",
         trigger: '.oe_product_cart a:contains("Product With Optional (TEST)")',
         run: "click",
+        willUnload: true,
     }, {
         content: "Check that the stock quantity is displayed and correct",
         trigger: '#threshold_message:contains("30")',
@@ -36,6 +37,7 @@ registry.category("web_tour.tours").add('website_sale_stock_message_after_close_
         content: "Select Office Lamp",
         trigger: '.oe_product_cart a:contains("Product Without Optional (TEST)")',
         run: "click",
+        willUnload: true,
     }, {
         content: "Check that the stock quantity is displayed and correct",
         trigger: '#threshold_message:contains("30")',

--- a/addons/website_sale_stock/static/tests/tours/website_sale_stock_product_configurator.js
+++ b/addons/website_sale_stock/static/tests/tours/website_sale_stock_product_configurator.js
@@ -42,6 +42,7 @@ registry
                 content: "Proceed to checkout",
                 trigger: 'button:contains(Proceed to Checkout)',
                 run: 'click',
+                willUnload: true,
             },
             {
                 content: "Verify the quantity in the cart",

--- a/addons/website_sale_wishlist/static/tests/tours/website_sale_wishlist.js
+++ b/addons/website_sale_wishlist/static/tests/tours/website_sale_wishlist.js
@@ -17,6 +17,7 @@ registry.category("web_tour.tours").add('shop_wishlist', {
             content: "go to wishlist",
             trigger: 'a[href="/shop/wishlist"]',
             run: "click",
+            willUnload: true,
         },
         {
             content: "remove first item in whishlist",
@@ -59,6 +60,7 @@ registry.category("web_tour.tours").add('shop_wishlist', {
             content: "click on Customizable Desk (TEST)",
             trigger: '.oe_product_cart a:contains("Customizable Desk")',
             run: "click",
+            willUnload: true,
         },
         {
             content: "check the first variant is already in wishlist",
@@ -184,6 +186,7 @@ registry.category("web_tour.tours").add('shop_wishlist', {
                     window.location.href = '/web/session/logout?redirect=/shop?search=Bottle';
                 });
             },
+            willUnload: true,
         },
         {
             trigger: '.oe_product_cart:contains("Bottle")',
@@ -204,6 +207,7 @@ registry.category("web_tour.tours").add('shop_wishlist', {
             content: "Click on product",
             trigger: '.oe_product_cart a:contains("Bottle")',
             run: "click",
+            willUnload: true,
         },
         {
             content: "Select Bottle with second variant from /product",
@@ -237,6 +241,7 @@ registry.category("web_tour.tours").add('shop_wishlist', {
             run: function () {
                 window.location.href = '/shop/wishlist';
             },
+            willUnload: true,
         },
         {
             content: "Check wishlist contains first variant",
@@ -252,6 +257,7 @@ registry.category("web_tour.tours").add('shop_wishlist', {
             run: function () {
                 window.location.href = "/web/login";
             },
+            willUnload: true,
         },
         {
             content: "Submit login as admin",
@@ -286,6 +292,7 @@ registry.category("web_tour.tours").add('shop_wishlist', {
                     window.location.href = '/web/session/logout?redirect=/shop?search=Bottle';
                 });
             },
+            willUnload: true,
         },
         {
             trigger: ".js_sale",
@@ -298,6 +305,7 @@ registry.category("web_tour.tours").add('shop_wishlist', {
             content: "Click on product",
             trigger: '.oe_product_cart a:contains("Bottle")',
             run: "click",
+            willUnload: true,
         },
         {
             content: "Select Bottle with first variant (red) from /product",
@@ -324,6 +332,7 @@ registry.category("web_tour.tours").add('shop_wishlist', {
             run: function () {
                 window.location.href = "/web/login";
             },
+            willUnload: true,
         },
         {
             content: "Submit login",
@@ -357,7 +366,8 @@ registry.category("web_tour.tours").add('shop_wishlist', {
                 .then(function () {
                     window.location.href = '/web/session/logout?redirect=/shop?search=Bottle';
                 });
-            }
+            },
+            willUnload: true,
         },
         {
             trigger: ".js_sale",
@@ -370,6 +380,7 @@ registry.category("web_tour.tours").add('shop_wishlist', {
             content: "Click on product",
             trigger: '.oe_product_cart a:contains("Bottle")',
             run: "click",
+            willUnload: true,
         },
         {
             content: "Check that there is no wishlist button from /product",
@@ -382,6 +393,7 @@ registry.category("web_tour.tours").add('shop_wishlist', {
             run: function () {
                 window.location.href = '/shop?search=Customizable Desk '
             },
+            willUnload: true,
         },
         {
             content: "Click on the product",

--- a/addons/website_slides/static/tests/tours/slides_course_reviews.js
+++ b/addons/website_slides/static/tests/tours/slides_course_reviews.js
@@ -38,13 +38,10 @@ registry.category("web_tour.tours").add("course_reviews", {
         },
         {
             trigger: ".o_wslides_course_header_nav_review",
-            run() {
-                const a = document.querySelector("a[id=review-tab]");
-                if (a.textContent !== "Reviews (1)") {
-                    throw Error("Text should be 'Reviews (1)'.")
-                }
-                a.click();
-            },
+        },
+        {
+            trigger: "a[id=review-tab]:contains('Reviews (1)')",
+            run: "click",
         },
         {
             trigger: "#chatterRoot:shadow .o-mail-Message-textContent:contains(Great course!)",
@@ -59,13 +56,9 @@ registry.category("web_tour.tours").add("course_reviews", {
             run: "edit Mid course!",
         },
         {
-            trigger: ".modal.modal_shown.show button.o_portal_chatter_composer_btn",
-            run() {
-                if (this.anchor.textContent !== "Update review") {
-                    throw Error("Button text should be 'Update review'.")
-                }
-                this.anchor.click();
-            },
+            trigger:
+                ".modal.modal_shown.show button.o_portal_chatter_composer_btn:contains(update review)",
+            run: "click",
         },
         {
             content: "Reload page (fetch message)",
@@ -73,6 +66,7 @@ registry.category("web_tour.tours").add("course_reviews", {
             run() {
                 location.reload();
             },
+            willUnload: true,
         },
         {
             trigger: "a[id=review-tab]",
@@ -91,7 +85,8 @@ registry.category("web_tour.tours").add("course_reviews", {
             run: "click",
         },
         {
-            trigger: "#chatterRoot:shadow .o-mail-Message .o-mail-MessageReactions-add:not(:visible)",
+            trigger:
+                "#chatterRoot:shadow .o-mail-Message .o-mail-MessageReactions-add:not(:visible)",
         },
         {
             trigger: "#chatterRoot:shadow .o-mail-Message .o-mail-MessageReaction",

--- a/odoo/addons/test_main_flows/static/tests/tours/switch_company_access_error_tour.js
+++ b/odoo/addons/test_main_flows/static/tests/tours/switch_company_access_error_tour.js
@@ -32,6 +32,7 @@ registry.category("web_tour.tours").add("test_company_switch_access_error", {
         {
             trigger: ".o_switch_company_menu_buttons button:contains(Confirm)",
             run: "click",
+            willUnload: true,
         },
         {
             trigger: ".o_view_controller.o_list_view",

--- a/odoo/addons/test_main_flows/static/tests/tours/test_company_access_error_redirect_tour.js
+++ b/odoo/addons/test_main_flows/static/tests/tours/test_company_access_error_redirect_tour.js
@@ -11,6 +11,7 @@ registry.category("web_tour.tours").add("test_company_access_error_redirect", {
     steps: () => [
         {
             trigger: ".o_form_view .o_last_breadcrumb_item:contains(p2)",
+            willUnload: "continue",
         },
         {
             trigger: ".o_switch_company_menu button",


### PR DESCRIPTION
Before this commit, when a page is reloaded or a page is moved to
another location in a tour, it doesn't necessarily stop immediately.
The toor continues while the page is actually unloaded.
The tour can continue for one or more steps, or not.
This can lead to indeterminisms in tours.
With this commit, we must now explicitly declare that a step will
cause the page to be unloaded in order to stop the macro and avoid
this kind of indeterminism.

willUnload: true => allows the page to be unloaded and stops the macro
willUnload: "continue" => allows the page to be unloaded but does not
stop the macro (download can trigger )