### PR TITLE
[REF] *: use ISO formatted dates

### DIFF
--- a/addons/event/tests/test_event_internals.py
+++ b/addons/event/tests/test_event_internals.py
@@ -394,7 +394,7 @@ class TestEventData(TestEventInternalsCommon):
             registration.invalidate_recordset(['event_date_range'])
             self.assertEqual(registration.event_date_range, 'in 6 days')
 
-    @freeze_time('2020-1-31 10:00:00')
+    @freeze_time('2020-01-31 10:00:00')
     @users('user_eventmanager')
     def test_event_date_timezone(self):
         event = self.event_0.with_user(self.env.user)
@@ -459,7 +459,7 @@ class TestEventData(TestEventInternalsCommon):
         templates = self.env['mail.template'].with_context(filter_template_on_event=True).search([('name', '=', 'test template')])
         self.assertEqual(len(templates), 1, 'Should also return only mail templates related to the event registration model using search')
 
-    @freeze_time('2020-1-31 10:00:00')
+    @freeze_time('2020-01-31 10:00:00')
     @users('user_eventmanager')
     def test_event_registrable(self):
         """Test if `_compute_event_registrations_open` works properly."""
@@ -511,7 +511,7 @@ class TestEventData(TestEventInternalsCommon):
         self.assertTrue(ticket.is_expired)
         self.assertFalse(event.event_registrations_open)
 
-    @freeze_time('2020-1-31 10:00:00')
+    @freeze_time('2020-01-31 10:00:00')
     @users('user_eventmanager')
     def test_event_multi_slots_registrable(self):
         """Test if `_compute_event_registrations_open` works properly on multi slots events. """
@@ -582,7 +582,7 @@ class TestEventData(TestEventInternalsCommon):
         } for slot in slot1 + slot2 for _ in range(2)])
         self.assertFalse(event.event_registrations_open)
 
-    @freeze_time('2020-1-31 10:00:00')
+    @freeze_time('2020-01-31 10:00:00')
     @users('user_eventmanager')
     def test_event_ongoing(self):
         event_1 = self.env['event.event'].create({
@@ -910,7 +910,7 @@ class TestEventRegistrationPhone(EventCase):
 @tagged('event_ticket')
 class TestEventTicketData(TestEventInternalsCommon):
 
-    @freeze_time('2020-1-31 10:00:00')
+    @freeze_time('2020-01-31 10:00:00')
     @users('user_eventmanager')
     def test_event_ticket_fields(self):
         """ Test event ticket fields synchronization """

--- a/addons/google_calendar/tests/test_sync_google2odoo.py
+++ b/addons/google_calendar/tests/test_sync_google2odoo.py
@@ -398,8 +398,8 @@ class TestSyncGoogle2Odoo(TestSyncGoogle):
             'attendees': [],  # <= attendee removed in Google
             'recurrence': ['RRULE:FREQ=WEEKLY;COUNT=2;BYDAY=MO'],
             'reminders': {'useDefault': True},
-            'start': {'date': '2020-01-6'},
-            'end': {'date': '2020-01-7'},
+            'start': {'date': '2020-01-06'},
+            'end': {'date': '2020-01-07'},
         }])
         events = recurrence.calendar_event_ids.sorted('start')
         self.assertEqual(events.partner_ids, user.partner_id)
@@ -420,8 +420,8 @@ class TestSyncGoogle2Odoo(TestSyncGoogle):
             'summary': 'Pricing new update',
             'recurrence': ['RRULE:FREQ=WEEKLY;WKST=SU;COUNT=3;BYDAY=MO'],
             'reminders': {'useDefault': True},
-            'start': {'date': '2020-01-6'},
-            'end': {'date': '2020-01-7'},
+            'start': {'date': '2020-01-06'},
+            'end': {'date': '2020-01-07'},
             'transparency': 'opaque',
         }
         self.env['calendar.recurrence']._sync_google2odoo(GoogleEvent([values]))
@@ -478,8 +478,8 @@ class TestSyncGoogle2Odoo(TestSyncGoogle):
             'organizer': {'email': self.env.user.email, 'self': True},
             'recurrence': ['RRULE:FREQ=WEEKLY;WKST=SU;COUNT=3;BYDAY=MO'],
             'reminders': {'useDefault': True},
-            'start': {'date': '2020-01-6'},
-            'end': {'date': '2020-01-7'},
+            'start': {'date': '2020-01-06'},
+            'end': {'date': '2020-01-07'},
         }, {   # Third event has been deleted
             'id': '%s_20200113' % recurrence_id,
             'originalStartTime': {'dateTime': '2020-01-13'},
@@ -503,9 +503,9 @@ class TestSyncGoogle2Odoo(TestSyncGoogle):
             "id": recurrence_id,
             "updated": "2020-01-13T16:17:03.806Z",
             "summary": "r rul",
-            "start": {"date": "2020-01-6"},
+            "start": {"date": "2020-01-06"},
             'organizer': {'email': self.env.user.email, 'self': True},
-            "end": {"date": "2020-01-7"},
+            "end": {"date": "2020-01-07"},
             'reminders': {'useDefault': True},
             "recurrence": ["RRULE:FREQ=WEEKLY;WKST=SU;COUNT=3;BYDAY=MO"],
         }, {
@@ -601,8 +601,8 @@ class TestSyncGoogle2Odoo(TestSyncGoogle):
             'id': recurrence_id,
             'summary': 'Pricing new update',
             'recurrence': ['RRULE:FREQ=WEEKLY;WKST=SU;COUNT=3;BYDAY=MO'],
-            'start': {'date': '2020-01-6'},
-            'end': {'date': '2020-01-7'},
+            'start': {'date': '2020-01-06'},
+            'end': {'date': '2020-01-07'},
             'reminders': {'useDefault': True},
             'updated': self.now,
             'guestsCanModify': True,
@@ -960,8 +960,8 @@ class TestSyncGoogle2Odoo(TestSyncGoogle):
             'recurrence': ['EXDATE;TZID=Europe/Rome:20200113',
                            'RRULE;X-EVOLUTION-ENDDATE=20200120:FREQ=WEEKLY;COUNT=3;BYDAY=MO;X-RELATIVE=1'],
             'reminders': {'useDefault': True},
-            'start': {'date': '2020-01-6'},
-            'end': {'date': '2020-01-7'},
+            'start': {'date': '2020-01-06'},
+            'end': {'date': '2020-01-07'},
         }
         self.env['calendar.recurrence']._sync_google2odoo(GoogleEvent([values]))
         recurrence = self.env['calendar.recurrence'].search([('google_id', '=', values.get('id'))])
@@ -1759,8 +1759,8 @@ class TestSyncGoogle2Odoo(TestSyncGoogle):
             }, ],
             'recurrence': ['RRULE:FREQ=WEEKLY;WKST=SU;COUNT=3;BYDAY=MO'],
             'reminders': {'useDefault': True},
-            'start': {'date': '2020-01-6'},
-            'end': {'date': '2020-01-7'},
+            'start': {'date': '2020-01-06'},
+            'end': {'date': '2020-01-07'},
         }
         self.env['calendar.recurrence']._sync_google2odoo(GoogleEvent([values]))
         recurrence = self.env['calendar.recurrence'].search([('google_id', '=', values.get('id'))])

--- a/addons/hr/data/hr_demo.xml
+++ b/addons/hr/data/hr_demo.xml
@@ -228,8 +228,8 @@ If you have development competencies, we can propose you specific traineeships</
             <field name="work_phone">(555)-125-2389</field>
             <field name="work_email">admin@yourcompany.example.com</field>
             <field name="category_ids" eval="[Command.set([ref('employee_category_4'), ref('employee_category_3')])]"/>
-            <field name="date_version" eval="time.strftime('%Y')+'-1-1'"/>
-            <field name="contract_date_start" eval="time.strftime('%Y')+'-1-1'"/>
+            <field name="date_version" eval="time.strftime('%Y')+'-01-01'"/>
+            <field name="contract_date_start" eval="time.strftime('%Y')+'-01-01'"/>
             <field name="contract_date_end" eval="False"/>
             <field name="contract_type_id" ref="contract_type_permanent"/>
             <field name="structure_type_id" ref="structure_type_employee"/>
@@ -314,8 +314,8 @@ If you have development competencies, we can propose you specific traineeships</
             <field name="work_contact_id" ref="hr.work_contact_al"/>
             <field name="image_1920" type="base64" file="hr/static/img/employee_al-image.jpg"/>
             <field name="create_date">2010-01-01 00:00:00</field>
-            <field name="date_version" eval="time.strftime('%Y')+'-1-1'"/>
-            <field name="contract_date_start" eval="time.strftime('%Y')+'-1-1'"/>
+            <field name="date_version" eval="time.strftime('%Y')+'-01-01'"/>
+            <field name="contract_date_start" eval="time.strftime('%Y')+'-01-01'"/>
             <field name="contract_type_id" ref="contract_type_permanent"/>
             <field name="structure_type_id" ref="structure_type_employee"/>
             <field name="wage">4000.00</field>
