### PR TITLE
[IMP] l10n_in: introduce PAN Entity Model to Manage GST Contacts with Same PAN

### DIFF
--- a/addons/l10n_in/__manifest__.py
+++ b/addons/l10n_in/__manifest__.py
@@ -42,6 +42,7 @@ Sheet, now only Vertical format has been permitted Which is Supported By Odoo.
         'data/account_tax_report_tds_data.xml',
         'data/l10n_in.section.alert.csv',
         'wizard/l10n_in_withhold_wizard.xml',
+        'views/l10n_in_pan_entity_views.xml',
         'views/l10n_in_section_alert_views.xml',
         'views/account_account_views.xml',
         'views/account_invoice_views.xml',

--- a/addons/l10n_in/demo/demo_company.xml
+++ b/addons/l10n_in/demo/demo_company.xml
@@ -2,7 +2,7 @@
 <odoo>
     <record id="base.partner_demo_company_in" model="res.partner" forcecreate="1">
         <field name="name">IN Company</field>
-        <field name="vat">24DUMMY1234AAZA</field>
+        <field name="vat">24FANCY1234AAZA</field>
         <field name="street">Block no. 401</field>
         <field name="street2">Street 2</field>
         <field name="city">Gandhinagar</field>

--- a/addons/l10n_in/models/__init__.py
+++ b/addons/l10n_in/models/__init__.py
@@ -14,3 +14,4 @@ from . import res_partner
 from . import uom_uom
 from . import account_account
 from . import l10n_in_section_alert
+from . import l10n_in_pan_entity

--- a/addons/l10n_in/models/iap_account.py
+++ b/addons/l10n_in/models/iap_account.py
@@ -4,7 +4,7 @@ from odoo.addons.iap import jsonrpc
 DEFAULT_IAP_ENDPOINT = "https://l10n-in-edi.api.odoo.com"
 DEFAULT_IAP_TEST_ENDPOINT = "https://l10n-in-edi-demo.api.odoo.com"
 IAP_SERVICE_NAME = 'l10n_in_edi'
-TEST_GST_NUMBER = '24DUMMY1234AAZA'
+TEST_GST_NUMBER = '24FANCY1234AAZA'
 
 
 class IapAccount(models.Model):

--- a/addons/l10n_in/models/l10n_in_pan_entity.py
+++ b/addons/l10n_in/models/l10n_in_pan_entity.py
@@ -1,0 +1,92 @@
+import base64
+
+from stdnum.in_ import pan
+from odoo import api, fields, models, _
+
+from odoo.exceptions import ValidationError
+
+
+class L10nInPanEntity(models.Model):
+    _name = 'l10n_in.pan.entity'
+    _inherit = ['mail.thread', 'mail.activity.mixin']
+    _description = 'Indian PAN Entity'
+
+    name = fields.Char(string="PAN", tracking=1)
+    type = fields.Selection([
+        ('a', 'Association of Persons'),
+        ('b', 'Body of Individuals'),
+        ('c', 'Company'),
+        ('f', 'Firms'),
+        ('g', 'Government'),
+        ('h', 'Hindu Undivided Family'),
+        ('j', 'Artificial Judicial Person'),
+        ('l', 'Local Authority'),
+        ('p', 'Individual'),
+        ('t', 'Association of Persons for a Trust'),
+        ('k', 'Krish (Trust Krish)'),
+    ], compute='_compute_type', readonly=True, store=True)
+    partner_ids = fields.One2many(
+        comodel_name='res.partner',
+        inverse_name='l10n_in_pan_entity_id',
+        string="Partners",
+        domain="[('l10n_in_pan_entity_id', '=', False), '|', ('vat', '=', False), ('vat', 'like', name)]"
+    )
+    tds_deduction = fields.Selection([
+        ('normal', 'Normal'),
+        ('lower', 'Lower'),
+        ('higher', 'Higher'),
+        ('no', 'No'),
+    ], string="TDS Deduction", default='normal', tracking=2)
+    tds_certificate = fields.Binary(string="TDS Certificate", copy=False)
+    tds_certificate_filename = fields.Char(string="TDS Certificate Filename", copy=False)
+
+    # MSME/Udyam Registration details
+    msme_type = fields.Selection([
+        ("micro", "Micro"),
+        ("small", "Small"),
+        ("medium", "Medium")
+    ], string="MSME/Udyam Registration Type", copy=False)
+    msme_number = fields.Char(string="MSME/Udyam Registration Number", copy=False)
+
+    _name_uniq = models.Constraint(
+        'unique (name)',
+        'A PAN Entity with same PAN Number already exists.',
+    )
+
+    @api.constrains('name')
+    def _check_pan_name(self):
+        if 'import_file' in self.env.context:
+            return
+        for record in self:
+            if record.name and not pan.is_valid(record.name):
+                raise ValidationError(_("The entered PAN %s seems invalid. Please enter a valid PAN.", record.name))
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        records = super().create(vals_list)
+        for record in records:
+            record.name = record.name.upper()
+        return records
+
+    def write(self, vals):
+        if vals.get('name'):
+            vals['name'] = vals['name'].upper()
+        res = super().write(vals)
+        if vals.get('tds_certificate'):
+            for rec in self:
+                rec.message_post(
+                    body=_("TDS Certificate Added"),
+                    message_type='notification',
+                    subtype_xmlid='mail.mt_note',
+                    attachments=[(rec.tds_certificate_filename, base64.b64decode(vals['tds_certificate']))]
+                )
+        return res
+
+    @api.depends('name')
+    def _compute_type(self):
+        for record in self:
+            if record.name:
+                if pan.is_valid(record.name):
+                    record.type = record.name[3].lower()
+                else:
+                    record.type = False

