### PR TITLE
[IMP] web: allow overwrite of warning message when editing properties

### DIFF
--- a/addons/web/static/src/views/fields/properties/properties_field.js
+++ b/addons/web/static/src/views/fields/properties/properties_field.js
@@ -79,14 +79,9 @@ export class PropertiesField extends Component {
                 if (!canChangeDefinition) {
                     canChangeDefinition = await this.checkDefinitionWriteAccess();
                     if (!canChangeDefinition) {
-                        this.notification.add(
-                            _t('Oops! You cannot edit the %(parentFieldLabel)s "%(parentName)s".', {
-                                parentName: this.props.record.data[this.definitionRecordField][1],
-                                parentFieldLabel:
-                                    this.props.record.fields[this.definitionRecordField].string,
-                            }),
-                            { type: "warning" }
-                        );
+                        this.notification.add(this._getPropertyEditWarningText(), {
+                            type: "warning",
+                        });
                     }
                 }
                 const isInEditMode = canChangeDefinition && !this.props.readonly;
@@ -990,6 +985,17 @@ export class PropertiesField extends Component {
         if (separator) {
             this._unfoldSeparators([separator.name], true);
         }
+    }
+
+    /**
+     * Returns the text for the warning raised in the "PROPERTY_FIELD:EDIT"
+     * bus event, if the PropertiesField component cannot enter edit mode.
+     */
+    _getPropertyEditWarningText() {
+        return _t('Oops! You cannot edit the %(parentFieldLabel)s "%(parentName)s".', {
+            parentName: this.props.record.data[this.definitionRecordField][1],
+            parentFieldLabel: this.props.record.fields[this.definitionRecordField].string,
+        });
     }
 }
 


### PR DESCRIPTION
When the button 'Add Properties' is clicked in an asset without an asset model associated, a warning is raised. The warning message is unclear in this case: "Oops! You cannot edit the Model undefined".

This commit moves the warning message to the method `_propertyEditWarningText()`, which can then be extended in account_assets in odoo/enterprise#87807

task-4822091

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
