### PR TITLE
[IMP] im_livechat: enhance agent overview on livechat channel

### DIFF
--- a/addons/im_livechat/static/src/views/boolean_phone/boolean_phone.js
+++ b/addons/im_livechat/static/src/views/boolean_phone/boolean_phone.js
@@ -1,0 +1,13 @@
+import { registry } from "@web/core/registry";
+import { _t } from "@web/core/l10n/translation";
+import { booleanField, BooleanField } from "@web/views/fields/boolean/boolean_field";
+
+export class BooleanPhoneField extends BooleanField {
+    static template = "im_livechat.BooleanPhoneField";
+}
+
+registry.category("fields").add("boolean_phone", {
+    ...booleanField,
+    component: BooleanPhoneField,
+    displayName: _t("In call"),
+});

--- a/addons/im_livechat/static/src/views/boolean_phone/boolean_phone.xml
+++ b/addons/im_livechat/static/src/views/boolean_phone/boolean_phone.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+    <t t-name="im_livechat.BooleanPhoneField">
+        <i t-if="state.value" class="fa fa-fw fa-phone" role="img" title="In a Call"/>
+    </t>
+</templates>

--- a/addons/im_livechat/tests/test_im_livechat_channel.py
+++ b/addons/im_livechat/tests/test_im_livechat_channel.py
@@ -101,11 +101,16 @@ class TestImLivechatChannel(TestImLivechatCommon, TestGetOperator):
         self.assertEqual(self.livechat_channel.review_link, "https://www.odoo.com")
 
     def test_ongoing_session_count(self):
-        livechat_channel = self.livechat_channel
-        session_1 = self._create_conversation(livechat_channel, livechat_channel.user_ids[0])
-        session_2 = self._create_conversation(livechat_channel, livechat_channel.user_ids[0])
-        self.assertEqual(livechat_channel.ongoing_session_count, 2)
-        session_1.livechat_end_dt = Datetime.now() - timedelta(minutes=4)
+        self.authenticate(None, None)
+        john = self._create_operator("fr_FR")
+        livechat_channel = self.env["im_livechat.channel"].create(
+            {"name": "Livechat Channel", "user_ids": [john.id]},
+        )
+        data = self.make_jsonrpc_request(
+            "/im_livechat/get_session",
+            {"channel_id": livechat_channel.id},
+        )
+        channel = self.env["discuss.channel"].browse(data["channel_id"])
         self.assertEqual(livechat_channel.ongoing_session_count, 1)
-        session_2.livechat_end_dt = Datetime.now() - timedelta(minutes=2)
+        channel.livechat_end_dt = Datetime.now() - timedelta(minutes=2)
         self.assertEqual(livechat_channel.ongoing_session_count, 0)

--- a/addons/im_livechat/views/im_livechat_channel_views.xml
+++ b/addons/im_livechat/views/im_livechat_channel_views.xml
@@ -93,8 +93,20 @@
                         </div>
                         <notebook>
                             <page string="Operators" name="operators">
-                                    <field name="user_ids" nolabel="1" colspan="2" domain="[['all_group_ids', 'in', %(im_livechat.im_livechat_group_user)d]]">
-                                        <kanban>
+                                    <field name="user_ids"
+                                           nolabel="1"
+                                           colspan="2"
+                                           domain="[['all_group_ids', 'in', %(im_livechat.im_livechat_group_user)d]]"
+                                           mode="list,kanban"
+                                           context="{'add_livechat_channel_ctx': True}">
+                                        <list no_open="1">
+                                            <field name="partner_id" string="Agent" widget="many2one_avatar_user" width="175px" context="{'im_livechat.hide_partner_company': True}"/>
+                                            <field name="livechat_is_in_call" widget="boolean_phone" nolabel="1"/>
+                                            <field string="Languages" name="livechat_lang_ids" widget="many2many_tags" optional="show"/>
+                                            <field string="Expertise" name="livechat_expertise_ids" widget="many2many_tags" optional="show"/>
+                                            <field string="Ongoing Sessions" name="livechat_ongoing_session_count" width="150px" optional="show"/>
+                                        </list>
+                                        <kanban class="o_kanban_mobile" can_open="False">
                                             <templates>
                                                 <t t-name="card" class="flex-row">
                                                     <aside>
@@ -107,15 +119,38 @@
                                                                 <i title="Remove operator" class="fa fa-fw fa-lg fa-close"/>
                                                             </a>
                                                         </div>
-                                                        <field name="livechat_username" string="Online Chat Name"/>
+                                                        <field t-if="record.livechat_lang_ids.raw_value.length > 0" name="livechat_lang_ids" widget="many2many_tags"/>
+                                                        <field t-if="record.livechat_expertise_ids.raw_value.length > 0" name="livechat_expertise_ids" widget="many2many_tags"/>
+                                                        <div class="d-flex justify-content-between align-items-baseline">
+                                                            <div class="column">
+                                                                <span>Ongoing Sessions:</span><field name="livechat_ongoing_session_count" class="ms-1"/>
+                                                            </div>
+                                                            <field name="livechat_is_in_call" class="me-1" widget="boolean_phone"/>
+                                                        </div>
                                                     </main>
                                                 </t>
                                             </templates>
                                         </kanban>
                                     </field>
-                                    <p class="text-muted" colspan="2">
-                                        Operators that do not show any activity In Odoo for more than 30 minutes will be considered as disconnected.
-                                    </p>
+                                    <group>
+                                        <group class="order-1 order-lg-0">
+                                            <p class="text-muted" colspan="2">
+                                                Operators that do not show any activity In Odoo for more than 30 minutes will be considered as disconnected.
+                                            </p>
+                                        </group>
+                                        <group class="oe_subtotal_footer d-flex justify-content-end">
+                                            <div class="container">
+                                                <div class="row mb-2">
+                                                    <div class="col"><label class="fw-bold" for="ongoing_session_count"/></div>
+                                                    <div class="col me-1"><field name="ongoing_session_count" nolabel="1"/></div>
+                                                </div>
+                                                <div class="row mb-2" invisible="max_sessions_mode!='limited'">
+                                                    <div class="col"><label class="fw-bold" for="remaining_session_capacity"/></div>
+                                                    <div class="col me-1"><field name="remaining_session_capacity" nolabel="1"/></div>
+                                                </div>
+                                            </div>
+                                        </group>
+                                    </group>
                             </page>
                             <page string="Options" name="options" groups="im_livechat.im_livechat_group_manager">
                                 <group>


### PR DESCRIPTION
**Current behavior before PR:**

In the Livechat channel form view, under the `Operators` page, agents are displayed in a kanban view.

**Desired behavior after PR is merged:**

Agents will be displayed in a list view for desktop users, while kanban view is retained for mobile users.

task-4772546


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
