### PR TITLE
[FIX] l10n_it_edi_website_sale: remove unkonwn test flag

### DIFF
--- a/addons/l10n_it_edi_website_sale/static/tests/tours/website_sale_checkout_address.js
+++ b/addons/l10n_it_edi_website_sale/static/tests/tours/website_sale_checkout_address.js
@@ -48,7 +48,6 @@ registry.category("web_tour.tours").add('shop_checkout_address', {
 });
 
 registry.category("web_tour.tours").add('shop_checkout_address_create_partner', {
-    test: true,
     url: '/shop',
     steps: () => [
         ...tourUtils.addToCart({ productName: "Storage Box" }),


### PR DESCRIPTION
steps to reproduce :
1. Install l10n_it_edi_website_sale 
2. run the test `test_public_user_codice_fiscale`

remove the unknown key `test` from the tour

build_error-223784
