### PR TITLE
[FIX] website: hover mega menu ok with rounded box menu


### DIFF
--- a/addons/website/static/src/js/content/menu.js
+++ b/addons/website/static/src/js/content/menu.js
@@ -672,7 +672,11 @@ publicWidget.registry.hoverableDropdown = animations.Animation.extend({
     _dropdownHover: function () {
         this.$dropdownMenus.attr('data-bs-popper', 'none');
         if (uiUtils.getSize() >= SIZES.LG) {
-            this.$dropdownMenus.css('margin-top', '0');
+            for (const menuEl of this.$dropdownMenus) {
+                if (!menuEl.closest('.o_mega_menu_is_offcanvas')) {
+                    menuEl.style.setProperty('margin-top', '0', 'important');
+                }
+            }
             this.$dropdownMenus.css('top', 'unset');
         } else {
             this.$dropdownMenus.css('margin-top', '');


### PR DESCRIPTION
Scenario:

- edit navigation bar to "Rounded box menu" (header_boxed_opt)
- select option "Sub Menus" to "On Hover"
- add a mega menu
- outside of editor, hover the mega menu item and move mouse over it

Result: the mega menu content closes before we get to it.

History:

In saas-18.1 and saas-18.2, these menus with the show on hover have been
broken and fixed through different changes:

(A) normal popup menu
(B) all mega menu
(C) mega menu with header_boxed_opt menu bar

Here is the list of commit and what was broken after them:

- 671515811436a01ea8931d4aa92b62608f8aec90 (nov 2024): C
- b9b3a605e0f4c5da3a258c980107d6162da7f44f (jan 2025): A+C
- ddf071267bd8aca341cb9b7481f3153a254212e7 (apr 2025): B+C
- e65d4cf16a2e973482497c3d9d405b566007e705 (apr 2025): C

And hopefully this commit will fix C that happen since in
671515811436a01ea8931d4aa92b62608f8aec90 where we added a !important
margin-top to the mega menu in case of header_boxed_opt header that
is causing issue C.

We do not the the change for a menu inside .o_mega_menu_is_offcanvas
because in this case "header_sidebar_opt" doesn't need the fix and needs
to have a margin-top because:

- it is in the margin-top space that the go back button is
- the height is computed taking into account the margin-top, so if we
  removed it the height of the megamenu+margin-top would not be 100% and
  there would be a gap at the bottom

opw-4876149