### PR TITLE
[FIX] http_routing: invalid HTTP code for QWeb access error

### DIFF
--- a/addons/http_routing/models/ir_http.py
+++ b/addons/http_routing/models/ir_http.py
@@ -542,7 +542,7 @@ class IrHttp(models.AbstractModel):
             values.update(qweb_exception=exception)
             exception = exception.__cause__ or exception.__context__
 
-        elif isinstance(exception, exceptions.UserError):
+        if isinstance(exception, exceptions.UserError):
             code = exception.http_status
             values['error_message'] = exception.args[0]
         elif isinstance(exception, werkzeug.exceptions.HTTPException):

--- a/addons/test_website/controllers/main.py
+++ b/addons/test_website/controllers/main.py
@@ -16,6 +16,12 @@ class WebsiteTest(Home):
     def test_view(self, **kwargs):
         return request.render('test_website.test_view')
 
+    @http.route('/test_view_access_error', type='http', auth='public', website=True, sitemap=False)
+    def test_view_access_error(self, **kwargs):
+        public = self.env.ref('base.public_user')
+        record = self.env.ref('test_website.test_model_exposed_record_not_published')
+        return request.render('test_website.test_view_access_error', {'record': record.with_user(public)})
+
     @http.route('/ignore_args/converteronly/<string:a>', type='http', auth="public", website=True, sitemap=False)
     def test_ignore_args_converter_only(self, a):
         return request.make_response(json.dumps(dict(a=a, kw=None)))

--- a/addons/test_website/data/test_website_data.xml
+++ b/addons/test_website/data/test_website_data.xml
@@ -124,6 +124,9 @@
                 <p>placeholder</p>
             </xpath>
         </template>
+        <template id="test_view_access_error">
+            <p><t t-out="record.name"/></p>
+        </template>
 
         <!-- RECORDS FOR MODULE OPERATION TESTS -->
         <template id="update_module_base_view">
@@ -157,6 +160,14 @@
         <!-- Test model record -->
         <record id="test_model_record" model="test.model">
             <field name="name">Test Model Record</field>
+        </record>
+        <record id="test_model_exposed_record_published" model="test.model">
+            <field name="name">Test Model Exposed Record (published)</field>
+            <field name="website_published">True</field>
+        </record>
+        <record id="test_model_exposed_record_not_published" model="test.model">
+            <field name="name">Test Model Exposed Record (not published)</field>
+            <field name="website_published">False</field>
         </record>
     </data>
 </odoo>

--- a/addons/test_website/static/tests/tours/error_views.js
+++ b/addons/test_website/static/tests/tours/error_views.js
@@ -151,6 +151,29 @@ registry.category("web_tour.tours").add('test_error_website', {
         content: "http access error page debug has traceback closed",
         trigger: 'body:has(div#error_traceback.collapse:not(.show) pre#exception_traceback)',
         run: function () {
+                window.location.href = window.location.origin + '/test_view_access_error?debug=0';
+        },
+    },
+    {
+        trigger: 'h1:contains("403: Forbidden")',
+    },
+    {
+        content: "http access error page has title and message",
+        trigger: 'div.container pre:contains("Uh-oh! Looks like you have stumbled upon some top-secret records.")',
+        run: function () {
+                window.location.href = window.location.origin + '/test_view_access_error?debug=1';
+        },
+    },
+    {
+        trigger: 'h1:contains("403: Forbidden")',
+    },
+    {
+        content: "http access error page debug has title and message open",
+        trigger: 'div#error_main.collapse.show pre:contains("Uh-oh! Looks like you have stumbled upon some top-secret records.")',
+    }, {
+        content: "http access error page debug has traceback closed",
+        trigger: 'body:has(div#error_traceback.collapse:not(.show) pre#exception_traceback)',
+        run: function () {
                 window.location.href = window.location.origin + '/test_missing_error_http?debug=0';
         },
     },

--- a/addons/test_website/tests/test_fuzzy.py
+++ b/addons/test_website/tests/test_fuzzy.py
@@ -98,8 +98,8 @@ class TestAutoComplete(TransactionCase):
             )
 
     def test_indirect(self):
-        self._autocomplete('module', 2, 'model')
-        self._autocomplete('rechord', 1, 'record')
+        self._autocomplete('module', 4, 'model')
+        self._autocomplete('rechord', 3, 'record')
         self._autocomplete('suborder', 1, 'submodel')
         # Sub-sub-fields are currently not supported.
         # Adapt expected result if this becomes a feature.


### PR DESCRIPTION
Render a template using record that the current user as no access to. While rendering the template QWeb fail with a AccessError exception, that exception is wrapped inside a QWebException and catch by `ir.http._handle_error`. In `http_routing` a custom template is rendered for every common errors, including AccessError.

Fine-tuning of 2ef1ae4, unwrapping the QWebException must be done independently of the other `isinstance`s.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
