### PR TITLE
[IMP] im_livechat: hide author name in livechat rating feedback

### DIFF
--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_1.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_1.xml
@@ -126,7 +126,7 @@
             <field eval="False" name="partner_id"/>
             <field eval="True" name="consumed"/>
         </record>
-        <function model="discuss.channel" name="rating_apply"
-            eval="([ref('im_livechat.livechat_channel_session_1')], 5, 'LIVECHAT_1', None, 'Good Job')"/>
+        <function model="discuss.channel" name="_apply_livechat_feedback"
+            eval="([ref('im_livechat.livechat_channel_session_1')], 5, 'Good Job')"/>
     </data>
 </odoo>

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_10.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_10.xml
@@ -121,7 +121,7 @@
             <field name="create_date" eval="datetime.now() - timedelta(days=1, seconds=-53)"/>
             <field name="res_id" ref="im_livechat.livechat_channel_session_10"/>
         </record>
-        <function model="discuss.channel" name="rating_apply"
-            eval="([ref('im_livechat.livechat_channel_session_10')], 1, 'LIVECHAT_10', None, 'Pas satisfait')"/>
+        <function model="discuss.channel" name="_apply_livechat_feedback"
+            eval="([ref('im_livechat.livechat_channel_session_10')], 1, 'Pas satisfait')"/>
     </data>
 </odoo>

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_13.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_13.xml
@@ -77,7 +77,7 @@
             <field name="create_date" eval="datetime.now() - timedelta(days=1, seconds=-53)"/>
             <field name="res_id" ref="im_livechat.livechat_channel_session_13"/>
         </record>
-        <function model="discuss.channel" name="rating_apply"
-            eval="([ref('im_livechat.livechat_channel_session_13')], 1, 'LIVECHAT_13', None, 'Personne ne m\'a répondu!')"/>
+        <function model="discuss.channel" name="_apply_livechat_feedback"
+            eval="([ref('im_livechat.livechat_channel_session_13')], 1, 'Personne ne m\'a répondu!')"/>
     </data>
 </odoo>

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_2.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_2.xml
@@ -123,7 +123,7 @@
             <field eval="False" name="partner_id"/>
             <field eval="True" name="consumed"/>
         </record>
-        <function model="discuss.channel" name="rating_apply"
-            eval="([ref('im_livechat.livechat_channel_session_2')], 5, 'LIVECHAT_2', None, 'Super Job')"/>
+        <function model="discuss.channel" name="_apply_livechat_feedback"
+            eval="([ref('im_livechat.livechat_channel_session_2')], 5, 'Super Job')"/>
     </data>
 </odoo>

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_3.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_3.xml
@@ -85,7 +85,7 @@
             <field name="partner_id" ref="base.partner_demo_portal"/>
             <field eval="True" name="consumed"/>
         </record>
-        <function model="discuss.channel" name="rating_apply"
-            eval="([ref('im_livechat.livechat_channel_session_3')], 5, 'LIVECHAT_3', None, 'Mega Job')"/>
+        <function model="discuss.channel" name="_apply_livechat_feedback"
+            eval="([ref('im_livechat.livechat_channel_session_3')], 5, 'Mega Job')"/>
     </data>
 </odoo>

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_4.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_4.xml
@@ -86,7 +86,7 @@
             <field name="partner_id" ref="base.partner_demo_portal"/>
             <field eval="True" name="consumed"/>
         </record>
-        <function model="discuss.channel" name="rating_apply"
-            eval="([ref('im_livechat.livechat_channel_session_4')], 5, 'LIVECHAT_4', None, 'Good Job')"/>
+        <function model="discuss.channel" name="_apply_livechat_feedback"
+            eval="([ref('im_livechat.livechat_channel_session_4')], 5, 'Good Job')"/>
     </data>
 </odoo>

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_5.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_5.xml
@@ -94,7 +94,7 @@
             <field eval="False" name="partner_id"/>
             <field eval="True" name="consumed"/>
         </record>
-        <function model="discuss.channel" name="rating_apply"
-            eval="([ref('im_livechat.livechat_channel_session_5')], 5, 'LIVECHAT_5', None, 'Super Job')"/>
+        <function model="discuss.channel" name="_apply_livechat_feedback"
+            eval="([ref('im_livechat.livechat_channel_session_5')], 5, 'Super Job')"/>
     </data>
 </odoo>

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_6.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_6.xml
@@ -94,7 +94,7 @@
             <field eval="False" name="partner_id"/>
             <field eval="True" name="consumed"/>
         </record>
