### PR TITLE
[IMP] l10n_tw: set 'round_globally' as default tax rounding method in taiwan

### DIFF
--- a/addons/l10n_tw/models/template_tw.py
+++ b/addons/l10n_tw/models/template_tw.py
@@ -37,5 +37,6 @@ class AccountChartTemplate(models.AbstractModel):
                 'default_cash_difference_expense_account_id': 'tw_718600',
                 'account_sale_tax_id': 'tw_tax_sale_5',
                 'account_purchase_tax_id': 'tw_tax_purchase_5',
+                'tax_calculation_rounding_method': 'round_globally',
             },
         }


### PR DESCRIPTION
For general invoicing purposes, VAT of Taiwan is rounded per invoice level, not 
per invoice. Also, they do not separately compute the tax amount per each line 
to generate the final totals. They use total sales amount * tax.

task - 4875546