### PR TITLE
[IMP] l10n_sa_edi: Adapt exemption reaso code

### DIFF
--- a/addons/account_edi_ubl_cii_tax_extension/models/account_tax.py
+++ b/addons/account_edi_ubl_cii_tax_extension/models/account_tax.py
@@ -1,8 +1,74 @@
 from odoo import api, fields, models
 
 
+EXEMPTION_REASON_CODES = [
+    ('VATEX-EU-79-C', 'VATEX-EU-79-C - Exempt based on article 79, point c of Council Directive 2006/112/EC'),
+    ('VATEX-EU-132', 'VATEX-EU-132 - Exempt based on article 132 of Council Directive 2006/112/EC'),
+    ('VATEX-EU-132-1A', 'VATEX-EU-132-1A - Exempt based on article 132, section 1 (a) of Council Directive 2006/112/EC'),
+    ('VATEX-EU-132-1B', 'VATEX-EU-132-1B - Exempt based on article 132, section 1 (b) of Council Directive 2006/112/EC'),
+    ('VATEX-EU-132-1C', 'VATEX-EU-132-1C - Exempt based on article 132, section 1 (c) of Council Directive 2006/112/EC'),
+    ('VATEX-EU-132-1D', 'VATEX-EU-132-1D - Exempt based on article 132, section 1 (d) of Council Directive 2006/112/EC'),
+    ('VATEX-EU-132-1E', 'VATEX-EU-132-1E - Exempt based on article 132, section 1 (e) of Council Directive 2006/112/EC'),
+    ('VATEX-EU-132-1F', 'VATEX-EU-132-1F - Exempt based on article 132, section 1 (f) of Council Directive 2006/112/EC'),
+    ('VATEX-EU-132-1G', 'VATEX-EU-132-1G - Exempt based on article 132, section 1 (g) of Council Directive 2006/112/EC'),
+    ('VATEX-EU-132-1H', 'VATEX-EU-132-1H - Exempt based on article 132, section 1 (h) of Council Directive 2006/112/EC'),
+    ('VATEX-EU-132-1I', 'VATEX-EU-132-1I - Exempt based on article 132, section 1 (i) of Council Directive 2006/112/EC'),
+    ('VATEX-EU-132-1J', 'VATEX-EU-132-1J - Exempt based on article 132, section 1 (j) of Council Directive 2006/112/EC'),
+    ('VATEX-EU-132-1K', 'VATEX-EU-132-1K - Exempt based on article 132, section 1 (k) of Council Directive 2006/112/EC'),
+    ('VATEX-EU-132-1L', 'VATEX-EU-132-1L - Exempt based on article 132, section 1 (l) of Council Directive 2006/112/EC'),
+    ('VATEX-EU-132-1M', 'VATEX-EU-132-1M - Exempt based on article 132, section 1 (m) of Council Directive 2006/112/EC'),
+    ('VATEX-EU-132-1N', 'VATEX-EU-132-1N - Exempt based on article 132, section 1 (n) of Council Directive 2006/112/EC'),
+    ('VATEX-EU-132-1O', 'VATEX-EU-132-1O - Exempt based on article 132, section 1 (o) of Council Directive 2006/112/EC'),
+    ('VATEX-EU-132-1P', 'VATEX-EU-132-1P - Exempt based on article 132, section 1 (p) of Council Directive 2006/112/EC'),
+    ('VATEX-EU-132-1Q', 'VATEX-EU-132-1Q - Exempt based on article 132, section 1 (q) of Council Directive 2006/112/EC'),
+    ('VATEX-EU-143', 'VATEX-EU-143 - Exempt based on article 143 of Council Directive 2006/112/EC'),
+    ('VATEX-EU-143-1A', 'VATEX-EU-143-1A - Exempt based on article 143, section 1 (a) of Council Directive 2006/112/EC'),
+    ('VATEX-EU-143-1B', 'VATEX-EU-143-1B - Exempt based on article 143, section 1 (b) of Council Directive 2006/112/EC'),
+    ('VATEX-EU-143-1C', 'VATEX-EU-143-1C - Exempt based on article 143, section 1 (c) of Council Directive 2006/112/EC'),
+    ('VATEX-EU-143-1D', 'VATEX-EU-143-1D - Exempt based on article 143, section 1 (d) of Council Directive 2006/112/EC'),
+    ('VATEX-EU-143-1E', 'VATEX-EU-143-1E - Exempt based on article 143, section 1 (e) of Council Directive 2006/112/EC'),
+    ('VATEX-EU-143-1F', 'VATEX-EU-143-1F - Exempt based on article 143, section 1 (f) of Council Directive 2006/112/EC'),
+    ('VATEX-EU-143-1FA', 'VATEX-EU-143-1FA - Exempt based on article 143, section 1 (fa) of Council Directive 2006/112/EC'),
+    ('VATEX-EU-143-1G', 'VATEX-EU-143-1G - Exempt based on article 143, section 1 (g) of Council Directive 2006/112/EC'),
+    ('VATEX-EU-143-1H', 'VATEX-EU-143-1H - Exempt based on article 143, section 1 (h) of Council Directive 2006/112/EC'),
+    ('VATEX-EU-143-1I', 'VATEX-EU-143-1I - Exempt based on article 143, section 1 (i) of Council Directive 2006/112/EC'),
+    ('VATEX-EU-143-1J', 'VATEX-EU-143-1J - Exempt based on article 143, section 1 (j) of Council Directive 2006/112/EC'),
+    ('VATEX-EU-143-1K', 'VATEX-EU-143-1K - Exempt based on article 143, section 1 (k) of Council Directive 2006/112/EC'),
+    ('VATEX-EU-143-1L', 'VATEX-EU-143-1L - Exempt based on article 143, section 1 (l) of Council Directive 2006/112/EC'),
+    ('VATEX-EU-148', 'VATEX-EU-148 - Exempt based on article 148 of Council Directive 2006/112/EC'),
+    ('VATEX-EU-148-A', 'VATEX-EU-148-A - Exempt based on article 148, section (a) of Council Directive 2006/112/EC'),
+    ('VATEX-EU-148-B', 'VATEX-EU-148-B - Exempt based on article 148, section (b) of Council Directive 2006/112/EC'),
+    ('VATEX-EU-148-C', 'VATEX-EU-148-C - Exempt based on article 148, section (c) of Council Directive 2006/112/EC'),
+    ('VATEX-EU-148-D', 'VATEX-EU-148-D - Exempt based on article 148, section (d) of Council Directive 2006/112/EC'),
+    ('VATEX-EU-148-E', 'VATEX-EU-148-E - Exempt based on article 148, section (e) of Council Directive 2006/112/EC'),
+    ('VATEX-EU-148-F', 'VATEX-EU-148-F - Exempt based on article 148, section (f) of Council Directive 2006/112/EC'),
+    ('VATEX-EU-148-G', 'VATEX-EU-148-G - Exempt based on article 148, section (g) of Council Directive 2006/112/EC'),
+    ('VATEX-EU-151', 'VATEX-EU-151 - Exempt based on article 151 of Council Directive 2006/112/EC'),
+    ('VATEX-EU-151-1A', 'VATEX-EU-151-1A - Exempt based on article 151, section 1 (a) of Council Directive 2006/112/EC'),
+    ('VATEX-EU-151-1AA', 'VATEX-EU-151-1AA - Exempt based on article 151, section 1 (aa) of Council Directive 2006/112/EC'),
+    ('VATEX-EU-151-1B', 'VATEX-EU-151-1B - Exempt based on article 151, section 1 (b) of Council Directive 2006/112/EC'),
+    ('VATEX-EU-151-1C', 'VATEX-EU-151-1C - Exempt based on article 151, section 1 (c) of Council Directive 2006/112/EC'),
+    ('VATEX-EU-151-1D', 'VATEX-EU-151-1D - Exempt based on article 151, section 1 (d) of Council Directive 2006/112/EC'),
+    ('VATEX-EU-151-1E', 'VATEX-EU-151-1E - Exempt based on article 151, section 1 (e) of Council Directive 2006/112/EC'),
+    ('VATEX-EU-309', 'VATEX-EU-309 - Exempt based on article 309 of Council Directive 2006/112/EC'),
+    ('VATEX-EU-AE', 'VATEX-EU-AE - Reverse charge'),
+    ('VATEX-EU-D', 'VATEX-EU-D - Intra-Community acquisition from second hand means of transport'),
+    ('VATEX-EU-F', 'VATEX-EU-F - Intra-Community acquisition of second hand goods'),
+    ('VATEX-EU-G', 'VATEX-EU-G - Export outside the EU'),
+    ('VATEX-EU-I', 'VATEX-EU-I - Intra-Community acquisition of works of art'),
+    ('VATEX-EU-IC', 'VATEX-EU-IC - Intra-Community supply'),
+    ('VATEX-EU-O', 'VATEX-EU-O - Not subject to VAT'),
+    ('VATEX-EU-J', 'VATEX-EU-J - Intra-Community acquisition of collectors items and antiques'),
+    ('VATEX-FR-FRANCHISE', 'VATEX-FR-FRANCHISE - France domestic VAT franchise in base'),
+    ('VATEX-FR-CNWVAT', 'VATEX-FR-CNWVAT - France domestic Credit Notes without VAT, due to supplier forfeit of VAT for discount'),
+]
+
+
 class AccountTax(models.Model):
     _inherit = 'account.tax'
