### PR TITLE
[FIX] survey: fix missing query count

### DIFF
--- a/addons/survey/tests/test_survey_flow.py
+++ b/addons/survey/tests/test_survey_flow.py
@@ -95,7 +95,7 @@ class TestSurveyFlow(common.TestSurveyCommon, HttpCase):
             page0_q1.id: {'value': ['44.0']},
         }
         post_data = self._format_submission_data(page_0, answer_data, {'csrf_token': csrf_token, 'token': answer_token, 'button_submit': 'next'})
-        r = self._access_submit(survey, answer_token, post_data, query_count=44)  # ! 44 without `website` (single app CI), 37 `survey+website`, 38 "full" runbot
+        r = self._access_submit(survey, answer_token, post_data, query_count=45)  # ! 45 without `website` (single app CI), 38 `survey+website`, 39 "full" runbot
         self.assertResponse(r, 200)
         answers.invalidate_recordset()  # TDE note: necessary as lots of sudo in controllers messing with cache
 


### PR DESCRIPTION
Fix missing query count following the addition of
the survey button update depending on the selected answers and if they trigger conditional questions.

One more query to access the suggested_answer_ids.

related: odoo/odoo#212890

Runbot error: 226757

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
