### PR TITLE
[FIX] html_builder: check only a string value

### DIFF
--- a/addons/html_builder/static/src/core/core_builder_action_plugin.js
+++ b/addons/html_builder/static/src/core/core_builder_action_plugin.js
@@ -6,6 +6,7 @@ import {
     normalizeColor,
 } from "@html_builder/utils/utils_css";
 import { BuilderAction } from "@html_builder/core/builder_action";
+import { getValueFromVar } from "@html_builder/utils/utils";
 
 export function withoutTransition(editingElement, callback) {
     if (editingElement.classList.contains("o_we_force_no_transition")) {
@@ -170,8 +171,7 @@ class DataAttributeAction extends BuilderAction {
     }
     isApplied({ editingElement, params: { mainParam: attributeName } = {}, value }) {
         if (value) {
-            const match = value.match(/^var\(--(.*)\)$/);
-            value = match ? match[1] : value;
+            value = getValueFromVar(value.toString());
             return editingElement.dataset[attributeName] === value;
         } else {
             return !(attributeName in editingElement.dataset);
@@ -179,8 +179,7 @@ class DataAttributeAction extends BuilderAction {
     }
     apply({ editingElement, params: { mainParam: attributeName } = {}, value }) {
         if (value) {
-            const match = value.match(/^var\(--(.*)\)$/);
-            value = match ? match[1] : value;
+            value = getValueFromVar(value.toString());
             editingElement.dataset[attributeName] = value;
         } else {
             delete editingElement.dataset[attributeName];

--- a/addons/website/static/tests/builder/builder_action.test.js
+++ b/addons/website/static/tests/builder/builder_action.test.js
@@ -177,6 +177,18 @@ describe("HTML builder tests", () => {
         expect.verifySteps(["prepare"]);
     });
 
+    test("Data Attribute action works with non string values", async () => {
+        addBuilderOption({
+            selector: ".s_test",
+            template: xml`<BuilderButton dataAttributeAction="'customerOrderIds'" dataAttributeActionValue="[100, 200]">Click</BuilderButton>`,
+        });
+        await setupHTMLBuilder(`<section class="s_test">Test</section>`);
+        await contains(":iframe .s_test").click();
+        await contains(".we-bg-options-container button:contains('Click')").click();
+        expect(".we-bg-options-container button:contains('Click')").toHaveClass("active");
+        expect(":iframe .s_test").toHaveAttribute("data-customer-order-ids", "100,200");
+    });
+
     describe("isPreviewing is passed to action's apply and clean", () => {
         beforeEach(async () => {
             addBuilderAction({


### PR DESCRIPTION
In some cases the value passed might be not string (e.g. a number), 
so we don't need to check if it starts with ('var(--)'). Also, since the data-* attributes
are always strings we need to convert the value to a string when comparing them.
To replicate the error, open website and start editing, drop a "Discussion Group" snippet, 
click on  it, go to the Discussion Group option and change its value to something else
=> We have an error. 
This commit follows [the html_builder refactoring].

[the html_builder refactoring]: odoo/odoo@9fe45e2b7ddb

Related to task-4367641