### PR TITLE
[IMP] mrp: allow in progress workorders to move workcenters

### DIFF
--- a/addons/mrp/models/mrp_workorder.py
+++ b/addons/mrp/models/mrp_workorder.py
@@ -490,9 +490,11 @@ class MrpWorkorder(models.Model):
             new_workcenter = self.env['mrp.workcenter'].browse(values['workcenter_id'])
             for workorder in self:
                 if workorder.workcenter_id.id != values['workcenter_id']:
-                    if workorder.state in ('progress', 'done', 'cancel'):
-                        raise UserError(_('You cannot change the workcenter of a work order that is in progress or done.'))
+                    if workorder.state in ('done', 'cancel'):
+                        raise UserError(_('You cannot change the workcenter of a work order that is done.'))
                     workorder.leave_id.resource_id = new_workcenter.resource_id
+                    if workorder.state == 'progress':
+                        continue
                     workorder.duration_expected = workorder._get_duration_expected()
                     if workorder.date_start:
                         workorder.date_finished = workorder._calculate_date_finished(new_workcenter=new_workcenter)


### PR DESCRIPTION
**Desired behavior after PR is merged:**
- Allow workorders that are still in progress to be moved to any other workcenter.
- Timer doesn't get reset when moved from a workcenter to another therefore blocking them from moving while in progress is unnecessary.

 Task:4850003



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
