### PR TITLE
[FIX] hr_skills:  Resume tab step in skills tour

### DIFF
--- a/addons/hr_skills/static/tests/tours/skills_tour.js
+++ b/addons/hr_skills/static/tests/tours/skills_tour.js
@@ -26,6 +26,11 @@ registry.category("web_tour.tours").add('hr_skills_tour', {
         trigger: ".o_form_button_save",
     },
     {
+        content: "Open the Resume tab",
+        trigger: ".o_notebook_headers a.nav-link[name='skills_resume']",
+        run: "click",
+    },
+    {
         content: "Add a new Resume experience",
         trigger: ".o_field_resume_one2many tr.o_resume_group_header button.btn-secondary",
     },


### PR DESCRIPTION
step to reproduce:
1. install l10n_ch_hr_payroll_account
2. without demo
3. run test SkillsTestUI.test_ui

added missing step is to go to resume tab
in the tour

build_error_181683