--- a/addons/l10n_in/models/res_config_settings.py
+++ b/addons/l10n_in/models/res_config_settings.py
@@ -40,6 +40,10 @@ class ResConfigSettings(models.TransientModel):
         related='company_id.l10n_in_withholding_journal_id',
         readonly=False
     )
+    l10n_in_tan = fields.Char(
+        related='company_id.l10n_in_tan',
+        readonly=False
+    )
 
     # GST settings
     l10n_in_is_gst_registered = fields.Boolean(

--- a/addons/l10n_in/security/ir.model.access.csv
+++ b/addons/l10n_in/security/ir.model.access.csv
@@ -4,3 +4,4 @@ access_port_code_account_manager,port.code.user,model_l10n_in_port_code,account.
 l10n_in.access_l10n_in_withhold_wizard,access_l10n_in_withhold_wizard,l10n_in.model_l10n_in_withhold_wizard,account.group_account_invoice,1,1,1,1
 access_l10n_in_section_alert_account_readonly,l10n_in.section.alert.account.readonly,model_l10n_in_section_alert,account.group_account_readonly,1,0,0,0
 access_l10n_in_section_alert_account_manager,l10n_in.section.alert.account.manager,model_l10n_in_section_alert,account.group_account_manager,1,1,1,1
+access_l10n_in_pan_entity,l10n_in.pan.entity,model_l10n_in_pan_entity,base.group_user,1,1,1,1

--- a/addons/l10n_in/tests/test_tds_tcs_alert.py
+++ b/addons/l10n_in/tests/test_tds_tcs_alert.py
@@ -47,13 +47,8 @@ class TestTdsTcsAlert(L10nInTestInvoicingCommon):
 
         country_in_id = cls.env.ref("base.in").id
 
-        # ==== Partners ====
-        cls.partner_a.write({
-            'l10n_in_pan': 'ABCPM8965E'
-        })
         cls.partner_b.write({
             'vat': '27ABCPM8965E1ZE',
-            'l10n_in_pan': 'ABCPM8965E'
         })
         cls.partner_foreign_2 = cls.partner_foreign.copy()
 

--- a/addons/l10n_in/views/account_invoice_views.xml
+++ b/addons/l10n_in/views/account_invoice_views.xml
@@ -70,7 +70,7 @@
             </xpath>
             <xpath expr="//header" position="inside">
                 <button name="%(l10n_in_withholding_entry_form_action)d" string="TDS Entry" type="action" class="btn btn-secondary float-end"
-                        invisible="country_code != 'IN' or not l10n_in_tds_feature_enabled or move_type not in ('out_invoice', 'in_invoice', 'out_refund', 'in_refund') or state != 'posted'"/>
+                        invisible="country_code != 'IN' or l10n_in_tds_deduction == 'no' or not l10n_in_tds_feature_enabled or move_type not in ('out_invoice', 'in_invoice', 'out_refund', 'in_refund') or state != 'posted'"/>
                 <button name="action_l10n_in_apply_higher_tax" string="Apply Higher TCS" type="object" class="btn btn-secondary float-end"
                         invisible="not l10n_in_display_higher_tcs_button or not l10n_in_tcs_feature_enabled"/>
             </xpath>

--- a/addons/l10n_in/views/l10n_in_pan_entity_views.xml
+++ b/addons/l10n_in/views/l10n_in_pan_entity_views.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="l10n_in_pan_entity_view_form" model="ir.ui.view">
+        <field name="name">l10n_in.pan.entity.view.form</field>
+        <field name="model">l10n_in.pan.entity</field>
+        <field name="arch" type="xml">
+            <form string="PAN Entity">
+                <div class="alert alert-warning w-100 d-flex align-items-center gap-1" invisible="tds_deduction != 'lower' or message_attachment_count" role="alert">
+                    <span>Attaching a certificate would provide better clarity and understanding.</span>
+                </div>
+                <sheet>
+                    <group>
+                        <group>
+                            <field name="name" help="Permanent Account Number"/>
+                            <field name="type"/>
+                            <field name="partner_ids" widget="many2many_tags_avatar" options="{'no_create': True}"/>
+                            <field name="tds_deduction" required="1"/>
+                            <field name="tds_certificate"
+                                   widget="binary"
+                                   filename="tds_certificate_filename"
+                                   options="{'accepted_file_extensions': '.pdf', 'allowed_mime_type' : 'application/pdf'}"
+                            />
+                            <field name="tds_certificate_filename" invisible="1"/> <!-- Hidden field to store the filename of the uploaded certificate -->
+                        </group>
+                        <group>
+                            <field name="msme_type"/>
+                            <field name="msme_number" placeholder="e.g. UDYAM-XX-00-0000000"/>
+                        </group>
+                    </group>
+                </sheet>
+                <chatter/>
+            </form>
+        </field>
+    </record>
+
+    <record id="l10n_in_pan_entity_view_tree" model="ir.ui.view">
+        <field name="name">l10n_in.pan.entity.view.tree</field>
+        <field name="model">l10n_in.pan.entity</field>
+        <field name="arch" type="xml">
+            <list string="PAN Entity">
+                <field name="name"/>
+                <field name="type"/>
+                <field name="partner_ids" widget="many2many_tags_avatar" options="{'no_create': True}"/>
+                <field name="type"/>
+            </list>
+        </field>
+    </record>
+
+    <record id="l10n_in_pan_entity_action" model="ir.actions.act_window">
+        <field name="name">PAN Entity</field>
+        <field name="res_model">l10n_in.pan.entity</field>
+        <field name="view_mode">list,form</field>
+    </record>
+
+    <menuitem
+        id="menu_l10n_in_pan_entity"
+        name="PAN Entity"
+        parent="account.account_transactions_menu"
+        action="l10n_in_pan_entity_action"
+    />
+
+</odoo>

--- a/addons/l10n_in/views/res_company_views.xml
+++ b/addons/l10n_in/views/res_company_views.xml
@@ -15,7 +15,8 @@
                <field class="o_form_label mb-0" name="l10n_in_pan_type" invisible="not l10n_in_pan_type"/>
             </xpath>
             <xpath expr="//field[@name='vat']" position="after">
-                <field name="l10n_in_pan" invisible="country_code != 'IN'"/>
+                <field name="l10n_in_pan_entity_id" invisible="country_code != 'IN'"/>
+                <field name="l10n_in_tan" invisible="not l10n_in_pan_entity_id"/>
             </xpath>
             <xpath expr="//sheet" position="before">
                 <div class="alert alert-warning mt-1 mb-1" role="alert" invisible="not l10n_in_gst_state_warning or country_code != 'IN'">

--- a/addons/l10n_in/views/res_config_settings_views.xml
+++ b/addons/l10n_in/views/res_config_settings_views.xml
@@ -19,6 +19,12 @@
                                  string="TDS"
                                  documentation="/applications/finance/fiscal_localizations/india.html">
                             <field name="l10n_in_tds_feature"/>
+                            <div class="content-group" invisible="not l10n_in_tds_feature">
+                                <div class="row mt8">
+                                    <label for="l10n_in_tan" class="col-lg-5 o_light_label" string="TAN"/>
+                                    <field name="l10n_in_tan" required="l10n_in_tds_feature"/>
+                                </div>
+                            </div>
                         </setting>
                         <setting name="l10n_in_tcs"
                                  help="Enable this to activate the Tax Collected at Source (TCS) feature and the account-based TCS section suggestion."

--- a/addons/l10n_in/views/res_partner_views.xml
+++ b/addons/l10n_in/views/res_partner_views.xml
@@ -13,7 +13,8 @@
                 <field name="l10n_in_gst_treatment" invisible="'IN' not in fiscal_country_codes or not l10n_in_is_gst_registered_enabled" readonly="parent_id"/>
             </xpath>
             <xpath expr="//field[@name='vat']" position="after">
-                <field name="l10n_in_pan" placeholder="e.g. ABCTY1234D" invisible="'IN' not in fiscal_country_codes" readonly="parent_id"/>
+                <field name="l10n_in_pan_entity_id" invisible="country_code != 'IN'" readonly="parent_id"/>
+                <field name="l10n_in_tan" invisible="country_code != 'IN' or not l10n_in_pan_entity_id" readonly="parent_id"/>
             </xpath>
             <xpath expr="//sheet" position="before">
                 <div class="alert alert-warning" role="alert"
@@ -29,6 +30,31 @@
                             type="object"/>
                 </div>
             </xpath>
+        </field>
+    </record>
+
+    <record id="l10n_in_view_partner_tree" model="ir.ui.view">
+        <field name="name">l10n.in.res.partner.tree</field>
+        <field name="model">res.partner</field>
+        <field name="inherit_id" ref="base.view_partner_tree"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='vat']" position="after">
+                <field name="l10n_in_pan_entity_id" optional="hide"/>
+            </xpath>
+        </field>
+    </record>
+
+    <record id="l10n_in_view_res_partner_filter" model="ir.ui.view">
+        <field name="name">l10n.in.view.res.partner.filter.inherit</field>
+        <field name="model">res.partner</field>
+        <field name="inherit_id" ref="base.view_res_partner_filter"/>
+        <field name="arch" type="xml">
+            <field name="user_id" position="after">
+                <field name="l10n_in_pan_entity_id"/>
+            </field>
+            <filter name="group_country" position="after">
+                <filter name="l10n_in_pan_entity_id" string="PAN" context="{'group_by': 'l10n_in_pan_entity_id'}"/>
+            </filter>
         </field>
     </record>
 

