### PR TITLE
[FIX] pos_self_order : prevent table selection when table identifier

### DIFF
--- a/addons/pos_self_order/static/src/app/pages/eating_location_page/eating_location_page.js
+++ b/addons/pos_self_order/static/src/app/pages/eating_location_page/eating_location_page.js
@@ -17,7 +17,6 @@ export class EatingLocationPage extends Component {
 
     selectPreset(preset) {
         this.selfOrder.currentOrder.setPreset(preset);
-        this.selfOrder.currentTable = null;
         this.router.navigate("product_list");
     }
 

--- a/addons/pos_self_order/static/tests/tours/self_order_mobile_tour.js
+++ b/addons/pos_self_order/static/tests/tours/self_order_mobile_tour.js
@@ -258,3 +258,18 @@ registry.category("web_tour.tours").add("SelfOrderOrderNumberTour", {
         Utils.checkIsNoBtn("Ok"),
     ],
 });
+
+registry.category("web_tour.tours").add("self_mobile_auto_table_selection_takeaway_in", {
+    steps: () => [
+        Utils.checkIsNoBtn("My Order"),
+        Utils.clickBtn("Order Now"),
+        LandingPage.selectLocation("Test-In"),
+        ProductPage.clickProduct("Coca-Cola"),
+        Utils.clickBtn("Order"),
+        CartPage.checkProduct("Coca-Cola", "2.53", "1"),
+        Utils.clickBtn("Pay"),
+        CartPage.checkNoTableSelector(),
+        Utils.clickBtn("Ok"),
+        Utils.checkIsNoBtn("Order Now"),
+    ],
+});

--- a/addons/pos_self_order/static/tests/tours/utils/cart_page_util.js
+++ b/addons/pos_self_order/static/tests/tours/utils/cart_page_util.js
@@ -6,6 +6,13 @@ export function clickBack() {
     };
 }
 
+export function checkNoTableSelector() {
+    return {
+        content: `Check if the table selection is not displayed`,
+        trigger: `body:not(:has(.self_order_popup_table))`,
+    };
+}
+
 export function selectTable(table) {
     return [
         {

--- a/addons/pos_self_order/tests/test_self_order_mobile.py
+++ b/addons/pos_self_order/tests/test_self_order_mobile.py
@@ -77,3 +77,6 @@ class TestSelfOrderMobile(SelfOrderCommonTest):
 
         # Cancel in each
         self.start_tour(self_route, "self_order_mobile_each_cancel")
+
+        self_route_table = self.pos_config._get_self_order_route(table_id=floor.table_ids[0].id)
+        self.start_tour(self_route_table, "self_mobile_auto_table_selection_takeaway_in")


### PR DESCRIPTION
Before this commit, when you made a self order at Table, the table selector was trigger and you had to pick one, even if the tableIndicator was there.

In practice, the `selectedTable` in `selfOrder` was removed by the `selectPreset()` function of `EatingLocationPage`

```js
selectPreset(preset) {
	this.selfOrder.currentOrder.setPreset(preset);
	this.selfOrder.currentTable = null;
	this.router.navigate("product_list");
}
```

That was fixed in 18.2 by this commit : https://github.com/odoo/odoo/commit/5e01d444cfd0594dd88a420129375ae1a6fdfc62

The test `self_mobile_auto_table_selection_takeaway_in` as been added.

Steps to reproduce (in runbot 18.1) :
- Go in Point of Sale > Configuration > Settings
- Select the Restaurant
- Set the Self Ordering Method to QR menu + Ordering
- Save
- Get the code using Print QR Codes
- Open the Table: 1 URL in incognito window
- Make sure the Restaurant is Open and the table 1 have no remaining order
- Select Eat In as eating location and make an order
- When you click pay, the table selection displayed

opw-4641352