### PR TITLE
[FIX] website: make image gallery responsive in edit mode

### DIFF
--- a/addons/website/static/src/interactions/carousel/carousel_slider.js
+++ b/addons/website/static/src/interactions/carousel/carousel_slider.js
@@ -70,6 +70,12 @@ export class CarouselSlider extends Interaction {
     }
 
     computeMaxHeight() {
+        //In the Image Gallery Snippet the size is set on the snippet so there's
+        // no need to set a min-height on the items since it just make the img
+        // unresponsive and cause it to disappear behind the padding.
+        if (this.el.closest(".s_image_gallery")) {
+            return;
+        }
         this.maxHeight = undefined;
         // "updateContent()" is necessary to reset the min-height before the
         // following check.


### PR DESCRIPTION
Steps to reproduce:
- Open the website builder.
- drag and drop the s_image_gallery snippets in the page.
- add an image to the carousel.
- Add a big padding on the carousel.
- The image is not responsive and disapear behind the padding.

Cause:
Unlike other carousels, the s_image_gallery snippet has a fixed height,
while others adapt their height based on the tallest slide. This causes
layout issues when extra padding is applied.

Solution:
This fix removes the height constraint from slides specifically in the
s_image_gallery snippet. This ensures that images remain responsive
within the fixed-height container and are no longer hidden by excessive
padding.
