### PR TITLE
[FIX] website: remove powerbutton plugin in translation mode

### DIFF
--- a/addons/website/static/src/builder/website_builder.js
+++ b/addons/website/static/src/builder/website_builder.js
@@ -41,17 +41,24 @@ export class WebsiteBuilder extends Component {
         const websitePlugins = this.props.translation
             ? TRANSLATION_PLUGINS
             : registry.category("website-plugins").getAll();
-        const mainEditorPlugins = removePlugins(
-            [...MAIN_EDITOR_PLUGINS],
-            [
-                "PowerButtonsPlugin",
-                "DoubleClickImagePreviewPlugin",
-                "SeparatorPlugin",
-                "StarPlugin",
-                "BannerPlugin",
-                "MoveNodePlugin",
-            ]
-        );
+        const mainEditorPluginsToRemove = [
+            "PowerButtonsPlugin",
+            "DoubleClickImagePreviewPlugin",
+            "SeparatorPlugin",
+            "StarPlugin",
+            "BannerPlugin",
+            "MoveNodePlugin",
+        ];
+        const pluginsBlockedInTranslationMode = [
+            "PowerboxPlugin",
+            "SearchPowerboxPlugin",
+            "YoutubePlugin",
+            "ImagePlugin",
+        ];
+        const pluginsToRemove = this.props.translation
+            ? [...mainEditorPluginsToRemove, ...pluginsBlockedInTranslationMode]
+            : mainEditorPluginsToRemove;
+        const mainEditorPlugins = removePlugins([...MAIN_EDITOR_PLUGINS], pluginsToRemove);
         const coreBuilderPlugins = this.props.translation ? [] : CORE_BUILDER_PLUGINS;
         const Plugins = [...mainEditorPlugins, ...coreBuilderPlugins, ...(websitePlugins || [])];
         builderProps.Plugins = Plugins;

--- a/addons/website/static/tests/builder/translation.test.js
+++ b/addons/website/static/tests/builder/translation.test.js
@@ -6,6 +6,7 @@ import { beforeEach, describe, expect, test } from "@odoo/hoot";
 import { animationFrame, manuallyDispatchProgrammaticEvent, queryAllTexts } from "@odoo/hoot-dom";
 import { contains, mockService, onRpc, patchWithCleanup } from "@web/../tests/web_test_helpers";
 import { defineWebsiteModels, invisibleEl, setupWebsiteBuilder } from "./website_helpers";
+import { expectElementCount } from "@html_editor/../tests/_helpers/ui_expectations";
 
 defineWebsiteModels();
 
@@ -184,6 +185,21 @@ test("translate select", async () => {
     expect(queryAllTexts(":iframe [data-initial-translation-value='Option 1']")).toEqual([
         "Option fr",
     ]);
+});
+
+test("test that powerbox should not open in translate mode", async () => {
+    const { getEditor } = await setupSidebarBuilderForTranslation({
+        websiteContent: getTranslateEditable("&nbsp;"),
+    });
+    const editor = getEditor();
+    const textNode = editor.editable.querySelector("span").firstChild;
+    expect(textNode.nodeType).toBe(Node.TEXT_NODE);
+    setSelection({ anchorNode: textNode, anchorOffset: 0 });
+    await animationFrame();
+    // Simulate typing `/`
+    await insertText(editor, "/");
+    await animationFrame();
+    await expectElementCount(".o-we-powerbox", 0);
 });
 
 describe("save translation", () => {


### PR DESCRIPTION
This commit removes the `powerbox` plugin from the website in translation mode. The `powerbox` plugin was added after the refactoring in master, but it is not needed in translation mode as it does not serve a purpose there.

Issue: 
![image](https://github.com/user-attachments/assets/3b1a686c-b165-4702-ae1d-c8c18591068e)
