### PR TITLE
[IMP] l10n_es_edi_facturae: improve Factura-e generation workflow for ES partners

### DIFF
--- a/addons/l10n_es_edi_facturae/models/account_move.py
+++ b/addons/l10n_es_edi_facturae/models/account_move.py
@@ -120,15 +120,23 @@ class AccountMove(models.Model):
         fields_list.append("l10n_es_edi_facturae_xml_file")
         return fields_list
 
+    def _l10n_es_edi_facturae_export_data_check(self):
+        """ This function checks the Settings, Company, Partners involved in the
+            sending activity and returns an errors dictionary ready for the
+            actionable_errors widget to display. """
+
+        return {
+            **self.mapped("company_id")._l10n_es_edi_facturae_export_check(),
+            **self.mapped("partner_id")._l10n_es_edi_facturae_export_check(),
+        }
+
     def _l10n_es_edi_facturae_get_default_enable(self):
         self.ensure_one()
         return not self.invoice_pdf_report_id \
             and not self.l10n_es_edi_facturae_xml_id \
             and not self.l10n_es_is_simplified \
             and self.is_invoice(include_receipts=True) \
-            and (self.partner_id.is_company or self.partner_id.vat) \
-            and self.company_id.country_code == 'ES' \
-            and self.company_id.currency_id.name == 'EUR' \
+            and self.country_code == 'ES' \
             and self.company_id.sudo().l10n_es_edi_facturae_certificate_ids  # We only enable Facturae if a certificate is valid or has been valid (which will raise an error)
 
     def _l10n_es_edi_facturae_get_filename(self):

--- a/addons/l10n_es_edi_facturae/models/res_company.py
+++ b/addons/l10n_es_edi_facturae/models/res_company.py
@@ -1,4 +1,4 @@
-from odoo import fields, models
+from odoo import _, fields, models
 
 
 class Company(models.Model):
@@ -7,3 +7,34 @@ class Company(models.Model):
     l10n_es_edi_facturae_residence_type = fields.Char(string='Facturae EDI Residency Type Code', related='partner_id.l10n_es_edi_facturae_residence_type')
     l10n_es_edi_facturae_certificate_ids = fields.One2many(string='Facturae EDI signing certificate',
         comodel_name='certificate.certificate', inverse_name='company_id', domain=[('scope', '=', 'facturae')])
+
+    def _l10n_es_edi_facturae_export_check(self):
+        checks = {
+            'company_currency_check': {
+                'fields': [('currency_id',)],
+                'message': _("The company's currency must be set to Euro (€)."),
+            },
+        }
+        errors = {}
+        for key, check in checks.items():
+            for fields_tuple in check.pop('fields'):
+                if invalid_records := self.filtered(lambda record: not any(record[field] for field in fields_tuple)):
+                    errors[f"l10n_es_edi_facturae_{key}"] = {
+                        'level': 'danger',
+                        'message': check['message'],
+                        'action_text': _("View Company(s)"),
+                        'action': invalid_records._get_records_action(name=_("Check Company Data")),
+                    }
+        if invalid_records := self.filtered(lambda company: not company.l10n_es_edi_facturae_certificate_ids):
+            errors["l10n_es_edi_company_facturae_certificate_check"] = {
+                'level': 'danger',
+                'message': _("Company must have a valid Factura-e certificate configured."),
+                'action_text': _("View Certificate(s)"),
+                'action': {
+                    'name': _("Settings"),
+                    'type': 'ir.actions.act_url',
+                    'target': 'self',
+                    'url': '/odoo/settings#certificates_settings',
+                },
+            }
+        return errors

--- a/addons/l10n_es_edi_facturae/models/res_partner.py
+++ b/addons/l10n_es_edi_facturae/models/res_partner.py
@@ -74,3 +74,14 @@ class Partner(models.Model):
                 partner.l10n_es_edi_facturae_residence_type = 'U'
             else:
                 partner.l10n_es_edi_facturae_residence_type = 'E'
+
+    def _l10n_es_edi_facturae_export_check(self):
+        errors = {}
+        if invalid_records := self.filtered(lambda partner: not (partner.is_company or partner.vat)):
+            errors["l10n_es_edi_facturae_partner_check"] = {
+                'level': 'danger',
+                'message': _("Partner must be a company or have a VAT number"),
+                'action_text': _("View Partner(s)"),
+                'action': invalid_records._get_records_action(name=_("Check Partner(s)")),
+            }
+        return errors

--- a/addons/l10n_es_edi_facturae/tests/test_edi_xml.py
+++ b/addons/l10n_es_edi_facturae/tests/test_edi_xml.py
@@ -201,8 +201,9 @@ class TestEdiFacturaeXmls(AccountTestInvoicingCommon):
         invoice = self.create_invoice(partner_id=self.partner_a.id, move_type='out_invoice', invoice_line_ids=[{'price_unit': 100.0, 'tax_ids': [self.tax.id]}])
         invoice.action_post()
         wizard = self.create_send_and_print(invoice)
-        wizard.action_send_and_print()
-        self.assertFalse(invoice.l10n_es_edi_facturae_xml_id)
+        # Expect a UserError if no certificate is configured
+        with self.assertRaises(UserError):
+            wizard.action_send_and_print()
 
     def test_tax_withheld(self):
         with freeze_time(self.frozen_today), \

--- a/addons/l10n_es_edi_facturae/wizard/__init__.py
+++ b/addons/l10n_es_edi_facturae/wizard/__init__.py
@@ -1,1 +1,2 @@
 from . import account_move_reversal
+from . import account_move_send_wizard

--- a/addons/l10n_es_edi_facturae/wizard/account_move_send_wizard.py
+++ b/addons/l10n_es_edi_facturae/wizard/account_move_send_wizard.py
@@ -1,0 +1,22 @@
+from odoo import models
+
+
+class AccountMoveSendWizard(models.TransientModel):
+    _inherit = 'account.move.send.wizard'
+
+    def _compute_extra_edi_checkboxes(self):
+        super()._compute_extra_edi_checkboxes()
+        for wizard in self:
+            checkboxes = wizard.extra_edi_checkboxes or {}
+            if 'es_facturae' in checkboxes:
+                # Set 'checked' status for the 'es_facturae' checkbox
+                checkboxes['es_facturae']['checked'] = wizard.move_id._l10n_es_edi_facturae_get_default_enable()
+
+    def action_send_and_print(self, allow_fallback_pdf=False):
+        action = super().action_send_and_print(allow_fallback_pdf)
+        checkboxes = self.extra_edi_checkboxes or {}
+        if 'es_facturae' in checkboxes and checkboxes['es_facturae']['checked']:
+            # Set partner's invoice_edi_format to 'es_facturae' after sending
+            partner = self.move_id.commercial_partner_id
+            partner.invoice_edi_format = 'es_facturae'
+        return action


### PR DESCRIPTION
Currently, `Factura-e` generation is controlled only by an partner E-invoice format setting, making it difficult for users to enable or disable when sending invoices.

This PR adds a dedicated Factura-e checkbox on the `Send & Print` wizard for partners in Spain if the `l10n_es_edi_facturae` module is installed. The checkbox defaults to the partner’s current `E-invoice format` but can be toggled by the user. When enabled, it triggers Factura-e file generation and updates the partner’s E-invoice format to ensure consistency.

This approach simplifies the user flow and reduces configuration errors.

> Task-4831835