@@ -341,9 +341,9 @@ If you have development competencies, we can propose you specific traineeships</
             <field name="work_contact_id" ref="hr.work_contact_vad"/>
             <field name="image_1920" type="base64" file="hr/static/img/employee_vad-image.jpg"/>
             <field name="create_date">2010-01-01 00:00:00</field>
-            <field name="date_version" eval="'2015-1-1'"/>
-            <field name="contract_date_start" eval="'2015-1-1'"/>
-            <field name="contract_date_end" eval="'2018-2-1'"/>
+            <field name="date_version" eval="'2015-01-01'"/>
+            <field name="contract_date_start" eval="'2015-01-01'"/>
+            <field name="contract_date_end" eval="'2018-02-01'"/>
             <field name="contract_type_id" ref="contract_type_full_time"/>
             <field name="structure_type_id" ref="structure_type_employee"/>
             <field name="wage">4000.00</field>
@@ -403,8 +403,8 @@ If you have development competencies, we can propose you specific traineeships</
             <field name="create_date">2010-01-01 00:00:00</field>
             <field name="sex">female</field>
             <field name="distance_home_work">7</field>
-            <field name="date_version" eval="'2014-1-1'"/>
-            <field name="contract_date_start" eval="'2014-1-1'"/>
+            <field name="date_version" eval="'2014-01-01'"/>
+            <field name="contract_date_start" eval="'2014-01-01'"/>
             <field name="contract_date_end" eval="'2014-12-31'"/>
             <field name="contract_type_id" ref="contract_type_full_time"/>
             <field name="structure_type_id" ref="structure_type_employee"/>
@@ -420,9 +420,9 @@ If you have development competencies, we can propose you specific traineeships</
         <function name="create_version" model="hr.employee">
             <value eval="[ref('hr.employee_fpi')]"/>
             <value eval="{
-                'date_version': '2015-1-1',
-                'contract_date_start': '2015-1-1',
-                'contract_date_end': '2017-12-1',
+                'date_version': '2015-01-01',
+                'contract_date_start': '2015-01-01',
+                'contract_date_end': '2017-12-01',
                 'wage': 3750.00
             }"/>
         </function>
@@ -444,7 +444,7 @@ If you have development competencies, we can propose you specific traineeships</
             <field name="work_phone">(555)-169-1352</field>
             <field name="work_contact_id" ref="hr.work_contact_lur"/>
             <field name="image_1920" type="base64" file="hr/static/img/employee_lur-image.jpg"/>
-            <field name="date_version" eval="'2010-1-1'"/>
+            <field name="date_version" eval="'2010-01-01'"/>
             <field name="sex">male</field>
         </record>
 
@@ -465,7 +465,7 @@ If you have development competencies, we can propose you specific traineeships</
             <field name="work_phone">(555)-267-3735</field>
             <field name="work_contact_id" ref="hr.work_contact_jod"/>
             <field name="image_1920" type="base64" file="hr/static/img/employee_jod-image.jpg"/>
-            <field name="date_version" eval="'2010-1-1'"/>
+            <field name="date_version" eval="'2010-01-01'"/>
             <field name="sex">female</field>
         </record>
 
@@ -482,8 +482,8 @@ If you have development competencies, we can propose you specific traineeships</
             <field name="work_contact_id" ref="hr.work_contact_fme"/>
             <field name="image_1920" type="base64" file="hr/static/img/employee_fme-image.jpg"/>
             <field name="create_date">2010-01-01 00:00:00</field>
-            <field name="date_version" eval="'2015-1-1'"/>
-            <field name="contract_date_start" eval="'2015-1-1'"/>
+            <field name="date_version" eval="'2015-01-01'"/>
+            <field name="contract_date_start" eval="'2015-01-01'"/>
             <field name="contract_date_end" eval="time.strftime('%Y-%m-%d')"/>
             <field name="contract_type_id" ref="contract_type_full_time"/>
             <field name="structure_type_id" ref="structure_type_employee"/>
@@ -516,7 +516,7 @@ If you have development competencies, we can propose you specific traineeships</
             <field name="work_phone">(555)-331-5378</field>
             <field name="work_contact_id" ref="hr.work_contact_jep"/>
             <field name="image_1920" type="base64" file="hr/static/img/employee_jep-image.jpg"/>
-            <field name="date_version" eval="'2010-1-1'"/>
+            <field name="date_version" eval="'2010-01-01'"/>
             <field name="sex">female</field>
             <field name="distance_home_work">13</field>
         </record>
@@ -538,7 +538,7 @@ If you have development competencies, we can propose you specific traineeships</
             <field name="work_phone">(555)-518-8232</field>
             <field name="work_contact_id" ref="hr.work_contact_jgo"/>
             <field name="image_1920" type="base64" file="hr/static/img/employee_jgo-image.jpg"/>
-            <field name="date_version" eval="'2010-1-1'"/>
+            <field name="date_version" eval="'2010-01-01'"/>
             <field name="sex">male</field>
         </record>
 
@@ -555,8 +555,8 @@ If you have development competencies, we can propose you specific traineeships</
             <field name="work_contact_id" ref="hr.work_contact_jth"/>
             <field name="image_1920" type="base64" file="hr/static/img/employee_jth-image.jpg"/>
             <field name="create_date">2010-01-01 00:00:00</field>
-            <field name="date_version" eval="(DateTime.today() - relativedelta(months=2)).strftime('%Y-%m')+'-1'"/>
-            <field name="contract_date_start" eval="(DateTime.today() - relativedelta(months=2)).strftime('%Y-%m')+'-1'"/>
+            <field name="date_version" eval="(DateTime.today() - relativedelta(months=2)).strftime('%Y-%m')+'-01'"/>
+            <field name="contract_date_start" eval="(DateTime.today() - relativedelta(months=2)).strftime('%Y-%m')+'-01'"/>
             <field name="contract_date_end" eval="time.strftime('%Y')+'-12-1'"/>
             <field name="contract_type_id" ref="contract_type_permanent"/>
             <field name="structure_type_id" ref="structure_type_employee"/>
@@ -584,8 +584,8 @@ If you have development competencies, we can propose you specific traineeships</
             <field name="work_contact_id" ref="hr.work_contact_mit"/>
             <field name="image_1920" type="base64" file="hr/static/img/employee_mit-image.jpg"/>
             <field name="create_date">2010-01-01 00:00:00</field>
-            <field name="date_version" eval="time.strftime('%Y')+'-1-1'"/>
-            <field name="contract_date_start" eval="time.strftime('%Y')+'-1-1'"/>
+            <field name="date_version" eval="time.strftime('%Y')+'-01-01'"/>
+            <field name="contract_date_start" eval="time.strftime('%Y')+'-01-01'"/>
             <field name="contract_type_id" ref="contract_type_permanent"/>
             <field name="structure_type_id" ref="structure_type_employee"/>
             <field name="wage">4500.00</field>
@@ -614,8 +614,8 @@ If you have development competencies, we can propose you specific traineeships</
             <field name="work_contact_id" ref="hr.work_contact_niv"/>
             <field name="image_1920" type="base64" file="hr/static/img/employee_niv-image.jpg"/>
             <field name="create_date">2010-01-01 00:00:00</field>
-            <field name="date_version" eval="(DateTime.today() - relativedelta(months=2)).strftime('%Y-%m')+'-1'"/>
-            <field name="contract_date_start" eval="(DateTime.today() - relativedelta(months=2)).strftime('%Y-%m')+'-1'"/>
+            <field name="date_version" eval="(DateTime.today() - relativedelta(months=2)).strftime('%Y-%m')+'-01'"/>
+            <field name="contract_date_start" eval="(DateTime.today() - relativedelta(months=2)).strftime('%Y-%m')+'-01'"/>
             <field name="contract_date_end" eval="time.strftime('%Y')+'-12-1'"/>
             <field name="contract_type_id" ref="contract_type_full_time"/>
             <field name="structure_type_id" ref="structure_type_employee"/>
@@ -642,8 +642,8 @@ If you have development competencies, we can propose you specific traineeships</
             <field name="work_contact_id" ref="hr.work_contact_stw"/>
             <field name="image_1920" type="base64" file="hr/static/img/employee_stw-image.jpg"/>
             <field name="create_date">2010-01-01 00:00:00</field>
-            <field name="date_version" eval="time.strftime('%Y')+'-2-1'"/>
-            <field name="contract_date_start" eval="time.strftime('%Y')+'-2-1'"/>
+            <field name="date_version" eval="time.strftime('%Y')+'-02-01'"/>
+            <field name="contract_date_start" eval="time.strftime('%Y')+'-02-01'"/>
             <field name="contract_date_end" eval="time.strftime('%Y')+'-12-1'"/>
             <field name="contract_type_id" ref="contract_type_full_time"/>
             <field name="structure_type_id" ref="structure_type_employee"/>
@@ -670,8 +670,8 @@ If you have development competencies, we can propose you specific traineeships</
             <field name="work_contact_id" ref="hr.work_contact_chs"/>
             <field name="image_1920" type="base64" file="hr/static/img/employee_chs-image.jpg"/>
             <field name="create_date">2010-01-01 00:00:00</field>
