### PR TITLE
[FIX] website: fix s_numbers_charts display and prevent crash

### DIFF
--- a/addons/website/static/src/js/editor/snippets.editor.js
+++ b/addons/website/static/src/js/editor/snippets.editor.js
@@ -272,6 +272,23 @@ export class WebsiteSnippetsMenu extends weSnippetEditor.SnippetsMenu {
             containerWidthOptionEl.dataset.selector += ", .s_carousel .carousel-item";
         }
 
+        // TODO remove in master: add s_progress_bar_text in progress bar where it's missing, fix the previous wrong width
+        const progressBarEls = html.querySelectorAll(".progress-bar");
+        progressBarEls.forEach((el) => {
+            if (el.style.width === "45%") {
+                el.style.width = "25%";
+            }
+            if (!el.querySelector(".s_progress_bar_text")) {
+                const textEl = document.createElement("span");
+                textEl.classList.add("s_progress_bar_text", "small");
+                textEl.textContent = el.style.width;
+                if (el.closest(".s_progress_bar_label_hidden")) {
+                    textEl.classList.add("d-none");
+                }
+                el.appendChild(textEl);
+            }
+        });
+
         return super._computeSnippetTemplates(html);
     }
     /**

--- a/addons/website/static/src/snippets/s_progress_bar/options.js
+++ b/addons/website/static/src/snippets/s_progress_bar/options.js
@@ -42,7 +42,9 @@ options.registry.progress = options.Class.extend({
 
         // Temporary hide the label. It's effectively removed in cleanForSave
         // if the option is confirmed
-        progressLabel.classList.toggle('d-none', widgetValue === 'none');
+        if (progressLabel) {
+            progressLabel.classList.toggle('d-none', widgetValue === 'none');
+        }
     },
     /**
      * Sets the progress bar value.

--- a/addons/website/views/snippets/s_numbers_charts.xml
+++ b/addons/website/views/snippets/s_numbers_charts.xml
@@ -15,7 +15,9 @@
                     <div class="s_progress_bar s_progress_bar_label_hidden" data-display="inline" data-vcss="001" data-snippet="s_progress_bar">
                         <div class="s_progress_bar_wrapper d-flex gap-2">
                             <div class="progress" role="progressbar" aria-label="Progress bar" aria-valuenow="80" aria-valuemin="0" aria-valuemax="100">
-                                <div class="progress-bar overflow-visible bg-o-color-2" style="width: 80%; min-width: 3%"/>
+                                <div class="progress-bar overflow-visible bg-o-color-2" style="width: 80%; min-width: 3%">
+                                    <span class="s_progress_bar_text small d-none">80%</span>
+                                </div>
                             </div>
                         </div>
                     </div>
@@ -26,7 +28,9 @@
                     <div class="s_progress_bar s_progress_bar_label_hidden" data-display="inline" data-vcss="001" data-snippet="s_progress_bar">
                         <div class="s_progress_bar_wrapper d-flex gap-2">
                             <div class="progress" role="progressbar" aria-label="Progress bar" aria-valuenow="25" aria-valuemin="0" aria-valuemax="100">
-                                <div class="progress-bar overflow-visible bg-o-color-2" style="width: 45%; min-width: 3%"/>
+                                <div class="progress-bar overflow-visible bg-o-color-2" style="width: 25%; min-width: 3%">
+                                    <span class="s_progress_bar_text small d-none">25%</span>
+                                </div>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
The `s_numbers_charts` snippet had two main issues:
- The progress bar within `s_numbers_charts` visually appeared as 45% on
  initial rendering, despite its actual configured value being 25%. This
was due to a mismatch between its `aria-valuenow` attribute and its
style `width` property. The display would correct itself when the user
manually changed the value.

- A crash would occur when attempting to select the "Label" option after
  dropping the `s_numbers_charts` snippet. This happened because
`s_progress_bar_text` was forgotten during the initial implementation of
`s_numbers_charts` [1].

This commit addresses these problems by:
- Adding the missing `s_progress_bar_text` to the `s_numbers_charts` template.
- Including `s_progress_bar_text` in `_computeSnippetTemplates` to
  ensure that existing databases also receive this fix, as snippets are
stored in the database.
- Adding a check in the `progress` option to prevent the aforementioned crash.

Steps to reproduce the crash:
- Drop the `s_numbers_charts` snippet.
- Click on a progress bar within the snippet.
- Select the option `Label`.
- Hover over "Hide" without any other prior interactions.
- A crash will occur.

[1]: https://github.com/odoo/odoo/commit/6c94fd66c1db75d74588ce670fb6cf1e960cf8bd
