### PR TITLE
[FIX] delivery: correct product tag matching

### DIFF
--- a/addons/delivery/models/delivery_carrier.py
+++ b/addons/delivery/models/delivery_carrier.py
@@ -184,7 +184,10 @@ class DeliveryCarrier(models.Model):
 
     def _match_must_have_tags(self, order):
         self.ensure_one()
-        return all(tag in order.order_line.product_id.all_product_tag_ids for tag in self.must_have_tag_ids)
+        return not self.must_have_tag_ids or any(
+            tag in order.order_line.product_id.all_product_tag_ids
+            for tag in self.must_have_tag_ids
+        )
 
     def _match_excluded_tags(self, order):
         self.ensure_one()

--- a/addons/delivery/tests/test_delivery_availability.py
+++ b/addons/delivery/tests/test_delivery_availability.py
@@ -127,18 +127,10 @@ class TestDeliveryAvailability(DeliveryCommon, SaleCommon):
         self.assertFalse(self.carrier.id in choose_delivery_carrier.available_carrier_ids.ids, "Order lines should be converted to the default UoM before checking volume")
 
     def test_04_check_must_have_tag(self):
-        self.carrier.write({
-            'must_have_tag_ids': [self.must_have_tag.id],
-        })
-
-        self.sale_order = self.env['sale.order'].create({
-            'partner_id': self.partner.id,
-            'partner_invoice_id': self.partner.id,
-            'order_line': [Command.create({
-                'product_id': self.product.id,
-                'product_uom_qty': 1,
-            })],
-        })
+        self.carrier.must_have_tag_ids = [
+            Command.link(self.must_have_tag.id),
+            Command.link(self.must_have_tag.copy({'name': "Alt Must Have"}).id),
+        ]
 
         delivery_wizard = Form(self.env['choose.delivery.carrier'].with_context({
             'default_order_id': self.sale_order.id,


### PR DESCRIPTION
Versions
--------
- 18.0+

Feature doesn't exist in earlier versions.

Steps
-----
1. Create a product with a tag;
2. create another product with a different tag;
3. create a delivery method with these 2 tags as Must Have Tags;
4. add one product to the cart in eCommerce;
5. go to checkout.

Issue
-----
Delivery method isn't available for selection.

Cause
-----
While the "Must Have Tags" description states that the method should be available if at least one product on the order has at least one of these tags, the `_match_must_have_tags` method requires *all* of the `must_have_tags` to be present in the order.

Solution
--------
Instead of using `all`, use `any` when matching must-have tags.

opw-4836137