### PR TITLE
[FIX] web: Do not filter on progress bar's selected filter

### DIFF
--- a/addons/web/models/models.py
+++ b/addons/web/models/models.py
@@ -819,13 +819,13 @@ class Base(models.AbstractModel):
             return value
 
         result = defaultdict(lambda: dict.fromkeys(progress_bar['colors'], 0))
-        domain = AND([domain, [(progress_bar['field'], 'in', list(progress_bar['colors']))]])
 
         for main_group, field_value, count in self._read_group(
             domain, [group_by, progress_bar['field']], ['__count'],
         ):
-            group_by_value = str(adapt(main_group))
-            result[group_by_value][field_value] += count
+            if field_value in progress_bar['colors']:
+                group_by_value = str(adapt(main_group))
+                result[group_by_value][field_value] += count
 
         return result
 


### PR DESCRIPTION
Description
-----------
Following d5a6e97abab04282c7a69093cd790b539a958241, the currently selected filter of the progress bar in the kanban view is injected into the domain of the kanban view during `read_progress_bar`.

This behaves well in general, but it's a performance regression when the filtering field is a non-stored search field that potentially does elaborate subqueries (e.g.: `activity_state`).

This commit reverts this modification to the previous behavior, to avoid this pathological case.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
