### PR TITLE
[FIX] point_of_sale: use payment method bank

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -650,6 +650,8 @@ class PosOrder(models.Model):
         bank_partner_id = False
         if self.amount_total <= 0 and self.partner_id.bank_ids:
             bank_partner_id = self.partner_id.bank_ids[0].id
+        elif self.amount_total >= 0 and self.payment_ids and self.payment_ids[0].payment_method_id.journal_id.bank_account_id:
+            bank_partner_id = self.payment_ids[0].payment_method_id.journal_id.bank_account_id.id
         elif self.amount_total >= 0 and self.company_id.partner_id.bank_ids:
             bank_partner_id = self.company_id.partner_id.bank_ids[0].id
         return bank_partner_id


### PR DESCRIPTION
When generating an invoice for a PoS order we were never using the bank account set on the payment method, but always the one set on the company partner.

Steps to reproduce:
-------------------
* Create two bank account A and B
* Set the bank account A as the company partner bank account
* Set the bank account B on any payment method journal
* Open PoS and create a new pos_order
* Go to the payment screen and check the invoice button
* Pay using the payment method linked to bank account B
> Observation: The generated invoice will use bank account A

Why the fix:
------------
We first try to use the bank account set on the payment method journal if none is present we fallback on the one set on the company partner.

opw-4705497