### PR TITLE
[IMP] *: persist dark mode as per user preference

### DIFF
--- a/addons/hr_holidays/static/src/views/graph/hr_holidays_graph_renderer.js
+++ b/addons/hr_holidays/static/src/views/graph/hr_holidays_graph_renderer.js
@@ -2,12 +2,12 @@
 
 import { _t } from "@web/core/l10n/translation";
 
-import { cookie } from "@web/core/browser/cookie";
 import { getColor } from "@web/core/colors/colors";
 import { GraphRenderer } from "@web/views/graph/graph_renderer";
 import { groupBy } from "@web/core/utils/arrays";
+import { session } from "@web/session";
 
-const colorScheme = cookie.get("color_scheme");
+const colorScheme = session.color_scheme;
 
 
 export class HrHolidaysGraphRenderer extends GraphRenderer {

--- a/addons/html_editor/static/src/main/font/font_size_selector.js
+++ b/addons/html_editor/static/src/main/font/font_size_selector.js
@@ -4,8 +4,8 @@ import { DropdownItem } from "@web/core/dropdown/dropdown_item";
 import { toolbarButtonProps } from "@html_editor/main/toolbar/toolbar";
 import { useDropdownState } from "@web/core/dropdown/dropdown_hooks";
 import { useDebounced } from "@web/core/utils/timing";
-import { cookie } from "@web/core/browser/cookie";
 import { getCSSVariableValue, getHtmlStyle } from "@html_editor/utils/formatting";
+import { session } from "@web/session";
 
 const MAX_FONT_SIZE = 144;
 
@@ -40,7 +40,7 @@ export class FontSizeSelector extends Component {
                 }
 
                 this.fontSizeInput = iframeDoc.createElement("input");
-                const isDarkMode = cookie.get("color_scheme") === "dark";
+                const isDarkMode = session.color_scheme === "dark";
                 const htmlStyle = getHtmlStyle(this.props.document);
                 const backgroundColor = getCSSVariableValue(
                     isDarkMode ? "gray-200" : "white",

--- a/addons/mail/static/src/core/common/message.js
+++ b/addons/mail/static/src/core/common/message.js
@@ -36,12 +36,12 @@ import { useService } from "@web/core/utils/hooks";
 import { createElementWithContent } from "@web/core/utils/html";
 import { url } from "@web/core/utils/urls";
 import { useMessageActions } from "./message_actions";
-import { cookie } from "@web/core/browser/cookie";
 import { rpc } from "@web/core/network/rpc";
 import { MessageActionMenuMobile } from "./message_action_menu_mobile";
 import { discussComponentRegistry } from "./discuss_component_registry";
 import { NotificationMessage } from "./notification_message";
 import { useLongPress } from "@mail/utils/common/hooks";
+import { session } from "@web/session";
 
 /**
  * @typedef {Object} Props
@@ -139,7 +139,7 @@ export class Message extends Component {
         onMounted(() => {
             if (this.shadowBody.el) {
                 this.shadowRoot = this.shadowBody.el.attachShadow({ mode: "open" });
-                const color = cookie.get("color_scheme") === "dark" ? "white" : "black";
+                const color = session.color_scheme === "dark" ? "white" : "black";
                 const shadowStyle = document.createElement("style");
                 shadowStyle.textContent = `
                     * {
@@ -156,7 +156,7 @@ export class Message extends Component {
                         background: ${this.constructor.SHADOW_HIGHLIGHT_COLOR} !important;
                     }
                 `;
-                if (cookie.get("color_scheme") === "dark") {
+                if (session.color_scheme === "dark") {
                     this.shadowRoot.appendChild(shadowStyle);
                 }
                 const ellipsisStyle = document.createElement("style");

--- a/addons/mrp/static/src/workcenter_dashboard_graph/workcenter_dashboard_graph_field.js
+++ b/addons/mrp/static/src/workcenter_dashboard_graph/workcenter_dashboard_graph_field.js
@@ -1,15 +1,15 @@
 import { _t } from "@web/core/l10n/translation";
-import { cookie } from "@web/core/browser/cookie";
 import { getColor, hexToRGBA, darkenColor } from "@web/core/colors/colors";
 import { registry } from "@web/core/registry";
 import { JournalDashboardGraphField } from "@web/views/fields/journal_dashboard_graph/journal_dashboard_graph_field";
+import { session } from "@web/session";
 
 export class WorkcenterDashboardGraphField extends JournalDashboardGraphField{
     getBarChartConfig() {
         const labels = this.data[0].labels;
-        const color19 = getColor(1, cookie.get("color_scheme"), "odoo");
-        const color13 = getColor(2, cookie.get("color_scheme"), "odoo");
-        const color10 = getColor(3, cookie.get("color_scheme"), "odoo");
+        const color19 = getColor(1, session.color_scheme, "odoo");
+        const color13 = getColor(2, session.color_scheme, "odoo");
+        const color10 = getColor(3, session.color_scheme, "odoo");
         const loadBarColor = this.data[0].is_sample_data ? hexToRGBA(color19, 0.1) : color19;
         const excessBarColor = this.data[0].is_sample_data ? hexToRGBA(color13, 0.1) : color13;
         const maxLoadLineColor = this.data[0].is_sample_data ? hexToRGBA(color10, 0.1) : hexToRGBA(color10, 0.5);

--- a/addons/point_of_sale/static/src/backend/pos_kanban_view/pos_kanban_view.js
+++ b/addons/point_of_sale/static/src/backend/pos_kanban_view/pos_kanban_view.js
@@ -1,6 +1,5 @@
 import { AlertDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
 import { registry } from "@web/core/registry";
-import { cookie } from "@web/core/browser/cookie";
 import { kanbanView } from "@web/views/kanban/kanban_view";
 import { onWillStart, useState, onWillRender } from "@odoo/owl";
 import { KanbanRenderer } from "@web/views/kanban/kanban_renderer";
@@ -9,6 +8,7 @@ import { useService } from "@web/core/utils/hooks";
 import { useTrackedAsync } from "@point_of_sale/app/hooks/hooks";
 import { _t } from "@web/core/l10n/translation";
 import { KanbanController } from "@web/views/kanban/kanban_controller";
+import { session } from "@web/session";
 
 async function updatePosKanbanViewState(orm, stateObj) {
     const result = await orm.call("pos.config", "get_pos_kanban_view_state");
@@ -75,7 +75,7 @@ export class PosKanbanRenderer extends KanbanRenderer {
     }
 
     get isDarkTheme() {
-        return cookie.get("color_scheme") === "dark";
+        return session.color_scheme === "dark";
     }
 
     async callWithViewUpdate(func) {

--- a/addons/stock/static/src/picking_type_dashboard_graph/picking_type_dashboard_graph_field.js
+++ b/addons/stock/static/src/picking_type_dashboard_graph/picking_type_dashboard_graph_field.js
@@ -1,8 +1,8 @@
-import { cookie } from "@web/core/browser/cookie";
 import { getColor, getCustomColor } from "@web/core/colors/colors";
 import { useService } from "@web/core/utils/hooks";
 import { registry } from "@web/core/registry";
 import { JournalDashboardGraphField } from "@web/views/fields/journal_dashboard_graph/journal_dashboard_graph_field";
+import { session } from "@web/session";
 
 export class PickingTypeDashboardGraphField extends JournalDashboardGraphField {
     setup() {
@@ -15,9 +15,9 @@ export class PickingTypeDashboardGraphField extends JournalDashboardGraphField {
         const labels = [];
         const backgroundColor = [];
 
-        const colorPast = getColor(8, cookie.get("color_scheme"));
-        const colorPresent = getColor(16, cookie.get("color_scheme"));
-        const colorFuture = getColor(12, cookie.get("color_scheme"));
+        const colorPast = getColor(8, session.color_scheme);
+        const colorPresent = getColor(16, session.color_scheme);
+        const colorFuture = getColor(12, session.color_scheme);
         this.data[0].values.forEach((pt) => {
             data.push(pt.value);
             labels.push(pt.label);
@@ -28,7 +28,7 @@ export class PickingTypeDashboardGraphField extends JournalDashboardGraphField {
             } else if (pt.type === "future") {
                 backgroundColor.push(colorFuture);
             } else {
-                backgroundColor.push(getCustomColor(cookie.get("color_scheme"), "#ebebeb", "#3C3E4B"));
+                backgroundColor.push(getCustomColor(session.color_scheme, "#ebebeb", "#3C3E4B"));
             }
         });
         return {

--- a/addons/web/static/src/core/color_picker/color_picker.js
+++ b/addons/web/static/src/core/color_picker/color_picker.js
@@ -2,9 +2,9 @@ import { Component, useEffect, useRef, useState } from "@odoo/owl";
 import { CustomColorPicker } from "@web/core/color_picker/custom_color_picker/custom_color_picker";
 import { usePopover } from "@web/core/popover/popover_hook";
 import { isCSSColor, isColorGradient } from "@web/core/utils/colors";
-import { cookie } from "@web/core/browser/cookie";
 import { GradientPicker } from "./gradient_picker/gradient_picker";
 import { POSITION_BUS } from "../position/position_hook";
+import { session } from "@web/session";
 
 // These colors are already normalized as per normalizeCSSColor in @web/legacy/js/widgets/colorpicker
 export const DEFAULT_COLORS = [
@@ -100,7 +100,7 @@ export class ColorPicker extends Component {
     }
 
     get isDarkTheme() {
-        return cookie.get("color_scheme") === "dark";
+        return session.color_scheme === "dark";
     }
 
     setTab(tab) {

--- a/addons/web/static/src/views/fields/ace/ace_field.js
+++ b/addons/web/static/src/views/fields/ace/ace_field.js
@@ -7,7 +7,7 @@ import { CodeEditor } from "@web/core/code_editor/code_editor";
 import { Component, useState } from "@odoo/owl";
 import { useRecordObserver } from "@web/model/relational_model/utils";
 import { formatText } from "@web/views/fields/formatters";
-import { cookie } from "@web/core/browser/cookie";
+import { session } from "@web/session";
 
 export class AceField extends Component {
     static template = "web.AceField";
@@ -39,7 +39,7 @@ export class AceField extends Component {
         return this.props.mode === "xml" ? "qweb" : this.props.mode;
     }
     get theme() {
-        return cookie.get("color_scheme") === "dark" ? "monokai" : "";
+        return session.color_scheme === "dark" ? "monokai" : "";
     }
 
     handleChange(editedValue) {

--- a/addons/web/static/src/views/fields/journal_dashboard_graph/journal_dashboard_graph_field.js
+++ b/addons/web/static/src/views/fields/journal_dashboard_graph/journal_dashboard_graph_field.js
@@ -4,9 +4,9 @@ import { getColor, hexToRGBA, getCustomColor } from "@web/core/colors/colors";
 import { standardFieldProps } from "../standard_field_props";
 
 import { Component, onWillStart, useEffect, useRef } from "@odoo/owl";
-import { cookie } from "@web/core/browser/cookie";
+import { session } from "@web/session";
 
-const colorScheme = cookie.get("color_scheme");
+const colorScheme = session.color_scheme;
 const GRAPH_GRID_COLOR = getCustomColor(colorScheme, "#d8dadd", "#3C3E4B");
 const GRAPH_LABEL_COLOR = getCustomColor(colorScheme, "#111827", "#E4E4E4");
 export class JournalDashboardGraphField extends Component {
@@ -53,7 +53,7 @@ export class JournalDashboardGraphField extends Component {
         const labels = this.data[0].values.map(function (pt) {
             return pt.x;
         });
-        const color10 = getColor(3, cookie.get("color_scheme"), "odoo");
+        const color10 = getColor(3, session.color_scheme, "odoo");
         const borderColor = this.data[0].is_sample_data ? hexToRGBA(color10, 0.1) : color10;
         const backgroundColor = this.data[0].is_sample_data
             ? hexToRGBA(color10, 0.05)
@@ -106,8 +106,8 @@ export class JournalDashboardGraphField extends Component {
         const labels = [];
         const backgroundColor = [];
 
-        const color13 = getColor(2, cookie.get("color_scheme"), "odoo");
-        const color19 = getColor(1, cookie.get("color_scheme"), "odoo");
+        const color13 = getColor(2, session.color_scheme, "odoo");
+        const color19 = getColor(1, session.color_scheme, "odoo");
         this.data[0].values.forEach((pt) => {
             data.push(pt.value);
             labels.push(pt.label);

--- a/addons/web/static/src/views/graph/graph_renderer.js
+++ b/addons/web/static/src/views/graph/graph_renderer.js
@@ -19,17 +19,17 @@ import { useService } from "@web/core/utils/hooks";
 import { Component, onWillUnmount, useEffect, useRef, onWillStart, markup } from "@odoo/owl";
 import { Dropdown } from "@web/core/dropdown/dropdown";
 import { DropdownItem } from "@web/core/dropdown/dropdown_item";
-import { cookie } from "@web/core/browser/cookie";
 import { createElementWithContent } from "@web/core/utils/html";
 import { ReportViewMeasures } from "@web/views/view_components/report_view_measures";
 import { Widget } from "@web/views/widgets/widget";
 import { getCurrency } from "@web/core/currency";
 import { rpc } from "@web/core/network/rpc";
+import { session } from "@web/session";
 
 const NO_DATA = _t("No data");
 const formatters = registry.category("formatters");
 
-const colorScheme = cookie.get("color_scheme");
+const colorScheme = session.color_scheme;
 const GRAPH_LEGEND_COLOR = getCustomColor(colorScheme, "#111827", "#ffffff");
 const GRAPH_GRID_COLOR = getCustomColor(colorScheme, "rgba(0,0,0,.1)", "rgba(255,255,255,.15");
 const GRAPH_LABEL_COLOR = getCustomColor(colorScheme, "#111827", "#E4E4E4");
@@ -585,10 +585,7 @@ export class GraphRenderer extends Component {
             type: "linear",
             title: {
                 text: measures[measure].string,
-                color:
-                    cookie.get("color_scheme") === "dark"
-                        ? getColor(15, cookie.get("color_scheme"))
-                        : null,
+                color: session.color_scheme === "dark" ? getColor(15, session.color_scheme) : null,
             },
             ticks: {
                 callback: (value) => this.formatValue(value, false, fieldAttrs[measure]?.widget),

--- a/addons/web/static/src/views/view.js
+++ b/addons/web/static/src/views/view.js
@@ -11,7 +11,6 @@ import { WithSearch } from "@web/search/with_search/with_search";
 import { useActionLinks } from "@web/views/view_hook";
 import { computeViewClassName } from "./utils";
 import { loadBundle } from "@web/core/assets";
-import { cookie } from "@web/core/browser/cookie";
 import {
     Component,
     markRaw,
@@ -345,7 +344,7 @@ export class View extends Component {
             : props.jsClass || type;
         if (!viewRegistry.contains(jsClass)) {
             await loadBundle(
-                cookie.get("color_scheme") === "dark"
+                session.color_scheme === "dark"
                     ? "web.assets_backend_lazy_dark"
                     : "web.assets_backend_lazy"
             );

--- a/addons/web/views/webclient_templates.xml
+++ b/addons/web/views/webclient_templates.xml
@@ -295,8 +295,7 @@
                     }
                 </script>
                 <t t-call-assets="web.assets_web_print" media="print" t-js="false"/>
-
-                <t t-if="request.cookies.get('color_scheme') == 'dark'">
+                <t t-if="session_info.get('color_scheme') == 'dark'">
                     <t t-call-assets="web.assets_web_dark" media="screen"/>
                 </t>
                 <t t-else="">

--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -2633,7 +2633,7 @@ class ResetViewArchWizard(models.TransientModel):
                     (view_arch, get_table_name(view.view_id) if view.reset_mode == 'other_view' else _("Current Arch")),
                     (diff_to, diff_to_name),
                     custom_style=False,
-                    dark_color_scheme=request and request.cookies.get('color_scheme') == 'dark',
+                    dark_color_scheme=request and request.env.user.color_scheme == 'dark',
                 )
                 view.has_diff = view_arch != diff_to
 


### PR DESCRIPTION
Previously, dark mode was accessed via a cookie. This caused the dark mode setting to be lost when a user logged out and logged back in, defaulting to light mode.

With this commit, the dark mode preference is now stored in the user session, making it persist across devices.

task-4286033



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
