### PR TITLE
[FIX] account: Create reversal reference using partner's language

### DIFF
--- a/addons/account/wizard/account_move_reversal.py
+++ b/addons/account/wizard/account_move_reversal.py
@@ -97,6 +97,7 @@ class AccountMoveReversal(models.TransientModel):
     def _prepare_default_reversal(self, move):
         reverse_date = self.date if self.date_mode == 'custom' else move.date
         mixed_payment_term = move.invoice_payment_term_id.id if move.invoice_payment_term_id and move.company_id.early_pay_discount_computation == 'mixed' else None
+        self.env.context = {'lang': move.partner_id.lang or self.env.lang}
         return {
             'ref': _('Reversal of: %(move_name)s, %(reason)s', move_name=move.name, reason=self.reason)
                    if self.reason


### PR DESCRIPTION
Steps to reproduce:
====================
- Create an invoice
- Add a customer whose language differs from the user's language
- Create a reversal
- Print the PDF

Problem:
=========
The reversal reference is generated using the user's language, making it impossible to translate properly because the string value is changed and concatenated with the invoice name.

Solution:
==========
Generate the reversal reference using the partner's language to enable proper translation.

opw-4743430
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
