### PR TITLE
[FIX] purchase_requisition: purchase agreement line not brought to PO

### DIFF
--- a/addons/purchase_requisition/models/purchase.py
+++ b/addons/purchase_requisition/models/purchase.py
@@ -276,7 +276,10 @@ class PurchaseOrderLine(models.Model):
                 po_lines_without_requisition |= pol
                 continue
             for line in pol.order_id.requisition_id.line_ids:
-                if line.product_id == pol.product_id:
+                line_name = line.display_name
+                if line.product_description_variants:
+                    line_name += "\n" + line.product_description_variants
+                if line.product_id == pol.product_id and line_name == pol.name:
                     pol.price_unit = line.product_uom_id._compute_price(line.price_unit, pol.product_uom)
                     partner = pol.order_id.partner_id or pol.order_id.requisition_id.vendor_id
                     params = {'order_id': pol.order_id}


### PR DESCRIPTION
Step to reproduce:
- Create a Blanket Order
- Put several line with the same product with different description and unit price
- Transform to RFQ

Previous behavior:
- RFQ line Description and Unit Price are copied from the first line of this product in the Blanket Order

Expected behavior:
- RFQ line Description and Unit Price come from the Blanket Order

Some field need to be computed according to the corresponding line of the blanket order. However it was computed from the first line of the same product. I didn't find a sustainable way to find the related line in the BO so I compare the RFQ line and BO line on product and description. If a customer has a problem, they can update the description to differentiate the lines.

opw-4333298

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
