### PR TITLE
[FIX] website_sale: add max product grid column number

### DIFF
--- a/addons/website_sale/static/src/website_builder/products_item_option.js
+++ b/addons/website_sale/static/src/website_builder/products_item_option.js
@@ -30,7 +30,9 @@ export class ProductsItemOption extends BaseOptionComponent {
             this.displayReOrder = this.defaultSort[0].shop_default_sort === "website_sequence asc";
 
             // If /shop page layout is list, do not display Size option
-            this.displaySizeOption = !this.env.getEditingElement().closest("#o_wsale_container").classList.contains("o_wsale_layout_list");
+            const wsale_container = this.env.getEditingElement().closest("#o_wsale_container");
+            this.displaySizeOption = !wsale_container.classList.contains("o_wsale_layout_list");
+            this.maxWidth = parseInt(wsale_container.dataset.ppr) || 5;
         });
 
         onMounted(() => {

--- a/addons/website_sale/static/src/website_builder/products_item_option.xml
+++ b/addons/website_sale/static/src/website_builder/products_item_option.xml
@@ -7,7 +7,7 @@
                     <table t-ref="table" t-on-mouseenter="_onTableMouseEnter" t-on-mouseleave="_onTableMouseLeave">
                         <t t-foreach="[0, 1, 2, 3]" t-as="i" t-key="i">
                             <tr>
-                                <t t-foreach="[0, 1, 2, 3]" t-as="j" t-key="j">
+                                <t t-foreach="[...Array(this.maxWidth).keys()]" t-as="j" t-key="j">
                                     <td t-on-mouseover="()=>this._onTableCellMouseOver(i, j)" t-on-click="()=>this._onTableCellMouseClick(i, j)">
                                         <BuilderButton preview="false" actionValue="[i, j]" />
                                     </td>

--- a/addons/website_sale/static/src/website_builder/website_sale.editor.scss
+++ b/addons/website_sale/static/src/website_builder/website_sale.editor.scss
@@ -36,6 +36,7 @@
                 margin: 0;
                 width: 100%;
                 height: 100%;
+                min-height: unset;
             }
 
             .btn,


### PR DESCRIPTION
Product grid size option should not allow to set a width bigger than the currently set grid column number. To see the issue: go to /shop, start editing, change the size to 3 columns, click on any product -> the grid still has 4 columns. This commit also introduces setting the width to 5 columns (whole row).
This commit follows [the html_builder refactoring].

[the html_builder refactoring]: odoo/odoo@9fe45e2b7ddb

Related to task-4367641