### PR TITLE
[FIX] base_import: fix error on importing improper csv file

### DIFF
--- a/addons/base_import/models/base_import.py
+++ b/addons/base_import/models/base_import.py
@@ -1110,12 +1110,15 @@ class Import(models.TransientModel):
 
         if options.get('has_headers'):
             rows_to_import = rows_to_import[1:]
-        data = [
-            list(row) for row in map(mapper, rows_to_import)
-            # don't try inserting completely empty rows (e.g. from
-            # filtering out o2m fields)
-            if any(row)
-        ]
+        try:
+            data = [
+                list(row) for row in map(mapper, rows_to_import)
+                # don't try inserting completely empty rows (e.g. from
+                # filtering out o2m fields)
+                if any(row)
+            ]
+        except IndexError as e:
+            raise ImportValidationError(_("Import failed: some rows might have missing columns—please check for empty fields or incorrect separators in the file (%(error)s)") % {"error": e})
 
         # slicing needs to happen after filtering out empty rows as the
         # data offsets from load are post-filtering


### PR DESCRIPTION
This error occurs when importing a CSV file containing rows with missing columns or incorrect separators. Large files may bypass preview checks, leading to failures during the actual import.

**Steps to replicate:**
* Settings>User & Companies>Users >Gear icon>Import Records
* Import the [csv file](https://drive.google.com/file/d/1rkYjuiS_8ZO94lBwt_DvPbuRDr36xW1N/view?usp=sharing).
* Set role field > title > Import

`IndexError: list index out of range`

**Solution:**
* Catch `IndexError` during row processing and raise a `ImportValidationError` to handle rows with missing or misaligned columns.

**Sentry-5588088802**
