### PR TITLE
[FIX] l10n_jo_edi: Credit notes lines matching by discount

### DIFF
--- a/addons/l10n_jo_edi/models/account_edi_xml_ubl_21_jo.py
+++ b/addons/l10n_jo_edi/models/account_edi_xml_ubl_21_jo.py
@@ -59,7 +59,8 @@ class AccountEdiXmlUBL21JO(models.AbstractModel):
         for invoice_line_id, invoice_line in enumerate(invoice_lines, 1):
             if line.product_id == invoice_line.product_id \
                     and line.name == invoice_line.name \
-                    and line.price_unit == invoice_line.price_unit:
+                    and line.price_unit == invoice_line.price_unit \
+                    and line.discount == invoice_line.discount:
                 line_id = invoice_line_id
                 break
         if line_id == -1:

--- a/addons/l10n_jo_edi/tests/test_files/type_2.xml
+++ b/addons/l10n_jo_edi/tests/test_files/type_2.xml
@@ -78,7 +78,7 @@
 		<cbc:PayableAmount currencyID="JO">130.680</cbc:PayableAmount>
 	</cac:LegalMonetaryTotal>
 	<cac:InvoiceLine>
-		<cbc:ID>2</cbc:ID>
+		<cbc:ID>___ignore___</cbc:ID>
 		<cbc:InvoicedQuantity unitCode="PCE">44.0</cbc:InvoicedQuantity>
 		<cbc:LineExtensionAmount currencyID="JO">130.680</cbc:LineExtensionAmount>
 		<cac:Item>


### PR DESCRIPTION
When generating a credit note for an invoice with multiple lines of the same product
(same product_id, name, and price_unit) but different discounts,
the system incorrectly matches both credit note lines to the same invoice line.
This commit solves this issue by adding line discount to
the criteria used to match credit notes lines with invoices lines.

task-4876849




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
