### PR TITLE
[FIX] stock: fix error when clicking on replenishment

### DIFF
--- a/addons/stock/models/stock_orderpoint.py
+++ b/addons/stock/models/stock_orderpoint.py
@@ -535,9 +535,12 @@ class StockWarehouseOrderpoint(models.Model):
             else:
                 orderpoint_values = self.env['stock.warehouse.orderpoint']._get_orderpoint_values(product, location_id)
                 location = self.env['stock.location'].browse(location_id)
+                warehouse = location.warehouse_id or self.env['stock.warehouse'].search([('company_id', '=', location.company_id.id)], limit=1)
+                if not warehouse:
+                    self.env['stock.warehouse']._warehouse_redirect_warning()
                 orderpoint_values.update({
                     'name': _('Replenishment Report'),
-                    'warehouse_id': location.warehouse_id.id or self.env['stock.warehouse'].search([('company_id', '=', location.company_id.id)], limit=1).id,
+                    'warehouse_id': warehouse.id,
                     'company_id': location.company_id.id,
                 })
                 orderpoint_values_list.append(orderpoint_values)


### PR DESCRIPTION
When there is no warehouse and user clicks on the replenishment,
A traceback will appear.

Steps to reproduce the error:
- Install ``stock`` module
- Go to Inventory > Configuration > Settings > Enable Multi-Step Routes
- Create new product > Click on ``On Hand`` smart button > Add Negative On Hand Quantity (e.g. -10)
- Go to Inventory > Configuration > Rules > Delete all Rules
- Go to Inventory > Configuration > Warehouses > Delete Warehouse
- Go to Inventory > Operations > Replenishment

Traceback:
```
NotNullViolation: null value in column 'warehouse_id' of relation
'stock_warehouse_orderpoint' violates not-null constraint
```

https://github.com/odoo/odoo/blob/54204e664ed1924f512ba4626be010e39c2d17a3/addons/stock/models/stock_orderpoint.py#L538-L545
When there is no warehouse available, the ``warehouse_id`` is set to False.
when the method tries to create orderpoints using this ``False`` value for ``warehouse_id``.
So, It will raise the above traceback.

sentry-6682818532

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
