### PR TITLE
[FIX] website: add line separator between the navbar and the website

### DIFF
--- a/addons/website/static/src/client_actions/website_preview/website_builder_action.xml
+++ b/addons/website/static/src/client_actions/website_preview/website_builder_action.xml
@@ -3,7 +3,7 @@
 
 <t t-name="html_builder.WebsiteBuilder">
     <div class="d-flex h-100 w-100" t-ref="container">
-        <div class="o_website_preview flex-grow-1" t-ref="website_preview">
+        <div class="o_website_preview border-top flex-grow-1" t-ref="website_preview">
             <div class="o_iframe_container">
                 <iframe t-att-src="initialUrl" t-ref="iframe" t-on-load="onIframeLoad" />
                 <div t-if="this.websiteContext.isMobile" class="o_mobile_preview_layout">


### PR DESCRIPTION
This commit returns the missing top border (line separator) from 18.3. 
This commit follows [the html_builder refactoring].

[the html_builder refactoring]: odoo/odoo@9fe45e2b7ddb 
Related to task-4367641

