### PR TITLE
[IMP] hr: add default filter for employee time off

### DIFF
--- a/addons/hr_holidays/models/hr_employee.py
+++ b/addons/hr_holidays/models/hr_employee.py
@@ -277,6 +277,7 @@ class HrEmployee(models.Model):
             'domain': [('employee_id', 'in', self.ids)],
             'context': {
                 'employee_id': self.ids,
+                'search_default_to_approve': True,
             },
         }
 


### PR DESCRIPTION
Before:
- When clicking the Time Off smart button on the employee profile,
all leave records were shown by default.

After:
- A default filter is now applied to show only the most relevant
time off records:
  - First Approval
  - Second Approval

Task-4868581