### PR TITLE
[FIX] account: prevent error on invoice confirmation when 'autocheck on post' is disabled in sales journal

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -5168,7 +5168,7 @@ class AccountMove(models.Model):
                 move.sudo().activity_schedule(
                     activity_type_id=self.env.ref('mail.mail_activity_data_todo').id,
                     summary=_('To check'),
-                    user_id=move.invoice_user_id.name,
+                    user_id=move.invoice_user_id.id,
                 )
 
         if validation_msgs:


### PR DESCRIPTION
**Issue**
When the Autocheck on Post option is unchecked in the Sales Journal, confirming an invoice triggers an error.

**Steps to Reproduce**
1. Install the Accounting module.
2. Navigate to Accounting > Configuration > Journals > Sales.
3. Under the Advanced Settings tab, uncheck Autocheck on Post.
4. Go to Accounting > Customers > Invoices.
5. Create a new invoice.
6. Attempt to confirm the invoice.

**Root Cause**
The method `self.env['mail.activity'].create(create_vals_list)` expects the field `user_id` to be an integer (user record ID), but it was incorrectly receiving a username string instead, causing a type error.

**Fix**
Ensure user_id is assigned the proper user ID (user.id) rather than the user’s name.

Opw-4859180
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
