### PR TITLE
[FIX] account: analytic lines rounding error

### DIFF
--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -2630,6 +2630,8 @@ class AccountMoveLine(models.Model):
                 line_values = self._prepare_analytic_distribution_line(float(distribution), account_id, distribution_on_each_plan)
                 if not self.currency_id.is_zero(line_values.get('amount')):
                     analytic_line_vals.append(line_values)
+
+            self._round_analytic_distribution_line(analytic_line_vals)
         return analytic_line_vals
 
     def _prepare_analytic_distribution_line(self, distribution, account_id, distribution_on_each_plan):
@@ -2663,6 +2665,32 @@ class AccountMoveLine(models.Model):
             'company_id': account.company_id.id or self.company_id.id or self.env.company.id,
             'category': 'invoice' if self.move_id.is_sale_document() else 'vendor_bill' if self.move_id.is_purchase_document() else 'other',
         }
+
+    def _round_analytic_distribution_line(self, analytic_lines_vals):
+        """ Round the analytic lines amount, and cancel the rounding error. """
+        if not analytic_lines_vals:
+            return
+
+        rounding_error = 0
+        for line in analytic_lines_vals:
+            rounded_amount = self.currency_id.round(line['amount'])
+            rounding_error += rounded_amount - line['amount']
+            line['amount'] = rounded_amount
+
+        # distributing the rounding error
+        for line in analytic_lines_vals:
+            if self.currency_id.is_zero(rounding_error):
+                break
+            amt = max(
+                self.currency_id.rounding,
+                abs(self.currency_id.round(rounding_error / len(analytic_lines_vals)))
+            )
+            if rounding_error < 0.0:
+                line['amount'] += amt
+                rounding_error += amt
+            else:
+                line['amount'] -= amt
+                rounding_error -= amt
 
     # -------------------------------------------------------------------------
     # MISC

--- a/addons/account/tests/test_account_analytic.py
+++ b/addons/account/tests/test_account_analytic.py
@@ -28,6 +28,21 @@ class TestAccountAnalyticAccount(AccountTestInvoicingCommon):
             'plan_id': cls.default_plan.id,
             'company_id': False,
         })