-            <field name="date_version" eval="(DateTime.today() - relativedelta(months=2)).strftime('%Y-%m')+'-1'"/>
-            <field name="contract_date_start" eval="(DateTime.today() - relativedelta(months=2)).strftime('%Y-%m')+'-1'"/>
+            <field name="date_version" eval="(DateTime.today() - relativedelta(months=2)).strftime('%Y-%m')+'-01'"/>
+            <field name="contract_date_start" eval="(DateTime.today() - relativedelta(months=2)).strftime('%Y-%m')+'-01'"/>
             <field name="contract_date_end" eval="time.strftime('%Y')+'-12-1'"/>
             <field name="contract_type_id" ref="contract_type_permanent"/>
             <field name="structure_type_id" ref="structure_type_employee"/>
@@ -697,8 +697,8 @@ If you have development competencies, we can propose you specific traineeships</
             <field name="work_contact_id" ref="hr.work_contact_jve"/>
             <field name="image_1920" type="base64" file="hr/static/img/employee_jve-image.jpg"/>
             <field name="create_date">2010-01-01 00:00:00</field>
-            <field name="date_version" eval="(DateTime.today() - relativedelta(months=2)).strftime('%Y-%m')+'-1'"/>
-            <field name="contract_date_start" eval="(DateTime.today() - relativedelta(months=2)).strftime('%Y-%m')+'-1'"/>
+            <field name="date_version" eval="(DateTime.today() - relativedelta(months=2)).strftime('%Y-%m')+'-01'"/>
+            <field name="contract_date_start" eval="(DateTime.today() - relativedelta(months=2)).strftime('%Y-%m')+'-01'"/>
             <field name="contract_date_end" eval="time.strftime('%Y')+'-12-1'"/>
             <field name="contract_type_id" ref="contract_type_permanent"/>
             <field name="structure_type_id" ref="structure_type_employee"/>
@@ -724,8 +724,8 @@ If you have development competencies, we can propose you specific traineeships</
             <field name="work_contact_id" ref="hr.work_contact_han"/>
             <field name="image_1920" type="base64" file="hr/static/img/employee_han-image.jpg"/>
             <field name="create_date">2010-01-01 00:00:00</field>
-            <field name="date_version" eval="time.strftime('%Y')+'-3-1'"/>
-            <field name="contract_date_start" eval="time.strftime('%Y')+'-3-1'"/>
+            <field name="date_version" eval="time.strftime('%Y')+'-03-01'"/>
+            <field name="contract_date_start" eval="time.strftime('%Y')+'-03-01'"/>
             <field name="contract_type_id" ref="contract_type_permanent"/>
             <field name="structure_type_id" ref="structure_type_employee"/>
             <field name="wage">4600.00</field>
@@ -757,7 +757,7 @@ If you have development competencies, we can propose you specific traineeships</
             <field name="work_phone">(555)-532-3841</field>
             <field name="work_contact_id" ref="hr.work_contact_jog"/>
             <field name="image_1920" type="base64" file="hr/static/img/employee_jog-image.jpg"/>
-            <field name="date_version" eval="'2010-1-1'"/>
+            <field name="date_version" eval="'2010-01-01'"/>
             <field name="sex">female</field>
             <field name="distance_home_work">50</field>
         </record>
@@ -771,9 +771,9 @@ If you have development competencies, we can propose you specific traineeships</
             <field name="name">Barty McBly</field>
             <field name="work_phone">(555)-234-3424</field>
             <field name="work_contact_id" ref="hr.work_contact_barty_mcbly"/>
-            <field name="date_version">1885-9-2</field>
-            <field name="contract_date_start">1885-9-2</field>
-            <field name="contract_date_end">1885-9-7</field>
+            <field name="date_version">1885-09-02</field>
+            <field name="contract_date_start">1885-09-02</field>
+            <field name="contract_date_end">1885-09-07</field>
             <field name="contract_type_id" ref="contract_type_full_time"/>
             <field name="structure_type_id" ref="structure_type_employee"/>
             <field name="resource_calendar_id" ref="resource.resource_calendar_std_38h"/>
@@ -788,8 +788,8 @@ If you have development competencies, we can propose you specific traineeships</
         <function name="create_version" model="hr.employee">
             <value eval="[ref('hr.employee_barty_mcbly')]"/>
             <value eval="{
-                'date_version': '1955-11-5',
-                'contract_date_start': '1955-11-5',
+                'date_version': '1955-11-05',
+                'contract_date_start': '1955-11-05',
                 'contract_date_end': '1984-11-12',
                 'wage': 250.00
             }"/>

--- a/addons/hr_attendance/tests/test_hr_attendance_overtime.py
+++ b/addons/hr_attendance/tests/test_hr_attendance_overtime.py
@@ -428,8 +428,7 @@ class TestHrAttendanceOvertime(TransactionCase):
                                                               ('date', '=', datetime(2024, 5, 29))])
         self.assertAlmostEqual(overtime_record2.duration, 5)
 
