### PR TITLE
[FIX] point_of_sale: exclusion with inactive ptav

### DIFF
--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -137,7 +137,7 @@ class PosSession(models.Model):
     def _load_pos_data_models(self, config_id):
         return ['pos.config', 'pos.preset', 'resource.calendar.attendance', 'pos.order', 'pos.order.line', 'pos.pack.operation.lot', 'pos.payment', 'pos.payment.method', 'pos.printer',
             'pos.category', 'pos.bill', 'res.company', 'account.tax', 'account.tax.group', 'product.template', 'product.product', 'product.attribute', 'product.attribute.custom.value',
-            'product.template.attribute.line', 'product.template.attribute.value', 'product.template.attribute.exclusion', 'product.combo', 'product.combo.item', 'res.users', 'res.partner', 'product.uom',
+            'product.template.attribute.line', 'product.template.attribute.exclusion', 'product.template.attribute.value', 'product.combo', 'product.combo.item', 'res.users', 'res.partner', 'product.uom',
             'decimal.precision', 'uom.uom', 'res.country', 'res.country.state', 'res.lang', 'product.pricelist', 'product.pricelist.item', 'product.category',
             'account.cash.rounding', 'account.fiscal.position', 'account.fiscal.position.tax', 'stock.picking.type', 'res.currency', 'pos.note', 'product.tag', 'ir.module.module']
 

--- a/addons/point_of_sale/models/product_attribute.py
+++ b/addons/point_of_sale/models/product_attribute.py
@@ -48,6 +48,8 @@ class ProductTemplateAttributeValue(models.Model):
     def _load_pos_data_domain(self, data):
         ptav_ids = {ptav_id for p in data['product.product'] for ptav_id in p['product_template_variant_value_ids']}
         ptav_ids.update({ptav_id for ptal in data['product.template.attribute.line'] for ptav_id in ptal['product_template_value_ids']})
+        ptav_ids.update({attr['product_template_attribute_value_id'] for attr in data['product.template.attribute.exclusion']})
+        ptav_ids.update({ptav_id for attr in data['product.template.attribute.exclusion'] for ptav_id in attr['value_ids']})
         return AND([
             [('ptav_active', '=', True)],
             [('attribute_id', 'in', [attr['id'] for attr in data['product.attribute']])],
@@ -56,7 +58,7 @@ class ProductTemplateAttributeValue(models.Model):
 
     @api.model
     def _load_pos_data_fields(self, config_id):
-        return ['attribute_id', 'attribute_line_id', 'product_attribute_value_id', 'price_extra', 'name', 'is_custom', 'html_color', 'image', 'exclude_for']
+        return ['attribute_id', 'attribute_line_id', 'product_attribute_value_id', 'price_extra', 'name', 'is_custom', 'html_color', 'image']
 
 class ProductTemplateAttributeExclusion(models.Model):
     _name = 'product.template.attribute.exclusion'
@@ -65,7 +67,11 @@ class ProductTemplateAttributeExclusion(models.Model):
     @api.model
     def _load_pos_data_domain(self, data):
         loaded_product_tmpl_ids = list({p['id'] for p in data['product.template']})
-        return [('product_tmpl_id', 'in', loaded_product_tmpl_ids)]
+        return AND([
+            [('product_template_attribute_value_id.ptav_active', '=', True)],
+            [('value_ids', 'any', [('ptav_active', '=', True)])],
+            [('product_tmpl_id', 'in', loaded_product_tmpl_ids)]
+        ])
 
     @api.model
     def _load_pos_data_fields(self, config_id):

--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -448,8 +448,15 @@ export class PosStore extends WithLazyGetterTrap {
         };
 
         for (const exclusion of this.models["product.template.attribute.exclusion"].getAll()) {
+            if (!exclusion.product_template_attribute_value_id) {
+                continue;
+            }
             const ptavId = exclusion.product_template_attribute_value_id.id;
-            for (const { id: valueId } of exclusion.value_ids) {
+            for (const value of exclusion.value_ids) {
+                if (!value) {
+                    continue;
+                }
+                const valueId = value.id;
                 addExclusion(ptavId, valueId);
                 addExclusion(valueId, ptavId);
             }


### PR DESCRIPTION
Since this commit https://github.com/odoo/odoo/pull/213789/commits/a3b5ddd909ceb3b09acd0ebb1dde6f2561a8244e, the exclusion is computed at the launch of the pos. It was not expected to have inactive values in the exclusion causing an error. It is now fixed by checking the values loaded and we are checking the values before working with them.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
