### PR TITLE
[FIX] hr: fix avatar_card_employee_popover with missing fields

### DIFF
--- a/addons/hr/models/hr_employee_public.py
+++ b/addons/hr/models/hr_employee_public.py
@@ -50,6 +50,14 @@ class HrEmployeePublic(models.Model):
     resource_calendar_id = fields.Many2one('resource.calendar', readonly=True)
     country_code = fields.Char(compute='_compute_country_code')
 
+    share = fields.Boolean(related='user_id.share')
+    im_status = fields.Char(related="user_id.im_status")
+    job_title = fields.Char(readonly=False)
+    work_location_type = fields.Selection([
+        ("home", "Home"),
+        ("office", "Office"),
+        ("other", "Other")], compute='_compute_work_location_type')
+
     # Manager-only fields
     is_manager = fields.Boolean(compute='_compute_is_manager')
 
@@ -102,6 +110,9 @@ class HrEmployeePublic(models.Model):
 
     def _compute_country_code(self):
         self._compute_from_employee('country_code')
+
+    def _compute_work_location_type(self):
+        self._compute_from_employee('work_location_type')
 
     @api.depends_context('uid')
     @api.depends('parent_id')

--- a/addons/hr/models/hr_version.py
+++ b/addons/hr/models/hr_version.py
@@ -103,7 +103,8 @@ class HrVersion(models.Model):
     member_of_department = fields.Boolean("Member of department", compute='_compute_part_of_department', search='_search_part_of_department',
         help="Whether the employee is a member of the active user's department or one of it's child department.")
     job_id = fields.Many2one('hr.job', check_company=True, tracking=True)
-    job_title = fields.Char(related='job_id.name', readonly=False, string="Job Title", groups="hr.group_hr_user")
+    job_title = fields.Char(compute='_compute_job_title', store=True, readonly=False, string="Job Title",
+                            groups="hr.group_hr_user")
     address_id = fields.Many2one(
         'res.partner',
         string='Work Address',
@@ -464,6 +465,11 @@ class HrVersion(models.Model):
         for version in self:
             if not version.structure_type_id or (version.structure_type_id.country_id and version.structure_type_id.country_id != version.company_id.country_id):
                 version.structure_type_id = _default_salary_structure(version.company_id.country_id.id)
+
+    @api.depends('job_id.name')
+    def _compute_job_title(self):
+        for version in self.filtered('job_id'):
+            version.job_title = version.job_id.name
 
     @api.depends("work_location_id.name", "work_location_id.location_type")
     def _compute_work_location_name_type(self):

--- a/addons/hr/static/src/components/avatar_card_employee/avatar_card_employee_popover.js
+++ b/addons/hr/static/src/components/avatar_card_employee/avatar_card_employee_popover.js
@@ -11,7 +11,13 @@ export class AvatarCardEmployeePopover extends AvatarCardResourcePopover {
     }
 
     get fieldNames() {
-        const excludedFields = ["employee_id", "resource_type"];
+        let excludedFields = ["employee_id", "resource_type"];
+        /* if user is not hr_user, record model is employee.public, then, exclude email and phone
+           and share because no idea why we need it.
+         */
+        if (this.props.recordModel === 'hr.employee.public') {
+            excludedFields = excludedFields.concat(["email", "phone"]);
+        }
         return super.fieldNames.filter((field) => !excludedFields.includes(field));
     }
 }

--- a/addons/hr/static/src/components/avatar_card_resource/avatar_card_resource_popover.xml
+++ b/addons/hr/static/src/components/avatar_card_resource/avatar_card_resource_popover.xml
@@ -17,7 +17,7 @@
     </t>
 
     <t t-name="hr.avatarCardResourceInfos">
-        <small class="text-muted" t-if="record.job_id" t-esc="record.job_id[1]"/>
+        <small class="text-muted" t-if="record.job_title" t-esc="record.job_title"/>
         <span class="text-muted" t-if="record.department_id" data-tooltip="Department" t-esc="record.department_id[1]"/>
     </t>
 </templates>


### PR DESCRIPTION
avatar_card_employee_popover was crashing because of missing fields on hr.employee.public model (used when current user is not hr officer).

This commit add missing fields to display the popover properly. But we also removed email and phone from fields to fetch in case of public employee as this private information should not be displayed publicly for non hr officer users.

Job title has been reset as before hr contract / employee merge as this field definition was wrongly modified during refactoring.

Task-4868799
