### PR TITLE
[IMP] website: make carousel slides linkable

### DIFF
--- a/addons/website/static/src/builder/plugins/options/carousel_slides_option.xml
+++ b/addons/website/static/src/builder/plugins/options/carousel_slides_option.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+
+<t t-name="website.CarouselSlidesOption">
+    <BuilderRow label.translate="Make it clickable" tooltip.translate="Enable to make the slide clickable">
+        <BuilderCheckbox id="'make_slide_clickable_opt'" action="'makeSlideClickable'" classAction="'clickable-slide'"/>
+    </BuilderRow>
+
+    <BuilderRow t-if="isActiveItem('make_slide_clickable_opt')" label.translate="Your URL" level="1">
+        <WebsiteUrlPicker title.translate="Your URL"
+            action="'setSlideAnchorUrl'"
+            placeholder.translate="e.g. /your-website-page"/>
+    </BuilderRow>
+
+    <BuilderRow label.translate="Open in New Tab" tooltip.translate="Enable this to open the link in a new browser tab" level="1">
+        <BuilderCheckbox applyTo="'.slide-link'" attributeAction="'target'" attributeActionValue="'_blank'" preview="false"/>
+    </BuilderRow>
+</t>
+
+</templates>

--- a/addons/website/static/src/builder/plugins/options/carousel_slides_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/carousel_slides_option_plugin.js
@@ -1,0 +1,89 @@
+import { BuilderAction } from "@html_builder/core/builder_action";
+import { SNIPPET_SPECIFIC_END } from "@html_builder/utils/option_sequence";
+import { Plugin } from "@html_editor/plugin";
+import { withSequence } from "@html_editor/utils/resource";
+import { registry } from "@web/core/registry";
+
+export class CarouselSlidesOptionPlugin extends Plugin {
+    static id = "carouselSlidesOption";
+    resources = {
+        builder_options: [
+            withSequence(SNIPPET_SPECIFIC_END, {
+                template: "website.CarouselSlidesOption",
+                selector: ".carousel .carousel-item",
+                exclude: ".s_image_gallery .carousel-item",
+            }),
+        ],
+        builder_actions: {
+            MakeSlideClickableAction,
+            SetSlideAnchorUrlAction,
+        },
+        clean_for_save_handlers: this.cleanForSave.bind(this),
+    };
+
+    /**
+     * Remove `clickable-slide` class from slides when there is no link element.
+     * TODO: Find a better approach. The class is currently used so the "active"
+     * state of the `BuilderCheckbox` can be taken into account.
+     * It would probably be better to handle this via an option state, or adapt
+     * the`BuilderCheckbox to expose its 'checkbox active state' when no action
+     * is linked to it...
+     *
+     * @param {HTMLElement} root
+     */
+    cleanForSave({ root }) {
+        const noLinkSlideEls = root.querySelectorAll(
+            ".carousel-item.clickable-slide:not(:has(.slide-link))"
+        );
+        for (const slideEl of noLinkSlideEls) {
+            slideEl.classList.remove("clickable-slide");
+        }
+    }
+}
+
+class MakeSlideClickableAction extends BuilderAction {
+    static id = "makeSlideClickable";
+    setup() {
+        this.preview = false;
+    }
+    clean({ editingElement }) {
+        // Remove unnecessary link from the slide when toggled off.
+        const linkEl = editingElement.querySelector("a.slide-link");
+        linkEl?.remove();
+    }
+}
+
+/**
+ * Custom action to add, update, or remove a slide-link for clickable carousel
+ * slides.
+ */
+class SetSlideAnchorUrlAction extends BuilderAction {
+    static id = "setSlideAnchorUrl";
+    setup() {
+        this.preview = false;
+    }
+    apply({ editingElement, value }) {
+        const url = value;
+        const linkEl = editingElement.querySelector("a.slide-link");
+
+        if (!url) {
+            linkEl.remove();
+            return;
+        }
+        if (linkEl) {
+            linkEl.setAttribute("href", url);
+            return;
+        }
+        const anchorEl = document.createElement("a");
+        anchorEl.className = "slide-link position-absolute top-0 start-0 w-100 h-100 d-none";
+        anchorEl.setAttribute("href", url);
+        anchorEl.style.zIndex = 100;
+        editingElement.prepend(anchorEl);
+    }
+    getValue({ editingElement }) {
+        const linkEl = editingElement.querySelector("a.slide-link");
+        return linkEl?.getAttribute("href") || "";
+    }
+}
+
+registry.category("website-plugins").add(CarouselSlidesOptionPlugin.id, CarouselSlidesOptionPlugin);

