### PR TITLE
[FIX] point_of_sale: prevent error when ptav with exclusion is archived

### DIFF
--- a/addons/point_of_sale/models/product_attribute.py
+++ b/addons/point_of_sale/models/product_attribute.py
@@ -65,7 +65,7 @@ class ProductTemplateAttributeExclusion(models.Model):
     @api.model
     def _load_pos_data_domain(self, data):
         loaded_product_tmpl_ids = list({p['id'] for p in data['product.template']})
-        return [('product_tmpl_id', 'in', loaded_product_tmpl_ids)]
+        return [('product_tmpl_id', 'in', loaded_product_tmpl_ids), ('product_template_attribute_value_id.ptav_active', '=', True)]
 
     @api.model
     def _load_pos_data_fields(self, config_id):

--- a/addons/point_of_sale/static/tests/pos/tours/product_configurator_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/product_configurator_tour.js
@@ -127,3 +127,12 @@ registry.category("web_tour.tours").add("test_exclusion_attribute_values", {
             Chrome.endTour(),
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("test_exclusion_attribute_values_after_deactivation", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            ProductScreen.clickDisplayedProduct("Configurable Chair"),
+            Chrome.endTour(),
+        ].flat(),
+});

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -2186,6 +2186,12 @@ class TestUi(TestPointOfSaleHttpCommon):
         self.main_pos_config.with_user(self.pos_user).open_ui()
         self.start_pos_tour('test_exclusion_attribute_values')
 
+        chair_color_red_ptav.write({
+            'ptav_active': False,
+        })
+
+        self.start_pos_tour('test_exclusion_attribute_values_after_deactivation')
+
 
 # This class just runs the same tests as above but with mobile emulation
 class MobileTestUi(TestUi):


### PR DESCRIPTION
Before this commit, if you added an exclusion on a ptav and then removed it from the attribute, you would get an error when loading the PoS and could not open the PoS interface.

opw-4874297

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
