### PR TITLE
[FIX] website_sale: fix tour steps for reordering from portal

### DIFF
--- a/addons/website_sale/static/tests/tours/website_sale_reorder_from_portal.js
+++ b/addons/website_sale/static/tests/tours/website_sale_reorder_from_portal.js
@@ -70,14 +70,12 @@ registry.category("web_tour.tours").add('website_sale_reorder_from_portal', {
             content: "Deleting All products from cart",
             trigger: 'div.js_cart_lines',
             run: async () => {
-                $('a.js_delete_product:first').click();
-                await new Promise((r) => setTimeout(r, 1000));
-                $('a.js_delete_product:first').click();
-                await new Promise((r) => setTimeout(r, 1000));
-                $('a.js_delete_product:first').click();
-                await new Promise((r) => setTimeout(r, 1000));
-                $('a.js_delete_product:first').click();
-                await new Promise((r) => setTimeout(r, 1000));
+
+                // Keep clicking delete buttons until none are left
+                while ($('a.js_delete_product').length > 0) {
+                    $('a.js_delete_product:first').click();
+                    await new Promise(resolve => setTimeout(resolve, 1200)); 
+                }
             }
         },
         {


### PR DESCRIPTION

steps to reproduce (nondeterministic):
1- install website_sale
2- without demo data fresh database
3- while in debug mode decrease the performance of the browser
   (for example in Chrome, open devtools, go to the Performance tab,
   and select "Slow 3G" in the Network throttling dropdown and "Slow 4x CPU" in
   the CPU throttling dropdown)
4- run the tour test test_website_sale_reorder_from_portal

noticed it : when my laptop was in power saving mode, which made the browser even slower

the  tour was failing because the step
was not waiting enough time for all the elements to be
deleted which resulted products were remaining in the cart
and later on the confirmation dialog of "Empty your cart?" was popping up which
was not expected

increased the wait time and added a check for the
cart to be empty before proceeding to the next step

build_error-190573