### PR TITLE
[FIX] base: prevent xpath error on opening web studio

### DIFF
--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -595,6 +595,12 @@ actual arch.
         if vals.get('active') or 'arch_db' in vals:
             self.filtered('active')._check_xml()
 
+        for view in self:
+            if view.type in ('form', 'list') and view.model_data_id and view.model_data_id.module == 'studio_customization' and view.invalid_locators:
+                filtered = list(filter(lambda loc: loc.get('attrib', {}).get('position') != 'move', view.invalid_locators))
+                if filtered:
+                    raise ValidationError(_("Invalid XPath in Studio view '%(view)s' (line %(line)s).") % {'view': view.name, 'line': filtered[0].get('sourceline')})
+
         return res
 
     def unlink(self):


### PR DESCRIPTION
This error occurs when a user modifies a Studio-generated custom form view by updating it through the technical settings and adds an invalid XPath expression. As a result, Web Studio fails to open and load the view.

**Steps to replicate:**
* Install `contacts` and `web_studio`
* Open form view for any contact and Add/remove any field using studio.
* Go to technical>User Interface>Views> `Odoo Studio:res.partner.form customization`
* Add the following line:`<xpath expr='/form[1]/field[6]'/>` inside data and save.
* Go to contact form view and open studio.

`ValueError:The element <xpath expr='/form[1]/field[6]'/> cannot be located in the main view`

**Solution**
* Prevent users from saving changes to a view by raising a validation error when an invalid XPath expression is detected.

**Sentry-6678221213**