### PR TITLE
[FIX] html_builder, website: set 0 as default for BuilderNumberInput, [FIX] website: handle missing progress bar text element

### DIFF
--- a/addons/html_builder/static/src/core/building_blocks/builder_number_input.js
+++ b/addons/html_builder/static/src/core/building_blocks/builder_number_input.js
@@ -32,6 +32,7 @@ export class BuilderNumberInput extends Component {
     static defaultProps = {
         composable: false,
         applyWithUnit: true,
+        default: 0,
     };
 
     setup() {

--- a/addons/html_builder/static/src/plugins/border_configurator_option.xml
+++ b/addons/html_builder/static/src/plugins/border_configurator_option.xml
@@ -3,7 +3,7 @@
 
 <t t-name="html_builder.BorderConfiguratorOption">
     <BuilderRow label="props.label">
-        <BuilderNumberInput action="props.action" actionParam="{ mainParam: getStyleActionParam('width'), extraClass: props.withBSClass and 'border' }" unit="'px'" min="0" default="0" composable="true"/>
+        <BuilderNumberInput action="props.action" actionParam="{ mainParam: getStyleActionParam('width'), extraClass: props.withBSClass and 'border' }" unit="'px'" min="0" composable="true"/>
         <BuilderSelect action="props.action" actionParam="getStyleActionParam('style')" t-if="state.hasBorder">
             <BuilderSelectItem title.translate="Solid" actionValue="'solid'"><div class="o-hb-border-preview" style="border-style: solid;"/></BuilderSelectItem>
             <BuilderSelectItem title.translate="Dashed" actionValue="'dashed'"><div class="o-hb-border-preview" style="border-style: dashed;"/></BuilderSelectItem>
@@ -18,7 +18,7 @@
 
     <!-- TODO: handle the dependency with border_width_opt bg_color_opt-->
     <BuilderRow t-if="props.withRoundCorner" label.translate="Round Corners">
-        <BuilderNumberInput action="props.action" actionParam="{ mainParam: 'border-radius', extraClass: props.withBSClass and 'rounded' }" unit="'px'" default="0" min="0" composable="true"/>
+        <BuilderNumberInput action="props.action" actionParam="{ mainParam: 'border-radius', extraClass: props.withBSClass and 'rounded' }" unit="'px'" min="0" composable="true"/>
     </BuilderRow>
 </t>
 

--- a/addons/website/static/src/builder/plugins/options/animate_option.xml
+++ b/addons/website/static/src/builder/plugins/options/animate_option.xml
@@ -73,7 +73,7 @@
         <BuilderContext t-if="this.isActiveItem('animation_on_appearance_opt')">
             <!-- Start After -->
             <BuilderRow label.translate="Start After" level="1">
-                <BuilderNumberInput styleAction="'animation-delay'" action="'forceAnimation'" default="0" unit="'s'" />
+                <BuilderNumberInput styleAction="'animation-delay'" action="'forceAnimation'" unit="'s'" />
             </BuilderRow>
             <!-- Duration -->
             <BuilderRow label.translate="Duration" level="1">

--- a/addons/website/static/src/builder/plugins/options/progress_bar_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/progress_bar_option_plugin.js
@@ -81,9 +81,15 @@ class ProgressBarValueAction extends BuilderAction {
         const progressBarEl = editingElement.querySelector(".progress-bar");
         const progressBarTextEl = editingElement.querySelector(".s_progress_bar_text");
         const progressMainEl = editingElement.querySelector(".progress");
-        // Target precisely the XX% not only XX to not replace wrong element
-        // eg 'Since 1978 we have completed 45%' <- don't replace 1978
-        progressBarTextEl.innerText = progressBarTextEl.innerText.replace(/[0-9]+%/, value + "%");
+        // Added to address the prior omission of s_progress_bar_text in s_numbers_charts.
+        if (progressBarTextEl) {
+            // Target precisely the XX% not only XX to not replace wrong element
+            // eg 'Since 1978 we have completed 45%' <- don't replace 1978
+            progressBarTextEl.innerText = progressBarTextEl.innerText.replace(
+                /[0-9]+%/,
+                value + "%"
+            );
+        }
         progressMainEl.setAttribute("aria-valuenow", value);
         progressBarEl.style.width = value + "%";
     }

--- a/addons/website/static/tests/builder/custom_tab/builder_components/builder_number_input.test.js
+++ b/addons/website/static/tests/builder/custom_tab/builder_components/builder_number_input.test.js
@@ -132,8 +132,8 @@ describe("default value", () => {
 
         await clear();
         await click(".options-container");
-        expect("[data-action-id='customAction'] input").toHaveValue("");
-        expect(":iframe .test-options-target").toHaveInnerHTML("");
+        expect("[data-action-id='customAction'] input").toHaveValue("0");
+        expect(":iframe .test-options-target").toHaveInnerHTML("0");
     });
     test("clear BuilderNumberInput with default value", async () => {
         addActionOption({

--- a/addons/website/static/tests/builder/custom_tab/builder_shorthand_action.test.js
+++ b/addons/website/static/tests/builder/custom_tab/builder_shorthand_action.test.js
@@ -102,7 +102,7 @@ describe("styleAction", () => {
         expect(":iframe .test-options-target").toHaveAttribute("style", "width: 101px;"); // no !important
 
         await contains("input").edit("");
-        expect(":iframe .test-options-target").toHaveAttribute("style", "");
+        expect(":iframe .test-options-target").toHaveAttribute("style", "width: 0px;");
     });
     test("should set a style with its associated class", async () => {
         addOption({


### PR DESCRIPTION
The issues addressed in this commit were introduced by the website
refactor [1].

The `s_progress_bar_text` element was forgotten when adding `s_numbers_charts`
snippet [2].
Not checking for its presence would lead to a crash.

Additionally, leaving the progress bar value input field empty would result in NaN and cause a crash.
A default value of 0 is now set for this field.

[1]: https://github.com/odoo/odoo/commit/9fe45e2b7ddbbfd0445ffe25a859e67a316d02b2
[2]: https://github.com/odoo/odoo/commit/6c94fd66c1db75d74588ce670fb6cf1e960cf8bd