### PR TITLE
[FIX] google_calendar: Google not sending email to organiers

### DIFF
--- a/addons/google_calendar/models/calendar_attendee.py
+++ b/addons/google_calendar/models/calendar_attendee.py
@@ -3,21 +3,11 @@
 
 from odoo import models
 
-from odoo.addons.google_calendar.models.google_sync import google_calendar_token
 from odoo.addons.google_calendar.utils.google_calendar import GoogleCalendarService
 
 class Attendee(models.Model):
     _name = 'calendar.attendee'
     _inherit = 'calendar.attendee'
-
-    def _send_mail_to_attendees(self, mail_template, force_send=False):
-        """ Override
-        If not synced with Google, let Odoo in charge of sending emails
-        Otherwise, nothing to do: Google will send them
-        """
-        with google_calendar_token(self.env.user.sudo()) as token:
-            if not token:
-                super()._send_mail_to_attendees(mail_template, force_send)
 
     def do_tentative(self):
         # Synchronize event after state change


### PR DESCRIPTION
revert of https://github.com/odoo/odoo/commit/c0a2729d4b7ba6fefe4dbde9247b2e6e868f5771

To reproduce:
=============
- Sync the calendar with google calendar, and organize some events.
- Invited people will receive invitation from google, but not the organizer.

Problem:
========
We count on google to send the email to the organizer, so that we don't send two emails, but google is not consistent in that.

Solution:
=========
Sending two emails is better than not sending any email at all

opw-4703948
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
