### PR TITLE
[FIX] mail: prevent traceback when clicking on chatbot

### DIFF
--- a/addons/mail/static/src/discuss/core/common/channel_member_list.js
+++ b/addons/mail/static/src/discuss/core/common/channel_member_list.js
@@ -39,7 +39,7 @@ export class ChannelMemberList extends Component {
     }
 
     canOpenChatWith(member) {
-        if (this.store.inPublicPage) {
+        if (this.store.inPublicPage || !member.persona.userId) {
             return false;
         }
         if (member.persona.type === "guest") {

--- a/addons/mail/static/tests/discuss/core/channel_member_list.test.js
+++ b/addons/mail/static/tests/discuss/core/channel_member_list.test.js
@@ -230,3 +230,20 @@ test("Members are partitioned by online/offline", async () => {
         after: ["h6", { text: "Offline - 1" }],
     });
 });
+
+test("Do not open avatar card for chatbot", async () => {
+    const pyEnv = await startServer();
+    const partnerId = pyEnv["res.partner"].create({ name: "Bot" });
+    const channelId = pyEnv["discuss.channel"].create({
+        name: "TestChannel",
+        channel_member_ids: [
+            Command.create({ partner_id: serverState.partnerId }),
+            Command.create({ partner_id: partnerId }),
+        ],
+        channel_type: "channel",
+    });
+    await start();
+    await openDiscuss(channelId);
+    await contains(".o-discuss-ChannelMember", { count: 2 });
+    await contains(".o-discuss-ChannelMember.cursor-pointer");
+});


### PR DESCRIPTION
**Current behavior before PR:**

When a user tests a chatbot using the test button and tries to open the chatbot
avatar card from the discuss channel member list, it results in a traceback.
This happens because the bot does not have a `user_id`.

**Desired behavior after PR is merged:**

Clicking on a chatbot no longer causes a traceback.
 
**Task**-[4642940](https://www.odoo.com/odoo/project/1519/tasks/4642940)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
