### PR TITLE
[FIX] account: fix discount rounding with precise currency rate

### DIFF
--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -1058,6 +1058,10 @@ class AccountMoveLine(models.Model):
                     'display_type': 'discount',
                     'name': _("Discount"),
                     'amount_currency': amount,
+                    'balance': (
+                        self.company_currency_id.round(amount / line.currency_rate)
+                        if line.currency_id != self.company_currency_id else amount
+                    ),
                     'analytic_distribution': {
                         account_id: 100 * value / total
                         for account_id, value in dist.items()


### PR DESCRIPTION
When a separate discount account is set on customer invoices and a foreign currency is used with a highly precise rate, rounding issues could cause the journal entry to become unbalanced.

Steps to reproduce:
- Set a separate discount account for customer invoices.
- Create a currency with rate 0.019560839590356895.
- Create a customer invoice in that currency with the following lines:
  - Line 1: price 480.00, discount 10%
  - Line 2: price 150.00, discount 30%
  - Line 3: price 700.00, discount 20%
  - Line 4: line with negative amount -322.00
- Use the default revenue account on lines 1, 2, and 4.
- Use a different account on line 3.
- Validate the invoice, error raised due to unbalanced journal entry.

Before this PR:
- Discounts on lines sharing the same account were summed in foreign currency, then converted together to company currency. This could cause rounding issues when using precise exchange rates.

After this PR:
- Each line’s discount is converted then rounded individually before grouping, ensuring accurate and balanced journal entries regardless of rate precision.

opw-4756076