### PR TITLE
[FIX] mail: guard against chat bubble no thread

### DIFF
--- a/addons/mail/static/src/core/common/chat_bubble.js
+++ b/addons/mail/static/src/core/common/chat_bubble.js
@@ -33,10 +33,10 @@ export class ChatBubble extends Component {
         this.rootRef = useRef("root");
         this.state = useState({ bouncing: false, showClose: true });
         useEffect(
-            () => {
-                this.state.bouncing = this.thread.importantCounter ? true : this.state.bouncing;
+            (importantCounter) => {
+                this.state.bouncing = Boolean(importantCounter);
             },
-            () => [this.thread.importantCounter]
+            () => [this.thread?.importantCounter]
         );
         if (this.env.embedLivechat) {
             this.position = useState({ left: "auto", top: "auto" });


### PR DESCRIPTION
There are some rare cases there's a chat bubble
but no thread, e.g. when the thread is deleted and/or data hasn't be fetched (yet).

These cases should assume no thread for a short time instead of following crash:

```
TypeError: Cannot read properties of undefined (reading 'importantCounter')
```