### PR TITLE
[FIX] html_editor: ensure video options toggle buttons renders correctly

### DIFF
--- a/addons/html_editor/static/src/main/media/media_dialog/video_selector.scss
+++ b/addons/html_editor/static/src/main/media/media_dialog/video_selector.scss
@@ -1,0 +1,40 @@
+$o-we-switch-size: 1.2em !default;
+$o-we-switch-inactive-color: rgba($text-muted, 0.4) !default;
+.o_switch {
+    display: flex;
+    align-items: center;
+    font-weight: normal;
+    cursor: pointer;
+
+    > input {
+        display: none;
+
+        + span {
+            border-radius: $o-we-switch-size;
+            width: $o-we-switch-size * 1.7;
+            padding-left: 3px;
+            padding-right: 3px;
+            background-color: $o-we-switch-inactive-color;
+            font-size: $o-we-switch-size * 1.09;
+            line-height: $o-we-switch-size;
+            color: $o-we-switch-inactive-color;
+            transition: all 0.2s cubic-bezier(0.19, 1, 0.22, 1);
+
+            &:after {
+                content: "\f057"; // fa-times-circle
+                font-family: 'FontAwesome';
+                color: white;
+                transition: all 0.2s cubic-bezier(0.19, 1, 0.22, 1);
+            }
+        }
+
+        &:checked + span {
+            background: $o-brand-primary;
+
+            &:after {
+                content: "\f058"; // fa-check-circle
+                margin-left: ($o-we-switch-size * 1.7) - $o-we-switch-size;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Description of the issue this PR addresses:

- The video settings popup has toggle options like autoplay and loop. These need styles from the website module to look like switches. Without that module, they show as checkboxes.

Current behavior before PR:

- When the website module is not installed, Toggle options look like checkboxes instead of switches.

Desired behavior after PR is merged:

- Basic switch styles are added directly in the html_editor module. Toggles now look correct even without the website module.

task-4865400

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