+
+    def _get_exemption_reason_code_selection(self):
+        return EXEMPTION_REASON_CODES
 
     ubl_cii_tax_category_code = fields.Selection(
         help="The VAT category code used for electronic invoicing purposes.",
@@ -23,69 +89,11 @@ class AccountTax(models.Model):
     ubl_cii_tax_exemption_reason_code = fields.Selection(
         help="The reason why the amount is exempted from VAT or why no VAT is being charged, used for electronic invoicing purposes.",
         string="Tax Exemption Reason Code",
-        selection=[
-            ('VATEX-EU-79-C', 'VATEX-EU-79-C - Exempt based on article 79, point c of Council Directive 2006/112/EC'),
-            ('VATEX-EU-132', 'VATEX-EU-132 - Exempt based on article 132 of Council Directive 2006/112/EC'),
-            ('VATEX-EU-132-1A', 'VATEX-EU-132-1A - Exempt based on article 132, section 1 (a) of Council Directive 2006/112/EC'),
-            ('VATEX-EU-132-1B', 'VATEX-EU-132-1B - Exempt based on article 132, section 1 (b) of Council Directive 2006/112/EC'),
-            ('VATEX-EU-132-1C', 'VATEX-EU-132-1C - Exempt based on article 132, section 1 (c) of Council Directive 2006/112/EC'),
-            ('VATEX-EU-132-1D', 'VATEX-EU-132-1D - Exempt based on article 132, section 1 (d) of Council Directive 2006/112/EC'),
-            ('VATEX-EU-132-1E', 'VATEX-EU-132-1E - Exempt based on article 132, section 1 (e) of Council Directive 2006/112/EC'),
-            ('VATEX-EU-132-1F', 'VATEX-EU-132-1F - Exempt based on article 132, section 1 (f) of Council Directive 2006/112/EC'),
-            ('VATEX-EU-132-1G', 'VATEX-EU-132-1G - Exempt based on article 132, section 1 (g) of Council Directive 2006/112/EC'),
-            ('VATEX-EU-132-1H', 'VATEX-EU-132-1H - Exempt based on article 132, section 1 (h) of Council Directive 2006/112/EC'),
-            ('VATEX-EU-132-1I', 'VATEX-EU-132-1I - Exempt based on article 132, section 1 (i) of Council Directive 2006/112/EC'),
-            ('VATEX-EU-132-1J', 'VATEX-EU-132-1J - Exempt based on article 132, section 1 (j) of Council Directive 2006/112/EC'),
-            ('VATEX-EU-132-1K', 'VATEX-EU-132-1K - Exempt based on article 132, section 1 (k) of Council Directive 2006/112/EC'),
-            ('VATEX-EU-132-1L', 'VATEX-EU-132-1L - Exempt based on article 132, section 1 (l) of Council Directive 2006/112/EC'),
-            ('VATEX-EU-132-1M', 'VATEX-EU-132-1M - Exempt based on article 132, section 1 (m) of Council Directive 2006/112/EC'),
-            ('VATEX-EU-132-1N', 'VATEX-EU-132-1N - Exempt based on article 132, section 1 (n) of Council Directive 2006/112/EC'),
-            ('VATEX-EU-132-1O', 'VATEX-EU-132-1O - Exempt based on article 132, section 1 (o) of Council Directive 2006/112/EC'),
-            ('VATEX-EU-132-1P', 'VATEX-EU-132-1P - Exempt based on article 132, section 1 (p) of Council Directive 2006/112/EC'),
-            ('VATEX-EU-132-1Q', 'VATEX-EU-132-1Q - Exempt based on article 132, section 1 (q) of Council Directive 2006/112/EC'),
-            ('VATEX-EU-143', 'VATEX-EU-143 - Exempt based on article 143 of Council Directive 2006/112/EC'),
-            ('VATEX-EU-143-1A', 'VATEX-EU-143-1A - Exempt based on article 143, section 1 (a) of Council Directive 2006/112/EC'),
-            ('VATEX-EU-143-1B', 'VATEX-EU-143-1B - Exempt based on article 143, section 1 (b) of Council Directive 2006/112/EC'),
-            ('VATEX-EU-143-1C', 'VATEX-EU-143-1C - Exempt based on article 143, section 1 (c) of Council Directive 2006/112/EC'),
-            ('VATEX-EU-143-1D', 'VATEX-EU-143-1D - Exempt based on article 143, section 1 (d) of Council Directive 2006/112/EC'),
-            ('VATEX-EU-143-1E', 'VATEX-EU-143-1E - Exempt based on article 143, section 1 (e) of Council Directive 2006/112/EC'),
-            ('VATEX-EU-143-1F', 'VATEX-EU-143-1F - Exempt based on article 143, section 1 (f) of Council Directive 2006/112/EC'),
-            ('VATEX-EU-143-1FA', 'VATEX-EU-143-1FA - Exempt based on article 143, section 1 (fa) of Council Directive 2006/112/EC'),
-            ('VATEX-EU-143-1G', 'VATEX-EU-143-1G - Exempt based on article 143, section 1 (g) of Council Directive 2006/112/EC'),
-            ('VATEX-EU-143-1H', 'VATEX-EU-143-1H - Exempt based on article 143, section 1 (h) of Council Directive 2006/112/EC'),
-            ('VATEX-EU-143-1I', 'VATEX-EU-143-1I - Exempt based on article 143, section 1 (i) of Council Directive 2006/112/EC'),
-            ('VATEX-EU-143-1J', 'VATEX-EU-143-1J - Exempt based on article 143, section 1 (j) of Council Directive 2006/112/EC'),
-            ('VATEX-EU-143-1K', 'VATEX-EU-143-1K - Exempt based on article 143, section 1 (k) of Council Directive 2006/112/EC'),
-            ('VATEX-EU-143-1L', 'VATEX-EU-143-1L - Exempt based on article 143, section 1 (l) of Council Directive 2006/112/EC'),
-            ('VATEX-EU-148', 'VATEX-EU-148 - Exempt based on article 148 of Council Directive 2006/112/EC'),
-            ('VATEX-EU-148-A', 'VATEX-EU-148-A - Exempt based on article 148, section (a) of Council Directive 2006/112/EC'),
-            ('VATEX-EU-148-B', 'VATEX-EU-148-B - Exempt based on article 148, section (b) of Council Directive 2006/112/EC'),
-            ('VATEX-EU-148-C', 'VATEX-EU-148-C - Exempt based on article 148, section (c) of Council Directive 2006/112/EC'),
-            ('VATEX-EU-148-D', 'VATEX-EU-148-D - Exempt based on article 148, section (d) of Council Directive 2006/112/EC'),
-            ('VATEX-EU-148-E', 'VATEX-EU-148-E - Exempt based on article 148, section (e) of Council Directive 2006/112/EC'),
-            ('VATEX-EU-148-F', 'VATEX-EU-148-F - Exempt based on article 148, section (f) of Council Directive 2006/112/EC'),
-            ('VATEX-EU-148-G', 'VATEX-EU-148-G - Exempt based on article 148, section (g) of Council Directive 2006/112/EC'),
-            ('VATEX-EU-151', 'VATEX-EU-151 - Exempt based on article 151 of Council Directive 2006/112/EC'),
-            ('VATEX-EU-151-1A', 'VATEX-EU-151-1A - Exempt based on article 151, section 1 (a) of Council Directive 2006/112/EC'),
-            ('VATEX-EU-151-1AA', 'VATEX-EU-151-1AA - Exempt based on article 151, section 1 (aa) of Council Directive 2006/112/EC'),
-            ('VATEX-EU-151-1B', 'VATEX-EU-151-1B - Exempt based on article 151, section 1 (b) of Council Directive 2006/112/EC'),
-            ('VATEX-EU-151-1C', 'VATEX-EU-151-1C - Exempt based on article 151, section 1 (c) of Council Directive 2006/112/EC'),
-            ('VATEX-EU-151-1D', 'VATEX-EU-151-1D - Exempt based on article 151, section 1 (d) of Council Directive 2006/112/EC'),
-            ('VATEX-EU-151-1E', 'VATEX-EU-151-1E - Exempt based on article 151, section 1 (e) of Council Directive 2006/112/EC'),
-            ('VATEX-EU-309', 'VATEX-EU-309 - Exempt based on article 309 of Council Directive 2006/112/EC'),
-            ('VATEX-EU-AE', 'VATEX-EU-AE - Reverse charge'),
-            ('VATEX-EU-D', 'VATEX-EU-D - Intra-Community acquisition from second hand means of transport'),
-            ('VATEX-EU-F', 'VATEX-EU-F - Intra-Community acquisition of second hand goods'),
-            ('VATEX-EU-G', 'VATEX-EU-G - Export outside the EU'),
-            ('VATEX-EU-I', 'VATEX-EU-I - Intra-Community acquisition of works of art'),
-            ('VATEX-EU-IC', 'VATEX-EU-IC - Intra-Community supply'),
-            ('VATEX-EU-O', 'VATEX-EU-O - Not subject to VAT'),
-            ('VATEX-EU-J', 'VATEX-EU-J - Intra-Community acquisition of collectors items and antiques'),
-            ('VATEX-FR-FRANCHISE', 'VATEX-FR-FRANCHISE - France domestic VAT franchise in base'),
-            ('VATEX-FR-CNWVAT', 'VATEX-FR-CNWVAT - France domestic Credit Notes without VAT, due to supplier forfeit of VAT for discount'),
-        ]
+        selection=lambda self: self._get_exemption_reason_code_selection(),
     )
     ubl_cii_requires_exemption_reason = fields.Boolean(compute='_compute_ubl_cii_requires_exemption_reason')
+
+    show_tax_category_code = fields.Boolean(compute='_compute_show_tax_category_code')
 
     @api.depends('ubl_cii_tax_category_code')
     def _compute_ubl_cii_requires_exemption_reason(self):
@@ -97,3 +105,7 @@ class AccountTax(models.Model):
         for tax in self:
             if not tax.ubl_cii_requires_exemption_reason:
                 tax.ubl_cii_tax_exemption_reason_code = False
+
+    def _compute_show_tax_category_code(self):
+        for tax in self:
+            tax.show_tax_category_code = True

--- a/addons/account_edi_ubl_cii_tax_extension/views/account_tax_views.xml
+++ b/addons/account_edi_ubl_cii_tax_extension/views/account_tax_views.xml
@@ -6,7 +6,9 @@
         <field name="inherit_id" ref="account.view_tax_form"/>
         <field name="arch" type="xml">
             <xpath expr="//field[@name='country_id']" position="after">
-                <field name="ubl_cii_tax_category_code"/>
+                <field name="ubl_cii_tax_category_code"
+                    invisible="not show_tax_category_code"
+                />
                 <field name="ubl_cii_tax_exemption_reason_code"
                        invisible="not ubl_cii_requires_exemption_reason"
                        required="ubl_cii_requires_exemption_reason"

--- a/addons/l10n_sa_edi/__manifest__.py
+++ b/addons/l10n_sa_edi/__manifest__.py
@@ -12,6 +12,7 @@
         'l10n_sa',
         'base_vat',
         'certificate',
+        'account_edi_ubl_cii_tax_extension'
     ],
     'summary': """
         E-Invoicing, Universal Business Language

--- a/addons/l10n_sa_edi/models/account_edi_format.py
+++ b/addons/l10n_sa_edi/models/account_edi_format.py
@@ -285,7 +285,7 @@ class AccountEdiFormat(models.Model):
             Helper function to check if ZATCA mandated partner fields are missing for the buyer
         """
         fields_to_check = []
