### PR TITLE
[IMP] html_editor: prefill URL input

### DIFF
--- a/addons/html_editor/static/src/main/link/link_popover.js
+++ b/addons/html_editor/static/src/main/link/link_popover.js
@@ -74,7 +74,7 @@ export class LinkPopover extends Component {
         );
         this.state = useState({
             editing: this.props.LinkPopoverState.editing,
-            url: this.props.linkElement.href || "",
+            url: this.props.linkElement.href || this.deduceUrl(textContent),
             label: labelEqualsUrl ? "" : textContent,
             previewIcon: {
                 /** @type {'fa'|'imgSrc'|'mimetype'} */

--- a/addons/html_editor/static/tests/link/popover.test.js
+++ b/addons/html_editor/static/tests/link/popover.test.js
@@ -1424,3 +1424,84 @@ describe("link popover with empty URL", () => {
         );
     });
 });
+
+describe("label is a valid URL", () => {
+    test("URL input should be prefilled by corresponding URL if the label matches the URL format", async () => {
+        const { el } = await setupEditor("<p>[google.com]</p>");
+        await waitFor(".o-we-toolbar");
+        await click(".o-we-toolbar .fa-link");
+        await waitFor(".o-we-linkpopover");
+        expect("input.o_we_label_link").toHaveValue("google.com");
+        expect("input.o_we_href_input_link").toHaveValue("https://google.com");
+        await click(".o_we_apply_link");
+        expect(cleanLinkArtifacts(getContent(el))).toBe(
+            '<p><a href="https://google.com">google.com[]</a></p>'
+        );
+    });
+    test("URL input should be prefilled by corresponding URL if the label matches the URL format (2)", async () => {
+        const { el } = await setupEditor("<p>[https://google.com]</p>");
+        await waitFor(".o-we-toolbar");
+        await click(".o-we-toolbar .fa-link");
+        await waitFor(".o-we-linkpopover");
+        expect("input.o_we_label_link").toHaveValue("https://google.com");
+        expect("input.o_we_href_input_link").toHaveValue("https://google.com");
+        await click(".o_we_apply_link");
+        expect(cleanLinkArtifacts(getContent(el))).toBe(
+            '<p><a href="https://google.com">https://google.com[]</a></p>'
+        );
+    });
+    test("URL input should be prefilled by corresponding URL if the label matches the email format", async () => {
+        const { el } = await setupEditor("<p>[test@test.com]</p>");
+        await waitFor(".o-we-toolbar");
+        await click(".o-we-toolbar .fa-link");
+        await waitFor(".o-we-linkpopover");
+        expect("input.o_we_label_link").toHaveValue("test@test.com");
+        expect("input.o_we_href_input_link").toHaveValue("mailto:test@test.com");
+        await click(".o_we_apply_link");
+        expect(cleanLinkArtifacts(getContent(el))).toBe(
+            '<p><a href="mailto:test@test.com">test@test.com[]</a></p>'
+        );
+    });
+    test("URL input should be prefilled by corresponding URL if the label matches the email format (2)", async () => {
+        const { el } = await setupEditor("<p>[mailto:test@test.com]</p>");
+        await waitFor(".o-we-toolbar");
+        await click(".o-we-toolbar .fa-link");
+        await waitFor(".o-we-linkpopover");
+        expect("input.o_we_label_link").toHaveValue("mailto:test@test.com");
+        expect("input.o_we_href_input_link").toHaveValue("mailto:test@test.com");
+        await click(".o_we_apply_link");
+        expect(cleanLinkArtifacts(getContent(el))).toBe(
+            '<p><a href="mailto:test@test.com">mailto:test@test.com[]</a></p>'
+        );
+    });
+    test("URL input should be prefilled by corresponding URL if the label matches the telephone format", async () => {
+        const { el } = await setupEditor("<p>[12345678]</p>");
+        await waitFor(".o-we-toolbar");
+        await click(".o-we-toolbar .fa-link");
+        await waitFor(".o-we-linkpopover");
+        expect("input.o_we_label_link").toHaveValue("12345678");
+        expect("input.o_we_href_input_link").toHaveValue("tel:12345678");
+        await click(".o_we_apply_link");
+        expect(cleanLinkArtifacts(getContent(el))).toBe(
+            '<p><a href="tel:12345678">12345678[]</a></p>'
+        );
+    });
+    test("URL input should be prefilled by corresponding URL if the label matches the telephone format (2)", async () => {
+        const { el } = await setupEditor("<p>[tel:123]</p>");
+        await waitFor(".o-we-toolbar");
+        await click(".o-we-toolbar .fa-link");
+        await waitFor(".o-we-linkpopover");
+        expect("input.o_we_label_link").toHaveValue("tel:123");
+        expect("input.o_we_href_input_link").toHaveValue("tel:123");
+        await click(".o_we_apply_link");
+        expect(cleanLinkArtifacts(getContent(el))).toBe('<p><a href="tel:123">tel:123[]</a></p>');
+    });
+    test("popover should display href URL even if label is a valid URL and differs from href", async () => {
+        await setupEditor('<p><a href="https://odoo.com/">googl[]e.com</a></p>');
+        await waitFor(".o-we-linkpopover", { timeout: 1500 });
+        expect(queryFirst(".o-we-linkpopover a").href).toBe("https://odoo.com/");
+        await click(".o_we_edit_link");
+        await waitFor(".o_we_href_input_link");
+        expect("input.o_we_href_input_link").toHaveValue("https://odoo.com/");
+    });
+});


### PR DESCRIPTION
This PR ensures that when opening link popover, if selected label text is a valid URL then URL input in link popover is prefilled by the corresponding URL.

task-4844337



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
