### PR TITLE
[FIX] mail, im_livechat: make _get_or_create_chat deterministic

### DIFF
--- a/addons/im_livechat/models/im_livechat_channel.py
+++ b/addons/im_livechat/models/im_livechat_channel.py
@@ -204,6 +204,9 @@ class Im_LivechatChannel(models.Model):
     def _get_livechat_discuss_channel_vals(
         self, anonymous_name, previous_operator_id=None, chatbot_script=None, user_id=None, country_id=None, lang=None
     ):
+        # use the same "now" in the whole function to ensure unpin_dt > last_interest_dt
+        now = fields.Datetime.now()
+        last_interest_dt = now - timedelta(seconds=1)
         user_operator = False
         if chatbot_script:
             if chatbot_script.id not in self.browse(self.ids).mapped('rule_ids.chatbot_script_id.id'):
@@ -216,7 +219,13 @@ class Im_LivechatChannel(models.Model):
         # partner to add to the discuss.channel
         operator_partner_id = user_operator.partner_id.id if user_operator else chatbot_script.operator_partner_id.id
         members_to_add = [
-            Command.create({"partner_id": operator_partner_id, "unpin_dt": fields.Datetime.now()})
+            Command.create(
+                {
+                    "last_interest_dt": last_interest_dt,
+                    "partner_id": operator_partner_id,
+                    "unpin_dt": now,
+                }
+            )
         ]
         visitor_user = False
         if user_id:

--- a/addons/mail/models/discuss/discuss_channel.py
+++ b/addons/mail/models/discuss/discuss_channel.py
@@ -15,6 +15,7 @@ from odoo.exceptions import UserError, ValidationError
 from odoo.osv import expression
 from odoo.tools import format_list, get_lang, html_escape
 from odoo.tools.misc import OrderedSet
