### PR TITLE
[FIX] website_sale: Traceback on the Suggested Accessories toggle button

### DIFF
--- a/addons/website_event_sale/views/website_sale_templates.xml
+++ b/addons/website_event_sale/views/website_sale_templates.xml
@@ -20,7 +20,7 @@
     </template>
 
     <!-- If the sale order line concerns an event, we want to show an additional line with the event name even on small screens -->
-    <template id="cart_lines_inherit_website_event_sale" inherit_id="website_sale.cart_lines" name="Event Shopping Cart Lines">
+    <template id="cart_lines_inherit_website_event_sale" inherit_id="website_sale.cart_lines_price" name="Event Shopping Cart Lines">
         <xpath expr="//del" position="attributes">
             <attribute name="t-attf-class" separator=" " add="#{line.event_id and 'd-none' or ''}"/>
         </xpath>

--- a/addons/website_sale_loyalty/views/website_sale_templates.xml
+++ b/addons/website_sale_loyalty/views/website_sale_templates.xml
@@ -124,7 +124,7 @@
         </xpath>
     </template>
 
-    <template id="website_sale_coupon_cart_hide_qty" inherit_id="website_sale.cart_lines">
+    <template id="website_sale_coupon_cart_hide_qty" inherit_id="website_sale.cart_lines_price">
         <xpath expr="//del" position="attributes">
             <attribute name="t-if">not line.is_reward_line</attribute>
         </xpath>


### PR DESCRIPTION
Traceback when editing the toggle button, through the website editor The element '<xpath expr="//del">' cannot be located in the parent view

Description of the issue/feature this PR addresses:
This issue has happened because of the standard change in the module.

Current behavior before PR:
Traceback click on Suggested Accessories, the toggle button through the website editor.
in v18.2 the module [website_event_sale](https://github.com/odoo/odoo/blob/saas-18.2/addons/website_event_sale/views/website_sale_templates.xml#L24) and [website_sale_loyalty](https://github.com/odoo/odoo/blob/saas-18.2/addons/website_sale_loyalty/views/website_sale_templates.xml#L128) is inherit the cart_line and target the [node](https://github.com/odoo/odoo/blob/saas-18.2/addons/website_sale/views/templates.xml#L2087) is available in the view. But in version 18.3 this node is move to other [template](https://github.com/odoo/odoo/blob/saas-18.3/addons/website_sale/views/templates.xml#L2341) that's why the node is not find. 


Desired behavior after PR is merged:

After the change i target the new [template](https://github.com/odoo/odoo/blob/saas-18.3/addons/website_sale/views/templates.xml#L2435) so the node is now find.

Issued PR https://github.com/odoo/odoo/pull/190720

[OPW](https://www.odoo.com/odoo/project/70/tasks/4864959?debug=1)


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
