### PR TITLE
[FIX] web: avoid opening Dropdown menu if not needed

### DIFF
--- a/addons/web_tour/static/src/tour_service/tour_utils.js
+++ b/addons/web_tour/static/src/tour_service/tour_utils.js
@@ -207,8 +207,11 @@ export const stepUtils = {
                 isActive: ["auto", "mobile"],
                 trigger: ".o_statusbar_buttons",
                 run: (actions) => {
+                    const buttonOutSideDropdownMenu = hoot.queryFirst(
+                        `.o_statusbar_buttons button:enabled:contains('${innerTextButton}')`
+                    );
                     const node = hoot.queryFirst(".o_statusbar_buttons button:has(.oi-ellipsis-v)");
-                    if (node) {
+                    if (!buttonOutSideDropdownMenu && node) {
                         hoot.click(node);
                     }
                 },


### PR DESCRIPTION
This is a follow-up of the simplification of the StatusBarButtons rendering and usability on smaller screen (cf. PR [1]) where only the first button is displayed and the other ones (if available) are folded into a Dropdown. But the adaptation of the related tour utils missed the change of behavior and always opened the Dropdown (if present), even when the button that the tour looks for is the first one displayed, leading to inconsistent behavior in some edge cases.

This commit properly adapts the tour's util to the actual StatusBarButtons' behavior.

[1]: odoo/odoo#198621

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
