### PR TITLE
[FIX] mrp_workorder: ignoring microsecond variations in productivity

### DIFF
--- a/addons/mrp/models/mrp_workorder.py
+++ b/addons/mrp/models/mrp_workorder.py
@@ -347,7 +347,7 @@ class MrpWorkorder(models.Model):
             if delta_duration > 0:
                 if order.state not in ('progress', 'done'):
                     order.state = 'progress'
-                enddate = datetime.now()
+                enddate = fields.Datetime.now()
                 date_start = enddate - timedelta(seconds=_float_duration_to_second(delta_duration))
                 if order.duration_expected >= new_order_duration or old_order_duration >= order.duration_expected:
                     # either only productive or only performance (i.e. reduced speed) time respectively


### PR DESCRIPTION
The `_set_duration` inverse method of `mrp.workorder` is ignoring microsecond variations when computing the `date_start `of a workorder productivity record. This method uses the current time as the end date but does not remove microseconds from it.

This causes a intermittent error when running the
`test_labor_cost_balancing_with_cost_share`, because the computed duration (around 0.03 hours or 1.8 seconds) can vary slightly depending on the microseconds captured by `datetime.now()`. This fluctuation results in a 1- or 2-second difference, which breaks the test.

To fix it, we simply set the microsseconds of the end date to zero.

This bug was introduced in:
https://github.com/odoo/odoo/pull/211853

Runbot failure example:
https://runbot.odoo.com/odoo/runbot.build.error/226657

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
