### PR TITLE
[FIX] hr_work_entry_contract: fix error when generating work entries

### DIFF
--- a/addons/hr_work_entry_contract/models/hr_contract.py
+++ b/addons/hr_work_entry_contract/models/hr_contract.py
@@ -100,6 +100,8 @@ class HrContract(models.Model):
             employees_by_calendar[contract.resource_calendar_id] |= contract.employee_id
         result = dict()
         for calendar, employees in employees_by_calendar.items():
+            if not calendar:
+                continue
             result.update(calendar._attendance_intervals_batch(
                 start_dt,
                 end_dt,
@@ -115,6 +117,8 @@ class HrContract(models.Model):
             employees_by_calendar[contract.resource_calendar_id] |= contract.employee_id
         result = {}
         for calendar, employees in employees_by_calendar.items():
+            if not calendar:
+                continue
             result.update(calendar._attendance_intervals_batch(
                 start_dt,
                 end_dt,
@@ -155,7 +159,7 @@ class HrContract(models.Model):
             resource = employee.resource_id
             # if the contract is fully flexible, we refer to the employee's timezone
             tz = pytz.timezone(resource.tz) if contract._is_fully_flexible() else pytz.timezone(calendar.tz)
-            attendances = attendances_by_resource[resource.id]
+            attendances = attendances_by_resource[resource.id] if attendances_by_resource else WorkIntervals()
 
             # Other calendars: In case the employee has declared time off in another calendar
             # Example: Take a time off, then a credit time.

--- a/addons/hr_work_entry_contract/tests/test_work_entry.py
+++ b/addons/hr_work_entry_contract/tests/test_work_entry.py
@@ -358,3 +358,10 @@ class TestWorkEntry(TestWorkEntryBase):
         self.assertEqual(work_entry.duration, 1, "The duration should be 1 hour")
         self.assertEqual(one_day_entry.duration, 24.5, "Duration should be 24 hours and half an hour")
         self.assertEqual(multi_day_entry.duration, 169, "Duration should be 169 hours (7 days and one hour)")
+
+    def test_work_entry_without_resource_calendar(self):
+        """ Test generating work entries without a resource calendar """
+        self.richard_emp.contract_id.resource_calendar_id = False
+        self.richard_emp.generate_work_entries(self.start, self.end)
+        entries = self.env['hr.work.entry'].search([('employee_id', '=', self.richard_emp.id)])
+        self.assertFalse(entries)


### PR DESCRIPTION
A traceback occurs when generating work entries for an employee whose contract
has no working schedule set.

steps to reproduce the error:
- Install ``hr_payroll`` and ``hr_attendance`` module
- Create a new Employee A
- Go to Payroll > Contracts > Create a new contract > Employee: Employee A
  Work Entry Source: Attendances > Unset Working Schedule > Status: Running
- Uninstall ``hr_attendance`` module
- Go to Payroll > Work Entries > Regenerate Work Entries > Select Employee A > Regenerate Work Entries

Traceback:
```
AttributeError: 'bool' object has no attribute 'upper'
```

https://github.com/odoo/odoo/blob/99a87be39c734dd2916a51bc5663162dda32a16b/addons/hr_work_entry_contract/models/hr_contract.py#L107
Here, When calendar is False and user tries to generate work entries
for an employee. So, It will lead to the above traceback.

sentry-6672998106,6808497160

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
