### PR TITLE
[FIX] tests: disable tests failing with blocked network

### DIFF
--- a/addons/link_tracker/tests/test_tracker_http_requests.py
+++ b/addons/link_tracker/tests/test_tracker_http_requests.py
@@ -7,7 +7,8 @@ from odoo.tools import mute_logger
 class TestTrackerHttpRequests(MockLinkTracker, common.HttpCase):
 
     @mute_logger("odoo.addons.http_routing.models.ir_http", "odoo.http")
-    def test_no_preview_tracking(self):
+    # fails with network disabled
+    def _test_no_preview_tracking(self):
         """Ensure that requests with a user agent matching known preview user agents will not be registered as a click"""
         link_tracker = self.env['link.tracker'].create({
                 'url': 'https://odoo.com',

--- a/addons/mass_mailing/tests/test_mailing_controllers.py
+++ b/addons/mass_mailing/tests/test_mailing_controllers.py
@@ -11,7 +11,7 @@ from odoo.tests.common import HttpCase
 from odoo.tests import tagged
 
 
-@tagged('link_tracker')
+@tagged('link_tracker', '-standard', 'external')
 class TestMailingControllers(MassMailCommon, HttpCase):
 
     @classmethod

--- a/addons/website/tests/test_assets.py
+++ b/addons/website/tests/test_assets.py
@@ -9,7 +9,8 @@ from odoo.tools import config
 @odoo.tests.common.tagged('post_install', '-at_install')
 class TestWebsiteAssets(odoo.tests.HttpCase):
 
-    def test_01_multi_domain_assets_generation(self):
+    # fails with network disabled
+    def _test_01_multi_domain_assets_generation(self):
         Website = self.env['website']
         Attachment = self.env['ir.attachment']
         # Create an additional website to ensure it works in multi-website setup

--- a/addons/website_event/tests/test_website_event.py
+++ b/addons/website_event/tests/test_website_event.py
@@ -48,10 +48,12 @@ class TestEventRegisterUTM(HttpCase, TestEventOnlineCommon):
 @tagged('post_install', '-at_install')
 class TestUi(HttpCaseWithUserDemo):
 
-    def test_website_event_tour_admin(self):
+    # fails with network disabled
+    def _test_website_event_tour_admin(self):
         self.start_tour(self.env['website'].get_client_action_url('/'), 'website_event_tour', login='admin', step_delay=100)
 
-    def test_website_event_pages_seo(self):
+    # fails with network disabled
+    def _test_website_event_pages_seo(self):
         website = self.env['website'].get_current_website()
         event = self.env['event.event'].create({
             'name': 'Event With Menu',


### PR DESCRIPTION
Runbot will soon block all external requests inside a docker, disabling the tests that are breaking when it is the case.