### PR TITLE
[FIX] point_of_sale, pos_sale: fix product loading in POS

### DIFF
--- a/addons/l10n_es_pos/static/src/app/screens/payment_screen/payment_screen.js
+++ b/addons/l10n_es_pos/static/src/app/screens/payment_screen/payment_screen.js
@@ -28,7 +28,7 @@ patch(PaymentScreen.prototype, {
                 if (!order.partner_id) {
                     const setPricelist =
                         this.pos.config.pricelist_id?.id != order.pricelist_id?.id
-                            ? order.pricelist_id.id
+                            ? order.pricelist_id
                             : false;
                     order.setPartner(this.pos.config.simplified_partner_id);
                     if (setPricelist) {

--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -138,7 +138,7 @@ class PosSession(models.Model):
         return ['pos.config', 'pos.preset', 'resource.calendar.attendance', 'pos.order', 'pos.order.line', 'pos.pack.operation.lot', 'pos.payment', 'pos.payment.method', 'pos.printer',
             'pos.category', 'pos.bill', 'res.company', 'account.tax', 'account.tax.group', 'product.template', 'product.product', 'product.attribute', 'product.attribute.custom.value',
             'product.template.attribute.line', 'product.template.attribute.value', 'product.template.attribute.exclusion', 'product.combo', 'product.combo.item', 'res.users', 'res.partner', 'product.uom',
-            'decimal.precision', 'uom.uom', 'res.country', 'res.country.state', 'res.lang', 'product.pricelist', 'product.pricelist.item', 'product.category',
+            'decimal.precision', 'uom.uom', 'res.country', 'res.country.state', 'res.lang', 'product.pricelist', 'product.category', 'product.pricelist.item',
             'account.cash.rounding', 'account.fiscal.position', 'account.fiscal.position.tax', 'stock.picking.type', 'res.currency', 'pos.note', 'product.tag', 'ir.module.module']
 
     @api.model

--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -1858,46 +1858,14 @@ class PosSession(models.Model):
         return []
 
     def find_product_by_barcode(self, barcode, config_id):
-        product_fields = self.env['product.product']._load_pos_data_fields(config_id)
-        product_template_fields = self.env['product.template']._load_pos_data_fields(config_id)
-        packaging_fields = self.env['product.uom']._load_pos_data_fields(config_id)
-        product_tmpl_attr_value_fields = self.env['product.template.attribute.value']._load_pos_data_fields(config_id)
-        product_context = {**self.env.context, 'display_default_code': False}
-        product = self.env['product.product'].search([
+        # Kept for backward compatibility.
+        return self.env['product.template'].load_product_from_pos(config_id, [
+            '|',
+            ('product_variant_ids.barcode', '=', barcode),
             ('barcode', '=', barcode),
-            ('sale_ok', '=', True),
             ('available_in_pos', '=', True),
+            ('sale_ok', '=', True),
         ])
-        if product:
-            product = product.with_context(product_context)
-            return {
-                'product.product': product.read(product_fields, load=False),
-                'product.template': product.product_tmpl_id.read(product_template_fields, load=False),
-                'product.template.attribute.value': product.product_template_attribute_value_ids.read(product_tmpl_attr_value_fields, load=False)
-            }
-
-        domain = [('barcode', 'not in', ['', False])]
-        loaded_data = self._context.get('loaded_data')
-        if loaded_data:
-            loaded_product_ids = [x['id'] for x in loaded_data['product.product']]
-            domain = AND([domain, [('product_id', 'in', [x['id'] for x in self._context.get('loaded_data')['product.product']])]]) if self._context.get('loaded_data') else []
-            domain = AND([domain, [('product_id', 'in', loaded_product_ids)]])
-        packaging_params = {
-            'search_params': {
-                'domain': domain,
-                'fields': ['barcode', 'product_id', 'uom_id'],
-            },
-        }
-        packaging_params['search_params']['domain'] = [['barcode', '=', barcode]]
-        packaging = self.env['product.uom'].search(packaging_params['search_params']['domain'])
-        product = packaging.product_id.with_context(product_context)
-        condition = packaging and packaging.product_id
-        return {
-            'product.product': product.read(product_fields, load=False) if condition else [],
-            'product.template.attribute.value': product.product_template_attribute_value_ids.read(product_tmpl_attr_value_fields, load=False) if condition else [],
-            'product.template': product.product_tmpl_id.read(product_template_fields, load=False) if condition else [],
-            'product.uom': packaging.read(packaging_fields, load=False) if condition else [],
-        }
 
     def get_total_discount(self):
         amount = 0

--- a/addons/point_of_sale/models/product_pricelist.py
+++ b/addons/point_of_sale/models/product_pricelist.py
@@ -25,6 +25,7 @@ class ProductPricelistItem(models.Model):
     def _load_pos_data_domain(self, data):
         product_tmpl_ids = [p['product_tmpl_id'] for p in data['product.product']]
         product_ids = [p['id'] for p in data['product.product']]
+        product_categ = [c['id'] for c in data['product.category']]
         pricelist_ids = [p['id'] for p in data['product.pricelist']]
         today = fields.Date.today()
         return [
@@ -32,7 +33,8 @@ class ProductPricelistItem(models.Model):
             '|', ('product_tmpl_id', '=', False), ('product_tmpl_id', 'in', product_tmpl_ids),
             '|', ('product_id', '=', False), ('product_id', 'in', product_ids),
             '|', ('date_start', '=', False), ('date_start', '<=', today),
-            '|', ('date_end', '=', False), ('date_end', '>=', today)
+            '|', ('date_end', '=', False), ('date_end', '>=', today),
+            '|', ('categ_id', '=', False), ('categ_id', 'in', product_categ),
         ]
 
     @api.model

--- a/addons/point_of_sale/static/src/app/components/popups/product_configurator_popup/product_configurator_popup.js
+++ b/addons/point_of_sale/static/src/app/components/popups/product_configurator_popup/product_configurator_popup.js
@@ -114,7 +114,7 @@ export class ProductConfiguratorPopup extends Component {
 
         if (hasVariants) {
             const selectedAttributeValuesIds = this.selectedValues.map(({ id }) => id);
-            product = this.pos.models["product.product"].find(
+            product = this.props.productTemplate.product_variant_ids.find(
                 (product) =>
                     product.product_template_variant_value_ids?.length > 0 &&
                     product.product_template_variant_value_ids.every(({ id }) =>

--- a/addons/point_of_sale/static/src/app/models/product_pricelist.js
+++ b/addons/point_of_sale/static/src/app/models/product_pricelist.js
@@ -1,0 +1,55 @@
+import { registry } from "@web/core/registry";
+import { Base } from "./related_models";
+
+export class ProductPricelist extends Base {
+    static pythonModel = "product.pricelist";
+
+    setup() {
+        super.setup(...arguments);
+
+        this.uiState = {
+            generalRulesByCateg: {},
+            generalRules: {},
+        };
+
+        // General rules can be computed only on starting since they
+        // are loaded by default, if a new pricelist is created
+        // after the POS is started, it will be computed during the setup
+        this.computeGeneralRulesByCateg();
+    }
+
+    getGeneralRulesByCategories(categoryIds) {
+        const rules = {};
+
+        for (const id of categoryIds) {
+            if (this.uiState.generalRulesByCateg[id]) {
+                Object.assign(rules, this.uiState.generalRulesByCateg[id]);
+            }
+        }
+
+        Object.assign(rules, this.uiState.generalRules);
+        return Object.values(rules);
+    }
+
+    computeGeneralRulesByCateg() {
+        for (const index in this.item_ids) {
+            const item = this.item_ids[index];
+            if (item.product_id || item.product_tmpl_id) {
+                continue;
+            }
+
+            if (item.categ_id) {
+                if (!this.uiState.generalRulesByCateg[item.categ_id.id]) {
+                    this.uiState.generalRulesByCateg[item.categ_id.id] = {};
+                }
+
+                this.uiState.generalRulesByCateg[item.categ_id.id][index] = item;
+                continue;
+            }
+
+            this.uiState.generalRules[index] = item;
+        }
+    }
+}
+
+registry.category("pos_available_models").add(ProductPricelist.pythonModel, ProductPricelist);

--- a/addons/point_of_sale/static/src/app/models/product_pricelist.js
+++ b/addons/point_of_sale/static/src/app/models/product_pricelist.js
@@ -8,8 +8,8 @@ export class ProductPricelist extends Base {
         super.setup(...arguments);
 
         this.uiState = {
-            generalRulesByCateg: {},
-            generalRules: {},
+            generalRulesIdsByCateg: {},
+            generalRulesIds: {},
         };
 
         // General rules can be computed only on starting since they
@@ -18,36 +18,37 @@ export class ProductPricelist extends Base {
         this.computeGeneralRulesByCateg();
     }
 
-    getGeneralRulesByCategories(categoryIds) {
+    getGeneralRulesIdsByCategories(categoryIds) {
         const rules = {};
 
         for (const id of categoryIds) {
-            if (this.uiState.generalRulesByCateg[id]) {
-                Object.assign(rules, this.uiState.generalRulesByCateg[id]);
+            if (this.uiState.generalRulesIdsByCateg[id]) {
+                Object.assign(rules, this.uiState.generalRulesIdsByCateg[id]);
             }
         }
 
-        Object.assign(rules, this.uiState.generalRules);
+        Object.assign(rules, this.uiState.generalRulesIds);
         return Object.values(rules);
     }
 
     computeGeneralRulesByCateg() {
-        for (const index in this.item_ids) {
+        for (const idx in this.item_ids) {
+            const index = parseInt(idx);
             const item = this.item_ids[index];
             if (item.product_id || item.product_tmpl_id) {
                 continue;
             }
 
             if (item.categ_id) {
-                if (!this.uiState.generalRulesByCateg[item.categ_id.id]) {
-                    this.uiState.generalRulesByCateg[item.categ_id.id] = {};
+                if (!this.uiState.generalRulesIdsByCateg[item.categ_id.id]) {
+                    this.uiState.generalRulesIdsByCateg[item.categ_id.id] = {};
                 }
 
-                this.uiState.generalRulesByCateg[item.categ_id.id][index] = item;
+                this.uiState.generalRulesIdsByCateg[item.categ_id.id][index] = item.id;
                 continue;
             }
 
-            this.uiState.generalRules[index] = item;
+            this.uiState.generalRulesIds[index] = item.id;
         }
     }
 }

--- a/addons/point_of_sale/static/src/app/models/product_template.js
+++ b/addons/point_of_sale/static/src/app/models/product_template.js
@@ -18,13 +18,6 @@ import { accountTaxHelpers } from "@account/helpers/account_tax";
 export class ProductTemplate extends Base {
     static pythonModel = "product.template";
 
-    setup(_vals) {
-        super.setup(...arguments);
-        this.uiState = {
-            applicablePricelistRules: {},
-        };
-    }
-
     prepareProductBaseLineForTaxesComputationExtraValues(
         price,
         pricelist = false,
@@ -169,19 +162,8 @@ export class ProductTemplate extends Base {
         const filter = (r) => r.pricelist_id.id === pricelist.id;
         const rules = (this["<-product.pricelist.item.product_tmpl_id"] || []).filter(filter);
         const rulesSet = new Set(rules.map((r) => r.id));
-
-        if (this.uiState.applicablePricelistRules[pricelist.id] && !rulesSet.size) {
-            return this.uiState.applicablePricelistRules[pricelist.id];
-        }
-
-        const generalRules = pricelist.getGeneralRulesByCategories(this.parentCategories);
-
-        this.uiState.applicablePricelistRules[pricelist.id] = [
-            ...rulesSet,
-            ...generalRules.map((rule) => rule.id),
-        ];
-
-        return this.uiState.applicablePricelistRules[pricelist.id];
+        const generalRulesIds = pricelist.getGeneralRulesIdsByCategories(this.parentCategories);
+        return [...rulesSet, ...generalRulesIds];
     }
 
     // Port of _get_product_price on product.pricelist.

--- a/addons/point_of_sale/static/src/app/models/utils/indexed_db.js
+++ b/addons/point_of_sale/static/src/app/models/utils/indexed_db.js
@@ -10,7 +10,7 @@ export default class IndexedDB {
         this.dbVersion = dbVersion;
         this.dbStores = dbStores;
         this.dbInstance = null;
-        this.activeTransactions = 0;
+        this.activeTransactions = new Set();
         this.databaseEventListener(whenReady);
     }
 
@@ -49,10 +49,14 @@ export default class IndexedDB {
         if (!arrData?.length) {
             return;
         }
+
         // Batch processing for large arrays to avoid performance issues
         // or transaction failures due to large data sets
         const results = [];
         for (let i = 0; i < arrData.length; i += BATCH_SIZE) {
+            let timeoutId;
+            let finished = false;
+
             const batch = arrData.slice(i, i + BATCH_SIZE);
             const transaction = this.getNewTransaction([storeName], "readwrite");
 
@@ -61,18 +65,17 @@ export default class IndexedDB {
                 continue;
             }
 
-            let timeoutId;
-            let finished = false;
-
             const doneMethod = () => {
                 finished = true;
                 clearTimeout(timeoutId);
+                this.activeTransactions.delete(transaction);
             };
 
             // Mark transaction as finished in all cases
             transaction.oncomplete = doneMethod;
             transaction.onabort = doneMethod;
             transaction.onerror = doneMethod;
+            transaction.onsuccess = doneMethod;
 
             const batchPromise = new Promise((resolve, reject) => {
                 const store = transaction.objectStore(storeName);
@@ -92,29 +95,42 @@ export default class IndexedDB {
 
                 if (odoo.debug) {
                     console.debug(
-                        `%cIndexedDB: ${method} ${storeName} with ${batch.length} items`,
-                        "color: #ffb7a8"
+                        `[%cIndexedDB%c]: %c${method} ${batch.length}%c ${storeName}`,
+                        "color:lime;",
+                        "",
+                        "font-weight:bold;color:#e67e22",
+                        ""
                     );
                 }
 
-                batch.forEach((data) => {
-                    const request = store[method](data);
+                for (const data of batch) {
+                    try {
+                        const deepCloned = JSON.parse(JSON.stringify(data));
+                        const request = store[method](deepCloned);
 
-                    request.onsuccess = () => {
-                        completed++;
-                        if (completed === batch.length && !hasError && !finished) {
+                        request.onsuccess = () => {
+                            completed++;
+                            if (completed === batch.length && !hasError && !finished) {
+                                clearTimeout(timeoutId);
+                                resolve();
+                            }
+                        };
+
+                        request.onerror = (event) => {
+                            hasError = true;
                             clearTimeout(timeoutId);
-                            resolve();
+                            console.error("IndexedDB error:", event.target?.error);
+                            reject(event.target?.error || "Unknown error");
+                        };
+                    } catch {
+                        if (odoo.debug === "assets") {
+                            console.debug(
+                                `%cIndexedDB: Error processing ${method} for ${storeName}`,
+                                "color: #ffb7a8"
+                            );
                         }
-                    };
-
-                    request.onerror = (event) => {
-                        hasError = true;
-                        clearTimeout(timeoutId);
-                        console.error("IndexedDB error:", event.target?.error);
-                        reject(event.target?.error || "Unknown error");
-                    };
-                });
+                    }
+                }
             });
 
             results.push(batchPromise);
@@ -129,11 +145,8 @@ export default class IndexedDB {
                 return false;
             }
 
-            this.activeTransactions++;
             const transaction = this.db.transaction(dbStore, "readwrite");
-            transaction.onerror = () => this.activeTransactions--;
-            transaction.onabort = () => this.activeTransactions--;
-            transaction.oncomplete = () => this.activeTransactions--;
+            this.activeTransactions.add(transaction);
             return transaction;
         } catch (e) {
             console.info("DATABASE is not ready yet", e);
@@ -156,16 +169,24 @@ export default class IndexedDB {
         return this.promises(storeName, arrData, "put");
     }
 
-    readAll(storeName = [], retry = 0) {
-        const storeNames =
-            storeName.length > 0 ? storeName : this.dbStores.map((store) => store[1]);
+    readAll(store = [], retry = 0) {
+        const storeNames = store.length > 0 ? store : this.dbStores.map((store) => store[1]);
         const transaction = this.getNewTransaction(storeNames, "readonly");
 
         if (!transaction && retry < 5) {
-            return this.readAll(storeName, retry + 1);
+            return this.readAll(store, retry + 1);
         } else if (!transaction) {
             return new Promise((reject) => reject(false));
         }
+
+        const removeTransaction = () => {
+            this.activeTransactions.delete(transaction);
+        };
+
+        transaction.oncomplete = removeTransaction;
+        transaction.onabort = removeTransaction;
+        transaction.onerror = removeTransaction;
+        transaction.onsuccess = removeTransaction;
 
         const promises = storeNames.map(
             (store) =>
@@ -173,14 +194,19 @@ export default class IndexedDB {
                     const objectStore = transaction.objectStore(store);
                     const request = objectStore.getAll();
 
-                    request.onerror = () => {
-                        console.warn("Internal error reading data from the indexed database.");
-                        reject();
+                    const errorMethod = (event) => {
+                        console.error("Error reading data from the indexed database:", event);
+                        reject(event.target.error || "Unknown error");
                     };
-                    request.onsuccess = (event) => {
+
+                    const successMethod = (event) => {
                         const result = event.target.result;
                         resolve({ [store]: result });
                     };
+
+                    request.onerror = errorMethod;
+                    request.onabort = errorMethod;
+                    request.onsuccess = successMethod;
                 })
         );
 

--- a/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
@@ -203,7 +203,6 @@ export class ProductScreen extends Component {
             const records = await this.pos.loadNewProducts([
                 ["product_variant_ids.barcode", "in", [code.base_code]],
             ]);
-            await this.pos.processProductAttributes();
 
             if (records && records["product.product"].length > 0) {
                 return records["product.product"][0];
@@ -360,7 +359,6 @@ export class ProductScreen extends Component {
         }
 
         const results = await this.pos.loadNewProducts(domain, this.state.currentOffset, 30);
-        await this.pos.processProductAttributes();
         return results["product.product"];
     }
 

--- a/addons/point_of_sale/static/src/app/services/data_service.js
+++ b/addons/point_of_sale/static/src/app/services/data_service.js
@@ -3,7 +3,7 @@ import { Base, createRelatedModels } from "@point_of_sale/app/models/related_mod
 import { registry } from "@web/core/registry";
 import { Mutex } from "@web/core/utils/concurrency";
 import { markRaw } from "@odoo/owl";
-import { batched } from "@web/core/utils/timing";
+import { batched, debounce } from "@web/core/utils/timing";
 import IndexedDB from "../models/utils/indexed_db";
 import { DataServiceOptions } from "../models/data_service_options";
 import { getOnNotified, uuidv4 } from "@point_of_sale/utils";
@@ -33,6 +33,10 @@ export class PosData extends Reactive {
         this.records = {};
         this.opts = new DataServiceOptions();
         this.channels = [];
+        this.debouncedSynchronizeLocalDataInIndexedDB = debounce(
+            this.synchronizeLocalDataInIndexedDB.bind(this),
+            300
+        );
 
         this.network = {
             warningTriggered: false,
@@ -370,16 +374,57 @@ export class PosData extends Reactive {
         this.relations = relations;
         this.models = models;
 
+        if (odoo.debug === "assets") {
+            window.performance.mark("pos_data_service_init");
+        }
+
         await this.initData();
         await this.getLocalDataFromIndexedDB();
         this.initListeners();
+
+        if (odoo.debug === "assets") {
+            window.performance.mark("pos_data_service_init_end");
+        }
+
+        this.debugInfos();
         this.network.loading = false;
+    }
+
+    debugInfos() {
+        if (odoo.debug === "assets") {
+            const sortedByLength = Object.keys(this.models)
+                .map((m) => [m, this.models[m].length])
+                .sort((a, b) => a[1] - b[1]);
+
+            for (const [model, length] of sortedByLength) {
+                console.debug(
+                    `[%c${model}%c]: %c${length}%c records`,
+                    "color:lime;",
+                    "",
+                    "font-weight:bold;color:#e67e22",
+                    ""
+                );
+            }
+
+            const measure = window.performance.measure(
+                "pos_loading",
+                "pos_data_service_init",
+                "pos_data_service_init_end"
+            );
+
+            console.debug(
+                `%cPosDataService initialized in %c${measure.duration.toFixed(2)}ms%c`,
+                "color:lime;font-weight:bold",
+                "color:#e67e22;font-weight:bold",
+                ""
+            );
+        }
     }
 
     initListeners() {
         this.models["pos.order"].addEventListener(
             "update",
-            batched(this.synchronizeLocalDataInIndexedDB.bind(this))
+            batched(this.debouncedSynchronizeLocalDataInIndexedDB.bind(this))
         );
 
         const ignore = Object.keys(this.opts.databaseTable);
@@ -642,6 +687,20 @@ export class PosData extends Reactive {
             }
 
             try {
+                if (["product.product", "product.template"].includes(model)) {
+                    await this.callRelated("product.template", "load_product_from_pos", [
+                        odoo.pos_config_id,
+                        [
+                            "|",
+                            ["product_variant_ids.id", "in", Array.from(ids)],
+                            ["id", "in", Array.from(ids)],
+                        ],
+                        0,
+                        0,
+                    ]);
+                    continue;
+                }
+
                 const data = await this.orm.read(model, Array.from(ids), this.fields[model], {
                     load: false,
                 });

--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -363,11 +363,6 @@ export class PosStore extends WithLazyGetterTrap {
         }
         this.config.iface_printers = !!this.unwatched.printers.length;
 
-        // Monitor product pricelist
-        this.models["product.product"].addEventListener(
-            "create",
-            this.computeProductPricelistCache.bind(this)
-        );
         this.models["product.pricelist.item"].addEventListener("create", () => {
             const order = this.getOrder();
             if (!order) {
@@ -552,6 +547,26 @@ export class PosStore extends WithLazyGetterTrap {
     async _onBeforeDeleteOrder(order) {
         return true;
     }
+
+    /**
+     * This method is used to load new products from the server.
+     * It also load pricelists, attributes and packagings
+     * @param {Array} domain
+     * @param {number} offset
+     * @param {number} limit
+     * @returns {Promise<Object>}
+     */
+    async loadNewProducts(domain, offset = 0, limit = 0) {
+        const result = await this.data.callRelated("product.template", "load_product_from_pos", [
+            odoo.pos_config_id,
+            domain,
+            offset,
+            limit,
+        ]);
+        return result;
+    }
+
+    // FIXME Dead code to be deleted in master
     computeProductPricelistCache(data) {
         if (!data) {
             return;
@@ -565,6 +580,7 @@ export class PosStore extends WithLazyGetterTrap {
         this._loadMissingPricelistItems(products);
     }
 
+    // FIXME Dead code to be deleted in master
     async _loadMissingPricelistItems(products) {
         const validProducts = products.filter((product) => typeof product.id === "number");
         if (!validProducts.length) {
@@ -1150,7 +1166,7 @@ export class PosStore extends WithLazyGetterTrap {
                 throw error;
             }
         } finally {
-            this.data.synchronizeLocalDataInIndexedDB();
+            this.data.debouncedSynchronizeLocalDataInIndexedDB();
         }
     }
     /**

--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -563,6 +563,7 @@ export class PosStore extends WithLazyGetterTrap {
             offset,
             limit,
         ]);
+        this.computeProductAttributesExclusion();
         return result;
     }
 

--- a/addons/point_of_sale/static/tests/generic_helpers/utils.js
+++ b/addons/point_of_sale/static/tests/generic_helpers/utils.js
@@ -31,7 +31,7 @@ export function refresh() {
         await new Promise((resolve) => {
             const checkTransaction = () => {
                 const activeTransactions = posmodel.data.indexedDB.activeTransactions;
-                if (activeTransactions <= 0) {
+                if (activeTransactions.size === 0) {
                     window.location.reload();
                     resolve();
                 } else {

--- a/addons/point_of_sale/static/tests/pos/tours/pricelist_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/pricelist_tour.js
@@ -6,6 +6,7 @@ import * as Dialog from "@point_of_sale/../tests/generic_helpers/dialog_util";
 import * as Pricelist from "@point_of_sale/../tests/pos/tours/utils/pricelist_util";
 import * as Chrome from "@point_of_sale/../tests/pos/tours/utils/chrome_util";
 import * as OfflineUtil from "@point_of_sale/../tests/generic_helpers/offline_util";
+import { scan_barcode } from "@point_of_sale/../tests/generic_helpers/utils";
 
 registry.category("web_tour.tours").add("pos_pricelist", {
     steps: () =>
@@ -45,5 +46,79 @@ registry.category("web_tour.tours").add("pos_pricelist", {
             ProductScreen.clickPriceList("min_quantity ordering"),
             OfflineUtil.setOnlineMode(),
             ProductScreen.closePos(),
+        ].flat(),
+});
+
+// # With test_pricelist set on the order:
+// # - First banana variant will be priced at 100 via product variant
+// # - Second banana variant will be priced at 150 via product variant
+// # - Third banana variant will be priced at 20 via product template
+// # - First apple variant will be priced at 100 via product variant
+// # - All product without rules and with product_category will be priced at 500
+registry.category("web_tour.tours").add("test_pricelists_in_pos", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+
+            ProductScreen.clickPriceList("Test Pricelist"),
+            scan_barcode("banana_0"),
+            ProductScreen.selectedOrderlineHas("Banana", "1", "100.0", "BIG"),
+            scan_barcode("banana_1"),
+            ProductScreen.selectedOrderlineHas("Banana", "1", "150.0", "MEDIUM"),
+            scan_barcode("banana_2"),
+            ProductScreen.selectedOrderlineHas("Banana", "1", "20.0", "SMALL"),
+            scan_barcode("apple_0"),
+            ProductScreen.selectedOrderlineHas("Apple", "1", "100.0", "BIG"),
+            scan_barcode("apple_1"),
+            ProductScreen.selectedOrderlineHas("Apple", "1", "500.0", "MEDIUM"),
+            scan_barcode("apple_2"),
+            ProductScreen.selectedOrderlineHas("Apple", "1", "500.0", "SMALL"),
+
+            ProductScreen.clickPriceList("Percentage Pricelist"),
+            scan_barcode("banana_0"),
+            ProductScreen.selectedOrderlineHas("Banana", "2", "100.0", "BIG"),
+            scan_barcode("banana_1"),
+            ProductScreen.selectedOrderlineHas("Banana", "2", "150.0", "MEDIUM"),
+            scan_barcode("banana_2"),
+            ProductScreen.selectedOrderlineHas("Banana", "2", "20.0", "SMALL"),
+            scan_barcode("apple_0"),
+            ProductScreen.selectedOrderlineHas("Apple", "2", "100.0", "BIG"),
+            scan_barcode("apple_1"),
+            ProductScreen.selectedOrderlineHas("Apple", "2", "500.0", "MEDIUM"),
+            scan_barcode("apple_2"),
+            ProductScreen.selectedOrderlineHas("Apple", "2", "500.0", "SMALL"),
+
+            // Try scan a product with nested pricelist on variant
+            scan_barcode("pear_0"),
+            ProductScreen.selectedOrderlineHas("Pear", "1", "10.0", "BIG"),
+            scan_barcode("pear_1"),
+            ProductScreen.selectedOrderlineHas("Pear", "1", "20.0", "MEDIUM"),
+            scan_barcode("pear_2"),
+            ProductScreen.selectedOrderlineHas("Pear", "1", "30.0", "SMALL"),
+
+            // Try scan a product with nested pricelist on template
+            scan_barcode("lime_0"),
+            ProductScreen.selectedOrderlineHas("Lime", "1", "50.0", "BIG"),
+            scan_barcode("lime_1"),
+            ProductScreen.selectedOrderlineHas("Lime", "1", "100.0", "MEDIUM"),
+            scan_barcode("lime_2"),
+            ProductScreen.selectedOrderlineHas("Lime", "1", "200.0", "SMALL"),
+
+            // Try scan a product with nested pricelist on category
+            scan_barcode("orange_0"),
+            ProductScreen.selectedOrderlineHas("Orange", "1", "500.0", "BIG"),
+            scan_barcode("orange_1"),
+            ProductScreen.selectedOrderlineHas("Orange", "1", "300.0", "MEDIUM"),
+            scan_barcode("orange_2"),
+            ProductScreen.selectedOrderlineHas("Orange", "1", "250.0", "SMALL"),
+
+            // Try scan a product with no pricelist rules
+            scan_barcode("kiwi_0"),
+            ProductScreen.selectedOrderlineHas("Kiwi", "1", "10.0", "BIG"),
+            scan_barcode("kiwi_1"),
+            ProductScreen.selectedOrderlineHas("Kiwi", "1", "5.0", "MEDIUM"),
+            scan_barcode("kiwi_2"),
+            ProductScreen.selectedOrderlineHas("Kiwi", "1", "5.0", "SMALL"),
         ].flat(),
 });

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -4,7 +4,7 @@
 import logging
 from contextlib import contextmanager
 from unittest.mock import patch
-from odoo import Command
+from odoo import Command, api
 
 from odoo.tools import DEFAULT_SERVER_DATE_FORMAT
 from odoo.tests import tagged
@@ -2191,6 +2191,133 @@ class TestUi(TestPointOfSaleHttpCommon):
         })
 
         self.start_pos_tour('test_exclusion_attribute_values_after_deactivation')
+
+    def test_pricelists_in_pos(self):
+        pos_limited_category = self.env['pos.category'].create({'name': 'Limited Category'})
+        pos_category = self.env['pos.category'].create({'name': 'test_pricelists_in_pos'})
+        product_category = self.env['product.category'].create({'name': 'test_pricelists_in_pos'})
+        orange_category = self.env['product.category'].create({'name': 'Orange Category'})
+
+        def generate_pricelist_items(pricelist, fixed_price, product=None, product_tmpl=None, product_category=None):
+            applied_on = '0_product_variant' if product else '1_product' if product_tmpl else '2_product_category' if product_category else '3_global'
+            return self.env['product.pricelist.item'].create({
+                'pricelist_id': pricelist.id,
+                'product_id': product.id if product else False,
+                'product_tmpl_id': product_tmpl.id if product_tmpl else False,
+                'categ_id': product_category.id if product_category else False,
+                'compute_price': 'fixed',
+                'applied_on': applied_on,
+                'fixed_price': fixed_price,
+            })
+
+        def generate_product_template_with_attributes(name, price, pos_category=None, product_category=None):
+            size_attribute = self.env['product.attribute'].create({
+                'name': 'Size',
+                'sequence': 4,
+                'value_ids': [(0, 0, {
+                    'name': 'BIG',
+                    'sequence': 1,
+                }), (0, 0, {
+                    'name': 'MEDIUM',
+                    'sequence': 2,
+                }), (0, 0, {
+                    'name': 'SMALL',
+                    'sequence': 3,
+                })],
+            })
+
+            product_tmpl = self.env['product.template'].create({
+                'name': name.capitalize(),
+                'available_in_pos': True,
+                'categ_id': product_category.id if product_category else False,
+                'pos_categ_ids': [(4, pos_category.id)] if pos_category else False,
+                'list_price': price,
+                'taxes_id': False,
+                'attribute_line_ids': [(0, 0, {
+                    'attribute_id': size_attribute.id,
+                    'value_ids': [(6, 0, size_attribute.value_ids.ids)]
+                })],
+            })
+
+            for index, variant in enumerate(product_tmpl.product_variant_ids):
+                variant.write({'barcode': f'{name}_{index}'})
+
+            return product_tmpl
+
+        banana = generate_product_template_with_attributes('banana', 10.00, pos_category)
+        apple = generate_product_template_with_attributes('apple', 5.00, False, product_category)
+        pear = generate_product_template_with_attributes('pear', 2.00)
+        lime = generate_product_template_with_attributes('lime', 1.00)
+        orange = generate_product_template_with_attributes('orange', 3.00, False, orange_category)
+        kiwi = generate_product_template_with_attributes('kiwi', 4.00)
+
+        test_pricelist = self.env['product.pricelist'].create({
+            'name': 'Test Pricelist',
+        })
+
+        percentage_pricelist = self.env['product.pricelist'].create({
+            'name': 'Percentage Pricelist',
+        })
+
+        generate_pricelist_items(test_pricelist, 20, False, banana)
+        generate_pricelist_items(test_pricelist, 100, banana.product_variant_ids[0])
+        generate_pricelist_items(test_pricelist, 150, banana.product_variant_ids[1])
+        generate_pricelist_items(test_pricelist, 500, False, False, product_category)
+        generate_pricelist_items(test_pricelist, 1000, False, False, orange_category)
+        generate_pricelist_items(test_pricelist, 100, apple.product_variant_ids[0])
+        generate_pricelist_items(test_pricelist, 20, pear.product_variant_ids[0])
+        generate_pricelist_items(test_pricelist, 40, pear.product_variant_ids[1])
+        generate_pricelist_items(test_pricelist, 60, pear.product_variant_ids[2])
+        generate_pricelist_items(test_pricelist, 100, False, lime)
+        generate_pricelist_items(test_pricelist, 200, lime.product_variant_ids[1])
+        generate_pricelist_items(test_pricelist, 400, lime.product_variant_ids[2])
+        generate_pricelist_items(test_pricelist, 600, orange.product_variant_ids[1])
+        generate_pricelist_items(test_pricelist, 500, orange.product_variant_ids[2])
+        generate_pricelist_items(test_pricelist, 10)
+        generate_pricelist_items(test_pricelist, 20, kiwi.product_variant_ids[0])
+
+        self.env['product.pricelist.item'].create({
+            'pricelist_id': percentage_pricelist.id,
+            'base': 'pricelist',
+            'base_pricelist_id': test_pricelist.id,
+            'compute_price': 'percentage',
+            'percent_price': 50,
+            'applied_on': '3_global',
+        })
+
+        self.main_pos_config.write({
+            "limit_categories": True,
+            "iface_available_categ_ids": [(6, 0, [pos_limited_category.id])],
+            'available_pricelist_ids': [(6, 0, [test_pricelist.id, percentage_pricelist.id])],
+            'pricelist_id': test_pricelist.id,
+        })
+
+        load_product_from_pos_stats = {'count': 0, 'items': {}}
+        product_template = self.env.registry.models['product.template']
+
+        @api.model
+        def load_product_from_pos_patch(self, config_id, domain, offset=0, limit=0):
+            load_product_from_pos_stats['count'] += 1
+            result = super(product_template, self).load_product_from_pos(config_id, domain, offset, limit)
+            lowered_name = result['product.template'][0]['display_name'].lower()
+            load_product_from_pos_stats['items'][lowered_name] = len(result['product.pricelist.item'])
+            return result
+
+        with patch.object(product_template, "load_product_from_pos", load_product_from_pos_patch):
+            self.start_pos_tour('test_pricelists_in_pos')
+
+        # Should load 6 different products, since 6 products were created
+        self.assertEqual(load_product_from_pos_stats['count'], 6)
+
+        # Length of loaded pricelist items should correspond to the number of items linked
+        # to the product template or product variant
+        # Global rules are loaded at starting of the PoS
+        self.assertEqual(load_product_from_pos_stats['items']['banana'], 3, "Banana should have 3 pricelist items")
+        self.assertEqual(load_product_from_pos_stats['items']['apple'], 1, "Apple should have 1 pricelist item")
+        self.assertEqual(load_product_from_pos_stats['items']['pear'], 3, "Pear should have 3 pricelist items")
+        self.assertEqual(load_product_from_pos_stats['items']['lime'], 3, "Lime should have 3 pricelist items")
+        self.assertEqual(load_product_from_pos_stats['items']['orange'], 2, "Orange should have 2 pricelist items")
+        self.assertEqual(load_product_from_pos_stats['items']['kiwi'], 1, "Kiwi should have 1 pricelist item")
 
 
 # This class just runs the same tests as above but with mobile emulation

--- a/addons/pos_loyalty/models/loyalty_card.py
+++ b/addons/pos_loyalty/models/loyalty_card.py
@@ -16,7 +16,7 @@ class LoyaltyCard(models.Model):
 
     @api.model
     def _load_pos_data_domain(self, data):
-        return [('program_id', 'in', [program["id"] for program in data["loyalty.program"]])]
+        return False
 
     @api.model
     def _load_pos_data_fields(self, config_id):

--- a/addons/pos_loyalty/static/src/app/screens/product_screen/order_summary/order_summary.js
+++ b/addons/pos_loyalty/static/src/app/screens/product_screen/order_summary/order_summary.js
@@ -173,7 +173,7 @@ patch(OrderSummary.prototype, {
                 this.currentOrder.processGiftCard(code, points, expirationDate);
 
                 // update indexedDB
-                this.pos.data.synchronizeLocalDataInIndexedDB();
+                this.pos.data.debouncedSynchronizeLocalDataInIndexedDB();
             },
         });
     },

--- a/addons/pos_sale/models/sale_order.py
+++ b/addons/pos_sale/models/sale_order.py
@@ -30,11 +30,7 @@ class SaleOrder(models.Model):
         product_ids = self.order_line.product_id.ids
         product_tmpls = self.env['product.template'].load_product_from_pos(
             config_id,
-            [
-                '|',
-                ('product_variant_ids.id', 'in', product_ids),
-                ('id', 'in', product_ids),
-            ]
+            [('product_variant_ids.id', 'in', product_ids)]
         )
         sale_order_fields = self._load_pos_data_fields(config_id)
         sale_order_read = self.read(sale_order_fields, load=False)

--- a/addons/pos_sale/models/sale_order.py
+++ b/addons/pos_sale/models/sale_order.py
@@ -36,10 +36,12 @@ class SaleOrder(models.Model):
         sale_order_read = self.read(sale_order_fields, load=False)
         sale_order_line_fields = self.order_line._load_pos_data_fields(config_id)
         sale_order_line_read = self.order_line.read(sale_order_line_fields, load=False)
+        partner_fields = self.env['res.partner']._load_pos_data_fields(config_id)
 
         return {
             'sale.order': sale_order_read,
             'sale.order.line': sale_order_line_read,
+            'res.partner': self.partner_id.read(partner_fields, load=False),
             **product_tmpls,
         }
 

--- a/addons/pos_sale/static/src/app/services/pos_store.js
+++ b/addons/pos_sale/static/src/app/services/pos_store.js
@@ -66,8 +66,11 @@ patch(PosStore.prototype, {
         this.selectOrderLine(this.getOrder(), this.getOrder().lines.at(-1));
     },
     async _getSaleOrder(id) {
-        const sale_order = (await this.data.read("sale.order", [id]))[0];
-        return sale_order;
+        const result = await this.data.callRelated("sale.order", "load_sale_order_from_pos", [
+            id,
+            this.config.id,
+        ]);
+        return result["sale.order"][0];
     },
     async settleSO(sale_order, orderFiscalPos) {
         if (sale_order.pricelist_id) {

--- a/addons/pos_sale/static/src/overrides/components/payment_screen/payment_screen.js
+++ b/addons/pos_sale/static/src/overrides/components/payment_screen/payment_screen.js
@@ -14,7 +14,7 @@ patch(PaymentScreen.prototype, {
                 "sale.order.line",
                 orders.flatMap((o) => o.order_line).map((ol) => ol.id)
             );
-            this.pos.data.synchronizeLocalDataInIndexedDB(this.pos.data.records);
+            this.pos.data.debouncedSynchronizeLocalDataInIndexedDB(this.pos.data.records);
         }
         await super.afterOrderValidation();
     },

--- a/addons/pos_self_order/models/pos_config.py
+++ b/addons/pos_self_order/models/pos_config.py
@@ -253,7 +253,7 @@ class PosConfig(models.Model):
 
     def _load_self_data_models(self):
         return ['pos.session', 'pos.preset', 'resource.calendar.attendance', 'pos.order', 'pos.order.line', 'pos.payment', 'pos.payment.method', 'res.partner',
-            'res.currency', 'pos.category', 'product.template', 'product.product',  'product.combo', 'product.combo.item', 'res.company', 'account.tax',
+            'res.currency', 'pos.category', 'product.template', 'product.product', 'product.combo', 'product.combo.item', 'res.company', 'account.tax', 'product.category',
             'account.tax.group', 'pos.printer', 'res.country', 'product.pricelist', 'product.pricelist.item', 'account.fiscal.position', 'account.fiscal.position.tax',
             'res.lang', 'product.attribute', 'product.attribute.custom.value', 'product.template.attribute.line', 'product.template.attribute.value',
             'decimal.precision', 'uom.uom', 'pos.printer', 'pos_self_order.custom_link', 'restaurant.floor', 'restaurant.table', 'account.cash.rounding',

--- a/addons/pos_self_order/static/src/app/services/self_order_service.js
+++ b/addons/pos_self_order/static/src/app/services/self_order_service.js
@@ -664,7 +664,7 @@ export class SelfOrder extends Reactive {
                 uuid = result["pos.order"][0].uuid;
             }
 
-            this.data.synchronizeLocalDataInIndexedDB();
+            this.data.debouncedSynchronizeLocalDataInIndexedDB();
             this.currentOrder.recomputeChanges();
             return this.models["pos.order"].getBy("uuid", uuid);
         } catch (error) {


### PR DESCRIPTION
## Commit 1
[FIX] point_of_sale, pos_sale: fix product loading in POS

Before this commit, when loading additional products after the initial
load, the PoS were not receiving all necessary data related to the
products, for example product's precomputed taxes objects.

This commit add a method which will load all necessary data for the
products when loading them in the PoS.

What's more, when a product was loaded via barcode, it didn't yet have
its associated pricelists, as these were loaded in another RPC. This
commit unifies data reception via a single RPC.

Loyalty cards are not longer loaded at the beginning of the PoS since
they are loaded each time a partner is selected. Loyalty cards doesn't
works with offline mode anyway since some backend check must be done
before validating them.

Some debug information about loading times and records is now printed
in the console when the PoS is started in debug mode.

IndexedDB method is now debounced to avoid calling it too often when the
PoS is started. The create method is also batched to avoid putting large
amount of data in IndexedDB at once.

Loaded data includes:
- `product.product`
- `product.template`
- `product.combo`
- `product.combo.item`
- `product.uom`
- `product.pricelist`
- `product.pricelist.item`
- `product.template.attribute.value`
- `product.template.attribute.line`
- `account.tax`

## Commit 2

[PERF] point_of_sale: pricelist computations
Before this commit, when we were trying to compute pricelist item for
a product, we were iterating over all pricelist items of the pricelist
and checking if the product was in the item or if the item didn't
have any product set. This was very inefficient, especially when
there were many pricelist items and products.

This commit add a pre-computation of pricelist items for general rules
which eliminates the need to calculate rules on the fly.