### PR TITLE
[IMP] hr: revert gender field renaming

### DIFF
--- a/addons/hr/models/hr_version.py
+++ b/addons/hr/models/hr_version.py
@@ -58,7 +58,7 @@ class HrVersion(models.Model):
         ('male', 'Male'),
         ('female', 'Female'),
         ('other', 'Other'),
-    ], groups="hr.group_hr_user", tracking=True, help="This is the legal sex recognized by the state.")
+    ], groups="hr.group_hr_user", tracking=True, help="This is the legal sex recognized by the state.", string='Gender')
 
     private_street = fields.Char(string="Private Street", groups="hr.group_hr_user")
     private_street2 = fields.Char(string="Private Street2", groups="hr.group_hr_user")


### PR DESCRIPTION
Originally, there was a field named gender for the employee. In the last update, gender field has been renamed to sex. To tackle this issue, the string parameter for the field has been updated to 'Gender', so as to avoid changing the whole code base.

