### PR TITLE
[FIX] product_expiry: prevent error when lot/serial has no expiration date

### DIFF
--- a/addons/product_expiry/models/production_lot.py
+++ b/addons/product_expiry/models/production_lot.py
@@ -26,11 +26,11 @@ class StockLot(models.Model):
     def _compute_display_name(self):
         lots_to_process_ids = []
         for lot in self:
-            if lot.env.context.get('formatted_display_name') and lot.use_expiration_date:
+            if lot.env.context.get('formatted_display_name') and lot.use_expiration_date and lot.expiration_date:
                 name = f"{lot.name}"
                 if fields.Datetime.now() >= lot.expiration_date:
                     name += self.env._("\t--Expired--")
-                elif fields.Datetime.now() >= lot.alert_date:
+                elif lot.alert_date and fields.Datetime.now() >= lot.alert_date:
                     name += self.env._("\t--Expire on %(date)s--", date=fields.Datetime.to_string(lot.expiration_date))
                 lot.display_name = name
             else:

--- a/addons/product_expiry/tests/test_stock_lot.py
+++ b/addons/product_expiry/tests/test_stock_lot.py
@@ -675,3 +675,24 @@ class TestStockLot(TestStockCommon):
         delivery.action_confirm()
 
         self.assertAlmostEqual(delivery.move_line_ids[0].expiration_date, expiration_date, delta=delta)
+
+    def test_compute_display_name(self):
+        apple_lot1 = self.LotObj.create({
+            'name': 'LOT-00001',
+            'product_id': self.apple_product.id,
+            'expiration_date': False,
+            'alert_date': False,
+        })
+        apple_lot2 = self.LotObj.create({
+            'name': 'LOT-00002',
+            'product_id': self.apple_product.id,
+            'expiration_date': datetime.today() - timedelta(days=10),
+        })
+        apple_lot3 = self.LotObj.create({
+            'name': 'LOT-00003',
+            'product_id': self.apple_product.id,
+            'alert_date': datetime.today() - timedelta(days=10),
+        })
+        self.assertEqual(apple_lot1.with_context(formatted_display_name=True).display_name, "LOT-00001")
+        self.assertEqual(apple_lot2.with_context(formatted_display_name=True).display_name, "LOT-00002\t--Expired--")
+        self.assertEqual(apple_lot3.with_context(formatted_display_name=True).display_name, "LOT-00003\t--Expire on " + fields.Datetime.to_string(apple_lot3.expiration_date) + "--")


### PR DESCRIPTION
When selecting a **Lot/Serial Number** that does not have an expiration date set, it raises an error due to an invalid comparison between a datetime and boolean.

**Steps to reproduce:**
- Install `mrp` and `product_expiry` modules.
- Create a product with **Tracking** set to _By Lots_ and enable **Expiration Date** in the Inventory tab.
- Create a **Lot/Serial Number** for this product without setting an expiration date.
- In an **unbuild** order, select this product and try to assign the Lot/Serial Number.

**Error:**
`TypeError: '>=' not supported between instances of 'datetime.datetime' and 'bool'`

Here, an error occurs at [1], where the system tries to compare a `datetime` with `lot.expiration_date`, which is unset (`False`).

[1] - https://github.com/odoo/odoo/blob/9176a8e6fdb41caf575ec007fe17aa308bde7b4f/addons/product_expiry/models/production_lot.py#L31-L33

This commit ensures that comparisons involving `expiration_date` and `alert_date` are only made when these fields are set.

Sentry - 6676608121