-
-    @freeze_time("2024-02-1 23:00:00")
+    @freeze_time("2024-02-01 23:00:00")
     def test_auto_check_out(self):
         self.company.write({
             'auto_check_out': True,
@@ -540,7 +539,7 @@ class TestHrAttendanceOvertime(TransactionCase):
             self.assertEqual(att.worked_hours, 8)
             self.assertEqual(att.check_out, datetime(2025, 3, 12, 17, 0))
 
-    @freeze_time("2024-02-1 14:00:00")
+    @freeze_time("2024-02-01 14:00:00")
     def test_absence_management(self):
         self.company.write({
             'absence_management': True,

--- a/addons/hr_holidays/data/hr_holidays_demo.xml
+++ b/addons/hr_holidays/data/hr_holidays_demo.xml
@@ -71,7 +71,7 @@
         <field name="number_of_days">20</field>
         <field name="employee_id" ref="hr.employee_admin"/>
         <field name="state">confirm</field>
-        <field name="date_from" eval="time.strftime('%Y-1-1')"/>
+        <field name="date_from" eval="time.strftime('%Y-01-01')"/>
         <field name="date_to" eval="time.strftime('%Y-12-31')"/>
     </record>
 
@@ -81,7 +81,7 @@
         <field name="number_of_days">7</field>
         <field name="employee_id" ref="hr.employee_admin"/>
         <field name="state">confirm</field>
-        <field name="date_from" eval="time.strftime('%Y-1-1')"/>
+        <field name="date_from" eval="time.strftime('%Y-01-01')"/>
         <field name="date_to" eval="time.strftime('%Y-12-31')"/>
     </record>
 
@@ -91,7 +91,7 @@
         <field name="number_of_days">7</field>
         <field name="state">confirm</field>
         <field name="employee_id" ref="hr.employee_admin"/>
-        <field name="date_from" eval="time.strftime('%Y-1-1')"/>
+        <field name="date_from" eval="time.strftime('%Y-01-01')"/>
         <field name="date_to" eval="time.strftime('%Y-12-31')"/>
     </record>
 
@@ -101,7 +101,7 @@
         <field name="number_of_days">12</field>
         <field name="employee_id" ref="hr.employee_admin"/>
         <field name="state">confirm</field>
-        <field name="date_from" eval="time.strftime('%Y-1-1')"/>
+        <field name="date_from" eval="time.strftime('%Y-01-01')"/>
         <field name="date_to" eval="time.strftime('%Y-12-31')"/>
     </record>
     <function model="hr.leave.allocation" name="action_approve">
@@ -157,7 +157,7 @@
         <field name="number_of_days">20</field>
         <field name="employee_id" ref="hr.employee_al"/>
         <field name="state">confirm</field>
-        <field name="date_from" eval="time.strftime('%Y-1-1')"/>
+        <field name="date_from" eval="time.strftime('%Y-01-01')"/>
         <field name="date_to" eval="time.strftime('%Y-12-31')"/>
     </record>
 
@@ -167,7 +167,7 @@
         <field name="number_of_days">10</field>
         <field name="employee_id" ref="hr.employee_al"/>
         <field name="state">confirm</field>
-        <field name="date_from" eval="time.strftime('%Y-1-1')"/>
+        <field name="date_from" eval="time.strftime('%Y-01-01')"/>
         <field name="date_to" eval="time.strftime('%Y-12-31')"/>
     </record>
 
@@ -177,7 +177,7 @@
         <field name="number_of_days">12</field>
         <field name="employee_id" ref="hr.employee_al"/>
         <field name="state">confirm</field>
-        <field name="date_from" eval="time.strftime('%Y-1-1')"/>
+        <field name="date_from" eval="time.strftime('%Y-01-01')"/>
         <field name="date_to" eval="time.strftime('%Y-12-31')"/>
     </record>
     <function model="hr.leave.allocation" name="action_approve">
@@ -216,7 +216,7 @@
         <field name="number_of_days">20</field>
         <field name="employee_id" ref="hr.employee_mit"/>
         <field name="state">confirm</field>
-        <field name="date_from" eval="time.strftime('%Y-1-1')"/>
+        <field name="date_from" eval="time.strftime('%Y-01-01')"/>
         <field name="date_to" eval="time.strftime('%Y-12-31')"/>
     </record>
     <function model="hr.leave.allocation" name="action_approve">
@@ -229,7 +229,7 @@
         <field name="number_of_days">7</field>
         <field name="state">confirm</field>
         <field name="employee_id" ref="hr.employee_mit"/>
-        <field name="date_from" eval="time.strftime('%Y-1-1')"/>
+        <field name="date_from" eval="time.strftime('%Y-01-01')"/>
         <field name="date_to" eval="time.strftime('%Y-12-31')"/>
     </record>
 
@@ -265,7 +265,7 @@
         <field name="number_of_days">20</field>
         <field name="employee_id" ref="hr.employee_qdp"/>
         <field name="state">confirm</field>
-        <field name="date_from" eval="time.strftime('%Y-1-1')"/>
+        <field name="date_from" eval="time.strftime('%Y-01-01')"/>
         <field name="date_to" eval="time.strftime('%Y-12-31')"/>
     </record>
 
@@ -275,7 +275,7 @@
         <field name="number_of_days">7</field>
         <field name="employee_id" ref="hr.employee_qdp"/>
         <field name="state">confirm</field>
-        <field name="date_from" eval="time.strftime('%Y-1-1')"/>
+        <field name="date_from" eval="time.strftime('%Y-01-01')"/>
         <field name="date_to" eval="time.strftime('%Y-12-31')"/>
     </record>
     <function model="hr.leave.allocation" name="action_approve">
@@ -315,7 +315,7 @@
         <field name="number_of_days">20</field>
         <field name="employee_id" ref="hr.employee_fpi"/>
         <field name="state">confirm</field>
-        <field name="date_from" eval="time.strftime('%Y-1-1')"/>
+        <field name="date_from" eval="time.strftime('%Y-01-01')"/>
         <field name="date_to" eval="time.strftime('%Y-12-31')"/>
     </record>
     <function model="hr.leave.allocation" name="action_approve">
@@ -328,7 +328,7 @@
         <field name="number_of_days">7</field>
         <field name="employee_id" ref="hr.employee_fpi"/>
         <field name="state">confirm</field>
-        <field name="date_from" eval="time.strftime('%Y-1-1')"/>
+        <field name="date_from" eval="time.strftime('%Y-01-01')"/>
         <field name="date_to" eval="time.strftime('%Y-12-31')"/>
     </record>
 
@@ -340,7 +340,7 @@
         <field name="number_of_days">20</field>
         <field name="employee_id" ref="hr.employee_niv"/>
         <field name="state">confirm</field>
-        <field name="date_from" eval="time.strftime('%Y-1-1')"/>
+        <field name="date_from" eval="time.strftime('%Y-01-01')"/>
         <field name="date_to" eval="time.strftime('%Y-12-31')"/>
     </record>
 
@@ -350,7 +350,7 @@
         <field name="number_of_days">5</field>
         <field name="employee_id" ref="hr.employee_niv"/>
         <field name="state">confirm</field>
-        <field name="date_from" eval="time.strftime('%Y-1-1')"/>
+        <field name="date_from" eval="time.strftime('%Y-01-01')"/>
         <field name="date_to" eval="time.strftime('%Y-12-31')"/>
     </record>
     <function model="hr.leave.allocation" name="action_approve">
@@ -389,7 +389,7 @@
         <field name="number_of_days">20</field>
         <field name="employee_id" ref="hr.employee_jve"/>
         <field name="state">confirm</field>
-        <field name="date_from" eval="time.strftime('%Y-1-1')"/>
+        <field name="date_from" eval="time.strftime('%Y-01-01')"/>
         <field name="date_to" eval="time.strftime('%Y-12-31')"/>
     </record>
 
@@ -399,7 +399,7 @@
         <field name="number_of_days">5</field>
         <field name="state">confirm</field>
         <field name="employee_id" ref="hr.employee_jve"/>
-        <field name="date_from" eval="time.strftime('%Y-1-1')"/>
+        <field name="date_from" eval="time.strftime('%Y-01-01')"/>
         <field name="date_to" eval="time.strftime('%Y-12-31')"/>
     </record>
 

--- a/addons/hr_holidays/models/hr_leave_type.py
+++ b/addons/hr_holidays/models/hr_leave_type.py
@@ -142,8 +142,9 @@ class HrLeaveType(models.Model):
             date_to = fields.Date.context_today(self, default_date_to_dt)
 
         else:
-            date_from = fields.Date.today().strftime('%Y-1-1')
-            date_to = fields.Date.today().strftime('%Y-12-31')
+            current_year = fields.Date.today().year
+            date_from = date(current_year, 1, 1)
+            date_to = date(current_year, 12, 31)
 
         employee_id = self._context.get('default_employee_id', self._context.get('employee_id')) or self.env.user.employee_id.id
 

--- a/addons/hr_holidays/tests/test_accrual_allocations.py
+++ b/addons/hr_holidays/tests/test_accrual_allocations.py
@@ -98,7 +98,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
         accrual_plan.unlink()
 
     def test_frequency_hourly_calendar(self):
-        with freeze_time("2017-12-5"):
+        with freeze_time("2017-12-05"):
             accrual_plan = self.env['hr.leave.accrual.plan'].with_context(tracking_disable=True).create({
                 'name': 'Accrual Plan For Test',
                 'level_ids': [(0, 0, {
@@ -135,7 +135,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 self.assertEqual(allocation.number_of_days, 8, 'There should be only 8 day allocated.')
 
     def test_frequency_hourly_worked_hours(self):
-        with freeze_time("2017-12-5"):
+        with freeze_time("2017-12-05"):
             accrual_plan = self.env['hr.leave.accrual.plan'].with_context(tracking_disable=True).create({
                 'name': 'Accrual Plan For Test',
                 'is_based_on_worked_time': True,
@@ -191,7 +191,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 self.assertEqual(allocation.number_of_days, 4, 'There should be only 4 day allocated.')
 
     def test_frequency_daily(self):
-        with freeze_time("2017-12-5"):
+        with freeze_time("2017-12-05"):
             accrual_plan = self.env['hr.leave.accrual.plan'].with_context(tracking_disable=True).create({
                 'name': 'Accrual Plan For Test',
                 'level_ids': [(0, 0, {
@@ -228,7 +228,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 self.assertEqual(allocation.number_of_days, 1, 'There should be only 1 day allocated.')
 
     def test_frequency_weekly(self):
-        with freeze_time("2017-12-5"):
+        with freeze_time("2017-12-05"):
             accrual_plan = self.env['hr.leave.accrual.plan'].with_context(tracking_disable=True).create({
                 'name': 'Accrual Plan For Test',
                 'level_ids': [(0, 0, {
@@ -559,7 +559,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
             self.assertEqual(allocation_worked_time.nextcall, next_date, 'The next call date of the cron should be September 20th')
 
     def test_check_max_value(self):
-        with freeze_time("2017-12-5"):
+        with freeze_time("2017-12-05"):
             accrual_plan = self.env['hr.leave.accrual.plan'].with_context(tracking_disable=True).create({
                 'name': 'Accrual Plan For Test',
                 'level_ids': [(0, 0, {
@@ -599,7 +599,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 self.assertEqual(allocation.number_of_days, 1, 'There should be only 1 day allocated.')
 
     def test_check_max_value_hours(self):
-        with freeze_time("2017-12-5"):
+        with freeze_time("2017-12-05"):
             accrual_plan = self.env['hr.leave.accrual.plan'].with_context(tracking_disable=True).create({
                 'name': 'Accrual Plan For Test',
                 'level_ids': [(0, 0, {
@@ -674,7 +674,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
             self.assertAlmostEqual(allocation_data["remaining_leaves"], 5 / hours_per_day, 1, '5 hours accrued.')
 
     def test_accrual_transition_immediately(self):
-        with freeze_time("2017-12-5"):
+        with freeze_time("2017-12-05"):
             # 1 accrual with 2 levels and level transition immediately
             accrual_plan = self.env['hr.leave.accrual.plan'].with_context(tracking_disable=True).create({
                 'name': 'Accrual Plan For Test',
@@ -710,7 +710,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
             self.assertEqual(allocation._get_current_accrual_plan_level_id(next_date)[0], second_level, 'The second level should be selected')
 
     def test_accrual_transition_after_period(self):
-        with freeze_time("2017-12-5"):
+        with freeze_time("2017-12-05"):
             # 1 accrual with 2 levels and level transition after
             accrual_plan = self.env['hr.leave.accrual.plan'].with_context(tracking_disable=True).create({
                 'name': 'Accrual Plan For Test',
@@ -1006,7 +1006,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'action_with_unused_accruals': 'all',
             })],
         })
-        with freeze_time('2020-8-16'):
+        with freeze_time('2020-08-16'):
             allocation = self.env['hr.leave.allocation'].with_user(self.user_hrmanager_id).with_context(tracking_disable=True).create({
                 'name': 'Accrual Allocation - Test',
                 'accrual_plan_id': accrual_plan.id,
@@ -1017,7 +1017,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'date_from': datetime.date(2020, 8, 16),
             })
             allocation.action_approve()
-        with freeze_time('2022-1-10'):
+        with freeze_time('2022-01-10'):
             allocation._update_accrual()
         self.assertAlmostEqual(allocation.number_of_days, 30.82, 2, "Invalid number of days")
 
@@ -1054,7 +1054,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'first_day': 31,
             })],
         })
-        with freeze_time('2022-1-31'):
+        with freeze_time('2022-01-31'):
             allocation = self.env['hr.leave.allocation'].with_user(self.user_hrmanager_id).with_context(tracking_disable=True).create({
                 'name': 'Accrual Allocation - Test',
                 'accrual_plan_id': accrual_plan.id,
@@ -1065,7 +1065,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'date_from': datetime.date(2022, 1, 31),
             })
             allocation.action_approve()
-        with freeze_time('2022-7-20'):
+        with freeze_time('2022-07-20'):
             allocation._update_accrual()
         # The first level gives 3 days
         # The second level could give 6 days but since the first level was already giving
@@ -1125,7 +1125,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 }),
             ],
         })
-        with freeze_time('2021-1-1'):
+        with freeze_time('2021-01-01'):
             allocation = self.env['hr.leave.allocation'].with_user(self.user_hrmanager_id).with_context(tracking_disable=True).create({
                 'name': 'Accrual Allocation - Test',
                 'accrual_plan_id': accrual_plan.id,
@@ -1136,7 +1136,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'date_from': datetime.date(2021, 1, 1),
             })
             allocation.action_approve()
-        with freeze_time('2022-4-4'):
+        with freeze_time('2022-04-04'):
             allocation._update_accrual()
         self.assertEqual(allocation.number_of_days, 4, "Invalid number of days")
 
@@ -1178,7 +1178,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 })
             ],
         })
-        with freeze_time('2019-1-1'):
+        with freeze_time('2019-01-01'):
             allocation = self.env['hr.leave.allocation'].with_user(self.user_hrmanager_id).with_context(tracking_disable=True).create({
                 'name': 'Accrual Allocation - Test',
                 'accrual_plan_id': accrual_plan.id,
@@ -1190,7 +1190,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
             })
             allocation.action_approve()
 
-        with freeze_time('2022-4-1'):
+        with freeze_time('2022-04-01'):
             allocation._update_accrual()
         self.assertAlmostEqual(allocation.number_of_days, 3, 2, "Invalid number of days")
 
@@ -1207,7 +1207,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'maximum_leave': 5,
             })],
         })
-        with freeze_time("2021-9-3"):
+        with freeze_time("2021-09-03"):
             allocation = self.env['hr.leave.allocation'].with_user(self.user_hrmanager_id).with_context(tracking_disable=True).create({
                 'name': 'Accrual allocation for employee',
                 'accrual_plan_id': accrual_plan.id,
@@ -1218,7 +1218,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'date_from': '2021-09-03',
             })
 
-        with freeze_time("2021-10-3"):
+        with freeze_time("2021-10-03"):
             allocation.action_approve()
             allocation._update_accrual()
 
@@ -1236,7 +1236,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'cap_accrued_time': False,
             })],
         })
-        with freeze_time("2021-9-3"):
+        with freeze_time("2021-09-03"):
             allocation = self.env['hr.leave.allocation'].with_user(self.user_hrmanager_id).with_context(tracking_disable=True).create({
                 'name': 'Accrual allocation for employee',
                 'accrual_plan_id': accrual_plan.id,
@@ -1247,7 +1247,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'date_from': '2021-09-03',
             })
 
-        with freeze_time("2021-10-3"):
+        with freeze_time("2021-10-03"):
             allocation.action_approve()
             allocation._update_accrual()
 
@@ -1267,7 +1267,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'maximum_leave': 5,
             })],
         })
