### PR TITLE
[FIX] web: hide invalid non-monetary aggregates in list view

### DIFF
--- a/addons/web/static/src/views/list/list_renderer.js
+++ b/addons/web/static/src/views/list/list_renderer.js
@@ -711,12 +711,6 @@ export class ListRenderer extends Component {
         const { widget, attrs } = column;
         const field = this.props.list.fields[column.name];
         const aggregateValue = group.aggregates[column.name];
-        if (aggregateValue === false) {
-            return {
-                help: _t("Different currencies cannot be aggregated"),
-                value: "—",
-            };
-        }
         if (
             !(column.name in group.aggregates) ||
             widget === "handle" ||
@@ -732,7 +726,14 @@ export class ListRenderer extends Component {
             escape: true,
         };
         if (field.type === "monetary") {
-            formatOptions.currencyId = group.aggregates[field.currency_field][0];
+            const currencies = group.aggregates[field.currency_field];
+            if (currencies.length > 1) {
+                return {
+                    help: _t("Different currencies cannot be aggregated"),
+                    value: "—",
+                };
+            }
+            formatOptions.currencyId = currencies[0];
         }
         return {
             value: formatter ? formatter(aggregateValue, formatOptions) : aggregateValue,


### PR DESCRIPTION
This commit fixes an issue where non-monetary aggregates in list views were incorrectly displaying the "—" symbol along with a tooltip meant for monetary fields with mixed currencies.

This behavior is now restricted to monetary field aggregates only when there are multiple currencies. For other field types, false aggregate values are simply hidden to avoid confusion.

task-4868373