### PR TITLE
[FIX] pos_self_order : prevent table selection when table identifier

### DIFF
--- a/addons/pos_self_order/static/src/app/pages/eating_location_page/eating_location_page.js
+++ b/addons/pos_self_order/static/src/app/pages/eating_location_page/eating_location_page.js
@@ -17,7 +17,6 @@ export class EatingLocationPage extends Component {
 
     selectPreset(preset) {
         this.selfOrder.currentOrder.setPreset(preset);
-        this.selfOrder.currentTable = null;
         this.router.navigate("product_list");
     }
 


### PR DESCRIPTION
# [FIX] pos_self_order : prevent table selection when table identifier

Before this commit, when you made a self order at Table, the table selector was trigger and you had to pick one, even if the tableIndicator was there

In practice, the `selectedTable` in `selfOrder` was removed by the `selectPreset()` function of `EatingLocationPage`

```js
selectPreset(preset) {
	this.selfOrder.currentOrder.setPreset(preset);
	this.selfOrder.currentTable = null;
	this.router.navigate("product_list");
}
```

That was fixed in 18.2 by this commit : https://github.com/odoo/odoo/commit/5e01d444cfd0594dd88a420129375ae1a6fdfc62


## Steps to reproduce (in runbot 18.1) :
- Go in Point of Sale > Configuration > Settings
- Select the Restaurant
- Set the Self Ordering Method to QR menu + Ordering
- Save
- Get the code using Print QR Codes
- Open the Table: 1 URL in incognito window
- Make sure the Restaurant is Open and the table 1 have no remaining order
- Select Eat In as eating location and make an order
- When you click pay, the table selection displayed


opw-4641352