### PR TITLE
[FIX] mail: attempt fixing runbot error 181952

### DIFF
--- a/addons/mail/static/tests/message/message.test.js
+++ b/addons/mail/static/tests/message/message.test.js
@@ -197,13 +197,13 @@ test("Can edit message comment in chatter", async () => {
     await press("Enter");
     await animationFrame();
     await contains(".o-mail-Message .o-mail-Composer-input"); // still editing message
-    await contains(".o-mail-Message .o-mail-Composer-input", { value: "edited again\n" });
+    await contains(".o-mail-Message .o-mail-Composer-input:value('edited again')"); // FIXME: even though value has trailing '\n', HOOT selector doesn't see it on the node
     await triggerHotkey("control+Enter"); // somehow press doesn't work :(
     await contains(".o-mail-Message-content", { text: "edited again (edited)" });
     // save without change should keep (edited)
     await click(".o-mail-Message [title='Expand']");
     await click(".o-mail-Message-moreMenu [title='Edit']");
-    await contains(".o-mail-Message .o-mail-Composer-input", { value: "edited again" });
+    await contains(".o-mail-Message .o-mail-Composer-input:value('edited again')");
     await contains(".o-mail-Message:contains('Escape to cancel, CTRL-Enter to save')");
     await triggerHotkey("control+Enter"); // somehow press doesn't work :(
     await contains(".o-mail-Message-content", { text: "edited again (edited)" });


### PR DESCRIPTION
Following non-deterministic test failure happens on runbot:
```
[HOOT] Test "@mail/message/message/Can edit message comment in chatter" failed:
[HOOT] Error: Failed to find 1 of ".o-mail-Message .o-mail-Composer-input" with value "edited again" (Timeout of 3 seconds). Found 0 instead.
```

We couldn't reproduce in practice to see why this fails, and we are not helped from HOOT tests on runbot being run in headless mode thus screenshots are useless.

One theory of failure is race condition of composer input still containing the trailing `\n` character when we'd expect it to be removed. The `contains({ value })` of mail test helpers checks for exact match of value thus the error.

This commit attempts to fix the issue by using relaxing the condition for input containing at least the expected character. In other words: it replaces the `{ value }` (exact match) by `:value()` (includes match). That way if the value still has the `/n` trailing character, assertion `edited again` would pass with `edited again/n`.

Note that `:value` seems to not see newlines `\n` in inputs. This is a bit annoying so we had to relax the other value assertion too. There's plan to use web selectors rather than mail ones, which is another reason to not improve mail_test_helpers further and instead put effort to migrate to web test helpers.

runbot-181952
