### PR TITLE
[IMP] html_editor: add a getter to show url in popover

### DIFF
--- a/addons/html_editor/static/src/main/link/link_popover.js
+++ b/addons/html_editor/static/src/main/link/link_popover.js
@@ -652,6 +652,10 @@ export class LinkPopover extends Component {
         return customStyles;
     }
 
+    get showUrl() {
+        return this.state.urlTitle && this.state.url && this.state.urlTitle !== this.state.url;
+    }
+
     async uploadFile() {
         const { upload, getURL } = this.uploadService;
         const { resModel, resId } = this.props.recordInfo;

--- a/addons/html_editor/static/src/main/link/link_popover.xml
+++ b/addons/html_editor/static/src/main/link/link_popover.xml
@@ -194,7 +194,7 @@
                                     </t>
                                 </div>
                             </div>
-                            <div t-if="state.urlTitle and state.url and state.urlTitle !== state.url" class="text-truncate" style="max-width: 200px; font-size: 12px;">
+                            <div t-if="showUrl" class="text-truncate" style="max-width: 200px; font-size: 12px;">
                                 <span t-attf-class="o_we_full_url text-muted o_we_webkit_box" t-attf-title="{{state.url}}">
                                     <t t-if="state.url" t-esc="state.url"/>
                                     <t t-else="">No URL specified</t>


### PR DESCRIPTION
This commit adds a getter method in the link popover to determine if url should be shown in the popover.
The need to introduce this getter is to patch it for the article link. From related enterprise commit, we will show the preview popover also for the article links.

Task-4624296