### PR TITLE
[FIX] marketing_card: various fixes around previews

### DIFF
--- a/addons/marketing_card/controllers/marketing_card.py
+++ b/addons/marketing_card/controllers/marketing_card.py
@@ -100,7 +100,10 @@ class MarketingCardController(Controller):
         card = _get_card_from_url(card_id, card_slug)
 
         campaign_sudo = card.sudo().campaign_id
-        redirect_url = campaign_sudo.link_tracker_id.short_url or campaign_sudo.target_url or campaign_sudo.get_base_url()
+        # don't count clicks from preview
+        redirect_url = campaign_sudo.target_url or campaign_sudo.get_base_url()
+        if card.active:
+            redirect_url = campaign_sudo.link_tracker_id.short_url or redirect_url
 
         if _is_crawler(request):
             return request.render('marketing_card.card_campaign_crawler', {

--- a/addons/marketing_card/models/__init__.py
+++ b/addons/marketing_card/models/__init__.py
@@ -2,5 +2,6 @@ from . import card_campaign
 from . import card_campaign_tag
 from . import card_template
 from . import card_card
+from . import ir_model
 from . import mailing_mailing
 from . import utm_source

--- a/addons/marketing_card/models/card_campaign.py
+++ b/addons/marketing_card/models/card_campaign.py
@@ -273,10 +273,10 @@ class CardCampaign(models.Model):
 
 <div class="s_text_block o_mail_snippet_general pt24 pb24" style="padding-left: 15px; padding-right: 15px;" data-snippet="s_text_block" data-name="Text">
     <div class="container s_allow_columns">
-        <p class="o_default_snippet_text">Hello everyone</p>
-        <p class="o_default_snippet_text">Here's the link to advertise your participation.
-        <br> Your help with this promotion would be greatly appreciated!`</p>
-        <p class="o_default_snippet_text">Many thanks</p>
+        <p class="o_default_snippet_text">{_("Hello everyone")}</p>
+        <p class="o_default_snippet_text">{_("Here's the link to advertise your participation.")}
+        <br>{_("Your help with this promotion would be greatly appreciated!")}</p>
+        <p class="o_default_snippet_text">{_("Many thanks")}</p>
     </div>
 </div>
 
@@ -286,7 +286,7 @@ class CardCampaign(models.Model):
             <tr>
                 <td align="center">
                     <a href="/cards/{self.id}/preview" style="padding-left: 3px !important; padding-right: 3px !important">
-                        <img src="/web/image/card.campaign/{self.id}/image_preview" alt="Card Preview" class="img-fluid" style="width: 540px;"/>
+                        <img src="/web/image/card.campaign/{self.id}/image_preview" alt="{_("Card Preview")}" class="img-fluid" style="width: 540px;"/>
                     </a>
                 </td>
             </tr>

--- a/addons/marketing_card/models/ir_model.py
+++ b/addons/marketing_card/models/ir_model.py
@@ -1,0 +1,13 @@
+from odoo import models
+
+
+class IrModel(models.Model):
+    _inherit = 'ir.model'
+
+    def unlink(self):
+        """Remove campaigns on removed models."""
+        self.env['card.campaign'].search([
+            ('res_model', 'in', self.mapped('model'))
+        ]).unlink()
+
+        return super().unlink()

--- a/addons/marketing_card/static/src/scss/card_campaign.scss
+++ b/addons/marketing_card/static/src/scss/card_campaign.scss
@@ -8,3 +8,12 @@
 .o_marketing_card_image_preview img {
     border: 3px solid $border-color !important;
 }
+
+.o_card_campaign_form {
+     .o_field_widget.o_field_DynamicModelFieldSelectorChar {
+        width: auto;
+        &:has(.o_model_field_selector_value:empty) {
+            width: 100%;
+        }
+    }
+}

--- a/addons/marketing_card/tests/test_campaign.py
+++ b/addons/marketing_card/tests/test_campaign.py
@@ -249,6 +249,15 @@ class TestMarketingCardRouting(HttpCase, MarketingCardCommon):
         self.assertTrue(image_request_headers.get('Content-Length'))
         self.assertTrue(card.image)
         self.assertEqual(card.share_status, 'visited')
+        self.assertEqual(card.active, False, "preview card was updated and is thus considered not valid")
+        self.campaign.flush_recordset()
+        self.assertEqual(self.campaign.card_count, 19)
+        self.assertEqual(self.campaign.card_click_count, 0)
+        self.assertEqual(self.campaign.card_share_count, 0, 'A regular user fetching the card should not count as a share.')
+
+        # recipient opens the card they received
+        card.active = True  # reset as if it were never used as preview
+        image_request_headers = self.url_open(card._get_card_url())
         self.campaign.flush_recordset()
         self.assertEqual(self.campaign.card_count, 20)
         self.assertEqual(self.campaign.card_click_count, 1)

--- a/addons/marketing_card/views/card_campaign_views.xml
+++ b/addons/marketing_card/views/card_campaign_views.xml
@@ -85,20 +85,20 @@
                     <page name="Card Layout" string="Card Layout">
                         <group>
                         <group>
-                            <field name="content_background" widget="image" options="{'img_class': 'w-25 object-fit-contain'}"/>
+                            <field name="content_background" widget="image" class="w-25"/>
                             <label for="content_header"/>
                             <div class="d-flex">
                                 <field name="content_header_dyn" title="Dynamic Field?"/>
                                 <field name="content_header" invisible="content_header_dyn" placeholder="e.g. Join Odoo Experience 2024"/>
                                 <field name="content_header_path" invisible="not content_header_dyn" placeholder="Select a field" widget="DynamicModelFieldSelectorChar" options="{'model': 'res_model'}"/>
-                                <field name="content_header_color" widget="color" style="width: 40px"/>
+                                <field name="content_header_color" widget="color" class="ms-auto" style="min-width: 40px; max-width: 40px;"/>
                             </div>
                             <label for="content_sub_header"/>
                             <div class="d-flex">
                                 <field name="content_sub_header_dyn"/>
                                 <field name="content_sub_header" invisible="content_sub_header_dyn" placeholder="e.g. Aug 24, Brussels Expo"/>
                                 <field name="content_sub_header_path" invisible="not content_sub_header_dyn" placeholder="Select a field" widget="DynamicModelFieldSelectorChar" options="{'model': 'res_model'}"/>
-                                <field name="content_sub_header_color" widget="color" style="width: 40px"/>
+                                <field name="content_sub_header_color" widget="color" class="ms-auto" style="min-width: 40px; max-width: 40px;"/>
                             </div>
                             <label for="content_section"/>
                             <div class="d-flex">

--- a/addons/web/static/src/views/fields/dynamic_widget/dynamic_model_field_selector_char.js
+++ b/addons/web/static/src/views/fields/dynamic_widget/dynamic_model_field_selector_char.js
@@ -32,6 +32,7 @@ export class DynamicModelFieldSelectorChar extends CharField {
     //---- Getters ----
     get getSelectorProps() {
         return {
+            allowEmpty: !this.props.required,
             path: this.props.record.data[this.props.name],
             resModel: this.getResModel(),
             readonly: this.props.readonly,


### PR DESCRIPTION
- Avoid counting "clicks" on archived (implicitly preview) cards
- Pick the preview card when building the default mailing body
- Translate the default mailing body
- If a card targets a model that has been uninstalled, remove the campaign as is done for mailings

task-4247003
 