### PR TITLE
[FIX] point_of_sale: adapt receipt template for blackbox override

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/receipt_header/receipt_header.xml
+++ b/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/receipt_header/receipt_header.xml
@@ -3,7 +3,7 @@
     <t t-name="point_of_sale.ReceiptHeader">
         <img t-attf-src="/web/image?model=res.company&amp;id={{order.company.id}}&amp;field=logo" alt="Logo" class="pos-receipt-logo"/>
         <div class="text-center pt-3" style="font-size: 75%;">
-            <span>
+            <span class="pos-receipt-vat">
                 <t t-if="order.config._IS_VAT"> VAT </t>
                 Ticket
                 <t t-out="order.pos_reference"/>

--- a/addons/point_of_sale/static/src/css/pos_receipts.css
+++ b/addons/point_of_sale/static/src/css/pos_receipts.css
@@ -48,7 +48,7 @@
 }
 
 .pos-receipt .pos-receipt-header {
-    font-size: 125%;
+    font-size: 125% !important;
     text-align: center;
 }
 

--- a/addons/pos_self_order/controllers/orders.py
+++ b/addons/pos_self_order/controllers/orders.py
@@ -210,6 +210,18 @@ class PosSelfOrderController(http.Controller):
 
         return {'order': order_sudo.read(order_sudo._load_pos_data_fields(pos_config.id), load=False), 'payment_status': status}
 
+    @http.route('/pos_self_order/kiosk/increment_nb_print/', auth='public', type='jsonrpc', website=True)
+    def pos_kiosk_increment_nb_print(self, access_token, order_id, order_access_token):
+        pos_config = self._verify_pos_config(access_token)
+        pos_order = pos_config.env['pos.order'].browse(order_id)
+
+        if not pos_order.exists() or not consteq(pos_order.access_token, order_access_token):
+            raise MissingError(_("Your order does not exist or has been removed"))
+
+        pos_order.write({
+            'nb_print': 1,
+        })
+
     @http.route('/pos-self-order/change-printer-status', auth='public', type='jsonrpc', website=True)
     def change_printer_status(self, access_token, has_paper):
         pos_config = self._verify_pos_config(access_token)

--- a/addons/pos_self_order/static/src/app/pages/confirmation_page/confirmation_page.js
+++ b/addons/pos_self_order/static/src/app/pages/confirmation_page/confirmation_page.js
@@ -97,7 +97,7 @@ export class ConfirmationPage extends Component {
             try {
                 this.isPrinting = true;
                 const order = this.confirmedOrder;
-                await this.printer.print(
+                const result = await this.printer.print(
                     OrderReceipt,
                     {
                         order: order,
@@ -108,6 +108,13 @@ export class ConfirmationPage extends Component {
                     this.updateHasPaper(true);
                 }
                 order.nb_print = 1;
+                if (typeof order.id === "number" && result) {
+                    await rpc("/pos_self_order/kiosk/increment_nb_print/", {
+                        access_token: this.selfOrder.access_token,
+                        order_id: order.id,
+                        order_access_token: order.access_token,
+                    });
+                }
             } catch (e) {
                 if (e.errorCode === "EPTR_REC_EMPTY") {
                     this.dialog.add(OutOfPaperPopup, {

--- a/addons/pos_self_order/static/src/overrides/components/receipt_header/receipt_header.xml
+++ b/addons/pos_self_order/static/src/overrides/components/receipt_header/receipt_header.xml
@@ -8,7 +8,7 @@
                     <span t-elif="order.preset_id?.identification == 'name' or (!order.preset_id and order.config.self_ordering_service_mode != 'table')">Pickup At Counter</span>
                     <span t-else="">Delivery</span>
                 </div>
-                <h1 class="tracking-number text-center" style="font-size: 100px" t-out="order.tracking_number" />
+                <h1 t-if="order.tracking_number" class="tracking-number text-center" style="font-size: 100px" t-out="order.tracking_number" />
                 <div t-if="order.config.self_ordering_mode !== 'nothing' and order.table_stand_number" class="table-tracker text-center">
                     Table Tracker:
                     <span class="pt-3" t-out="order.table_stand_number" />


### PR DESCRIPTION
Since this revmap of the POS receipt (https://github.com/odoo/odoo/pull/201105), we have to make some changes on the receipt when using `pos_blackbox_be`:
- Display if the ticket is valid or not (Pro Format) & increase its size.
- Display if the order was a refund or not.
- No need to display the `blackbox_date` since we now have the `date_order` inside `/point_of_sale/static/src/app/screens/receipt_screen/receipt/receipt_header/receipt_header.xml``.
- No need to display the `order.company.street` since the whole adress is now displayed inside `/point_of_sale/static/src/app/screens/receipt_screen/receipt/order_receipt.xml`.

task-id: 4848882

enterprise PR: https://github.com/odoo/enterprise/pull/87759



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
