### PR TITLE
[FIX] web_editor, website: fix carousel traceback issue

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -2752,6 +2752,9 @@ var SnippetsMenu = Widget.extend({
                 }
                 resolve(null);
             }).then(async editorToEnable => {
+                if (editorToEnable && editorToEnable.$target[0] && !editorToEnable.$target[0].closest("body")) {
+                    return null;
+                }
                 if (!previewMode && this._enabledEditorHierarchy[0] === editorToEnable
                         || ifInactiveOptions && this._enabledEditorHierarchy.includes(editorToEnable)) {
                     return editorToEnable;

--- a/addons/website/static/tests/tours/carousel_content_removal.js
+++ b/addons/website/static/tests/tours/carousel_content_removal.js
@@ -92,6 +92,39 @@ wTourUtils.registerWebsitePreviewTour("snippet_carousel", {
         trigger: `${carouselInnerSelector} > div.active:nth-child(2)`,
         isCheck: true,
     },
+    // Ensure quickly adding/removing slides doesn’t give a traceback
+    // (Includes delays to better simulate real user interactions and
+    // expose potential race conditions.)
+    {
+        content: "Add a slide",
+        trigger: ".snippet-option-CarouselItem .o_we_bg_success",
+        run: function(helpers) {
+            helpers.click();
+            return new Promise(resolve => {
+                setTimeout(resolve, 360);
+            });
+        },
+    },
+    {
+        content: "Remove a slide",
+        trigger: ".snippet-option-CarouselItem .o_we_bg_danger",
+        run: function(helpers) {
+            helpers.click();
+            return new Promise(resolve => {
+                setTimeout(resolve, 360);
+            });
+        },
+    },
+    {
+        content: "Add a slide",
+        trigger: ".snippet-option-CarouselItem .o_we_bg_success",
+        run: function(helpers) {
+            helpers.click();
+            return new Promise(resolve => {
+                setTimeout(resolve, 360);
+            });
+        },
+    },
     ...wTourUtils.clickOnSave(),
     // Check that saving always sets the first slide as active.
     {


### PR DESCRIPTION
Previously, when rapidly adding and removing slides in the Carousel 
snippet (s_carousel), a JavaScript traceback would occur under certain 
conditions.

Step to reproduce:

  1. Drag and Drop a Carousel Snippet (s_carousel) on the page.
  2. Rapidly `add -> remove -> add` slides button in editor.
  3. Traceback occurs.

Cause:

 - The issue occurred because the currently active slide was passed as 
   the target to activate a snippet. During rapid DOM changes, the 
   active slide could be destroyed or not yet rendered, resulting in a 
   race condition and JavaScript error.

Solution:

 - Additional guards have been added in the `_activateSnippet` function 
   to ensure the `editorToEnable` target is still present in the DOM.

task-4270369

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr