### PR TITLE
[IMP] hr_recruitment: homepage (job position) UI/X

### DIFF
--- a/addons/hr_recruitment/models/hr_job.py
+++ b/addons/hr_recruitment/models/hr_job.py
@@ -62,8 +62,7 @@ class HrJob(models.Model):
     currency_id = fields.Many2one("res.currency", related="company_id.currency_id", readonly=True)
     compensation = fields.Monetary(currency_field="currency_id")
 
-    activities_overdue = fields.Integer(compute='_compute_activities')
-    activities_today = fields.Integer(compute='_compute_activities')
+    activity_count = fields.Integer(compute='_compute_activities')
 
     job_properties = fields.Properties('Properties', definition='company_id.job_properties_definition')
 
@@ -96,19 +95,15 @@ class HrJob(models.Model):
         self.env.cr.execute("""
             SELECT
                 app.job_id,
-                COUNT(*) AS act_count,
-                CASE
-                    WHEN %(today)s::date - act.date_deadline::date = 0 THEN 'today'
-                    WHEN %(today)s::date - act.date_deadline::date > 0 THEN 'overdue'
-                END AS act_state
+                COUNT(*) AS act_count
              FROM mail_activity act
              JOIN hr_applicant app ON app.id = act.res_id
              JOIN hr_recruitment_stage sta ON app.stage_id = sta.id
             WHERE act.user_id = %(user_id)s AND act.res_model = 'hr.applicant'
-              AND act.date_deadline <= %(today)s::date AND app.active
+              AND app.active
               AND app.job_id IN %(job_ids)s
               AND sta.hired_stage IS NOT TRUE
-            GROUP BY app.job_id, act_state
+            GROUP BY app.job_id
         """, {
             'today': fields.Date.context_today(self),
             'user_id': self.env.uid,
@@ -117,10 +112,9 @@ class HrJob(models.Model):
         })
         job_activities = defaultdict(dict)
         for activity in self.env.cr.dictfetchall():
-            job_activities[activity['job_id']][activity['act_state']] = activity['act_count']
+            job_activities[activity['job_id']] = activity['act_count']
         for job in self:
-            job.activities_overdue = job_activities[job.id].get('overdue', 0)
-            job.activities_today = job_activities[job.id].get('today', 0)
+            job.activity_count = job_activities[job.id]
 
     @api.depends('application_ids.interviewer_ids')
     def _compute_extended_interviewer_ids(self):
@@ -345,24 +339,10 @@ class HrJob(models.Model):
         views = ['activity'] + [view for view in action['view_mode'].split(',') if view != 'activity']
         action['view_mode'] = ','.join(views)
         action['views'] = [(False, view) for view in views]
-        return action
-
-    def action_open_late_activities(self):
-        action = self.action_open_activities()
         action['context'] = {
             'default_job_id': self.id,
             'search_default_job_id': self.id,
-            'search_default_activities_overdue': True,
             'search_default_running_applicant_activities': True,
-        }
-        return action
-
-    def action_open_today_activities(self):
-        action = self.action_open_activities()
-        action['context'] = {
-            'default_job_id': self.id,
-            'search_default_job_id': self.id,
-            'search_default_activities_today': True,
         }
         return action
 

--- a/addons/hr_recruitment/static/src/scss/hr_applicant.scss
+++ b/addons/hr_recruitment/static/src/scss/hr_applicant.scss
@@ -20,3 +20,8 @@
     }
 }
 
+.o_hr_applicant_view_activity {
+    .o_m2o_avatar {
+        margin-right: 0px !important;
+    }
+}

