### PR TITLE
[FIX] point_of_sale: compute refund order name

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -481,8 +481,6 @@ class PosOrder(models.Model):
 
     @api.model
     def _complete_values_from_session(self, session, values):
-        if values.get('state') and values['state'] == 'paid' and not values.get('name'):
-            values['name'] = self._compute_order_name(session)
         values.setdefault('pricelist_id', session.config_id.pricelist_id.id)
         values.setdefault('fiscal_position_id', session.config_id.default_fiscal_position_id.id)
         values.setdefault('company_id', session.config_id.company_id.id)

--- a/addons/point_of_sale/static/tests/tours/ticket_screen_tour.js
+++ b/addons/point_of_sale/static/tests/tours/ticket_screen_tour.js
@@ -179,6 +179,10 @@ registry.category("web_tour.tours").add("FiscalPositionNoTaxRefund", {
             ProductScreen.isShown(),
             { ...ProductScreen.back(), isActive: ["mobile"] },
             ProductScreen.totalAmountIs("100.00"),
+            ProductScreen.clickPayButton(),
+            PaymentScreen.clickPaymentMethod("Bank"),
+            PaymentScreen.clickValidate(),
+            ReceiptScreen.isShown(),
         ].flat(),
 });
 

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -1130,6 +1130,8 @@ class TestUi(TestPointOfSaleHttpCommon):
 
         self.main_pos_config.with_user(self.pos_user).open_ui()
         self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'FiscalPositionNoTaxRefund', login="pos_user")
+        order = self.env['pos.order'].search([])
+        self.assertTrue(order[0].name == order[1].name + " REFUND")
 
     def test_lot_refund(self):
 


### PR DESCRIPTION
Currently, when refunding an order the name of the order does not show "REFUND".

Steps to reproduce:
-------------------
* Open pos session
* Make an order
* Refund the order
* Go to the backend and see all orders
> The refund orders does not show the "REFUND" label

Why the fix:
------------
In previous version, when in `sync_from_ui` the state of the order in vals was 'draft'. In this version the state in vals is `paid`. This difference leads to the name being computed in `_complete_values_from_session`.

This means that `_compute_order_name` is called before the order is fully created and thus `refunded_order_id` is not yet set and we're always using the next sequence to compute the order name.

Now, when we already know the order is a refund we will not compute the name in `complete_values_from_session`. The name will get computed in `write`, which is called by `action_pos_order_paid`, as in previous version.

opw-4521070