### PR TITLE
[FIX] website: trigger an event to rerender the navbar

### DIFF
--- a/addons/website/static/src/client_actions/website_preview/website_builder_action.js
+++ b/addons/website/static/src/client_actions/website_preview/website_builder_action.js
@@ -125,6 +125,7 @@ export class WebsiteBuilder extends Component {
         onWillDestroy(() => {
             websiteSystrayRegistry.remove("website.WebsiteSystrayItem");
             this.websiteService.currentWebsiteId = null;
+            websiteSystrayRegistry.trigger("EDIT-WEBSITE");
         });
 
         effect(

--- a/addons/website/static/tests/tours/website_navbar_menu.js
+++ b/addons/website/static/tests/tours/website_navbar_menu.js
@@ -1,4 +1,5 @@
 import { registry } from "@web/core/registry";
+import { registerWebsitePreviewTour } from "@website/js/tours/tour_utils";
 
 registry.category("web_tour.tours").add("website_navbar_menu", {
     url: "/",
@@ -20,3 +21,28 @@ registry.category("web_tour.tours").add("website_navbar_menu", {
         },
     ],
 });
+
+registerWebsitePreviewTour(
+    "website_systray_items_disappear",
+    { url: "/" },
+    () => [
+        {
+            content: "Ensure frontend systray items have been added to the navbar",
+            trigger: ".o_main_navbar .o_menu_systray:has(.o_edit_website_container)",
+        },
+        {
+            content: "Open configuration dropdown",
+            trigger: ".o_main_navbar button:contains(Configuration)",
+            run: "click",
+        },
+        {
+            content: "Go to settings",
+            trigger: `.o_popover .o-dropdown-item:contains(Settings)`,
+            run: "click",
+        },
+        {
+            content: "Ensure frontend systray items have disappeared",
+            trigger: `.o_main_navbar .o_menu_systray:not(:has(.o_edit_website_container, .o_new_content_container))`,
+        },
+    ]
+);

--- a/addons/website/tests/test_ui.py
+++ b/addons/website/tests/test_ui.py
@@ -727,3 +727,6 @@ class TestUi(HttpCaseWithWebsiteUser):
 
     def test_popup_visibility_option(self):
         self.start_tour("/", "website_popup_visibility_option", login="admin")
+
+    def test_systray_items_disappear(self):
+        self.start_tour("/", "website_systray_items_disappear", login="admin")


### PR DESCRIPTION
We need to rerender the navbar when the website builder component is
destroyed to prevent having the frontend systray items in the
backend navbar.
Steps to reproduce the issue:
- Go to Website as an admin
- Click on the navbar "Settings" menu
- Choose any option

=> We're redirected to the backend, but the systray items are not
updated.
This commit follows [the html_builder refactoring].

[the html_builder refactoring]: https://github.com/odoo/odoo/commit/9fe45e2b7ddb

Related to task-4367641