### PR TITLE
[IMP] html_editor: handle unobserved mutations

### DIFF
--- a/addons/html_editor/static/src/core/history_plugin.js
+++ b/addons/html_editor/static/src/core/history_plugin.js
@@ -1258,6 +1258,9 @@ export class HistoryPlugin extends Plugin {
      *        of other mutations
      */
     applyMutations(mutations, { forNewStep = false, reverse } = {}) {
+        if (forNewStep) {
+            this.fixClassListMutationsForNewStep(mutations);
+        }
         for (const mutation of mutations) {
             switch (mutation.type) {
                 case "custom": {
@@ -1272,7 +1275,7 @@ export class HistoryPlugin extends Plugin {
                     break;
                 }
                 case "classList": {
-                    const node = this.idToNodeMap.get(mutation.id);
+                    const node = this.nodeMap.getNode(mutation.id);
                     if (node) {
                         toggleClass(node, mutation.className, mutation.value);
                     }
@@ -1307,6 +1310,38 @@ export class HistoryPlugin extends Plugin {
                     break;
                 }
             }
+        }
+    }
+
+    /**
+     * When applying mutations for a new step, we expect them to produce
+     * observable mutations, which will then be stored in a new step. However,
+     * there are situations where applying a classList mutation would not
+     * produce an observable mutation:
+     * - adding a class that is already present
+     * - removing a class that is already absent
+     * These scenarios might happen due to the class having been already added
+     * or removed by a previous unobserved mutation. We want, nevertheless to
+     * produce the observable mutation of adding/removing this class, as this
+     * does correspond to a state change in observable history and should be
+     * included in the new step. In order to produce such observable mutations,
+     * we set the dom state to the one that would produce the desired result.
+     * This is equivalent to restoring the dom to the observed state in recorded
+     * history before applying a mutation, that is, oldValue (as oldValue is
+     * always !value for staged classList records).
+     *
+     * @param { HistoryMutation[] } mutations
+     */
+    fixClassListMutationsForNewStep(mutations) {
+        // Mutations that when applied would not produce observable classList mutations
+        const nonObservableClassMutations = mutations
+            .filter(({ type }) => type === "classList")
+            .map((mutation) => ({ ...mutation, node: this.nodeMap.getNode(mutation.id) }))
+            .filter(({ node, className, value }) => value === node?.classList.contains(className));
+        if (nonObservableClassMutations.length) {
+            const setToOldValue = ({ node, className, oldValue }) =>
+                toggleClass(node, className, oldValue);
+            this.withObserverOff(() => nonObservableClassMutations.forEach(setToOldValue));
         }
     }
 

--- a/addons/html_editor/static/src/core/history_plugin.js
+++ b/addons/html_editor/static/src/core/history_plugin.js
@@ -366,6 +366,9 @@ export class HistoryPlugin extends Plugin {
      * /!\ This method should be used with extreme caution. Not observing some
      * mutations could lead to mutations that are impossible to undo/redo.
      *
+     * /!\ Do not re-introduce nodes that had been already added to the DOM in
+     * a history step. @see isObservedNode
+     *
      * @param {Function} callback
      */
     ignoreDOMMutations(callback) {
@@ -404,8 +407,7 @@ export class HistoryPlugin extends Plugin {
         /** @type {HistoryMutationRecord[]} */
         let records = this.transformToHistoryMutationRecords(mutationRecords);
         records = records.filter((record) => !this.isSystemMutationRecord(record));
-        records = this.handleUnobservedMutations(records);
-        records = records.filter((record) => !this.isNoOpRecord(record));
+        records = this.filterAndAdjustHistoryMutationRecords(records);
         this.stageRecords(records);
         records
             .filter(({ type }) => type === "attributes")
@@ -416,11 +418,21 @@ export class HistoryPlugin extends Plugin {
     /**
      * @param {HistoryMutationRecord} record
      */
-    isNoOpRecord(record) {
-        if (["attributes", "classList", "characterData"].includes(record.type)) {
-            return record.value === record.oldValue;
+    isValidRecord(record) {
+        switch (record.type) {
+            case "attributes":
+            case "classList":
+            case "characterData":
+                // Filter out no-op
+                return record.value !== record.oldValue;
+            case "childList":
+                return (
+                    // Filter out no-op
+                    (record.addedTrees.length || record.removedTrees.length) &&
+                    // Filter out mutation without a valid position for node insertion
+                    (record.previousSibling !== undefined || record.nextSibling !== undefined)
+                );
         }
-        return false;
     }
 
     dispatchContentUpdated() {
@@ -454,24 +466,18 @@ export class HistoryPlugin extends Plugin {
     }
 
     /**
-     * @param { HistoryMutationRecord[] } records
+     * @param {HistoryMutationRecord} record
      */
-    setIdOnRecords(records) {
-        for (const record of records) {
-            if (record.type !== "childList") {
-                continue;
-            }
-            const addedNodes = record.addedTrees.flatMap(treeToNodes);
-            const removedNodes = record.removedTrees.flatMap(treeToNodes);
-            for (const node of [...addedNodes, ...removedNodes]) {
-                if (this.nodeMap.hasNode(node)) {
-                    continue;
-                }
-                const id = node === this.editable ? "root" : this.generateId();
-                this.nodeMap.set(id, node);
-            }
+    setIdOnAddedNodes(record) {
+        if (record.type !== "childList") {
+            return;
         }
+        record.addedTrees
+            .flatMap(treeToNodes)
+            .filter((node) => !this.nodeMap.hasNode(node))
+            .forEach((node) => this.nodeMap.set(this.generateId(), node));
     }
+
     /**
      * @param { MutationRecord[] } records
      * @returns { MutationRecord[] }
@@ -710,18 +716,58 @@ export class HistoryPlugin extends Plugin {
      * target's affected property (attribute/class/textContent) and drop the
      * record.
      *
-     * Otherwise (observer enabled), update the record's `oldValue` with the
-     * last observed state of that target's property.
+     * Otherwise (observer enabled), update the record as follows:
+     * - mutations targeting an unobserved node are dropped
+     * - mutations of type "attributes", "classList", and "characterData" have
+     * their `oldValue` adjusted to the last observed state of that target's
+     * property
+     * - mutations of type "childList" are updated to not include references to
+     * unobserved nodes.
      *
      * @param {HistoryMutationRecord[]} records
      * @returns {HistoryMutationRecord[]}
      */
-    handleUnobservedMutations(records) {
+    filterAndAdjustHistoryMutationRecords(records) {
         if (this.isObserverDisabled) {
-            records.forEach((record) => this.storeOldValue(record));
+            records
+                .filter((record) => record.type !== "childList")
+                .filter((record) => this.isObservedNode(record.target))
+                .forEach((record) => this.storeOldValue(record));
             return [];
         }
-        return records.map((record) => this.updateOldValue(record));
+
+        const result = [];
+        for (const record of records) {
+            if (!this.isObservedNode(record.target)) {
+                continue;
+            }
+            const updatedRecord =
+                record.type === "childList"
+                    ? this.updateChildListRecord(record)
+                    : this.updateOldValue(record);
+            if (this.isValidRecord(updatedRecord)) {
+                this.setIdOnAddedNodes(record);
+                result.push(updatedRecord);
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Any node that was added to the DOM without a mutation record in a history
+     * step (tipically due to {@link ignoreDOMMutations}) is considered an
+     * unobserved node.
+     *
+     * A known limitation to this approach is when a node that had been present
+     * in the editable before (and thus has an entry in the nodeMap) is re-added
+     * with {@link ignoreDOMMutations}. Such node will not be flagged as
+     * unobserved and history might become inconsistent.
+     *
+     * @param {Node} node
+     * @returns {boolean}
+     */
+    isObservedNode(node) {
+        return this.nodeMap.hasNode(node);
     }
 
     /**
@@ -740,12 +786,9 @@ export class HistoryPlugin extends Plugin {
      *
      * @see updateOldValue
      *
-     * @param {HistoryMutationRecord} record
+     * @param {MutationRecordAttributes|MutationRecordClassList|MutationRecordCharacterData} record
      */
     storeOldValue(record) {
-        if (record.type === "childList") {
-            return;
-        }
         const { stateMap, key } = this.getObservedStateStorage(record);
         // Only store it if not already stored.
         if (!stateMap.has(key)) {
@@ -764,13 +807,10 @@ export class HistoryPlugin extends Plugin {
      * future mutation records targeting the same attribute/class of the same
      * element, which would create incorrect history mutations.
      *
-     * @param {HistoryMutationRecord} record
-     * @returns {HistoryMutationRecord}
+     * @param {MutationRecordAttributes|MutationRecordClassList|MutationRecordCharacterData} record
+     * @returns {MutationRecordAttributes|MutationRecordClassList|MutationRecordCharacterData}
      */
     updateOldValue(record) {
-        if (record.type === "childList") {
-            return record;
-        }
         const { stateMap, key } = this.getObservedStateStorage(record);
         if (!stateMap.has(key)) {
             return record;
@@ -805,6 +845,37 @@ export class HistoryPlugin extends Plugin {
             default:
                 throw new Error(`Unsupported mutation type: ${record.type}`);
         }
+    }
+
+    /**
+     * @param {MutationRecordChildList} record
+     * @returns {MutationRecordChildList}
+     */
+    updateChildListRecord(record) {
+        // Invalidate sibling references to unobserved nodes
+        const isValidReference = (node) => node === null || this.isObservedNode(node);
+        const updateSibling = (sibling) => (isValidReference(sibling) ? sibling : undefined);
+        const previousSibling = updateSibling(record.previousSibling);
+        const nextSibling = updateSibling(record.nextSibling);
+
+        // Filter out unobserved nodes in removedTrees
+        const removeUnobservedNodes = (tree) => {
+            if (!this.isObservedNode(tree.node)) {
+                return null;
+            }
+            return {
+                node: tree.node,
+                children: tree.children.map(removeUnobservedNodes).filter(Boolean),
+            };
+        };
+        const removedTrees = record.removedTrees.map(removeUnobservedNodes).filter(Boolean);
+
+        return {
+            ...record,
+            previousSibling,
+            nextSibling,
+            removedTrees,
+        };
     }
 
     /**
@@ -852,7 +923,6 @@ export class HistoryPlugin extends Plugin {
      * @param { HistoryMutationRecord[] } records
      */
     stageRecords(records) {
-        this.setIdOnRecords(records);
         for (const record of records) {
             switch (record.type) {
                 case "characterData":
@@ -897,19 +967,9 @@ export class HistoryPlugin extends Plugin {
                 return { type, id, parentId, node: serializedNode, nextId, previousId };
             });
 
-        // When nodes are expected to not be observed by the history, e.g.
-        // because they belong to a distinct lifecycle such as interactions,
-        // some operations such as replaceChildren might impact such a node
-        // together with observed ones. Marking the node with skipHistoryHack
-        // makes sure that it does not accidentally get observed during those
-        // operations.
-        // TODO Find a better solution.
-        const skipHistoryHackFilter = (node) => !node.dataset?.skipHistoryHack;
-        const removedTrees = record.removedTrees.filter((tree) => skipHistoryHackFilter(tree.node));
-        const addedTrees = record.addedTrees.filter((tree) => skipHistoryHackFilter(tree.node));
         return [
-            ...makeSingleNodeRecords(removedTrees, "remove"),
-            ...makeSingleNodeRecords(addedTrees, "add"),
+            ...makeSingleNodeRecords(record.removedTrees, "remove"),
+            ...makeSingleNodeRecords(record.addedTrees, "add"),
         ];
     }
 
@@ -1278,8 +1338,6 @@ export class HistoryPlugin extends Plugin {
             return;
         }
 
-        this.setNodeId(toAdd);
-
         const parent = this.nodeMap.getNode(parentId);
         if (!parent) {
             console.warn("Mutation could not be applied, parent node is missing.", mutation);
@@ -1598,7 +1656,7 @@ export class HistoryPlugin extends Plugin {
         const node = tree.node;
         const nodeId = this.nodeMap.getId(node);
         if (!nodeId) {
-            return;
+            throw new Error("Missing nodeId for serialization");
         }
         const result = {
             nodeType: node.nodeType,

--- a/addons/html_editor/static/src/core/history_plugin.js
+++ b/addons/html_editor/static/src/core/history_plugin.js
@@ -32,46 +32,39 @@ import { omit, pick } from "@web/core/utils/objects";
  *
  * @typedef { Object } HistoryMutationCharacterData
  * @property { "characterData" } type
- * // todo change id to nodeId
- * @property { string } id
+ * @property { string } nodeId
  * @property { string } value
  * @property { string } oldValue
  *
  * @typedef { Object } HistoryMutationAttributes
  * @property { "attributes" } type
- * // todo change id to nodeId
- * @property { string } id
+ * @property { string } nodeId
  * @property { string } attributeName
  * @property { string } value
  * @property { string } oldValue
  *
  * @typedef { Object } HistoryMutationClassList
  * @property { "classList" } type
- * @property { string } id
+ * @property { string } nodeId
  * @property { string } className
  * @property { boolean } value
  * @property { boolean } oldValue
  *
  * @typedef { Object } HistoryMutationAdd
  * @property { "add" } type
- * // todo change id to nodeId
- * @property { string } id
- * @property { string } parentId
- * @property { string } node
- * @property { string } nextId
- * @property { string } previousId
+ * @property { string } nodeId
+ * @property { string } parentNodeId
+ * @property { SerializedNode } serializedNode
+ * @property { string } nextNodeId
+ * @property { string } previousNodeId
  *
  * @typedef { Object } HistoryMutationRemove
  * @property { "remove" } type
- * // todo change id to nodeId
- * @property { string } id
- * // todo change parentId to parentNodeId
- * @property { string } parentId
- * @property { Node } node
- * // todo change nextId to nextNodeId
- * @property { string } nextId
- * // todo change previousId to previousNodeId
- * @property { string } previousId
+ * @property { string } nodeId
+ * @property { string } parentNodeId
+ * @property { SerializedNode } serializedNode
+ * @property { string } nextNodeId
+ * @property { string } previousNodeId
  *
  * @typedef { HistoryMutationCharacterData | HistoryMutationAttributes | HistoryMutationClassList | HistoryMutationAdd | HistoryMutationRemove } HistoryMutation
  *
@@ -305,10 +298,10 @@ export class HistoryPlugin extends Plugin {
             },
             mutations: childNodes(this.editable).map((node) => ({
                 type: "add",
-                parentId: "root",
-                id: this.nodeMap.getId(node),
-                node: this.serializeNode(node),
-                nextId: null,
+                parentNodeId: "root",
+                nodeId: this.nodeMap.getId(node),
+                serializedNode: this.serializeNode(node),
+                nextNodeId: null,
             })),
             id: this.steps[this.steps.length - 1]?.id || this.generateId(),
             previousStepId: undefined,
@@ -925,8 +918,8 @@ export class HistoryPlugin extends Plugin {
                 case "characterData":
                 case "classList":
                 case "attributes": {
-                    const id = this.nodeMap.getId(record.target);
-                    this.currentStep.mutations.push({ ...omit(record, "target"), id });
+                    const nodeId = this.nodeMap.getId(record.target);
+                    this.currentStep.mutations.push({ ...omit(record, "target"), nodeId });
                     break;
                 }
                 case "childList": {
@@ -942,8 +935,8 @@ export class HistoryPlugin extends Plugin {
      * @returns { (HistoryMutationRemove|HistoryMutationAdd)[] }
      */
     splitChildListRecord(record) {
-        const parentId = this.nodeMap.getId(record.target);
-        if (!parentId) {
+        const parentNodeId = this.nodeMap.getId(record.target);
+        if (!parentNodeId) {
             throw new Error("Unknown parent node");
         }
 
@@ -955,13 +948,13 @@ export class HistoryPlugin extends Plugin {
                     type === "add"
                         ? [nodeList[index - 1] || record.previousSibling, record.nextSibling]
                         : [record.previousSibling, nodeList[index + 1] || record.nextSibling];
-                const [nextId, previousId] = [nextSibling, previousSibling].map((sibling) =>
+                const [nextNodeId, previousNodeId] = [nextSibling, previousSibling].map((sibling) =>
                     // Preserve undefined and null values
                     sibling ? this.nodeMap.getId(sibling) : sibling
                 );
-                const id = this.nodeMap.getId(node);
+                const nodeId = this.nodeMap.getId(node);
                 const serializedNode = this.serializeTree(tree);
-                return { type, id, parentId, node: serializedNode, nextId, previousId };
+                return { type, nodeId, parentNodeId, serializedNode, nextNodeId, previousNodeId };
             });
 
         return [
@@ -1265,21 +1258,21 @@ export class HistoryPlugin extends Plugin {
                     break;
                 }
                 case "characterData": {
-                    const node = this.nodeMap.getNode(mutation.id);
+                    const node = this.nodeMap.getNode(mutation.nodeId);
                     if (node) {
                         node.textContent = mutation.value;
                     }
                     break;
                 }
                 case "classList": {
-                    const node = this.nodeMap.getNode(mutation.id);
+                    const node = this.nodeMap.getNode(mutation.nodeId);
                     if (node) {
                         toggleClass(node, mutation.className, mutation.value);
                     }
                     break;
                 }
                 case "attributes": {
-                    const node = this.nodeMap.getNode(mutation.id);
+                    const node = this.nodeMap.getNode(mutation.nodeId);
                     if (node) {
                         let value = mutation.value;
                         for (const cb of this.getResource("attribute_change_processors")) {
@@ -1333,7 +1326,7 @@ export class HistoryPlugin extends Plugin {
         // Mutations that when applied would not produce observable classList mutations
         const nonObservableClassMutations = mutations
             .filter(({ type }) => type === "classList")
-            .map((mutation) => ({ ...mutation, node: this.nodeMap.getNode(mutation.id) }))
+            .map((mutation) => ({ ...mutation, node: this.nodeMap.getNode(mutation.nodeId) }))
             .filter(({ node, className, value }) => value === node?.classList.contains(className));
         if (nonObservableClassMutations.length) {
             const setToOldValue = ({ node, className, oldValue }) =>
@@ -1346,8 +1339,8 @@ export class HistoryPlugin extends Plugin {
      * @param {HistoryMutationRemove} mutation
      */
     applyRemoveMutation(mutation) {
-        const parent = this.nodeMap.getNode(mutation.parentId);
-        const toRemove = this.nodeMap.getNode(mutation.id);
+        const parent = this.nodeMap.getNode(mutation.parentNodeId);
+        const toRemove = this.nodeMap.getNode(mutation.nodeId);
         if (!toRemove) {
             console.warn("Mutation could not be applied, node to remove is unknown.", mutation);
             return;
@@ -1363,32 +1356,33 @@ export class HistoryPlugin extends Plugin {
      * @param {HistoryMutationAdd} mutation
      */
     applyAddMutation(mutation) {
-        const { id, node, parentId, nextId, previousId } = mutation;
+        const { nodeId, serializedNode, parentNodeId, nextNodeId, previousNodeId } = mutation;
 
-        const toAdd = this.nodeMap.getNode(id) || this.unserializeNode(node);
+        const toAdd = this.nodeMap.getNode(nodeId) || this.unserializeNode(serializedNode);
         if (!toAdd) {
             return;
         }
 
-        const parent = this.nodeMap.getNode(parentId);
+        const parent = this.nodeMap.getNode(parentNodeId);
         if (!parent) {
             console.warn("Mutation could not be applied, parent node is missing.", mutation);
             return;
         }
-        if (previousId === null) {
+        if (previousNodeId === null) {
             parent.prepend(toAdd);
             return;
         }
-        if (nextId === null) {
+        if (nextNodeId === null) {
             parent.append(toAdd);
             return;
         }
         const isValid = (node) => node?.parentNode === parent;
-        const [previousNode, nextNode] = [previousId, nextId].map((id) => this.nodeMap.getNode(id));
+        const previousNode = this.nodeMap.getNode(previousNodeId);
         if (isValid(previousNode)) {
             previousNode.after(toAdd);
             return;
         }
+        const nextNode = this.nodeMap.getNode(nextNodeId);
         if (isValid(nextNode)) {
             nextNode.before(toAdd);
             return;
@@ -1431,12 +1425,12 @@ export class HistoryPlugin extends Plugin {
     }
     /**
      * Returns the deepest common ancestor element of the given mutations.
-     * @param {HistoryMutation[]} - The array of mutations.
+     * @param {HistoryMutation[]} mutations - The array of mutations.
      * @returns {HTMLElement|null} - The common ancestor element.
      */
     getMutationsRoot(mutations) {
         const nodes = mutations
-            .map((m) => this.nodeMap.getNode(m.parentId || m.id))
+            .map((m) => this.nodeMap.getNode(m.parentNodeId || m.nodeId))
             .filter((node) => this.editable.contains(node));
         let commonAncestor = getCommonAncestor(nodes, this.editable);
         if (commonAncestor?.nodeType === Node.TEXT_NODE) {

--- a/addons/html_editor/static/src/core/history_plugin.js
+++ b/addons/html_editor/static/src/core/history_plugin.js
@@ -95,7 +95,19 @@ import { omit, pick } from "@web/core/utils/objects";
  * @property { string } oldValue
  * @property { string } value
  *
- * @typedef { MutationRecord | MutationRecordClassList | MutationRecordAttributes | MutationRecordCharacterData } HistoryMutationRecord
+ * @typedef {Object} Tree
+ * @property {Node} node
+ * @property {Tree[]} children
+ *
+ * @typedef {Object} MutationRecordChildList
+ * @property { "childList" } type
+ * @property { Node } target
+ * @property { Node } previousSibling
+ * @property { Node } nextSibling
+ * @property { Tree[] } addedTrees
+ * @property { Tree[] } removedTrees
+ *
+ * @typedef { MutationRecordClassList | MutationRecordAttributes | MutationRecordCharacterData | MutationRecordChildList } HistoryMutationRecord
  *
  * @typedef { Object } PreviewableOperation
  * @property { Function } commit
@@ -391,10 +403,8 @@ export class HistoryPlugin extends Plugin {
         }
         mutationRecords = this.filterMutationRecords(mutationRecords);
         /** @type {HistoryMutationRecord[]} */
-        let records = mutationRecords
-            .flatMap((record) => this.transformRecord(record))
-            .filter((record) => !this.isSystemMutationRecord(record));
-
+        let records = this.transformToHistoryMutationRecords(mutationRecords);
+        records = records.filter((record) => !this.isSystemMutationRecord(record));
         records = this.handleUnobservedMutations(records);
         records = records.filter((record) => !this.isNoOpRecord(record));
         this.stageRecords(records);
@@ -445,14 +455,22 @@ export class HistoryPlugin extends Plugin {
     }
 
     /**
-     * @param { MutationRecord[] } records
+     * @param { HistoryMutationRecord[] } records
      */
     setIdOnRecords(records) {
         for (const record of records) {
-            if (record.type === "childList") {
-                for (const node of record.addedNodes) {
-                    this.setNodeId(node);
+            if (record.type !== "childList") {
+                continue;
+            }
+            const addedNodes = record.addedTrees.flatMap(treeToNodes);
+            const removedNodes = record.removedTrees.flatMap(treeToNodes);
+            for (const node of [...addedNodes, ...removedNodes]) {
+                if (this.nodeToIdMap.has(node)) {
+                    continue;
                 }
+                const id = node === this.editable ? "root" : this.generateId();
+                this.nodeToIdMap.set(node, id);
+                this.idToNodeMap.set(id, node);
             }
         }
     }
@@ -560,27 +578,87 @@ export class HistoryPlugin extends Plugin {
     }
 
     /**
+     * Transforms MutationRecords into HistoryMutationRecords.
+     *
+     * ChildList record have added/removed trees added to them.
      * Class attribute records are expanded into multiple classList records.
      * Attribute records have their oldValue normalized and new value added to it.
-     * CharacterData records have new value added to it.
+     * CharacterData records have the new value added to it.
      *
-     * @param { MutationRecord } record
-     * @returns { HistoryMutationRecord | HistoryMutationRecord[] }
+     * @param {MutationRecord[]} records
+     * @returns {HistoryMutationRecord[]}
      */
-    transformRecord(record) {
-        if (record.type === "attributes") {
-            if (record.attributeName === "class") {
-                return this.splitClassMutationRecord(record);
+    transformToHistoryMutationRecords(records) {
+        records = this.transformChildListRecords(records);
+        return records.flatMap((record) => {
+            if (record.type === "attributes") {
+                if (record.attributeName === "class") {
+                    return this.splitClassMutationRecord(record);
+                }
+                const oldValue = record.oldValue === undefined ? null : record.oldValue;
+                const value = record.target.getAttribute(record.attributeName);
+                return { ...pick(record, "type", "target", "attributeName"), oldValue, value };
             }
-            const oldValue = record.oldValue === undefined ? null : record.oldValue;
-            const value = record.target.getAttribute(record.attributeName);
-            return { ...pick(record, "type", "target", "attributeName"), oldValue, value };
-        }
-        if (record.type === "characterData") {
-            const value = record.target.textContent;
-            return { ...pick(record, "type", "target", "oldValue"), value };
-        }
-        return record;
+            if (record.type === "characterData") {
+                const value = record.target.textContent;
+                return { ...pick(record, "type", "target", "oldValue"), value };
+            }
+            return record;
+        });
+    }
+
+    /**
+     * ChildList mutation records do not contain information about the
+     * descendants of the added/removed nodes at the time of the mutation. This
+     * method transforms childList mutation records to include information about
+     * the added/removed trees.
+     *
+     * @param {MutationRecord[]} records
+     * @returns {(HistoryMutationRecord|MutationRecord)[]}
+     */
+    transformChildListRecords(records) {
+        /** @type {WeakMap<Node, Node[]>} */
+        const childListSnapshot = new WeakMap();
+        /** @type {(node: Node) => Node[]} */
+        const getChildListSnapshot = (node) => childListSnapshot.get(node) || childNodes(node);
+        /** @type {(node: Node) => Tree} */
+        const makeSnapshotTree = (node) => ({
+            node,
+            children: getChildListSnapshot(node).map(makeSnapshotTree),
+        });
+
+        // Reconstructs the child list before a mutation based on the state
+        // after it and the child list modifications
+        /** @type {(childListAfter: Node[], record: MutationRecord) => Node[]} */
+        const reconstructChildList = (childListAfter, record) => {
+            const { removedNodes, previousSibling, nextSibling } = record;
+            const previousSiblingNodes = previousSibling
+                ? childListAfter.slice(0, childListAfter.indexOf(previousSibling) + 1)
+                : [];
+            const nextSiblingNodes = nextSibling
+                ? childListAfter.slice(childListAfter.indexOf(nextSibling))
+                : [];
+            return [...previousSiblingNodes, ...removedNodes, ...nextSiblingNodes];
+        };
+
+        return records
+            .toReversed()
+            .map((/** @type {MutationRecord} */ record) => {
+                if (record.type !== "childList") {
+                    return record;
+                }
+                const transformedRecord = {
+                    ...pick(record, "type", "previousSibling", "nextSibling", "target"),
+                    addedTrees: [...record.addedNodes].map(makeSnapshotTree),
+                    removedTrees: [...record.removedNodes].map(makeSnapshotTree),
+                };
+                // Update snapshot for previous mutations
+                const childListAfterMutation = getChildListSnapshot(record.target);
+                const childListBefore = reconstructChildList(childListAfterMutation, record);
+                childListSnapshot.set(record.target, childListBefore);
+                return transformedRecord;
+            })
+            .toReversed();
     }
 
     /**
@@ -780,25 +858,6 @@ export class HistoryPlugin extends Plugin {
      */
     stageRecords(records) {
         this.setIdOnRecords(records);
-        // @todo @phoenix test this feature.
-        // There is a case where node A is added and node B is a descendant of
-        // node A where node B was not in the observed tree) then node B is
-        // added into another node. In that case, we need to keep track of node
-        // B so when serializing node A, we strip node B from the node A tree to
-        // avoid the duplication of node A.
-        const mutatedNodes = new Set();
-        for (const record of records) {
-            if (record.type === "childList") {
-                for (const node of record.addedNodes) {
-                    const id = this.setNodeId(node);
-                    mutatedNodes.add(id);
-                }
-                for (const node of record.removedNodes) {
-                    const id = this.setNodeId(node);
-                    mutatedNodes.delete(id);
-                }
-            }
-        }
         for (const record of records) {
             switch (record.type) {
                 case "characterData":
@@ -809,9 +868,7 @@ export class HistoryPlugin extends Plugin {
                     break;
                 }
                 case "childList": {
-                    this.currentStep.mutations.push(
-                        ...this.splitChildListRecord(record, mutatedNodes)
-                    );
+                    this.currentStep.mutations.push(...this.splitChildListRecord(record));
                     break;
                 }
             }
@@ -819,18 +876,19 @@ export class HistoryPlugin extends Plugin {
     }
 
     /**
-     * @param {MutationRecord} record of type "childList"
-     * @param {Set<string>} mutatedNodes
+     * @param {MutationRecordChildList} record
      * @returns { (HistoryMutationRemove|HistoryMutationAdd)[] }
      */
-    splitChildListRecord(record, mutatedNodes) {
+    splitChildListRecord(record) {
         const parentId = this.nodeToIdMap.get(record.target);
         if (!parentId) {
             throw new Error("Unknown parent node");
         }
 
-        const makeSingleNodeRecords = (nodes, type) =>
-            nodes.map((node, index, nodeList) => {
+        const makeSingleNodeRecords = (trees, type) =>
+            trees.map((tree, index, treeList) => {
+                const node = tree.node;
+                const nodeList = treeList.map((t) => t.node);
                 const [previousSibling, nextSibling] =
                     type === "add"
                         ? [nodeList[index - 1] || record.previousSibling, record.nextSibling]
@@ -840,10 +898,7 @@ export class HistoryPlugin extends Plugin {
                     sibling ? this.nodeToIdMap.get(sibling) : sibling
                 );
                 const id = this.nodeToIdMap.get(node);
-                const serializedNode = this.serializeNode(
-                    node,
-                    type === "add" ? mutatedNodes : undefined
-                );
+                const serializedNode = this.serializeTree(tree);
                 return { type, id, parentId, node: serializedNode, nextId, previousId };
             });
 
@@ -855,11 +910,11 @@ export class HistoryPlugin extends Plugin {
         // operations.
         // TODO Find a better solution.
         const skipHistoryHackFilter = (node) => !node.dataset?.skipHistoryHack;
-        const removedNodes = [...record.removedNodes].filter(skipHistoryHackFilter);
-        const addedNodes = [...record.addedNodes].filter(skipHistoryHackFilter);
+        const removedTrees = record.removedTrees.filter((tree) => skipHistoryHackFilter(tree.node));
+        const addedTrees = record.addedTrees.filter((tree) => skipHistoryHackFilter(tree.node));
         return [
-            ...makeSingleNodeRecords(removedNodes, "remove"),
-            ...makeSingleNodeRecords(addedNodes, "add"),
+            ...makeSingleNodeRecords(removedTrees, "remove"),
+            ...makeSingleNodeRecords(addedTrees, "add"),
         ];
     }
 
@@ -1502,12 +1557,11 @@ export class HistoryPlugin extends Plugin {
         }
     }
     /**
-     * Serialize a node and its children if the collaboration is true.
+     * Serialize a node and its children.
      * @param { Node } node
-     * @param { Set<Node> } nodesToStripFromChildren
      */
-    serializeNode(node, mutatedNodes) {
-        return this._serializeNode(node, mutatedNodes, this.nodeToIdMap);
+    serializeNode(node) {
+        return this.serializeTree(nodeToTree(node));
     }
     /**
      * Unserialize a node and its children if the collaboration is true.
@@ -1551,13 +1605,13 @@ export class HistoryPlugin extends Plugin {
             return unserializedNode;
         }
     }
+
     /**
-     * Serialize a node and its children.
-     * @param { Node } node
-     * @param { [Set<Node>] } nodesToStripFromChildren
-     * @returns { SerializedNode }
+     * @param {Tree} tree
+     * @returns {SerializedNode}
      */
-    _serializeNode(node, nodesToStripFromChildren = new Set()) {
+    serializeTree(tree) {
+        const node = tree.node;
         const nodeId = this.nodeToIdMap.get(node);
         if (!nodeId) {
             return;
@@ -1569,24 +1623,17 @@ export class HistoryPlugin extends Plugin {
         if (node.nodeType === Node.TEXT_NODE) {
             result.textValue = node.nodeValue;
         } else if (node.nodeType === Node.ELEMENT_NODE) {
-            let childrenToSerialize = childNodes(node);
+            let childTreesToSerialize = tree.children;
             for (const cb of this.getResource("serializable_descendants_processors")) {
-                childrenToSerialize = cb(node, childrenToSerialize);
+                childTreesToSerialize = cb(node, childTreesToSerialize);
             }
             result.tagName = node.tagName;
-            result.children = [];
-            result.attributes = {};
-            for (let i = 0; i < node.attributes.length; i++) {
-                result.attributes[node.attributes[i].name] = node.attributes[i].value;
-            }
-            for (const child of childrenToSerialize) {
-                if (!nodesToStripFromChildren.has(this.nodeToIdMap.get(child))) {
-                    const serializedChild = this._serializeNode(child, nodesToStripFromChildren);
-                    if (serializedChild) {
-                        result.children.push(serializedChild);
-                    }
-                }
-            }
+            result.attributes = Object.fromEntries(
+                [...node.attributes].map((attr) => [attr.name, attr.value])
+            );
+            result.children = childTreesToSerialize
+                .map((tree) => this.serializeTree(tree))
+                .filter(Boolean);
         }
         return result;
     }
@@ -1648,4 +1695,23 @@ export class HistoryPlugin extends Plugin {
             this._onKeyupResetContenteditableNodes = [];
         }
     }
+}
+
+/**
+ * @param {Node} node
+ * @returns {Tree}
+ */
+export function nodeToTree(node) {
+    return {
+        node,
+        children: childNodes(node).map(nodeToTree),
+    };
+}
+
+/**
+ * @param {Tree} tree
+ * @returns {Node[]}
+ */
+function treeToNodes(tree) {
+    return [tree.node, ...tree.children.flatMap(treeToNodes)];
 }

--- a/addons/html_editor/static/src/core/history_plugin.js
+++ b/addons/html_editor/static/src/core/history_plugin.js
@@ -423,20 +423,9 @@ export class HistoryPlugin extends Plugin {
      */
     setIdOnRecords(records) {
         for (const record of records) {
-            if (record.type === "childList" && record.addedNodes.length) {
-                const { addedNodes, removedNodes } = record;
-                if (this.isSameTextContentMutation(record)) {
-                    const oldId = this.nodeToIdMap.get(removedNodes[0]);
-                    if (oldId) {
-                        this.nodeToIdMap.delete(removedNodes[0]);
-                        this.idToNodeMap.delete(oldId);
-                        this.nodeToIdMap.set(addedNodes[0], oldId);
-                        this.idToNodeMap.set(oldId, addedNodes[0]);
-                    }
-                } else {
-                    for (const node of addedNodes) {
-                        this.setNodeId(node);
-                    }
+            if (record.type === "childList") {
+                for (const node of record.addedNodes) {
+                    this.setNodeId(node);
                 }
             }
         }
@@ -451,9 +440,7 @@ export class HistoryPlugin extends Plugin {
             records = records.filter(callback);
         }
         records = this.filterAttributeMutationRecords(records);
-        // @todo: this removes mutation records that change the node reference.
-        // Fix this!
-        records = records.filter((record) => !this.isSameTextContentMutation(record));
+        records = this.filterSameTextContentMutationRecords(records);
         records = this.filterOutIntermediateStateMutationRecords(records);
         return records;
     }
@@ -475,6 +462,29 @@ export class HistoryPlugin extends Plugin {
             }
             return true;
         });
+    }
+
+    /**
+     * @param { MutationRecord[] } records
+     * @returns { MutationRecord[] }
+     */
+    filterSameTextContentMutationRecords(records) {
+        const filteredRecords = [];
+        for (const record of records) {
+            if (record.type === "childList" && this.isSameTextContentMutation(record)) {
+                const { addedNodes, removedNodes } = record;
+                const oldId = this.nodeToIdMap.get(removedNodes[0]);
+                if (oldId) {
+                    this.nodeToIdMap.delete(removedNodes[0]);
+                    this.idToNodeMap.delete(oldId);
+                    this.nodeToIdMap.set(addedNodes[0], oldId);
+                    this.idToNodeMap.set(oldId, addedNodes[0]);
+                }
+                continue;
+            }
+            filteredRecords.push(record);
+        }
+        return filteredRecords;
     }
 
     /**

--- a/addons/html_editor/static/src/others/collaboration/collaboration_plugin.js
+++ b/addons/html_editor/static/src/others/collaboration/collaboration_plugin.js
@@ -121,22 +121,19 @@ export class CollaborationPlugin extends Plugin {
      */
     onExternalHistorySteps(newSteps) {
         let stepIndex = 0;
-        let selectionData;
-        this.dependencies.history.ignoreDOMMutations(() => {
-            selectionData = this.dependencies.selection.getSelectionData();
+        const selectionData = this.dependencies.selection.getSelectionData();
 
-            const steps = this.dependencies.history.getHistorySteps();
-            for (const newStep of newSteps) {
-                // todo: add a test that no 2 history_missing_parent_step_handlers
-                // are called in same stack.
-                const insertIndex = this.getInsertStepIndex(steps, newStep);
-                if (typeof insertIndex === "undefined") {
-                    continue;
-                }
-                this.dependencies.history.addExternalStep(newStep, insertIndex);
-                stepIndex++;
+        const steps = this.dependencies.history.getHistorySteps();
+        for (const newStep of newSteps) {
+            // todo: add a test that no 2 history_missing_parent_step_handlers
+            // are called in same stack.
+            const insertIndex = this.getInsertStepIndex(steps, newStep);
+            if (typeof insertIndex === "undefined") {
+                continue;
             }
-        });
+            this.dependencies.history.addExternalStep(newStep, insertIndex);
+            stepIndex++;
+        }
         if (selectionData.documentSelectionIsInEditable) {
             this.dependencies.selection.rectifySelection(selectionData.editableSelection);
         }

--- a/addons/html_editor/static/src/others/embedded_component_plugin.js
+++ b/addons/html_editor/static/src/others/embedded_component_plugin.js
@@ -1,3 +1,4 @@
+import { nodeToTree } from "@html_editor/core/history_plugin";
 import { Plugin } from "@html_editor/plugin";
 import { memoize } from "@web/core/utils/functions";
 
@@ -59,12 +60,19 @@ export class EmbeddedComponentPlugin extends Plugin {
         return true;
     }
 
+    /**
+     * @typedef {import("@html_editor/core/history_plugin").Tree} Tree
+     *
+     * @param {Node} elem
+     * @param {Tree[]} serializableDescendants
+     * @returns {Tree[]}
+     */
     processDescendantsToSerialize(elem, serializableDescendants) {
         const embedding = this.getEmbedding(elem);
         if (!embedding) {
             return serializableDescendants;
         }
-        return Object.values(embedding.getEditableDescendants?.(elem) || {});
+        return Object.values(embedding.getEditableDescendants?.(elem) || {}).map(nodeToTree);
     }
 
     handleComponents(elem) {

--- a/addons/html_editor/static/tests/_helpers/collaboration.js
+++ b/addons/html_editor/static/tests/_helpers/collaboration.js
@@ -210,8 +210,8 @@ export function renderTextualSelection(peerInfos) {
         const { anchorNode, anchorOffset, focusNode, focusOffset } = peerSelection;
 
         const peerId = peerInfo.peerId;
-        const focusNodeId = historyPlugin.nodeToIdMap.get(focusNode);
-        const anchorNodeId = historyPlugin.nodeToIdMap.get(anchorNode);
+        const focusNodeId = historyPlugin.nodeMap.getId(focusNode);
+        const anchorNodeId = historyPlugin.nodeMap.getId(anchorNode);
         cursorNodes[focusNodeId] = cursorNodes[focusNodeId] || [];
         cursorNodes[focusNodeId].push({ type: "focus", peerId, offset: focusOffset });
         cursorNodes[anchorNodeId] = cursorNodes[anchorNodeId] || [];
@@ -227,7 +227,7 @@ export function renderTextualSelection(peerInfos) {
     for (const peerInfo of peerInfosList) {
         const historyPlugin = peerInfo.historyPlugin;
         for (const [nodeId, cursorsData] of Object.entries(cursorNodes)) {
-            const node = historyPlugin.idToNodeMap.get(nodeId);
+            const node = historyPlugin.nodeMap.getNode(nodeId);
             for (const cursorData of cursorsData) {
                 const cursorString =
                     cursorData.type === "anchor"

--- a/addons/html_editor/static/tests/collaboration.test.js
+++ b/addons/html_editor/static/tests/collaboration.test.js
@@ -282,7 +282,7 @@ test("should reset from snapshot", async () => {
             expect(peerInfos.c2.historyPlugin.steps.map((x) => x.id)).toEqual([
                 "fake_concurrent_id_1",
             ]);
-            expect(peerInfos.c2.historyPlugin.steps[0].mutations.map((x) => x.id)).toEqual([
+            expect(peerInfos.c2.historyPlugin.steps[0].mutations.map((x) => x.nodeId)).toEqual([
                 "fake_id_4",
             ]);
         },

--- a/addons/html_editor/static/tests/collaboration.test.js
+++ b/addons/html_editor/static/tests/collaboration.test.js
@@ -425,6 +425,10 @@ describe("sanitize", () => {
     });
 
     test("should sanitize when undo is adding a script node", async () => {
+        // Prevent console.warn from making the test fail due to inexistent node
+        // to remove. The script node is non existent in the collaborator's DOM
+        // (c2) because of sanitization of serialized nodes.
+        patchWithCleanup(console, { warn: () => {} });
         await testMultiEditor({
             peerIds: ["c1", "c2"],
             contentBefore: "<p>a</p>",

--- a/addons/html_editor/static/tests/data-oe/protected.test.js
+++ b/addons/html_editor/static/tests/data-oe/protected.test.js
@@ -573,8 +573,8 @@ test("protected plugin is robust against other plugins which can filter mutation
         isMutationRecordSavable(record) {
             if (
                 record.type === "childList" &&
-                record.removedNodes.length === 1 &&
-                [...record.removedNodes][0] === a
+                record.removedTrees.length === 1 &&
+                record.removedTrees[0].node === a
             ) {
                 // Artificially hide the removal of `a` node
                 return false;

--- a/addons/html_editor/static/tests/data-oe/protected.test.js
+++ b/addons/html_editor/static/tests/data-oe/protected.test.js
@@ -427,7 +427,7 @@ test("moving a protected node at an unprotected location, only remove should be 
     const lastStep = historySteps.at(-1);
     expect(lastStep.mutations.length).toBe(1);
     expect(lastStep.mutations[0].type).toBe("add");
-    expect(historyPlugin.idToNodeMap.get(lastStep.mutations[0].id)).toBe(a);
+    expect(historyPlugin.nodeMap.getNode(lastStep.mutations[0].id)).toBe(a);
     expect(getContent(el)).toBe(
         unformat(`
             <div data-oe-protected="true" contenteditable="false">
@@ -463,7 +463,7 @@ test("moving an unprotected node at a protected location, only add should be ign
     const lastStep = historySteps.at(-1);
     expect(lastStep.mutations.length).toBe(1);
     expect(lastStep.mutations[0].type).toBe("remove");
-    expect(historyPlugin.idToNodeMap.get(lastStep.mutations[0].id)).toBe(a);
+    expect(historyPlugin.nodeMap.getNode(lastStep.mutations[0].id)).toBe(a);
     expect(getContent(el)).toBe(
         unformat(`
             <div data-oe-protected="true" contenteditable="false">

--- a/addons/html_editor/static/tests/data-oe/protected.test.js
+++ b/addons/html_editor/static/tests/data-oe/protected.test.js
@@ -259,9 +259,9 @@ test("should protect disconnected nodes", async () => {
     const lastStep = editor.shared.history.getHistorySteps().at(-1);
     expect(lastStep.mutations.length).toBe(1);
     expect(lastStep.mutations[0].type).toBe("remove");
-    expect(plugins.get("history").unserializeNode(lastStep.mutations[0].node).outerHTML).toBe(
-        `<div contenteditable="false" data-oe-protected="true"></div>`
-    );
+    expect(
+        plugins.get("history").unserializeNode(lastStep.mutations[0].serializedNode).outerHTML
+    ).toBe(`<div contenteditable="false" data-oe-protected="true"></div>`);
 });
 
 test("should not crash when changing attributes and removing a protecting anchor", async () => {
@@ -276,7 +276,9 @@ test("should not crash when changing attributes and removing a protecting anchor
     expect(lastStep.mutations.length).toBe(2);
     expect(lastStep.mutations[0].type).toBe("attributes");
     expect(lastStep.mutations[1].type).toBe("remove");
-    expect(plugins.get("history").unserializeNode(lastStep.mutations[1].node).outerHTML).toBe(
+    expect(
+        plugins.get("history").unserializeNode(lastStep.mutations[1].serializedNode).outerHTML
+    ).toBe(
         `<div contenteditable="false" data-attr="other" data-oe-protected="true"><p>a</p></div>`
     );
 });
@@ -427,7 +429,7 @@ test("moving a protected node at an unprotected location, only remove should be 
     const lastStep = historySteps.at(-1);
     expect(lastStep.mutations.length).toBe(1);
     expect(lastStep.mutations[0].type).toBe("add");
-    expect(historyPlugin.nodeMap.getNode(lastStep.mutations[0].id)).toBe(a);
+    expect(historyPlugin.nodeMap.getNode(lastStep.mutations[0].nodeId)).toBe(a);
     expect(getContent(el)).toBe(
         unformat(`
             <div data-oe-protected="true" contenteditable="false">
@@ -463,7 +465,7 @@ test("moving an unprotected node at a protected location, only add should be ign
     const lastStep = historySteps.at(-1);
     expect(lastStep.mutations.length).toBe(1);
     expect(lastStep.mutations[0].type).toBe("remove");
-    expect(historyPlugin.nodeMap.getNode(lastStep.mutations[0].id)).toBe(a);
+    expect(historyPlugin.nodeMap.getNode(lastStep.mutations[0].nodeId)).toBe(a);
     expect(getContent(el)).toBe(
         unformat(`
             <div data-oe-protected="true" contenteditable="false">

--- a/addons/html_editor/static/tests/history.test.js
+++ b/addons/html_editor/static/tests/history.test.js
@@ -227,7 +227,7 @@ describe("selection", () => {
         await pointerUp(pElement);
         await tick();
         const historyPlugin = plugins.get("history");
-        const nodeId = historyPlugin.nodeToIdMap.get(pElement.firstChild);
+        const nodeId = historyPlugin.nodeMap.getId(pElement.firstChild);
         expect(historyPlugin.currentStep.selection).toEqual({
             anchorNodeId: nodeId,
             anchorOffset: 0,
@@ -884,7 +884,7 @@ describe("serialization", () => {
 
         const historyPlugin = plugins.get("history");
         const mutations = historyPlugin.currentStep.mutations;
-        const idToNode = (id) => historyPlugin.idToNodeMap.get(id);
+        const idToNode = (id) => historyPlugin.nodeMap.getNode(id);
 
         expect(mutations.length).toBe(3);
 
@@ -926,7 +926,7 @@ describe("serialization", () => {
 
         const historyPlugin = plugins.get("history");
         const mutations = historyPlugin.currentStep.mutations;
-        const idToNode = (id) => historyPlugin.idToNodeMap.get(id);
+        const idToNode = (id) => historyPlugin.nodeMap.getNode(id);
 
         expect(mutations.length).toBe(5);
 
@@ -957,6 +957,18 @@ describe("serialization", () => {
         ({ nodeId, children } = mutations[4].node);
         expect(idToNode(nodeId)).toBe(c);
         expect(children.length).toBe(0);
+    });
+
+    test("unserialization of text node should not duplicate an existing one", async () => {
+        const { el, editor, plugins } = await setupEditor(`<p><br></p>`);
+        const historyPlugin = plugins.get("history");
+        const p = el.querySelector("p");
+        const textNode = editor.document.createTextNode("test");
+        p.prepend(textNode);
+        editor.shared.history.addStep();
+        const serializedNode = historyPlugin.serializeNode(textNode);
+        const unserializedTextNode = historyPlugin.unserializeNode(serializedNode);
+        expect(unserializedTextNode).toBe(textNode);
     });
 });
 

--- a/addons/html_editor/static/tests/history.test.js
+++ b/addons/html_editor/static/tests/history.test.js
@@ -934,14 +934,14 @@ describe("serialization", () => {
 
         // Serialized node should not have textNode as child, even though it
         // current has it as child (otherwise it would duplicate it on unserialization)
-        let { nodeId, children } = mutations[0].node;
+        let { nodeId, children } = mutations[0].serializedNode;
         expect(idToNode(nodeId)).toBe(strong);
         expect(children.length).toBe(0);
 
         // 2nd and 3rd mutations: textNode is moved into strong
-        ({ nodeId } = mutations[1].node);
+        ({ nodeId } = mutations[1].serializedNode);
         expect(idToNode(nodeId)).toBe(textNode);
-        ({ nodeId } = mutations[2].node);
+        ({ nodeId } = mutations[2].serializedNode);
         expect(idToNode(nodeId)).toBe(textNode);
     });
 
@@ -976,29 +976,29 @@ describe("serialization", () => {
 
         // Serialized node A should not have children, even though it currently
         // has B and D as children.
-        let { nodeId, children } = mutations[0].node;
+        let { nodeId, children } = mutations[0].serializedNode;
         expect(idToNode(nodeId)).toBe(a);
         expect(children.length).toBe(0);
 
         // Serialized node B should have C as child, even though it currently
         // has no children
-        ({ nodeId, children } = mutations[1].node);
+        ({ nodeId, children } = mutations[1].serializedNode);
         expect(idToNode(nodeId)).toBe(b);
         expect(children.length).toBe(1);
         expect(idToNode(children[0].nodeId)).toBe(c);
 
         // Serialized node D should not have children, even though it currently
         // has C as child.
-        ({ nodeId, children } = mutations[2].node);
+        ({ nodeId, children } = mutations[2].serializedNode);
         expect(idToNode(nodeId)).toBe(d);
         expect(children.length).toBe(0);
 
         // Serialized node C should have no children
-        ({ nodeId, children } = mutations[3].node);
+        ({ nodeId, children } = mutations[3].serializedNode);
         expect(idToNode(nodeId)).toBe(c);
         expect(children.length).toBe(0);
 
-        ({ nodeId, children } = mutations[4].node);
+        ({ nodeId, children } = mutations[4].serializedNode);
         expect(idToNode(nodeId)).toBe(c);
         expect(children.length).toBe(0);
     });

--- a/addons/html_editor/static/tests/history.test.js
+++ b/addons/html_editor/static/tests/history.test.js
@@ -901,3 +901,17 @@ describe("serialization", () => {
         expect(idToNode(nodeId)).toBe(textNode);
     });
 });
+
+describe("mutations order", () => {
+    test("should revert mutations in the correct order", async () => {
+        const { el, editor } = await setupEditor(`<p>[]<br></p>`);
+        const p = el.querySelector("p");
+        p.replaceChildren(editor.document.createTextNode("a"), editor.document.createTextNode("b"));
+        editor.shared.history.addStep();
+        expect(getContent(el)).toBe(`<p>[]ab</p>`);
+        p.replaceChildren();
+        editor.shared.history.addStep();
+        editor.shared.history.undo();
+        expect(getContent(el)).toBe(`<p>[]ab</p>`);
+    });
+});

--- a/addons/html_editor/static/tests/history.test.js
+++ b/addons/html_editor/static/tests/history.test.js
@@ -590,9 +590,9 @@ describe("destroy", () => {
             isMutationRecordSavable(record) {
                 if (
                     record.type === "childList" &&
-                    record.addedNodes.length === 1 &&
-                    record.addedNodes.item(0).nodeType === Node.ELEMENT_NODE &&
-                    record.addedNodes.item(0).matches(".test")
+                    record.addedTrees.length === 1 &&
+                    record.addedTrees[0].node.nodeType === Node.ELEMENT_NODE &&
+                    record.addedTrees[0].node.matches(".test")
                 ) {
                     expect.step("dispatch");
                     return false;

--- a/addons/html_editor/static/tests/history.test.js
+++ b/addons/html_editor/static/tests/history.test.js
@@ -777,7 +777,7 @@ describe("unobserved mutations", () => {
             editor.shared.history.undo();
             expect(p.className).toBe("b a");
         });
-        test.todo("should produce a undo step even with no class change", async () => {
+        test("should produce mutations in undo step even with no class change", async () => {
             const { editor } = await setupEditor(`<p>test</p>`);
             /** @type {HTMLElement} */
             const p = editor.editable.querySelector("p");

--- a/addons/html_editor/static/tests/history.test.js
+++ b/addons/html_editor/static/tests/history.test.js
@@ -900,6 +900,64 @@ describe("serialization", () => {
         ({ nodeId } = mutations[2].node);
         expect(idToNode(nodeId)).toBe(textNode);
     });
+
+    test("serialized node should have the childlist as it was at mutation time", async () => {
+        const { editor, plugins } = await setupEditor(`<p><br></p>`);
+        const p = editor.editable.querySelector("p");
+        const [a, b, c, d] = ["a", "b", "c", "d"].map((name) => {
+            const span = editor.document.createElement("span");
+            span.className = name;
+            return span;
+        });
+        // A is added with no children.
+        p.append(a);
+
+        // B is added having C as child.
+        b.append(c); // B is not yet observed
+        a.append(b); // B - C is added to A
+
+        // D is added to A with no children.
+        a.append(d);
+
+        // C is moved from B to D (creates 2 records: removal and addition).
+        d.append(c);
+
+        await microTick();
+
+        const historyPlugin = plugins.get("history");
+        const mutations = historyPlugin.currentStep.mutations;
+        const idToNode = (id) => historyPlugin.idToNodeMap.get(id);
+
+        expect(mutations.length).toBe(5);
+
+        // Serialized node A should not have children, even though it currently
+        // has B and D as children.
+        let { nodeId, children } = mutations[0].node;
+        expect(idToNode(nodeId)).toBe(a);
+        expect(children.length).toBe(0);
+
+        // Serialized node B should have C as child, even though it currently
+        // has no children
+        ({ nodeId, children } = mutations[1].node);
+        expect(idToNode(nodeId)).toBe(b);
+        expect(children.length).toBe(1);
+        expect(idToNode(children[0].nodeId)).toBe(c);
+
+        // Serialized node D should not have children, even though it currently
+        // has C as child.
+        ({ nodeId, children } = mutations[2].node);
+        expect(idToNode(nodeId)).toBe(d);
+        expect(children.length).toBe(0);
+
+        // Serialized node C should have no children
+        ({ nodeId, children } = mutations[3].node);
+        expect(idToNode(nodeId)).toBe(c);
+        expect(children.length).toBe(0);
+
+        ({ nodeId, children } = mutations[4].node);
+        expect(idToNode(nodeId)).toBe(c);
+        expect(children.length).toBe(0);
+    });
 });
 
 describe("mutations order", () => {

--- a/addons/html_editor/static/tests/history.test.js
+++ b/addons/html_editor/static/tests/history.test.js
@@ -705,6 +705,38 @@ describe("custom mutation", () => {
     });
 });
 
+describe("same text node mutations", () => {
+    test("should not record same text mutation", async () => {
+        const { el, editor } = await setupEditor(`<p>[]test</p>`);
+        const p = el.querySelector("p");
+        const textNode = editor.document.createTextNode("a");
+        p.append(textNode);
+        editor.shared.history.addStep();
+        expect(getContent(el)).toBe(`<p>[]testa</p>`);
+        // Replace text node with a new one with the same content
+        p.replaceChild(editor.document.createTextNode("a"), textNode);
+        // addStep returns false when there are no mutations
+        expect(editor.shared.history.addStep()).toBe(false);
+    });
+    test("same text node mutation should not break history", async () => {
+        const { el, editor } = await setupEditor(`<p>[]hello </p>`);
+        const p = el.querySelector("p");
+        const textNode = editor.document.createTextNode("world");
+        p.append(textNode);
+        editor.shared.history.addStep();
+        expect(getContent(el)).toBe(`<p>[]hello world</p>`);
+        // Replace text node with a new one with the same content
+        p.replaceChild(editor.document.createTextNode("world"), textNode);
+        // It should not create a step but, the old node should be remapped to
+        // the new one and history keep working
+        expect(editor.shared.history.addStep()).toBe(false);
+        editor.shared.history.undo();
+        expect(getContent(el)).toBe(`<p>[]hello </p>`);
+        editor.shared.history.redo();
+        expect(getContent(el)).toBe(`<p>[]hello world</p>`);
+    });
+});
+
 describe("unobserved mutations", () => {
     const withAddStep = (editor, callback) => {
         callback();

--- a/addons/website/static/src/builder/plugins/highlight/highlight_plugin.js
+++ b/addons/website/static/src/builder/plugins/highlight/highlight_plugin.js
@@ -49,12 +49,13 @@ export class HighlightPlugin extends Plugin {
             }
         },
         /**
-         * @param {MutationRecord} mutationRecord
+         * @param {import("@html_editor/core/history_plugin").HistoryMutationRecord} mutationRecord
          */
         savable_mutation_record_predicates: (mutationRecord) =>
-            ![...mutationRecord.addedNodes, ...mutationRecord.removedNodes].some((node) =>
-                closestElement(node, ".o_text_highlight_svg")
-            ),
+            mutationRecord.type !== "childList" ||
+            ![...mutationRecord.addedTrees, ...mutationRecord.removedTrees]
+                .map((tree) => tree.node)
+                .some((node) => closestElement(node, ".o_text_highlight_svg")),
         normalize_handlers: (root) => {
             // Remove highlight SVGs when the text is removed.
             for (const svg of root.querySelectorAll(".o_text_highlight_svg")) {

--- a/addons/website/static/src/builder/plugins/layout_option/spacing_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/layout_option/spacing_option_plugin.js
@@ -15,10 +15,13 @@ class SpacingOptionPlugin extends Plugin {
         clean_for_save_handlers: this.cleanForSave.bind(this),
     };
 
+    /**
+     * @param {import("@html_editor/core/history_plugin").HistoryMutationRecord} record
+     */
     isMutationRecordSavable(record) {
         // Do not consider the grid preview in the history.
         if (record.type === "childList") {
-            const node = record.addedNodes[0] || record.removedNodes[0];
+            const node = (record.addedTrees[0] || record.removedTrees[0]).node;
             if (node.matches && node.matches(".o_we_grid_preview") && isBlock(node)) {
                 return false;
             }

--- a/addons/website/static/src/core/website_edit_service.js
+++ b/addons/website/static/src/core/website_edit_service.js
@@ -212,12 +212,6 @@ registry.category("services").add("website_edit", {
                     insert(...args) {
                         const el = args[0];
                         super.insert(...args);
-                        // Avoid deletion accidents.
-                        // E.g. if an interaction inserts a node into a parent
-                        // node, and an option uses replaceChildren on the
-                        // parent node, you do not want the inserted node to be
-                        // reinserted upon undo of the option's action.
-                        el.dataset.skipHistoryHack = "true";
                         el.setAttribute("contenteditable", "false");
                     },
                 }),


### PR DESCRIPTION
This series of commits makes improvements and fixes in the History Plugin.
Most notably, it handles the impact of unobserved mutations in history integrity.
For "attribute", "classList" and "characterData" mutation records, the `oldValue` of the recorded step is ajusted so that it does not reflect a state introduced by unobserved mutations.
For childlist mutations, mutations that depend on previous unobserved mutations are not recorded (e.g. removal of nodes that had been added with observer off).

task-4678910