### PR TITLE
[FIX] base: paper format unnecessary constrain

### DIFF
--- a/doc/cla/individual/darkel61.md
+++ b/doc/cla/individual/darkel61.md
@@ -1,0 +1,11 @@
+Venezuela, 2025-05-30
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Henry Yu ddhenry809@hotmail.com https://github.com/darkel61

--- a/odoo/addons/base/models/report_paperformat.py
+++ b/odoo/addons/base/models/report_paperformat.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import fields, models, _
+from odoo import api, fields, models, _
+from odoo.exceptions import ValidationError
 
 # see http://doc.qt.io/archives/qt-4.8/qprinter.html#PaperSize-enum
 PAPER_SIZES = [

--- a/odoo/addons/base/models/report_paperformat.py
+++ b/odoo/addons/base/models/report_paperformat.py
@@ -189,11 +189,6 @@ class report_paperformat(models.Model):
     print_page_height = fields.Float('Print page height (mm)', compute='_compute_print_page_size')
     css_margins = fields.Boolean('Use css margins', default=False)
 
-    @api.constrains('format')
-    def _check_format_or_page(self):
-        if self.filtered(lambda x: x.format != 'custom' and (x.page_width or x.page_height)):
-            raise ValidationError(_('You can select either a format or a specific page width/height, but not both.'))
-
     def _compute_print_page_size(self):
         for record in self:
             width = height = 0.0

--- a/odoo/addons/base/models/report_paperformat.py
+++ b/odoo/addons/base/models/report_paperformat.py
@@ -1,8 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import api, fields, models, _
-from odoo.exceptions import ValidationError
+from odoo import fields, models, _
 
 # see http://doc.qt.io/archives/qt-4.8/qprinter.html#PaperSize-enum
 PAPER_SIZES = [


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
When you set a `custom` Paper size, you can't swap to another one without setting the `Page height (mm)` and `Page width (mm)` to 0 just to swap it again, this could be just skiped since the paperformat uses the computed fields made on `_compute_print_page_size` to get the proper height and width.

Current behavior before PR:
This happens when you swap Paper size from `custom` to any other.
![image](https://github.com/user-attachments/assets/22d62aca-8041-48a4-9fdc-d69265f94684)


Desired behavior after PR is merged:
After deleting this validation, should swap without this popup, and we could save the original values if the user wants to swap again to custom format.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
