### PR TITLE
[IMP] purchase: restrict purchase user access to bills with POs

### DIFF
--- a/addons/purchase/security/purchase_security.xml
+++ b/addons/purchase/security/purchase_security.xml
@@ -63,13 +63,13 @@
     <record id="purchase_user_account_move_line_rule" model="ir.rule">
         <field name="name">Purchase User Account Move Line</field>
         <field name="model_id" ref="account.model_account_move_line"/>
-        <field name="domain_force">[('move_id.move_type', 'in', ('in_invoice', 'in_refund', 'in_receipt'))]</field>
+        <field name="domain_force">['&amp;', ('move_id.move_type', 'in', ('in_invoice', 'in_refund', 'in_receipt')), ('move_id.line_ids.purchase_order_id', '!=', False)]</field>
         <field name="groups" eval="[(4, ref('purchase.group_purchase_user'))]"/>
     </record>
     <record id="purchase_user_account_move_rule" model="ir.rule">
         <field name="name">Purchase User Account Move</field>
         <field name="model_id" ref="account.model_account_move"/>
-        <field name="domain_force">[('move_type', 'in', ('in_invoice', 'in_refund', 'in_receipt'))]</field>
+        <field name="domain_force">['&amp;', ('move_type', 'in', ('in_invoice', 'in_refund', 'in_receipt')), ('line_ids.purchase_order_id', '!=', False)]</field>
         <field name="groups" eval="[(4, ref('purchase.group_purchase_user'))]"/>
     </record>
     <record id="portal_purchase_order_line_rule" model="ir.rule">

--- a/addons/purchase_stock/static/tests/tours/tour_test_purchase_stock_flow.js
+++ b/addons/purchase_stock/static/tests/tours/tour_test_purchase_stock_flow.js
@@ -1,0 +1,27 @@
+/** @odoo-module */
+
+import { registry } from "@web/core/registry";
+
+registry.category("web_tour.tours").add("test_purchase_user_access_flow", {
+    steps: () => [
+        {
+            content: "The bill matching button must not be accessible to the purchase user.",
+            trigger: ".o-form-buttonbox:not(:has(button[name='action_bill_matching']))",
+        },
+        {
+            content: "The purchase user should be able to access the relevant bills.",
+            trigger: "button[name='action_view_invoice']",
+            run: "click",
+        },
+        {
+            content: "Return to the purchase order.",
+            trigger: "button[name='action_view_source_purchase_orders']",
+            run: "click",
+        },
+        {
+            content: "The purchase user should be able to access the order's pickings.",
+            trigger: "button[name='action_view_picking']",
+            run: "click",
+        },
+    ],
+})

--- a/addons/purchase_stock/tests/__init__.py
+++ b/addons/purchase_stock/tests/__init__.py
@@ -19,6 +19,7 @@ from . import test_purchase_order_process
 from . import test_purchase_order_suggest
 from . import test_purchase_stock_accrued_entries
 from . import test_purchase_stock_report
+from . import test_purchase_user_access_flow
 from . import test_reordering_rule
 from . import test_replenish_wizard
 from . import test_routes

