### PR TITLE
[IMP] core: show apt install command for missing external dependencies

### DIFF
--- a/addons/account_peppol/__manifest__.py
+++ b/addons/account_peppol/__manifest__.py
@@ -20,7 +20,10 @@
         'account_edi_ubl_cii',
     ],
     'external_dependencies': {
-        'python': ['phonenumbers']
+        'python': ['phonenumbers'],
+        'apt': {
+            'phonenumbers': 'python3-phonenumbers',
+        },
     },
     'data': [
         'data/cron.xml',

--- a/addons/auth_ldap/__manifest__.py
+++ b/addons/auth_ldap/__manifest__.py
@@ -12,6 +12,9 @@
     ],
     'external_dependencies': {
         'python': ['python-ldap'],
+        'apt': {
+            'python-ldap': 'python3-ldap',
+        },
     },
     'author': 'Odoo S.A.',
     'license': 'LGPL-3',

--- a/addons/cloud_storage_google/__manifest__.py
+++ b/addons/cloud_storage_google/__manifest__.py
@@ -9,7 +9,12 @@
     "data": [
         "views/settings.xml",
     ],
-    "external_dependencies": {"python": ["google-auth"]},
+    "external_dependencies": {
+        "python": ["google-auth"],
+        "apt": {
+            "google-auth": "python3-google-auth",
+        },
+    },
     'assets': {
         'web.assets_backend': [
             'cloud_storage_google/static/src/**/*',

--- a/addons/l10n_eg_edi_eta/__manifest__.py
+++ b/addons/l10n_eg_edi_eta/__manifest__.py
@@ -12,7 +12,6 @@ Integrates with the ETA portal to automatically send and sign the Invoices to th
     'author': 'Odoo S.A., Plementus',
     'category': 'account',
     'version': '0.2',
-    'author': 'Odoo S.A.',
     'license': 'LGPL-3',
     'depends': ['account_edi', 'l10n_eg'],
     'icon': '/account/static/description/l10n.png',
@@ -40,5 +39,8 @@ Integrates with the ETA portal to automatically send and sign the Invoices to th
     },
     'external_dependencies': {
         'python': ['asn1crypto'],
+        'apt': {
+            'asn1crypto': 'python3-asn1crypto',
+        },
     },
 }

--- a/addons/website/__manifest__.py
+++ b/addons/website/__manifest__.py
@@ -23,6 +23,9 @@
     ],
     'external_dependencies': {
         'python': ['geoip2'],
+        'apt': {
+            'geoip2': 'python3-geoip2',
+        },
     },
     'installable': True,
     'data': [

--- a/odoo/modules/__init__.py
+++ b/odoo/modules/__init__.py
@@ -10,6 +10,7 @@ from . import db  # used directly during some migration scripts
 
 from . import module
 from .module import (
+    MissingDependency,
     adapt_version,
     check_manifest_dependencies,
     check_version,


### PR DESCRIPTION
Enterprise: https://github.com/odoo/enterprise/pull/87622

The new exception:

```
27:29.654 ERROR o.registry: Failed to load registry 
27:29.654 CRITICAL o.s.server: Failed to initialize database `odoo-apt-dependencies`. 
Traceback (most recent call last):
  File "/home/julien/Odoo/community/odoo/modules/module.py", line 501, in check_python_external_dependency
    version = importlib.metadata.version(requirement.name)
  File "/usr/lib/python3.10/importlib/metadata/__init__.py", line 996, in version
    return distribution(distribution_name).version
  File "/usr/lib/python3.10/importlib/metadata/__init__.py", line 969, in distribution
    return Distribution.from_name(distribution_name)
  File "/usr/lib/python3.10/importlib/metadata/__init__.py", line 548, in from_name
    raise PackageNotFoundError(name)
importlib.metadata.PackageNotFoundError: No package metadata was found for phonenumbers

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/julien/Odoo/community/odoo/addons/base/models/ir_module.py", line 329, in check_external_dependencies
    modules.check_manifest_dependencies(terp)
  File "/home/julien/Odoo/community/odoo/modules/module.py", line 529, in check_manifest_dependencies
    check_python_external_dependency(pydep)
  File "/home/julien/Odoo/community/odoo/modules/module.py", line 511, in check_python_external_dependency
    raise MissingDependency(msg, pydep) from e
odoo.modules.module.MissingDependency: External dependency 'phonenumbers' not installed: No package metadata was found for phonenumbers

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/julien/Odoo/community/odoo/service/server.py", line 1406, in preload_registries
    registry = Registry.new(dbname, update_module=update_module, install_modules=config['init'], upgrade_modules=config['update'])
  File "<decorator-gen-6>", line 2, in new
  File "/home/julien/Odoo/community/odoo/tools/func.py", line 89, in locked
    return func(inst, *args, **kwargs)
  File "/home/julien/Odoo/community/odoo/orm/registry.py", line 173, in new
    load_modules(
  File "/home/julien/Odoo/community/odoo/modules/loading.py", line 425, in load_modules
    modules.button_install()
  File "<decorator-gen-48>", line 2, in button_install
  File "/home/julien/Odoo/community/odoo/addons/base/models/ir_module.py", line 68, in check_and_log
    return method(self, *args, **kwargs)
  File "/home/julien/Odoo/community/odoo/addons/base/models/ir_module.py", line 400, in button_install
    modules._state_update('to install', ['uninstalled'])
  File "/home/julien/Odoo/community/odoo/addons/base/models/ir_module.py", line 377, in _state_update
    self.check_external_dependencies(module.name, newstate)
  File "/home/julien/Odoo/community/odoo/addons/base/models/ir_module.py", line 349, in check_external_dependencies
    raise UserError(msg) from e
odoo.exceptions.UserError: Unable to install module "whatsapp" because an external dependency is not met: phonenumbers
It can be installed running: apt install python3-phonenumbers
```