### PR TITLE
[FIX] hw_drivers: send certificate end date after record creation

### DIFF
--- a/addons/hw_drivers/main.py
+++ b/addons/hw_drivers/main.py
@@ -87,13 +87,13 @@ class Manager(Thread):
             helpers.check_git_branch()
             helpers.generate_password()
 
-        certificate.ensure_validity()
-
         # We first add the IoT Box to the connected DB because IoT handlers cannot be downloaded if
         # the identifier of the Box is not found in the DB. So add the Box to the DB.
         self.send_all_devices()
         helpers.download_iot_handlers()
         helpers.load_iot_handlers()
+
+        certificate.ensure_validity()
 
         for interface in interfaces.values():
             interface().start()


### PR DESCRIPTION
We sent the certificate end date to the database before the record was created in the db, resulting in getting the "No subscription linked to your IoT Box toaster" as it cannot read the "certificate end date" field.
This commit fixes it by checking the certificate right after sending all devices.
