### PR TITLE
[FIX] core: prevent _name_search crash on type mismatch

### DIFF
--- a/odoo/orm/models.py
+++ b/odoo/orm/models.py
@@ -1467,7 +1467,7 @@ class BaseModel(metaclass=MetaModel):
             elif isinstance(value, COLLECTION_TYPES):
                 typed_value = []
                 for v in value:
-                    with contextlib.suppress(ValueError):
+                    with contextlib.suppress(ValueError, TypeError):
                         typed_value.append(field.convert_to_write(v, self))
                 domains.append([(field_name, operator, typed_value)])
             else:


### PR DESCRIPTION
this the same fix but it was handled not correctly in the forward port of saas-18.3

refer to this [commit](https://github.com/odoo/odoo/pull/212975/commits/43747d23a3a6a75cc8a24aeda67780d20c39a3c6) 

build_error-110207

