### PR TITLE
[REM] website, web_editor: fix video platform related issues

### DIFF
--- a/addons/web_editor/static/src/components/media_dialog/video_selector.js
+++ b/addons/web_editor/static/src/components/media_dialog/video_selector.js
@@ -32,7 +32,7 @@ export class VideoSelector extends Component {
             autoplay: {
                 label: _t("Autoplay"),
                 description: _t("Videos are muted when autoplay is enabled"),
-                platforms: [this.PLATFORMS.youtube, this.PLATFORMS.dailymotion, this.PLATFORMS.vimeo],
+                platforms: [this.PLATFORMS.youtube, this.PLATFORMS.vimeo],
                 urlParameter: 'autoplay=1',
             },
             loop: {
@@ -42,7 +42,7 @@ export class VideoSelector extends Component {
             },
             hide_controls: {
                 label: _t("Hide player controls"),
-                platforms: [this.PLATFORMS.youtube, this.PLATFORMS.dailymotion, this.PLATFORMS.vimeo],
+                platforms: [this.PLATFORMS.youtube, this.PLATFORMS.vimeo],
                 urlParameter: 'controls=0',
             },
             hide_fullscreen: {
@@ -50,16 +50,6 @@ export class VideoSelector extends Component {
                 platforms: [this.PLATFORMS.youtube],
                 urlParameter: 'fs=0',
                 isHidden: () => this.state.options.filter(option => option.id === 'hide_controls')[0].value,
-            },
-            hide_dm_logo: {
-                label: _t("Hide Dailymotion logo"),
-                platforms: [this.PLATFORMS.dailymotion],
-                urlParameter: 'ui-logo=0',
-            },
-            hide_dm_share: {
-                label: _t("Hide sharing button"),
-                platforms: [this.PLATFORMS.dailymotion],
-                urlParameter: 'sharing-enable=0',
             },
         };
 

--- a/addons/web_editor/static/src/components/media_dialog/video_selector.js
+++ b/addons/web_editor/static/src/components/media_dialog/video_selector.js
@@ -25,7 +25,6 @@ export class VideoSelector extends Component {
             youtube: 'youtube',
             dailymotion: 'dailymotion',
             vimeo: 'vimeo',
-            youku: 'youku',
         };
 
         this.OPTIONS = {

--- a/addons/web_editor/static/src/components/media_dialog/video_selector.xml
+++ b/addons/web_editor/static/src/components/media_dialog/video_selector.xml
@@ -29,7 +29,7 @@
                     <b>Video code </b>(URL or Embed)
                 </label>
                 <div class="text-start">
-                    <small class="text-muted">Accepts <b><i>Youtube</i></b>, <b><i>Vimeo</i></b>, <b><i>Dailymotion</i></b> and <b><i>Youku</i></b> videos</small>
+                    <small class="text-muted">Accepts <b><i>Youtube</i></b>, <b><i>Vimeo</i></b>, <b><i>Dailymotion</i></b> and <b><i>Instagram</i></b> videos</small>
                 </div>
                 <textarea t-ref="autofocus" t-model="state.urlInput" class="form-control" id="o_video_text" placeholder="Copy-paste your URL or embed code here" t-on-input="onChangeUrl" t-att-class="{ 'is-valid': state.urlInput and !this.state.errorMessage, 'is-invalid': state.urlInput and this.state.errorMessage }"/>
             </div>

--- a/addons/web_editor/tests/test_tools.py
+++ b/addons/web_editor/tests/test_tools.py
@@ -17,15 +17,12 @@ class TestVideoUtils(common.BaseCase):
         'vimeo_player': 'https://player.vimeo.com/video/395399735',
         'vimeo_player_unlisted_video': 'https://player.vimeo.com/video/795669787?h=0763fdb816',
         'dailymotion': 'https://www.dailymotion.com/video/x7svr6t',
-        'youku': 'https://v.youku.com/v_show/id_XMzY1MjY4.html?spm=a2hzp.8244740.0.0',
         'instagram': 'https://www.instagram.com/p/B6dXGTxggTG/',
         'dailymotion_hub_no_video': 'http://www.dailymotion.com/hub/x9q_Galatasaray',
         'dailymotion_hub_#video': 'http://www.dailymotion.com/hub/x9q_Galatasaray#video=x2jvvep',
         'dai.ly': 'https://dai.ly/x578has',
         'dailymotion_embed': 'https://www.dailymotion.com/embed/video/x578has?autoplay=1',
         'dailymotion_video_extra': 'https://www.dailymotion.com/video/x2jvvep_hakan-yukur-klip_sport',
-        'player_youku': 'https://player.youku.com/player.php/sid/XMTI5Mjg5NjE4MA==/v.swf',
-        'youku_embed': 'https://player.youku.com/embed/XNTIwMzE1MzUzNg',
     }
 
     def test_player_regexes(self):
@@ -38,8 +35,6 @@ class TestVideoUtils(common.BaseCase):
         self.assertIsNotNone(re.search(tools.player_regexes['vimeo_player'], TestVideoUtils.urls['vimeo_player_unlisted_video']))
         #dailymotion
         self.assertIsNotNone(re.search(tools.player_regexes['dailymotion'], TestVideoUtils.urls['dailymotion']))
-        #youku
-        self.assertIsNotNone(re.search(tools.player_regexes['youku'], TestVideoUtils.urls['youku']))
         #instagram
         self.assertIsNotNone(re.search(tools.player_regexes['instagram'], TestVideoUtils.urls['instagram']))
 
@@ -71,13 +66,6 @@ class TestVideoUtils(common.BaseCase):
         self.assertEqual('x578has', tools.get_video_source_data(TestVideoUtils.urls['dailymotion_embed'])[1])
         self.assertEqual('dailymotion', tools.get_video_source_data(TestVideoUtils.urls['dailymotion_video_extra'])[0])
         self.assertEqual('x2jvvep', tools.get_video_source_data(TestVideoUtils.urls['dailymotion_video_extra'])[1])
-        #youku
-        self.assertEqual('youku', tools.get_video_source_data(TestVideoUtils.urls['youku'])[0])
-        self.assertEqual('XMzY1MjY4', tools.get_video_source_data(TestVideoUtils.urls['youku'])[1])
-        self.assertEqual('youku', tools.get_video_source_data(TestVideoUtils.urls['player_youku'])[0])
-        self.assertEqual('XMTI5Mjg5NjE4MA', tools.get_video_source_data(TestVideoUtils.urls['player_youku'])[1])
-        self.assertEqual('youku', tools.get_video_source_data(TestVideoUtils.urls['youku_embed'])[0])
-        self.assertEqual('XNTIwMzE1MzUzNg', tools.get_video_source_data(TestVideoUtils.urls['youku_embed'])[1])
         #instagram
         self.assertEqual('instagram', tools.get_video_source_data(TestVideoUtils.urls['instagram'])[0])
         self.assertEqual('B6dXGTxggTG', tools.get_video_source_data(TestVideoUtils.urls['instagram'])[1])
@@ -108,8 +96,6 @@ class TestVideoUtils(common.BaseCase):
             })
         #dailymotion
         self.assertEqual('dailymotion', tools.get_video_url_data(TestVideoUtils.urls['dailymotion'])['platform'])
