### PR TITLE
[FIX] website: improve url autocomplete test coverage

### DIFF
--- a/addons/website/static/tests/website_html_editor.test.js
+++ b/addons/website/static/tests/website_html_editor.test.js
@@ -25,7 +25,7 @@ test("autocomplete should shown and able to edit the link", async () => {
                     values: [
                         {
                             value: "/contactus",
-                            icon: "/website_crm/static/description/icon.png",
+                            icon: "/website/static/description/icon.png",
                             label: "/contactus (Contact Us)",
                         },
                     ],
@@ -48,10 +48,25 @@ test("autocomplete should shown and able to edit the link", async () => {
     await waitFor(".o-autocomplete--dropdown-menu", { timeout: 3000 });
     expect.verifySteps(["/website/get_suggested_links"]);
 
+    expect(".ui-autocomplete-category").toHaveCount(1);
+    expect(".o-autocomplete--dropdown-item img").toHaveCount(1);
+
     await click(".o-autocomplete--dropdown-item:first");
     await click(".o_we_apply_link");
     // the url should be applied after selecting a dropdown item
     expect(cleanLinkArtifacts(getContent(el))).toBe(
         '<p>this is a <a href="/contactus">li[]nk</a></p>'
     );
+
+    await waitFor(".o_we_edit_link");
+    await click(".o_we_edit_link");
+    await animationFrame();
+    await contains(".o-autocomplete--input").focus();
+
+    await press(["ctrl", "a"]);
+    await press("#");
+    await waitFor(".o-autocomplete--dropdown-menu", { timeout: 3000 });
+    // check the default page anchors are in the autocomplete dropdown
+    expect(".o-autocomplete--dropdown-item:first").toHaveText("#top");
+    expect(".o-autocomplete--dropdown-item:last").toHaveText("#bottom");
 });


### PR DESCRIPTION
Before this commit: we have basic test for the url autocomplete in the linkpopover, but we miss the case for the page anchors

After this commit: we added the page anchor test, also updated the icon path to the one inside website module

Related PR: https://github.com/odoo/odoo/pull/187091



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
