### PR TITLE
[IMP] event: track changes in date_closed to manage multi-day events

### DIFF
--- a/addons/event/static/src/client_action/event_registration_summary_dialog.js
+++ b/addons/event/static/src/client_action/event_registration_summary_dialog.js
@@ -30,6 +30,7 @@ export class EventRegistrationSummaryDialog extends Component {
         this.orm = useService("orm");
         this.notification = useService("notification");
         this.continueButtonRef = useRef("continueButton");
+        this.button = useState({enabled: true});
 
         this.registrationStatus = useState({value: this.registration.status});
         const storedPrintSettings = browser.localStorage.getItem(PRINT_SETTINGS_LOCAL_STORAGE_KEY);
@@ -82,8 +83,11 @@ export class EventRegistrationSummaryDialog extends Component {
     }
 
     async onRegistrationConfirm() {
-        await this.orm.call("event.registration", "action_set_done", [this.registration.id]);
-        this.registrationStatus.value = "confirmed_registration";
+        if (this.registrationStatus.value !== "confirmed_registration") {
+            this.button.enabled = false
+            await this.orm.call("event.registration", "action_set_done", [this.registration.id]).catch(() => this.button.enabled = true);
+            this.registrationStatus.value = "confirmed_registration";
+        }
         this.props.close();
         if (this.props.model) {
             this.props.model.load();

--- a/addons/event/static/src/client_action/event_registration_summary_dialog.xml
+++ b/addons/event/static/src/client_action/event_registration_summary_dialog.xml
@@ -26,7 +26,12 @@
                             <span>Cancelled registration</span>
                         </t>
                         <t t-elif="registrationStatus.value == 'already_registered'">
-                            <span>Ticket already scanned!</span>
+                            <t t-if="!registration.is_date_closed_today">
+                                <span>Ticket was first scanned on <t t-esc="registration.date_closed_formatted"/></span>
+                            </t>
+                            <t t-else="">
+                                <span>Ticket already scanned!</span>
+                            </t>
                         </t>
                         <button type="button" class="btn btn-link ms-3 ms-sm-5" t-on-click="undoRegistration">
                             Undo
@@ -74,7 +79,7 @@
                 </div>
             </div>
             <t t-set-slot="footer">
-                <button t-ref="continueButton" class="btn btn-primary" t-on-click="() => this.onRegistrationConfirm()">Continue</button>
+                <button t-att-disabled="!button.enabled" t-ref="continueButton" class="btn btn-primary" t-on-click="() => this.onRegistrationConfirm()">Continue</button>
                 <button t-att-disabled="!hasSelectedPrinter()" class="btn btn-primary" t-on-click="() => this.onRegistrationPrintPdf()">Print</button>
                 <button class="btn btn-secondary" t-on-click="() => this.onRegistrationView()">Edit</button>
             </t>


### PR DESCRIPTION
**Purpose:**
If there is a multi-day event, there's no way manage attendance for each day.

**Specifications:**
- When ticket is scanned show log in chatter.
- In the Registration Desk, when scanning or manually selecting an attendee, if the attendee is already marked as `done` but today's date is different from the current `date_closed`, update the warning message to 'Ticket was last scanned on `<DATE>`'

Task-4864066