### PR TITLE
[IMP] hw_drivers: do not show duplicate printers

### DIFF
--- a/addons/iot_box_image/configuration/packages.txt
+++ b/addons/iot_box_image/configuration/packages.txt
@@ -48,6 +48,7 @@ python3-usb
 python3-vobject
 python3-werkzeug
 python3-zeep
+python3-zeroconf
 rsync
 screen
 seatd


### PR DESCRIPTION
Before this commit, some printers would be detected multiple times by
CUPS using different protocols (for example IPP and DNSSD). This would
result in confusion for the user as they would see their printer appear
multiple times, and wouldn't know which one to select.

After this commit, we use the following logic to determine which
printers to return:
- Group all printers that have the same IP
- If there is just one printer, return it.
- If there are multiple, return the first one with device ID information
  (which helps us identify receipt/label printers).
- If we have previously detected a printer with an IP and a new one is
  found, we just return the old one.

To find the IPs of DNSSD printers, a new `python-zeroconf` module is now
required.

task-4813808

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
