### PR TITLE
[FIX] mail: fix scroll on message edit in shadow DOM

### DIFF
--- a/addons/mail/static/src/core/common/composer.js
+++ b/addons/mail/static/src/core/common/composer.js
@@ -250,6 +250,7 @@ export class Composer extends Component {
     }
 
     onClickCancelOrSaveEditText(ev) {
+        ev.preventDefault();
         const composer = toRaw(this.props.composer);
         if (composer.message && ev.target.dataset?.type === EDIT_CLICK_TYPE.CANCEL) {
             this.props.onDiscardCallback(ev);


### PR DESCRIPTION
**Current behavior before PR:**

Clicking "Cancel" or "Save" in the composer
would unintentionally cause the page to scroll.

**Desired behavior after PR is merged:**

This default behavior is now prevented
in `onClickCancelOrSaveEditText`.

**task**-[4826935](https://www.odoo.com/odoo/my-tasks/4826935)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
