### PR TITLE
[FIX] mail: record.toData() keeps markup of html fields

### DIFF
--- a/addons/mail/static/src/model/record.js
+++ b/addons/mail/static/src/model/record.js
@@ -1,4 +1,4 @@
-import { toRaw } from "@odoo/owl";
+import { markup, toRaw } from "@odoo/owl";
 import {
     IS_DELETED_SYM,
     OR_SYM,
@@ -20,6 +20,8 @@ import { serializeDate, serializeDateTime } from "@web/core/l10n/dates";
  * @property {boolean} depth Whether to recursively fetch deep data for all related records
  * @property {string[]} fields An array of field names to fetch, using dot notation (e.g., `"persona.group_ids"`).
  */
+
+const Markup = markup().constructor;
 
 export class Record {
     /** @type {import("./model_internal").ModelInternal} */
@@ -415,6 +417,8 @@ export class Record {
                     data[name] = serializeDateTime(value);
                 } else if (Model._.fieldsType.get(name) === "date" && value) {
                     data[name] = serializeDate(value);
+                } else if (Model._.fieldsHtml.get(name) && value instanceof Markup) {
+                    data[name] = ["markup", value.toString()];
                 } else {
                     data[name] = value;
                 }

--- a/addons/mail/static/tests/core/record.test.js
+++ b/addons/mail/static/tests/core/record.test.js
@@ -923,6 +923,7 @@ test("record.toData() is JSON stringified and can be reinserted as record", asyn
         due_datetime = fields.Attr(undefined, { type: "datetime" });
         messages = fields.Many("Message");
         team = fields.One("Team");
+        signature = fields.Html("");
     }).register(localRegistry);
     (class Message extends Record {
         static id = "body";
@@ -939,10 +940,13 @@ test("record.toData() is JSON stringified and can be reinserted as record", asyn
         names: ["John", "Marc"],
         messages: [{ body: "1" }, { body: "2" }],
         team: "Discuss",
+        signature: ["markup", "<p>-- John</p>"],
     });
     expect(p.names).toEqual(["John", "Marc"]);
     expect(p.messages.map((msg) => msg.body)).toEqual(["1", "2"]);
     expect(p.team.name).toBe("Discuss");
+    expect(p.signature.toString()).toBe("<p>-- John</p>");
+    expect(p.signature).toBeInstanceOf(Markup);
     expect(toRaw(store.Person.records[p.localId])).toBe(toRaw(p));
     expect(serializeDateTime(p.due_datetime)).toBe("2024-08-28 10:19:44");
     // export data, delete, then insert back
@@ -960,6 +964,8 @@ test("record.toData() is JSON stringified and can be reinserted as record", asyn
     expect(p2.team.name).toBe("Discuss");
     expect(toRaw(store.Person.records[p2.localId])).toBe(toRaw(p2));
     expect(serializeDateTime(p2.due_datetime)).toBe("2024-08-28 10:19:44");
+    expect(p2.signature.toString()).toBe("<p>-- John</p>");
+    expect(p.signature).toBeInstanceOf(Markup);
 });
 
 test("record.toData() returns flat data", async () => {


### PR DESCRIPTION
Before this commit, `record.toData()` was not retrieving the "markup" flag of html fields.

This is a problem because inserting this data would remove the `Markup` of these html fields, therefore showing html as text content in UI.

This commit fixes the issue by having `record.toData()` return `["markup", string]` rather than `string` on html fields that have markup content, so that insert preserves the markup.
