### PR TITLE
[FIX] website_sale: handle products with 'never' attribute in cart

### DIFF
--- a/addons/website_sale/static/src/js/sale_variant_mixin.js
+++ b/addons/website_sale/static/src/js/sale_variant_mixin.js
@@ -279,7 +279,7 @@ var VariantMixin = {
                 noVariantAttributeValues.push({
                     'custom_product_template_attribute_value_id': $variantValueInput.data('value_id'),
                     'attribute_value_name': $variantValueInput.data('value_name'),
-                    'value': $variantValueInput.val(),
+                    'value': parseInt($variantValueInput.val()),
                     'attribute_name': $variantValueInput.data('attribute_name'),
                     'is_custom': $variantValueInput.data('is_custom')
                 });


### PR DESCRIPTION
To reproduce:
==============
- Create an attribute with Variants Creation Mode set to Never
- Create a product and link this attribute to it
- Publish the product and go to the shop
- Add the product to the cart twice, in two separate actions

Problem:
========
- Each add-to-cart action creates a new order line, even though it's the same product. This happens because when we get order line in code we ignore products with no_variant attributes.
https://github.com/odoo/odoo/blob/0297b0888ec8581b39edc85c41c50cfdcefc21d5/addons/website_sale/models/sale_order.py#L255 

Solution:
=========
- Filter cart lines by matching the exact set of no_variant attribute value IDs
- Compare the specific no_variant attribute IDs to find existing lines with
  the same attributes

opw-4859369
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