-        with freeze_time("2022-1-1"):
+        with freeze_time("2022-01-01"):
             allocation = self.env['hr.leave.allocation'].with_user(self.user_hrmanager_id).with_context(tracking_disable=True).create({
                 'name': 'Accrual allocation for employee',
                 'accrual_plan_id': accrual_plan.id,
@@ -1279,7 +1279,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
             })
             allocation.action_approve()
 
-        with freeze_time("2022-3-2"):
+        with freeze_time("2022-03-02"):
             allocation._update_accrual()
 
         self.assertEqual(allocation.number_of_days, 5, "Maximum of 5 days accrued")
@@ -1293,7 +1293,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
         })
         leave.action_approve()
 
-        with freeze_time("2022-6-1"):
+        with freeze_time("2022-06-01"):
             allocation._update_accrual()
         self.assertEqual(allocation.number_of_days, 10, "Should accrue 5 additional days")
 
@@ -1477,7 +1477,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'maximum_leave': 5,
             })],
         })
-        with freeze_time("2023-4-24"):
+        with freeze_time("2023-04-24"):
             allocation = self.env['hr.leave.allocation'].with_user(self.user_hrmanager_id).with_context(tracking_disable=True).create({
                 'name': 'Accrual allocation for employee',
                 'accrual_plan_id': accrual_plan.id,
@@ -1494,7 +1494,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
         self.assertEqual(allocation.number_of_days, 0, "Should accrue 0 days, because the period is not done yet.")
 
         accrual_plan.accrued_gain_time = 'start'
-        with freeze_time("2023-4-24"):
+        with freeze_time("2023-04-24"):
             allocation = self.env['hr.leave.allocation'].with_user(self.user_hrmanager_id).with_context(tracking_disable=True).create({
                 'name': 'Accrual allocation for employee',
                 'accrual_plan_id': accrual_plan.id,
@@ -1525,7 +1525,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'maximum_leave': 15,
             })],
         })
-        with freeze_time("2023-4-13"):
+        with freeze_time("2023-04-13"):
             allocation = self.env['hr.leave.allocation'].with_user(self.user_hrmanager_id).with_context(tracking_disable=True).create({
                 'name': 'Accrual allocation for employee',
                 'accrual_plan_id': accrual_plan.id,
@@ -1540,7 +1540,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
 
         self.assertAlmostEqual(allocation.number_of_days, 1.5, 2)
 
-        with freeze_time("2023-9-13"):
+        with freeze_time("2023-09-13"):
             allocation._update_accrual()
 
         self.assertAlmostEqual(allocation.number_of_days, 9, 2)
@@ -1571,7 +1571,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 })
             ],
         })
-        with freeze_time("2023-4-26"):
+        with freeze_time("2023-04-26"):
             allocation = self.env['hr.leave.allocation'].with_user(self.user_hrmanager_id).with_context(tracking_disable=True).create({
                 'name': 'Accrual allocation for employee',
                 'accrual_plan_id': accrual_plan.id,
@@ -1585,12 +1585,12 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
             allocation._update_accrual()
         self.assertEqual(allocation.number_of_days, 1, "Should accrue 1 day, at the start of the period.")
 
-        with freeze_time("2023-7-5"):
+        with freeze_time("2023-07-05"):
             allocation._update_accrual()
         self.assertEqual(allocation.number_of_days, 10, "Should accrue 10 days, days received, but not over limit.")
 
         # first wednesday at the second level
-        with freeze_time("2023-8-02"):
+        with freeze_time("2023-08-02"):
             allocation._update_accrual()
         self.assertEqual(allocation.number_of_days, 5, "Should accrue 5 days, after level transfer 10 are cut to 5")
 
@@ -1610,7 +1610,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'action_with_unused_accruals': 'lost',
             })],
         })
-        with freeze_time("2023-4-26"):
+        with freeze_time("2023-04-26"):
             allocation = self.env['hr.leave.allocation'].with_user(self.user_hrmanager_id).with_context(tracking_disable=True).create({
                 'name': 'Accrual allocation for employee',
                 'accrual_plan_id': accrual_plan.id,
@@ -1624,7 +1624,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
             allocation._update_accrual()
         self.assertAlmostEqual(allocation.number_of_days, 0.03, 2, "Should accrue 0.03 days, accrued_gain_time == start.")
 
-        with freeze_time("2023-4-27"):
+        with freeze_time("2023-04-27"):
             allocation._update_accrual()
         self.assertAlmostEqual(allocation.number_of_days, 1.03, 2, "Should accrue 1 day, days are added on 27th.")
 
@@ -1787,7 +1787,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'holiday_status_id': self.leave_type.id,
                 'number_of_days': 9,
                 'allocation_type': 'accrual',
-                'date_from': '2023-04-4',
+                'date_from': '2023-04-04',
             })
             allocation.action_approve()
 
@@ -2185,7 +2185,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
             self.assertEqual(allowed_negative_leave.state, 'cancel')
 
     def test_check_lastcall_change_regular_to_accrual(self):
-        with freeze_time("2017-12-5"):
+        with freeze_time("2017-12-05"):
             accrual_plan = self.env['hr.leave.accrual.plan'].with_context(tracking_disable=True).create({
                 'name': 'Accrual Plan For Test',
             })
@@ -2460,7 +2460,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                     'frequency': 'yearly',
                 })],
         })
