### PR TITLE
[FIX] html_editor: fix base64 image src from being prefixed with origin

### DIFF
--- a/addons/html_editor/static/src/core/clipboard_plugin.js
+++ b/addons/html_editor/static/src/core/clipboard_plugin.js
@@ -760,7 +760,7 @@ export function isHtmlContentSupported(node) {
 function prependOriginToImages(doc, origin) {
     doc.querySelectorAll("img").forEach((img) => {
         const src = img.getAttribute("src");
-        if (src && !src.startsWith("http") && !src.startsWith("//")) {
+        if (src && !/^(http|\/\/|data:)/.test(src)) {
             img.src = origin + (src.startsWith("/") ? src : "/" + src);
         }
     });

--- a/addons/html_editor/static/tests/copy.test.js
+++ b/addons/html_editor/static/tests/copy.test.js
@@ -168,4 +168,16 @@ describe("range not collapsed", () => {
             `<p><img src="${window.location.origin}/nice.png"></p>`
         );
     });
+
+    test("should not add origin to base64 images", async () => {
+        const base64Img =
+            "data:image/png;base64, iVBORw0KGgoAAAANSUhEUgAAAAUA\n        AAAFCAYAAACNbyblAAAAHElEQVQI12P4//8/w38GIAXDIBKE0DHxgljNBAAO\n            9TXL0Y4OHwAAAABJRU5ErkJggg==";
+        await setupEditor(`<p>[<img src="${base64Img}">]</p>`);
+        const clipboardData = new DataTransfer();
+        await press(["ctrl", "c"], { dataTransfer: clipboardData });
+        expect(clipboardData.getData("text/html")).toBe(`<p><img src="${base64Img}"></p>`);
+        expect(clipboardData.getData("application/vnd.odoo.odoo-editor")).toBe(
+            `<p><img src="${base64Img}"></p>`
+        );
+    });
 });


### PR DESCRIPTION
Problem:
When copying content that includes an image with a `src` in base64 format, the origin is incorrectly prepended to the `src`, resulting in a broken image on subsequent paste.

Cause:
The logic that prepends the origin doesn't exclude base64 images, causing the final `src` to be invalid.

Solution:
Skip appending the origin if the `img.src` is already in base64 format.

Steps to reproduce:
1. Copy an image (with base64 `src`) into the editor.
2. Copy the image again from within the editor.
3. Paste the image. → The image is not shown due to incorrect `src`.

opw-4872676


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
