### PR TITLE
[FIX] l10n_tr_nilvera_einvoice: exclude ID without schemeID

### DIFF
--- a/addons/l10n_tr_nilvera_einvoice/models/account_edi_xml_ubl_tr.py
+++ b/addons/l10n_tr_nilvera_einvoice/models/account_edi_xml_ubl_tr.py
@@ -42,6 +42,9 @@ class AccountEdiXmlUblTr(models.AbstractModel):
             'pricing_currency_code': invoice.currency_id.name.upper() if invoice.currency_id != invoice.company_id.currency_id else False,
             'currency_dp': 2,
         })
+        # Nilvera will reject any <BuyerReference> tag, so remove it
+        if vals['vals'].get('buyer_reference'):
+            del vals['vals']['buyer_reference']
         return vals
 
     def _get_country_vals(self, country):
@@ -53,6 +56,9 @@ class AccountEdiXmlUblTr(models.AbstractModel):
     def _get_partner_party_identification_vals_list(self, partner):
         # EXTENDS account.edi.xml.ubl_21
         vals = super()._get_partner_party_identification_vals_list(partner)
+        # Nilvera will reject any <ID> without a <schemeID>, so remove all items not
+        # having the following structure : {'id': '...', 'id_attrs': {'schemeID': '...'}}
+        vals = [v for v in vals if v.get('id') and v.get('id_attrs', {}).get('schemeID')]
         vals.append({
             'id_attrs': {
                 'schemeID': 'VKN' if partner.is_company else 'TCKN',

--- a/addons/l10n_tr_nilvera_einvoice/tests/test_xml_ubl_tr.py
+++ b/addons/l10n_tr_nilvera_einvoice/tests/test_xml_ubl_tr.py
@@ -81,6 +81,9 @@ class TestUBLTR(AccountTestInvoicingCommon):
 
     def test_xml_invoice_einvoice(self):
         with freeze_time('2025-03-05'):
+            # Adding a ref field to the partner because this field has an influence on <BuyerReference> and
+            # <PartyIdentification> tags in UBL but we have special code to not take it into account for UBL TR 1.2
+            self.partner_1.ref = '1234567890'
             generated_xml = self._generate_invoice_xml()
 
         with file_open('l10n_tr_nilvera_einvoice/tests/expected_xmls/invoice_einvoice.xml', 'rb') as expected_xml_file:


### PR DESCRIPTION
[FIX] l10n_tr_nilvera_einvoice: exclude ID without schemeID
Nilvera expects a `<schemeID>` with every `<ID>`. In Odoo currently, we only
support VKN or TCKN as a schemeID that get impacted from the VAT Number.
Also, Nilvera reject any `<BuyerReference>` tag.

Before:
- The generated XML contains some `<ID>` tags without 'schemeID'
attribute.
- The generated XML contains some `<BuyerReference>` tag.
After:
- The `<ID>` tags with no 'schemeID' are removed from the XML.
- The `<BuyerReference>` tag is removed from the XML.

Task-4822777
runbot: https://runbot.odoo.com/runbot/bundle/18-0-tr-nilvera-partner-ref-override-tax-id-roto-376352
