### PR TITLE
[IMP] barcodes, hr_attendance: correct barcode scanned with a differe…

### DIFF
--- a/addons/barcodes/static/src/barcode_service.js
+++ b/addons/barcodes/static/src/barcode_service.js
@@ -33,14 +33,15 @@ export const barcodeService = {
         const bus = new EventBus();
         let timeout = null;
 
+        let rawKeysBarcode = [];
         let bufferedBarcode = "";
         let currentTarget = null;
         let barcodeInput = null;
 
         function handleBarcode(barcode, target) {
-            bus.trigger('barcode_scanned', {barcode,target});
+            bus.trigger('barcode_scanned', {barcode, rawKeysBarcode, target});
             if (target.getAttribute('barcode_events') === "true") {
-                const barcodeScannedEvent = new CustomEvent("barcode_scanned", { detail: { barcode, target } });
+                const barcodeScannedEvent = new CustomEvent("barcode_scanned", { detail: { barcode, rawKeysBarcode, target } });
                 target.dispatchEvent(barcodeScannedEvent);
             }
         }
@@ -61,6 +62,7 @@ export const barcodeService = {
                 barcodeInput.value = "";
             }
             bufferedBarcode = "";
+            rawKeysBarcode = [];
             currentTarget = null;
         }
 
@@ -100,6 +102,7 @@ export const barcodeService = {
                 checkBarcode(ev);
             } else {
                 bufferedBarcode += ev.key;
+                rawKeysBarcode.push({code: ev.code, shiftKey: ev.shiftKey});
                 timeout = setTimeout(checkBarcode, barcodeService.maxTimeBetweenKeysInMs);
             }
         }


### PR DESCRIPTION
…nt keyboard layout

In the kiosk mode of the Attendance app, according to your keyboard, the RFID/barcode scanner will not be recognized and will show an error message.

Steps to reproduce:
1. Open the kiosk mode of the Attendance app.
2. Connect an RFID reader to your device.
3. Change the keyboard layout to a language with a different key mapping, such as French (Belgian).
4. Scan an employee badge set up with an alphanumeric ID in English "0013748911".

Issue / current behavior:
The RFID reader translates the key codes according to the current keyboard layout of the device. In case of French (Belgian), it reads "àà&"è'!ç&&", leading to an unsuccessful scan of the employee badge.

Required behavior:
The app should correctly read the RFID badge regardless of the current keyboard layout set at the Kiosk device.

Fix:
Capture the raw key press events in the barcode service, and send it along the barcode on the event bus. Translate the key presses to an English layout if the given barcode is not alphanumeric (resulting from using a different layout).

task-4668188

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
