### PR TITLE
[FIX] l10n_co: try loading coa for parent company first

### DIFF
--- a/addons/l10n_co/migrations/1.0/end-migrate_update_taxes.py
+++ b/addons/l10n_co/migrations/1.0/end-migrate_update_taxes.py
@@ -4,5 +4,5 @@ from odoo import api, SUPERUSER_ID
 
 def migrate(cr, version):
     env = api.Environment(cr, SUPERUSER_ID, {})
-    for company in env['res.company'].search([('chart_template', '=', 'co')]):
+    for company in env['res.company'].search([('chart_template', '=', 'co')], order="parent_path"):
         env['account.chart.template'].try_loading('co', company)


### PR DESCRIPTION
In migration scripts, while loading the chart of accounts, we should always initiate with parent companies to avoid creating duplicate chart records.

When a new account is added and the chart is loaded from the child company before the parent (due to sequence, name ordering), the account will be created for both companies. Sometimes resulting into singleton error from [here](https://github.com/odoo/enterprise/blob/saas-18.3/account_reports/models/chart_template.py#L31).

With this commit, the COA for Colombian-based companies will now be loaded hierarchically — i.e. parent company first — ensuring proper inheritance and avoiding redundant account or journal creation.

Community PR - #182706 
UPG - [2982418](https://upgrade.odoo.com/odoo/upgrade.request/2982418)

Traceback faced:

```python
Traceback (most recent call last):
  File "/home/odoo/src/odoo/saas-18.3/odoo/service/server.py", line 1396, in preload_registries
    registry = Registry.new(dbname, update_module=update_module, install_modules=config['init'], upgrade_modules=config['update'])
  File "<decorator-gen-6>", line 2, in new
  File "/home/odoo/src/odoo/saas-18.3/odoo/tools/func.py", line 83, in locked
    return func(inst, *args, **kwargs)
  File "/home/odoo/src/odoo/saas-18.3/odoo/orm/registry.py", line 167, in new
    load_modules(
  File "/home/odoo/src/odoo/saas-18.3/odoo/modules/loading.py", line 487, in load_modules
    migrations.migrate_module(package, 'end')
  File "/home/odoo/src/odoo/saas-18.3/odoo/modules/migration.py", line 220, in migrate_module
    exec_script(self.cr, installed_version, pyfile, pkg.name, stage, stageformat[stage] % version)
  File "/home/odoo/src/odoo/saas-18.3/odoo/modules/migration.py", line 257, in exec_script
    mod.migrate(cr, installed_version)
  File "/home/odoo/src/odoo/saas-18.3/addons/l10n_co/migrations/1.0/end-migrate_update_taxes.py", line 8, in migrate
    env['account.chart.template'].try_loading('co', company)
  File "/home/odoo/src/odoo/saas-18.3/addons/account/models/chart_template.py", line 160, in try_loading
    return self._load(template_code, company, install_demo, force_create)
  File "/home/odoo/src/odoo/saas-18.3/addons/account/models/chart_template.py", line 244, in _load
    self._load(template_code, subsidiary, install_demo, force_create)
  File "/home/odoo/src/odoo/saas-18.3/addons/account/models/chart_template.py", line 227, in _load
    self._post_load_data(template_code, company, template_data)
  File "/home/odoo/src/enterprise/saas-18.3/account_reports/models/chart_template.py", line 29, in _post_load_data
    'account_tax_return_journal_id': closing_journal.id,
  File "/home/odoo/src/odoo/saas-18.3/odoo/orm/fields_misc.py", line 117, in __get__
    raise ValueError("Expected singleton: %s" % record)
ValueError: Expected singleton: account.journal(28, 29)
```

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
