### PR TITLE
[FIX] test_main_flow: Form view instead of KanbanQuickCreate appears

### DIFF
--- a/odoo/addons/test_main_flows/static/tests/tours/main_flow.js
+++ b/odoo/addons/test_main_flows/static/tests/tours/main_flow.js
@@ -598,7 +598,7 @@ stepUtils.autoExpandMoreButtons(),
 ...stepUtils.toggleHomeMenu(),
 ...stepUtils.goToAppSteps('crm.crm_menu_root', markup(_t('Organize your sales activities with the <b>CRM app</b>.'))),
 {
-    trigger: '.o_opportunity_kanban',
+    trigger: '.o_opportunity_kanban .o_kanban_renderer',
 },
 {
     trigger: ".o-kanban-button-new",


### PR DESCRIPTION
In the main flow tours, at some point we are on a `Kanban` view, and we want to create a new record. The tours expect to have a `QuickCreate` appears in the Kanban but instead the regular `Form` view is shown.

This bug is due to the change made in the commit[1], has now we show the control panel as soon as possible, and in some condition the model in not ready yet, but the tour `click` on the `new` button and due to the changes made by the commit now we load the regular `Form` view.

To fixes this bug we modify the step in the tour by adding `.o_kanban_renderer` to the `.o_opportunity_kanban` trigger so we ensure that the model is ready due to the following code: `addons/web/static/src/views/kanban/kanban_controller.xml:84`
```xml
<t t-component="props.Renderer" t-if="model.isReady"
```
and so now the tour will click on the `new` button the following code will be true:
`addons/web/static/src/views/kanban/kanban_controller.js:413`
```javascript
if (this.canQuickCreate && onCreate === "quick_create") {
```
as the getter `canQuickCreate` will return `true` as the model `isReady` is true.

runbot-error-223065

[1]: https://github.com/odoo/odoo/commit/74ede9d6c6db583ecf54a1b04781e36aaf1c1a8d

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
