### PR TITLE
[FIX] web: truncate m2o text

### DIFF
--- a/addons/web/static/src/views/fields/many2one/many2one.xml
+++ b/addons/web/static/src/views/fields/many2one/many2one.xml
@@ -8,7 +8,7 @@
             </t>
             <t t-elif="!props.readonly">
                 <span class="o_avatar o_m2o_avatar">
-                    <a class="o_quick_assign btn-link d-flex align-items-center text-dark" href="#" role="button" tabIndex="-1" aria-label="Assign" data-tooltip="Assign" t-on-click.stop.prevent="(e) => this.openAssignPopover(e.currentTarget)">
+                    <a class="o_quick_assign btn-link d-flex align-items-center text-dark" href="#" role="button" tabindex="-1" aria-label="Assign" data-tooltip="Assign" t-on-click.stop.prevent="(e) => this.openAssignPopover(e.currentTarget)">
                         <i class="fa fa-user-plus"/>
                     </a>
                 </span>
@@ -17,7 +17,7 @@
     </t>
 
     <t t-name="web.Many2One">
-        <div class="o_many2one" t-att-class="props.cssClass">
+        <div class="o_many2one text-truncate" t-att-class="props.cssClass">
             <t t-if="props.readonly">
                 <t t-if="value">
                     <t t-if="props.canOpen">


### PR DESCRIPTION
After this commit, the text of many2ones is truncated when the list view's columns are too small for the text.