### PR TITLE
[FIX] website, html_builder: hide header/navbar containers for mega menu

### DIFF
--- a/addons/html_builder/static/src/core/builder_options_plugin.js
+++ b/addons/html_builder/static/src/core/builder_options_plugin.js
@@ -218,7 +218,7 @@ export class BuilderOptionsPlugin extends Plugin {
         }
 
         const previousElementToIdMap = new Map(this.lastContainers.map((c) => [c.element, c.id]));
-        return [...elementToOptions]
+        let containers = [...elementToOptions]
             .sort(([a], [b]) => (b.contains(a) ? 1 : -1))
             .map(([element, options]) => ({
                 id: previousElementToIdMap.get(element) || uniqueId(),
@@ -235,6 +235,13 @@ export class BuilderOptionsPlugin extends Plugin {
                 cloneDisabledReason: this.getCloneDisabledReason(element),
                 optionsContainerTopButtons: this.getOptionsContainerTopButtons(element),
             }));
+        const lastValidContainerIdx = containers.findLastIndex((c) =>
+            this.getResource("no_parent_containers").some((selector) => c.element.matches(selector))
+        );
+        if (lastValidContainerIdx > 0) {
+            containers = containers.slice(lastValidContainerIdx);
+        }
+        return containers;
     }
 
     getPageContainers() {

--- a/addons/website/static/src/builder/plugins/options/mega_menu_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/mega_menu_option_plugin.js
@@ -20,6 +20,7 @@ export class MegaMenuOptionPlugin extends Plugin {
             }),
         ],
         save_handlers: this.saveMegaMenuClasses.bind(this),
+        no_parent_containers: ".o_mega_menu",
     };
 
     getTemplatePrefix() {

--- a/addons/website/static/src/builder/plugins/options/popup_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/popup_option_plugin.js
@@ -43,6 +43,7 @@ class PopupOptionPlugin extends Plugin {
         on_cloned_handlers: this.onCloned.bind(this),
         on_remove_handlers: this.onRemove.bind(this),
         on_snippet_dropped_handlers: this.onSnippetDropped.bind(this),
+        no_parent_containers: ".s_popup",
     };
 
     onCloned({ cloneEl }) {

--- a/addons/website/static/tests/builder/builder_option.test.js
+++ b/addons/website/static/tests/builder/builder_option.test.js
@@ -1,8 +1,10 @@
 import { expect, test } from "@odoo/hoot";
+import { Plugin } from "@html_editor/plugin";
 import { contains } from "@web/../tests/web_test_helpers";
 import {
     addActionOption,
     addOption,
+    addPlugin,
     defineWebsiteModels,
     setupWebsiteBuilder,
 } from "./website_helpers";
@@ -189,4 +191,50 @@ test("Do not activate/update containers if the element clicked is excluded", asy
     expect(".options-container [data-class-action='test']").toHaveCount(1);
     await contains(":iframe .target1").click();
     expect(".options-container").toHaveAttribute("data-container-title", "Target 2");
+});
+
+test("Do not show parent container for no_parent_containers targets", async () => {
+    class TestPlugin extends Plugin {
+            static id = "test";
+            resources = {
+                no_parent_containers: ".test-child-target",
+            };
+        }
+    addPlugin(TestPlugin);
+    addOption({
+        selector: ".test-parent-target",
+        template: xml`<BuilderButton classAction="'test'">Test</BuilderButton>`,
+    });
+    addOption({
+        selector: ".test-child-target",
+        template: xml`<BuilderButton classAction="'test'">Test</BuilderButton>`,
+    });
+    addOption({
+        selector: ".test-grand-child-target",
+        template: xml`<BuilderButton classAction="'test'">Test</BuilderButton>`,
+    });
+    await setupWebsiteBuilder(`
+        <div data-name="Parent" class="test-parent-target">
+            Parent
+            <div data-name="Child" class="test-child-target">
+                Child
+                <div data-name="Grand-child" class="test-grand-child-target">
+                    Grand-Child
+                </div>
+            </div>
+        </div>
+    `);
+
+    await contains(":iframe .test-child-target").click();
+    expect(".options-container").toHaveCount(1);
+    expect(".options-container").toHaveAttribute("data-container-title", "Child");
+    // Try with several layers
+    await contains(":iframe .test-grand-child-target").click();
+    expect(".options-container").toHaveCount(2);
+    expect(".options-container:eq(0)").toHaveAttribute("data-container-title", "Child");
+    expect(".options-container:eq(1)").toHaveAttribute("data-container-title", "Grand-child");
+    // Make sure the parent's options still appear for itself.
+    await contains(":iframe .test-parent-target").click();
+    expect(".options-container").toHaveCount(1);
+    expect(".options-container").toHaveAttribute("data-container-title", "Parent");
 });


### PR DESCRIPTION
Up to 18.3, and since commit [1], when clicking on a mega menu, only the
mega menu options were displayed, while the header and navbar options
were hidden. This behavior was lost with [2].

This commit reintroduces a resource `no_parent_containers` for those
kind of targets (currently only `.o_mega_menu` and `.s_popup`).

[1]: https://github.com/odoo/odoo/commit/daed2428199c29bb397f1cfd5a39742be61102ab
[2]: https://github.com/odoo/odoo/commit/9fe45e2b7ddbbfd0445ffe25a859e67a316d02b2

task-4367641