-        <function model="discuss.channel" name="rating_apply"
-            eval="([ref('im_livechat.livechat_channel_session_6')], 5, 'LIVECHAT_6', None, 'Good Job')"/>
+        <function model="discuss.channel" name="_apply_livechat_feedback"
+            eval="([ref('im_livechat.livechat_channel_session_6')], 5, 'Good Job')"/>
     </data>
 </odoo>

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_7.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_7.xml
@@ -86,7 +86,7 @@
             <field name="partner_id" ref="base.partner_demo_portal"/>
             <field eval="True" name="consumed"/>
         </record>
-        <function model="discuss.channel" name="rating_apply"
-            eval="([ref('im_livechat.livechat_channel_session_7')], 5, 'LIVECHAT_7', None, 'Super Job')"/>
+        <function model="discuss.channel" name="_apply_livechat_feedback"
+            eval="([ref('im_livechat.livechat_channel_session_7')], 5, 'Super Job')"/>
     </data>
 </odoo>

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_8.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_8.xml
@@ -92,7 +92,7 @@
             <field eval="False" name="partner_id"/>
             <field eval="True" name="consumed"/>
         </record>
-        <function model="discuss.channel" name="rating_apply"
-            eval="([ref('im_livechat.livechat_channel_session_8')], 5, 'LIVECHAT_8', None, 'Super Job')"/>
+        <function model="discuss.channel" name="_apply_livechat_feedback"
+            eval="([ref('im_livechat.livechat_channel_session_8')], 5, 'Super Job')"/>
     </data>
 </odoo>

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_9.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_9.xml
@@ -130,7 +130,7 @@
             <field name="create_date" eval="datetime.now() - timedelta(days=1, seconds=-53)"/>
             <field name="res_id" ref="im_livechat.livechat_channel_session_9"/>
         </record>
-        <function model="discuss.channel" name="rating_apply"
-            eval="([ref('im_livechat.livechat_channel_session_9')], 5, 'LIVECHAT_9', None, 'Super Job')"/>
+        <function model="discuss.channel" name="_apply_livechat_feedback"
+            eval="([ref('im_livechat.livechat_channel_session_9')], 5, 'Super Job')"/>
     </data>
 </odoo>

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_support_bot_session_1.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_support_bot_session_1.xml
@@ -202,7 +202,7 @@
             <field eval="False" name="partner_id"/>
             <field eval="True" name="consumed"/>
         </record>
-        <function model="discuss.channel" name="rating_apply"
-            eval="[ref('im_livechat.support_bot_session_1_demo')], 5, 'BOT_SESSION_1', None, 'Bon travail'"/>
+        <function model="discuss.channel" name="_apply_livechat_feedback"
+            eval="[ref('im_livechat.support_bot_session_1_demo')], 5, 'Bon travail'"/>
     </data>
 </odoo>

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_support_bot_session_6.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_support_bot_session_6.xml
@@ -145,7 +145,7 @@
             <field eval="False" name="partner_id"/>
             <field eval="True" name="consumed"/>
         </record>
-        <function model="discuss.channel" name="rating_apply"
-            eval="[ref('im_livechat.support_bot_session_6_demo')], 3, 'BOT_SESSION_6', None, 'OK'"/>
+        <function model="discuss.channel" name="_apply_livechat_feedback"
+            eval="[ref('im_livechat.support_bot_session_6_demo')], 3, 'OK'"/>
     </data>
 </odoo>


### PR DESCRIPTION
**Purpose of this PR:**
In the demo data of livechat sessions, the feedback content was not aligned with that of actual livechat sessions.
This PR improves the demo feedback so that it matches the behavior of actual livechat sessions, where only the rating and feedback text are shown, without displaying the author’s name `(e.g., Visitor 234)`.

**Before/After :**

<img height="500" src="https://github.com/user-attachments/assets/913132eb-dd5d-411a-8dc6-6634d30c3efa" /> <img height="500" src="https://github.com/user-attachments/assets/0682366b-97f7-48a1-b02b-ccc0e849eeba" />


Task- [4671525](https://www.odoo.com/odoo/project/1519/tasks/4671525)
