### PR TITLE
[FIX] html_editor: text color and background (firefox)

### DIFF
--- a/addons/html_editor/static/src/core/selection_plugin.js
+++ b/addons/html_editor/static/src/core/selection_plugin.js
@@ -248,8 +248,8 @@ export class SelectionPlugin extends Plugin {
                     this.dispatchTo("selection_leave_handlers");
                 }
             };
-            this.addDomListener(this.document, "focus", focusEditable, { capture: true });
-            this.addDomListener(document, "focus", unFocusEditable, { capture: true });
+            this.addDomListener(this.document, "focusin", focusEditable, { capture: true });
+            this.addDomListener(document, "focusin", unFocusEditable, { capture: true });
             this.addDomListener(this.document, "pointerdown", focusEditable, { capture: true });
             this.addDomListener(document, "pointerdown", unFocusEditable, { capture: true });
         }


### PR DESCRIPTION
problem: In the website editor, while editing text, it is impossible to change the text color or text background, only on Firefox.

On Firefox, the DomListener was not focusing the right element, instead it was focusing the html document.
