### PR TITLE
[FIX] l10n_ae: align VAT column header in AE invoice

### DIFF
--- a/addons/l10n_ae/views/report_invoice_templates.xml
+++ b/addons/l10n_ae/views/report_invoice_templates.xml
@@ -16,7 +16,7 @@
 
         <xpath expr="//thead//th[@name='th_taxes']" position="replace">
             <th name="th_taxes"
-                t-attf-class="text-start {{ 'd-none d-md-table-cell' if report_type == 'html' else '' }}">
+                t-attf-class="text-end {{ 'd-none d-md-table-cell' if report_type == 'html' else '' }}">
                 <span t-if="o.company_id.country_id.code == 'AE'">VAT</span>
                 <span t-else="">Taxes</span>
             </th>


### PR DESCRIPTION
**Step to reproduce:**

1. Install l10n_ae module.
2. Create and post a customer invoice with product and Taxes.
3. Print the invoice using the Invoice PDF report.

**Issue:**

The "VAT" columns in the invoice report for AE localization are left-aligned, 
which causes a visual misalignment.

**Cause:**

The header cells for the "VAT" columns use the text-start class, which left-aligns them, 
whereas the VAT data is right-aligned.It arises because the `<th name="th_taxes">` element is 
aligned with text-end in the base view account.report_invoice_document , but it is overridden
for the l10n_ae module with text-start.
https://github.com/odoo/odoo/blob/638268a81ed5a292a02d7fc353c4954159de54e1/addons/account/views/report_invoice.xml#L116

**Solution:**

To fix this, update the alignment of the "VAT" header columns to use text-end,
ensuring consistent alignment.

opw-4863313

Before fix:
![rkth_Before_fix_Vat](https://github.com/user-attachments/assets/685785df-797c-4564-b65f-c12dda369258)

After fix:
![rkth_After_Fix_Vat](https://github.com/user-attachments/assets/db32f7a6-6299-438c-b953-6bfd8b2f508e)
