### PR TITLE
[FIX] website, html_builder: review `remove` plugin and its use

### DIFF
--- a/addons/html_builder/static/src/core/disable_snippets_plugin.js
+++ b/addons/html_builder/static/src/core/disable_snippets_plugin.js
@@ -7,7 +7,7 @@ export class DisableSnippetsPlugin extends Plugin {
     static dependencies = ["setup_editor_plugin", "dropzone", "dropzone_selector"];
     static shared = ["disableUndroppableSnippets"];
     resources = {
-        after_remove_handlers: this.disableUndroppableSnippets.bind(this),
+        on_removed_handlers: this.disableUndroppableSnippets.bind(this),
         post_undo_handlers: this.disableUndroppableSnippets.bind(this),
         post_redo_handlers: this.disableUndroppableSnippets.bind(this),
         on_mobile_preview_clicked: withSequence(20, this.disableUndroppableSnippets.bind(this)),

--- a/addons/html_builder/static/src/core/grid_layout/grid_layout_plugin.js
+++ b/addons/html_builder/static/src/core/grid_layout/grid_layout_plugin.js
@@ -32,6 +32,7 @@ export class GridLayoutPlugin extends Plugin {
             getButtons: this.getActiveOverlayButtons.bind(this),
         }),
         on_cloned_handlers: this.onCloned.bind(this),
+        on_removed_handlers: this.onRemoved.bind(this),
         // Drag and drop from sidebar
         on_snippet_preview_handlers: this.onSnippetPreviewOrDropped.bind(this),
         on_snippet_dropped_handlers: this.onSnippetPreviewOrDropped.bind(this),
@@ -91,6 +92,15 @@ export class GridLayoutPlugin extends Plugin {
             const rowEl = cloneEl.parentElement;
             setElementToMaxZindex(cloneEl, rowEl);
             resizeGrid(rowEl);
+        }
+    }
+
+    onRemoved({ nextTargetEl }) {
+        // Resize the grid, if any, to have the correct row count.
+        // If the active element after a removal is a grid item, it means we
+        // potentially removed a sibling grid item.
+        if (nextTargetEl.classList.contains("o_grid_item")) {
+            resizeGrid(nextTargetEl.parentElement);
         }
     }
 

--- a/addons/html_builder/static/src/core/move_plugin.js
+++ b/addons/html_builder/static/src/core/move_plugin.js
@@ -36,7 +36,7 @@ export class MovePlugin extends Plugin {
             getButtons: this.getActiveOverlayButtons.bind(this),
         }),
         on_cloned_handlers: this.onCloned.bind(this),
