### PR TITLE
[FIX] point_of_sale: change weigh amount size

### DIFF
--- a/addons/point_of_sale/static/src/app/generic_components/product_card/product_card.xml
+++ b/addons/point_of_sale/static/src/app/generic_components/product_card/product_card.xml
@@ -19,9 +19,9 @@
                     t-att-class="{'no-image d-flex justify-content-center align-items-center text-center fs-4': !props.imageUrl}"
                     t-attf-id="article_product_{{props.productId}}"
                     t-esc="props.name" />
-                <h1 t-if="props.productCartQty"
+                <div t-if="props.productCartQty"
                     t-out="this.productQty"
-                    class="product-cart-qty text-muted display-6 fw-bolder m-0 mt-auto" />
+                    class="overflow-hidden lh-sm product-name my-2" />
             </div>
             <div t-if="props.comboExtraPrice" class="d-flex px-2 pb-1">
                 <span class="price-extra px-2 py-0 rounded-pill text-bg-info">


### PR DESCRIPTION
This small PR changes the text size displaying last weighed value for a product

**Before:**
![image](https://github.com/user-attachments/assets/821e2f7f-33f6-4aea-8766-00ab429bf3c6)


**Now:**
![image](https://github.com/user-attachments/assets/a91b35df-6792-47e8-9c04-53a555a64978)