### PR TITLE
[REF] html_builder: recover translations from former addons

### DIFF
--- a/addons/html_builder/i18n/af.po
+++ b/addons/html_builder/i18n/af.po
@@ -1,0 +1,576 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* html_builder
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 16.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-05-16 13:50+0000\n"
+"PO-Revision-Date: 2022-09-22 05:55+0000\n"
+"Last-Translator: Martin Trigaux, 2022\n"
+"Language-Team: Afrikaans (https://www.transifex.com/odoo/teams/41243/af/)\n"
+"Language: af\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "ACCESS OPTIONS ANYWAY"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_list.js:0
+msgid "Add"
+msgstr "Voeg by"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Almost there! Snippets are incoming, grab a coffee and relax!"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_plugin.js:0
+msgid "Anchor copied to clipboard%(br)sLink: %(anchorLink)s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Anchor name"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Are you sure you want to delete the block %s?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Blocks"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Blur"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Button"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "Cancel"
+msgstr "Gekanselleer"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Categories"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.js:0
+msgid "Choose a record..."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Choose an anchor name"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Color"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Column"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "Confirm"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid "Continue"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Could not install module %(title)s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Create \""
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Create a custom snippet"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Custom %s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Custom Button"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Custom Inner Content"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Customize"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/setup_editor_plugin.js:0
+msgid "DRAG BUILDING BLOCKS HERE"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Dashed"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Discard"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Do you want to install %s App?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Do you want to save this snippet as a custom one?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Dotted"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Double"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.js:0
+msgid "Drag and drop the building block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/drag_and_drop_move_handle.js:0
+msgid "Drag and move"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "Duplicate this block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_plugin.js:0
+msgid "Edit"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/drop_zone_plugin.js:0
+msgid "For technical reasons, this block cannot be dropped here"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Icon"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid ""
+"If you discard the current edits, all unsaved changes will be lost. You can "
+"cancel to return to edit mode."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid "If you proceed, your changes will be lost"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Image"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Inner Content"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Insert a block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/media_website_plugin.js:0
+msgid "Insert a video"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+#: code:addons/html_builder/static/src/sidebar/snippet.xml:0
+msgid "Insert snippet"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Inset"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/snippet.xml:0
+msgid "Install"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Install %s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/invisible_elements_panel.xml:0
+msgid "Invisible Elements"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_list.js:0
+msgid "Item"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.js:0
+msgid "Link Anchor"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Mobile Preview"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "More info about this app."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Name"
+msgstr "Naam"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "No"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "No block of this category can be dropped on this page."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "No snippets found"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_select.js:0
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "None"
+msgstr "Geen"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Offset (X, Y)"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Oops! No snippets found."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Outset"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Page Options"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "REPLACE BY NEW VERSION"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Remove"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "Remove this block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Rename the block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Round Corners"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Save"
+msgstr "Stoor"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Save & Copy"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Save and Install"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Search for a block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search for records..."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search more..."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search to show more records"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/customize_tab.xml:0
+msgid "Select a block on your page to style it."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/customize_translation_tab.xml:0
+msgid "Select content on your page to translate it."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Shadow"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Solid"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Spread"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Take a look at the search bar, there might be a small typo!"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "The chosen name already exists"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Theme"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "This block cannot be dropped anywhere on this page."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "This block is outdated."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Tip: Esc to preview"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_row.xml:0
+msgid "Toggle more options"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/media_website_plugin.js:0
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Video"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Yes"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "You can still access the block options but it might be ineffective."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "You might not be able to customize it anymore."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/save_snippet_plugin.js:0
+msgid ""
+"Your custom snippet was successfully saved as <strong>%s</strong>. Find it "
+"in your snippets collection."
+msgstr ""

--- a/addons/html_builder/i18n/ar.po
+++ b/addons/html_builder/i18n/ar.po
@@ -1,0 +1,576 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* html_builder
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 16.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-05-16 13:50+0000\n"
+"PO-Revision-Date: 2022-09-22 05:55+0000\n"
+"Last-Translator: Malaz Abuidris <msea@odoo.com>, 2023\n"
+"Language-Team: Arabic (https://app.transifex.com/odoo/teams/41243/ar/)\n"
+"Language: ar\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: nplurals=6; plural=n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : n%100>=3 && n%100<=10 ? 3 : n%100>=11 && n%100<=99 ? 4 : 5;\n"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "ACCESS OPTIONS ANYWAY"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_list.js:0
+msgid "Add"
+msgstr "إضافة"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Almost there! Snippets are incoming, grab a coffee and relax!"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_plugin.js:0
+msgid "Anchor copied to clipboard%(br)sLink: %(anchorLink)s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Anchor name"
+msgstr "اسم نقطة الارتساء "
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Are you sure you want to delete the block %s?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Block"
+msgstr "كتلة برمجية إنشائية "
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Blocks"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Blur"
+msgstr "تمويه "
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Button"
+msgstr "زر"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "Cancel"
+msgstr "إلغاء "
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Categories"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.js:0
+msgid "Choose a record..."
+msgstr "اختر سجلاً... "
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Choose an anchor name"
+msgstr "اختر اسماً لنقطة الارتساء "
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Color"
+msgstr "اللون"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Column"
+msgstr "العمود"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "Confirm"
+msgstr "تأكيد"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid "Continue"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Could not install module %(title)s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Create \""
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Create a custom snippet"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Custom %s"
+msgstr "مخصص %s "
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Custom Button"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Custom Inner Content"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Customize"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/setup_editor_plugin.js:0
+msgid "DRAG BUILDING BLOCKS HERE"
+msgstr "اسحب الكتل البرمجية الإنشائية إلى هنا "
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Dashed"
+msgstr "متقطع"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Discard"
+msgstr "تجاهل"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Do you want to install %s App?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Do you want to save this snippet as a custom one?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Dotted"
+msgstr "منقط"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Double"
+msgstr "مزدوج "
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.js:0
+msgid "Drag and drop the building block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/drag_and_drop_move_handle.js:0
+msgid "Drag and move"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "Duplicate this block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_plugin.js:0
+msgid "Edit"
+msgstr "تحرير"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/drop_zone_plugin.js:0
+msgid "For technical reasons, this block cannot be dropped here"
+msgstr "لا يمكن إفلات الكتلة البنائية هنا لأسباب تقنية "
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Icon"
+msgstr "الأيقونة"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid ""
+"If you discard the current edits, all unsaved changes will be lost. You can "
+"cancel to return to edit mode."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid "If you proceed, your changes will be lost"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Image"
+msgstr "صورة"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Inner Content"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Insert a block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/media_website_plugin.js:0
+msgid "Insert a video"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+#: code:addons/html_builder/static/src/sidebar/snippet.xml:0
+msgid "Insert snippet"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Inset"
+msgstr "داخل مربع نص "
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/snippet.xml:0
+msgid "Install"
+msgstr "تثبيت"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Install %s"
+msgstr "تثبيت %s "
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/invisible_elements_panel.xml:0
+msgid "Invisible Elements"
+msgstr "العناصر الخفية "
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_list.js:0
+msgid "Item"
+msgstr "العنصر "
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.js:0
+msgid "Link Anchor"
+msgstr "رابط نقطة الارتساء "
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Mobile Preview"
+msgstr "معاينة الهاتف المحمول "
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "More info about this app."
+msgstr "المزيد من المعلومات حول هذا التطبيق. "
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Name"
+msgstr "الاسم"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "No"
+msgstr "لا"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "No block of this category can be dropped on this page."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "No snippets found"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_select.js:0
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "None"
+msgstr "لا شيء"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Offset (X, Y)"
+msgstr "إزاحة (X, Y) "
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Oops! No snippets found."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Outset"
+msgstr "البداية "
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Page Options"
+msgstr "خيارات الصفحة "
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "REPLACE BY NEW VERSION"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Remove"
+msgstr "إزالة"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "Remove this block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Rename the block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Round Corners"
+msgstr "زوايا مستديرة "
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Save"
+msgstr "حفظ"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Save & Copy"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Save and Install"
+msgstr "حفظ وتثبيت "
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Search for a block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search for records..."
+msgstr "البحث عن السجلات... "
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search more..."
+msgstr "البحث عن المزيد... "
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search to show more records"
+msgstr "البحث لإظهار المزيد من السجلات "
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/customize_tab.xml:0
+msgid "Select a block on your page to style it."
+msgstr "اختر كتلة بنائية في صفحتك لتزيينها. "
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/customize_translation_tab.xml:0
+msgid "Select content on your page to translate it."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Shadow"
+msgstr "الظل"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Solid"
+msgstr "لون خالص "
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Spread"
+msgstr "انتشار "
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Take a look at the search bar, there might be a small typo!"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "The chosen name already exists"
+msgstr "الاسم الذي اخترته موجود بالفعل "
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Theme"
+msgstr "السمة "
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "This block cannot be dropped anywhere on this page."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "This block is outdated."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Tip: Esc to preview"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_row.xml:0
+msgid "Toggle more options"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/media_website_plugin.js:0
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Video"
+msgstr "الفيديو"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Yes"
+msgstr "نعم"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "You can still access the block options but it might be ineffective."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "You might not be able to customize it anymore."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/save_snippet_plugin.js:0
+msgid ""
+"Your custom snippet was successfully saved as <strong>%s</strong>. Find it "
+"in your snippets collection."
+msgstr ""

--- a/addons/html_builder/i18n/az.po
+++ b/addons/html_builder/i18n/az.po
@@ -1,0 +1,576 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* html_builder
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 16.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-05-16 13:50+0000\n"
+"PO-Revision-Date: 2022-09-22 05:55+0000\n"
+"Last-Translator: erpgo translator <jumshud@erpgo.az>, 2022\n"
+"Language-Team: Azerbaijani (https://app.transifex.com/odoo/teams/41243/az/)\n"
+"Language: az\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "ACCESS OPTIONS ANYWAY"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_list.js:0
+msgid "Add"
+msgstr "Əlavə edin"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Almost there! Snippets are incoming, grab a coffee and relax!"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_plugin.js:0
+msgid "Anchor copied to clipboard%(br)sLink: %(anchorLink)s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Anchor name"
+msgstr "Bağlanma nöqtəsinin adı"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Are you sure you want to delete the block %s?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Block"
+msgstr "Blok"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Blocks"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Blur"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Button"
+msgstr "Düymə"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "Cancel"
+msgstr "Ləğv edin"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Categories"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.js:0
+msgid "Choose a record..."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Choose an anchor name"
+msgstr "Alternativ ad seçin"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Color"
+msgstr "Rəng"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Column"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "Confirm"
+msgstr "Təsdiq edin"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid "Continue"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Could not install module %(title)s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Create \""
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Create a custom snippet"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Custom %s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Custom Button"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Custom Inner Content"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Customize"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/setup_editor_plugin.js:0
+msgid "DRAG BUILDING BLOCKS HERE"
+msgstr "STRUKTUR BLOKLARINI BURAYA SÜRÜKLƏYİN"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Dashed"
+msgstr "Ştrixlənmiş"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Discard"
+msgstr "Ləğv edin"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Do you want to install %s App?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Do you want to save this snippet as a custom one?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Dotted"
+msgstr "Nöqtəli"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Double"
+msgstr "İki dəfə"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.js:0
+msgid "Drag and drop the building block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/drag_and_drop_move_handle.js:0
+msgid "Drag and move"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "Duplicate this block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_plugin.js:0
+msgid "Edit"
+msgstr "Redaktə edin"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/drop_zone_plugin.js:0
+msgid "For technical reasons, this block cannot be dropped here"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Icon"
+msgstr "Simvol"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid ""
+"If you discard the current edits, all unsaved changes will be lost. You can "
+"cancel to return to edit mode."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid "If you proceed, your changes will be lost"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Image"
+msgstr "Şəkil"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Inner Content"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Insert a block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/media_website_plugin.js:0
+msgid "Insert a video"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+#: code:addons/html_builder/static/src/sidebar/snippet.xml:0
+msgid "Insert snippet"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Inset"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/snippet.xml:0
+msgid "Install"
+msgstr "Quraşdır"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Install %s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/invisible_elements_panel.xml:0
+msgid "Invisible Elements"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_list.js:0
+msgid "Item"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.js:0
+msgid "Link Anchor"
+msgstr "Link Bağlama"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Mobile Preview"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "More info about this app."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Name"
+msgstr "Ad"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "No"
+msgstr "Tapılmayanlar"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "No block of this category can be dropped on this page."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "No snippets found"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_select.js:0
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "None"
+msgstr "Heçbiri"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Offset (X, Y)"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Oops! No snippets found."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Outset"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Page Options"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "REPLACE BY NEW VERSION"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Remove"
+msgstr "Sil"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "Remove this block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Rename the block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Round Corners"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Save"
+msgstr "Yadda Saxla"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Save & Copy"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Save and Install"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Search for a block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search for records..."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search more..."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search to show more records"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/customize_tab.xml:0
+msgid "Select a block on your page to style it."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/customize_translation_tab.xml:0
+msgid "Select content on your page to translate it."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Shadow"
+msgstr "Kölgə"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Solid"
+msgstr "Cisim"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Spread"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Take a look at the search bar, there might be a small typo!"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "The chosen name already exists"
+msgstr "Seçilmiş ad artıq mövcuddur"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Theme"
+msgstr "Tema "
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "This block cannot be dropped anywhere on this page."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "This block is outdated."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Tip: Esc to preview"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_row.xml:0
+msgid "Toggle more options"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/media_website_plugin.js:0
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Video"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Yes"
+msgstr "Bəli"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "You can still access the block options but it might be ineffective."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "You might not be able to customize it anymore."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/save_snippet_plugin.js:0
+msgid ""
+"Your custom snippet was successfully saved as <strong>%s</strong>. Find it "
+"in your snippets collection."
+msgstr ""

--- a/addons/html_builder/i18n/bg.po
+++ b/addons/html_builder/i18n/bg.po
@@ -1,0 +1,576 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* html_builder
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 16.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-05-16 13:50+0000\n"
+"PO-Revision-Date: 2022-09-22 05:55+0000\n"
+"Last-Translator: Martin Trigaux, 2023\n"
+"Language-Team: Bulgarian (https://app.transifex.com/odoo/teams/41243/bg/)\n"
+"Language: bg\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "ACCESS OPTIONS ANYWAY"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_list.js:0
+msgid "Add"
+msgstr "Добави"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Almost there! Snippets are incoming, grab a coffee and relax!"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_plugin.js:0
+msgid "Anchor copied to clipboard%(br)sLink: %(anchorLink)s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Anchor name"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Are you sure you want to delete the block %s?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Block"
+msgstr "Блокирайте"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Blocks"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Blur"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Button"
+msgstr "Бутон"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "Cancel"
+msgstr "Отказ"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Categories"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.js:0
+msgid "Choose a record..."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Choose an anchor name"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Color"
+msgstr "Цвят"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Column"
+msgstr "Графа"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "Confirm"
+msgstr "Потвърждение"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid "Continue"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Could not install module %(title)s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Create \""
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Create a custom snippet"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Custom %s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Custom Button"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Custom Inner Content"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Customize"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/setup_editor_plugin.js:0
+msgid "DRAG BUILDING BLOCKS HERE"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Dashed"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Discard"
+msgstr "Отхвърлете"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Do you want to install %s App?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Do you want to save this snippet as a custom one?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Dotted"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Double"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.js:0
+msgid "Drag and drop the building block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/drag_and_drop_move_handle.js:0
+msgid "Drag and move"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "Duplicate this block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_plugin.js:0
+msgid "Edit"
+msgstr "Редактирай"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/drop_zone_plugin.js:0
+msgid "For technical reasons, this block cannot be dropped here"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Icon"
+msgstr "Икона"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid ""
+"If you discard the current edits, all unsaved changes will be lost. You can "
+"cancel to return to edit mode."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid "If you proceed, your changes will be lost"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Image"
+msgstr "Изображение"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Inner Content"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Insert a block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/media_website_plugin.js:0
+msgid "Insert a video"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+#: code:addons/html_builder/static/src/sidebar/snippet.xml:0
+msgid "Insert snippet"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Inset"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/snippet.xml:0
+msgid "Install"
+msgstr "Инсталирайте"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Install %s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/invisible_elements_panel.xml:0
+msgid "Invisible Elements"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_list.js:0
+msgid "Item"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.js:0
+msgid "Link Anchor"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Mobile Preview"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "More info about this app."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Name"
+msgstr "Име"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "No"
+msgstr "Не"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "No block of this category can be dropped on this page."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "No snippets found"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_select.js:0
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "None"
+msgstr "Никакъв"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Offset (X, Y)"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Oops! No snippets found."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Outset"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Page Options"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "REPLACE BY NEW VERSION"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Remove"
+msgstr "Премахнете"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "Remove this block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Rename the block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Round Corners"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Save"
+msgstr "Запазете"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Save & Copy"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Save and Install"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Search for a block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search for records..."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search more..."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search to show more records"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/customize_tab.xml:0
+msgid "Select a block on your page to style it."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/customize_translation_tab.xml:0
+msgid "Select content on your page to translate it."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Shadow"
+msgstr "Сянка"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Solid"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Spread"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Take a look at the search bar, there might be a small typo!"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "The chosen name already exists"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Theme"
+msgstr "Тема"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "This block cannot be dropped anywhere on this page."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "This block is outdated."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Tip: Esc to preview"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_row.xml:0
+msgid "Toggle more options"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/media_website_plugin.js:0
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Video"
+msgstr "Видео"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Yes"
+msgstr "Да"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "You can still access the block options but it might be ineffective."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "You might not be able to customize it anymore."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/save_snippet_plugin.js:0
+msgid ""
+"Your custom snippet was successfully saved as <strong>%s</strong>. Find it "
+"in your snippets collection."
+msgstr ""

--- a/addons/html_builder/i18n/bs.po
+++ b/addons/html_builder/i18n/bs.po
@@ -1,0 +1,576 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* html_builder
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server saas~11.5\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-05-16 13:50+0000\n"
+"PO-Revision-Date: 2018-10-02 10:06+0000\n"
+"Last-Translator: Bole <bole@dajmi5.com>, 2018\n"
+"Language-Team: Bosnian (https://www.transifex.com/odoo/teams/41243/bs/)\n"
+"Language: bs\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "ACCESS OPTIONS ANYWAY"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_list.js:0
+msgid "Add"
+msgstr "Dodaj"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Almost there! Snippets are incoming, grab a coffee and relax!"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_plugin.js:0
+msgid "Anchor copied to clipboard%(br)sLink: %(anchorLink)s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Anchor name"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Are you sure you want to delete the block %s?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Block"
+msgstr "Blokiraj"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Blocks"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Blur"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Button"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "Cancel"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Categories"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.js:0
+msgid "Choose a record..."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Choose an anchor name"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Color"
+msgstr "Boja"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Column"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "Confirm"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid "Continue"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Could not install module %(title)s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Create \""
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Create a custom snippet"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Custom %s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Custom Button"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Custom Inner Content"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Customize"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/setup_editor_plugin.js:0
+msgid "DRAG BUILDING BLOCKS HERE"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Dashed"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Discard"
+msgstr "Odbaci"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Do you want to install %s App?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Do you want to save this snippet as a custom one?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Dotted"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Double"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.js:0
+msgid "Drag and drop the building block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/drag_and_drop_move_handle.js:0
+msgid "Drag and move"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "Duplicate this block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_plugin.js:0
+msgid "Edit"
+msgstr "Uredi"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/drop_zone_plugin.js:0
+msgid "For technical reasons, this block cannot be dropped here"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Icon"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid ""
+"If you discard the current edits, all unsaved changes will be lost. You can "
+"cancel to return to edit mode."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid "If you proceed, your changes will be lost"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Image"
+msgstr "Slika"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Inner Content"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Insert a block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/media_website_plugin.js:0
+msgid "Insert a video"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+#: code:addons/html_builder/static/src/sidebar/snippet.xml:0
+msgid "Insert snippet"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Inset"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/snippet.xml:0
+msgid "Install"
+msgstr "Instalacija"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Install %s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/invisible_elements_panel.xml:0
+msgid "Invisible Elements"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_list.js:0
+msgid "Item"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.js:0
+msgid "Link Anchor"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Mobile Preview"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "More info about this app."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Name"
+msgstr "Naziv:"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "No"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "No block of this category can be dropped on this page."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "No snippets found"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_select.js:0
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "None"
+msgstr "Ništa"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Offset (X, Y)"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Oops! No snippets found."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Outset"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Page Options"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "REPLACE BY NEW VERSION"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Remove"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "Remove this block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Rename the block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Round Corners"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Save"
+msgstr "Sačuvaj"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Save & Copy"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Save and Install"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Search for a block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search for records..."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search more..."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search to show more records"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/customize_tab.xml:0
+msgid "Select a block on your page to style it."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/customize_translation_tab.xml:0
+msgid "Select content on your page to translate it."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Shadow"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Solid"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Spread"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Take a look at the search bar, there might be a small typo!"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "The chosen name already exists"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Theme"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "This block cannot be dropped anywhere on this page."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "This block is outdated."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Tip: Esc to preview"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_row.xml:0
+msgid "Toggle more options"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/media_website_plugin.js:0
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Video"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Yes"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "You can still access the block options but it might be ineffective."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "You might not be able to customize it anymore."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/save_snippet_plugin.js:0
+msgid ""
+"Your custom snippet was successfully saved as <strong>%s</strong>. Find it "
+"in your snippets collection."
+msgstr ""

--- a/addons/html_builder/i18n/ca.po
+++ b/addons/html_builder/i18n/ca.po
@@ -1,0 +1,576 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* html_builder
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 16.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-05-16 13:50+0000\n"
+"PO-Revision-Date: 2022-09-22 05:55+0000\n"
+"Last-Translator: martioodo hola, 2023\n"
+"Language-Team: Catalan (https://app.transifex.com/odoo/teams/41243/ca/)\n"
+"Language: ca\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "ACCESS OPTIONS ANYWAY"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_list.js:0
+msgid "Add"
+msgstr "Afegir"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Almost there! Snippets are incoming, grab a coffee and relax!"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_plugin.js:0
+msgid "Anchor copied to clipboard%(br)sLink: %(anchorLink)s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Anchor name"
+msgstr "Nom de l'àncora"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Are you sure you want to delete the block %s?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Block"
+msgstr "Bloquejar"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Blocks"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Blur"
+msgstr "Desenfocament"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Button"
+msgstr "Botó "
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "Cancel"
+msgstr "Cancel·lar"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Categories"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.js:0
+msgid "Choose a record..."
+msgstr "Tria un disc..."
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Choose an anchor name"
+msgstr "Triï un nom d'ancora"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Color"
+msgstr "Color"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Column"
+msgstr "Columna"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "Confirm"
+msgstr "Confirmar"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid "Continue"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Could not install module %(title)s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Create \""
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Create a custom snippet"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Custom %s"
+msgstr "Personalizado %s"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Custom Button"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Custom Inner Content"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Customize"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/setup_editor_plugin.js:0
+msgid "DRAG BUILDING BLOCKS HERE"
+msgstr "ARROSSEGA ELS BLOCS DE CONSTRUCCIÓ AQUÍ"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Dashed"
+msgstr "Ratllat"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Discard"
+msgstr "Descartar"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Do you want to install %s App?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Do you want to save this snippet as a custom one?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Dotted"
+msgstr "Puntejat"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Double"
+msgstr "Doble"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.js:0
+msgid "Drag and drop the building block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/drag_and_drop_move_handle.js:0
+msgid "Drag and move"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "Duplicate this block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_plugin.js:0
+msgid "Edit"
+msgstr "Modifica"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/drop_zone_plugin.js:0
+msgid "For technical reasons, this block cannot be dropped here"
+msgstr "Per raons tècniques, aquest bloc no es pot deixar anar aquí"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Icon"
+msgstr "Icona"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid ""
+"If you discard the current edits, all unsaved changes will be lost. You can "
+"cancel to return to edit mode."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid "If you proceed, your changes will be lost"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Image"
+msgstr "Imatge"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Inner Content"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Insert a block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/media_website_plugin.js:0
+msgid "Insert a video"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+#: code:addons/html_builder/static/src/sidebar/snippet.xml:0
+msgid "Insert snippet"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Inset"
+msgstr "Inserit"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/snippet.xml:0
+msgid "Install"
+msgstr "Instal·lar "
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Install %s"
+msgstr "Instal·lar %s"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/invisible_elements_panel.xml:0
+msgid "Invisible Elements"
+msgstr "Elements invisibles"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_list.js:0
+msgid "Item"
+msgstr "Element"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.js:0
+msgid "Link Anchor"
+msgstr "Àncora d'enllaç"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Mobile Preview"
+msgstr "Vista prèvia adaptativa"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "More info about this app."
+msgstr "Més informació sobre aquesta app."
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Name"
+msgstr "Nom"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "No"
+msgstr "No"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "No block of this category can be dropped on this page."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "No snippets found"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_select.js:0
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "None"
+msgstr "Cap"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Offset (X, Y)"
+msgstr "Desplaçament (X, Y)"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Oops! No snippets found."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Outset"
+msgstr "Inici"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Page Options"
+msgstr "Opcions de pàgina"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "REPLACE BY NEW VERSION"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Remove"
+msgstr "Eliminar"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "Remove this block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Rename the block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Round Corners"
+msgstr "Cantonades arrodonides"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Save"
+msgstr "Desar"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Save & Copy"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Save and Install"
+msgstr "Desar i instal·lar"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Search for a block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search for records..."
+msgstr "Cerca registres..."
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search more..."
+msgstr "Cerca més..."
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search to show more records"
+msgstr "Busca més registres"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/customize_tab.xml:0
+msgid "Select a block on your page to style it."
+msgstr "Selecciona un bloc a la teva pàgina per donar-li estil."
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/customize_translation_tab.xml:0
+msgid "Select content on your page to translate it."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Shadow"
+msgstr "Ombra"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Solid"
+msgstr "Sòlid"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Spread"
+msgstr "Escampa"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Take a look at the search bar, there might be a small typo!"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "The chosen name already exists"
+msgstr "El nom triat ja existeix"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Theme"
+msgstr "Tema"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "This block cannot be dropped anywhere on this page."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "This block is outdated."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Tip: Esc to preview"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_row.xml:0
+msgid "Toggle more options"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/media_website_plugin.js:0
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Video"
+msgstr "Vídeo"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Yes"
+msgstr "Sí"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "You can still access the block options but it might be ineffective."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "You might not be able to customize it anymore."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/save_snippet_plugin.js:0
+msgid ""
+"Your custom snippet was successfully saved as <strong>%s</strong>. Find it "
+"in your snippets collection."
+msgstr ""

--- a/addons/html_builder/i18n/cs.po
+++ b/addons/html_builder/i18n/cs.po
@@ -1,0 +1,576 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* html_builder
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 16.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-05-16 13:50+0000\n"
+"PO-Revision-Date: 2022-09-22 05:55+0000\n"
+"Last-Translator: Martin Trigaux, 2023\n"
+"Language-Team: Czech (https://app.transifex.com/odoo/teams/41243/cs/)\n"
+"Language: cs\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: nplurals=4; plural=(n == 1 && n % 1 == 0) ? 0 : (n >= 2 && n <= 4 && n % 1 == 0) ? 1: (n % 1 != 0 ) ? 2 : 3;\n"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "ACCESS OPTIONS ANYWAY"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_list.js:0
+msgid "Add"
+msgstr "Přidat"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Almost there! Snippets are incoming, grab a coffee and relax!"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_plugin.js:0
+msgid "Anchor copied to clipboard%(br)sLink: %(anchorLink)s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Anchor name"
+msgstr "Název ukotvení"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Are you sure you want to delete the block %s?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Block"
+msgstr "Blok"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Blocks"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Blur"
+msgstr "Blur"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Button"
+msgstr "Tlačítko"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "Cancel"
+msgstr "Zrušit"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Categories"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.js:0
+msgid "Choose a record..."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Choose an anchor name"
+msgstr "Zvolte název kotvy"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Color"
+msgstr "Barva"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Column"
+msgstr "Sloupec"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "Confirm"
+msgstr "Potvrdit"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid "Continue"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Could not install module %(title)s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Create \""
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Create a custom snippet"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Custom %s"
+msgstr "Přizpůsoben %s"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Custom Button"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Custom Inner Content"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Customize"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/setup_editor_plugin.js:0
+msgid "DRAG BUILDING BLOCKS HERE"
+msgstr "SEM PŘESUNOUT STAVEBNÍ BLOKY"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Dashed"
+msgstr "Přerušovaná"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Discard"
+msgstr "Zrušit"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Do you want to install %s App?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Do you want to save this snippet as a custom one?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Dotted"
+msgstr "Tečkovaná"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Double"
+msgstr "Dvojitá"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.js:0
+msgid "Drag and drop the building block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/drag_and_drop_move_handle.js:0
+msgid "Drag and move"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "Duplicate this block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_plugin.js:0
+msgid "Edit"
+msgstr "Upravit"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/drop_zone_plugin.js:0
+msgid "For technical reasons, this block cannot be dropped here"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Icon"
+msgstr "Ikona"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid ""
+"If you discard the current edits, all unsaved changes will be lost. You can "
+"cancel to return to edit mode."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid "If you proceed, your changes will be lost"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Image"
+msgstr "Obrázek"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Inner Content"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Insert a block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/media_website_plugin.js:0
+msgid "Insert a video"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+#: code:addons/html_builder/static/src/sidebar/snippet.xml:0
+msgid "Insert snippet"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Inset"
+msgstr "Vložit"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/snippet.xml:0
+msgid "Install"
+msgstr "Instalovat"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Install %s"
+msgstr "Instalovat %s"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/invisible_elements_panel.xml:0
+msgid "Invisible Elements"
+msgstr "Neviditelné prvky"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_list.js:0
+msgid "Item"
+msgstr "Položka"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.js:0
+msgid "Link Anchor"
+msgstr "Kotva odkazu"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Mobile Preview"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "More info about this app."
+msgstr "Více informací o této aplikaci."
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Name"
+msgstr "Jméno"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "No"
+msgstr "Ne"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "No block of this category can be dropped on this page."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "No snippets found"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_select.js:0
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "None"
+msgstr "Nic"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Offset (X, Y)"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Oops! No snippets found."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Outset"
+msgstr "Na začátku"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Page Options"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "REPLACE BY NEW VERSION"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Remove"
+msgstr "Odebrat"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "Remove this block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Rename the block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Round Corners"
+msgstr "Kulaté rohy"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Save"
+msgstr "Uložit"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Save & Copy"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Save and Install"
+msgstr "Uložit a nainstalovat"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Search for a block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search for records..."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search more..."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search to show more records"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/customize_tab.xml:0
+msgid "Select a block on your page to style it."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/customize_translation_tab.xml:0
+msgid "Select content on your page to translate it."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Shadow"
+msgstr "Stín"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Solid"
+msgstr "Pevný"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Spread"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Take a look at the search bar, there might be a small typo!"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "The chosen name already exists"
+msgstr "Vybrané jméno již existuje"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Theme"
+msgstr "Téma"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "This block cannot be dropped anywhere on this page."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "This block is outdated."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Tip: Esc to preview"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_row.xml:0
+msgid "Toggle more options"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/media_website_plugin.js:0
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Video"
+msgstr "Video"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Yes"
+msgstr "Ano"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "You can still access the block options but it might be ineffective."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "You might not be able to customize it anymore."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/save_snippet_plugin.js:0
+msgid ""
+"Your custom snippet was successfully saved as <strong>%s</strong>. Find it "
+"in your snippets collection."
+msgstr ""

