### PR TITLE
[IMP] website: add record fields as field visibility conditions

### DIFF
--- a/addons/test_website/static/tests/tours/form.js
+++ b/addons/test_website/static/tests/tours/form.js
@@ -2,6 +2,7 @@ import {
     clickOnEditAndWaitEditMode,
     clickOnSave,
     registerWebsitePreviewTour,
+    changeOptionInPopover,
 } from "@website/js/tours/tour_utils";
 
 registerWebsitePreviewTour(
@@ -16,24 +17,15 @@ registerWebsitePreviewTour(
             trigger: ":iframe .s_website_form .s_website_form_input[name=name]",
             run: "click",
         },
-        {
-            content: "Open visibility dropdown",
-            trigger: 'we-select:has([data-set-visibility="conditional"])',
-            run: "click",
-        },
-        {
-            content: "Set visibility to conditional",
-            trigger: '[data-set-visibility="conditional"]',
-            run: "click",
-        },
+        ...changeOptionInPopover("Field", "Visibility", "Visible only if"),
         {
             content: "Open model selector",
-            trigger: 'we-select:has([data-select-data-attribute="2"])',
+            trigger: "button[id='hidden_condition_record_opt']:contains('Test Tag')",
             run: "click",
         },
         {
             content: "Set model to tag #2",
-            trigger: '[data-select-data-attribute="2"]',
+            trigger: ".o_popover div.o-dropdown-item:contains('Test Tag #2')",
             run: "click",
         },
         ...clickOnSave(),
@@ -50,12 +42,12 @@ registerWebsitePreviewTour(
         },
         {
             content: "Open comparator dropdown",
-            trigger: 'we-select:has([data-select-data-attribute="!selected"])',
+            trigger: "button[id='hidden_condition_record_opt']:contains('Is equal to')",
             run: "click",
         },
         {
             content: "Set comparator to Is not equal",
-            trigger: '[data-select-data-attribute="!selected"]',
+            trigger: ".o_popover div.o-dropdown-item:contains('Is not equal to')",
             run: "click",
         },
         ...clickOnSave(),

--- a/addons/test_website/tests/test_form.py
+++ b/addons/test_website/tests/test_form.py
@@ -1,11 +1,8 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo.tests import tagged, HttpCase
-import unittest
 
 
-# TODO master-mysterious-egg fix error
-@unittest.skip("prepare mysterious-egg for merging")
 @tagged('-at_install', 'post_install')
 class TestForm(HttpCase):
 


### PR DESCRIPTION
This commit fixes the test_form_conditional_visibility_record_field tour.

During the refactoring, the logic to handle record fields in conditional visibility was unintentionally removed. This functionality was originally introduced in commit [1].

This commit reintroduces the missing logic to ensure record fields are correctly handled in conditional visibility conditions.

[1]: https://github.com/odoo/odoo/commit/24a7112d7b85d045ffb0629f7feb6e5556e809a1
