### PR TITLE
[FIX] website: do not COW iframefallback template

### DIFF
--- a/addons/website/controllers/backend.py
+++ b/addons/website/controllers/backend.py
@@ -37,8 +37,9 @@ class WebsiteBackend(http.Controller):
     @http.route('/website/iframefallback', type="http", auth='user', website=True)
     def get_iframe_fallback(self):
         # TODO adapt in master (done like this as a fix in stable)
-        view = request.env.ref('website.iframefallback')
-        view.arch = view.arch.replace('"website.assets_wysiwyg"', '"website.assets_wysiwyg_inside"')
+        view = request.env.ref('website.iframefallback').with_context(no_cow=True).sudo()
+        if '"website.assets_wysiwyg"' in view.arch:
+            view.arch = view.arch.replace('"website.assets_wysiwyg"', '"website.assets_wysiwyg_inside"')
         return request.render('website.iframefallback')
 
     @http.route('/website/check_new_content_access_rights', type="json", auth='user')


### PR DESCRIPTION
To avoid unused font type faces to be defined in iframes, [1] did introduce dedicated assets that do not contain those definitions. In order for those assets to be taken into a count, the `website.iframefallback` template was updated on the fly in order to reference the right asset bundle.

Unfortunately two aspects were overseen:
- this created a COW version of the template for the current website, which is useless
- if the user did not have rights to apply this patch, the complete call actually did fail

This commit makes sure that there is no COW, that the patch is applied only once, and using sufficient rights.

[1]: https://github.com/odoo/odoo/commit/c4e74991e1fd971918aee2514c2f3c40f3dd7a8c

task-3080104