--- a/addons/html_builder/i18n/da.po
+++ b/addons/html_builder/i18n/da.po
@@ -1,0 +1,576 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* html_builder
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 16.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-05-16 13:50+0000\n"
+"PO-Revision-Date: 2022-09-22 05:55+0000\n"
+"Last-Translator: Martin Trigaux, 2023\n"
+"Language-Team: Danish (https://app.transifex.com/odoo/teams/41243/da/)\n"
+"Language: da\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "ACCESS OPTIONS ANYWAY"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_list.js:0
+msgid "Add"
+msgstr "Tilføj"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Almost there! Snippets are incoming, grab a coffee and relax!"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_plugin.js:0
+msgid "Anchor copied to clipboard%(br)sLink: %(anchorLink)s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Anchor name"
+msgstr "Anker navn"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Are you sure you want to delete the block %s?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Block"
+msgstr "Blokér"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Blocks"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Blur"
+msgstr "Slør"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Button"
+msgstr "Knap"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "Cancel"
+msgstr "Annullér"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Categories"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.js:0
+msgid "Choose a record..."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Choose an anchor name"
+msgstr "Vælg et anker navn"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Color"
+msgstr "Farve"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Column"
+msgstr "Kolonne"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "Confirm"
+msgstr "Bekræft"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid "Continue"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Could not install module %(title)s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Create \""
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Create a custom snippet"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Custom %s"
+msgstr "Tilpasset %s"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Custom Button"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Custom Inner Content"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Customize"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/setup_editor_plugin.js:0
+msgid "DRAG BUILDING BLOCKS HERE"
+msgstr "TRÆK BYGGEBLOKKE HERTIL"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Dashed"
+msgstr "Streget"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Discard"
+msgstr "Kassér"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Do you want to install %s App?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Do you want to save this snippet as a custom one?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Dotted"
+msgstr "Prikket"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Double"
+msgstr "Dobbelt"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.js:0
+msgid "Drag and drop the building block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/drag_and_drop_move_handle.js:0
+msgid "Drag and move"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "Duplicate this block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_plugin.js:0
+msgid "Edit"
+msgstr "Rediger"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/drop_zone_plugin.js:0
+msgid "For technical reasons, this block cannot be dropped here"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Icon"
+msgstr "Ikon"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid ""
+"If you discard the current edits, all unsaved changes will be lost. You can "
+"cancel to return to edit mode."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid "If you proceed, your changes will be lost"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Image"
+msgstr "Billede"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Inner Content"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Insert a block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/media_website_plugin.js:0
+msgid "Insert a video"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+#: code:addons/html_builder/static/src/sidebar/snippet.xml:0
+msgid "Insert snippet"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Inset"
+msgstr "Indsat"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/snippet.xml:0
+msgid "Install"
+msgstr "Installer"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Install %s"
+msgstr "Installer %s"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/invisible_elements_panel.xml:0
+msgid "Invisible Elements"
+msgstr "Usynlige Elementer"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_list.js:0
+msgid "Item"
+msgstr "Genstand"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.js:0
+msgid "Link Anchor"
+msgstr "Link anker"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Mobile Preview"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "More info about this app."
+msgstr "Mere info om denne applikation."
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Name"
+msgstr "Navn"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "No"
+msgstr "Nej"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "No block of this category can be dropped on this page."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "No snippets found"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_select.js:0
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "None"
+msgstr "Ingen"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Offset (X, Y)"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Oops! No snippets found."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Outset"
+msgstr "Begyndelse"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Page Options"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "REPLACE BY NEW VERSION"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Remove"
+msgstr "Fjern"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "Remove this block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Rename the block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Round Corners"
+msgstr "Afrund Hjørner"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Save"
+msgstr "Gem"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Save & Copy"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Save and Install"
+msgstr "Gem og Installer"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Search for a block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search for records..."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search more..."
+msgstr "Søg flere..."
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search to show more records"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/customize_tab.xml:0
+msgid "Select a block on your page to style it."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/customize_translation_tab.xml:0
+msgid "Select content on your page to translate it."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Shadow"
+msgstr "Skygge"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Solid"
+msgstr "Fast"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Spread"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Take a look at the search bar, there might be a small typo!"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "The chosen name already exists"
+msgstr "Det valgte navn eksisterer allerede"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Theme"
+msgstr "Tema"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "This block cannot be dropped anywhere on this page."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "This block is outdated."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Tip: Esc to preview"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_row.xml:0
+msgid "Toggle more options"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/media_website_plugin.js:0
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Video"
+msgstr "Video"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Yes"
+msgstr "Ja"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "You can still access the block options but it might be ineffective."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "You might not be able to customize it anymore."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/save_snippet_plugin.js:0
+msgid ""
+"Your custom snippet was successfully saved as <strong>%s</strong>. Find it "
+"in your snippets collection."
+msgstr ""

--- a/addons/html_builder/i18n/de.po
+++ b/addons/html_builder/i18n/de.po
@@ -1,0 +1,576 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* html_builder
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 16.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-05-16 13:50+0000\n"
+"PO-Revision-Date: 2022-09-22 05:55+0000\n"
+"Last-Translator: Stefan Reisich <nafex@gmx.net>, 2023\n"
+"Language-Team: German (https://app.transifex.com/odoo/teams/41243/de/)\n"
+"Language: de\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "ACCESS OPTIONS ANYWAY"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_list.js:0
+msgid "Add"
+msgstr "Hinzufügen"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Almost there! Snippets are incoming, grab a coffee and relax!"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_plugin.js:0
+msgid "Anchor copied to clipboard%(br)sLink: %(anchorLink)s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Anchor name"
+msgstr "Anker-Bezeichnung"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Are you sure you want to delete the block %s?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Block"
+msgstr "Blockieren"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Blocks"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Blur"
+msgstr "Unschärfe"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Button"
+msgstr "Button"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "Cancel"
+msgstr "Abbrechen"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Categories"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.js:0
+msgid "Choose a record..."
+msgstr "Wählen Sie einen Datensatz..."
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Choose an anchor name"
+msgstr "Wählen Sie einen Ankernamen"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Color"
+msgstr "Farbe"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Column"
+msgstr "Spalten"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "Confirm"
+msgstr "Bestätigen"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid "Continue"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Could not install module %(title)s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Create \""
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Create a custom snippet"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Custom %s"
+msgstr "Benutzerdef. %s"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Custom Button"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Custom Inner Content"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Customize"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/setup_editor_plugin.js:0
+msgid "DRAG BUILDING BLOCKS HERE"
+msgstr "ZIEHEN SIE BAUSTEINE HIERHER"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Dashed"
+msgstr "Gestrichelt"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Discard"
+msgstr "Verwerfen"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Do you want to install %s App?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Do you want to save this snippet as a custom one?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Dotted"
+msgstr "Gepunktet"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Double"
+msgstr "Doppelt"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.js:0
+msgid "Drag and drop the building block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/drag_and_drop_move_handle.js:0
+msgid "Drag and move"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "Duplicate this block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_plugin.js:0
+msgid "Edit"
+msgstr "Bearbeiten"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/drop_zone_plugin.js:0
+msgid "For technical reasons, this block cannot be dropped here"
+msgstr "Aus technischen Gründen kann dieser Baustein hier nicht abgelegt werden"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Icon"
+msgstr "Icon"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid ""
+"If you discard the current edits, all unsaved changes will be lost. You can "
+"cancel to return to edit mode."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid "If you proceed, your changes will be lost"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Image"
+msgstr "Bild"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Inner Content"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Insert a block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/media_website_plugin.js:0
+msgid "Insert a video"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+#: code:addons/html_builder/static/src/sidebar/snippet.xml:0
+msgid "Insert snippet"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Inset"
+msgstr "Einsatz"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/snippet.xml:0
+msgid "Install"
+msgstr "Installieren"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Install %s"
+msgstr "%s Installieren"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/invisible_elements_panel.xml:0
+msgid "Invisible Elements"
+msgstr "Unsichtbare Elemente"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_list.js:0
+msgid "Item"
+msgstr "Element"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.js:0
+msgid "Link Anchor"
+msgstr "Link-Anker"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Mobile Preview"
+msgstr "Mobile Ansicht"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "More info about this app."
+msgstr "Mehr Infos über diese App."
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Name"
+msgstr "Name"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "No"
+msgstr "Nein"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "No block of this category can be dropped on this page."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "No snippets found"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_select.js:0
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "None"
+msgstr "Keine"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Offset (X, Y)"
+msgstr "Absetzung (X,Y)"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Oops! No snippets found."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Outset"
+msgstr "Hervorgehoben"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Page Options"
+msgstr "Seitenoptionen"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "REPLACE BY NEW VERSION"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Remove"
+msgstr "Entfernen"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "Remove this block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Rename the block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Round Corners"
+msgstr "Runde Ecken"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Save"
+msgstr "Speichern"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Save & Copy"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Save and Install"
+msgstr "Speichern und istallieren"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Search for a block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search for records..."
+msgstr "Nach Datensätzen suchen..."
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search more..."
+msgstr "Mehr suchen..."
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search to show more records"
+msgstr "Suchen, um mehr Datensätze anzuzeigen"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/customize_tab.xml:0
+msgid "Select a block on your page to style it."
+msgstr "Wählen Sie einen Block auf Ihrer Seite aus und gestalten Sie."
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/customize_translation_tab.xml:0
+msgid "Select content on your page to translate it."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Shadow"
+msgstr "Schatten"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Solid"
+msgstr "Durchgezogen"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Spread"
+msgstr "Ausbreiten"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Take a look at the search bar, there might be a small typo!"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "The chosen name already exists"
+msgstr "Der gewählte Name existiert bereits"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Theme"
+msgstr "Design"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "This block cannot be dropped anywhere on this page."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "This block is outdated."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Tip: Esc to preview"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_row.xml:0
+msgid "Toggle more options"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/media_website_plugin.js:0
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Video"
+msgstr "Video"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Yes"
+msgstr "Ja"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "You can still access the block options but it might be ineffective."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "You might not be able to customize it anymore."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/save_snippet_plugin.js:0
+msgid ""
+"Your custom snippet was successfully saved as <strong>%s</strong>. Find it "
+"in your snippets collection."
+msgstr ""

--- a/addons/html_builder/i18n/el.po
+++ b/addons/html_builder/i18n/el.po
@@ -1,0 +1,576 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* html_builder
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server saas~11.5\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-05-16 13:50+0000\n"
+"PO-Revision-Date: 2018-10-02 10:06+0000\n"
+"Last-Translator: Stefanos Nikou <stefanos.nikou@gmail.com>, 2018\n"
+"Language-Team: Greek (https://www.transifex.com/odoo/teams/41243/el/)\n"
+"Language: el\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "ACCESS OPTIONS ANYWAY"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_list.js:0
+msgid "Add"
+msgstr "Προσθήκη"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Almost there! Snippets are incoming, grab a coffee and relax!"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_plugin.js:0
+msgid "Anchor copied to clipboard%(br)sLink: %(anchorLink)s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Anchor name"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Are you sure you want to delete the block %s?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Block"
+msgstr "Αποκλεισμός"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Blocks"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Blur"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Button"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "Cancel"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Categories"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.js:0
+msgid "Choose a record..."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Choose an anchor name"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Color"
+msgstr "Χρώμα"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Column"
+msgstr "Στήλη"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "Confirm"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid "Continue"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Could not install module %(title)s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Create \""
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Create a custom snippet"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Custom %s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Custom Button"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Custom Inner Content"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Customize"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/setup_editor_plugin.js:0
+msgid "DRAG BUILDING BLOCKS HERE"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Dashed"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Discard"
+msgstr "Απόρριψη"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Do you want to install %s App?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Do you want to save this snippet as a custom one?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Dotted"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Double"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.js:0
+msgid "Drag and drop the building block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/drag_and_drop_move_handle.js:0
+msgid "Drag and move"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "Duplicate this block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_plugin.js:0
+msgid "Edit"
+msgstr "Επεξεργασία"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/drop_zone_plugin.js:0
+msgid "For technical reasons, this block cannot be dropped here"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Icon"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid ""
+"If you discard the current edits, all unsaved changes will be lost. You can "
+"cancel to return to edit mode."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid "If you proceed, your changes will be lost"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Image"
+msgstr "Εικόνα"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Inner Content"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Insert a block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/media_website_plugin.js:0
+msgid "Insert a video"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+#: code:addons/html_builder/static/src/sidebar/snippet.xml:0
+msgid "Insert snippet"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Inset"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/snippet.xml:0
+msgid "Install"
+msgstr "Εγκατάσταση"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Install %s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/invisible_elements_panel.xml:0
+msgid "Invisible Elements"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_list.js:0
+msgid "Item"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.js:0
+msgid "Link Anchor"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Mobile Preview"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "More info about this app."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Name"
+msgstr "Περιγραφή"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "No"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "No block of this category can be dropped on this page."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "No snippets found"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_select.js:0
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "None"
+msgstr "Κανένα"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Offset (X, Y)"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Oops! No snippets found."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Outset"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Page Options"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "REPLACE BY NEW VERSION"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Remove"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "Remove this block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Rename the block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Round Corners"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Save"
+msgstr "Αποθήκευση"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Save & Copy"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Save and Install"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Search for a block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search for records..."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search more..."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search to show more records"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/customize_tab.xml:0
+msgid "Select a block on your page to style it."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/customize_translation_tab.xml:0
+msgid "Select content on your page to translate it."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Shadow"
+msgstr "Σκιά"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Solid"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Spread"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Take a look at the search bar, there might be a small typo!"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "The chosen name already exists"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Theme"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "This block cannot be dropped anywhere on this page."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "This block is outdated."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Tip: Esc to preview"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_row.xml:0
+msgid "Toggle more options"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/media_website_plugin.js:0
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Video"
+msgstr "Βίντεο"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Yes"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "You can still access the block options but it might be ineffective."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "You might not be able to customize it anymore."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/save_snippet_plugin.js:0
+msgid ""
+"Your custom snippet was successfully saved as <strong>%s</strong>. Find it "
+"in your snippets collection."
+msgstr ""

--- a/addons/html_builder/i18n/es.po
+++ b/addons/html_builder/i18n/es.po
@@ -1,0 +1,576 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* html_builder
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 16.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-05-16 13:50+0000\n"
+"PO-Revision-Date: 2022-09-22 05:55+0000\n"
+"Last-Translator: Pedro M. Baeza <pedro.baeza@tecnativa.com>, 2023\n"
+"Language-Team: Spanish (https://app.transifex.com/odoo/teams/41243/es/)\n"
+"Language: es\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: nplurals=3; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 ? 1 : 2;\n"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "ACCESS OPTIONS ANYWAY"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_list.js:0
+msgid "Add"
+msgstr "Añadir"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Almost there! Snippets are incoming, grab a coffee and relax!"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_plugin.js:0
+msgid "Anchor copied to clipboard%(br)sLink: %(anchorLink)s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Anchor name"
+msgstr "Nombre del ancla"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Are you sure you want to delete the block %s?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Block"
+msgstr "Bloquear"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Blocks"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Blur"
+msgstr "Desenfocar"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Button"
+msgstr "Botón"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "Cancel"
+msgstr "Cancelar"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Categories"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.js:0
+msgid "Choose a record..."
+msgstr "Elija un registro..."
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Choose an anchor name"
+msgstr "Elige un nombre de ancla"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Color"
+msgstr "Color"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Column"
+msgstr "Columna"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "Confirm"
+msgstr "Confirmar"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid "Continue"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Could not install module %(title)s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Create \""
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Create a custom snippet"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Custom %s"
+msgstr "Personalizado %s"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Custom Button"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Custom Inner Content"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Customize"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/setup_editor_plugin.js:0
+msgid "DRAG BUILDING BLOCKS HERE"
+msgstr "ARRASTRE BLOQUES AQUÍ"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Dashed"
+msgstr "Rayado"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Discard"
+msgstr "Descartar"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Do you want to install %s App?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Do you want to save this snippet as a custom one?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Dotted"
+msgstr "Punteado"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Double"
+msgstr "Doble"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.js:0
+msgid "Drag and drop the building block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/drag_and_drop_move_handle.js:0
+msgid "Drag and move"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "Duplicate this block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_plugin.js:0
+msgid "Edit"
+msgstr "Editar"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/drop_zone_plugin.js:0
+msgid "For technical reasons, this block cannot be dropped here"
+msgstr "Por razones técnicas, no puede soltar este bloque aquí"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Icon"
+msgstr "Icono"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid ""
+"If you discard the current edits, all unsaved changes will be lost. You can "
+"cancel to return to edit mode."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid "If you proceed, your changes will be lost"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Image"
+msgstr "Imagen"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Inner Content"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Insert a block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/media_website_plugin.js:0
+msgid "Insert a video"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+#: code:addons/html_builder/static/src/sidebar/snippet.xml:0
+msgid "Insert snippet"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Inset"
+msgstr "Inset"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/snippet.xml:0
+msgid "Install"
+msgstr "Instalar"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Install %s"
+msgstr "Instalar %s"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/invisible_elements_panel.xml:0
+msgid "Invisible Elements"
+msgstr "Elementos invisibles"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_list.js:0
+msgid "Item"
+msgstr "Tema"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.js:0
+msgid "Link Anchor"
+msgstr "Enlace de anclaje"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Mobile Preview"
+msgstr "Previsualización móvil"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "More info about this app."
+msgstr "Más información sobre esta aplicación."
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Name"
+msgstr "Nombre"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "No"
+msgstr "No"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "No block of this category can be dropped on this page."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "No snippets found"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_select.js:0
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "None"
+msgstr "Ninguno"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Offset (X, Y)"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Oops! No snippets found."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Outset"
+msgstr "Outset"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Page Options"
+msgstr "Opciones de página"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "REPLACE BY NEW VERSION"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Remove"
+msgstr "Eliminar"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "Remove this block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Rename the block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Round Corners"
+msgstr "Esquinas redondas"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Save"
+msgstr "Guardar"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Save & Copy"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Save and Install"
+msgstr "Guardar e instalar"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Search for a block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search for records..."
+msgstr "Buscar registros..."
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search more..."
+msgstr "Buscar más..."
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search to show more records"
+msgstr "Buscar más registros"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/customize_tab.xml:0
+msgid "Select a block on your page to style it."
+msgstr "Seleccione un bloque en su página para darle estilo."
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/customize_translation_tab.xml:0
+msgid "Select content on your page to translate it."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Shadow"
+msgstr "Sombra"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Solid"
+msgstr "Sólido"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Spread"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Take a look at the search bar, there might be a small typo!"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "The chosen name already exists"
+msgstr "El nombre elegido ya existe"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Theme"
+msgstr "Tema"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "This block cannot be dropped anywhere on this page."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "This block is outdated."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Tip: Esc to preview"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_row.xml:0
+msgid "Toggle more options"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/media_website_plugin.js:0
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Video"
+msgstr "Video"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Yes"
+msgstr "Sí"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "You can still access the block options but it might be ineffective."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "You might not be able to customize it anymore."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/save_snippet_plugin.js:0
+msgid ""
+"Your custom snippet was successfully saved as <strong>%s</strong>. Find it "
+"in your snippets collection."
+msgstr ""

--- a/addons/html_builder/i18n/es_CL.po
+++ b/addons/html_builder/i18n/es_CL.po
@@ -1,0 +1,576 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* html_builder
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo 9.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-05-16 13:50+0000\n"
+"PO-Revision-Date: 2016-03-12 06:25+0000\n"
+"Last-Translator: Martin Trigaux\n"
+"Language-Team: Spanish (Chile) (http://www.transifex.com/odoo/odoo-9/language/es_CL/)\n"
+"Language: es_CL\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "ACCESS OPTIONS ANYWAY"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_list.js:0
+msgid "Add"
+msgstr "Agregar"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Almost there! Snippets are incoming, grab a coffee and relax!"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_plugin.js:0
+msgid "Anchor copied to clipboard%(br)sLink: %(anchorLink)s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Anchor name"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Are you sure you want to delete the block %s?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Blocks"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Blur"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Button"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "Cancel"
+msgstr "Cancelar"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Categories"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.js:0
+msgid "Choose a record..."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Choose an anchor name"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Color"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Column"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "Confirm"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid "Continue"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Could not install module %(title)s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Create \""
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Create a custom snippet"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Custom %s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Custom Button"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Custom Inner Content"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Customize"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/setup_editor_plugin.js:0
+msgid "DRAG BUILDING BLOCKS HERE"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Dashed"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Discard"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Do you want to install %s App?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Do you want to save this snippet as a custom one?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Dotted"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Double"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.js:0
+msgid "Drag and drop the building block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/drag_and_drop_move_handle.js:0
+msgid "Drag and move"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "Duplicate this block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_plugin.js:0
+msgid "Edit"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/drop_zone_plugin.js:0
+msgid "For technical reasons, this block cannot be dropped here"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Icon"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid ""
+"If you discard the current edits, all unsaved changes will be lost. You can "
+"cancel to return to edit mode."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid "If you proceed, your changes will be lost"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Image"
+msgstr "Imagen"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Inner Content"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Insert a block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/media_website_plugin.js:0
+msgid "Insert a video"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+#: code:addons/html_builder/static/src/sidebar/snippet.xml:0
+msgid "Insert snippet"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Inset"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/snippet.xml:0
+msgid "Install"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Install %s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/invisible_elements_panel.xml:0
+msgid "Invisible Elements"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_list.js:0
+msgid "Item"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.js:0
+msgid "Link Anchor"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Mobile Preview"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "More info about this app."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Name"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "No"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "No block of this category can be dropped on this page."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "No snippets found"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_select.js:0
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "None"
+msgstr "Ninguno"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Offset (X, Y)"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Oops! No snippets found."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Outset"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Page Options"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "REPLACE BY NEW VERSION"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Remove"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "Remove this block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Rename the block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Round Corners"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Save"
+msgstr "Guardar"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Save & Copy"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Save and Install"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Search for a block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search for records..."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search more..."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search to show more records"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/customize_tab.xml:0
+msgid "Select a block on your page to style it."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/customize_translation_tab.xml:0
+msgid "Select content on your page to translate it."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Shadow"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Solid"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Spread"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Take a look at the search bar, there might be a small typo!"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "The chosen name already exists"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Theme"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "This block cannot be dropped anywhere on this page."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "This block is outdated."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Tip: Esc to preview"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_row.xml:0
+msgid "Toggle more options"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/media_website_plugin.js:0
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Video"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Yes"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "You can still access the block options but it might be ineffective."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "You might not be able to customize it anymore."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/save_snippet_plugin.js:0
+msgid ""
+"Your custom snippet was successfully saved as <strong>%s</strong>. Find it "
+"in your snippets collection."
+msgstr ""

--- a/addons/html_builder/i18n/et.po
+++ b/addons/html_builder/i18n/et.po
@@ -1,0 +1,576 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* html_builder
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 16.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-05-16 13:50+0000\n"
+"PO-Revision-Date: 2022-09-22 05:55+0000\n"
+"Last-Translator: Martin Trigaux, 2023\n"
+"Language-Team: Estonian (https://app.transifex.com/odoo/teams/41243/et/)\n"
+"Language: et\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "ACCESS OPTIONS ANYWAY"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_list.js:0
+msgid "Add"
+msgstr "Lisa"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Almost there! Snippets are incoming, grab a coffee and relax!"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_plugin.js:0
+msgid "Anchor copied to clipboard%(br)sLink: %(anchorLink)s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Anchor name"
+msgstr "Ankru nimi"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Are you sure you want to delete the block %s?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Block"
+msgstr "Blokeeri"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Blocks"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Blur"
+msgstr "Hägustama"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Button"
+msgstr "Nupp"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "Cancel"
+msgstr "Tühista"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Categories"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.js:0
+msgid "Choose a record..."
+msgstr "Vali kirje..."
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Choose an anchor name"
+msgstr "Valige muu ankru nimi"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Color"
+msgstr "Värv"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Column"
+msgstr "Veerg"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "Confirm"
+msgstr "Kinnita"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid "Continue"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Could not install module %(title)s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Create \""
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Create a custom snippet"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Custom %s"
+msgstr "Kohandatud %s"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Custom Button"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Custom Inner Content"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Customize"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/setup_editor_plugin.js:0
+msgid "DRAG BUILDING BLOCKS HERE"
+msgstr "LOHISTAGE PLOKID SIIA"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Dashed"
+msgstr "Tühikutega"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Discard"
+msgstr "Loobu"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Do you want to install %s App?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Do you want to save this snippet as a custom one?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Dotted"
+msgstr "Täpitatud"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Double"
+msgstr "Topelt"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.js:0
+msgid "Drag and drop the building block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/drag_and_drop_move_handle.js:0
+msgid "Drag and move"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "Duplicate this block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_plugin.js:0
+msgid "Edit"
+msgstr "Muuda"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/drop_zone_plugin.js:0
+msgid "For technical reasons, this block cannot be dropped here"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Icon"
+msgstr "Ikoon"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid ""
+"If you discard the current edits, all unsaved changes will be lost. You can "
+"cancel to return to edit mode."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid "If you proceed, your changes will be lost"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Image"
+msgstr "Pilt"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Inner Content"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Insert a block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/media_website_plugin.js:0
+msgid "Insert a video"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+#: code:addons/html_builder/static/src/sidebar/snippet.xml:0
+msgid "Insert snippet"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Inset"
+msgstr "Inset"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/snippet.xml:0
+msgid "Install"
+msgstr "Paigalda"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Install %s"
+msgstr "Installi %s"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/invisible_elements_panel.xml:0
+msgid "Invisible Elements"
+msgstr "Nähtamatud elemendid"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_list.js:0
+msgid "Item"
+msgstr "Üksus"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.js:0
+msgid "Link Anchor"
+msgstr "Lingi ankur"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Mobile Preview"
+msgstr "Mobiili eelvaade"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "More info about this app."
+msgstr "Rohkem infot rakenduse kohta."
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Name"
+msgstr "Nimi"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "No"
+msgstr "Ei"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "No block of this category can be dropped on this page."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "No snippets found"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_select.js:0
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "None"
+msgstr "Pole"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Offset (X, Y)"
+msgstr "Nihe (X, Y)"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Oops! No snippets found."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Outset"
+msgstr "Algus"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Page Options"
+msgstr "Lehe valikud"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "REPLACE BY NEW VERSION"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Remove"
+msgstr "Eemalda"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "Remove this block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Rename the block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Round Corners"
+msgstr "Ümarad nurgad"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Save"
+msgstr "Salvesta"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Save & Copy"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Save and Install"
+msgstr "Salvesta ja installi"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Search for a block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search for records..."
+msgstr "Otsin kirjeid.."
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search more..."
+msgstr "Otsi veel..."
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search to show more records"
+msgstr "Otsi rohkemate kirjete kuvamiseks"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/customize_tab.xml:0
+msgid "Select a block on your page to style it."
+msgstr "Vali plokk, et luua plokile stiil"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/customize_translation_tab.xml:0
+msgid "Select content on your page to translate it."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Shadow"
+msgstr "Vari"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Solid"
+msgstr "Solid"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Spread"
+msgstr "Kattuvus"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Take a look at the search bar, there might be a small typo!"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "The chosen name already exists"
+msgstr "Valitud nimi eksisteerib juba"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Theme"
+msgstr "Teema"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "This block cannot be dropped anywhere on this page."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "This block is outdated."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Tip: Esc to preview"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_row.xml:0
+msgid "Toggle more options"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/media_website_plugin.js:0
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Video"
+msgstr "Video"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Yes"
+msgstr "Jah"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "You can still access the block options but it might be ineffective."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "You might not be able to customize it anymore."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/save_snippet_plugin.js:0
+msgid ""
+"Your custom snippet was successfully saved as <strong>%s</strong>. Find it "
+"in your snippets collection."
+msgstr ""

