### PR TITLE
[IMP] account:  Display tax replacement field in list views

### DIFF
--- a/addons/account/views/account_tax_views.xml
+++ b/addons/account/views/account_tax_views.xml
@@ -11,6 +11,7 @@
                     <field name="name"/>
                     <field name="description" optional="show"/>
                     <field name="type_tax_use"/>
+                    <field name="original_tax_ids" widget="many2many_tax_tags" optional="hide"/>
                     <field name="tax_scope"/>
                     <field name="invoice_label"/>
                     <field name="company_id" options="{'no_create': True}" groups="base.group_multi_company"/>
@@ -60,6 +61,7 @@
             <field name="arch" type="xml">
                 <list string="Account Tax">
                     <field name="display_name" string="Name"/>
+                    <field name="original_tax_ids" widget="many2many_tax_tags"/>
                     <field name="tax_scope"/>
                     <field name="description"/>
                 </list>


### PR DESCRIPTION
Before this pr:
The 'Replaces' field was not visible in the list view of the tax model, including when accessed via the Fiscal Position form view.

After this pr:
The 'Replaces' field is now available in both list views:
- In the list view accessed from the Fiscal Position form view, it is visible by default.
- In the main tax list view, it is available but hidden by default.

Task: 4879111