### PR TITLE
[IMP] hr: Disable employee duplication

### DIFF
--- a/addons/hr/views/hr_employee_views.xml
+++ b/addons/hr/views/hr_employee_views.xml
@@ -84,7 +84,7 @@
             <field name="name">hr.employee.form</field>
             <field name="model">hr.employee</field>
             <field name="arch" type="xml">
-                <form string="Employee" js_class="hr_employee_form">
+                <form string="Employee" js_class="hr_employee_form" duplicate="false">
                     <header groups="hr.group_hr_user">
                         <button string="Create User" name="action_create_user" type="object"
                                 class="btn btn-primary" invisible="user_id" groups="hr.group_hr_user"
@@ -368,7 +368,7 @@
             <field name="name">hr.employee.list</field>
             <field name="model">hr.employee</field>
             <field name="arch" type="xml">
-                <list string="Employees" expand="context.get('expand', False)" multi_edit="1" sample="1" js_class="hr_employee_list">
+                <list string="Employees" expand="context.get('expand', False)" multi_edit="1" duplicate="false" sample="1" js_class="hr_employee_list">
                     <header>
                         <button name="%(plan_wizard_action)d" string="Launch Plan" type="action" groups="hr.group_hr_user"/>
                     </header>
@@ -407,7 +407,7 @@
             <field name="name">hr.employee.list</field>
             <field name="model">hr.employee</field>
             <field name="arch" type="xml">
-                <list string="Employees" multi_edit="1" editable="bottom" sample="1" js_class="hr_employee_list">
+                <list string="Employees" multi_edit="1" editable="bottom" duplicate="false" sample="1" js_class="hr_employee_list">
                     <field name="name" readonly="1"/>
                     <field name="company_id" optional="hide"/>
                     <field name="department_id" optional="hide"/>
@@ -424,7 +424,7 @@
             <field name="model">hr.employee</field>
             <field name="priority">10</field>
             <field name="arch" type="xml">
-                <kanban class="o_hr_employee_kanban" sample="1">
+                <kanban class="o_hr_employee_kanban" sample="1" duplicate="false">
                     <field name="show_hr_icon_display"/>
                     <field name="image_128" />
                     <field name="company_id"/>


### PR DESCRIPTION
This PR removes the `Duplicate` option from employee views. Instead of duplicating employees, users should utilize contract templates to replicate similar employee data in a more structured and consistent way.

Task: 4878427



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
