### PR TITLE
[FIX] point_of_sale: print receipt images correctly on IoT printer

### DIFF
--- a/addons/point_of_sale/static/src/app/services/render_service.js
+++ b/addons/point_of_sale/static/src/app/services/render_service.js
@@ -1,6 +1,7 @@
 import { registry } from "@web/core/registry";
 import { Component, onRendered, reactive, useRef, xml } from "@odoo/owl";
 import { toCanvas } from "@point_of_sale/app/utils/html-to-image";
+import { waitImages } from "@point_of_sale/utils";
 
 export class RenderContainer extends Component {
     static props = ["comp", "onRendered"];
@@ -109,12 +110,14 @@ export const htmlToCanvas = async (el, options) => {
     return await applyWhenMounted({
         el,
         container: document.querySelector(".render-container"),
-        callback: async (el) =>
-            toCanvas(el, {
+        callback: async (el) => {
+            await waitImages(el); // Ensure all images in the cloned element are fully loaded to be rendered correctly
+            return toCanvas(el, {
                 backgroundColor: "#ffffff",
                 height: Math.ceil(el.clientHeight),
                 width: Math.ceil(el.clientWidth),
                 pixelRatio: 1,
-            }),
+            });
+        },
     });
 };


### PR DESCRIPTION
Before this commit, the logo and QR code images on receipts printed via the IoT printer did not appear. Now, the htmlToCanvas conversion waits until these images are fully loaded before proceeding.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
