### PR TITLE
[FIX] hr_recruitment: prevent creating mail templates with empty model

### DIFF
--- a/addons/hr_recruitment/views/hr_recruitment_stage_views.xml
+++ b/addons/hr_recruitment/views/hr_recruitment_stage_views.xml
@@ -64,7 +64,7 @@
                         <group>
                             <field name="name"/>
                             <field name="sequence" groups="base.group_no_one"/>
-                            <field name="template_id" domain= "[('model_id.model', '=', 'hr.applicant')]"/>
+                            <field name="template_id" domain= "[('model_id.model', '=', 'hr.applicant')]" options="{'no_quick_create': True}"/>
                         </group>
                         <group name="stage_details">
                             <field name="fold"/>


### PR DESCRIPTION
An error occurs when a user quickly creates a template for a stage, bypassing the validation of the `Applies to` field. As a result, an error is triggered when the user selects a stage that uses that template.

**Steps to reproduce:**
* Install `hr_recruitment`
* hr_recruitment>Configuration>Stages>stage named `New`>Quick Create a mail template with random name and save.
* Applications>All Applications>New application>Set stage to `New`

`KeyError:False`

**Solution:**
* Disable quick create as to prevent creating mail templates with empty model ids.

 **Sentry-6675399135**

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