--- a/addons/hr_recruitment/static/src/scss/hr_job.scss
+++ b/addons/hr_recruitment/static/src/scss/hr_job.scss
@@ -1,27 +1,31 @@
 .o_hr_recruitment_kanban {
     .o_kanban_renderer {
         padding: 0px;
+        border-top: 0px !important;
 
         &.o_kanban_ungrouped .o_kanban_record {
             width: 100%;
+            --KanbanRecord-padding-v: 4px !important;
+            --KanbanRecord-padding-h: 0px !important;
+            --Ribbon-font-size: 0.6rem;
+            --Ribbon-wrapper-width: 5rem;
+            --Ribbon-height: 1.9;
+
             &:not(.o_kanban_ghost) {
-                min-height: 80px;
                 justify-content: center;
             }
-            margin-bottom: 1rem;
-        }
-
-        .text_top_padding{
-            padding-top: 0.375rem;
         }
 
         .o_kanban_card_header_title {
-            min-height: 3rem;
-
-            .o_field_boolean_favorite {
-                display: inline;
-            }
+            line-height: 1.3rem !important;
+            margin-bottom: 4px !important;
+            margin-top: 1px !important;
         }
+
+        .o_kanban_card_header {
+            margin-bottom: 1px;
+        }
+
         .o_field_many2one_avatar_user .o_avatar{
             column-gap: 0.375rem;
         }
@@ -59,15 +63,28 @@
     margin: 0px;
 }
 
-.o_hr_recruitment_kanban_card {
-    border: 0px;
+.o_hr_recruitment_kanban_card_mobile_screen {
+    min-height: 0px !important;
 }
 
-.number {
-    font-weight: bold;
-    font-size: 1.5rem;
-    margin: 0.5rem;
-    align-content: center;
+.o_hr_recruitment_kanban {
+    .o_m2o_avatar {
+        margin-right: 0px !important;
+    }
+
+    .number {
+        font-size: 2rem !important;
+        margin-top: 0.1rem;
+        margin-bottom: 0rem;
+        margin-left: 0rem;
+        margin-right: 0.5rem;
+        font-weight: bold;
+        align-content: center;
+    }
+}
+
+.activity_badge {
+    --badge-padding-x: .55em;
 }
 
 .number_description {

--- a/addons/hr_recruitment/views/hr_applicant_views.xml
+++ b/addons/hr_recruitment/views/hr_applicant_views.xml
@@ -422,9 +422,9 @@
         <field name="arch" type="xml">
             <activity string="Applicants">
                 <templates>
-                    <div t-name="activity-box">
+                    <div t-name="activity-box" class="o_hr_applicant_view_activity">
                         <field name="user_id" widget="many2one_avatar_user"/>
-                        <div class="flex-grow-1">
+                        <div class="flex-grow-1 ms-1">
                             <field name="partner_name" muted="1" display="full" class="o_text_block"/>
                         </div>
                     </div>

--- a/addons/hr_recruitment/views/hr_job_views.xml
+++ b/addons/hr_recruitment/views/hr_job_views.xml
@@ -72,7 +72,93 @@
                     <t t-name="card">
                         <div class="o_hr_recruitment_kanban_card_large_screen">
                             <main>
-                                <div class="o_hr_recruitment_kanban_card_main_content d-flex flex-column">
+                                <div class="d-flex flex-row align-content-center ms-2">
+                                    <div class="col-3 d-flex flex-column align-self-center o_kanban_card_header">
+                                        <div class="d-flex flex-row">
+                                            <div class="d-flex fw-bold fs-3 o_kanban_card_header_title">
+                                                <field name="is_favorite" widget="boolean_favorite" nolabel="1"/>
+                                                <field class="fs-3" name="name"/>
+                                            </div>
+                                            <div t-if="record.alias_email.value" class="d-flex flex-wrap">
+                                                <field name="alias_id"/>
+                                            </div>
+                                        </div>
+                                        <div class="d-flex flex-row">
+                                            <div class="col">
+                                                <div groups="!base.group_multi_company">
+                                                    <field name="user_id" widget="many2one_avatar_user"
+                                                        options="{'display_avatar_name': True}"/>
+                                                </div>
+                                                <div groups="base.group_multi_company">
+                                                    <t t-if="record.company_id.raw_value != 0">
+                                                        <div class="d-flex flex-row align-items-center">
+                                                            <field name="user_id" widget="many2one_avatar_user"
+                                                                options="{'display_avatar_name': False}"/>
+                                                            <field class="ms-1" name="company_id"/>
+                                                        </div>
+                                                    </t>
+                                                    <t t-else="">
+                                                        <field name="user_id" widget="many2one_avatar_user"
+                                                            options="{'display_avatar_name': True}"/>
+                                                    </t>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div class="col align-content-center">
+                                        <div class="d-flex justify-content-center">
+                                            <field name="no_of_recruitment" class="number"/>
+                                            <div class="number_description fs-4 lh-1">
+                                                to<br/>recruit
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div class="col align-content-center">
+                                        <div class="d-flex justify-content-center">
+                                            <field name="new_application_count" class="number"/>
+                                            <div class="number_description text-body-secondary fs-4 lh-1">
+                                                new<br/>applications
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div class="col align-content-center">
+                                        <div class="d-flex justify-content-center">
+                                            <field name="old_application_count" class="number"/>
+                                            <div class=" number_description text-body-secondary fs-4 lh-1">
+                                                in<br/>progress
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div class="col align-content-center">
+                                        <div class="d-flex flex-row justify-content-center mt-1">
+                                            <div class="position-relative">
+                                                <button name="action_open_activities" type="object" class="ps-1 pe-1 pt-0 pb-0">
+                                                    <i class="fa fa-2x fa-clock-o" role="img" aria-label="Activities"></i>
+                                                    <span class="activity_badge position-absolute top-0 start-100 translate-middle badge rounded-pill bg-danger text-light">
+                                                        <field name="activity_count"/>
+                                                    </span> 
+                                                </button>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div class="col align-content-center me-5">
+                                        <div class="d-flex justify-content-center">
+                                            <div class="me-2">
+                                                <button class="btn btn-primary" name="%(action_hr_job_applications)d" type="action">
+                                                    Job Page
+                                                </button>
+                                            </div>
+                                            <button class="btn btn-secondary" type="open">
+                                                Configure
+                                            </button>
+                                        </div>
+                                    </div>
+                                </div>
+                            </main>
+                        </div>
+                        <div class="o_hr_recruitment_kanban_card_mobile_screen">
+                            <main>
+                                <div class="d-flex flex-column gap-1 mb-1">
                                     <div class="mb-2">
                                         <div class="d-flex fw-bold fs-3">
                                             <field name="is_favorite" widget="boolean_favorite" nolabel="1"/>
@@ -83,105 +169,37 @@
                                         </div>
                                     </div>
                                     <div class="d-flex flex-row">
-                                        <div class="col align-content-center">
-                                            <field name="user_id" widget="many2one_avatar_user"
-                                                options="{'display_avatar_name': True}"/>
-                                        </div>
-                                        <div class="col">
-                                            <span
-                                                name="edit_job"
-                                                type="open"
-                                                t-attf-class="{{ record.no_of_recruitment.raw_value == 0 ? 'text-secondary' : '' }}"
-                                            >
-                                                <div class="d-flex">
-                                                    <field name="no_of_recruitment" class="number"/>
-                                                    <div class="number_description">
-                                                        <span>Open</span>
-                                                        <span>
-                                                            <t t-if="record.no_of_recruitment.raw_value == 1">Slot</t>
-                                                            <t t-else="">Slots</t>
-                                                        </span>
-                                                    </div>
-                                                </div>
-                                            </span>
-                                        </div>
-                                        <div class="col">
-                                            <div class="d-flex">
-                                                <field name="application_count" class="number"/>
-                                                <div class="number_description">
-                                                <span>Open</span>
-                                                    <t t-if="record.application_count.raw_value == 1">Application</t>
-                                                    <t t-else="">Applications</t>
-                                                </div>
-                                            </div>
-                                        </div>
-                                        <div t-if="record.company_id.raw_value" class="col align-content-center" groups="base.group_multi_company">
-                                            <i class="fa fa-building-o" role="img" aria-label="Company" title="Company"></i> <field name="company_id"/>
-                                        </div>
-                                        <div class="col align-content-center">
-                                            <button class="btn btn-primary" name="%(action_hr_job_applications)d" type="action">
-                                                Job Page
-                                            </button>
-                                        </div>
-                                    </div>
-                                </div>
-                                <div name="activities" class="text-end">
-                                    <div class="d-inline-block me-4" invisible="not activities_today and not activities_overdue">
-                                        <a t-if="record.activities_overdue.raw_value > 0" name="action_open_late_activities" type="object" class="text-danger"><field name="activities_overdue"/> Late Activities</a>
-                                        <br t-if="record.activities_today.raw_value > 0 and record.activities_overdue.raw_value > 0"/>
-                                        <a t-if="record.activities_today.raw_value > 0" name="action_open_today_activities" type="object" class="text-warning"><field name="activities_today"/> Activities Today</a>
-                                    </div>
-                                </div>
-                            </main>
-                        </div>
-                        <div class="o_hr_recruitment_kanban_card_mobile_screen">
-                            <main>
-                                <div class="o_hr_recruitment_kanban_card_main_content d-flex flex-column">
-                                    <div class="mb-2">
-                                        <div class="d-flex fw-bold fs-3">
-                                            <field name="is_favorite" widget="boolean_favorite" nolabel="1"/>
-                                            <field name="name"/>
-                                        </div>
-                                        <div t-if="record.alias_email.value" class="d-flex flex-wrap">
-                                            <field name="alias_id"/>
-                                        </div>
-                                    </div>
-                                    <div class="d-flex">
-                                        <div class="col-6 d-flex align-items-center justify-content-center">
-                                            <button class="btn btn-primary" name="%(action_hr_job_applications)d" type="action">
-                                                Job Page
-                                            </button>
-                                        </div>
-                                        <div class="col-6 d-flex">
-                                            <div class="d-flex flex-column text-end me-2">
+                                        <div class="col-1 align-content-end me-1">
+                                            <div class="d-flex flex-row justify-content-center">
                                                 <field name="user_id" widget="many2one_avatar_user"
                                                     options="{'display_avatar_name': False}"/>
-                                                <field name="no_of_recruitment"/>
-                                                <field name="application_count"/>
                                             </div>
-                                            <div class="d-flex flex-column">
+                                        </div>
+                                        <div class="col align-content-end">
+                                            <div groups="base.group_multi_company">
+                                                <t t-if="record.company_id.raw_value != 0">
+                                                    <field name="company_id"/>
+                                                </t>
+                                                <t t-else="">
+                                                    <field name="user_id"/>
+                                                </t>
+                                            </div>
+                                            <div groups="!base.group_multi_company">
                                                 <field name="user_id"/>
-                                                <a
-                                                    name="edit_job"
-                                                    type="open"
-                                                    t-attf-class="{{ record.no_of_recruitment.raw_value == 0 ? 'text-secondary' : '' }}"
-                                                    groups="hr_recruitment.group_hr_recruitment_user"
-                                                >
-                                                    <t t-if="record.no_of_recruitment.raw_value == 1">Open Slot</t>
-                                                    <t t-else="">Open Slots</t>
-                                                </a>
-                                                <span
-                                                    name="edit_job"
-                                                    type="open"
-                                                    t-attf-class="{{ record.no_of_recruitment.raw_value == 0 ? 'text-secondary' : '' }}"
-                                                    groups="!hr_recruitment.group_hr_recruitment_user"
-                                                >
-                                                    <t t-if="record.no_of_recruitment.raw_value == 1">Open Slot</t>
-                                                    <t t-else="">Open Slots</t>
-                                                </span>
-                                                <t t-if="record.application_count.raw_value == 1">Open Application</t>
-                                                <t t-else="">Open Applications</t>
                                             </div>
+                                        </div>
+                                    </div>
+                                    <div class="d-flex flex-row">
+                                        <div class="col-1 align-content-end me-1">
+                                            <div class="d-flex flex-row justify-content-center">
+                                                <i class="fa fa-user fa-2x" title="new_applications_icon"/>
+                                            </div>
+                                        </div>
+                                        <div class="col align-content-end">
+                                            <span>
+                                                <field name="application_count"/>
+                                                <span > new applications</span>
+                                            </span>
                                         </div>
                                     </div>
                                 </div>


### PR DESCRIPTION
Making a cleaner recruitment job positions view:
- Adding activity and configure button directly in the view to avoid losing time clicking o_kanban_card_manage_settings -> Activities/Configuration
- Renaming
	- open slots -> new applications
	- open applications -> new applications
- Adding "in progress" (more convenient)
- Displaying company name when it's possible instead of the user_id (more convenient)

Cleaner recruitment job position for mobile:
- Displaying only usefull infos
- Displaying company name when it's possible instead of the user_id (more convenient)

On job position activities view:
- Adjusting spacing right to the assignee avatar

Upgrade PR: odoo/upgrade/pull/7971
Task: #4762193