### PR TITLE
[FIX] point_of_sale: Fix related models and data service

### DIFF
--- a/addons/point_of_sale/static/src/app/models/related_models.js
+++ b/addons/point_of_sale/static/src/app/models/related_models.js
@@ -297,7 +297,7 @@ export function createRelatedModels(modelDefs, modelClasses = {}, opts = {}) {
         const inverse = inverseMap.get(field);
         if (field.type === "many2one") {
             const prevConnectedRecord = ownerRecord[field.name];
-            if (prevConnectedRecord?.isEqual(recordToConnect)) {
+            if (prevConnectedRecord?.isEqual?.(recordToConnect)) {
                 return;
             }
             if (recordToConnect && inverse.name in recordToConnect) {

--- a/addons/point_of_sale/static/src/app/services/data_service.js
+++ b/addons/point_of_sale/static/src/app/services/data_service.js
@@ -144,8 +144,13 @@ export class PosData extends Reactive {
                 }
             }
 
-            await this.indexedDB.delete(model, remove);
-            await this.indexedDB.create(model, put);
+            if (remove.length) {
+                await this.indexedDB.delete(model, remove);
+            }
+
+            if (put.length) {
+                await this.indexedDB.create(model, put);
+            }
         }
     }
 


### PR DESCRIPTION
Prevent sending empty array to indexedDB to avoid useless writes and potential errors.

Check variable before calling a the `isEquals` method on it to avoid TypeError when the variable is undefined.

