### PR TITLE
[FIX] web: allow exiting forms with required fields when empty

### DIFF
--- a/addons/web/static/tests/views/form/form_view.test.js
+++ b/addons/web/static/tests/views/form/form_view.test.js
@@ -9173,7 +9173,7 @@ test(`form view is not broken if save operation fails with redirect warning`, as
                 args: [
                     "The message",
                     {
-                        name: "Sub view",
+                        name: "Create New Record",
                         res_model: "partner",
                         type: "ir.actions.act_window",
                         domain: [],
@@ -9210,7 +9210,7 @@ test(`form view is not broken if save operation fails with redirect warning`, as
     expect.verifySteps(["get_views", "onchange"]);
 
     // RedirectWarning dialog
-    expect(`.modal-title`).toHaveText("Sub view");
+    expect(`.modal-title`).toHaveText("Create New Record");
 });
 
 test(`form view is not broken if save failed in readonly mode on field changed`, async () => {
@@ -10270,7 +10270,7 @@ test(`discard after a failed save (and close notifications)`, async () => {
     //cannot save because there is a required field
     await contains(`.o_control_panel .o_form_button_save`).click();
     expect(`.o_notification`).toHaveCount(1);
-
+    
     await contains(`.o_control_panel .o_form_button_cancel`).click();
     expect(`.o_form_view`).toHaveCount(0);
     expect(`.o_kanban_view`).toHaveCount(1);

--- a/doc/cla/individual/diogoadr.md
+++ b/doc/cla/individual/diogoadr.md
@@ -1,0 +1,11 @@
+Portugal, 08/04/2025
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Diogo Afonso Duarte Rodrigues diogo.d.rodrigues@tecnico.ulisboa.pt https://github.com/diogoadr


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**

Previously, users were blocked when trying to exit forms (e.g., Purchase Orders) if any required fields (such as the vendor) were present in the view, even when no actual data had been entered. This created a confusing and unnecessarily rigid user experience.

**Current behavior before PR:**

Users are blocked from exiting a form as soon as any required field is rendered, even if the form remains effectively empty.

**Desired behavior after PR is merged:**

Confirmation dialogs are introduced to explain why the form cannot be closed immediately and to allow users to exit anyway when appropriate. This improves the UX by avoiding forced data entry in empty or unused forms.

Fixes: #200754

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
