### PR TITLE
[FIX] hr_recruitment: Fixing None stage creation when moving an application to the existing None stage

### DIFF
--- a/addons/web/static/src/model/relational_model/dynamic_group_list.js
+++ b/addons/web/static/src/model/relational_model/dynamic_group_list.js
@@ -121,10 +121,11 @@ export class DynamicGroupList extends DynamicList {
         sourceGroup._removeRecords([record.id]);
         targetGroup._addRecord(record, refIndex + 1);
         // step 2: update record value
-        const value =
-            targetGroup.groupByField.type === "many2one"
-                ? [targetGroup.value, targetGroup.displayName]
-                : targetGroup.value;
+        let value = targetGroup.value;
+        if (targetGroup.groupByField.type === "many2one") {
+            value = value ? [value, targetGroup.displayName] : false;
+        }
+
         const revert = () => {
             targetGroup._removeRecords([record.id]);
             sourceGroup._addRecord(record, oldIndex);

--- a/addons/web/static/tests/views/kanban/kanban_view.test.js
+++ b/addons/web/static/tests/views/kanban/kanban_view.test.js
@@ -3473,6 +3473,54 @@ test("quick create is disabled until record is created and read", async () => {
 });
 
 test.tags("desktop");
+test("kanban grouped by stage_id: move record from to the None column", async () => {
+    // Fake model: partner.stage (only for group headers)
+    const Stage = class extends models.Model {
+        _name = "partner.stage";
+        name = fields.Char();
+        _records = [{ id: 10, name: "New" }];
+    };
+    defineModels([Stage]);
+
+    // Set up a record with no stage initially
+    Partner._records = [
+        { id: 1, foo: "Task A", stage_id: false },
+        { id: 2, foo: "Task B", stage_id: 10},
+    ];
+    Partner._fields.stage_id = fields.Many2one({ relation: "partner.stage" });
+
+    await mountView({
+        type: "kanban",
+        resModel: "partner",
+        arch: `
+            <kanban>
+                <templates>
+                    <t t-name="card">
+                        <field name="foo"/>
+                    </t>
+                </templates>
+            </kanban>`,
+        groupBy: ["stage_id"],
+    });
+
+    expect(queryAll(".o_kanban_group")).toHaveCount(2); // None and New
+
+    await click(".o_kanban_group:first .o_kanban_header");
+    
+    // Drag a record to the "None" column
+    let dragActions = await contains(".o_kanban_record:contains(Task B)").drag();
+    await dragActions.moveTo(".o_kanban_group:nth-child(1) .o_kanban_header");
+    await dragActions.drop();
+
+    // Reload
+    await validateSearch();
+
+    // Assert it's back in "None"
+    expect(queryAll(".o_kanban_record", { root: getKanbanColumn(0) })).toHaveCount(2);
+    expect(queryAllTexts(".o_kanban_record", { root: getKanbanColumn(0) })[1]).toBe("Task B");
+});
+
+test.tags("desktop");
 test("quick create record fail in grouped by many2one", async () => {
     Partner._views["form"] = `
         <form>


### PR DESCRIPTION
In this PR, we fixed the creation of a new None stage each time when we move an application to the existing None stage (stage_id = false).

## Description of the issue/feature this PR addresses:
In the Kanban view of the application dashboard, when a user moves an application to the "None" stage (which corresponds to stage_id = False) and refreshes the page, a new stage labeled "None" is incorrectly created.
The issue arose from the way we were updating the many2one field for stage_id. Specifically, we were setting the value as:
`{ id: false, display_name: "None" }`

This object was interpreted by the model layer as an instruction to create a new related record (i.e., a new stage) with the name "None", which is unintended.

## Fix:
We adjusted the logic so that if the targetGroup.value is falsy (i.e., null, undefined, or false), we now explicitly pass false instead of constructing an object. This correctly unsets the many2one field without triggering record creation.
This ensures:
- If a valid stage is selected, we pass the appropriate { id, display_name } object.
- If "None" is selected, we pass false to unset the stage_id, avoiding the creation of a phantom stage.

Current behavior before PR:
![screen-capture](https://github.com/user-attachments/assets/b6463875-c274-429d-9a2b-6a044946d9ef)


Desired behavior after PR is merged:
![chrome-capture-2025-6-17](https://github.com/user-attachments/assets/f4cb13bf-5f15-4b3e-908b-7732dad525f2)

 Task: 4873853

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
