### PR TITLE
[FIX] mail: push to talk should be released on stop keydown 

### DIFF
--- a/addons/mail/static/src/discuss/call/common/ptt_extension_service.js
+++ b/addons/mail/static/src/discuss/call/common/ptt_extension_service.js
@@ -47,7 +47,7 @@ export const pttExtensionHookService = {
                         if (voiceActivated) {
                             rtc.setPttReleaseTimeout(0);
                         } else {
-                            rtc.onPushToTalk();
+                            rtc.onPushToTalk({ withAutoRelease: false });
                         }
                         voiceActivated = !voiceActivated;
                     }
@@ -91,6 +91,9 @@ export const pttExtensionHookService = {
             },
             get isEnabled() {
                 return isEnabled;
+            },
+            get voiceActivated() {
+                return voiceActivated;
             },
         };
     },


### PR DESCRIPTION
Before this commit, when using push-to-talk in a discuss call, sometimes the push-to-talk was kept on although user had it released.

Steps to reproduce:
- do not use discuss extensions' push-to-talk key
- start a call
- enable push-to-talk with chosen shortcut
- press and hold the push-to-talk key
- switch to another browser tab while keeping the push-to-talk key pressed (e.g. alt-tab while holding push-to-talk)
- release push-to-talk key
=> Even after a long time and coming back to the call tab, the push to talk is still on

This happens because the release of push to talk is designed with keyup intercepted on the call tab. While this happens most of the time, sometimes the keyup is triggered outside of call tab and never in call tab, thus the push-to-talk is not released.

This commit fixes the issue by adding a timeout slightly greater than keyup release in the push-to-talk keydown phase, so that it forces release when no keydown has been intercepted for some time.

task-[4707634](https://www.odoo.com/odoo/project/1519/tasks/4707634)