### PR TITLE
[FIX] l10n_hu_edi: set customer bank account on credit note NAV XML

### DIFF
--- a/addons/l10n_hu_edi/models/account_move.py
+++ b/addons/l10n_hu_edi/models/account_move.py
@@ -833,6 +833,9 @@ class AccountMove(models.Model):
         supplier = self.company_id.partner_id
         customer = self.partner_id.commercial_partner_id
 
+        supplier_bank = self.partner_bank_id if self.partner_bank_id and self.move_type == "out_invoice" else supplier.bank_ids[:1]
+        customer_bank = self.partner_bank_id if self.partner_bank_id and self.move_type == "out_refund" else customer.bank_ids[:1]
+
         currency_huf = self.env.ref('base.HUF')
         currency_rate = self._l10n_hu_get_currency_rate()
 
@@ -846,12 +849,12 @@ class AccountMove(models.Model):
             'base_invoice': base_invoice if base_invoice != self else None,
             'supplier': supplier,
             'supplier_vat_data': get_vat_data(supplier, self.fiscal_position_id.foreign_vat),
-            'supplierBankAccountNumber': format_bank_account_number(self.partner_bank_id or supplier.bank_ids[:1]),
+            'supplierBankAccountNumber': format_bank_account_number(supplier_bank),
             'individualExemption': self.company_id.l10n_hu_tax_regime == 'ie',
             'customer': customer,
             'customerVatStatus': (not customer.is_company and 'PRIVATE_PERSON') or (customer.country_code == 'HU' and 'DOMESTIC') or 'OTHER',
             'customer_vat_data': get_vat_data(customer) if customer.is_company else None,
-            'customerBankAccountNumber': format_bank_account_number(customer.bank_ids[:1]),
+            'customerBankAccountNumber': format_bank_account_number(customer_bank),
             'smallBusinessIndicator': self.company_id.l10n_hu_tax_regime == 'sb',
             'exchangeRate': currency_rate,
             'cashAccountingIndicator': self.company_id.l10n_hu_tax_regime == 'ca',

--- a/addons/l10n_hu_edi/tests/invoice_xmls/credit_note.xml
+++ b/addons/l10n_hu_edi/tests/invoice_xmls/credit_note.xml
@@ -30,6 +30,7 @@
                             <base:additionalAddressDetail>Akácfa utca 74.</base:additionalAddressDetail>
                         </base:simpleAddress>
                     </supplierAddress>
+                    <supplierBankAccountNumber>HU0123456789</supplierBankAccountNumber>
                     <individualExemption>false</individualExemption>
                 </supplierInfo>
                 <customerInfo>
@@ -50,6 +51,7 @@
                             <base:additionalAddressDetail>Alkotmány utca 11.</base:additionalAddressDetail>
                         </base:simpleAddress>
                     </customerAddress>
+                    <customerBankAccountNumber>HU9487189480</customerBankAccountNumber>
                 </customerInfo>
                 <invoiceDetail>
                     <invoiceCategory>NORMAL</invoiceCategory>

--- a/addons/l10n_hu_edi/tests/invoice_xmls/invoice_advance.xml
+++ b/addons/l10n_hu_edi/tests/invoice_xmls/invoice_advance.xml
@@ -25,6 +25,7 @@
                             <base:additionalAddressDetail>Akácfa utca 74.</base:additionalAddressDetail>
                         </base:simpleAddress>
                     </supplierAddress>
+                    <supplierBankAccountNumber>HU0123456789</supplierBankAccountNumber>
                     <individualExemption>false</individualExemption>
                 </supplierInfo>
                 <customerInfo>
@@ -45,6 +46,7 @@
                             <base:additionalAddressDetail>Alkotmány utca 11.</base:additionalAddressDetail>
                         </base:simpleAddress>
                     </customerAddress>
+                    <customerBankAccountNumber>HU6666666666</customerBankAccountNumber>
                 </customerInfo>
                 <invoiceDetail>
                     <invoiceCategory>NORMAL</invoiceCategory>

--- a/addons/l10n_hu_edi/tests/invoice_xmls/invoice_complex_eur.xml
+++ b/addons/l10n_hu_edi/tests/invoice_xmls/invoice_complex_eur.xml
@@ -25,6 +25,7 @@
                             <base:additionalAddressDetail>Akácfa utca 74.</base:additionalAddressDetail>
                         </base:simpleAddress>
                     </supplierAddress>
