### PR TITLE
[FIX] purchase: Fix 'Upload Bill' traceback on RfQ list view

### DIFF
--- a/addons/purchase/models/purchase_order.py
+++ b/addons/purchase/models/purchase_order.py
@@ -783,7 +783,10 @@ class PurchaseOrder(models.Model):
 
         if len(invoices) != 1:
             raise ValidationError(_("You can only upload a bill for a single vendor at a time."))
-        invoices.with_context(skip_is_manually_modified=True)._extend_with_attachments(attachments, new=True)
+        invoices.with_context(skip_is_manually_modified=True)._extend_with_attachments(
+            invoices._to_files_data(attachments),
+            new=True,
+        )
 
         invoices.message_post(attachment_ids=attachments.ids)
 


### PR DESCRIPTION
In e7c93e5a6 we modified the call signature of `AccountMove._extend_with_attachments()`

Now it takes not an `ir.attachment` recordset, but a list of dicts. But we forgot to modify the calling code in `PurchaseOrder.action_create_invoice`.

As a result, the 'Upload Bill' button is currently broken.

Steps to reproduce:
- go to Purchase > Requests for Quotation
- select a purchase order in the list view
- click on `Upload Bill` and upload a PDF -> a traceback occurs.

![image](https://github.com/user-attachments/assets/a3b9e3ae-4c40-4dc0-8f39-0aba3cb4c262)

This PR fixes the calling code in `action_create_invoice`.

task-none