### PR TITLE
[IMP] mrp: prevent invalid work order actions on cancelled/done MOs

### DIFF
--- a/addons/mrp/models/mrp_bom.py
+++ b/addons/mrp/models/mrp_bom.py
@@ -80,7 +80,7 @@ class MrpBom(models.Model):
     possible_product_template_attribute_value_ids = fields.Many2many(
         'product.template.attribute.value',
         compute='_compute_possible_product_template_attribute_value_ids')
-    allow_operation_dependencies = fields.Boolean('Operation Dependencies',
+    allow_operation_dependencies = fields.Boolean('Custom Operation Dependencies',
         help="Create operation level dependencies that will influence both planning and the status of work orders upon MO confirmation. If this feature is ticked, and nothing is specified, Odoo will assume that all operations can be started simultaneously."
     )
     produce_delay = fields.Integer(

--- a/addons/mrp/models/mrp_workorder.py
+++ b/addons/mrp/models/mrp_workorder.py
@@ -313,6 +313,11 @@ class MrpWorkorder(models.Model):
             if self.env.context.get('prefix_product'):
                 wo.display_name = f"{wo.product_id.name} - {wo.production_id.name} - {wo.name}"
 
+    @api.ondelete(at_uninstall=False)
+    def _unlink_except_done(self):
+        if any(wo.state == 'done' for wo in self):
+            raise UserError(self.env._('Cannot delete a work order in done state.'))
+
     def unlink(self):
         # Removes references to workorder to avoid Validation Error
         (self.mapped('move_raw_ids') | self.mapped('move_finished_ids')).write({'workorder_id': False})

--- a/addons/mrp/views/mrp_production_views.xml
+++ b/addons/mrp/views/mrp_production_views.xml
@@ -476,7 +476,7 @@
                         <page string="Work Orders" name="operations" groups="mrp.group_mrp_routings">
                             <field name="workorder_ids"
                                 context="{'list_view_ref': 'mrp.mrp_production_workorder_tree_editable_view_mo_form', 'from_manufacturing_order': True}"
-                                options="{'create': [('id', '!=', False), ('state', '!=', 'done')]}"
+                                options="{'create': [('id', '!=', False), ('state', 'not in', ['done', 'cancel'])], 'delete': [('state', 'not in', ['done', 'cancel'])]}"
                                 />
                         </page>
                         <page string="By-Products" name="finished_products" groups="mrp.group_mrp_byproducts">


### PR DESCRIPTION
Currently, work orders can still be added to cancelled manufacturing orders,
and deletion actions remain available even after a manufacturing order or work
order reaches a terminal state. This can lead to inconsistent data and
unintended user actions, particularly in B2B manufacturing flows.

This change tightens work order management by preventing the creation of work
orders on cancelled manufacturing orders and disallowing the deletion of work
orders that are already completed. The user interface is also adjusted to hide
deletion options when they are no longer relevant, reducing the risk of
accidental actions and making the workflow clearer.

Additionally, the “Operation Dependencies” field is renamed to
“Custom Operation Dependencies” to better reflect its purpose and avoid
ambiguity.

Overall, these improvements enhance usability, enforce data consistency,
'and help users avoid invalid operations during the lifecycle of
manufacturing orders.

Task ID: 4813058