### PR TITLE
[IMP] rating: Hide author name in livechat rating feedback

### DIFF
--- a/addons/rating/models/mail_thread.py
+++ b/addons/rating/models/mail_thread.py
@@ -138,11 +138,18 @@ class MailThread(models.AbstractModel):
                 fields.Datetime.now() + datetime.timedelta(hours=2)
                 if notify_delay_send else None
             )
-            rating_body = (
-                    markupsafe.Markup(
-                        "<img src='%s' alt=':%s/5' style='width:18px;height:18px;float:left;margin-right: 5px;'/>%s"
-                    ) % (rating.rating_image_url, rate, feedback)
-            )
+            if (self.channel_type == 'livechat'):
+                rating_body = (
+                        markupsafe.Markup(
+                            "<div class='o_mail_notification o_hide_author'>Rating: <img src='%s' alt=':%s/5' style='width:18px;height:18px;'/><br/>%s</div>",
+                        ) % (rating.rating_image_url, rate, feedback)
+                )
+            else:
+                rating_body = (
+                        markupsafe.Markup(
+                            "<img src='%s' alt=':%s/5' style='width:18px;height:18px;float:left;margin-right: 5px;'/>%s",
+                        ) % (rating.rating_image_url, rate, feedback)
+                )
 
             if rating.message_id:
                 self._message_update_content(


### PR DESCRIPTION
This commit hides the author name (e.g., Visitor 234) from rating feedback messages in livechat sessions of demo data. Only the rating and feedback content are shown now, as intended.

**Current behavior before PR:**
![image](https://github.com/user-attachments/assets/df1b6ce7-1f04-4fb0-af08-8797bb9e852c)

**Desired behavior after PR is merged:**
![image](https://github.com/user-attachments/assets/c8e4d447-190a-47d1-87e9-3a31c98d9d66)

Task - 4671525