### PR TITLE
[FIX] web: display our inputs and text-areas without border-radius on IOS

### DIFF
--- a/addons/web/static/src/webclient/webclient.scss
+++ b/addons/web/static/src/webclient/webclient.scss
@@ -171,7 +171,9 @@ select {
   width: 100%;
   display: block;
   outline: none;
+  border-radius: 0; // webkit OSX browsers have a border-radius on select, input and textarea
 }
+
 select {
 
   // FIXME buggy 'padding-left'
@@ -180,7 +182,6 @@ select {
 
   appearance: none;
   background: transparent $o-caret-down no-repeat right center;
-  border-radius: 0; // webkit OSX browsers have a border-radius on select
 
   color: $o-main-text-color;
 


### PR DESCRIPTION
Before this PR, inputs and text-areas were getting a browser default border-radius on safari IOS (iPad, iPhone), now it is displayed without being rounded, as it should.

task-4701008

| Before | After |
|--------|--------|
| ![IMG_0929](https://github.com/user-attachments/assets/944e6266-6ea2-4289-8fa9-571e4cd70668) | ![IMG_0930](https://github.com/user-attachments/assets/4fcf4f2f-ee61-4b0c-b6ed-50f5dc4a2cb7) |

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
