### PR TITLE
[IMP] web, base: handle currency in pivot and graph views

### DIFF
--- a/addons/web/static/src/views/graph/graph_controller.js
+++ b/addons/web/static/src/views/graph/graph_controller.js
@@ -65,8 +65,4 @@ export class GraphController extends Component {
         }
         return context;
     }
-
-    loadAll() {
-        return this.model.forceLoadAll();
-    }
 }

--- a/addons/web/static/src/views/graph/graph_controller.xml
+++ b/addons/web/static/src/views/graph/graph_controller.xml
@@ -67,14 +67,6 @@
 					<t t-if="!model.hasData() or model.useSampleModel and props.info.noContentHelp">
 						<ActionHelper noContentHelp="props.noContentHelp" showRibbon="model.useSampleModel"/>
                     </t>
-                    <t t-if="model.data.exceeds">
-                        <div class="alert alert-info text-center o_graph_alert" role="status">
-                            There are too many data. The graph only shows a sample. Use the filters to refine the scope.
-                            <a class="o_graph_load_all_btn" href="#" t-on-click="() => this.loadAll()">
-                                Load everything anyway.
-                            </a>
-                        </div>
-                    </t>
                     <t t-component="props.Renderer" model="model" buttonTemplate="props.buttonTemplate" />
                 </t>
                 <t t-elif="model.isReady" t-call="web.NoContentHelper">

--- a/addons/web/static/src/views/graph/graph_renderer.xml
+++ b/addons/web/static/src/views/graph/graph_renderer.xml
@@ -31,6 +31,25 @@
 
     <t t-name="web.GraphRenderer">
         <div t-att-class="'o_graph_renderer o_renderer h-100 d-flex flex-column border-top ' + props.class" t-ref="root">
+            <t t-if="model.currencyState?.currencies.length > 1">
+                <div class="alert alert-info o_graph_alert p-2 m-3 mb-2" role="status">
+                    The graph is hiding data due to mixing several currencies. Select one of them to perform an accurate analysis:
+                    <t t-foreach="model.currencyState.currencies" t-as="currency" t-key="currency_index">
+                        <t t-if="currency_index > 0">
+                            -
+                        </t>
+                        <a t-if="currency" class="px-1" t-out="getCurrency(currency)" href="#" t-on-click="() => this.filterCurrency(currency)"/>
+                    </t>
+                </div>
+            </t>
+            <t t-if="model.data.exceeds">
+                <div class="alert alert-info text-center o_graph_alert m-3 mb-2" role="status">
+                    There are too many data. The graph only shows a sample. Use the filters to refine the scope.
+                    <a class="o_graph_load_all_btn" href="#" t-on-click="() => this.loadAll()">
+                        Load everything anyway.
+                    </a>
+                </div>
+            </t>
             <div class="d-flex d-print-none gap-1 flex-shrink-0 mt-2 mx-3 mb-3 overflow-x-auto">
                 <t t-call="{{ props.buttonTemplate }}"/>
             </div>

--- a/addons/web/static/src/views/pivot/pivot_renderer.js
+++ b/addons/web/static/src/views/pivot/pivot_renderer.js
@@ -99,6 +99,12 @@ export class PivotRenderer extends Component {
         if (formatter.extractOptions) {
             Object.assign(formatOptions, formatter.extractOptions(fieldInfo));
         }
+        if (formatType === "monetary") {
+            if (cell.currencyId === false) {
+                return false;
+            }
+            formatOptions.currencyId = cell.currencyId;
+        }
         return formatter(cell.value, formatOptions);
     }
     /**
@@ -149,6 +155,10 @@ export class PivotRenderer extends Component {
      */
     get hideCustomGroupBy() {
         return this.env.searchModel.hideCustomGroupBy || false;
+    }
+
+    get invalidValueTooltip() {
+        return _t("Different currencies cannot be aggregated");
     }
 
     /**

--- a/addons/web/static/src/views/pivot/pivot_renderer.xml
+++ b/addons/web/static/src/views/pivot/pivot_renderer.xml
@@ -47,7 +47,13 @@
                                         <div t-elif="model.metaData.measures[cell.measure].type === 'boolean'" class="o_value">
                                             <CheckBox disabled="true" value="cell.value" />
                                         </div>
-                                        <div t-else="1" class="o_value" t-esc="getFormattedValue(cell)"/>
+                                        <div t-else="1" class="o_value">
+                                            <t t-set="formattedValue" t-value="getFormattedValue(cell)"/>
+                                            <t t-if="formattedValue === false">
+                                                <b t-att-data-tooltip="invalidValueTooltip">—</b>
+                                            </t>
+                                            <t t-else="" t-esc="formattedValue"/>
+                                        </div>
                                     </t>
                                 </td>
                             </t>

--- a/odoo/addons/base/models/res_currency.py
+++ b/odoo/addons/base/models/res_currency.py
@@ -72,7 +72,7 @@ class ResCurrency(models.Model):
 
     def write(self, vals):
         res = super().write(vals)
-        if vals.keys() & {'active', 'digits', 'position', 'symbol'}:
+        if vals.keys() & {'active', 'digits', 'name', 'position', 'symbol'}:
             # invalidate cache for get_all_currencies
             self.env.registry.clear_cache()
         if 'active' not in vals:
@@ -263,9 +263,9 @@ class ResCurrency(models.Model):
     @ormcache()
     @api.model
     def get_all_currencies(self):
-        currencies = self.sudo().search_fetch([('active', '=', True)], ['symbol', 'position', 'decimal_places'])
+        currencies = self.sudo().search_fetch([('active', '=', True)], ['name', 'symbol', 'position', 'decimal_places'])
         return {
-            c.id: {'symbol': c.symbol, 'position': c.position, 'digits': [69, c.decimal_places]}
+            c.id: {'name': c.name, 'symbol': c.symbol, 'position': c.position, 'digits': [69, c.decimal_places]}
             for c in currencies
         }
 


### PR DESCRIPTION
This PR builds on the changes introduced in https://github.com/odoo/odoo/pull/199958 to improve the display and clarity of monetary aggregates in both pivot and graph views.

- **Pivot View**:
   Currency symbols are now displayed alongside monetary group aggregates. When values in different currencies are present, invalid totals are replaced with a "—" symbol to clearly indicate that aggregation is not meaningful across mixed currencies.

- **Graph View**:
  Tooltips now show the appropriate currency for monetary fields. When mixed currencies are detected, a banner is shown to inform the user and suggest filtering by a single currency for more consistent results. Additionally, the currency name has been added to the session’s currency data, as it's required for the banner messaging.

task-4853634