### PR TITLE
[FIX] website: make System Fonts selectable in theme tab

### DIFF
--- a/addons/website/static/src/builder/builder_fontfamilypicker.js
+++ b/addons/website/static/src/builder/builder_fontfamilypicker.js
@@ -53,7 +53,7 @@ export class BuilderFontFamilyPicker extends Component {
     }
     forwardProps(fontValue) {
         const result = Object.assign({}, this.props, {
-            [this.props.valueParamName]: fontValue.fontFamily,
+            [this.props.valueParamName]: fontValue.fontFamilyValue,
         });
         delete result.selectMethod;
         delete result.valueParamName;

--- a/addons/website/static/src/builder/builder_fontfamilypicker.xml
+++ b/addons/website/static/src/builder/builder_fontfamilypicker.xml
@@ -7,7 +7,7 @@
         <t t-foreach="fonts" t-as="font" t-key="font_index">
             <BuilderSelectItem t-props="forwardProps(font)">
                 <div class="d-flex justify-content-between">
-                    <span t-attf-style="font-family: {{font.fontFamily}};">
+                    <span t-attf-style="font-family: {{font.styleFontFamily}};">
                         <i t-if="font.type === 'cloud'" role="button" class="me-2 fa fa-cloud" title="This font is hosted and served to your visitors by Google servers"></i>
                         <t t-out="font.string"/>
                     </span>

--- a/addons/website/static/src/builder/plugins/font/font_plugin.js
+++ b/addons/website/static/src/builder/plugins/font/font_plugin.js
@@ -178,11 +178,12 @@ class FontPlugin extends Plugin {
             const fontKey = getCSSVariableValue(`font-number-${realFontNb}`, style);
             allFonts.push(fontKey);
             let fontName = fontKey.slice(1, -1); // Unquote
-            let fontFamily = fontName;
+            const fontFamilyValue = fontName;
+            let styleFontFamily = fontName;
             const isSystemFonts = fontName === "SYSTEM_FONTS";
             if (isSystemFonts) {
                 fontName = _t("System Fonts");
-                fontFamily = "var(--o-system-fonts)";
+                styleFontFamily = "var(--o-system-fonts)";
             }
 
             let type = "cloud";
@@ -199,7 +200,8 @@ class FontPlugin extends Plugin {
             _fonts.push({
                 type,
                 indexForType,
-                fontFamily,
+                fontFamilyValue,
+                styleFontFamily,
                 string: fontName,
             });
         }


### PR DESCRIPTION
When [1] introduced `html_builder`, the font family picker was re-created in Owl.
The new implementation did not make the difference between the font family used as style to display the font example inside the dropdown, and the font family value actually being set inside the SCSS.

When picking "System Fonts", this led to entries in the `user_values.scss` looking like this:
```scss
    'font': var(--o-system-fonts),
```
instead of this:
```scss
    'font': 'SYSTEM_FONTS',
```

This commit introduces a distinction between both values to solve this issue.

[1]: https://github.com/odoo/odoo/commit/9fe45e2b7ddbbfd0445ffe25a859e67a316d02b2

task-4367641
