### PR TITLE
[FIX] point_of_sale: update partner self invoice

### DIFF
--- a/addons/point_of_sale/controllers/main.py
+++ b/addons/point_of_sale/controllers/main.py
@@ -225,7 +225,7 @@ class PosController(PortalAccount):
     def _get_invoice(self, partner_values, invoice_values, pos_order, additional_invoice_fields, kwargs):
         # If the user is not connected, then we will simply create a new partner with the form values.
         # Matching with existing partner was tried, but we then can't update the values, and it would force the user to use the ones from the first invoicing.
-        if request.env.user._is_public() and not pos_order.partner_id.id:
+        if kwargs:
             partner_values.update({key: kwargs[key] for key in self._get_mandatory_fields()})
             partner_values.update({key: kwargs[key] for key in self._get_optional_fields() if key in kwargs})
             for field in {'country_id', 'state_id'} & set(partner_values.keys()):
@@ -234,6 +234,7 @@ class PosController(PortalAccount):
                 except Exception:
                     partner_values[field] = False
             partner_values.update({'zip': partner_values.pop('zipcode', '')})
+        if request.env.user._is_public() and not pos_order.partner_id.id:
             partner = request.env['res.partner'].sudo().create(partner_values)  # In this case, partner_values contains the whole partner info form.
         # If the user is connected, then we can update if needed its fields with the additional localized fields if any, then proceed.
         else:


### PR DESCRIPTION
When doing a self invoice with the QR code on the PoS receipt, if a partner was linked to the order, the record would not be updated with the values entered in the self invoice form.

Steps to reproduce:
-------------------
* Enable the self service invoice feature in the PoS settings.
* Open a PoS session.
* Make and order with a partner set on it.
* Finalize the order and scan the QRCode on the receipt.
* Fill the form with some new informations (like a new VAT number)
> Observation: Check the partner on the backend, the values are not
  updated.

Why the fix:
------------
We update all the mandatory and optionnal fields of the partner record with the values entered in the self invoice form.

opw-4676244