### PR TITLE
[IMP] hr_holidays: Improving first day of accrual plan.

### DIFF
--- a/addons/hr_holidays/models/hr_leave_accrual_plan_level.py
+++ b/addons/hr_holidays/models/hr_leave_accrual_plan_level.py
@@ -339,7 +339,7 @@ class HrLeaveAccrualLevel(models.Model):
             date = last_call + relativedelta(day=int(self.first_day))
             if last_call >= date:
                 return date
-            return last_call + relativedelta(day=int(self.first_day), months=-1)
+            return last_call + relativedelta(day=int(self.first_day), months=-1, days=1)
 
         if self.frequency == 'biyearly':
             first_date = last_call + relativedelta(month=int(self.first_month), day=int(self.first_month_day))

--- a/addons/hr_holidays/models/hr_leave_allocation.py
+++ b/addons/hr_holidays/models/hr_leave_allocation.py
@@ -152,7 +152,7 @@ class HrLeaveAllocation(models.Model):
         return _(
             '%(name)s (%(duration)s day(s))',
             name=self.holiday_status_id.name,
-            duration=self.number_of_days,
+            duration=float_round(self.number_of_days, precision_digits=2),
         )
 
     @api.onchange('name')
@@ -981,8 +981,8 @@ class HrLeaveAllocation(models.Model):
                         note = _(
                             'New Allocation Request created by %(user)s: %(count)s Days of %(allocation_type)s',
                             user=allocation.create_uid.name,
-                            count=allocation.number_of_days,
-                            allocation_type=allocation.holiday_status_id.name
+                            count=float_round(allocation.number_of_days, precision_digits=2),
+                            allocation_type=allocation.holiday_status_id.name,
                         )
                     else:
                         activity_type = approval_activity


### PR DESCRIPTION
This PR improves the calculation logic for the first day of an accrual plan by adjusting the start of the first accrual period. 

## Description of the issue/feature this PR addresses:
When accrual is configured to occur at the end of the period, users were not receiving the full accrual amount for what appears to be a complete allocation (e.g., from the 1st to the end of the month).

## Current behavior before PR:
Given the following configuration:
- Accrued gain time: End of the accrual period
- Carry-over time: At the allocation date
- Accrual: 2.089 days monthly, on the last day of each month
- Start accruing: 0 days after the start date
If an allocation was created from 01/05 to 31/05, the accrual calculation would return 2.02 days — slightly less than the full expected 2.089 days.
To get the full amount, users had to manually shift the allocation start date to 30/04, which was unintuitive and logically incorrect, since it extended the period beyond a single calendar month.
The dislayed amount in the description and the log message are not rounded.
![image](https://github.com/user-attachments/assets/2bf1bff2-7b92-46b4-b64c-ae08568286f7)


## Desired behavior after PR is merged:
We now add 1 day to the start date of the first accrual period, allowing the system to recognize the full intended accrual period.
With the same configuration, creating an allocation from 01/05 to 31/05 now correctly results in 2.089 days, without requiring any date manipulation by the user.
![image](https://github.com/user-attachments/assets/2407c11e-6484-49bb-b12c-c88fd8b49b7a)


Task: 4855241.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
