### PR TITLE
[IMP] account: make invoice rate editable

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -472,9 +472,14 @@ class AccountMove(models.Model):
         required=True,
         compute='_compute_currency_id', inverse='_inverse_currency_id', store=True, readonly=False, precompute=True,
     )
+    expected_currency_rate = fields.Float(
+        compute="_compute_expected_currency_rate",
+        digits=0,
+    )
     invoice_currency_rate = fields.Float(
         string='Currency Rate',
         compute='_compute_invoice_currency_rate', store=True, precompute=True,
+        readonly=False,
         copy=False,
         digits=0,
         help="Currency rate from company currency to document currency.",
@@ -1050,18 +1055,23 @@ class AccountMove(models.Model):
         return self.invoice_date or fields.Date.context_today(self)
 
     @api.depends('currency_id', 'company_currency_id', 'company_id', 'invoice_date')
+    def _compute_expected_currency_rate(self):
+        for move in self:
+            if move.currency_id:
+                move.expected_currency_rate = move.env['res.currency']._get_conversion_rate(
+                    from_currency=move.company_currency_id,
+                    to_currency=move.currency_id,
+                    company=move.company_id,
+                    date=move._get_invoice_currency_rate_date(),
+                )
+            else:
+                move.expected_currency_rate = 1
+
+    @api.depends('currency_id', 'company_currency_id', 'company_id', 'invoice_date')
     def _compute_invoice_currency_rate(self):
         for move in self:
             if move.is_invoice(include_receipts=True):
-                if move.currency_id:
-                    move.invoice_currency_rate = self.env['res.currency']._get_conversion_rate(
-                        from_currency=move.company_currency_id,
-                        to_currency=move.currency_id,
-                        company=move.company_id,
-                        date=move._get_invoice_currency_rate_date(),
-                    )
-                else:
-                    move.invoice_currency_rate = 1
+                move.invoice_currency_rate = move.expected_currency_rate
 
     @api.depends('move_type')
     def _compute_direction_sign(self):
@@ -5146,6 +5156,21 @@ class AccountMove(models.Model):
                         if line.display_type == 'product'
                     ]
                 })
+
+    def get_currency_rate(self, company_id, to_currency_id, date):
+        company = self.env['res.company'].browse(company_id)
+        to_currency = self.env['res.currency'].browse(to_currency_id)
+
+        return self.env['res.currency']._get_conversion_rate(
+            from_currency=company.currency_id,
+            to_currency=to_currency,
+            company=company,
+            date=date,
+        )
+
+    def refresh_invoice_currency_rate(self):
+        for move in self:
+            move.invoice_currency_rate = move.expected_currency_rate
 
     def action_register_payment(self):
         if any(m.state != 'posted' for m in self):

--- a/addons/account/static/src/components/account_pick_currency_rate/account_pick_currency_rate.js
+++ b/addons/account/static/src/components/account_pick_currency_rate/account_pick_currency_rate.js
@@ -1,0 +1,44 @@
+import { Component } from "@odoo/owl";
+import { registry } from "@web/core/registry";
+import { useDateTimePicker } from "@web/core/datetime/datetime_hook";
+import { useService } from "@web/core/utils/hooks";
+import { today } from "@web/core/l10n/dates";
+import { standardWidgetProps } from "@web/views/widgets/standard_widget_props";
+
+
+export class AccountPickCurrencyDate extends Component {
+    static template = "account.AccountPickCurrencyDate";
+    static props = {
+        ...standardWidgetProps,
+        record: { type: Object, optional: true },
+    };
+
+    setup() {
+        this.orm = useService("orm");
+        this.dateTimePicker = useDateTimePicker({
+            target: 'datetime-picker-target',
+            onApply: async (date) => {
+                const record = this.props.record
+                const rate = await this.orm.call(
+                    'account.move',
+                    'get_currency_rate',
+                    [record.resId, record.data.company_id[0], record.data.currency_id[0], date],
+                );
+                this.props.record.update({ invoice_currency_rate: rate });
+                await this.props.record.save();
+            },
+            get pickerProps() {
+                return {
+                    type: 'date',
+                    value: today(),
+                };
+            },
+        });
+    }
+}
+
+export const accountPickCurrencyDate = {
+    component: AccountPickCurrencyDate,
+}
+
+registry.category("view_widgets").add("account_pick_currency_date",  accountPickCurrencyDate);

--- a/addons/account/static/src/components/account_pick_currency_rate/account_pick_currency_rate.xml
+++ b/addons/account/static/src/components/account_pick_currency_rate/account_pick_currency_rate.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<template>
+    <t t-name="account.AccountPickCurrencyDate">
+        <button
+            type="button"
+            t-on-click.prevent="() => this.dateTimePicker.open()"
+            class="btn btn-link text-dark p-0"
+            title="Pick the rate on a certain date"
+            t-ref="datetime-picker-target"
+        >
+            <i class="fa fa-calendar"/>
+        </button>
+    </t>
+
+</template>

--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -929,6 +929,7 @@
                         <field name="bank_partner_id" invisible="1"/>
                         <field name="display_qr_code" invisible="1"/>
                         <field name="show_reset_to_draft_button" invisible="1"/>
