### PR TITLE
[FIX] account: include future points in dashboard graph

### DIFF
--- a/addons/account/models/account_journal_dashboard.py
+++ b/addons/account/models/account_journal_dashboard.py
@@ -165,11 +165,10 @@ class account_journal(models.Model):
               JOIN account_move move ON move.id = st_line.move_id
              WHERE move.journal_id = ANY(%s)
                AND move.date > %s
-               AND move.date <= %s
           GROUP BY move.date, move.journal_id
           ORDER BY move.date DESC
         """
-        self.env.cr.execute(query, (self.ids, last_month, today))
+        self.env.cr.execute(query, (self.ids, last_month))
         query_result = group_by_journal(self.env.cr.dictfetchall())
 
         result = {}
@@ -189,15 +188,16 @@ class account_journal(models.Model):
                     graph_key = _('Sample data')
             else:
                 last_balance = journal.current_statement_balance
-                data.append(build_graph_data(today, last_balance, currency))
+                # Make sure the last point in the graph is at least today or a future date
+                if not journal_result or journal_result[0]['date'] < today.date():
+                    data.append(build_graph_data(today, last_balance, currency))
                 date = today
                 amount = last_balance
                 #then we subtract the total amount of bank statement lines per day to get the previous points
                 #(graph is drawn backward)
                 for val in journal_result:
                     date = val['date']
-                    if date.strftime(DF) != today.strftime(DF):  # make sure the last point in the graph is today
-                        data[:0] = [build_graph_data(date, amount, currency)]
+                    data[:0] = [build_graph_data(date, amount, currency)]
                     amount -= val['amount']
 
                 # make sure the graph starts 1 month ago


### PR DESCRIPTION
Before this commit:
When adding any statement line with a date in the future, the amount is reflected in the journal's final balance.
While it's not considered when calculating the graph points of the dashboard.
Which results in a discrepancy between balances and graph points of all past points.

With this commit:
Future points are considered in graph points aggregation and visualization.

Steps:
1- Create 2 bank transaction in a bank journal one with date in the past, the other in future.
2- Check dashboard graph points of past transaction, will notice a difference between the graph point and real balance. (difference amount is exactly equal the future transaction amount)

opw-4823770