### PR TITLE
[FIX] html_builder, website: prevent editing design elements

### DIFF
--- a/addons/html_builder/static/src/core/content_editable_plugin.js
+++ b/addons/html_builder/static/src/core/content_editable_plugin.js
@@ -1,0 +1,38 @@
+import { Plugin } from "@html_editor/plugin";
+import { registry } from "@web/core/registry";
+
+/**
+ * This plugin is responsible for setting the contenteditable attribute on some
+ * elements. For example, on sections with a container, only the container
+ * should be editable but not its sibling nodes in the section.
+ * 
+ * The force_editable_selector and force_not_editable_selector resources allow
+ * other plugins to easily add editable or non editable elements.
+ */
+class ContentEditable extends Plugin {
+    static id = "contentEditable";
+    resources = {
+        normalize_handlers: this.normalize.bind(this),
+        force_not_editable_selector: [
+            "section:has(> .o_container_small, > .container, > .container-fluid)",
+        ],
+        force_editable_selector: [
+            "section > .o_container_small",
+            "section > .container",
+            "section > .container-fluid",
+        ],
+    };
+
+    normalize(root) {
+        const toDisableSelector = this.getResource("force_not_editable_selector").join(",");
+        for(const toDisable of root.querySelectorAll(toDisableSelector)) {
+            toDisable.setAttribute("contenteditable", "false");
+        }
+
+        const toEnableSelector = this.getResource("force_editable_selector").join(",");
+        for(const toEnable of root.querySelectorAll(toEnableSelector)) {
+            toEnable.setAttribute("contenteditable", "true");
+        }
+    }
+}
+registry.category("website-plugins").add(ContentEditable.id, ContentEditable);

--- a/addons/test_website/static/tests/tours/snippet_background_video.js
+++ b/addons/test_website/static/tests/tours/snippet_background_video.js
@@ -75,5 +75,9 @@ registerWebsitePreviewTour(
             content: "Verify that the video is set as the background of the snippet.",
             trigger: ":iframe #wrap section.o_background_video",
         },
+        {
+            content: "Check that the video container is not editable.",
+            trigger: ":iframe #wrap section.o_background_video > .o_bg_video_container[contenteditable=false]",
+        },
     ]
 );

--- a/addons/website/static/src/builder/plugins/background_option/background_image_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/background_option/background_image_option_plugin.js
@@ -24,6 +24,7 @@ export class BackgroundImageOptionPlugin extends Plugin {
             ReplaceBgImageAction,
             DynamicColorAction,
         },
+        force_not_editable_selector: ".o_we_bg_filter",
     };
     /**
      * Transfers the background-image and the dataset information relative to

--- a/addons/website/static/src/builder/plugins/background_option/background_shape_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/background_option/background_shape_option_plugin.js
@@ -26,6 +26,7 @@ export class BackgroundShapeOptionPlugin extends Plugin {
         background_shape_target_providers: withSequence(5, (editingElement) =>
             editingElement.querySelector(":scope > .o_we_bg_filter")
         ),
+        force_not_editable_selector: ".o_we_shape",
     };
     static shared = [
         "getShapeStyleUrl",

--- a/addons/website/static/src/builder/plugins/options/parallax_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/parallax_option_plugin.js
@@ -13,6 +13,7 @@ class WebsiteParallaxPlugin extends Plugin {
             SetParallaxTypeAction,
         },
         on_bg_image_hide_handlers: this.onBgImageHide.bind(this),
+        force_not_editable_selector: ".s_parallax_bg, section.s_parallax > .oe_structure",
     };
     setup() {
         this.backgroundOptionSelectorParams = getSelectorParams(

--- a/addons/website/static/src/core/website_edit_service.js
+++ b/addons/website/static/src/core/website_edit_service.js
@@ -215,6 +215,7 @@ registry.category("services").add("website_edit", {
                         // parent node, you do not want the inserted node to be
                         // reinserted upon undo of the option's action.
                         el.dataset.skipHistoryHack = "true";
+                        el.setAttribute("contenteditable", "false");
                     },
                 }),
                 patch(publicInteractions.constructor.prototype, {

--- a/addons/website/static/tests/builder/content_editable.test.js
+++ b/addons/website/static/tests/builder/content_editable.test.js
@@ -1,0 +1,46 @@
+import { expect, test } from "@odoo/hoot";
+import { queryOne } from "@odoo/hoot-dom";
+import { contains, onRpc } from "@web/../tests/web_test_helpers";
+import { defineWebsiteModels, setupWebsiteBuilder, setupWebsiteBuilderWithSnippet } from "./website_helpers";
+
+defineWebsiteModels();
+
+test("Check contenteditable attribute", async () => {
+    expect.assertions(8);
+
+    await setupWebsiteBuilder(`
+        <section>
+            <div class="not_a_container_class">
+                <div class="container"></div>
+            </div>
+        </section>
+        <section><div class="o_container_small"></div></section>
+        <section><div class="container-fluid"></div></section>
+        <section>
+            <div class="container">
+                <div class="o_we_bg_filter"></div>
+                <div class="o_we_shape"></div>
+            </div>
+        </section>
+    `);
+    expect(":iframe section:not([contenteditable=false]) > .not_a_container_class").toHaveCount(1);
+    expect(":iframe section[contenteditable=false] > .o_container_small[contenteditable=true]").toHaveCount(1);
+    expect(":iframe section[contenteditable=false] > .container-fluid[contenteditable=true]").toHaveCount(1);
+    expect(":iframe section[contenteditable=false] > .container[contenteditable=true]").toHaveCount(1);
+    expect(":iframe .o_we_bg_filter[contenteditable=false]").toHaveCount(1);
+    expect(":iframe .o_we_shape[contenteditable=false]").toHaveCount(1);
+
+    onRpc("ir.ui.view", "save", ({ args }) => {
+        // Make sure the content is saved and doesn't contain "contenteditable"
+        expect(args[1].includes("<section")).toBe(true);
+        expect(args[1].includes("contenteditable")).toBe(false);
+        return true;
+    });
+    queryOne(":iframe .o_container_small").textContent = "dirty for save";
+    await contains(".o-snippets-top-actions [data-action='save']").click();
+});
+
+test("Check contenteditable on Parallax snippet", async () => {
+    await setupWebsiteBuilderWithSnippet("s_parallax");
+    expect(":iframe section.s_parallax > .oe_structure[contenteditable=false]").toHaveCount(1);
+});


### PR DESCRIPTION
Some divs in snippets are used to store metadata, and as targets for css. However, they should not be editable. Before this commit, it was possible for the user to navigate with the keyboard inside them, and to write text. This add some weird visual looks.

This commit fixes the issue by adding an interaction that will simply set the contenteditable flag to false on these divs.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
