### PR TITLE
[IMP] auth_totp: change limit bruteforce

### DIFF
--- a/addons/auth_totp/models/res_users.py
+++ b/addons/auth_totp/models/res_users.py
@@ -22,8 +22,8 @@ _logger = logging.getLogger(__name__)
 compress = functools.partial(re.sub, r'\s', '')
 
 TOTP_RATE_LIMITS = {
-    'send_email': (10, 3600),
-    'code_check': (10, 3600),
+    'send_email': (5, 3600),
+    'code_check': (5, 3600),
 }
 
 


### PR DESCRIPTION
To be compliant with:
https://softwaredevelopers.ato.gov.au/operational_framework/further-guidance-requirements

> brute force lockouts are applied after a maximum of 5 unsuccessful
> login attempts. This specifies that an event must occur, not how each
> DSP handles this lockout before a client can re-try logon. We do not
> seek the details of the lockout process, only that it occurs.

Related: https://github.com/odoo/odoo/pull/213829