### PR TITLE
[FIX] calendar: use search().ids instead of _search()

### DIFF
--- a/addons/calendar/models/calendar_event.py
+++ b/addons/calendar/models/calendar_event.py
@@ -910,12 +910,13 @@ class Meeting(models.Model):
         return videocall_channel
 
     def _get_default_privacy_domain(self):
-        # Sub query user settings from calendars that are not private ('public' and 'confidential').
-        public_calendars_settings = self.env['res.users.settings'].sudo()._search([('calendar_default_privacy', '!=', 'private')])
+        # search user settings from calendars that are not private ('public' and 'confidential').
+        public_users_settings_ids = self.env['res.users.settings'].sudo().search(
+            [('calendar_default_privacy', '!=', 'private')]).ids
         # display public, confidential events and events with default privacy when owner's default privacy is not private
         return [
             '|', '|', '|', ('privacy', '=', 'public'), ('privacy', '=', 'confidential'), ('user_id', '=', self.env.user.id),
-            '&', ('privacy', '=', False), ('user_id.res_users_settings_id', 'in', public_calendars_settings)
+            '&', ('privacy', '=', False), ('user_id.res_users_settings_id', 'in', public_users_settings_ids)
         ]
 
     def _is_event_over(self):


### PR DESCRIPTION
Using `_search()` was returning a query object, which broke the
domain logic when checking `user_id.res_users_settings_id`. Replaced
with `search(...).ids` to ensure a proper list of IDs is passed.

`_get_default_privacy_domain` timing:
before is always the same since it doesn't execute the sql query
| Number of users | Before PR | After PR |
|:------------------:|:-----------:|:--------:|
| 10k          | 0.1 ms    | 8 ms     |
| 30k          | 0.1 ms    | 14 ms    |
| 50k          | 0.1 ms    | 20 ms    |
| 70k          | 0.1 ms    | 28 ms    |
| 90k          | 0.1 ms    | 35 ms    |

opw-4841266
bug introduced in:[#5f55544][1]

[1]:https://github.com/odoo/odoo/commit/5f5554460c61d3e715e71dd7c946b77083411ae7
