### PR TITLE
[FIX] point_of_sale: correct cash in/out time and date label in cash move detail

### DIFF
--- a/addons/point_of_sale/static/src/app/components/popups/cash_move_popup/cash_move_list_popup/cash_move_list_popup.xml
+++ b/addons/point_of_sale/static/src/app/components/popups/cash_move_popup/cash_move_list_popup/cash_move_list_popup.xml
@@ -10,15 +10,15 @@
                             <t t-foreach="props.cashMoves" t-as="cm" t-key="cm.id">
                                 <tr class="cash-move-row" >
                                     <td>
-                                        <div class="fs-6 fw-bolder"><t t-esc="this.pos.getDate(cm.date)"></t></div>
-                                        <div class="small text-muted"><t t-esc="this.pos.getTime(cm.date)"></t></div>
+                                        <div class="cash-move-date fs-6 fw-bolder"><t t-esc="this.pos.getDate(cm.date)"></t></div>
+                                        <div class="cash-move-time small text-muted"><t t-esc="this.pos.getTime(cm.date)"></t></div>
                                     </td>
                                     <td>
                                         <t t-if="cm.cashier_name" t-esc="cm.cashier_name"/>
                                     </td>
                                     <td class="align-middle text-end">
                                         <t t-set="status" t-value="getStatus(cm)" />
-                                        <div t-attf-class="w-50 text-center badge rounded fs-6 text-bg-{{status === 'In' ? 'success' : 'danger'}}">
+                                        <div t-attf-class="text-center badge rounded fs-6 text-bg-{{status === 'In' ? 'success' : 'danger'}}">
                                             <t t-esc="status"></t>
                                         </div>
                                     </td>
@@ -42,8 +42,8 @@
                         <div class="container">
                             <div class="cash-move-row row">
                                 <div class="col-2 align-self-center">
-                                        <div class="fw-bolder"><t t-esc="this.pos.getDate(cm.date)"></t></div>
-                                        <div class="small text-muted"><t t-esc="this.pos.getTime(cm.date)"></t></div>
+                                        <div class="cash-move-date fw-bolder"><t t-esc="this.pos.getDate(cm.date)"></t></div>
+                                        <div class="cash-move-time small text-muted"><t t-esc="this.pos.getTime(cm.date)"></t></div>
                                 </div>
                                 <div class="col-3 align-self-center">
                                     <t t-if="cm.cashier_name" t-esc="cm.cashier_name"/>

--- a/addons/point_of_sale/static/src/app/components/popups/cash_move_popup/cash_move_popup.js
+++ b/addons/point_of_sale/static/src/app/components/popups/cash_move_popup/cash_move_popup.js
@@ -108,7 +108,10 @@ export class CashMovePopup extends Component {
             this.pos.session.id,
         ]);
         this.dialog.add(CashMoveListPopup, {
-            cashMoves: cashMoves.map((m) => ({ ...m, date: DateTime.fromSQL(m.date) })),
+            cashMoves: cashMoves.map((m) => ({
+                ...m,
+                date: DateTime.fromSQL(m.date, { zone: "UTC" }).setZone("local"),
+            })),
             partnerId: this.partnerId,
         });
     }

--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -2438,7 +2438,7 @@ export class PosStore extends WithLazyGetterTrap {
     }
     getDate(date) {
         const todayTs = DateTime.now().startOf("day").ts;
-        if (DateTime.fromSQL(date, { zone: "utc" }).toLocal().startOf("day").ts === todayTs) {
+        if (date.toLocal().startOf("day").ts === todayTs) {
             return _t("Today");
         } else {
             return formatDate(date);

--- a/addons/point_of_sale/static/tests/pos/tours/chrome_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/chrome_tour.js
@@ -203,6 +203,7 @@ registry.category("web_tour.tours").add("test_cash_in_out", {
         [
             Chrome.startPoS(),
             Dialog.confirm("Open Register"),
+            Chrome.freezeDateTime(1749965940000),
             Chrome.doCashMove("10", "MOBT in"),
             Chrome.doCashMove("5", "MOBT out"),
             Chrome.clickMenuOption("Close Register"),
@@ -211,6 +212,7 @@ registry.category("web_tour.tours").add("test_cash_in_out", {
             CashMoveList.checkNumberOfRows(2),
             CashMoveList.checkCashMoveShown("10"),
             CashMoveList.checkCashMoveShown("5"),
+            CashMoveList.checkCashMoveDateTime(),
             CashMoveList.deleteCashMove("10"),
             CashMoveList.checkNumberOfRows(1),
             CashMoveList.checkCashMoveShown("5"),

--- a/addons/point_of_sale/static/tests/pos/tours/utils/cash_move_list_util.js
+++ b/addons/point_of_sale/static/tests/pos/tours/utils/cash_move_list_util.js
@@ -28,3 +28,11 @@ export function checkNumberOfRows(number) {
         },
     };
 }
+export function checkCashMoveDateTime() {
+    const date = "Today";
+    const time = "11:09";
+    return {
+        content: `Check has cash move with Date: ${date} and Time: ${time}`,
+        trigger: `.cash-move-list .cash-move-row:has(.cash-move-date:contains(${date})):has(.cash-move-time:contains(${time}))`,
+    };
+}

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -13,6 +13,7 @@ from odoo.addons.point_of_sale.tests.common_setup_methods import setup_product_c
 from datetime import date, timedelta
 from odoo.addons.point_of_sale.tests.common import archive_products
 from odoo.exceptions import UserError
+from freezegun import freeze_time
 
 _logger = logging.getLogger(__name__)
 
@@ -1801,6 +1802,7 @@ class TestUi(TestPointOfSaleHttpCommon):
         self.main_pos_config.with_user(self.pos_user).open_ui()
         self.start_tour(f"/pos/ui?config_id={self.main_pos_config.id}", 'ProductCardUoMPrecision', login="pos_user")
 
+    @freeze_time("2025-06-15 11:09")
     def test_cash_in_out(self):
         self.pos_user.write({
             'group_ids': [


### PR DESCRIPTION
Before this commit:
===================
- Cash in/out time was displayed incorrectly, not reflecting the local timezone.
- Today's cash in/out date was shown as the actual date instead of using the `Today` label.
- The cash in/out label was not properly aligned for responsive UI.

Issue:
======
- The datetime was stored in UTC but interpreted using the system timezone, causing a mismatch.
- The value was already a DateTime object but was unnecessarily re-parsed, leading to incorrect results.

After this commit:
==================
- Cash in/out time now displays correctly according to the local timezone.
- Today's date is properly labeled as `Today` instead of displaying the date directly.
- Cash in/out labels are properly aligned and displayed across different screen sizes for responsive UI.

Task-4862777