--- a/addons/purchase_stock/tests/test_purchase_user_access_flow.py
+++ b/addons/purchase_stock/tests/test_purchase_user_access_flow.py
@@ -1,0 +1,56 @@
+from odoo import Command
+from odoo.tests import HttpCase, tagged
+
+
+@tagged('-at_install', 'post_install')
+class TestPurchaseUserAccessFlow(HttpCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.purchase_user = cls.env['res.users'].create({
+            'company_id': cls.env.ref('base.main_company').id,
+            'name': "Purchase J. User",
+            'login': "puser",
+            'email': "pj@us.er",
+            'group_ids': [Command.set([cls.env.ref('purchase.group_purchase_user').id])],
+        })
+
+        cls.partner = cls.env['res.partner'].create({
+            'name': 'P. Artner',
+            'email': 'p@rtn.er',
+        })
+
+        cls.product = cls.env['product.product'].create({
+            'name': 'Acme Hotdog',
+            'type': 'consu',
+        })
+
+        cls.purchase_order = cls.env['purchase.order'].create({
+            'partner_id': cls.partner.id,
+            'order_line': [
+                Command.create({
+                    'product_id': cls.product.id,
+                    'product_qty': 5.0,
+                }),
+            ],
+        })
+
+    def test_purchase_user_access_flow(self):
+        """Test whether the purchase user can access the bills
+           and pickings related to a purchase order."""
+        self.purchase_order.button_confirm()
+        self.env['account.move'].create({
+            'move_type': 'in_invoice',
+            'partner_id': self.partner.id,
+            'invoice_line_ids': [
+                Command.create({
+                    'product_id': self.product.id,
+                    'purchase_line_id': self.purchase_order.order_line.id,
+                    'quantity': 5.0,
+                }),
+            ],
+        }).action_post()
+
+        self.start_tour('/odoo/purchase/%d' % self.purchase_order.id,
+                        'test_purchase_user_access_flow',
+                        login=self.purchase_user.login)

--- a/addons/purchase_stock/views/purchase_views.xml
+++ b/addons/purchase_stock/views/purchase_views.xml
@@ -16,7 +16,7 @@
                 <button type="object"
                     name="action_view_picking"
                     class="oe_stat_button"
-                    icon="fa-truck" invisible="incoming_picking_count == 0" groups="stock.group_stock_user">
+                    icon="fa-truck" invisible="incoming_picking_count == 0" groups="stock.group_stock_user,purchase.group_purchase_user">
                     <field name="incoming_picking_count" widget="statinfo" string="Receipt" help="Incoming Shipments"/>
                 </button>
             </xpath>

--- a/addons/repair/views/stock_picking_views.xml
+++ b/addons/repair/views/stock_picking_views.xml
@@ -36,10 +36,11 @@
         <field name="inherit_id" ref="stock.view_picking_form"/>
         <field name="arch" type="xml">
             <xpath expr="//button[@name='action_see_packages']" position="after">
-                <field name="repair_ids" invisible="1"/>
+                <field name="repair_ids" invisible="1"
+                       groups="stock.group_stock_user"/>
                 <button name="action_view_repairs" type="object"
                         class="oe_stat_button" icon="fa-wrench"
-                        invisible="nbr_repairs == 0">
+                        invisible="nbr_repairs == 0" groups="stock.group_stock_user">
                         <field name="nbr_repairs" string="Repair Orders" widget="statinfo"/>
                 </button>
             </xpath>

--- a/addons/stock_delivery/views/delivery_view.xml
+++ b/addons/stock_delivery/views/delivery_view.xml
@@ -18,7 +18,7 @@
             <field name="arch" type="xml">
               <data>
                 <xpath expr="//group[@name='other_infos']" position="before">
-                    <group name='carrier_data' string="Shipping Information">
+                    <group name='carrier_data' string="Shipping Information" groups="stock.group_stock_user">
                         <field name="is_return_picking" invisible="1"/>
                         <field name="carrier_id" readonly="state in ('done', 'cancel')" options="{'no_create': True, 'no_open': True}"/>
                         <field name="integration_level" invisible="1"/>
@@ -45,10 +45,12 @@
                          invisible="not carrier_tracking_ref or not carrier_id or delivery_type == 'grid'" />
                 </div>
                 <xpath expr="/form/header/button[last()]" position="after">
-                    <button name="send_to_shipper" string="Send to Shipper" type="object" invisible="carrier_tracking_ref or delivery_type in ['fixed', 'base_on_rule'] or not delivery_type or state != 'done' or picking_type_code == 'incoming'" data-hotkey="shift+v"/>
+                    <button name="send_to_shipper" string="Send to Shipper" type="object" data-hotkey="shift+v" groups="stock.group_stock_user"
+                            invisible="carrier_tracking_ref or delivery_type in ['fixed', 'base_on_rule'] or not delivery_type or state != 'done' or picking_type_code == 'incoming'"/>
                 </xpath>
                 <xpath expr="/form/header/button[last()]" position="after">
-                    <button name="print_return_label" string="Print Return Label" type="object" invisible="not is_return_picking or state == 'done' or picking_type_code != 'incoming'" data-hotkey="shift+o"/>
+                    <button name="print_return_label" string="Print Return Label" type="object" data-hotkey="shift+o" groups="stock.group_stock_user"
+                            invisible="not is_return_picking or state == 'done' or picking_type_code != 'incoming'"/>
                 </xpath>
                 <xpath expr="//field[@name='partner_id']" position="attributes">
                     <attribute name="required">carrier_id and integration_level == 'rate_and_ship'</attribute>


### PR DESCRIPTION
~~We would prefer not to reveal to purchase users all account moves we have on the record, so we restrict their access to the ones that are relevant to them, namely inbound moves (such as bills) with existing purchase orders.~~

Scratch that. New plan: we create a whole new `account.move` view for purchase users so we don't have to play whack-a-mole with the countless fields tacked on the view without `groups` down the line in myriad little modules.

Task ID: [4752378](https://www.odoo.com/odoo/my-tasks/4752378)
