### PR TITLE
[FIX] mass_mailing : prevent external link changes for mailing campaign tests

### DIFF
--- a/addons/mass_mailing/models/mail_mail.py
+++ b/addons/mass_mailing/models/mail_mail.py
@@ -26,13 +26,14 @@ class MailMail(models.Model):
         body = super(MailMail, self)._send_prepare_body()
 
         if self.mailing_id and body and self.mailing_trace_ids:
+            base_url_parsed = werkzeug.urls.url_parse(self.get_base_url(), scheme='http')
             for match in set(re.findall(tools.URL_REGEX, self.body_html)):
                 href = match[0]
                 url = match[1]
 
                 parsed = werkzeug.urls.url_parse(url, scheme='http')
 
-                if parsed.scheme.startswith('http') and parsed.path.startswith('/r/'):
+                if parsed.scheme.startswith('http') and base_url_parsed.host == parsed.host and parsed.path.startswith('/r/'):
                     new_href = href.replace(url, url + '/m/' + str(self.mailing_trace_ids[0].id))
                     body = body.replace(href, new_href)
 


### PR DESCRIPTION
# [FIX] mass_mailing : prevent external link changes for mailing campaign tests


Before this commit, external links including /r/ in a mailing campaign template was replaced to add a tracking code That's could break some urls

It will now be check that the url to change is inside the base_url domain


## Steps:
- Create a campaign in Marketing Automation
- Add a New Activity
- In the Activity > Mail Template add a button
- Edit the button link to be an external link with /r/ like "https://www.reddit.com/r/Odoo"
- Save and Launch A Test
- Choose a Contact with an email address -> Continue
- Click the Play button
- It should be Processed
- Check the mail send in the MailHog, the link should be broken (or page not found)


opw-4624970