+                    <supplierBankAccountNumber>HU0123456789</supplierBankAccountNumber>
                     <individualExemption>false</individualExemption>
                 </supplierInfo>
                 <customerInfo>
@@ -45,6 +46,7 @@
                             <base:additionalAddressDetail>Alkotmány utca 11.</base:additionalAddressDetail>
                         </base:simpleAddress>
                     </customerAddress>
+                    <customerBankAccountNumber>HU6666666666</customerBankAccountNumber>
                 </customerInfo>
                 <invoiceDetail>
                     <invoiceCategory>NORMAL</invoiceCategory>

--- a/addons/l10n_hu_edi/tests/invoice_xmls/invoice_complex_huf.xml
+++ b/addons/l10n_hu_edi/tests/invoice_xmls/invoice_complex_huf.xml
@@ -25,6 +25,7 @@
                             <base:additionalAddressDetail>Akácfa utca 74.</base:additionalAddressDetail>
                         </base:simpleAddress>
                     </supplierAddress>
+                    <supplierBankAccountNumber>HU0123456789</supplierBankAccountNumber>
                     <individualExemption>false</individualExemption>
                 </supplierInfo>
                 <customerInfo>
@@ -45,6 +46,7 @@
                             <base:additionalAddressDetail>Alkotmány utca 11.</base:additionalAddressDetail>
                         </base:simpleAddress>
                     </customerAddress>
+                    <customerBankAccountNumber>HU6666666666</customerBankAccountNumber>
                 </customerInfo>
                 <invoiceDetail>
                     <invoiceCategory>NORMAL</invoiceCategory>

--- a/addons/l10n_hu_edi/tests/invoice_xmls/invoice_final.xml
+++ b/addons/l10n_hu_edi/tests/invoice_xmls/invoice_final.xml
@@ -25,6 +25,7 @@
                             <base:additionalAddressDetail>Akácfa utca 74.</base:additionalAddressDetail>
                         </base:simpleAddress>
                     </supplierAddress>
+                    <supplierBankAccountNumber>HU0123456789</supplierBankAccountNumber>
                     <individualExemption>false</individualExemption>
                 </supplierInfo>
                 <customerInfo>
@@ -45,6 +46,7 @@
                             <base:additionalAddressDetail>Alkotmány utca 11.</base:additionalAddressDetail>
                         </base:simpleAddress>
                     </customerAddress>
+                    <customerBankAccountNumber>HU6666666666</customerBankAccountNumber>
                 </customerInfo>
                 <invoiceDetail>
                     <invoiceCategory>NORMAL</invoiceCategory>

--- a/addons/l10n_hu_edi/tests/invoice_xmls/invoice_simple.xml
+++ b/addons/l10n_hu_edi/tests/invoice_xmls/invoice_simple.xml
@@ -25,6 +25,7 @@
                             <base:additionalAddressDetail>Akácfa utca 74.</base:additionalAddressDetail>
                         </base:simpleAddress>
                     </supplierAddress>
+                    <supplierBankAccountNumber>HU7357735773</supplierBankAccountNumber>
                     <individualExemption>false</individualExemption>
                 </supplierInfo>
                 <customerInfo>
@@ -45,6 +46,7 @@
                             <base:additionalAddressDetail>Alkotmány utca 11.</base:additionalAddressDetail>
                         </base:simpleAddress>
                     </customerAddress>
+                    <customerBankAccountNumber>HU6666666666</customerBankAccountNumber>
                 </customerInfo>
                 <invoiceDetail>
                     <invoiceCategory>NORMAL</invoiceCategory>

--- a/addons/l10n_hu_edi/tests/invoice_xmls/invoice_simple_discount.xml
+++ b/addons/l10n_hu_edi/tests/invoice_xmls/invoice_simple_discount.xml
@@ -25,6 +25,7 @@
                             <base:additionalAddressDetail>Akácfa utca 74.</base:additionalAddressDetail>
                         </base:simpleAddress>
                     </supplierAddress>
+                    <supplierBankAccountNumber>HU0123456789</supplierBankAccountNumber>
                     <individualExemption>false</individualExemption>
                 </supplierInfo>
                 <customerInfo>
@@ -45,6 +46,7 @@
                             <base:additionalAddressDetail>Alkotmány utca 11.</base:additionalAddressDetail>
                         </base:simpleAddress>
                     </customerAddress>
+                    <customerBankAccountNumber>HU6666666666</customerBankAccountNumber>
                 </customerInfo>
                 <invoiceDetail>
                     <invoiceCategory>NORMAL</invoiceCategory>

