### PR TITLE
[IMP] web: Introduce getDialogProps method

### DIFF
--- a/addons/web/static/src/views/widgets/signature/signature.js
+++ b/addons/web/static/src/views/widgets/signature/signature.js
@@ -21,6 +21,11 @@ export class SignatureWidget extends Component {
     }
 
     onClickSignature() {
+        const dialogProps = this.getDialogProps();
+        this.dialogService.add(SignatureDialog, dialogProps);
+    }
+
+    getDialogProps() {
         const nameAndSignatureProps = {
             mode: "draw",
             displaySignatureRatio: 3,
@@ -42,12 +47,11 @@ export class SignatureWidget extends Component {
 
         nameAndSignatureProps.defaultFont = this.props.defaultFont;
 
-        const dialogProps = {
+        return {
             defaultName,
             nameAndSignatureProps,
             uploadSignature: (data) => this.uploadSignature(data),
-        };
-        this.dialogService.add(SignatureDialog, dialogProps);
+        }
     }
 
     async uploadSignature({ signatureImage }) {


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**

Introducing getDialogProps method to be called by onClickSignature instead of having the logic in the later method.
This cleans and helps to patch the widget better.

I had to patch the SignatureWidget for a project but had to monkey patch the whole 40 lines of onClickSignature just to add some props in the dialog. With the improvement in this PR, the patch will be cleaner and easier to maintain (changes to original method would not be ignored).

**Current behavior before PR:** /

**Desired behavior after PR is merged:**
Same as before.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
