### PR TITLE
[FIX] core: binary can store raw bytes

### DIFF
--- a/odoo/addons/test_http/tests/test_static.py
+++ b/odoo/addons/test_http/tests/test_static.py
@@ -405,20 +405,14 @@ class TestHttpStatic(TestHttpStaticCommon):
             'name': 'dummy test_http test_static server',
             'smtp_host': 'localhost',
         })
-
-        for name, value, error_msg in [
-            ('raw bad padding', b'()', "binascii.Error: Non-base64 digit found"),
-            ('raw good padding', b'()==', "binascii.Error: Non-base64 digit found"),
-            ('b64 bad padding', b'YB', "binascii.Error: Incorrect padding"),
-        ]:
-            with self.subTest(name=name):
-                record.smtp_ssl_certificate = value
-                with self.assertLogs('odoo.http') as capture:
-                    res = self.url_open(f'/web/content/ir.mail_server/{record.id}/smtp_ssl_certificate')
-                self.assertEqual(res.status_code, 500)
-                self.assertEqual(len(capture.output), 1, capture.output)
-                self.assertIn(error_msg, capture.output[0])
-                self.assertIn("ir.mail_server.smtp_ssl_certificate", capture.output[0])
+        record.smtp_ssl_certificate = b'non base64 value'
+        self.assertDownload(
+            f'/web/content/ir.mail_server/{record.id}/smtp_ssl_certificate',
+            headers={},
+            assert_status_code=200,
+            assert_headers={},
+            assert_content=b'non base64 value',
+        )
 
 @tagged('post_install', '-at_install')
 class TestHttpStaticLogo(TestHttpStaticCommon):


### PR DESCRIPTION
Follow up of 1c17cb5a27483bb41b1e5ed820bc771a7337ec6d. It is OK to write raw bytes in a Binary attachment=False field.

The thing actually is:

* Binary fields, accept raw bytes, store raw bytes in db.
* Image fields, reject raw bytes, want base64, store base64 in db.

When reading Image fields it is easy: always decode the base64.

For Binary fields it is complicated, because some crazy people encode
their binary fields in base64, and expect automatic base64 decoding
when read. Crazy! So *attempt* to decode the b64 and if the decoding
fail just assume it was raw bytes from the begining.

Those crazy people even use silly base64 libraries to encode their
bytes, e.g. `base64.encodebytes` which is a Email MIME utility: it adds
`\r\n` every 76th character because of the folding requirements in email
headers. So those bytes are "technically" not base64 (as far as
`validate=True` is concerned) but we still must decode them. CRAZY.

I'm looking at you `base.language.export.data`.
