### PR TITLE
[FIX] point_of_sale: created test UoM in test to prevent failure

### DIFF
--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -2029,24 +2029,28 @@ class TestUi(TestPointOfSaleHttpCommon):
         self.start_pos_tour('test_preset_timing_retail')
 
     def test_quantity_package_of_non_basic_unit(self):
-        pack_of_12_inch = self.env['uom.uom'].create({
-            'name': 'Pack of 12_inch',
+        test_uom_unit = self.env['uom.uom'].create({
+            "name": "test unit uom",
+            "relative_factor": "1.0",
+        })
+        pack_of_12_unit = self.env['uom.uom'].create({
+            'name': 'Pack of 12 unit',
             'relative_factor': 12,
-            'relative_uom_id': self.env.ref('uom.product_uom_inch').id,
+            'relative_uom_id': test_uom_unit.id,
             'is_pos_groupable': True,
         })
         product_cord = self.env['product.product'].create({
             'name': 'Cord',
             'is_storable': True,
             'available_in_pos': True,
-            'uom_id': self.env.ref('uom.product_uom_inch').id,
-            'uom_ids': [pack_of_12_inch.id],
+            'uom_id': test_uom_unit.id,
+            'uom_ids': [pack_of_12_unit.id],
             'lst_price': 10.0,
         })
         self.env['product.uom'].create({
             'barcode': '555555',
             'product_id': product_cord.id,
-            'uom_id': pack_of_12_inch.id,
+            'uom_id': pack_of_12_unit.id,
         })
         self.main_pos_config.with_user(self.pos_user).open_ui()
         self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'test_quantity_package_of_non_basic_unit', login="pos_user")


### PR DESCRIPTION
Before this commit:
=
- The test `test_quantity_package_of_non_basic_unit` used `product_uom_inch`, which is `archived` by default,  causing the test to fail without demo data.
- It only worked with demo data because `l10n_us_account` `unarchives` this UoM.

After this commit:
=
- Created a **test UoM** to ensure consistent test behavior.

Runbot-error: 223122