-        if any(tax.l10n_sa_exemption_reason_code in ('VATEX-SA-HEA', 'VATEX-SA-EDU') for tax in
+        if any(tax.ubl_cii_tax_exemption_reason_code in ('VATEX-SA-HEA', 'VATEX-SA-EDU') for tax in
                invoice.invoice_line_ids.filtered(
                    lambda line: line.display_type == 'product').tax_ids):
             fields_to_check += [

--- a/addons/l10n_sa_edi/models/account_tax.py
+++ b/addons/l10n_sa_edi/models/account_tax.py
@@ -2,22 +2,23 @@ from odoo import fields, models, api, _
 from odoo.exceptions import UserError
 
 
-EXEMPTION_REASON_CODES = [
-    ('VATEX-SA-29', 'VATEX-SA-29 Financial services mentioned in Article 29 of the VAT Regulations.'),
-    ('VATEX-SA-29-7', 'VATEX-SA-29-7 Life insurance services mentioned in Article 29 of the VAT.'),
-    ('VATEX-SA-30', 'VATEX-SA-30 Real estate transactions mentioned in Article 30 of the VAT Regulations.'),
-    ('VATEX-SA-32', 'VATEX-SA-32 Export of goods.'),
-    ('VATEX-SA-33', 'VATEX-SA-33 Export of Services.'),
-    ('VATEX-SA-34-1', 'VATEX-SA-34-1 The international transport of Goods.'),
-    ('VATEX-SA-34-2', 'VATEX-SA-34-1 The international transport of Passengers.'),
-    ('VATEX-SA-34-3', 'VATEX-SA-34-3 Services directly connected and incidental to a Supply of international passenger transport.'),
-    ('VATEX-SA-34-4', 'VATEX-SA-34-4 Supply of a qualifying means of transport.'),
-    ('VATEX-SA-34-5', 'VATEX-SA-34-5 Any services relating to Goods or passenger transportation, as defined in article twenty five of these Regulations.'),
-    ('VATEX-SA-35', 'VATEX-SA-35 Medicines and medical equipment.'),
-    ('VATEX-SA-36', 'VATEX-SA-36 Qualifying metals.'),
-    ('VATEX-SA-EDU', 'VATEX-SA-EDU Private education to citizen.'),
-    ('VATEX-SA-HEA', 'VATEX-SA-HEA Private healthcare to citizen.'),
-    ('VATEX-SA-OOS', 'VATEX-SA-OOS Not subject to VAT.')
+SA_EXEMPTION_REASON_CODES = [
+    ('VATEX-SA-29', 'VATEX-SA-29 Financial services mentioned in Article 29 of the VAT Regulations | الخدمات المالية'),
+    ('VATEX-SA-29-7', 'VATEX-SA-29-7 Life insurance services mentioned in Article 29 of the VAT Regulations | عقد تأمين على الحياة'),
+    ('VATEX-SA-30', 'VATEX-SA-30 Real estate transactions mentioned in Article 30 of the VAT Regulations | التوريدات العقارية المعفاة من الضريبة'),
+    ('VATEX-SA-32', 'VATEX-SA-32 Export of goods | صادرات السلع من المملكة'),
+    ('VATEX-SA-33', 'VATEX-SA-33 Export of Services | صادرات الخدمات من المملكة'),
+    ('VATEX-SA-34-1', 'VATEX-SA-34-1 The international transport of Goods | النقل الدولي للسلع'),
+    ('VATEX-SA-34-2', 'VATEX-SA-34-2 The international transport of Passengers | النقل الدولي للركاب'),
+    ('VATEX-SA-34-3', 'VATEX-SA-34-3 Services directly connected and incidental to a Supply of international passenger transport | الخدمات المرتبطة مباشرة أو عرضيا بتوريد النقل الدولي للركاب'),
+    ('VATEX-SA-34-4', 'VATEX-SA-34-4 Supply of a qualifying means of transport | توريد وسائل نقل مؤهلة'),
+    ('VATEX-SA-34-5', 'VATEX-SA-34-5 Any services relating to Goods or passenger transportation, as defined in article twenty five of these Regulations | الخدمات ذات الصلة بنقل السلع أو الركاب، وفقا ً للتعريف الوارد بالمادة الخامسة والعشرين من الالئحة التنفيذية لنظام ضريبة القيامة المضافة'),
+    ('VATEX-SA-35', 'VATEX-SA-35 Medicines and medical equipment | الأدوية والمعدات الطبية'),
+    ('VATEX-SA-36', 'VATEX-SA-36 Qualifying metals | المعادن المؤهلة'),
+    ('VATEX-SA-EDU', 'VATEX-SA-EDU Private education to citizen | الخدمات التعليمية الخاصة للمواطنين'),
+    ('VATEX-SA-HEA', 'VATEX-SA-HEA Private healthcare to citizen | الخدمات الصحية الخاصة للمواطنين'),
+    ('VATEX-SA-MLTRY', 'VATEX-SA-MLTRY Supply of qualified military goods | توريد السلع العسكرية المؤهلة'),
+    ('VATEX-SA-OOS', 'VATEX-SA-OOS Reason is free text, Exemption Reason will be used')
 ]
 
 
@@ -26,9 +27,7 @@ class AccountTax(models.Model):
 
     l10n_sa_is_retention = fields.Boolean("Is Retention", default=False,
                                           help="Determines whether or not a tax counts as a Withholding Tax")
-
-    l10n_sa_exemption_reason_code = fields.Selection(string="Exemption Reason Code",
-                                                     selection=EXEMPTION_REASON_CODES, help="Tax Exemption Reason Code (ZATCA)")
+    free_text_exemption_reason = fields.Char("Exemption Reason", help="Free text exemption reason for VATEX-SA-OOS")
 
     @api.onchange('amount')
     def onchange_amount(self):
@@ -40,3 +39,27 @@ class AccountTax(models.Model):
         for tax in self:
             if tax.amount >= 0 and tax.l10n_sa_is_retention and tax.type_tax_use == 'sale':
                 raise UserError(_("Cannot set a tax to Retention if the amount is greater than or equal 0"))
+
+    @api.depends('ubl_cii_tax_category_code')
+    def _compute_ubl_cii_requires_exemption_reason(self):
+        # EXTEND
+        super()._compute_ubl_cii_requires_exemption_reason()
+        for tax in self:
+            if tax.country_code == 'SA':
+                tax.ubl_cii_requires_exemption_reason = (
+                    tax.type_tax_use == 'sale' and
+                    tax.amount == 0
+                )
+
+    def _get_exemption_reason_code_selection(self):
+        # EXTEND
+        if self.env.company.country_id.code == 'SA':
+            return SA_EXEMPTION_REASON_CODES
+        return super()._get_exemption_reason_code_selection()
+
+    def _compute_show_tax_category_code(self):
+        # EXTEND
+        super()._compute_show_tax_category_code()
+        for tax in self:
+            if tax.country_code == 'SA':
+                tax.show_tax_category_code = False

--- a/addons/l10n_sa_edi/views/account_tax_views.xml
+++ b/addons/l10n_sa_edi/views/account_tax_views.xml
@@ -8,7 +8,9 @@
         <field name="arch" type="xml">
             <xpath expr="//field[@name='country_id']" position="after">
                 <field name="l10n_sa_is_retention" invisible="type_tax_use != 'sale' or country_code != 'SA' or amount &gt;= 0"/>
-                <field name="l10n_sa_exemption_reason_code" invisible="type_tax_use != 'sale' or country_code != 'SA' or amount != 0"/>
+            </xpath>
+            <xpath expr="//field[@name='invoice_legal_notes']" position="before">
+                <field name="free_text_exemption_reason" invisible="ubl_cii_tax_exemption_reason_code != 'VATEX-SA-OOS'" required="ubl_cii_tax_exemption_reason_code == 'VATEX-SA-OOS'"/>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
We have a custom field l10n_sa_exemption_reason_code used for the VAT Categories Code as per the UN/CEFACT code list 5305, D,16B. However, we now support the categories in standard ubl_cii_tax_category_code and ubl_cii_tax_exemption_reason_code Therefore, we should adapt this EDI accordingly.

taskId-4863944



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
