### PR TITLE
[FIX] sale: compute price_unit when updating taxes on a sale order

### DIFF
--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -1123,6 +1123,7 @@ class SaleOrder(models.Model):
 
     def _recompute_taxes(self):
         lines_to_recompute = self.order_line.filtered(lambda line: not line.display_type)
+        lines_to_recompute._compute_price_unit()
         lines_to_recompute._compute_tax_id()
         self.show_update_fpos = False
 


### PR DESCRIPTION
- Create a tax of 21% and another of 0%. On both, enable the Included in Price option.

- Create a fiscal position mapping 21% to 0%.

- Create a product priced at 10.0 with the 21% tax.

- Create a sale order with this product. Then, change the fiscal position of the sale order to the 21-to-0 mapping. Click on Update Taxes.

The untaxed amount of the invoice will be 10.0. However, this should be 8.26 since the price includes tax.

This happens because the price_unit is not recomputed when updating taxes for lines with price-included taxes.

Commit 8df3d0424b30289d81e15a483dcc779bfe3964ba fixed this issue for invoices. This commit applies the same fix to sale orders.

opw-4854789



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