--- a/addons/html_builder/i18n/fa.po
+++ b/addons/html_builder/i18n/fa.po
@@ -1,0 +1,576 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* html_builder
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 16.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-05-16 13:50+0000\n"
+"PO-Revision-Date: 2022-09-22 05:55+0000\n"
+"Last-Translator: Martin Trigaux, 2023\n"
+"Language-Team: Persian (https://app.transifex.com/odoo/teams/41243/fa/)\n"
+"Language: fa\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "ACCESS OPTIONS ANYWAY"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_list.js:0
+msgid "Add"
+msgstr "افزودن"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Almost there! Snippets are incoming, grab a coffee and relax!"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_plugin.js:0
+msgid "Anchor copied to clipboard%(br)sLink: %(anchorLink)s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Anchor name"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Are you sure you want to delete the block %s?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Block"
+msgstr "مسدود کردن"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Blocks"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Blur"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Button"
+msgstr "دکمه"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "Cancel"
+msgstr "لغو"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Categories"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.js:0
+msgid "Choose a record..."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Choose an anchor name"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Color"
+msgstr "رنگ"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Column"
+msgstr "ستون"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "Confirm"
+msgstr "تایید کردن"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid "Continue"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Could not install module %(title)s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Create \""
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Create a custom snippet"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Custom %s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Custom Button"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Custom Inner Content"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Customize"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/setup_editor_plugin.js:0
+msgid "DRAG BUILDING BLOCKS HERE"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Dashed"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Discard"
+msgstr "رها کردن"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Do you want to install %s App?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Do you want to save this snippet as a custom one?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Dotted"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Double"
+msgstr "دوبل"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.js:0
+msgid "Drag and drop the building block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/drag_and_drop_move_handle.js:0
+msgid "Drag and move"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "Duplicate this block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_plugin.js:0
+msgid "Edit"
+msgstr "ویرایش"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/drop_zone_plugin.js:0
+msgid "For technical reasons, this block cannot be dropped here"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Icon"
+msgstr "شمایل"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid ""
+"If you discard the current edits, all unsaved changes will be lost. You can "
+"cancel to return to edit mode."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid "If you proceed, your changes will be lost"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Image"
+msgstr "تصویر"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Inner Content"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Insert a block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/media_website_plugin.js:0
+msgid "Insert a video"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+#: code:addons/html_builder/static/src/sidebar/snippet.xml:0
+msgid "Insert snippet"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Inset"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/snippet.xml:0
+msgid "Install"
+msgstr "نصب"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Install %s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/invisible_elements_panel.xml:0
+msgid "Invisible Elements"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_list.js:0
+msgid "Item"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.js:0
+msgid "Link Anchor"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Mobile Preview"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "More info about this app."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Name"
+msgstr "نام"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "No"
+msgstr "خیر"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "No block of this category can be dropped on this page."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "No snippets found"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_select.js:0
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "None"
+msgstr "هیچکدام"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Offset (X, Y)"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Oops! No snippets found."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Outset"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Page Options"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "REPLACE BY NEW VERSION"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Remove"
+msgstr "حذف"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "Remove this block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Rename the block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Round Corners"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Save"
+msgstr "ذخیره"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Save & Copy"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Save and Install"
+msgstr "ذخیره و نصب"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Search for a block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search for records..."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search more..."
+msgstr "جستجوی بیشتر..."
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search to show more records"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/customize_tab.xml:0
+msgid "Select a block on your page to style it."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/customize_translation_tab.xml:0
+msgid "Select content on your page to translate it."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Shadow"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Solid"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Spread"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Take a look at the search bar, there might be a small typo!"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "The chosen name already exists"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Theme"
+msgstr "تم"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "This block cannot be dropped anywhere on this page."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "This block is outdated."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Tip: Esc to preview"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_row.xml:0
+msgid "Toggle more options"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/media_website_plugin.js:0
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Video"
+msgstr "ویدئو"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Yes"
+msgstr "بله"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "You can still access the block options but it might be ineffective."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "You might not be able to customize it anymore."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/save_snippet_plugin.js:0
+msgid ""
+"Your custom snippet was successfully saved as <strong>%s</strong>. Find it "
+"in your snippets collection."
+msgstr ""

--- a/addons/html_builder/i18n/fi.po
+++ b/addons/html_builder/i18n/fi.po
@@ -1,0 +1,576 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* html_builder
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 16.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-05-16 13:50+0000\n"
+"PO-Revision-Date: 2022-09-22 05:55+0000\n"
+"Last-Translator: Ossi Mantylahti <ossi.mantylahti@obs-solutions.fi>, 2023\n"
+"Language-Team: Finnish (https://app.transifex.com/odoo/teams/41243/fi/)\n"
+"Language: fi\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "ACCESS OPTIONS ANYWAY"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_list.js:0
+msgid "Add"
+msgstr "Lisää"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Almost there! Snippets are incoming, grab a coffee and relax!"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_plugin.js:0
+msgid "Anchor copied to clipboard%(br)sLink: %(anchorLink)s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Anchor name"
+msgstr "Ankkurin nimi"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Are you sure you want to delete the block %s?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Block"
+msgstr "Ryhmä"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Blocks"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Blur"
+msgstr "Sumennus"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Button"
+msgstr "Nappi"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "Cancel"
+msgstr "Peruuta"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Categories"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.js:0
+msgid "Choose a record..."
+msgstr "Valitse tietue..."
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Choose an anchor name"
+msgstr "Valitse ankkurin nimi"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Color"
+msgstr "Väri"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Column"
+msgstr "Sarake"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "Confirm"
+msgstr "Vahvista"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid "Continue"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Could not install module %(title)s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Create \""
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Create a custom snippet"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Custom %s"
+msgstr "Mukautettu %s"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Custom Button"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Custom Inner Content"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Customize"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/setup_editor_plugin.js:0
+msgid "DRAG BUILDING BLOCKS HERE"
+msgstr "RAAHAA RAKENNE-ELEMENTTEJÄ TÄHÄN"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Dashed"
+msgstr "Katkoviiva"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Discard"
+msgstr "Hylkää"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Do you want to install %s App?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Do you want to save this snippet as a custom one?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Dotted"
+msgstr "Pisteviiva"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Double"
+msgstr "Tuplaviiva"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.js:0
+msgid "Drag and drop the building block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/drag_and_drop_move_handle.js:0
+msgid "Drag and move"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "Duplicate this block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_plugin.js:0
+msgid "Edit"
+msgstr "Muokkaa"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/drop_zone_plugin.js:0
+msgid "For technical reasons, this block cannot be dropped here"
+msgstr "Tätä lohkoa ei voida teknisistä syistä tiputtaa tähän"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Icon"
+msgstr "Kuvake"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid ""
+"If you discard the current edits, all unsaved changes will be lost. You can "
+"cancel to return to edit mode."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid "If you proceed, your changes will be lost"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Image"
+msgstr "Kuva"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Inner Content"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Insert a block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/media_website_plugin.js:0
+msgid "Insert a video"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+#: code:addons/html_builder/static/src/sidebar/snippet.xml:0
+msgid "Insert snippet"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Inset"
+msgstr "Sisennä"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/snippet.xml:0
+msgid "Install"
+msgstr "Asenna"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Install %s"
+msgstr "Asenna %s"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/invisible_elements_panel.xml:0
+msgid "Invisible Elements"
+msgstr "Näkymättömät elementit"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_list.js:0
+msgid "Item"
+msgstr "Kohde"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.js:0
+msgid "Link Anchor"
+msgstr "Linkkiankkuri"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Mobile Preview"
+msgstr "Esikatselu mobiililaitteille"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "More info about this app."
+msgstr "Lisätietoja tästä sovelluksesta."
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Name"
+msgstr "Nimi"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "No"
+msgstr "Ei"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "No block of this category can be dropped on this page."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "No snippets found"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_select.js:0
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "None"
+msgstr "Ei mitään"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Offset (X, Y)"
+msgstr "Offset (X, Y)"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Oops! No snippets found."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Outset"
+msgstr "Loitonna"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Page Options"
+msgstr "Sivuasetukset"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "REPLACE BY NEW VERSION"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Remove"
+msgstr "Poista"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "Remove this block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Rename the block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Round Corners"
+msgstr "Pyöristetyt kulmat"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Save"
+msgstr "Tallenna"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Save & Copy"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Save and Install"
+msgstr "Tallenna ja asenna"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Search for a block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search for records..."
+msgstr "Etsi tietueita..."
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search more..."
+msgstr "Etsi lisää..."
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search to show more records"
+msgstr "Etsi näyttääksesi lisää tietueita"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/customize_tab.xml:0
+msgid "Select a block on your page to style it."
+msgstr "Valitse lohko sivultasi muotoillaksesi sen."
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/customize_translation_tab.xml:0
+msgid "Select content on your page to translate it."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Shadow"
+msgstr "Varjo"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Solid"
+msgstr "Kiinteä"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Spread"
+msgstr "Levitys"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Take a look at the search bar, there might be a small typo!"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "The chosen name already exists"
+msgstr "Valittu nimi on jo olemassa"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Theme"
+msgstr "Teema"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "This block cannot be dropped anywhere on this page."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "This block is outdated."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Tip: Esc to preview"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_row.xml:0
+msgid "Toggle more options"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/media_website_plugin.js:0
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Video"
+msgstr "Video"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Yes"
+msgstr "Kyllä"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "You can still access the block options but it might be ineffective."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "You might not be able to customize it anymore."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/save_snippet_plugin.js:0
+msgid ""
+"Your custom snippet was successfully saved as <strong>%s</strong>. Find it "
+"in your snippets collection."
+msgstr ""

--- a/addons/html_builder/i18n/fr.po
+++ b/addons/html_builder/i18n/fr.po
@@ -1,0 +1,576 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* html_builder
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 16.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-05-16 13:50+0000\n"
+"PO-Revision-Date: 2022-09-22 05:55+0000\n"
+"Last-Translator: Jolien De Paepe, 2023\n"
+"Language-Team: French (https://app.transifex.com/odoo/teams/41243/fr/)\n"
+"Language: fr\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: nplurals=3; plural=(n == 0 || n == 1) ? 0 : n != 0 && n % 1000000 == 0 ? 1 : 2;\n"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "ACCESS OPTIONS ANYWAY"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_list.js:0
+msgid "Add"
+msgstr "Ajouter"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Almost there! Snippets are incoming, grab a coffee and relax!"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_plugin.js:0
+msgid "Anchor copied to clipboard%(br)sLink: %(anchorLink)s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Anchor name"
+msgstr "Nom d'ancrage"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Are you sure you want to delete the block %s?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Block"
+msgstr "Bloquer"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Blocks"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Blur"
+msgstr "Blur"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Button"
+msgstr "Bouton"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "Cancel"
+msgstr "Annuler"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Categories"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.js:0
+msgid "Choose a record..."
+msgstr "Choisir un enregistrement..."
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Choose an anchor name"
+msgstr "Choisissez un nom d'ancrage"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Color"
+msgstr "Couleur"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Column"
+msgstr "Colonne"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "Confirm"
+msgstr "Confirmer"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid "Continue"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Could not install module %(title)s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Create \""
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Create a custom snippet"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Custom %s"
+msgstr "Personnalisé %s"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Custom Button"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Custom Inner Content"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Customize"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/setup_editor_plugin.js:0
+msgid "DRAG BUILDING BLOCKS HERE"
+msgstr "GLISSEZ UN BLOC ICI"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Dashed"
+msgstr "Pointillé"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Discard"
+msgstr "Ignorer"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Do you want to install %s App?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Do you want to save this snippet as a custom one?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Dotted"
+msgstr "Pointillé"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Double"
+msgstr "Double"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.js:0
+msgid "Drag and drop the building block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/drag_and_drop_move_handle.js:0
+msgid "Drag and move"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "Duplicate this block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_plugin.js:0
+msgid "Edit"
+msgstr "Éditer"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/drop_zone_plugin.js:0
+msgid "For technical reasons, this block cannot be dropped here"
+msgstr "Pour des raisons techniques, ce bloc ne peut pas être déposé ici"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Icon"
+msgstr "Icône"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid ""
+"If you discard the current edits, all unsaved changes will be lost. You can "
+"cancel to return to edit mode."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid "If you proceed, your changes will be lost"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Image"
+msgstr "Image"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Inner Content"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Insert a block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/media_website_plugin.js:0
+msgid "Insert a video"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+#: code:addons/html_builder/static/src/sidebar/snippet.xml:0
+msgid "Insert snippet"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Inset"
+msgstr "Encart"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/snippet.xml:0
+msgid "Install"
+msgstr "Installer"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Install %s"
+msgstr "Installer %s"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/invisible_elements_panel.xml:0
+msgid "Invisible Elements"
+msgstr "Éléments invisibles"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_list.js:0
+msgid "Item"
+msgstr "Article"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.js:0
+msgid "Link Anchor"
+msgstr "Lien d'ancrage"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Mobile Preview"
+msgstr "Aperçu adaptatif"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "More info about this app."
+msgstr "Plus d'informations à propos de cette application."
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Name"
+msgstr "Nom"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "No"
+msgstr "Non"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "No block of this category can be dropped on this page."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "No snippets found"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_select.js:0
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "None"
+msgstr "Aucun"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Offset (X, Y)"
+msgstr "Offset (X, Y)"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Oops! No snippets found."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Outset"
+msgstr "Début"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Page Options"
+msgstr "Options de la page"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "REPLACE BY NEW VERSION"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Remove"
+msgstr "Supprimer"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "Remove this block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Rename the block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Round Corners"
+msgstr "Coins arrondis"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Save"
+msgstr "Sauvegarder"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Save & Copy"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Save and Install"
+msgstr "Sauvegarder et installer"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Search for a block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search for records..."
+msgstr "Rechercher des enregistrements..."
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search more..."
+msgstr "Recherche avancée..."
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search to show more records"
+msgstr "Rechercher pour afficher plus d'enregistrements"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/customize_tab.xml:0
+msgid "Select a block on your page to style it."
+msgstr "Sélectionnez un bloc sur votre page pour le styliser."
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/customize_translation_tab.xml:0
+msgid "Select content on your page to translate it."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Shadow"
+msgstr "Ombre"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Solid"
+msgstr "Solide"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Spread"
+msgstr "Diffusion"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Take a look at the search bar, there might be a small typo!"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "The chosen name already exists"
+msgstr "Le nom pour ce type existe déjà"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Theme"
+msgstr "Thème"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "This block cannot be dropped anywhere on this page."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "This block is outdated."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Tip: Esc to preview"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_row.xml:0
+msgid "Toggle more options"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/media_website_plugin.js:0
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Video"
+msgstr "Vidéo"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Yes"
+msgstr "Oui"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "You can still access the block options but it might be ineffective."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "You might not be able to customize it anymore."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/save_snippet_plugin.js:0
+msgid ""
+"Your custom snippet was successfully saved as <strong>%s</strong>. Find it "
+"in your snippets collection."
+msgstr ""

--- a/addons/html_builder/i18n/fr_CA.po
+++ b/addons/html_builder/i18n/fr_CA.po
@@ -1,0 +1,576 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* html_builder
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo 9.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-05-16 13:50+0000\n"
+"PO-Revision-Date: 2015-10-09 05:53+0000\n"
+"Last-Translator: Martin Trigaux\n"
+"Language-Team: French (Canada) (http://www.transifex.com/odoo/odoo-9/language/fr_CA/)\n"
+"Language: fr_CA\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "ACCESS OPTIONS ANYWAY"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_list.js:0
+msgid "Add"
+msgstr "Ajouter"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Almost there! Snippets are incoming, grab a coffee and relax!"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_plugin.js:0
+msgid "Anchor copied to clipboard%(br)sLink: %(anchorLink)s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Anchor name"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Are you sure you want to delete the block %s?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Blocks"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Blur"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Button"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "Cancel"
+msgstr "Annuler"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Categories"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.js:0
+msgid "Choose a record..."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Choose an anchor name"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Color"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Column"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "Confirm"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid "Continue"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Could not install module %(title)s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Create \""
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Create a custom snippet"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Custom %s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Custom Button"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Custom Inner Content"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Customize"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/setup_editor_plugin.js:0
+msgid "DRAG BUILDING BLOCKS HERE"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Dashed"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Discard"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Do you want to install %s App?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Do you want to save this snippet as a custom one?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Dotted"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Double"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.js:0
+msgid "Drag and drop the building block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/drag_and_drop_move_handle.js:0
+msgid "Drag and move"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "Duplicate this block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_plugin.js:0
+msgid "Edit"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/drop_zone_plugin.js:0
+msgid "For technical reasons, this block cannot be dropped here"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Icon"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid ""
+"If you discard the current edits, all unsaved changes will be lost. You can "
+"cancel to return to edit mode."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid "If you proceed, your changes will be lost"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Image"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Inner Content"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Insert a block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/media_website_plugin.js:0
+msgid "Insert a video"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+#: code:addons/html_builder/static/src/sidebar/snippet.xml:0
+msgid "Insert snippet"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Inset"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/snippet.xml:0
+msgid "Install"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Install %s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/invisible_elements_panel.xml:0
+msgid "Invisible Elements"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_list.js:0
+msgid "Item"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.js:0
+msgid "Link Anchor"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Mobile Preview"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "More info about this app."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Name"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "No"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "No block of this category can be dropped on this page."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "No snippets found"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_select.js:0
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "None"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Offset (X, Y)"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Oops! No snippets found."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Outset"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Page Options"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "REPLACE BY NEW VERSION"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Remove"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "Remove this block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Rename the block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Round Corners"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Save"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Save & Copy"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Save and Install"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Search for a block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search for records..."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search more..."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search to show more records"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/customize_tab.xml:0
+msgid "Select a block on your page to style it."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/customize_translation_tab.xml:0
+msgid "Select content on your page to translate it."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Shadow"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Solid"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Spread"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Take a look at the search bar, there might be a small typo!"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "The chosen name already exists"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Theme"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "This block cannot be dropped anywhere on this page."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "This block is outdated."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Tip: Esc to preview"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_row.xml:0
+msgid "Toggle more options"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/media_website_plugin.js:0
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Video"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Yes"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "You can still access the block options but it might be ineffective."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "You might not be able to customize it anymore."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/save_snippet_plugin.js:0
+msgid ""
+"Your custom snippet was successfully saved as <strong>%s</strong>. Find it "
+"in your snippets collection."
+msgstr ""

--- a/addons/html_builder/i18n/gl.po
+++ b/addons/html_builder/i18n/gl.po
@@ -1,0 +1,576 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* html_builder
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo 9.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-05-16 13:50+0000\n"
+"PO-Revision-Date: 2015-09-30 09:29+0000\n"
+"Last-Translator: Martin Trigaux\n"
+"Language-Team: Galician (http://www.transifex.com/odoo/odoo-9/language/gl/)\n"
+"Language: gl\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "ACCESS OPTIONS ANYWAY"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_list.js:0
+msgid "Add"
+msgstr "Engadir"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Almost there! Snippets are incoming, grab a coffee and relax!"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_plugin.js:0
+msgid "Anchor copied to clipboard%(br)sLink: %(anchorLink)s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Anchor name"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Are you sure you want to delete the block %s?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Blocks"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Blur"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Button"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "Cancel"
+msgstr "Cancelar"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Categories"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.js:0
+msgid "Choose a record..."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Choose an anchor name"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Color"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Column"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "Confirm"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid "Continue"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Could not install module %(title)s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Create \""
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Create a custom snippet"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Custom %s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Custom Button"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Custom Inner Content"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Customize"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/setup_editor_plugin.js:0
+msgid "DRAG BUILDING BLOCKS HERE"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Dashed"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Discard"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Do you want to install %s App?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Do you want to save this snippet as a custom one?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Dotted"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Double"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.js:0
+msgid "Drag and drop the building block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/drag_and_drop_move_handle.js:0
+msgid "Drag and move"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "Duplicate this block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_plugin.js:0
+msgid "Edit"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/drop_zone_plugin.js:0
+msgid "For technical reasons, this block cannot be dropped here"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Icon"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid ""
+"If you discard the current edits, all unsaved changes will be lost. You can "
+"cancel to return to edit mode."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid "If you proceed, your changes will be lost"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Image"
+msgstr "Imaxe"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Inner Content"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Insert a block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/media_website_plugin.js:0
+msgid "Insert a video"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+#: code:addons/html_builder/static/src/sidebar/snippet.xml:0
+msgid "Insert snippet"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Inset"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/snippet.xml:0
+msgid "Install"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Install %s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/invisible_elements_panel.xml:0
+msgid "Invisible Elements"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_list.js:0
+msgid "Item"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.js:0
+msgid "Link Anchor"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Mobile Preview"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "More info about this app."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Name"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "No"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "No block of this category can be dropped on this page."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "No snippets found"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_select.js:0
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "None"
+msgstr "Ningún"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Offset (X, Y)"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Oops! No snippets found."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Outset"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Page Options"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "REPLACE BY NEW VERSION"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Remove"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "Remove this block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Rename the block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Round Corners"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Save"
+msgstr "Gardar"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Save & Copy"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Save and Install"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Search for a block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search for records..."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search more..."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search to show more records"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/customize_tab.xml:0
+msgid "Select a block on your page to style it."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/customize_translation_tab.xml:0
+msgid "Select content on your page to translate it."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Shadow"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Solid"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Spread"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Take a look at the search bar, there might be a small typo!"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "The chosen name already exists"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Theme"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "This block cannot be dropped anywhere on this page."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "This block is outdated."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Tip: Esc to preview"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_row.xml:0
+msgid "Toggle more options"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/media_website_plugin.js:0
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Video"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Yes"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "You can still access the block options but it might be ineffective."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "You might not be able to customize it anymore."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/save_snippet_plugin.js:0
+msgid ""
+"Your custom snippet was successfully saved as <strong>%s</strong>. Find it "
+"in your snippets collection."
+msgstr ""

--- a/addons/html_builder/i18n/gu.po
+++ b/addons/html_builder/i18n/gu.po
@@ -1,0 +1,576 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* html_builder
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server saas~11.5\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-05-16 13:50+0000\n"
+"PO-Revision-Date: 2018-10-02 10:06+0000\n"
+"Last-Translator: Dharmraj Jhala <dja@openerp.com>, 2018\n"
+"Language-Team: Gujarati (https://www.transifex.com/odoo/teams/41243/gu/)\n"
+"Language: gu\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "ACCESS OPTIONS ANYWAY"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_list.js:0
+msgid "Add"
+msgstr "ઉમેરો"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Almost there! Snippets are incoming, grab a coffee and relax!"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_plugin.js:0
+msgid "Anchor copied to clipboard%(br)sLink: %(anchorLink)s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Anchor name"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Are you sure you want to delete the block %s?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Blocks"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Blur"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Button"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "Cancel"
+msgstr "Cancel"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Categories"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.js:0
+msgid "Choose a record..."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Choose an anchor name"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Color"
+msgstr "રંગ"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Column"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "Confirm"
+msgstr "Confirm"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid "Continue"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Could not install module %(title)s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Create \""
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Create a custom snippet"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Custom %s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Custom Button"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Custom Inner Content"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Customize"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/setup_editor_plugin.js:0
+msgid "DRAG BUILDING BLOCKS HERE"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Dashed"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Discard"
+msgstr "Discard"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Do you want to install %s App?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Do you want to save this snippet as a custom one?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Dotted"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Double"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.js:0
+msgid "Drag and drop the building block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/drag_and_drop_move_handle.js:0
+msgid "Drag and move"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "Duplicate this block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_plugin.js:0
+msgid "Edit"
+msgstr "ફેરફાર કરો"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/drop_zone_plugin.js:0
+msgid "For technical reasons, this block cannot be dropped here"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Icon"
+msgstr "Icon"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid ""
+"If you discard the current edits, all unsaved changes will be lost. You can "
+"cancel to return to edit mode."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid "If you proceed, your changes will be lost"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Image"
+msgstr "ચિત્ર"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Inner Content"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Insert a block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/media_website_plugin.js:0
+msgid "Insert a video"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+#: code:addons/html_builder/static/src/sidebar/snippet.xml:0
+msgid "Insert snippet"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Inset"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/snippet.xml:0
+msgid "Install"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Install %s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/invisible_elements_panel.xml:0
+msgid "Invisible Elements"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_list.js:0
+msgid "Item"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.js:0
+msgid "Link Anchor"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Mobile Preview"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "More info about this app."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Name"
+msgstr "નામ"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "No"
+msgstr "No"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "No block of this category can be dropped on this page."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "No snippets found"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_select.js:0
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "None"
+msgstr "કશું નંહિ"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Offset (X, Y)"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Oops! No snippets found."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Outset"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Page Options"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "REPLACE BY NEW VERSION"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Remove"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "Remove this block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Rename the block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Round Corners"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Save"
+msgstr "સંગ્રહો"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Save & Copy"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Save and Install"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Search for a block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search for records..."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search more..."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search to show more records"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/customize_tab.xml:0
+msgid "Select a block on your page to style it."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/customize_translation_tab.xml:0
+msgid "Select content on your page to translate it."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Shadow"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Solid"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Spread"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Take a look at the search bar, there might be a small typo!"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "The chosen name already exists"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Theme"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "This block cannot be dropped anywhere on this page."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "This block is outdated."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Tip: Esc to preview"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_row.xml:0
+msgid "Toggle more options"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/media_website_plugin.js:0
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Video"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Yes"
+msgstr "હા"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "You can still access the block options but it might be ineffective."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "You might not be able to customize it anymore."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/save_snippet_plugin.js:0
+msgid ""
+"Your custom snippet was successfully saved as <strong>%s</strong>. Find it "
+"in your snippets collection."
+msgstr ""

--- a/addons/html_builder/i18n/he.po
+++ b/addons/html_builder/i18n/he.po
@@ -1,0 +1,576 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* html_builder
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 16.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-05-16 13:50+0000\n"
+"PO-Revision-Date: 2022-09-22 05:55+0000\n"
+"Last-Translator: Martin Trigaux, 2023\n"
+"Language-Team: Hebrew (https://app.transifex.com/odoo/teams/41243/he/)\n"
+"Language: he\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: nplurals=4; plural=(n == 1 && n % 1 == 0) ? 0 : (n == 2 && n % 1 == 0) ? 1: (n % 10 == 0 && n % 1 == 0 && n > 10) ? 2 : 3;\n"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "ACCESS OPTIONS ANYWAY"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_list.js:0
+msgid "Add"
+msgstr "הוסף"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Almost there! Snippets are incoming, grab a coffee and relax!"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_plugin.js:0
+msgid "Anchor copied to clipboard%(br)sLink: %(anchorLink)s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Anchor name"
+msgstr "שם עוגן"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Are you sure you want to delete the block %s?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Block"
+msgstr "חסום"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Blocks"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Blur"
+msgstr "טשטוש"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Button"
+msgstr "כפתור"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "Cancel"
+msgstr "בטל"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Categories"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.js:0
+msgid "Choose a record..."
+msgstr "בחירת רשומה..."
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Choose an anchor name"
+msgstr "בחר שם עוגן"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Color"
+msgstr "צבע"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Column"
+msgstr "עמודה"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "Confirm"
+msgstr "אשר"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid "Continue"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Could not install module %(title)s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Create \""
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Create a custom snippet"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Custom %s"
+msgstr "%s מותאת"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Custom Button"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Custom Inner Content"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Customize"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/setup_editor_plugin.js:0
+msgid "DRAG BUILDING BLOCKS HERE"
+msgstr "גרור בלוקים לכאן"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Dashed"
+msgstr "מקווקו"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Discard"
+msgstr "בטל"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Do you want to install %s App?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Do you want to save this snippet as a custom one?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Dotted"
+msgstr "מנוקד"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Double"
+msgstr "כפול"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.js:0
+msgid "Drag and drop the building block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/drag_and_drop_move_handle.js:0
+msgid "Drag and move"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "Duplicate this block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_plugin.js:0
+msgid "Edit"
+msgstr "ערוך"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/drop_zone_plugin.js:0
+msgid "For technical reasons, this block cannot be dropped here"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Icon"
+msgstr "סמל"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid ""
+"If you discard the current edits, all unsaved changes will be lost. You can "
+"cancel to return to edit mode."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid "If you proceed, your changes will be lost"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Image"
+msgstr "תמונה"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Inner Content"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Insert a block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/media_website_plugin.js:0
+msgid "Insert a video"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+#: code:addons/html_builder/static/src/sidebar/snippet.xml:0
+msgid "Insert snippet"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Inset"
+msgstr "הבלעה"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/snippet.xml:0
+msgid "Install"
+msgstr "להתקין"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Install %s"
+msgstr "התקנת %s"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/invisible_elements_panel.xml:0
+msgid "Invisible Elements"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_list.js:0
+msgid "Item"
+msgstr "פריט"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.js:0
+msgid "Link Anchor"
+msgstr "קשר עוגן"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Mobile Preview"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "More info about this app."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Name"
+msgstr "שם"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "No"
+msgstr "לא"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "No block of this category can be dropped on this page."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "No snippets found"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_select.js:0
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "None"
+msgstr "אף אחד"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Offset (X, Y)"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Oops! No snippets found."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Outset"
+msgstr "ראשית"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Page Options"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "REPLACE BY NEW VERSION"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Remove"
+msgstr "הסר"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "Remove this block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Rename the block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Round Corners"
+msgstr "פינות עגולות"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Save"
+msgstr "שמור"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Save & Copy"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Save and Install"
+msgstr "שמירה והתקנה"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Search for a block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search for records..."
+msgstr "חפש רשומות..."
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search more..."
+msgstr "חפש עוד..."
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search to show more records"
+msgstr "חפש כדי להראות עוד רשומות"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/customize_tab.xml:0
+msgid "Select a block on your page to style it."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/customize_translation_tab.xml:0
+msgid "Select content on your page to translate it."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Shadow"
+msgstr "צללית"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Solid"
+msgstr "מוצק"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Spread"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Take a look at the search bar, there might be a small typo!"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "The chosen name already exists"
+msgstr "השם שנבחר כבר קיים"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Theme"
+msgstr "ערכת נושא"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "This block cannot be dropped anywhere on this page."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "This block is outdated."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Tip: Esc to preview"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_row.xml:0
+msgid "Toggle more options"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/media_website_plugin.js:0
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Video"
+msgstr "וידאו"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Yes"
+msgstr "כן"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "You can still access the block options but it might be ineffective."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "You might not be able to customize it anymore."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/save_snippet_plugin.js:0
+msgid ""
+"Your custom snippet was successfully saved as <strong>%s</strong>. Find it "
+"in your snippets collection."
+msgstr ""

