### PR TITLE
[FIX] website: video if cookie without wasted space


### DIFF
--- a/addons/website/static/src/interactions/video/media_video.js
+++ b/addons/website/static/src/interactions/video/media_video.js
@@ -12,7 +12,6 @@ export class MediaVideo extends Interaction {
         if (this.el.dataset.needCookiesApproval) {
             this.sizeContainerEl = this.el.querySelector(":scope > .media_iframe_video_size");
             this.sizeContainerEl.classList.add("d-none");
-            this.addListener(document, "optionalCookiesAccepted", this.sizeContainerEl.classList.remove("d-none"))
             this.registerCleanup(() => this.sizeContainerEl.classList.remove("d-none"));
         }
     }
@@ -33,6 +32,7 @@ export class MediaVideo extends Interaction {
                 this.waitFor(promise).then(this.protectSyncAfterAsync(() => triggerAutoplay(iframeEl)));
             }
         }
+        this.addListener(document, "optionalCookiesAccepted", () => this.sizeContainerEl.classList.remove("d-none"))
     }
 
     generateIframe() {


### PR DESCRIPTION

Scenario:

- add a youtube video on a website page, enable the cookie bar with 3rd
  party blocking
- go in incognito to the page

Result: there is a block with the notice "To see the interactive content
, you need to accept optional cookies." and a big empty whitespace above
it.

Fix: fix the typo in the code so the code showing the element
.media_iframe_video_size is run when the cookies are accepted as was the
intent and the case in 18.0 version.

opw-4866088
