### PR TITLE
[FIX] mail: guard against missing correspondent persona

### DIFF
--- a/addons/mail/static/src/core/common/thread_model.js
+++ b/addons/mail/static/src/core/common/thread_model.js
@@ -430,7 +430,7 @@ export class Thread extends Record {
     }
 
     get correspondents() {
-        return this.channelMembers.filter(({ persona }) => persona.notEq(this.store.self));
+        return this.channelMembers.filter(({ persona }) => persona?.notEq(this.store.self));
     }
 
     computeCorrespondent() {


### PR DESCRIPTION
There are several flows where the persona of a member might not (or no longer) be known in JS. These members should simply be ignored when computing the correspondent of a channel rather than crashing.