### PR TITLE
[FIX] website: make dataset color visible by default

### DIFF
--- a/addons/website/static/src/builder/plugins/options/chart_option.js
+++ b/addons/website/static/src/builder/plugins/options/chart_option.js
@@ -25,6 +25,23 @@ export class ChartOption extends BaseOptionComponent {
             data: this.getData(editingElement),
             isPieChart: this.isPieChart(editingElement),
         }));
+        this.setDefaultState();
+    }
+
+    /**
+     * Resets the current cell to the topleft cell
+     * and sets the colorpicker labels based on chart type.
+     */
+    setDefaultState() {
+        const { backgroundLabel, borderLabel } = this.getColorpickersLabels(
+            this.domState.isPieChart
+        );
+        this.updateCurrentCell({
+            backgroundLabel,
+            borderLabel,
+            datasetIndex: 0,
+            dataIndex: 0,
+        });
     }
 
     getData(editingElement) {
@@ -50,16 +67,20 @@ export class ChartOption extends BaseOptionComponent {
         });
         return data;
     }
-
     isPieChart(editingElement) {
         const isPieChart = this.props.isPieChart(editingElement);
         if (!this.domState || this.domState.isPieChart !== isPieChart) {
             // Pie charts set color on a data cell basis, whereas the
-            // other ones set it on a dataset basis. Just reset the
-            // current cell to avoid bugs.
-            this.state.currentCell = {};
+            // other ones set it on a dataset basis
+            const { backgroundLabel, borderLabel } = this.getColorpickersLabels(isPieChart);
+            this.updateCurrentCell({ backgroundLabel, borderLabel });
         }
         return isPieChart;
+    }
+    getColorpickersLabels(isPieChart) {
+        const backgroundLabel = isPieChart ? _t("Data Color") : _t("Dataset Color");
+        const borderLabel = isPieChart ? _t("Data Border") : _t("Dataset Border");
+        return { backgroundLabel, borderLabel };
     }
     /**
      * Retrieve the colors already in use in the chart.
@@ -84,47 +105,134 @@ export class ChartOption extends BaseOptionComponent {
         colorSet.delete(""); // No color, remove to avoid bugs.
         return colorSet;
     }
+
+    /**
+     * @param {Object} updatedCellInfo
+     * @param {Number} [updatedCellInfo.dataIndex]
+     * @param {Number} [updatedCellInfo.datasetIndex]
+     * @param {String} [updatedCellInfo.backgroundLabel]
+     * @param {String} [updatedCellInfo.borderLabel]
+     */
+    updateCurrentCell(updatedCellInfo) {
+        for (const key in updatedCellInfo) {
+            this.state.currentCell[key] = updatedCellInfo[key];
+        }
+    }
+
+    /**
+     * Extracts information about the table cell from a table event.
+     *
+     * @param {Event} ev - The event triggered on the table.
+     * @returns {Object} Containing:
+     *   - cellEl: The cell element (td or th) that was interacted.
+     *   - cellSectionEl: The section element (THEAD or TBODY) containing the cell.
+     *   - datasetIndex: The column index of the cell (excluding label column).
+     *   - dataIndex: The row index of the cell (only for TBODY rows).
+     */
+    getCellInfo(ev) {
+        const cellEl = ev.target.closest("td, th");
+        if (cellEl) {
+            const cellRowEl = cellEl.parentElement;
+            const cellSectionEl = cellRowEl.parentElement;
+            const datasetIndex = [...cellRowEl.children].indexOf(cellEl) - 1;
+            let dataIndex;
+            if (cellSectionEl.tagName === "TBODY") {
+                dataIndex = [...cellSectionEl.children].indexOf(cellRowEl);
+            }
+            return { cellEl, cellSectionEl, datasetIndex, dataIndex };
+        }
+        return {};
+    }
+
+    isTableButton(target) {
+        return !!target.closest(
+            ".o_builder_matrix_remove_row, .add_row, .o_builder_matrix_remove_col, .add_column"
+        );
+    }
     /**
      * Store in the state the coords of the cell that is currently focused.
-     * (Used to display the corresponding colorpickers.)
      *
      * @param {Event} ev
      */
     onTableFocusin(ev) {
         this.onTableMouseover(ev);
-        ev.currentTarget
-            .querySelector(".o_builder_matrix_selected_cell")
-            ?.classList.remove("o_builder_matrix_selected_cell");
-        const cellEl = ev.target.closest("td, th");
-        const cellSectionEl = cellEl.parentElement.parentElement;
-        const datasetIndex = [...cellEl.parentElement.children].indexOf(cellEl) - 1;
-        if (datasetIndex === -1 || datasetIndex === cellEl.parentElement.children.length - 2) {
-            // Dataset label cell or remove row button: no color to show.
-            this.state.currentCell = {};
+        this.handleCellFocus(ev);
+    }
+    /**
+     * Used to display the corresponding colorpickers.
+     *
+     * @param {Event} ev
+     */
+    handleCellFocus(ev) {
+        if (this.isTableButton(ev.target)) {
             return;
         }
-        let dataIndex;
-        if (cellSectionEl.tagName === "TBODY") {
-            dataIndex = [...cellSectionEl.children].indexOf(cellEl.parentElement);
-            if (dataIndex === cellSectionEl.children.length - 1) {
-                // Remove column button: no color to show.
-                this.state.currentCell = {};
-                return;
+        const { cellEl, cellSectionEl, datasetIndex, dataIndex } = this.getCellInfo(ev);
+        if (!cellEl) {
+            return;
+        }
+        const cellRowEl = cellEl.parentElement;
+        if (cellSectionEl.tagName === "THEAD" && datasetIndex !== -1) {
+            this.updateCurrentCell({
+                datasetIndex: this.domState.isPieChart ? null : datasetIndex,
+                dataIndex: this.domState.isPieChart ? null : 0,
+            });
+        }
+        // click on a table inner cell
+        else if (datasetIndex !== -1 && datasetIndex !== cellRowEl.children.length - 2) {
+            this.updateCurrentCell({ datasetIndex, dataIndex });
+        }
+    }
+    /**
+     * Handles the click on table buttons.
+     *
+     * @param {Event} ev - The event triggered on the table cell button.
+     */
+    onButtonCellClick(ev) {
+        if (!this.isTableButton(ev.target)) {
+            return;
+        }
+        const { cellEl, cellSectionEl, datasetIndex, dataIndex } = this.getCellInfo(ev);
+        const isColumnButton = dataIndex === cellSectionEl.children.length - 1;
+        const isRowButton = datasetIndex === cellEl.parentElement.children.length - 2;
+
+        if (isColumnButton) {
+            if (ev.target.classList.contains("add_row")) {
+                this.updateCurrentCell({ datasetIndex: 0, dataIndex });
             }
+            // if we delete a column with the current cell
+            else if (datasetIndex === this.state.currentCell.datasetIndex) {
+                this.setDefaultState();
+            } else if (datasetIndex < this.state.currentCell.datasetIndex) {
+                this.updateCurrentCell({ datasetIndex: this.state.currentCell.datasetIndex - 1 });
+            }
+            return;
         }
 
-        let backgroundLabel = _t("Dataset Color");
-        let borderLabel = _t("Dataset Border");
-        if (this.domState.isPieChart) {
-            backgroundLabel = _t("Data Color");
-            borderLabel = _t("Data Border");
-            if (cellSectionEl.tagName === "THEAD") {
-                this.state.currentCell = {};
-                return;
+        if (isRowButton) {
+            if (ev.target.classList.contains("add_column")) {
+                this.updateCurrentCell({ datasetIndex, dataIndex: 0 });
+            }
+            // if we delete a row with the current cell
+            else if (dataIndex === this.state.currentCell.dataIndex) {
+                this.setDefaultState();
+            } else if (dataIndex < this.state.currentCell.dataIndex) {
+                this.updateCurrentCell({ dataIndex: this.state.currentCell.dataIndex - 1 });
             }
         }
-        cellEl.classList.add("o_builder_matrix_selected_cell");
-        this.state.currentCell = { datasetIndex, dataIndex, backgroundLabel, borderLabel };
+    }
+
+    /**
+     * Handles the click on the THEAD (Dataset Labels).
+     *
+     * @param {Event} ev - The event triggered on the thead cell.
+     */
+    onDatasetLabelClick(ev) {
+        const { datasetIndex } = this.getCellInfo(ev);
+        this.updateCurrentCell({
+            datasetIndex: this.domState.isPieChart ? null : datasetIndex,
+            dataIndex: this.domState.isPieChart ? null : 0,
+        });
     }
 
     onTableMouseoutOrFocusout(ev) {

--- a/addons/website/static/src/builder/plugins/options/chart_option.scss
+++ b/addons/website/static/src/builder/plugins/options/chart_option.scss
@@ -5,20 +5,25 @@ table.o_builder_matrix {
     td, th {
         text-align: center;
 
-        &.o_builder_matrix_selected_cell input {
-            background-color: darken($primary, 10%);
-        }
-
         > :is(div, button) {
             width: 100% !important;
         }
+
+        > div {
+            padding: 0;
+        
+            .o-hb-input-number {
+                padding: 0.15rem $o-we-sidebar-content-field-clickable-spacing;
+            }
+        }
+
 
         .btn {
             padding: unset;
         }
 
-        input {
-            background-color: $o-we-sidebar-content-field-input-bg;
+        .o-hb-input-number {
+            margin-right: 0;
         }
 
         &:last-child {

--- a/addons/website/static/src/builder/plugins/options/chart_option.xml
+++ b/addons/website/static/src/builder/plugins/options/chart_option.xml
@@ -41,7 +41,7 @@
             <tr>
                 <th></th> <!-- Empty cell in the top left corner -->
                 <t t-foreach="domState.data.datasets" t-as="dataset" t-key="dataset.key">
-                    <th>
+                    <th t-on-click.capture="onDatasetLabelClick">
                         <BuilderTextInput
                             action="'updateDatasetLabel'"
                             actionParam="dataset.key"
@@ -49,7 +49,7 @@
                     </th>
                 </t>
 
-                <th>
+                <th t-on-click.capture="onButtonCellClick">
                     <BuilderButton
                         action="'addColumn'"
                         className="'add_column fa fa-fw fa-plus text-success d-inline-block'"
@@ -76,7 +76,7 @@
                     </td>
                 </t>
 
-                <td>
+                <td t-on-click.capture="onButtonCellClick">
                     <BuilderButton t-if="domState.data.labels.length > 1"
                         action="'removeRow'"
                         actionParam="label_index"
@@ -88,7 +88,7 @@
             </tr>
 
             <tr>
-                <th>
+                <th t-on-click.capture="onButtonCellClick">
                     <BuilderButton
                         action="'addRow'"
                         className="'add_row fa fa-fw fa-plus text-success d-inline-block'"
@@ -97,7 +97,7 @@
                         preview="false"/>
                 </th>
                 <t t-foreach="domState.data.datasets" t-as="dataset" t-key="dataset.key">
-                    <td>
+                    <td t-on-click.capture="onButtonCellClick">
                         <BuilderButton t-if="domState.data.datasets.length > 1"
                             action="'removeColumn'"
                             actionParam="dataset.key"
@@ -123,7 +123,8 @@
                 datasetIndex: state.currentCell.datasetIndex,
                 dataIndex: state.currentCell.dataIndex,
                 backgroundColor: state.currentCell.backgroundColor,
-            }"/>
+            }"
+            enabledTabs = "['solid', 'custom']"/>
     </BuilderRow>
     <BuilderRow t-if="state.currentCell.datasetIndex or state.currentCell.datasetIndex === 0"
                 t-key="window.String(state.currentCell.datasetIndex) + window.String(state.currentCell.dataIndex)"
@@ -136,7 +137,8 @@
                 datasetIndex: state.currentCell.datasetIndex,
                 dataIndex: state.currentCell.dataIndex,
                 borderColor: state.currentCell.borderColor,
-            }"/>
+            }"
+            enabledTabs = "['solid', 'custom']"/>
     </BuilderRow>
     <BuilderRow t-if="isActiveItem('bar_chart_opt') or isActiveItem('horizontal_bar_chart_opt') or isActiveItem('line_chart_opt')"
                 label.translate="Min Axis">

--- a/addons/website/static/src/builder/plugins/options/chart_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/chart_option_plugin.js
@@ -126,7 +126,7 @@ export class AddColumnAction extends BaseChartAction {
             data: fillDatasetArray(0),
             backgroundColor: this.isPieChart(editingElement)
                 ? data.labels.map(() => this.randomColor())
-                : "",
+                : this.randomColor(),
             borderColor: this.isPieChart(editingElement) ? fillDatasetArray("") : "",
         };
         data.datasets.push(newDataset);


### PR DESCRIPTION
Before [the refactoring of the html_builder], [0,0] cell was selected by default and the selected cell was kept when we switched the chart type. Now, this was lost in the refactoring.

[the refactoring of the html_builder]: https://github.com/odoo/odoo/commit/9fe45e2b7ddb
Related to task-4367641
