### PR TITLE
[FIX] uom: prevent error on enabling global discount in POS

### DIFF
--- a/addons/uom/models/uom_uom.py
+++ b/addons/uom/models/uom_uom.py
@@ -72,14 +72,10 @@ class UomUom(models.Model):
     @api.depends('name', 'relative_factor', 'relative_uom_id')
     @api.depends_context('formatted_display_name')
     def _compute_display_name(self):
-        uom_to_process_ids = []
+        super()._compute_display_name()
         for uom in self:
             if uom.env.context.get('formatted_display_name') and uom.relative_uom_id:
                 uom.display_name = f"{uom.name}\t--{uom.relative_factor} {uom.relative_uom_id.name}--"
-            else:
-                uom_to_process_ids.append(uom.id)
-        if uom_to_process_ids:
-            super(UomUom, self.env['uom.uom'].browse(uom_to_process_ids))._compute_display_name()
 
     def _compute_quantity(self, qty, to_unit, round=True, rounding_method='UP', raise_if_failure=True):
         """ Convert the given quantity from the current UoM `self` into a given one


### PR DESCRIPTION
Currently, enabling a global discount in the POS settings triggers an error.

**Steps to Reproduce:**
- Install hr_timesheet and point_of_sale moules(without demo)
- Navigate to settings>Point of Sale
- Create shop, enable **Global Discounts** under pricing section and save the changes.

**Error:**
`ValueError: Compute method failed to assign uom.uom(4,).display_name`

**Root Cause:**
since https://github.com/odoo/odoo/pull/207217/commits/ec25070d3a239cc3b874f641616ae460dba54515 , a new method `_compute_display_name` was introduced to UOM, a super call has been made to identify the `display_name` of that particular `uom` as mentioned at [1]. but the obtained  value of `display_name` here is `false`, which is causing an issue.

[1]- https://github.com/odoo/odoo/blob/3cf555159a6d62f0556568b91dca3441a40713d5/addons/uom/models/uom_uom.py#L82

This commit ensures that `display_name` is present before accessing it.

sentry- 6672929300

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
