### PR TITLE
[FIX] mail: hide message actions on transient threads

### DIFF
--- a/addons/mail/static/src/core/common/message.js
+++ b/addons/mail/static/src/core/common/message.js
@@ -285,7 +285,12 @@ export class Message extends Component {
      * @returns {boolean}
      */
     get canToggleStar() {
-        return Boolean(!this.message.is_transient && this.message.res_id && this.store.user);
+        return Boolean(
+            !this.message.is_transient &&
+                this.message.res_id &&
+                this.store.user &&
+                this.message.persistent
+        );
     }
 
     get showUnfollow() {

--- a/addons/mail/static/src/core/common/message_actions.js
+++ b/addons/mail/static/src/core/common/message_actions.js
@@ -57,7 +57,9 @@ messageActionsRegistry
     })
     .add("mark-as-unread", {
         condition: (component) =>
-            component.props.thread.model === "discuss.channel" && component.store.user,
+            component.props.thread?.model === "discuss.channel" &&
+            component.store.user &&
+            component.props.message.persistent,
         icon: "fa-eye-slash",
         title: _t("Mark as Unread"),
         onClick: (component) => component.onClickMarkAsUnread(),

--- a/addons/mail/static/src/core/common/message_model.js
+++ b/addons/mail/static/src/core/common/message_model.js
@@ -270,6 +270,10 @@ export class Message extends Record {
         return candidates.has(this.subject?.toLowerCase());
     }
 
+    get persistent() {
+        return Number.isInteger(this.id);
+    }
+
     get resUrl() {
         return `${url("/web")}#model=${this.model}&id=${this.res_id}`;
     }


### PR DESCRIPTION
**Before this PR:** 
the toggle-star and mark-as-read actions were visible
on chatbot messages in a non-persisted livechat thread.
Clicking these actions caused errors.

This PR hides these actions when the thread is in a
non-persisted state, preventing such errors.


task-[4743758](https://www.odoo.com/odoo/project/1519/tasks/4743758)