--- a/addons/html_builder/i18n/hr.po
+++ b/addons/html_builder/i18n/hr.po
@@ -1,0 +1,576 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* html_builder
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 16.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-05-16 13:50+0000\n"
+"PO-Revision-Date: 2022-09-22 05:55+0000\n"
+"Last-Translator: Martin Trigaux, 2023\n"
+"Language-Team: Croatian (https://app.transifex.com/odoo/teams/41243/hr/)\n"
+"Language: hr\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "ACCESS OPTIONS ANYWAY"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_list.js:0
+msgid "Add"
+msgstr "Dodaj"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Almost there! Snippets are incoming, grab a coffee and relax!"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_plugin.js:0
+msgid "Anchor copied to clipboard%(br)sLink: %(anchorLink)s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Anchor name"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Are you sure you want to delete the block %s?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Block"
+msgstr "Blokiraj"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Blocks"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Blur"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Button"
+msgstr "Gumb"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "Cancel"
+msgstr "Odustani"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Categories"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.js:0
+msgid "Choose a record..."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Choose an anchor name"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Color"
+msgstr "Boja"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Column"
+msgstr "Kolona"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "Confirm"
+msgstr "Potvrdi"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid "Continue"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Could not install module %(title)s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Create \""
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Create a custom snippet"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Custom %s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Custom Button"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Custom Inner Content"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Customize"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/setup_editor_plugin.js:0
+msgid "DRAG BUILDING BLOCKS HERE"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Dashed"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Discard"
+msgstr "Odbaci"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Do you want to install %s App?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Do you want to save this snippet as a custom one?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Dotted"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Double"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.js:0
+msgid "Drag and drop the building block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/drag_and_drop_move_handle.js:0
+msgid "Drag and move"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "Duplicate this block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_plugin.js:0
+msgid "Edit"
+msgstr "Uredi"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/drop_zone_plugin.js:0
+msgid "For technical reasons, this block cannot be dropped here"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Icon"
+msgstr "Ikona"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid ""
+"If you discard the current edits, all unsaved changes will be lost. You can "
+"cancel to return to edit mode."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid "If you proceed, your changes will be lost"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Image"
+msgstr "Slika"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Inner Content"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Insert a block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/media_website_plugin.js:0
+msgid "Insert a video"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+#: code:addons/html_builder/static/src/sidebar/snippet.xml:0
+msgid "Insert snippet"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Inset"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/snippet.xml:0
+msgid "Install"
+msgstr "Instaliraj"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Install %s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/invisible_elements_panel.xml:0
+msgid "Invisible Elements"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_list.js:0
+msgid "Item"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.js:0
+msgid "Link Anchor"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Mobile Preview"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "More info about this app."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Name"
+msgstr "Naziv"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "No"
+msgstr "Ne"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "No block of this category can be dropped on this page."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "No snippets found"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_select.js:0
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "None"
+msgstr "Ništa"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Offset (X, Y)"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Oops! No snippets found."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Outset"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Page Options"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "REPLACE BY NEW VERSION"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Remove"
+msgstr "Ukloni"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "Remove this block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Rename the block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Round Corners"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Save"
+msgstr "Spremi"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Save & Copy"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Save and Install"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Search for a block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search for records..."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search more..."
+msgstr "Traži više..."
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search to show more records"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/customize_tab.xml:0
+msgid "Select a block on your page to style it."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/customize_translation_tab.xml:0
+msgid "Select content on your page to translate it."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Shadow"
+msgstr "Sjena"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Solid"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Spread"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Take a look at the search bar, there might be a small typo!"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "The chosen name already exists"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Theme"
+msgstr "Tema"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "This block cannot be dropped anywhere on this page."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "This block is outdated."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Tip: Esc to preview"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_row.xml:0
+msgid "Toggle more options"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/media_website_plugin.js:0
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Video"
+msgstr "Video"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Yes"
+msgstr "Da"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "You can still access the block options but it might be ineffective."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "You might not be able to customize it anymore."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/save_snippet_plugin.js:0
+msgid ""
+"Your custom snippet was successfully saved as <strong>%s</strong>. Find it "
+"in your snippets collection."
+msgstr ""

--- a/addons/html_builder/i18n/html_builder.pot
+++ b/addons/html_builder/i18n/html_builder.pot
@@ -1,0 +1,575 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* html_builder
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 18.4a1\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-06-16 08:02+0000\n"
+"PO-Revision-Date: 2025-06-16 08:02+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "ACCESS OPTIONS ANYWAY"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_list.js:0
+msgid "Add"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Almost there! Snippets are incoming, grab a coffee and relax!"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_plugin.js:0
+msgid "Anchor copied to clipboard%(br)sLink: %(anchorLink)s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Anchor name"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Are you sure you want to delete the block %s?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Blocks"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Blur"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Button"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "Cancel"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Categories"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.js:0
+msgid "Choose a record..."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Choose an anchor name"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Color"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Column"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "Confirm"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid "Continue"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Could not install module %(title)s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Create \""
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Create a custom snippet"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Custom %s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Custom Button"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Custom Inner Content"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Customize"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/setup_editor_plugin.js:0
+msgid "DRAG BUILDING BLOCKS HERE"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Dashed"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Discard"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Do you want to install %s App?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Do you want to save this snippet as a custom one?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Dotted"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Double"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.js:0
+msgid "Drag and drop the building block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/drag_and_drop_move_handle.js:0
+msgid "Drag and move"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "Duplicate this block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_plugin.js:0
+msgid "Edit"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/drop_zone_plugin.js:0
+msgid "For technical reasons, this block cannot be dropped here"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Icon"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid ""
+"If you discard the current edits, all unsaved changes will be lost. You can "
+"cancel to return to edit mode."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid "If you proceed, your changes will be lost"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Image"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Inner Content"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Insert a block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/media_website_plugin.js:0
+msgid "Insert a video"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+#: code:addons/html_builder/static/src/sidebar/snippet.xml:0
+msgid "Insert snippet"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Inset"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/snippet.xml:0
+msgid "Install"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Install %s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/invisible_elements_panel.xml:0
+msgid "Invisible Elements"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_list.js:0
+msgid "Item"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.js:0
+msgid "Link Anchor"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Mobile Preview"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "More info about this app."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Name"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "No"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "No block of this category can be dropped on this page."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "No snippets found"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_select.js:0
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "None"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Offset (X, Y)"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Oops! No snippets found."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Outset"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Page Options"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "REPLACE BY NEW VERSION"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Remove"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "Remove this block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Rename the block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Round Corners"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Save"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Save & Copy"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Save and Install"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Search for a block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search for records..."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search more..."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search to show more records"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/customize_tab.xml:0
+msgid "Select a block on your page to style it."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/customize_translation_tab.xml:0
+msgid "Select content on your page to translate it."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Shadow"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Solid"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Spread"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Take a look at the search bar, there might be a small typo!"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "The chosen name already exists"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Theme"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "This block cannot be dropped anywhere on this page."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "This block is outdated."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Tip: Esc to preview"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_row.xml:0
+msgid "Toggle more options"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/media_website_plugin.js:0
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Video"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Yes"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "You can still access the block options but it might be ineffective."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "You might not be able to customize it anymore."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/save_snippet_plugin.js:0
+msgid ""
+"Your custom snippet was successfully saved as <strong>%s</strong>. Find it "
+"in your snippets collection."
+msgstr ""

--- a/addons/html_builder/i18n/hu.po
+++ b/addons/html_builder/i18n/hu.po
@@ -1,0 +1,576 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* html_builder
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 16.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-05-16 13:50+0000\n"
+"PO-Revision-Date: 2022-09-22 05:55+0000\n"
+"Last-Translator: Martin Trigaux, 2023\n"
+"Language-Team: Hungarian (https://app.transifex.com/odoo/teams/41243/hu/)\n"
+"Language: hu\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "ACCESS OPTIONS ANYWAY"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_list.js:0
+msgid "Add"
+msgstr "Hozzáadás"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Almost there! Snippets are incoming, grab a coffee and relax!"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_plugin.js:0
+msgid "Anchor copied to clipboard%(br)sLink: %(anchorLink)s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Anchor name"
+msgstr "Horgony név"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Are you sure you want to delete the block %s?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Block"
+msgstr "Blokkolás"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Blocks"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Blur"
+msgstr "Életlenítés"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Button"
+msgstr "Gomb"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "Cancel"
+msgstr "Mégse"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Categories"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.js:0
+msgid "Choose a record..."
+msgstr "Rekord választása..."
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Choose an anchor name"
+msgstr "Válasszon egy horgony nevet"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Color"
+msgstr "Szín"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Column"
+msgstr "Oszlop"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "Confirm"
+msgstr "Megerősítés"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid "Continue"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Could not install module %(title)s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Create \""
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Create a custom snippet"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Custom %s"
+msgstr "Egyedi %s"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Custom Button"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Custom Inner Content"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Customize"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/setup_editor_plugin.js:0
+msgid "DRAG BUILDING BLOCKS HERE"
+msgstr "HÚZZA IDE AZ ÉPÍTŐKOCKÁKAT"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Dashed"
+msgstr "Szaggatott"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Discard"
+msgstr "Elvetés"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Do you want to install %s App?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Do you want to save this snippet as a custom one?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Dotted"
+msgstr "Pontozott"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Double"
+msgstr "Dupla"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.js:0
+msgid "Drag and drop the building block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/drag_and_drop_move_handle.js:0
+msgid "Drag and move"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "Duplicate this block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_plugin.js:0
+msgid "Edit"
+msgstr "Szerkesztés"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/drop_zone_plugin.js:0
+msgid "For technical reasons, this block cannot be dropped here"
+msgstr "Technikai okok miatt ezt a blokkot nem lehet itt elhelyezni"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Icon"
+msgstr "Ikon"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid ""
+"If you discard the current edits, all unsaved changes will be lost. You can "
+"cancel to return to edit mode."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid "If you proceed, your changes will be lost"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Image"
+msgstr "Kép"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Inner Content"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Insert a block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/media_website_plugin.js:0
+msgid "Insert a video"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+#: code:addons/html_builder/static/src/sidebar/snippet.xml:0
+msgid "Insert snippet"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Inset"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/snippet.xml:0
+msgid "Install"
+msgstr "Telepítés"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Install %s"
+msgstr "%s telepítése"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/invisible_elements_panel.xml:0
+msgid "Invisible Elements"
+msgstr "Láthatatlan elemek"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_list.js:0
+msgid "Item"
+msgstr "Elem"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.js:0
+msgid "Link Anchor"
+msgstr "Hivatkozás horgony"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Mobile Preview"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "More info about this app."
+msgstr "További információ erről az alkalmazásról."
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Name"
+msgstr "Név"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "No"
+msgstr "Nem"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "No block of this category can be dropped on this page."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "No snippets found"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_select.js:0
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "None"
+msgstr "Nincs"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Offset (X, Y)"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Oops! No snippets found."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Outset"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Page Options"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "REPLACE BY NEW VERSION"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Remove"
+msgstr "Eltávolítás"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "Remove this block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Rename the block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Round Corners"
+msgstr "Lekerekítés"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Save"
+msgstr "Mentés"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Save & Copy"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Save and Install"
+msgstr "Mentés és telepítés"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Search for a block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search for records..."
+msgstr "Rekordok keresése..."
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search more..."
+msgstr "További keresés..."
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search to show more records"
+msgstr "További rekordokért keresés"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/customize_tab.xml:0
+msgid "Select a block on your page to style it."
+msgstr "Válasszon ki egy blokkot az oldalon a stílus beállításához."
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/customize_translation_tab.xml:0
+msgid "Select content on your page to translate it."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Shadow"
+msgstr "Árnyék"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Solid"
+msgstr "Szolíd"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Spread"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Take a look at the search bar, there might be a small typo!"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "The chosen name already exists"
+msgstr "A választott név már létezik."
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Theme"
+msgstr "Téma"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "This block cannot be dropped anywhere on this page."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "This block is outdated."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Tip: Esc to preview"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_row.xml:0
+msgid "Toggle more options"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/media_website_plugin.js:0
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Video"
+msgstr "Videó"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Yes"
+msgstr "Igen"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "You can still access the block options but it might be ineffective."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "You might not be able to customize it anymore."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/save_snippet_plugin.js:0
+msgid ""
+"Your custom snippet was successfully saved as <strong>%s</strong>. Find it "
+"in your snippets collection."
+msgstr ""

--- a/addons/html_builder/i18n/id.po
+++ b/addons/html_builder/i18n/id.po
@@ -1,0 +1,576 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* html_builder
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 16.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-05-16 13:50+0000\n"
+"PO-Revision-Date: 2022-09-22 05:55+0000\n"
+"Last-Translator: Martin Trigaux, 2023\n"
+"Language-Team: Indonesian (https://app.transifex.com/odoo/teams/41243/id/)\n"
+"Language: id\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "ACCESS OPTIONS ANYWAY"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_list.js:0
+msgid "Add"
+msgstr "Tambah"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Almost there! Snippets are incoming, grab a coffee and relax!"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_plugin.js:0
+msgid "Anchor copied to clipboard%(br)sLink: %(anchorLink)s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Anchor name"
+msgstr "Nama Anchor"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Are you sure you want to delete the block %s?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Block"
+msgstr "Blokir"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Blocks"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Blur"
+msgstr "Blur"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Button"
+msgstr "Tombol"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "Cancel"
+msgstr "Batal"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Categories"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.js:0
+msgid "Choose a record..."
+msgstr "Pilih record..."
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Choose an anchor name"
+msgstr "Pilih nama anchor"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Color"
+msgstr "Warna"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Column"
+msgstr "Kolom"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "Confirm"
+msgstr "Konfirmasi"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid "Continue"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Could not install module %(title)s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Create \""
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Create a custom snippet"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Custom %s"
+msgstr "Kustom %s"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Custom Button"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Custom Inner Content"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Customize"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/setup_editor_plugin.js:0
+msgid "DRAG BUILDING BLOCKS HERE"
+msgstr "SERET BLOK PENYUSUN KESINI"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Dashed"
+msgstr "Putus-Putus"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Discard"
+msgstr "Buang"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Do you want to install %s App?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Do you want to save this snippet as a custom one?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Dotted"
+msgstr "Bertitik-titik"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Double"
+msgstr "Double"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.js:0
+msgid "Drag and drop the building block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/drag_and_drop_move_handle.js:0
+msgid "Drag and move"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "Duplicate this block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_plugin.js:0
+msgid "Edit"
+msgstr "Edit"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/drop_zone_plugin.js:0
+msgid "For technical reasons, this block cannot be dropped here"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Icon"
+msgstr "Ikon"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid ""
+"If you discard the current edits, all unsaved changes will be lost. You can "
+"cancel to return to edit mode."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid "If you proceed, your changes will be lost"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Image"
+msgstr "Gambar"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Inner Content"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Insert a block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/media_website_plugin.js:0
+msgid "Insert a video"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+#: code:addons/html_builder/static/src/sidebar/snippet.xml:0
+msgid "Insert snippet"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Inset"
+msgstr "Inset"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/snippet.xml:0
+msgid "Install"
+msgstr "Pasang"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Install %s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/invisible_elements_panel.xml:0
+msgid "Invisible Elements"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_list.js:0
+msgid "Item"
+msgstr "Item"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.js:0
+msgid "Link Anchor"
+msgstr "Link Anchor"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Mobile Preview"
+msgstr "Pratinjau Mobile"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "More info about this app."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Name"
+msgstr "Nama"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "No"
+msgstr "Tidak"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "No block of this category can be dropped on this page."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "No snippets found"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_select.js:0
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "None"
+msgstr "Tidak Ada"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Offset (X, Y)"
+msgstr "Offset (X, Y)"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Oops! No snippets found."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Outset"
+msgstr "Outset"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Page Options"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "REPLACE BY NEW VERSION"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Remove"
+msgstr "Hapus"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "Remove this block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Rename the block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Round Corners"
+msgstr "Round Corners"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Save"
+msgstr "Simpan"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Save & Copy"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Save and Install"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Search for a block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search for records..."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search more..."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search to show more records"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/customize_tab.xml:0
+msgid "Select a block on your page to style it."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/customize_translation_tab.xml:0
+msgid "Select content on your page to translate it."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Shadow"
+msgstr "Bayangan"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Solid"
+msgstr "SOlid"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Spread"
+msgstr "Spread"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Take a look at the search bar, there might be a small typo!"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "The chosen name already exists"
+msgstr "Nama yang dipilih sudah ada"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Theme"
+msgstr "Tema"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "This block cannot be dropped anywhere on this page."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "This block is outdated."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Tip: Esc to preview"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_row.xml:0
+msgid "Toggle more options"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/media_website_plugin.js:0
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Video"
+msgstr "Video"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Yes"
+msgstr "Ya"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "You can still access the block options but it might be ineffective."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "You might not be able to customize it anymore."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/save_snippet_plugin.js:0
+msgid ""
+"Your custom snippet was successfully saved as <strong>%s</strong>. Find it "
+"in your snippets collection."
+msgstr ""

--- a/addons/html_builder/i18n/is.po
+++ b/addons/html_builder/i18n/is.po
@@ -1,0 +1,576 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* html_builder
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 16.0beta\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-05-16 13:50+0000\n"
+"PO-Revision-Date: 2022-09-22 05:55+0000\n"
+"Last-Translator: Martin Trigaux, 2022\n"
+"Language-Team: Icelandic (https://www.transifex.com/odoo/teams/41243/is/)\n"
+"Language: is\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: nplurals=2; plural=(n % 10 != 1 || n % 100 == 11);\n"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "ACCESS OPTIONS ANYWAY"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_list.js:0
+msgid "Add"
+msgstr "Bæta við"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Almost there! Snippets are incoming, grab a coffee and relax!"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_plugin.js:0
+msgid "Anchor copied to clipboard%(br)sLink: %(anchorLink)s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Anchor name"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Are you sure you want to delete the block %s?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Block"
+msgstr "Block"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Blocks"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Blur"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Button"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "Cancel"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Categories"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.js:0
+msgid "Choose a record..."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Choose an anchor name"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Color"
+msgstr "Color"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Column"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "Confirm"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid "Continue"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Could not install module %(title)s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Create \""
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Create a custom snippet"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Custom %s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Custom Button"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Custom Inner Content"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Customize"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/setup_editor_plugin.js:0
+msgid "DRAG BUILDING BLOCKS HERE"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Dashed"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Discard"
+msgstr "Hætta við"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Do you want to install %s App?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Do you want to save this snippet as a custom one?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Dotted"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Double"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.js:0
+msgid "Drag and drop the building block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/drag_and_drop_move_handle.js:0
+msgid "Drag and move"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "Duplicate this block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_plugin.js:0
+msgid "Edit"
+msgstr "Skrifa"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/drop_zone_plugin.js:0
+msgid "For technical reasons, this block cannot be dropped here"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Icon"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid ""
+"If you discard the current edits, all unsaved changes will be lost. You can "
+"cancel to return to edit mode."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid "If you proceed, your changes will be lost"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Image"
+msgstr "Mynd"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Inner Content"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Insert a block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/media_website_plugin.js:0
+msgid "Insert a video"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+#: code:addons/html_builder/static/src/sidebar/snippet.xml:0
+msgid "Insert snippet"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Inset"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/snippet.xml:0
+msgid "Install"
+msgstr "Install"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Install %s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/invisible_elements_panel.xml:0
+msgid "Invisible Elements"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_list.js:0
+msgid "Item"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.js:0
+msgid "Link Anchor"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Mobile Preview"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "More info about this app."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Name"
+msgstr "Nafn"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "No"
+msgstr "No"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "No block of this category can be dropped on this page."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "No snippets found"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_select.js:0
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "None"
+msgstr "Ekkert"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Offset (X, Y)"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Oops! No snippets found."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Outset"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Page Options"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "REPLACE BY NEW VERSION"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Remove"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "Remove this block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Rename the block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Round Corners"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Save"
+msgstr "Vista"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Save & Copy"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Save and Install"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Search for a block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search for records..."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search more..."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search to show more records"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/customize_tab.xml:0
+msgid "Select a block on your page to style it."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/customize_translation_tab.xml:0
+msgid "Select content on your page to translate it."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Shadow"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Solid"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Spread"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Take a look at the search bar, there might be a small typo!"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "The chosen name already exists"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Theme"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "This block cannot be dropped anywhere on this page."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "This block is outdated."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Tip: Esc to preview"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_row.xml:0
+msgid "Toggle more options"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/media_website_plugin.js:0
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Video"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Yes"
+msgstr "Yes"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "You can still access the block options but it might be ineffective."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "You might not be able to customize it anymore."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/save_snippet_plugin.js:0
+msgid ""
+"Your custom snippet was successfully saved as <strong>%s</strong>. Find it "
+"in your snippets collection."
+msgstr ""

--- a/addons/html_builder/i18n/it.po
+++ b/addons/html_builder/i18n/it.po
@@ -1,0 +1,576 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* html_builder
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 16.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-05-16 13:50+0000\n"
+"PO-Revision-Date: 2022-09-22 05:55+0000\n"
+"Last-Translator: Marianna Ciofani, 2023\n"
+"Language-Team: Italian (https://app.transifex.com/odoo/teams/41243/it/)\n"
+"Language: it\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: nplurals=3; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 ? 1 : 2;\n"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "ACCESS OPTIONS ANYWAY"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_list.js:0
+msgid "Add"
+msgstr "Aggiungi"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Almost there! Snippets are incoming, grab a coffee and relax!"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_plugin.js:0
+msgid "Anchor copied to clipboard%(br)sLink: %(anchorLink)s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Anchor name"
+msgstr "Nome di ancoraggio"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Are you sure you want to delete the block %s?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Block"
+msgstr "Blocco"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Blocks"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Blur"
+msgstr "Sfocatura"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Button"
+msgstr "Pulsante"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "Cancel"
+msgstr "Annulla"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Categories"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.js:0
+msgid "Choose a record..."
+msgstr "Scegli un record..."
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Choose an anchor name"
+msgstr "Scegli un nome di ancoraggio"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Color"
+msgstr "Colore"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Column"
+msgstr "Colonna"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "Confirm"
+msgstr "Conferma"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid "Continue"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Could not install module %(title)s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Create \""
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Create a custom snippet"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Custom %s"
+msgstr "%s su misura"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Custom Button"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Custom Inner Content"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Customize"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/setup_editor_plugin.js:0
+msgid "DRAG BUILDING BLOCKS HERE"
+msgstr "TRASCINA QUI I VARI COMPONENTI"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Dashed"
+msgstr "Tratteggiato"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Discard"
+msgstr "Abbandona"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Do you want to install %s App?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Do you want to save this snippet as a custom one?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Dotted"
+msgstr "Punteggiato"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Double"
+msgstr "Doppio"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.js:0
+msgid "Drag and drop the building block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/drag_and_drop_move_handle.js:0
+msgid "Drag and move"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "Duplicate this block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_plugin.js:0
+msgid "Edit"
+msgstr "Modifica"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/drop_zone_plugin.js:0
+msgid "For technical reasons, this block cannot be dropped here"
+msgstr "Per ragioni tecniche, qui non è possibile rilasciare il blocco"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Icon"
+msgstr "Icona"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid ""
+"If you discard the current edits, all unsaved changes will be lost. You can "
+"cancel to return to edit mode."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid "If you proceed, your changes will be lost"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Image"
+msgstr "Immagine"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Inner Content"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Insert a block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/media_website_plugin.js:0
+msgid "Insert a video"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+#: code:addons/html_builder/static/src/sidebar/snippet.xml:0
+msgid "Insert snippet"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Inset"
+msgstr "Interna"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/snippet.xml:0
+msgid "Install"
+msgstr "Installa"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Install %s"
+msgstr "Installazione di «%s»"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/invisible_elements_panel.xml:0
+msgid "Invisible Elements"
+msgstr "Elementi invisibili"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_list.js:0
+msgid "Item"
+msgstr "Voce"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.js:0
+msgid "Link Anchor"
+msgstr "Link di ancoraggio"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Mobile Preview"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "More info about this app."
+msgstr "Maggiori informazioni su questa applicazione."
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Name"
+msgstr "Nome"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "No"
+msgstr "No"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "No block of this category can be dropped on this page."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "No snippets found"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_select.js:0
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "None"
+msgstr "Nessuno"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Offset (X, Y)"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Oops! No snippets found."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Outset"
+msgstr "Esterna"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Page Options"
+msgstr "Opzioni pagina"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "REPLACE BY NEW VERSION"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Remove"
+msgstr "Rimuovi"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "Remove this block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Rename the block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Round Corners"
+msgstr "Angoli arrotondati"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Save"
+msgstr "Salva"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Save & Copy"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Save and Install"
+msgstr "Salva e installa"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Search for a block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search for records..."
+msgstr "Cerca record..."
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search more..."
+msgstr "Cerca di più ..."
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search to show more records"
+msgstr "Cerca per mostrare più record"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/customize_tab.xml:0
+msgid "Select a block on your page to style it."
+msgstr "Seleziona un blocco sulla tua pagina per disegnarla."
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/customize_translation_tab.xml:0
+msgid "Select content on your page to translate it."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Shadow"
+msgstr "Ombra"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Solid"
+msgstr "Tinta unita"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Spread"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Take a look at the search bar, there might be a small typo!"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "The chosen name already exists"
+msgstr "Il nome scelto esiste già"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Theme"
+msgstr "Tema"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "This block cannot be dropped anywhere on this page."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "This block is outdated."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Tip: Esc to preview"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_row.xml:0
+msgid "Toggle more options"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/media_website_plugin.js:0
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Video"
+msgstr "Video"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Yes"
+msgstr "Sì"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "You can still access the block options but it might be ineffective."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "You might not be able to customize it anymore."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/save_snippet_plugin.js:0
+msgid ""
+"Your custom snippet was successfully saved as <strong>%s</strong>. Find it "
+"in your snippets collection."
+msgstr ""

--- a/addons/html_builder/i18n/ja.po
+++ b/addons/html_builder/i18n/ja.po
@@ -1,0 +1,576 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* html_builder
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 16.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-05-16 13:50+0000\n"
+"PO-Revision-Date: 2022-09-22 05:55+0000\n"
+"Last-Translator: Martin Trigaux, 2023\n"
+"Language-Team: Japanese (https://app.transifex.com/odoo/teams/41243/ja/)\n"
+"Language: ja\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "ACCESS OPTIONS ANYWAY"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_list.js:0
+msgid "Add"
+msgstr "追加"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Almost there! Snippets are incoming, grab a coffee and relax!"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_plugin.js:0
+msgid "Anchor copied to clipboard%(br)sLink: %(anchorLink)s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Anchor name"
+msgstr "アンカー名"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Are you sure you want to delete the block %s?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Block"
+msgstr "ブロック"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Blocks"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Blur"
+msgstr "ぼかし"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Button"
+msgstr "ボタン"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "Cancel"
+msgstr "キャンセル"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Categories"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.js:0
+msgid "Choose a record..."
+msgstr "レコードを選択..."
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Choose an anchor name"
+msgstr "アンカー名を選択"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Color"
+msgstr "色"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Column"
+msgstr "列"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "Confirm"
+msgstr "確認"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid "Continue"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Could not install module %(title)s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Create \""
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Create a custom snippet"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Custom %s"
+msgstr "カスタム%s"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Custom Button"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Custom Inner Content"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Customize"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/setup_editor_plugin.js:0
+msgid "DRAG BUILDING BLOCKS HERE"
+msgstr "ここにブロックをドラッグ"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Dashed"
+msgstr "破線"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Discard"
+msgstr "破棄"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Do you want to install %s App?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Do you want to save this snippet as a custom one?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Dotted"
+msgstr "点線"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Double"
+msgstr "ダブル"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.js:0
+msgid "Drag and drop the building block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/drag_and_drop_move_handle.js:0
+msgid "Drag and move"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "Duplicate this block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_plugin.js:0
+msgid "Edit"
+msgstr "編集"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/drop_zone_plugin.js:0
+msgid "For technical reasons, this block cannot be dropped here"
+msgstr "技術上の理由でこのブロックはここにドロップできません"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Icon"
+msgstr "アイコン"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid ""
+"If you discard the current edits, all unsaved changes will be lost. You can "
+"cancel to return to edit mode."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid "If you proceed, your changes will be lost"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Image"
+msgstr "画像"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Inner Content"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Insert a block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/media_website_plugin.js:0
+msgid "Insert a video"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+#: code:addons/html_builder/static/src/sidebar/snippet.xml:0
+msgid "Insert snippet"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Inset"
+msgstr "挿入"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/snippet.xml:0
+msgid "Install"
+msgstr "インストール"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Install %s"
+msgstr "インストール%s"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/invisible_elements_panel.xml:0
+msgid "Invisible Elements"
+msgstr "非表示要素"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_list.js:0
+msgid "Item"
+msgstr "項目"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.js:0
+msgid "Link Anchor"
+msgstr "リンクアンカー"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Mobile Preview"
+msgstr "モバイルプレビュー"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "More info about this app."
+msgstr "このアプリについての詳細情報。"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Name"
+msgstr "名称"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "No"
+msgstr "いいえ"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "No block of this category can be dropped on this page."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "No snippets found"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_select.js:0
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "None"
+msgstr "なし"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Offset (X, Y)"
+msgstr "オフセット (X, Y)"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Oops! No snippets found."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Outset"
+msgstr "アウトセット"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Page Options"
+msgstr "ページオプション"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "REPLACE BY NEW VERSION"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Remove"
+msgstr "削除"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "Remove this block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Rename the block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Round Corners"
+msgstr "角丸"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Save"
+msgstr "保存"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Save & Copy"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Save and Install"
+msgstr "保存してインストール"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Search for a block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search for records..."
+msgstr "レコードを検索..."
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search more..."
+msgstr "もっと検索..."
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search to show more records"
+msgstr "検索してさらにレコードを表示"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/customize_tab.xml:0
+msgid "Select a block on your page to style it."
+msgstr "ページ中のブロックを選択して編集します。"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/customize_translation_tab.xml:0
+msgid "Select content on your page to translate it."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Shadow"
+msgstr "影"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Solid"
+msgstr "ソリッド"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Spread"
+msgstr "スプレッド"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Take a look at the search bar, there might be a small typo!"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "The chosen name already exists"
+msgstr "選択した名前はすでに存在しています"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Theme"
+msgstr "テーマ"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "This block cannot be dropped anywhere on this page."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "This block is outdated."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Tip: Esc to preview"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_row.xml:0
+msgid "Toggle more options"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/media_website_plugin.js:0
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Video"
+msgstr "動画"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Yes"
+msgstr "はい"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "You can still access the block options but it might be ineffective."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "You might not be able to customize it anymore."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/save_snippet_plugin.js:0
+msgid ""
+"Your custom snippet was successfully saved as <strong>%s</strong>. Find it "
+"in your snippets collection."
+msgstr ""

