### PR TITLE
[FIX] sale: missing field dependency

### DIFF
--- a/addons/sale/static/src/js/sale_product_field.js
+++ b/addons/sale/static/src/js/sale_product_field.js
@@ -134,10 +134,12 @@ export class SaleOrderLineProductField extends ProductLabelSectionAndNoteField {
     }
 
     get label() {
-        let label = super.label;
+        let label = this.props.record.data.name;
         if (this.translatedProductName && label.startsWith(this.translatedProductName)) {
             // Remove the translated name as it is already shown to the salesman on the SOL.
-            label = label.slice(label.indexOf("\n") + 1);
+            label = label.slice(this.translatedProductName.length + 1);  // + "\n"
+        } else {
+            label = super.label;
         }
         return label;
     }
@@ -147,15 +149,13 @@ export class SaleOrderLineProductField extends ProductLabelSectionAndNoteField {
     }
 
     updateLabel(value) {
-        if (this.translatedProductName === undefined) {
-            // View was not updated to include `translatedProductName`
+        if (!this.translatedProductName) {
             return super.updateLabel(value);
         }
         this.props.record.update({
             name: (
-                this.translatedProductName && value && this.translatedProductName.concat("\n", value)
-                || !value && this.translatedProductName
-                || value
+                value && this.translatedProductName.concat("\n", value)
+                || this.translatedProductName
             ),
         });
     }

--- a/addons/sale/static/tests/sale_product_field.test.js
+++ b/addons/sale/static/tests/sale_product_field.test.js
@@ -91,7 +91,7 @@ test("pressing tab with incomplete text will create a product", async () => {
     ]);
 });
 
-test("On outdated form, product name should stay hidden", async () => {
+test("On updated form, product name should stay hidden", async () => {
     const product = saleModels.ProductProduct._records[0];
     const pyEnv = await startServer();
     const soId = pyEnv["sale.order"].create({
@@ -112,7 +112,7 @@ test("On outdated form, product name should stay hidden", async () => {
     expect(".o_field_product_label_section_and_note_cell textarea").toHaveValue("A description");
 });
 
-test("On outdated form, translated product name should be hidden if present", async () => {
+test("On updated form, translated product name should be hidden if present", async () => {
     const product = saleModels.ProductProduct._records[0];
     const pyEnv = await startServer();
     const translatedProductName = "Produit de test";
@@ -134,7 +134,7 @@ test("On outdated form, translated product name should be hidden if present", as
     expect(".o_field_product_label_section_and_note_cell textarea").toHaveValue("A description");
 });
 
-test("On updated form, should continue to hide product name", async () => {
+test("On outdated form, should continue to hide product name", async () => {
     const product = saleModels.ProductProduct._records[0];
     const pyEnv = await startServer();
     const soId = pyEnv["sale.order"].create({
@@ -155,7 +155,7 @@ test("On updated form, should continue to hide product name", async () => {
     expect(".o_field_product_label_section_and_note_cell textarea").toHaveValue("A description");
 });
 
-test("On updated form and translated product name already in the SOL name, should not hide the translated product name", async () => {
+test("On outdated form and translated product name already in the SOL name, should not hide the translated product name", async () => {
     const product = saleModels.ProductProduct._records[0];
     const pyEnv = await startServer();
     const translatedProductName = "Produit de test";
@@ -179,7 +179,7 @@ test("On updated form and translated product name already in the SOL name, shoul
     );
 });
 
-test("On updated form, editing the description should work as before", async () => {
+test("On outdated form, editing the description should work as before", async () => {
     const product = saleModels.ProductProduct._records[0];
     const pyEnv = await startServer();
     const translatedProductName = "Produit de test";
@@ -210,7 +210,7 @@ test("On updated form, editing the description should work as before", async () 
     expect(sol.name).toBe(product.name.concat("\nA description"));
 });
 
-test("On outdated form, editing the description shouldn't show the translated product name", async () => {
+test("On updated form, editing the description shouldn't show the translated product name", async () => {
     const product = saleModels.ProductProduct._records[0];
     const pyEnv = await startServer();
     const translatedProductName = "Produit de test";
@@ -239,4 +239,48 @@ test("On outdated form, editing the description shouldn't show the translated pr
 
     expect(".o_field_product_label_section_and_note_cell textarea").toHaveValue("A description");
     expect(sol.name).toBe(translatedProductName.concat("\nA description"));
+});
+
+test("No description should be shown if there does not exist one apart from the product name", async () => {
+    const product = saleModels.ProductProduct._records[0];
+    const pyEnv = await startServer();
+    const translatedProductName = "Produit de test";
+    const soId = pyEnv["sale.order"].create({
+        partner_id: serverState.partnerId,
+        order_line: [Command.create({
+            product_id: product.id,
+            name: product.name,
+            translated_product_name: translatedProductName,
+        })],
+    });
+    await mountView({
+        type: "form",
+        resModel: "sale.order",
+        resId: soId,
+        arch: WithTranslatedNameForm,
+    });
+
+    expect(".o_field_product_label_section_and_note_cell textarea").not.toBeDisplayed();
+});
+
+test("No description should be shown if there does not exist one apart from the translated product name", async () => {
+    const product = saleModels.ProductProduct._records[0];
+    const pyEnv = await startServer();
+    const translatedProductName = "Produit de test";
+    const soId = pyEnv["sale.order"].create({
+        partner_id: serverState.partnerId,
+        order_line: [Command.create({
+            product_id: product.id,
+            name: translatedProductName,
+            translated_product_name: translatedProductName,
+        })],
+    });
+    await mountView({
+        type: "form",
+        resModel: "sale.order",
+        resId: soId,
+        arch: WithTranslatedNameForm,
+    });
+
+    expect(".o_field_product_label_section_and_note_cell textarea").not.toBeDisplayed();
 });

--- a/addons/sale/views/sale_order_views.xml
+++ b/addons/sale/views/sale_order_views.xml
@@ -612,6 +612,7 @@
                                 <field name="selected_combo_items" column_invisible="1"/>
                                 <field name="virtual_id" column_invisible="1"/>
                                 <field name="linked_virtual_id" column_invisible="1"/>
+                                <field name="translated_product_name" column_invisible="1"/>
 
                                 <!-- Currency, needed for monetary widgets to display the currency symbol -->
                                 <field name="currency_id" column_invisible="True"/>


### PR DESCRIPTION
After [1], the translated product name was missing from the view, resulting in the SOL description displaying the product name twice since it couldn't be pruned in the displayed description.

This commit simply adds the missing field dependency, ensuring the ORM fetches the field to the client.

This commit also fixes an issue from [2] when the SOL description did not include a newline after the translated product name, which caused it to show unexpectedly.

opw-4760300

---

1. https://github.com/odoo/odoo/pull/214099
2. https://github.com/odoo/odoo/pull/209141

Related:
- https://github.com/odoo/odoo/pull/214569

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
