### PR TITLE
[FIX] iot_box_image: odoo logs saturating /var

### DIFF
--- a/addons/iot_box_image/overwrite_before_init/etc/logrotate.d/odoo
+++ b/addons/iot_box_image/overwrite_before_init/etc/logrotate.d/odoo
@@ -1,4 +1,5 @@
 /var/log/odoo/*.log {
+    size 100M
     copytruncate
     missingok
     notifempty

--- a/addons/iot_box_image/overwrite_before_init/etc/systemd/system/odoo.service
+++ b/addons/iot_box_image/overwrite_before_init/etc/systemd/system/odoo.service
@@ -15,7 +15,7 @@ ExecStartPre=sudo /bin/chown odoo:odoo /run/odoo
 ExecStartPre=sudo timedatectl set-ntp true
 ExecStart=/usr/bin/python3 /home/pi/odoo/odoo-bin --config /home/pi/odoo.conf
 Restart=on-failure
-RestartSec=5s
+RestartSec=10s
 StandardOutput=null
 StandardError=append:/var/log/odoo/odoo-server.log
 


### PR DESCRIPTION
Logs were rotating after 2 days, but not above a certain filesize, which could lead to saturation of `/var`, which size is limited to 192MB.

We now rotate above 100M.