--- a/addons/html_builder/i18n/ka.po
+++ b/addons/html_builder/i18n/ka.po
@@ -1,0 +1,576 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* html_builder
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo 9.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-05-16 13:50+0000\n"
+"PO-Revision-Date: 2016-06-27 15:58+0000\n"
+"Last-Translator: Martin Trigaux\n"
+"Language-Team: Georgian (http://www.transifex.com/odoo/odoo-9/language/ka/)\n"
+"Language: ka\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "ACCESS OPTIONS ANYWAY"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_list.js:0
+msgid "Add"
+msgstr "დამატება"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Almost there! Snippets are incoming, grab a coffee and relax!"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_plugin.js:0
+msgid "Anchor copied to clipboard%(br)sLink: %(anchorLink)s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Anchor name"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Are you sure you want to delete the block %s?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Blocks"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Blur"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Button"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "Cancel"
+msgstr "შეწყვეტა"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Categories"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.js:0
+msgid "Choose a record..."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Choose an anchor name"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Color"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Column"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "Confirm"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid "Continue"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Could not install module %(title)s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Create \""
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Create a custom snippet"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Custom %s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Custom Button"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Custom Inner Content"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Customize"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/setup_editor_plugin.js:0
+msgid "DRAG BUILDING BLOCKS HERE"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Dashed"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Discard"
+msgstr "გაუქმება"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Do you want to install %s App?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Do you want to save this snippet as a custom one?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Dotted"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Double"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.js:0
+msgid "Drag and drop the building block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/drag_and_drop_move_handle.js:0
+msgid "Drag and move"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "Duplicate this block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_plugin.js:0
+msgid "Edit"
+msgstr "შეცვლა"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/drop_zone_plugin.js:0
+msgid "For technical reasons, this block cannot be dropped here"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Icon"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid ""
+"If you discard the current edits, all unsaved changes will be lost. You can "
+"cancel to return to edit mode."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid "If you proceed, your changes will be lost"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Image"
+msgstr "გამოსახულება"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Inner Content"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Insert a block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/media_website_plugin.js:0
+msgid "Insert a video"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+#: code:addons/html_builder/static/src/sidebar/snippet.xml:0
+msgid "Insert snippet"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Inset"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/snippet.xml:0
+msgid "Install"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Install %s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/invisible_elements_panel.xml:0
+msgid "Invisible Elements"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_list.js:0
+msgid "Item"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.js:0
+msgid "Link Anchor"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Mobile Preview"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "More info about this app."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Name"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "No"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "No block of this category can be dropped on this page."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "No snippets found"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_select.js:0
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "None"
+msgstr "არცერთი"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Offset (X, Y)"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Oops! No snippets found."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Outset"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Page Options"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "REPLACE BY NEW VERSION"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Remove"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "Remove this block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Rename the block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Round Corners"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Save"
+msgstr "შენახვა"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Save & Copy"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Save and Install"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Search for a block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search for records..."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search more..."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search to show more records"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/customize_tab.xml:0
+msgid "Select a block on your page to style it."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/customize_translation_tab.xml:0
+msgid "Select content on your page to translate it."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Shadow"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Solid"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Spread"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Take a look at the search bar, there might be a small typo!"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "The chosen name already exists"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Theme"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "This block cannot be dropped anywhere on this page."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "This block is outdated."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Tip: Esc to preview"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_row.xml:0
+msgid "Toggle more options"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/media_website_plugin.js:0
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Video"
+msgstr "ვიდეო"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Yes"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "You can still access the block options but it might be ineffective."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "You might not be able to customize it anymore."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/save_snippet_plugin.js:0
+msgid ""
+"Your custom snippet was successfully saved as <strong>%s</strong>. Find it "
+"in your snippets collection."
+msgstr ""

--- a/addons/html_builder/i18n/kab.po
+++ b/addons/html_builder/i18n/kab.po
@@ -1,0 +1,576 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* html_builder
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo 9.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-05-16 13:50+0000\n"
+"PO-Revision-Date: 2015-09-30 09:29+0000\n"
+"Last-Translator: Martin Trigaux\n"
+"Language-Team: Kabyle (http://www.transifex.com/odoo/odoo-9/language/kab/)\n"
+"Language: kab\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "ACCESS OPTIONS ANYWAY"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_list.js:0
+msgid "Add"
+msgstr "Rnu"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Almost there! Snippets are incoming, grab a coffee and relax!"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_plugin.js:0
+msgid "Anchor copied to clipboard%(br)sLink: %(anchorLink)s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Anchor name"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Are you sure you want to delete the block %s?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Blocks"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Blur"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Button"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "Cancel"
+msgstr "Sefsex"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Categories"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.js:0
+msgid "Choose a record..."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Choose an anchor name"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Color"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Column"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "Confirm"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid "Continue"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Could not install module %(title)s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Create \""
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Create a custom snippet"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Custom %s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Custom Button"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Custom Inner Content"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Customize"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/setup_editor_plugin.js:0
+msgid "DRAG BUILDING BLOCKS HERE"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Dashed"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Discard"
+msgstr "Sefsex"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Do you want to install %s App?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Do you want to save this snippet as a custom one?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Dotted"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Double"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.js:0
+msgid "Drag and drop the building block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/drag_and_drop_move_handle.js:0
+msgid "Drag and move"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "Duplicate this block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_plugin.js:0
+msgid "Edit"
+msgstr "Ẓreg"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/drop_zone_plugin.js:0
+msgid "For technical reasons, this block cannot be dropped here"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Icon"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid ""
+"If you discard the current edits, all unsaved changes will be lost. You can "
+"cancel to return to edit mode."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid "If you proceed, your changes will be lost"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Image"
+msgstr "Tugna"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Inner Content"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Insert a block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/media_website_plugin.js:0
+msgid "Insert a video"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+#: code:addons/html_builder/static/src/sidebar/snippet.xml:0
+msgid "Insert snippet"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Inset"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/snippet.xml:0
+msgid "Install"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Install %s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/invisible_elements_panel.xml:0
+msgid "Invisible Elements"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_list.js:0
+msgid "Item"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.js:0
+msgid "Link Anchor"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Mobile Preview"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "More info about this app."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Name"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "No"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "No block of this category can be dropped on this page."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "No snippets found"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_select.js:0
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "None"
+msgstr "Ulac"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Offset (X, Y)"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Oops! No snippets found."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Outset"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Page Options"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "REPLACE BY NEW VERSION"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Remove"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "Remove this block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Rename the block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Round Corners"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Save"
+msgstr "Kles"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Save & Copy"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Save and Install"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Search for a block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search for records..."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search more..."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search to show more records"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/customize_tab.xml:0
+msgid "Select a block on your page to style it."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/customize_translation_tab.xml:0
+msgid "Select content on your page to translate it."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Shadow"
+msgstr "Tili"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Solid"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Spread"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Take a look at the search bar, there might be a small typo!"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "The chosen name already exists"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Theme"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "This block cannot be dropped anywhere on this page."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "This block is outdated."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Tip: Esc to preview"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_row.xml:0
+msgid "Toggle more options"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/media_website_plugin.js:0
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Video"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Yes"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "You can still access the block options but it might be ineffective."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "You might not be able to customize it anymore."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/save_snippet_plugin.js:0
+msgid ""
+"Your custom snippet was successfully saved as <strong>%s</strong>. Find it "
+"in your snippets collection."
+msgstr ""

--- a/addons/html_builder/i18n/km.po
+++ b/addons/html_builder/i18n/km.po
@@ -1,0 +1,576 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* html_builder
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server saas~11.5\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-05-16 13:50+0000\n"
+"PO-Revision-Date: 2018-10-02 10:06+0000\n"
+"Last-Translator: Chan Nath <channath@gmail.com>, 2018\n"
+"Language-Team: Khmer (https://www.transifex.com/odoo/teams/41243/km/)\n"
+"Language: km\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "ACCESS OPTIONS ANYWAY"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_list.js:0
+msgid "Add"
+msgstr "បន្ថែម"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Almost there! Snippets are incoming, grab a coffee and relax!"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_plugin.js:0
+msgid "Anchor copied to clipboard%(br)sLink: %(anchorLink)s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Anchor name"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Are you sure you want to delete the block %s?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Blocks"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Blur"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Button"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "Cancel"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Categories"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.js:0
+msgid "Choose a record..."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Choose an anchor name"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Color"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Column"
+msgstr "ជួរឈរ"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "Confirm"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid "Continue"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Could not install module %(title)s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Create \""
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Create a custom snippet"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Custom %s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Custom Button"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Custom Inner Content"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Customize"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/setup_editor_plugin.js:0
+msgid "DRAG BUILDING BLOCKS HERE"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Dashed"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Discard"
+msgstr "បោះបង់"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Do you want to install %s App?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Do you want to save this snippet as a custom one?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Dotted"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Double"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.js:0
+msgid "Drag and drop the building block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/drag_and_drop_move_handle.js:0
+msgid "Drag and move"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "Duplicate this block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_plugin.js:0
+msgid "Edit"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/drop_zone_plugin.js:0
+msgid "For technical reasons, this block cannot be dropped here"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Icon"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid ""
+"If you discard the current edits, all unsaved changes will be lost. You can "
+"cancel to return to edit mode."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid "If you proceed, your changes will be lost"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Image"
+msgstr "Image"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Inner Content"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Insert a block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/media_website_plugin.js:0
+msgid "Insert a video"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+#: code:addons/html_builder/static/src/sidebar/snippet.xml:0
+msgid "Insert snippet"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Inset"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/snippet.xml:0
+msgid "Install"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Install %s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/invisible_elements_panel.xml:0
+msgid "Invisible Elements"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_list.js:0
+msgid "Item"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.js:0
+msgid "Link Anchor"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Mobile Preview"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "More info about this app."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Name"
+msgstr "ឈ្មោះ"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "No"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "No block of this category can be dropped on this page."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "No snippets found"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_select.js:0
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "None"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Offset (X, Y)"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Oops! No snippets found."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Outset"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Page Options"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "REPLACE BY NEW VERSION"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Remove"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "Remove this block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Rename the block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Round Corners"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Save"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Save & Copy"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Save and Install"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Search for a block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search for records..."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search more..."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search to show more records"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/customize_tab.xml:0
+msgid "Select a block on your page to style it."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/customize_translation_tab.xml:0
+msgid "Select content on your page to translate it."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Shadow"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Solid"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Spread"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Take a look at the search bar, there might be a small typo!"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "The chosen name already exists"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Theme"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "This block cannot be dropped anywhere on this page."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "This block is outdated."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Tip: Esc to preview"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_row.xml:0
+msgid "Toggle more options"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/media_website_plugin.js:0
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Video"
+msgstr "វីដេអូ"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Yes"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "You can still access the block options but it might be ineffective."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "You might not be able to customize it anymore."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/save_snippet_plugin.js:0
+msgid ""
+"Your custom snippet was successfully saved as <strong>%s</strong>. Find it "
+"in your snippets collection."
+msgstr ""

--- a/addons/html_builder/i18n/ko.po
+++ b/addons/html_builder/i18n/ko.po
@@ -1,0 +1,576 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* html_builder
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 16.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-05-16 13:50+0000\n"
+"PO-Revision-Date: 2022-09-22 05:55+0000\n"
+"Last-Translator: Martin Trigaux, 2023\n"
+"Language-Team: Korean (https://app.transifex.com/odoo/teams/41243/ko/)\n"
+"Language: ko\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "ACCESS OPTIONS ANYWAY"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_list.js:0
+msgid "Add"
+msgstr "추가"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Almost there! Snippets are incoming, grab a coffee and relax!"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_plugin.js:0
+msgid "Anchor copied to clipboard%(br)sLink: %(anchorLink)s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Anchor name"
+msgstr "앵커 이름"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Are you sure you want to delete the block %s?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Block"
+msgstr "블록"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Blocks"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Blur"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Button"
+msgstr "버튼"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "Cancel"
+msgstr "취소"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Categories"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.js:0
+msgid "Choose a record..."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Choose an anchor name"
+msgstr "앵커 이름 선택"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Color"
+msgstr "색상"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Column"
+msgstr "열"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "Confirm"
+msgstr "승인"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid "Continue"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Could not install module %(title)s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Create \""
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Create a custom snippet"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Custom %s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Custom Button"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Custom Inner Content"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Customize"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/setup_editor_plugin.js:0
+msgid "DRAG BUILDING BLOCKS HERE"
+msgstr "작성 블럭을 여기로 끌어오십시오"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Dashed"
+msgstr "현황판에 게시"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Discard"
+msgstr "작성 취소"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Do you want to install %s App?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Do you want to save this snippet as a custom one?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Dotted"
+msgstr "점 찍힘"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Double"
+msgstr "두번"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.js:0
+msgid "Drag and drop the building block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/drag_and_drop_move_handle.js:0
+msgid "Drag and move"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "Duplicate this block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_plugin.js:0
+msgid "Edit"
+msgstr "편집하기"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/drop_zone_plugin.js:0
+msgid "For technical reasons, this block cannot be dropped here"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Icon"
+msgstr "아이콘"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid ""
+"If you discard the current edits, all unsaved changes will be lost. You can "
+"cancel to return to edit mode."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid "If you proceed, your changes will be lost"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Image"
+msgstr "이미지"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Inner Content"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Insert a block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/media_website_plugin.js:0
+msgid "Insert a video"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+#: code:addons/html_builder/static/src/sidebar/snippet.xml:0
+msgid "Insert snippet"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Inset"
+msgstr "삽입"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/snippet.xml:0
+msgid "Install"
+msgstr "설치하기"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Install %s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/invisible_elements_panel.xml:0
+msgid "Invisible Elements"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_list.js:0
+msgid "Item"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.js:0
+msgid "Link Anchor"
+msgstr "링크 앵커"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Mobile Preview"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "More info about this app."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Name"
+msgstr "이름"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "No"
+msgstr "아니오"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "No block of this category can be dropped on this page."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "No snippets found"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_select.js:0
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "None"
+msgstr "없음"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Offset (X, Y)"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Oops! No snippets found."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Outset"
+msgstr "시초"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Page Options"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "REPLACE BY NEW VERSION"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Remove"
+msgstr "제거"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "Remove this block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Rename the block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Round Corners"
+msgstr "둥근 모서리"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Save"
+msgstr "저장"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Save & Copy"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Save and Install"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Search for a block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search for records..."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search more..."
+msgstr "추가 검색..."
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search to show more records"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/customize_tab.xml:0
+msgid "Select a block on your page to style it."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/customize_translation_tab.xml:0
+msgid "Select content on your page to translate it."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Shadow"
+msgstr "그림자"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Solid"
+msgstr "고체"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Spread"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Take a look at the search bar, there might be a small typo!"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "The chosen name already exists"
+msgstr "선택한 이름이 이미 존재합니다."
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Theme"
+msgstr "테마"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "This block cannot be dropped anywhere on this page."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "This block is outdated."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Tip: Esc to preview"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_row.xml:0
+msgid "Toggle more options"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/media_website_plugin.js:0
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Video"
+msgstr "동영상"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Yes"
+msgstr "예"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "You can still access the block options but it might be ineffective."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "You might not be able to customize it anymore."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/save_snippet_plugin.js:0
+msgid ""
+"Your custom snippet was successfully saved as <strong>%s</strong>. Find it "
+"in your snippets collection."
+msgstr ""

--- a/addons/html_builder/i18n/lb.po
+++ b/addons/html_builder/i18n/lb.po
@@ -1,0 +1,575 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* html_builder
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server saas~12.5\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-05-16 13:50+0000\n"
+"PO-Revision-Date: 2019-08-26 09:15+0000\n"
+"Language-Team: Luxembourgish (https://www.transifex.com/odoo/teams/41243/lb/)\n"
+"Language: lb\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "ACCESS OPTIONS ANYWAY"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_list.js:0
+msgid "Add"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Almost there! Snippets are incoming, grab a coffee and relax!"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_plugin.js:0
+msgid "Anchor copied to clipboard%(br)sLink: %(anchorLink)s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Anchor name"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Are you sure you want to delete the block %s?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Blocks"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Blur"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Button"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "Cancel"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Categories"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.js:0
+msgid "Choose a record..."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Choose an anchor name"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Color"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Column"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "Confirm"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid "Continue"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Could not install module %(title)s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Create \""
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Create a custom snippet"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Custom %s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Custom Button"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Custom Inner Content"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Customize"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/setup_editor_plugin.js:0
+msgid "DRAG BUILDING BLOCKS HERE"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Dashed"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Discard"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Do you want to install %s App?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Do you want to save this snippet as a custom one?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Dotted"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Double"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.js:0
+msgid "Drag and drop the building block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/drag_and_drop_move_handle.js:0
+msgid "Drag and move"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "Duplicate this block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_plugin.js:0
+msgid "Edit"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/drop_zone_plugin.js:0
+msgid "For technical reasons, this block cannot be dropped here"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Icon"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid ""
+"If you discard the current edits, all unsaved changes will be lost. You can "
+"cancel to return to edit mode."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid "If you proceed, your changes will be lost"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Image"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Inner Content"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Insert a block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/media_website_plugin.js:0
+msgid "Insert a video"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+#: code:addons/html_builder/static/src/sidebar/snippet.xml:0
+msgid "Insert snippet"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Inset"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/snippet.xml:0
+msgid "Install"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Install %s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/invisible_elements_panel.xml:0
+msgid "Invisible Elements"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_list.js:0
+msgid "Item"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.js:0
+msgid "Link Anchor"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Mobile Preview"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "More info about this app."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Name"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "No"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "No block of this category can be dropped on this page."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "No snippets found"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_select.js:0
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "None"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Offset (X, Y)"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Oops! No snippets found."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Outset"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Page Options"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "REPLACE BY NEW VERSION"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Remove"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "Remove this block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Rename the block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Round Corners"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Save"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Save & Copy"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Save and Install"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Search for a block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search for records..."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search more..."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search to show more records"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/customize_tab.xml:0
+msgid "Select a block on your page to style it."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/customize_translation_tab.xml:0
+msgid "Select content on your page to translate it."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Shadow"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Solid"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Spread"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Take a look at the search bar, there might be a small typo!"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "The chosen name already exists"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Theme"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "This block cannot be dropped anywhere on this page."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "This block is outdated."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Tip: Esc to preview"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_row.xml:0
+msgid "Toggle more options"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/media_website_plugin.js:0
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Video"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Yes"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "You can still access the block options but it might be ineffective."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "You might not be able to customize it anymore."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/save_snippet_plugin.js:0
+msgid ""
+"Your custom snippet was successfully saved as <strong>%s</strong>. Find it "
+"in your snippets collection."
+msgstr ""

--- a/addons/html_builder/i18n/lt.po
+++ b/addons/html_builder/i18n/lt.po
@@ -1,0 +1,576 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* html_builder
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 16.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-05-16 13:50+0000\n"
+"PO-Revision-Date: 2022-09-22 05:55+0000\n"
+"Last-Translator: Martin Trigaux, 2023\n"
+"Language-Team: Lithuanian (https://app.transifex.com/odoo/teams/41243/lt/)\n"
+"Language: lt\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: nplurals=4; plural=(n % 10 == 1 && (n % 100 > 19 || n % 100 < 11) ? 0 : (n % 10 >= 2 && n % 10 <=9) && (n % 100 > 19 || n % 100 < 11) ? 1 : n % 1 != 0 ? 2: 3);\n"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "ACCESS OPTIONS ANYWAY"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_list.js:0
+msgid "Add"
+msgstr "Pridėti"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Almost there! Snippets are incoming, grab a coffee and relax!"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_plugin.js:0
+msgid "Anchor copied to clipboard%(br)sLink: %(anchorLink)s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Anchor name"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Are you sure you want to delete the block %s?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Block"
+msgstr "Blokuoti"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Blocks"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Blur"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Button"
+msgstr "Mygtukas"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "Cancel"
+msgstr "Atšaukti"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Categories"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.js:0
+msgid "Choose a record..."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Choose an anchor name"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Color"
+msgstr "Spalva"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Column"
+msgstr "Stulpelis"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "Confirm"
+msgstr "Patvirtinti"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid "Continue"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Could not install module %(title)s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Create \""
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Create a custom snippet"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Custom %s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Custom Button"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Custom Inner Content"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Customize"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/setup_editor_plugin.js:0
+msgid "DRAG BUILDING BLOCKS HERE"
+msgstr "TEMPKITE BLOKUS ČIA"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Dashed"
+msgstr "Brūkšniuotas"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Discard"
+msgstr "Atmesti"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Do you want to install %s App?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Do you want to save this snippet as a custom one?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Dotted"
+msgstr "Taškuotas"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Double"
+msgstr "Dvigubas"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.js:0
+msgid "Drag and drop the building block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/drag_and_drop_move_handle.js:0
+msgid "Drag and move"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "Duplicate this block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_plugin.js:0
+msgid "Edit"
+msgstr "Redaguoti"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/drop_zone_plugin.js:0
+msgid "For technical reasons, this block cannot be dropped here"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Icon"
+msgstr "Piktograma"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid ""
+"If you discard the current edits, all unsaved changes will be lost. You can "
+"cancel to return to edit mode."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid "If you proceed, your changes will be lost"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Image"
+msgstr "Paveikslėlis"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Inner Content"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Insert a block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/media_website_plugin.js:0
+msgid "Insert a video"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+#: code:addons/html_builder/static/src/sidebar/snippet.xml:0
+msgid "Insert snippet"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Inset"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/snippet.xml:0
+msgid "Install"
+msgstr "Diegti"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Install %s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/invisible_elements_panel.xml:0
+msgid "Invisible Elements"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_list.js:0
+msgid "Item"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.js:0
+msgid "Link Anchor"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Mobile Preview"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "More info about this app."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Name"
+msgstr "Pavadinimas"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "No"
+msgstr "Ne"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "No block of this category can be dropped on this page."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "No snippets found"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_select.js:0
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "None"
+msgstr "Nieko"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Offset (X, Y)"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Oops! No snippets found."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Outset"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Page Options"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "REPLACE BY NEW VERSION"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Remove"
+msgstr "Pašalinti"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "Remove this block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Rename the block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Round Corners"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Save"
+msgstr "Išsaugoti"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Save & Copy"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Save and Install"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Search for a block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search for records..."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search more..."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search to show more records"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/customize_tab.xml:0
+msgid "Select a block on your page to style it."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/customize_translation_tab.xml:0
+msgid "Select content on your page to translate it."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Shadow"
+msgstr "Šešėlis"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Solid"
+msgstr "Vientisas"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Spread"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Take a look at the search bar, there might be a small typo!"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "The chosen name already exists"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Theme"
+msgstr "Tema"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "This block cannot be dropped anywhere on this page."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "This block is outdated."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Tip: Esc to preview"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_row.xml:0
+msgid "Toggle more options"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/media_website_plugin.js:0
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Video"
+msgstr "Video"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Yes"
+msgstr "Taip"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "You can still access the block options but it might be ineffective."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "You might not be able to customize it anymore."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/save_snippet_plugin.js:0
+msgid ""
+"Your custom snippet was successfully saved as <strong>%s</strong>. Find it "
+"in your snippets collection."
+msgstr ""

--- a/addons/html_builder/i18n/lv.po
+++ b/addons/html_builder/i18n/lv.po
@@ -1,0 +1,576 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* html_builder
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 16.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-05-16 13:50+0000\n"
+"PO-Revision-Date: 2022-09-22 05:55+0000\n"
+"Last-Translator: Martin Trigaux, 2023\n"
+"Language-Team: Latvian (https://app.transifex.com/odoo/teams/41243/lv/)\n"
+"Language: lv\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n != 0 ? 1 : 2);\n"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "ACCESS OPTIONS ANYWAY"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_list.js:0
+msgid "Add"
+msgstr "Pievienot"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Almost there! Snippets are incoming, grab a coffee and relax!"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_plugin.js:0
+msgid "Anchor copied to clipboard%(br)sLink: %(anchorLink)s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Anchor name"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Are you sure you want to delete the block %s?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Block"
+msgstr "Bloķēt"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Blocks"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Blur"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Button"
+msgstr "Poga"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "Cancel"
+msgstr "Atcelt"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Categories"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.js:0
+msgid "Choose a record..."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Choose an anchor name"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Color"
+msgstr "Krāsa"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Column"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "Confirm"
+msgstr "Apstiprināt"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid "Continue"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Could not install module %(title)s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Create \""
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Create a custom snippet"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Custom %s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Custom Button"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Custom Inner Content"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Customize"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/setup_editor_plugin.js:0
+msgid "DRAG BUILDING BLOCKS HERE"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Dashed"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Discard"
+msgstr "Atmest"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Do you want to install %s App?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Do you want to save this snippet as a custom one?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Dotted"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Double"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.js:0
+msgid "Drag and drop the building block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/drag_and_drop_move_handle.js:0
+msgid "Drag and move"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "Duplicate this block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_plugin.js:0
+msgid "Edit"
+msgstr "Labot"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/drop_zone_plugin.js:0
+msgid "For technical reasons, this block cannot be dropped here"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Icon"
+msgstr "Ikona"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid ""
+"If you discard the current edits, all unsaved changes will be lost. You can "
+"cancel to return to edit mode."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid "If you proceed, your changes will be lost"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Image"
+msgstr "Attēls"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Inner Content"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Insert a block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/media_website_plugin.js:0
+msgid "Insert a video"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+#: code:addons/html_builder/static/src/sidebar/snippet.xml:0
+msgid "Insert snippet"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Inset"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/snippet.xml:0
+msgid "Install"
+msgstr "Install"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Install %s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/invisible_elements_panel.xml:0
+msgid "Invisible Elements"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_list.js:0
+msgid "Item"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.js:0
+msgid "Link Anchor"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Mobile Preview"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "More info about this app."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Name"
+msgstr "Nosaukums"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "No"
+msgstr "Numurs"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "No block of this category can be dropped on this page."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "No snippets found"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_select.js:0
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "None"
+msgstr "Nav"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Offset (X, Y)"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Oops! No snippets found."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Outset"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Page Options"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "REPLACE BY NEW VERSION"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Remove"
+msgstr "Noņemt"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "Remove this block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Rename the block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Round Corners"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Save"
+msgstr "Saglabāt"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Save & Copy"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Save and Install"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Search for a block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search for records..."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search more..."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search to show more records"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/customize_tab.xml:0
+msgid "Select a block on your page to style it."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/customize_translation_tab.xml:0
+msgid "Select content on your page to translate it."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Shadow"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Solid"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Spread"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Take a look at the search bar, there might be a small typo!"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "The chosen name already exists"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Theme"
+msgstr "Theme"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "This block cannot be dropped anywhere on this page."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "This block is outdated."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Tip: Esc to preview"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_row.xml:0
+msgid "Toggle more options"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/media_website_plugin.js:0
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Video"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Yes"
+msgstr "Jā"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "You can still access the block options but it might be ineffective."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "You might not be able to customize it anymore."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/save_snippet_plugin.js:0
+msgid ""
+"Your custom snippet was successfully saved as <strong>%s</strong>. Find it "
+"in your snippets collection."
+msgstr ""

--- a/addons/html_builder/i18n/mk.po
+++ b/addons/html_builder/i18n/mk.po
@@ -1,0 +1,579 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* html_builder
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo 9.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-05-16 13:50+0000\n"
+"PO-Revision-Date: 2016-07-08 16:00+0000\n"
+"Last-Translator: Aleksandar Vangelovski <aleksandarv@hbee.eu>\n"
+"Language-Team: Macedonian (http://www.transifex.com/odoo/odoo-9/language/mk/)\n"
+"Language: mk\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"#-#-#-#-#  mk.po (Odoo 9.0)  #-#-#-#-#\n"
+"Plural-Forms: nplurals=2; plural=(n % 10 == 1 && n % 100 != 11) ? 0 : 1;\n"
+"#-#-#-#-#  mk.po (Odoo 9.0)  #-#-#-#-#\n"
+"Plural-Forms: nplurals=2; plural=(n % 10 == 1 && n % 100 != 11) ? 0 : 1;\n"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "ACCESS OPTIONS ANYWAY"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_list.js:0
+msgid "Add"
+msgstr "Додади"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Almost there! Snippets are incoming, grab a coffee and relax!"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_plugin.js:0
+msgid "Anchor copied to clipboard%(br)sLink: %(anchorLink)s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Anchor name"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Are you sure you want to delete the block %s?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Blocks"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Blur"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Button"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "Cancel"
+msgstr "Откажи"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Categories"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.js:0
+msgid "Choose a record..."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Choose an anchor name"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Color"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Column"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "Confirm"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid "Continue"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Could not install module %(title)s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Create \""
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Create a custom snippet"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Custom %s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Custom Button"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Custom Inner Content"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Customize"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/setup_editor_plugin.js:0
+msgid "DRAG BUILDING BLOCKS HERE"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Dashed"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Discard"
+msgstr "Отфрли"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Do you want to install %s App?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Do you want to save this snippet as a custom one?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Dotted"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Double"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.js:0
+msgid "Drag and drop the building block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/drag_and_drop_move_handle.js:0
+msgid "Drag and move"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "Duplicate this block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_plugin.js:0
+msgid "Edit"
+msgstr "Уреди"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/drop_zone_plugin.js:0
+msgid "For technical reasons, this block cannot be dropped here"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Icon"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid ""
+"If you discard the current edits, all unsaved changes will be lost. You can "
+"cancel to return to edit mode."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid "If you proceed, your changes will be lost"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Image"
+msgstr "Слика"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Inner Content"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Insert a block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/media_website_plugin.js:0
+msgid "Insert a video"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+#: code:addons/html_builder/static/src/sidebar/snippet.xml:0
+msgid "Insert snippet"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Inset"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/snippet.xml:0
+msgid "Install"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Install %s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/invisible_elements_panel.xml:0
+msgid "Invisible Elements"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_list.js:0
+msgid "Item"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.js:0
+msgid "Link Anchor"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Mobile Preview"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "More info about this app."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Name"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "No"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "No block of this category can be dropped on this page."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "No snippets found"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_select.js:0
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "None"
+msgstr "Ништо"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Offset (X, Y)"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Oops! No snippets found."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Outset"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Page Options"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "REPLACE BY NEW VERSION"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Remove"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "Remove this block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Rename the block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Round Corners"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Save"
+msgstr "Зачувај"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Save & Copy"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Save and Install"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Search for a block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search for records..."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search more..."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search to show more records"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/customize_tab.xml:0
+msgid "Select a block on your page to style it."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/customize_translation_tab.xml:0
+msgid "Select content on your page to translate it."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Shadow"
+msgstr "Сенка"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Solid"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Spread"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Take a look at the search bar, there might be a small typo!"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "The chosen name already exists"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Theme"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "This block cannot be dropped anywhere on this page."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "This block is outdated."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Tip: Esc to preview"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_row.xml:0
+msgid "Toggle more options"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/media_website_plugin.js:0
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Video"
+msgstr "Видео"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Yes"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "You can still access the block options but it might be ineffective."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "You might not be able to customize it anymore."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/save_snippet_plugin.js:0
+msgid ""
+"Your custom snippet was successfully saved as <strong>%s</strong>. Find it "
+"in your snippets collection."
+msgstr ""

