### PR TITLE
[FIX] l10n_{ar, pe}_pos: fix pos ticket validation screen override

### DIFF
--- a/addons/l10n_ar_pos/views/templates.xml
+++ b/addons/l10n_ar_pos/views/templates.xml
@@ -12,7 +12,7 @@
         </xpath>
 
         <!-- If the user is NOT log in we should hide the partner form, this one lost functionality because the get my invoice button is not shown and then the partner info is never save. In they want they can sign up and fill data from there -->
-        <xpath expr="//div[hasclass('o_customer_address_fill')]" position="attributes">
+        <xpath expr="//div[hasclass('o_customer_address_fill')] | //div[hasclass('o_portal_details')]" position="attributes">
             <attribute name="t-if">pos_order.company_id.country_code != 'AR'</attribute>
         </xpath>
         <xpath expr="//div[@id='get_info_div']" position="attributes">

--- a/addons/l10n_pe_pos/views/templates.xml
+++ b/addons/l10n_pe_pos/views/templates.xml
@@ -16,7 +16,7 @@
         <!-- If the user is NOT logged in we should hide the partner form, this one lost functionality
         because the get my invoice button is not shown and then the partner info is never saved. In they
         want they can sign up and fill data from there -->
-        <xpath expr="//div[hasclass('o_customer_address_fill')]" position="attributes">
+        <xpath expr="//div[hasclass('o_customer_address_fill')] | //div[hasclass('o_portal_details')]" position="attributes">
             <attribute name="t-if" add="(pos_order.company_id.country_code != 'PE')" separator="and" />
         </xpath>
         <xpath expr="//div[@id='get_info_div']" position="attributes">


### PR DESCRIPTION
The Ticket Validation screen in POS has recently been updated. However, this change may break the override defined in the Ticket Validation screen view when installing any of the `l10n_{ar/pe/ec_edi}_pos` modules. This issue occurs if the `point_of_sale` module was installed before the update and you install one of these localization modules after pulling the latest code.

To ensure compatibility and prevent the override from failing, we have updated the XPath expression in the `l10n_{ar/pe/ec_edi}_pos` modules to make it more resilient to view changes.

Followup of: https://github.com/odoo/odoo/pull/201995/commits/d6f75fc61c54ba8d6726508c78ed91c11ea6b1bd

sentry-6673777020

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
