### PR TITLE
[REF] web, *: improve SelectMenu style and behavior

### DIFF
--- a/addons/account/static/src/components/account_type_selection/account_type_selection.js
+++ b/addons/account/static/src/components/account_type_selection/account_type_selection.js
@@ -4,17 +4,42 @@ import { SelectionField, selectionField } from "@web/views/fields/selection/sele
 
 export class AccountTypeSelection extends SelectionField {
     static template = "account.AccountTypeSelection";
-    get hierarchyOptions() {
-        const opts = this.options;
-        return [
-            { name: _t('Balance Sheet') },
-            { name: _t('Assets'), children: opts.filter(x => x[0] && x[0].startsWith('asset')) },
-            { name: _t('Liabilities'), children: opts.filter(x => x[0] && x[0].startsWith('liability')) },
-            { name: _t('Equity'), children: opts.filter(x => x[0] && x[0].startsWith('equity')) },
-            { name: _t('Profit & Loss') },
-            { name: _t('Income'), children: opts.filter(x => x[0] && x[0].startsWith('income')) },
-            { name: _t('Expense'), children: opts.filter(x => x[0] && x[0].startsWith('expense')) },
-            { name: _t('Other'), children: opts.filter(x => x[0] && x[0] === 'off_balance') },
+    setup() {
+        super.setup();
+        const getChoicesForGroup = (group) => {
+            return this.choices.filter(x => x.value.startsWith(group));
+        }
+        this.groups = [
+            {
+                label: _t('Balance Sheet'),
+            },
+            {
+                label: _t('Assets'),
+                choices: getChoicesForGroup('asset'),
+            },
+            {
+                label: _t('Liabilities'),
+                choices: getChoicesForGroup('liability'),
+            },
+            {
+                label: _t('Equity'),
+                choices: getChoicesForGroup('equity'),
+            },
+            {
+                label: _t('Profit & Loss'),
+            },
+            {
+                label: _t('Income'),
+                choices: getChoicesForGroup('income'),
+            },
+            {
+                label: _t('Expense'),
+                choices: getChoicesForGroup('expense'),
+            },
+            {
+                label: _t('Other'),
+                choices: getChoicesForGroup('off_balance'),
+            },
         ];
     }
 }

--- a/addons/account/static/src/components/account_type_selection/account_type_selection.xml
+++ b/addons/account/static/src/components/account_type_selection/account_type_selection.xml
@@ -3,19 +3,9 @@
 <templates>
 
     <t t-name="account.AccountTypeSelection" t-inherit="web.SelectionField" t-inherit-mode="primary">
-        <xpath expr="//t[@t-foreach='options']" position="replace">
-            <t t-foreach="hierarchyOptions" t-as="group" t-key="group_index">
-                <optgroup t-att-label="group.name">
-                    <t t-if="!!group.children">
-                        <t t-foreach="group.children" t-as="child" t-key="child[0]">
-                            <option
-                                t-att-selected="child[0] === value"
-                                t-att-value="stringify(child[0])"
-                                t-out="child[1]"/>
-                        </t>
-                    </t>
-                </optgroup>
-            </t>
+        <xpath expr="//SelectMenu" position="attributes">
+            <attribute name="choices"></attribute>
+            <attribute name="groups">groups</attribute>
         </xpath>
     </t>
 

--- a/addons/base_automation/static/src/base_automation_trigger_selection_field.js
+++ b/addons/base_automation/static/src/base_automation_trigger_selection_field.js
@@ -8,7 +8,7 @@ import { useService } from "@web/core/utils/hooks";
 
 const OPT_GROUPS = [
     {
-        group: { sequence: 10, key: "values", name: _t("Values Updated") },
+        group: { sequence: 10, key: "values", label: _t("Values Updated") },
         triggers: [
             "on_stage_set",
             "on_user_set",
@@ -20,23 +20,23 @@ const OPT_GROUPS = [
         ],
     },
     {
-        group: { sequence: 30, key: "timing", name: _t("Timing Conditions") },
-        triggers: ["on_time", "on_time_created", "on_time_updated"],
-    },
-    {
-        group: { sequence: 40, key: "custom", name: _t("Custom") },
-        triggers: ["on_create", "on_create_or_write", "on_unlink", "on_change"],
-    },
-    {
-        group: { sequence: 50, key: "external", name: _t("External") },
-        triggers: ["on_webhook"],
-    },
-    {
-        group: { sequence: 20, key: "mail", name: _t("Email Events") },
+        group: { sequence: 20, key: "mail", label: _t("Email Events") },
         triggers: ["on_message_sent", "on_message_received"],
     },
     {
-        group: { sequence: 60, key: "deprecated", name: _t("Deprecated (do not use)") },
+        group: { sequence: 30, key: "timing", label: _t("Timing Conditions") },
+        triggers: ["on_time", "on_time_created", "on_time_updated"],
+    },
+    {
+        group: { sequence: 40, key: "custom", label: _t("Custom") },
+        triggers: ["on_create", "on_create_or_write", "on_unlink", "on_change"],
+    },
+    {
+        group: { sequence: 50, key: "external", label: _t("External") },
+        triggers: ["on_webhook"],
+    },
+    {
+        group: { sequence: 60, key: "deprecated", label: _t("Deprecated (do not use)") },
         triggers: ["on_write"],
     },
 ];
@@ -97,20 +97,25 @@ export class TriggerSelectionField extends SelectionField {
                 { excludeGroups: data.model_is_mail_thread ? [] : ["mail"] }
             );
 
-            // then group and sort them
+            // then group them
             this.groupedOptions.length = 0;
             for (const option of derivedOptions) {
                 const group = this.groupedOptions.find((g) => g.key === option.group.key) ?? {
                     ...option.group,
-                    options: [],
+                    choices: [],
                 };
-                group.options.push(option);
+                delete option.group;
+                group.choices.push(option);
                 if (!this.groupedOptions.includes(group)) {
                     this.groupedOptions.push(group);
                 }
             }
             this.groupedOptions.sort((a, b) => a.sequence - b.sequence);
         });
+    }
+
+    get groups() {
+        return this.groupedOptions.map(({ label, choices }) => ({ label, choices }));
     }
 }
 

--- a/addons/base_automation/static/src/base_automation_trigger_selection_field.xml
+++ b/addons/base_automation/static/src/base_automation_trigger_selection_field.xml
@@ -2,18 +2,9 @@
 
 <templates>
     <t t-name="base_automation.TriggerSelectionField" t-inherit="web.SelectionField" t-inherit-mode="primary">
-        <xpath expr="//t[@t-foreach='options']" position="replace">
-            <t t-foreach="groupedOptions" t-as="group" t-key="group.key">
-                <optgroup t-att-label="group.name" class="text-black">
-                    <t t-foreach="group.options" t-as="option" t-key="option.value">
-                        <option
-                            class="text-black"
-                            t-att-selected="option.value === value"
-                            t-att-value="stringify(option.value)"
-                            t-esc="option.label"/>
-                    </t>
-                </optgroup>
-            </t>
+        <xpath expr="//SelectMenu" position="attributes">
+            <attribute name="choices"></attribute>
+            <attribute name="groups">groups</attribute>
         </xpath>
     </t>
 </templates>

--- a/addons/base_automation/views/base_automation_views.xml
+++ b/addons/base_automation/views/base_automation_views.xml
@@ -38,7 +38,7 @@
                                 <label for="trigger"/>
                                 <div>
                                     <div class="d-flex flex-row">
-                                        <field name="trigger" widget="base_automation_trigger_selection" class="oe_inline me-3"/>
+                                        <field name="trigger" widget="base_automation_trigger_selection"/>
                                         <field name="trg_date_id" class="oe_inline" placeholder="Select a date field..."
                                             options="{'no_open': True, 'no_create': True}"
                                             context="{'hide_model': 1}"

--- a/addons/base_import/static/src/import_data_content/import_data_content.scss
+++ b/addons/base_import/static/src/import_data_content/import_data_content.scss
@@ -38,13 +38,13 @@
     }
 }
 
