### PR TITLE
[FIX] sale: forbid country update on used addresses

### DIFF
--- a/addons/sale/models/res_partner.py
+++ b/addons/sale/models/res_partner.py
@@ -68,6 +68,7 @@ class ResPartner(models.Model):
         """ Can't edit `country_id` if there is (non draft) issued SO. """
         return super()._can_edit_country() and not self._has_order(
             [
+                '|',
                 ('partner_invoice_id', '=', self.id),
                 ('partner_id', '=', self.id),
             ]


### PR DESCRIPTION
This domain was too strict and only catching cases where the same address was used as main and invoicing addresses on the SO.




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
