### PR TITLE
[FIX] html_builder: redispatch click after dropping snippet

### DIFF
--- a/addons/html_builder/static/src/core/builder_options_plugin.js
+++ b/addons/html_builder/static/src/core/builder_options_plugin.js
@@ -93,7 +93,9 @@ export class BuilderOptionsPlugin extends Plugin {
     }
 
     onClick(ev) {
-        this.updateContainers(ev.target);
+        this.dependencies.operation.next(() => {
+            this.updateContainers(ev.target);
+        });
     }
 
     getReloadSelector(editingElement) {

--- a/addons/html_builder/static/src/sidebar/block_tab.js
+++ b/addons/html_builder/static/src/sidebar/block_tab.js
@@ -113,7 +113,10 @@ export class BlockTab extends Component {
                 this.state.ongoingInsertion = false;
                 delete this.cancelDragAndDrop;
             },
-            { withLoadingEffect: false }
+            {
+                withLoadingEffect: false,
+                shouldInterceptClick: true,
+            }
         );
     }
 
@@ -385,7 +388,10 @@ export class BlockTab extends Component {
                             async () => {
                                 await this.onSnippetGroupDrop(snippet, snippetEl);
                             },
-                            { withLoadingEffect: false }
+                            {
+                                withLoadingEffect: false,
+                                shouldInterceptClick: true,
+                            }
                         );
                     }
                 } else {

--- a/addons/html_builder/static/tests/block_tab.test.js
+++ b/addons/html_builder/static/tests/block_tab.test.js
@@ -1,0 +1,69 @@
+import { expect, test } from "@odoo/hoot";
+import { animationFrame, click, Deferred, queryOne, waitFor } from "@odoo/hoot-dom";
+import { loadBundle } from "@web/core/assets";
+import { contains, patchWithCleanup } from "@web/../tests/web_test_helpers";
+import { BuilderOptionsPlugin } from "@html_builder/core/builder_options_plugin";
+import { Operation } from "@html_builder/core/operation";
+import { setupHTMLBuilder } from "./helpers";
+
+test.tags("desktop");
+test("click just after drop is redispatched in next operation", async () => {
+    const nextDef = new Deferred();
+    patchWithCleanup(Operation.prototype, {
+        next(fn, ...args) {
+            const originalFn = fn;
+            fn = async () => {
+                await originalFn();
+                nextDef.resolve();
+            };
+            expect.step(`next${args[0]?.shouldInterceptClick ? " should intercept" : ""}`);
+            const res = super.next(fn, ...args);
+            return res;
+        },
+    });
+    patchWithCleanup(BuilderOptionsPlugin.prototype, {
+        async onClick(ev) {
+            expect.step("onClick");
+            super.onClick(ev);
+        },
+        updateContainers(...args) {
+            expect.step("updateContainers");
+            super.updateContainers(...args);
+        },
+    });
+    await setupHTMLBuilder("", {
+        styleContent: /*css*/ `
+            .o_loading_screen {
+                position: absolute;
+                inset: 0;
+            }
+            section {
+                height: 100%; /* to easily target */
+            }`,
+    });
+
+    // TODO: the next lines replicate website's `insertCategorySnippet` helper.
+    // It should be moved to html_builder.
+    await contains(".o-snippets-menu #snippet_groups .o_snippet_thumbnail_area").click();
+    await animationFrame();
+    await loadBundle("html_builder.iframe_add_dialog", {
+        targetDoc: queryOne("iframe.o_add_snippet_iframe").contentDocument,
+        js: false,
+    });
+    await waitFor(".o_add_snippet_dialog iframe.show.o_add_snippet_iframe");
+    await contains(
+        ".o_add_snippet_dialog .o_add_snippet_iframe:iframe .o_snippet_preview_wrap"
+    ).click();
+    await animationFrame();
+    expect.verifySteps(["next should intercept"]); // On snippet selected
+
+    await waitFor(":iframe .o_loading_screen");
+    await click(":iframe", { position: { x: 200, y: 50 }, relative: true });
+    expect.verifySteps(["next"]); // On click
+    await nextDef;
+    expect.verifySteps(["updateContainers"]); // End of drop, on addStep()
+    await animationFrame();
+    expect.verifySteps(["onClick", "next", "updateContainers"]); // On click redispatched
+    await animationFrame();
+    expect(".o-snippets-tabs .o-hb-btn.active").toHaveText("Edit");
+});

--- a/addons/html_builder/static/tests/helpers.js
+++ b/addons/html_builder/static/tests/helpers.js
@@ -9,7 +9,7 @@ import { MAIN_PLUGINS } from "@html_editor/plugin_sets";
 import { withSequence } from "@html_editor/utils/resource";
 import { defineMailModels } from "@mail/../tests/mail_test_helpers";
 import { after } from "@odoo/hoot";
-import { animationFrame } from "@odoo/hoot-dom";
+import { animationFrame, queryOne } from "@odoo/hoot-dom";
 import { Component, onMounted, useRef, useState, useSubEnv, xml } from "@odoo/owl";
 import {
     defineModels,
@@ -124,7 +124,10 @@ class IrUiView extends models.Model {
     }
 }
 
-export async function setupHTMLBuilder(content = "", { snippetContent, dropzoneSelectors } = {}) {
+export async function setupHTMLBuilder(
+    content = "",
+    { snippetContent, dropzoneSelectors, styleContent } = {}
+) {
     defineMailModels(); // fuck this shit
 
     defineModels([IrUiView]);
@@ -200,6 +203,12 @@ export async function setupHTMLBuilder(content = "", { snippetContent, dropzoneS
     });
     const comp = await mountWithCleanup(BuilderContainer, { props: { content, Plugins } });
     await comp.iframeLoaded;
+    if (styleContent) {
+        const iframeDocument = queryOne(":iframe");
+        const styleEl = iframeDocument.createElement("style");
+        styleEl.textContent = styleContent;
+        iframeDocument.head.appendChild(styleEl);
+    }
     comp.state.isEditing = true;
     await prom;
     await animationFrame();


### PR DESCRIPTION
Steps to reproduce:
1. Add a block into your page
2. Click immediately inside
=> The block is not selected, you have to wait the end of the invisible
loading element to be able to click.
This was not the case in 18.3.

While this commit does not remove the delay, it catches clicks made
while the iframe is blocked and redispatches them once it is freed. This
delay is needed to avoid rogue steps and conflicts in the history:
accepting the click immediately creates a snapshot of the selection,
which could appear in the middle of the mutations done by dropping the
snippet. If you then make some change and want to undo it, it would be
impossible to revert to a stable state.

[task-4367641](https://www.odoo.com/web#id=4367641&cids=1&menu_id=4720&action=333&active_id=1695&model=project.task&view_type=form)