### PR TITLE
[FIX] account_debit_note: duplicate message log when create debit note

### DIFF
--- a/addons/account/i18n/account.pot
+++ b/addons/account/i18n/account.pot
@@ -14371,7 +14371,7 @@ msgstr ""
 #. odoo-python
 #: code:addons/account/models/account_move.py:0
 #, python-format
-msgid "This entry has been duplicated from %s%s"
+msgid "This entry has been duplicated from %s"
 msgstr ""
 
 #. module: account

--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -2252,13 +2252,20 @@ class AccountMove(models.Model):
         copied_am = super().copy(default)
         message_origin = '' if not copied_am.auto_post_origin_id else \
             '<br/>' + _('This recurring entry originated from %s', copied_am.auto_post_origin_id._get_html_link())
-        copied_am._message_log(body=_(
-            'This entry has been duplicated from %s%s',
-            self._get_html_link(),
-            message_origin,
-        ))
+        message_content = self._get_copy_message_content(default)
+        copied_am._message_log(
+            body=message_content + message_origin,
+        )
 
         return copied_am
+
+    def _get_copy_message_content(self, default):
+        """Hook method to customize the message content when copying a move.
+        This method can be overridden by other modules to add custom logic.
+        :param default: The default values dict passed to copy method
+        :return: The message content string
+        """
+        return _('This entry has been duplicated from %s', self._get_html_link())
 
     def _sanitize_vals(self, vals):
         if vals.get('invoice_line_ids') and vals.get('line_ids'):

--- a/addons/account_debit_note/models/account_move.py
+++ b/addons/account_debit_note/models/account_move.py
@@ -28,3 +28,9 @@ class AccountMove(models.Model):
             'view_mode': 'tree,form',
             'domain': [('debit_origin_id', '=', self.id)],
         }
+
+    def _get_copy_message_content(self, default):
+        """Override to handle debit note specific messages."""
+        if default and default.get('debit_origin_id'):
+            return _('This debit note was created from: %s', self._get_html_link())
+        return super()._get_copy_message_content(default)

--- a/addons/account_debit_note/wizard/account_debit_note.py
+++ b/addons/account_debit_note/wizard/account_debit_note.py
@@ -67,11 +67,6 @@ class AccountDebitNote(models.TransientModel):
         for move in self.move_ids.with_context(include_business_fields=True): #copy sale/purchase links
             default_values = self._prepare_default_values(move)
             new_move = move.copy(default=default_values)
-            move_msg = _(
-                "This debit note was created from: %s",
-                move._get_html_link(),
-            )
-            new_move.message_post(body=move_msg)
             new_moves |= new_move
 
         action = {


### PR DESCRIPTION
* PROBLEM: install account_debit_note module, add a debit note -> check the log at chatter we will see 2 message, one is 'This entry has been duplicated from ...' and another is 'This debit note was created from..'

* Fix by only keep one message log in that case, just like in odoo 18 check the default value to have a appropriate message content

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
