### PR TITLE
[FIX] bus: fix non-deterministic bus test

### DIFF
--- a/addons/bus/static/tests/bus_tests.js
+++ b/addons/bus/static/tests/bus_tests.js
@@ -86,6 +86,14 @@ QUnit.test("tabs share message from a channel", async () => {
 });
 
 QUnit.test("second tab still receives notifications after main pagehide", async () => {
+    patchWebsocketWorkerWithCleanup({
+        _unregisterClient(client) {
+            // Ensure that the worker does not receive any messages from the main tab
+            // after pagehide, mimicking real-world behavior.
+            client.onmessage = null;
+            super._unregisterClient(client);
+        },
+    });
     addBusServicesToRegistry();
     const pyEnv = await startServer();
     const mainEnv = await makeTestEnv({ activateMockServer: true });


### PR DESCRIPTION
This commit fixes the `second tab still receives notifications after main pagehide` test. This test simulates the main tab being closed. As a result, the main tab unregister itself from the worker. Upon message reception, the worker would try to access client's specific data such as channels or debug mode which are supposed to be available. However, since the client was unregistered, an error occurred.

runbot-75372

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
