### PR TITLE
[IMP] hr: make some fields read-only on Employee Versions

### DIFF
--- a/addons/hr/views/hr_version_views.xml
+++ b/addons/hr/views/hr_version_views.xml
@@ -20,8 +20,8 @@
                 <field name="company_id" groups="base.group_multi_company" readonly="1" optional="hide"/>
                 <field name="create_uid" optional="hide"/>
                 <field name="create_date" optional="hide"/>
-                <field name="last_modified_uid" optional="hide"/>
-                <field name="last_modified_date" optional="hide"/>
+                <field name="last_modified_uid" optional="hide" readonly="1"/>
+                <field name="last_modified_date" optional="hide" readonly="1"/>
             </list>
         </field>
     </record>


### PR DESCRIPTION
- Made the 'Last Modified By' and 'Last Modified On' fields read-only in the list view of Employee Versions.
- Aligns with system-generated metadata convention.

Task - 4865935