### PR TITLE
[FIX] website_sale: recompute cart taxes on address update

### DIFF
--- a/addons/website_sale/tests/test_website_sale_fiscal_position.py
+++ b/addons/website_sale/tests/test_website_sale_fiscal_position.py
@@ -12,7 +12,39 @@ class TestWebsiteSaleFiscalPosition(ProductCommon, HttpCaseWithUserPortal):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+
+        cls.env.company.country_id = cls.env.ref('base.us')
         cls._use_currency('USD')
+
+        cls.website = cls.env.ref('website.default_website')
+        cls.website.company_id = cls.env.company
+
+        # Create a fiscal position with a mapping of taxes
+        cls.tax_15_excl = cls.env['account.tax'].create({
+            'name': "15% excl",
+            'type_tax_use': 'sale',
+            'amount_type': 'percent',
+            'amount': 15,
+            'price_include': False,
+            'include_base_amount': False,
+        })
+        cls.tax_0 = cls.env['account.tax'].create({
+            'name': "0%",
+            'type_tax_use': 'sale',
+            'amount_type': 'percent',
+            'amount': 0,
+        })
+        belgium = cls.env.ref('base.be')
+        cls.fpos_be = cls.env['account.fiscal.position'].create({
+            'name': "Fiscal Position BE",
+            'auto_apply': True,
+            'country_id': belgium.id,
+            'tax_ids': [Command.create({
+                'tax_src_id': cls.tax_15_excl.id,
+                'tax_dest_id': cls.tax_0.id,
+            })],
+        })
+        cls.partner_portal.country_id = belgium
 
     def test_shop_fiscal_position_products_template(self):
         """
@@ -21,42 +53,15 @@ class TestWebsiteSaleFiscalPosition(ProductCommon, HttpCaseWithUserPortal):
             The goal of this test is to check that this template
             is up to date with the fiscal position detected.
         """
-        self.env.company.country_id = self.env.ref('base.us')
-        website_id = self.env.ref('website.default_website').id
-        belgium_id = self.env.ref('base.be').id
         # Set setting to display tax included on the website
         config = self.env['res.config.settings'].create({})
         config.show_line_subtotals_tax_selection = "tax_included"
         config.execute()
-        # Create a fiscal position with a mapping of taxes
-        tax_15_excl = self.env['account.tax'].create({
-            'name': '15% excl',
-            'type_tax_use': 'sale',
-            'amount_type': 'percent',
-            'amount': 15,
-            'price_include': False,
-            'include_base_amount': False,
-        })
-        tax_0 = self.env['account.tax'].create({
-            'name': '0%',
-            'type_tax_use': 'sale',
-            'amount_type': 'percent',
-            'amount': 0,
-        })
-        self.env['account.fiscal.position'].create({
-            'name': 'fiscal_pos_belgium',
-            'auto_apply': True,
-            'country_id': belgium_id,
-            'tax_ids': [Command.create({
-                'tax_src_id': tax_15_excl.id,
-                'tax_dest_id': tax_0.id,
-            })]
-        })
         # Create a pricelist which will be automatically detected
         self.env['product.pricelist'].create({
             'name': 'EUROPE EUR',
             'selectable': True,
-            'website_id': website_id,
+            'website_id': self.website.id,
             'country_group_ids': [Command.link(self.env.ref('base.europe').id)],
             'sequence': 1,
             'currency_id': self.env.ref('base.EUR').id,
@@ -65,7 +70,7 @@ class TestWebsiteSaleFiscalPosition(ProductCommon, HttpCaseWithUserPortal):
         self.env["product.product"].create({
             'name': "Super product",
             'list_price': 40.00,
-            'taxes_id': [tax_15_excl.id],
+            'taxes_id': self.tax_15_excl.ids,
             'website_published': True,
         })
         # Create a conversion rate (1 USD <=> 2 EUR)
@@ -77,7 +82,7 @@ class TestWebsiteSaleFiscalPosition(ProductCommon, HttpCaseWithUserPortal):
             'name': '2023-01-01',
         })
 
-        self.partner_portal.country_id = belgium_id
+        self.partner_portal.country_id = self.env.ref('base.be')
 
         # [1]   By going to the shop page with the portal user,
         #       a t-cache key `pricelist,products` + `fiscal_position_id` is generated
@@ -87,3 +92,26 @@ class TestWebsiteSaleFiscalPosition(ProductCommon, HttpCaseWithUserPortal):
         #       the prices must not be those previously calculated for the portal user.
         #       Because the fiscal position differs from that of the public user.
         self.start_tour("/shop", 'website_sale_fiscal_position_public_tour', login="")
+
+    def test_recompute_taxes_on_address_change(self):
+        self.product.website_published = True
+        self.product.taxes_id = self.tax_15_excl
+        cart = self.env['sale.order'].create({
+            'partner_id': self.partner_portal.id,
+            'website_id': self.website.id,
+            'order_line': [Command.create({'product_id': self.product.id})],
+        })
+        self.assertEqual(cart.fiscal_position_id, self.fpos_be)
+        self.assertEqual(cart.order_line.tax_id, self.tax_0)
+
+        self.partner_portal.country_id = self.env.ref('base.us')
+        self.assertNotEqual(cart.fiscal_position_id, self.fpos_be)
+        self.assertEqual(cart.order_line.tax_id, self.tax_15_excl)
+
+        cart.action_confirm()
+        self.partner_portal.country_id = self.env.ref('base.be')
+        self.assertEqual(
+            cart.order_line.tax_id,
+            self.tax_15_excl,
+            "Tax should no longer change after order confirmation",
+        )


### PR DESCRIPTION
Versions
--------
- 16.0+

Steps
-----
1. Have a fiscal position with a country-based tax mapping;
2. go to `/shop` as a public user,
3. create a new account;
4. add a product to your cart;
5. go to user settings & add an address that matches the fiscal position;
6. go to checkout & pay for the cart.

Issue
-----
The fiscal position's taxes aren't applied to the order.

Cause
-----
The `_compute_fiscal_position_id` method is triggered when changing the `partner_id` or `partner_shipping_id` of an order. It does not trigger when modifying the address of the order's current partner.

There is logic in place to recompute fiscal position & taxes when an address gets entered via checkout, but not via any other route.

Solution
--------
Adding address fields to the `api.depends` of the compute method could introduce the unintended behavior of changing taxes & fiscal position of confirmed sale orders. Instead, we can check for fields relevant to fiscal position in `write`, then search for unconfirmed website orders, and recompute their fiscal position & taxes if need be.

opw-4844132
opw-4753332