### PR TITLE
[FIX] spreadsheet: ensure from/to order is correct

### DIFF
--- a/addons/spreadsheet/static/src/global_filters/components/date_filter_dropdown/date_filter_dropdown.js
+++ b/addons/spreadsheet/static/src/global_filters/components/date_filter_dropdown/date_filter_dropdown.js
@@ -196,9 +196,18 @@ export class DateFilterDropdown extends Component {
             case "year":
                 this.props.update(this.selectedValues.year);
                 break;
-            case "range":
+            case "range": {
+                const { from, to } = this.selectedValues.range;
+                if (from && to) {
+                    // Ensure 'to' is after 'from'
+                    if (DateTime.fromISO(from) > DateTime.fromISO(to)) {
+                        this.selectedValues.range.to = from;
+                        this.selectedValues.range.from = to;
+                    }
+                }
                 this.props.update(this.selectedValues.range);
                 break;
+            }
             default:
                 this.props.update(undefined);
         }

--- a/addons/spreadsheet/static/tests/global_filters/date_filter_value.test.js
+++ b/addons/spreadsheet/static/tests/global_filters/date_filter_value.test.js
@@ -434,3 +434,26 @@ test("Can open date time picker to select a range", async function () {
     await contains("input.o_datetime_input:first").click();
     expect(".o_datetime_picker").toHaveCount(1);
 });
+
+test("Choosing a from after the to will re-order dates", async function () {
+    let firstCall = true;
+    const env = await makeMockEnv();
+    await mountDateFilterValue(env, {
+        value: { type: "range", from: "2023-01-30", to: "2023-01-31" },
+        update: (value) => {
+            if (firstCall) {
+                // Bypass the first call as it is just the initial value
+                // (activate when clicking on the input)
+                firstCall = false;
+                return;
+            }
+            expect(value).toEqual({ type: "range", from: "2023-01-01", to: "2023-01-30" });
+            expect.step("update");
+        },
+    });
+    await contains("input").click();
+    await contains("input.o_datetime_input:last").click();
+    // Select 1th of January 2023
+    await contains(".o_date_item_cell.o_datetime_button:first").click();
+    expect.verifySteps(["update"]);
+});


### PR DESCRIPTION
Steps to reproduce:
- Create a spreadsheet with a date filter
- Select a date range, with a from date after the to date => The date range is not correctly ordered, leading to incorrect filtering

Task: 4875901

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
