### PR TITLE
[IMP] web: tree editor: multi operators

### DIFF
--- a/addons/web/static/src/core/domain_selector/domain_selector_operator_editor.js
+++ b/addons/web/static/src/core/domain_selector/domain_selector_operator_editor.js
@@ -17,7 +17,7 @@ function getSpecificOperators(fieldDef, params) {
         case "many2one":
         case "many2many":
         case "one2many":
-            return ["ilike", "not ilike", "starts_with", "ends_with"];
+            return ["multi ilike", "multi not ilike", "multi starts_with", "multi ends_with"];
         case "date":
         case "datetime":
             return [
@@ -31,9 +31,9 @@ function getSpecificOperators(fieldDef, params) {
         case "integer":
         case "float":
         case "monetary":
-            return [">", "<", "between", "not_between", "ilike", "not ilike"];
+            return [">", "<", "between", "not_between", "multi ilike", "multi not ilike"];
         case "json":
-            return ["ilike", "not ilike"];
+            return ["multi ilike", "multi not ilike"];
         case "date_option":
         case "time_option":
         case "datetime_option":

--- a/addons/web/static/src/core/record_selectors/multi_record_selector.js
+++ b/addons/web/static/src/core/record_selectors/multi_record_selector.js
@@ -52,7 +52,7 @@ export class MultiRecordSelector extends Component {
      * a tag, the input is still empty.
      */
     get placeholder() {
-        return this.getIds().length ? "" : this.props.placeholder;
+        return this.getTags(this.props, {}).length ? "" : this.props.placeholder;
     }
 
     getIds(props = this.props) {

--- a/addons/web/static/src/core/tree_editor/tree_editor_datetime_options.js
+++ b/addons/web/static/src/core/tree_editor/tree_editor_datetime_options.js
@@ -89,7 +89,7 @@ export function getEditorInfoForOptionsWithSelect(name, params) {
             update: (value) => update(fromSelectValue(value)),
             options,
             addBlankOption: params.addBlankOption,
-            placeholder: displayPlaceholder && _t(`Select one or several criteria`),
+            placeholder: displayPlaceholder && _t(`Select at least one criterion`),
         }),
         defaultValue: getCurrent(UNITS[name]),
         isSupported: (value) => typeof value !== "string" && getOption(value),

--- a/addons/web/static/src/core/tree_editor/tree_editor_operator_editor.js
+++ b/addons/web/static/src/core/tree_editor/tree_editor_operator_editor.js
@@ -16,8 +16,8 @@ const OPERATOR_DESCRIPTIONS = {
     "=ilike": _t("=ilike"),
     like: _t("like"),
     "not like": _t("not like"),
-    ilike: _t("contains"),
-    "not ilike": _t("not contains"),
+    ilike: _t("ilike"),
+    "not ilike": _t("not ilike"),
     in: _t("equals"),
     "not in": _t("not equals"),
     child_of: _t("child of"),
@@ -27,8 +27,14 @@ const OPERATOR_DESCRIPTIONS = {
     set: _t("set"),
     not_set: _t("not set"),
 
+    "multi ilike": _t("contains"),
+    "multi not ilike": _t("not contains"),
+
     starts_with: _t("starts with"),
     ends_with: _t("ends with"),
+
+    "multi starts_with": _t("starts with"),
+    "multi ends_with": _t("ends with"),
 
     today: _t("today"),
     not_today: _t("not today"),

--- a/addons/web/static/src/core/tree_editor/utils.js
+++ b/addons/web/static/src/core/tree_editor/utils.js
@@ -229,6 +229,12 @@ function _getConditionDescription(node, getFieldDef, getPathDescription, display
             join = " ";
             addParenthesis = false;
             break;
+        case "multi ilike":
+        case "multi not ilike":
+        case "multi starts_with":
+        case "multi ends_with":
+            addParenthesis = false;
+        // eslint-disable-next-line no-fallthrough
         case "in":
         case "not in":
             addParenthesis = values.length === 0;

--- a/addons/web/static/tests/core/domain_selector/domain_selector.test.js
+++ b/addons/web/static/tests/core/domain_selector/domain_selector.test.js
@@ -310,11 +310,9 @@ test("building a domain with a m2o without following the relation", async () => 
             expect.step(domain);
         },
     });
-    expect.verifySteps([]);
-    expect(isNotSupportedValue()).toBe(true);
 
-    await clearNotSupported();
-    expect.verifySteps([`[("product_id", "ilike", "")]`]);
+    await contains(`${SELECTORS.valueEditor} .o_tag .o_delete`).click();
+    expect.verifySteps([`[(0, "=", 1)]`]);
 
     await contains(`${SELECTORS.valueEditor} input`).edit("pad");
     expect.verifySteps([`[("product_id", "ilike", "pad")]`]);
@@ -454,7 +452,7 @@ test("json field with operator change from 'equal' to 'ilike'", async () => {
     expect(getCurrentOperator()).toBe("=");
     expect(getCurrentValue()).toBe(`hey`);
 
-    await selectOperator("ilike");
+    await selectOperator("multi ilike");
     expect(getCurrentOperator()).toBe("contains");
 });
 
@@ -1577,13 +1575,13 @@ test("many2one field: operator switch (edit)", async () => {
     expect(getCurrentValue()).toBe("");
     expect.verifySteps([`[("product_id", "not in", [])]`]);
 
-    await selectOperator("ilike");
+    await selectOperator("multi ilike");
     expect(getCurrentValue()).toBe("");
-    expect.verifySteps([`[("product_id", "ilike", "")]`]);
+    expect.verifySteps([`[(0, "=", 1)]`]);
 
-    await selectOperator("not ilike");
+    await selectOperator("multi not ilike");
     expect(getCurrentValue()).toBe("");
-    expect.verifySteps([`[("product_id", "not ilike", "")]`]);
+    expect.verifySteps([`[]`]);
 });
 
 test("many2one field and operator =/!= (edit)", async () => {
@@ -1685,21 +1683,26 @@ test("many2one field and operator ilike/not ilike (edit)", async () => {
     });
     expect(getCurrentOperator()).toBe("contains");
     expect(".o-autocomplete--input").toHaveCount(0);
-    expect(`${SELECTORS.valueEditor} .o_input`).toHaveCount(1);
-    expect(getCurrentValue()).toBe("abc");
+    expect(`${SELECTORS.valueEditor} input`).toHaveCount(1);
+    expect(`${SELECTORS.valueEditor} input`).toHaveValue("");
+    expect(queryAllTexts(SELECTORS.tag)).toEqual(["abc"]);
     expect.verifySteps([]);
 
-    await contains(`${SELECTORS.valueEditor} .o_input`).edit("def");
+    await contains(`${SELECTORS.valueEditor} input`).edit("def");
     expect(getCurrentOperator()).toBe("contains");
-    expect(`${SELECTORS.valueEditor} .o_input`).toHaveCount(1);
-    expect(getCurrentValue()).toBe("def");
-    expect.verifySteps([`[("product_id", "ilike", "def")]`]);
+    expect(`${SELECTORS.valueEditor} input`).toHaveCount(1);
+    expect(`${SELECTORS.valueEditor} input`).toHaveValue("");
+    expect(queryAllTexts(SELECTORS.tag)).toEqual(["abc", "def"]);
+    expect.verifySteps([`["|", ("product_id", "ilike", "abc"), ("product_id", "ilike", "def")]`]);
 
-    await selectOperator("not ilike");
+    await selectOperator("multi not ilike");
     expect(getCurrentOperator()).toBe("not contains");
-    expect(`${SELECTORS.valueEditor} .o_input`).toHaveCount(1);
-    expect(getCurrentValue()).toBe("def");
-    expect.verifySteps([`[("product_id", "not ilike", "def")]`]);
+    expect(`${SELECTORS.valueEditor} input`).toHaveCount(1);
+    expect(`${SELECTORS.valueEditor} input`).toHaveValue("");
+    expect(queryAllTexts(SELECTORS.tag)).toEqual(["abc", "def"]);
+    expect.verifySteps([
+        `["&", ("product_id", "not ilike", "abc"), ("product_id", "not ilike", "def")]`,
+    ]);
 });
 
 test("many2many field and operator set/not set (edit)", async () => {
@@ -1785,17 +1788,17 @@ test("x2many field: operator switch (edit)", async () => {
     expect(getCurrentValue()).toBe("");
     expect.verifySteps([`[("product_ids", "not in", [])]`]);
 
-    await selectOperator("ilike");
+    await selectOperator("multi ilike");
     expect(getCurrentValue()).toBe("");
-    expect.verifySteps([`[("product_ids", "ilike", "")]`]);
+    expect.verifySteps([`[(0, "=", 1)]`]);
 
     await selectOperator("not_set");
     expect(".o_ds_value_cell").toHaveCount(0);
     expect.verifySteps([`[("product_ids", "=", False)]`]);
 
-    await selectOperator("not ilike");
+    await selectOperator("multi not ilike");
     expect(getCurrentValue()).toBe("");
-    expect.verifySteps([`[("product_ids", "not ilike", "")]`]);
+    expect.verifySteps([`[]`]);
 
     await selectOperator("set");
     expect(".o_ds_value_cell").toHaveCount(0);
@@ -1875,21 +1878,26 @@ test("many2many field: operator ilike/not ilike (edit)", async () => {
     });
     expect(getCurrentOperator()).toBe("contains");
     expect(".o-autocomplete--input").toHaveCount(0);
-    expect(`${SELECTORS.valueEditor} .o_input`).toHaveCount(1);
-    expect(getCurrentValue()).toBe("abc");
+    expect(`${SELECTORS.valueEditor} input`).toHaveCount(1);
+    expect(`${SELECTORS.valueEditor} input`).toHaveValue("");
+    expect(queryAllTexts(SELECTORS.tag)).toEqual(["abc"]);
     expect.verifySteps([]);
 
-    await contains(`${SELECTORS.valueEditor} .o_input`).edit("def");
+    await contains(`${SELECTORS.valueEditor} input`).edit("def");
     expect(getCurrentOperator()).toBe("contains");
-    expect(`${SELECTORS.valueEditor} .o_input`).toHaveCount(1);
-    expect(getCurrentValue()).toBe("def");
-    expect.verifySteps([`[("product_ids", "ilike", "def")]`]);
+    expect(`${SELECTORS.valueEditor} input`).toHaveCount(1);
+    expect(`${SELECTORS.valueEditor} input`).toHaveValue("");
+    expect(queryAllTexts(SELECTORS.tag)).toEqual(["abc", "def"]);
+    expect.verifySteps([`["|", ("product_ids", "ilike", "abc"), ("product_ids", "ilike", "def")]`]);
 
-    await selectOperator("not ilike");
+    await selectOperator("multi not ilike");
     expect(getCurrentOperator()).toBe("not contains");
-    expect(`${SELECTORS.valueEditor} .o_input`).toHaveCount(1);
-    expect(getCurrentValue()).toBe("def");
-    expect.verifySteps([`[("product_ids", "not ilike", "def")]`]);
+    expect(`${SELECTORS.valueEditor} input`).toHaveCount(1);
+    expect(`${SELECTORS.valueEditor} input`).toHaveValue("");
+    expect(queryAllTexts(SELECTORS.tag)).toEqual(["abc", "def"]);
+    expect.verifySteps([
+        `["&", ("product_ids", "not ilike", "abc"), ("product_ids", "not ilike", "def")]`,
+    ]);
 });
 
 test("many2many field: operator set/not set (edit)", async () => {
@@ -3252,7 +3260,7 @@ test("date options (edit): This day/This month", async () => {
     await openModelFieldSelectorPopover();
     await contains(`.o_model_field_selector_popover_item[data-name='day_of_month'] button`).click();
     expect.verifySteps([`[("date.day_of_month", "in", [])]`]);
-    expect(getCurrentValue()).toBe("Select one or several criteria");
+    expect(getCurrentValue()).toBe(`Select at least one criterion`);
     await selectValue("context_today().day");
     expect(getCurrentValue()).toBe("This day");
     expect.verifySteps([`[("date.day_of_month", "in", [context_today().day])]`]);
@@ -3314,7 +3322,7 @@ test("many2one: placeholders for in operator", async () => {
     });
     expect(`${SELECTORS.valueEditor} input`).toHaveAttribute(
         "placeholder",
-        `Select one or several criteria`
+        `Select at least one criterion`
     );
 });
 
@@ -3324,7 +3332,7 @@ test("datetime: placeholders for in operator", async () => {
     });
     expect(`${SELECTORS.valueEditor} input`).toHaveAttribute(
         "placeholder",
-        `Select one or several criteria`
+        `Select at least one criterion`
     );
 });
 
@@ -3334,7 +3342,7 @@ test("date: placeholders for in operator", async () => {
     });
     expect(`${SELECTORS.valueEditor} input`).toHaveAttribute(
         "placeholder",
-        `Select one or several criteria`
+        `Select at least one criterion`
     );
 });
 
@@ -3344,7 +3352,7 @@ test("char: placeholders for in operator", async () => {
     });
     expect(`${SELECTORS.valueEditor} input`).toHaveAttribute(
         "placeholder",
-        `Press "Enter" to add criterion`
+        `Enter at least one criterion`
     );
 });
 
@@ -3352,7 +3360,7 @@ test("selection: placeholders for in operator", async () => {
     await makeDomainSelector({
         domain: `[("state", "in", [])]`,
     });
-    expect(`${SELECTORS.valueEditor} select`).toHaveValue(`Select one or several criteria`);
+    expect(`${SELECTORS.valueEditor} select`).toHaveValue(`Select at least one criterion`);
 });
 
 test(`datetime option 'Date': placeholders for in operator`, async () => {
@@ -3364,7 +3372,7 @@ test(`datetime option 'Date': placeholders for in operator`, async () => {
     await contains(".o_model_field_selector_popover_item:contains('Date') button").click();
     expect(`${SELECTORS.valueEditor} input`).toHaveAttribute(
         "placeholder",
-        `Select one or several criteria`
+        `Select at least one criterion`
     );
 });
 

--- a/addons/web/static/tests/search/search_bar.test.js
+++ b/addons/web/static/tests/search/search_bar.test.js
@@ -1450,16 +1450,18 @@ test("edit a favorite", async () => {
     expect(`.modal`).toHaveCount(1);
     expect(getCurrentPath()).toBe("Foo");
     expect(getCurrentOperator()).toBe("contains");
-    expect(getCurrentValue()).toBe("abc");
+    expect(`${SELECTORS.valueEditor} input`).toHaveValue("");
+    expect(queryAllTexts(SELECTORS.tag)).toEqual(["abc"]);
 
     await editValue("def");
     expect(getCurrentPath()).toBe("Foo");
     expect(getCurrentOperator()).toBe("contains");
-    expect(getCurrentValue()).toBe("def");
+    expect(`${SELECTORS.valueEditor} input`).toHaveValue("");
+    expect(queryAllTexts(SELECTORS.tag)).toEqual(["abc", "def"]);
 
     await contains(".modal footer button").click();
     expect(`.modal`).toHaveCount(0);
-    expect(getFacetTexts()).toEqual(["Foo contains def", "Bool\n>\nCompany"]);
+    expect(getFacetTexts()).toEqual(["Foo contains abc or def", "Bool\n>\nCompany"]);
 });
 
 test("edit a field", async () => {
@@ -1485,14 +1487,11 @@ test("edit a field", async () => {
     expect(getFacetTexts()).toEqual(["Foo\nabc\nor\ndef"]);
 
     await contains(".o_facet_with_domain .o_searchview_facet_label").click();
-    expect(SELECTORS.condition).toHaveCount(2);
-
-    expect(getCurrentPath(0)).toBe("Foo");
-    expect(getCurrentOperator(0)).toBe("contains");
-    expect(getCurrentValue(0)).toBe("abc");
-    expect(getCurrentPath(1)).toBe("Foo");
-    expect(getCurrentOperator(1)).toBe("contains");
-    expect(getCurrentValue(1)).toBe("def");
+    expect(SELECTORS.condition).toHaveCount(1);
+    expect(getCurrentPath()).toBe("Foo");
+    expect(getCurrentOperator()).toBe("contains");
+    expect(`${SELECTORS.valueEditor} input`).toHaveValue("");
+    expect(queryAllTexts(SELECTORS.tag)).toEqual(["abc", "def"]);
 
     await contains(".modal footer button").click();
     expect(getFacetTexts()).toEqual([`Foo\nabc\nor\ndef`]);

--- a/addons/web/static/tests/search/search_bar_menu/favorite_menu.test.js
+++ b/addons/web/static/tests/search/search_bar_menu/favorite_menu.test.js
@@ -232,7 +232,7 @@ test("edit a favorite with a groupby", async () => {
     await editValue("abcde");
     await contains(`.modal footer button`).click();
     expect(`.modal`).toHaveCount(0);
-    expect(getFacetTexts()).toEqual(["Foo contains abcde", "Bar"]);
+    expect(getFacetTexts()).toEqual(["Foo contains abc or abcde", "Bar"]);
 
     await toggleSearchBarMenu();
     expect(`.o_group_by_menu .o_menu_item:not(.o_add_custom_group_menu)`).toHaveCount(0);


### PR DESCRIPTION
We no longer propose "ilike", "not ilike", "stars_with", and "end_with" for selection in the tree editor but instead multi versions of them. This is similar to what we have done in https://github.com/odoo/odoo/pull/208592 where "in" replaces "=". This means that for most operators, we have now the possibility to add several values at once in a single
condition. For example, to

Author contains abc ~ [("author", "ilike", "abc")]

we can add "def" and the domain becomes

Author contains abc, def ~ ["|", ("author", "ilike", "abc"), ("author", "ilike", "def")]

Task ID: 4610804