### PR TITLE
[FIX] web: keep view in DOM when reloading

### DIFF
--- a/addons/web/static/src/views/graph/graph_controller.js
+++ b/addons/web/static/src/views/graph/graph_controller.js
@@ -35,7 +35,12 @@ export class GraphController extends Component {
     }
 
     get modelOptions() {
-        return { lazy: !this.env.inDialog && !!this.props.display.controlPanel };
+        return {
+            lazy:
+                !this.env.config.isReloadingController &&
+                !this.env.inDialog &&
+                !!this.props.display.controlPanel,
+        };
     }
 
     /**

--- a/addons/web/static/src/views/kanban/kanban_controller.js
+++ b/addons/web/static/src/views/kanban/kanban_controller.js
@@ -306,7 +306,12 @@ export class KanbanController extends Component {
     }
 
     get modelOptions() {
-        return { lazy: !this.env.inDialog && !!this.props.display.controlPanel };
+        return {
+            lazy:
+                !this.env.config.isReloadingController &&
+                !this.env.inDialog &&
+                !!this.props.display.controlPanel,
+        };
     }
 
     get progressBarAggregateFields() {

--- a/addons/web/static/src/views/list/list_controller.js
+++ b/addons/web/static/src/views/list/list_controller.js
@@ -233,7 +233,12 @@ export class ListController extends Component {
     }
 
     get modelOptions() {
-        return { lazy: !this.env.inDialog && !!this.props.display.controlPanel };
+        return {
+            lazy:
+                !this.env.config.isReloadingController &&
+                !this.env.inDialog &&
+                !!this.props.display.controlPanel,
+        };
     }
 
     get actionMenuProps() {

--- a/addons/web/static/src/views/pivot/pivot_controller.js
+++ b/addons/web/static/src/views/pivot/pivot_controller.js
@@ -46,7 +46,12 @@ export class PivotController extends Component {
     }
 
     get modelOptions() {
-        return { lazy: !this.env.inDialog && !!this.props.display.controlPanel };
+        return {
+            lazy:
+                !this.env.config.isReloadingController &&
+                !this.env.inDialog &&
+                !!this.props.display.controlPanel,
+        };
     }
 
     /**

--- a/addons/web/static/src/webclient/actions/action_service.js
+++ b/addons/web/static/src/webclient/actions/action_service.js
@@ -876,6 +876,7 @@ export function makeActionManager(env, router = _router) {
                 env.bus.trigger("WEBCLIENT:LOAD_DEFAULT_APP");
             }
         };
+        controller.config.isReloadingController = controller === controllerStack.at(-1);
 
         class ControllerComponent extends Component {
             static template = ControllerComponentTemplate;


### PR DESCRIPTION
This commit is a followup of odoo/odoo#205129 where we now directly display the view, without waiting for its data, such that the control panel is directly available. However, this isn't necessary when we are reloading the view by clicking on the view switcher. Indeed, in that case, the control panel is already displayed. Moreover, clearing the view in that case produces an annoying flickering.

This commit thus disables the "show control panel asap" logic in the case of a reload.

Followup of task-4727791

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
