### PR TITLE
[FIX] mass_mailing: moved commit operation after mailing update

### DIFF
--- a/addons/mass_mailing/models/mailing.py
+++ b/addons/mass_mailing/models/mailing.py
@@ -1117,15 +1117,20 @@ class MassMailing(models.Model):
             ).create(composer_values)
 
             # auto-commit except in testing mode
-            composer._action_send_mail(
-                auto_commit=not getattr(threading.current_thread(), 'testing', False)
-            )
+            auto_commit = not getattr(threading.current_thread(), 'testing', False)
+            composer._action_send_mail(auto_commit=auto_commit)
+
             mailing.write({
                 'state': 'done',
                 'sent_date': fields.Datetime.now(),
                 # send the KPI mail only if it's the first sending
                 'kpi_mail_required': not mailing.sent_date,
             })
+
+            # ensure mailing state update after auto-commit
+            if auto_commit is True:
+                self.env.cr.commit()
+
         return True
 
     def convert_links(self):


### PR DESCRIPTION
**Steps to reproduce:**
- Install `Email Marketing` app
- Setup mail catcher
- Create a first mailing `test_1`
- Insert a dynamic field in the body template to trigger an error (easy way is to setup a dynamic field and then change the `Recipients` type)
- Ensure this mailing has recipients
- Create a second mailing `test_2` with correct template / recipients
- Disable the `Mail Marketing: Process queue` action to prevent automatic processing (optional but could avoid issues)
- For `test_1` and then `test_2`, click on "Send" to trigger the `action_launch()`
- Manually trigger the scheduled action `Mail Marketing: Process queue`
- An error should be raised as expected ('Failed to render QWeb template')
- The mails for `test_2` are properly sent
- However `test_2` remains in `sending` state instead of `done`

**Issue:**
This issue is caused by the transaction rollback when the `test_1` error is raised. When sending the mail, `_action_send_mail` is called with `auto_commit` set to `True` before the mailing state is updated to `done` but after it is set to `sending`.
This means that, when there is an issue later on, the uncommitted changes will be rolled back, which removes the last state modification and the state gets back to `sending` even if the mails were properly sent.
This could lead to unintended behavior such as mailings being retried and resent on next trigger.

**Fix:**
Explicitly called `commit()` after the state update and disabled the `auto_commit` of `_action_send_mail()`.

Could be better to use `post_send_callback` parameter from
`def send(self, auto_commit=False, raise_exception=False, post_send_callback=None):`
but we would need to modify multiple function signatures (which seems bad in stable).

No test was added as the issue require manual committing which is not supported in tests.

opw-4832616

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
