### PR TITLE
[REF] mail: make document-access check for message multi-enabled

### DIFF
--- a/addons/event/models/event_event.py
+++ b/addons/event/models/event_event.py
@@ -672,18 +672,13 @@ class EventEvent(models.Model):
         vals_list = super().copy_data(default=default)
         return [dict(vals, name=self.env._("%s (copy)", event.name)) for event, vals in zip(self, vals_list)]
 
-    @api.model
-    def _get_mail_message_access(self, res_ids, operation, model_name=None):
-        if (
-            operation == 'create'
-            and self.env.user.has_group('event.group_event_registration_desk')
-            and (not model_name or model_name == 'event.event')
-        ):
+    def _mail_get_operation_for_mail_message_operation(self, message_operation):
+        if (message_operation == 'create' and self.env.user.has_group('event.group_event_registration_desk')):
             # allow the registration desk users to post messages on Event
             # can not be done with "_mail_post_access" otherwise public user will be
             # able to post on published Event (see website_event)
-            return 'read'
-        return super(EventEvent, self)._get_mail_message_access(res_ids, operation, model_name)
+            return dict.fromkeys(self, 'read')
+        return super()._mail_get_operation_for_mail_message_operation(message_operation)
 
     def _set_tz_context(self):
         self.ensure_one()

--- a/addons/im_livechat/controllers/attachment.py
+++ b/addons/im_livechat/controllers/attachment.py
@@ -13,9 +13,7 @@ class LivechatAttachmentController(AttachmentController):
     @route()
     @add_guest_to_context
     def mail_attachment_upload(self, ufile, thread_id, thread_model, is_pending=False, **kwargs):
