### PR TITLE
[FIX] website: prevent destroy on hover effct interaction

### DIFF
--- a/addons/website/static/src/interactions/image_shape_hover_effect.js
+++ b/addons/website/static/src/interactions/image_shape_hover_effect.js
@@ -18,6 +18,9 @@ export class ImageShapeHoverEffect extends Interaction {
     }
 
     destroy() {
+        if (this.isDestroyed) {
+            return;
+        }
         if (this.el.dataset.originalSrcBeforeHover && !this.el.classList.contains("o_modified_image_to_save")) {
             // Replace the image source by its original one if it has not been
             // modified in edit mode.


### PR DESCRIPTION
In case the interaction is destroyed, we should not try to destroy it again.






---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
