### PR TITLE
[FIX] account: handle decimal.InvalidOperation in Original Bills

### DIFF
--- a/addons/account/models/ir_actions_report.py
+++ b/addons/account/models/ir_actions_report.py
@@ -38,7 +38,7 @@ class IrActionsReport(models.Model):
                     record = self.env[attachment.res_model].browse(attachment.res_id)
                     try:
                         stream = pdf.add_banner(stream, record.name, logo=True)
-                    except (ValueError, PdfReadError, TypeError, zlib_error, NotImplementedError, DependencyError):
+                    except (ValueError, PdfReadError, TypeError, zlib_error, NotImplementedError, DependencyError, ArithmeticError):
                         record._message_log(body=_(
                             "There was an error when trying to add the banner to the original PDF.\n"
                             "Please make sure the source file is valid."


### PR DESCRIPTION
**Steps to reproduce:**
- Install Accounting
- Upload some particular PDF as a bill
- Go to the bills list view
- Select the uploaded bill
- Print "Original Bills"

**Issue:**
A traceback is raised: "Arbitrary Uncaught Python Exception"

Cause:
When printing the original bill, we try to add a banner on the PDF. In this case, PyPDF2 fails to add a banner and raises an error from decimal library (i.e. "decimal.InvalidOperation") that is not catched.

**Solution:**
Bypass the addition of the banner in such case by handling the error.

opw-4829787




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
