### PR TITLE
[FIX] website, website{_blog,_forum}: consistent highlighting of website menus buttons

### DIFF
--- a/addons/website_blog/models/__init__.py
+++ b/addons/website_blog/models/__init__.py
@@ -3,4 +3,5 @@
 
 from . import website
 from . import website_blog
+from . import website_menu
 from . import website_snippet_filter

--- a/addons/website_blog/models/website_menu.py
+++ b/addons/website_blog/models/website_menu.py
@@ -1,0 +1,10 @@
+from odoo import models
+
+
+class WebsiteMenu(models.Model):
+    _inherit = 'website.menu'
+
+    def _get_current_pages_and_models_dict(self):
+        return super()._get_current_pages_and_models_dict() | {
+            "blog": "blog.blog",
+        }

--- a/addons/website_blog/tests/test_performance.py
+++ b/addons/website_blog/tests/test_performance.py
@@ -50,7 +50,7 @@ class TestBlogPerformance(UtilPerf):
         self.assertEqual(self._get_url_hot_query('/blog'), 10)
         self.assertLessEqual(self._get_url_hot_query('/blog', cache=False), 33)
         self.assertLessEqual(self._get_url_hot_query(blog_post[0].website_url), 21)
-        self.assertLessEqual(self._get_url_hot_query(blog_post[0].website_url, cache=False), 24)
+        self.assertLessEqual(self._get_url_hot_query(blog_post[0].website_url, cache=False), 25)
 
     def test_30_perf_sql_blog_bigger_data_scaling(self):
         BlogPost = self.env['blog.post']
@@ -65,4 +65,4 @@ class TestBlogPerformance(UtilPerf):
         self.assertLessEqual(self._get_url_hot_query('/blog'), 29)
         self.assertLessEqual(self._get_url_hot_query('/blog', cache=False), 71)
         self.assertLessEqual(self._get_url_hot_query(blog_post[0].website_url), 34)
-        self.assertLessEqual(self._get_url_hot_query(blog_post[0].website_url, cache=False), 33)
+        self.assertLessEqual(self._get_url_hot_query(blog_post[0].website_url, cache=False), 34)

--- a/addons/website_forum/models/__init__.py
+++ b/addons/website_forum/models/__init__.py
@@ -10,3 +10,4 @@ from . import gamification_karma_tracking
 from . import ir_attachment
 from . import res_users
 from . import website
+from . import website_menu

--- a/addons/website_forum/models/website_menu.py
+++ b/addons/website_forum/models/website_menu.py
@@ -1,0 +1,10 @@
+from odoo import models
+
+
+class WebsiteMenu(models.Model):
+    _inherit = 'website.menu'
+
+    def _get_current_pages_and_models_dict(self):
+        return super()._get_current_pages_and_models_dict() | {
+            "forum": "forum.forum",
+        }

--- a/addons/website_forum/tests/test_performance.py
+++ b/addons/website_forum/tests/test_performance.py
@@ -36,7 +36,7 @@ class TestForumPerformance(UtilPerf):
         number_of_queries = self._get_url_hot_query(self.post.website_url)
         self.assertEqual(number_of_queries, 21)
         number_of_queries = self._get_url_hot_query(self.post.website_url, cache=False)
-        self.assertLessEqual(number_of_queries, 25)
+        self.assertLessEqual(number_of_queries, 26)
 
     def test_perf_sql_forum_scaling_answers(self):
         self.env['forum.tag'].create([
@@ -65,7 +65,7 @@ class TestForumPerformance(UtilPerf):
         number_of_queries = self._get_url_hot_query(self.post.website_url)
         self.assertEqual(number_of_queries, 24)
         number_of_queries = self._get_url_hot_query(self.post.website_url, cache=False)
-        self.assertLessEqual(number_of_queries, 28)
+        self.assertLessEqual(number_of_queries, 29)
 
     def test_perf_sql_forum_scaling_posts(self):
         self.env['forum.post'].create([
@@ -85,4 +85,4 @@ class TestForumPerformance(UtilPerf):
         number_of_queries = self._get_url_hot_query(self.forum._compute_website_url())
         self.assertEqual(number_of_queries, 24)
         number_of_queries = self._get_url_hot_query(self.forum._compute_website_url(), cache=False)
-        self.assertLessEqual(number_of_queries, 29)
+        self.assertLessEqual(number_of_queries, 30)


### PR DESCRIPTION
[FIX] website, website{_blog,_forum}: consistent highlighting of website menus buttons

**Issue**
When they have only one child, menu buttons (for Help, Appointment, Blog and
Forum) in the "roundex box menu" layout are not highlighted.

**Steps to reproduce**
Example with Forum:
- Create a single forum visible from the website.
- Click on the "Forum" menu
==> The button is not highlighted.
(Note: Same steps apply to the other menus listed above.)

**Explanation**
The bug occurs because a redirection is made to the child. Instead of going to
"base/forum", we're directly redirected to "base/forum/forum-1".

**Fix**
We add the url page name (key) and its model name (value) of the "problematic" menus to
a dictionary. Then a regex checks whether the url accessed is a redirected url.
In this case, we set the `active` field to True.

Note: Some performance tests on the number of requests have been incremented by 1
to compensate an added search.

ENT PR: odoo/enterprise#87624
Task-4791681