### PR TITLE
[FIX] microsoft_calendar: read token during synchronization

### DIFF
--- a/addons/microsoft_calendar/models/res_users.py
+++ b/addons/microsoft_calendar/models/res_users.py
@@ -163,7 +163,7 @@ class User(models.Model):
         sync_status = 'missing_credentials'
         if credentials_status.get('microsoft_calendar'):
             sync_status = self._get_microsoft_sync_status()
-            if sync_status == 'sync_active' and not self.microsoft_calendar_token:
+            if sync_status == 'sync_active' and not self.sudo().microsoft_calendar_token:
                 sync_status = 'sync_stopped'
         res['microsoft_calendar'] = sync_status
         return res


### PR DESCRIPTION
Steps:
- Open Calendar app without group_system access right

Actual result:
- Access error due to microsoft_calendar_token field

Expected result
- No error

opw-4850523

Caused-by: https://github.com/odoo/odoo/pull/150186