### PR TITLE
[FIX] stock: Print each package of a report on a separate page

### DIFF
--- a/addons/stock/report/report_package_barcode.xml
+++ b/addons/stock/report/report_package_barcode.xml
@@ -147,6 +147,7 @@
                     </table>
                 </t>
             </div>
+            <p style="page-break-after: always;"/>
         </t>
     </t>
 </template>


### PR DESCRIPTION

When printing package reports, when having two or more packages, every 
package was printing one on top of another, instead of cleanly one on each 
page.

### Steps to reproduce 
1. Click on the general settings tab, and look for Packages in the search 
bar. Then, check the box under Operations in the Inventory section. 
2. Go to the inventory app.
3. Click on receipts and New.
4. Fill the "Receive from" field, add a product line and specify an amount
under "Demand". 
5. Click on Mark as Todo. Then, click on the hamburger menu of the product
line and add at least 2 packages, spreading the product amounts across 
them.
6. Click on validate. Then, click on the action menu (cog), click on 
print and click on "Packages". Once the PDF has finished downloading, open 
it. 

#### Expected behavior
Each page prints the content of a single package.

#### Unexpected behavior
On the pdf, all the packages are one on top of another.

### Origin of the issue
In the /odoo-community/addons/stock/report/report_package_barcode.xml file, 
a for-each operation is present. This for-each iterates over each package 
present in the report. However, no page break was setup.

### Explanation of the fix
I simply added a page breaker as an anchor (line 150). 

___
opw-4806024