--- a/addons/l10n_hu_edi/tests/invoice_xmls/invoice_tax_price_include.xml
+++ b/addons/l10n_hu_edi/tests/invoice_xmls/invoice_tax_price_include.xml
@@ -21,6 +21,7 @@
                             <base:additionalAddressDetail>Ak&#225;cfa utca 74.</base:additionalAddressDetail>
                         </base:simpleAddress>
                     </supplierAddress>
+                    <supplierBankAccountNumber>HU0123456789</supplierBankAccountNumber>
                     <individualExemption>false</individualExemption>
                 </supplierInfo>
                 <customerInfo>
@@ -41,6 +42,7 @@
                             <base:additionalAddressDetail>Alkotm&#225;ny utca 11.</base:additionalAddressDetail>
                         </base:simpleAddress>
                     </customerAddress>
+                    <customerBankAccountNumber>HU6666666666</customerBankAccountNumber>
                 </customerInfo>
                 <invoiceDetail>
                     <invoiceCategory>NORMAL</invoiceCategory>

--- a/addons/l10n_hu_edi/tests/test_invoice_xml.py
+++ b/addons/l10n_hu_edi/tests/test_invoice_xml.py
@@ -1,4 +1,4 @@
-from odoo import tools, fields
+from odoo import tools, fields, Command
 from odoo.tests.common import tagged
 from odoo.addons.l10n_hu_edi.tests.common import L10nHuEdiTestCommon
 
@@ -15,9 +15,29 @@ class L10nHuEdiTestInvoiceXml(L10nHuEdiTestCommon):
         with freeze_time('2024-02-01'):
             super().setUpClass(chart_template_ref=chart_template_ref)
 
+            cls.company_data['company'].write({
+                'bank_ids': [Command.create({
+                    'acc_number': 'HU0123456789',
+                })]
+            })
+            cls.partner_company.write({
+                'bank_ids': [Command.create({
+                    'acc_number': 'HU6666666666',
+                })]
+            })
+            cls.bank_company = cls.env['res.partner.bank'].create({
+                'acc_number': 'HU7357735773',
+                'partner_id': cls.company_data['company'].partner_id.id,
+            })
+            cls.bank_partner = cls.env['res.partner.bank'].create({
+                'acc_number': 'HU9487189480',
+                'partner_id': cls.partner_company.id,
+            })
+
     def test_invoice_and_credit_note(self):
         with freeze_time('2024-02-01'):
             invoice = self.create_invoice_simple()
+            invoice.partner_bank_id = self.bank_company
             invoice.action_post()
             invoice._l10n_hu_edi_set_chain_index()
             invoice_xml = invoice._l10n_hu_edi_generate_xml()
@@ -32,6 +52,7 @@ class L10nHuEdiTestInvoiceXml(L10nHuEdiTestCommon):
             invoice.write({'l10n_hu_edi_state': 'confirmed'})
 
             credit_note = self.create_reversal(invoice)
+            credit_note.partner_bank_id = self.bank_partner
             credit_note.action_post()
             credit_note._l10n_hu_edi_set_chain_index()
             credit_note_xml = credit_note._l10n_hu_edi_generate_xml()
@@ -102,6 +123,7 @@ class L10nHuEdiTestInvoiceXml(L10nHuEdiTestCommon):
     def test_tax_audit_export(self):
         with freeze_time('2024-02-01'):
             invoice = self.create_invoice_simple()
+            invoice.partner_bank_id = self.bank_company
             invoice.action_post()
 
             tax_audit_export = self.env['l10n_hu_edi.tax_audit_export'].create({


### PR DESCRIPTION
### Steps to reproduce:
- Install l10n_hu_edi and switch to a Hungarian company
- In the settings set the NAV mode to "demo"
- Create an invoice to a Hungarian contact with an account number
- Send it to NAV
- Create the credit note for this invoice
- Send it to NAV and download the XML in the page "NAV 3.0"
- The account number in `supplierBankAccountNumber` and `customerBankAccountNumber` are the same

### Cause:
The code was doing:
`'supplierBankAccountNumber': format_bank_account_number(self.partner_bank_id or supplier.bank_ids[:1]),` But for credit notes `self.partner_bank_id` is the bank account of the customer not the supplier.

### Solution:
Only use `supplier.bank_ids[:1]`.

As the bank account were never tested in l10n_hu_edi, this commit adds it in the setup and changed the XMLs to always test it.

opw-4845026