### PR TITLE
[FIX] l10n_ro_edi_stock: map EU VAT country codes for consistency

### DIFF
--- a/addons/l10n_ro_edi_stock/models/stock_picking.py
+++ b/addons/l10n_ro_edi_stock/models/stock_picking.py
@@ -239,6 +239,10 @@ STATE_CODES = {
     'GR': '52',
 }
 
+_eu_country_vat = {
+    'GR': 'EL'
+}
+
 
 class Picking(models.Model):
     _inherit = 'stock.picking'
@@ -837,7 +841,7 @@ class Picking(models.Model):
                     for move in data['stock_move_ids'] for product in move.product_id
                 ],
                 'partenerComercial': {
-                    'codTara': commercial_partner.country_code,
+                    'codTara': _eu_country_vat.get(commercial_partner.country_code, commercial_partner.country_code),
                     'denumire': commercial_partner.name,
                     'cod': commercial_partner_code,
                 },
@@ -845,7 +849,7 @@ class Picking(models.Model):
                     'nrVehicul': data['l10n_ro_edi_stock_vehicle_number'].upper(),
                     'nrRemorca1': data['l10n_ro_edi_stock_trailer_1_number'].upper() if data['l10n_ro_edi_stock_trailer_1_number'] else None,
                     'nrRemorca2': data['l10n_ro_edi_stock_trailer_2_number'].upper() if data['l10n_ro_edi_stock_trailer_2_number'] else None,
-                    'codTaraOrgTransport': transport_partner.country_code,
+                    'codTaraOrgTransport': _eu_country_vat.get(transport_partner.country_code, transport_partner.country_code),
                     'codOrgTransport': self._l10n_ro_edi_stock_get_cod(transport_partner),
                     'denumireOrgTransport': transport_partner.name,
                     'dataTransport': scheduled_date,


### PR DESCRIPTION
Added a mapping for EU VAT country codes to ensure that the VAT prefix aligns with EU standards (e.g., 'GR' -> 'EL') in EDI exports.  

## Description of the issue/feature this PR addresses:
This PR adds country code mapping functionality to ensure compatibility with the format required by the Romanian eTransport system. Specifically, it adds the conversion of the country code "GR" (Greece) to "EL" according to European VAT standards and applies this mapping to relevant fields in transport documents.

## Current behavior before PR:
Before this PR, the country code for Greece was sent as "GR" to the eTransport system, which could cause validation errors because in European VAT systems, Greece is identified by the code "EL". Also, there was no consistent mapping for country codes in different parts of the system.

## Desired behavior after PR is merged:
After implementing this PR, country codes will be correctly mapped to comply with European VAT standards, especially the conversion of "GR" to "EL" for Greece. This ensures that documents sent through eTransport contain the correct country codes and will pass system validations. The mapping is applied to country codes for both commercial partners and transporters.
 
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
