### PR TITLE
[FIX] link_tracker,mass_mailing_sms: match commas in text urls

### DIFF
--- a/addons/link_tracker/tests/test_mail_render_mixin.py
+++ b/addons/link_tracker/tests/test_mail_render_mixin.py
@@ -121,7 +121,7 @@ class TestMailRenderMixin(common.TransactionCase):
             'This is another: {base_url}/web#debug=1&more=2\n'
             'A third: {base_url}\n'
             'A forth: {base_url}\n'
-            'And a last, with question mark: https://boinc.berkeley.edu/forum_thread.php?id=14544&postid=106833'
+            'And a last, more complex: https://boinc.berkeley.edu/forum_thread.php?id=14544&postid=106833#options=2,3'
             .format(base_url=self.base_url)
         )
         expected_pattern = re.compile(
@@ -129,7 +129,7 @@ class TestMailRenderMixin(common.TransactionCase):
             'This is another: {base_url}/r/[\\w]+\n'
             'A third: {base_url}/r/([\\w]+)\n'
             'A forth: {base_url}/r/([\\w]+)\n'
-            'And a last, with question mark: {base_url}/r/([\\w]+)'
+            'And a last, more complex: {base_url}/r/([\\w]+)'
             .format(base_url=self.base_url)
         )
         new_content = self.env["mail.render.mixin"]._shorten_links_text(content, {})

--- a/addons/mass_mailing_sms/static/src/components/sms_widget/fields_sms_widget.js
+++ b/addons/mass_mailing_sms/static/src/components/sms_widget/fields_sms_widget.js
@@ -7,7 +7,7 @@ import { SmsWidget } from "@sms/components/sms_widget/fields_sms_widget";
 
 import { onWillStart } from "@odoo/owl";
 
-const TEXT_URL_REGEX = /https?:\/\/[\w@:%.+&~#=/-]+(?:\?\S+)?/g;  // from tools.mail.TEXT_URL_REGEX
+const TEXT_URL_REGEX = /https?:\/\/[\w@:%.,+&~#=/-]+(?:\?\S+)?/g;  // from tools.mail.TEXT_URL_REGEX
 
 /**
  * Patch to provide extra characters count information to

--- a/odoo/tools/mail.py
+++ b/odoo/tools/mail.py
@@ -330,7 +330,7 @@ def html_sanitize(src, silent=True, sanitize_tags=True, sanitize_attributes=Fals
 # ----------------------------------------------------------
 
 URL_REGEX = r'(\bhref=[\'"](?!mailto:|tel:|sms:)([^\'"]+)[\'"])'
-TEXT_URL_REGEX = r'https?://[\w@:%.+&~#=/-]+(?:\?\S+)?'
+TEXT_URL_REGEX = r'https?://[\w@:%.,+&~#=/-]+(?:\?\S+)?'
 # retrieve inner content of the link
 HTML_TAG_URL_REGEX = URL_REGEX + r'([^<>]*>([^<>]+)<\/)?'
 HTML_TAGS_REGEX = re.compile('<.*?>')


### PR DESCRIPTION
The method that shortens urls in plain text
does not expect commas to be part of the url even though they are completely valid.

This leads to urls with commas breaking in sms marketing campaigns.

This is a problem as commas are notably used for product variant identification. Meaning users cannot send urls for specific versions of products.

The fix is simple and should be completely safe as it only impacts plain text urls.

task-4876650