### PR TITLE
[IMP] website: supporting website page generation using AI

### DIFF
--- a/addons/html_builder/static/src/builder.js
+++ b/addons/html_builder/static/src/builder.js
@@ -216,9 +216,12 @@ export class Builder extends Component {
     discard() {
         if (this.state.canUndo) {
             this.dialog.add(ConfirmationDialog, {
+                title: _t("Discard all changes?"),
                 body: _t(
-                    "If you discard the current edits, all unsaved changes will be lost. You can cancel to return to edit mode."
+                    "Are you sure you want to discard all your changes? Once you do, they're gone for good."
                 ),
+                confirmLabel: _t("Discard changes"),
+                cancelLabel: _t("Keep editing"),
                 confirm: () => this.props.closeEditor(),
                 cancel: () => {},
             });

--- a/addons/website/static/src/components/dialog/add_page_dialog.js
+++ b/addons/website/static/src/components/dialog/add_page_dialog.js
@@ -11,7 +11,7 @@ import { onceAllImagesLoaded } from "@website/utils/images";
 
 const NO_OP = () => {};
 
-class AddPageConfirmDialog extends Component {
+export class AddPageConfirmDialog extends Component {
     static template = "website.AddPageConfirmDialog";
     static props = {
         close: Function,


### PR DESCRIPTION
## Purpose

The enterprise PR introduces a new bridge module, ai_website, which enables AI-assisted generation of website page content. This PR includes one change to the discard confirmation dialog required in the html builder.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
task-[4825509](https://www.odoo.com/odoo/project/19060/tasks/4532108/project.project/19060/tasks/4825509)
