### PR TITLE
[IMP] point_of_sale: show units on orderline quantity

### DIFF
--- a/addons/point_of_sale/static/src/app/generic_components/orderline/orderline.xml
+++ b/addons/point_of_sale/static/src/app/generic_components/orderline/orderline.xml
@@ -21,7 +21,9 @@
                 </div>
                 <ul class="info-list d-flex flex-column">
                     <li class="price-per-unit">
-                        <span class="qty px-1 border rounded text-bg-view fw-bolder me-1" t-esc="line.qty"/>
+                        <span class="qty px-1 border rounded text-bg-view fw-bolder me-1">
+                            <t t-esc="line.qty" /> <t t-if="line.unit and line.unit !== 'Units'" t-esc="line.unit" />
+                        </span>
                         <t t-if="!props.basic_receipt">
                             x
                             <t t-if="line.price !== 0">


### PR DESCRIPTION
This commit adds the the unit e.g. 'kg' to each orderline next to the quantity. The reason for this change was to satisfy the requirements of the LNE to allow Odoo to be certified for weighing scales in the EU.

task-4869128

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
