### PR TITLE
[FIX] ai,mail: prevent chat bubbles from being hidden behind form status bar

### DIFF
--- a/addons/mail/static/src/core/common/chat_hub.scss
+++ b/addons/mail/static/src/core/common/chat_hub.scss
@@ -1,6 +1,6 @@
 .o-mail-ChatHub-bubbles {
     width: $o-mail-ChatHub-bubblesWidth;
-    z-index: $o-mail-NavigableList-zIndex - 1;
+    z-index: $zindex-sticky;
 
     &.o-liftUp {
         transform: translateY(-25px);

--- a/addons/mail/static/src/core/common/chat_window.scss
+++ b/addons/mail/static/src/core/common/chat_window.scss
@@ -1,7 +1,7 @@
 .o-mail-ChatWindow {
     width: $o-mail-ChatWindow-width;
 
-    z-index: $zindex-sticky;
+    z-index: $zindex-sticky + 1;
     &:not(.o-mobile) {
         --border-opacity: .15;
         height: Min(95vh, $o-mail-ChatWindow-width * 15 / 9)


### PR DESCRIPTION
Current behavior before PR:
 - Chat notification bubbles appear behind the form status bar
 
![image](https://github.com/user-attachments/assets/72346182-be05-43a0-a341-23457efa9a74)


Desired behavior after PR is merged:
 - Chat notification bubbles are properly displayed above the form status bar

![image](https://github.com/user-attachments/assets/8aac1b4a-38e1-476c-be15-6f2e709dcf61)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
