### PR TITLE
[FIX] l10n_tr_nilvera_einvoice: remove InvoicePerdiod from XML lines

### DIFF
--- a/addons/l10n_tr_nilvera_einvoice/models/account_edi_xml_ubl_tr.py
+++ b/addons/l10n_tr_nilvera_einvoice/models/account_edi_xml_ubl_tr.py
@@ -185,6 +185,7 @@ class AccountEdiXmlUblTr(models.AbstractModel):
         invoice_line_vals = super()._get_invoice_line_vals(line, line_id, taxes_vals)
         invoice_line_vals['line_quantity_attrs'] = {'unitCode': line.product_uom_id._get_unece_code()}
         invoice_line_vals['currency_dp'] = 2
+        invoice_line_vals['invoice_period_vals_list'] = []  # UBL-TR does not support invoice periods per line
         return invoice_line_vals
 
     def _get_pricing_exchange_rate_vals_list(self, invoice):


### PR DESCRIPTION
To comply with UBL-TR 1.2.1 standards, invoice lines must not contain InvoicePeriod. Otherwise, we encounter a Schematron validation error: `Şema/Şematron Hatas1.: cvc-complex-type.2.4.a: Invalid content was found starting with element 'cac:InvoicePeriod'. One of...` (see ticket for full error message).

Steps to reproduce:
- Set up a connection to Nilvera (see the related ticket for a link to the Google Doc with test credentials).
- Create a new invoice.
- Add a line with a start and end date.
- Validate the invoice.
- Send the invoice to Nilvera, the error will appear.

We reset `invoice_period_vals_list` to an empty list to prevent the field from being included.
You can get the official UBL-TR documentation for more details: https://ebelge.gib.gov.tr/efaturamevzuat.html — by clicking on the link titled "UBL-TR1.2.1 Kılavuzları"

opw-4835975