### PR TITLE
[FIX] calendar: correct selectivity in alarm query

### DIFF
--- a/addons/calendar/models/calendar_alarm_manager.py
+++ b/addons/calendar/models/calendar_alarm_manager.py
@@ -23,7 +23,9 @@ class AlarmManager(models.AbstractModel):
         result = {}
         delta_request = """
             SELECT
-                rel.calendar_event_id, max(alarm.duration_minutes) AS max_delta,min(alarm.duration_minutes) AS min_delta
+                rel.calendar_event_id,
+                max(alarm.duration_minutes) AS max_delta,
+                min(alarm.duration_minutes) AS min_delta
             FROM
                 calendar_alarm_calendar_event_rel AS rel
             LEFT JOIN calendar_alarm AS alarm ON alarm.id = rel.calendar_alarm_id
@@ -31,30 +33,24 @@ class AlarmManager(models.AbstractModel):
             GROUP BY rel.calendar_event_id
         """
         base_request = """
-                    SELECT
-                        cal.id,
-                        cal.start - interval '1' minute  * calcul_delta.max_delta AS first_alarm,
-                        CASE
-                            WHEN cal.recurrency THEN rrule.until - interval '1' minute  * calcul_delta.min_delta
-                            ELSE cal.stop - interval '1' minute  * calcul_delta.min_delta
-                        END as last_alarm,
-                        cal.start as first_event_date,
-                        CASE
-                            WHEN cal.recurrency THEN rrule.until
-                            ELSE cal.stop
-                        END as last_event_date,
-                        calcul_delta.min_delta,
-                        calcul_delta.max_delta,
-                        rrule.rrule AS rule
-                    FROM
-                        calendar_event AS cal
-                    RIGHT JOIN calcul_delta ON calcul_delta.calendar_event_id = cal.id
-                    LEFT JOIN calendar_recurrence as rrule ON rrule.id = cal.recurrence_id
-             """
-
+            SELECT
+                cal.id,
+                cal.start - interval '1' minute * calcul_delta.max_delta AS first_alarm,
+                cal.stop - interval '1' minute * calcul_delta.min_delta AS last_alarm,
+                cal.start AS first_meeting,
+                cal.start AS last_meeting,
+                calcul_delta.min_delta,
+                calcul_delta.max_delta
+            FROM
+                calendar_event AS cal
+            INNER JOIN calcul_delta ON calcul_delta.calendar_event_id = cal.id
+            WHERE cal.active = True
+        """
         filter_user = """
-                RIGHT JOIN calendar_event_res_partner_rel AS part_rel ON part_rel.calendar_event_id = cal.id
-                    AND part_rel.res_partner_id IN %s
+            INNER JOIN calendar_event_res_partner_rel AS part_rel
+                ON part_rel.calendar_event_id = cal.id
+                AND part_rel.res_partner_id IN %s
+            WHERE cal.active = True
         """
 
         # Add filter on alarm type
@@ -62,7 +58,7 @@ class AlarmManager(models.AbstractModel):
 
         # Add filter on partner_id
         if partners:
-            base_request += filter_user
+            base_request = base_request.replace("WHERE cal.active = True", filter_user)
             tuple_params += (tuple(partners.ids), )
 
         # Upper bound on first_alarm of requested events
@@ -84,12 +80,12 @@ class AlarmManager(models.AbstractModel):
         self._cr.execute("""
             WITH calcul_delta AS (%s)
             SELECT *
-                FROM ( %s WHERE cal.active = True ) AS ALL_EVENTS
-               WHERE ALL_EVENTS.first_alarm < %s
-                 AND ALL_EVENTS.last_event_date > (now() at time zone 'utc')
+                FROM ( %s ) AS ALL_EVENTS
+            WHERE ALL_EVENTS.first_alarm < %s
+                AND ALL_EVENTS.last_alarm > (now() at time zone 'utc')
         """ % (delta_request, base_request, first_alarm_max_value), tuple_params)
 
-        for event_id, first_alarm, last_alarm, first_meeting, last_meeting, min_duration, max_duration, rule in self._cr.fetchall():
+        for event_id, first_alarm, last_alarm, first_meeting, last_meeting, min_duration, max_duration in self._cr.fetchall():
             result[event_id] = {
                 'event_id': event_id,
                 'first_alarm': first_alarm,
@@ -98,7 +94,6 @@ class AlarmManager(models.AbstractModel):
                 'last_meeting': last_meeting,
                 'min_duration': min_duration,
                 'max_duration': max_duration,
-                'rrule': rule
             }
 
         # determine accessible events


### PR DESCRIPTION
Steps to reproduce the issue:


1. Create a calendar event (meeting, for example)

2. Set the start date as yesterday and in 30 minutes from now.

3. Set it to be recurrent every week with end_type set to end_date 
and in the future(1 month from now). 

4. Add a reminder to the event (30 mins, for example)
and ensure that `calendar_last_notif_ack` is set before
the alarm window for your user's res.partner.

5. Save the event and observe an alarm notification made for an
event in the past.


After the fix, the calendar alarms will only trigger for events in 
the future and in their designated time windows

opw-4776638

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
