### PR TITLE
[ADD] html_editor: add placeholder blocks at the edges of the editor

### DIFF
--- a/addons/html_editor/static/src/core/history_plugin.js
+++ b/addons/html_editor/static/src/core/history_plugin.js
@@ -724,9 +724,11 @@ export class HistoryPlugin extends Plugin {
         this.dispatchTo("before_filter_mutation_record_handlers", records);
         const savableRecordPredicates = this.getResource("savable_mutation_record_predicates");
         const isRecordSavable = (record) => savableRecordPredicates.every((p) => p(record));
+        const ignoredRecordPredicates = this.getResource("ignored_mutation_record_predicates");
+        const isRecordIgnored = (record) => ignoredRecordPredicates.some((p) => p(record));
         const result = [];
         for (const record of records) {
-            if (!this.isObservedNode(record.target)) {
+            if (!this.isObservedNode(record.target) || isRecordIgnored(record)) {
                 continue;
             }
             if (this.isObserverDisabled || !isRecordSavable(record)) {

--- a/addons/html_editor/static/src/main/banner_plugin.js
+++ b/addons/html_editor/static/src/main/banner_plugin.js
@@ -131,14 +131,6 @@ export class BannerPlugin extends Plugin {
             ? blockEl.nodeName
             : this.dependencies.baseContainer.getDefaultNodeName();
         this.dependencies.dom.setTag({ tagName: nextNode });
-        // If the first child of editable is contenteditable false element
-        // a chromium bug prevents selecting the container.
-        // Add a baseContainer above it so it's no longer the first child.
-        if (this.editable.firstChild === bannerElement) {
-            const firstBaseContainer = this.dependencies.baseContainer.createBaseContainer();
-            firstBaseContainer.append(this.document.createElement("br"));
-            bannerElement.before(firstBaseContainer);
-        }
         this.dependencies.selection.setCursorEnd(
             bannerElement.querySelector(`.o_editor_banner_content > ${baseContainer.tagName}`)
         );

--- a/addons/html_editor/static/src/main/placeholder_block.scss
+++ b/addons/html_editor/static/src/main/placeholder_block.scss
@@ -1,0 +1,18 @@
+.o-placeholder-block-container {
+    position: relative;
+    height: 0;
+
+    .o-placeholder-block-top, .o-placeholder-block-bottom {
+        height: 50px;
+        width: 100%;
+        position: absolute;
+    }
+
+    .o-placeholder-block-top {
+        bottom: 0;
+    }
+
+    .o-placeholder-block-bottom {
+        top: 0;
+    }
+}

--- a/addons/html_editor/static/src/main/placeholder_block_plugin.js
+++ b/addons/html_editor/static/src/main/placeholder_block_plugin.js
@@ -22,13 +22,15 @@ export class PlaceholderBlockPlugin extends Plugin {
     static dependencies = ["baseContainer", "selection", "history"];
     resources = {
         clean_for_save_handlers: this.cleanForSave.bind(this),
-        step_added_handlers: this.resetPlaceholderBlockContainers.bind(this),
+        normalize_handlers: this.resetPlaceholderBlockContainers.bind(this),
+        history_step_handlers: this.resetPlaceholderBlockContainers.bind(this),
+        external_history_step_handlers: this.resetPlaceholderBlockContainers.bind(this),
         selectionchange_handlers: this.onSelectionChange.bind(this),
         unremovable_node_predicates: isPartOfPlaceholderBlock,
         unsplittable_node_predicates: isPartOfPlaceholderBlock,
         ignored_mutation_record_predicates: (record) => {
             // Ignore the insertion/removal of placeholder blocks.
-            const node = record.addedNodes?.[0] || record.removedNodes?.[0];
+            const node = record.addedTrees?.[0]?.node || record.removedTrees?.[0]?.node;
             return node && isPartOfPlaceholderBlock(node);
         },
         move_node_blacklist_selectors: PLACEHOLDER_SELECTORS,

--- a/addons/html_editor/static/src/main/placeholder_block_plugin.js
+++ b/addons/html_editor/static/src/main/placeholder_block_plugin.js
@@ -1,0 +1,118 @@
+import { BASE_CONTAINER_CLASS } from "@html_editor/utils/base_container";
+import { Plugin } from "../plugin";
+import { closestElement } from "@html_editor/utils/dom_traversal";
+import { xml } from "@odoo/owl";
+import { renderToElement } from "@web/core/utils/render";
+import { nodeSize } from "@html_editor/utils/position";
+
+const PLACEHOLDER_CLASS_PREFIX = "o-placeholder-block";
+const BLOCK_CLASSES = Object.fromEntries(
+    ["top", "bottom"].map((side) => [side, `${PLACEHOLDER_CLASS_PREFIX}-${side}`])
+);
+const CONTAINER_CLASS = `${PLACEHOLDER_CLASS_PREFIX}-container`;
+const CONTAINER_SELECTOR = `.${CONTAINER_CLASS}`;
+const PLACEHOLDER_SELECTORS = [
+    CONTAINER_SELECTOR,
+    ...Object.values(BLOCK_CLASSES).map((cls) => `.${cls}`),
+];
+const isPartOfPlaceholderBlock = (node) => closestElement(node, CONTAINER_SELECTOR) || false;
+
+export class PlaceholderBlockPlugin extends Plugin {
+    static id = "placeholderBlock";
+    static dependencies = ["baseContainer", "selection", "history"];
+    resources = {
+        clean_for_save_handlers: this.cleanForSave.bind(this),
+        step_added_handlers: this.resetPlaceholderBlockContainers.bind(this),
+        selectionchange_handlers: this.onSelectionChange.bind(this),
+        unremovable_node_predicates: isPartOfPlaceholderBlock,
+        unsplittable_node_predicates: isPartOfPlaceholderBlock,
+        ignored_mutation_record_predicates: (record) => {
+            // Ignore the insertion/removal of placeholder blocks.
+            const node = record.addedNodes?.[0] || record.removedNodes?.[0];
+            return node && isPartOfPlaceholderBlock(node);
+        },
+        move_node_blacklist_selectors: PLACEHOLDER_SELECTORS,
+        system_classes: [CONTAINER_CLASS, ...Object.values(BLOCK_CLASSES)],
+    };
+
+    setup() {
+        super.setup();
+        const nodeName = this.dependencies.baseContainer.getDefaultNodeName().toLowerCase();
+        const baseClass = nodeName === "P" ? "" : BASE_CONTAINER_CLASS;
+        this.templates = Object.fromEntries(
+            ["top", "bottom"].map((side) => [
+                side,
+                xml`<div class="${CONTAINER_CLASS}" contenteditable="false">
+                <${nodeName} class="${BLOCK_CLASSES[side]} ${baseClass}" contenteditable="true">
+                    <br/>
+                </${nodeName}>
+            </div>`,
+            ])
+        );
+        this.resetPlaceholderBlockContainers();
+    }
+
+    cleanForSave({ root }) {
+        root.querySelectorAll(CONTAINER_SELECTOR).forEach((block) => block.remove());
+    }
+
+    resetPlaceholderBlockContainers() {
+        const selectionData = this.dependencies.selection.getSelectionData();
+        const selection = selectionData.editableSelection;
+        const newOffsets = { anchor: selection.anchorOffset, focus: selection.focusOffset };
+        const editableSize = nodeSize(this.editable);
+        for (const [side, containerName, edgeElementName, insertFunctionName] of [
+            ["top", "containerTop", "firstElementChild", "prepend"],
+            ["bottom", "containerBottom", "lastElementChild", "append"],
+        ]) {
+            this[containerName]?.remove();
+            const edgeElement = this.editable[edgeElementName];
+            this[containerName] = undefined;
+            if (
+                edgeElement?.getAttribute("contenteditable") === "false" ||
+                edgeElement?.nodeName === "TABLE"
+            ) {
+                const container = renderToElement(this.templates[side]);
+                this.editable[insertFunctionName](container);
+                this[containerName] = container;
+                const limit = side === "top" ? 0 : editableSize;
+                for (const name of ["anchor", "focus"]) {
+                    if (selection[name + "Node"] === this.editable && newOffsets[name] === limit) {
+                        newOffsets[name] += side === "top" ? 1 : -1;
+                    }
+                }
+            }
+        }
+        if (
+            selectionData.documentSelectionIsInEditable &&
+            (newOffsets.anchor !== selection.anchorOffset ||
+                newOffsets.focus !== selection.focusOffset)
+        ) {
+            this.dependencies.selection.setSelection({
+                anchorNode: selection.anchorNode,
+                anchorOffset: newOffsets.anchor,
+                focusNode: selection.focusNode,
+                focusOffset: newOffsets.focus,
+            });
+        }
+    }
+
+    onSelectionChange(selectionData) {
+        const anchor = closestElement(selectionData.editableSelection.anchorNode);
+        if (
+            selectionData.editableSelection.isCollapsed &&
+            anchor?.matches(PLACEHOLDER_SELECTORS.join(","))
+        ) {
+            // Persist the block.
+            const block = anchor.classList.contains(CONTAINER_CLASS)
+                ? anchor.querySelector(PLACEHOLDER_SELECTORS)
+                : anchor;
+            const container = block.parentElement;
+            block.classList.remove(...Object.values(BLOCK_CLASSES));
+            block.removeAttribute("contenteditable");
+            container[container === this.containerTop ? "after" : "before"](block);
+            this.dependencies.history.addStep();
+            this.dependencies.selection.setCursorEnd(block);
+        }
+    }
+}

--- a/addons/html_editor/static/src/others/embedded_component_plugin.js
+++ b/addons/html_editor/static/src/others/embedded_component_plugin.js
@@ -1,5 +1,6 @@
 import { nodeToTree } from "@html_editor/core/history_plugin";
 import { Plugin } from "@html_editor/plugin";
+import { withSequence } from "@html_editor/utils/resource";
 import { memoize } from "@web/core/utils/functions";
 
 /**
@@ -11,7 +12,7 @@ export class EmbeddedComponentPlugin extends Plugin {
     static dependencies = ["history", "protectedNode"];
     resources = {
         /** Handlers */
-        normalize_handlers: this.normalize.bind(this),
+        normalize_handlers: withSequence(0, this.normalize.bind(this)), // ProtectedNodePlugin does this with sequence 0.
         clean_for_save_handlers: ({ root }) => this.cleanForSave(root),
         attribute_change_handlers: this.onChangeAttribute.bind(this),
         restore_savepoint_handlers: () => this.handleComponents(this.editable),

--- a/addons/html_editor/static/src/plugin_sets.js
+++ b/addons/html_editor/static/src/plugin_sets.js
@@ -55,6 +55,7 @@ import { TextDirectionPlugin } from "./main/text_direction_plugin";
 import { ToolbarPlugin } from "./main/toolbar/toolbar_plugin";
 import { YoutubePlugin } from "./main/youtube_plugin";
 import { PlaceholderPlugin } from "./main/placeholder_plugin";
+import { PlaceholderBlockPlugin } from "./main/placeholder_block_plugin";
 import { CollaborationOdooPlugin } from "./others/collaboration/collaboration_odoo_plugin";
 import { CollaborationPlugin } from "./others/collaboration/collaboration_plugin";
 import { CollaborationSelectionAvatarPlugin } from "./others/collaboration/collaboration_selection_avatar_plugin";
@@ -172,6 +173,7 @@ export const MAIN_PLUGINS = [
     InlineCodePlugin,
     TableResizePlugin,
     PlaceholderPlugin,
+    PlaceholderBlockPlugin,
 ];
 
 export const COLLABORATION_PLUGINS = [

--- a/addons/html_editor/static/src/utils/dom_info.js
+++ b/addons/html_editor/static/src/utils/dom_info.js
@@ -265,6 +265,7 @@ export function hasHeight(node) {
  * @param {Node} node
  * @returns {boolean}
  */
+// TODO: the changes here break the test "should select the table when clicked on a hook"
 export function isVisible(node) {
     return (
         !!node &&

--- a/addons/html_editor/static/src/utils/dom_info.js
+++ b/addons/html_editor/static/src/utils/dom_info.js
@@ -241,6 +241,19 @@ export function isSelfClosingElement(node) {
     return node && selfClosingElementTags.includes(node.nodeName);
 }
 
+export function hasHeight(node) {
+    if (
+        node.nodeType === Node.ELEMENT_NODE &&
+        node.ownerDocument.defaultView.getComputedStyle(node).height?.replace(/[^\d]*/g, "") === "0"
+    ) {
+        return false;
+    } else if (node.parentElement) {
+        return hasHeight(node.parentElement);
+    } else {
+        return true;
+    }
+}
+
 /**
  * Returns whether removing the given node from the DOM will have a visible
  * effect or not.
@@ -256,10 +269,10 @@ export function isVisible(node) {
     return (
         !!node &&
         ((node.nodeType === Node.TEXT_NODE && isVisibleTextNode(node)) ||
-            isSelfClosingElement(node) ||
             // @todo: handle it in resources?
-            isMediaElement(node) ||
-            hasVisibleContent(node) ||
+            (hasHeight(node.parentElement) &&
+                (isSelfClosingElement(node) || isMediaElement(node))) ||
+            (hasHeight(node) && hasVisibleContent(node)) ||
             isProtecting(node) ||
             isEmbeddedComponent(node))
     );

--- a/addons/html_editor/static/tests/_helpers/dispatch.js
+++ b/addons/html_editor/static/tests/_helpers/dispatch.js
@@ -15,6 +15,12 @@ export function cleanHints(editor) {
     }
 }
 
+export function cleanPlaceholderBlocks(editor) {
+    for (const element of editor.editable.querySelectorAll(".o-placeholder-block-container")) {
+        element.remove();
+    }
+}
+
 export function dispatchCleanForSave(editor, payload) {
     dispatchTo(editor, "clean_for_save_handlers", payload);
 }

--- a/addons/html_editor/static/tests/_helpers/placeholder_block.js
+++ b/addons/html_editor/static/tests/_helpers/placeholder_block.js
@@ -1,0 +1,16 @@
+import { unformat } from "./format";
+
+export const PLACEHOLDER_BLOCK_CONTAINER = (
+    side,
+    baseContainerNodeName = "P",
+    baseContainerClass = "o-paragraph"
+) =>
+    unformat(
+        `<div class="o-placeholder-block-container" contenteditable="false">
+            <${baseContainerNodeName.toLowerCase()} class="o-placeholder-block-${side}${
+            baseContainerClass ? " " + baseContainerClass : ""
+        }" contenteditable="true">
+                <br>
+            </${baseContainerNodeName.toLowerCase()}>
+        </div>`
+    );

--- a/addons/html_editor/static/tests/align.test.js
+++ b/addons/html_editor/static/tests/align.test.js
@@ -10,6 +10,7 @@ import {
     alignBottom,
 } from "./_helpers/user_actions";
 import { expandToolbar } from "./_helpers/toolbar";
+import { PLACEHOLDER_BLOCK_CONTAINER } from "./_helpers/placeholder_block";
 
 test("should have align tool only if the block is content editable", async () => {
     for (const [contenteditable, count] of [
@@ -36,9 +37,13 @@ describe("left", () => {
     test("should not align left a non-editable node", async () => {
         await testEditor({
             contentBefore: '<p>ab</p><div contenteditable="false"><p>c[]d</p></div>',
-            contentBeforeEdit: '<p>ab</p><div contenteditable="false"><p>c[]d</p></div>',
+            contentBeforeEdit: `<p>ab</p><div contenteditable="false"><p>c[]d</p></div>${PLACEHOLDER_BLOCK_CONTAINER(
+                "bottom"
+            )}`,
             stepFunction: alignLeft,
-            contentAfterEdit: '<p>ab</p><div contenteditable="false"><p>c[]d</p></div>',
+            contentAfterEdit: `<p>ab</p><div contenteditable="false"><p>c[]d</p></div>${PLACEHOLDER_BLOCK_CONTAINER(
+                "bottom"
+            )}`,
             contentAfter: '<p>ab</p><div contenteditable="false"><p>c[]d</p></div>',
         });
     });

--- a/addons/html_editor/static/tests/banner.test.js
+++ b/addons/html_editor/static/tests/banner.test.js
@@ -8,6 +8,7 @@ import { loader } from "@web/core/emoji_picker/emoji_picker";
 import { execCommand } from "./_helpers/userCommands";
 import { unformat } from "./_helpers/format";
 import { expectElementCount } from "./_helpers/ui_expectations";
+import { PLACEHOLDER_BLOCK_CONTAINER } from "./_helpers/placeholder_block";
 
 test("should insert a banner with focus inside followed by a paragraph", async () => {
     const { el, editor } = await setupEditor("<p>Test[]</p>");
@@ -16,9 +17,12 @@ test("should insert a banner with focus inside followed by a paragraph", async (
     expect(".active .o-we-command-name").toHaveText("Banner Info");
 
     await press("enter");
+    await animationFrame();
     expect(unformat(getContent(el))).toBe(
         unformat(
-            `<p><br></p><div class="o_editor_banner user-select-none o-contenteditable-false lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" data-oe-role="status" contenteditable="false" role="status">
+            `${PLACEHOLDER_BLOCK_CONTAINER(
+                "top"
+            )}<div class="o_editor_banner user-select-none o-contenteditable-false lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" data-oe-role="status" contenteditable="false" role="status">
                     <i class="o_editor_banner_icon mb-3 fst-normal" data-oe-aria-label="Banner Info" aria-label="Banner Info">💡</i>
                     <div class="o_editor_banner_content o-contenteditable-true w-100 px-3" contenteditable="true">
                         <p>Test[]</p>
@@ -34,7 +38,6 @@ test("should insert a banner with focus inside followed by a paragraph", async (
     await insertText(editor, "banner");
     await animationFrame();
     await expectElementCount(".o-we-powerbox", 0);
-
 });
 
 test("press 'ctrl+a' inside a banner should select all the banner content", async () => {
@@ -52,7 +55,9 @@ test("press 'ctrl+a' inside a banner should select all the banner content", asyn
     await press(["ctrl", "a"]);
     expect(unformat(getContent(el))).toBe(
         unformat(
-            `<p><br></p><div class="o_editor_banner user-select-none o-contenteditable-false lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" data-oe-role="status" contenteditable="false" role="status">
+            `${PLACEHOLDER_BLOCK_CONTAINER(
+                "top"
+            )}<div class="o_editor_banner user-select-none o-contenteditable-false lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" data-oe-role="status" contenteditable="false" role="status">
                     <i class="o_editor_banner_icon mb-3 fst-normal" data-oe-aria-label="Banner Info" aria-label="Banner Info">💡</i>
                     <div class="o_editor_banner_content o-contenteditable-true w-100 px-3" contenteditable="true">
                         <p>[Test</p><p>Test1</p><p>Test2]<br></p>
@@ -77,7 +82,9 @@ test("remove all content should preserve the first paragraph tag inside the bann
     await press(["ctrl", "a"]);
     expect(unformat(getContent(el))).toBe(
         unformat(
-            `<p><br></p><div class="o_editor_banner user-select-none o-contenteditable-false lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" data-oe-role="status" contenteditable="false" role="status">
+            `${PLACEHOLDER_BLOCK_CONTAINER(
+                "top"
+            )}<div class="o_editor_banner user-select-none o-contenteditable-false lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" data-oe-role="status" contenteditable="false" role="status">
                     <i class="o_editor_banner_icon mb-3 fst-normal" data-oe-aria-label="Banner Info" aria-label="Banner Info">💡</i>
                     <div class="o_editor_banner_content o-contenteditable-true w-100 px-3" contenteditable="true">
                         <p>[Test</p><p>Test1</p><p>Test2]<br></p>
@@ -89,28 +96,12 @@ test("remove all content should preserve the first paragraph tag inside the bann
     await press("Backspace");
     expect(unformat(getContent(el))).toBe(
         unformat(
-            `<p><br></p><div class="o_editor_banner user-select-none o-contenteditable-false lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" data-oe-role="status" contenteditable="false" role="status">
+            `${PLACEHOLDER_BLOCK_CONTAINER(
+                "top"
+            )}<div class="o_editor_banner user-select-none o-contenteditable-false lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" data-oe-role="status" contenteditable="false" role="status">
                     <i class="o_editor_banner_icon mb-3 fst-normal" data-oe-aria-label="Banner Info" aria-label="Banner Info">💡</i>
                     <div class="o_editor_banner_content o-contenteditable-true w-100 px-3" contenteditable="true"><p o-we-hint-text='Type "/" for commands' class="o-we-hint">[]<br></p></div>
                 </div><p><br></p>`
-        )
-    );
-});
-
-test("Inserting a banner at the top of the editable also inserts a paragraph above it", async () => {
-    const { el, editor } = await setupEditor("<p>test[]</p>");
-    await insertText(editor, "/bannerinfo");
-    await press("enter");
-    expect(unformat(getContent(el))).toBe(
-        unformat(
-            `<p><br></p>
-            <div class="o_editor_banner user-select-none o-contenteditable-false lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" data-oe-role="status" contenteditable="false" role="status">
-                <i class="o_editor_banner_icon mb-3 fst-normal" data-oe-aria-label="Banner Info" aria-label="Banner Info">💡</i>
-                <div class="o_editor_banner_content o-contenteditable-true w-100 px-3" contenteditable="true">
-                    <p>test[]</p>
-                </div>
-            </div>
-            <p><br></p>`
         )
     );
 });
@@ -127,7 +118,9 @@ test("Everything gets selected with ctrl+a, including a contenteditable=false as
     await press(["ctrl", "a"]);
     await animationFrame();
     expect(getContent(el)).toBe(
-        `<div class="o_editor_banner user-select-none o-contenteditable-false lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" data-oe-role="status" contenteditable="false" role="status">
+        `${PLACEHOLDER_BLOCK_CONTAINER(
+            "top"
+        )}<div class="o_editor_banner user-select-none o-contenteditable-false lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" data-oe-role="status" contenteditable="false" role="status">
                 <i class="o_editor_banner_icon mb-3 fst-normal" data-oe-aria-label="Banner Info" aria-label="Banner Info">[💡</i>
                 <div class="w-100 px-3" contenteditable="true">
                     <p><br></p>
@@ -149,8 +142,10 @@ test("Everything gets selected with ctrl+a, including a banner", async () => {
     await insertText(editor, "Test2");
     await press(["ctrl", "a"]);
     expect(getContent(el)).toBe(
-        `<p>[<br></p><div class="o_editor_banner user-select-none o-contenteditable-false lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" data-oe-role="status" contenteditable="false" role="status">
-                <i class="o_editor_banner_icon mb-3 fst-normal" data-oe-aria-label="Banner Info" aria-label="Banner Info">💡</i>
+        `${PLACEHOLDER_BLOCK_CONTAINER(
+            "top"
+        )}<div class="o_editor_banner user-select-none o-contenteditable-false lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" data-oe-role="status" contenteditable="false" role="status">
+                <i class="o_editor_banner_icon mb-3 fst-normal" data-oe-aria-label="Banner Info" aria-label="Banner Info">[💡</i>
                 <div class="o_editor_banner_content o-contenteditable-true w-100 px-3" contenteditable="true">
                     <p>test</p>
                 </div>
@@ -169,7 +164,9 @@ test("Everything gets selected with ctrl+a, including a contenteditable=false as
     );
     await press(["ctrl", "a"]);
     expect(getContent(el)).toBe(
-        '<div data-oe-role="status" contenteditable="false" role="status">[a</div><div data-oe-role="status" contenteditable="false" role="status">b</div><p>cd]</p>'
+        `${PLACEHOLDER_BLOCK_CONTAINER(
+            "top"
+        )}<div data-oe-role="status" contenteditable="false" role="status">[a</div><div data-oe-role="status" contenteditable="false" role="status">b</div><p>cd]</p>`
     );
 
     await press("Backspace");
@@ -275,8 +272,11 @@ test("should move heading element inside the banner, with paragraph element afte
     expect(".active .o-we-command-name").toHaveText("Banner Info");
 
     await press("enter");
+    await animationFrame();
     expect(getContent(el)).toBe(
-        `<p><br></p><div class="o_editor_banner user-select-none o-contenteditable-false lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" data-oe-role="status" contenteditable="false" role="status">
+        `${PLACEHOLDER_BLOCK_CONTAINER(
+            "top"
+        )}<div class="o_editor_banner user-select-none o-contenteditable-false lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" data-oe-role="status" contenteditable="false" role="status">
                 <i class="o_editor_banner_icon mb-3 fst-normal" data-oe-aria-label="Banner Info" aria-label="Banner Info">💡</i>
                 <div class="o_editor_banner_content o-contenteditable-true w-100 px-3" contenteditable="true">
                     <h1>Test[]</h1>

--- a/addons/html_editor/static/tests/caption.test.js
+++ b/addons/html_editor/static/tests/caption.test.js
@@ -19,6 +19,7 @@ import { deleteBackward, deleteForward, insertText } from "./_helpers/user_actio
 import { cleanHints } from "./_helpers/dispatch";
 import { getContent } from "./_helpers/selection";
 import { expectElementCount } from "./_helpers/ui_expectations";
+import { PLACEHOLDER_BLOCK_CONTAINER } from "./_helpers/placeholder_block";
 
 class CaptionPluginWithPredictableId extends CaptionPlugin {
     getCaptionId() {
@@ -121,14 +122,14 @@ test("add a caption to an image and focus it", async () => {
             cleanHints(editor);
         },
         contentAfterEdit: unformat(
-            `<p><br></p>
+            `${PLACEHOLDER_BLOCK_CONTAINER("top")}
             <figure contenteditable="false">
                 <img class="img-fluid test-image o_editable_media" src="${base64Img}" data-caption-id="${captionId}" data-caption="">
                 <figcaption ${getFigcaptionAttributes(captionId, "", true)}>
                     <input ${CAPTION_INPUT_ATTRIBUTES}>
                 </figcaption>
             </figure>
-            <p><br></p>`
+            ${PLACEHOLDER_BLOCK_CONTAINER("bottom")}`
         ),
     });
 });
@@ -175,37 +176,34 @@ test("saving an image with a caption replaces the input with plain text", async 
             </figure>`
         ),
         contentBeforeEdit: unformat(
-            // Paragraphs get added to ensure we can write before/after the figure.
-            `<p><br></p>
+            `${PLACEHOLDER_BLOCK_CONTAINER("top")}
             <figure contenteditable="false">
                 <img class="img-fluid test-image o_editable_media" src="${base64Img}" data-caption-id="${captionId}" data-caption="${caption}">
                 <figcaption ${getFigcaptionAttributes(captionId, caption)}>
                     <input ${CAPTION_INPUT_ATTRIBUTES}>
                 </figcaption>
             </figure>
-            <p><br></p>`
+            ${PLACEHOLDER_BLOCK_CONTAINER("bottom")}`
         ),
         // Unchanged.
         contentAfterEdit: unformat(
-            `<p><br></p>
+            `${PLACEHOLDER_BLOCK_CONTAINER("top")}
             <figure contenteditable="false">
                 <img class="img-fluid test-image o_editable_media" src="${base64Img}" data-caption-id="${captionId}" data-caption="${caption}">
                 <figcaption ${getFigcaptionAttributes(captionId, caption)}>
                     <input ${CAPTION_INPUT_ATTRIBUTES}>
                 </figcaption>
             </figure>
-            <p><br></p>`
+            ${PLACEHOLDER_BLOCK_CONTAINER("bottom")}`
         ),
         // Cleaned up for screen readers.
         contentAfter: unformat(
-            `<p><br></p>
-            <figure>
+            `<figure>
                 <img class="img-fluid test-image" src="${base64Img}">
                 <figcaption>
                     ${caption}
                 </figcaption>
-            </figure>
-            <p><br></p>`
+            </figure>`
         ),
     });
 });
@@ -244,15 +242,11 @@ test("clicking the caption button on an image with a caption removes the caption
             await expectElementCount(".o-we-toolbar", 1);
         },
         contentAfterEdit: unformat(
-            `<p><br></p>
-            <p>[<img class="img-fluid test-image" src="${base64Img}" data-caption="${caption}">]</p>
-            <p><br></p>`
+            `<p>[<img class="img-fluid test-image" src="${base64Img}" data-caption="${caption}">]</p>`
         ),
         // Unchanged
         contentAfter: unformat(
-            `<p><br></p>
-            <p>[<img class="img-fluid test-image" src="${base64Img}" data-caption="${caption}">]</p>
-            <p><br></p>`
+            `<p>[<img class="img-fluid test-image" src="${base64Img}" data-caption="${caption}">]</p>`
         ),
     });
 });
@@ -281,7 +275,7 @@ test("leaving the caption persists its value", async () => {
             await animationFrame(); // Wait for the selection to change.
         },
         contentAfterEdit: unformat(
-            `<p><br></p>
+            `${PLACEHOLDER_BLOCK_CONTAINER("top")}
             <figure contenteditable="false">
                 <img class="img-fluid test-image o_editable_media" src="${base64Img}" data-caption="${caption}ab" data-caption-id="${captionId}">
                 <figcaption ${getFigcaptionAttributes(captionId, caption + "ab", true)}>
@@ -291,8 +285,7 @@ test("leaving the caption persists its value", async () => {
             <h1>[]Heading</h1>`
         ),
         contentAfter: unformat(
-            `<p><br></p>
-            <figure>
+            `<figure>
                 <img class="img-fluid test-image" src="${base64Img}">
                 <figcaption>
                     ${caption}ab
@@ -321,8 +314,7 @@ test("can't use the powerbox in a caption", async () => {
             await animationFrame(); // Wait for the selection to change.
         },
         contentAfter: unformat(
-            `<p><br></p>
-            <figure>
+            `<figure>
                 <img class="img-fluid test-image" src="${base64Img}">
                 <figcaption>
                     /
@@ -355,8 +347,7 @@ test("can't use the toolbar in a caption", async () => {
             await animationFrame(); // Wait for the selection to change.
         },
         contentAfter: unformat(
-            `<p><br></p>
-            <figure>
+            `<figure>
                 <img class="img-fluid test-image" src="${base64Img}">
                 <figcaption>a</figcaption>
             </figure>
@@ -487,10 +478,7 @@ test("remove an image with a caption", async () => {
             await waitFor(".o-we-toolbar button[name='image_delete']");
             await click(".o-we-toolbar button[name='image_delete']");
         },
-        contentAfter: unformat(
-            `<p><br></p>
-            <h1>[]Heading</h1>`
-        ),
+        contentAfter: unformat(`<h1>[]Heading</h1>`),
     });
 });
 
@@ -510,7 +498,7 @@ const getDeleteImageTestData = () => {
             // Check that we indeed have a proper figure structure.
             expect(getContent(editor.editable).replace("[]", "")).toBe(
                 unformat(
-                    `<p><br></p>
+                    `${PLACEHOLDER_BLOCK_CONTAINER("top")}
                             <figure contenteditable="false">
                             <img class="img-fluid test-image o_editable_media" data-caption="${caption}" src="${base64Img}" data-caption-id="${captionId}">
                             <figcaption ${getFigcaptionAttributes(
@@ -529,10 +517,7 @@ const getDeleteImageTestData = () => {
             await click("h1");
             await click("img");
         },
-        contentAfter: unformat(
-            `<p><br></p>
-            <h1>[]Heading</h1>`
-        ),
+        contentAfter: unformat(`<h1>[]Heading</h1>`),
     };
 };
 
@@ -598,8 +583,7 @@ test("replace an image with a caption", async () => {
         },
         // TODO: fix the weird final selection
         contentAfter: unformat(
-            `<p><br></p>
-            <figure>
+            `<figure>
                 <img src="/web/static/img/logo2.png" alt="" data-attachment-id="1" class="img img-fluid o_we_custom_image">
                 <figcaption>Hello</figcaption>
             </figure>
@@ -624,8 +608,7 @@ test("add a link to an image with a caption", async () => {
             await expectElementCount(".o-we-toolbar", 1);
         },
         contentAfter: unformat(
-            `<p><br></p>
-            <p>
+            `<p>
                 <a href="https://odoo.com">
                     <figure>
                         [<img class="img-fluid test-image" src="${base64Img}">]
@@ -659,8 +642,7 @@ test("add a caption to an image with a link", async () => {
             selection.removeAllRanges();
         },
         contentAfter: unformat(
-            `<p><br></p>
-            <div>
+            `<div>
                 <a href="https://odoo.com">
                     <figure>
                         <img class="img-fluid test-image" src="${base64Img}">

--- a/addons/html_editor/static/tests/collaboration.test.js
+++ b/addons/html_editor/static/tests/collaboration.test.js
@@ -34,6 +34,7 @@ import { getContent } from "./_helpers/selection";
 import { addStep, deleteBackward, deleteForward, redo, undo } from "./_helpers/user_actions";
 import { execCommand } from "./_helpers/userCommands";
 import { wrapInlinesInBlocks } from "@html_editor/utils/dom";
+import { PLACEHOLDER_BLOCK_CONTAINER } from "./_helpers/placeholder_block";
 
 /**
  * @param {Editor} editor
@@ -648,6 +649,7 @@ describe("data-oe-protected", () => {
                 await animationFrame();
                 expect(getContent(peerInfos.c1.editor.editable, { sortAttrs: true })).toBe(
                     unformat(`
+                        ${PLACEHOLDER_BLOCK_CONTAINER("top")}
                         <div contenteditable="false" data-oe-protected="true">
                             <p id="true">a<br></p>
                             <div contenteditable="true" data-oe-protected="false">
@@ -659,6 +661,7 @@ describe("data-oe-protected", () => {
                 );
                 expect(getContent(peerInfos.c2.editor.editable, { sortAttrs: true })).toBe(
                     unformat(`
+                        ${PLACEHOLDER_BLOCK_CONTAINER("top")}
                         <div contenteditable="false" data-oe-protected="true">
                             <p id="true"><br></p>
                             <div contenteditable="true" data-oe-protected="false">
@@ -695,6 +698,7 @@ describe("data-oe-protected", () => {
         mergePeersSteps(peerInfos);
         expect(getContent(e1.editable, { sortAttrs: true })).toBe(
             unformat(`
+                ${PLACEHOLDER_BLOCK_CONTAINER("top")}
                 <div contenteditable="false" data-oe-protected="true">
                     <div contenteditable="true" data-oe-protected="false">
                         <p>d</p>
@@ -705,6 +709,7 @@ describe("data-oe-protected", () => {
         );
         expect(getContent(e2.editable, { sortAttrs: true })).toBe(
             unformat(`
+                ${PLACEHOLDER_BLOCK_CONTAINER("top")}
                 <div contenteditable="false" data-oe-protected="true">
                     <div contenteditable="true" data-oe-protected="false">
                         <p>d</p>
@@ -784,13 +789,16 @@ describe("Collaboration with embedded components", () => {
         validateSameHistory(peerInfos);
         cleanHints(e2);
         expect(getContent(e2.editable, { sortAttrs: true })).toBe(
-            `<div contenteditable="false" data-embedded="counter" data-oe-protected="true"></div><p>[]<br></p>`
+            `${PLACEHOLDER_BLOCK_CONTAINER(
+                "top"
+            )}<div contenteditable="false" data-embedded="counter" data-oe-protected="true"></div><p>[]<br></p>`
         );
         await animationFrame();
         cleanHints(e1);
         cleanHints(e2);
         expect(getContent(e1.editable, { sortAttrs: true })).toBe(
             unformat(`
+                ${PLACEHOLDER_BLOCK_CONTAINER("top")}
                 <div contenteditable="false" data-embedded="counter" data-oe-protected="true">
                     <span class="counter">Counter:0</span>
                 </div>
@@ -799,6 +807,7 @@ describe("Collaboration with embedded components", () => {
         );
         expect(getContent(e2.editable, { sortAttrs: true })).toBe(
             unformat(`
+                ${PLACEHOLDER_BLOCK_CONTAINER("top")}
                 <div contenteditable="false" data-embedded="counter" data-oe-protected="true">
                     <span class="counter">Counter:0</span>
                 </div>
@@ -962,6 +971,7 @@ describe("Collaboration with embedded components", () => {
         mergePeersSteps(peerInfos);
         // Before mount:
         let editable = unformat(`
+            ${PLACEHOLDER_BLOCK_CONTAINER("top")}
             <div contenteditable="false" data-embedded="wrapper" data-oe-protected="true">
                 <div contenteditable="true" data-embedded-editable="deep" data-oe-protected="false">
                     <p>deep12</p>
@@ -974,6 +984,7 @@ describe("Collaboration with embedded components", () => {
         await animationFrame();
         // After mount:
         editable = unformat(`
+            ${PLACEHOLDER_BLOCK_CONTAINER("top")}
             <div contenteditable="false" data-embedded="wrapper" data-oe-protected="true">
                 <div>
                     <div class="deep">
@@ -994,6 +1005,7 @@ describe("Collaboration with embedded components", () => {
         e2.shared.history.addStep();
         mergePeersSteps(peerInfos);
         editable = unformat(`
+            ${PLACEHOLDER_BLOCK_CONTAINER("top")}
             <div contenteditable="false" data-embedded="wrapper" data-oe-protected="true">
                 <div>
                     <div class="deep">
@@ -1063,6 +1075,7 @@ describe("Collaboration with embedded components", () => {
         mergePeersSteps(peerInfos);
         expect(getContent(e1.editable, { sortAttrs: true })).toBe(
             unformat(`
+                ${PLACEHOLDER_BLOCK_CONTAINER("top")}
                 <div contenteditable="false" data-embedded="wrapper" data-oe-protected="true">
                     <div>
                         <div class="switched">
@@ -1079,6 +1092,7 @@ describe("Collaboration with embedded components", () => {
         );
         expect(getContent(e2.editable, { sortAttrs: true })).toBe(
             unformat(`
+                ${PLACEHOLDER_BLOCK_CONTAINER("top")}
                 <div contenteditable="false" data-embedded="wrapper" data-oe-protected="true">
                     <div>
                         <div class="deep">
@@ -1139,6 +1153,7 @@ describe("Collaboration with embedded components", () => {
         e2.shared.history.addStep();
         mergePeersSteps(peerInfos);
         const editable = unformat(`
+            ${PLACEHOLDER_BLOCK_CONTAINER("top")}
             <div contenteditable="false" data-embedded="wrapper" data-oe-protected="true">
                 <div class="deep">
                     <div contenteditable="true" data-embedded-editable="deep" data-oe-protected="false">
@@ -1203,6 +1218,7 @@ describe("Collaboration with embedded components", () => {
         e2.shared.history.addStep();
         mergePeersSteps(peerInfos);
         const editable = unformat(`
+            ${PLACEHOLDER_BLOCK_CONTAINER("top")}
             <div contenteditable="false" data-embedded="wrapper" data-oe-protected="true">
                 <div class="deep">
                     <div contenteditable="true" data-embedded-editable="deep" data-oe-protected="false">

--- a/addons/html_editor/static/tests/collaboration.test.js
+++ b/addons/html_editor/static/tests/collaboration.test.js
@@ -1397,20 +1397,24 @@ describe("Collaboration with embedded components", () => {
             const obj2 = [...peerInfos.c2.plugins.get("embeddedComponents").components][0].root.node
                 .component;
             expect(getContent(e1.editable, { sortAttrs: true })).toBe(
-                `<p>a[]</p><div contenteditable="false" data-embedded="obj" data-embedded-props='{"obj":{"1":1}}' data-oe-protected="true"><div class="obj">1_1</div></div>`
+                `<p>a[]</p><div contenteditable="false" data-embedded="obj" data-embedded-props='{"obj":{"1":1}}' data-oe-protected="true"><div class="obj">1_1</div></div>` +
+                    PLACEHOLDER_BLOCK_CONTAINER("bottom")
             );
             expect(getContent(e2.editable, { sortAttrs: true })).toBe(
-                `<p>a[]</p><div contenteditable="false" data-embedded="obj" data-embedded-props='{"obj":{"1":1}}' data-oe-protected="true"><div class="obj">1_1</div></div>`
+                `<p>a[]</p><div contenteditable="false" data-embedded="obj" data-embedded-props='{"obj":{"1":1}}' data-oe-protected="true"><div class="obj">1_1</div></div>` +
+                    PLACEHOLDER_BLOCK_CONTAINER("bottom")
             );
             obj2.embeddedState.obj["2"] = 2;
             await animationFrame();
             mergePeersSteps(peerInfos);
             await animationFrame();
             expect(getContent(e1.editable, { sortAttrs: true })).toBe(
-                `<p>a[]</p><div contenteditable="false" data-embedded="obj" data-embedded-props='{"obj":{"1":1,"2":2}}' data-embedded-state='{"stateChangeId":1,"previous":{"obj":{"1":1}},"next":{"obj":{"1":1,"2":2}}}' data-oe-protected="true"><div class="obj">1_1,2_2</div></div>`
+                `<p>a[]</p><div contenteditable="false" data-embedded="obj" data-embedded-props='{"obj":{"1":1,"2":2}}' data-embedded-state='{"stateChangeId":1,"previous":{"obj":{"1":1}},"next":{"obj":{"1":1,"2":2}}}' data-oe-protected="true"><div class="obj">1_1,2_2</div></div>` +
+                    PLACEHOLDER_BLOCK_CONTAINER("bottom")
             );
             expect(getContent(e2.editable, { sortAttrs: true })).toBe(
-                `<p>a[]</p><div contenteditable="false" data-embedded="obj" data-embedded-props='{"obj":{"1":1,"2":2}}' data-embedded-state='{"stateChangeId":1,"previous":{"obj":{"1":1}},"next":{"obj":{"1":1,"2":2}}}' data-oe-protected="true"><div class="obj">1_1,2_2</div></div>`
+                `<p>a[]</p><div contenteditable="false" data-embedded="obj" data-embedded-props='{"obj":{"1":1,"2":2}}' data-embedded-state='{"stateChangeId":1,"previous":{"obj":{"1":1}},"next":{"obj":{"1":1,"2":2}}}' data-oe-protected="true"><div class="obj">1_1,2_2</div></div>` +
+                    PLACEHOLDER_BLOCK_CONTAINER("bottom")
             );
             const savepoint = e1.shared.history.makeSavePoint();
             delete obj2.embeddedState.obj["1"];
@@ -1418,10 +1422,12 @@ describe("Collaboration with embedded components", () => {
             mergePeersSteps(peerInfos);
             await animationFrame();
             expect(getContent(e1.editable, { sortAttrs: true })).toBe(
-                `<p>a[]</p><div contenteditable="false" data-embedded="obj" data-embedded-props='{"obj":{"2":2}}' data-embedded-state='{"stateChangeId":2,"previous":{"obj":{"1":1,"2":2}},"next":{"obj":{"2":2}}}' data-oe-protected="true"><div class="obj">2_2</div></div>`
+                `<p>a[]</p><div contenteditable="false" data-embedded="obj" data-embedded-props='{"obj":{"2":2}}' data-embedded-state='{"stateChangeId":2,"previous":{"obj":{"1":1,"2":2}},"next":{"obj":{"2":2}}}' data-oe-protected="true"><div class="obj">2_2</div></div>` +
+                    PLACEHOLDER_BLOCK_CONTAINER("bottom")
             );
             expect(getContent(e2.editable, { sortAttrs: true })).toBe(
-                `<p>a[]</p><div contenteditable="false" data-embedded="obj" data-embedded-props='{"obj":{"2":2}}' data-embedded-state='{"stateChangeId":2,"previous":{"obj":{"1":1,"2":2}},"next":{"obj":{"2":2}}}' data-oe-protected="true"><div class="obj">2_2</div></div>`
+                `<p>a[]</p><div contenteditable="false" data-embedded="obj" data-embedded-props='{"obj":{"2":2}}' data-embedded-state='{"stateChangeId":2,"previous":{"obj":{"1":1,"2":2}},"next":{"obj":{"2":2}}}' data-oe-protected="true"><div class="obj">2_2</div></div>` +
+                    PLACEHOLDER_BLOCK_CONTAINER("bottom")
             );
             obj1.embeddedState.obj["3"] = 3;
             await animationFrame();
@@ -1432,10 +1438,12 @@ describe("Collaboration with embedded components", () => {
             mergePeersSteps(peerInfos);
             await animationFrame();
             expect(getContent(e1.editable, { sortAttrs: true })).toBe(
-                `<p>a[]</p><div contenteditable="false" data-embedded="obj" data-embedded-props='{"obj":{"2":2,"3":3,"4":4}}' data-embedded-state='{"stateChangeId":4,"previous":{"obj":{"2":2,"3":3}},"next":{"obj":{"2":2,"3":3,"4":4}}}' data-oe-protected="true"><div class="obj">2_2,3_3,4_4</div></div>`
+                `<p>a[]</p><div contenteditable="false" data-embedded="obj" data-embedded-props='{"obj":{"2":2,"3":3,"4":4}}' data-embedded-state='{"stateChangeId":4,"previous":{"obj":{"2":2,"3":3}},"next":{"obj":{"2":2,"3":3,"4":4}}}' data-oe-protected="true"><div class="obj">2_2,3_3,4_4</div></div>` +
+                    PLACEHOLDER_BLOCK_CONTAINER("bottom")
             );
             expect(getContent(e2.editable, { sortAttrs: true })).toBe(
-                `<p>a[]</p><div contenteditable="false" data-embedded="obj" data-embedded-props='{"obj":{"2":2,"3":3,"4":4}}' data-embedded-state='{"stateChangeId":4,"previous":{"obj":{"2":2,"3":3}},"next":{"obj":{"2":2,"3":3,"4":4}}}' data-oe-protected="true"><div class="obj">2_2,3_3,4_4</div></div>`
+                `<p>a[]</p><div contenteditable="false" data-embedded="obj" data-embedded-props='{"obj":{"2":2,"3":3,"4":4}}' data-embedded-state='{"stateChangeId":4,"previous":{"obj":{"2":2,"3":3}},"next":{"obj":{"2":2,"3":3,"4":4}}}' data-oe-protected="true"><div class="obj">2_2,3_3,4_4</div></div>` +
+                    PLACEHOLDER_BLOCK_CONTAINER("bottom")
             );
             savepoint();
             await animationFrame();
@@ -1451,10 +1459,12 @@ describe("Collaboration with embedded components", () => {
             // {2, 3, 4} to {2, 4}, and that is why it is applied correctly
             // for both users.
             expect(getContent(e1.editable, { sortAttrs: true })).toBe(
-                `<p>a[]</p><div contenteditable="false" data-embedded="obj" data-embedded-props='{"obj":{"2":2,"4":4}}' data-embedded-state='{"stateChangeId":9,"previous":{"obj":{"2":2}},"next":{"obj":{"2":2,"4":4}}}' data-oe-protected="true"><div class="obj">2_2,4_4</div></div>`
+                `<p>a[]</p><div contenteditable="false" data-embedded="obj" data-embedded-props='{"obj":{"2":2,"4":4}}' data-embedded-state='{"stateChangeId":9,"previous":{"obj":{"2":2}},"next":{"obj":{"2":2,"4":4}}}' data-oe-protected="true"><div class="obj">2_2,4_4</div></div>` +
+                    PLACEHOLDER_BLOCK_CONTAINER("bottom")
             );
             expect(getContent(e2.editable, { sortAttrs: true })).toBe(
-                `<p>a[]</p><div contenteditable="false" data-embedded="obj" data-embedded-props='{"obj":{"2":2,"4":4}}' data-embedded-state='{"stateChangeId":9,"previous":{"obj":{"2":2}},"next":{"obj":{"2":2,"4":4}}}' data-oe-protected="true"><div class="obj">2_2,4_4</div></div>`
+                `<p>a[]</p><div contenteditable="false" data-embedded="obj" data-embedded-props='{"obj":{"2":2,"4":4}}' data-embedded-state='{"stateChangeId":9,"previous":{"obj":{"2":2}},"next":{"obj":{"2":2,"4":4}}}' data-oe-protected="true"><div class="obj">2_2,4_4</div></div>` +
+                    PLACEHOLDER_BLOCK_CONTAINER("bottom")
             );
         });
 
@@ -1522,20 +1532,24 @@ describe("Collaboration with embedded components", () => {
             mergePeersSteps(peerInfos);
             await animationFrame();
             expect(getContent(e1.editable, { sortAttrs: true })).toBe(
-                `<p>a[]</p><div contenteditable="false" data-embedded="obj" data-embedded-props='{"obj":{"1":1,"2":2,"3":3,"4":4}}' data-embedded-state='{"stateChangeId":2,"previous":{"obj":{"1":1}},"next":{"obj":{"1":1,"3":3,"4":4}}}' data-oe-protected="true"><div class="obj">1_1,2_2,3_3,4_4</div></div>`
+                `<p>a[]</p><div contenteditable="false" data-embedded="obj" data-embedded-props='{"obj":{"1":1,"2":2,"3":3,"4":4}}' data-embedded-state='{"stateChangeId":2,"previous":{"obj":{"1":1}},"next":{"obj":{"1":1,"3":3,"4":4}}}' data-oe-protected="true"><div class="obj">1_1,2_2,3_3,4_4</div></div>` +
+                    PLACEHOLDER_BLOCK_CONTAINER("bottom")
             );
             expect(getContent(e2.editable, { sortAttrs: true })).toBe(
-                `<p>a[]</p><div contenteditable="false" data-embedded="obj" data-embedded-props='{"obj":{"1":1,"2":2,"3":3,"4":4}}' data-embedded-state='{"stateChangeId":2,"previous":{"obj":{"1":1}},"next":{"obj":{"1":1,"3":3,"4":4}}}' data-oe-protected="true"><div class="obj">1_1,2_2,3_3,4_4</div></div>`
+                `<p>a[]</p><div contenteditable="false" data-embedded="obj" data-embedded-props='{"obj":{"1":1,"2":2,"3":3,"4":4}}' data-embedded-state='{"stateChangeId":2,"previous":{"obj":{"1":1}},"next":{"obj":{"1":1,"3":3,"4":4}}}' data-oe-protected="true"><div class="obj">1_1,2_2,3_3,4_4</div></div>` +
+                    PLACEHOLDER_BLOCK_CONTAINER("bottom")
             );
             undo(e2);
             await animationFrame();
             mergePeersSteps(peerInfos);
             await animationFrame();
             expect(getContent(e1.editable, { sortAttrs: true })).toBe(
-                `<p>a[]</p><div contenteditable="false" data-embedded="obj" data-embedded-props='{"obj":{"1":1,"2":2}}' data-embedded-state='{"stateChangeId":3,"previous":{"obj":{"1":1,"2":2,"3":3,"4":4}},"next":{"obj":{"1":1,"2":2}}}' data-oe-protected="true"><div class="obj">1_1,2_2</div></div>`
+                `<p>a[]</p><div contenteditable="false" data-embedded="obj" data-embedded-props='{"obj":{"1":1,"2":2}}' data-embedded-state='{"stateChangeId":3,"previous":{"obj":{"1":1,"2":2,"3":3,"4":4}},"next":{"obj":{"1":1,"2":2}}}' data-oe-protected="true"><div class="obj">1_1,2_2</div></div>` +
+                    PLACEHOLDER_BLOCK_CONTAINER("bottom")
             );
             expect(getContent(e2.editable, { sortAttrs: true })).toBe(
-                `<p>a[]</p><div contenteditable="false" data-embedded="obj" data-embedded-props='{"obj":{"1":1,"2":2}}' data-embedded-state='{"stateChangeId":3,"previous":{"obj":{"1":1,"2":2,"3":3,"4":4}},"next":{"obj":{"1":1,"2":2}}}' data-oe-protected="true"><div class="obj">1_1,2_2</div></div>`
+                `<p>a[]</p><div contenteditable="false" data-embedded="obj" data-embedded-props='{"obj":{"1":1,"2":2}}' data-embedded-state='{"stateChangeId":3,"previous":{"obj":{"1":1,"2":2,"3":3,"4":4}},"next":{"obj":{"1":1,"2":2}}}' data-oe-protected="true"><div class="obj">1_1,2_2</div></div>` +
+                    PLACEHOLDER_BLOCK_CONTAINER("bottom")
             );
         });
 
@@ -1566,10 +1580,12 @@ describe("Collaboration with embedded components", () => {
             // When steps were merged, both users updated their state with
             // both changes, even if the component was outside of the dom.
             expect(getContent(e1.editable, { sortAttrs: true })).toBe(
-                `<p>a[]</p><div contenteditable="false" data-embedded="obj" data-embedded-props='{"obj":{"1":1,"2":2,"3":3}}' data-embedded-state='{"stateChangeId":2,"previous":{"obj":{"1":1}},"next":{"obj":{"1":1,"3":3}}}' data-oe-protected="true"><div class="obj">1_1,2_2,3_3</div></div>`
+                `<p>a[]</p><div contenteditable="false" data-embedded="obj" data-embedded-props='{"obj":{"1":1,"2":2,"3":3}}' data-embedded-state='{"stateChangeId":2,"previous":{"obj":{"1":1}},"next":{"obj":{"1":1,"3":3}}}' data-oe-protected="true"><div class="obj">1_1,2_2,3_3</div></div>` +
+                    PLACEHOLDER_BLOCK_CONTAINER("bottom")
             );
             expect(getContent(e2.editable, { sortAttrs: true })).toBe(
-                `<p>a[]</p><div contenteditable="false" data-embedded="obj" data-embedded-props='{"obj":{"1":1,"2":2,"3":3}}' data-embedded-state='{"stateChangeId":2,"previous":{"obj":{"1":1}},"next":{"obj":{"1":1,"3":3}}}' data-oe-protected="true"><div class="obj">1_1,2_2,3_3</div></div>`
+                `<p>a[]</p><div contenteditable="false" data-embedded="obj" data-embedded-props='{"obj":{"1":1,"2":2,"3":3}}' data-embedded-state='{"stateChangeId":2,"previous":{"obj":{"1":1}},"next":{"obj":{"1":1,"3":3}}}' data-oe-protected="true"><div class="obj">1_1,2_2,3_3</div></div>` +
+                    PLACEHOLDER_BLOCK_CONTAINER("bottom")
             );
         });
 
@@ -1712,10 +1728,12 @@ describe("Collaboration with embedded components", () => {
             mergePeersSteps(peerInfos);
             await animationFrame();
             expect(getContent(e1.editable, { sortAttrs: true })).toBe(
-                `<p>a[]</p><div contenteditable="false" data-embedded="obj" data-embedded-props='{"obj":{"1":1}}' data-embedded-state='{"stateChangeId":2,"previous":{"obj":{"1":1,"2":2}},"next":{"obj":{"1":1}}}' data-oe-protected="true"><div class="obj">1_1</div></div>`
+                `<p>a[]</p><div contenteditable="false" data-embedded="obj" data-embedded-props='{"obj":{"1":1}}' data-embedded-state='{"stateChangeId":2,"previous":{"obj":{"1":1,"2":2}},"next":{"obj":{"1":1}}}' data-oe-protected="true"><div class="obj">1_1</div></div>` +
+                    PLACEHOLDER_BLOCK_CONTAINER("bottom")
             );
             expect(getContent(e2.editable, { sortAttrs: true })).toBe(
-                `<p>a[]</p><div contenteditable="false" data-embedded="obj" data-embedded-props='{"obj":{"1":1}}' data-embedded-state='{"stateChangeId":2,"previous":{"obj":{"1":1,"2":2}},"next":{"obj":{"1":1}}}' data-oe-protected="true"><div class="obj">1_1</div></div>`
+                `<p>a[]</p><div contenteditable="false" data-embedded="obj" data-embedded-props='{"obj":{"1":1}}' data-embedded-state='{"stateChangeId":2,"previous":{"obj":{"1":1,"2":2}},"next":{"obj":{"1":1}}}' data-oe-protected="true"><div class="obj">1_1</div></div>` +
+                    PLACEHOLDER_BLOCK_CONTAINER("bottom")
             );
         });
 
@@ -1785,20 +1803,24 @@ describe("Collaboration with embedded components", () => {
             mergePeersSteps(peerInfos);
             await animationFrame();
             expect(getContent(e1.editable, { sortAttrs: true })).toBe(
-                `<p>a[]</p><div contenteditable="false" data-embedded="obj" data-embedded-props='{"obj":{"1":1,"2":2}}' data-embedded-state='{"stateChangeId":2,"previous":{"obj":{"1":1}},"next":{"obj":{"1":1,"2":2}}}' data-oe-protected="true"><div class="obj">1_1,2_2</div></div>`
+                `<p>a[]</p><div contenteditable="false" data-embedded="obj" data-embedded-props='{"obj":{"1":1,"2":2}}' data-embedded-state='{"stateChangeId":2,"previous":{"obj":{"1":1}},"next":{"obj":{"1":1,"2":2}}}' data-oe-protected="true"><div class="obj">1_1,2_2</div></div>` +
+                    PLACEHOLDER_BLOCK_CONTAINER("bottom")
             );
             expect(getContent(e2.editable, { sortAttrs: true })).toBe(
-                `<p>a[]</p><div contenteditable="false" data-embedded="obj" data-embedded-props='{"obj":{"1":1,"2":2}}' data-embedded-state='{"stateChangeId":2,"previous":{"obj":{"1":1}},"next":{"obj":{"1":1,"2":2}}}' data-oe-protected="true"><div class="obj">1_1,2_2</div></div>`
+                `<p>a[]</p><div contenteditable="false" data-embedded="obj" data-embedded-props='{"obj":{"1":1,"2":2}}' data-embedded-state='{"stateChangeId":2,"previous":{"obj":{"1":1}},"next":{"obj":{"1":1,"2":2}}}' data-oe-protected="true"><div class="obj">1_1,2_2</div></div>` +
+                    PLACEHOLDER_BLOCK_CONTAINER("bottom")
             );
             undo(e1);
             await animationFrame();
             mergePeersSteps(peerInfos);
             await animationFrame();
             expect(getContent(e1.editable, { sortAttrs: true })).toBe(
-                `<p>a[]</p><div contenteditable="false" data-embedded="obj" data-embedded-props='{"obj":{"2":2}}' data-embedded-state='{"stateChangeId":3,"previous":{"obj":{"1":1,"2":2}},"next":{"obj":{"2":2}}}' data-oe-protected="true"><div class="obj">2_2</div></div>`
+                `<p>a[]</p><div contenteditable="false" data-embedded="obj" data-embedded-props='{"obj":{"2":2}}' data-embedded-state='{"stateChangeId":3,"previous":{"obj":{"1":1,"2":2}},"next":{"obj":{"2":2}}}' data-oe-protected="true"><div class="obj">2_2</div></div>` +
+                    PLACEHOLDER_BLOCK_CONTAINER("bottom")
             );
             expect(getContent(e2.editable, { sortAttrs: true })).toBe(
-                `<p>a[]</p><div contenteditable="false" data-embedded="obj" data-embedded-props='{"obj":{"2":2}}' data-embedded-state='{"stateChangeId":3,"previous":{"obj":{"1":1,"2":2}},"next":{"obj":{"2":2}}}' data-oe-protected="true"><div class="obj">2_2</div></div>`
+                `<p>a[]</p><div contenteditable="false" data-embedded="obj" data-embedded-props='{"obj":{"2":2}}' data-embedded-state='{"stateChangeId":3,"previous":{"obj":{"1":1,"2":2}},"next":{"obj":{"2":2}}}' data-oe-protected="true"><div class="obj">2_2</div></div>` +
+                    PLACEHOLDER_BLOCK_CONTAINER("bottom")
             );
         });
     });

--- a/addons/html_editor/static/tests/color_selector.test.js
+++ b/addons/html_editor/static/tests/color_selector.test.js
@@ -20,6 +20,8 @@ import { getContent, setSelection } from "./_helpers/selection";
 import { expandToolbar } from "./_helpers/toolbar";
 import { execCommand } from "./_helpers/userCommands";
 import { expectElementCount } from "./_helpers/ui_expectations";
+import { unformat } from "./_helpers/format";
+import { PLACEHOLDER_BLOCK_CONTAINER } from "./_helpers/placeholder_block";
 
 test("can set foreground color", async () => {
     const { el } = await setupEditor("<p>[test]</p>");
@@ -939,7 +941,9 @@ describe("color preview", () => {
         await animationFrame();
         // Hover a color
         await hover(queryOne("button[data-color='#CE0000']"));
-        expect(getContent(el)).toBe(`
+        expect(unformat(getContent(el))).toBe(
+            unformat(`
+            ${PLACEHOLDER_BLOCK_CONTAINER("top")}
             <table class="table table-bordered o_table o_selected_table">
                 <tbody>
                     <tr>
@@ -954,11 +958,15 @@ describe("color preview", () => {
                     </tr>
                 </tbody>
             </table>
-        `);
+            ${PLACEHOLDER_BLOCK_CONTAINER("bottom")}
+        `)
+        );
         // Hover out
         await hover(queryOne(".o-we-toolbar .o-select-color-foreground"));
         await animationFrame();
-        expect(getContent(el)).toBe(`
+        expect(unformat(getContent(el))).toBe(
+            unformat(`
+            ${PLACEHOLDER_BLOCK_CONTAINER("top")}
             <table class="table table-bordered o_table o_selected_table">
                 <tbody>
                     <tr>
@@ -973,8 +981,10 @@ describe("color preview", () => {
                     </tr>
                 </tbody>
             </table>
-        `);
-        await expectElementCount(".o-we-toolbar", 1);
+            ${PLACEHOLDER_BLOCK_CONTAINER("bottom")}
+        `)
+        );
+        await expectElementCount(".o-we-toolbar", 1); // toolbar still open
     });
 
     test("should preview color in table on hover in custom tab", async () => {
@@ -1007,7 +1017,9 @@ describe("color preview", () => {
         await animationFrame();
         // Hover a color
         await hover(queryOne("button[data-color='black']"));
-        expect(getContent(el)).toBe(`
+        expect(unformat(getContent(el))).toBe(
+            unformat(`
+            ${PLACEHOLDER_BLOCK_CONTAINER("top")}
             <table class="table table-bordered o_table o_selected_table">
                 <tbody>
                     <tr>
@@ -1022,11 +1034,15 @@ describe("color preview", () => {
                     </tr>
                 </tbody>
             </table>
-        `);
+            ${PLACEHOLDER_BLOCK_CONTAINER("bottom")}
+        `)
+        );
         // Hover out
         await hover(queryOne(".o-we-toolbar .o-select-color-foreground"));
         await animationFrame();
-        expect(getContent(el)).toBe(`
+        expect(unformat(getContent(el))).toBe(
+            unformat(`
+            ${PLACEHOLDER_BLOCK_CONTAINER("top")}
             <table class="table table-bordered o_table o_selected_table">
                 <tbody>
                     <tr>
@@ -1041,8 +1057,10 @@ describe("color preview", () => {
                     </tr>
                 </tbody>
             </table>
-        `);
-        await expectElementCount(".o-we-toolbar", 1);
+            ${PLACEHOLDER_BLOCK_CONTAINER("bottom")}
+        `)
+        );
+        await expectElementCount(".o-we-toolbar", 1); // toolbar still open
     });
 
     test("should preview selected text color when tabbing", async () => {

--- a/addons/html_editor/static/tests/columnize.test.js
+++ b/addons/html_editor/static/tests/columnize.test.js
@@ -6,6 +6,7 @@ import { getContent, setSelection } from "./_helpers/selection";
 import { insertText, redo, undo } from "./_helpers/user_actions";
 import { execCommand } from "./_helpers/userCommands";
 import { nodeSize } from "@html_editor/utils/position";
+import { PLACEHOLDER_BLOCK_CONTAINER } from "./_helpers/placeholder_block";
 
 function columnsContainer(contents) {
     return `<div class="container o_text_columns o-contenteditable-false"><div class="row">${contents}</div></div>`;
@@ -39,10 +40,12 @@ describe("2 columns", () => {
                     column(6, "<p><br></p>")
                 ),
             contentAfterEdit:
+                PLACEHOLDER_BLOCK_CONTAINER("top") +
                 columsDuringEditContainer(
                     columnDuringEdit(6, `<p o-we-hint-text="Empty column" class="o-we-hint">[]<br></p>`) +
                     columnDuringEdit(6, `<p o-we-hint-text="Empty column" class="o-we-hint"><br></p>`)
-                ),
+                ) +
+                PLACEHOLDER_BLOCK_CONTAINER("bottom"),
             /* eslint-enable */
         });
     });
@@ -56,10 +59,12 @@ describe("2 columns", () => {
                     column(6, "<p><br></p>")
                 ),
             contentAfterEdit:
+                PLACEHOLDER_BLOCK_CONTAINER("top") +
                 columsDuringEditContainer(
                     columnDuringEdit(6, `<table><tbody><tr><td><p o-we-hint-text='Type "/" for commands' class="o-we-hint">[]<br></p></td><td><p><br></p></td></tr></tbody></table>`) +
                     columnDuringEdit(6, `<p o-we-hint-text="Empty column" class="o-we-hint"><br></p>`)
-                ),
+                ) +
+                PLACEHOLDER_BLOCK_CONTAINER("bottom"),
             /* eslint-enable */
         });
     });
@@ -82,6 +87,7 @@ describe("2 columns", () => {
             stepFunction: columnize(2),
             contentAfterEdit:
             /* eslint-disable */
+                PLACEHOLDER_BLOCK_CONTAINER("top") +
                 columsDuringEditContainer(
                     columnDuringEdit(6, "<p>[]abcd</p>") +
                     columnDuringEdit(6, `<p o-we-hint-text="Empty column" class="o-we-hint"><br></p>`)
@@ -134,7 +140,8 @@ describe("2 columns", () => {
 
         await press("enter");
         expect(getContent(el)).toBe(
-            `<div class="container o_text_columns o-contenteditable-false" contenteditable="false"><div class="row"><div class="col-6 o-contenteditable-true" contenteditable="true"><p>ab[]cd</p></div><div class="col-6 o-contenteditable-true" contenteditable="true"><p o-we-hint-text="Empty column" class="o-we-hint"><br></p></div></div></div><p><br></p>`
+            PLACEHOLDER_BLOCK_CONTAINER("top") +
+                `<div class="container o_text_columns o-contenteditable-false" contenteditable="false"><div class="row"><div class="col-6 o-contenteditable-true" contenteditable="true"><p>ab[]cd</p></div><div class="col-6 o-contenteditable-true" contenteditable="true"><p o-we-hint-text="Empty column" class="o-we-hint"><br></p></div></div></div><p><br></p>`
         );
 
         await insertText(editor, "/columns");
@@ -154,11 +161,13 @@ describe("3 columns", () => {
             ),
             /* eslint-disable */
             contentBeforeEdit:
+                PLACEHOLDER_BLOCK_CONTAINER("top") +
                 columsDuringEditContainer(
                     columnDuringEdit(4, "<p>abcd</p>") +
                     columnDuringEdit(4, `<p o-we-hint-text="Empty column" class="o-we-hint"><br></p>`) +
                     columnDuringEdit(4, `<p o-we-hint-text="Empty column" class="o-we-hint">[]<br></p>`)
-                ),
+                ) +
+                PLACEHOLDER_BLOCK_CONTAINER("bottom"),
             /* eslint-enable */
             stepFunction: columnize(3),
             contentAfter: columnsContainer(
@@ -173,6 +182,7 @@ describe("3 columns", () => {
             stepFunction: columnize(3),
             /* eslint-disable */
             contentAfterEdit:
+                PLACEHOLDER_BLOCK_CONTAINER("top") +
                 columsDuringEditContainer(
                     columnDuringEdit(4, "<p>ab[]cd</p>") +
                     columnDuringEdit(4, `<p o-we-hint-text="Empty column" class="o-we-hint"><br></p>`) +
@@ -227,7 +237,8 @@ describe("3 columns", () => {
 
         await press("enter");
         expect(getContent(el)).toBe(
-            `<div class="container o_text_columns o-contenteditable-false" contenteditable="false"><div class="row"><div class="col-4 o-contenteditable-true" contenteditable="true"><p>ab[]cd</p></div><div class="col-4 o-contenteditable-true" contenteditable="true"><p o-we-hint-text="Empty column" class="o-we-hint"><br></p></div><div class="col-4 o-contenteditable-true" contenteditable="true"><p o-we-hint-text="Empty column" class="o-we-hint"><br></p></div></div></div><p><br></p>`
+            PLACEHOLDER_BLOCK_CONTAINER("top") +
+                `<div class="container o_text_columns o-contenteditable-false" contenteditable="false"><div class="row"><div class="col-4 o-contenteditable-true" contenteditable="true"><p>ab[]cd</p></div><div class="col-4 o-contenteditable-true" contenteditable="true"><p o-we-hint-text="Empty column" class="o-we-hint"><br></p></div><div class="col-4 o-contenteditable-true" contenteditable="true"><p o-we-hint-text="Empty column" class="o-we-hint"><br></p></div></div></div><p><br></p>`
         );
 
         await insertText(editor, "/columns");
@@ -313,7 +324,8 @@ describe("4 columns", () => {
 
         await press("enter");
         expect(getContent(el)).toBe(
-            `<div class="container o_text_columns o-contenteditable-false" contenteditable="false"><div class="row"><div class="col-3 o-contenteditable-true" contenteditable="true"><p>ab[]cd</p></div><div class="col-3 o-contenteditable-true" contenteditable="true"><p o-we-hint-text="Empty column" class="o-we-hint"><br></p></div><div class="col-3 o-contenteditable-true" contenteditable="true"><p o-we-hint-text="Empty column" class="o-we-hint"><br></p></div><div class="col-3 o-contenteditable-true" contenteditable="true"><p o-we-hint-text="Empty column" class="o-we-hint"><br></p></div></div></div><p><br></p>`
+            PLACEHOLDER_BLOCK_CONTAINER("top") +
+                `<div class="container o_text_columns o-contenteditable-false" contenteditable="false"><div class="row"><div class="col-3 o-contenteditable-true" contenteditable="true"><p>ab[]cd</p></div><div class="col-3 o-contenteditable-true" contenteditable="true"><p o-we-hint-text="Empty column" class="o-we-hint"><br></p></div><div class="col-3 o-contenteditable-true" contenteditable="true"><p o-we-hint-text="Empty column" class="o-we-hint"><br></p></div><div class="col-3 o-contenteditable-true" contenteditable="true"><p o-we-hint-text="Empty column" class="o-we-hint"><br></p></div></div></div><p><br></p>`
         );
 
         await insertText(editor, "/columns");
@@ -383,7 +395,8 @@ describe("remove columns", () => {
         // add 2 columns
         await press("enter");
         expect(getContent(el)).toBe(
-            `<div class="container o_text_columns o-contenteditable-false" contenteditable="false"><div class="row"><div class="col-6 o-contenteditable-true" contenteditable="true"><p>ab[]cd</p></div><div class="col-6 o-contenteditable-true" contenteditable="true"><p o-we-hint-text="Empty column" class="o-we-hint"><br></p></div></div></div><p><br></p>`
+            PLACEHOLDER_BLOCK_CONTAINER("top") +
+                `<div class="container o_text_columns o-contenteditable-false" contenteditable="false"><div class="row"><div class="col-6 o-contenteditable-true" contenteditable="true"><p>ab[]cd</p></div><div class="col-6 o-contenteditable-true" contenteditable="true"><p o-we-hint-text="Empty column" class="o-we-hint"><br></p></div></div></div><p><br></p>`
         );
 
         await insertText(editor, "/removecolumns");
@@ -513,11 +526,13 @@ describe("helper hint", () => {
                     column(4, "<p><br></p>")
                 ),
             contentAfterEdit:
+                PLACEHOLDER_BLOCK_CONTAINER("top") +
                 columsDuringEditContainer(
                     columnDuringEdit(4, `<p o-we-hint-text="Empty column" class="o-we-hint">[]<br></p>`) +
                     columnDuringEdit(4, `<h1 o-we-hint-text="Heading 1" class="o-we-hint"><br></h1>` + "<h2><br></h2>") +
                     columnDuringEdit(4, `<p o-we-hint-text="Empty column" class="o-we-hint"><br></p>`)
-                ),
+                ) +
+                PLACEHOLDER_BLOCK_CONTAINER("bottom"),
             /* eslint-enable */
         });
     });
@@ -532,11 +547,13 @@ describe("helper hint", () => {
                     column(4, "<p><br></p>")
                 ),
             contentAfterEdit:
+                PLACEHOLDER_BLOCK_CONTAINER("top") +
                 columsDuringEditContainer(
                     columnDuringEdit(4, `<p o-we-hint-text="Empty column" class="o-we-hint"><br></p>`) +
                     columnDuringEdit(4, "<h1><br></h1>" + `<h2 o-we-hint-text="Heading 2" class="o-we-hint">[]<br></h2>`) +
                     columnDuringEdit(4, `<p o-we-hint-text="Empty column" class="o-we-hint"><br></p>`)
-                ),
+                ) +
+                PLACEHOLDER_BLOCK_CONTAINER("bottom"),
             /* eslint-enable */
         });
     });
@@ -551,11 +568,13 @@ describe("helper hint", () => {
                     column(4, "<p><br></p>")
                 ),
             contentAfterEdit:
+                PLACEHOLDER_BLOCK_CONTAINER("top") +
                 columsDuringEditContainer(
                     columnDuringEdit(4, "<p><br></p>" + `<p o-we-hint-text='Type "/" for commands' class="o-we-hint">[]<br></p>`) +
                     columnDuringEdit(4, `<p o-we-hint-text="Empty column" class="o-we-hint"><br></p>`) +
                     columnDuringEdit(4, `<p o-we-hint-text="Empty column" class="o-we-hint"><br></p>`)
-                ),
+                ) +
+                PLACEHOLDER_BLOCK_CONTAINER("bottom"),
             /* eslint-enable */
         });
     });

--- a/addons/html_editor/static/tests/copy.test.js
+++ b/addons/html_editor/static/tests/copy.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "@odoo/hoot";
-import { press } from "@odoo/hoot-dom";
+import { animationFrame, press } from "@odoo/hoot-dom";
 import { setupEditor } from "./_helpers/editor";
 
 describe("range collapsed", () => {
@@ -45,6 +45,7 @@ describe("range not collapsed", () => {
         await setupEditor(
             `]<table><tbody><tr><td><ul><li>a[</li><li>b</li><li>c</li></ul></td><td><br></td></tr></tbody></table>`
         );
+        await animationFrame();
         const clipboardData = new DataTransfer();
         await press(["ctrl", "c"], { dataTransfer: clipboardData });
         expect(clipboardData.getData("text/plain")).toBe("a");

--- a/addons/html_editor/static/tests/data-oe/protected.test.js
+++ b/addons/html_editor/static/tests/data-oe/protected.test.js
@@ -8,6 +8,7 @@ import { Plugin } from "@html_editor/plugin";
 import { MAIN_PLUGINS } from "@html_editor/plugin_sets";
 import { execCommand } from "../_helpers/userCommands";
 import { expectElementCount } from "../_helpers/ui_expectations";
+import { PLACEHOLDER_BLOCK_CONTAINER } from "../_helpers/placeholder_block";
 
 test("should ignore protected elements children mutations (true)", async () => {
     await testEditor({
@@ -27,6 +28,7 @@ test("should ignore protected elements children mutations (true)", async () => {
         contentAfterEdit: unformat(`
                 <div><p>ab[]</p></div>
                 <div data-oe-protected="true" contenteditable="false"><p>ab</p></div>
+                ${PLACEHOLDER_BLOCK_CONTAINER("bottom")}
                 `),
     });
 });
@@ -36,7 +38,7 @@ test("should not ignore unprotected elements children mutations (false)", async 
         contentBefore: unformat(`
                 <div><p>a[]</p></div>
                 <div data-oe-protected="true"><div data-oe-protected="false"><p>a</p></div></div>
-                `),
+        `),
         stepFunction: async (editor) => {
             await insertText(editor, "bc");
             const unProtectedParagraph = editor.editable.querySelector(
@@ -49,7 +51,8 @@ test("should not ignore unprotected elements children mutations (false)", async 
         contentAfterEdit: unformat(`
                 <div><p>abc</p></div>
                 <div data-oe-protected="true" contenteditable="false"><div data-oe-protected="false" contenteditable="true"><p>ab[]</p></div></div>
-                `),
+                ${PLACEHOLDER_BLOCK_CONTAINER("bottom")}
+        `),
     });
 });
 
@@ -82,7 +85,7 @@ test("should not normalize protected elements children (true)", async () => {
                     <p><i class="fa"></i></p>
                     <ul><li>abc<p><br></p></li></ul>
                 </div>
-                `),
+        `),
         contentAfterEdit: unformat(`
                 <div>
                     <p>\ufeff<i class="fa" contenteditable="false">\u200B</i>\ufeff</p>
@@ -92,7 +95,8 @@ test("should not normalize protected elements children (true)", async () => {
                     <p><i class="fa"></i></p>
                     <ul><li>abc<p><br></p></li></ul>
                 </div>
-                `),
+                ${PLACEHOLDER_BLOCK_CONTAINER("bottom")}
+        `),
     });
 });
 
@@ -123,6 +127,7 @@ test("should normalize unprotected elements children (false)", async () => {
                 </div>
                 `),
         contentAfterEdit: unformat(`
+                ${PLACEHOLDER_BLOCK_CONTAINER("top")}
                 <div data-oe-protected="true" contenteditable="false">
                     <p><i class="fa"></i></p>
                     <ul><li>abc<p><br></p></li></ul>
@@ -131,6 +136,7 @@ test("should normalize unprotected elements children (false)", async () => {
                         <ul><li><p>abc</p><p><br></p></li></ul>
                     </div>
                 </div>
+                ${PLACEHOLDER_BLOCK_CONTAINER("bottom")}
                 `),
     });
 });
@@ -143,9 +149,11 @@ test("should not handle table selection in protected elements children (true)", 
                 </div>
                 `),
         contentAfterEdit: unformat(`
+                ${PLACEHOLDER_BLOCK_CONTAINER("top")}
                 <div data-oe-protected="true" contenteditable="false">
                     <p>a[bc</p><table><tbody><tr><td>a]b</td><td>cd</td><td>ef</td></tr></tbody></table>
                 </div>
+                ${PLACEHOLDER_BLOCK_CONTAINER("bottom")}
                 `),
     });
 });
@@ -160,6 +168,7 @@ test("should handle table selection in unprotected elements", async () => {
                 </div>
                 `),
         contentAfterEdit: unformat(`
+                ${PLACEHOLDER_BLOCK_CONTAINER("top")}
                 <div data-oe-protected="true" contenteditable="false">
                     <div data-oe-protected="false" contenteditable="true">
                         <p>a[bc</p>
@@ -170,6 +179,7 @@ test("should handle table selection in unprotected elements", async () => {
                         </tr></tbody></table>
                     </div>
                 </div>
+                ${PLACEHOLDER_BLOCK_CONTAINER("bottom")}
                 `),
     });
 });
