### PR TITLE
[FIX] stock: break infinite loop in forecast replenishment

### DIFF
--- a/addons/stock/static/src/stock_forecasted/forecasted_buttons.js
+++ b/addons/stock/static/src/stock_forecasted/forecasted_buttons.js
@@ -24,7 +24,7 @@ export class ForecastedButtons extends Component {
      * @param {Object | undefined} res
      */
     _onClose(res) {
-        return res?.special || this.props.reloadReport();
+        return res?.special || !res?.noReload || this.props.reloadReport();
     }
 
     async _onClickReplenish() {

--- a/addons/stock/static/tests/tours/stock_report_tests.js
+++ b/addons/stock/static/tests/tours/stock_report_tests.js
@@ -96,3 +96,42 @@ registry.category("web_tour.tours").add("test_context_from_warehouse_filter", {
         },
     ],
 });
+
+registry.category("web_tour.tours").add("test_forecast_replenishment", {
+    steps: () => [
+        {
+            trigger: ".o_kanban_record:contains(Lovely product)",
+            run: "click",
+        },
+        {
+            trigger: "button[name=action_product_tmpl_forecast_report]",
+            run: "click",
+        },
+        {
+            trigger: "button.o_forecasted_replenish_btn",
+            run: "click",
+        },
+        {
+            trigger: ".modal-dialog .btn-close",
+            run: "click",
+        },
+        {
+            trigger: ".o_web_client:not(:has(.modal-dialog))",
+        },
+        {
+            trigger: "button.o_forecasted_replenish_btn",
+            run: "click",
+        },
+        {
+            trigger: "button[name=launch_replenishment]",
+            run: "click",
+        },
+        {
+            trigger: ".o_web_client:not(:has(.modal-dialog))",
+        },
+        {
+            trigger:
+                ".o_notification:contains(The following replenishment order have been generated)",
+        },
+    ],
+});


### PR DESCRIPTION
### Steps to reproduce:

- Create a storable product
- Click on the Forecast smart button > Replenish
- Process the dialog or close it
#### > Your browser will crash as you just started an infinite loop this can be seen in the logged by an infinite amount of `search_read` on the stock.warehouse model made to render the template an infinite amount of time.

### Cause of the issue:

Closing on replenish will open a dialog. Closing this dialog will in turn call its `_onClose` method:
https://github.com/odoo/odoo/blob/ef356e1f803a6f82811a83f5b8a8dd54ef41cf32/addons/stock/static/src/stock_forecasted/forecasted_buttons.js#L26-L28 Now the issue is that `res` does nto contains a special key and hence the `reloadReport` call will execute an `ir.actions.client` to relaod the forecast page:
https://github.com/odoo/odoo/blob/ef356e1f803a6f82811a83f5b8a8dd54ef41cf32/addons/stock/static/src/stock_forecasted/stock_forecasted.js#L97-L106 This is highly problematic since executing such an action will call the `_updateUi` method and hence close all existing dialog: https://github.com/odoo/odoo/blob/ef356e1f803a6f82811a83f5b8a8dd54ef41cf32/addons/web/static/src/webclient/actions/action_service.js#L1274 https://github.com/odoo/odoo/blob/ef356e1f803a6f82811a83f5b8a8dd54ef41cf32/addons/web/static/src/webclient/actions/action_service.js#L1111 Since our dialog hasn't been closed yet this will in turn call back the `_onClose` that started this call resulting in this chain of action: `_onClose -> updateUi -> closeAll -> _onClose -> ...` And, since the `noReload` parameter is not used in our `_onClose` we end up in an infinite loop.

### Note:

The infinite loop has become possible since saas-18.1 see commit d606be75c44fccf0b1ddf5216892f1d4b7162686
which changes the order on which a dialog is closed and its call back  method called (onClose). Prior to that change the dialog was closed and  then its call back called. It is now the opposite so that if the onClose of a dialog triggers an action closing all dialogs, it will in turn call the onClose of the dialog one more time. The way to avoid infinite recursion is therefore to ensure that the `noReload` parameter of the onClose is correctly used as introduced here:
https://github.com/odoo/odoo/commit/d606be75c44fccf0b1ddf5216892f1d4b7162686#diff-552aefb62246b1f4fe6a2607ec8f0a01773e53de2d68293266b38bc99c5cb56dL1123-R1108

opw-4847129
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
