### PR TITLE
[IMP] Suggest combo packs during checkout if cheaper

### DIFF
--- a/addons/website_sale_combo_suggestions/__init__.py
+++ b/addons/website_sale_combo_suggestions/__init__.py
@@ -1,0 +1,1 @@
+from . import controllers

--- a/addons/website_sale_combo_suggestions/__manifest__.py
+++ b/addons/website_sale_combo_suggestions/__manifest__.py
@@ -1,0 +1,19 @@
+{
+    'name': 'Website Sale Combo Suggestions',
+    'version': '1.0',
+    'category': 'Website/Website',
+    'summary': 'Suggest combo packs during checkout when individual products are in cart',
+    'description': """
+        This module automatically detects when users have individual products in their cart
+        that could be replaced by a cheaper combo pack and suggests the substitution.
+    """,
+    'depends': ['website_sale'],
+    'assets': {
+        'web.assets_frontend': [
+            'website_sale_combo_suggestions/static/src/js/combo_manager.js',
+        ],
+    },
+    'installable': True,
+    'author': 'Diogo Rodrigues, Beatriz Abreu',
+    'license': 'LGPL-3',
+}

--- a/addons/website_sale_combo_suggestions/controllers/__init__.py
+++ b/addons/website_sale_combo_suggestions/controllers/__init__.py
@@ -1,0 +1,1 @@
+from . import main

