### PR TITLE
[FIX] hr_holidays: fix traceback when creating a leave request

### DIFF
--- a/addons/hr_holidays/models/hr_leave_type.py
+++ b/addons/hr_holidays/models/hr_leave_type.py
@@ -167,7 +167,7 @@ class HolidaysType(models.Model):
                 allowed_excess = holiday_type.max_allowed_negative if holiday_type.allows_negative else 0
                 allocations = allocations.filtered(lambda alloc:
                     alloc.allocation_type == 'accrual'
-                    or (alloc.max_leaves > 0 and alloc.virtual_remaining_leaves > -allowed_excess)
+                    or (alloc.max_leaves > 0 and (alloc.max_leaves - alloc.leaves_taken) > -allowed_excess)
                 )
                 holiday_type.has_valid_allocation = bool(allocations)
             else:

--- a/addons/hr_holidays/tests/test_allocations.py
+++ b/addons/hr_holidays/tests/test_allocations.py
@@ -315,3 +315,31 @@ class TestAllocations(TestHrHolidaysCommon):
             default_date_to='2024-08-18 15:00:00'
         ).name_search(args=[['id', '=', leave_type.id]])
         self.assertEqual(result[0][1], 'Compensatory Days (72 remaining out of 72 hours)')
+
+    def test_leave_allocation_and_leave_request(self):
+        leave_type = self.env.ref('hr_holidays.holiday_status_comp')
+        self.env['hr.leave.allocation'].sudo().create([
+            {
+                'employee_id': employee.id,
+                'holiday_status_id': leave_type.id,
+                'number_of_days': 3,
+                'allocation_type': 'regular',
+                'date_from': date(2024, 1, 1),
+            }
+            for employee in [self.employee, self.employee_emp]
+        ]).action_validate()
+
+        leave_request = self.env['hr.leave'].create({
+            'employee_id': self.employee_emp.id,
+            'holiday_status_id': leave_type.id,
+            'request_date_from': date(2024, 1, 5),
+            'request_date_to': date(2024, 1, 7),
+        })
+
+        with Form(leave_request) as leave:
+            leave.employee_ids = self.employee
+
+        leave_request.action_approve()
+
+        self.assertEqual(leave_request.employee_id, self.employee)
+        self.assertEqual(leave_request.state, 'validate')


### PR DESCRIPTION
Currently, a traceback occurrs when creating a leave request for an employee

**To reproduce this issue in 18.0:**

1) Install hr_holidays
2) Navigate to Time Off > Management > Allocations. 
3) Create an allocation for 2 employees with same leave type 
4) Navigate to Time Off > Management > Time Off.
5) Create a new time off  for employye1, with above leave type 
6) Now, change the employee to employee2

**Error:-**
```
'hr.leave.allocation' object has no attribute 'virtual_remaining_leaves'
```

**Cause:-**

The field `virtual_remaining_leaves` is  present in `hr.leave.type`, 
it was introduced from saas~18.3 in `hr.leave.allocation`.
https://github.com/odoo/odoo/commit/944c11e61abead4f5157a7a7cb7b1f536bc14411#diff-3a9cd2e66cdd2827ecf6d9e693aff35eeacdfaaa68875b7b2572edde23b757eaR123

So indeed a traceback will occur when trying to access `virtual_remaining_leaves` 
from allocation from the below line. 

https://github.com/odoo/odoo/blob/97f9ad816cb4b35aa2d4713038cc2c623dfaf176/addons/hr_holidays/models/hr_leave_type.py#L168-L170

**Solution:-**

Since the value of `virtual_remaining_leaves` is retrieved from the same method 
(_get_consumed_leaves) for both `hr.leave.type` and `hr.leave.allocation` in 18.3, 
So we can use the value of `virtual_remaining_leaves` from `hr.leave.type`.

opw-4860637,4868969
