### PR TITLE
[FIX] web: update css for boxed layout

### DIFF
--- a/addons/web/static/src/webclient/actions/reports/report_tables.scss
+++ b/addons/web/static/src/webclient/actions/reports/report_tables.scss
@@ -165,6 +165,12 @@ div#total {
             border-top: none;
         }
     }
+
+    .mt-5 .o_total_table:not(.o_ignore_layout_styling) {
+        &::before {
+            border-top: $border-width solid $border-color;
+        }
+    }
 }
 
 .o_table_boxed-rounded {


### PR DESCRIPTION
**Description:**

Due to a recent [commit](https://github.com/odoo/odoo/commit/12ef230df58122fbdac0b4c1b4781c535b8516ba), a margin-top was added to the total table for the report type-pdf. Previously,in the box layout, this table did not have a top border because it appeared visually connected to the preceding table — they seemed seamlessly joined.

However, after the margin was added,the table now appears visually disconnected, making the absence of a top border look inconsistent and awkward.

Steps to reproduce:
- install account module
- select box external layout
- create invoice
- print report as pdf

Before commit:
![before-commit](https://github.com/user-attachments/assets/1fc5076c-879d-4b4e-9dfe-aa3b5a420d5e)

After commit:
![after-commit](https://github.com/user-attachments/assets/a0ec957c-7b01-45ba-8f69-05499ff5c162)


opw - [4873157](https://www.odoo.com/odoo/project/70/tasks/4873157)
upg - [2839564](https://upgrade.odoo.com/odoo/upgrade.request/2839564)


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
