### PR TITLE
[FIX] web_editor: handle WebP images when rendering image shapes

### DIFF
--- a/addons/web_editor/controllers/main.py
+++ b/addons/web_editor/controllers/main.py
@@ -23,7 +23,7 @@ from odoo.addons.web_editor.tools import get_video_url_data
 from odoo.exceptions import UserError, MissingError, AccessError
 from odoo.tools.misc import file_open
 from odoo.tools.mimetypes import guess_mimetype
-from odoo.tools.image import image_data_uri, binary_to_image
+from odoo.tools.image import image_data_uri, binary_to_image, get_webp_size
 from odoo.addons.iap.tools import iap_tools
 from odoo.addons.base.models.assetsbundle import AssetsBundle
 
@@ -748,8 +748,11 @@ class Web_Editor(http.Controller):
             return stream.get_response()
 
         image = stream.read()
-        img = binary_to_image(image)
-        width, height = tuple(str(size) for size in img.size)
+        if record.mimetype == "image/webp":
+            width, height = tuple(str(size) for size in get_webp_size(image))
+        else:
+            img = binary_to_image(image)
+            width, height = tuple(str(size) for size in img.size)
         root = etree.fromstring(svg)
 
         if root.attrib.get("data-forced-size"):


### PR DESCRIPTION
Before master, this bug is mostly hidden since no WebP files are used by default. However, an upcoming PR targeting master converts all website images to WebP (https://github.com/odoo/odoo/pull/168862), revealing warnings in the server logs due to `binary_to_image` crashing on WebP inputs.

This patch avoids the crash by explicitly handling WebP files with `get_webp_size()`.