-        with freeze_time('2024-1-01'):
+        with freeze_time('2024-01-01'):
             allocation = self.env['hr.leave.allocation'].with_context(tracking_disable=True).create({
                 'name': 'Accrual allocation for employee',
                 'employee_id': self.employee_emp.id,
@@ -2472,15 +2472,15 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
             })
             allocation.action_approve()
 
-        with freeze_time('2025-1-01'):
+        with freeze_time('2025-01-01'):
             allocation._update_accrual()
         self.assertEqual(allocation.number_of_days, 10, "10 days should be accrued")
 
-        with freeze_time('2025-7-01'):
+        with freeze_time('2025-07-01'):
             allocation._update_accrual()
         self.assertEqual(allocation.number_of_days, 10, "No Days should be accrued on the carryover date")
 
-        with freeze_time('2026-1-01'):
+        with freeze_time('2026-01-01'):
             allocation._update_accrual()
         self.assertEqual(allocation.number_of_days, 20,
                          "10 additional days should be accrued on January 1st. The total number of accrued days should be 20")
@@ -2521,7 +2521,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                     'action_with_unused_accruals': 'lost'
                 })],
         })
-        with freeze_time('2024-1-01'):
+        with freeze_time('2024-01-01'):
             allocation = self.env['hr.leave.allocation'].with_context(tracking_disable=True).create({
                 'name': 'Accrual allocation for employee',
                 'employee_id': self.employee_emp.id,
@@ -2533,11 +2533,11 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
             })
             allocation.action_approve()
 
-        with freeze_time('2025-1-01'):
+        with freeze_time('2025-01-01'):
             allocation._update_accrual()
         self.assertEqual(allocation.number_of_days, 10, "10 days are accrued")
 
-        with freeze_time('2026-1-01'):
+        with freeze_time('2026-01-01'):
             allocation._update_accrual()
         self.assertEqual(allocation.number_of_days, 10,
                          "All previous days are lost. 10 new days are added.")
@@ -2592,7 +2592,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                     'action_with_unused_accruals': 'lost'
                 })],
         })
-        with freeze_time('2024-1-01'):
+        with freeze_time('2024-01-01'):
             allocation = self.env['hr.leave.allocation'].with_context(tracking_disable=True).create({
                 'name': 'Accrual allocation for employee',
                 'employee_id': self.employee_emp.id,
@@ -2604,15 +2604,15 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
             })
             allocation.action_approve()
 
-        with freeze_time('2025-1-01'):
+        with freeze_time('2025-01-01'):
             allocation._update_accrual()
         self.assertEqual(allocation.number_of_days, 12, "12 days are accrued")
 
-        with freeze_time('2025-7-01'):
+        with freeze_time('2025-07-01'):
             allocation._update_accrual()
         self.assertAlmostEqual(allocation.number_of_days, 6, 1,
                          "All previous days are lost. 6 new days are added.")
-        with freeze_time('2026-1-01'):
+        with freeze_time('2026-01-01'):
             allocation._update_accrual()
         self.assertAlmostEqual(allocation.number_of_days, 13, 1,
                         "7 days are accrued. Total days = 6 + 7 = 13.")
@@ -2673,7 +2673,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                     'postpone_max_days': 5
                 })],
         })
-        with freeze_time('2024-1-01'):
+        with freeze_time('2024-01-01'):
             allocation = self.env['hr.leave.allocation'].with_context(tracking_disable=True).create({
                 'name': 'Accrual allocation for employee',
                 'employee_id': self.employee_emp.id,
@@ -2685,19 +2685,19 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
             })
             allocation.action_approve()
 
-        with freeze_time('2024-5-01'):
+        with freeze_time('2024-05-01'):
             allocation._update_accrual()
         self.assertEqual(allocation.number_of_days, 5)
 
-        with freeze_time('2024-6-01'):
+        with freeze_time('2024-06-01'):
             allocation._update_accrual()
         self.assertEqual(allocation.number_of_days, 1)
 
-        with freeze_time('2024-8-01'):
+        with freeze_time('2024-08-01'):
             allocation._update_accrual()
         self.assertEqual(allocation.number_of_days, 3)
 
-        with freeze_time('2024-9-01'):
+        with freeze_time('2024-09-01'):
             allocation._update_accrual()
         self.assertEqual(allocation.number_of_days, 4)
 
@@ -2705,7 +2705,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
             allocation._update_accrual()
         self.assertEqual(allocation.number_of_days, 7)
 
-        with freeze_time('2025-1-01'):
+        with freeze_time('2025-01-01'):
             allocation._update_accrual()
         self.assertEqual(allocation.number_of_days, 8)
 
@@ -2763,7 +2763,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                     'action_with_unused_accruals': 'all',
                 })],
         })
-        with freeze_time('2024-1-01'):
+        with freeze_time('2024-01-01'):
             allocation = self.env['hr.leave.allocation'].with_context(tracking_disable=True).create({
                 'name': 'Accrual allocation for employee',
                 'employee_id': self.employee_emp.id,
@@ -2775,31 +2775,31 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
             })
             allocation.action_approve()
 
-        with freeze_time('2024-1-01'):
+        with freeze_time('2024-01-01'):
             allocation._update_accrual()
         self.assertEqual(allocation.number_of_days, 10)
 
-        with freeze_time('2025-1-01'):
+        with freeze_time('2025-01-01'):
             allocation._update_accrual()
         self.assertEqual(allocation.number_of_days, 20)
 
-        with freeze_time('2025-6-01'):
+        with freeze_time('2025-06-01'):
             allocation._update_accrual()
         self.assertEqual(allocation.number_of_days, 0)
 
-        with freeze_time('2026-1-01'):
+        with freeze_time('2026-01-01'):
             allocation._update_accrual()
         self.assertEqual(allocation.number_of_days, 10)
 
-        with freeze_time('2026-6-01'):
+        with freeze_time('2026-06-01'):
             allocation._update_accrual()
         self.assertEqual(allocation.number_of_days, 0)
 
-        with freeze_time('2026-9-01'):
+        with freeze_time('2026-09-01'):
             allocation._update_accrual()
         self.assertAlmostEqual(allocation.number_of_days, 10.7, 1)
 
-        with freeze_time('2027-1-01'):
+        with freeze_time('2027-01-01'):
             allocation._update_accrual()
         self.assertAlmostEqual(allocation.number_of_days, 22.67, 2)
 
@@ -3692,7 +3692,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
         """
         check that creating an accrual allocation for an employee without working hours doesn't raise a traceback error
         """
-        with freeze_time("2017-12-5"):
+        with freeze_time("2017-12-05"):
             employee_without_calendar = self.env['hr.employee'].create({
                 'name': 'employee without calendar',
                 'resource_calendar_id': False,

--- a/addons/hr_holidays/tests/test_expiring_leaves.py
+++ b/addons/hr_holidays/tests/test_expiring_leaves.py
@@ -261,9 +261,9 @@ class TestExpiringLeaves(HttpCase, TestHrHolidaysCommon):
         })
 
         logged_in_emp = self.env.user.employee_id
