### PR TITLE
[FIX] purchase_stock: switch to MTS after PO cancellation

### DIFF
--- a/addons/purchase_stock/models/purchase_order.py
+++ b/addons/purchase_stock/models/purchase_order.py
@@ -145,8 +145,10 @@ class PurchaseOrder(models.Model):
         for order_line in order_lines:
             moves_to_cancel_ids.update(order_line.move_ids.ids)
             if order_line.move_dest_ids:
-                move_dest_ids = order_line.move_dest_ids.filtered(lambda move: move.state != 'done' and not move.scrapped
-                                                                  and move.rule_id.route_id == move.location_dest_id.warehouse_id.reception_route_id)
+                move_dest_ids = order_line.move_dest_ids.filtered(lambda move: move.state != 'done' and not move.scrapped)
+                moves_to_mts = move_dest_ids.filtered(lambda move: move.rule_id.route_id != move.location_dest_id.warehouse_id.reception_route_id)
+                move_dest_ids -= moves_to_mts
+                moves_to_recompute_ids.update(moves_to_mts.ids)
                 moves_to_unlink = move_dest_ids.filtered(lambda m: len(m.created_purchase_line_ids.ids) > 1)
                 if moves_to_unlink:
                     moves_to_unlink.created_purchase_line_ids = [Command.unlink(order_line.id)]

--- a/addons/purchase_stock/tests/test_move_cancel_propagation.py
+++ b/addons/purchase_stock/tests/test_move_cancel_propagation.py
@@ -128,6 +128,7 @@ class TestMoveCancelPropagation(PurchaseTestCommon):
 
         # Check the status of picking after canceling po.
         self.assertNotEqual(self.move.picking_id.state, 'cancel')
+        self.assertEqual(self.move.procure_method, 'make_to_stock')
 
     def test_04_cancel_confirm_purchase_order_two_steps_push(self):
         """ Check the picking and moves status related PO, When canceling purchase order
@@ -191,6 +192,7 @@ class TestMoveCancelPropagation(PurchaseTestCommon):
         purchase_order.button_cancel()
 
         self.assertNotEqual(self.move.picking_id.state, 'cancel')
+        self.assertEqual(self.move.procure_method, 'make_to_stock')
 
     def test_06_cancel_confirm_purchase_order_three_steps_push(self):
         """ Check the picking and moves status related PO, When canceling purchase order


### PR DESCRIPTION
Steps to reproduce the bug:
- Unarchive the MTO route
- Create a product P1:
    - Type: Storable
    - Route: MTO
    - Supplier: Vendor A
- Create a sales order for 1 unit of P1
- Confirm the SO
    → A purchase order is created for Vendor A with 1 unit of P1
- Cancel the PO
- Update the quantity on hand of P1 to 1
- Go to the delivery picking of the SO
- Check availability

Problem:
The quantity on hand is not taken into account, and the picking remains
in the "Waiting Availability" state.

When the purchase order is cancelled, the stock move should switch to
MTS instead of remaining in MTO.



opw-[4876611](https://www.odoo.com/web#id=4876611&view_type=form&model=project.task)
opw-[4874199](https://www.odoo.com/web#id=4874199&view_type=form&model=project.task)