-        on_remove_handlers: this.onRemove.bind(this),
+        on_will_remove_handlers: this.onWillRemove.bind(this),
         on_element_dropped_handlers: this.onElementDropped.bind(this),
         is_movable_selector: [
             {
@@ -161,7 +161,7 @@ export class MovePlugin extends Plugin {
         }
     }
 
-    onRemove(toRemoveEl) {
+    onWillRemove(toRemoveEl) {
         if (!this.isMovable(toRemoveEl)) {
             return;
         }

--- a/addons/html_builder/static/src/sidebar/option_container.js
+++ b/addons/html_builder/static/src/sidebar/option_container.js
@@ -117,9 +117,7 @@ export class OptionsContainer extends BaseOptionComponent {
     // Actions of the buttons in the title bar.
     removeElement() {
         this.callOperation(() => {
-            this.env.editor.shared.remove.removeElementAndUpdateContainers(
-                this.props.editingElement
-            );
+            this.env.editor.shared.remove.removeElement(this.props.editingElement);
         });
     }
 

--- a/addons/website/static/src/builder/plugins/carousel_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/carousel_option_plugin.js
@@ -15,6 +15,8 @@ const carouselWrapperSelector =
 const carouselControlsSelector =
     ".carousel-control-prev, .carousel-control-next, .carousel-indicators";
 
+const carouselItemOptionSelector = ".s_carousel .carousel-item, .s_quotes_carousel .carousel-item, .s_carousel_intro .carousel-item, .s_carousel_cards .carousel-item";
+
 export class CarouselOptionPlugin extends Plugin {
     static id = "carouselOption";
     static dependencies = ["clone", "builderOptions", "builderActions"];
@@ -42,8 +44,7 @@ export class CarouselOptionPlugin extends Plugin {
         ],
         builder_header_middle_buttons: {
             Component: CarouselItemHeaderMiddleButtons,
-            selector:
-                ".s_carousel .carousel-item, .s_quotes_carousel .carousel-item, .s_carousel_intro .carousel-item, .s_carousel_cards .carousel-item",
+            selector: carouselItemOptionSelector,
             props: {
                 addSlide: (editingElement) => this.addSlide(editingElement.closest(".carousel")),
                 removeSlide: async (editingElement) => {
@@ -57,8 +58,7 @@ export class CarouselOptionPlugin extends Plugin {
             },
         },
         container_title: {
-            selector:
-                ".s_carousel .carousel-item, .s_quotes_carousel .carousel-item, .s_carousel_intro .carousel-item, .s_carousel_cards .carousel-item",
+            selector: carouselItemOptionSelector,
             getTitleExtraInfo: (editingElement) => this.getTitleExtraInfo(editingElement),
         },
         builder_actions: {
@@ -85,6 +85,7 @@ export class CarouselOptionPlugin extends Plugin {
             }
             return Promise.all(proms);
         },
+        is_unremovable_selector: carouselItemOptionSelector,
     };
 
     getTitleExtraInfo(editingElement) {

--- a/addons/website/static/src/builder/plugins/options/card_image_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/card_image_option_plugin.js
@@ -81,12 +81,11 @@ export class RemoveCoverImageAction extends BuilderAction {
     static id = "removeCoverImage";
     static dependencies = ["history", "builderOptions", "remove"];
     apply({ editingElement }) {
-        const imageWrapper = editingElement.querySelector(".o_card_img_wrapper");
-        const elementToSelect = this.dependencies.remove.removeElement(imageWrapper);
+        const imageWrapperEl = editingElement.querySelector(".o_card_img_wrapper");
+        imageWrapperEl.remove();
+        // Remove the classes and styles linked to the wrapper.
         editingElement.classList.remove(...imageRelatedClasses);
         imageRelatedStyles.forEach((prop) => editingElement.style.removeProperty(prop));
-        this.dependencies.history.addStep();
-        this.dependencies["builderOptions"].updateContainers(elementToSelect);
     }
 }
 export class AddCoverImageAction extends BuilderAction {

--- a/addons/website/static/src/builder/plugins/options/dynamic_snippet_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/dynamic_snippet_option_plugin.js
@@ -35,6 +35,7 @@ class DynamicSnippetOptionPlugin extends Plugin {
             CustomizeTemplateAction,
         },
         on_snippet_dropped_handlers: this.onSnippetDropped.bind(this),
+        is_unremovable_selector: ".s_dynamic_snippet_title",
     };
     setup() {
         this.dynamicFiltersCache = new Cache(this._fetchDynamicFilters, JSON.stringify);

--- a/addons/website/static/src/builder/plugins/options/image_gallery_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/image_gallery_option_plugin.js
@@ -41,8 +41,8 @@ class ImageGalleryOption extends Plugin {
         system_classes: ["o_empty_gallery_alert"],
         get_gallery_items_handlers: this.getGalleryItems.bind(this),
         reorder_items_handlers: this.reorderGalleryItems.bind(this),
-        on_remove_handlers: this.onRemove.bind(this),
-        after_remove_handlers: this.afterRemove.bind(this),
+        on_will_remove_handlers: this.onWillRemove.bind(this),
+        on_removed_handlers: this.onRemoved.bind(this),
         on_snippet_dropped_handlers: ({ snippetEl }) => {
             const carousels = snippetEl.querySelectorAll(".s_image_gallery .carousel");
             this.addCarouselListener(carousels);
@@ -388,15 +388,17 @@ class ImageGalleryOption extends Plugin {
         );
     }
 
-    onRemove(elementToRemove) {
-        // If the removed element is an image from a gallery, store the gallery element for afterRemove
-        if (elementToRemove.matches(".s_image_gallery img")) {
-            this.imageRemovedGalleryElement = elementToRemove.closest(".s_image_gallery");
+    onWillRemove(toRemoveEl) {
+        // If the removed element is an image from a gallery, store the gallery
+        // element for `onRemoved`.
+        if (toRemoveEl.matches(".s_image_gallery img")) {
+            this.imageRemovedGalleryElement = toRemoveEl.closest(".s_image_gallery");
         }
     }
 
-    afterRemove(elementRemoved) {
-        // If the removed element is an image from a gallery, relayout the gallery
+    onRemoved() {
+        // If the removed element is an image from a gallery, relayout the
+        // gallery.
         if (this.imageRemovedGalleryElement) {
             const mode = this.getMode(this.imageRemovedGalleryElement);
             const images = this.getImages(this.imageRemovedGalleryElement);

--- a/addons/website/static/src/builder/plugins/options/mega_menu_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/mega_menu_option_plugin.js
@@ -21,6 +21,7 @@ export class MegaMenuOptionPlugin extends Plugin {
         ],
         save_handlers: this.saveMegaMenuClasses.bind(this),
         no_parent_containers: ".o_mega_menu",
+        is_unremovable_selector: ".o_mega_menu > section",
     };
 
     getTemplatePrefix() {

--- a/addons/website/static/src/builder/plugins/options/navtabs_style_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/navtabs_style_option_plugin.js
@@ -29,6 +29,7 @@ class NavTabsStyleOptionPlugin extends Plugin {
         get_overlay_buttons: withSequence(0, {
             getButtons: this.getActiveOverlayButtons.bind(this),
         }),
+        is_unremovable_selector: ".nav-item",
     };
     isNavItem(el) {
         return el.matches(".nav-item") && !!el.closest(".s_tabs, .s_tabs_images");

--- a/addons/website/static/src/builder/plugins/options/popup_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/popup_option_plugin.js
@@ -41,7 +41,6 @@ class PopupOptionPlugin extends Plugin {
             SetPopupDelayAction,
         },
         on_cloned_handlers: this.onCloned.bind(this),
-        on_remove_handlers: this.onRemove.bind(this),
         on_snippet_dropped_handlers: this.onSnippetDropped.bind(this),
         no_parent_containers: ".s_popup",
     };
@@ -50,16 +49,6 @@ class PopupOptionPlugin extends Plugin {
         if (cloneEl.matches(".s_popup")) {
             this.assignUniqueID(cloneEl);
         }
-    }
-
-    onRemove(el) {
-        this.dependencies.popupVisibilityPlugin.onTargetHide(el);
-        this.dependencies.history.addCustomMutation({
-            apply: () => {},
-            revert: () => {
-                this.dependencies.popupVisibilityPlugin.onTargetShow(el);
-            },
-        });
     }
 
     onSnippetDropped({ snippetEl }) {

--- a/addons/website/static/src/builder/plugins/options/table_of_content_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/table_of_content_option_plugin.js
@@ -19,7 +19,7 @@ function getTocAndHeadingId(headingEl) {
 
 class TableOfContentOptionPlugin extends Plugin {
     static id = "tableOfContentOption";
-    static dependencies = ["clone"];
+    static dependencies = ["clone", "remove"];
     resources = {
         builder_options: [
             {
@@ -55,6 +55,7 @@ class TableOfContentOptionPlugin extends Plugin {
             }
             return true;
         },
+        is_unremovable_selector: ".s_table_of_content_navbar_wrap, .s_table_of_content_main",
     };
 
     normalize(root) {
@@ -76,7 +77,7 @@ class TableOfContentOptionPlugin extends Plugin {
 
         if (tableOfContentMain.children.length === 0) {
             // Remove the table of content if empty content.
-            tableOfContent.remove();
+            this.dependencies.remove.removeElement(tableOfContent)
             return;
         }
 


### PR DESCRIPTION
This commit improves the code of the `remove` plugin:

- Rename the `on_remove_handlers` and `after_remove_handlers` resources as `on_will_remove_handlers` and `on_removed_handlers` respectively, to be more consistent.

- Adds a `is_unremovable_selector` resource in order to use it to get the selectors of the elements that are unremovable. It allows to have the resources in the different option plugins, instead of duplicating these selectors in multiple files.

- Merge back the behaviors of `removeElementAndUpdateContainers` and `removeElement` as it was not correct to split them and in order to have only one main `removeElement` function. Its goal was to replace the old `remove_snippet` event, and it was clearly not used everywhere.

- Remove the use of the `remove` plugin where only the JS element `remove` function was needed. We know if a given case needs to activate the parents/siblings and there are other ways to activate them anyway.

- Use the `remove` plugin when this time it was necessary (e.g. when a "Table of Content" is empty).

- Clean the code.

task-4367641