-        with freeze_time("2024-1-1"):
+        with freeze_time("2024-01-01"):
             allocation_with_carryover = self.env['hr.leave.allocation'].sudo().create({
-                'date_from': '2024-1-1',
+                'date_from': '2024-01-01',
                 'allocation_type': 'accrual',
                 'accrual_plan_id': accrual_plan_1.id,
                 'holiday_status_id': self.leave_type.id,
@@ -273,12 +273,12 @@ class TestExpiringLeaves(HttpCase, TestHrHolidaysCommon):
             leave = self.env['hr.leave'].create({
                 'employee_id': logged_in_emp.id,
                 'holiday_status_id': self.leave_type.id,
-                'request_date_from': '2025-12-1',
-                'request_date_to': '2025-12-5'
+                'request_date_from': '2025-12-01',
+                'request_date_to': '2025-12-05'
             })
             # The expiring allocation
             self.env['hr.leave.allocation'].sudo().create({
-                'date_from': '2024-1-1',
+                'date_from': '2024-01-01',
                 'date_to': '2025-12-31',
                 'allocation_type': 'accrual',
                 'accrual_plan_id': accrual_plan_2.id,
@@ -389,7 +389,7 @@ class TestExpiringLeaves(HttpCase, TestHrHolidaysCommon):
         If the target date is 01/01/2025, then the expiration date should be 01/01/2026 because 5 of the days
         accrued on 01/01/2025 will expire on 01/01/2026.
         """
-        with freeze_time('2024-1-01'):
+        with freeze_time('2024-01-01'):
             accrual_plan = self.env['hr.leave.accrual.plan'].with_context(tracking_disable=True).sudo().create({
                 'name': 'Test Accrual Plan',
                 'carryover_date': 'year_start',
@@ -469,10 +469,10 @@ class TestExpiringLeaves(HttpCase, TestHrHolidaysCommon):
         })
 
         logged_in_emp = self.env.user.employee_id
-        with freeze_time("2023-1-1"):
+        with freeze_time("2023-01-01"):
             # Allocation 1
             self.env['hr.leave.allocation'].sudo().create({
-                'date_from': '2023-1-1',
+                'date_from': '2023-01-01',
                 'allocation_type': 'accrual',
                 'accrual_plan_id': accrual_plan.id,
                 'holiday_status_id': self.leave_type.id,
@@ -481,8 +481,8 @@ class TestExpiringLeaves(HttpCase, TestHrHolidaysCommon):
             })
             # Allocation 2
             self.env['hr.leave.allocation'].sudo().create({
-                'date_from': '2023-1-1',
-                'date_to': '2024-10-1',
+                'date_from': '2023-01-01',
+                'date_to': '2024-10-01',
                 'allocation_type': 'accrual',
                 'accrual_plan_id': accrual_plan.id,
                 'holiday_status_id': self.leave_type.id,
@@ -490,7 +490,7 @@ class TestExpiringLeaves(HttpCase, TestHrHolidaysCommon):
                 'number_of_days': 0,
             })
 
-        with freeze_time("2024-1-1"):
+        with freeze_time("2024-01-01"):
             self.env['hr.leave.allocation'].with_user(self.user_hruser)._update_accrual()
 
         target_date = date(2024, 1, 1)
@@ -714,11 +714,11 @@ class TestExpiringLeaves(HttpCase, TestHrHolidaysCommon):
         })
 
         logged_in_emp = self.env.user.employee_id
-        with freeze_time("2023-1-1"):
+        with freeze_time("2023-01-01"):
             # Allocation 1
             self.env['hr.leave.allocation'].sudo().create({
-                'date_from': '2023-1-1',
-                'date_to': '2024-10-1',
+                'date_from': '2023-01-01',
+                'date_to': '2024-10-01',
                 'allocation_type': 'accrual',
                 'accrual_plan_id': accrual_plan_without_accrual_validity.id,
                 'holiday_status_id': self.leave_type.id,
@@ -727,7 +727,7 @@ class TestExpiringLeaves(HttpCase, TestHrHolidaysCommon):
             })
             # Allocation 2
             self.env['hr.leave.allocation'].sudo().create({
-                'date_from': '2023-1-1',
+                'date_from': '2023-01-01',
                 'allocation_type': 'accrual',
                 'accrual_plan_id': self.accrual_plan_with_accrual_validity.id,
                 'holiday_status_id': self.leave_type.id,
@@ -735,7 +735,7 @@ class TestExpiringLeaves(HttpCase, TestHrHolidaysCommon):
                 'number_of_days': 0,
             })
 
-        with freeze_time("2024-4-1"):
+        with freeze_time("2024-04-01"):
             self.env['hr.leave.allocation'].with_user(self.user_hruser)._update_accrual()
 
         target_date = date(2024, 4, 1)
@@ -772,9 +772,9 @@ class TestExpiringLeaves(HttpCase, TestHrHolidaysCommon):
         """
 
         logged_in_emp = self.env.user.employee_id
-        with freeze_time("2023-1-1"):
+        with freeze_time("2023-01-01"):
             self.env['hr.leave.allocation'].sudo().create({
-                'date_from': '2023-1-1',
+                'date_from': '2023-01-01',
                 'allocation_type': 'accrual',
                 'accrual_plan_id': self.accrual_plan_with_accrual_validity.id,
                 'holiday_status_id': self.leave_type.id,
@@ -782,7 +782,7 @@ class TestExpiringLeaves(HttpCase, TestHrHolidaysCommon):
                 'number_of_days': 0,
             })
 
-        with freeze_time("2024-4-1"):
+        with freeze_time("2024-04-01"):
             self.env['hr.leave.allocation'].with_user(self.user_hruser)._update_accrual()
             leave = self.env['hr.leave'].create({
                 'name': 'leave',

--- a/addons/hr_holidays/tests/test_global_leaves.py
+++ b/addons/hr_holidays/tests/test_global_leaves.py
@@ -210,8 +210,8 @@ class TestGlobalLeaves(TestHrHolidaysCommon):
 
         global_leave = self.env['resource.calendar.leaves'].with_user(self.env.user).create({
             'name': 'Public holiday',
-            'date_from': "2024-12-4 06:00:00",
-            'date_to': "2024-12-4 23:00:00",
+            'date_from': "2024-12-04 06:00:00",
+            'date_to': "2024-12-04 23:00:00",
             'calendar_id': self.calendar_1.id,
         })
 

--- a/addons/hr_holidays/tests/test_leave_requests.py
+++ b/addons/hr_holidays/tests/test_leave_requests.py
@@ -119,7 +119,7 @@ class TestLeaveRequests(TestHrHolidaysCommon):
                 'holiday_status_id': self.holidays_type_2.id,
                 'number_of_days': 2,
                 'state': 'confirm',
-                'date_from': time.strftime('%Y-1-1'),
+                'date_from': time.strftime('%Y-01-01'),
                 'date_to': time.strftime('%Y-12-31'),
             })
 
@@ -159,7 +159,7 @@ class TestLeaveRequests(TestHrHolidaysCommon):
                 'holiday_status_id': self.holidays_type_2.id,
                 'number_of_days': 2,
                 'state': 'confirm',
-                'date_from': time.strftime('%Y-1-1'),
+                'date_from': time.strftime('%Y-01-01'),
                 'date_to': time.strftime('%Y-12-31'),
             })
             allocation.action_approve()
@@ -354,8 +354,8 @@ class TestLeaveRequests(TestHrHolidaysCommon):
             'number_of_days': 20,
             'employee_id': employee.id,
             'state': 'confirm',
-            'date_from': time.strftime('2018-1-1'),
-            'date_to': time.strftime('%Y-1-1'),
+            'date_from': time.strftime('2018-01-01'),
+            'date_to': time.strftime('%Y-01-01'),
         })
 
         leave1 = self.env['hr.leave'].create({
@@ -418,16 +418,16 @@ class TestLeaveRequests(TestHrHolidaysCommon):
             'number_of_days': 20,
             'employee_id': employee.id,
             'state': 'confirm',
-            'date_from': time.strftime('2018-1-1'),
-            'date_to': time.strftime('%Y-1-1'),
+            'date_from': time.strftime('2018-01-01'),
+            'date_to': time.strftime('%Y-01-01'),
         })
 
         leave0 = self.env['hr.leave'].create({
             'name': 'Holiday 1 day',
             'employee_id': employee.id,
             'holiday_status_id': leave_type.id,
-            'request_date_from': fields.Date.from_string('2019-12-9'),
-            'request_date_to': fields.Date.from_string('2019-12-9'),
+            'request_date_from': fields.Date.from_string('2019-12-09'),
+            'request_date_to': fields.Date.from_string('2019-12-09'),
         })
 
         self.assertAlmostEqual(leave0.number_of_hours, 24, 2)

--- a/addons/hr_holidays/tests/test_multi_contract.py
+++ b/addons/hr_holidays/tests/test_multi_contract.py
@@ -58,7 +58,7 @@ class TestHolidaysMultiContract(TestHolidayContract):
         # begins during contract, ends after contract => should not raise
         self.contract_cdi.date_end = datetime.strptime('2015-11-30', '%Y-%m-%d').date()
         start = datetime.strptime('2015-11-25 07:00:00', '%Y-%m-%d %H:%M:%S')
-        end = datetime.strptime('2015-12-5 18:00:00', '%Y-%m-%d %H:%M:%S')
+        end = datetime.strptime('2015-12-05 18:00:00', '%Y-%m-%d %H:%M:%S')
         self.create_leave(start, end, name="Doctor Appointment", employee_id=self.jules_emp.id)
 
     def test_no_leave_overlapping_contracts(self):
@@ -199,14 +199,14 @@ class TestHolidaysMultiContract(TestHolidayContract):
             {
                 'employee_id': employee.id,
                 'holiday_status_id': leave_type.id,
-                'request_date_from': '2023-1-3',  # Tuesday
-                'request_date_to': '2023-1-5',  # Thursday
+                'request_date_from': '2023-01-03',  # Tuesday
+                'request_date_to': '2023-01-05',  # Thursday
             },
             {
                 'employee_id': employee.id,
                 'holiday_status_id': leave_type.id,
-                'request_date_from': '2023-12-5',  # Tuesday
-                'request_date_to': '2023-12-7',  # Thursday
+                'request_date_from': '2023-12-05',  # Tuesday
+                'request_date_to': '2023-12-07',  # Thursday
             },
         ])
         self.assertEqual(leave_during_full_time.number_of_days, 3)

--- a/addons/hr_holidays_attendance/tests/test_accrual_allocations.py
+++ b/addons/hr_holidays_attendance/tests/test_accrual_allocations.py
@@ -24,7 +24,7 @@ class TestAccrualAllocationsAttendance(TestHrHolidaysCommon):
         })
 
     def test_frequency_hourly_attendance(self):