-        #youku
-        self.assertEqual('youku', tools.get_video_url_data(TestVideoUtils.urls['youku'])['platform'])
         #instagram
         self.assertEqual('instagram', tools.get_video_url_data(TestVideoUtils.urls['instagram'])['platform'])
 
@@ -129,5 +115,3 @@ class TestVideoUtilsExternal(common.BaseCase):
         self.assertIsInstance(tools.get_video_thumbnail(TestVideoUtils.urls['dailymotion']), bytes)
         #instagram
         self.assertIsInstance(tools.get_video_thumbnail(TestVideoUtils.urls['instagram']), bytes)
-        #default
-        self.assertIsInstance(tools.get_video_thumbnail(TestVideoUtils.urls['youku']), bytes)

--- a/addons/web_editor/tools.py
+++ b/addons/web_editor/tools.py
@@ -113,15 +113,6 @@ def get_video_url_data(video_url, autoplay=False, loop=False, hide_controls=Fals
                 params['h'] = url_params['h'][0]
         embed_url = f'//player.vimeo.com/video/{video_id}'
     elif platform == 'dailymotion':
-        params['autoplay'] = autoplay and 1 or 0
-        if autoplay:
-            params['mute'] = 1
-        if hide_controls:
-            params['controls'] = 0
-        if hide_dm_logo:
-            params['ui-logo'] = 0
-        if hide_dm_share:
-            params['sharing-enable'] = 0
         embed_url = f'//www.dailymotion.com/embed/video/{video_id}'
     elif platform == 'instagram':
         embed_url = f'//www.instagram.com/p/{video_id}/embed/'

--- a/addons/web_editor/tools.py
+++ b/addons/web_editor/tools.py
@@ -28,7 +28,6 @@ player_regexes = {
     'vimeo_player': r'^(?:(?:https?:)?//)?player\.vimeo\.com\/video\/(?P<id>[^/\?]+)(?:\?(?P<params>[^\s]+))?$',
     'dailymotion': r'(https?:\/\/)(www\.)?(dailymotion\.com\/(embed\/video\/|embed\/|video\/|hub\/.*#video=)|dai\.ly\/)(?P<id>[A-Za-z0-9]{6,7})',
     'instagram': r'(?:(.*)instagram.com|instagr\.am)/p/(.[a-zA-Z0-9-_\.]*)',
-    'youku': r'(?:(https?:\/\/)?(v\.youku\.com/v_show/id_|player\.youku\.com/player\.php/sid/|player\.youku\.com/embed/|cloud\.youku\.com/services/sharev\?vid=|video\.tudou\.com/v/)|youku:)(?P<id>[A-Za-z0-9]+)(?:\.html|/v\.swf|)',
 }
 
 
@@ -54,9 +53,6 @@ def get_video_source_data(video_url):
         instagram_match = re.search(player_regexes['instagram'], video_url)
         if instagram_match:
             return ('instagram', instagram_match[2], instagram_match)
-        youku_match = re.search(player_regexes['youku'], video_url)
-        if youku_match:
-            return ('youku', youku_match.group("id"), youku_match)
     return None
 
 
@@ -116,8 +112,6 @@ def get_video_url_data(video_url, autoplay=False, loop=False, hide_controls=Fals
         embed_url = f'//www.dailymotion.com/embed/video/{video_id}'
     elif platform == 'instagram':
         embed_url = f'//www.instagram.com/p/{video_id}/embed/'
-    elif platform == 'youku':
-        embed_url = f'//player.youku.com/embed/{video_id}'
 
     if params:
         embed_url = f'{embed_url}?{url_encode(params)}'

--- a/addons/website/static/src/js/content/generate_video_iframe.js
+++ b/addons/website/static/src/js/content/generate_video_iframe.js
@@ -9,8 +9,6 @@ const SUPPORTED_DOMAINS = [
     "player.vimeo.com",
     "vimeo.com",
     "dailymotion.com",
-    "player.youku.com",
-    "youku.com",
 ];
 
 /**


### PR DESCRIPTION
Specification:
Improve `VideoSelector` Component.

After this PR:

- Dailymotion has deprecated its legacy embed endpoint starting
September 23, 2024. Removed support for embedding Dailymotion videos
in the media dialog.
- Embedding Youku videos via iframe has become unreliable and no longer
functions properly in the media dialog. Removed support for Youku
embeds to prevent broken video content.
- The supported platforms string now correctly lists YouTube,
Vimeo, and Dailymotion, Instagram as supported platforms.

task-4855038


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
