### PR TITLE
[FIX] l10n_ar: fix table size in pdf form

### DIFF
--- a/addons/l10n_ar/views/report_invoice.xml
+++ b/addons/l10n_ar/views/report_invoice.xml
@@ -280,7 +280,7 @@
 
         <div id="qrcode" position="after">
             <!-- RG 5614/2024: Show ARCA VAT and Other National Internal Taxes -->
-            <div class="col-sm-7 col-md-6">
+            <div t-attf-class="#{'col-6' if report_type != 'html' else 'col-sm-7 col-md-6'}">
                 <table class="table table-sm table-borderless" style="page-break-inside: avoid;" t-if="tax_totals.get('detail_ar_tax')">
                     <th class="border-black" style="border-bottom: 1px solid" colspan="2">
                            Fiscal Transparency Regime for the Final Consumer (Law 27.743)


### PR DESCRIPTION
The tax breakdown is required by Argentinian law to be displayed in the bottom left corner of the invoice report. This was added in [^1] and works well for the HTML view but min-width related classes don't work well with pdf rendering, so the table stretched across the entire width of the pdf.

The fix is to follow the rest of the file and use a fixed col width on the table for the pdf view.

task-4779975

[^1]: https://github.com/odoo/odoo/pull/201257