-        with freeze_time("2017-12-5"):
+        with freeze_time("2017-12-05"):
             accrual_plan = self.env['hr.leave.accrual.plan'].with_context(tracking_disable=True).create({
                 'name': 'Accrual Plan For Test',
                 'is_based_on_worked_time': True,

--- a/addons/hr_holidays_attendance/tests/test_holidays_overtime.py
+++ b/addons/hr_holidays_attendance/tests/test_holidays_overtime.py
@@ -129,8 +129,8 @@ class TestHolidaysOvertime(TransactionCase):
             'name': 'no overtime',
             'employee_id': self.employee.id,
             'holiday_status_id': self.leave_type_no_alloc.id,
-            'request_date_from': '2021-1-4',
-            'request_date_to': '2021-1-4',
+            'request_date_from': '2021-01-04',
+            'request_date_to': '2021-01-04',
         })
         self.assertEqual(self.employee.total_overtime, 8)
 
@@ -152,7 +152,7 @@ class TestHolidaysOvertime(TransactionCase):
                     'employee_id': self.employee.id,
                     'number_of_days': 1,
                     'state': 'confirm',
-                    'date_from': time.strftime('%Y-1-1'),
+                    'date_from': time.strftime('%Y-01-01'),
                     'date_to': time.strftime('%Y-12-31'),
                 })
 
@@ -165,7 +165,7 @@ class TestHolidaysOvertime(TransactionCase):
                 'employee_id': self.employee.id,
                 'number_of_days': 1,
                 'state': 'confirm',
-                'date_from': time.strftime('%Y-1-1'),
+                'date_from': time.strftime('%Y-01-01'),
                 'date_to': time.strftime('%Y-12-31'),
             })
             self.assertEqual(self.employee.total_overtime, 0)
@@ -186,7 +186,7 @@ class TestHolidaysOvertime(TransactionCase):
                 'employee_id': self.employee.id,
                 'number_of_days': 1,
                 'state': 'confirm',
-                'date_from': time.strftime('%Y-1-1'),
+                'date_from': time.strftime('%Y-01-01'),
                 'date_to': time.strftime('%Y-12-31'),
             })
 
@@ -201,7 +201,7 @@ class TestHolidaysOvertime(TransactionCase):
             'employee_id': self.employee.id,
             'number_of_days': 1,
             'state': 'confirm',
-            'date_from': time.strftime('%Y-1-1'),
+            'date_from': time.strftime('%Y-01-01'),
             'date_to': time.strftime('%Y-12-31'),
         })
         self.assertEqual(self.employee.total_overtime, 8)
@@ -212,7 +212,7 @@ class TestHolidaysOvertime(TransactionCase):
         alloc.number_of_days = 2
         self.assertEqual(self.employee.total_overtime, 0)
 
-    @freeze_time('2022-1-1')
+    @freeze_time('2022-01-01')
     def test_leave_check_cancel(self):
         self.new_attendance(check_in=datetime(2021, 1, 2, 8), check_out=datetime(2021, 1, 2, 16))
         self.new_attendance(check_in=datetime(2021, 1, 3, 8), check_out=datetime(2021, 1, 3, 16))
@@ -222,8 +222,8 @@ class TestHolidaysOvertime(TransactionCase):
             'name': 'no overtime',
             'employee_id': self.employee.id,
             'holiday_status_id': self.leave_type_no_alloc.id,
-            'request_date_from': '2022-1-6',
-            'request_date_to': '2022-1-6',
+            'request_date_from': '2022-01-06',
+            'request_date_to': '2022-01-06',
         })
         leave.with_user(self.user_manager).action_approve()
         self.assertEqual(self.employee.total_overtime, 8)

--- a/addons/l10n_ar/demo/exento_demo.xml
+++ b/addons/l10n_ar/demo/exento_demo.xml
@@ -21,7 +21,7 @@
         <field name="partner_id" ref="base.partner_exento"/>
         <field name="name">(AR) Exento</field>
         <field name="l10n_ar_gross_income_type">exempt</field>
-        <field name="l10n_ar_afip_start_date" eval="time.strftime('%Y-%m')+'-1'"/>
+        <field name="l10n_ar_afip_start_date" eval="time.strftime('%Y-%m')+'-01'"/>
     </record>
 
     <function model="res.users" name="write">

--- a/addons/l10n_ar/demo/mono_demo.xml
+++ b/addons/l10n_ar/demo/mono_demo.xml
@@ -21,7 +21,7 @@
         <field name="partner_id" ref="base.partner_mono"/>
         <field name="name">(AR) Monotributista</field>
         <field name="l10n_ar_gross_income_type">exempt</field>
-        <field name="l10n_ar_afip_start_date" eval="time.strftime('%Y-%m')+'-1'"/>
+        <field name="l10n_ar_afip_start_date" eval="time.strftime('%Y-%m')+'-01'"/>
     </record>
 
     <function model="res.users" name="write">

--- a/addons/mail/tests/test_mail_activity.py
+++ b/addons/mail/tests/test_mail_activity.py
@@ -20,7 +20,7 @@ class TestMailActivityChatter(HttpCase):
         )
 
     def test_mail_activity_date_format(self):
-        with freeze_time("2024-1-1 09:00:00 AM"):
+        with freeze_time("2024-01-01 09:00:00 AM"):
             LANG_CODE = "en_US"
             self.env = self.env(context={"lang": LANG_CODE})
             testuser = self.env['res.users'].create({

--- a/addons/payment/tests/test_payment_token.py
+++ b/addons/payment/tests/test_payment_token.py
@@ -47,7 +47,7 @@ class TestPaymentToken(PaymentCommon):
         token = self._create_token()
         self.assertEqual(token._build_display_name(), '•••• 1234')
 
-    @freeze_time('2024-1-31 10:00:00')
+    @freeze_time('2024-01-31 10:00:00')
     def test_display_name_for_empty_payment_details(self):
         """ Test that the display name is still built for token without payment details. """
         token = self._create_token(payment_details='')

--- a/addons/stock/report/report_package_barcode.xml
+++ b/addons/stock/report/report_package_barcode.xml
@@ -38,7 +38,7 @@
                 <div class="row mt32 mb32">
                     <div t-if="o.pack_date" class="col">
                         <strong>Pack Date:</strong>
-                        <span t-field="o.pack_date">2021-9-01</span>
+                        <span t-field="o.pack_date">2021-09-01</span>
                     </div>
                     <div t-if="o.package_type_id" class="o_packaging_type col">
                         <strong>Package Type:</strong>

--- a/addons/test_mail/static/tests/activity.test.js
+++ b/addons/test_mail/static/tests/activity.test.js
@@ -86,7 +86,7 @@ disableAnimations();
 describe.current.tags("desktop");
 defineTestMailModels();
 beforeEach(async () => {
-    mockDate("2023-4-8 10:00:00", 0);
+    mockDate("2023-04-08 10:00:00", 0);
     patchWithCleanup(DynamicList.prototype, {
         async load(params) {
             return patchActivityDomain(super.load.bind(this), params);

--- a/addons/test_mail/static/tests/systray_activity_menu.test.js
+++ b/addons/test_mail/static/tests/systray_activity_menu.test.js
@@ -9,7 +9,7 @@ import { serializeDate, today } from "@web/core/l10n/dates";
 describe.current.tags("desktop");
 defineTestMailModels();
 // Avoid problem around midnight (Ex.: tomorrow activities become today activities when reaching midnight)
-beforeEach(() => mockDate("2023-4-8 10:00:00", 0));
+beforeEach(() => mockDate("2023-04-08 10:00:00", 0));
 
 test("menu with no records", async () => {
     await start();

--- a/addons/test_resource/tests/test_resource.py
+++ b/addons/test_resource/tests/test_resource.py
@@ -1173,7 +1173,7 @@ class TestTimezones(TestResourceCommon):
         self.assertEqual(count, 0)
 
         # Using two different timezones
-        # 2018-4-10 06:00:00 - 2018-4-10 22:00:00
+        # 2018-04-10 06:00:00 - 2018-04-10 22:00:00
         count = self.calendar_jean.get_work_hours_count(
             datetime_tz(2018, 4, 10, 8, 0, 0, tzinfo=self.tz2),
             datetime_tz(2018, 4, 10, 12, 0, 0, tzinfo=self.tz4),

--- a/odoo/orm/domains.py
+++ b/odoo/orm/domains.py
@@ -1254,17 +1254,8 @@ def _value_to_date(value):
     if isinstance(value, (SQL, date)) or value is False:
         return value
     if isinstance(value, str):
-        # TODO can we use fields.Date.to_date? same for datetime
-        if len(value) == 10:
+        if len(value) <= 10:
             return date.fromisoformat(value)
-        if len(value) < 10:
-            # TODO deprecate or raise error
-            # probably the value is missing zeroes
-            try:
-                parts = value.split('-')
-                return date(*[int(part) for part in parts])
-            except (ValueError, TypeError):
-                raise ValueError(f"Invalid isoformat string {value!r}")
         return datetime.fromisoformat(value).date()
     if isinstance(value, COLLECTION_TYPES):
         return OrderedSet(_value_to_date(v) for v in value)


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
ISO formatted dates are YYYY-MM-DD and don't accept single digit months or days.
Fixing usages and removing hack in Domains to support misformatted dates.

odoo/enterprise#87736


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
