### PR TITLE
[IMP] mail: Allow creating group chat without selected participants

### DIFF
--- a/addons/mail/static/src/discuss/core/common/@types/models.d.ts
+++ b/addons/mail/static/src/discuss/core/common/@types/models.d.ts
@@ -24,7 +24,7 @@ declare module "models" {
         getRecentChatPartnerIds: () => number[];
         onlineMemberStatuses: Readonly<string[]>;
         sortMembers: (m1: ChannelMember, m2: ChannelMember) => number;
-        startChat: (partnerIds: number[]) => Promise<void>;
+        startChat: (partnerIds: number[], groupChat?: boolean) => Promise<void>;
         updateBusSubscription: (() => unknown) & { cancel: () => void };
     }
     export interface Thread {

--- a/addons/mail/static/src/discuss/core/common/channel_invitation.js
+++ b/addons/mail/static/src/discuss/core/common/channel_invitation.js
@@ -37,7 +37,10 @@ export class ChannelInvitation extends Component {
             searchResultCount: 0,
             searchStr: "",
         });
-        this.debouncedFetchPartnersToInvite = useDebounced(this.fetchPartnersToInvite.bind(this), 250);
+        this.debouncedFetchPartnersToInvite = useDebounced(
+            this.fetchPartnersToInvite.bind(this),
+            250
+        );
         onWillStart(() => {
             if (this.store.self.type === "partner") {
                 this.fetchPartnersToInvite();
@@ -163,7 +166,7 @@ export class ChannelInvitation extends Component {
             if (this.props.thread.correspondent) {
                 partnerIds.unshift(this.props.thread.correspondent.persona.id);
             }
-            await this.store.startChat(partnerIds);
+            await this.store.startChat(partnerIds, true);
         } else {
             await this.orm.call("discuss.channel", "add_members", [[this.props.thread.id]], {
                 partner_ids: this.selectedPartners.map((partner) => partner.id),

--- a/addons/mail/static/src/discuss/core/common/channel_invitation.xml
+++ b/addons/mail/static/src/discuss/core/common/channel_invitation.xml
@@ -47,7 +47,7 @@
                             </t>
                         </div>
                     </div>
-                    <button t-if="props.thread" class="btn btn-primary w-100 my-2" t-att-disabled="selectedPartners.length === 0" t-att-title="invitationButtonText" t-on-click="onClickInvite">
+                    <button t-if="props.thread" class="btn btn-primary w-100 my-2" t-att-disabled="selectedPartners.length === 0 and this.props.thread.channel_type != 'chat'" t-att-title="invitationButtonText" t-on-click="onClickInvite">
                         <t t-esc="invitationButtonText"/>
                     </button>
                 </t>

--- a/addons/mail/static/src/discuss/core/common/store_service_patch.js
+++ b/addons/mail/static/src/discuss/core/common/store_service_patch.js
@@ -70,13 +70,16 @@ const storeServicePatch = {
     sortMembers(m1, m2) {
         return m1.name?.localeCompare(m2.name) || m1.id - m2.id;
     },
-    /** @param {number[]} partnerIds */
-    async startChat(partnerIds) {
+    /**
+     * @param {number[]} partnerIds
+     * @param {boolean} [groupChat=false]
+     */
+    async startChat(partnerIds, groupChat = false) {
         const partners_to = [...new Set([this.self.id, ...partnerIds])];
         if (partners_to.length === 1) {
             const chat = await this.joinChat(partners_to[0], true);
             chat.open({ focus: true, bypassCompact: true });
-        } else if (partners_to.length === 2) {
+        } else if (partners_to.length === 2 && !groupChat) {
             const correspondentId = partners_to.find(
                 (partnerId) => partnerId !== this.store.self.id
             );

--- a/addons/mail/static/tests/discuss/core/channel_invitation.test.js
+++ b/addons/mail/static/tests/discuss/core/channel_invitation.test.js
@@ -145,6 +145,30 @@ test("should be able to create a new group chat from an existing chat", async ()
     });
 });
 
+test("create a new group chat with no participants selected", async () => {
+    const pyEnv = await startServer();
+    const partnerId_1 = pyEnv["res.partner"].create({
+        email: "testpartner@odoo.com",
+        name: "TestPartner",
+    });
+    pyEnv["res.users"].create({ partner_id: partnerId_1 });
+    const channelId = pyEnv["discuss.channel"].create({
+        name: "TestChannel",
+        channel_member_ids: [
+            Command.create({ partner_id: serverState.partnerId }),
+            Command.create({ partner_id: partnerId_1 }),
+        ],
+        channel_type: "chat",
+    });
+    await start();
+    await openDiscuss(channelId);
+    await click(".o-mail-Discuss-header button[title='Invite People']");
+    await click("button[title='Create Group Chat']:enabled");
+    await contains(".o-mail-DiscussSidebarChannel", {
+        text: "Mitchell Admin and TestPartner",
+    });
+});
+
 test("unnamed group chat should display correct name just after being invited", async () => {
     const pyEnv = await startServer();
     const partnerId = pyEnv["res.partner"].create({


### PR DESCRIPTION
Current behavior before PR:
- The "Create Group Chat" button was inactive if no participants were selected.
- Users were forced to select at least one other participant to initiate a group chat.

Desired behavior after PR is merged:
- The "Create Group Chat" button is always active.
- If no participants are selected, a group chat is still created with only the current user.
- This allows users to initiate a group and invite members later from within the chat.

task-id-[4790813](https://www.odoo.com/odoo/project/1519/tasks/4790813)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
