### PR TITLE
[FIX] account_peppol: prevent error on activating PEPPOL Electronic Invoicing

### DIFF
--- a/addons/account_peppol/wizard/peppol_registration.py
+++ b/addons/account_peppol/wizard/peppol_registration.py
@@ -80,7 +80,7 @@ class PeppolRegistration(models.TransientModel):
                 with contextlib.suppress(phonenumbers.NumberParseException):
                     parsed_phone_number = phonenumbers.parse(
                         wizard.phone_number,
-                        region=wizard.company_id.country_code,
+                        region=wizard.company_id.country_code or None,
                     )
                     wizard.phone_number = phonenumbers.format_number(
                         parsed_phone_number,


### PR DESCRIPTION
Currently, an error occurs when attempting to activate `PEPPOL Electronic
Invoicing` without a country set on the company profile.

**Steps to produce:**

- Install `l10n_be` and `account_peppol` modules.
- Switch to `BE Company CoA`.
- Navigate to: `Settings > Users & Companies > Companies > BE Company CoA` and
  remove the `country name` from the `Address`.
- Open `Settings`, search `'PEPPOL Electronic Invoicing'`, and click on
  `'Activate Electronic Invoicing'`.

**Error:**
`AttributeError: 'bool' object has no attribute 'upper'`

**Root Cause:**
At [1], `wizard.company_id.country_code` is `False`, and calling `.upper()` on it
raises an `error`.

[1]
https://github.com/odoo/odoo/blob/c88c1e2f69c7cb25ac9c51d91ea7f47c9236e229/addons/account_peppol/wizard/peppol_registration.py#L83

This commit prevents error when user activate `PEPPOL Electronic Invoicing` and
country is not set on company profile.

Sentry – 6680941491