### PR TITLE
[FIX] pos_discount: correctly load the Discount product

### DIFF
--- a/addons/pos_discount/models/product_template.py
+++ b/addons/pos_discount/models/product_template.py
@@ -7,11 +7,11 @@ class ProductTemplate(models.Model):
     def _load_pos_data(self, data):
         res = super()._load_pos_data(data)
         config_id = self.env['pos.config'].browse(data['pos.config'][0]['id'])
-        discount_product_id = config_id.discount_product_id.id
+        discount_product_id = config_id.discount_product_id.product_tmpl_id.id
         product_ids_set = {product['id'] for product in res}
 
         if config_id.module_pos_discount and discount_product_id not in product_ids_set:
-            productModel = self.env['product.product'].with_context({**self.env.context, 'display_default_code': False})
+            productModel = self.env['product.template'].with_context({**self.env.context, 'display_default_code': False})
             fields = self.env['product.template']._load_pos_data_fields(data['pos.config'][0]['id'])
             product = productModel.search_read([('id', '=', discount_product_id)], fields=fields, load=False)
             res.extend(product)


### PR DESCRIPTION
Before this commit, the product.product record was loaded for the Discount product when loading the product templates, which caused several issues.

opw-4876402

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