+from odoo.tools.sql import SQL
 
 channel_avatar = '''<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 530.06 530.06">
 <circle cx="265.03" cy="265.03" r="265.03" fill="#875a7b"/>
@@ -1070,55 +1071,71 @@ class DiscussChannel(models.Model):
             :returns: channel_info of the created or existing channel
             :rtype: dict
         """
-        if self.env.user.partner_id.id not in partners_to:
-            partners_to.append(self.env.user.partner_id.id)
-        if len(partners_to) > 2:
+        partners = (
+            self.env["res.partner"]
+            .with_context(active_test=False)
+            .search([("id", "in", partners_to)])
+        ) | self.env.user.partner_id
+        if len(partners) > 2:
             raise UserError(_("A chat should not be created with more than 2 persons. Create a group instead."))
         # determine type according to the number of partner in the channel
         self.flush_model()
         self.env['discuss.channel.member'].flush_model()
-        self.env.cr.execute("""
+        self.env.cr.execute(
+            SQL(
+                """
             SELECT M.channel_id
             FROM discuss_channel C, discuss_channel_member M
             WHERE M.channel_id = C.id
-                AND M.partner_id IN %s
+                AND M.partner_id IN %(partner_ids)s
                 AND C.channel_type LIKE 'chat'
                 AND NOT EXISTS (
                     SELECT 1
                     FROM discuss_channel_member M2
                     WHERE M2.channel_id = C.id
-                        AND M2.partner_id NOT IN %s
+                        AND M2.partner_id NOT IN %(partner_ids)s
                 )
             GROUP BY M.channel_id
-            HAVING ARRAY_AGG(DISTINCT M.partner_id ORDER BY M.partner_id) = %s
+            HAVING ARRAY_AGG(DISTINCT M.partner_id ORDER BY M.partner_id) = %(sorted_partner_ids)s
             LIMIT 1
-        """, (tuple(partners_to), tuple(partners_to), sorted(list(partners_to)),))
+                """,
+                partner_ids=tuple(partners.ids),
+                sorted_partner_ids=sorted(partners.ids),
+            )
+        )
         result = self.env.cr.dictfetchall()
+        # use the same "now" in the whole function to ensure unpin_dt > last_interest_dt
+        now = fields.Datetime.now()
+        last_interest_dt = now - timedelta(seconds=1)
         if result:
             # get the existing channel between the given partners
             channel = self.browse(result[0].get('channel_id'))
             # pin or open the channel for the current partner
             if pin:
-                member = self.env['discuss.channel.member'].search([('partner_id', '=', self.env.user.partner_id.id), ('channel_id', '=', channel.id)])
-                vals = {'last_interest_dt': fields.Datetime.now()}
-                if pin:
-                    vals['unpin_dt'] = False
-                member.write(vals)
+                channel.self_member_id.write(
+                    {"last_interest_dt": last_interest_dt, "unpin_dt": False}
+                )
             channel._broadcast(self.env.user.partner_id.ids)
         else:
             # create a new one
-            channel = self.create({
-                'channel_member_ids': [
-                    Command.create({
-                        'partner_id': partner_id,
-                        # only pin for the current user, so the chat does not show up for the correspondent until a message has been sent
-                        'unpin_dt': False if partner_id == self.env.user.partner_id.id else fields.Datetime.now(),
-                    }) for partner_id in partners_to
-                ],
-                'channel_type': 'chat',
-                'name': ', '.join(self.env['res.partner'].browse(partners_to).mapped('name')),
-            })
-            channel._broadcast(partners_to)
+            channel = self.create(
+                {
+                    "channel_member_ids": [
+                        Command.create(
+                            {
+                                "last_interest_dt": last_interest_dt,
+                                "partner_id": partner.id,
+                                # only pin for the current user, so the chat does not show up for the correspondent until a message has been sent
+                                "unpin_dt": False if partner == self.env.user.partner_id else now,
+                            }
+                        )
+                        for partner in partners
+                    ],
+                    "channel_type": "chat",
+                    "name": ", ".join(partners.mapped("name")),
+                }
+            )
+            channel._broadcast(partners.ids)
         return channel
 
     def channel_pin(self, pinned=False):

--- a/addons/mail/tests/discuss/test_discuss_channel.py
+++ b/addons/mail/tests/discuss/test_discuss_channel.py
@@ -355,23 +355,22 @@ class TestChannelInternals(MailCommon, HttpCase):
 
     # `channel_get` will pin the channel by default and thus last interest will be updated.
     @users('employee')
-    def test_channel_info_get_should_update_last_interest_dt(self):
-        self.env['discuss.channel']._get_or_create_chat(partners_to=self.partner_admin.ids)
-
-        retrieve_time = datetime(2021, 1, 1, 0, 0)
-        with patch.object(fields.Datetime, 'now', lambda: retrieve_time):
-            # `last_interest_dt` should be updated again when `channel_get` is called
-            # because `channel_pin` is called.
-            channel = self.env["discuss.channel"]._get_or_create_chat(
-                partners_to=self.partner_admin.ids
-            )
+    def test_get_or_create_chat_should_update_last_interest_dt(self):
+        """Ensure last_interest_dt of the current user is updated when calling _get_or_create_chat.
+        The last_interest_dt of the channel is only updated when creating the chat initially."""
+        with freeze_time("2025-06-18 10:40:22"):
+            channel = self.env["discuss.channel"]._get_or_create_chat(self.partner_admin.ids)
+        self.assertEqual(fields.Datetime.to_string(channel.last_interest_dt), "2025-06-18 10:40:21")
         self.assertEqual(
-            fields.Datetime.to_string(
-                channel.channel_member_ids.filtered(
-                    lambda member: member.partner_id == self.env.user.partner_id
-                ).last_interest_dt
-            ),
-            fields.Datetime.to_string(retrieve_time),
+            fields.Datetime.to_string(channel.self_member_id.last_interest_dt),
+            "2025-06-18 10:40:21",
+        )
+        with freeze_time("2025-06-18 10:40:58"):
+            self.env["discuss.channel"]._get_or_create_chat(self.partner_admin.ids)
+        self.assertEqual(fields.Datetime.to_string(channel.last_interest_dt), "2025-06-18 10:40:21")
+        self.assertEqual(
+            fields.Datetime.to_string(channel.self_member_id.last_interest_dt),
+            "2025-06-18 10:40:57",
         )
 
     @users('employee')
@@ -801,10 +800,9 @@ class TestChannelInternals(MailCommon, HttpCase):
 
     @users('employee')
     def test_create_chat_channel_should_only_pin_the_channel_for_the_current_user(self):
-        chat = self.env['discuss.channel']._get_or_create_chat(partners_to=self.test_partner.ids)
-        member_of_current_user = self.env['discuss.channel.member'].search([('channel_id', '=', chat.id), ('partner_id', '=', self.env.user.partner_id.id)])
-        member_of_correspondent = self.env['discuss.channel.member'].search([('channel_id', '=', chat.id), ('partner_id', '=', self.test_partner.id)])
-        self.assertTrue(member_of_current_user.is_pinned)
+        chat = self.env["discuss.channel"]._get_or_create_chat(self.test_partner.ids)
+        member_of_correspondent = chat.channel_member_ids - chat.self_member_id
+        self.assertTrue(chat.self_member_id.is_pinned)
         self.assertFalse(member_of_correspondent.is_pinned)
 
     @users("employee")


### PR DESCRIPTION
runbot-112917
runbot-112998

`unpin_dt` was using `now()` inside the function and `last_interest_dt` was using `now()` (-1 sec) from its default value.

When there was more than one sec between the two calls due to slow CPU or slow query, the channel would be considered pinned even though it was supposted to not be.

This commit ensures the same `now()` is used in both cases.

The opportunity is taken to clean the method a bit:

- ensure the provided ids are existing partners
- internally, use recordset of partners rather than ids
- use `self_member_id` rather than extra manual search