### PR TITLE
[IMP] account: statement attachment

### DIFF
--- a/addons/account/models/chart_template.py
+++ b/addons/account/models/chart_template.py
@@ -248,7 +248,7 @@ class AccountChartTemplate(models.AbstractModel):
         if not isinstance(companies, models.BaseModel):
             companies = self.env['res.company'].browse(companies)
         for company in companies:
-            self.sudo()._load_data(self._get_demo_data(company))
+            self.sudo().with_context(skip_pdf_attachment_generation=True)._load_data(self._get_demo_data(company))
             self._post_load_demo_data(company)
 
     def _pre_reload_data(self, company, template_data, data, force_create=True):


### PR DESCRIPTION
In the enterprise commit, we create a pdf at the creation of the statement. But for demo data, the connection to wkhtml2pdf is unreachable and it makes a warning. This will add a context key to avoid the pdf to be created when installing demo data

task-4866269




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
