### PR TITLE
[FIX] point_of_sale: prevent refund from multiple orders regardless of invoice status

### DIFF
--- a/addons/point_of_sale/static/src/js/Screens/TicketScreen/TicketScreen.js
+++ b/addons/point_of_sale/static/src/js/Screens/TicketScreen/TicketScreen.js
@@ -212,21 +212,15 @@ odoo.define('point_of_sale.TicketScreen', function (require) {
                 return;
             }
 
-            const invoicedOrderIds = new Set(
+            const orderIds = new Set(
                 allToRefundDetails
-                    .filter(
-                        (detail) =>
-                            this._state.syncedOrders.cache[detail.orderline.orderBackendId] &&
-                            this._state.syncedOrders.cache[detail.orderline.orderBackendId].state ===
-                            "invoiced"
-                    )
                     .map((detail) => detail.orderline.orderBackendId)
             );
 
-            if (invoicedOrderIds.size > 1) {
+            if (orderIds.size > 1) {
                 this.showPopup('ErrorPopup', {
-                    title: this.env._t('Multiple Invoiced Orders Selected'),
-                    body: this.env._t('You have selected orderlines from multiple invoiced orders. To proceed refund, please select orderlines from the same invoiced order.')
+                    title: this.env._t('Multiple Orders Selected'),
+                    body: this.env._t('You have selected orderlines from multiple orders. To proceed refund, please select orderlines from the same order.')
                 });
                 return;
             }


### PR DESCRIPTION
Before this fix, users could create a refund order from multiple POS orders as long as none of them were invoiced. A previous fix (commit https://github.com/odoo/odoo/commit/58fa77147eada8065ba9f3246a8ff9218d413788) already prevented refunds from multiple **invoiced** orders via the POS interface, as such cases could not be invoiced due to conflicts with multiple related account moves.

However, it was still possible to create a refund from multiple **non-invoiced** orders, and then later invoice those original orders through the backend. This ultimately leads to the same invoicing failure when trying to invoice the refund, because it ends up being linked to multiple account moves.

This commit improves upon the previous one by blocking refund creation from **more than one POS order, regardless of their invoicing status**, thus ensuring consistency and preventing invoicing errors in the future.





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