--- a/addons/website/static/src/interactions/carousel/carousel_slider.edit.js
+++ b/addons/website/static/src/interactions/carousel/carousel_slider.edit.js
@@ -11,6 +11,7 @@ const CarouselSliderEdit = I => class extends I {
     };
     // Pause carousel in edit mode.
     carouselOptions = { ride: false, pause: true };
+    showClickableSlideLinks = false;
 
     onContentChanged() {
         this.computeMaxHeight();

--- a/addons/website/static/src/interactions/carousel/carousel_slider.js
+++ b/addons/website/static/src/interactions/carousel/carousel_slider.js
@@ -20,8 +20,10 @@ export class CarouselSlider extends Interaction {
                 "min-height": this.maxHeight ? `${this.maxHeight}px` : "",
             }),
         },
+        ".slide-link": { "t-att-class": () => ({ "d-none": !this.showClickableSlideLinks }) },
     };
     carouselOptions = undefined;
+    showClickableSlideLinks = true;
 
     static OLD_AUTO_SLIDING_SNIPPETS = ["s_image_gallery"];
     setup() {

--- a/addons/website/static/src/scss/website.scss
+++ b/addons/website/static/src/scss/website.scss
@@ -887,6 +887,8 @@ $-o-carousel-indicators-dots-size: .75rem;
 $-o-carousel-controllers-size: var(--CarouselControllers-size, #{map-get($spacers, 5)});
 
 %o_horizontal_controllers {
+    pointer-events: none;
+
     @include media-breakpoint-up(md) {
         .carousel-indicators {
             position: relative;
@@ -897,6 +899,12 @@ $-o-carousel-controllers-size: var(--CarouselControllers-size, #{map-get($spacer
             position: relative;
             width: auto;
         }
+    }
+
+    // Allow clicks to pass through the carousel control's wrapper, while
+    // keeping the control buttons/indicators clickable.
+    .carousel-indicators > *, .carousel-control-prev, .carousel-control-next {
+        pointer-events: auto;
     }
 
     .o_arrows_wrapper {
@@ -1090,6 +1098,15 @@ $-o-carousel-controllers-size: var(--CarouselControllers-size, #{map-get($spacer
     .carousel-control-next,
     .carousel-indicators {
         position: absolute;
+    }
+
+    // Allow clicks to pass through the carousel control's wrapper, while
+    // keeping the control indicators clickable.
+    .carousel-indicators {
+        pointer-events: none;
+        > * {
+            pointer-events: auto;
+        }
     }
 
     .carousel-control-prev-icon, .carousel-control-next-icon {

--- a/addons/website/tests/test_ui.py
+++ b/addons/website/tests/test_ui.py
@@ -707,6 +707,9 @@ class TestUi(HttpCaseWithWebsiteUser):
     def test_snippet_carousel_autoplay(self):
         self.start_tour("/", "snippet_carousel_autoplay", login="admin")
 
+    def test_snippet_carousel_clickable_slides(self):
+        self.start_tour("/", "snippet_carousel_clickable_slides", login="admin")
+
     def test_media_iframe_video(self):
         self.start_tour("/", "website_media_iframe_video", login="admin")
 


### PR DESCRIPTION
**Previously**, users were unable to make an entire carousel slide clickable
to redirect to a target page. This limitation negatively impacted both
user experience and conversion rates.

**After this improvement**, all carousel-type snippets (except 
`s_image_gallery`, which already supports clickable images) now provide 
a 'Make it clickable' option, which allows the user to make the selected
slide clickable. This setting is slide-specific and other slides are 
unaffected.

The above option adds the following controls per slide when enabled:

1. Your URL (input field)
   Lets the user enter a target URL. Once entered, the selected slide
   becomes clickable and redirects visitors to that URL.

2. Open in New Tab (toggle)
   Enables the URL to open in a new browser tab.

**Note:**  
- Once the slide is made clickable, any elements placed inside it will
  no longer be interactive.
- Slides are not clickable in editing mode to avoid interfering
  with drag-and-drop or content editing.

task-4835986

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
