### PR TITLE
[FIX] stock: ensure bold table headers in PDF report rendering

### DIFF
--- a/addons/stock/report/report_deliveryslip.xml
+++ b/addons/stock/report/report_deliveryslip.xml
@@ -61,9 +61,9 @@
                     <table class="table table-borderless" t-if="o.state!='done'" name="stock_move_table">
                         <thead>
                             <tr>
-                                <th name="th_sm_product">Product</th>
-                                <th name="th_sm_ordered" class="text-end">Ordered</th>
-                                <th name="th_sm_quantity" class="text-end">Delivered</th>
+                                <th name="th_sm_product"><strong>Product</strong></th>
+                                <th name="th_sm_ordered" class="text-end"><strong>Ordered</strong></th>
+                                <th name="th_sm_quantity" class="text-end"><strong>Delivered</strong></th>
                             </tr>
                         </thead>
                         <tbody>


### PR DESCRIPTION
Problem:
When printing the stock report, table headers are not bold in the generated PDF despite being styled that way in the HTML template.

Cause:
The bold styling is applied via CSS on the `thead` element, which doesn't render properly in the PDF output.

Solution:
Use `<strong>` tags inside table headers to apply bold formatting, as done in version 17.0. Also remove `font-weight` rules from CSS for `thead` to avoid conflicts and ensure consistent output.

Steps to reproduce:
1. Go to Inventory > Inventory Overview.
2. Select any inventory record.
3. Print the report. → Table headers are not bold as expected, despite formatting.

opw-4840380


enterprise PR: https://github.com/odoo/enterprise/pull/87852
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
