### PR TITLE
[FIX] hr: fix error when creating a user of employee

### DIFF
--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -340,7 +340,7 @@ class HrEmployee(models.Model):
                     'type': 'ir.actions.client',
                     'tag': 'display_notification',
                     'params': {
-                        'title': _("User Creation Notification"),
+                        'title': self.env._("User Creation Notification"),
                         'type': message_type,
                         'message': message,
                         'next': next_action
@@ -350,12 +350,16 @@ class HrEmployee(models.Model):
         old_users = []
         new_users = []
         users_without_emails = []
+        users_with_invalid_emails = []
         for employee in self:
             if employee.user_id:
                 old_users.append(employee.name)
                 continue
             if not employee.work_email:
                 users_without_emails.append(employee.name)
+                continue
+            if not tools.email_normalize(employee.work_email):
+                users_with_invalid_emails.append(employee.name)
                 continue
             new_users.append({
                 'create_employee_id': employee.id,
@@ -381,6 +385,10 @@ class HrEmployee(models.Model):
 
         if users_without_emails:
             message = _("You need to set the work email address for %s", ', '.join(users_without_emails))
+            next_action = _get_user_creation_notification_action(message, 'danger', next_action)
+
+        if users_with_invalid_emails:
+            message = _("You need to set a valid work email address for %s", ', '.join(users_with_invalid_emails))
             next_action = _get_user_creation_notification_action(message, 'danger', next_action)
 
         return next_action

--- a/addons/hr/tests/test_hr_employee.py
+++ b/addons/hr/tests/test_hr_employee.py
@@ -518,6 +518,16 @@ class TestHrEmployee(TestHrCommon):
         self.assertTrue(days)
         self.assertFalse(days['2025-01-04'])
 
+    def test_user_creation_from_employee_with_invalid_email(self):
+        employee = self.env['hr.employee'].create({
+            'name': 'Test Employee',
+            'work_email': 'test'
+        })
+
+        action = employee.action_create_users()
+        self.assertEqual(action['params']['message'], f'You need to set a valid work email address for {employee.name}')
+        self.assertFalse(employee.user_id)
+
 
 @tagged('-at_install', 'post_install')
 class TestHrEmployeeWebJson(HttpCase):


### PR DESCRIPTION
A traceback occurs when the employee's work email is invalid and
a user is created via the Create User action.

Steps to reproduce the error:
- Install ``hr`` module
- Create a new employee > Add a name > Work Email: test > Save
- Actions > Create User > Confirm

Traceback:
```
NotNullViolation
null value in column 'login' of relation 'res_users' violates not-null constraint
```

https://github.com/odoo/odoo/blob/af701b3e5bd9106c6ccea5b4a59b9e79424b3a26/addons/hr/models/hr_employee.py#L360-L370
When an employee's work email is invalid,
``tools.email_normalize(employee.work_email)`` returns ``False``.
As a result, the ``login`` field becomes ``False``.
So, Attempting to create a user with a ``False login`` value leads to the above traceback.

sentry-6685198779

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
