### PR TITLE
[FIX] website[_mass_mailing]: fix template name prefixes

### DIFF
--- a/addons/website/static/src/client_actions/website_preview/edit_website_systray_item.js
+++ b/addons/website/static/src/client_actions/website_preview/edit_website_systray_item.js
@@ -5,7 +5,7 @@ import { DropdownItem } from "@web/core/dropdown/dropdown_item";
 import { rpc } from "@web/core/network/rpc";
 
 export class EditWebsiteSystrayItem extends Component {
-    static template = "html_builder.EditWebsiteSystrayItem";
+    static template = "website.EditWebsiteSystrayItem";
     static props = {
         onNewPage: { type: Function },
         onEditPage: { type: Function },

--- a/addons/website/static/src/client_actions/website_preview/edit_website_systray_item.xml
+++ b/addons/website/static/src/client_actions/website_preview/edit_website_systray_item.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-<t t-name="html_builder.EditWebsiteSystrayItem">
+<t t-name="website.EditWebsiteSystrayItem">
     <div class="o_menu_systray_item o_edit_website_container d-none d-md-flex">
         <button t-if="!translatable and !this.websiteService.is404"
                 class="o-website-btn-custo-primary btn d-flex align-items-center rounded-0 border-0 px-3"

--- a/addons/website/static/src/client_actions/website_preview/install_module_dialog.js
+++ b/addons/website/static/src/client_actions/website_preview/install_module_dialog.js
@@ -4,7 +4,7 @@ import { WebsiteDialog } from "@website/components/dialog/dialog";
 
 export class InstallModuleDialog extends Component {
     static components = { WebsiteDialog };
-    static template = "html_builder.InstallModuleDialog";
+    static template = "website.InstallModuleDialog";
     static props = {
         title: String,
         installationText: String,

--- a/addons/website/static/src/client_actions/website_preview/install_module_dialog.xml
+++ b/addons/website/static/src/client_actions/website_preview/install_module_dialog.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-<t t-name="html_builder.InstallModuleDialog">
+<t t-name="website.InstallModuleDialog">
     <WebsiteDialog close="props.close"
         title="props.title"
         primaryTitle="installButtonTitle"

--- a/addons/website/static/src/client_actions/website_preview/new_content_element.js
+++ b/addons/website/static/src/client_actions/website_preview/new_content_element.js
@@ -8,7 +8,7 @@ export const MODULE_STATUS = {
 };
 
 export class NewContentElement extends Component {
-    static template = "html_builder.NewContentElement";
+    static template = "website.NewContentElement";
     static props = {
         name: { type: String, optional: true },
         title: String,

--- a/addons/website/static/src/client_actions/website_preview/new_content_element.xml
+++ b/addons/website/static/src/client_actions/website_preview/new_content_element.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-<t t-name="html_builder.NewContentElement">
+<t t-name="website.NewContentElement">
     <div class="o_new_content_element col-md-4 mb8" t-att-name="props.name">
         <button
                 t-on-click.prevent.stop="onClick"

--- a/addons/website/static/src/client_actions/website_preview/new_content_modal.js
+++ b/addons/website/static/src/client_actions/website_preview/new_content_modal.js
@@ -11,7 +11,7 @@ import { sprintf } from "@web/core/utils/strings";
 import { redirect } from "@web/core/utils/urls";
 
 export class NewContentModal extends Component {
-    static template = "html_builder.NewContentModal";
+    static template = "website.NewContentModal";
     static components = { NewContentElement };
     static props = {
         onNewPage: Function,

--- a/addons/website/static/src/client_actions/website_preview/new_content_modal.xml
+++ b/addons/website/static/src/client_actions/website_preview/new_content_modal.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-<t t-name="html_builder.NewContentModal">
+<t t-name="website.NewContentModal">
     <div id="o_new_content_menu_choices" t-ref="modalRef" role="dialog" aria-modal="true" aria-label="New Content" tabindex="-1">
         <div class="container pt32 pb32">
             <div class="row">

--- a/addons/website/static/src/client_actions/website_preview/new_content_systray_item.js
+++ b/addons/website/static/src/client_actions/website_preview/new_content_systray_item.js
@@ -3,7 +3,7 @@ import { Component, useState } from "@odoo/owl";
 import { useService } from "@web/core/utils/hooks";
 
 export class NewContentSystrayItem extends Component {
-    static template = "html_builder.NewContentSystrayItem";
+    static template = "website.NewContentSystrayItem";
     static components = { NewContentModal };
     static props = {
         onNewPage: Function,

--- a/addons/website/static/src/client_actions/website_preview/new_content_systray_item.xml
+++ b/addons/website/static/src/client_actions/website_preview/new_content_systray_item.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-<t t-name="html_builder.NewContentSystrayItem">
+<t t-name="website.NewContentSystrayItem">
     <div class="o_menu_systray_item o_new_content_container d-none d-md-flex" t-on-click="onClick">
         <button accesskey="c" class="o-website-btn-custo-secondary btn d-flex align-items-center rounded-0 border-0 px-3">New</button>
         <NewContentModal t-if="websiteContext.showNewContentModal" onNewPage="props.onNewPage"/>

--- a/addons/website/static/src/client_actions/website_preview/website_builder_action.js
+++ b/addons/website/static/src/client_actions/website_preview/website_builder_action.js
@@ -33,7 +33,7 @@ import { isBrowserMicrosoftEdge } from "@web/core/browser/feature_detection";
 const websiteSystrayRegistry = registry.category("website_systray");
 
 export class WebsiteBuilder extends Component {
-    static template = "html_builder.WebsiteBuilder";
+    static template = "website.WebsiteBuilder";
     static components = { LazyComponent, LocalOverlayContainer, ResizablePanel, ResourceEditor };
     static props = { ...standardActionServiceProps };
 

--- a/addons/website/static/src/client_actions/website_preview/website_builder_action.xml
+++ b/addons/website/static/src/client_actions/website_preview/website_builder_action.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-<t t-name="html_builder.WebsiteBuilder">
+<t t-name="website.WebsiteBuilder">
     <div class="d-flex h-100 w-100" t-ref="container">
         <div class="o_website_preview flex-grow-1" t-ref="website_preview">
             <div class="o_iframe_container">

--- a/addons/website/static/src/client_actions/website_preview/website_systray_item.js
+++ b/addons/website/static/src/client_actions/website_preview/website_systray_item.js
@@ -8,7 +8,7 @@ import { PublishSystrayItem } from "./publish_website_systray_item";
 import { WebsiteSwitcherSystrayItem } from "./website_switcher_systray_item";
 
 export class WebsiteSystrayItem extends Component {
-    static template = "html_builder.WebsiteSystrayItem";
+    static template = "website.WebsiteSystrayItem";
     static props = {
         onNewPage: { type: Function },
         onEditPage: { type: Function },

--- a/addons/website/static/src/client_actions/website_preview/website_systray_item.xml
+++ b/addons/website/static/src/client_actions/website_preview/website_systray_item.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-<t t-name="html_builder.WebsiteSystrayItem">
+<t t-name="website.WebsiteSystrayItem">
     <div class="d-flex">
         <WebsiteSwitcherSystrayItem t-if="this.hasMultiWebsites"/>
         <PublishSystrayItem t-if="this.canPublish"/>

--- a/addons/website_mass_mailing/static/src/website_builder/mailing_list_subscribe_option.js
+++ b/addons/website_mass_mailing/static/src/website_builder/mailing_list_subscribe_option.js
@@ -2,7 +2,7 @@ import { onWillStart } from "@odoo/owl";
 import { BaseOptionComponent } from "@html_builder/core/utils";
 
 export class MailingListSubscribeOption extends BaseOptionComponent {
-    static template = "html_builder.MailingListSubscribeOption";
+    static template = "website_mass_mailing.MailingListSubscribeOption";
     static props = {
         fetchMailingLists: Function,
     };

--- a/addons/website_mass_mailing/static/src/website_builder/mailing_list_subscribe_option.xml
+++ b/addons/website_mass_mailing/static/src/website_builder/mailing_list_subscribe_option.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-<t t-name="html_builder.MailingListSubscribeOption">
+<t t-name="website_mass_mailing.MailingListSubscribeOption">
 
     <BuilderRow label.translate="Newsletter" t-if="!isActiveItem('form_opt')">
         <BuilderSelect dataAttributeAction="'listId'">
@@ -21,7 +21,7 @@
 
 </t>
 
-<t t-name="html_builder.MailingListSubscribeFormOption">
+<t t-name="website_mass_mailing.MailingListSubscribeFormOption">
 
     <BuilderRow label.translate="Placeholder">
         <BuilderTextInput attributeAction="'placeholder'" applyTo="'.s_newsletter_subscribe_form_input'"/>

--- a/addons/website_mass_mailing/static/src/website_builder/newsletter_subscribe_common_option.js
+++ b/addons/website_mass_mailing/static/src/website_builder/newsletter_subscribe_common_option.js
@@ -3,7 +3,7 @@ import { MailingListSubscribeOption } from "./mailing_list_subscribe_option";
 import { RecaptchaSubscribeOption } from "./recaptcha_subscribe_option";
 
 export class NewsletterSubscribeCommonOption extends BaseOptionComponent {
-    static template = "html_builder.NewsletterSubscribeCommonOption";
+    static template = "website_mass_mailing.NewsletterSubscribeCommonOption";
     static components = {
         MailingListSubscribeOption,
         RecaptchaSubscribeOption,

--- a/addons/website_mass_mailing/static/src/website_builder/newsletter_subscribe_common_option.xml
+++ b/addons/website_mass_mailing/static/src/website_builder/newsletter_subscribe_common_option.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-<t t-name="html_builder.NewsletterSubscribeCommonOption">
+<t t-name="website_mass_mailing.NewsletterSubscribeCommonOption">
 
     <MailingListSubscribeOption fetchMailingLists="props.fetchMailingLists"/>
     <RecaptchaSubscribeOption hasRecaptcha="props.hasRecaptcha"/>

--- a/addons/website_mass_mailing/static/src/website_builder/newsletter_subscribe_common_option_plugin.js
+++ b/addons/website_mass_mailing/static/src/website_builder/newsletter_subscribe_common_option_plugin.js
@@ -31,7 +31,7 @@ class NewsletterSubscribeCommonOptionPlugin extends Plugin {
                 applyTo: ".s_newsletter_list",
             }),
             withSequence(SNIPPET_SPECIFIC, {
-                template: "html_builder.MailingListSubscribeFormOption",
+                template: "website_mass_mailing.MailingListSubscribeFormOption",
                 selector: ".s_newsletter_subscribe_form",
             }),
         ],

--- a/addons/website_mass_mailing/static/src/website_builder/recaptcha_subscribe_option.js
+++ b/addons/website_mass_mailing/static/src/website_builder/recaptcha_subscribe_option.js
@@ -1,7 +1,7 @@
 import { BaseOptionComponent } from "@html_builder/core/utils";
 
 export class RecaptchaSubscribeOption extends BaseOptionComponent {
-    static template = "html_builder.RecaptchaSubscribeOption";
+    static template = "website_mass_mailing.RecaptchaSubscribeOption";
     static props = {
         hasRecaptcha: Function,
     };

--- a/addons/website_mass_mailing/static/src/website_builder/recaptcha_subscribe_option.xml
+++ b/addons/website_mass_mailing/static/src/website_builder/recaptcha_subscribe_option.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-<t t-name="html_builder.RecaptchaSubscribeOption">
+<t t-name="website_mass_mailing.RecaptchaSubscribeOption">
 
     <BuilderRow label.translate="Show reCaptcha Policy" t-if="this.props.hasRecaptcha()">
         <BuilderCheckbox dataAttributeAction="'toggleRecaptchaLegal'" dataAttributeActionValue="'true'" action="'toggleRecaptchaLegal'"/>


### PR DESCRIPTION
When [1] introduced `html_builder`, some templates were moved across modules but their names were not adapted accordingly.

This commit adjusts the template names so that they reflect the addon within which they are defined.

[1]: https://github.com/odoo/odoo/commit/9fe45e2b7ddbbfd0445ffe25a859e67a316d02b2

task-4367641
