### PR TITLE
[FIX] hr_work_entry: Avoid generating work entries for flexible versions

### DIFF
--- a/addons/hr_work_entry/models/hr_employee.py
+++ b/addons/hr_work_entry/models/hr_employee.py
@@ -45,4 +45,5 @@ class HrEmployee(models.Model):
             versions = self._get_versions_with_contract_overlap_with_period(date_start, date_stop)
         else:
             versions = self._get_all_versions_with_contract_overlap_with_period(date_start, date_stop)
+        versions = versions.filtered('resource_calendar_id')
         return versions.generate_work_entries(date_start, date_stop, force=force)


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
