### PR TITLE
[FIX] l10n_it_edi: add sudo() to sale order creation

### DIFF
--- a/addons/l10n_it_edi/tests/test_edi_export.py
+++ b/addons/l10n_it_edi/tests/test_edi_export.py
@@ -473,7 +473,7 @@ class TestItEdiExport(TestItEdi):
         if self.env['ir.module.module']._get('sale').state != 'installed':
             self.skipTest("sale module is not installed")
 
-        sale_order = self.env['sale.order'].with_company(self.company).create({
+        sale_order = self.env['sale.order'].with_company(self.company).sudo().create({
             'partner_id': self.italian_partner_a.id,
             'order_line': [
                 Command.create({'product_id': self.service_product.id, 'price_unit': 200.00}),
@@ -483,7 +483,7 @@ class TestItEdiExport(TestItEdi):
 
         for amount in (50, 100):
             self.env['account.move'].with_company(self.company).browse(
-                self.env['sale.advance.payment.inv'].create([{
+                self.env['sale.advance.payment.inv'].sudo().create([{
                     'advance_payment_method': 'fixed',
                     'fixed_amount': amount,
                     'sale_order_ids': [Command.link(sale_order.id)],
@@ -491,7 +491,7 @@ class TestItEdiExport(TestItEdi):
             ).action_post()
 
         invoice = self.env['account.move'].with_company(self.company).browse(
-            self.env['sale.advance.payment.inv'].create([{
+            self.env['sale.advance.payment.inv'].sudo().create([{
                 'advance_payment_method': 'delivered',
                 'sale_order_ids': [Command.link(sale_order.id)],
             }]).create_invoices()['res_id']


### PR DESCRIPTION
Steps to reproduce:
1. install `l10n_it_stock_ddt` without demo data
2. run `test_export_invoice_with_two_downpayments`

missing sudo in test case to create sale order in the test

Error [link](https://runbot.odoo.com/odoo/error/163631)
build_error-163631