--- a/addons/html_builder/i18n/mn.po
+++ b/addons/html_builder/i18n/mn.po
@@ -1,0 +1,576 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* html_builder
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 16.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-05-16 13:50+0000\n"
+"PO-Revision-Date: 2022-09-22 05:55+0000\n"
+"Last-Translator: Martin Trigaux, 2023\n"
+"Language-Team: Mongolian (https://app.transifex.com/odoo/teams/41243/mn/)\n"
+"Language: mn\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "ACCESS OPTIONS ANYWAY"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_list.js:0
+msgid "Add"
+msgstr "Нэмэх"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Almost there! Snippets are incoming, grab a coffee and relax!"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_plugin.js:0
+msgid "Anchor copied to clipboard%(br)sLink: %(anchorLink)s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Anchor name"
+msgstr "Зангууны нэр"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Are you sure you want to delete the block %s?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Block"
+msgstr "Түгжих"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Blocks"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Blur"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Button"
+msgstr "Товчлуур"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "Cancel"
+msgstr "Цуцлах"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Categories"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.js:0
+msgid "Choose a record..."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Choose an anchor name"
+msgstr "Зангууны нэр сонгох"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Color"
+msgstr "Өнгө"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Column"
+msgstr "Багана"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "Confirm"
+msgstr "Батлах"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid "Continue"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Could not install module %(title)s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Create \""
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Create a custom snippet"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Custom %s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Custom Button"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Custom Inner Content"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Customize"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/setup_editor_plugin.js:0
+msgid "DRAG BUILDING BLOCKS HERE"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Dashed"
+msgstr "Зураасан шугам"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Discard"
+msgstr "Үл хэрэгсэх"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Do you want to install %s App?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Do you want to save this snippet as a custom one?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Dotted"
+msgstr "Цэг"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Double"
+msgstr "Давхар"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.js:0
+msgid "Drag and drop the building block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/drag_and_drop_move_handle.js:0
+msgid "Drag and move"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "Duplicate this block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_plugin.js:0
+msgid "Edit"
+msgstr "Засах"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/drop_zone_plugin.js:0
+msgid "For technical reasons, this block cannot be dropped here"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Icon"
+msgstr "Дүрс"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid ""
+"If you discard the current edits, all unsaved changes will be lost. You can "
+"cancel to return to edit mode."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid "If you proceed, your changes will be lost"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Image"
+msgstr "Зураг"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Inner Content"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Insert a block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/media_website_plugin.js:0
+msgid "Insert a video"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+#: code:addons/html_builder/static/src/sidebar/snippet.xml:0
+msgid "Insert snippet"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Inset"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/snippet.xml:0
+msgid "Install"
+msgstr "Суулгах"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Install %s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/invisible_elements_panel.xml:0
+msgid "Invisible Elements"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_list.js:0
+msgid "Item"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.js:0
+msgid "Link Anchor"
+msgstr "Холбоос зангуу"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Mobile Preview"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "More info about this app."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Name"
+msgstr "Нэр"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "No"
+msgstr "Үгүй"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "No block of this category can be dropped on this page."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "No snippets found"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_select.js:0
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "None"
+msgstr "Байхгүй"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Offset (X, Y)"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Oops! No snippets found."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Outset"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Page Options"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "REPLACE BY NEW VERSION"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Remove"
+msgstr "Хасах"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "Remove this block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Rename the block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Round Corners"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Save"
+msgstr "Хадгалах"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Save & Copy"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Save and Install"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Search for a block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search for records..."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search more..."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search to show more records"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/customize_tab.xml:0
+msgid "Select a block on your page to style it."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/customize_translation_tab.xml:0
+msgid "Select content on your page to translate it."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Shadow"
+msgstr "Сүүдэр"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Solid"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Spread"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Take a look at the search bar, there might be a small typo!"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "The chosen name already exists"
+msgstr "Нэр аль хэдийн сонгогдсон байна"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Theme"
+msgstr "Загвар"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "This block cannot be dropped anywhere on this page."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "This block is outdated."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Tip: Esc to preview"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_row.xml:0
+msgid "Toggle more options"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/media_website_plugin.js:0
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Video"
+msgstr "Видео"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Yes"
+msgstr "Тийм"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "You can still access the block options but it might be ineffective."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "You might not be able to customize it anymore."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/save_snippet_plugin.js:0
+msgid ""
+"Your custom snippet was successfully saved as <strong>%s</strong>. Find it "
+"in your snippets collection."
+msgstr ""

--- a/addons/html_builder/i18n/nb.po
+++ b/addons/html_builder/i18n/nb.po
@@ -1,0 +1,576 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* html_builder
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 16.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-05-16 13:50+0000\n"
+"PO-Revision-Date: 2022-09-22 05:55+0000\n"
+"Last-Translator: Martin Trigaux, 2023\n"
+"Language-Team: Norwegian Bokmål (https://app.transifex.com/odoo/teams/41243/nb/)\n"
+"Language: nb\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "ACCESS OPTIONS ANYWAY"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_list.js:0
+msgid "Add"
+msgstr "Legg til"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Almost there! Snippets are incoming, grab a coffee and relax!"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_plugin.js:0
+msgid "Anchor copied to clipboard%(br)sLink: %(anchorLink)s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Anchor name"
+msgstr "Ankernavn"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Are you sure you want to delete the block %s?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Block"
+msgstr "Blokker"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Blocks"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Blur"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Button"
+msgstr "Knapp"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "Cancel"
+msgstr "Kanseller"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Categories"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.js:0
+msgid "Choose a record..."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Choose an anchor name"
+msgstr "Velg et ankernavn"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Color"
+msgstr "Farge"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Column"
+msgstr "Kolonne"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "Confirm"
+msgstr "Bekreft"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid "Continue"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Could not install module %(title)s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Create \""
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Create a custom snippet"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Custom %s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Custom Button"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Custom Inner Content"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Customize"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/setup_editor_plugin.js:0
+msgid "DRAG BUILDING BLOCKS HERE"
+msgstr "DRA BLOKKER HIT"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Dashed"
+msgstr "Stiplet"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Discard"
+msgstr "Avbryt"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Do you want to install %s App?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Do you want to save this snippet as a custom one?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Dotted"
+msgstr "Prikket"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Double"
+msgstr "Dobbel"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.js:0
+msgid "Drag and drop the building block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/drag_and_drop_move_handle.js:0
+msgid "Drag and move"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "Duplicate this block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_plugin.js:0
+msgid "Edit"
+msgstr "Rediger"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/drop_zone_plugin.js:0
+msgid "For technical reasons, this block cannot be dropped here"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Icon"
+msgstr "Ikon"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid ""
+"If you discard the current edits, all unsaved changes will be lost. You can "
+"cancel to return to edit mode."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid "If you proceed, your changes will be lost"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Image"
+msgstr "Bilde"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Inner Content"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Insert a block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/media_website_plugin.js:0
+msgid "Insert a video"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+#: code:addons/html_builder/static/src/sidebar/snippet.xml:0
+msgid "Insert snippet"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Inset"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/snippet.xml:0
+msgid "Install"
+msgstr "Installer"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Install %s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/invisible_elements_panel.xml:0
+msgid "Invisible Elements"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_list.js:0
+msgid "Item"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.js:0
+msgid "Link Anchor"
+msgstr "Anker"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Mobile Preview"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "More info about this app."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Name"
+msgstr "Navn"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "No"
+msgstr "Nei"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "No block of this category can be dropped on this page."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "No snippets found"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_select.js:0
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "None"
+msgstr "Ingen"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Offset (X, Y)"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Oops! No snippets found."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Outset"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Page Options"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "REPLACE BY NEW VERSION"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Remove"
+msgstr "Fjern"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "Remove this block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Rename the block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Round Corners"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Save"
+msgstr "Lagre"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Save & Copy"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Save and Install"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Search for a block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search for records..."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search more..."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search to show more records"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/customize_tab.xml:0
+msgid "Select a block on your page to style it."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/customize_translation_tab.xml:0
+msgid "Select content on your page to translate it."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Shadow"
+msgstr "Skygge"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Solid"
+msgstr "Solid"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Spread"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Take a look at the search bar, there might be a small typo!"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "The chosen name already exists"
+msgstr "Navnet du oppga er allerede i bruk"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Theme"
+msgstr "Tema"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "This block cannot be dropped anywhere on this page."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "This block is outdated."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Tip: Esc to preview"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_row.xml:0
+msgid "Toggle more options"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/media_website_plugin.js:0
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Video"
+msgstr "Video"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Yes"
+msgstr "Ja"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "You can still access the block options but it might be ineffective."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "You might not be able to customize it anymore."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/save_snippet_plugin.js:0
+msgid ""
+"Your custom snippet was successfully saved as <strong>%s</strong>. Find it "
+"in your snippets collection."
+msgstr ""

--- a/addons/html_builder/i18n/nl.po
+++ b/addons/html_builder/i18n/nl.po
@@ -1,0 +1,576 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* html_builder
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 16.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-05-16 13:50+0000\n"
+"PO-Revision-Date: 2022-09-22 05:55+0000\n"
+"Last-Translator: Erwin van der Ploeg <erwin@odooexperts.nl>, 2023\n"
+"Language-Team: Dutch (https://app.transifex.com/odoo/teams/41243/nl/)\n"
+"Language: nl\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "ACCESS OPTIONS ANYWAY"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_list.js:0
+msgid "Add"
+msgstr "Toevoegen"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Almost there! Snippets are incoming, grab a coffee and relax!"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_plugin.js:0
+msgid "Anchor copied to clipboard%(br)sLink: %(anchorLink)s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Anchor name"
+msgstr "Ankernaam"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Are you sure you want to delete the block %s?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Block"
+msgstr "Blok"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Blocks"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Blur"
+msgstr "Vervagen"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Button"
+msgstr "Knop"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "Cancel"
+msgstr "Annuleren"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Categories"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.js:0
+msgid "Choose a record..."
+msgstr "Kies een record..."
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Choose an anchor name"
+msgstr "Kies een ankernaam"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Color"
+msgstr "Kleur"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Column"
+msgstr "Kolom"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "Confirm"
+msgstr "Bevestigen"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid "Continue"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Could not install module %(title)s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Create \""
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Create a custom snippet"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Custom %s"
+msgstr "Op maat %s"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Custom Button"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Custom Inner Content"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Customize"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/setup_editor_plugin.js:0
+msgid "DRAG BUILDING BLOCKS HERE"
+msgstr "SLEEP HIER BOUWBLOKKEN"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Dashed"
+msgstr "Gestippeld"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Discard"
+msgstr "Negeren"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Do you want to install %s App?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Do you want to save this snippet as a custom one?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Dotted"
+msgstr "Gestippeld"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Double"
+msgstr "Dubbel"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.js:0
+msgid "Drag and drop the building block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/drag_and_drop_move_handle.js:0
+msgid "Drag and move"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "Duplicate this block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_plugin.js:0
+msgid "Edit"
+msgstr "Bewerken"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/drop_zone_plugin.js:0
+msgid "For technical reasons, this block cannot be dropped here"
+msgstr "Om technische redenen kan dit blok hier niet worden neergezet"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Icon"
+msgstr "Icoon"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid ""
+"If you discard the current edits, all unsaved changes will be lost. You can "
+"cancel to return to edit mode."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid "If you proceed, your changes will be lost"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Image"
+msgstr "Afbeelding"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Inner Content"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Insert a block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/media_website_plugin.js:0
+msgid "Insert a video"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+#: code:addons/html_builder/static/src/sidebar/snippet.xml:0
+msgid "Insert snippet"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Inset"
+msgstr "Inzet"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/snippet.xml:0
+msgid "Install"
+msgstr "Installeren"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Install %s"
+msgstr "Installeer %s"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/invisible_elements_panel.xml:0
+msgid "Invisible Elements"
+msgstr "Onzichtbare elementen"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_list.js:0
+msgid "Item"
+msgstr "Item"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.js:0
+msgid "Link Anchor"
+msgstr "Link anker"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Mobile Preview"
+msgstr "Mobiele weergave"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "More info about this app."
+msgstr "Meer info over deze app."
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Name"
+msgstr "Naam"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "No"
+msgstr "Nee"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "No block of this category can be dropped on this page."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "No snippets found"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_select.js:0
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "None"
+msgstr "Geen"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Offset (X, Y)"
+msgstr "Offset (X, Y)"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Oops! No snippets found."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Outset"
+msgstr "Begin"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Page Options"
+msgstr "Pagina opties"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "REPLACE BY NEW VERSION"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Remove"
+msgstr "Verwijderen"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "Remove this block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Rename the block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Round Corners"
+msgstr "Afgeronde hoeken"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Save"
+msgstr "Opslaan"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Save & Copy"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Save and Install"
+msgstr "Opslaan en installeren"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Search for a block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search for records..."
+msgstr "Zoek naar records..."
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search more..."
+msgstr "Zoek meer..."
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search to show more records"
+msgstr "Zoeken om meer records weer te geven"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/customize_tab.xml:0
+msgid "Select a block on your page to style it."
+msgstr "Selecteer een blok op je pagina om het op te maken."
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/customize_translation_tab.xml:0
+msgid "Select content on your page to translate it."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Shadow"
+msgstr "Schaduw"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Solid"
+msgstr "Vast"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Spread"
+msgstr "Verspreiding"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Take a look at the search bar, there might be a small typo!"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "The chosen name already exists"
+msgstr "De gekozen naam bestaat al"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Theme"
+msgstr "Thema"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "This block cannot be dropped anywhere on this page."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "This block is outdated."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Tip: Esc to preview"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_row.xml:0
+msgid "Toggle more options"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/media_website_plugin.js:0
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Video"
+msgstr "Video"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Yes"
+msgstr "Ja"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "You can still access the block options but it might be ineffective."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "You might not be able to customize it anymore."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/save_snippet_plugin.js:0
+msgid ""
+"Your custom snippet was successfully saved as <strong>%s</strong>. Find it "
+"in your snippets collection."
+msgstr ""

--- a/addons/html_builder/i18n/pl.po
+++ b/addons/html_builder/i18n/pl.po
@@ -1,0 +1,576 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* html_builder
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 16.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-05-16 13:50+0000\n"
+"PO-Revision-Date: 2022-09-22 05:55+0000\n"
+"Last-Translator: Tadeusz Karpiński <tadeuszkarpinski@gmail.com>, 2023\n"
+"Language-Team: Polish (https://app.transifex.com/odoo/teams/41243/pl/)\n"
+"Language: pl\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: nplurals=4; plural=(n==1 ? 0 : (n%10>=2 && n%10<=4) && (n%100<12 || n%100>14) ? 1 : n!=1 && (n%10>=0 && n%10<=1) || (n%10>=5 && n%10<=9) || (n%100>=12 && n%100<=14) ? 2 : 3);\n"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "ACCESS OPTIONS ANYWAY"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_list.js:0
+msgid "Add"
+msgstr "Dodaj"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Almost there! Snippets are incoming, grab a coffee and relax!"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_plugin.js:0
+msgid "Anchor copied to clipboard%(br)sLink: %(anchorLink)s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Anchor name"
+msgstr "Nazwa odnośnika"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Are you sure you want to delete the block %s?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Block"
+msgstr "Blokuj"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Blocks"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Blur"
+msgstr "Smuga"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Button"
+msgstr "Przycisk"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "Cancel"
+msgstr "Anuluj"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Categories"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.js:0
+msgid "Choose a record..."
+msgstr "Wybierz zapis"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Choose an anchor name"
+msgstr "Wybierz nazwę odnośnika"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Color"
+msgstr "Kolor"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Column"
+msgstr "Kolumna"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "Confirm"
+msgstr "Potwierdź"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid "Continue"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Could not install module %(title)s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Create \""
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Create a custom snippet"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Custom %s"
+msgstr "Własny %s"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Custom Button"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Custom Inner Content"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Customize"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/setup_editor_plugin.js:0
+msgid "DRAG BUILDING BLOCKS HERE"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Dashed"
+msgstr "Przerywany"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Discard"
+msgstr "Odrzuć"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Do you want to install %s App?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Do you want to save this snippet as a custom one?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Dotted"
+msgstr "Wykropkowany"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Double"
+msgstr "Podwójny"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.js:0
+msgid "Drag and drop the building block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/drag_and_drop_move_handle.js:0
+msgid "Drag and move"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "Duplicate this block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_plugin.js:0
+msgid "Edit"
+msgstr "Edytuj"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/drop_zone_plugin.js:0
+msgid "For technical reasons, this block cannot be dropped here"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Icon"
+msgstr "Ikona"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid ""
+"If you discard the current edits, all unsaved changes will be lost. You can "
+"cancel to return to edit mode."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid "If you proceed, your changes will be lost"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Image"
+msgstr "Obraz"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Inner Content"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Insert a block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/media_website_plugin.js:0
+msgid "Insert a video"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+#: code:addons/html_builder/static/src/sidebar/snippet.xml:0
+msgid "Insert snippet"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Inset"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/snippet.xml:0
+msgid "Install"
+msgstr "Instaluj"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Install %s"
+msgstr "Zainstaluj %s"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/invisible_elements_panel.xml:0
+msgid "Invisible Elements"
+msgstr "Niewidoczne elementy"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_list.js:0
+msgid "Item"
+msgstr "Element"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.js:0
+msgid "Link Anchor"
+msgstr "Odnośnik"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Mobile Preview"
+msgstr "Podgląd mobilny"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "More info about this app."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Name"
+msgstr "Nazwa"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "No"
+msgstr "Nie"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "No block of this category can be dropped on this page."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "No snippets found"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_select.js:0
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "None"
+msgstr "Brak"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Offset (X, Y)"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Oops! No snippets found."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Outset"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Page Options"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "REPLACE BY NEW VERSION"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Remove"
+msgstr "Usuń"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "Remove this block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Rename the block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Round Corners"
+msgstr "Zaokrąglone rogi"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Save"
+msgstr "Zapisz"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Save & Copy"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Save and Install"
+msgstr "Zapisz i zainstaluj"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Search for a block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search for records..."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search more..."
+msgstr "Wyszukaj więcej..."
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search to show more records"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/customize_tab.xml:0
+msgid "Select a block on your page to style it."
+msgstr "Wybierz blok na stronie, aby nadać mu styl."
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/customize_translation_tab.xml:0
+msgid "Select content on your page to translate it."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Shadow"
+msgstr "Cień"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Solid"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Spread"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Take a look at the search bar, there might be a small typo!"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "The chosen name already exists"
+msgstr "Wybrana nazwa już istnieje"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Theme"
+msgstr "Motyw"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "This block cannot be dropped anywhere on this page."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "This block is outdated."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Tip: Esc to preview"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_row.xml:0
+msgid "Toggle more options"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/media_website_plugin.js:0
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Video"
+msgstr "Wideo"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Yes"
+msgstr "Tak"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "You can still access the block options but it might be ineffective."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "You might not be able to customize it anymore."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/save_snippet_plugin.js:0
+msgid ""
+"Your custom snippet was successfully saved as <strong>%s</strong>. Find it "
+"in your snippets collection."
+msgstr ""

--- a/addons/html_builder/i18n/pt.po
+++ b/addons/html_builder/i18n/pt.po
@@ -1,0 +1,576 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* html_builder
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 16.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-05-16 13:50+0000\n"
+"PO-Revision-Date: 2022-09-22 05:55+0000\n"
+"Last-Translator: Manuela Silva <mmsrs@sky.com>, 2023\n"
+"Language-Team: Portuguese (https://app.transifex.com/odoo/teams/41243/pt/)\n"
+"Language: pt\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: nplurals=3; plural=(n == 0 || n == 1) ? 0 : n != 0 && n % 1000000 == 0 ? 1 : 2;\n"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "ACCESS OPTIONS ANYWAY"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_list.js:0
+msgid "Add"
+msgstr "Adicionar"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Almost there! Snippets are incoming, grab a coffee and relax!"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_plugin.js:0
+msgid "Anchor copied to clipboard%(br)sLink: %(anchorLink)s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Anchor name"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Are you sure you want to delete the block %s?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Block"
+msgstr "Bloquear"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Blocks"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Blur"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Button"
+msgstr "Botão"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "Cancel"
+msgstr "Cancelar"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Categories"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.js:0
+msgid "Choose a record..."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Choose an anchor name"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Color"
+msgstr "Cor"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Column"
+msgstr "Coluna"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "Confirm"
+msgstr "Confirmar"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid "Continue"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Could not install module %(title)s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Create \""
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Create a custom snippet"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Custom %s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Custom Button"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Custom Inner Content"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Customize"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/setup_editor_plugin.js:0
+msgid "DRAG BUILDING BLOCKS HERE"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Dashed"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Discard"
+msgstr "Descartar"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Do you want to install %s App?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Do you want to save this snippet as a custom one?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Dotted"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Double"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.js:0
+msgid "Drag and drop the building block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/drag_and_drop_move_handle.js:0
+msgid "Drag and move"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "Duplicate this block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_plugin.js:0
+msgid "Edit"
+msgstr "Editar"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/drop_zone_plugin.js:0
+msgid "For technical reasons, this block cannot be dropped here"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Icon"
+msgstr "Ícone"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid ""
+"If you discard the current edits, all unsaved changes will be lost. You can "
+"cancel to return to edit mode."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid "If you proceed, your changes will be lost"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Image"
+msgstr "Imagem"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Inner Content"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Insert a block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/media_website_plugin.js:0
+msgid "Insert a video"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+#: code:addons/html_builder/static/src/sidebar/snippet.xml:0
+msgid "Insert snippet"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Inset"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/snippet.xml:0
+msgid "Install"
+msgstr "Instalar"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Install %s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/invisible_elements_panel.xml:0
+msgid "Invisible Elements"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_list.js:0
+msgid "Item"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.js:0
+msgid "Link Anchor"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Mobile Preview"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "More info about this app."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Name"
+msgstr "Nome"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "No"
+msgstr "Não"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "No block of this category can be dropped on this page."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "No snippets found"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_select.js:0
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "None"
+msgstr "Nenhum(a)"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Offset (X, Y)"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Oops! No snippets found."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Outset"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Page Options"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "REPLACE BY NEW VERSION"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Remove"
+msgstr "Remover"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "Remove this block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Rename the block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Round Corners"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Save"
+msgstr "Guardar"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Save & Copy"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Save and Install"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Search for a block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search for records..."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search more..."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search to show more records"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/customize_tab.xml:0
+msgid "Select a block on your page to style it."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/customize_translation_tab.xml:0
+msgid "Select content on your page to translate it."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Shadow"
+msgstr "Sombra"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Solid"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Spread"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Take a look at the search bar, there might be a small typo!"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "The chosen name already exists"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Theme"
+msgstr "Tema"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "This block cannot be dropped anywhere on this page."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "This block is outdated."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Tip: Esc to preview"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_row.xml:0
+msgid "Toggle more options"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/media_website_plugin.js:0
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Video"
+msgstr "Vídeo"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Yes"
+msgstr "Sim"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "You can still access the block options but it might be ineffective."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "You might not be able to customize it anymore."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/save_snippet_plugin.js:0
+msgid ""
+"Your custom snippet was successfully saved as <strong>%s</strong>. Find it "
+"in your snippets collection."
+msgstr ""

--- a/addons/html_builder/i18n/pt_BR.po
+++ b/addons/html_builder/i18n/pt_BR.po
@@ -1,0 +1,576 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* html_builder
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 16.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-05-16 13:50+0000\n"
+"PO-Revision-Date: 2022-09-22 05:55+0000\n"
+"Last-Translator: Kevilyn Rosa, 2023\n"
+"Language-Team: Portuguese (Brazil) (https://app.transifex.com/odoo/teams/41243/pt_BR/)\n"
+"Language: pt_BR\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: nplurals=3; plural=(n == 0 || n == 1) ? 0 : n != 0 && n % 1000000 == 0 ? 1 : 2;\n"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "ACCESS OPTIONS ANYWAY"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_list.js:0
+msgid "Add"
+msgstr "Adicionar"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Almost there! Snippets are incoming, grab a coffee and relax!"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_plugin.js:0
+msgid "Anchor copied to clipboard%(br)sLink: %(anchorLink)s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Anchor name"
+msgstr "Nome da âncora"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Are you sure you want to delete the block %s?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Block"
+msgstr "Bloquear"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Blocks"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Blur"
+msgstr "Blur"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Button"
+msgstr "Botão"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "Cancel"
+msgstr "Cancelar"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Categories"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.js:0
+msgid "Choose a record..."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Choose an anchor name"
+msgstr "Escolha o nome da âncora"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Color"
+msgstr "Cor"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Column"
+msgstr "Coluna"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "Confirm"
+msgstr "Confirmar"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid "Continue"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Could not install module %(title)s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Create \""
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Create a custom snippet"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Custom %s"
+msgstr "Personalizar %s"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Custom Button"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Custom Inner Content"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Customize"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/setup_editor_plugin.js:0
+msgid "DRAG BUILDING BLOCKS HERE"
+msgstr "ARRASTE OS BLOCOS DE CONSTRUÇÃO AQUI"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Dashed"
+msgstr "Tracejado"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Discard"
+msgstr "Descartar"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Do you want to install %s App?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Do you want to save this snippet as a custom one?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Dotted"
+msgstr "Pontilhado"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Double"
+msgstr "Duplo"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.js:0
+msgid "Drag and drop the building block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/drag_and_drop_move_handle.js:0
+msgid "Drag and move"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "Duplicate this block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_plugin.js:0
+msgid "Edit"
+msgstr "Editar"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/drop_zone_plugin.js:0
+msgid "For technical reasons, this block cannot be dropped here"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Icon"
+msgstr "Ícone"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid ""
+"If you discard the current edits, all unsaved changes will be lost. You can "
+"cancel to return to edit mode."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid "If you proceed, your changes will be lost"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Image"
+msgstr "Imagem"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Inner Content"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Insert a block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/media_website_plugin.js:0
+msgid "Insert a video"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+#: code:addons/html_builder/static/src/sidebar/snippet.xml:0
+msgid "Insert snippet"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Inset"
+msgstr "Inserir"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/snippet.xml:0
+msgid "Install"
+msgstr "Instalar"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Install %s"
+msgstr "Instalar %s"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/invisible_elements_panel.xml:0
+msgid "Invisible Elements"
+msgstr "Elementos invisíveis"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_list.js:0
+msgid "Item"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.js:0
+msgid "Link Anchor"
+msgstr "Âncora do Link"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Mobile Preview"
+msgstr "Visualização com dispositivo Móvel"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "More info about this app."
+msgstr "Mais informações sobre este app."
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Name"
+msgstr "Nome"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "No"
+msgstr "Não"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "No block of this category can be dropped on this page."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "No snippets found"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_select.js:0
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "None"
+msgstr "Nenhum"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Offset (X, Y)"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Oops! No snippets found."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Outset"
+msgstr "Começo"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Page Options"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "REPLACE BY NEW VERSION"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Remove"
+msgstr "Remover"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "Remove this block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Rename the block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Round Corners"
+msgstr "Cantos Arredondados"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Save"
+msgstr "Salvar"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Save & Copy"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Save and Install"
+msgstr "Salve e Instale"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Search for a block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search for records..."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search more..."
+msgstr "Pesquisar mais..."
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search to show more records"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/customize_tab.xml:0
+msgid "Select a block on your page to style it."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/customize_translation_tab.xml:0
+msgid "Select content on your page to translate it."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Shadow"
+msgstr "Sombra"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Solid"
+msgstr "Sólido"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Spread"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Take a look at the search bar, there might be a small typo!"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "The chosen name already exists"
+msgstr "O nome escolhido já existe"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Theme"
+msgstr "Tema"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "This block cannot be dropped anywhere on this page."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "This block is outdated."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Tip: Esc to preview"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_row.xml:0
+msgid "Toggle more options"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/media_website_plugin.js:0
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Video"
+msgstr "Vídeo"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Yes"
+msgstr "Sim"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "You can still access the block options but it might be ineffective."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "You might not be able to customize it anymore."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/save_snippet_plugin.js:0
+msgid ""
+"Your custom snippet was successfully saved as <strong>%s</strong>. Find it "
+"in your snippets collection."
+msgstr ""

