### PR TITLE
[FIX] base: change the decimal point depending on language

### DIFF
--- a/odoo/addons/base/models/res_lang.py
+++ b/odoo/addons/base/models/res_lang.py
@@ -408,12 +408,13 @@ class ResLang(models.Model):
 
         formatted = percent % value
 
+        data = self._get_data(id=self.id)
+        if not data:
+            raise UserError(_("The language %s is not installed.", self.name))
+        decimal_point = data.decimal_point
         # floats and decimal ints need special action!
         if grouping:
-            data = self._get_data(id=self.id)
-            if not data:
-                raise UserError(_("The language %s is not installed.", self.name))
-            lang_grouping, thousands_sep, decimal_point = data.grouping, data.thousands_sep or '', data.decimal_point
+            lang_grouping, thousands_sep = data.grouping, data.thousands_sep or ''
             eval_lang_grouping = ast.literal_eval(lang_grouping)
 
             if percent[-1] in 'eEfFgG':
@@ -424,6 +425,9 @@ class ResLang(models.Model):
 
             elif percent[-1] in 'diu':
                 formatted = intersperse(formatted, eval_lang_grouping, thousands_sep)[0]
+
+        elif percent[-1] in 'eEfFgG' and '.' in formatted:
+            formatted = formatted.replace('.', decimal_point)
 
         return formatted
 

--- a/odoo/addons/base/tests/test_misc.py
+++ b/odoo/addons/base/tests/test_misc.py
@@ -370,7 +370,7 @@ class TestFormatLang(TransactionCase):
         self.env['res.lang']._activate_lang('fLT')
 
         self.assertEqual(misc.formatLang(self.env['res.lang'].with_context(lang='fLT').env, 1000000000, grouping=True), '10000?00?000!00')
-        self.assertEqual(misc.formatLang(self.env['res.lang'].with_context(lang='fLT').env, 1000000000, grouping=False), '1000000000.00')
+        self.assertEqual(misc.formatLang(self.env['res.lang'].with_context(lang='fLT').env, 1000000000, grouping=False), '1000000000!00')
 
     def test_decimal_precision(self):
         decimal_precision = self.env['decimal.precision'].create({
@@ -431,6 +431,24 @@ class TestFormatLang(TransactionCase):
         self.assertEqual(misc.formatLang(self.env, 1822060000, rounding_method='HALF-UP', rounding_unit='lakhs'), '18,221')
         self.assertEqual(misc.formatLang(self.env, 1822050000, rounding_method='HALF-UP', rounding_unit='lakhs'), '18,221')
         self.assertEqual(misc.formatLang(self.env, 1822049900, rounding_method='HALF-UP', rounding_unit='lakhs'), '18,220')
+
+    def test_format_decimal_point_without_grouping(self):
+        lang = self.env['res.lang'].browse(misc.get_lang(self.env).id)
+        self.assertEqual(lang.format(f'%.{1}f', 1200.50, grouping=True), '1,200.5')
+        self.assertEqual(lang.format(f'%.{1}f', 1200.50, grouping=False), '1200.5')
+
+        comma_lang = self.env['res.lang'].create({
+            'name': 'Comma (CM)',
+            'code': 'co_MA',
+            'iso_code': 'co_MA',
+            'thousands_sep': ' ',
+            'decimal_point': ',',
+            'grouping': '[3,0]',
+            'active': True,
+        })
+
+        self.assertEqual(comma_lang.format(f'%.{1}f', 1200.50, grouping=True), '1 200,5')
+        self.assertEqual(comma_lang.format(f'%.{1}f', 1200.50, grouping=False), '1200,5')
 
 
 class TestUrlValidate(BaseCase):


### PR DESCRIPTION
**Problem:**
If the *grouping* parameter (which is used to have a ',' between the thousands in english) is set to False, the decimal point will revert to the default one, not taking the user's language into account and writing '.' all the time.

**Steps to reproduce**
- Call the format function with a language that doesn't have '.' as a decimal point, like French
- If grouping is True (it is by default), the decimal separator becomes ',' as it should
- If grouping is False, the decimal point stays as '.'

**Fix:**
The decimal point is changed even if the grouping is False, so that all language can have their preferred decimal point every time.
