### PR TITLE
[FIX] html_builder, website: prevent update input in preview

### DIFF
--- a/addons/html_builder/static/src/core/building_blocks/builder_text_input_base.js
+++ b/addons/html_builder/static/src/core/building_blocks/builder_text_input_base.js
@@ -1,4 +1,4 @@
-import { Component } from "@odoo/owl";
+import { Component, onWillUpdateProps, useState } from "@odoo/owl";
 import { useForwardRefToParent } from "@web/core/utils/hooks";
 import { useActionInfo } from "../utils";
 
@@ -28,16 +28,25 @@ export class BuilderTextInputBase extends Component {
     };
 
     setup() {
+        this.isEditing = false;
         this.info = useActionInfo();
         this.inputRef = useForwardRefToParent("inputRef");
+        this.state = useState({ value: this.props.value });
+        onWillUpdateProps((nextProps) => {
+            if ("value" in nextProps) {
+                this.state.value = this.isEditing ? this.inputRef.el.value : nextProps.value;
+            }
+        });
     }
 
     onChange(ev) {
+        this.isEditing = false;
         const normalizedDisplayValue = this.props.commit(ev.target.value);
         ev.target.value = normalizedDisplayValue;
     }
 
     onInput(ev) {
+        this.isEditing = true;
         this.props.preview(ev.target.value);
     }
 

--- a/addons/html_builder/static/src/core/building_blocks/builder_text_input_base.xml
+++ b/addons/html_builder/static/src/core/building_blocks/builder_text_input_base.xml
@@ -26,7 +26,7 @@
             t-on-input="onInput"
             t-on-focus="onFocus"
             t-on-keydown="onKeydown"
-            t-att-value="props.value"
+            t-att-value="state.value"
             t-att-style="props.style"
         />
         <t t-slot="default"/>


### PR DESCRIPTION
[FIX] html_builder, website: prevent update input in preview

Here is the flow that this commit fixes:
- The user types something ("A") as input and clicks somewhere else to
commit its change.
- The custom action linked to the input in asynchronous and it takes
time to finish.
- The user types something else ("B") and stays on the same input (no
update of the input state so no update of the UI).
- The custom action of "A" finishes and updates the state of the input.

-> "A" is displayed in the option input and "B" is lost. If the user
continues to type, it will not be the wanted input.

Related to task-4367641