--- a/addons/html_builder/i18n/ro.po
+++ b/addons/html_builder/i18n/ro.po
@@ -1,0 +1,576 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* html_builder
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 16.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-05-16 13:50+0000\n"
+"PO-Revision-Date: 2022-09-22 05:55+0000\n"
+"Last-Translator: Dorin Hongu <dhongu@gmail.com>, 2023\n"
+"Language-Team: Romanian (https://app.transifex.com/odoo/teams/41243/ro/)\n"
+"Language: ro\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: nplurals=3; plural=(n==1?0:(((n%100>19)||((n%100==0)&&(n!=0)))?2:1));\n"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "ACCESS OPTIONS ANYWAY"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_list.js:0
+msgid "Add"
+msgstr "Adaugă"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Almost there! Snippets are incoming, grab a coffee and relax!"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_plugin.js:0
+msgid "Anchor copied to clipboard%(br)sLink: %(anchorLink)s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Anchor name"
+msgstr "Nume ancoră"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Are you sure you want to delete the block %s?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Block"
+msgstr "Bloc"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Blocks"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Blur"
+msgstr "Aburire"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Button"
+msgstr "Buton"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "Cancel"
+msgstr "Anulează"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Categories"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.js:0
+msgid "Choose a record..."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Choose an anchor name"
+msgstr "Alegeti un nume de ancoră"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Color"
+msgstr "Color"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Column"
+msgstr "Coloana"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "Confirm"
+msgstr "Confirmă"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid "Continue"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Could not install module %(title)s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Create \""
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Create a custom snippet"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Custom %s"
+msgstr "Personalizat %s"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Custom Button"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Custom Inner Content"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Customize"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/setup_editor_plugin.js:0
+msgid "DRAG BUILDING BLOCKS HERE"
+msgstr "TRAGE BLOCURI DE CONSTRUCȚIE AICI"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Dashed"
+msgstr "Întrerupt"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Discard"
+msgstr "Abandonează"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Do you want to install %s App?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Do you want to save this snippet as a custom one?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Dotted"
+msgstr "Punctat"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Double"
+msgstr "Dublu"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.js:0
+msgid "Drag and drop the building block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/drag_and_drop_move_handle.js:0
+msgid "Drag and move"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "Duplicate this block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_plugin.js:0
+msgid "Edit"
+msgstr "Editare"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/drop_zone_plugin.js:0
+msgid "For technical reasons, this block cannot be dropped here"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Icon"
+msgstr "Pictogramă"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid ""
+"If you discard the current edits, all unsaved changes will be lost. You can "
+"cancel to return to edit mode."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid "If you proceed, your changes will be lost"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Image"
+msgstr "Imagine"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Inner Content"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Insert a block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/media_website_plugin.js:0
+msgid "Insert a video"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+#: code:addons/html_builder/static/src/sidebar/snippet.xml:0
+msgid "Insert snippet"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Inset"
+msgstr "Inset"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/snippet.xml:0
+msgid "Install"
+msgstr "Instalează"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Install %s"
+msgstr "Instalare %s"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/invisible_elements_panel.xml:0
+msgid "Invisible Elements"
+msgstr "Elemente Invizibile"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_list.js:0
+msgid "Item"
+msgstr "Articol"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.js:0
+msgid "Link Anchor"
+msgstr "Link ancoră"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Mobile Preview"
+msgstr "Previzualizare mobil"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "More info about this app."
+msgstr "Mai multe informații despre această aplicație."
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Name"
+msgstr "Nume"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "No"
+msgstr "Nu"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "No block of this category can be dropped on this page."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "No snippets found"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_select.js:0
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "None"
+msgstr "Fără"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Offset (X, Y)"
+msgstr "Offset (X, Y)"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Oops! No snippets found."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Outset"
+msgstr "Ieșire"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Page Options"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "REPLACE BY NEW VERSION"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Remove"
+msgstr "Elimină"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "Remove this block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Rename the block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Round Corners"
+msgstr "Colțuri rotunde"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Save"
+msgstr "Salvează"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Save & Copy"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Save and Install"
+msgstr "Salvare și instalare"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Search for a block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search for records..."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search more..."
+msgstr "Caută mai mult ..."
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search to show more records"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/customize_tab.xml:0
+msgid "Select a block on your page to style it."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/customize_translation_tab.xml:0
+msgid "Select content on your page to translate it."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Shadow"
+msgstr "Umbră"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Solid"
+msgstr "Solid"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Spread"
+msgstr "Răspândire"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Take a look at the search bar, there might be a small typo!"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "The chosen name already exists"
+msgstr "Numele ales există deja"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Theme"
+msgstr "Temă"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "This block cannot be dropped anywhere on this page."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "This block is outdated."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Tip: Esc to preview"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_row.xml:0
+msgid "Toggle more options"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/media_website_plugin.js:0
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Video"
+msgstr "Video"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Yes"
+msgstr "Da"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "You can still access the block options but it might be ineffective."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "You might not be able to customize it anymore."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/save_snippet_plugin.js:0
+msgid ""
+"Your custom snippet was successfully saved as <strong>%s</strong>. Find it "
+"in your snippets collection."
+msgstr ""

--- a/addons/html_builder/i18n/ru.po
+++ b/addons/html_builder/i18n/ru.po
@@ -1,0 +1,576 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* html_builder
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 17.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-02-12 10:38+0000\n"
+"PO-Revision-Date: 2024-01-30 15:14+0400\n"
+"Last-Translator: \n"
+"Language-Team: Russian (https://app.transifex.com/odoo/teams/41243/ru/)\n"
+"Language: ru\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || (n%100>=11 && n%100<=14)? 2 : 3);\n"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "ACCESS OPTIONS ANYWAY"
+msgstr "ВАРИАНТЫ ДОСТУПА В ЛЮБОМ СЛУЧАЕ"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_list.js:0
+msgid "Add"
+msgstr "Добавить"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Almost there! Snippets are incoming, grab a coffee and relax!"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_plugin.js:0
+msgid "Anchor copied to clipboard%(br)sLink: %(anchorLink)s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Anchor name"
+msgstr "Имя якоря"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Are you sure you want to delete the block %s?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Block"
+msgstr "Блок"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Blocks"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Blur"
+msgstr "Размытие"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Button"
+msgstr "Кнопка"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "Cancel"
+msgstr "Отменить"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Categories"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.js:0
+msgid "Choose a record..."
+msgstr "Выберите запись..."
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Choose an anchor name"
+msgstr "Выберите имя якоря"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Color"
+msgstr "Цвет"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Column"
+msgstr "Колонка"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "Confirm"
+msgstr "Подтвердить"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid "Continue"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Could not install module %(title)s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Create \""
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Create a custom snippet"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Custom %s"
+msgstr "Пользовательский %s"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Custom Button"
+msgstr "Пользовательская кнопка"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Custom Inner Content"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Customize"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/setup_editor_plugin.js:0
+msgid "DRAG BUILDING BLOCKS HERE"
+msgstr "ПЕРЕТАЩИТЕ СЮДА СТРОИТЕЛЬНЫЕ БЛОКИ"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Dashed"
+msgstr "Пунктирная"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Discard"
+msgstr "Отменить"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Do you want to install %s App?"
+msgstr "Вы хотите установить приложение %s?"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Do you want to save this snippet as a custom one?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Dotted"
+msgstr "Пунктирный"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Double"
+msgstr "Двойная"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.js:0
+msgid "Drag and drop the building block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/drag_and_drop_move_handle.js:0
+msgid "Drag and move"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "Duplicate this block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_plugin.js:0
+msgid "Edit"
+msgstr "Редактировать"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/drop_zone_plugin.js:0
+msgid "For technical reasons, this block cannot be dropped here"
+msgstr "По техническим причинам этот блок не может быть сброшен сюда"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Icon"
+msgstr "Иконка"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid ""
+"If you discard the current edits, all unsaved changes will be lost. You can "
+"cancel to return to edit mode."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid "If you proceed, your changes will be lost"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Image"
+msgstr "Изображение"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Inner Content"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Insert a block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/media_website_plugin.js:0
+msgid "Insert a video"
+msgstr "Вставить видео"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+#: code:addons/html_builder/static/src/sidebar/snippet.xml:0
+msgid "Insert snippet"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Inset"
+msgstr "Вставка"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/snippet.xml:0
+msgid "Install"
+msgstr "Установить"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Install %s"
+msgstr "Установить %s"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/invisible_elements_panel.xml:0
+msgid "Invisible Elements"
+msgstr "Невидимые элементы"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_list.js:0
+msgid "Item"
+msgstr "Пункт"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.js:0
+msgid "Link Anchor"
+msgstr "Якорь ссылки"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Mobile Preview"
+msgstr "Мобильный просмотр"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "More info about this app."
+msgstr "Дополнительная информация об этом приложении."
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Name"
+msgstr "Имя"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "No"
+msgstr "Нет"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "No block of this category can be dropped on this page."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "No snippets found"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_select.js:0
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "None"
+msgstr "Нет"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Offset (X, Y)"
+msgstr "Смещение (X, Y)"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Oops! No snippets found."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Outset"
+msgstr "Боковик"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Page Options"
+msgstr "Параметры страницы"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "REPLACE BY NEW VERSION"
+msgstr "ЗАМЕНИТЬ НА НОВУЮ ВЕРСИЮ"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Remove"
+msgstr "Удалить"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "Remove this block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Rename the block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Round Corners"
+msgstr "Круглые углы"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Save"
+msgstr "Сохранить"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Save & Copy"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Save and Install"
+msgstr "Сохранить и установить"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Search for a block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search for records..."
+msgstr "Поиск записей..."
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search more..."
+msgstr "Искать больше..."
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search to show more records"
+msgstr "Поиск, чтобы показать больше записей"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/customize_tab.xml:0
+msgid "Select a block on your page to style it."
+msgstr "Выберите блок на странице, чтобы придать ему стиль."
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/customize_translation_tab.xml:0
+msgid "Select content on your page to translate it."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Shadow"
+msgstr "Тень"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Solid"
+msgstr "Сплошная"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Spread"
+msgstr "Протяженность"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Take a look at the search bar, there might be a small typo!"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "The chosen name already exists"
+msgstr "Выбранное имя уже существует"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Theme"
+msgstr "Тема"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "This block cannot be dropped anywhere on this page."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "This block is outdated."
+msgstr "Этот блок устарел."
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Tip: Esc to preview"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_row.xml:0
+msgid "Toggle more options"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/media_website_plugin.js:0
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Video"
+msgstr "Видео"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Yes"
+msgstr "Да"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "You can still access the block options but it might be ineffective."
+msgstr "Вы все еще можете получить доступ к опциям блока, но это может оказаться неэффективным."
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "You might not be able to customize it anymore."
+msgstr "Возможно, вы больше не сможете настраивать его."
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/save_snippet_plugin.js:0
+msgid ""
+"Your custom snippet was successfully saved as <strong>%s</strong>. Find it "
+"in your snippets collection."
+msgstr ""

--- a/addons/html_builder/i18n/sk.po
+++ b/addons/html_builder/i18n/sk.po
@@ -1,0 +1,576 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* html_builder
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 16.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-05-16 13:50+0000\n"
+"PO-Revision-Date: 2022-09-22 05:55+0000\n"
+"Last-Translator: Jaroslav Bosansky <jaro.bosansky@ekoenergo.sk>, 2023\n"
+"Language-Team: Slovak (https://app.transifex.com/odoo/teams/41243/sk/)\n"
+"Language: sk\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: nplurals=4; plural=(n % 1 == 0 && n == 1 ? 0 : n % 1 == 0 && n >= 2 && n <= 4 ? 1 : n % 1 != 0 ? 2: 3);\n"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "ACCESS OPTIONS ANYWAY"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_list.js:0
+msgid "Add"
+msgstr "Pridať"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Almost there! Snippets are incoming, grab a coffee and relax!"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_plugin.js:0
+msgid "Anchor copied to clipboard%(br)sLink: %(anchorLink)s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Anchor name"
+msgstr "Názov kotvy"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Are you sure you want to delete the block %s?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Block"
+msgstr "Blokovať"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Blocks"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Blur"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Button"
+msgstr "Tlačidlo"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "Cancel"
+msgstr "Zrušené"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Categories"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.js:0
+msgid "Choose a record..."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Choose an anchor name"
+msgstr "Vyberte názov kotvy"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Color"
+msgstr "Farba"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Column"
+msgstr "Stĺpec"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "Confirm"
+msgstr "Potvrdiť"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid "Continue"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Could not install module %(title)s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Create \""
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Create a custom snippet"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Custom %s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Custom Button"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Custom Inner Content"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Customize"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/setup_editor_plugin.js:0
+msgid "DRAG BUILDING BLOCKS HERE"
+msgstr "TLAČTE STAVEBNÉ BLOKY"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Dashed"
+msgstr "Prerušovaný"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Discard"
+msgstr "Zrušiť"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Do you want to install %s App?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Do you want to save this snippet as a custom one?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Dotted"
+msgstr "Bodkované"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Double"
+msgstr "Dvojitý"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.js:0
+msgid "Drag and drop the building block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/drag_and_drop_move_handle.js:0
+msgid "Drag and move"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "Duplicate this block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_plugin.js:0
+msgid "Edit"
+msgstr "Upraviť"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/drop_zone_plugin.js:0
+msgid "For technical reasons, this block cannot be dropped here"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Icon"
+msgstr "Ikona"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid ""
+"If you discard the current edits, all unsaved changes will be lost. You can "
+"cancel to return to edit mode."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid "If you proceed, your changes will be lost"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Image"
+msgstr "Obrázok"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Inner Content"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Insert a block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/media_website_plugin.js:0
+msgid "Insert a video"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+#: code:addons/html_builder/static/src/sidebar/snippet.xml:0
+msgid "Insert snippet"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Inset"
+msgstr "Vložený"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/snippet.xml:0
+msgid "Install"
+msgstr "Nainštalovať"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Install %s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/invisible_elements_panel.xml:0
+msgid "Invisible Elements"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_list.js:0
+msgid "Item"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.js:0
+msgid "Link Anchor"
+msgstr "Spojovacia kotva"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Mobile Preview"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "More info about this app."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Name"
+msgstr "Meno"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "No"
+msgstr "Nie"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "No block of this category can be dropped on this page."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "No snippets found"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_select.js:0
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "None"
+msgstr "Žiadne"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Offset (X, Y)"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Oops! No snippets found."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Outset"
+msgstr "Na začiatku"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Page Options"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "REPLACE BY NEW VERSION"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Remove"
+msgstr "Odstrániť"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "Remove this block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Rename the block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Round Corners"
+msgstr "Oblé rohy"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Save"
+msgstr "Uložiť"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Save & Copy"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Save and Install"
+msgstr "Uložiť a inštalovať"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Search for a block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search for records..."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search more..."
+msgstr "Vyhľadať viac..."
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search to show more records"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/customize_tab.xml:0
+msgid "Select a block on your page to style it."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/customize_translation_tab.xml:0
+msgid "Select content on your page to translate it."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Shadow"
+msgstr "Tieň"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Solid"
+msgstr "Jednoliaty"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Spread"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Take a look at the search bar, there might be a small typo!"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "The chosen name already exists"
+msgstr "Vybraté meno už existuje"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Theme"
+msgstr "Téma"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "This block cannot be dropped anywhere on this page."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "This block is outdated."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Tip: Esc to preview"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_row.xml:0
+msgid "Toggle more options"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/media_website_plugin.js:0
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Video"
+msgstr "Video"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Yes"
+msgstr "Áno"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "You can still access the block options but it might be ineffective."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "You might not be able to customize it anymore."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/save_snippet_plugin.js:0
+msgid ""
+"Your custom snippet was successfully saved as <strong>%s</strong>. Find it "
+"in your snippets collection."
+msgstr ""

--- a/addons/html_builder/i18n/sl.po
+++ b/addons/html_builder/i18n/sl.po
@@ -1,0 +1,576 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* html_builder
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 16.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-05-16 13:50+0000\n"
+"PO-Revision-Date: 2022-09-22 05:55+0000\n"
+"Last-Translator: Tomaž Jug <tomaz@editor.si>, 2023\n"
+"Language-Team: Slovenian (https://app.transifex.com/odoo/teams/41243/sl/)\n"
+"Language: sl\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: nplurals=4; plural=(n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || n%100==4 ? 2 : 3);\n"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "ACCESS OPTIONS ANYWAY"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_list.js:0
+msgid "Add"
+msgstr "Dodaj"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Almost there! Snippets are incoming, grab a coffee and relax!"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_plugin.js:0
+msgid "Anchor copied to clipboard%(br)sLink: %(anchorLink)s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Anchor name"
+msgstr "Ime sidra"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Are you sure you want to delete the block %s?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Block"
+msgstr "Blok"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Blocks"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Blur"
+msgstr "Zameglitev"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Button"
+msgstr "Gumb"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "Cancel"
+msgstr "Prekliči"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Categories"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.js:0
+msgid "Choose a record..."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Choose an anchor name"
+msgstr "Izberite ime sidra"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Color"
+msgstr "Barva"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Column"
+msgstr "Stolpec"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "Confirm"
+msgstr "Potrdi"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid "Continue"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Could not install module %(title)s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Create \""
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Create a custom snippet"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Custom %s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Custom Button"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Custom Inner Content"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Customize"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/setup_editor_plugin.js:0
+msgid "DRAG BUILDING BLOCKS HERE"
+msgstr "SEM POVLECITE BLOKE"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Dashed"
+msgstr "Črtkano"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Discard"
+msgstr "Opusti"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Do you want to install %s App?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Do you want to save this snippet as a custom one?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Dotted"
+msgstr "Točkovano"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Double"
+msgstr "Dvojno"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.js:0
+msgid "Drag and drop the building block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/drag_and_drop_move_handle.js:0
+msgid "Drag and move"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "Duplicate this block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_plugin.js:0
+msgid "Edit"
+msgstr "Uredi"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/drop_zone_plugin.js:0
+msgid "For technical reasons, this block cannot be dropped here"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Icon"
+msgstr "Ikona"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid ""
+"If you discard the current edits, all unsaved changes will be lost. You can "
+"cancel to return to edit mode."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid "If you proceed, your changes will be lost"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Image"
+msgstr "Slika"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Inner Content"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Insert a block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/media_website_plugin.js:0
+msgid "Insert a video"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+#: code:addons/html_builder/static/src/sidebar/snippet.xml:0
+msgid "Insert snippet"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Inset"
+msgstr "Znotraj"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/snippet.xml:0
+msgid "Install"
+msgstr "Namesti"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Install %s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/invisible_elements_panel.xml:0
+msgid "Invisible Elements"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_list.js:0
+msgid "Item"
+msgstr "Element/a"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.js:0
+msgid "Link Anchor"
+msgstr "Sidro povezave"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Mobile Preview"
+msgstr "Mobilni predogled"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "More info about this app."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Name"
+msgstr "Naziv"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "No"
+msgstr "Ne"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "No block of this category can be dropped on this page."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "No snippets found"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_select.js:0
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "None"
+msgstr "Ni prenosa"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Offset (X, Y)"
+msgstr "Odmik (X, Y)"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Oops! No snippets found."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Outset"
+msgstr "Navzven"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Page Options"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "REPLACE BY NEW VERSION"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Remove"
+msgstr "Odstrani"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "Remove this block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Rename the block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Round Corners"
+msgstr "Okrogli vogali"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Save"
+msgstr "Shrani"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Save & Copy"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Save and Install"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Search for a block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search for records..."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search more..."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search to show more records"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/customize_tab.xml:0
+msgid "Select a block on your page to style it."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/customize_translation_tab.xml:0
+msgid "Select content on your page to translate it."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Shadow"
+msgstr "Senca"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Solid"
+msgstr "Normalno"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Spread"
+msgstr "Razpršitev"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Take a look at the search bar, there might be a small typo!"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "The chosen name already exists"
+msgstr "Izbrano ime že obstaja"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Theme"
+msgstr "Tema"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "This block cannot be dropped anywhere on this page."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "This block is outdated."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Tip: Esc to preview"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_row.xml:0
+msgid "Toggle more options"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/media_website_plugin.js:0
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Video"
+msgstr "Video"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Yes"
+msgstr "Da"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "You can still access the block options but it might be ineffective."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "You might not be able to customize it anymore."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/save_snippet_plugin.js:0
+msgid ""
+"Your custom snippet was successfully saved as <strong>%s</strong>. Find it "
+"in your snippets collection."
+msgstr ""

--- a/addons/html_builder/i18n/sr@latin.po
+++ b/addons/html_builder/i18n/sr@latin.po
@@ -1,0 +1,578 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* html_builder
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 16.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-05-16 13:50+0000\n"
+"PO-Revision-Date: 2022-09-22 05:55+0000\n"
+"Last-Translator: Dragan Vukosavljevic <dragan.vukosavljevic@gmail.com>, "
+"2023\n"
+"Language-Team: Serbian (https://app.transifex.com/odoo/teams/41243/sr/)\n"
+"Language: sr\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "ACCESS OPTIONS ANYWAY"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_list.js:0
+msgid "Add"
+msgstr "Dodaj"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Almost there! Snippets are incoming, grab a coffee and relax!"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_plugin.js:0
+msgid "Anchor copied to clipboard%(br)sLink: %(anchorLink)s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Anchor name"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Are you sure you want to delete the block %s?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Blocks"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Blur"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Button"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "Cancel"
+msgstr "Otkaži"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Categories"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.js:0
+msgid "Choose a record..."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Choose an anchor name"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Color"
+msgstr "Boja"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Column"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "Confirm"
+msgstr "Potvrdi"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid "Continue"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Could not install module %(title)s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Create \""
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Create a custom snippet"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Custom %s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Custom Button"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Custom Inner Content"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Customize"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/setup_editor_plugin.js:0
+msgid "DRAG BUILDING BLOCKS HERE"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Dashed"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Discard"
+msgstr "Poništi"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Do you want to install %s App?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Do you want to save this snippet as a custom one?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Dotted"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Double"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.js:0
+msgid "Drag and drop the building block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/drag_and_drop_move_handle.js:0
+msgid "Drag and move"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "Duplicate this block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_plugin.js:0
+msgid "Edit"
+msgstr "Uredi"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/drop_zone_plugin.js:0
+msgid "For technical reasons, this block cannot be dropped here"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Icon"
+msgstr "Ikona"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid ""
+"If you discard the current edits, all unsaved changes will be lost. You can "
+"cancel to return to edit mode."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid "If you proceed, your changes will be lost"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Image"
+msgstr "Slika"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Inner Content"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Insert a block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/media_website_plugin.js:0
+msgid "Insert a video"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+#: code:addons/html_builder/static/src/sidebar/snippet.xml:0
+msgid "Insert snippet"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Inset"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/snippet.xml:0
+msgid "Install"
+msgstr "Instaliraj"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Install %s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/invisible_elements_panel.xml:0
+msgid "Invisible Elements"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_list.js:0
+msgid "Item"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.js:0
+msgid "Link Anchor"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Mobile Preview"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "More info about this app."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Name"
+msgstr "Ime"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "No"
+msgstr "Ne"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "No block of this category can be dropped on this page."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "No snippets found"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_select.js:0
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "None"
+msgstr "Ništa"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Offset (X, Y)"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Oops! No snippets found."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Outset"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Page Options"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "REPLACE BY NEW VERSION"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Remove"
+msgstr "Ukloni"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "Remove this block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Rename the block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Round Corners"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Save"
+msgstr "Sačuvaj"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Save & Copy"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Save and Install"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Search for a block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search for records..."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search more..."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search to show more records"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/customize_tab.xml:0
+msgid "Select a block on your page to style it."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/customize_translation_tab.xml:0
+msgid "Select content on your page to translate it."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Shadow"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Solid"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Spread"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Take a look at the search bar, there might be a small typo!"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "The chosen name already exists"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Theme"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "This block cannot be dropped anywhere on this page."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "This block is outdated."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Tip: Esc to preview"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_row.xml:0
+msgid "Toggle more options"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/media_website_plugin.js:0
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Video"
+msgstr "Video"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Yes"
+msgstr "Da"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "You can still access the block options but it might be ineffective."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "You might not be able to customize it anymore."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/save_snippet_plugin.js:0
+msgid ""
+"Your custom snippet was successfully saved as <strong>%s</strong>. Find it "
+"in your snippets collection."
+msgstr ""

--- a/addons/html_builder/i18n/sv.po
+++ b/addons/html_builder/i18n/sv.po
@@ -1,0 +1,576 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* html_builder
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 16.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-05-16 13:50+0000\n"
+"PO-Revision-Date: 2022-09-22 05:55+0000\n"
+"Last-Translator: Patrik Lermon <patrik.lermon@gmail.com>, 2023\n"
+"Language-Team: Swedish (https://app.transifex.com/odoo/teams/41243/sv/)\n"
+"Language: sv\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "ACCESS OPTIONS ANYWAY"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_list.js:0
+msgid "Add"
+msgstr "Lägg till"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Almost there! Snippets are incoming, grab a coffee and relax!"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_plugin.js:0
+msgid "Anchor copied to clipboard%(br)sLink: %(anchorLink)s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Anchor name"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Are you sure you want to delete the block %s?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Block"
+msgstr "Block"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Blocks"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Blur"
+msgstr "Oskärpa"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Button"
+msgstr "Knapp"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "Cancel"
+msgstr "Avbryt"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Categories"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.js:0
+msgid "Choose a record..."
+msgstr "Välj en post..."
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Choose an anchor name"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Color"
+msgstr "Färg"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Column"
+msgstr "Kolumn"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "Confirm"
+msgstr "Bekräfta"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid "Continue"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Could not install module %(title)s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Create \""
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Create a custom snippet"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Custom %s"
+msgstr "Anpassad %s"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Custom Button"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Custom Inner Content"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Customize"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/setup_editor_plugin.js:0
+msgid "DRAG BUILDING BLOCKS HERE"
+msgstr "DRA BYGGBLOCK HIT"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Dashed"
+msgstr "Streckad"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Discard"
+msgstr "Avbryt"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Do you want to install %s App?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Do you want to save this snippet as a custom one?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Dotted"
+msgstr "Prickad"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Double"
+msgstr "Dubbel"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.js:0
+msgid "Drag and drop the building block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/drag_and_drop_move_handle.js:0
+msgid "Drag and move"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "Duplicate this block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_plugin.js:0
+msgid "Edit"
+msgstr "Redigera"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/drop_zone_plugin.js:0
+msgid "For technical reasons, this block cannot be dropped here"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Icon"
+msgstr "Ikon"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid ""
+"If you discard the current edits, all unsaved changes will be lost. You can "
+"cancel to return to edit mode."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid "If you proceed, your changes will be lost"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Image"
+msgstr "Bild"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Inner Content"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Insert a block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/media_website_plugin.js:0
+msgid "Insert a video"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+#: code:addons/html_builder/static/src/sidebar/snippet.xml:0
+msgid "Insert snippet"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Inset"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/snippet.xml:0
+msgid "Install"
+msgstr "Installera"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Install %s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/invisible_elements_panel.xml:0
+msgid "Invisible Elements"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_list.js:0
+msgid "Item"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.js:0
+msgid "Link Anchor"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Mobile Preview"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "More info about this app."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Name"
+msgstr "Namn"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "No"
+msgstr "Nej"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "No block of this category can be dropped on this page."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "No snippets found"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_select.js:0
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "None"
+msgstr "Inga"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Offset (X, Y)"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Oops! No snippets found."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Outset"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Page Options"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "REPLACE BY NEW VERSION"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Remove"
+msgstr "Ta bort"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "Remove this block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Rename the block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Round Corners"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Save"
+msgstr "Bokför"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Save & Copy"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Save and Install"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Search for a block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search for records..."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search more..."
+msgstr "Sök mer..."
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search to show more records"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/customize_tab.xml:0
+msgid "Select a block on your page to style it."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/customize_translation_tab.xml:0
+msgid "Select content on your page to translate it."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Shadow"
+msgstr "Skugga"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Solid"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Spread"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Take a look at the search bar, there might be a small typo!"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "The chosen name already exists"
+msgstr "Det valda namnet existerar redan"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Theme"
+msgstr "Tema"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "This block cannot be dropped anywhere on this page."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "This block is outdated."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Tip: Esc to preview"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_row.xml:0
+msgid "Toggle more options"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/media_website_plugin.js:0
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Video"
+msgstr "Video"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Yes"
+msgstr "Ja"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "You can still access the block options but it might be ineffective."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "You might not be able to customize it anymore."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/save_snippet_plugin.js:0
+msgid ""
+"Your custom snippet was successfully saved as <strong>%s</strong>. Find it "
+"in your snippets collection."
+msgstr ""