@@ -188,6 +198,7 @@ test("should not remove contenteditable attribute of a protected node", async ()
                 </div>
             `),
         contentAfterEdit: unformat(`
+                ${PLACEHOLDER_BLOCK_CONTAINER("top")}
                 <div data-oe-protected="true" contenteditable="false">
                     <p contenteditable="true">content</p>
                     <table contenteditable="true">
@@ -197,6 +208,7 @@ test("should not remove contenteditable attribute of a protected node", async ()
                         <p>content</p>
                     </div>
                 </div>
+                ${PLACEHOLDER_BLOCK_CONTAINER("bottom")}
             `),
     });
 });
@@ -216,6 +228,7 @@ test("should not select a protected table even if it is contenteditable='true'",
                 </div>
             `),
         contentAfterEdit: unformat(`
+            ${PLACEHOLDER_BLOCK_CONTAINER("top")}
                 <div data-oe-protected="true" contenteditable="false">
                     <table contenteditable="true"><tbody><tr>
                         <td>[ab</td>
@@ -224,6 +237,7 @@ test("should not select a protected table even if it is contenteditable='true'",
                         <td>cd]</td>
                     </tr></tbody></table>
                 </div>
+                ${PLACEHOLDER_BLOCK_CONTAINER("bottom")}
             `),
     });
 });
