### PR TITLE
[IMP] orm, base, web: make the properties work without parent

### DIFF
--- a/addons/mass_mailing/__manifest__.py
+++ b/addons/mass_mailing/__manifest__.py
@@ -21,6 +21,7 @@
     'data': [
         'data/res_groups_privilege_data.xml',
         'security/res_groups_data.xml',
+        'security/security.xml',
         'security/ir.model.access.csv',
         'data/digest_data.xml',
         'data/ir_attachment_data.xml',

--- a/addons/mass_mailing/models/mailing_contact.py
+++ b/addons/mass_mailing/models/mailing_contact.py
@@ -12,7 +12,7 @@ class MailingContact(models.Model):
     be able to deal with large contact list to email without bloating the partner
     base."""
     _name = 'mailing.contact'
-    _inherit = ['mail.thread.blacklist']
+    _inherit = ['mail.thread.blacklist', 'properties.base.definition.mixin']
     _description = 'Mailing Contact'
     _order = 'name ASC, id DESC'
     _mailing_enabled = True

--- a/addons/mass_mailing/security/ir.model.access.csv
+++ b/addons/mass_mailing/security/ir.model.access.csv
@@ -23,3 +23,4 @@ access_mailing_mailing_test,access.mailing.mailing.test,model_mailing_mailing_te
 access_mailing_contact_to_list,access.mailing.contact.to.list,model_mailing_contact_to_list,mass_mailing.group_mass_mailing_user,1,1,1,1
 access_mailing_schedule_date,access.mailing.schedule.date,model_mailing_mailing_schedule_date,mass_mailing.group_mass_mailing_user,1,1,1,1
 access_mailing_filter_mailing_user,access.mailing.filter.mailing.user,model_mailing_filter,mass_mailing.group_mass_mailing_user,1,1,1,1
+access_properties_base_definition_mailing_user,access_properties_base_definition,base.model_properties_base_definition,mass_mailing.group_mass_mailing_user,1,1,1,1

--- a/addons/mass_mailing/security/security.xml
+++ b/addons/mass_mailing/security/security.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <record id="properties_base_definition_rule_mailing_user" model="ir.rule">
+            <field name="name">properties.base.definition: mailing user</field>
+            <field name="model_id" ref="base.model_properties_base_definition"/>
+            <field name="groups" eval="[Command.link(ref('mass_mailing.group_mass_mailing_user'))]"/>
+            <field name="domain_force">[('properties_field_id', '=', user.env.ref('mass_mailing.field_mailing_contact__properties').id)]</field>
+        </record>
+    </data>
+</odoo>

--- a/addons/mass_mailing/views/mailing_contact_views.xml
+++ b/addons/mass_mailing/views/mailing_contact_views.xml
@@ -10,6 +10,7 @@
                     string="Name / Email"/>
                 <field name="tag_ids"/>
                 <field name="list_ids"/>
+                <field name="properties"/>
                 <separator/>
                 <filter string="Valid Email Recipients"
                     name="filter_valid_email_recipient"
@@ -31,6 +32,8 @@
                 <group expand="0" string="Group By">
                     <filter string="Creation Date" name="group_create_date"
                         context="{'group_by': 'create_date'}"/>
+                    <filter string="Properties" name="group_properties"
+                        context="{'group_by': 'properties'}"/>
                 </group>
             </search>
         </field>
@@ -56,6 +59,7 @@
                 <field name="message_bounce" sum="Total Bounces" readonly="1"/>
                 <field name="opt_out" readonly="1" column_invisible="'default_list_ids' not in context"/>
                 <field name="list_ids" widget="many2many_tags" optional="hide"/>
+                <field name="properties" optional="hide"/>
             </list>
         </field>
     </record>
@@ -78,10 +82,9 @@
                             </div>
                         </div>
                         <field name="tag_ids"/>
-                        <footer class="pt-1">
-                            <field name="email" class="fw-bolder"/>
-                            <field name="company_name" class="ms-auto"/>
-                        </footer>
+                        <field name="email" class="fw-bolder"/>
+                        <field name="company_name" class="ms-auto"/>
+                        <field name="properties" widget="properties"/>
                     </t>
                 </templates>
             </kanban>
@@ -123,6 +126,9 @@
                                    placeholder="e.g. &quot;VIP&quot;, &quot;Roadshow&quot;, ..." style="width: 100%"/>
                         </group>
                     </group>
+                    <div class="d-flex">
+                        <field name="properties" nolabel="1" columns="2"/>
+                    </div>
                     <notebook>
                         <page string="Subscriptions">
                             <field name="subscription_ids">

--- a/addons/test_mail/tests/test_performance.py
+++ b/addons/test_mail/tests/test_performance.py
@@ -531,7 +531,7 @@ class TestBaseAPIPerformance(BaseMailPerformance):
         test_record, test_template = self._create_test_records()
         test_template.write({'attachment_ids': [(5, 0)]})
 
-        with self.assertQueryCount(admin=28, employee=28):  # tm: 22/22
+        with self.assertQueryCount(admin=29, employee=29):  # tm: 23/23
             composer = self.env['mail.compose.message'].with_context({
                 'default_composition_mode': 'comment',
                 'default_model': test_record._name,
@@ -558,7 +558,7 @@ class TestBaseAPIPerformance(BaseMailPerformance):
     def test_mail_composer_w_template_attachments(self):
         test_record, test_template = self._create_test_records()
 
-        with self.assertQueryCount(admin=29, employee=29):  # tm: 23/23
+        with self.assertQueryCount(admin=30, employee=30):  # tm: 24/24
             composer = self.env['mail.compose.message'].with_context({
                 'default_composition_mode': 'comment',
                 'default_model': test_record._name,
@@ -617,7 +617,7 @@ class TestBaseAPIPerformance(BaseMailPerformance):
         test_record, test_template = self._create_test_records()
 
         customer = self.env['res.partner'].browse(self.customer.ids)
-        with self.assertQueryCount(admin=43, employee=43):  # tm 36/36
+        with self.assertQueryCount(admin=44, employee=44):  # tm 37/37
             composer_form = Form(
                 self.env['mail.compose.message'].with_context({
                     'default_composition_mode': 'comment',
@@ -993,7 +993,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
     @warmup
     def test_message_get_suggested_recipients(self):
         record = self.test_records_recipients[0].with_env(self.env)
-        with self.assertQueryCount(employee=21):  # tm: 15
+        with self.assertQueryCount(employee=22):  # tm: 16
             recipients = record._message_get_suggested_recipients(no_create=False)
         new_partner = self.env['res.partner'].search([('email_normalized', '=', 'only.email.1@test.example.com')])
         self.assertEqual(len(new_partner), 1)
@@ -1008,7 +1008,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
     @warmup
     def test_message_get_suggested_recipients_batch(self):
         records = self.test_records_recipients.with_env(self.env)
-        with self.assertQueryCount(employee=30):  # tm: 24
+        with self.assertQueryCount(employee=31):  # tm: 25
             _recipients = records._message_get_suggested_recipients_batch(no_create=False)
 
     @mute_logger('odoo.tests', 'odoo.addons.mail.models.mail_mail', 'odoo.models.unlink')
@@ -1120,7 +1120,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
     def test_partner_find_from_emails(self):
         """ Test '_partner_find_from_emails', notably to check batch optimization """
         records = self.test_records_recipients.with_user(self.env.user)
-        with self.assertQueryCount(employee=26):  # tm: 19
+        with self.assertQueryCount(employee=27):  # tm: 20
             partners = records._partner_find_from_emails(
                 {record: [record.email_from, record.partner_id.email, record.user_id.email] for record in records},
                 avoid_alias=True,

--- a/addons/web/models/__init__.py
+++ b/addons/web/models/__init__.py
@@ -11,3 +11,4 @@ from . import base_document_layout
 from . import res_config_settings
 from . import res_partner
 from . import res_users
+from . import properties_base_definition

--- a/addons/web/models/properties_base_definition.py
+++ b/addons/web/models/properties_base_definition.py
@@ -1,0 +1,21 @@
+from odoo import _, api, models
+from odoo.exceptions import AccessError
+
+
+class PropertiesBaseDefinition(models.Model):
+    _inherit = "properties.base.definition"
+
+    @api.model
+    def get_properties_base_definition(self, model_name, field_name):
+        """Return the base properties definition if we can read the model."""
+        model = self.env[model_name]
+        model.check_access("read")
+        if model._fields[field_name].type != "properties":
+            raise AccessError(_("You can not read that field definition."))
+        return self.sudo().web_search_read(
+            [
+                ["properties_field_id.name", "=", field_name],
+                ["properties_field_id.model", "=", model_name],
+            ],
+            specification={"display_name": {}, "properties_definition": {}},
+        )

--- a/addons/web/static/src/core/field_service.js
+++ b/addons/web/static/src/core/field_service.js
@@ -41,22 +41,31 @@ export const fieldService = {
          * @param {import("@web/core/domain").DomainListRepr} [domain=[]]
          * @returns {Promise<Object>}
          */
-        async function _loadPropertyDefinitions(fieldDefs, name, domain = []) {
+        async function _loadPropertyDefinitions(resModel, fieldDefs, name, domain = []) {
             const {
                 definition_record: definitionRecord,
                 definition_record_field: definitionRecordField,
             } = fieldDefs[name];
             const definitionRecordModel = fieldDefs[definitionRecord].relation;
 
-            // @ts-ignore
-            domain = Domain.and([[[definitionRecordField, "!=", false]], domain]).toList();
-
-            const result = await orm.webSearchRead(definitionRecordModel, domain, {
-                specification: {
-                    display_name: {},
-                    [definitionRecordField]: {},
-                },
-            });
+            let result;
+            if (definitionRecordModel === "properties.base.definition") {
+                // Record without parent (eg `res.partner`)
+                result = await orm.call(
+                    "properties.base.definition",
+                    "get_properties_base_definition",
+                    [resModel, name]
+                );
+            } else {
+                // @ts-ignore
+                domain = Domain.and([[[definitionRecordField, "!=", false]], domain]).toList();
+                result = await orm.webSearchRead(definitionRecordModel, domain, {
+                    specification: {
+                        display_name: {},
+                        [definitionRecordField]: {},
+                    },
+                });
+            }
 
             const definitions = {};
             for (const record of result.records) {
@@ -84,7 +93,7 @@ export const fieldService = {
          */
         async function loadPropertyDefinitions(resModel, fieldName, domain) {
             const fieldDefs = await loadFields(resModel);
-            return _loadPropertyDefinitions(fieldDefs, fieldName, domain);
+            return _loadPropertyDefinitions(resModel, fieldDefs, fieldName, domain);
         }
 
         /**
@@ -120,7 +129,7 @@ export const fieldService = {
             } else if (fieldDef.type === "properties") {
                 subResult = await _loadPath(
                     followRelationalProperties ? resModel : "*",
-                    await _loadPropertyDefinitions(fieldDefs, name),
+                    await _loadPropertyDefinitions(resModel, fieldDefs, name),
                     remainingNames
                 );
             }

--- a/addons/web/static/src/search/search_model.js
+++ b/addons/web/static/src/search/search_model.js
@@ -1022,7 +1022,9 @@ export class SearchModel extends EventBus {
                     propertyDomain: [definitionRecord, "=", definitionRecordId],
                     propertyFieldDefinition: definition,
                     propertyItemId: searchItem.id,
-                    description: `${definition.string} (${definitionRecordName})`,
+                    description: definitionRecordName
+                        ? `${definition.string} (${definitionRecordName})`
+                        : definition.string,
                     groupId: this.nextGroupId++,
                 };
                 if (["many2many", "tags"].includes(definition.type)) {

--- a/addons/web/static/src/views/fields/formatters.js
+++ b/addons/web/static/src/views/fields/formatters.js
@@ -76,7 +76,7 @@ export function formatChar(value, options) {
     if (options && options.escape) {
         value = escape(value);
     }
-    return value;
+    return value || "";
 }
 formatChar.extractOptions = ({ attrs }) => ({
     isPassword: exprToBoolean(attrs.password),

--- a/addons/web/static/src/views/fields/properties/properties_field.js
+++ b/addons/web/static/src/views/fields/properties/properties_field.js
@@ -646,17 +646,23 @@ export class PropertiesField extends Component {
      * @param {string} propertyName
      */
     onPropertyDelete(propertyName) {
+        let message = _t("Are you sure you want to delete this property field?") + " ";
+        if (this.definitionRecordModel !== "properties.base.definition") {
+            const parentName = this.props.record.data[this.definitionRecordField].display_name;
+            const parentFieldLabel = this.props.record.fields[this.definitionRecordField].string;
+            message += _t(
+                'It will be removed for everyone using the "%(parentName)s" %(parentFieldLabel)s.',
+                { parentName, parentFieldLabel }
+            );
+        } else {
+            message += _t("It will be removed for everyone!");
+        }
         this.popover.close();
         const dialogProps = {
             title: _t("Delete Property Field"),
-            body: _t(
-                'Are you sure you want to delete this property field? It will be removed for everyone using the "%(parentName)s" %(parentFieldLabel)s.',
-                {
-                    parentName: this.props.record.data[this.definitionRecordField].display_name,
-                    parentFieldLabel: this.props.record.fields[this.definitionRecordField].string,
-                }
-            ),
+            body: message,
             confirmLabel: _t("Delete Field"),
+            cancelLabel: _t("Discard"),
             confirm: () => {
                 const propertiesDefinitions = this.propertiesList;
                 propertiesDefinitions.find(

--- a/addons/web/tests/__init__.py
+++ b/addons/web/tests/__init__.py
@@ -25,4 +25,5 @@ from . import test_ir_qweb
 from . import test_reports
 from . import test_perf_load_menu
 from . import test_pivot_export
+from . import test_res_partner_properties
 from . import test_action

--- a/addons/web/tests/test_res_partner_properties.py
+++ b/addons/web/tests/test_res_partner_properties.py
@@ -1,0 +1,18 @@
+from unittest.mock import patch
+
+from odoo.exceptions import AccessError
+from odoo.tests import TransactionCase
+
+
+class TestWebProperties(TransactionCase):
+    def test_get_properties_base_definition(self):
+        """Check that we can not get the base definition if we can not read the model."""
+        self.env["properties.base.definition"].get_properties_base_definition("res.partner", "properties")
+
+        def _check_access(mode):
+            if mode == "read":
+                raise AccessError("")
+
+        with patch.object(self.registry['res.partner'], 'check_access', side_effect=_check_access), \
+             self.assertRaises(AccessError):
+            self.env["properties.base.definition"].get_properties_base_definition("res.partner", "properties")

--- a/odoo/addons/base/models/__init__.py
+++ b/odoo/addons/base/models/__init__.py
@@ -28,6 +28,8 @@ from . import ir_logging
 from . import ir_module
 from . import ir_demo
 from . import ir_demo_failure
+from . import properties_base_definition
+from . import properties_base_definition_mixin
 from . import report_layout
 from . import report_paperformat
 

--- a/odoo/addons/base/models/properties_base_definition.py
+++ b/odoo/addons/base/models/properties_base_definition.py
@@ -1,0 +1,67 @@
+from odoo import _, api, fields, models
+from odoo.exceptions import AccessError, ValidationError
+from odoo.tools import ormcache
+
+
+class PropertiesBaseDefinition(models.Model):
+    """Models storing the properties definition of the record without parent."""
+
+    _name = "properties.base.definition"
+    _description = "Properties Base Definition"
+
+    properties_field_id = fields.Many2one(
+        "ir.model.fields",
+        required=True,
+        ondelete="cascade",
+    )
+    properties_definition = fields.PropertiesDefinition("Properties Definition")
+
+    _unique_properties_field_id = models.Constraint(
+        "UNIQUE(properties_field_id)",
+        "Only one definition per properties field",
+    )
+
+    @api.depends("properties_field_id")
+    def _compute_display_name(self):
+        for definition in self:
+            if not definition.properties_field_id.model:
+                definition.display_name = False
+                continue
+
+            definition.display_name = _(
+                "%s Properties",
+                self.env[definition.properties_field_id.model]._description,
+            )
+
+    @api.constrains("properties_field_id")
+    def _check_properties_field_id(self):
+        if invalid_fields := self.mapped("properties_field_id").filtered(lambda f: f.ttype != 'properties'):
+            raise ValidationError(
+                _("The definition needs to be linked to a properties field. Those fields are not: %s.", ', '.join(invalid_fields.mapped('name')))
+            )
+
+    def write(self, vals):
+        if 'properties_field_id' in vals:
+            raise AccessError(_("You can not change the field of a base definition"))
+        return super().write(vals)
+
+    def _get_definition_for_property_field(self, model_name, field_name):
+        return self.browse(self._get_definition_id_for_property_field(model_name, field_name))
+
+    @ormcache("model_name", "field_name")
+    def _get_definition_id_for_property_field(self, model_name, field_name):
+        definition_record = self.sudo().search(
+            [
+                ("properties_field_id.model", "=", model_name),
+                ("properties_field_id.name", "=", field_name),
+            ],
+            limit=1,
+        )
+        if not definition_record:
+            field = self.env["ir.model.fields"].sudo()._get(model_name, field_name)
+            definition_record = self.sudo().create(
+                {
+                    "properties_field_id": field.id,
+                },
+            )
+        return definition_record.id

--- a/odoo/addons/base/models/properties_base_definition_mixin.py
+++ b/odoo/addons/base/models/properties_base_definition_mixin.py
@@ -1,0 +1,56 @@
+from collections.abc import Iterable
+
+from odoo import models, api, fields
+from odoo.fields import Domain
+from odoo.tools import SQL
+
+
+class PropertiesBaseDefinitionMixin(models.AbstractModel):
+    """Mixin that add properties without parent on a model."""
+
+    _name = "properties.base.definition.mixin"
+    _description = "Properties Base Definition Mixin"
+
+    properties = fields.Properties(
+        string="Properties",
+        definition="properties_base_definition_id.properties_definition",
+        copy=True,
+    )
+    properties_base_definition_id = fields.Many2one(
+        "properties.base.definition",
+        compute="_compute_properties_base_definition_id",
+        search="_search_properties_base_definition_id",
+    )
+
+    def _compute_properties_base_definition_id(self):
+        self.properties_base_definition_id = self.env["properties.base.definition"] \
+            .sudo()._get_definition_for_property_field(self._name, "properties")
+
+    def _search_properties_base_definition_id(self, operator, value):
+        if operator != "in":
+            return NotImplemented
+
+        properties_base_definition_id = self.env["properties.base.definition"] \
+            .sudo()._get_definition_id_for_property_field(self._name, "properties")
+
+        if not isinstance(value, Iterable):
+            value = (value,)
+        return Domain.TRUE if properties_base_definition_id in value else Domain.FALSE
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        parent = self.env["properties.base.definition"] \
+            ._get_definition_id_for_property_field(self._name, "properties")
+        for vals in vals_list:
+            # Needed to add the default properties values
+            vals["properties_base_definition_id"] = parent
+        return super().create(vals_list)
+
+    def _field_to_sql(self, alias, fname, query=None, flush: bool = True):
+        if fname == 'properties_base_definition_id':
+            # Allow the export to work
+            parent = self.env["properties.base.definition"] \
+                ._get_definition_id_for_property_field(self._name, "properties")
+            return SQL("%s", parent)
+
+        return super()._field_to_sql(alias, fname, query, flush)

--- a/odoo/addons/base/models/res_partner.py
+++ b/odoo/addons/base/models/res_partner.py
@@ -183,7 +183,7 @@ class ResPartnerCategory(models.Model):
 class ResPartner(models.Model):
     _name = 'res.partner'
     _description = 'Contact'
-    _inherit = ['format.address.mixin', 'format.vat.label.mixin', 'avatar.mixin']
+    _inherit = ['format.address.mixin', 'format.vat.label.mixin', 'avatar.mixin', 'properties.base.definition.mixin']
     _order = "complete_name ASC, id DESC"
     _rec_names_search = ['complete_name', 'email', 'ref', 'vat', 'company_registry']  # TODO vat must be sanitized the same way for storing/searching
     _allow_sudo_commands = False

--- a/odoo/addons/base/security/base_security.xml
+++ b/odoo/addons/base/security/base_security.xml
@@ -253,5 +253,11 @@
             <field name="groups" eval="[Command.link(ref('base.group_system'))]"/>
         </record>
 
+        <record id="properties_base_definition_rule_admin" model="ir.rule">
+            <field name="name">properties.base.definition: system all access</field>
+            <field name="model_id" ref="base.model_properties_base_definition"/>
+            <field name="groups" eval="[Command.link(ref('base.group_system'))]"/>
+            <field name="domain_force">[(1, '=', 1)]</field>
+        </record>
     </data>
 </odoo>

--- a/odoo/addons/base/security/ir.model.access.csv
+++ b/odoo/addons/base/security/ir.model.access.csv
@@ -144,3 +144,4 @@ access_res_users_settings_user,res.users.settings,model_res_users_settings,group
 "access_base_enable_profiling_wizard","access.base.enable.profiling.wizard","model_base_enable_profiling_wizard","group_system",1,1,1,0
 "access_res_device",access_res_device,base.model_res_device,base.group_user,1,0,0,0
 "access_res_device_log",access_res_device_log,base.model_res_device_log,base.group_user,1,0,0,0
+"access_properties_base_definition_group_system",access_properties_base_definition,base.model_properties_base_definition,base.group_system,1,1,1,1

--- a/odoo/addons/base/views/res_partner_views.xml
+++ b/odoo/addons/base/views/res_partner_views.xml
@@ -30,6 +30,7 @@
                     <field name="application_statistics" widget="contact_statistics" nolabel="1" optional="show" width="270"/>
                     <field name="category_id" optional="hide" widget="many2many_tags" options="{'color_field': 'color'}"/>
                     <field name="company_id" groups="base.group_multi_company" readonly="1" optional="hide"/>
+                    <field name="properties" optional="hide"/>
                 </list>
             </field>
         </record>
@@ -190,6 +191,9 @@
                                    placeholder='e.g. "B2B", "VIP", "Consulting", ...'/>
                         </group>
                     </group>
+                    <div class="d-flex">
+                        <field name="properties" nolabel="1" columns="2"/>
+                    </div>
 
                     <notebook colspan="4">
                         <page string="Contacts" name="contact_addresses" autofocus="autofocus">
@@ -323,11 +327,13 @@
                     <filter string="Companies" name="type_company" domain="[('is_company', '=', True)]"/>
                     <separator/>
                     <filter string="Archived" name="inactive" domain="[('active', '=', False)]"/>
+                    <field name="properties"/>
                     <separator/>
                     <group expand="0" name="group_by" string="Group By">
                         <filter name="salesperson" string="Salesperson" domain="[]" context="{'group_by' : 'user_id'}" />
                         <filter name="group_company" string="Company" context="{'group_by': 'parent_id'}"/>
                         <filter name="group_country" string="Country" context="{'group_by': 'country_id'}"/>
+                        <filter string="Properties" name="group_by_properties" context="{'group_by': 'properties'}"/>
                     </group>
                 </search>
             </field>
@@ -375,6 +381,7 @@
                                     <span t-if="record.city.raw_value and record.country_id.raw_value">, </span>
                                     <field name="country_id"/>
                                 </div>
+                                <field name="properties" widget="properties"/>
                                 <footer><field name="application_statistics" widget="contact_statistics"/></footer>
                             </main>
                         </t>

--- a/odoo/addons/test_orm/models/test_orm.py
+++ b/odoo/addons/test_orm/models/test_orm.py
@@ -157,7 +157,7 @@ class TestOrmMessage(models.Model):
     has_important_sibling = fields.Boolean(compute='_compute_has_important_sibling')
 
     attributes = fields.Properties(
-        string='Properties',
+        string='Discussion Properties',
         definition='discussion.attributes_definition',
     )
 
@@ -242,6 +242,7 @@ class TestOrmEmailmessage(models.Model):
     _name = 'test_orm.emailmessage'
     _description = 'Test ORM Email Message'
     _inherits = {'test_orm.message': 'message'}
+    _inherit = 'properties.base.definition.mixin'
 
     message = fields.Many2one('test_orm.message', 'Message',
                               required=True, ondelete='cascade')


### PR DESCRIPTION
Purpose
=======
Make the properties work when there's no parent (mainly for `res.partner`).

Technical
=========
The definition of those records is stored in a dedicated model. That way, we will re-use the code of the `PropertiesDefinition` field (with all the verification, etc).

If in the future we want more models to have properties without parent, they will also use that dedicated model (one record per properties field that should work without parent).

The simplest way to implement that (without adding complexity in the `Properties` field code), is to use what already exist in the ORM, and to make a computed / searchable field for the definition record (so all records of that model will share the same definition record, without adding a new column).

For now, only admin can change the properties definition of those records.

Task-4865894