### PR TITLE
[16.0][FIX] base: avoid fail with wrong mimetype

### DIFF
--- a/odoo/addons/base/models/ir_attachment.py
+++ b/odoo/addons/base/models/ir_attachment.py
@@ -335,6 +335,10 @@ class IrAttachment(models.Model):
                     else:  # datas
                         img = ImageProcess(base64.b64decode(values['datas']), verify_resolution=False)
 
+                    if not img.image:
+                        _logger.info('Post processing ignored : Empty source, SVG, or WEBP')
+                        return values
+
                     w, h = img.image.size
                     nw, nh = map(int, max_resolution.split('x'))
                     if w > nw or h > nh:

--- a/odoo/addons/base/tests/test_ir_attachment.py
+++ b/odoo/addons/base/tests/test_ir_attachment.py
@@ -262,6 +262,13 @@ class TestIrAttachment(TransactionCaseWithUserDemo):
         self.Attachment._gc_file_store_unsafe()
         self.assertFalse(os.path.isfile(store_path), 'file removed')
 
+    def test_14_invalid_mimetype_with_correct_file_extension_no_post_processing(self):
+        # test with fake svg with png mimetype
+        unique_blob = b'<svg xmlns="http://www.w3.org/2000/svg"></svg>'
+        a1 = self.Attachment.create({'name': 'a1', 'raw': unique_blob, 'mimetype': 'image/png'})
+        self.assertEqual(a1.raw, unique_blob)
+        self.assertEqual(a1.mimetype, 'image/png')
+
 
 class TestPermissions(TransactionCaseWithUserDemo):
     def setUp(self):


### PR DESCRIPTION
Backport from 17.0: https://github.com/odoo/odoo/pull/162976

Uploading a WEBP or SVG file disguised with a proper file extension (JPG, PNG) will cause a traceback because img.image is
not populated when there is an empty source, SVG, or WEBP file uploaded as this code should not be reached with these file types.

The reason this occurs is because we check for the file extension when deciding to post process an image, but when we get to initializing the ImageProcess object, we then check the actual file structure to verify the type of file.

This is a workaround for the time being, but should not be a final solution in future versions.

Adding a null check on img.image in the _postprocess_contents method in order to avoid attempting to access the size of this image when it is null.

Raises a user error in order to trigger the catch and exit the code while logging the error and 'Post processing ignored:'.

Includes test for this new workflow with no errors.

opw-3672250

closes odoo/odoo#162976

X-original-commit: e9750b16a61c3598f7a2b14a1552fcb4ecf1a293

@Tecnativa

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
