### PR TITLE
[FIX] html_builder: get record info from correct element

### DIFF
--- a/addons/html_builder/static/src/builder.js
+++ b/addons/html_builder/static/src/builder.js
@@ -1,5 +1,4 @@
 import { Editor } from "@html_editor/editor";
-import { closestElement } from "@html_editor/utils/dom_traversal";
 import {
     Component,
     EventBus,
@@ -33,6 +32,7 @@ export class Builder extends Component {
     static props = {
         closeEditor: { type: Function },
         reloadEditor: { type: Function, optional: true },
+        onEditorLoad: { type: Function, optional: true },
         snippetsName: { type: String },
         toggleMobile: { type: Function },
         overlayRef: { type: Function },
@@ -43,6 +43,7 @@ export class Builder extends Component {
         getThemeTab: { type: Function, optional: true },
     };
     static defaultProps = {
+        onEditorLoad: () => {},
         config: {},
     };
 
@@ -114,19 +115,6 @@ export class Builder extends Component {
 
                     // disable the toolbar for images and icons
                 },
-                getRecordInfo: (editableEl) => {
-                    if (!editableEl) {
-                        editableEl = closestElement(
-                            this.editor.shared.selection.getEditableSelection().anchorNode
-                        );
-                    }
-                    return {
-                        resModel: editableEl.dataset["oeModel"],
-                        resId: editableEl.dataset["oeId"],
-                        field: editableEl.dataset["oeField"],
-                        type: editableEl.dataset["oeType"],
-                    };
-                },
                 localOverlayContainers: {
                     key: this.env.localOverlayContainerKey,
                     ref: this.props.overlayRef,
@@ -141,6 +129,7 @@ export class Builder extends Component {
             },
             this.env.services
         );
+        this.props.onEditorLoad(this.editor);
 
         this.snippetModel = useState(useService("html_builder.snippets"));
         this.snippetModel.registerBeforeReload(this.save.bind(this));

--- a/addons/website/static/src/builder/website_builder.js
+++ b/addons/website/static/src/builder/website_builder.js
@@ -7,6 +7,7 @@ import { SetupEditorPlugin } from "@html_builder/core/setup_editor_plugin";
 import { VisibilityPlugin } from "@html_builder/core/visibility_plugin";
 import { removePlugins } from "@html_builder/utils/utils";
 import { MAIN_PLUGINS as MAIN_EDITOR_PLUGINS } from "@html_editor/plugin_sets";
+import { closestElement } from "@html_editor/utils/dom_traversal";
 import { Component } from "@odoo/owl";
 import { registry } from "@web/core/registry";
 import { HighlightPlugin } from "./plugins/highlight/highlight_plugin";
@@ -55,6 +56,26 @@ export class WebsiteBuilder extends Component {
         const coreBuilderPlugins = this.props.translation ? [] : CORE_BUILDER_PLUGINS;
         const Plugins = [...mainEditorPlugins, ...coreBuilderPlugins, ...(websitePlugins || [])];
         builderProps.Plugins = Plugins;
+        builderProps.onEditorLoad = (editor) => {
+            this.editor = editor;
+        };
+        builderProps.config.getRecordInfo = (editableEl) => {
+            if (this.editor && !editableEl) {
+                editableEl = closestElement(
+                    this.editor.shared.selection.getEditableSelection().anchorNode,
+                    "[data-oe-model]",
+                );
+            }
+            if (!editableEl) {
+                return {};
+            }
+            return {
+                resModel: editableEl.dataset["oeModel"],
+                resId: editableEl.dataset["oeId"],
+                field: editableEl.dataset["oeField"],
+                type: editableEl.dataset["oeType"],
+            };
+        };
         return builderProps;
     }
 }


### PR DESCRIPTION
__Current behavior before commit:__
`getRecordInfo` tries to get the record info from the closest element of the selection. However the info may rather be in one of its ancestor.

This can lead to a crash when using the AI toolbar button after selecting some text.

__Description of the fix:__
Add a `predicate` argument in the `closestElement` call in order to make sure that `editableEl` has the record info.

Website refactor: https://github.com/odoo/odoo/pull/187419
task-4367641