### PR TITLE
[FIX] base: prevent errors from invalid domains on relational fields

### DIFF
--- a/odoo/addons/base/models/ir_model.py
+++ b/odoo/addons/base/models/ir_model.py
@@ -633,7 +633,10 @@ class IrModelFields(models.Model):
     @api.constrains('domain')
     def _check_domain(self):
         for field in self:
-            safe_eval(field.domain or '[]')
+            try:
+                safe_eval(field.domain or '[]')
+            except SyntaxError:
+                raise ValidationError(_("Invalid domain syntax: %s", field.domain))
 
     @api.constrains('name')
     def _check_name(self):

--- a/odoo/addons/base/tests/test_ir_model.py
+++ b/odoo/addons/base/tests/test_ir_model.py
@@ -442,6 +442,22 @@ class TestIrModelEdition(TransactionCase):
             form.related = 'id'
             self.assertEqual(form.ttype, 'integer')
 
+    def test_ir_model_fields_invalid_domain(self):
+        model = self.env['ir.model'].create({
+            'name': 'Bananas',
+            'model': 'x_bananas',
+        })
+        field = self.env['ir.model.fields'].create({
+            'model_id': model.id,
+            'name': 'x_krip_field',
+            'field_description': 'my_m2o',
+            'ttype': 'many2one',
+            'relation': 'x_bananas',
+        })
+
+        with self.assertRaises(ValidationError):
+            field.domain = "[('is_company, '=', True)]"  # intentionally broken domain
+
     def test_delete_manual_models_with_base_fields(self):
         model = self.env["ir.model"].create({
             "model": "x_test_base_delete",


### PR DESCRIPTION
Currently an error occurs when a syntactically invalid domain is added to any relational field.

Steps to replicate:
- Go to `Settings > technical > Fields` and click on New.
- Make the field type as `Many2one` (any relational type would work).
- Add the domain as `[('x_isLaundy), '=', True)]`, which has a syntax error.
- Add other required fields and save.

Error:
`SyntaxError: unterminated string literal (detected at line 1) (, line 1)`

This error was caused by a `SyntaxError` raised during `safe_eval()` [1] evaluation of a malformed domain. Since the exception wasn't handled properly, it resulted in a traceback.

This commit resolves the issue by catching the `SyntaxError` raised during domain evaluation and converting it into a user-friendly `ValidationError`, preventing unhandled tracebacks.

[1] - https://github.com/odoo/odoo/blob/a3e9b4de2714bd0cc7831e924a0cce490f5da39e/odoo/addons/base/models/ir_model.py#L633-L636

sentry-6676988276
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
