### PR TITLE
[FIX] website: prevent switching page after edit

### DIFF
--- a/addons/web/static/lib/hoot-dom/helpers/dom.js
+++ b/addons/web/static/lib/hoot-dom/helpers/dom.js
@@ -414,7 +414,11 @@ function isNodeHidden(node) {
 
 /** @type {NodeFilter} */
 function isNodeInteractive(node) {
-    return getStyle(node).pointerEvents !== "none";
+    return (
+        getStyle(node).pointerEvents !== "none" &&
+        !node.closest("[inert]") &&
+        !node.ownerDocument.defaultView.frameElement?.matches("[inert]")
+    );
 }
 
 /**

--- a/addons/website/__manifest__.py
+++ b/addons/website/__manifest__.py
@@ -344,6 +344,7 @@
         ],
         'web.assets_unit_tests': [
             'web/static/src/legacy/js/public/minimal_dom.js',
+            'website/static/src/client_actions/website_preview/website_builder_action_test_mode.js',
             'website/static/tests/core/**/*',
             'website/static/tests/helpers.js',
             'website/static/tests/interactions/**/*',

--- a/addons/website/static/src/client_actions/website_preview/website_builder_action.js
+++ b/addons/website/static/src/client_actions/website_preview/website_builder_action.js
@@ -240,10 +240,20 @@ export class WebsiteBuilderClientAction extends Component {
     }
 
     async onEditPage() {
-        await this.iframeLoaded;
-        await this.publicRootReady;
-        await this.loadAssetsEditBundle();
+        this.blockIframe();
+        await this.loadIframeAndBundles(true);
+        this.unblockIframe();
         this.state.isEditing = true;
+    }
+    /**
+     * @param {Boolean} isEditing
+     */
+    async loadIframeAndBundles(isEditing) {
+        await this.iframeLoaded;
+        if (isEditing) {
+            await this.publicRootReady;
+            await this.loadAssetsEditBundle();
+        }
     }
 
     async loadAssetsEditBundle() {
@@ -342,6 +352,13 @@ export class WebsiteBuilderClientAction extends Component {
         if (this.withLoader) {
             this.websiteService.hideLoader();
         }
+    }
+
+    blockIframe() {
+        this.websiteContent.el.setAttribute("inert", "");
+    }
+    unblockIframe() {
+        this.websiteContent.el.removeAttribute("inert");
     }
 
     setupClickListener() {
@@ -463,11 +480,7 @@ export class WebsiteBuilderClientAction extends Component {
         } else {
             this.websiteContent.el.contentWindow.location.reload();
         }
-        await this.iframeLoaded;
-        if (isEditing) {
-            await this.publicRootReady;
-            await this.loadAssetsEditBundle();
-        }
+        await this.loadIframeAndBundles(isEditing);
         this.ui.unblock();
     }
 

--- a/addons/website/static/tests/builder/operation.test.js
+++ b/addons/website/static/tests/builder/operation.test.js
@@ -172,8 +172,8 @@ describe("Async operations", () => {
         await setupWebsiteBuilder(`<div class="test-options-target">TEST</div>`);
         await contains(":iframe .test-options-target").click();
         await contains(".options-container [data-label='Type'] .btn-secondary ").click();
-        await hover(".options-container [data-action-value='first']");
-        await hover(".options-container [data-action-value='second']");
+        await hover(".popover [data-action-value='first']");
+        await hover(".popover [data-action-value='second']");
         await advanceTime(applyDelay + 50);
         expect.verifySteps(["apply first", "revert", "apply second"]);
         expect(":iframe .test-options-target").toHaveClass("second");

--- a/addons/website/static/tests/builder/options/countdown_option.test.js
+++ b/addons/website/static/tests/builder/options/countdown_option.test.js
@@ -1,5 +1,5 @@
 import { expect, test } from "@odoo/hoot";
-import { click, queryFirst, waitFor } from "@odoo/hoot-dom";
+import { queryFirst, waitFor } from "@odoo/hoot-dom";
 import { contains } from "@web/../tests/web_test_helpers";
 import { defineWebsiteModels, setupWebsiteBuilderWithSnippet } from "../website_helpers";
 
@@ -7,9 +7,8 @@ defineWebsiteModels();
 
 async function setLayout(layout, selectorAdd = "") {
     await waitFor("[data-label='At The End']");
-    await click("[data-label='At The End'] button.o-dropdown");
-    await waitFor(`[data-action-value='${layout}']`);
-    await click(`[data-action-value='${layout}']`);
+    await contains("[data-label='At The End'] button.o-dropdown").click();
+    await contains(`.popover [data-action-value='${layout}']`).click();
     expect(`:iframe .s_countdown${selectorAdd}`).toHaveAttribute("data-end-action", layout);
 }
 


### PR DESCRIPTION
With a slow connection, it is possible to click on edit, then click on a menu link before the builder opens and be redirected. This should not be possible and was not the case before [1].

Steps to reproduce:
- Set your network to "regular 3G"
- Click on Edit
- Click on another menu item => The iframe is redirected, then the builder sidebar opens but you can't edit the page.

[1]: https://github.com/odoo/odoo/commit/9fe45e2b7ddbbfd0445ffe25a859e67a316d02b2

task-4367641