+        cls.analytic_account_c = cls.env['account.analytic.account'].create({
+            'name': 'analytic_account_c',
+            'plan_id': cls.default_plan.id,
+            'company_id': False,
+        })
+        cls.analytic_account_d = cls.env['account.analytic.account'].create({
+            'name': 'analytic_account_d',
+            'plan_id': cls.default_plan.id,
+            'company_id': False,
+        })
+
+    def get_analytic_lines(self, invoice):
+        return self.env['account.analytic.line'].search([
+            ('move_line_id', 'in', invoice.line_ids.ids),
+        ]).sorted('amount')
 
     def create_invoice(self, partner, product, move_type='out_invoice'):
         return self.env['account.move'].create([{
@@ -59,10 +74,6 @@ class TestAccountAnalyticAccount(AccountTestInvoicingCommon):
 
     def test_analytic_lines(self):
         ''' Ensures analytic lines are created when posted and are recreated when editing the account.move'''
-        def get_analytic_lines():
-            return self.env['account.analytic.line'].search([
-                ('move_line_id', 'in', out_invoice.line_ids.ids)
-            ]).sorted('amount')
 
         out_invoice = self.env['account.move'].create([{
             'move_type': 'out_invoice',
@@ -82,11 +93,9 @@ class TestAccountAnalyticAccount(AccountTestInvoicingCommon):
         out_invoice.action_post()
 
         # Analytic lines are created when posting the invoice
-        self.assertRecordValues(get_analytic_lines(), [{
+        self.assertRecordValues(self.get_analytic_lines(out_invoice), [{
             'amount': 100,
             'account_id': self.analytic_account_b.id,
-            'partner_id': self.partner_a.id,
-            'product_id': self.product_a.id,
         }, {
             'amount': 200,
             'account_id': self.analytic_account_a.id,
@@ -99,7 +108,7 @@ class TestAccountAnalyticAccount(AccountTestInvoicingCommon):
             self.analytic_account_a.id: 100,
             self.analytic_account_b.id: 25,
         }
-        self.assertRecordValues(get_analytic_lines(), [{
+        self.assertRecordValues(self.get_analytic_lines(out_invoice), [{
             'amount': 50,
             'account_id': self.analytic_account_b.id,
         }, {
@@ -109,7 +118,86 @@ class TestAccountAnalyticAccount(AccountTestInvoicingCommon):
 
         # Analytic lines are deleted when resetting to draft
         out_invoice.button_draft()
-        self.assertFalse(get_analytic_lines())
+        self.assertFalse(self.get_analytic_lines(out_invoice))
+
+    def test_analytic_lines_rounding(self):
+        """ Ensures analytic lines rounding errors are spread across all lines, in such a way that summing them gives the right amount.
+        For example, when distributing 100% of the the price, the sum of analytic lines should be exactly equal to the price. """
+
+        # in this scenario,
+        # 94% of 182.25 = 171.315 rounded to 171.32
+        # 2% of 182.25 = 3.645 rounded to 3.65
+        # 3 * 3.65 + 171.32 = 182.27
+        # we remove 0.01 to two lines to counter the rounding errors.
+        out_invoice = self.env['account.move'].create([{
+            'move_type': 'out_invoice',
+            'partner_id': self.partner_a.id,
+            'date': '2017-01-01',
+            'invoice_date': '2017-01-01',
+            'invoice_line_ids': [Command.create({
+                'product_id': self.product_a.id,
+                'price_unit': 182.25,
+                'analytic_distribution': {
+                    self.analytic_account_a.id: 94,
+                    self.analytic_account_b.id: 2,
+                    self.analytic_account_c.id: 2,
+                    self.analytic_account_d.id: 2,
+                },
+            })]
+        }])
+
+        out_invoice.action_post()
+
+        self.assertRecordValues(self.get_analytic_lines(out_invoice), [
+            {
+                'amount': 3.64,
+                'account_id': self.analytic_account_b.id,
+            },
+            {
+                'amount': 3.65,
+                'account_id': self.analytic_account_d.id,
+            },
+            {
+                'amount': 3.65,
+                'account_id': self.analytic_account_c.id,
+            },
+            {
+                'amount': 171.31,
+                'account_id': self.analytic_account_a.id,
+            },
+        ])
+
+        out_invoice.button_draft()
+        # in this scenario,
+        # 25% of 182.25 = 45.5625 rounded to 45.56
+        # 45.56 * 4 = 182.24
+        # we add 0.01 to one of the line to counter the rounding errors.
+        out_invoice.invoice_line_ids[0].analytic_distribution = {
+            self.analytic_account_a.id: 25,
+            self.analytic_account_b.id: 25,
+            self.analytic_account_c.id: 25,
+            self.analytic_account_d.id: 25,
+        }
+        out_invoice.action_post()
+
+        self.assertRecordValues(self.get_analytic_lines(out_invoice), [
+            {
+                'amount': 45.56,
+                'account_id': self.analytic_account_d.id,
+            },
+            {
+                'amount': 45.56,
+                'account_id': self.analytic_account_c.id,
+            },
+            {
+                'amount': 45.56,
+                'account_id': self.analytic_account_b.id,
+            },
+            {
+                'amount': 45.57,
+                'account_id': self.analytic_account_a.id,
+            },
+        ])
 
     def test_model_score(self):
         """Test that the models are applied correctly based on the score"""


### PR DESCRIPTION
**PROBLEM**
Sometimes, the sum of the generated analytic lines for an invoice line doesn't equal the amount on the invoice line. For example, in invoice line with a price of 182.25, with an analytic distribution split into 98% and 2%, the generated analytic lines amount to 182.26 (off by 0.01) because of rounding.

**STEP TO REPRODUCE**
1. install the accounting module and enable the Analytical Accounting option.
2. create an invoice, with a line with a price of 182.25, and a distribution of 98%/2%.
3. confirm the invoice.
4. go to Accounting/Analytics Items and notice the sum of analytical line is 182.26 instead of 182.25.

**CAUSE**
We only apply rounding after having calculated all the analytic line amounts. This mean we will sum the rounding error.
In our example, the computation is like so:
98% of 182.25 = 178.605 rounded to 178.61
2% of 182.25 = 3.645 rounded to 3.65
178.61 + 3.65 = 182.26

**FIX**
We compute the last analytic line for each plan, relatively to the other. `last_line_amount = invoice_price - sum(rounded_other_line_amount)` This ensure that the sum of analytic lines is always equal to the invoice price.

opw-4848784