### PR TITLE
[IMP] payment_xendit: authentication and multi use tokens

### DIFF
--- a/addons/payment_xendit/controllers/main.py
+++ b/addons/payment_xendit/controllers/main.py
@@ -22,15 +22,16 @@ class XenditController(http.Controller):
     _return_url = '/payment/xendit/return'
 
     @http.route('/payment/xendit/payment', type='json', auth='public')
-    def xendit_payment(self, reference, token_ref):
+    def xendit_payment(self, reference, token_ref, auth_id=None):
         """ Make a payment by token request and handle the response.
 
         :param str reference: The reference of the transaction.
         :param str token_ref: The reference of the Xendit token to use to make the payment.
+        :param str auth_id: The authentication id to use to make the payment.
         :return: None
         """
         tx_sudo = request.env['payment.transaction'].sudo().search([('reference', '=', reference)])
-        tx_sudo._xendit_create_charge(token_ref)
+        tx_sudo._xendit_create_charge(token_ref, auth_id=auth_id)
 
     @http.route(_webhook_url, type='http', methods=['POST'], auth='public', csrf=False)
     def xendit_webhook(self):

--- a/addons/payment_xendit/data/payment_provider_data.xml
+++ b/addons/payment_xendit/data/payment_provider_data.xml
@@ -5,7 +5,6 @@
         <field name="code">xendit</field>
         <field name="redirect_form_view_id" ref="redirect_form"/>
         <field name="inline_form_view_id" ref="inline_form"/>
-        <field name="allow_tokenization">True</field>
     </record>
 
 </odoo>


### PR DESCRIPTION
By default, Xendit will require authentication for all credit card payment. Previously, we assume that optional 3DS is easily configurable for each user which will omit authentication for tokenization flow. Turns out, this configuration requires permission from Xendit. Instead of that, Xendit provides the Merchant Initiated Transactions (MIT) which allow users to purchase without authorization as long as the first transaction was already authorized successfully. To accomodate this, we need to support authentication flow and adding extra parameter `is_recurring` in the payload,


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
