### PR TITLE
[FIX] website_sale_wishlist: improve product configurator in wishlist

### DIFF
--- a/addons/website_sale_wishlist/static/src/js/website_sale_wishlist.js
+++ b/addons/website_sale_wishlist/static/src/js/website_sale_wishlist.js
@@ -164,7 +164,7 @@ publicWidget.registry.ProductWishlist = publicWidget.Widget.extend(VariantMixin,
     /**
      * @private
      */
-    _addOrMoveWish: function (ev) {
+    async _addOrMoveWish(ev) {
         const td = ev.currentTarget.parentElement;
 
         const productId = parseInt(
@@ -176,15 +176,22 @@ publicWidget.registry.ProductWishlist = publicWidget.Widget.extend(VariantMixin,
         const isCombo = td.querySelector(
             'input[type="hidden"][name="product_type"]'
         )?.value === 'combo';
+        const ptavs = JSON.parse(
+            td.querySelector('input[type="hidden"][name="ptav_ids"]')?.value || '[]'
+        );
 
         const addToCart = this.call('cart', 'add', {
             productTemplateId: productTemplateId,
             productId: parseInt(productId, 10),
             isCombo: isCombo,
+            ptavs: ptavs,
+        }, {
+            redirectToCart: false,
+            isConfigured: false, // custom attributes may still require input
         });
-
-        if (!document.getElementById('b2b_wish').checked) {
-            this._removeWish(ev, addToCart);
+        const quantity = await addToCart;
+        if (quantity > 0 && !document.getElementById('b2b_wish').checked) {
+            this._removeWish(ev, false);
         }
         return addToCart;
     },

--- a/addons/website_sale_wishlist/views/website_sale_wishlist_template.xml
+++ b/addons/website_sale_wishlist/views/website_sale_wishlist_template.xml
@@ -284,6 +284,11 @@
                                                 t-att-value="wish.product_id.product_tmpl_id.type"
                                                 type="hidden"
                                             />
+                                            <input
+                                                name="ptav_ids"
+                                                t-att-value="wish.product_id.product_template_attribute_value_ids.ids"
+                                                type="hidden"
+                                            />
                                             <a
                                                 t-if="combination_info['prevent_zero_price_sale']"
                                                 t-att-href="website.contact_us_button_url"


### PR DESCRIPTION
Versions
--------
- saas-18.2+

Steps
-----
1. Have a product with optional products and/or variants;
2. add the product to your wishlist;
3. go to wishlist;
4. click on the cart button;
5. close the configurator using the × in the top right corner.

Issue
-----
The product gets removed from the wishlist, even though it wasn't added to the cart.

Cause
-----
Before b8d0ab4275b24, the product configurator would never get shown from the wishlist, but with the centralizing of the "Add to Cart" logic, it does pop up. The issue is that it shows up after the product has already been removed from the wishlist.

Solution
--------
Await the result of `addToCart`, which returns the quantity add to the cart, and only call `_removeWish` if it is greater than zero.

Also ensure that the product configurator opens with the correct product attributes, and that closing it doesn't automatically redirect you to checkout, unless selected in the configurator.

opw-4783677