### PR TITLE
[FIX] account: do not break reco on reset to draft

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -5606,7 +5606,6 @@ class AccountMove(models.Model):
         self._check_draftable()
         # We remove all the analytics entries for this journal
         self.line_ids.analytic_line_ids.with_context(skip_analytic_sync=True).unlink()
-        self.mapped('line_ids').remove_move_reconcile()
         self.state = 'draft'
 
         self._detach_attachments()
@@ -5696,6 +5695,7 @@ class AccountMove(models.Model):
         if any(move.state != 'draft' for move in self):
             raise UserError(_("Only draft journal entries can be cancelled."))
 
+        self.line_ids.remove_move_reconcile()
         self.payment_ids.state = "canceled"
         self.write({'auto_post': 'no', 'state': 'cancel'})
 

--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -1577,11 +1577,7 @@ class AccountMoveLine(models.Model):
                     if self.env['account.move']._field_will_change(line, vals, field_name)
                 })
             ):
-                matching2lines = dict(self.env['account.move.line'].sudo()._read_group(
-                    domain=[('matching_number', 'in', [n for n in self.mapped('matching_number') if n])],
-                    groupby=['matching_number'],
-                    aggregates=['id:recordset'],
-                )) if matching2lines is None else matching2lines
+                matching2lines = self._reconciled_by_number() if matching2lines is None else matching2lines
                 if (
                     # allow changing the account on all the lines of a reconciliation together
                     changing_fields - {'account_id'}
@@ -1696,8 +1692,7 @@ class AccountMoveLine(models.Model):
         if not self:
             return True
 
-        # Check the lines are not reconciled (partially or not).
-        self._check_reconciliation()
+        self.remove_move_reconcile()
 
         # Check the lock date. (Only relevant if the move is posted)
         self.move_id.filtered(lambda m: m.state == 'posted')._check_fiscal_lock_dates()
@@ -3314,11 +3309,11 @@ class AccountMoveLine(models.Model):
         """Get the mapping of all the lines matched with the lines in self grouped by matching number."""
         matching_numbers = [n for n in set(self.mapped('matching_number')) if n]
         if matching_numbers:
-            return dict(self._read_group(
+            return {number: lines.with_env(self.env) for number, lines in self.sudo()._read_group(
                 domain=[('matching_number', 'in', matching_numbers)],
                 groupby=['matching_number'],
                 aggregates=['id:recordset'],
-            ))
+            )}
         return {}
 
     def _filter_reconciled_by_number(self, mapping: dict):

--- a/addons/account/tests/test_account_move_reconcile.py
+++ b/addons/account/tests/test_account_move_reconcile.py
@@ -4693,8 +4693,7 @@ class TestAccountMoveReconcile(AccountTestInvoicingCommon):
         self.assertTrue(all(line.full_reconcile_id for line in lines_to_reconcile), "All tax lines should be fully reconciled")
 
     def test_caba_undo_reconciliation(self):
-        ''' Make sure there is no traceback like "Record has already been deleted" during the deletion of partials. '''
-        self.cash_basis_transfer_account.reconcile = True
+        self.env.company.tax_exigibility = True
 
         bill = self.env['account.move'].create({
             'move_type': 'in_invoice',
@@ -4711,12 +4710,21 @@ class TestAccountMoveReconcile(AccountTestInvoicingCommon):
         bill.action_post()
 
         # Register a payment creating the CABA journal entry on the fly and reconcile it with the tax line.
-        self.env['account.payment.register']\
+        payment = self.env['account.payment.register']\
             .with_context(active_ids=bill.ids, active_model='account.move')\
             .create({})\
             ._create_payments()
 
+        init_reconciliation = (payment.move_id + bill).line_ids._reconciled_by_number()
+        self.assertEqual(len(init_reconciliation), 2)  # reconciled for caba and receivable
+
+        # Make sure that we don't break any reconciliation before
         bill.button_draft()
+        self.assertEqual((payment.move_id + bill).line_ids._reconciled_by_number(), init_reconciliation)
+
+        # Make sure there is no traceback like "Record has already been deleted" during the deletion of partials.
+        bill.line_ids.remove_move_reconcile()
+        self.assertFalse((payment.move_id + bill).line_ids._reconciled_by_number())
 
     def test_caba_foreign_vat(self):
         self.env.company.tax_exigibility = True

--- a/addons/account/tests/test_account_payment.py
+++ b/addons/account/tests/test_account_payment.py
@@ -521,6 +521,7 @@ class TestAccountPayment(AccountTestInvoicingCommon, MailCommon):
         invoice.js_assign_outstanding_line(credit_line.id)
         self.assertTrue(invoice.payment_state in ('in_payment', 'paid'), "Invoice should be paid")
         invoice.button_draft()
+        invoice.line_ids.remove_move_reconcile()
         self.assertTrue(invoice.payment_state == 'not_paid', "Invoice should'nt be paid anymore")
         self.assertTrue(invoice.state == 'draft', "Invoice should be draft")
 

--- a/addons/hr_expense/tests/test_expenses.py
+++ b/addons/hr_expense/tests/test_expenses.py
@@ -185,6 +185,7 @@ class TestExpenses(TestExpenseCommon):
 
         # Unlinking moves
         (payment_1 | payment_2).action_draft()
+        (payment_1 | payment_2).move_id.line_ids.remove_move_reconcile()
         self.assertEqual(first_expense_by_employee.state, 'posted')
         expenses_by_employee.account_move_id.button_draft()
         expenses_by_employee.account_move_id.unlink()

--- a/addons/hr_expense/tests/test_expenses_states.py
+++ b/addons/hr_expense/tests/test_expenses_states.py
@@ -160,6 +160,7 @@ class TestExpensesStates(TestExpenseCommon):
         self.get_new_payment(self.expenses_employee, self.expenses_employee.total_amount)
 
         self.expenses_employee.account_move_id.button_draft()
+        self.expenses_employee.account_move_id.line_ids.remove_move_reconcile()
         self.assertEqual(self.expenses_employee.state, 'posted')
         self.assertRecordValues(self.expenses_employee.account_move_id, [
             {'state': 'draft', 'payment_state': 'not_paid'},

--- a/addons/l10n_in/tests/test_tds_tcs_alert.py
+++ b/addons/l10n_in/tests/test_tds_tcs_alert.py
@@ -441,8 +441,7 @@ class TestTdsTcsAlert(L10nInTestInvoicingCommon):
         )
         self.assertEqual(move.l10n_in_warning['tds_tcs_threshold_alert']['message'], "It's advisable to deduct TDS u/s 194C on this transaction.")
         self.tds_wizard_entry(move=move, lines=[(self.tax_194c, 100000)])
-        move.button_draft()
-        move.action_post()
+        move.line_ids.remove_move_reconcile()
         self.assertEqual(move.l10n_in_warning, False)
 
     def test_tcs_tds_warning_for_company_branches(self):


### PR DESCRIPTION
Since [^1], we allow reconciliation in draft. To allow that, a mechanism has been added to break the reconciliation when changing certain fields rather instead.
However, resetting to draft was still breaking the reconciliation, which is counter productive.

Reproduce:
* create an invoice
* create a bank statement line with the same amount
* reconcile both in the bank reco widget
* reset the invoice to draft

=> The invoice is not marked as paid anymore, the statement line still has the amount on the receivable account, we need to reconcile manually both lines.

This commit also fixes 2 related issues:
* the test `test_caba_undo_reconciliation` was actually not generating a caba move. Now, it is checking that we unreconcile what we need, when we need, and that it was reconciled in the first place.
* the function `_reconciled_by_number` was not using `sudo`, leading to lines potentially missing from the returned set. However, the logic using it needed to see the whole picture. Instead, we now do the search in `sudo`, while keeping the initial access rights for reading the field if necessary.

task-4873072

[^1]: https://github.com/odoo/odoo/commit/404fbaeeeb16a65900c60f47967d6d79373c6213
