### PR TITLE
[IMP] account: sending of invoices should happen in postcommit

### DIFF
--- a/addons/account/models/account_move_send.py
+++ b/addons/account/models/account_move_send.py
@@ -1,8 +1,13 @@
 from collections import defaultdict
+from functools import wraps
 from markupsafe import Markup
+
+import logging
 
 from odoo import _, api, models, modules, tools
 from odoo.exceptions import UserError, ValidationError
+
+_logger = logging.getLogger(__name__)
 
 
 class AccountMoveSend(models.AbstractModel):
@@ -732,6 +737,40 @@ class AccountMoveSend(models.AbstractModel):
             sending_method in dict(self.env['res.partner']._fields['invoice_sending_method'].selection)
             for sending_method in custom_settings.get('sending_methods', [])
         ) if 'sending_methods' in custom_settings else True
+
+    # As we are often sending invoices to the government, we want to make sure that
+    # the record is correctly stored in the db before sending it
+    def after_commit(func):
+        @wraps(func)
+        def wrapped(self, moves, *args, **kwargs):
+            if self.env['account.move']._can_commit():
+                @self.env.cr.postcommit.add
+                def called_after():
+                    try:
+                        with self.env.registry.cursor() as cr:
+                            self_env = self.env(cr=cr)
+                            moves_env = moves.env(cr=cr)
+                            func(self.with_env(self_env), moves.with_env(moves_env), *args, **kwargs)
+                            cr.commit()
+                    except Exception:
+                        _logger.warning("Could not sync record now: %s, moves: %s", self, moves)
+                        _logger.exception('Error in post_commit for invoice sending. ')
+            else:
+                func(self, moves, *args, **kwargs)
+        return wrapped
+
+    @api.model
+    @after_commit
+    def _generate_and_send_invoices_post_commit(
+        self, moves, from_cron=False, allow_raising=True, allow_fallback_pdf=False, **custom_settings
+    ):
+        self._generate_and_send_invoices(
+            moves,
+            from_cron=from_cron,
+            allow_raising=allow_raising,
+            allow_fallback_pdf=allow_fallback_pdf,
+            **custom_settings
+        )
 
     @api.model
     def _generate_and_send_invoices(self, moves, from_cron=False, allow_raising=True, allow_fallback_pdf=False, **custom_settings):

--- a/addons/sale/models/payment_transaction.py
+++ b/addons/sale/models/payment_transaction.py
@@ -163,7 +163,7 @@ class PaymentTransaction(models.Model):
                 if mail_template.exists():
                     send_context['mail_template'] = mail_template
 
-            tx.env['account.move.send']._generate_and_send_invoices(
+            tx.env['account.move.send']._generate_and_send_invoices_post_commit(
                 invoice_to_send,
                 **send_context,
             )


### PR DESCRIPTION
When the payment transactions trigger the creation of invoices and then the sending of those invoices by mail and through the EDI to the government, any concurrent update can make that entire process fail all at once.  This mainly happens when the user himself is paying through the portal as this will create the invoice from the payment.

When invoices are sent to the government however, we want to be sure that when sent, it gets updated in Odoo as well, so we are aware what is happening.

The problem we got is that invoice 1 is sent to the government (l10n_in_edi) as number 01 and then that transaction is totally rolled back that the invoice is not even there anymore, it risks that the government's numbers and your numbers do not correspond anymore.

So, we should avoid that that invoice can be sent when before there is a concurrent update (on payment transaction in this case) waiting for destroying it when committing.  So, the simple idea would be to only do the invoice sending through a post commit.  As we are locking the invoice itself for the sending to the government that should be enough to avoid the invoice sending for not being registered in Odoo.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