@@ -236,13 +250,17 @@ test("select a protected element shouldn't open the toolbar", async () => {
 
     setContent(
         el,
-        `<div><p>a</p></div><div data-oe-protected="true"><p>[b]</p><div data-oe-protected="false">c</div></div>`
+        `<div><p>a</p></div><div data-oe-protected="true"><p>[b]</p><div data-oe-protected="false">c</div></div>${PLACEHOLDER_BLOCK_CONTAINER(
+            "bottom"
+        )}`
     );
     await expectElementCount(".o-we-toolbar", 0);
 
     setContent(
         el,
-        `<div><p>a</p></div><div data-oe-protected="true"><p>b</p><div data-oe-protected="false">[c]</div></div>`
+        `<div><p>a</p></div><div data-oe-protected="true"><p>b</p><div data-oe-protected="false">[c]</div></div>${PLACEHOLDER_BLOCK_CONTAINER(
+            "bottom"
+        )}`
     );
     await expectElementCount(".o-we-toolbar", 1);
 });
@@ -251,7 +269,7 @@ test("should protect disconnected nodes", async () => {
     const { editor, el, plugins } = await setupEditor(
         `<div data-oe-protected="true"><p>a</p></div><p>a</p>`
     );
-    const div = el.querySelector("div");
+    const div = el.querySelector("div[data-oe-protected]");
     const protectedP = div.querySelector("p");
     protectedP.remove();
     div.remove();
@@ -268,7 +286,7 @@ test("should not crash when changing attributes and removing a protecting anchor
     const { editor, el, plugins } = await setupEditor(
         `<div data-oe-protected="true" data-attr="value"><p>a</p></div><p>a</p>`
     );
-    const div = el.querySelector("div");
+    const div = el.querySelector("div[data-oe-protected]");
     div.dataset.attr = "other";
     div.remove();
     editor.shared.history.addStep();
@@ -291,7 +309,9 @@ test("removing a protected node should be undo-able", async () => {
     expect(getContent(el)).toBe(`<p>[]a</p>`);
     undo(editor);
     expect(getContent(el)).toBe(
-        `<div data-oe-protected="true" contenteditable="false"><p>a</p></div><p>[]a</p>`
+        `${PLACEHOLDER_BLOCK_CONTAINER(
+            "top"
+        )}<div data-oe-protected="true" contenteditable="false"><p>a</p></div><p>[]a</p>`
     );
 });
 
@@ -336,6 +356,7 @@ test("removing a recursively protected then unprotected node should be undo-able
     undo(editor);
     expect(getContent(el)).toBe(
         unformat(`
+            ${PLACEHOLDER_BLOCK_CONTAINER("top")}
             <div data-oe-protected="true" contenteditable="false">
                 <p>a</p>
                 <div data-oe-protected="false" contenteditable="true">
@@ -376,7 +397,13 @@ test("removing a protected node and then removing its protected parent should be
     editor.shared.history.addStep();
     expect(editor.shared.history.getHistorySteps().length).toBe(1);
     expect(historyPlugin.currentStep.mutations).toEqual([]);
-    expect(getContent(el)).toBe(`<div data-oe-protected="true" contenteditable="false"></div>`);
+    expect(getContent(el)).toBe(
+        `${PLACEHOLDER_BLOCK_CONTAINER(
+            "top"
+        )}<div data-oe-protected="true" contenteditable="false"></div>${PLACEHOLDER_BLOCK_CONTAINER(
+            "bottom"
+        )}`
+    );
 });
 
 test("removing a protected ancestor, then a protected descendant, then its protected parent should be ignored", async () => {
@@ -403,7 +430,13 @@ test("removing a protected ancestor, then a protected descendant, then its prote
     editor.shared.history.addStep();
     expect(editor.shared.history.getHistorySteps().length).toBe(1);
     expect(historyPlugin.currentStep.mutations).toEqual([]);
-    expect(getContent(el)).toBe(`<div data-oe-protected="true" contenteditable="false"></div>`);
+    expect(getContent(el)).toBe(
+        `${PLACEHOLDER_BLOCK_CONTAINER(
+            "top"
+        )}<div data-oe-protected="true" contenteditable="false"></div>${PLACEHOLDER_BLOCK_CONTAINER(
+            "bottom"
+        )}`
+    );
 });
 
 test("moving a protected node at an unprotected location, only remove should be ignored", async () => {
@@ -432,12 +465,14 @@ test("moving a protected node at an unprotected location, only remove should be 
     expect(historyPlugin.nodeMap.getNode(lastStep.mutations[0].nodeId)).toBe(a);
     expect(getContent(el)).toBe(
         unformat(`
+            ${PLACEHOLDER_BLOCK_CONTAINER("top")}
             <div data-oe-protected="true" contenteditable="false">
                 <div class="b" data-oe-protected="false" contenteditable="true">
                     <p class="a"></p>
                 </div>
             </div>
             <div data-oe-protected="true" contenteditable="false"></div>
+            ${PLACEHOLDER_BLOCK_CONTAINER("bottom")}
         `)
     );
 });
@@ -468,12 +503,14 @@ test("moving an unprotected node at a protected location, only add should be ign
     expect(historyPlugin.nodeMap.getNode(lastStep.mutations[0].nodeId)).toBe(a);
     expect(getContent(el)).toBe(
         unformat(`
+            ${PLACEHOLDER_BLOCK_CONTAINER("top")}
             <div data-oe-protected="true" contenteditable="false">
                 <div data-oe-protected="false" contenteditable="true"></div>
             </div>
             <div class="b" data-oe-protected="true" contenteditable="false">
                 <p class="a">content</p>
             </div>
+            ${PLACEHOLDER_BLOCK_CONTAINER("bottom")}
         `)
     );
 });
@@ -498,20 +535,24 @@ test("sequentially added nodes under a protecting parent are correctly protected
     expect(protectedPlugin.protectedNodes.has(node)).toBe(true);
     expect(getContent(el)).toBe(
         unformat(`
+            ${PLACEHOLDER_BLOCK_CONTAINER("top")}
             <div data-oe-protected="true" contenteditable="false">
                 <div>a</div>
                 content
             </div>
+            ${PLACEHOLDER_BLOCK_CONTAINER("bottom")}
         `)
     );
     node.remove();
     editor.shared.history.addStep();
     expect(getContent(el)).toBe(
         unformat(`
+            ${PLACEHOLDER_BLOCK_CONTAINER("top")}
             <div data-oe-protected="true" contenteditable="false">
                 <div></div>
                 content
             </div>
+            ${PLACEHOLDER_BLOCK_CONTAINER("bottom")}
         `)
     );
     expect(editor.shared.history.getHistorySteps().length).toBe(1);
@@ -541,6 +582,7 @@ test("don't protect a node under data-oe-protected='false' through delete and un
     expect(protectedPlugin.protectedNodes.has(node)).toBe(false);
     expect(getContent(el)).toBe(
         unformat(`
+            ${PLACEHOLDER_BLOCK_CONTAINER("top")}
             <div data-oe-protected="true" contenteditable="false">
                 <div data-oe-protected="false" contenteditable="true">
                     <p>b</p>
@@ -554,6 +596,7 @@ test("don't protect a node under data-oe-protected='false' through delete and un
     undo(editor);
     expect(getContent(el)).toBe(
         unformat(`
+            ${PLACEHOLDER_BLOCK_CONTAINER("top")}
             <div data-oe-protected="true" contenteditable="false">
                 <div data-oe-protected="false" contenteditable="true">
                     <p>b</p>
@@ -606,5 +649,11 @@ test("protected plugin is robust against other plugins which can filter mutation
     editor.shared.history.addStep();
     expect(editor.shared.history.getHistorySteps().length).toBe(1);
     expect(historyPlugin.currentStep.mutations).toEqual([]);
-    expect(getContent(el)).toBe(`<div data-oe-protected="true" contenteditable="false"></div>`);
+    expect(getContent(el)).toBe(
+        `${PLACEHOLDER_BLOCK_CONTAINER(
+            "top"
+        )}<div data-oe-protected="true" contenteditable="false"></div>${PLACEHOLDER_BLOCK_CONTAINER(
+            "bottom"
+        )}`
+    );
 });

--- a/addons/html_editor/static/tests/delete/backward.test.js
+++ b/addons/html_editor/static/tests/delete/backward.test.js
@@ -1874,8 +1874,8 @@ describe("Selection not collapsed", () => {
                 </tbody></table>`
             ),
             contentBeforeEdit: unformat(
-                `[${PLACEHOLDER_BLOCK_CONTAINER("top")}
-                <table class="o_selected_table"><tbody>
+                `${PLACEHOLDER_BLOCK_CONTAINER("top")}
+                [<table class="o_selected_table"><tbody>
                     <tr><td class="o_selected_td"><br></td><td class="o_selected_td"><br></td></tr>
                     <tr><td class="o_selected_td"><br></td><td class="o_selected_td">]<br></td></tr>
                 </tbody></table>

--- a/addons/html_editor/static/tests/delete/backward.test.js
+++ b/addons/html_editor/static/tests/delete/backward.test.js
@@ -7,6 +7,7 @@ import { setupEditor, testEditor } from "../_helpers/editor";
 import { unformat } from "../_helpers/format";
 import { getContent, setSelection } from "../_helpers/selection";
 import { deleteBackward, insertText, tripleClick, undo } from "../_helpers/user_actions";
+import { PLACEHOLDER_BLOCK_CONTAINER } from "../_helpers/placeholder_block";
 
 /**
  * content of the "deleteBackward" sub suite in editor.test.js
@@ -1873,10 +1874,12 @@ describe("Selection not collapsed", () => {
                 </tbody></table>`
             ),
             contentBeforeEdit: unformat(
-                `[<table class="o_selected_table"><tbody>
+                `[${PLACEHOLDER_BLOCK_CONTAINER("top")}
+                <table class="o_selected_table"><tbody>
                     <tr><td class="o_selected_td"><br></td><td class="o_selected_td"><br></td></tr>
                     <tr><td class="o_selected_td"><br></td><td class="o_selected_td">]<br></td></tr>
-                </tbody></table>`
+                </tbody></table>
+                ${PLACEHOLDER_BLOCK_CONTAINER("bottom")}`
             ),
             stepFunction: deleteBackward,
             contentAfter: unformat("<p>[]<br></p>"),

--- a/addons/html_editor/static/tests/delete/delete_range.test.js
+++ b/addons/html_editor/static/tests/delete/delete_range.test.js
@@ -410,15 +410,17 @@ describe("deleteSelection", () => {
                         <p>gh]i</p>`
                     ),
                     stepFunction: deleteSelection,
-                    contentAfterEdit: unformat(
-                        `<div class="container o_text_columns o-contenteditable-false" contenteditable="false">
+                    contentAfterEdit:
+                        PLACEHOLDER_BLOCK_CONTAINER("top") +
+                        unformat(
+                            `<div class="container o_text_columns o-contenteditable-false" contenteditable="false">
                             <div class="row">
                                 <div class="col-6 o-contenteditable-true" contenteditable="true">a[]</div>
                                 <div class="col-6 o-contenteditable-true" contenteditable="true"><p o-we-hint-text="Empty column" class="o-we-hint"><br></p></div>
                             </div>
                         </div>
                         <p>i</p>`
-                    ),
+                        ),
                     contentAfter: unformat(
                         `<div class="container o_text_columns o-contenteditable-false">
                             <div class="row">

--- a/addons/html_editor/static/tests/delete/delete_range.test.js
+++ b/addons/html_editor/static/tests/delete/delete_range.test.js
@@ -3,6 +3,7 @@ import { setupEditor, testEditor } from "../_helpers/editor";
 import { unformat } from "../_helpers/format";
 import { CORE_PLUGINS } from "@html_editor/plugin_sets";
 import { getContent, setSelection } from "../_helpers/selection";
+import { PLACEHOLDER_BLOCK_CONTAINER } from "../_helpers/placeholder_block";
 
 async function testCoreEditor(testConfig) {
     return testEditor({ ...testConfig, config: { Plugins: CORE_PLUGINS } });
@@ -242,10 +243,12 @@ describe("deleteRange method", () => {
             */
             deleteRange(editor);
             const contentAfter = unformat(
-                `[<table><tbody>
+                `[${PLACEHOLDER_BLOCK_CONTAINER("top")}
+                <table><tbody>
                     <tr><td><br></td><td><br></td></tr>
                     <tr><td>]<br></td><td><br></td></tr>
-                </tbody></table>`
+                </tbody></table>
+                ${PLACEHOLDER_BLOCK_CONTAINER("bottom")}`
             );
             expect(getContent(el)).toBe(contentAfter);
         });

--- a/addons/html_editor/static/tests/delete/find_adjacent_position.test.js
+++ b/addons/html_editor/static/tests/delete/find_adjacent_position.test.js
@@ -4,6 +4,7 @@ import { getContent, setSelection } from "../_helpers/selection";
 import { unformat } from "../_helpers/format";
 import { FilePlugin } from "@html_editor/main/media/file_plugin";
 import { CORE_PLUGINS } from "@html_editor/plugin_sets";
+import { PLACEHOLDER_BLOCK_CONTAINER } from "../_helpers/placeholder_block";
 
 function findAdjacentPosition(editor, direction) {
     const deletePlugin = editor.plugins.find((p) => p.constructor.id === "delete");
@@ -154,7 +155,11 @@ describe("findAdjacentPosition method", () => {
                 <p>fgh</p>
             `);
             const { editor } = await setupEditor(previous);
-            assertAdjacentPositions(editor, previous, next);
+            assertAdjacentPositions(
+                editor,
+                PLACEHOLDER_BLOCK_CONTAINER("top") + previous,
+                PLACEHOLDER_BLOCK_CONTAINER("top") + next
+            );
         });
         test("should not find anything outside the closest editable root", async () => {
             const { editor } = await setupEditor(
@@ -201,6 +206,7 @@ describe("findAdjacentPosition method", () => {
                 // it's the desirable one to compose a range for deletion,
                 // allowing to remove the div with deleteBackward
                 unformat(`
+                    ${PLACEHOLDER_BLOCK_CONTAINER("top")}
                     []<div contenteditable="false">
                         <p>abc</p>
                         <p contenteditable="true">def</p>
@@ -231,6 +237,7 @@ describe("findAdjacentPosition method", () => {
                         <p>abc</p>
                         <p contenteditable="true">def</p>
                     </div>[]
+                    ${PLACEHOLDER_BLOCK_CONTAINER("bottom")}
                 `)
             );
         });

--- a/addons/html_editor/static/tests/embedded_components.test.js
+++ b/addons/html_editor/static/tests/embedded_components.test.js
@@ -42,6 +42,7 @@ import { Deferred } from "@web/core/utils/concurrency";
 import { Plugin } from "@html_editor/plugin";
 import { cleanHints, dispatchCleanForSave } from "./_helpers/dispatch";
 import { expectElementCount } from "./_helpers/ui_expectations";
+import { PLACEHOLDER_BLOCK_CONTAINER } from "./_helpers/placeholder_block";
 
 function getConfig(components) {
     return {
@@ -386,6 +387,7 @@ describe("Mount and Destroy embedded components", () => {
         expect.verifySteps(["mount 1", "mount 2", "mount 3"]);
         expect(getContent(el)).toBe(
             unformat(`
+                ${PLACEHOLDER_BLOCK_CONTAINER("top")}
                 <div data-embedded="recursiveComponent" data-oe-protected="true" contenteditable="false">
                     <div>
                         <div class="click count-2">Count:2</div>
@@ -439,6 +441,7 @@ describe("Mount and Destroy embedded components", () => {
         // outermost host.
         expect(getContent(el)).toBe(
             unformat(`
+                ${PLACEHOLDER_BLOCK_CONTAINER("top")}
                 <div data-embedded="recursiveComponent" data-oe-protected="true" contenteditable="false"></div>
                 <p class="target o-we-hint" o-we-hint-text='Type "/" for commands'>[]<br></p>
             `)
@@ -580,6 +583,7 @@ describe("Selection after embedded component insertion", () => {
         cleanHints(editor);
         expect(getContent(el)).toBe(
             unformat(`
+                ${PLACEHOLDER_BLOCK_CONTAINER("top")}
                 <div data-embedded="counter" data-oe-protected="true" contenteditable="false"><span class="counter">Counter:0</span></div>
                 <p>[]<br></p>`)
         );
@@ -609,6 +613,7 @@ describe("Selection after embedded component insertion", () => {
         cleanHints(editor);
         expect(getContent(el)).toBe(
             unformat(`
+                ${PLACEHOLDER_BLOCK_CONTAINER("top")}
                 <div data-embedded="counter" data-oe-protected="true" contenteditable="false"><span class="counter">Counter:0</span></div>
                 <p>[]a</p>`)
         );
@@ -1049,6 +1054,7 @@ describe("editable descendants", () => {
         await animationFrame();
         expect(getContent(el)).toBe(
             unformat(`
+                ${PLACEHOLDER_BLOCK_CONTAINER("top")}
                 <div data-embedded="wrapper" data-oe-protected="true" contenteditable="false">
                     <div class="deep">
                         <div data-embedded-editable="deep" data-oe-protected="false" contenteditable="true">

--- a/addons/html_editor/static/tests/embedded_components_plugins/toggle_block.test.js
+++ b/addons/html_editor/static/tests/embedded_components_plugins/toggle_block.test.js
@@ -23,6 +23,7 @@ import { MAIN_PLUGINS } from "@html_editor/plugin_sets";
 import { EmbeddedComponentPlugin } from "@html_editor/others/embedded_component_plugin";
 import { ToggleBlockPlugin } from "@html_editor/others/embedded_components/plugins/toggle_block_plugin/toggle_block_plugin";
 import { parseHTML } from "@html_editor/utils/html";
+import { PLACEHOLDER_BLOCK_CONTAINER } from "../_helpers/placeholder_block";
 
 let embeddedToggleMountedPromise;
 
@@ -89,7 +90,8 @@ describe("deleteBackward applied to toggle", () => {
                             <p>asdf[]stuff</p>
                         </div>
                     </div>
-                </div>`)
+                </div>
+                ${PLACEHOLDER_BLOCK_CONTAINER("bottom")}`)
         );
     });
     test("toggle closed, after toggle: should append to title", async () => {
@@ -132,7 +134,8 @@ describe("deleteBackward applied to toggle", () => {
                             <p>asdf</p>
                         </div>
                     </div>
-                </div>`)
+                </div>
+                ${PLACEHOLDER_BLOCK_CONTAINER("bottom")}`)
         );
     });
     test("start of title: should explode toggle", async () => {
@@ -234,6 +237,7 @@ describe("deleteForward applied to toggle", () => {
         deleteForward(editor);
         expect(getContent(el)).toBe(
             unformat(`
+                ${PLACEHOLDER_BLOCK_CONTAINER("top")}
                 <div data-embedded="toggleBlock" data-oe-protected="true" data-embedded-props='{ "toggleBlockId": "1" }' contenteditable="false">
                     <div class="d-flex flex-row align-items-center">
                         <button class="btn p-0 border-0 align-items-center justify-content-center btn-light">
@@ -250,7 +254,8 @@ describe("deleteForward applied to toggle", () => {
                             <p>asdf</p>
                         </div>
                     </div>
-                </div>`)
+                </div>
+                ${PLACEHOLDER_BLOCK_CONTAINER("bottom")}`)
         );
     });
     test("end of paragraph, before toggle: should explode sibling toggle", async () => {
@@ -308,6 +313,7 @@ describe("deleteForward applied to toggle", () => {
         deleteForward(editor);
         expect(getContent(el)).toBe(
             unformat(`
+                ${PLACEHOLDER_BLOCK_CONTAINER("top")}
                 <div data-embedded="toggleBlock" data-oe-protected="true" data-embedded-props='{ "toggleBlockId": "1" }' contenteditable="false">
                     <div class="d-flex flex-row align-items-center">
                         <button class="btn p-0 border-0 align-items-center justify-content-center btn-light">
@@ -324,7 +330,8 @@ describe("deleteForward applied to toggle", () => {
                             <p>third</p>
                         </div>
                     </div>
-                </div>`)
+                </div>
+                ${PLACEHOLDER_BLOCK_CONTAINER("bottom")}`)
         );
     });
     test("toggle closed, end of title: should explode sibling toggle and append to title", async () => {
@@ -355,6 +362,7 @@ describe("deleteForward applied to toggle", () => {
         deleteForward(editor);
         expect(getContent(el)).toBe(
             unformat(`
+                ${PLACEHOLDER_BLOCK_CONTAINER("top")}
                 <div data-embedded="toggleBlock" data-oe-protected="true" data-embedded-props='{ "toggleBlockId": "1" }' contenteditable="false">
                     <div class="d-flex flex-row align-items-center">
                         <button class="btn p-0 border-0 align-items-center justify-content-center btn-light">
@@ -405,6 +413,7 @@ describe("deleteForward applied to toggle", () => {
         deleteForward(editor);
         expect(getContent(el)).toBe(
             unformat(`
+                ${PLACEHOLDER_BLOCK_CONTAINER("top")}
                 <div data-embedded="toggleBlock" data-oe-protected="true" data-embedded-props='{ "toggleBlockId": "1" }' contenteditable="false">
                     <div class="d-flex flex-row align-items-center">
                         <button class="btn p-0 border-0 align-items-center justify-content-center btn-light">
@@ -457,6 +466,7 @@ describe("Enter applied to toggle title", () => {
         await embeddedToggleMountedPromise;
         expect(getContent(el)).toBe(
             unformat(`
+                ${PLACEHOLDER_BLOCK_CONTAINER("top")}
                 <div data-embedded="toggleBlock" data-oe-protected="true" contenteditable="false" data-embedded-props='{"toggleBlockId":"2"}'>
                     <div class="d-flex flex-row align-items-center">
                         <button class="btn p-0 border-0 align-items-center justify-content-center btn-light">
@@ -491,6 +501,7 @@ describe("Enter applied to toggle title", () => {
                         </div>
                     </div>
                 </div>
+                ${PLACEHOLDER_BLOCK_CONTAINER("bottom")}
             `)
         );
     });
@@ -522,6 +533,7 @@ describe("Enter applied to toggle title", () => {
         await embeddedToggleMountedPromise;
         expect(getContent(el)).toBe(
             unformat(`
+            ${PLACEHOLDER_BLOCK_CONTAINER("top")}
             <div data-embedded="toggleBlock" data-oe-protected="true" data-embedded-props='{ "toggleBlockId": "1" }' contenteditable="false">
                 <div class="d-flex flex-row align-items-center">
                     <button class="btn p-0 border-0 align-items-center justify-content-center btn-light">
@@ -556,6 +568,7 @@ describe("Enter applied to toggle title", () => {
                     </div>
                 </div>
             </div>
+            ${PLACEHOLDER_BLOCK_CONTAINER("bottom")}
         `)
         );
     });
@@ -581,6 +594,7 @@ describe("Enter applied to toggle title", () => {
         splitBlock(editor);
         expect(getContent(el)).toBe(
             unformat(`
+            ${PLACEHOLDER_BLOCK_CONTAINER("top")}
             <div data-embedded="toggleBlock" data-oe-protected="true" contenteditable="false" data-embedded-props='{ "toggleBlockId": "1" }'>
                 <div class="d-flex flex-row align-items-center">
                     <button class="btn p-0 border-0 align-items-center justify-content-center btn-light">
@@ -598,7 +612,8 @@ describe("Enter applied to toggle title", () => {
                         <p>asdf</p>
                     </div>
                 </div>
-            </div>`)
+            </div>
+            ${PLACEHOLDER_BLOCK_CONTAINER("bottom")}`)
         );
     });
     test("empty title: should explode toggle", async () => {
@@ -661,6 +676,7 @@ describe("Tab applied to toggle title", () => {
         await animationFrame();
         expect(getContent(el)).toBe(
             unformat(`
+            ${PLACEHOLDER_BLOCK_CONTAINER("top")}
             <div data-embedded="toggleBlock" data-oe-protected="true" contenteditable="false" data-embedded-props='{ "toggleBlockId": "1" }'>
                 <div class="d-flex flex-row align-items-center">
                     <button class="btn p-0 border-0 align-items-center justify-content-center btn-light">
@@ -693,7 +709,8 @@ describe("Tab applied to toggle title", () => {
                         </div>
                     </div>
                 </div>
-            </div>`)
+            </div>
+            ${PLACEHOLDER_BLOCK_CONTAINER("bottom")}`)
         );
     });
     test("toggle open, should move inside previous toggle and unwrap content", async () => {
@@ -728,6 +745,7 @@ describe("Tab applied to toggle title", () => {
         await animationFrame();
         expect(getContent(el)).toBe(
             unformat(`
+            ${PLACEHOLDER_BLOCK_CONTAINER("top")}
             <div data-embedded="toggleBlock" data-oe-protected="true" contenteditable="false" data-embedded-props='{ "toggleBlockId": "1" }'>
                 <div class="d-flex flex-row align-items-center">
                     <button class="btn p-0 border-0 align-items-center justify-content-center btn-light">
@@ -761,7 +779,8 @@ describe("Tab applied to toggle title", () => {
                         <p>asdf</p>
                     </div>
                 </div>
-            </div>`)
+            </div>
+            ${PLACEHOLDER_BLOCK_CONTAINER("bottom")}`)
         );
     });
 });
@@ -797,6 +816,7 @@ describe("Shift+Tab applied to toggle title", () => {
         await animationFrame();
         expect(getContent(el)).toBe(
             unformat(`
+            ${PLACEHOLDER_BLOCK_CONTAINER("top")}
             <div data-embedded="toggleBlock" data-oe-protected="true" contenteditable="false" data-embedded-props='{ "toggleBlockId": "1" }'>
                 <div class="d-flex flex-row align-items-center">
                     <button class="btn p-0 border-0 align-items-center justify-content-center btn-light">
@@ -831,6 +851,7 @@ describe("Shift+Tab applied to toggle title", () => {
                     </div>
                 </div>
             </div>
+            ${PLACEHOLDER_BLOCK_CONTAINER("bottom")}
         `)
         );
     });
@@ -897,6 +918,7 @@ describe("Insert (paste, drop) inside toggle title", () => {
         addStep(editor);
         expect(getContent(el)).toBe(
             unformat(`
+                ${PLACEHOLDER_BLOCK_CONTAINER("top")}
                 <div data-embedded="toggleBlock" data-oe-protected="true" contenteditable="false" data-embedded-props='{ "toggleBlockId": "1" }'>
                     <div class="d-flex flex-row align-items-center">
                         <button class="btn p-0 border-0 align-items-center justify-content-center btn-light"><i class="fa align-self-center fa-caret-right"></i></button>

--- a/addons/html_editor/static/tests/format/bold.test.js
+++ b/addons/html_editor/static/tests/format/bold.test.js
@@ -8,6 +8,7 @@ import { getContent } from "../_helpers/selection";
 import { BOLD_TAGS, em, notStrong, span, strong } from "../_helpers/tags";
 import { expectElementCount } from "../_helpers/ui_expectations";
 import { bold, italic, simulateArrowKeyPress, tripleClick } from "../_helpers/user_actions";
+import { PLACEHOLDER_BLOCK_CONTAINER } from "../_helpers/placeholder_block";
 
 const styleH1Bold = `h1 { font-weight: bold; }`;
 
@@ -206,6 +207,7 @@ test("should make a few characters bold inside table (bold)", async () => {
             </table>`),
         stepFunction: bold,
         contentAfterEdit: unformat(`
+            ${PLACEHOLDER_BLOCK_CONTAINER("top")}
             <table class="table table-bordered o_table o_selected_table">
                 <tbody>
                     <tr>
@@ -224,7 +226,8 @@ test("should make a few characters bold inside table (bold)", async () => {
                         <td><p><br></p></td>
                     </tr>
             </tbody>
-            </table>`),
+            </table>
+            ${PLACEHOLDER_BLOCK_CONTAINER("bottom")}`),
     });
 });
 

--- a/addons/html_editor/static/tests/format/italic.test.js
+++ b/addons/html_editor/static/tests/format/italic.test.js
@@ -5,6 +5,7 @@ import { em, span } from "../_helpers/tags";
 import { italic, tripleClick, simulateArrowKeyPress } from "../_helpers/user_actions";
 import { unformat } from "../_helpers/format";
 import { tick } from "@odoo/hoot-mock";
+import { PLACEHOLDER_BLOCK_CONTAINER } from "../_helpers/placeholder_block";
 
 test("should make a few characters italic", async () => {
     await testEditor({
@@ -205,6 +206,7 @@ test("should make a few characters italic inside table (italic)", async () => {
             </table>`),
         stepFunction: italic,
         contentAfterEdit: unformat(`
+            ${PLACEHOLDER_BLOCK_CONTAINER("top")}
             <table class="table table-bordered o_table o_selected_table">
                 <tbody>
                     <tr>
@@ -223,6 +225,7 @@ test("should make a few characters italic inside table (italic)", async () => {
                         <td><p><br></p></td>
                     </tr>
                 </tbody>
-            </table>`),
+            </table>
+            ${PLACEHOLDER_BLOCK_CONTAINER("bottom")}`),
     });
 });

--- a/addons/html_editor/static/tests/format/remove_format.test.js
+++ b/addons/html_editor/static/tests/format/remove_format.test.js
@@ -7,6 +7,7 @@ import { execCommand } from "../_helpers/userCommands";
 import { expandToolbar } from "../_helpers/toolbar";
 import { unformat } from "../_helpers/format";
 import { expectElementCount } from "../_helpers/ui_expectations";
+import { PLACEHOLDER_BLOCK_CONTAINER } from "../_helpers/placeholder_block";
 
 test("should do nothing if no format is set", async () => {
     await testEditor({
@@ -899,7 +900,9 @@ describe("Toolbar", () => {
         );
         await removeFormatClick();
         expect(getContent(el)).toBe(
-            `<table class="table table-bordered o_table o_selected_table"><tbody><tr><td class="o_selected_td"><p>[abc</p></td><td class="o_selected_td"><p>\u200b</p></td></tr></tbody></table><p>]\u200b</p>`
+            `${PLACEHOLDER_BLOCK_CONTAINER(
+                "top"
+            )}<table class="table table-bordered o_table o_selected_table"><tbody><tr><td class="o_selected_td"><p>[abc</p></td><td class="o_selected_td"><p>\u200b</p></td></tr></tbody></table><p>]\u200b</p>`
         );
     });
 
@@ -909,7 +912,22 @@ describe("Toolbar", () => {
         );
         await removeFormatClick();
         expect(getContent(el)).toBe(
-            `<table class="table table-bordered o_table o_selected_table"><tbody><tr><td style="" class="o_selected_td"><p>[\u200b</p></td><td style="" class="o_selected_td"><p>]\u200b</p></td></tr></tbody></table>`
+            unformat(
+                `${PLACEHOLDER_BLOCK_CONTAINER("top")}
+                <table class="table table-bordered o_table o_selected_table">
+                    <tbody>
+                        <tr>
+                            <td style="" class="o_selected_td">
+                                <p>[\u200b</p>
+                            </td>
+                            <td style="" class="o_selected_td">
+                                <p>]\u200b</p>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+                ${PLACEHOLDER_BLOCK_CONTAINER("bottom")}`
+            )
         );
     });
 
@@ -933,6 +951,7 @@ describe("Toolbar", () => {
         await removeFormatClick();
         expect(getContent(el)).toBe(
             unformat(`
+                ${PLACEHOLDER_BLOCK_CONTAINER("top")}
                 <table class="table table-bordered o_table o_selected_table">
                     <tbody>
                         <tr style="height: 100px;">
@@ -945,6 +964,7 @@ describe("Toolbar", () => {
                         </tr>
                     </tbody>
                 </table>
+                ${PLACEHOLDER_BLOCK_CONTAINER("bottom")}
             `)
         );
     });

--- a/addons/html_editor/static/tests/format/strike_through.test.js
+++ b/addons/html_editor/static/tests/format/strike_through.test.js
@@ -10,6 +10,7 @@ import {
     simulateArrowKeyPress,
 } from "../_helpers/user_actions";
 import { unformat } from "../_helpers/format";
+import { PLACEHOLDER_BLOCK_CONTAINER } from "../_helpers/placeholder_block";
 
 test("should make a few characters strikeThrough", async () => {
     await testEditor({
@@ -228,6 +229,7 @@ test("should make a few characters strikeThrough inside table (strikeThrough)", 
             </table>`),
         stepFunction: strikeThrough,
         contentAfterEdit: unformat(`
+            ${PLACEHOLDER_BLOCK_CONTAINER("top")}
             <table class="table table-bordered o_table o_selected_table">
                 <tbody>
                     <tr>
@@ -246,7 +248,8 @@ test("should make a few characters strikeThrough inside table (strikeThrough)", 
                         <td><p><br></p></td>
                     </tr>
                 </tbody>
-            </table>`),
+            </table>
+            ${PLACEHOLDER_BLOCK_CONTAINER("bottom")}`),
     });
 });
 

--- a/addons/html_editor/static/tests/format/underline.test.js
+++ b/addons/html_editor/static/tests/format/underline.test.js
@@ -12,6 +12,7 @@ import {
     underline,
 } from "../_helpers/user_actions";
 import { unformat } from "../_helpers/format";
+import { PLACEHOLDER_BLOCK_CONTAINER } from "../_helpers/placeholder_block";
 
 test("should make a few characters underline", async () => {
     await testEditor({
@@ -197,6 +198,7 @@ test("should make a few characters underline inside table (underline)", async ()
             </table>`),
         stepFunction: underline,
         contentAfterEdit: unformat(`
+            ${PLACEHOLDER_BLOCK_CONTAINER("top")}
             <table class="table table-bordered o_table o_selected_table">
                 <tbody>
                     <tr>
@@ -215,7 +217,8 @@ test("should make a few characters underline inside table (underline)", async ()
                         <td><p><br></p></td>
                     </tr>
                 </tbody>
-            </table>`),
+            </table>
+            ${PLACEHOLDER_BLOCK_CONTAINER("bottom")}`),
     });
 });
 

--- a/addons/html_editor/static/tests/hint.test.js
+++ b/addons/html_editor/static/tests/hint.test.js
@@ -9,6 +9,7 @@ import {
     setSelection,
 } from "./_helpers/selection";
 import { insertText } from "./_helpers/user_actions";
+import { PLACEHOLDER_BLOCK_CONTAINER } from "./_helpers/placeholder_block";
 
 test("hints are removed when editor is destroyed", async () => {
     const { el, editor } = await setupEditor("<p>[]</p>", {});
@@ -76,7 +77,9 @@ test("should not display hint in a non-editable paragraph", async () => {
     const content = '<div contenteditable="false"><p>[]</p></div>';
     const { el } = await setupEditor(content);
     // Unchanged, no empty paragraph hint.
-    expect(getContent(el)).toBe(content);
+    expect(getContent(el)).toBe(
+        PLACEHOLDER_BLOCK_CONTAINER("top") + content + PLACEHOLDER_BLOCK_CONTAINER("bottom")
+    );
 });
 
 test("should not lose track of temporary hints on split block", async () => {

--- a/addons/html_editor/static/tests/history.test.js
+++ b/addons/html_editor/static/tests/history.test.js
@@ -273,13 +273,13 @@ describe("selection", () => {
 describe("step", () => {
     test('should allow insertion of nested contenteditable="true"', async () => {
         await testEditor({
-            contentBefore: `<div contenteditable="false"></div>`,
+            contentBefore: `<div id="target" contenteditable="false"></div>`,
             stepFunction: async (editor) => {
                 const editable = '<div contenteditable="true">abc</div>';
-                editor.editable.querySelector("div").innerHTML = editable;
+                editor.editable.querySelector("div#target").innerHTML = editable;
                 editor.shared.history.addStep();
             },
-            contentAfter: `<div contenteditable="false"><div contenteditable="true">abc</div></div>`,
+            contentAfter: `<div id="target" contenteditable="false"><div contenteditable="true">abc</div></div>`,
         });
     });
 });

--- a/addons/html_editor/static/tests/html_field.test.js
+++ b/addons/html_editor/static/tests/html_field.test.js
@@ -35,6 +35,7 @@ import { insertText, pasteOdooEditorHtml, pasteText, undo } from "./_helpers/use
 import { unformat } from "./_helpers/format";
 import { expandToolbar } from "./_helpers/toolbar";
 import { expectElementCount } from "./_helpers/ui_expectations";
+import { PLACEHOLDER_BLOCK_CONTAINER } from "./_helpers/placeholder_block";
 
 class Partner extends models.Model {
     txt = fields.Html({ trim: true });
@@ -613,10 +614,18 @@ test("edit a html field with `o-contenteditable-true` or `o-contenteditable-fals
             </form>`,
     });
     expect.verifySteps(["setup_wysiwyg"]);
-    expect(`[name="txt"] .odoo-editor-editable`).toHaveInnerHTML(getTxtValue("inside", true));
+    expect(`[name="txt"] .odoo-editor-editable`).toHaveInnerHTML(
+        PLACEHOLDER_BLOCK_CONTAINER("top", "div") +
+            getTxtValue("inside", true) +
+            PLACEHOLDER_BLOCK_CONTAINER("bottom", "div")
+    );
     setSelectionInHtmlField();
     pasteOdooEditorHtml(htmlEditor, "addon");
-    expect(`[name="txt"] .odoo-editor-editable`).toHaveInnerHTML(getTxtValue("addoninside", true));
+    expect(`[name="txt"] .odoo-editor-editable`).toHaveInnerHTML(
+        PLACEHOLDER_BLOCK_CONTAINER("top", "div") +
+            getTxtValue("addoninside", true) +
+            PLACEHOLDER_BLOCK_CONTAINER("bottom", "div")
+    );
     await clickSave();
     expect.verifySteps(["update_value", "web_save"]);
 });

--- a/addons/html_editor/static/tests/html_migrations.test.js
+++ b/addons/html_editor/static/tests/html_migrations.test.js
@@ -8,6 +8,7 @@ import {
     mountView,
     patchWithCleanup,
 } from "@web/../tests/web_test_helpers";
+import { PLACEHOLDER_BLOCK_CONTAINER } from "./_helpers/placeholder_block";
 
 const VERSIONS = htmlEditorVersions();
 const CURRENT_VERSION = VERSIONS.at(-1);
@@ -81,7 +82,8 @@ describe("test the migration process", () => {
                     <div class="w-100 px-3 o_editor_banner_content o-contenteditable-true" contenteditable="true">
                         <p>content</p>
                     </div>
-                </div>`
+                </div>
+                ${PLACEHOLDER_BLOCK_CONTAINER("bottom", "div")}`
             );
             expect(htmlFieldComponent.editor.getContent()).toBe(
                 `<p data-oe-version="${CURRENT_VERSION}">test</p>

--- a/addons/html_editor/static/tests/insert/html.test.js
+++ b/addons/html_editor/static/tests/insert/html.test.js
@@ -8,6 +8,7 @@ import { cleanHints } from "../_helpers/dispatch";
 import { MAIN_PLUGINS } from "@html_editor/plugin_sets";
 import { addStep } from "../_helpers/user_actions";
 import { Plugin } from "@html_editor/plugin";
+import { PLACEHOLDER_BLOCK_CONTAINER } from "../_helpers/placeholder_block";
 
 function span(text) {
     const span = document.createElement("span");
@@ -42,8 +43,9 @@ describe("collapsed selection", () => {
                 );
                 editor.shared.history.addStep();
             },
-            contentAfterEdit:
-                '<p><br></p><i class="fa fa-pastafarianism" contenteditable="false">\u200b</i>[]',
+            contentAfterEdit: `<p><br></p><i class="fa fa-pastafarianism" contenteditable="false">\u200b</i>[]${PLACEHOLDER_BLOCK_CONTAINER(
+                "bottom"
+            )}`,
             contentAfter: '<p><br></p><i class="fa fa-pastafarianism"></i>[]',
             config: { allowInlineAtRoot: true },
         });

--- a/addons/html_editor/static/tests/insert/separator.test.js
+++ b/addons/html_editor/static/tests/insert/separator.test.js
@@ -4,6 +4,7 @@ import { getContent } from "../_helpers/selection";
 import { execCommand } from "../_helpers/userCommands";
 import { simulateArrowKeyPress } from "../_helpers/user_actions";
 import { animationFrame } from "@odoo/hoot-dom";
+import { PLACEHOLDER_BLOCK_CONTAINER } from "../_helpers/placeholder_block";
 
 async function insertSeparator(editor) {
     execCommand(editor, "insertSeparator");
@@ -14,7 +15,9 @@ describe("insert separator", () => {
         await testEditor({
             contentBefore: "<p>[]<br></p>",
             stepFunction: insertSeparator,
-            contentAfterEdit: `<hr contenteditable="false"><p o-we-hint-text='Type "/" for commands' class="o-we-hint">[]<br></p>`,
+            contentAfterEdit: `${PLACEHOLDER_BLOCK_CONTAINER(
+                "top"
+            )}<hr contenteditable="false"><p o-we-hint-text='Type "/" for commands' class="o-we-hint">[]<br></p>`,
             contentAfter: "<hr><p>[]<br></p>",
         });
     });

--- a/addons/html_editor/static/tests/list/automatic_list_detection.test.js
+++ b/addons/html_editor/static/tests/list/automatic_list_detection.test.js
@@ -6,6 +6,7 @@ import { getContent } from "../_helpers/selection";
 import { unformat } from "../_helpers/format";
 import { animationFrame } from "@odoo/hoot-mock";
 import { execCommand } from "../_helpers/userCommands";
+import { PLACEHOLDER_BLOCK_CONTAINER } from "../_helpers/placeholder_block";
 
 test("typing '1. ' should create number list", async () => {
     const { el, editor } = await setupEditor("<p>[]</p>");
@@ -95,6 +96,7 @@ test("creating list directly inside table column (td)", async () => {
     await insertText(editor, "A. ");
     expect(getContent(el)).toBe(
         unformat(`
+            ${PLACEHOLDER_BLOCK_CONTAINER("top")}
             <table class="table table-bordered o_table">
                 <tbody>
                     <tr>

--- a/addons/html_editor/static/tests/list/toggle_cl.test.js
+++ b/addons/html_editor/static/tests/list/toggle_cl.test.js
@@ -5,6 +5,7 @@ import { unformat } from "../_helpers/format";
 import { getContent } from "../_helpers/selection";
 import { insertText, toggleCheckList } from "../_helpers/user_actions";
 import { dispatchNormalize } from "../_helpers/dispatch";
+import { PLACEHOLDER_BLOCK_CONTAINER } from "../_helpers/placeholder_block";
 
 describe("Range collapsed", () => {
     describe("Insert", () => {
@@ -201,6 +202,7 @@ describe("Range collapsed", () => {
                 `),
                 stepFunction: toggleCheckList,
                 contentAfterEdit: unformat(`
+                    ${PLACEHOLDER_BLOCK_CONTAINER("top")}
                     <table class="table table-bordered o_selected_table">
                         <tbody>
                             <tr>
@@ -215,6 +217,7 @@ describe("Range collapsed", () => {
                             </tr>
                         </tbody>
                     </table>
+                    ${PLACEHOLDER_BLOCK_CONTAINER("bottom")}
                 `),
                 contentAfter: unformat(`
                     <table class="table table-bordered">
@@ -366,6 +369,7 @@ describe("Range collapsed", () => {
                 `),
                 stepFunction: toggleCheckList,
                 contentAfterEdit: unformat(`
+                    ${PLACEHOLDER_BLOCK_CONTAINER("top")}
                     <table class="table table-bordered o_selected_table">
                         <tbody>
                             <tr>
@@ -380,6 +384,7 @@ describe("Range collapsed", () => {
                             </tr>
                         </tbody>
                     </table>
+                    ${PLACEHOLDER_BLOCK_CONTAINER("bottom")}
                 `),
                 contentAfter: unformat(`
                     <table class="table table-bordered">

--- a/addons/html_editor/static/tests/list/toggle_ol.test.js
+++ b/addons/html_editor/static/tests/list/toggle_ol.test.js
@@ -3,6 +3,7 @@ import { press } from "@odoo/hoot-dom";
 import { testEditor } from "../_helpers/editor";
 import { unformat } from "../_helpers/format";
 import { toggleOrderedList } from "../_helpers/user_actions";
+import { PLACEHOLDER_BLOCK_CONTAINER } from "../_helpers/placeholder_block";
 
 describe("Range collapsed", () => {
     describe("Insert", () => {
@@ -93,6 +94,7 @@ describe("Range collapsed", () => {
                 `),
                 stepFunction: toggleOrderedList,
                 contentAfterEdit: unformat(`
+                    ${PLACEHOLDER_BLOCK_CONTAINER("top")}
                     <table class="table table-bordered o_selected_table">
                         <tbody>
                             <tr>
@@ -107,6 +109,7 @@ describe("Range collapsed", () => {
                             </tr>
                         </tbody>
                     </table>
+                    ${PLACEHOLDER_BLOCK_CONTAINER("bottom")}
                 `),
                 contentAfter: unformat(`
                     <table class="table table-bordered">
@@ -224,6 +227,7 @@ describe("Range collapsed", () => {
                 `),
                 stepFunction: toggleOrderedList,
                 contentAfterEdit: unformat(`
+                    ${PLACEHOLDER_BLOCK_CONTAINER("top")}
                     <table class="table table-bordered o_selected_table">
                         <tbody>
                             <tr>
@@ -238,6 +242,7 @@ describe("Range collapsed", () => {
                             </tr>
                         </tbody>
                     </table>
+                    ${PLACEHOLDER_BLOCK_CONTAINER("bottom")}
                 `),
                 contentAfter: unformat(`
                     <table class="table table-bordered">

--- a/addons/html_editor/static/tests/list/toggle_ul.test.js
+++ b/addons/html_editor/static/tests/list/toggle_ul.test.js
@@ -3,6 +3,7 @@ import { press } from "@odoo/hoot-dom";
 import { testEditor } from "../_helpers/editor";
 import { unformat } from "../_helpers/format";
 import { toggleUnorderedList } from "../_helpers/user_actions";
+import { PLACEHOLDER_BLOCK_CONTAINER } from "../_helpers/placeholder_block";
 
 describe("Range collapsed", () => {
     describe("Insert", () => {
@@ -101,6 +102,7 @@ describe("Range collapsed", () => {
                 `),
                 stepFunction: toggleUnorderedList,
                 contentAfterEdit: unformat(`
+                    ${PLACEHOLDER_BLOCK_CONTAINER("top")}
                     <table class="table table-bordered o_selected_table">
                         <tbody>
                             <tr>
@@ -115,6 +117,7 @@ describe("Range collapsed", () => {
                             </tr>
                         </tbody>
                     </table>
+                    ${PLACEHOLDER_BLOCK_CONTAINER("bottom")}
                 `),
                 contentAfter: unformat(`
                     <table class="table table-bordered">
@@ -265,6 +268,7 @@ describe("Range collapsed", () => {
                 `),
                 stepFunction: toggleUnorderedList,
                 contentAfterEdit: unformat(`
+                    ${PLACEHOLDER_BLOCK_CONTAINER("top")}
                     <table class="table table-bordered o_selected_table">
                         <tbody>
                             <tr>
@@ -279,6 +283,7 @@ describe("Range collapsed", () => {
                             </tr>
                         </tbody>
                     </table>
+                    ${PLACEHOLDER_BLOCK_CONTAINER("bottom")}
                 `),
                 contentAfter: unformat(`
                     <table class="table table-bordered">

--- a/addons/html_editor/static/tests/media.test.js
+++ b/addons/html_editor/static/tests/media.test.js
@@ -9,6 +9,7 @@ import { getContent } from "./_helpers/selection";
 import { expectElementCount } from "./_helpers/ui_expectations";
 import { deleteBackward, deleteForward, insertText } from "./_helpers/user_actions";
 import { MAIN_PLUGINS, NO_EMBEDDED_COMPONENTS_FALLBACK_PLUGINS } from "@html_editor/plugin_sets";
+import { PLACEHOLDER_BLOCK_CONTAINER } from "./_helpers/placeholder_block";
 
 test("Can replace an image", async () => {
     onRpc("ir.attachment", "search_read", () => [
@@ -175,7 +176,11 @@ describe("(non-)editable media", () => {
             await animationFrame();
             await expectElementCount(".o-we-toolbar", 0);
             expect(getContent(editor.editable)).toBe(
-                `<div contenteditable="false">[<img src="${base64Img}">]</div>`
+                `${PLACEHOLDER_BLOCK_CONTAINER(
+                    "top"
+                )}<div contenteditable="false">[<img src="${base64Img}">]</div>${PLACEHOLDER_BLOCK_CONTAINER(
+                    "bottom"
+                )}`
             );
         });
         test("toolbar should open when clicking on an editable image in a non-editable context", async () => {
@@ -187,7 +192,11 @@ describe("(non-)editable media", () => {
             await expectElementCount(".o-we-toolbar", 1);
             // Now pressing the delete button should remove the image.
             await click(".o-we-toolbar button[name='image_delete']");
-            expect(getContent(editor.editable)).toBe(`<div contenteditable="false">[]<br></div>`);
+            expect(getContent(editor.editable)).toBe(
+                `${PLACEHOLDER_BLOCK_CONTAINER(
+                    "top"
+                )}<div contenteditable="false">[]<br></div>${PLACEHOLDER_BLOCK_CONTAINER("bottom")}`
+            );
         });
     });
     describe("delete", () => {
@@ -233,7 +242,7 @@ describe("(non-)editable media", () => {
                     deleteBackward(editor);
                 },
                 // TODO: there should be no difference between forward and backward.
-                contentAfter: `<div contenteditable="false">[]<img src="${base64Img}"></div>`,
+                contentAfter: `[]<div contenteditable="false"><img src="${base64Img}"></div>`,
             });
         });
         test("delete should remove an editable image in a non-editable context", async () => {

--- a/addons/html_editor/static/tests/mouse/click.test.js
+++ b/addons/html_editor/static/tests/mouse/click.test.js
@@ -4,6 +4,7 @@ import { animationFrame, pointerDown, pointerUp, waitForNone } from "@odoo/hoot-
 import { tick } from "@odoo/hoot-mock";
 import { setupEditor, testEditor } from "../_helpers/editor";
 import { getContent, setSelection } from "../_helpers/selection";
+import { PLACEHOLDER_BLOCK_CONTAINER } from "../_helpers/placeholder_block";
 
 /**
  * Simulates placing the cursor at the editable root after a mouse click.
@@ -93,7 +94,9 @@ test("should insert a paragraph before the table, then one after it", async () =
     const table = el.querySelector("table");
     await simulateMouseClick(table, true);
     expect(getContent(el)).toBe(
-        `<p o-we-hint-text='Type "/" for commands' class="o-we-hint">[]<br></p><table></table>`
+        `<p o-we-hint-text='Type "/" for commands' class="o-we-hint">[]<br></p><table></table>${PLACEHOLDER_BLOCK_CONTAINER(
+            "bottom"
+        )}`
     );
     await simulateMouseClick(table);
     expect(getContent(el)).toBe(

--- a/addons/html_editor/static/tests/movenode.test.js
+++ b/addons/html_editor/static/tests/movenode.test.js
@@ -7,6 +7,7 @@ import { getContent } from "./_helpers/selection";
 import { unformat } from "./_helpers/format";
 import { expectElementCount } from "./_helpers/ui_expectations";
 import { EMBEDDED_COMPONENT_PLUGINS, MAIN_PLUGINS } from "@html_editor/plugin_sets";
+import { PLACEHOLDER_BLOCK_CONTAINER } from "./_helpers/placeholder_block";
 
 describe.current.tags("desktop");
 
@@ -317,7 +318,8 @@ describe("click", () => {
         await click(".oe-sidewidget-move");
         await animationFrame();
         expect(getContent(el)).toBe(
-            unformat(`
+            PLACEHOLDER_BLOCK_CONTAINER("top") +
+                unformat(`
                 <table class="o_selected_table">
                     <tbody>
                         <tr>

--- a/addons/html_editor/static/tests/powerbox.test.js
+++ b/addons/html_editor/static/tests/powerbox.test.js
@@ -27,6 +27,7 @@ import { SearchPowerboxPlugin } from "@html_editor/main/powerbox/search_powerbox
 import { withSequence } from "@html_editor/utils/resource";
 import { execCommand } from "./_helpers/userCommands";
 import { expectElementCount } from "./_helpers/ui_expectations";
+import { PLACEHOLDER_BLOCK_CONTAINER } from "./_helpers/placeholder_block";
 
 function commandNames() {
     return queryAllTexts(".o-we-command-name");
@@ -485,7 +486,9 @@ test("should insert a 3x3 table on type `/table`", async () => {
     await press("Enter");
     await tick();
     expect(getContent(el)).toBe(
-        `<table class="table table-bordered o_table"><tbody><tr><td><p o-we-hint-text='Type "/" for commands' class="o-we-hint">[]<br></p></td><td><p><br></p></td><td><p><br></p></td></tr><tr><td><p><br></p></td><td><p><br></p></td><td><p><br></p></td></tr><tr><td><p><br></p></td><td><p><br></p></td><td><p><br></p></td></tr></tbody></table><p><br></p>`
+        `${PLACEHOLDER_BLOCK_CONTAINER(
+            "top"
+        )}<table class="table table-bordered o_table"><tbody><tr><td><p o-we-hint-text='Type "/" for commands' class="o-we-hint">[]<br></p></td><td><p><br></p></td><td><p><br></p></td></tr><tr><td><p><br></p></td><td><p><br></p></td><td><p><br></p></td></tr><tr><td><p><br></p></td><td><p><br></p></td><td><p><br></p></td></tr></tbody></table><p><br></p>`
     );
 });
 

--- a/addons/html_editor/static/tests/sanitize.test.js
+++ b/addons/html_editor/static/tests/sanitize.test.js
@@ -2,6 +2,7 @@ import { expect, test } from "@odoo/hoot";
 import { markup } from "@odoo/owl";
 import { setupEditor, testEditor } from "./_helpers/editor";
 import { fixInvalidHTML } from "@html_editor/utils/sanitize";
+import { PLACEHOLDER_BLOCK_CONTAINER } from "./_helpers/placeholder_block";
 
 const Markup = markup().constructor;
 
@@ -32,7 +33,9 @@ test("sanitize should leave t-field, t-out, t-esc as is", async () => {
 test("sanitize plugin should handle contenteditable attribute with o-contenteditable-[true/false] class", async () => {
     await testEditor({
         contentBefore: `<p class="o-contenteditable-true">a[]</p><p class="o-contenteditable-false">b</p>`,
-        contentAfterEdit: `<p class="o-contenteditable-true" contenteditable="true">a[]</p><p class="o-contenteditable-false" contenteditable="false">b</p>`,
+        contentAfterEdit: `<p class="o-contenteditable-true" contenteditable="true">a[]</p><p class="o-contenteditable-false" contenteditable="false">b</p>${PLACEHOLDER_BLOCK_CONTAINER(
+            "bottom"
+        )}`,
         contentAfter: `<p class="o-contenteditable-true">a[]</p><p class="o-contenteditable-false">b</p>`,
     });
 });

--- a/addons/html_editor/static/tests/selection.test.js
+++ b/addons/html_editor/static/tests/selection.test.js
@@ -15,6 +15,7 @@ import { MAIN_PLUGINS } from "../src/plugin_sets";
 import { setupEditor } from "./_helpers/editor";
 import { getContent, setSelection } from "./_helpers/selection";
 import { insertText, tripleClick } from "./_helpers/user_actions";
+import { PLACEHOLDER_BLOCK_CONTAINER } from "./_helpers/placeholder_block";
 
 test("getEditableSelection should work, even if getSelection returns null", async () => {
     const { editor } = await setupEditor("<p>a[b]</p>");
@@ -188,7 +189,11 @@ test("press 'ctrl+a' in 'contenteditable' should only select his content", async
     );
     await press(["ctrl", "a"]);
     expect(getContent(el)).toBe(
-        `<div contenteditable="false"><p contenteditable="true">[ab]</p><p contenteditable="true">cd</p></div>`
+        `${PLACEHOLDER_BLOCK_CONTAINER(
+            "top"
+        )}<div contenteditable="false"><p contenteditable="true">[ab]</p><p contenteditable="true">cd</p></div>${PLACEHOLDER_BLOCK_CONTAINER(
+            "bottom"
+        )}`
     );
 });
 

--- a/addons/html_editor/static/tests/table/children.test.js
+++ b/addons/html_editor/static/tests/table/children.test.js
@@ -5,6 +5,7 @@ import { setupEditor, testEditor } from "../_helpers/editor";
 import { unformat } from "../_helpers/format";
 import { undo } from "../_helpers/user_actions";
 import { getContent } from "../_helpers/selection";
+import { PLACEHOLDER_BLOCK_CONTAINER } from "../_helpers/placeholder_block";
 
 function addRow(position) {
     return (editor) => {
@@ -537,6 +538,7 @@ describe("tab", () => {
         await press("Tab");
 
         const expectedContent = unformat(`
+            ${PLACEHOLDER_BLOCK_CONTAINER("top")}
             <table><tbody>
                 <tr style="height: 20px;">
                     <td style="width: 20px;">ab</td>
@@ -548,13 +550,18 @@ describe("tab", () => {
                     <td><p><br></p></td>
                     <td><p><br></p></td>
                 </tr>
-            </tbody></table>`);
+            </tbody></table>
+            ${PLACEHOLDER_BLOCK_CONTAINER("bottom")}`);
 
         expect(getContent(el)).toBe(expectedContent);
 
         // Check that it was registed as a history step.
         undo(editor);
-        expect(getContent(el)).toBe(contentBefore);
+        expect(getContent(el)).toBe(
+            PLACEHOLDER_BLOCK_CONTAINER("top") +
+                contentBefore +
+                PLACEHOLDER_BLOCK_CONTAINER("bottom")
+        );
     });
 
     test("should not select whole text of the next cell", async () => {

--- a/addons/html_editor/static/tests/table/selection.test.js
+++ b/addons/html_editor/static/tests/table/selection.test.js
@@ -6,6 +6,7 @@ import { getContent, setSelection } from "../_helpers/selection";
 import { press, queryAll, manuallyDispatchProgrammaticEvent } from "@odoo/hoot-dom";
 import { animationFrame, tick } from "@odoo/hoot-mock";
 import { nodeSize } from "@html_editor/utils/position";
+import { PLACEHOLDER_BLOCK_CONTAINER } from "../_helpers/placeholder_block";
 
 function expectContentToBe(el, html) {
     expect(getContent(el)).toBe(unformat(html));
@@ -27,6 +28,7 @@ describe("custom selection", () => {
         );
         expect(getContent(el)).toBe(
             unformat(`
+            ${PLACEHOLDER_BLOCK_CONTAINER("top")}
             <table class="o_selected_table">
                 <tbody>
                     <tr>
@@ -35,7 +37,8 @@ describe("custom selection", () => {
                         <td class="o_selected_td">e]f</td>
                     </tr>
                 </tbody>
-            </table>`)
+            </table>
+            ${PLACEHOLDER_BLOCK_CONTAINER("bottom")}`)
         );
         const overlayColorTDs = queryAll("table td").map(
             (td) => getComputedStyle(td)["box-shadow"]
@@ -60,7 +63,8 @@ describe("select a full table on cross over", () => {
                     '<td class="o_selected_td">ab</td>' +
                     '<td class="o_selected_td">cd</td>' +
                     '<td class="o_selected_td">ef]</td>' +
-                    "</tr></tbody></table>",
+                    "</tr></tbody></table>" +
+                    PLACEHOLDER_BLOCK_CONTAINER("bottom"),
             });
         });
 
@@ -69,6 +73,7 @@ describe("select a full table on cross over", () => {
                 contentBefore:
                     "<table><tbody><tr><td>ab</td><td>cd</td><td>e[f</td></tr></tbody></table><p>a]bc</p>",
                 contentAfterEdit:
+                    PLACEHOLDER_BLOCK_CONTAINER("top") +
                     '<table class="o_selected_table"><tbody><tr>' +
                     '<td class="o_selected_td">ab</td>' +
                     '<td class="o_selected_td">cd</td>' +
@@ -100,7 +105,8 @@ describe("select a full table on cross over", () => {
                     '<p>abc</p><table class="o_selected_table"><tbody><tr>' +
                     '<td class="o_selected_td">ab</td>' +
                     '<td class="o_selected_td">cd</td>' +
-                    '<td class="o_selected_td">ef]</td></tr></tbody></table>',
+                    '<td class="o_selected_td">ef]</td></tr></tbody></table>' +
+                    PLACEHOLDER_BLOCK_CONTAINER("bottom"),
             });
         });
 
@@ -137,7 +143,8 @@ describe("select a full table on cross over", () => {
                     '<td class="o_selected_td"><strong>ab</strong></td>' +
                     '<td class="o_selected_td"><strong>cd</strong></td>' +
                     '<td class="o_selected_td"><strong>ef]</strong></td>' +
-                    "</tr></tbody></table>",
+                    "</tr></tbody></table>" +
+                    PLACEHOLDER_BLOCK_CONTAINER("bottom"),
             });
         });
 
@@ -151,6 +158,7 @@ describe("select a full table on cross over", () => {
                     "</tr></tbody></table><p>a]bc</p>",
                 stepFunction: bold,
                 contentAfterEdit:
+                    PLACEHOLDER_BLOCK_CONTAINER("top") +
                     '<table class="o_selected_table"><tbody><tr>' +
                     '<td class="o_selected_td"><strong>[ab</strong></td>' +
                     '<td class="o_selected_td"><strong>cd</strong></td>' +
@@ -210,7 +218,8 @@ describe("select a full table on cross over", () => {
                     '<td class="o_selected_td"><strong>ab</strong></td>' +
                     '<td class="o_selected_td"><strong>cd</strong></td>' +
                     '<td class="o_selected_td"><strong>ef]</strong></td>' +
-                    "</tr></tbody></table>",
+                    "</tr></tbody></table>" +
+                    PLACEHOLDER_BLOCK_CONTAINER("bottom"),
             });
         });
 
@@ -287,7 +296,8 @@ describe("select a full table on cross over", () => {
                                 </td>
                             </tr>
                         </tbody>
-                    </table>`),
+                    </table>
+                    ${PLACEHOLDER_BLOCK_CONTAINER("bottom")}`),
             });
         });
 
@@ -301,6 +311,7 @@ describe("select a full table on cross over", () => {
                     "</tr></tbody></table><p>a]bc</p>",
                 stepFunction: setColor("aquamarine", "color"),
                 contentAfterEdit: unformat(`
+                    ${PLACEHOLDER_BLOCK_CONTAINER("top")}
                     <table class="o_selected_table">
                         <tbody><tr>
                             <td class="o_selected_td">
@@ -407,7 +418,8 @@ describe("select a full table on cross over", () => {
                                 <font style="color: aquamarine;">ef]</font>
                             </td>
                         </tr></tbody>
-                    </table>`),
+                    </table>
+                    ${PLACEHOLDER_BLOCK_CONTAINER("bottom")}`),
             });
         });
 
@@ -472,11 +484,13 @@ describe("select columns on cross over", () => {
                 contentBefore:
                     "<table><tbody><tr><td>a[b</td><td>c]d</td><td>ef</td></tr></tbody></table>",
                 contentAfterEdit:
+                    PLACEHOLDER_BLOCK_CONTAINER("top") +
                     '<table class="o_selected_table"><tbody><tr>' +
                     '<td class="o_selected_td">a[b</td>' +
                     '<td class="o_selected_td">c]d</td>' +
                     "<td>ef</td>" +
-                    "</tr></tbody></table>",
+                    "</tr></tbody></table>" +
+                    PLACEHOLDER_BLOCK_CONTAINER("bottom"),
             });
         });
 
@@ -485,11 +499,13 @@ describe("select columns on cross over", () => {
                 contentBefore:
                     "<table><tbody><tr><td>a[b</td><td>cd</td><td>e]f</td></tr><tr><td>ab</td><td>cd</td><td>ef</td></tr></tbody></table>",
                 contentAfterEdit:
+                    PLACEHOLDER_BLOCK_CONTAINER("top") +
                     '<table class="o_selected_table"><tbody><tr>' +
                     '<td class="o_selected_td">a[b</td>' +
                     '<td class="o_selected_td">cd</td>' +
                     '<td class="o_selected_td">e]f</td>' +
-                    "</tr><tr><td>ab</td><td>cd</td><td>ef</td></tr></tbody></table>",
+                    "</tr><tr><td>ab</td><td>cd</td><td>ef</td></tr></tbody></table>" +
+                    PLACEHOLDER_BLOCK_CONTAINER("bottom"),
             });
         });
 
@@ -502,6 +518,7 @@ describe("select columns on cross over", () => {
                     "<tr><td>a]b</td><td>cd</td><td>ef</td></tr>" +
                     "</tbody></table>",
                 contentAfterEdit:
+                    PLACEHOLDER_BLOCK_CONTAINER("top") +
                     '<table class="o_selected_table"><tbody>' +
                     "<tr>" +
                     '<td class="o_selected_td">a[b</td>' +
@@ -518,7 +535,8 @@ describe("select columns on cross over", () => {
                     "<td>cd</td>" +
                     "<td>ef</td>" +
                     "</tr>" +
-                    "</tbody></table>",
+                    "</tbody></table>" +
+                    PLACEHOLDER_BLOCK_CONTAINER("bottom"),
             });
         });
 
@@ -531,6 +549,7 @@ describe("select columns on cross over", () => {
                     "<tr><td>ab</td><td>cd</td><td>ef</td></tr>" +
                     "</tbody></table>",
                 contentAfterEdit:
+                    PLACEHOLDER_BLOCK_CONTAINER("top") +
                     '<table class="o_selected_table"><tbody>' +
                     "<tr>" +
                     '<td class="o_selected_td">a[b</td>' +
@@ -547,7 +566,8 @@ describe("select columns on cross over", () => {
                     "<td>cd</td>" +
                     "<td>ef</td>" +
                     "</tr>" +
-                    "</tbody></table>",
+                    "</tbody></table>" +
+                    PLACEHOLDER_BLOCK_CONTAINER("bottom"),
             });
         });
 
@@ -560,6 +580,7 @@ describe("select columns on cross over", () => {
                     "<tr><td>ab</td><td>cd</td><td>e]f</td></tr>" +
                     "</tbody></table>",
                 contentAfterEdit:
+                    PLACEHOLDER_BLOCK_CONTAINER("top") +
                     '<table class="o_selected_table"><tbody>' +
                     "<tr>" +
                     '<td class="o_selected_td">a[b</td>' +
@@ -576,7 +597,8 @@ describe("select columns on cross over", () => {
                     '<td class="o_selected_td">cd</td>' +
                     '<td class="o_selected_td">e]f</td>' +
                     "</tr>" +
-                    "</tbody></table>",
+                    "</tbody></table>" +
+                    PLACEHOLDER_BLOCK_CONTAINER("bottom"),
             });
         });
     });
@@ -592,11 +614,13 @@ describe("select columns on cross over", () => {
                     "</tr></tbody></table>",
                 stepFunction: bold,
                 contentAfterEdit:
+                    PLACEHOLDER_BLOCK_CONTAINER("top") +
                     '<table class="o_selected_table"><tbody><tr>' +
                     '<td class="o_selected_td"><strong>[ab</strong></td>' +
                     '<td class="o_selected_td"><strong>cd]</strong></td>' +
                     "<td>ef</td>" +
-                    "</tr></tbody></table>",
+                    "</tr></tbody></table>" +
+                    PLACEHOLDER_BLOCK_CONTAINER("bottom"),
             });
         });
 
@@ -610,11 +634,13 @@ describe("select columns on cross over", () => {
                     "</tr><tr><td>ab</td><td>cd</td><td>ef</td></tr></tbody></table>",
                 stepFunction: bold,
                 contentAfterEdit:
+                    PLACEHOLDER_BLOCK_CONTAINER("top") +
                     '<table class="o_selected_table"><tbody><tr>' +
                     '<td class="o_selected_td"><strong>[ab</strong></td>' +
                     '<td class="o_selected_td"><strong>cd</strong></td>' +
                     '<td class="o_selected_td"><strong>ef]</strong></td>' +
-                    "</tr><tr><td>ab</td><td>cd</td><td>ef</td></tr></tbody></table>",
+                    "</tr><tr><td>ab</td><td>cd</td><td>ef</td></tr></tbody></table>" +
+                    PLACEHOLDER_BLOCK_CONTAINER("bottom"),
             });
         });
 
@@ -640,6 +666,7 @@ describe("select columns on cross over", () => {
                     "</tbody></table>",
                 stepFunction: bold,
                 contentAfterEdit:
+                    PLACEHOLDER_BLOCK_CONTAINER("top") +
                     '<table class="o_selected_table"><tbody>' +
                     "<tr>" +
                     '<td class="o_selected_td"><strong>[ab</strong></td>' +
@@ -656,7 +683,8 @@ describe("select columns on cross over", () => {
                     "<td>cd</td>" +
                     "<td>ef</td>" +
                     "</tr>" +
-                    "</tbody></table>",
+                    "</tbody></table>" +
+                    PLACEHOLDER_BLOCK_CONTAINER("bottom"),
             });
         });
 
@@ -682,6 +710,7 @@ describe("select columns on cross over", () => {
                     "</tbody></table>",
                 stepFunction: bold,
                 contentAfterEdit:
+                    PLACEHOLDER_BLOCK_CONTAINER("top") +
                     '<table class="o_selected_table"><tbody>' +
                     "<tr>" +
                     '<td class="o_selected_td"><strong>[ab</strong></td>' +
@@ -698,7 +727,8 @@ describe("select columns on cross over", () => {
                     "<td>cd</td>" +
                     "<td>ef</td>" +
                     "</tr>" +
-                    "</tbody></table>",
+                    "</tbody></table>" +
+                    PLACEHOLDER_BLOCK_CONTAINER("bottom"),
             });
         });
 
@@ -724,6 +754,7 @@ describe("select columns on cross over", () => {
                     "</tbody></table>",
                 stepFunction: bold,
                 contentAfterEdit:
+                    PLACEHOLDER_BLOCK_CONTAINER("top") +
                     '<table class="o_selected_table"><tbody>' +
                     "<tr>" +
                     '<td class="o_selected_td"><strong>[ab</strong></td>' +
@@ -740,7 +771,8 @@ describe("select columns on cross over", () => {
                     '<td class="o_selected_td"><strong>cd</strong></td>' +
                     '<td class="o_selected_td"><strong>ef]</strong></td>' +
                     "</tr>" +
-                    "</tbody></table>",
+                    "</tbody></table>" +
+                    PLACEHOLDER_BLOCK_CONTAINER("bottom"),
             });
         });
     });
@@ -910,6 +942,7 @@ describe("select columns on cross over", () => {
                     "</tr></tbody></table>",
                 stepFunction: setColor("aquamarine", "color"),
                 contentAfterEdit: unformat(`
+                    ${PLACEHOLDER_BLOCK_CONTAINER("top")}
                     <table class="o_selected_table">
                         <tbody><tr>
                             <td class="o_selected_td">
@@ -920,7 +953,8 @@ describe("select columns on cross over", () => {
                             </td>
                             <td>ef</td>
                         </tr></tbody>
-                    </table>`),
+                    </table>
+                    ${PLACEHOLDER_BLOCK_CONTAINER("bottom")}`),
             });
         });
 
@@ -934,6 +968,7 @@ describe("select columns on cross over", () => {
                     "</tr><tr><td>ab</td><td>cd</td><td>ef</td></tr></tbody></table>",
                 stepFunction: setColor("aquamarine", "color"),
                 contentAfterEdit: unformat(`
+                    ${PLACEHOLDER_BLOCK_CONTAINER("top")}
                     <table class="o_selected_table">
                         <tbody><tr>
                             <td class="o_selected_td">
@@ -951,7 +986,8 @@ describe("select columns on cross over", () => {
                             <td>cd</td>
                             <td>ef</td>
                         </tr></tbody>
-                    </table>`),
+                    </table>
+                    ${PLACEHOLDER_BLOCK_CONTAINER("bottom")}`),
             });
         });
 
@@ -977,6 +1013,7 @@ describe("select columns on cross over", () => {
                     "</tbody></table>",
                 stepFunction: setColor("aquamarine", "color"),
                 contentAfterEdit: unformat(`
+                    ${PLACEHOLDER_BLOCK_CONTAINER("top")}
                     <table class="o_selected_table">
                         <tbody><tr>
                             <td class="o_selected_td">
@@ -999,7 +1036,8 @@ describe("select columns on cross over", () => {
                             <td>cd</td>
                             <td>ef</td>
                         </tr></tbody>
-                    </table>`),
+                    </table>
+                    ${PLACEHOLDER_BLOCK_CONTAINER("bottom")}`),
             });
         });
 
@@ -1025,6 +1063,7 @@ describe("select columns on cross over", () => {
                     "</tbody></table>",
                 stepFunction: setColor("aquamarine", "color"),
                 contentAfterEdit: unformat(`
+                    ${PLACEHOLDER_BLOCK_CONTAINER("top")}
                     <table class="o_selected_table">
                         <tbody><tr>
                             <td class="o_selected_td">
@@ -1049,7 +1088,8 @@ describe("select columns on cross over", () => {
                             <td>cd</td>
                             <td>ef</td>
                         </tr></tbody>
-                    </table>`),
+                    </table>
+                    ${PLACEHOLDER_BLOCK_CONTAINER("bottom")}`),
             });
         });
 
@@ -1075,6 +1115,7 @@ describe("select columns on cross over", () => {
                     "</tbody></table>",
                 stepFunction: setColor("aquamarine", "color"),
                 contentAfterEdit: unformat(`
+                    ${PLACEHOLDER_BLOCK_CONTAINER("top")}
                     <table class="o_selected_table">
                         <tbody><tr>
                             <td class="o_selected_td">
@@ -1109,7 +1150,8 @@ describe("select columns on cross over", () => {
                                 <font style="color: aquamarine;">e]f</font>
                             </td>
                         </tr></tbody>
-                    </table>`),
+                    </table>
+                    ${PLACEHOLDER_BLOCK_CONTAINER("bottom")}`),
             });
         });
     });
@@ -1532,12 +1574,14 @@ describe("symmetrical selection", () => {
         // Select single empty cell
         expectContentToBe(
             el,
-            `<table class="table table-bordered o_table o_selected_table">
+            `${PLACEHOLDER_BLOCK_CONTAINER(
+                "top"
+            )}<table class="table table-bordered o_table o_selected_table">
                 <tbody>
                     <tr><td class="o_selected_td">[]<br></td><td><br></td><td><br></td></tr>
                     <tr><td><br></td><td><br></td><td><br></td></tr>
                 </tbody>
-            </table>`
+            </table>${PLACEHOLDER_BLOCK_CONTAINER("bottom")}`
         );
 
         press(["Shift", "ArrowRight"]);
@@ -1546,12 +1590,14 @@ describe("symmetrical selection", () => {
         // Select two cells consecutively
         expectContentToBe(
             el,
-            `<table class="table table-bordered o_table o_selected_table">
+            `${PLACEHOLDER_BLOCK_CONTAINER(
+                "top"
+            )}<table class="table table-bordered o_table o_selected_table">
                 <tbody>
                     <tr><td class="o_selected_td">[<br></td><td class="o_selected_td">]<br></td><td><br></td></tr>
                     <tr><td><br></td><td><br></td><td><br></td></tr>
                 </tbody>
-            </table>`
+            </table>${PLACEHOLDER_BLOCK_CONTAINER("bottom")}`
         );
 
         press(["Shift", "ArrowDown"]);
@@ -1560,12 +1606,14 @@ describe("symmetrical selection", () => {
         // Extend selection from two cells to four cells
         expectContentToBe(
             el,
-            `<table class="table table-bordered o_table o_selected_table">
+            `${PLACEHOLDER_BLOCK_CONTAINER(
+                "top"
+            )}<table class="table table-bordered o_table o_selected_table">
                 <tbody>
                     <tr><td class="o_selected_td">[<br></td><td class="o_selected_td"><br></td><td><br></td></tr>
                     <tr><td class="o_selected_td"><br></td><td class="o_selected_td">]<br></td><td><br></td></tr>
                 </tbody>
-            </table>`
+            </table>${PLACEHOLDER_BLOCK_CONTAINER("bottom")}`
         );
 
         press(["Shift", "ArrowLeft"]);
@@ -1574,12 +1622,14 @@ describe("symmetrical selection", () => {
         // Shrink selection from four cells to two cells
         expectContentToBe(
             el,
-            `<table class="table table-bordered o_table o_selected_table">
+            `${PLACEHOLDER_BLOCK_CONTAINER(
+                "top"
+            )}<table class="table table-bordered o_table o_selected_table">
                 <tbody>
                     <tr><td class="o_selected_td">[<br></td><td><br></td><td><br></td></tr>
                     <tr><td class="o_selected_td">]<br></td><td><br></td><td><br></td></tr>
                 </tbody>
-            </table>`
+            </table>${PLACEHOLDER_BLOCK_CONTAINER("bottom")}`
         );
 
         press(["Shift", "ArrowUp"]);
@@ -1588,12 +1638,14 @@ describe("symmetrical selection", () => {
         // Shrink selection from two cells to single cell
         expectContentToBe(
             el,
-            `<table class="table table-bordered o_table o_selected_table">
+            `${PLACEHOLDER_BLOCK_CONTAINER(
+                "top"
+            )}<table class="table table-bordered o_table o_selected_table">
                 <tbody>
                     <tr><td class="o_selected_td">[]<br></td><td><br></td><td><br></td></tr>
                     <tr><td><br></td><td><br></td><td><br></td></tr>
                 </tbody>
-            </table>`
+            </table>${PLACEHOLDER_BLOCK_CONTAINER("bottom")}`
         );
     });
 
@@ -1613,12 +1665,12 @@ describe("symmetrical selection", () => {
 
         expectContentToBe(
             el,
-            `<table class="table table-bordered o_table">
+            `${PLACEHOLDER_BLOCK_CONTAINER("top")}<table class="table table-bordered o_table">
                 <tbody>
                     <tr><td>ab[]<br></td><td><br></td><td><br></td></tr>
                     <tr><td><br></td><td><br></td><td><br></td></tr>
                 </tbody>
-            </table>`
+            </table>${PLACEHOLDER_BLOCK_CONTAINER("bottom")}`
         );
         const firstTd = el.querySelector("td");
         setSelection({
@@ -1633,12 +1685,14 @@ describe("symmetrical selection", () => {
 
         expectContentToBe(
             el,
-            `<table class="table table-bordered o_table o_selected_table">
+            `${PLACEHOLDER_BLOCK_CONTAINER(
+                "top"
+            )}<table class="table table-bordered o_table o_selected_table">
                 <tbody>
                     <tr><td class="o_selected_td">[ab<br>]</td><td><br></td><td><br></td></tr>
                     <tr><td><br></td><td><br></td><td><br></td></tr>
                 </tbody>
-            </table>`
+            </table>${PLACEHOLDER_BLOCK_CONTAINER("bottom")}`
         );
     });
 });
@@ -1676,12 +1730,14 @@ describe("single cell selection", () => {
 
         expectContentToBe(
             el,
-            `<table class="table table-bordered o_table o_selected_table">
+            `${PLACEHOLDER_BLOCK_CONTAINER(
+                "top"
+            )}<table class="table table-bordered o_table o_selected_table">
                 <tbody>
                     <tr><td class="o_selected_td">[]<br></td><td><br></td><td><br></td></tr>
                     <tr><td><br></td><td><br></td><td><br></td></tr>
                 </tbody>
-            </table>`
+            </table>${PLACEHOLDER_BLOCK_CONTAINER("bottom")}`
         );
     });
 
@@ -1717,12 +1773,14 @@ describe("single cell selection", () => {
 
         expectContentToBe(
             el,
-            `<table class="table table-bordered o_table o_selected_table">
+            `${PLACEHOLDER_BLOCK_CONTAINER(
+                "top"
+            )}<table class="table table-bordered o_table o_selected_table">
                 <tbody>
                     <tr><td class="o_selected_td">[abc]<br></td><td><br></td><td><br></td></tr>
                     <tr><td><br></td><td><br></td><td><br></td></tr>
                 </tbody>
-            </table>`
+            </table>${PLACEHOLDER_BLOCK_CONTAINER("bottom")}`
         );
     });
 
@@ -1747,12 +1805,12 @@ describe("single cell selection", () => {
 
         expectContentToBe(
             el,
-            `<table class="table table-bordered o_table">
+            `${PLACEHOLDER_BLOCK_CONTAINER("top")}<table class="table table-bordered o_table">
                 <tbody>
                     <tr><td>ab[]c<br></td><td><br></td><td><br></td></tr>
                     <tr><td><br></td><td><br></td><td><br></td></tr>
                 </tbody>
-            </table>`
+            </table>${PLACEHOLDER_BLOCK_CONTAINER("bottom")}`
         );
     });
 
@@ -1778,12 +1836,12 @@ describe("single cell selection", () => {
 
         expectContentToBe(
             el,
-            `<table class="table table-bordered o_table">
+            `${PLACEHOLDER_BLOCK_CONTAINER("top")}<table class="table table-bordered o_table">
                 <tbody>
                     <tr><td>[]<br></td><td><br></td><td><br></td></tr>
                     <tr><td><br></td><td><br></td><td><br></td></tr>
                 </tbody>
-            </table>`
+            </table>${PLACEHOLDER_BLOCK_CONTAINER("bottom")}`
         );
     });
 });
@@ -1810,7 +1868,7 @@ describe("deselecting table", () => {
                         <tr><td class="o_selected_td"><br></td><td class="o_selected_td"><br></td><td class="o_selected_td"><br></td></tr>
                         <tr><td class="o_selected_td"><br></td><td class="o_selected_td"><br></td><td class="o_selected_td">]<br></td></tr>
                     </tbody>
-                </table>`
+                </table>${PLACEHOLDER_BLOCK_CONTAINER("bottom")}`
         );
 
         press(["Shift", "ArrowUp"]);
@@ -1824,7 +1882,7 @@ describe("deselecting table", () => {
                     <tr><td><br></td><td><br></td><td><br></td></tr>
                     <tr><td><br></td><td><br></td><td><br></td></tr>
                 </tbody>
-            </table>`
+            </table>${PLACEHOLDER_BLOCK_CONTAINER("bottom")}`
         );
     });
 });

--- a/addons/html_editor/static/tests/table/ui.test.js
+++ b/addons/html_editor/static/tests/table/ui.test.js
@@ -6,6 +6,7 @@ import { unformat } from "../_helpers/format";
 import { getContent } from "../_helpers/selection";
 import { undo } from "../_helpers/user_actions";
 import { expectElementCount } from "../_helpers/ui_expectations";
+import { PLACEHOLDER_BLOCK_CONTAINER } from "../_helpers/placeholder_block";
 
 function availableCommands(menu) {
     return queryAllAttributes("span div.user-select-none", "name", { root: menu });
@@ -350,23 +351,27 @@ test("basic delete column operation", async () => {
     // not sure about selection...
     expect(getContent(el)).toBe(
         unformat(`
+        ${PLACEHOLDER_BLOCK_CONTAINER("top")}
         <table>
             <tbody>
                 <tr><td class="a">[]1</td></tr>
                 <tr><td class="c">3</td></tr>
             </tbody>
-        </table>`)
+        </table>
+        ${PLACEHOLDER_BLOCK_CONTAINER("bottom")}`)
     );
 
     undo(editor);
     expect(getContent(el)).toBe(
         unformat(`
+        ${PLACEHOLDER_BLOCK_CONTAINER("top")}
         <table>
             <tbody>
                 <tr><td class="a">1[]</td><td class="b">2</td></tr>
                 <tr><td class="c">3</td><td class="d">4</td></tr>
             </tbody>
-        </table>`)
+        </table>
+        ${PLACEHOLDER_BLOCK_CONTAINER("bottom")}`)
     );
 });
 
@@ -395,23 +400,27 @@ test("basic clear column content operation", async () => {
     // not sure about selection...
     expect(getContent(el)).toBe(
         unformat(`
+        ${PLACEHOLDER_BLOCK_CONTAINER("top")}
         <table>
             <tbody>
                 <tr><td class="a"><p>1[]</p></td><td class="b"><p><br></p></td></tr>
                 <tr><td class="c"><p>3</p></td><td class="d"><p><br></p></td></tr>
             </tbody>
-        </table>`)
+        </table>
+        ${PLACEHOLDER_BLOCK_CONTAINER("bottom")}`)
     );
 
     undo(editor);
     expect(getContent(el)).toBe(
         unformat(`
+        ${PLACEHOLDER_BLOCK_CONTAINER("top")}
         <table>
             <tbody>
                 <tr><td class="a"><p>1[]</p></td><td class="b"><p>2</p></td></tr>
                 <tr><td class="c"><p>3</p></td><td class="d"><h1>4</h1></td></tr>
             </tbody>
-        </table>`)
+        </table>
+        ${PLACEHOLDER_BLOCK_CONTAINER("bottom")}`)
     );
 });
 
@@ -440,22 +449,26 @@ test("basic delete row operation", async () => {
     // not sure about selection...
     expect(getContent(el)).toBe(
         unformat(`
+            ${PLACEHOLDER_BLOCK_CONTAINER("top")}
         <table>
             <tbody>
                 <tr><td class="a">[]1</td><td class="b">2</td></tr>
             </tbody>
-        </table>`)
+        </table>
+        ${PLACEHOLDER_BLOCK_CONTAINER("bottom")}`)
     );
 
     undo(editor);
     expect(getContent(el)).toBe(
         unformat(`
+        ${PLACEHOLDER_BLOCK_CONTAINER("top")}
         <table>
             <tbody>
                 <tr><td class="a">1[]</td><td class="b">2</td></tr>
                 <tr><td class="c">3</td><td class="d">4</td></tr>
             </tbody>
-        </table>`)
+        </table>
+        ${PLACEHOLDER_BLOCK_CONTAINER("bottom")}`)
     );
 });
 
@@ -484,23 +497,27 @@ test("basic clear row content operation", async () => {
     // not sure about selection...
     expect(getContent(el)).toBe(
         unformat(`
+        ${PLACEHOLDER_BLOCK_CONTAINER("top")}
         <table>
             <tbody>
                 <tr><td class="a"><p>1[]</p></td><td class="b"><p>2</p></td></tr>
                 <tr><td class="c"><p><br></p></td><td class="d"><p><br></p></td></tr>
             </tbody>
-        </table>`)
+        </table>
+        ${PLACEHOLDER_BLOCK_CONTAINER("bottom")}`)
     );
 
     undo(editor);
     expect(getContent(el)).toBe(
         unformat(`
+        ${PLACEHOLDER_BLOCK_CONTAINER("top")}
         <table>
             <tbody>
                 <tr><td class="a"><p>1[]</p></td><td class="b"><p>2</p></td></tr>
                 <tr><td class="c"><p>3</p></td><td class="d"><h2>4</h2></td></tr>
             </tbody>
-        </table>`)
+        </table>
+        ${PLACEHOLDER_BLOCK_CONTAINER("bottom")}`)
     );
 });
 
@@ -528,6 +545,7 @@ test("insert column left operation", async () => {
     await click("div[name='insert_left']");
     expect(getContent(el)).toBe(
         unformat(`
+        ${PLACEHOLDER_BLOCK_CONTAINER("top")}
         <table>
             <tbody>
                 <tr>
@@ -541,18 +559,21 @@ test("insert column left operation", async () => {
                     <td class="d">4</td>
                 </tr>
             </tbody>
-        </table>`)
+        </table>
+        ${PLACEHOLDER_BLOCK_CONTAINER("bottom")}`)
     );
 
     undo(editor);
     expect(getContent(el)).toBe(
         unformat(`
+        ${PLACEHOLDER_BLOCK_CONTAINER("top")}
         <table>
             <tbody>
                 <tr><td class="a">1[]</td><td class="b">2</td></tr>
                 <tr><td class="c">3</td><td class="d">4</td></tr>
             </tbody>
-        </table>`)
+        </table>
+        ${PLACEHOLDER_BLOCK_CONTAINER("bottom")}`)
     );
 });
 
@@ -580,6 +601,7 @@ test("insert column right operation", async () => {
     await click("div[name='insert_right']");
     expect(getContent(el)).toBe(
         unformat(`
+        ${PLACEHOLDER_BLOCK_CONTAINER("top")}
         <table>
             <tbody>
                 <tr>
@@ -593,18 +615,21 @@ test("insert column right operation", async () => {
                     <td class="d">4</td>
                 </tr>
             </tbody>
-        </table>`)
+        </table>
+        ${PLACEHOLDER_BLOCK_CONTAINER("bottom")}`)
     );
 
     undo(editor);
     expect(getContent(el)).toBe(
         unformat(`
+        ${PLACEHOLDER_BLOCK_CONTAINER("top")}
         <table>
             <tbody>
                 <tr><td class="a">1[]</td><td class="b">2</td></tr>
                 <tr><td class="c">3</td><td class="d">4</td></tr>
             </tbody>
-        </table>`)
+        </table>
+        ${PLACEHOLDER_BLOCK_CONTAINER("bottom")}`)
     );
 });
 
@@ -632,6 +657,7 @@ test("insert row above operation", async () => {
     await click("div[name='insert_above']");
     expect(getContent(el)).toBe(
         unformat(`
+        ${PLACEHOLDER_BLOCK_CONTAINER("top")}
         <table>
             <tbody>
                 <tr>
@@ -647,18 +673,21 @@ test("insert row above operation", async () => {
                     <td class="d">4</td>
                 </tr>
             </tbody>
-        </table>`)
+        </table>
+        ${PLACEHOLDER_BLOCK_CONTAINER("bottom")}`)
     );
 
     undo(editor);
     expect(getContent(el)).toBe(
         unformat(`
+        ${PLACEHOLDER_BLOCK_CONTAINER("top")}
         <table>
             <tbody>
                 <tr><td class="a">1[]</td><td class="b">2</td></tr>
                 <tr><td class="c">3</td><td class="d">4</td></tr>
             </tbody>
-        </table>`)
+        </table>
+        ${PLACEHOLDER_BLOCK_CONTAINER("bottom")}`)
     );
 });
 
@@ -686,6 +715,7 @@ test("insert row above operation should not retain height and width styles", asy
     await click("div[name='insert_above']");
     expect(getContent(el)).toBe(
         unformat(`
+        ${PLACEHOLDER_BLOCK_CONTAINER("top")}
         <table>
             <tbody>
                 <tr>
@@ -701,7 +731,8 @@ test("insert row above operation should not retain height and width styles", asy
                     <td class="d">4</td>
                 </tr>
             </tbody>
-        </table>`)
+        </table>
+        ${PLACEHOLDER_BLOCK_CONTAINER("bottom")}`)
     );
 });
 
@@ -729,6 +760,7 @@ test("insert row below operation", async () => {
     await click("div[name='insert_below']");
     expect(getContent(el)).toBe(
         unformat(`
+        ${PLACEHOLDER_BLOCK_CONTAINER("top")}
         <table>
             <tbody>
                 <tr>
@@ -744,18 +776,21 @@ test("insert row below operation", async () => {
                     <td class="d">4</td>
                 </tr>
             </tbody>
-        </table>`)
+        </table>
+        ${PLACEHOLDER_BLOCK_CONTAINER("bottom")}`)
     );
 
     undo(editor);
     expect(getContent(el)).toBe(
         unformat(`
+        ${PLACEHOLDER_BLOCK_CONTAINER("top")}
         <table>
             <tbody>
                 <tr><td class="a">1[]</td><td class="b">2</td></tr>
                 <tr><td class="c">3</td><td class="d">4</td></tr>
             </tbody>
-        </table>`)
+        </table>
+        ${PLACEHOLDER_BLOCK_CONTAINER("bottom")}`)
     );
 });
 
@@ -783,23 +818,27 @@ test("move column left operation", async () => {
     await click("div[name='move_left']");
     expect(getContent(el)).toBe(
         unformat(`
+        ${PLACEHOLDER_BLOCK_CONTAINER("top")}
         <table>
             <tbody>
             <tr><td class="b">2[]</td><td class="a">1</td></tr>
             <tr><td class="d">4</td><td class="c">3</td></tr>
             </tbody>
-        </table>`)
+        </table>
+        ${PLACEHOLDER_BLOCK_CONTAINER("bottom")}`)
     );
 
     undo(editor);
     expect(getContent(el)).toBe(
         unformat(`
+        ${PLACEHOLDER_BLOCK_CONTAINER("top")}
         <table>
             <tbody>
                 <tr><td class="a">1</td><td class="b">2[]</td></tr>
                 <tr><td class="c">3</td><td class="d">4</td></tr>
             </tbody>
-        </table>`)
+        </table>
+        ${PLACEHOLDER_BLOCK_CONTAINER("bottom")}`)
     );
 });
 
@@ -827,23 +866,27 @@ test("move column right operation", async () => {
     await click("div[name='move_right']");
     expect(getContent(el)).toBe(
         unformat(`
+        ${PLACEHOLDER_BLOCK_CONTAINER("top")}
         <table>
             <tbody>
             <tr><td class="b">2[]</td><td class="a">1</td></tr>
             <tr><td class="d">4</td><td class="c">3</td></tr>
             </tbody>
-        </table>`)
+        </table>
+        ${PLACEHOLDER_BLOCK_CONTAINER("bottom")}`)
     );
 
     undo(editor);
     expect(getContent(el)).toBe(
         unformat(`
+        ${PLACEHOLDER_BLOCK_CONTAINER("top")}
         <table>
             <tbody>
                 <tr><td class="a">1</td><td class="b">2[]</td></tr>
                 <tr><td class="c">3</td><td class="d">4</td></tr>
             </tbody>
-        </table>`)
+        </table>
+        ${PLACEHOLDER_BLOCK_CONTAINER("bottom")}`)
     );
 });
 
@@ -871,23 +914,27 @@ test("move row above operation", async () => {
     await click("div[name='move_up']");
     expect(getContent(el)).toBe(
         unformat(`
+        ${PLACEHOLDER_BLOCK_CONTAINER("top")}
         <table>
             <tbody>
             <tr><td class="c">3</td><td class="d">4</td></tr>
             <tr><td class="a">1[]</td><td class="b">2</td></tr>
             </tbody>
-        </table>`)
+        </table>
+        ${PLACEHOLDER_BLOCK_CONTAINER("bottom")}`)
     );
 
     undo(editor);
     expect(getContent(el)).toBe(
         unformat(`
+        ${PLACEHOLDER_BLOCK_CONTAINER("top")}
         <table>
             <tbody>
                 <tr><td class="a">1[]</td><td class="b">2</td></tr>
                 <tr><td class="c">3</td><td class="d">4</td></tr>
             </tbody>
-        </table>`)
+        </table>
+        ${PLACEHOLDER_BLOCK_CONTAINER("bottom")}`)
     );
 });
 
@@ -916,13 +963,15 @@ test("preserve table rows width on move row above operation", async () => {
     await click("div[name='move_up']");
     expect(getContent(el)).toBe(
         unformat(`
+        ${PLACEHOLDER_BLOCK_CONTAINER("top")}
         <table>
             <tbody>
                 <tr><td style="width: 100px;" class="c">3</td><td style="width: 200px;" class="d">4</td></tr>
                 <tr><td style="width: 100px;" class="a">1[]</td><td style="width: 200px;" class="b">2</td></tr>
                 <tr><td style="width: 150px;" class="e">5</td><td style="width: 150px;" class="f">6</td></tr>
             </tbody>
-        </table>`)
+        </table>
+        ${PLACEHOLDER_BLOCK_CONTAINER("bottom")}`)
     );
 });
 
@@ -950,23 +999,27 @@ test("move row below operation", async () => {
     await click("div[name='move_down']");
     expect(getContent(el)).toBe(
         unformat(`
+        ${PLACEHOLDER_BLOCK_CONTAINER("top")}
         <table>
             <tbody>
             <tr><td class="c">3</td><td class="d">4</td></tr>
             <tr><td class="a">1[]</td><td class="b">2</td></tr>
             </tbody>
-        </table>`)
+        </table>
+        ${PLACEHOLDER_BLOCK_CONTAINER("bottom")}`)
     );
 
     undo(editor);
     expect(getContent(el)).toBe(
         unformat(`
+        ${PLACEHOLDER_BLOCK_CONTAINER("top")}
         <table>
             <tbody>
                 <tr><td class="a">1[]</td><td class="b">2</td></tr>
                 <tr><td class="c">3</td><td class="d">4</td></tr>
             </tbody>
-        </table>`)
+        </table>
+        ${PLACEHOLDER_BLOCK_CONTAINER("bottom")}`)
     );
 });
 
@@ -995,13 +1048,15 @@ test("preserve table rows width on move row below operation", async () => {
     await click("div[name='move_down']");
     expect(getContent(el)).toBe(
         unformat(`
+        ${PLACEHOLDER_BLOCK_CONTAINER("top")}
         <table>
             <tbody>
                 <tr><td style="width: 100px;" class="c">3</td><td style="width: 200px;" class="d">4</td></tr>
                 <tr><td style="width: 100px;" class="a">1[]</td><td style="width: 200px;" class="b">2</td></tr>
                 <tr><td style="width: 150px;" class="e">5</td><td style="width: 150px;" class="f">6</td></tr>
             </tbody>
-        </table>`)
+        </table>
+        ${PLACEHOLDER_BLOCK_CONTAINER("bottom")}`)
     );
 });
 
@@ -1026,23 +1081,27 @@ test("reset table size to remove custom width", async () => {
     await click(queryOne(".dropdown-menu [name='reset_table_size']"));
     expect(getContent(el)).toBe(
         unformat(`
+        ${PLACEHOLDER_BLOCK_CONTAINER("top")}
         <table>
             <tbody>
                 <tr><td style="" class="a">1[]</td></tr>
                 <tr><td style="" class="b">2</td></tr>
             </tbody>
-        </table>`)
+        </table>
+        ${PLACEHOLDER_BLOCK_CONTAINER("bottom")}`)
     );
 
     undo(editor);
     expect(getContent(el)).toBe(
         unformat(`
+        ${PLACEHOLDER_BLOCK_CONTAINER("top")}
         <table style="width: 150px;">
             <tbody>
             <tr><td style="width: 100px;" class="a">1[]</td></tr>
             <tr><td style="width: 50px;" class="b">2</td></tr>
             </tbody>
-        </table>`)
+        </table>
+        ${PLACEHOLDER_BLOCK_CONTAINER("bottom")}`)
     );
 });
 
@@ -1067,23 +1126,27 @@ test("reset table size to remove custom height", async () => {
     await click(queryOne(".dropdown-menu [name='reset_table_size']"));
     expect(getContent(el)).toBe(
         unformat(`
+        ${PLACEHOLDER_BLOCK_CONTAINER("top")}
         <table>
             <tbody>
                 <tr style=""><td class="a">1[]</td></tr>
                 <tr style=""><td class="b">2</td></tr>
             </tbody>
-        </table>`)
+        </table>
+        ${PLACEHOLDER_BLOCK_CONTAINER("bottom")}`)
     );
 
     undo(editor);
     expect(getContent(el)).toBe(
         unformat(`
+        ${PLACEHOLDER_BLOCK_CONTAINER("top")}
         <table>
             <tbody>
             <tr style="height: 100px;"><td class="a">1[]</td></tr>
             <tr style="height: 50px;"><td class="b">2</td></tr>
             </tbody>
-        </table>`)
+        </table>
+        ${PLACEHOLDER_BLOCK_CONTAINER("bottom")}`)
     );
 });
 
@@ -1121,6 +1184,7 @@ test("reset row size to remove custom height", async () => {
     await click(queryOne(".dropdown-menu [name='reset_row_size']"));
     expect(getContent(el)).toBe(
         unformat(`
+            ${PLACEHOLDER_BLOCK_CONTAINER("top")}
             <table class="table table-bordered o_table">
                 <tbody>
                     <tr style="">
@@ -1139,7 +1203,8 @@ test("reset row size to remove custom height", async () => {
                         <td class="i">9</td>
                     </tr>
                 </tbody>
-            </table>`)
+            </table>
+            ${PLACEHOLDER_BLOCK_CONTAINER("bottom")}`)
     );
 });
 
@@ -1176,6 +1241,7 @@ test("should redistribute excess width from current column to smaller columns", 
     await click(queryOne(".dropdown-menu [name='reset_column_size']"));
     expect(getContent(el)).toBe(
         unformat(`
+            ${PLACEHOLDER_BLOCK_CONTAINER("top")}
             <table class="table table-bordered o_table" style="width: 500px">
                 <tbody>
                     <tr>
@@ -1193,7 +1259,8 @@ test("should redistribute excess width from current column to smaller columns", 
                         <td style="" class="j">10</td>
                     </tr>
                 </tbody>
-            </table>`)
+            </table>
+            ${PLACEHOLDER_BLOCK_CONTAINER("bottom")}`)
     );
 });
 
@@ -1234,6 +1301,7 @@ test("should redistribute excess width from larger columns to current column", a
     await click(queryOne(".dropdown-menu [name='reset_column_size']"));
     expect(getContent(el)).toBe(
         unformat(`
+            ${PLACEHOLDER_BLOCK_CONTAINER("top")}
             <table class="table table-bordered o_table" style="width: 700px">
                 <tbody>
                     <tr>
@@ -1255,6 +1323,7 @@ test("should redistribute excess width from larger columns to current column", a
                         <td style="width: 120px;" class="n">14</td>
                     </tr>
                 </tbody>
-            </table>`)
+            </table>
+            ${PLACEHOLDER_BLOCK_CONTAINER("bottom")}`)
     );
 });

--- a/addons/html_editor/static/tests/toolbar.test.js
+++ b/addons/html_editor/static/tests/toolbar.test.js
@@ -46,6 +46,7 @@ import { expandToolbar } from "./_helpers/toolbar";
 import { nodeSize } from "@html_editor/utils/position";
 import { expectElementCount } from "./_helpers/ui_expectations";
 import { ToolbarPlugin } from "@html_editor/main/toolbar/toolbar_plugin";
+import { PLACEHOLDER_BLOCK_CONTAINER } from "./_helpers/placeholder_block";
 
 test.tags("desktop");
 test("toolbar is only visible when selection is not collapsed in desktop", async () => {
@@ -533,6 +534,7 @@ test("toolbar should not open on keypress tab inside table", async () => {
         </table>
     `);
     const contentAfter = unformat(`
+        ${PLACEHOLDER_BLOCK_CONTAINER("top")}
         <table>
             <tbody>
                 <tr>
@@ -541,6 +543,7 @@ test("toolbar should not open on keypress tab inside table", async () => {
                 </tr>
             </tbody>
         </table>
+        ${PLACEHOLDER_BLOCK_CONTAINER("bottom")}
     `);
 
     const { el } = await setupEditor(contentBefore);
@@ -679,6 +682,7 @@ test("toolbar should close on keypress tab inside table", async () => {
         </table>
     `);
     const contentAfter = unformat(`
+        ${PLACEHOLDER_BLOCK_CONTAINER("top")}
         <table>
             <tbody>
                 <tr>
@@ -687,6 +691,7 @@ test("toolbar should close on keypress tab inside table", async () => {
                 </tr>
             </tbody>
         </table>
+        ${PLACEHOLDER_BLOCK_CONTAINER("bottom")}
     `);
 
     const { el } = await setupEditor(contentBefore);
@@ -724,6 +729,7 @@ test("toolbar works: show the correct vertical alignment", async () => {
     expect(".dropdown-menu button.active svg[name='vertical_align_middle']").toHaveCount(1);
     expect(getContent(el)).toBe(
         unformat(`
+            ${PLACEHOLDER_BLOCK_CONTAINER("top")}
             <table class="table table-bordered o_table o_selected_table">
                 <tbody>
                     <tr style="height: 100px;">
@@ -738,6 +744,7 @@ test("toolbar works: show the correct vertical alignment", async () => {
                     </tr>
                 </tbody>
             </table>
+            ${PLACEHOLDER_BLOCK_CONTAINER("bottom")}
         `)
     );
 });
@@ -768,6 +775,7 @@ test("toolbar works: show the correct vertical alignment after undo/redo", async
     expect(".dropdown-menu button.active svg[name='vertical_align_bottom']").toHaveCount(1);
     expect(getContent(el)).toBe(
         unformat(`
+            ${PLACEHOLDER_BLOCK_CONTAINER("top")}
             <table class="table table-bordered o_table o_selected_table">
                 <tbody>
                     <tr style="height: 100px;">
@@ -780,6 +788,7 @@ test("toolbar works: show the correct vertical alignment after undo/redo", async
                     </tr>
                 </tbody>
             </table>
+            ${PLACEHOLDER_BLOCK_CONTAINER("bottom")}
         `)
     );
     await press(["ctrl", "z"]);
@@ -787,6 +796,7 @@ test("toolbar works: show the correct vertical alignment after undo/redo", async
     expect("button[name='vertical_align'] svg[name='vertical_align_top']").toHaveCount(1);
     expect(getContent(el)).toBe(
         unformat(`
+            ${PLACEHOLDER_BLOCK_CONTAINER("top")}
             <table class="table table-bordered o_table">
                 <tbody>
                     <tr style="height: 100px;">
@@ -799,6 +809,7 @@ test("toolbar works: show the correct vertical alignment after undo/redo", async
                     </tr>
                 </tbody>
             </table>
+            ${PLACEHOLDER_BLOCK_CONTAINER("bottom")}
         `)
     );
     await press(["ctrl", "y"]);
@@ -807,6 +818,7 @@ test("toolbar works: show the correct vertical alignment after undo/redo", async
     expect(".dropdown-menu button.active svg[name='vertical_align_bottom']").toHaveCount(1);
     expect(getContent(el)).toBe(
         unformat(`
+            ${PLACEHOLDER_BLOCK_CONTAINER("top")}
             <table class="table table-bordered o_table o_selected_table">
                 <tbody>
                     <tr style="height: 100px;">
@@ -819,6 +831,7 @@ test("toolbar works: show the correct vertical alignment after undo/redo", async
                     </tr>
                 </tbody>
             </table>
+            ${PLACEHOLDER_BLOCK_CONTAINER("bottom")}
         `)
     );
 });

--- a/addons/html_editor/static/tests/unbreakable/split_element_block.test.js
+++ b/addons/html_editor/static/tests/unbreakable/split_element_block.test.js
@@ -2,6 +2,7 @@ import { expect, test } from "@odoo/hoot";
 import { setupEditor, testEditor } from "../_helpers/editor";
 import { splitBlock } from "../_helpers/user_actions";
 import { getContent } from "../_helpers/selection";
+import { PLACEHOLDER_BLOCK_CONTAINER } from "../_helpers/placeholder_block";
 
 test("should replace splitElementBlock with insertLineBreak (selection start)", async () => {
     await testEditor({
@@ -25,10 +26,14 @@ test("should replace splitElementBlock with insertLineBreak (selection end)", as
     });
 });
 test("should not split a contenteditable='false'", async () => {
-    const { editor, el } = await setupEditor(`<p contenteditable="false">ab</p>`);
-    const p = el.querySelector("p");
+    const { editor, el } = await setupEditor(`<p id="p" contenteditable="false">ab</p>`);
+    const p = el.querySelector("p#p");
     editor.shared.split.splitBlockNode({ targetNode: p, targetOffset: 0 });
-    expect(getContent(el)).toBe(`<p contenteditable="false">ab</p>`);
+    expect(getContent(el)).toBe(
+        `${PLACEHOLDER_BLOCK_CONTAINER(
+            "top"
+        )}<p id="p" contenteditable="false">ab</p>${PLACEHOLDER_BLOCK_CONTAINER("bottom")}`
+    );
 });
 test("should split an explicit contenteditable='true' if its ancestor isContentEditable", async () => {
     await testEditor({

--- a/addons/html_editor/static/tests/utils/dom.test.js
+++ b/addons/html_editor/static/tests/utils/dom.test.js
@@ -9,6 +9,7 @@ import {
 import { getContent } from "../_helpers/selection";
 import { parseHTML } from "@html_editor/utils/html";
 import { unformat } from "../_helpers/format";
+import { PLACEHOLDER_BLOCK_CONTAINER } from "../_helpers/placeholder_block";
 
 describe("splitAroundUntil", () => {
     test("should split a slice of text from its inline ancestry (1)", async () => {
@@ -301,10 +302,22 @@ describe("wrapInlinesInBlocks", () => {
 describe("fillEmpty", () => {
     test("should not add fill a shrunk protected block, nor add a ZWS to it", async () => {
         const { el } = await setupEditor('<div data-oe-protected="true"></div>');
-        expect(el.innerHTML).toBe('<div data-oe-protected="true" contenteditable="false"></div>');
+        expect(el.innerHTML).toBe(
+            `${PLACEHOLDER_BLOCK_CONTAINER(
+                "top"
+            )}<div data-oe-protected="true" contenteditable="false"></div>${PLACEHOLDER_BLOCK_CONTAINER(
+                "bottom"
+            )}`
+        );
         const div = el.firstChild;
         fillEmpty(div);
-        expect(el.innerHTML).toBe('<div data-oe-protected="true" contenteditable="false"></div>');
+        expect(el.innerHTML).toBe(
+            `${PLACEHOLDER_BLOCK_CONTAINER(
+                "top"
+            )}<div data-oe-protected="true" contenteditable="false"></div>${PLACEHOLDER_BLOCK_CONTAINER(
+                "bottom"
+            )}`
+        );
     });
     test("should not fill a block containing a canvas", async () => {
         const { el } = await setupEditor("<div><canvas></canvas></div>");


### PR DESCRIPTION
When the last element is a contenteditable="false", it can be hard to create a new empty paragraph just below. Some workarounds exist, but they aren't intuitive.

Like Notion, if the last element is not an empty paragraph, ensure a new empty paragraph is created when the user puts their cursor below this element. The same is done for above the first element.

task-4735561

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