+                        <field name="expected_currency_rate" invisible="1"/>
 
                         <field name="invoice_has_outstanding" invisible="1"/>
                         <field name="is_move_sent" invisible="1"/>
@@ -1046,8 +1047,8 @@
                                     <field name="invoice_date_due" force_save="1"
                                            placeholder="Date"
                                            invisible="invoice_payment_term_id"/>
-                                    <span class="o_form_label mx-3 oe_edit_only"
-                                          invisible="state != 'draft' or invoice_payment_term_id"> or </span>
+                                    <span class="o_form_label mx-3 oe_edit_only text-center" style="width: 6ch;"
+                                          invisible="state != 'draft' or invoice_payment_term_id">or</span>
                                     <field name="invoice_payment_term_id"
                                            context="{'example_date': invoice_date, 'example_amount': tax_totals['total_amount_currency']}"
                                            placeholder="Payment Terms"
@@ -1063,32 +1064,41 @@
                                            groups="account.group_account_readonly"
                                            options="{'no_create': True, 'no_open': True}"
                                            readonly="posted_before and name not in (False, '', '/')"/>
-
-                                    <span class="o_form_label mx-3 oe_edit_only"
-                                          groups="account.group_account_readonly"
-                                          invisible="move_type == 'entry'">
-                                        <span groups="base.group_multi_currency">in </span>
-                                    </span>
+                                    <div name="in_and_refresh_button_div"
+                                         groups="base.group_multi_currency"
+                                         class="d-flex flex-column mx-3 text-center"
+                                         style="width: 6ch;"
+                                         invisible="move_type == 'entry'">
+                                        <div>in</div>
+                                        <div class="d-flex flex-column justify-content-center flex-grow-1"
+                                             invisible="state != 'draft' or invoice_currency_rate == expected_currency_rate">
+                                            <button type="object"
+                                                    name="refresh_invoice_currency_rate"
+                                                    icon="fa-refresh"
+                                                    title="Refresh currency rate to the invoice date"
+                                                    class="btn btn-link p-0"/>
+                                        </div>
+                                    </div>
                                     <div name="currency_div"
                                          groups="base.group_multi_currency"
                                          class="w-100"
-                                         style="white-space: pre;"
                                          invisible="move_type == 'entry'">
-                                        <field name="currency_id"
-                                               readonly="state != 'draft'"
-                                               class="oe_inline"
-                                               options="{'no_create': True}"
-                                               context="{'search_default_active': 1, 'search_default_inactive': 1}"/>
-                                        <div class="break"/>
+                                        <div class="d-flex gap-1">
+                                            <field name="currency_id"
+                                                   readonly="state != 'draft'"
+                                                   class="oe_inline"
+                                                   options="{'no_create': True}"
+                                                   context="{'search_default_active': 1, 'search_default_inactive': 1}"/>
+                                            <widget name="account_pick_currency_date" invisible="state != 'draft' or currency_id == company_currency_id"/>
+                                        </div>
                                         <div name="currency_conversion_div"
-                                             class="d-flex text-muted float-start"
+                                             class="d-flex gap-1 text-muted"
                                              invisible="currency_id == company_currency_id">
-                                            <span>1 </span>
-                                            <field name="company_currency_id" readonly="True" options="{'no_open': True}"/>
-                                            <span> = </span>
-                                            <field name="invoice_currency_rate" digits="[12,6]" readonly="True"/>
-                                            <span> </span>
-                                            <field name="currency_id" readonly="True" options="{'no_open': True}"/>
+                                            <span>1</span>
+                                            <field name="company_currency_id" readonly="True" options="{'no_open': True}" class="w-auto"/>
+                                            <span>=</span>
+                                            <field name="invoice_currency_rate" digits="[12,6]" readonly="state != 'draft'"/>
+                                            <field name="currency_id" readonly="True" options="{'no_open': True}" class="w-auto"/>
                                         </div>
                                     </div>
                                 </div>

--- a/addons/l10n_cz/models/account_move.py
+++ b/addons/l10n_cz/models/account_move.py
@@ -19,6 +19,10 @@ class AccountMove(models.Model):
         # In the Czech Republic, the currency rate should be based on the taxable supply date.
         super()._compute_invoice_currency_rate()
 
+    @api.depends('taxable_supply_date')
+    def _compute_expected_currency_rate(self):
+        super()._compute_expected_currency_rate()
+
     def _get_invoice_currency_rate_date(self):
         self.ensure_one()
         if self.country_code == 'CZ' and self.taxable_supply_date:

--- a/addons/l10n_hu_edi/models/account_move.py
+++ b/addons/l10n_hu_edi/models/account_move.py
@@ -129,6 +129,10 @@ class AccountMove(models.Model):
         # In Hungary, the currency rate should be based on the delivery date.
         super()._compute_invoice_currency_rate()
 
+    @api.depends('delivery_date')
+    def _compute_expected_currency_rate(self):
+        super()._compute_expected_currency_rate()
+
     def _get_invoice_currency_rate_date(self):
         self.ensure_one()
         if self.country_code == 'HU' and self.delivery_date:


### PR DESCRIPTION
- Make `invoice_currency_rate` editable.
- Add a date picker widget that let the user apply the rate of a certain date.
- Add a refresh button when the rate is not the expected one.

To that end, the computed field `expected_currency_rate` is added.

task-4378994