### PR TITLE
[FIX] pos_self_order: cannot add product with description and no attributes

### DIFF
--- a/addons/pos_self_order/static/src/app/pages/kiosk_product_page/kiosk_product_page.js
+++ b/addons/pos_self_order/static/src/app/pages/kiosk_product_page/kiosk_product_page.js
@@ -102,6 +102,9 @@ export class KioskProductPage extends Component {
     }
 
     hasMissingAttributeValues() {
+        if (!this.productTemplate.attribute_line_ids.length) {
+            return false;
+        }
         const selection = this.state.selectedValues[this.productTemplate.id];
         if (!selection) {
             return true;

--- a/addons/pos_self_order/static/tests/tours/self_order_kiosk_tour.js
+++ b/addons/pos_self_order/static/tests/tours/self_order_kiosk_tour.js
@@ -54,6 +54,8 @@ registry.category("web_tour.tours").add("self_kiosk_each_counter_takeaway_in", {
         ProductPage.clickKioskCategory("Uncategorised"),
         ProductPage.clickKioskProduct("Yummy Burger"),
         ProductPage.clickKioskProduct("Taxi Burger"),
+        Utils.checkDescription("Nice Product"),
+        Utils.clickBtn("Add to cart"),
         Utils.clickBtn("Checkout"),
         CartPage.checkKioskProduct("Coca-Cola", "2.53"),
         CartPage.checkKioskProduct("Yummy Burger", "10"),

--- a/addons/pos_self_order/static/tests/tours/utils/common.js
+++ b/addons/pos_self_order/static/tests/tours/utils/common.js
@@ -104,3 +104,10 @@ export function increaseComboItemQty(productName, qty) {
 
     return steps;
 }
+
+export function checkDescription(descriptionText) {
+    return {
+        content: `Check product has description: "${descriptionText}"`,
+        trigger: `.scroll-container div:contains("${descriptionText}")`,
+    };
+}

--- a/addons/pos_self_order/tests/test_self_order_kiosk.py
+++ b/addons/pos_self_order/tests/test_self_order_kiosk.py
@@ -47,6 +47,7 @@ class TestSelfOrderKiosk(SelfOrderCommonTest):
             'available_in_pos': True,
             'list_price': 10,
             'taxes_id': [Command.set([tax_10_inc.id, tax_10_excl.id])],
+            'public_description': 'Nice Product',
         })
 
         # With preset location choices


### PR DESCRIPTION
Steps to reproduce:
-------------------------------
- Install pos_self_order
- Open kiosk
- Select product that has description and no attributes.
- Attempt to add it to the cart.

Issue:
-----------------------
- Add to Cart button remains disabled despite product being available.

Cause:
-------------------------
- The system incorrectly treated the product as having incomplete selection.

Fix:
---------------------
- Ensure such products are treated as valid and can be added to the cart.

Task-4868023