### PR TITLE
[IMP] stock_picking_batch: prevent crash when DMS is uninstalled

### DIFF
--- a/addons/stock_picking_batch/models/stock_picking_batch.py
+++ b/addons/stock_picking_batch/models/stock_picking_batch.py
@@ -438,3 +438,6 @@ class StockPickingBatch(models.Model):
             'description': self.description,
             'scheduled_date': self.scheduled_date,
         }
+
+    def _get_picking_batch_action(self):
+        return self.env['ir.actions.act_window']._for_xml_id("stock_picking_batch.stock_picking_batch_action")

--- a/addons/stock_picking_batch/views/stock_picking_batch_views.xml
+++ b/addons/stock_picking_batch/views/stock_picking_batch_views.xml
@@ -273,8 +273,15 @@
         </field>
     </record>
 
+    <record id="stock_picking_batch_server_action" model="ir.actions.server">
+        <field name="name">Batch Transfer</field>
+        <field name="model_id" ref="model_stock_picking_batch"/>
+        <field name="state">code</field>
+        <field name="code">action = model._get_picking_batch_action()</field>
+    </record>
+
     <menuitem id="menu_stock_jobs" name="Jobs" parent="stock.menu_stock_warehouse_mgmt" sequence="2"/>
-    <menuitem action="stock_picking_batch_action" id="stock_picking_batch_menu" parent="menu_stock_jobs" sequence="30"/>
+    <menuitem action="stock_picking_batch_server_action" id="stock_picking_batch_menu" parent="menu_stock_jobs" sequence="30"/>
 
     <record id="view_picking_internal_search_inherit_stock_picking_batch" model="ir.ui.view">
         <field name="name">stock.picking.search</field>


### PR DESCRIPTION
Previously, if the user enabled the DMS (Dispatch Management System) in the 
Inventory module, the Gantt view would appear in the Batch / Wave Transfers view. 
However, upon uninstalling the DMS, reopening the Batch / Wave Transfers view 
would raise a UserError.

This issue is now resolved by improving the design of the inheritance mechanism, 
ensuring that the view remains functional even after the DMS is uninstalled.

task-4804805

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
