### PR TITLE
[FIX] hw_drivers: no print_id in action params

### DIFF
--- a/addons/hw_drivers/iot_handlers/drivers/PrinterDriver_L.py
+++ b/addons/hw_drivers/iot_handlers/drivers/PrinterDriver_L.py
@@ -254,7 +254,7 @@ class PrinterDriver(PrinterDriverBase):
     def _action_default(self, data):
         _logger.debug("_action_default called for printer %s", self.device_name)
         self.print_raw(b64decode(data['document']))
-        return {'print_id': data['print_id']}
+        return {'print_id': data['print_id']} if 'print_id' in data else {}
 
     def _cancel_job_with_error(self, job_id, error_message):
         self.job_ids.remove(job_id)

--- a/addons/hw_drivers/iot_handlers/drivers/PrinterDriver_W.py
+++ b/addons/hw_drivers/iot_handlers/drivers/PrinterDriver_W.py
@@ -113,7 +113,7 @@ class PrinterDriver(PrinterDriverBase):
         else:
             self.print_raw(document)
         _logger.debug("_action_default finished with mimetype %s for printer %s", mimetype, self.device_name)
-        return {'print_id': data['print_id']}
+        return {'print_id': data['print_id']} if 'print_id' in data else {}
 
     def print_status(self, _data=None):
         """Prints the status ticket of the IoT Box on the current printer.


### PR DESCRIPTION
Most print actions to IoT Box were not provided a print_id, resulting in a traceback when returning. The document were correctly printed, but we did not get the event corresponting to the action because of a traceback.