### PR TITLE
[FIX] account: Fix js tax grouping function

### DIFF
--- a/addons/account/static/src/helpers/account_tax.js
+++ b/addons/account/static/src/helpers/account_tax.js
@@ -995,7 +995,7 @@ export const accountTaxHelpers = {
         };
 
         // Global tax values.
-        const global_grouping_function = (base_line, tax_data) => true;
+        const global_grouping_function = (base_line, tax_data) => tax_data !== null;
 
         let base_lines_aggregated_values = this.aggregate_base_lines_tax_details(base_lines, global_grouping_function);
         let values_per_grouping_key = this.aggregate_base_lines_aggregated_values(base_lines_aggregated_values);


### PR DESCRIPTION
In 540e4243f4 we modified the `_aggregate_base_line_tax_details` method so that base lines without any taxes are no longer automatically grouped under the `None` / `null` grouping key and are instead also passed to the grouping function which evaluates a grouping key for them.

As part of this improvement, all existing grouping functions needed to be adapted to explicitly return `None` or `null` for base lines with no tax.

We forgot to modify the grouping function which computes the tax totals summary in JS.

task-none