### PR TITLE
[FIX] html_editor: properly resize image by adjusting dimensions

### DIFF
--- a/addons/html_editor/static/src/main/media/image_plugin.js
+++ b/addons/html_editor/static/src/main/media/image_plugin.js
@@ -287,6 +287,7 @@ export class ImagePlugin extends Plugin {
             return;
         }
         targetedImg.style.width = size || "";
+        targetedImg.style.height = size || "";
         this.dependencies.history.addStep();
     }
 
@@ -466,6 +467,8 @@ export class ImagePlugin extends Plugin {
             "style",
             (image.getAttribute("style") || "").replace(/[^;]*transform[\w:]*;?/g, "")
         );
+        image.style.removeProperty("width");
+        image.style.removeProperty("height");
         this.dependencies.history.addStep();
     }
 


### PR DESCRIPTION
**Problem**:
Resizing an image only affected its visual scale via CSS transformations. The actual DOM width and height remained unchanged, causing the image to still occupy a large area.

**Solution**:
Instead of applying CSS `scale`, update the image's `width` and `height` properties directly to reflect its resized dimensions. This ensures that both the visual and DOM sizes match, improving UX.

**Steps to reproduce**:
1. Add an image in the HTML editor.
2. Apply a transform to the image.
3. Resize it to make it smaller. → The image looks smaller visually but still takes up a large
   footprint in the DOM.

opw-4717603

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