--- a/addons/html_builder/i18n/th.po
+++ b/addons/html_builder/i18n/th.po
@@ -1,0 +1,576 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* html_builder
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 16.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-05-16 13:50+0000\n"
+"PO-Revision-Date: 2022-09-22 05:55+0000\n"
+"Last-Translator: Martin Trigaux, 2023\n"
+"Language-Team: Thai (https://app.transifex.com/odoo/teams/41243/th/)\n"
+"Language: th\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "ACCESS OPTIONS ANYWAY"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_list.js:0
+msgid "Add"
+msgstr "เพิ่ม"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Almost there! Snippets are incoming, grab a coffee and relax!"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_plugin.js:0
+msgid "Anchor copied to clipboard%(br)sLink: %(anchorLink)s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Anchor name"
+msgstr "ชื่อ Anchor"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Are you sure you want to delete the block %s?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Block"
+msgstr "บล็อก"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Blocks"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Blur"
+msgstr "เบลอ"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Button"
+msgstr "ปุ่ม"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "Cancel"
+msgstr "ยกเลิก"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Categories"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.js:0
+msgid "Choose a record..."
+msgstr "เลือกบันทึก..."
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Choose an anchor name"
+msgstr "เลือกชื่อ anchor"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Color"
+msgstr "สี"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Column"
+msgstr "คอลัมน์"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "Confirm"
+msgstr "ยืนยัน"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid "Continue"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Could not install module %(title)s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Create \""
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Create a custom snippet"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Custom %s"
+msgstr "กำหนดเอง %s"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Custom Button"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Custom Inner Content"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Customize"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/setup_editor_plugin.js:0
+msgid "DRAG BUILDING BLOCKS HERE"
+msgstr "ลากกล่องข้อความมาที่นี่"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Dashed"
+msgstr "เส้นประ"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Discard"
+msgstr "ละทิ้ง"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Do you want to install %s App?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Do you want to save this snippet as a custom one?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Dotted"
+msgstr "เส้นจุด"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Double"
+msgstr "สองเส้น"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.js:0
+msgid "Drag and drop the building block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/drag_and_drop_move_handle.js:0
+msgid "Drag and move"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "Duplicate this block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_plugin.js:0
+msgid "Edit"
+msgstr "การแก้ไข"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/drop_zone_plugin.js:0
+msgid "For technical reasons, this block cannot be dropped here"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Icon"
+msgstr "ไอคอน"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid ""
+"If you discard the current edits, all unsaved changes will be lost. You can "
+"cancel to return to edit mode."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid "If you proceed, your changes will be lost"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Image"
+msgstr "รูปภาพ"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Inner Content"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Insert a block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/media_website_plugin.js:0
+msgid "Insert a video"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+#: code:addons/html_builder/static/src/sidebar/snippet.xml:0
+msgid "Insert snippet"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Inset"
+msgstr "แทรก"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/snippet.xml:0
+msgid "Install"
+msgstr "ติดตั้ง"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Install %s"
+msgstr "ติดตั้ง %s"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/invisible_elements_panel.xml:0
+msgid "Invisible Elements"
+msgstr "องค์ประกอบที่มองไม่เห็น"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_list.js:0
+msgid "Item"
+msgstr "รายการ"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.js:0
+msgid "Link Anchor"
+msgstr "ลิงก์ Anchor"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Mobile Preview"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "More info about this app."
+msgstr "ข้อมูลเพิ่มเติมเกี่ยวกับแอปนี้"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Name"
+msgstr "ชื่อ"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "No"
+msgstr "ไม่"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "No block of this category can be dropped on this page."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "No snippets found"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_select.js:0
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "None"
+msgstr "ไม่มี"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Offset (X, Y)"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Oops! No snippets found."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Outset"
+msgstr "เริ่มแรก"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Page Options"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "REPLACE BY NEW VERSION"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Remove"
+msgstr "นำออก"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "Remove this block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Rename the block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Round Corners"
+msgstr "มุมโค้งมน"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Save"
+msgstr "บันทึก"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Save & Copy"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Save and Install"
+msgstr "บันทึกและติดตั้ง"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Search for a block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search for records..."
+msgstr "ค้นหาบันทึก..."
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search more..."
+msgstr "ค้นหาเพิ่มเติม..."
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search to show more records"
+msgstr "ค้นหาเพื่อแสดงบันทึกเพิ่มเติม"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/customize_tab.xml:0
+msgid "Select a block on your page to style it."
+msgstr "เลือกบล็อกบนเพจของคุณเพื่อจัดรูปแบบ"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/customize_translation_tab.xml:0
+msgid "Select content on your page to translate it."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Shadow"
+msgstr "เงา"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Solid"
+msgstr "ของแข็ง"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Spread"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Take a look at the search bar, there might be a small typo!"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "The chosen name already exists"
+msgstr "ชื่อที่เลือกมีอยู่แล้ว"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Theme"
+msgstr "ธีม"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "This block cannot be dropped anywhere on this page."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "This block is outdated."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Tip: Esc to preview"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_row.xml:0
+msgid "Toggle more options"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/media_website_plugin.js:0
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Video"
+msgstr "วิดีโอ"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Yes"
+msgstr "ใช่"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "You can still access the block options but it might be ineffective."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "You might not be able to customize it anymore."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/save_snippet_plugin.js:0
+msgid ""
+"Your custom snippet was successfully saved as <strong>%s</strong>. Find it "
+"in your snippets collection."
+msgstr ""

--- a/addons/html_builder/i18n/tr.po
+++ b/addons/html_builder/i18n/tr.po
@@ -1,0 +1,576 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* html_builder
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 16.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-05-16 13:50+0000\n"
+"PO-Revision-Date: 2022-09-22 05:55+0000\n"
+"Last-Translator: Martin Trigaux, 2023\n"
+"Language-Team: Turkish (https://app.transifex.com/odoo/teams/41243/tr/)\n"
+"Language: tr\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "ACCESS OPTIONS ANYWAY"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_list.js:0
+msgid "Add"
+msgstr "Ekle"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Almost there! Snippets are incoming, grab a coffee and relax!"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_plugin.js:0
+msgid "Anchor copied to clipboard%(br)sLink: %(anchorLink)s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Anchor name"
+msgstr "Bağlantı adı"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Are you sure you want to delete the block %s?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Block"
+msgstr "Engelle"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Blocks"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Blur"
+msgstr "Bulanıklık"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Button"
+msgstr "Buton"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "Cancel"
+msgstr "İptal"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Categories"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.js:0
+msgid "Choose a record..."
+msgstr "Bağlanacak kaydı seçin..."
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Choose an anchor name"
+msgstr "Bir bağlantı adı seçin"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Color"
+msgstr "Renk"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Column"
+msgstr "Sütun"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "Confirm"
+msgstr "Onayla"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid "Continue"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Could not install module %(title)s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Create \""
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Create a custom snippet"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Custom %s"
+msgstr "Özel%s"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Custom Button"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Custom Inner Content"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Customize"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/setup_editor_plugin.js:0
+msgid "DRAG BUILDING BLOCKS HERE"
+msgstr "YAPI BLOKLARINI BURYA SÜRÜKLEYİN"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Dashed"
+msgstr "Kesik"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Discard"
+msgstr "Vazgeç"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Do you want to install %s App?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Do you want to save this snippet as a custom one?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Dotted"
+msgstr "Noktalı"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Double"
+msgstr "Çift"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.js:0
+msgid "Drag and drop the building block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/drag_and_drop_move_handle.js:0
+msgid "Drag and move"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "Duplicate this block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_plugin.js:0
+msgid "Edit"
+msgstr "Düzenle"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/drop_zone_plugin.js:0
+msgid "For technical reasons, this block cannot be dropped here"
+msgstr "Teknik nedenlerden dolayı, bu blok buraya bırakılamaz"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Icon"
+msgstr "İkon"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid ""
+"If you discard the current edits, all unsaved changes will be lost. You can "
+"cancel to return to edit mode."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid "If you proceed, your changes will be lost"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Image"
+msgstr "Görsel"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Inner Content"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Insert a block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/media_website_plugin.js:0
+msgid "Insert a video"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+#: code:addons/html_builder/static/src/sidebar/snippet.xml:0
+msgid "Insert snippet"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Inset"
+msgstr "İlave"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/snippet.xml:0
+msgid "Install"
+msgstr "Yükle"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Install %s"
+msgstr "Yükle %s"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/invisible_elements_panel.xml:0
+msgid "Invisible Elements"
+msgstr "Görünmez Elemanlar"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_list.js:0
+msgid "Item"
+msgstr "Öğe"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.js:0
+msgid "Link Anchor"
+msgstr "Bağlantı Çapası"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Mobile Preview"
+msgstr "Mobil Önizleme"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "More info about this app."
+msgstr "Bu uygulama hakkında daha fazla bilgi."
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Name"
+msgstr "Adı"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "No"
+msgstr "Hayır"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "No block of this category can be dropped on this page."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "No snippets found"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_select.js:0
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "None"
+msgstr "Hiçbiri"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Offset (X, Y)"
+msgstr "Denkleştirmek (X, Y)"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Oops! No snippets found."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Outset"
+msgstr "Başlangıç"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Page Options"
+msgstr "Sayfa Seçenekleri"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "REPLACE BY NEW VERSION"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Remove"
+msgstr "Kaldır"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "Remove this block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Rename the block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Round Corners"
+msgstr "Yuvarlak köşeler"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Save"
+msgstr "Kaydet"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Save & Copy"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Save and Install"
+msgstr "Kaydet ve Yükle"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Search for a block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search for records..."
+msgstr "Kayıt arama..."
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search more..."
+msgstr "Daha fazlasını ara ..."
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search to show more records"
+msgstr "Daha fazla kayıt göstermek için arama yapın"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/customize_tab.xml:0
+msgid "Select a block on your page to style it."
+msgstr "Stil uygulamak için sayfanızda bir blok seçin."
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/customize_translation_tab.xml:0
+msgid "Select content on your page to translate it."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Shadow"
+msgstr "Gölge"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Solid"
+msgstr "Katı"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Spread"
+msgstr "Yayıldı"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Take a look at the search bar, there might be a small typo!"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "The chosen name already exists"
+msgstr "Seçilen ad zaten var"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Theme"
+msgstr "Tema"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "This block cannot be dropped anywhere on this page."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "This block is outdated."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Tip: Esc to preview"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_row.xml:0
+msgid "Toggle more options"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/media_website_plugin.js:0
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Video"
+msgstr "Video"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Yes"
+msgstr "Evet"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "You can still access the block options but it might be ineffective."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "You might not be able to customize it anymore."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/save_snippet_plugin.js:0
+msgid ""
+"Your custom snippet was successfully saved as <strong>%s</strong>. Find it "
+"in your snippets collection."
+msgstr ""

--- a/addons/html_builder/i18n/uk.po
+++ b/addons/html_builder/i18n/uk.po
@@ -1,0 +1,576 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* html_builder
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 16.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-05-16 13:50+0000\n"
+"PO-Revision-Date: 2022-09-22 05:55+0000\n"
+"Last-Translator: Martin Trigaux, 2023\n"
+"Language-Team: Ukrainian (https://app.transifex.com/odoo/teams/41243/uk/)\n"
+"Language: uk\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: nplurals=4; plural=(n % 1 == 0 && n % 10 == 1 && n % 100 != 11 ? 0 : n % 1 == 0 && n % 10 >= 2 && n % 10 <= 4 && (n % 100 < 12 || n % 100 > 14) ? 1 : n % 1 == 0 && (n % 10 ==0 || (n % 10 >=5 && n % 10 <=9) || (n % 100 >=11 && n % 100 <=14 )) ? 2: 3);\n"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "ACCESS OPTIONS ANYWAY"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_list.js:0
+msgid "Add"
+msgstr "Додати"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Almost there! Snippets are incoming, grab a coffee and relax!"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_plugin.js:0
+msgid "Anchor copied to clipboard%(br)sLink: %(anchorLink)s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Anchor name"
+msgstr "Назва якіра"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Are you sure you want to delete the block %s?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Block"
+msgstr "Блокувати"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Blocks"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Blur"
+msgstr "Замилювання"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Button"
+msgstr "Кнопка"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "Cancel"
+msgstr "Скасувати"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Categories"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.js:0
+msgid "Choose a record..."
+msgstr "Оберіть запис..."
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Choose an anchor name"
+msgstr "Оберіть назву якоря"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Color"
+msgstr "Колір"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Column"
+msgstr "Колонка"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "Confirm"
+msgstr "Підтвердити"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid "Continue"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Could not install module %(title)s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Create \""
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Create a custom snippet"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Custom %s"
+msgstr "Кастомний %s"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Custom Button"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Custom Inner Content"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Customize"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/setup_editor_plugin.js:0
+msgid "DRAG BUILDING BLOCKS HERE"
+msgstr "ПЕРЕТЯГНІТЬ СЮДИ БЛОКИ"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Dashed"
+msgstr "Підкреслено пунктиром"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Discard"
+msgstr "Відмінити"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Do you want to install %s App?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Do you want to save this snippet as a custom one?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Dotted"
+msgstr "Позначено пунктиром"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Double"
+msgstr "Подвійний"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.js:0
+msgid "Drag and drop the building block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/drag_and_drop_move_handle.js:0
+msgid "Drag and move"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "Duplicate this block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_plugin.js:0
+msgid "Edit"
+msgstr "Редагувати"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/drop_zone_plugin.js:0
+msgid "For technical reasons, this block cannot be dropped here"
+msgstr "З технічних причин цей блок не можна опустити сюди"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Icon"
+msgstr "Значок"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid ""
+"If you discard the current edits, all unsaved changes will be lost. You can "
+"cancel to return to edit mode."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid "If you proceed, your changes will be lost"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Image"
+msgstr "Зображення"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Inner Content"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Insert a block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/media_website_plugin.js:0
+msgid "Insert a video"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+#: code:addons/html_builder/static/src/sidebar/snippet.xml:0
+msgid "Insert snippet"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Inset"
+msgstr "Вставка"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/snippet.xml:0
+msgid "Install"
+msgstr "Встановити"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Install %s"
+msgstr "Встановити %s"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/invisible_elements_panel.xml:0
+msgid "Invisible Elements"
+msgstr "Невидимі елементи"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_list.js:0
+msgid "Item"
+msgstr "Елемент"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.js:0
+msgid "Link Anchor"
+msgstr "Пов'зати якір"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Mobile Preview"
+msgstr "Попередній перегляд мобільної версії"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "More info about this app."
+msgstr "Більше інформації про цей модуль."
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Name"
+msgstr "Назва"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "No"
+msgstr "Ні"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "No block of this category can be dropped on this page."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "No snippets found"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_select.js:0
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "None"
+msgstr "Немає"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Offset (X, Y)"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Oops! No snippets found."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Outset"
+msgstr "Справа"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Page Options"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "REPLACE BY NEW VERSION"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Remove"
+msgstr "Вилучити"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "Remove this block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Rename the block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Round Corners"
+msgstr "Заокруглені кути"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Save"
+msgstr "Зберегти"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Save & Copy"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Save and Install"
+msgstr "Зберегти та встановити"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Search for a block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search for records..."
+msgstr "Пошук записів..."
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search more..."
+msgstr "Шукати більше..."
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search to show more records"
+msgstr "Шукати, щоби показати більше записів"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/customize_tab.xml:0
+msgid "Select a block on your page to style it."
+msgstr "Оберіть блок на вашій сторінці, щоби стилізувати її."
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/customize_translation_tab.xml:0
+msgid "Select content on your page to translate it."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Shadow"
+msgstr "Тінь"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Solid"
+msgstr "Суцільний"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Spread"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Take a look at the search bar, there might be a small typo!"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "The chosen name already exists"
+msgstr "Вибрана назва вже існує"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Theme"
+msgstr "Тема"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "This block cannot be dropped anywhere on this page."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "This block is outdated."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Tip: Esc to preview"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_row.xml:0
+msgid "Toggle more options"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/media_website_plugin.js:0
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Video"
+msgstr "Відео"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Yes"
+msgstr "Так"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "You can still access the block options but it might be ineffective."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "You might not be able to customize it anymore."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/save_snippet_plugin.js:0
+msgid ""
+"Your custom snippet was successfully saved as <strong>%s</strong>. Find it "
+"in your snippets collection."
+msgstr ""

--- a/addons/html_builder/i18n/vi.po
+++ b/addons/html_builder/i18n/vi.po
@@ -1,0 +1,576 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* html_builder
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 16.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-05-16 13:50+0000\n"
+"PO-Revision-Date: 2022-09-22 05:55+0000\n"
+"Last-Translator: Thi Huong Nguyen, 2023\n"
+"Language-Team: Vietnamese (https://app.transifex.com/odoo/teams/41243/vi/)\n"
+"Language: vi\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "ACCESS OPTIONS ANYWAY"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_list.js:0
+msgid "Add"
+msgstr "Thêm"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Almost there! Snippets are incoming, grab a coffee and relax!"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_plugin.js:0
+msgid "Anchor copied to clipboard%(br)sLink: %(anchorLink)s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Anchor name"
+msgstr "Tên neo"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Are you sure you want to delete the block %s?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Block"
+msgstr "Khoá"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Blocks"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Blur"
+msgstr "Làm mờ"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Button"
+msgstr "Nút"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "Cancel"
+msgstr "Hủy"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Categories"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.js:0
+msgid "Choose a record..."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Choose an anchor name"
+msgstr "Chọn một tên liên kết"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Color"
+msgstr "Màu sắc"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Column"
+msgstr "Cột"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "Confirm"
+msgstr "Xác nhận"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid "Continue"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Could not install module %(title)s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Create \""
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Create a custom snippet"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Custom %s"
+msgstr "Chỉnh %s"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Custom Button"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Custom Inner Content"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Customize"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/setup_editor_plugin.js:0
+msgid "DRAG BUILDING BLOCKS HERE"
+msgstr "THẢ KHỐI TẠI ĐÂY"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Dashed"
+msgstr "Vượt qua"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Discard"
+msgstr "Huỷ bỏ"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Do you want to install %s App?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Do you want to save this snippet as a custom one?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Dotted"
+msgstr "Say mê"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Double"
+msgstr "Gấp đôi"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.js:0
+msgid "Drag and drop the building block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/drag_and_drop_move_handle.js:0
+msgid "Drag and move"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "Duplicate this block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_plugin.js:0
+msgid "Edit"
+msgstr "Sửa"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/drop_zone_plugin.js:0
+msgid "For technical reasons, this block cannot be dropped here"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Icon"
+msgstr "Biểu tượng"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid ""
+"If you discard the current edits, all unsaved changes will be lost. You can "
+"cancel to return to edit mode."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid "If you proceed, your changes will be lost"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Image"
+msgstr "Hình ảnh"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Inner Content"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Insert a block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/media_website_plugin.js:0
+msgid "Insert a video"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+#: code:addons/html_builder/static/src/sidebar/snippet.xml:0
+msgid "Insert snippet"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Inset"
+msgstr "Inset"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/snippet.xml:0
+msgid "Install"
+msgstr "Cài đặt"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Install %s"
+msgstr "Cài đặt %s"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/invisible_elements_panel.xml:0
+msgid "Invisible Elements"
+msgstr "Yếu tố vô hình"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_list.js:0
+msgid "Item"
+msgstr "Mục"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.js:0
+msgid "Link Anchor"
+msgstr "Link Anchor"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Mobile Preview"
+msgstr "Xem trước Mobile"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "More info about this app."
+msgstr "Thông tin thêm về ứng dụng này."
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Name"
+msgstr "Tên"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "No"
+msgstr "Không"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "No block of this category can be dropped on this page."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "No snippets found"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_select.js:0
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "None"
+msgstr "Không "
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Offset (X, Y)"
+msgstr "Chênh lệch (X, Y)"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Oops! No snippets found."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Outset"
+msgstr "Outset"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Page Options"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "REPLACE BY NEW VERSION"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Remove"
+msgstr "Gỡ"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "Remove this block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Rename the block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Round Corners"
+msgstr "Bo góc"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Save"
+msgstr "Lưu"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Save & Copy"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Save and Install"
+msgstr "Lưu và cài đặt"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Search for a block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search for records..."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search more..."
+msgstr "Search more..."
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search to show more records"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/customize_tab.xml:0
+msgid "Select a block on your page to style it."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/customize_translation_tab.xml:0
+msgid "Select content on your page to translate it."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Shadow"
+msgstr "Đổ bóng"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Solid"
+msgstr "Rắn"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Spread"
+msgstr "Truyền đi"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Take a look at the search bar, there might be a small typo!"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "The chosen name already exists"
+msgstr "Tên được chọn đã tồn tại"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Theme"
+msgstr "Chủ đề"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "This block cannot be dropped anywhere on this page."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "This block is outdated."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Tip: Esc to preview"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_row.xml:0
+msgid "Toggle more options"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/media_website_plugin.js:0
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Video"
+msgstr "Video"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Yes"
+msgstr "Có"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "You can still access the block options but it might be ineffective."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "You might not be able to customize it anymore."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/save_snippet_plugin.js:0
+msgid ""
+"Your custom snippet was successfully saved as <strong>%s</strong>. Find it "
+"in your snippets collection."
+msgstr ""

--- a/addons/html_builder/i18n/zh_CN.po
+++ b/addons/html_builder/i18n/zh_CN.po
@@ -1,0 +1,576 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* html_builder
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 16.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-05-16 13:50+0000\n"
+"PO-Revision-Date: 2022-09-22 05:55+0000\n"
+"Last-Translator: Martin Trigaux, 2023\n"
+"Language-Team: Chinese (China) (https://app.transifex.com/odoo/teams/41243/zh_CN/)\n"
+"Language: zh_CN\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "ACCESS OPTIONS ANYWAY"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_list.js:0
+msgid "Add"
+msgstr "添加"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Almost there! Snippets are incoming, grab a coffee and relax!"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_plugin.js:0
+msgid "Anchor copied to clipboard%(br)sLink: %(anchorLink)s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Anchor name"
+msgstr "锚点名称"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Are you sure you want to delete the block %s?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Block"
+msgstr "构造块"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Blocks"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Blur"
+msgstr "模糊"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Button"
+msgstr "按钮"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "Cancel"
+msgstr "取消"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Categories"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.js:0
+msgid "Choose a record..."
+msgstr "选择一个记录..."
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Choose an anchor name"
+msgstr "选择一个锚点名称"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Color"
+msgstr "颜色"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Column"
+msgstr "栏"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "Confirm"
+msgstr "确认"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid "Continue"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Could not install module %(title)s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Create \""
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Create a custom snippet"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Custom %s"
+msgstr "自定义%s"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Custom Button"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Custom Inner Content"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Customize"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/setup_editor_plugin.js:0
+msgid "DRAG BUILDING BLOCKS HERE"
+msgstr "在这里拖拽构建块"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Dashed"
+msgstr "虚线"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Discard"
+msgstr "丢弃"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Do you want to install %s App?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Do you want to save this snippet as a custom one?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Dotted"
+msgstr "点线"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Double"
+msgstr "双"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.js:0
+msgid "Drag and drop the building block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/drag_and_drop_move_handle.js:0
+msgid "Drag and move"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "Duplicate this block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_plugin.js:0
+msgid "Edit"
+msgstr "编辑"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/drop_zone_plugin.js:0
+msgid "For technical reasons, this block cannot be dropped here"
+msgstr "由于技术原因，构造块不能放在这里"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Icon"
+msgstr "图标"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid ""
+"If you discard the current edits, all unsaved changes will be lost. You can "
+"cancel to return to edit mode."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid "If you proceed, your changes will be lost"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Image"
+msgstr "图像"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Inner Content"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Insert a block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/media_website_plugin.js:0
+msgid "Insert a video"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+#: code:addons/html_builder/static/src/sidebar/snippet.xml:0
+msgid "Insert snippet"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Inset"
+msgstr "插图"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/snippet.xml:0
+msgid "Install"
+msgstr "安装"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Install %s"
+msgstr "安装 %s"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/invisible_elements_panel.xml:0
+msgid "Invisible Elements"
+msgstr "无形的元素"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_list.js:0
+msgid "Item"
+msgstr "项目"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.js:0
+msgid "Link Anchor"
+msgstr "链接锚"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Mobile Preview"
+msgstr "移动端预览"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "More info about this app."
+msgstr "关于此应用的更多信息。"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Name"
+msgstr "名称"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "No"
+msgstr "否"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "No block of this category can be dropped on this page."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "No snippets found"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_select.js:0
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "None"
+msgstr "无"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Offset (X, Y)"
+msgstr "偏移量(X，Y)"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Oops! No snippets found."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Outset"
+msgstr "一开始"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Page Options"
+msgstr "页面选项"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "REPLACE BY NEW VERSION"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Remove"
+msgstr "移除"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "Remove this block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Rename the block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Round Corners"
+msgstr "圆角"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Save"
+msgstr "保存"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Save & Copy"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Save and Install"
+msgstr "保存和安装"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Search for a block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search for records..."
+msgstr "搜索记录..."
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search more..."
+msgstr "搜索更多。。。"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search to show more records"
+msgstr "搜索以显示更多记录"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/customize_tab.xml:0
+msgid "Select a block on your page to style it."
+msgstr "在您的页面上选择一个构造块来设计它。"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/customize_translation_tab.xml:0
+msgid "Select content on your page to translate it."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Shadow"
+msgstr "阴影"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Solid"
+msgstr "实体"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Spread"
+msgstr "扩展"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Take a look at the search bar, there might be a small typo!"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "The chosen name already exists"
+msgstr "所选名称已存在"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Theme"
+msgstr "主题"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "This block cannot be dropped anywhere on this page."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "This block is outdated."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Tip: Esc to preview"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_row.xml:0
+msgid "Toggle more options"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/media_website_plugin.js:0
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Video"
+msgstr "视频"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Yes"
+msgstr "是"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "You can still access the block options but it might be ineffective."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "You might not be able to customize it anymore."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/save_snippet_plugin.js:0
+msgid ""
+"Your custom snippet was successfully saved as <strong>%s</strong>. Find it "
+"in your snippets collection."
+msgstr ""

--- a/addons/html_builder/i18n/zh_TW.po
+++ b/addons/html_builder/i18n/zh_TW.po
@@ -1,0 +1,576 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* html_builder
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 16.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-05-16 13:50+0000\n"
+"PO-Revision-Date: 2022-09-22 05:55+0000\n"
+"Last-Translator: Tony Ng, 2023\n"
+"Language-Team: Chinese (Taiwan) (https://app.transifex.com/odoo/teams/41243/zh_TW/)\n"
+"Language: zh_TW\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "ACCESS OPTIONS ANYWAY"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_list.js:0
+msgid "Add"
+msgstr "增加"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Almost there! Snippets are incoming, grab a coffee and relax!"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_plugin.js:0
+msgid "Anchor copied to clipboard%(br)sLink: %(anchorLink)s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Anchor name"
+msgstr "錨點名稱"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Are you sure you want to delete the block %s?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Block"
+msgstr "區塊"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Blocks"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Blur"
+msgstr "模糊"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Button"
+msgstr "按鈕"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "Cancel"
+msgstr "取消"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Categories"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.js:0
+msgid "Choose a record..."
+msgstr "選擇一項⋯"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Choose an anchor name"
+msgstr "選擇錨點名稱"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Color"
+msgstr "顏色"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Column"
+msgstr "欄"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "Confirm"
+msgstr "確認"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid "Continue"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Could not install module %(title)s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Create \""
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Create a custom snippet"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Custom %s"
+msgstr "Custom %s"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Custom Button"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Custom Inner Content"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Customize"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/setup_editor_plugin.js:0
+msgid "DRAG BUILDING BLOCKS HERE"
+msgstr "拖曳區塊到這裡"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Dashed"
+msgstr "虛線"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Discard"
+msgstr "捨棄"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Do you want to install %s App?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Do you want to save this snippet as a custom one?"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Dotted"
+msgstr "點點線"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Double"
+msgstr "雙實線"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.js:0
+msgid "Drag and drop the building block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/drag_and_drop_move_handle.js:0
+msgid "Drag and move"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "Duplicate this block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_plugin.js:0
+msgid "Edit"
+msgstr "編輯"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/drop_zone_plugin.js:0
+msgid "For technical reasons, this block cannot be dropped here"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Icon"
+msgstr "圖示"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid ""
+"If you discard the current edits, all unsaved changes will be lost. You can "
+"cancel to return to edit mode."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.js:0
+msgid "If you proceed, your changes will be lost"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Image"
+msgstr "圖片"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "Inner Content"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Insert a block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/media_website_plugin.js:0
+msgid "Insert a video"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+#: code:addons/html_builder/static/src/sidebar/snippet.xml:0
+msgid "Insert snippet"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Inset"
+msgstr "內部陰影"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/snippet.xml:0
+msgid "Install"
+msgstr "安裝"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Install %s"
+msgstr "安裝 %s"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/invisible_elements_panel.xml:0
+msgid "Invisible Elements"
+msgstr "隱藏項目"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_list.js:0
+msgid "Item"
+msgstr "項目"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.js:0
+msgid "Link Anchor"
+msgstr "連結錨點"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Mobile Preview"
+msgstr "流動裝置預覽"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "More info about this app."
+msgstr "有關此模組的更多資訊。"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Name"
+msgstr "名稱"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "No"
+msgstr "否"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+msgid "No block of this category can be dropped on this page."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "No snippets found"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_select.js:0
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "None"
+msgstr "無"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Offset (X, Y)"
+msgstr "移位（水平、垂直）"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Oops! No snippets found."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Outset"
+msgstr "外部陰影"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Page Options"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "REPLACE BY NEW VERSION"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Remove"
+msgstr "移除"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "Remove this block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Rename the block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Round Corners"
+msgstr "圓角"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+#: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
+msgid "Save"
+msgstr "儲存"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "Save & Copy"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Save and Install"
+msgstr "儲存並安裝"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Search for a block"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search for records..."
+msgstr "搜尋記錄"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search more..."
+msgstr "搜尋更多⋯"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/select_many2x.xml:0
+msgid "Search to show more records"
+msgstr "搜尋以顯示更多記錄"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/customize_tab.xml:0
+msgid "Select a block on your page to style it."
+msgstr "在頁面選取區塊，以設定樣式。"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/customize_translation_tab.xml:0
+msgid "Select content on your page to translate it."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Shadow"
+msgstr "陰影"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/border_configurator_option.xml:0
+msgid "Solid"
+msgstr "實色"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/plugins/shadow_option.xml:0
+msgid "Spread"
+msgstr "向外擴散"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/add_snippet_dialog.xml:0
+msgid "Take a look at the search bar, there might be a small typo!"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/anchor/anchor_dialog.xml:0
+msgid "The chosen name already exists"
+msgstr "所選名稱已存在"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Theme"
+msgstr "設計主題"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/block_tab.xml:0
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.xml:0
+msgid "This block cannot be dropped anywhere on this page."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "This block is outdated."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/builder.xml:0
+msgid "Tip: Esc to preview"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_row.xml:0
+msgid "Toggle more options"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/media_website_plugin.js:0
+#: code:addons/html_builder/static/src/utils/utils.js:0
+msgid "Video"
+msgstr "影片"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/snippets/snippet_service.js:0
+msgid "Yes"
+msgstr "是"
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "You can still access the block options but it might be ineffective."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/option_container.xml:0
+msgid "You might not be able to customize it anymore."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/save_snippet_plugin.js:0
+msgid ""
+"Your custom snippet was successfully saved as <strong>%s</strong>. Find it "
+"in your snippets collection."
+msgstr ""


### PR DESCRIPTION
When [1] introduced ´html_builder´, many texts were reused from either `web_editor` or `website`.

This commit recovers existing translations for those texts.

[1]: https://github.com/odoo/odoo/commit/9fe45e2b7ddbbfd0445ffe25a859e67a316d02b2

task-4367641
