### PR TITLE
[FIX] bus: fix postcommit test

### DIFF
--- a/addons/bus/tests/test_notify.py
+++ b/addons/bus/tests/test_notify.py
@@ -69,15 +69,16 @@ class NotifyTests(TransactionCase):
                 cr.commit()
                 conn = cr._cnx
                 sel.register(conn, selectors.EVENT_READ)
-                while sel.select(timeout=5) and not stop_event.is_set():
-                    conn.poll()
-                    if notify_channels := [
-                        c
-                        for c in json.loads(conn.notifies.pop().payload)
-                        if c[0] == self.env.cr.dbname
-                    ]:
-                        channels = notify_channels
-                        break
+                while not stop_event.is_set():
+                    if sel.select(timeout=5):
+                        conn.poll()
+                        if notify_channels := [
+                            c
+                            for c in json.loads(conn.notifies.pop().payload)
+                            if c[0] == self.env.cr.dbname
+                        ]:
+                            channels = notify_channels
+                            break
 
         thread = threading.Thread(target=single_listen)
         thread.start()


### PR DESCRIPTION
This commit fixes the `test_postcommit` that fails in a non deterministic fashion. This test ensures bus notifications created in the post commit hook result in only one batch.

To do so, the test listens on the connection with a selector. However, the loop condition is incorrect and exits after the first select timeout. As a result, if the test takes more than 5 seconds, it fails. This commit fixes the loop condition to continue until the stop event is set.

runbot-116746,161035,223589,77470

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
