### PR TITLE
[FIX] pos_restaurant: ensure order id passed when default screen is register

### DIFF
--- a/addons/pos_restaurant/static/src/app/services/pos_store.js
+++ b/addons/pos_restaurant/static/src/app/services/pos_store.js
@@ -36,7 +36,9 @@ patch(PosStore.prototype, {
                 tables: "FloorScreen",
             };
             screen.page = screens[this.config.default_screen];
-            screen.params = {};
+            if (screen.page === "FloorScreen") {
+                screen.params = {};
+            }
         }
         return screen;
     },

--- a/addons/pos_restaurant/static/tests/tours/floor_screen_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/floor_screen_tour.js
@@ -18,6 +18,7 @@ registry.category("web_tour.tours").add("FloorScreenTour", {
         [
             // check floors if they contain their corresponding tables
             Chrome.startPoS(),
+            FloorScreen.isShown(),
             FloorScreen.selectedFloorIs("Main Floor"),
             FloorScreen.hasTable("2"),
             FloorScreen.hasTable("4"),

--- a/addons/pos_restaurant/static/tests/tours/ticket_screen_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/ticket_screen_tour.js
@@ -12,6 +12,7 @@ registry.category("web_tour.tours").add("PosResTicketScreenTour", {
         [
             Chrome.startPoS(),
             Dialog.confirm("Open Register"),
+            ProductScreen.isShown(),
             // New Ticket button should not be in the ticket screen if no table is selected.
             Chrome.clickOrders(),
             Chrome.clickPlanButton(),
@@ -23,7 +24,7 @@ registry.category("web_tour.tours").add("PosResTicketScreenTour", {
             Chrome.clickPlanButton(),
             FloorScreen.orderCountSyncedInTableIs("5", "1"),
             Chrome.clickOrders(),
-            TicketScreen.deleteOrder("001"),
+            TicketScreen.deleteOrder("002"),
             Dialog.confirm(),
             Chrome.clickPlanButton(),
             FloorScreen.isShown(),

--- a/addons/pos_restaurant/tests/test_frontend.py
+++ b/addons/pos_restaurant/tests/test_frontend.py
@@ -48,6 +48,7 @@ class TestFrontendCommon(TestPointOfSaleHttpCommon):
             'company_id': cls.env.company.id,
             'journal_id': test_sale_journal_2.id,
             'invoice_journal_id': test_sale_journal_2.id,
+            'default_screen': 'tables',
             'payment_method_ids': [
                 (4, cls.bank_payment_method.id),
                 (0, 0, {
@@ -242,6 +243,7 @@ class TestFrontend(TestFrontendCommon):
 
     def test_04_ticket_screen(self):
         self.pos_config.is_order_printer = False
+        self.pos_config.default_screen = 'register'
         self.pos_config.with_user(self.pos_user).open_ui()
         self.start_pos_tour('PosResTicketScreenTour')
 


### PR DESCRIPTION
**Before this commit:**
When the POS default screen was set to register, the system did not ensure an open draft order existed, nor did it pass the orderUuid as a screen parameter. This could cause issues in rendering the ProductScreen, especially when no draft order was available.

**After this commit:**
Now, when default_screen is set to register, the system ensures a draft order exists (creating one if not available) and includes its uuid in the params so the ProductScreen loads with the appropriate order context.

Task - 4874330