--- a/addons/website_sale_combo_suggestions/controllers/main.py
+++ b/addons/website_sale_combo_suggestions/controllers/main.py
@@ -1,0 +1,251 @@
+"""Website combo suggestion controllers.
+
+This module suggests discounted combo packs during checkout and applies the
+discount when requested.  The implementation follows Odoo guidelines and keeps
+the logic compact and easy to maintain.
+"""
+
+from odoo import http, _
+from odoo.http import request
+
+import logging
+
+_logger = logging.getLogger(__name__)
+
+
+class ComboController(http.Controller):
+    """Controllers to manage combo suggestions and discounts."""
+
+    def _get_currency(self, order):
+        return order.currency_id or request.website.currency_id
+
+    def _format_currency(self, amount, currency):
+        amount = f"{amount:.2f}"
+        return (
+            f"{currency.symbol}{amount}"
+            if currency.position == "before"
+            else f"{amount}{currency.symbol}"
+        )
+
+    def _get_cart_quantities(self, order):
+        return {
+            line.product_id.id: line.product_uom_qty
+            for line in order.order_line
+            if line.product_id.default_code != "SIMPLE_DISCOUNT"
+        }
+
+    def _combo_requirements(self, combo):
+        return {
+            item.product_id.id: item.quatity or 1
+            for item in combo.combo_item_ids
+        }
+
+    def _count_applied_combos(self, order, requirements):
+        lines = order.order_line.filtered(
+            lambda l: l.product_id.id in requirements and l.discount > 0
+        )
+        if not lines:
+            return 0
+
+        counts = []
+        for line in lines:
+            req = requirements[line.product_id.id]
+            counts.append(int(line.product_uom_qty // req))
+
+        return min(counts) if counts else 0
+
+    def _clear_discounts(self, order):
+        for line in order.order_line:
+            if line.product_id.default_code != "SIMPLE_DISCOUNT" and line.discount:
+                line.discount = 0.0
+
+    def _consolidate_duplicate_lines(self, order):
+        groups = {}
+        for line in order.order_line:
+            if line.product_id.default_code == "SIMPLE_DISCOUNT":
+                continue
+
+            taxes = tuple(sorted(line.tax_id.ids)) if line.tax_id else ()
+            key = (line.product_id.id, line.price_unit, line.discount, taxes, line.product_uom.id)
+            groups.setdefault(key, []).append(line)
+
+        for lines in groups.values():
+            if len(lines) < 2:
+                continue
+            main = lines[0]
+            main.product_uom_qty = sum(l.product_uom_qty for l in lines)
+            for dup in lines[1:]:
+                dup.unlink()
+
+    def _apply_discount(self, order, combo):
+        requirements = self._combo_requirements(combo)
+        cart_qty = self._get_cart_quantities(order)
+        max_times = min(cart_qty.get(pid, 0) // qty for pid, qty in requirements.items())
+
+        if max_times <= 0:
+            return {
+                "success": False,
+                "error_code": "not_enough_qty",
+            }
+
+        self._clear_discounts(order)
+
+        lines_map = {
+            pid: order.order_line.filtered(lambda l, pid=pid: l.product_id.id == pid)
+            for pid in requirements
+        }
+
+        total_price = sum(lines_map[pid][0].price_unit * qty for pid, qty in requirements.items())
+        discount_percent = (total_price - combo.base_price) / total_price * 100
+
+        for pid, qty in requirements.items():
+            qty_to_discount = qty * max_times
+            for line in lines_map[pid]:
+                if qty_to_discount <= 0:
+                    break
+                if line.product_uom_qty > qty_to_discount:
+                    line.copy({
+                        "order_id": order.id,
+                        "order_partner_id": order.partner_id.id,
+                        "product_uom_qty": line.product_uom_qty - qty_to_discount,
+                        "discount": 0.0,
+                    })
+                    line.product_uom_qty = qty_to_discount
+
+                line.discount = min(discount_percent, 100)
+                qty_to_discount -= line.product_uom_qty
+
+        self._consolidate_duplicate_lines(order)
+
+        return {
+            "success": True,
+            "times_applied": max_times,
+            "savings_total": (total_price - combo.base_price) * max_times,
+            "combo_name": combo.name,
+        }
+
+    @http.route("/shop/check_combos", type="jsonrpc", auth="public", website=True)
+    def check_combos(self):
+        order = request.website.sale_get_order()
+        if not order:
+            return []
+
+        currency = self._get_currency(order)
+        cart_qty = self._get_cart_quantities(order)
+        if not cart_qty:
+            return []
+
+        combos = request.env["product.combo"].search([])
+        result = []
+
+        for combo in combos:
+            requirements = self._combo_requirements(combo)
+            max_times = min(cart_qty.get(pid, 0) // qty for pid, qty in requirements.items())
+
+            applied = self._count_applied_combos(order, requirements)
+            available = max_times - applied
+            if available <= 0:
+                continue
+
+            total_price = 0.0
+            for pid, qty in requirements.items():
+                line = order.order_line.filtered(lambda l, pid=pid: l.product_id.id == pid)[:1]
+                if line:
+                    total_price += line.price_unit * qty
+
+            savings = total_price - combo.base_price
+            result.append(
+                {
+                    "id": combo.id,
+                    "name": combo.name,
+                    "savings": savings,
+                    "individual_total": total_price,
+                    "combo_price": combo.base_price,
+                    "times_available": available,
+                    "currency_symbol": currency.symbol,
+                    "currency_position": currency.position,
+                    "translations": {
+                        "pack_available": _("Pack Available"),
+                        "savings": _("Savings"),
+                        "apply_discount": _("Apply Discount"),
+                        "times_available": _("times available"),
+                        "from": _("From"),
+                        "for": _("for"),
+                    },
+                }
+            )
+
+        return result
+
+    @http.route("/shop/apply_discount/<int:combo_id>", type="jsonrpc", auth="public", website=True)
+    def apply_discount(self, combo_id):
+        order = request.website.sale_get_order()
+        combo = request.env["product.combo"].browse(combo_id)
+
+        if not order or not combo:
+            currency = request.website.currency_id
+            return {
+                "success": False,
+                "error": _("Cart or combo not found"),
+                "currency_symbol": currency.symbol,
+                "currency_position": currency.position,
+            }
+
+        result = self._apply_discount(order, combo)
+        currency = self._get_currency(order)
+
+        if not result["success"]:
+            return {
+                "success": False,
+                "error": {
+                    "not_enough_qty": _("Insufficient quantity to apply combo"),
+                }.get(result.get("error_code"), _("Unknown error")),
+                "currency_symbol": currency.symbol,
+                "currency_position": currency.position,
+            }
+
+        return {
+            "success": True,
+            "message": _(
+                "%(count)sx Pack \"%(name)s\" applied - Total savings: %(amount)s",
+                {
+                    "count": result["times_applied"],
+                    "name": result["combo_name"],
+                    "amount": self._format_currency(result["savings_total"], currency),
+                }
+            ),
+            "currency_symbol": currency.symbol,
+            "currency_position": currency.position,
+            "translations": {
+                "discount_applied": _("Discount Applied!"),
+                "total_savings": _("Total savings"),
+            },
+        }
+
+    @http.route("/shop/recalculate_combos", type="jsonrpc", auth="public", website=True)
+    def recalculate_combos(self):
+        order = request.website.sale_get_order()
+        currency = (order.currency_id or request.website.currency_id) if order else request.website.currency_id
+
+        if not order:
+            return {
+                "success": False,
+                "error": _("Cart not found"),
+                "currency_symbol": currency.symbol,
+                "currency_position": currency.position,
+            }
+
+        self._clear_discounts(order)
+        self._consolidate_duplicate_lines(order)
+
+        return {
+            "success": True,
+            "message": _("Discounts cleared and lines consolidated"),
+            "refresh": True,
+            "currency_symbol": currency.symbol,
+            "currency_position": currency.position,
+            "translations": {
+                "recalculating": _("Recalculating combos..."),
+                "cleaning_discounts": _("Clearing discounts and optimizing available packs"),
+            },
+        }

--- a/addons/website_sale_combo_suggestions/i18n/en_US.po
+++ b/addons/website_sale_combo_suggestions/i18n/en_US.po
@@ -1,0 +1,128 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* website_sale_combo_suggestions
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 18.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-05-12 12:00+0000\n"
+"PO-Revision-Date: 2025-06-06 12:00+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: en_US\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+
+#. module: website_sale_combo_suggestions
+#: code:addons/website_sale_combo_suggestions/controllers/main.py:0
+#: model:ir.model,name:website_sale_combo_suggestions.model_simple_combo_controller
+msgid "Pack Available"
+msgstr "Pack Available"
+
+#. module: website_sale_combo_suggestions
+#: code:addons/website_sale_combo_suggestions/controllers/main.py:0
+msgid "Savings"
+msgstr "Savings"
+
+#. module: website_sale_combo_suggestions
+#: code:addons/website_sale_combo_suggestions/controllers/main.py:0
+msgid "Apply Discount"
+msgstr "Apply Discount"
+
+#. module: website_sale_combo_suggestions
+#: code:addons/website_sale_combo_suggestions/controllers/main.py:0
+msgid "times available"
+msgstr "times available"
+
+#. module: website_sale_combo_suggestions
+#: code:addons/website_sale_combo_suggestions/controllers/main.py:0
+msgid "From"
+msgstr "From"
+
+#. module: website_sale_combo_suggestions
+#: code:addons/website_sale_combo_suggestions/controllers/main.py:0
+msgid "for"
+msgstr "for"
+
+#. module: website_sale_combo_suggestions
+#: code:addons/website_sale_combo_suggestions/controllers/main.py:0
+msgid "Cart or combo not found"
+msgstr "Cart or combo not found"
+
+#. module: website_sale_combo_suggestions
+#: code:addons/website_sale_combo_suggestions/controllers/main.py:0
+msgid "Combo products are not in the cart"
+msgstr "Combo products are not in the cart"
+
+#. module: website_sale_combo_suggestions
+#: code:addons/website_sale_combo_suggestions/controllers/main.py:0
+msgid "Required product not found"
+msgstr "Required product not found"
+
+#. module: website_sale_combo_suggestions
+#: code:addons/website_sale_combo_suggestions/controllers/main.py:0
+msgid "Insufficient quantity to apply combo"
+msgstr "Insufficient quantity to apply combo"
+
+#. module: website_sale_combo_suggestions
+#: code:addons/website_sale_combo_suggestions/controllers/main.py:0
+msgid "The combo has no price advantage"
+msgstr "The combo has no price advantage"
+
+#. module: website_sale_combo_suggestions
+#: code:addons/website_sale_combo_suggestions/controllers/main.py:0
+msgid "%(count)sx Pack \"%(name)s\" applied - Total savings: %(amount)s"
+msgstr "%(count)sx Pack \"%(name)s\" applied - Total savings: %(amount)s"
+
+#. module: website_sale_combo_suggestions
+#: code:addons/website_sale_combo_suggestions/controllers/main.py:0
+msgid "Discount Applied!"
+msgstr "Discount Applied!"
+
+#. module: website_sale_combo_suggestions
+#: code:addons/website_sale_combo_suggestions/controllers/main.py:0
+msgid "Total savings"
+msgstr "Total savings"
+
+#. module: website_sale_combo_suggestions
+#: code:addons/website_sale_combo_suggestions/controllers/main.py:0
+msgid "Internal error: %(error)s"
+msgstr "Internal error: %(error)s"
+
+#. module: website_sale_combo_suggestions
+#: code:addons/website_sale_combo_suggestions/controllers/main.py:0
+msgid "Cart not found"
+msgstr "Cart not found"
+
+#. module: website_sale_combo_suggestions
+#: code:addons/website_sale_combo_suggestions/controllers/main.py:0
+msgid "Discounts cleared and lines consolidated"
+msgstr "Discounts cleared and lines consolidated"
+
+#. module: website_sale_combo_suggestions
+#: code:addons/website_sale_combo_suggestions/controllers/main.py:0
+msgid "Recalculating combos..."
+msgstr "Recalculating combos..."
+
+#. module: website_sale_combo_suggestions
+#: code:addons/website_sale_combo_suggestions/controllers/main.py:0
+msgid "Clearing discounts and optimizing available packs"
+msgstr "Clearing discounts and optimizing available packs"
+
+#. module: website_sale_combo_suggestions
+#: code:addons/website_sale_combo_suggestions/controllers/main.py:0
+msgid "Applying..."
+msgstr "Applying..."
+
+#. module: website_sale_combo_suggestions
+#: code:addons/website_sale_combo_suggestions/controllers/main.py:0
+msgid "Warning"
+msgstr "Warning"
+
+#. module: website_sale_combo_suggestions
+#: code:addons/website_sale_combo_suggestions/controllers/main.py:0
+msgid "Connection Error"
+msgstr "Connection Error"

--- a/addons/website_sale_combo_suggestions/i18n/pt_PT.po
+++ b/addons/website_sale_combo_suggestions/i18n/pt_PT.po
@@ -1,0 +1,128 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* website_sale_combo_suggestions
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 18.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-05-12 12:00+0000\n"
+"PO-Revision-Date: 2025-06-06 12:00+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: pt_PT\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+
+#. module: website_sale_combo_suggestions
+#: code:addons/website_sale_combo_suggestions/controllers/main.py:0
+#: model:ir.model,name:website_sale_combo_suggestions.model_simple_combo_controller
+msgid "Pack Available"
+msgstr "Pack Disponível"
+
+#. module: website_sale_combo_suggestions
+#: code:addons/website_sale_combo_suggestions/controllers/main.py:0
+msgid "Savings"
+msgstr "Poupança"
+
+#. module: website_sale_combo_suggestions
+#: code:addons/website_sale_combo_suggestions/controllers/main.py:0
+msgid "Apply Discount"
+msgstr "Aplicar Desconto"
+
+#. module: website_sale_combo_suggestions
+#: code:addons/website_sale_combo_suggestions/controllers/main.py:0
+msgid "times available"
+msgstr "vezes disponível"
+
+#. module: website_sale_combo_suggestions
+#: code:addons/website_sale_combo_suggestions/controllers/main.py:0
+msgid "From"
+msgstr "De"
+
+#. module: website_sale_combo_suggestions
+#: code:addons/website_sale_combo_suggestions/controllers/main.py:0
+msgid "for"
+msgstr "por"
+
+#. module: website_sale_combo_suggestions
+#: code:addons/website_sale_combo_suggestions/controllers/main.py:0
+msgid "Cart or combo not found"
+msgstr "Carrinho ou combo não encontrado"
+
+#. module: website_sale_combo_suggestions
+#: code:addons/website_sale_combo_suggestions/controllers/main.py:0
+msgid "Combo products are not in the cart"
+msgstr "Produtos do combo não estão no carrinho"
+
+#. module: website_sale_combo_suggestions
+#: code:addons/website_sale_combo_suggestions/controllers/main.py:0
+msgid "Required product not found"
+msgstr "Produto necessário não encontrado"
+
+#. module: website_sale_combo_suggestions
+#: code:addons/website_sale_combo_suggestions/controllers/main.py:0
+msgid "Insufficient quantity to apply combo"
+msgstr "Quantidade insuficiente para aplicar combo"
+
+#. module: website_sale_combo_suggestions
+#: code:addons/website_sale_combo_suggestions/controllers/main.py:0
+msgid "The combo has no price advantage"
+msgstr "O combo não tem vantagem de preço"
+
+#. module: website_sale_combo_suggestions
+#: code:addons/website_sale_combo_suggestions/controllers/main.py:0
+msgid "%(count)sx Pack \"%(name)s\" applied - Total savings: %(amount)s"
+msgstr "%(count)sx Pack \"%(name)s\" aplicados - Poupança total: %(amount)s"
+
+#. module: website_sale_combo_suggestions
+#: code:addons/website_sale_combo_suggestions/controllers/main.py:0
+msgid "Discount Applied!"
+msgstr "Desconto Aplicado!"
+
+#. module: website_sale_combo_suggestions
+#: code:addons/website_sale_combo_suggestions/controllers/main.py:0
+msgid "Total savings"
+msgstr "Poupança total"
+
+#. module: website_sale_combo_suggestions
+#: code:addons/website_sale_combo_suggestions/controllers/main.py:0
+msgid "Internal error: %(error)s"
+msgstr "Erro interno: %(error)s"
+
+#. module: website_sale_combo_suggestions
+#: code:addons/website_sale_combo_suggestions/controllers/main.py:0
+msgid "Cart not found"
+msgstr "Carrinho não encontrado"
+
+#. module: website_sale_combo_suggestions
+#: code:addons/website_sale_combo_suggestions/controllers/main.py:0
+msgid "Discounts cleared and lines consolidated"
+msgstr "Descontos limpos e linhas consolidadas"
+
+#. module: website_sale_combo_suggestions
+#: code:addons/website_sale_combo_suggestions/controllers/main.py:0
+msgid "Recalculating combos..."
+msgstr "A recalcular combos..."
+
+#. module: website_sale_combo_suggestions
+#: code:addons/website_sale_combo_suggestions/controllers/main.py:0
+msgid "Clearing discounts and optimizing available packs"
+msgstr "A limpar descontos e otimizar packs disponíveis"
+
+#. module: website_sale_combo_suggestions
+#: code:addons/website_sale_combo_suggestions/controllers/main.py:0
+msgid "Applying..."
+msgstr "A aplicar..."
+
+#. module: website_sale_combo_suggestions
+#: code:addons/website_sale_combo_suggestions/controllers/main.py:0
+msgid "Warning"
+msgstr "Aviso"
+
+#. module: website_sale_combo_suggestions
+#: code:addons/website_sale_combo_suggestions/controllers/main.py:0
+msgid "Connection Error"
+msgstr "Erro de Ligação"

--- a/addons/website_sale_combo_suggestions/static/src/js/combo_manager.js
+++ b/addons/website_sale_combo_suggestions/static/src/js/combo_manager.js
@@ -1,0 +1,198 @@
+/* global $ */
+(function () {
+    'use strict';
+
+    const ComboManager = {
+        init() {
+            $(document).ready(() => {
+                if (window.location.pathname === '/shop/cart') {
+                    setTimeout(() => {
+                        this.checkForCombos();
+                        this.initCartObserver();
+                    }, 300);
+                }
+            });
+        },
+
+        formatCurrency(amount, symbol, position) {
+            const formatted = parseFloat(amount).toFixed(2);
+            return position === 'before'
+                ? `${symbol}${formatted}`
+                : `${formatted}${symbol}`;
+        },
+
+        getTranslation(trans, key, fallback) {
+            return (trans && trans[key]) ? trans[key] : fallback;
+        },
+
+        getCsrfToken() {
+            if (typeof odoo !== 'undefined' && odoo.csrf_token) {
+                return odoo.csrf_token;
+            }
+            const metaTag = document.querySelector('meta[name="csrf-token"]');
+            return metaTag ? metaTag.getAttribute('content') : null;
+        },
+
+        initCartObserver() {
+            const cartContainer = document.querySelector('.oe_cart');
+            if (!cartContainer) {
+                return;
+            }
+            const observer = new MutationObserver(() => {
+                clearTimeout(window.comboCheckTimeout);
+                window.comboCheckTimeout = setTimeout(() => {
+                    this.recalculateAllCombos();
+                }, 1500);
+            });
+            observer.observe(cartContainer, {
+                childList: true,
+                subtree: true,
+                attributes: true,
+                attributeFilter: ['class'],
+            });
+        },
+
+        async recalculateAllCombos() {
+            $('.simple-combo-alert').remove();
+            try {
+                const response = await fetch('/shop/recalculate_combos', {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'X-CSRFToken': this.getCsrfToken(),
+                    },
+                    body: JSON.stringify({}),
+                });
+                const data = await response.json();
+                const result = data.result || data;
+                const t = result.translations || {};
+                const loadingHtml = `
+                    <div class="alert alert-info simple-combo-alert recalculating" style="margin: 15px 0;">
+                        <div style="text-align: center;">
+                            <h4>🔄 ${this.getTranslation(t, 'recalculating', 'Recalculating combos...')}</h4>
+                            <p>${this.getTranslation(t, 'cleaning_discounts', 'Clearing discounts and optimizing available packs')}</p>
+                        </div>
+                    </div>`;
+                $('.oe_cart').before(loadingHtml);
+                if (result.refresh) {
+                    window.location.reload();
+                    return;
+                }
+            } catch {
+                // Errors are not user-critical here
+            } finally {
+                $('.simple-combo-alert.recalculating').remove();
+                setTimeout(() => this.checkForCombos(), 500);
+            }
+        },
+
+        async checkForCombos() {
+            $('.simple-combo-alert').remove();
+            try {
+                const response = await fetch('/shop/check_combos', {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'X-CSRFToken': this.getCsrfToken(),
+                    },
+                    body: JSON.stringify({}),
+                });
+                if (!response.ok) {
+                    throw new Error(`HTTP ${response.status}`);
+                }
+                const data = await response.json();
+                const combos = data.result || data || [];
+                if (combos.length) {
+                    this.showComboAlerts(combos);
+                }
+            } catch {
+                // Ignore errors silently
+            }
+        },
+
+        showComboAlerts(combos) {
+            combos.forEach(combo => {
+                const t = combo.translations || {};
+                const symbol = combo.currency_symbol || '€';
+                const position = combo.currency_position || 'after';
+                const packText = this.getTranslation(t, 'pack_available', 'Pack Available');
+                const savingsText = this.getTranslation(t, 'savings', 'Savings');
+                const timesText = this.getTranslation(t, 'times_available', 'times available');
+                const fromText = this.getTranslation(t, 'from', 'From');
+                const forText = this.getTranslation(t, 'for', 'for');
+                const applyText = this.getTranslation(t, 'apply_discount', 'Apply Discount');
+                const qtyText = combo.times_available > 1 ? ` (${combo.times_available}x ${timesText})` : '';
+                const savings = this.formatCurrency(combo.savings, symbol, position);
+                const individual = this.formatCurrency(combo.individual_total, symbol, position);
+                const comboPrice = this.formatCurrency(combo.combo_price, symbol, position);
+
+                const alertHtml = `
+                    <div class="alert alert-success simple-combo-alert" style="margin: 15px 0; border: 2px solid #28a745;">
+                        <div style="display: flex; justify-content: space-between; align-items: center;">
+                            <div>
+                                <h4 style="margin: 0; color: #155724;">🎁 ${packText} "${combo.name}"!${qtyText}</h4>
+                                <p style="margin: 5px 0;">
+                                    <strong>${savingsText}: ${savings}</strong><br>
+                                    <small>${fromText} ${individual} ${forText} ${comboPrice}</small>
+                                </p>
+                            </div>
+                            <div>
+                                <button class="btn btn-success btn-lg" onclick="comboManager.applyDiscount(${combo.id}, '${combo.name}', ${combo.savings}, '${symbol}', '${position}', event)">💰 ${applyText}</button>
+                            </div>
+                        </div>
+                    </div>`;
+                $('.oe_cart').before(alertHtml);
+            });
+        },
+
+        async applyDiscount(id, name, savings, symbol, position, ev) {
+            const button = ev.target;
+            button.innerHTML = '⏳ Applying...';
+            button.disabled = true;
+            try {
+                const response = await fetch(`/shop/apply_discount/${id}`, {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'X-CSRFToken': this.getCsrfToken(),
+                    },
+                    body: JSON.stringify({}),
+                });
+                const data = await response.json();
+                const result = data.result || data;
+                const t = result.translations || {};
+                if (result.success) {
+                    const applied = this.getTranslation(t, 'discount_applied', 'Discount Applied!');
+                    $('.simple-combo-alert').removeClass('alert-success').addClass('alert-info');
+                    $('.simple-combo-alert h4').text(`✅ ${applied}`);
+                    $('.simple-combo-alert p').text(`<strong>${result.message}</strong>`);
+                    $('.simple-combo-alert button').remove();
+                    setTimeout(() => location.reload(), 2000);
+                } else {
+                    $('.simple-combo-alert').removeClass('alert-success').addClass('alert-warning');
+                    const warn = this.getTranslation(t, 'warning', 'Warning');
+                    $('.simple-combo-alert h4').text(`⚠️ ${warn}`);
+                    $('.simple-combo-alert p').text(`<strong>${result.error}</strong>`);
+                    $('.simple-combo-alert button').remove();
+                    setTimeout(() => $('.simple-combo-alert').fadeOut(), 5000);
+                }
+            } catch (error) {
+                $('.simple-combo-alert').removeClass('alert-success').addClass('alert-danger');
+                const connErr = this.getTranslation({}, 'connection_error', 'Connection Error');
+                $('.simple-combo-alert h4').text(`❌ ${connErr}`);
+                $('.simple-combo-alert p').text(`<strong>Error: ${error.message}</strong>`);
+                $('.simple-combo-alert button').remove();
+                setTimeout(() => $('.simple-combo-alert').fadeOut(), 5000);
+            }
+        },
+    };
+
+    ComboManager.init();
+    window.comboManager = ComboManager;
+    window.checkForCombos = (...args) => ComboManager.checkForCombos(...args);
+    window.showComboAlerts = (...args) => ComboManager.showComboAlerts(...args);
+    window.applySimpleDiscount = (...args) => ComboManager.applyDiscount(...args);
+    window.getSimpleCsrfToken = () => ComboManager.getCsrfToken();
+    window.initCartObserver = (...args) => ComboManager.initCartObserver(...args);
+    window.formatCurrency = (...args) => ComboManager.formatCurrency(...args);
+})();

--- a/addons/website_sale_combo_suggestions/tests/__init__.py
+++ b/addons/website_sale_combo_suggestions/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_combo_suggestions

--- a/addons/website_sale_combo_suggestions/tests/test_combo_suggestions.py
+++ b/addons/website_sale_combo_suggestions/tests/test_combo_suggestions.py
@@ -1,0 +1,118 @@
+from odoo.tests.common import TransactionCase
+from odoo.addons.website_sale_combo_suggestions.controllers.main import ComboController
+
+
+class TestComboSuggestion(TransactionCase):
+    """
+    Test cases for combo suggestion discount logic.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.controller = ComboController()
+
+        # Create products
+        Product = self.env['product.product']
+        self.prod_a = Product.create({'name': 'Product A', 'list_price': 10.0})
+        self.prod_b = Product.create({'name': 'Product B', 'list_price': 15.0})
+
+        # Create combo
+        Combo = self.env['product.combo']
+        ComboItem = self.env['product.combo.item']
+        self.combo = Combo.create({'name': 'Combo A+B'})
+        ComboItem.create({'combo_id': self.combo.id, 'product_id': self.prod_a.id})
+        ComboItem.create({'combo_id': self.combo.id, 'product_id': self.prod_b.id})
+
+        # Create sale order
+        self.order = self.env['sale.order'].create({
+            'partner_id': self.env.ref('base.res_partner_1').id,
+        })
+
+    def _add_order_line(self, product, qty=1, price=None, discount=0.0):
+        """
+        Helper to add a sale order line.
+        """
+        line = self.env['sale.order.line'].create({
+            'order_id': self.order.id,
+            'product_id': product.id,
+            'product_uom_qty': qty,
+            'price_unit': price if price is not None else product.list_price,
+            'discount': discount,
+            'name': product.name,
+        })
+        return line
+
+    def test_combo_applied_successfully(self):
+        """
+        Applying combo discount when all combo items are present.
+        """
+        self._add_order_line(self.prod_a)
+        self._add_order_line(self.prod_b)
+
+        response = self.controller._apply_discount(self.order, self.combo)
+        self.assertTrue(response['success'])
+
+        discounted_lines = self.order.order_line.filtered(lambda l: l.discount > 0)
+        self.assertEqual(len(discounted_lines), 2, "There should be 2 lines with discount")
+        total_discount = sum(
+            l.price_unit * l.product_uom_qty * (l.discount / 100) for l in discounted_lines
+        )
+        self.assertEqual(total_discount, self.prod_b.list_price)
+
+    def test_combo_not_applicable_after_removal(self):
+        """
+        Combo discount should not apply if a combo item is removed.
+        """
+        self._add_order_line(self.prod_a)
+        self._add_order_line(self.prod_b)
+
+        self.controller._apply_discount(self.order, self.combo)
+
+        # Remove one combo item
+        self.order.order_line.filtered(lambda l: l.product_id == self.prod_b).unlink()
+
+        response = self.controller._apply_discount(self.order, self.combo)
+
+        self.assertFalse(response['success'])
+
+    def test_multiple_combo_applicable(self):
+        """
+        Combo discount applies multiple times if quantities allow.
+        """
+        quantity = 2
+        self._add_order_line(self.prod_a, qty=quantity)
+        self._add_order_line(self.prod_b, qty=quantity)
+
+        response = self.controller._apply_discount(self.order, self.combo)
+        self.assertTrue(response['success'])
+
+        discounted_lines = self.order.order_line.filtered(lambda l: l.discount > 0)
+        self.assertEqual(len(discounted_lines), 2)
+        total_discount = sum(
+            l.price_unit * l.product_uom_qty * (l.discount / 100) for l in discounted_lines
+        )
+        self.assertEqual(total_discount, self.prod_b.list_price * quantity)
+
+    def test_clear_discounts(self):
+        """
+        Clear all discounts from order lines.
+        """
+        self._add_order_line(self.prod_a, discount=30.0)
+        self._add_order_line(self.prod_b, discount=30.0)
+
+        self.controller._clear_discounts(self.order)
+
+        self.assertTrue(all(line.discount == 0.0 for line in self.order.order_line))
+
+    def test_consolidate_duplicate_lines(self):
+        """
+        Consolidate duplicate order lines into a single line.
+        """
+        self._add_order_line(self.prod_a)
+        self._add_order_line(self.prod_a)
+
+        before_count = len(self.order.order_line)
+        self.controller._consolidate_duplicate_lines(self.order)
+        after_count = len(self.order.order_line)
+
+        self.assertLess(after_count, before_count)

--- a/doc/cla/individual/diogoadr.md
+++ b/doc/cla/individual/diogoadr.md
@@ -1,0 +1,11 @@
+Portugal, 2025-06-13
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Diogo Rodrigues diogo.d.rodrigues@tecnico.ulisboa.pt https://github.com/diogoadr

--- a/doc/cla/individual/stargazerbibi.md
+++ b/doc/cla/individual/stargazerbibi.md
@@ -1,0 +1,11 @@
+Portugal, 2025-06-13
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Beatriz Abreu beatrizvdmabreu@tecnico.ulisboa.pt https://github.com/stargazerbibi


### PR DESCRIPTION
**Description of the feature this PR addresses**
This PR introduces the suggestion of combo packs (product bundles) during the website checkout flow — only when the total cart price can be reduced.

When a customer’s cart matches a predefined product set (combo), a replacement suggestion is shown with a better price. Only the cheapest applicable combo is offered, and it can be applied with a single click.

**Current behavior before PR**
Combo packs exist in the backend but are not applied or suggested during website shopping.

**Desired behavior after PR is merged**
- Combo packs are automatically detected and suggested in the website cart when applicable;
- Users can apply the suggestion directly from the cart interface;
- Combo is only shown if it leads to a discounted total price.

**Technical details**
Implements:
- /shop/check_combos: checks cart against available combos
- /shop/apply_discount/<id>: replaces cart contents with selected combo
- /shop/recalculate_combos: clears and recomputes combo suggestions

The frontend displays a clear alert with the suggested combo and price difference. If accepted, the cart is automatically updated.

Example
Cart contains:
- 4× Fork
- 4× Knife
- 4× Spoon

Total: €24

Suggested:
- "Cutlery Pack" (same items) for €20 → €4 savings

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