-.o_select_active:has(.o_import_field_icon) {
+.o_select_menu_menu .active:has(.o_import_field_icon) {
     // Keep icon visible when selected
     position: relative;
     z-index: -1;
 }
 
-.o_select_active .o_import_field_icon {
+.o_select_menu_menu .active .o_import_field_icon {
     filter: brightness(6);
 }
 

--- a/addons/base_import/static/src/import_data_content/import_data_content.xml
+++ b/addons/base_import/static/src/import_data_content/import_data_content.xml
@@ -64,7 +64,6 @@
                                     groups="getGroups(column)"
                                     onSelect="(fieldPath) => this.onFieldChanged(column, fieldPath)"
                                     searchPlaceholder.translate="Search a field..."
-                                    togglerClass="column.fieldInfo ? 'ps-1' : ''"
                                 >
                                     <t t-if="column.fieldInfo">
                                         <i

--- a/addons/base_import/static/tests/import_action.test.js
+++ b/addons/base_import/static/tests/import_action.test.js
@@ -1077,13 +1077,10 @@ describe("Import view", () => {
             { message: "The third row should be the relational field" }
         );
 
-        expect("tr:nth-child(3) .o_select_menu_toggler_slot span").toHaveText(
-            "Many2Many / External ID",
-            {
-                message:
-                    "The relational field should be selected by default and the name should be the full path.",
-            }
-        );
+        expect("tr:nth-child(3) .o_select_menu_toggler").toHaveText("Many2Many / External ID", {
+            message:
+                "The relational field should be selected by default and the name should be the full path.",
+        });
 
         await contains(".o_control_panel_main_buttons button:first-child").click();
         expect.verifySteps(["execute_import"]);
@@ -1230,10 +1227,9 @@ describe("Import view", () => {
             { message: "The third row should be the relational field" }
         );
 
-        expect("tr:nth-child(3) .o_select_menu_toggler_slot span").toHaveText(
-            "Many2Many / External ID",
-            { message: "The relational field is properly mapped" }
-        );
+        expect("tr:nth-child(3) .o_select_menu_toggler").toHaveText("Many2Many / External ID", {
+            message: "The relational field is properly mapped",
+        });
 
         expect("tr:nth-child(3) .o_import_report.alert").toHaveCount(1, {
             message: "The relational field should have error messages on his row",

--- a/addons/html_builder/static/src/core/building_blocks/select_many2x.scss
+++ b/addons/html_builder/static/src/core/building_blocks/select_many2x.scss
@@ -70,7 +70,7 @@
 }
 
 .o-hb-selectMany2X-dropdown {
-    .o-hb-selectMany2x-search-input {
+    input {
         background-color: $o-we-sidebar-content-field-input-bg !important;
 
         &:hover, &:focus-within {

--- a/addons/html_builder/static/src/core/building_blocks/select_many2x.xml
+++ b/addons/html_builder/static/src/core/building_blocks/select_many2x.xml
@@ -11,7 +11,6 @@
         onInput.bind="onInput"
         class="'o-hb-selectMany2X-wrapper'"
         menuClass="'o-hb-select-dropdown o-hb-selectMany2X-dropdown'"
-        searchClass="'o-hb-selectMany2x-search-input'"
         togglerClass="'o-hb-selectMany2X-toggle btn-secondary'"
     >
         <t t-out="props.message"/>

--- a/addons/l10n_latam_base/static/src/components/select_menu_wrapper/select_menu_wrapper.xml
+++ b/addons/l10n_latam_base/static/src/components/select_menu_wrapper/select_menu_wrapper.xml
@@ -2,7 +2,7 @@
 <templates id="template" xml:space="preserve">
 
 <t t-name="l10n_latam_base.SelectMenuWrapper">
-    <SelectMenu t-props="state" class="'o_extended_address'" onSelect.bind="onSelect"/>
+    <SelectMenu t-props="state" togglerClass="'form-control'" class="'o_extended_address'" onSelect.bind="onSelect"/>
 </t>
 
 </templates>

--- a/addons/partner_autocomplete/static/tests/partner_autocomplete.test.js
+++ b/addons/partner_autocomplete/static/tests/partner_autocomplete.test.js
@@ -4,6 +4,7 @@ import { advanceTime, queryOne } from "@odoo/hoot-dom";
 import {
     contains,
     defineModels,
+    editSelectMenu,
     fields,
     models,
     mountView,
@@ -146,7 +147,9 @@ test("Partner autocomplete : Company type = Individual", async () => {
         type: "form",
     });
 
-    await contains("[name='company_type'] > select").select('"individual"');
+    await editSelectMenu("[name='company_type'] input", {
+        value: "Individual",
+    });
     expect("[name='name'] input").not.toHaveClass("o-autocomplete--input", {
         message: "The input for field 'name' should be a regular input",
     });
@@ -195,8 +198,9 @@ test("Partner autocomplete : Company type = Company / Name search", async () => 
         type: "form",
     });
 
-    // Set company type to Company
-    await contains("[name='company_type'] > select").select('"company"');
+    await editSelectMenu("[name='company_type'] input", {
+        value: "Company",
+    });
     await contains("[name='name'] .dropdown input").click();
     expect(
         "[name='name'] .o-autocomplete .o-autocomplete--dropdown-item.partner_autocomplete_dropdown_many2one"
@@ -240,8 +244,9 @@ test("Partner autocomplete : Company type = Company / VAT search", async () => {
         type: "form",
     });
 
-    // Set company type to Company
-    await contains("[name='company_type'] > select").select('"company"');
+    await editSelectMenu("[name='company_type'] input", {
+        value: "Company",
+    });
     await contains("[name='vat'] .dropdown input").click();
     expect(
         "[name='vat'] .o-autocomplete .o-autocomplete--dropdown-item.partner_autocomplete_dropdown_many2one"
@@ -354,8 +359,9 @@ test("Partner autocomplete : onChange should not disturb option selection", asyn
         type: "form",
     });
 
-    // Set company type to Company
-    await contains("[name='company_type'] > select").select('"company"');
+    await editSelectMenu("[name='company_type'] input", {
+        value: "Company",
+    });
     await contains("[name='name'] .dropdown input").click();
     await editAutocomplete("[name='name'] .dropdown input", "company");
     // 3 options + 1 for the worldwide option

--- a/addons/project/static/tests/tours/project_sharing_tour.js
+++ b/addons/project/static/tests/tours/project_sharing_tour.js
@@ -22,9 +22,12 @@ const projectSharingSteps = [...stepUtils.goToAppSteps("project.menu_main_pm", '
     trigger: '.ui-autocomplete a.dropdown-item:contains("Georges")',
     run: "click",
 }, {
-    trigger: '.modal div[name="collaborator_ids"] div[name="access_mode"] select',
-    content: 'Select "Edit" as Access mode in the "Share Project" wizard.',
-    run: 'select "edit"',
+    trigger: '.modal div[name="collaborator_ids"] div[name="access_mode"] input',
+    content: 'Open Access mode selection dropdown.',
+    run: 'click',
+},{
+    trigger: '.o_select_menu_item:contains(Edit)',
+    run: 'click',
 }, {
     trigger: '.modal footer > button[name="action_share_record"]',
     content: 'Confirm the project sharing with this portal user.',

--- a/addons/purchase_stock/static/tests/purchase_stock.test.js
+++ b/addons/purchase_stock/static/tests/purchase_stock.test.js
@@ -2,6 +2,7 @@ import { defineMailModels } from "@mail/../tests/mail_test_helpers";
 import { describe, destroy, expect, test } from "@odoo/hoot";
 import { mockDate } from "@odoo/hoot-mock";
 import {
+    contains,
     defineModels,
     fields,
     models,
@@ -44,10 +45,11 @@ describe("time_period_selection field", () => {
             type: "form",
             resModel: "purchase.order.suggest",
         });
-        expect("select option:nth-last-child(4)").toHaveText("November 2024");
-        expect("select option:nth-last-child(3)").toHaveText("December 2024");
-        expect("select option:nth-last-child(2)").toHaveText("January 2025");
-        expect("select option:last-child").toHaveText("Nov 2024-Jan 2025");
+        await contains(".o_field_widget[name='based_on'] input").click();
+        expect(".o_select_menu_menu .o_select_menu_item:nth-last-child(4)").toHaveText("November 2024");
+        expect(".o_select_menu_menu .o_select_menu_item:nth-last-child(3)").toHaveText("December 2024");
+        expect(".o_select_menu_menu .o_select_menu_item:nth-last-child(2)").toHaveText("January 2025");
+        expect(".o_select_menu_menu .o_select_menu_item:last-child").toHaveText("Nov 2024-Jan 2025");
         destroy(view);
         // Check for a different date.
         mockDate("2020-03-20 07:00:00");
@@ -55,9 +57,10 @@ describe("time_period_selection field", () => {
             type: "form",
             resModel: "purchase.order.suggest",
         });
-        expect("select option:nth-last-child(4)").toHaveText("March 2019");
-        expect("select option:nth-last-child(3)").toHaveText("April 2019");
-        expect("select option:nth-last-child(2)").toHaveText("May 2019");
-        expect("select option:last-child").toHaveText("Mar-May 2019");
+        await contains(".o_field_widget[name='based_on'] input").click();
+        expect(".o_select_menu_menu .o_select_menu_item:nth-last-child(4)").toHaveText("March 2019");
+        expect(".o_select_menu_menu .o_select_menu_item:nth-last-child(3)").toHaveText("April 2019");
+        expect(".o_select_menu_menu .o_select_menu_item:nth-last-child(2)").toHaveText("May 2019");
+        expect(".o_select_menu_menu .o_select_menu_item:last-child").toHaveText("Mar-May 2019");
     });
 });

--- a/addons/test_base_automation/static/tests/tour/base_automation_tour.js
+++ b/addons/test_base_automation/static/tests/tour/base_automation_tour.js
@@ -1,4 +1,3 @@
-import { waitUntil } from "@odoo/hoot-dom";
 import { registry } from "@web/core/registry";
 import { stepUtils } from "@web_tour/tour_utils";
 
@@ -40,9 +39,8 @@ registry.category("web_tour.tours").add("test_base_automation", {
             run: "click",
         },
         {
-            content: "Select On save",
-            trigger: ".o_form_renderer #trigger_0",
-            run: `select "on_create_or_write"`,
+            trigger: ".o_select_menu_item:contains(On create and edit)",
+            run: "click",
         },
         {
             content: "Add new action",
@@ -111,38 +109,39 @@ registry.category("web_tour.tours").add("test_base_automation_on_tag_added", {
             run: "click",
         },
         {
+            content: "Open select",
             trigger: ".o_form_renderer #trigger_0",
+            run: "click",
+        },
+        {
+            trigger: ".o_select_menu_menu",
             run() {
-                const options = Object.fromEntries(
-                    Array.from(this.anchor.querySelectorAll("option")).map((el) => [
-                        JSON.parse(el.value),
-                        el.textContent,
-                    ])
-                );
+                const options = [...this.anchor.querySelectorAll(".o_select_menu_item")].map(
+                        (el) => el.textContent
+                    );
 
                 assertEqual(
                     JSON.stringify(options),
-                    JSON.stringify({
-                        false: "",
-                        on_stage_set: "Stage is set to",
-                        on_user_set: "User is set",
-                        on_tag_set: "Tag is added",
-                        on_priority_set: "Priority is set to",
-                        on_time: "Based on date field",
-                        on_time_created: "After creation",
-                        on_time_updated: "After last update",
-                        on_create: "On create",
-                        on_create_or_write: "On create and edit",
-                        on_unlink: "On deletion",
-                        on_change: "On UI change",
-                        on_webhook: "On webhook",
-                    })
+                    JSON.stringify([
+                        "Stage is set to",
+                        "User is set",
+                        "Tag is added",
+                        "Priority is set to",
+                        "Based on date field",
+                        "After creation",
+                        "After last update",
+                        "On create",
+                        "On create and edit",
+                        "On deletion",
+                        "On UI change",
+                        "On webhook"
+                    ])
                 );
             },
         },
         {
-            trigger: ".o_form_renderer #trigger_0",
-            run: `select "on_tag_set"`,
+            trigger: ".o_select_menu_item:contains(Tag is added)",
+            run: "click",
         },
         {
             trigger: '.o_form_renderer div[name="trg_field_ref"] input',
@@ -273,8 +272,8 @@ registry.category("web_tour.tours").add("test_open_automation_from_grouped_kanba
             trigger: ".o_form_view",
             run() {
                 assertEqual(
-                    this.anchor.querySelector(".o_field_widget[name='trigger'] select").value,
-                    '"on_tag_set"'
+                    this.anchor.querySelector(".o_field_widget[name='trigger'] input").value,
+                    "Tag is added"
                 );
                 assertEqual(
                     this.anchor.querySelector(".o_field_widget[name='trg_field_ref'] input").value,
@@ -447,18 +446,25 @@ registry.category("web_tour.tours").add("test_form_view_model_id", {
             run: "click",
         },
         {
-            trigger: ".o_field_widget[name='trigger']",
+            trigger: ".o_field_widget[name='trigger'] input",
+            run: "click",
+        },
+        {
+            trigger: ".o_select_menu_menu",
             run() {
-                const triggerGroups = Array.from(this.anchor.querySelectorAll("optgroup"));
                 assertEqual(
-                    triggerGroups.map((el) => el.getAttribute("label")).join(" // "),
-                    "Values Updated // Timing Conditions // Custom // External"
+                    Array.from(this.anchor.querySelectorAll(".o_select_menu_group"))
+                        .map((el) => el.textContent)
+                        .join(", "),
+                    "Values Updated, Timing Conditions, Custom, External"
                 );
                 assertEqual(
-                    triggerGroups.map((el) => el.innerText).join(" // "),
-                    "User is set // Based on date fieldAfter creationAfter last update // On createOn create and editOn deletionOn UI change // On webhook"
+                    Array.from(this.anchor.querySelectorAll(".o_select_menu_item"))
+                        .map((el) => el.textContent)
+                        .join(", "),
+                    "User is set, Based on date field, After creation, After last update, On create, On create and edit, On deletion, On UI change, On webhook"
                 );
-            },
+            }
         },
         {
             trigger: ".o_field_widget[name='model_id'] input",
@@ -469,14 +475,25 @@ registry.category("web_tour.tours").add("test_form_view_model_id", {
             run: "click",
         },
         {
-            trigger: ".o_field_widget[name='trigger']",
-            async run() {
-                await waitUntil(() => {
-                    const triggerGroups = Array.from(this.anchor.querySelectorAll("optgroup"));
-                    return triggerGroups.map((el) => el.getAttribute("label")).join(" // ") === "Values Updated // Timing Conditions // Custom // External" &&
-                        triggerGroups.map((el) => el.innerText).join(" // ") === "Stage is set toUser is setTag is addedPriority is set to // Based on date fieldAfter creationAfter last update // On createOn create and editOn deletionOn UI change // On webhook";
-                }, { timeout: 500 });
-            },
+            trigger: ".o_field_widget[name='trigger'] input",
+            run: "click",
+        },
+        {
+            trigger: ".o_select_menu_menu",
+            run() {
+                assertEqual(
+                    Array.from(this.anchor.querySelectorAll(".o_select_menu_group"))
+                        .map((el) => el.textContent)
+                        .join(", "),
+                    "Values Updated, Timing Conditions, Custom, External"
+                );
+                assertEqual(
+                    Array.from(this.anchor.querySelectorAll(".o_select_menu_item"))
+                        .map((el) => el.textContent)
+                        .join(", "),
+                    "Stage is set to, User is set, Tag is added, Priority is set to, Based on date field, After creation, After last update, On create, On create and edit, On deletion, On UI change, On webhook"
+                );
+            }
         },
         {
             trigger: ".o_form_button_cancel",
@@ -502,8 +519,13 @@ registry.category("web_tour.tours").add("test_form_view_custom_reference_field",
             trigger: "body:not(:has(.o_field_widget[name='trg_field_ref']))",
         },
         {
-            trigger: ".o_field_widget[name='trigger'] select",
-            run: `select "on_stage_set"`,
+            content: "Open select",
+            trigger: ".o_form_renderer #trigger_0",
+            run: "click",
+        },
+        {
+            trigger: ".o_select_menu_item:contains(Stage is set to)",
+            run: "click",
         },
         {
             trigger: ".o_field_widget[name='trg_field_ref'] input",
@@ -517,8 +539,13 @@ registry.category("web_tour.tours").add("test_form_view_custom_reference_field",
             },
         },
         {
-            trigger: ".o_field_widget[name='trigger'] select",
-            run: `select "on_tag_set"`,
+            content: "Open select",
+            trigger: ".o_form_renderer #trigger_0",
+            run: "click",
+        },
+        {
+            trigger: ".o_select_menu_item:contains(Tag is added)",
+            run: "click",
         },
         {
             trigger:
@@ -556,11 +583,15 @@ registry.category("web_tour.tours").add("test_form_view_mail_triggers", {
             run: "click",
         },
         {
-            trigger: ".o_field_widget[name='trigger'] select",
+            trigger: ".o_field_widget[name='trigger'] input",
+            run: "click",
+        },
+        {
+            trigger: ".o_select_menu_menu",
             run() {
                 assertEqual(
-                    Array.from(this.anchor.querySelectorAll("optgroup"))
-                        .map((el) => el.label)
+                    Array.from(this.anchor.querySelectorAll(".o_select_menu_group"))
+                        .map((el) => el.textContent)
                         .join(", "),
                     "Values Updated, Timing Conditions, Custom, External"
                 );
@@ -575,15 +606,19 @@ registry.category("web_tour.tours").add("test_form_view_mail_triggers", {
             run: "click",
         },
         {
-            trigger: ".o_field_widget[name='trigger']",
-            async run() {
-                await waitUntil(() => {
-                    const textLabels = Array.from(this.anchor.querySelectorAll("select optgroup"))
-                        .map((el) => el.label)
-                        .join(", ");
-                    return textLabels === "Values Updated, Email Events, Timing Conditions, Custom, External"
-                }, { timeout: 500 });
-            },
+            trigger: ".o_field_widget[name='trigger'] input",
+            run: "click",
+        },
+        {
+            trigger: ".o_select_menu_menu",
+            run() {
+                assertEqual(
+                    Array.from(this.anchor.querySelectorAll(".o_select_menu_group "))
+                        .map((el) => el.textContent)
+                        .join(", "),
+                    "Values Updated, Email Events, Timing Conditions, Custom, External"
+                );
+            }
         },
         {
             trigger: "button.o_form_button_cancel",
@@ -615,8 +650,13 @@ registry.category("web_tour.tours").add("base_automation.on_change_rule_creation
             run: "click",
         },
         {
-            trigger: ".o_field_widget[name=trigger] select",
-            run: `select "on_change"`,
+            content: "Open select",
+            trigger: ".o_form_renderer #trigger_0",
+            run: "click",
+        },
+        {
+            trigger: ".o_select_menu_item:contains(On UI change)",
+            run: "click",
         },
         {
             trigger: ".o_field_widget[name=on_change_field_ids] input",

--- a/addons/test_mail/static/tests/tracking_value.test.js
+++ b/addons/test_mail/static/tests/tracking_value.test.js
@@ -1,6 +1,6 @@
 import {
-    click,
     contains,
+    click,
     insertText,
     openFormView,
     registerArchs,
@@ -9,8 +9,8 @@ import {
 } from "@mail/../tests/mail_test_helpers";
 import { beforeEach, describe, expect, test } from "@odoo/hoot";
 import { mockDate, mockTimeZone } from "@odoo/hoot-mock";
-import { defineTestMailModels, editSelect } from "@test_mail/../tests/test_mail_test_helpers";
-import { patchWithCleanup } from "@web/../tests/web_test_helpers";
+import { defineTestMailModels } from "@test_mail/../tests/test_mail_test_helpers";
+import { editSelectMenu, patchWithCleanup } from "@web/../tests/web_test_helpers";
 import { currencies } from "@web/core/currency";
 
 const archs = {
@@ -302,7 +302,7 @@ test("rendering of tracked field of type selection: from a selection to no selec
     await start();
     registerArchs(archs);
     await openFormView("mail.test.track.all", mailTestTrackAllId1);
-    await editSelect("div[name=selection_field] select", "false");
+    await editSelectMenu("div[name=selection_field] input", { value: "" });
     await click(".o_form_button_save");
     await contains(".o-mail-Message-tracking", { text: "firstNone(Selection)" });
 });
@@ -313,7 +313,7 @@ test("rendering of tracked field of type selection: from no selection to a selec
     await start();
     registerArchs(archs);
     await openFormView("mail.test.track.all", mailTestTrackAllId1);
-    await editSelect("div[name=selection_field] select", '"first"');
+    await editSelectMenu("div[name=selection_field] input", { value: "First" });
     await click(".o_form_button_save");
     await contains(".o-mail-Message-tracking", { text: "Nonefirst(Selection)" });
 });

--- a/addons/web/static/src/core/bottom_sheet/bottom_sheet.js
+++ b/addons/web/static/src/core/bottom_sheet/bottom_sheet.js
@@ -175,7 +175,6 @@ export class BottomSheet extends Component {
         const sheet = this.sheetRef.el;
         sheet.style.removeProperty("min-height");
         sheet.style.removeProperty("height");
-        sheet.style.maxHeight = "none";
 
         const naturalHeight = sheet.offsetHeight;
         const initialHeightPx = Math.min(naturalHeight, maxHeightPx);
@@ -205,7 +204,7 @@ export class BottomSheet extends Component {
 
         // Set CSS variables for heights
         rail.style.setProperty("--sheet-height", `${heightPercent}dvh`);
-        rail.style.setProperty("--sheet-max-height", `${this.maxHeightPercent}dvh`);
+        rail.style.setProperty("--sheet-max-height", `${this.measurements.viewportHeight}px`);
         rail.style.setProperty("--dismiss-height", `${this.measurements.initialHeight || 0}px`);
     }
 

--- a/addons/web/static/src/core/bottom_sheet/bottom_sheet.scss
+++ b/addons/web/static/src/core/bottom_sheet/bottom_sheet.scss
@@ -40,7 +40,6 @@
         @include o-position-absolute(0, 0, 0, 0);
         overflow-y: auto;
         scrollbar-width: none;
-        -ms-overflow-style: none;
         touch-action: pan-y;
         pointer-events: auto;
 
@@ -99,7 +98,7 @@
 
         margin: 0 auto;
         min-height: var(--sheet-height);
-        max-height: var(--sheet-max-height, 90dvh);
+        max-height: var(--sheet-max-height);
         border-radius: $border-radius-xl $border-radius-xl 0 0;
         border-bottom-width: 0;
         visibility: visible;
@@ -111,9 +110,7 @@
         background-color: $dropdown-bg;
 
         .o_bottom_sheet_body {
-            overflow-y: hidden; // Initially hidden, will be 'auto' when extended
             scrollbar-width: none;
-            -ms-overflow-style: none;
             flex: 1;
         }
     }

--- a/addons/web/static/src/core/bottom_sheet/bottom_sheet.xml
+++ b/addons/web/static/src/core/bottom_sheet/bottom_sheet.xml
@@ -39,7 +39,7 @@
                     <div
                         tabindex="-1"
                         role="button"
-                        class="o_bottom_sheet_handle text-center d-flex align-items-center justify-content-center opacity-50 pt-2 pb-1"
+                        class="o_bottom_sheet_handle text-center d-flex align-items-center justify-content-center opacity-50 py-2"
                         t-on-click.stop="slideOut"
                         >
                         <div class="o_bottom_sheet_handle_bar pt-1 mx-auto rounded-pill d-inline-block px-5 bg-dark"/>

--- a/addons/web/static/src/core/dropdown/dropdown.scss
+++ b/addons/web/static/src/core/dropdown/dropdown.scss
@@ -125,5 +125,5 @@
     --dropdown-box-shadow: none;
 
     position: static;
-    max-height: unset;
+    max-height: calc(var(--sheet-max-height) - #{$spacer} / 4);
 }

--- a/addons/web/static/src/core/navigation/navigation.js
+++ b/addons/web/static/src/core/navigation/navigation.js
@@ -123,6 +123,7 @@ export class Navigator {
             {
                 isNavigationAvailable: ({ target }) => this.contains(target),
                 shouldFocusChildInput: true,
+                shouldFocusFirstItem: false,
                 virtualFocus: false,
                 hotkeys: {
                     home: () => this.items[0]?.setActive(),
@@ -250,6 +251,10 @@ export class Navigator {
         }
 
         this._options.onUpdated?.(this);
+
+        if (this._options.shouldFocusFirstItem) {
+            this.items[0]?.setActive();
+        }
     }
 
     /**

--- a/addons/web/static/src/core/select_menu/select_menu.scss
+++ b/addons/web/static/src/core/select_menu/select_menu.scss
@@ -1,75 +1,82 @@
 .o_select_menu {
-    .o_select_menu_toggler {
-        display: grid;
-        grid-template-columns: auto 25px;
-    }
-    .o_select_menu_toggler.o_can_deselect {
-        grid-template-columns: auto 25px 25px;
-    }
-
-    .o_select_menu_toggler_slot {
-        flex-grow: 2;
-    }
-
-    .o_select_menu_toggler_caret {
-        grid-column: 2;
-    }
-    .o_can_deselect .o_select_menu_toggler_caret {
-        grid-column: 3;
+    &.o_select_menu_multi_select input {
+        flex: 1 0 50px;
     }
 
     .o_select_menu_toggler_clear {
-        grid-column: 2;
-    }
+        transform: translateY(-50%);
 
-    .o_select_menu_toggler_clear:hover i {
-        color: red;
+        &:hover i {
+            color: red;
+        }
     }
 
     .o_tag {
         margin: 2px;
     }
 
-    &--sticky {
-        position: sticky;
+    .o_select_menu_caret {
+        @include o-position-absolute($o-input-padding-y, $o-input-padding-x, $input-border-width);
+        visibility: hidden;
+
+        &:after {
+            @include o-caret-down;
+        }
+    }
+
+    &:hover, &:focus-within {
+        .o_select_menu_caret {
+            visibility: visible;
+        }
+    }
+
+    button .o_select_menu_caret {
+        right: 3px;
     }
 }
 
 .o_select_menu_menu {
-    min-width: fit-content;
-    max-height: 350px !important;
+    background-color: $dropdown-bg;
 
-    input {
-        cursor: text !important;
-    }
-    .o_select_menu_sticky {
-        background-color: $dropdown-bg !important;
+    .o_select_menu_searchbox {
+        background-color: $dropdown-bg;
+        position: sticky;
+        top: $dropdown-padding-y * -1;
+        padding: 5px;
 
-        &.o_select_menu_item.focus {
-            background: $dropdown-border-color !important;
+        input {
+            cursor: text !important;
+            height: $input-height;
+            padding-left: 20px;
+        }
+
+        &:before {
+            @include o-position-absolute($top: 50%);
+            transform: translateY(-50%);
+            content: "\f002";
+            font-family: 'FontAwesome';
         }
     }
+
     .o_select_menu_group {
-        top: 40px !important;
+        background-color: $dropdown-bg;
+        top: $input-height;
         &:not(.o_select_menu_searchable_group) {
-            top: -4px;
-        }
-    }
-    .o_select_active {
-        color: white;
-    }
-    &.o_select_menu_multi_select {
-        .o_select_active:hover {
-            background: $o-danger !important;
-            transition: background .5s;
+            top: $dropdown-padding-y * -1;
         }
     }
 }
 
-.dropup .o_select_menu_menu {
-    box-shadow: 0 -7px 10px rgba(8, 8, 8, 0.319);
+.dropdown-menu:not(.o_bottom_sheet) .o-dropdown-item:before {
+    display: none;
 }
 
-.dropdown .o_select_menu_menu {
-    box-shadow: 0 7px 10px rgba(8, 8, 8, 0.319);
+.o_bottom_sheet .o_select_menu_menu {
+    padding: 0;
+
+    .dropdown-item {
+        font-weight: normal;
+        margin: 0 auto;
+        max-width: calc(100% - 2 * var(--offcanvas-padding-x));
+    }
 }

--- a/addons/web/static/src/core/select_menu/select_menu.xml
+++ b/addons/web/static/src/core/select_menu/select_menu.xml
@@ -1,57 +1,72 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates>
+    <t t-name="web.SelectMenu.search">
+        <input
+            type="text"
+            t-attf-class="o_input {{inputClass}}"
+            t-ref="inputRef"
+            t-on-input="debouncedOnInput"
+            t-on-focus="onInputFocus"
+            t-on-blur="onInputBlur"
+            t-att-placeholder="placeholderValue"
+            t-att-value="displayValue"
+            t-att-id="props.id"
+            t-att-name="props.name"
+            t-att-disabled="props.disabled"
+            t-on-click="onInputClick"
+            autocomplete="selectMenuAutocompleteOff"
+            autocorrect="off"
+            spellcheck="false"
+        />
+    </t>
 
     <t t-name="web.SelectMenu">
-        <div t-att-class="`o_select_menu border w-auto rounded-2 overflow-hidden ${props.class || ''}`">
+        <div t-att-class="`o_select_menu w-auto position-relative ${props.multiSelect ? 'o_select_menu_multi_select' : ''} ${displayInputInToggler ? 'o_input_dropdown' : ''} ${props.class || ''}`" t-att-data-id="selectMenuId">
             <Dropdown
                 menuClass="this.menuClass"
                 menuRef="this.menuRef"
                 position="'bottom-fit'"
                 beforeOpen.bind="onBeforeOpen"
+                focusToggleOnClosed="!isBottomSheet"
                 onStateChanged.bind="onStateChanged"
                 navigationOptions="navigationOptions"
-            >
-                <button type="button" t-att-class="`o_select_menu_toggler btn btn-light w-100 bg-light ${props.togglerClass || ''} ${canDeselect ? 'o_can_deselect' : ''}`" t-att-disabled="props.disabled">
-                    <t t-if="props.multiSelect">
-                        <div class="text-wrap text-start">
-                            <t t-if="props.placeholder and !props.value.length">
-                                <span class="text-muted fst-italic" t-out="props.placeholder"/>
-                            </t>
-                            <t else="">
-                                <TagsList tags="multiSelectChoices"/>
-                            </t>
-                        </div>
-                    </t>
-                    <t t-else="">
+                state="dropdownState"
+                >
+                <t t-if="displayInputInToggler">
+                    <t t-set="inputClass" t-value="'o_select_menu_toggler ' + (!displayInputInDropdown ? 'o_select_menu_input ' : '') + props.togglerClass"/>
+                    <div class="o_input w-100 d-flex flex-wrap">
+                        <t t-if="props.multiSelect">
+                            <TagsList t-if="props.value.length" tags="multiSelectChoices"/>
+                        </t>
+                        <t t-call="web.SelectMenu.search" />
+                        <span t-if="!props.searchable and canDeselect" t-on-click.stop="onInputClear" class="o_select_menu_toggler_clear position-absolute top-50 end-0 me-3">
+                            <i class="fa fa-times"></i>
+                        </span>
+                        <span class="o_select_menu_caret align-self-center" />
+                    </div>
+                </t>
+                <t t-else="">
+                    <button type="button" t-attf-class="o_select_menu_toggler d-flex border btn btn-light w-100 bg-light {{ props.togglerClass }}" t-att-disabled="props.disabled">
                         <span class="o_select_menu_toggler_slot text-start text-truncate">
-                            <span t-if="props.placeholder and !props.value" class="text-muted fst-italic" t-out="props.placeholder"/>
+                            <span t-if="props.placeholder and !props.value" class="text-muted" t-out="props.placeholder"/>
                             <t t-if="!props.slots or !props.slots.default" t-esc="displayValue" />
                             <t t-else="" t-slot="default" />
                         </span>
-                        <span t-if="canDeselect" t-on-click.stop="() => this.props.onSelect(null)" class="o_select_menu_toggler_clear p-0 m-0">
+                        <span t-if="canDeselect" t-on-click.stop="onInputClear" class="o_select_menu_toggler_clear position-absolute top-50 end-0 me-3">
                             <i class="fa fa-times"></i>
                         </span>
-                    </t>
-                    <span class="o_select_menu_toggler_caret p-0 m-0">
-                        <i class="fa fa-caret-down"></i>
-                    </span>
-                </button>
-
+                        <span class="o_select_menu_caret align-self-center" />
+                    </button>
+                </t>
                 <t t-set-slot="content">
-                    <input
-                        t-if="props.searchable"
-                        type="text"
-                        class="dropdown-item o_select_menu_sticky px-3 py-3 position-sticky top-0 start-0 border-bottom"
-                        t-att-class="props.searchClass"
-                        t-ref="inputRef"
-                        t-on-input="debouncedOnInput"
-                        t-att-placeholder="props.searchPlaceholder"
-                        autocomplete="selectMenuAutocompleteOff"
-                        autocorrect="off"
-                        spellcheck="false"
-                    />
+                    <div class="o_select_menu_searchbox position-sticky start-0 d-empty-none" t-att-data-id="selectMenuId">
+                        <t t-if="displayInputInDropdown">
+                            <t t-set="inputClass" t-value="'o_select_menu_input dropdown-item'"/>
+                            <t t-call="web.SelectMenu.search" />
+                        </t>
+                    </div>
                     <t t-if="state.choices.length === 0">
-                        <span class="text-muted fst-italic mx-3">No result found</span>
+                        <p class="text-muted fst-italic mx-4 my-1">No results</p>
                     </t>
                     <t t-foreach="state.displayedOptions" t-as="choice" t-key="choice_index">
                         <t t-call="{{ this.constructor.choiceItemTemplate }}">
@@ -67,11 +82,10 @@
     <t t-name="web.SelectMenu.ChoiceItem">
         <div
             t-if="choice.isGroup"
-            class="o_select_menu_group position-sticky bg-light pt-2 px-1 fst-italic fw-bolder user-select-none"
-            t-att-class="{'o_select_menu_searchable_group': props.searchable }"
+            class="o_select_menu_group position-sticky start-0 px-1 fw-bolder user-select-none"
+            t-att-class="{'o_select_menu_searchable_group': displayInputInDropdown }"
         >
             <span t-esc="choice.label" />
-            <hr class="mt-2 mb-1" />
         </div>
         <DropdownItem
             t-if="!choice.isGroup"
@@ -80,7 +94,7 @@
         >
             <t t-if="props.slots and props.slots.choice" t-slot="choice" data="choice"/>
             <t t-else="">
-                <div class="o_select_menu_item_label text-wrap" t-esc="choice.label || choice.value" />
+                <div class="text-wrap" t-esc="choice.label || choice.value" />
             </t>
         </DropdownItem>
     </t>

--- a/addons/web/static/src/views/fields/selection/selection_field.js
+++ b/addons/web/static/src/views/fields/selection/selection_field.js
@@ -1,11 +1,16 @@
 import { Component } from "@odoo/owl";
 import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
+import { SelectMenu } from "@web/core/select_menu/select_menu";
 import { getFieldDomain } from "@web/model/relational_model/utils";
 import { useSpecialData } from "@web/views/fields/relational_utils";
+import { hasTouch } from "@web/core/browser/feature_detection";
 import { standardFieldProps } from "../standard_field_props";
 
 export class SelectionField extends Component {
+    static components = {
+        SelectMenu,
+    };
     static template = "web.SelectionField";
     static props = {
         ...standardFieldProps,
@@ -29,6 +34,12 @@ export class SelectionField extends Component {
         }
     }
 
+    get choices() {
+        return this.options.map(([value, label]) => ({ value, label }));
+    }
+    get isBottomSheet() {
+        return this.env.isSmall && hasTouch();
+    }
     get options() {
         switch (this.type) {
             case "many2one":
@@ -64,14 +75,10 @@ export class SelectionField extends Component {
         return JSON.stringify(value);
     }
 
-    /**
-     * @param {Event} ev
-     */
-    onChange(ev) {
-        const value = JSON.parse(ev.target.value);
+    onChange(value) {
         switch (this.type) {
             case "many2one":
-                if (value === false) {
+                if (value === null) {
                     this.props.record.update(
                         { [this.props.name]: false },
                         { save: this.props.autosave }
@@ -124,4 +131,3 @@ export const selectionField = {
 };
 
 registry.category("fields").add("selection", selectionField);
-registry.category("fields").add("kanban.selection", selectionField);

--- a/addons/web/static/src/views/fields/selection/selection_field.scss
+++ b/addons/web/static/src/views/fields/selection/selection_field.scss
@@ -1,10 +1,7 @@
-body:not(.o_touch_device) .o_field_selection {
-    &:not(.o_field_invalid):not(:hover):not(:focus-within) {
-        & select:not(:hover) {
-            background-image: none;
-        }
-    }
+.o_field_selection_menu {
+    min-width: 160px;
 }
-select:has(option.o_select_placeholder:checked) {
-    color: $input-placeholder-color;
+
+.o_form_view.o_field_highlight .o_select_menu .o_select_menu_caret {
+    visibility: visible;
 }

--- a/addons/web/static/src/views/fields/selection/selection_field.xml
+++ b/addons/web/static/src/views/fields/selection/selection_field.xml
@@ -6,28 +6,7 @@
             <span t-esc="string" t-att-raw-value="value" />
         </t>
         <t t-else="">
-            <t t-set="isPlaceholder" t-value="false === value" />
-            <select
-                class="o_input pe-3"
-                t-on-change="onChange"
-                t-on-click.stop="() =&gt; {}"
-                t-att-id="props.id">
-                <option
-                    t-if="!props.required || !value"
-                    t-attf-class="o_select_placeholder {{isPlaceholder ? 'd-none' : ''}}"
-                    t-att-selected="isPlaceholder"
-                    t-att-value="stringify(false)"
-                    t-esc="isPlaceholder and this.props.placeholder || ''"
-                />
-                <t t-foreach="options" t-as="option" t-key="option[0]">
-                    <option
-                        class="text-black"
-                        t-att-selected="option[0] === value"
-                        t-att-value="stringify(option[0])"
-                        t-esc="option[1]"
-                    />
-                </t>
-            </select>
+            <SelectMenu autoSort="false" class="'border-0'" menuClass="'o_field_selection_menu w-auto'" value="value" choices="choices" onSelect.bind="onChange" placeholder="props.placeholder" id="props.id" searchable="!isBottomSheet" />
         </t>
     </t>
 

--- a/addons/web/static/tests/tours/test_user_group_settings_tour.js
+++ b/addons/web/static/tests/tours/test_user_group_settings_tour.js
@@ -114,9 +114,13 @@ registry.category("web_tour.tours").add("test_user_group_settings", {
         },
         {
             trigger:
-                '.o_field_widget[name="group_ids"] .o_cell:has(label:contains("Privi Foo")) + .o_cell select',
+                '.o_field_widget[name="group_ids"] .o_cell:has(label:contains("Privi Foo")) + .o_cell .o_select_menu input',
             content: "Add 'Bar Manager' access to demo user",
-            run: `selectByLabel Bar Manager`,
+            run: `click`,
+        },
+        {
+            trigger: `.o-dropdown--menu .o_select_menu_item:contains("Bar Manager")`,
+            run: "click",
         },
         // open group information button (popover)
         {

--- a/addons/web/static/tests/views/fields/filterable_selection_field.test.js
+++ b/addons/web/static/tests/views/fields/filterable_selection_field.test.js
@@ -1,5 +1,13 @@
 import { expect, test } from "@odoo/hoot";
-import { contains, defineModels, fields, models, mountView } from "@web/../tests/web_test_helpers";
+import { queryAllTexts } from "@odoo/hoot-dom";
+import {
+    contains,
+    defineModels,
+    editSelectMenu,
+    fields,
+    models,
+    mountView,
+} from "@web/../tests/web_test_helpers";
 
 class Program extends models.Model {
     type = fields.Selection({
@@ -21,8 +29,6 @@ class Program extends models.Model {
 }
 defineModels([Program]);
 
-// Note: the `toHaveCount` always check for one more as there will be an invisible empty option every time.
-
 test(`FilterableSelectionField test whitelist`, async () => {
     await mountView({
         resModel: "program",
@@ -34,9 +40,9 @@ test(`FilterableSelectionField test whitelist`, async () => {
         `,
         resId: 1,
     });
-    expect(`select option`).toHaveCount(2);
-    expect(`.o_field_widget[name="type"] select option[value='"coupon"']`).toHaveCount(1);
-    expect(`.o_field_widget[name="type"] select option[value='"promotion"']`).toHaveCount(1);
+    await contains(".o_field_widget[name='type'] input").click();
+    expect(`.o_select_menu_item`).toHaveCount(2);
+    expect(queryAllTexts(".o_select_menu_item")).toEqual(["Coupons", "Promotion"]);
 });
 
 test(`FilterableSelectionField test blacklist`, async () => {
@@ -50,9 +56,9 @@ test(`FilterableSelectionField test blacklist`, async () => {
         `,
         resId: 1,
     });
-    expect(`select option`).toHaveCount(2);
-    expect(`.o_field_widget[name="type"] select option[value='"coupon"']`).toHaveCount(1);
-    expect(`.o_field_widget[name="type"] select option[value='"promotion"']`).toHaveCount(1);
+    await contains(".o_field_widget[name='type'] input").click();
+    expect(`.o_select_menu_item`).toHaveCount(2);
+    expect(queryAllTexts(".o_select_menu_item")).toEqual(["Coupons", "Promotion"]);
 });
 
 test(`FilterableSelectionField test with invalid value`, async () => {
@@ -67,16 +73,13 @@ test(`FilterableSelectionField test with invalid value`, async () => {
         `,
         resId: 2,
     });
-    expect(`select option`).toHaveCount(3);
-    expect(`.o_field_widget[name="type"] select option[value='"gift_card"']`).toHaveCount(1);
-    expect(`.o_field_widget[name="type"] select option[value='"coupon"']`).toHaveCount(1);
-    expect(`.o_field_widget[name="type"] select option[value='"promotion"']`).toHaveCount(1);
-
-    await contains(`.o_field_widget[name="type"] select`).select(`"coupon"`);
-    expect(`select option`).toHaveCount(2);
-    expect(`.o_field_widget[name="type"] select option[value='"gift_card"']`).toHaveCount(0);
-    expect(`.o_field_widget[name="type"] select option[value='"coupon"']`).toHaveCount(1);
-    expect(`.o_field_widget[name="type"] select option[value='"promotion"']`).toHaveCount(1);
+    await contains(".o_field_widget[name='type'] input").click();
+    expect(`.o_select_menu_item`).toHaveCount(3);
+    expect(queryAllTexts(".o_select_menu_item")).toEqual(["Coupons", "Promotion", "Gift card"]);
+    await editSelectMenu(".o_field_widget[name='type'] input", { value: "Coupons" });
+    await contains(".o_field_widget[name='type'] input").click();
+    expect(`.o_select_menu_item`).toHaveCount(2);
+    expect(queryAllTexts(".o_select_menu_item")).toEqual(["Coupons", "Promotion"]);
 });
 
 test(`FilterableSelectionField test whitelist_fname`, async () => {
@@ -91,7 +94,7 @@ test(`FilterableSelectionField test whitelist_fname`, async () => {
         `,
         resId: 1,
     });
-    expect(`select option`).toHaveCount(2);
-    expect(`.o_field_widget[name="type"] select option[value='"coupon"']`).toHaveCount(1);
-    expect(`.o_field_widget[name="type"] select option[value='"promotion"']`).toHaveCount(1);
+    await contains(".o_field_widget[name='type'] input").click();
+    expect(`.o_select_menu_item`).toHaveCount(2);
+    expect(queryAllTexts(".o_select_menu_item")).toEqual(["Coupons", "Promotion"]);
 });

--- a/addons/web/static/tests/views/fields/many2many_field.test.js
+++ b/addons/web/static/tests/views/fields/many2many_field.test.js
@@ -10,6 +10,7 @@ import {
     clickSave,
     contains,
     defineModels,
+    editSelectMenu,
     fieldInput,
     fields,
     models,
@@ -474,7 +475,7 @@ test("many2many kanban: conditional create/delete actions", async () => {
     await contains(".modal .modal-footer .o_form_button_cancel:eq(0)").click();
 
     // set color to black
-    await contains('div[name="color"] select').select('"black"');
+    await editSelectMenu(".o_field_widget[name='color'] input", { value: "Black" });
     expect(".o-kanban-button-new").toHaveCount(1, {
         message: '"Add" button should still be available even after color field changed',
     });
@@ -925,7 +926,7 @@ test("many2many list: conditional create/delete actions", async () => {
     await contains(".modal .modal-footer .o_form_button_cancel:eq(0)").click();
 
     // set color to black -> create and delete actions are no longer available
-    await contains('div[name="color"] select').select('"black"');
+    await editSelectMenu(".o_field_widget[name='color'] input", { value: "Black" });
 
     // add a line and remove icon should still be there as they don't create/delete records,
     // but rather add/remove links
@@ -968,7 +969,7 @@ test("many2many field with link/unlink options (list)", async () => {
     await contains(".modal .modal-footer .o_form_button_cancel:eq(0)").click();
 
     // set color to black -> link and unlink actions are no longer available
-    await contains('div[name="color"] select').select('"black"');
+    await editSelectMenu(".o_field_widget[name='color'] input", { value: "Black" });
 
     expect(".o_field_x2many_list_row_add").toHaveCount(0);
     expect(".o_list_record_remove").toHaveCount(0);
@@ -1006,7 +1007,7 @@ test('many2many field with link/unlink options (list, create="0")', async () => 
     await contains(".modal .modal-footer .o_form_button_cancel:eq(0)").click();
 
     // set color to black -> link and unlink actions are no longer available
-    await contains('div[name="color"] select').select('"black"');
+    await editSelectMenu(".o_field_widget[name='color'] input", { value: "Black" });
 
     expect(".o_field_x2many_list_row_add").toHaveCount(0);
     expect(".o_list_record_remove").toHaveCount(0);
@@ -1048,7 +1049,7 @@ test("many2many field with link option (kanban)", async () => {
     await contains(".modal .modal-footer .o_form_button_cancel:eq(0)").click();
 
     // set color to black -> link and unlink actions are no longer available
-    await contains('div[name="color"] select').select('"black"');
+    await editSelectMenu(".o_field_widget[name='color'] input", { value: "Black" });
 
     expect(".o-kanban-button-new").toHaveCount(0);
 });
@@ -1088,7 +1089,7 @@ test('many2many field with link option (kanban, create="0")', async () => {
     await contains(".modal .modal-footer .o_form_button_cancel:eq(0)").click();
 
     // set color to black -> link and unlink actions are no longer available
-    await contains('div[name="color"] select').select('"black"');
+    await editSelectMenu(".o_field_widget[name='color'] input", { value: "Black" });
 
     expect(".o-kanban-button-new").toHaveCount(0);
 });

--- a/addons/web/static/tests/views/fields/timezone_mismatch_field.test.js
+++ b/addons/web/static/tests/views/fields/timezone_mismatch_field.test.js
@@ -1,8 +1,8 @@
 import { expect, test } from "@odoo/hoot";
-import { queryText } from "@odoo/hoot-dom";
 import {
     contains,
     defineModels,
+    editSelectMenu,
     fields,
     models,
     mountView,
@@ -40,9 +40,8 @@ test("in a list view", async () => {
     });
     expect("td:contains(Belgium)").toHaveCount(1);
     await contains(".o_data_cell").click();
-    expect(".o_field_widget[name=country] select").toHaveCount(1);
-    await contains(".o_field_widget[name=country] select").select(`"usa"`);
-    expect(".o_data_cell:first").toHaveText(
+    await editSelectMenu(".o_field_widget[name='country'] input", { value: "United States" });
+    expect(".o_data_cell input").toHaveValue(
         /United States\s+\([0-9]+\/[0-9]+\/[0-9]+ [0-9]+:[0-9]+:[0-9]+\)/
     );
     expect(".o_tz_warning").toHaveCount(1);
@@ -60,10 +59,10 @@ test("in a form view", async () => {
             </form>
         `,
     });
-    expect(`.o_field_widget[name="country"]:contains(Belgium)`).toHaveCount(1);
-    expect(".o_field_widget[name=country] select").toHaveCount(1);
-    await contains(".o_field_widget[name=country] select").select(`"usa"`);
-    expect(queryText(`.o_field_widget[name="country"]:first`)).toMatch(
+    await contains(".o_field_widget[name='country'] input").click();
+    expect(".o_select_menu_item:contains(Belgium)").toHaveCount(1);
+    await editSelectMenu(".o_field_widget[name='country'] input", { value: "United States" });
+    expect(".o_field_widget[name='country'] input").toHaveValue(
         /United States\s+\([0-9]+\/[0-9]+\/[0-9]+ [0-9]+:[0-9]+:[0-9]+\)/
     );
     expect(".o_tz_warning").toHaveCount(1);

--- a/addons/web/static/tests/views/kanban/kanban_view.test.js
+++ b/addons/web/static/tests/views/kanban/kanban_view.test.js
@@ -3699,7 +3699,7 @@ test("quick create record fails in grouped by selection", async () => {
     await validateKanbanRecord();
 
     expect(".modal .o_form_view .o_form_editable").toHaveCount(1);
-    expect(".modal .o_field_widget[name=state] select:first").toHaveValue('"abc"');
+    expect(".modal .o_field_widget[name=state] input").toHaveValue("ABC");
 
     await contains(".modal .o_form_button_save").click();
 
@@ -4047,7 +4047,7 @@ test("quick create record in grouped by selection field (within quick_create_vie
     });
 
     await quickCreateKanbanRecord();
-    expect(".o_kanban_quick_create select:first").toHaveValue('"abc"', {
+    expect(".o_kanban_quick_create input").toHaveValue("ABC", {
         message: "should have set the correct state value by default",
     });
 

--- a/addons/web/static/tests/views/list/list_view.test.js
+++ b/addons/web/static/tests/views/list/list_view.test.js
@@ -39,6 +39,7 @@ import {
     defineModels,
     defineParams,
     editFavoriteName,
+    editSelectMenu,
     fields,
     getFacetTexts,
     getMenuItemTexts,
@@ -8685,7 +8686,9 @@ test(`modifiers of other x2many rows a re-evaluated when a subrecord is updated`
 
     // Make a change in the list to trigger the onchange
     await contains(`.o_field_widget[name=o2m] .o_data_row .o_data_cell:eq(1)`).click();
-    await contains(`.o_field_widget[name=o2m] .o_data_row [name=stage] select`).select(`"open"`);
+    await editSelectMenu(".o_field_widget[name=o2m] .o_data_row [name=stage] input", {
+        value: "Open",
+    });
     expect(queryAllTexts(`.o_field_widget[name=o2m] .o_data_row .o_data_cell:first-child`)).toEqual(
         ["", "Value 2"]
     );
@@ -16868,7 +16871,7 @@ test(`Properties: selection`, async () => {
     expect(`.o_field_cell.o_selection_cell`).toHaveCount(3);
 
     await contains(`.o_field_cell.o_selection_cell`).click();
-    await contains(`.o_field_cell.o_selection_cell select`).select(`"a"`);
+    await editSelectMenu(".o_field_cell.o_selection_cell input", { value: "A" });
     await contains(`.o_list_button_save`).click();
     expect(`.o_field_cell.o_selection_cell:eq(0)`).toHaveText("A");
     expect.verifySteps(["web_save"]);

--- a/addons/web/static/tests/web_test_helpers.js
+++ b/addons/web/static/tests/web_test_helpers.js
@@ -148,6 +148,7 @@ export {
     mountViewInDialog,
     parseViewProps,
     selectFieldDropdownItem,
+    editSelectMenu,
 } from "./_framework/view_test_helpers";
 export { mountWebClient, useTestClientAction } from "./_framework/webclient_test_helpers";
 

--- a/addons/web/static/tests/webclient/res_user_group_ids_field.test.js
+++ b/addons/web/static/tests/webclient/res_user_group_ids_field.test.js
@@ -1,8 +1,9 @@
 import { beforeEach, expect, test } from "@odoo/hoot";
-import { click, hover, queryAllTexts, runAllTimers, select } from "@odoo/hoot-dom";
+import { hover, queryAllTexts, queryAllValues, queryFirst, runAllTimers } from "@odoo/hoot-dom";
 import {
     contains,
     defineModels,
+    editSelectMenu,
     mountView,
     onRpc,
     serverState,
@@ -250,8 +251,10 @@ test("simple rendering", async () => {
     expect(".o_field_widget[name=group_ids] .o_inner_group:eq(0) .o_form_label").toHaveText(
         "Administration"
     );
-    expect(".o_field_widget[name=group_ids] .o_inner_group:eq(0) select").toHaveCount(1);
-    expect(".o_field_widget[name=group_ids] .o_inner_group:eq(0) select").toHaveValue("1");
+    expect(".o_field_widget[name=group_ids] .o_inner_group:eq(0) input").toHaveCount(1);
+    expect(".o_field_widget[name=group_ids] .o_inner_group:eq(0) input").toHaveValue(
+        "Access Rights"
+    );
 
     // second group has 2 privileges
     expect(
@@ -261,11 +264,12 @@ test("simple rendering", async () => {
     expect(
         queryAllTexts(".o_field_widget[name=group_ids] .o_inner_group:eq(1) .o_form_label")
     ).toEqual(["Project?", "Helpdesk"]);
-    expect(".o_field_widget[name=group_ids] .o_inner_group:eq(1) select").toHaveCount(2);
-    expect(".o_field_widget[name=group_ids] .o_inner_group:eq(1) select:eq(0)").toHaveValue("11");
-    expect(".o_field_widget[name=group_ids] .o_inner_group:eq(1) select:eq(1)").toHaveValue(
-        "false"
-    );
+    expect(".o_field_widget[name=group_ids] .o_inner_group:nth-child(2) input").toHaveCount(2);
+    expect(
+        queryAllValues(
+            ".o_field_widget[name=group_ids] .o_inner_group:nth-child(2) .o_wrap_input input"
+        )
+    ).toEqual(["Project User", ""]);
 
     expect(".o_group_info_button").toHaveCount(0); // not displayed in non debug mode
 });
@@ -315,10 +319,13 @@ test("add and remove groups", async () => {
         resId: 1,
     });
 
-    await click(".o_field_widget[name=group_ids] select:eq(1)");
-    await select("false");
-    await click(".o_field_widget[name=group_ids] select:eq(2)");
-    await select("15");
+    await editSelectMenu(".o_field_widget[name='group_ids'] .o_inner_group:eq(1) input", {
+        value: "",
+    });
+    await editSelectMenu(
+        ".o_field_widget[name='group_ids'] .o_inner_group:nth-child(2) .o_wrap_input:last-child input",
+        { value: "Helpdesk Administrator" }
+    );
     await contains(`.o_form_button_save`).click();
     expect.verifySteps(["web_save"]);
 });
@@ -342,10 +349,13 @@ test("editing groups doesn't remove groups (debug)", async () => {
         resId: 1,
     });
 
-    await click(".o_field_widget[name=group_ids] select:eq(1)");
-    await select("false");
-    await click(".o_field_widget[name=group_ids] select:eq(2)");
-    await select("15");
+    await editSelectMenu(".o_field_widget[name='group_ids'] .o_inner_group:eq(1) input", {
+        value: "",
+    });
+    await editSelectMenu(
+        ".o_field_widget[name='group_ids'] .o_inner_group:nth-child(2) .o_wrap_input:last-child input",
+        { value: "Helpdesk Administrator" }
+    );
     await contains(`.o_form_button_save`).click();
     expect.verifySteps(["web_save"]);
 });
@@ -386,14 +396,15 @@ test("implied groups rendering", async () => {
     });
 
     expect(".o_field_widget[name=group_ids] .o_group .o_inner_group").toHaveCount(2);
-    expect(".o_field_widget[name=group_ids] .o_inner_group:eq(1) select").toHaveCount(2);
-    expect(".o_field_widget[name=group_ids] .o_inner_group:eq(1) select:eq(0)").toHaveValue(
-        "false"
+    expect(".o_field_widget[name=group_ids] .o_inner_group:eq(1) input").toHaveCount(2);
+    expect(queryAllValues(".o_field_widget[name=group_ids] .o_inner_group:eq(1) input")).toEqual([
+        "",
+        "Helpdesk Administrator",
+    ]);
+    expect(".o_field_widget[name=group_ids] .o_inner_group:eq(1) input:eq(0)").toHaveAttribute(
+        "placeholder",
+        "Project Manager"
     );
-    expect(
-        ".o_field_widget[name=group_ids] .o_inner_group:eq(1) select:eq(0) option.o_select_placeholder"
-    ).toHaveText("Project Manager");
-    expect(".o_field_widget[name=group_ids] .o_inner_group:eq(1) select:eq(1)").toHaveValue("15");
 });
 
 test("implied groups rendering (debug)", async () => {
@@ -412,14 +423,15 @@ test("implied groups rendering (debug)", async () => {
     });
 
     expect(".o_field_widget[name=group_ids] .o_group .o_inner_group").toHaveCount(4);
-    expect(".o_field_widget[name=group_ids] .o_inner_group:eq(1) select").toHaveCount(2);
-    expect(".o_field_widget[name=group_ids] .o_inner_group:eq(1) select:eq(0)").toHaveValue(
-        "false"
+    expect(".o_field_widget[name=group_ids] .o_inner_group:eq(1) input").toHaveCount(2);
+    expect(queryAllValues(".o_field_widget[name=group_ids] .o_inner_group:eq(1) input")).toEqual([
+        "",
+        "Helpdesk Administrator",
+    ]);
+    expect(".o_field_widget[name=group_ids] .o_inner_group:eq(1) input:eq(0)").toHaveAttribute(
+        "placeholder",
+        "Project Manager"
     );
-    expect(
-        ".o_field_widget[name=group_ids] .o_inner_group:eq(1) select:eq(0) option.o_select_placeholder"
-    ).toHaveText("Project Manager");
-    expect(".o_field_widget[name=group_ids] .o_inner_group:eq(1) select:eq(1)").toHaveValue("15");
 
     await contains(".o_inner_group:eq(1) .o_group_info_button:eq(0)").click();
     expect(".o_popover").toHaveCount(1);
@@ -467,14 +479,15 @@ test("implied groups rendering: exclusive (debug)", async () => {
     });
 
     expect(".o_field_widget[name=group_ids] .o_group .o_inner_group").toHaveCount(4);
-    expect(".o_field_widget[name=group_ids] .o_inner_group:eq(1) select").toHaveCount(2);
-    expect(".o_field_widget[name=group_ids] .o_inner_group:eq(1) select:eq(0)").toHaveValue(
-        "false"
+    expect(".o_field_widget[name=group_ids] .o_inner_group:eq(1) input").toHaveCount(2);
+    expect(queryAllValues(".o_field_widget[name=group_ids] .o_inner_group:eq(1) input")).toEqual([
+        "",
+        "Helpdesk Administrator",
+    ]);
+    expect(".o_field_widget[name=group_ids] .o_inner_group:eq(1) input:eq(0)").toHaveAttribute(
+        "placeholder",
+        "Project Manager"
     );
-    expect(
-        ".o_field_widget[name=group_ids] .o_inner_group:eq(1) select:eq(0) option.o_select_placeholder"
-    ).toHaveText("Project Manager");
-    expect(".o_field_widget[name=group_ids] .o_inner_group:eq(1) select:eq(1)").toHaveValue("15");
 
     await contains(".o_inner_group:eq(1) .o_group_info_button:eq(0)").click();
     expect(".o_popover").toHaveCount(1);
@@ -507,21 +520,31 @@ test("implied groups: lower level groups no longer available", async () => {
         resId: 1,
     });
 
-    expect(".o_inner_group:eq(1) select").toHaveCount(2);
-    expect(".o_inner_group:eq(1) select:eq(0)").toHaveValue("11");
-    expect(".o_inner_group:eq(1) select:eq(0) option:not(.d-none)").toHaveCount(4);
-    expect(".o_inner_group:eq(1) select:eq(1)").toHaveValue("false");
+    expect(".o_inner_group:eq(1) .o_select_menu").toHaveCount(2);
+    await contains(queryFirst(".o_inner_group:eq(1) .o_wrap_input input")).click();
+    expect(queryFirst(".o_inner_group:eq(1) .o_wrap_input input")).toHaveValue("Project User");
+    expect(".o_select_menu_item").toHaveCount(3);
+    expect(".o_inner_group:eq(1) .o_wrap_input:last-child input").toHaveValue("");
+    await editSelectMenu(
+        ".o_field_widget[name='group_ids'] .o_inner_group:nth-child(2) .o_wrap_input:last-child input",
+        { value: "Helpdesk Administrator" }
+    );
 
-    await contains(".o_inner_group:eq(1) select:eq(1)").select("15");
-    expect(".o_inner_group:eq(1) select:eq(0)").toHaveValue("false");
-    expect(".o_inner_group:eq(1) select:eq(0) option.o_select_placeholder").toHaveText(
+    await contains(queryFirst(".o_inner_group:eq(1) .o_wrap_input input")).click();
+    expect(queryFirst(".o_inner_group:eq(1) .o_wrap_input input")).toHaveValue("");
+    expect(queryFirst(".o_inner_group:eq(1) .o_wrap_input input")).toHaveAttribute(
+        "placeholder",
         "Project Manager"
     );
-    expect(".o_inner_group:eq(1) select:eq(0) option:not(.d-none)").toHaveCount(2);
+    expect(".o_select_menu_item").toHaveCount(2);
+    await editSelectMenu(
+        ".o_field_widget[name='group_ids'] .o_inner_group:nth-child(2) .o_wrap_input:last-child input",
+        { value: "Helpdesk User" }
+    );
 
-    await contains(".o_inner_group:eq(1) select:eq(1)").select("14");
-    expect(".o_inner_group:eq(1) select:eq(0)").toHaveValue("11");
-    expect(".o_inner_group:eq(1) select:eq(0) option:not(.d-none)").toHaveCount(4);
+    expect(queryFirst(".o_inner_group:eq(1) .o_wrap_input input")).toHaveValue("Project User");
+    await contains(queryFirst(".o_inner_group:eq(1) .o_wrap_input input")).click();
+    expect(".o_select_menu_item").toHaveCount(3);
 });
 
 test("implied groups: lower level groups of same privilege still available", async () => {
@@ -537,7 +560,8 @@ test("implied groups: lower level groups of same privilege still available", asy
         resModel: "res.users",
         resId: 1,
     });
-    expect(".o_inner_group:eq(1) select:eq(0) option:not(.d-none)").toHaveCount(4);
+    await contains(queryFirst(".o_inner_group:eq(1) .o_wrap_input input")).click();
+    expect(".o_select_menu_item").toHaveCount(3);
 });
 
 test("do not lose shadowed groups when editing", async () => {
@@ -560,18 +584,22 @@ test("do not lose shadowed groups when editing", async () => {
         resId: 1,
     });
 
-    expect(".o_inner_group:eq(1) select:eq(0)").toHaveValue("false");
-    expect(".o_inner_group:eq(1) select:eq(0) option.o_select_placeholder").toHaveText(
+    await contains(queryFirst(".o_inner_group:eq(1) .o_wrap_input input")).click();
+    expect(queryFirst(".o_inner_group:eq(1) .o_wrap_input input")).toHaveValue("");
+    expect(queryFirst(".o_inner_group:eq(1) .o_wrap_input input")).toHaveAttribute(
+        "placeholder",
         "Project Manager"
     );
-    expect(".o_inner_group:eq(1) select:eq(0) option:not(.d-none)").toHaveCount(2);
+    expect(".o_select_menu_item").toHaveCount(2);
 
-    await contains(".o_inner_group:eq(0) select").select("2");
-    expect(".o_inner_group:eq(1) select:eq(0)").toHaveValue("false");
-    expect(".o_inner_group:eq(1) select:eq(0) option.o_select_placeholder").toHaveText(
+    await editSelectMenu(".o_inner_group:eq(0) .o_wrap_input input", { value: "Settings " });
+    await contains(queryFirst(".o_inner_group:eq(1) .o_wrap_input input")).click();
+    expect(queryFirst(".o_inner_group:eq(1) .o_wrap_input input")).toHaveValue("");
+    expect(queryFirst(".o_inner_group:eq(1) .o_wrap_input input")).toHaveAttribute(
+        "placeholder",
         "Project Manager"
     );
-    expect(".o_inner_group:eq(1) select:eq(0) option:not(.d-none)").toHaveCount(2);
+    expect(".o_select_menu_item").toHaveCount(2);
 
     await contains(".o_form_button_save").click();
     expect.verifySteps(["web_save"]);
@@ -597,13 +625,16 @@ test("do not keep shadowed group if higher level group is set", async () => {
         resId: 1,
     });
 
-    expect(".o_inner_group:eq(1) select:eq(0)").toHaveValue("false");
-    expect(".o_inner_group:eq(1) select:eq(0) option.o_select_placeholder").toHaveText(
+    await contains(queryFirst(".o_inner_group:eq(1) .o_wrap_input input")).click();
+    expect(queryFirst(".o_inner_group:eq(1) .o_wrap_input input")).toHaveValue("");
+    expect(queryFirst(".o_inner_group:eq(1) .o_wrap_input input")).toHaveAttribute(
+        "placeholder",
         "Project Manager"
     );
-    expect(".o_inner_group:eq(1) select:eq(0) option:not(.d-none)").toHaveCount(2);
-
-    await contains(".o_inner_group:eq(1) select:eq(0)").select("13");
+    expect(".o_select_menu_item").toHaveCount(2);
+    await editSelectMenu(".o_inner_group:eq(1) .o_wrap_input input", {
+        value: "Project Administrator",
+    });
     await contains(".o_form_button_save").click();
     expect.verifySteps(["web_save"]);
 });
@@ -700,11 +731,11 @@ test("privileges without category", async () => {
     expect(".o_field_widget[name=group_ids] .o_inner_group:eq(2) .o_form_label").toHaveText(
         "Other privilege"
     );
-    expect(".o_field_widget[name=group_ids] .o_inner_group:eq(2) select").toHaveCount(1);
-    expect(".o_field_widget[name=group_ids] .o_inner_group:eq(2) select option").toHaveCount(3);
-
-    await click(".o_field_widget[name=group_ids] .o_inner_group:eq(2) select");
-    await select("694");
+    await contains(".o_field_widget[name='group_ids'] .o_inner_group:eq(2) input").click();
+    expect(`.o_select_menu_item`).toHaveCount(2);
+    await editSelectMenu(".o_field_widget[name='group_ids'] .o_inner_group:eq(2) input", {
+        value: "Group 2 in Other Privilege",
+    });
     await contains(`.o_form_button_save`).click();
     expect.verifySteps(["web_save"]);
 });

--- a/addons/website/static/tests/builder/custom_tab/builder_components/basic_many2many.test.js
+++ b/addons/website/static/tests/builder/custom_tab/builder_components/basic_many2many.test.js
@@ -65,7 +65,6 @@ test("basic many2many: find tag, select tag, unselect tag", async () => {
     expect("table tr").toHaveCount(1);
 
     await contains(".btn.o-dropdown").click();
-    await contains("input[placeholder]").click();
     await delay(300); // debounce
     await animationFrame();
     expect("span.o-dropdown-item").toHaveCount(2);

--- a/addons/website/static/tests/builder/custom_tab/builder_components/builder_many2many.test.js
+++ b/addons/website/static/tests/builder/custom_tab/builder_components/builder_many2many.test.js
@@ -57,7 +57,6 @@ test("many2many: find tag, select tag, unselect tag", async () => {
     expect("table tr").toHaveCount(1);
 
     await contains(".btn.o-dropdown").click();
-    await contains("input[placeholder]").click();
     await delay(300); // debounce
     await animationFrame();
     expect("span.o-dropdown-item").toHaveCount(2);

--- a/addons/website/static/tests/builder/custom_tab/builder_components/model_many2many.test.js
+++ b/addons/website/static/tests/builder/custom_tab/builder_components/model_many2many.test.js
@@ -65,7 +65,6 @@ test("model many2many: find tag, select tag, unselect tag", async () => {
     expect("table tr").toHaveCount(1);
 
     await contains(".btn.o-dropdown").click();
-    await contains("input[placeholder]").click();
     await delay(300); // debounce
     await animationFrame();
     expect("span.o-dropdown-item").toHaveCount(2);

--- a/addons/website_blog/static/tests/tours/blog_tags_tour.js
+++ b/addons/website_blog/static/tests/tours/blog_tags_tour.js
@@ -29,15 +29,20 @@ registerWebsitePreviewTour('blog_tags', {
         content: "Open tag dropdown",
         trigger: "[data-label='Tags'] button.o_select_menu_toggler",
         run: "click",
-    }, {
+    },
+    {
         content: "Enter tag name",
-        trigger: ".dropdown-menu input",
-        run: "edit testtag",
-    }, {
+        trigger: ".o_select_menu_input",
+        run: async function() {
+            this.anchor.value = "testtag";
+            this.anchor.dispatchEvent(new InputEvent("input"));
+        }
+    },
+    {
         content: "Save tag",
         trigger: ".dropdown-menu a.o_we_m2o_create",
         run: "click",
-    }, 
+    },
     {
         content: "Verify tag appears in options",
         trigger: "[data-label='Tags'] table input[data-name='testtag']",

--- a/addons/website_event_track/static/src/xml/website_event_track_form_tags_wrapper.xml
+++ b/addons/website_event_track/static/src/xml/website_event_track_form_tags_wrapper.xml
@@ -4,9 +4,9 @@
 <t t-name="website_event_track.WebsiteEventTrackProposalFormTagsWrapper">
     <input name="tags" type="hidden" class="form-control o_wetrack_select_tags d-none" t-att-value="state.value"/>
     <SelectMenu
+        togglerClass="'form-control'"
         choices="state.defaultChoices"
         multiSelect="true"
-        searchable="true"
         onSelect.bind="onSelect"
         value="state.value"
         placeholder="state.placeholder"/>

--- a/addons/website_forum/static/src/components/website_forum_tags_wrapper.js
+++ b/addons/website_forum/static/src/components/website_forum_tags_wrapper.js
@@ -23,18 +23,17 @@ export class WebsiteForumTagsWrapper extends Component {
         });
     }
 
-    get showCreateOption() {
+    showCreateOption(searchValue) {
         // The "Create" option should not be visible if:
         // 1. Tag length is less than 2.
         // 2. The tag already exists (tags are created on form submission, so
         // consider the current value).
         // 3. There is insufficient karma.
-        const searchValue = this.select.data.searchValue;
         const karma = document.querySelector("#karma").value;
         const editKarma = document.querySelector("#karma_edit_retag").value;
         const hasEnoughKarma = parseInt(karma) >= parseInt(editKarma);
 
-        return hasEnoughKarma && searchValue.length >= 2
+        return hasEnoughKarma && searchValue?.length >= 2
             && !this.state.choices.some(c => c.label === searchValue)
             && !this.state.value.some(v => v === `_${searchValue.trim()}`);
     }

--- a/addons/website_forum/static/src/js/tours/website_forum.js
+++ b/addons/website_forum/static/src/js/tours/website_forum.js
@@ -34,17 +34,17 @@ registerBackendAndFrontendTour("question", {
     content: _t("Insert tags related to your question."),
     tooltipPosition: "top",
     run: "click",
-}, 
-{
-    trigger: ".o_select_menu_sticky",
-    run: "edit Test",
 },
 {
-    trigger: `.o_popover input.o_select_menu_sticky:not(:contains(Please enter 2 or more characters))`,
+    trigger: ".o_select_menu input",
+    run: async function() {
+        this.anchor.value = "Test";
+        this.anchor.dispatchEvent(new InputEvent("input"));
+    }
 },
 {
     content: "Select found select menu item",
-    trigger: ".o_popover.o_select_menu_menu .o_select_menu_item span:contains('Test')",
+    trigger: ".o_popover.o_select_menu_menu .o_select_menu_item:contains('Test')",
     run: 'click',
 },
 {

--- a/addons/website_forum/static/src/xml/website_forum_tags_wrapper.xml
+++ b/addons/website_forum/static/src/xml/website_forum_tags_wrapper.xml
@@ -4,16 +4,18 @@
 <t t-name="website_forum.WebsiteForumTagsWrapper">
     <input name="post_tags" type="hidden" class="form-control" t-att-value="state.value"/>
     <SelectMenu
+        togglerClass="'form-control'"
         choices="state.choices"
         value="state.value"
         onInput.bind="loadChoices"
         onSelect.bind="onSelect"
         multiSelect="true"
-        placeholder.translate="'Tags'"
+        placeholder.translate="Tags"
         disabled="props.isReadOnly"
-        searchPlaceholder.translate="'Please enter 2 or more characters'">
-        <t t-if="showCreateOption" t-set-slot="bottomArea" t-slot-scope="select">
+        searchPlaceholder.translate="Please enter 2 or more characters">
+        <t t-set-slot="bottomArea" t-slot-scope="select">
             <DropdownItem
+                t-if="this.showCreateOption(select.data.searchValue)"
                 onSelected="() => this.onCreateOption(select.data.searchValue)"
                 class="'o_select_menu_item p-2'"
             >

--- a/addons/website_forum/static/tests/tours/website_forum_question.js
+++ b/addons/website_forum/static/tests/tours/website_forum_question.js
@@ -30,11 +30,8 @@ registry.category("web_tour.tours").add('forum_question', {
         run: 'click',
     },
     {
-        trigger: '.o_popover input.o_select_menu_sticky',
+        trigger: '.o_select_menu_toggler',
         run: 'edit Tag',
-    },
-    {
-        trigger: "#wrap:not(:has(.o_popover input.o_select_menu_sticky:not(:contains(''))))",
     },
     {
         content: "Click to post your question.",

--- a/addons/website_links/static/src/xml/website_links_tags_wrapper.xml
+++ b/addons/website_links/static/src/xml/website_links_tags_wrapper.xml
@@ -5,6 +5,7 @@
     <input t-att-name="props.model.split('.')[1]+'-select'" type="hidden" class="form-control" t-att-value="state.value"/>
     <SelectMenu
         t-props="state"
+        togglerClass="'form-control'"
         onInput.bind="loadChoice"
         onSelect.bind="onSelect">
         <t t-if="showCreateOption" t-set-slot="bottomArea" t-slot-scope="select">

--- a/addons/website_links/static/tests/tours/website_links.js
+++ b/addons/website_links/static/tests/tours/website_links.js
@@ -10,18 +10,20 @@ function fillSelectMenu(inputID, search) {
         },
         {
             content: "Enter selectMenu search query",
-            trigger: ".o_popover input.o_select_menu_sticky",
-            run: `edit ${search}`,
+            trigger: `.o_website_links_utm_forms div#${inputID} .o_select_menu_input`,
+            run: async function() {
+                this.anchor.value = search;
+                this.anchor.dispatchEvent(new InputEvent("input"));
+            }
         },
         {
             content: "Select found selectMenu item",
-            trigger: `.o_popover span.o_select_menu_item div.o_select_menu_item_label:contains("/^${search}$/")`,
+            trigger: `.o_popover .o_select_menu_item:contains("${search}")`,
             run: "click",
         },
         {
             content: "Check that selectMenu is properly filled",
-            trigger: `#${inputID} .o_select_menu_toggler span.o_select_menu_toggler_slot:contains('/^${search}$/')`,
-            run: () => null,
+            trigger: `#${inputID} .o_select_menu_toggler:value('${search}')`,
         },
     ];
 }
@@ -47,25 +49,7 @@ registry.category("web_tour.tours").add('website_links_tour', {
             },
         },
         // First try to create a new UTM campaign from the UI
-        {
-            content: "Click select menu form item",
-            trigger: ".o_website_links_utm_forms div#campaign-select-wrapper .o_select_menu_toggler",
-            run: "click",
-        },
-        {
-            content: "Enter select menu search query",
-            trigger: '.o_popover input.o_select_menu_sticky',
-            run: "edit Some new campaign",
-        },
-        {
-            content: "Select found select menu item",
-            trigger: ".o_popover.o_select_menu_menu .o_select_menu_item span:contains('Some new campaign')",
-            run: 'click',
-        },
-        {
-            content: "Check that select menu is properly filled",
-            trigger: "#campaign-select-wrapper .o_select_menu_toggler span.o_select_menu_toggler_slot:contains('Some new campaign')"
-        },
+        ...fillSelectMenu("campaign-select-wrapper", "Some new campaign"),
         // Then proceed by using existing ones
         ...fillSelectMenu("campaign-select-wrapper", campaignValue),
         ...fillSelectMenu("channel-select-wrapper", mediumValue),

--- a/addons/website_slides/static/src/js/public/components/course_tag_add_dialog/course_tag_add_dialog.xml
+++ b/addons/website_slides/static/src/js/public/components/course_tag_add_dialog/course_tag_add_dialog.xml
@@ -16,10 +16,10 @@
             <div class="mb-3" t-att-class="{'form-control is-valid': validation.tagIsValid, 'form-control is-invalid': validation.tagIsValid === false}">
                 <label class="col-form-label">Tag</label>
                 <SelectMenu
+                    togglerClass="'form-control'"
                     choices="choices.tagIds"
                     onSelect.bind="onTagSelect"
-                    required="true" 
-                    togglerClass="'text-dark pe-1'"
+                    required="true"
                     value="choices.tagId"
                 >
                     <t t-out="displayTagValue"/>
@@ -36,11 +36,11 @@
             </div>
             <div t-if="state.showTagGroup" class="mb-3" t-att-class="{'form-control is-valid': validation.tagGroupIsValid, 'form-control is-invalid': validation.tagGroupIsValid === false}">
                 <label class="col-form-label">Tag Group</label>
-                <SelectMenu 
+                <SelectMenu
+                    togglerClass="'form-control'"
                     choices="choices.tagGroupIds"
                     onSelect.bind="onTagGroupSelect"
                     required="true"
-                    togglerClass="'text-dark pe-1'"
                     value="choices.tagGroupId"
                 >
                     <t t-out="displayTagGroupValue"/>

--- a/addons/website_slides/static/src/js/public/components/slide_upload_dialog/slide_upload_category.xml
+++ b/addons/website_slides/static/src/js/public/components/slide_upload_dialog/slide_upload_category.xml
@@ -93,10 +93,10 @@
         <div t-if="!state.defaultCategoryID" class="mb-3">
             <label for="category_id" class="col-form-label">Section</label>
             <SelectMenu
+                togglerClass="'form-control'"
                 choices="state.choices.categories"
                 value="state.choices.categoryId"
                 onSelect.bind="onCategorySelect"
-                togglerClass="'text-dark pe-1'"
             >
                 <t t-out="displayCategoryValue"/>
                 <t t-set-slot="bottomArea" t-slot-scope="select">
@@ -117,7 +117,6 @@
                 multiSelect="true"
                 value="state.choices.tagIds"
                 onSelect.bind="onTagsSelect"
-                togglerClass="'text-dark pe-1'"
             >
                 <t t-set-slot="bottomArea" t-slot-scope="select">
                     <DropdownItem

--- a/addons/website_slides/static/tests/tours/slides_tour_tools.js
+++ b/addons/website_slides/static/tests/tours/slides_tour_tools.js
@@ -120,7 +120,7 @@ var addArticleToSection = function (sectionName, pageName, backend) {
     run: "click",
 }, {
     content: 'eLearning: select Practice tag',
-    trigger: prefix + 'div.o_select_menu_item_label:contains("Practice")',
+    trigger: prefix + 'div.o_select_menu_item:contains("Practice")',
     run: "click",
 }, {
 	content: 'eLearning: fill article completion time',
@@ -276,7 +276,7 @@ var addExistingCourseTag = function (backend = false) {
         ...clickOnAddTagDropdown(prefix),
 {
     content: 'eLearning: select advanced tag',
-    trigger: prefix + 'div.o_select_menu_item_label:contains("Advanced")',
+    trigger: prefix + '.o_select_menu_item:contains("Advanced")',
     run: "click",
 }, {
     content: 'eLearning: add existing course tag',
@@ -306,7 +306,7 @@ var addNewCourseTag = function (courseTagName, backend) {
     run: "click",
 }, {
 	content: 'eLearning: select Tags tag group',
-    trigger: prefix + 'div.o_select_menu_item_label:contains("Tags")',
+    trigger: prefix + '.o_select_menu_item:contains("Tags")',
     run: "click",
 }, {
     content: 'eLearning: add new course tag',

--- a/addons/website_slides_survey/static/src/js/public/components/slide_upload_dialog/slide_upload_category.xml
+++ b/addons/website_slides_survey/static/src/js/public/components/slide_upload_dialog/slide_upload_category.xml
@@ -8,11 +8,10 @@
         <xpath expr="//canvas[@id='data_canvas']" position="before">
             <t t-if="props.slideCategory === 'certification'">
                 <SelectMenu
-                    choices="state.choices.certifications" 
+                    choices="state.choices.certifications"
                     value="state.choices.certificationId"
                     required="true"
                     onSelect.bind="onCertificationSelect"
-                    togglerClass="'text-dark pe-1'"
                 >
                     <t t-out="displayCertificationValue"/>
                 </SelectMenu>

--- a/odoo/addons/test_main_flows/static/tests/tours/main_flow.js
+++ b/odoo/addons/test_main_flows/static/tests/tours/main_flow.js
@@ -555,16 +555,24 @@ stepUtils.autoExpandMoreButtons(),
         }
     },
 }, {
-    trigger: '.o_field_widget[name=service_policy] select',
+    trigger: ".o_field_widget[name=service_policy] input",
     content: _t('Change service policy'),
     tooltipPosition: 'left',
-    run: `select "delivered_timesheet"`,
+    run: "click",
 }, {
-    trigger: '.o_field_widget[name=service_tracking] select',
-    content: _t('Change track service'),
+    content: "Select",
+    trigger: ".o_select_menu_item:contains(Based on Timesheets)",
+    run: "click",
+},  {
+    trigger: ".o_field_widget[name=service_tracking] input",
+    content: _t('Change service policy'),
     tooltipPosition: 'left',
-    run: `select "task_global_project"`,
+    run: "click",
 }, {
+    content: "Select",
+    trigger: ".o_select_menu_item:contains(Task)",
+    run: "click",
+},{
     isActive: ["desktop"],
     trigger: '.o_field_widget[name=project_id] input',
     content: _t('Choose project'),


### PR DESCRIPTION
*: account, base_automation, project, test_mail, website, website_forum, website_helpdesk

This commit reworks the SelectMenu component, to make it more consistent with the many2one input and dropdown style and behavior. Now, an input is directly present in the toggler, and the value can be edited or removed from this input directly, without the need for a dedicated 'delete' button, and the implementation of a toggler displaying the value and/or placeholder, since all of that is handled by the input.

Only on small screens, we keep the input visible inside the list of options, since it is more convenient to use, while displaying possible options.

The implementation has been overall simplified, and tests have been adapted as well. For example, the 'multiSelect' props was not used, and could be removed.

In the 'account' module, the AccountTypeSelection field has been adapted to be used properly with the latest version of the component.

In the 'base_automation' module, the TriggerSelectionField has also been adapted and the grouping/sorting code has been reworked slightly.

task-4270518