--- a/addons/l10n_in/wizard/l10n_in_withhold_wizard.xml
+++ b/addons/l10n_in/wizard/l10n_in_withhold_wizard.xml
@@ -23,7 +23,17 @@
                         <group id="header_left_group">
                             <field name="date" string="Entry Date"/>
                             <field name="base" widget="monetary" options="{'currency_field': 'currency_id'}" required="True"/>
-                            <field name="tax_id" domain="[('l10n_in_tax_type', '=', l10n_in_tds_tax_type)]" required="True"/>
+                            <label for="tax_id" string="TDS Section"/>
+                            <div>
+                                <field name="tax_id" class="oe_inline" domain="[('l10n_in_tax_type', '=', l10n_in_tds_tax_type)]" required="True"
+                                options="{'no_create': True, 'no_open': True}"/>
+                                <field name="tds_deduction" class="oe_inline"
+                                       decoration-success="tds_deduction == 'lower'"
+                                       decoration-danger="tds_deduction == 'higher'"
+                                       decoration-warning="tds_deduction == 'no'"
+                                       invisible="tds_deduction == 'normal'"
+                                />
+                            </div>
                             <field name="amount" widget="monetary" options="{'currency_field': 'currency_id'}"/>
                             <field name="currency_id" invisible="1"/> <!-- used to display the currency symbol -->
                             <field name="related_move_id" invisible="1"/> <!-- used to compute the l10n_in_tds_tax_type -->


### PR DESCRIPTION
In India, when one company operate in multiple states in each state it gets a different GST number, but they all share the same PAN number. In Odoo, each state-wise GST is usually created as a separate contact, which means multiple contacts can have the same PAN.

---

**Before this commit:**

* PAN was saved as plain text on each contact and company.

---

**After this commit:**

* A new model `l10n_in.pan.entity` is added to manage PAN separately.

* This model has:

  * `name`: the PAN number.
  * `type`: the type of entity (individual, company, etc.).
  * `tds_deduction`: defines the TDS deduction type.

    * If set to "No Deduction", the system will skip TDS warnings for any partner using that PAN.

* PAN is now linked to contacts and companies using a many2one field.

* When opening the TDS entry wizard:

  * The system automatically sets the **last used TDS tax** for that PAN, account, and section.

 Task - 4137199
 
 Enterprise PR - https://github.com/odoo/enterprise/pull/87621
 Upgrade PR - https://github.com/odoo/upgrade/pull/7865
