### PR TITLE
[FIX] spreadsheet: pass axistype from odoo charts to resolve trendline ui bug

### DIFF
--- a/addons/spreadsheet/static/src/chart/odoo_chart/odoo_line_chart.js
+++ b/addons/spreadsheet/static/src/chart/odoo_chart/odoo_line_chart.js
@@ -72,6 +72,7 @@ function createOdooChartRuntime(chart, getters) {
         dataSetsValues: datasets.map((ds) => ({ data: ds.data, label: ds.label })),
         locale,
         trendDataSetsValues,
+        axisType: definition.axisType || "category",
     };
 
     const chartJsDatasets = getLineChartDatasets(definition, chartData);

--- a/addons/spreadsheet/static/src/chart/odoo_chart/odoo_scatter_chart.js
+++ b/addons/spreadsheet/static/src/chart/odoo_chart/odoo_scatter_chart.js
@@ -65,6 +65,7 @@ function createOdooChartRuntime(chart, getters) {
         dataSetsValues: datasets.map((ds) => ({ data: ds.data, label: ds.label })),
         locale,
         trendDataSetsValues,
+        axisType: definition.axisType || "category",
     };
 
     const config = {


### PR DESCRIPTION
This commit fixes a UI bug in chart trendlines by ensuring 'AxisType' is
properly passed from Odoo charts to the spreadsheet.

Task: [4743602](https://www.odoo.com/odoo/2328/tasks/4743602)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