-        thread = self._get_thread_with_access(
-            thread_model, thread_id, mode=request.env[thread_model]._mail_post_access, **kwargs
-        )
+        thread = self._get_thread_with_access_for_post(thread_model, thread_id, **kwargs)
         if not thread:
             raise NotFound()
         if (

--- a/addons/mail/controllers/attachment.py
+++ b/addons/mail/controllers/attachment.py
@@ -46,9 +46,7 @@ class AttachmentController(ThreadController):
     @http.route("/mail/attachment/upload", methods=["POST"], type="http", auth="public")
     @add_guest_to_context
     def mail_attachment_upload(self, ufile, thread_id, thread_model, is_pending=False, **kwargs):
-        thread = self._get_thread_with_access(
-            thread_model, thread_id, mode=request.env[thread_model]._mail_post_access, **kwargs
-        )
+        thread = self._get_thread_with_access_for_post(thread_model, thread_id, **kwargs)
         if not thread:
             raise NotFound()
         vals = {

--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -483,26 +483,6 @@ class MailThread(models.AbstractModel):
         doc_name = self.env['ir.model']._get(self._name).name
         return _('%s created', doc_name)
 
-    @api.model
-    def _get_mail_message_access(self, res_ids, operation, model_name=None):
-        """ mail.message check permission rules for related document. This method is
-            meant to be inherited in order to implement addons-specific behavior.
-            A common behavior would be to allow creating messages when having read
-            access rule on the document, for portal document such as issues. """
-
-        DocModel = self.env[model_name] if model_name else self
-        create_allow = getattr(DocModel, '_mail_post_access', 'write')
-
-        if operation in ['write', 'unlink']:
-            check_operation = 'write'
-        elif operation == 'create' and create_allow in ['create', 'read', 'write', 'unlink']:
-            check_operation = create_allow
-        elif operation == 'create':
-            check_operation = 'write'
-        else:
-            check_operation = operation
-        return check_operation
-
     def _valid_field_parameter(self, field, name):
         # allow tracking on models inheriting from 'mail.thread'
         return name == 'tracking' or super()._valid_field_parameter(field, name)

--- a/addons/portal/controllers/portal_thread.py
+++ b/addons/portal/controllers/portal_thread.py
@@ -36,8 +36,7 @@ class PortalChatter(ThreadController):
             store.add(request.env.user.partner_id, {"is_user_publisher": True})
         thread = self._get_thread_with_access(thread_model, thread_id, **kwargs)
         if thread:
-            mode = request.env[thread_model]._get_mail_message_access([thread_id], "create")
-            has_react_access = self._get_thread_with_access(thread_model, thread_id, mode, **kwargs)
+            has_react_access = self._get_thread_with_access_for_post(thread_model, thread_id, **kwargs)
             can_react = has_react_access
             if request.env.user._is_public():
                 if portal_partner := get_portal_partner(

--- a/addons/test_mail/security/test_mail_security.xml
+++ b/addons/test_mail/security/test_mail_security.xml
@@ -56,6 +56,28 @@
         <field name="groups" eval="[(4, ref('base.group_system'))]"/>
     </record>
 
+    <!-- mail.test.access.custo -->
+    <record id="ir_rule_mail_test_access_custo_update_internal" model="ir.rule">
+        <field name="name">Internal: write/unlink unlocked</field>
+        <field name="model_id" ref="test_mail.model_mail_test_access_custo"/>
+        <field name="domain_force">[('is_locked', '=', False)]</field>
+        <field name="groups" eval="[(4, ref('base.group_user'))]"/>
+        <field name="perm_read" eval="False"/>
+        <field name="perm_write" eval="True"/>
+        <field name="perm_create" eval="False"/>
+        <field name="perm_unlink" eval="True"/>
+    </record>
+    <record id="ir_rule_mail_test_access_custo_update_admin" model="ir.rule">
+        <field name="name">Admin: all</field>
+        <field name="model_id" ref="test_mail.model_mail_test_access_custo"/>
+        <field name="domain_force">[(1, '=', 1)]</field>
+        <field name="groups" eval="[(4, ref('base.group_system'))]"/>
+        <field name="perm_read" eval="True"/>
+        <field name="perm_write" eval="True"/>
+        <field name="perm_create" eval="True"/>
+        <field name="perm_unlink" eval="True"/>
+    </record>
+
     <!-- MAIL.TEST.MULTI.COMPANY(.*) -->
     <record id="mail_test_multi_company_rule" model="ir.rule">
         <field name="name">Mail Test Multi Company</field>

--- a/addons/test_mail/tests/test_mail_message_security.py
+++ b/addons/test_mail/tests/test_mail_message_security.py
@@ -763,15 +763,13 @@ class TestMailMessageAccess(MessageAccessCommon):
         found_emp = self.env['mail.message'].with_user(self.user_employee).search([
             ('body', 'ilike', 'AnchorForSearch')
         ])
-        self.assertEqual(found_emp, messages_all, 'FIXME: should filter like read')
-        with self.assertRaises(AccessError):  # some unreadable messages
-            found_emp.read(['subject'])
+        self.assertEqual(found_emp, messages_all.filtered(lambda m: m.res_id != records[2].id), 'FIXME: should filter like read')
+        found_emp.read(['subject'])
         found_por = self.env['mail.message'].with_user(self.user_portal).search([
             ('body', 'ilike', 'AnchorForSearch')
         ])
-        self.assertEqual(found_por, messages_all, 'FIXME: should filter like read')
-        with self.assertRaises(AccessError):  # some unreadable messages
-            found_por.read(['subject'])
+        self.assertEqual(found_por, messages_all.filtered(lambda m: m.res_id != records[2].id), 'FIXME: should filter like read')
+        found_por.read(['subject'])
 
 
 @tagged('mail_message', 'security', 'post_install', '-at_install')

--- a/addons/website_forum/models/forum_post.py
+++ b/addons/website_forum/models/forum_post.py
@@ -728,15 +728,12 @@ class ForumPost(models.Model):
     # MESSAGING
     # ----------------------------------------------------------------------
 
-    @api.model
-    def _get_mail_message_access(self, res_ids, operation, model_name=None):
-        # XDO FIXME: to be correctly fixed with new _get_mail_message_access and filter access rule
-        if operation in ('write', 'unlink') and (not model_name or model_name == 'forum.post'):
-            # Make sure only author or moderator can edit/delete messages
-            for post in self.browse(res_ids):
-                if not post.can_edit:
-                    raise AccessError(_('%d karma required to edit a post.', post.karma_edit))
-        return super()._get_mail_message_access(res_ids, operation, model_name=model_name)
+    def _mail_get_operation_for_mail_message_operation(self, message_operation):
+        if message_operation in ('write', 'unlink'):
+            filtered_self = self.filtered(lambda post: post.can_edit)
+        else:
+            filtered_self = self
+        return super(ForumPost, filtered_self)._mail_get_operation_for_mail_message_operation(message_operation)
 
     def _notify_get_recipients_groups(self, message, model_description, msg_vals=False):
         groups = super()._notify_get_recipients_groups(


### PR DESCRIPTION
When checking mail.message rights, part of those are based on access
on related document. For example reading a message rely notably on
having the right to read the linked document; creating a message is
generally based on write rights on the document as it is considered
as modifying the document itself.

However we often need to customize the document check. This is done
by '_get_mail_message_access'. Current implementation is a bit
old school, part model-based, part generic. Notably it does not
really allow to split access check per record e.g. when reading
10 messages, 5 would require 'write' access on document, 5 would
require 'read' access on document. This is because it is not really
multi-based, more model-based.

With this change it now allows to return rights / document IDs. Method
is now multi enabled, return type must be modified accordingly.

We should have 'search' and 'read' aligned, as any result returned
by search should be readable. For mail.message it is done with this
commit that now correctly use ``_get_mail_message_access`` instead
of just checking read access on documents.

Task-4878312