### PR TITLE
[FIX] stock: prevent errors when picking type has no sequence

### DIFF
--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -29,7 +29,7 @@ class StockPickingType(models.Model):
     sequence = fields.Integer('Sequence', help="Used to order the 'All Operations' kanban view")
     sequence_id = fields.Many2one(
         'ir.sequence', 'Reference Sequence',
-        check_company=True, copy=False)
+        check_company=True, copy=False, required=True)
     sequence_code = fields.Char('Sequence Prefix', required=True)
     default_location_src_id = fields.Many2one(
         'stock.location', 'Source Location', compute='_compute_default_location_src_id',


### PR DESCRIPTION
Currently, an error occurs  when  a  repair order is created using a repair operation type without an assigned sequence.

Steps to Reproduce:
- Install `Repairs` and open `stock > configuration > Operation types > repair`.
- Remove the value from the field `Reference Sequence`.
- Go to `Repairs` and try to make a repair order, you will get the error.

Error:
`UndefinedFunction: operator does not exist: integer = boolean LINE 1: SELECT number_next FROM ir_sequence WHERE id=false FOR UPDAT...`

The error occurs because the sequence was removed from the picking type, and [1] attempts to get the next sequence number by executing query [2]. Since the sequence no longer exists, `self.id` is False in [2], which leads to an error.

This commit resolves the issue by making the sequence field required, preventing unexpected errors at runtime.

[1] - https://github.com/odoo/odoo/blob/3bd8a660d0e20e62e5b63b5483af8be05b673af8/addons/repair/models/repair.py#L387

[2] - https://github.com/odoo/odoo/blob/3bd8a660d0e20e62e5b63b5483af8be05b673af8/odoo/addons/base/models/ir_sequence.py#L57

**Link to Upgrade [PR](https://github.com/odoo/upgrade/pull/7886).**

sentry-6683755145
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
