### PR TITLE
[FIX] purchase: fix create bills error with multiple partenrs

### DIFF
--- a/addons/purchase/models/purchase_order.py
+++ b/addons/purchase/models/purchase_order.py
@@ -852,8 +852,9 @@ class PurchaseOrder(models.Model):
         else:
             result = {'type': 'ir.actions.act_window_close'}
 
-        result['context'] = literal_eval(result['context'])
-        result['context']['default_partner_id'] = self.partner_id.id
+        if len(invoices.partner_id) == 1:
+            result['context'] = literal_eval(result['context'])
+            result['context']['default_partner_id'] = self.partner_id.id
         return result
 
     @api.model


### PR DESCRIPTION
In [this PR](https://github.com/odoo/odoo/pull/209851) which was created for some improvements in the `Upload Bills` functionality, I didn't take into account `action_create_invoice` used the same code but with different vendors at the same time, so it gave error when creating bills for a batch of POs with different vendors.

This PR fixes the issue by making sure the code is triggered only if the POs batch shared the same vendor.
