### PR TITLE
[FIX] crm: skip falsy leads

### DIFF
--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -1447,7 +1447,7 @@ class Lead(models.Model):
         return {
             'description': lambda fname, leads: '<br/><br/>'.join(desc for desc in leads.mapped('description') if not is_html_empty(desc)),
             'type': lambda fname, leads: 'opportunity' if any(lead.type == 'opportunity' for lead in leads) else 'lead',
-            'priority': lambda fname, leads: max(leads.mapped('priority')) if leads else False,
+            'priority': lambda fname, leads: max(priorities) if (priorities := leads.filtered('priority').mapped('priority')) else False,
             'tag_ids': lambda fname, leads: leads.mapped('tag_ids'),
             'lost_reason_id': lambda fname, leads:
                 False if leads and leads[0].probability


### PR DESCRIPTION
The field priority is not required (even if it has a default) so it is possible to have False instead of a str.
Traceback occures when merging leads that contains historical data.

```
  File "/home/odoo/src/odoo/saas-18.3/addons/crm/models/crm_lead.py", line 1501, in _merge_opportunity
    merged_data = opportunities._merge_data(self._merge_get_fields())
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/src/odoo/saas-18.3/addons/crm/models/crm_lead.py", line 1457, in _merge_data
    data[field_name] = fcallable(field_name, self)
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/src/odoo/saas-18.3/addons/crm/models/crm_lead.py", line 1555, in <lambda>
    'priority': lambda fname, leads: max(leads.mapped('priority')) if leads else False,
                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: '>' not supported between instances of 'str' and 'bool'
```
