### PR TITLE
[FIX] spreadsheet: does not allow free text in boolean multi selector

### DIFF
--- a/addons/spreadsheet/static/src/global_filters/components/boolean_multi_selector/boolean_multi_selector.js
+++ b/addons/spreadsheet/static/src/global_filters/components/boolean_multi_selector/boolean_multi_selector.js
@@ -1,7 +1,8 @@
-import { Component } from "@odoo/owl";
+import { Component, useEffect } from "@odoo/owl";
 import { TagsList } from "@web/core/tags_list/tags_list";
 import { AutoComplete } from "@web/core/autocomplete/autocomplete";
 import { _t } from "@web/core/l10n/translation";
+import { useChildRef } from "@web/core/utils/hooks";
 
 function toBoolean(value) {
     return value === "true";
@@ -24,6 +25,17 @@ export class BooleanMultiSelector extends Component {
         update: Function,
         placeholder: { type: String, optional: true },
     };
+
+    setup() {
+        this.inputRef = useChildRef();
+        useEffect(
+            () => {
+                // Prevent the user from typing free-text by setting the maxlength to 0
+                this.inputRef.el?.setAttribute("maxlength", 0);
+            },
+            () => [this.inputRef.el]
+        );
+    }
 
     onSelect({ value }) {
         this.props.update([...this.props.selectedValues, toBoolean(value)]);

--- a/addons/spreadsheet/static/src/global_filters/components/boolean_multi_selector/boolean_multi_selector.xml
+++ b/addons/spreadsheet/static/src/global_filters/components/boolean_multi_selector/boolean_multi_selector.xml
@@ -3,7 +3,12 @@
     <t t-name="spreadsheet.BooleanMultiSelector">
         <div class="o_input d-flex flex-wrap gap-1">
             <TagsList tags="tags"/>
-            <AutoComplete sources="sources" placeholder="placeholder" onSelect.bind="onSelect" />
+            <AutoComplete
+                input="inputRef"
+                sources="sources"
+                placeholder="placeholder"
+                onSelect.bind="onSelect"
+            />
         </div>
     </t>
 </templates>

--- a/addons/spreadsheet/static/tests/global_filters/boolean_multi_selector.test.js
+++ b/addons/spreadsheet/static/tests/global_filters/boolean_multi_selector.test.js
@@ -55,3 +55,13 @@ test("Can click on delete", async function () {
     await contains(".o_badge:first .o_delete").click();
     expect.verifySteps(["update"]);
 });
+
+test("Cannot enter free text in the input", async function () {
+    const env = await makeMockEnv();
+    await mountBooleanMultiSelector(env, {
+        selectedValues: [],
+        update: () => {},
+    });
+    const input = getFixture().querySelector("input");
+    expect(input.getAttribute("maxlength")).toBe("0");
+});


### PR DESCRIPTION
Before this commit, users could enter free text in the boolean multi selector. It has no impact on the filter, but it's not a good user experience. This commit prevents users from entering free text in the boolean multi selector.

Task: 4878579

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
