### PR TITLE
[IMP] l10n_in_pos: include reversal orders in Place of supply computation

### DIFF
--- a/addons/l10n_in_pos/models/account_move.py
+++ b/addons/l10n_in_pos/models/account_move.py
@@ -5,10 +5,10 @@ from odoo import api, models
 class AccountMove(models.Model):
     _inherit = 'account.move'
 
-    @api.depends('pos_session_ids')
+    @api.depends('pos_session_ids', 'reversed_pos_order_id')
     def _compute_l10n_in_state_id(self):
         res = super()._compute_l10n_in_state_id()
-        to_compute = self.filtered(lambda m: m.country_code == 'IN' and not m.l10n_in_state_id and m.journal_id.type == 'general' and m.pos_session_ids)
+        to_compute = self.filtered(lambda m: m.country_code == 'IN' and not m.l10n_in_state_id and m.journal_id.type == 'general' and (m.pos_session_ids or m.reversed_pos_order_id))
         for move in to_compute:
             move.l10n_in_state_id = move.company_id.state_id
         return res


### PR DESCRIPTION
Before this commit:
- The `_compute_l10n_in_state_id` method only considered `pos_session_ids` when assigning the state for Indian POS moves.
- Reversed POS orders were ignored, leading to missing `l10n_in_state_id`.

After this commit:
- Added `reversed_pos_order_id` to the `@api.depends` decorator.
- Updated domain to include moves with `reversed_pos_order_id`.

Ensures correct place of supply is computed for reversed POS orders as well.

OPW: 4862639