### PR TITLE
[FIX] sale: double product name

### DIFF
--- a/addons/sale/static/src/js/sale_product_field.js
+++ b/addons/sale/static/src/js/sale_product_field.js
@@ -148,10 +148,12 @@ export class SaleOrderLineProductField extends ProductLabelSectionAndNoteField {
     }
 
     get label() {
-        let label = super.label;
+        let label = this.props.record.data.name;
         if (this.translatedProductName && label.startsWith(this.translatedProductName)) {
             // Remove the translated name as it is already shown to the salesman on the SOL.
-            label = label.slice(label.indexOf("\n") + 1);
+            label = label.slice(this.translatedProductName.length + 1);  // + "\n"
+        } else {
+            label = super.label;
         }
         return label;
     }
@@ -161,15 +163,13 @@ export class SaleOrderLineProductField extends ProductLabelSectionAndNoteField {
     }
 
     updateLabel(value) {
-        if (this.translatedProductName === undefined) {
-            // View was not updated to include `translatedProductName`
+        if (!this.translatedProductName) {
             return super.updateLabel(value);
         }
         this.props.record.update({
             name: (
-                this.translatedProductName && value && this.translatedProductName.concat("\n", value)
-                || !value && this.translatedProductName
-                || value
+                value && this.translatedProductName.concat("\n", value)
+                || this.translatedProductName
             ),
         });
     }

--- a/addons/sale/static/tests/sale_product_field.test.js
+++ b/addons/sale/static/tests/sale_product_field.test.js
@@ -187,3 +187,47 @@ test("On updated form, editing the description shouldn't show the translated pro
     expect(".o_field_product_label_section_and_note_cell textarea").toHaveValue("A description");
     expect(sol.name).toBe(translatedProductName.concat("\nA description"));
 });
+
+test("No description should be shown if there does not exist one apart from the product name", async () => {
+    const product = ProductProduct._records[0];
+    const pyEnv = await startServer();
+    const translatedProductName = "Produit de test";
+    const soId = pyEnv["sale.order"].create({
+        partner_id: serverState.partnerId,
+        order_line: [Command.create({
+            product_id: product.id,
+            name: product.name,
+            translated_product_name: translatedProductName,
+        })],
+    });
+    await mountView({
+        type: "form",
+        resModel: "sale.order",
+        resId: soId,
+        arch: WithTranslatedNameForm,
+    });
+
+    expect(".o_field_product_label_section_and_note_cell textarea").not.toBeDisplayed();
+});
+
+test("No description should be shown if there does not exist one apart from the translated product name", async () => {
+    const product = ProductProduct._records[0];
+    const pyEnv = await startServer();
+    const translatedProductName = "Produit de test";
+    const soId = pyEnv["sale.order"].create({
+        partner_id: serverState.partnerId,
+        order_line: [Command.create({
+            product_id: product.id,
+            name: translatedProductName,
+            translated_product_name: translatedProductName,
+        })],
+    });
+    await mountView({
+        type: "form",
+        resModel: "sale.order",
+        resId: soId,
+        arch: WithTranslatedNameForm,
+    });
+
+    expect(".o_field_product_label_section_and_note_cell textarea").not.toBeDisplayed();
+});


### PR DESCRIPTION
This commit fixes an issue from [1] when the SOL description did not include a newline after the translated product name, which caused it to show unexpectedly.

opw-4760300

---

1. https://github.com/odoo/odoo/pull/209141

Related:
- https://github.com/odoo/odoo/pull/214571

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
