### PR TITLE
[FIX] account_peppol: avoid overwrite of the sending method

### DIFF
--- a/addons/account_peppol/models/res_partner.py
+++ b/addons/account_peppol/models/res_partner.py
@@ -205,7 +205,7 @@ class ResPartner(models.Model):
             self.peppol_eas,
             self_partner._get_peppol_edi_format(),
         )
-        if self_partner.peppol_verification_state == 'valid':
+        if self_partner.peppol_verification_state == 'valid' and not self_partner.invoice_sending_method:
             self_partner.invoice_sending_method = 'peppol'
 
         self._log_verification_state_update(company, old_value, self_partner.peppol_verification_state)


### PR DESCRIPTION
Prevent invoice send method from being overwritten to "Peppol" when it is already manually set to another value like "Email".

Steps to reproduce:
1. Install the Peppol module.
2. Create a contact with "Email" as invoice send method and a valid Peppol endpoint.
3. Create an invoice for that contact.
4. Click "Print and Send".
5. The method wrongly switches to "Peppol" instead of staying "Email".

A similar overwrite also occurs when clicking "Verify" next to the Peppol endpoint verification on the contact form, but in that case the user sees it immediately, making it less confusing.

This fix prevents overwriting the send method if it is already manually set.

opw-4826186