### PR TITLE
[IMP] web: change primary colors

### DIFF
--- a/addons/web/static/src/scss/primary_variables.scss
+++ b/addons/web/static/src/scss/primary_variables.scss
@@ -70,8 +70,8 @@ $o-grays: (
     900: $o-gray-900,
 ) !default;
 
-$o-community-color: #71639e !default;
-$o-enterprise-color: #714B67 !default;
+$o-community-color: #3f5a7b !default;
+$o-enterprise-color: #90365a !default;
 $o-enterprise-action-color: #017e84 !default;
 
 $o-brand-odoo: $o-community-color !default;
@@ -81,8 +81,8 @@ $o-brand-secondary: #8f8f8f !default;
 $o-brand-lightsecondary: $o-gray-100 !default;
 
 $o-action: $o-brand-primary !default;
-$o-success: #28a745 !default;
-$o-info: #17a2b8 !default;
+$o-success: #48a25d !default;
+$o-info: #15c2bf !default;
 $o-warning: #ffac00 !default;
 $o-danger: #dc3545 !default;
 
@@ -90,7 +90,7 @@ $o-danger: #dc3545 !default;
 // Overrides $theme-colors generated 'text-x' classes only.
 // Custom colors are set by $o-text-colors-custom
 $o-theme-text-colors: (
-    "success": #008818,
+    "success": #379248,
     "info": #0180a5,
     "warning": #9a6b01,
     "danger": #d23f3a,
@@ -117,12 +117,12 @@ $o-font-family-monospace: o-add-unicode-support-font((SFMono-Regular, Menlo, Mon
 $o-headings-font-family: o-add-unicode-support-font(("SF Pro Display", $o-system-fonts)) !default;
 
 // Font colors
-$o-main-text-color: $o-gray-900 !default;
-$o-main-color-muted: rgba($o-gray-700, $o-opacity-muted) !default;
-$o-main-headings-color: $o-black !default;
-$o-main-link-color: darken($o-brand-primary, 5%) !default;
-$o-main-favorite-color: #f3cc00 !default;
-$o-main-code-color: #d2317b !default;
+$o-main-text-color: $o-gray-800 !default;
+$o-main-color-muted: rgba($o-main-text-color, $o-opacity-muted) !default;
+$o-main-headings-color: $o-gray-800 !default;
+$o-main-link-color: darken($o-brand-primary, 7%) !default;
+$o-main-favorite-color: #caae3c !default;
+$o-main-code-color: #b35983 !default;
 
 // Tables
 $o-table-cell-padding-x-sm: .3rem !default;


### PR DESCRIPTION
As part of R&D design team training, primary colors were changed to offer better text readability and better contrast.

Requires:
- https://github.com/odoo/enterprise/pull/87953

task-4875580


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
