### PR TITLE
[FIX] website: fix row positioning after img float

### DIFF
--- a/addons/website/static/src/scss/website.scss
+++ b/addons/website/static/src/scss/website.scss
@@ -642,6 +642,10 @@ font[class*='bg-'] {
     }
 }
 
+.row {
+    clear: both;
+}
+
 // Buttons
 .btn {
     &.flat {


### PR DESCRIPTION
Steps to reproduce:
- Open the website builder.
- Drag and drop the s_key_benefits snippets in the page.
- Drag and drop an image below the title, above the 3 columns.
- Set the 'alignement' option of the image to left.
- Observe that the `.row` appears next to the image instead of below it.

Previously, when a user dragged and dropped an image into the container above a `.row`, and applied the `float-start` class (via the builder), the floated image caused the `.row` to wrap around it instead of appearing below as expected. This broke the layout and alignment of content inside the `.row`.

I fixed this by adding `clear: both;` to the `.row` element, ensuring it always starts below any floated elements above it. This prevents layout breakage even when users insert floated images above rows.
