### PR TITLE
[FIX] website: readd iframe fallback in builder

### DIFF
--- a/addons/website/__manifest__.py
+++ b/addons/website/__manifest__.py
@@ -295,6 +295,7 @@
         'web.assets_tests': [
             'website/static/tests/tour_utils/lifecycle_dep_interaction.js',
             'website/static/tests/tours/**/*',
+            'website/static/src/client_actions/website_preview/website_builder_action_test_mode.js',
             'html_builder/static/src/utils/utils_css.js',
         ],
         'web.assets_backend': [
@@ -309,6 +310,7 @@
             'website/static/src/js/text_processing.js',
             'website/static/src/js/highlight_utils.js',
             'website/static/src/client_actions/*/*',
+            ('remove', 'website/static/src/client_actions/website_preview/website_builder_action_test_mode.js'),
             'website/static/src/components/fields/*',
             'website/static/src/components/fullscreen_indication/fullscreen_indication.js',
             'website/static/src/components/fullscreen_indication/fullscreen_indication.scss',

--- a/addons/website/static/src/client_actions/website_preview/website_builder_action.xml
+++ b/addons/website/static/src/client_actions/website_preview/website_builder_action.xml
@@ -5,6 +5,8 @@
     <div class="d-flex h-100 w-100" t-ref="container">
         <div class="o_website_preview border-top flex-grow-1" t-ref="website_preview">
             <div class="o_iframe_container">
+                <iframe t-if="!testMode" t-att-src="iframeFallbackUrl"
+                    t-ref="iframefallback"/>
                 <iframe t-att-src="initialUrl" t-ref="iframe" t-on-load="onIframeLoad" />
                 <div t-if="this.websiteContext.isMobile" class="o_mobile_preview_layout">
                     <img alt="phone" src="/html_builder/static/img/phone.svg"/>

--- a/addons/website/static/src/client_actions/website_preview/website_builder_action_test_mode.js
+++ b/addons/website/static/src/client_actions/website_preview/website_builder_action_test_mode.js
@@ -1,0 +1,12 @@
+/** @odoo-module **/
+import { patch } from "@web/core/utils/patch";
+import { WebsiteBuilderClientAction } from './website_builder_action';
+
+patch(WebsiteBuilderClientAction.prototype, {
+    /**
+     * @override
+     */
+    get testMode() {
+        return true;
+    }
+});


### PR DESCRIPTION
Since we refactored the website builder, the iframe fallback feature was lost: it is a second iframe that is useful to display the previous screen while we navigate from a page to another, so we reduce the white flash effect

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
