### PR TITLE
[REF] website: add flag "mysterious-egg" on skipped tours

### DIFF
--- a/addons/website/tests/test_attachment.py
+++ b/addons/website/tests/test_attachment.py
@@ -37,11 +37,13 @@ class TestWebsiteAttachment(odoo.tests.HttpCase):
         req = self.url_open(base + '/web/image/test.an_image_redirect_301', allow_redirects=True)
         self.assertEqual(req.status_code, 200)
 
-    @unittest.skip
+    # TODO master-mysterious-egg fix error
+    @unittest.skip("prepare mysterious-egg for merging")
     def test_02_image_quality(self):
         self.start_tour(self.env['website'].get_client_action_url('/'), 'website_image_quality', login="admin")
 
-    @unittest.skip
+    # TODO master-mysterious-egg fix error
+    @unittest.skip("prepare mysterious-egg for merging")
     def test_03_link_to_document(self):
         text = b'Lorem Ipsum'
         self.env['ir.attachment'].create({

--- a/addons/website/tests/test_snippets.py
+++ b/addons/website/tests/test_snippets.py
@@ -27,7 +27,8 @@ class TestSnippets(HttpCase):
     def test_02_default_shape_gets_palette_colors(self):
         self.start_tour('/@/', 'default_shape_gets_palette_colors', login='admin')
 
-    @unittest.skip
+    # TODO master-mysterious-egg fix error
+    @unittest.skip("prepare mysterious-egg for merging")
     def test_03_snippets_all_drag_and_drop(self):
         with MockRequest(self.env, website=self.env['website'].browse(1)):
             snippets_template = self.env['ir.ui.view'].render_public_asset('website.snippets')
@@ -83,7 +84,8 @@ class TestSnippets(HttpCase):
     def test_06_snippet_popup_add_remove(self):
         self.start_tour(self.env['website'].get_client_action_url('/'), 'snippet_popup_add_remove', login='admin')
 
-    @unittest.skip
+    # TODO master-mysterious-egg fix error
+    @unittest.skip("prepare mysterious-egg for merging")
     def test_07_image_gallery(self):
         self.start_tour(self.env['website'].get_client_action_url('/'), 'snippet_image_gallery', login='admin')
 
@@ -98,7 +100,8 @@ class TestSnippets(HttpCase):
     def test_10_parallax(self):
         self.start_tour(self.env['website'].get_client_action_url('/'), 'test_parallax', login='admin')
 
-    @unittest.skip
+    # TODO master-mysterious-egg fix error
+    @unittest.skip("prepare mysterious-egg for merging")
     def test_11_snippet_popup_display_on_click(self):
         # To make the tour reliable we need to wait a field using data-fill-with
         # to be patched, the step however relies on the company field being
@@ -115,14 +118,16 @@ class TestSnippets(HttpCase):
     def test_12_snippet_images_wall(self):
         self.start_tour('/', 'snippet_images_wall', login='admin')
 
-    @unittest.skip
+    # TODO master-mysterious-egg fix error
+    @unittest.skip("prepare mysterious-egg for merging")
     def test_snippet_popup_with_scrollbar_and_animations(self):
         website = self.env.ref('website.default_website')
         website.cookies_bar = True
         self.start_tour(self.env['website'].get_client_action_url('/'), 'snippet_popup_and_scrollbar', login='admin')
         self.start_tour(self.env['website'].get_client_action_url('/'), 'snippet_popup_and_animations', login='admin', timeout=90)
 
-    @unittest.skip
+    # TODO master-mysterious-egg fix error
+    @unittest.skip("prepare mysterious-egg for merging")
     def test_drag_and_drop_on_non_editable(self):
         self.start_tour(self.env['website'].get_client_action_url('/'), 'test_drag_and_drop_on_non_editable', login='admin')
 

--- a/addons/website/tests/test_ui.py
+++ b/addons/website/tests/test_ui.py
@@ -192,14 +192,16 @@ class TestUiHtmlEditor(HttpCaseWithUserDemo):
 
 @odoo.tests.tagged('external', '-standard', '-at_install', 'post_install')
 class TestUiHtmlEditorWithExternal(HttpCaseWithUserDemo):
-    @unittest.skip
+    # TODO master-mysterious-egg fix error
+    @unittest.skip("prepare mysterious-egg for merging")
     def test_media_dialog_external_library(self):
         self.start_tour("/", 'website_media_dialog_external_library', login='admin')
 
 
 @odoo.tests.tagged('-at_install', 'post_install')
 class TestUiTranslate(odoo.tests.HttpCase):
-    @unittest.skip
+    # TODO master-mysterious-egg fix error
+    @unittest.skip("prepare mysterious-egg for merging")
     def test_admin_tour_rte_translator(self):
         self.env['res.lang'].create({
             'name': 'Parseltongue',
@@ -209,7 +211,8 @@ class TestUiTranslate(odoo.tests.HttpCase):
         })
         self.start_tour(self.env['website'].get_client_action_url('/'), 'rte_translator', login='admin', timeout=120)
 
-    @unittest.skip
+    # TODO master-mysterious-egg fix error
+    @unittest.skip("prepare mysterious-egg for merging")
     def test_translate_menu_name(self):
         lang_en = self.env.ref('base.lang_en')
         parseltongue = self.env['res.lang'].create({
@@ -236,7 +239,8 @@ class TestUiTranslate(odoo.tests.HttpCase):
         self.assertNotEqual(new_menu.name, 'value pa-GB', msg="The new menu should not have its value edited, only its translation")
         self.assertEqual(new_menu.with_context(lang=parseltongue.code).name, 'value pa-GB', msg="The new translation should be set")
 
-    @unittest.skip
+    # TODO master-mysterious-egg fix error
+    @unittest.skip("prepare mysterious-egg for merging")
     def test_translate_text_options(self):
         lang_en = self.env.ref('base.lang_en')
         lang_fr = self.env.ref('base.lang_fr')
@@ -249,7 +253,8 @@ class TestUiTranslate(odoo.tests.HttpCase):
 
         self.start_tour(self.env['website'].get_client_action_url('/'), 'translate_text_options', login='admin')
 
-    @unittest.skip
+    # TODO master-mysterious-egg fix error
+    @unittest.skip("prepare mysterious-egg for merging")
     def test_snippet_translation(self):
         ResLang = self.env['res.lang']
         parseltongue, fake_user_lang = ResLang.create([{
@@ -296,7 +301,8 @@ class TestUi(HttpCaseWithWebsiteUser):
     def test_02_restricted_editor(self):
         self.start_tour(self.env['website'].get_client_action_url('/'), 'restricted_editor', login="website_user")
 
-    @unittest.skip
+    # TODO master-mysterious-egg fix error
+    @unittest.skip("prepare mysterious-egg for merging")
     def test_04_website_navbar_menu(self):
         website = self.env['website'].search([], limit=1)
         self.env['website.menu'].create({
@@ -308,7 +314,8 @@ class TestUi(HttpCaseWithWebsiteUser):
         })
         self.start_tour("/", 'website_navbar_menu')
 
-    @unittest.skip
+    # TODO master-mysterious-egg fix error
+    @unittest.skip("prepare mysterious-egg for merging")
     def test_05_specific_website_editor(self):
         asset_bundle_xmlid = 'website.assets_wysiwyg'
         website_default = self.env['website'].search([], limit=1)
@@ -418,11 +425,13 @@ class TestUi(HttpCaseWithWebsiteUser):
     def test_08_website_style_custo(self):
         self.start_tour(self.env['website'].get_client_action_url('/'), 'website_style_edition', login='admin')
 
-    @unittest.skip
+    # TODO master-mysterious-egg fix error
+    @unittest.skip("prepare mysterious-egg for merging")
     def test_09_website_edit_link_popover(self):
         self.start_tour('/@/', 'edit_link_popover', login='admin', step_delay=500, timeout=180)
 
-    @unittest.skip
+    # TODO master-mysterious-egg fix error
+    @unittest.skip("prepare mysterious-egg for merging")
     def test_10_website_conditional_visibility(self):
         self.start_tour(self.env['website'].get_client_action_url('/'), 'conditional_visibility_1', login='admin')
         self.start_tour('/odoo', 'conditional_visibility_2', login='website_user')
@@ -430,7 +439,8 @@ class TestUi(HttpCaseWithWebsiteUser):
         self.start_tour(self.env['website'].get_client_action_url('/'), 'conditional_visibility_4', login='admin')
         self.start_tour(self.env['website'].get_client_action_url('/'), 'conditional_visibility_5', login='admin')
 
-    @unittest.skip
+    # TODO master-mysterious-egg fix error
+    @unittest.skip("prepare mysterious-egg for merging")
     def test_11_website_snippet_background_edition(self):
         self.env['ir.attachment'].create({
             'public': True,
@@ -449,11 +459,13 @@ class TestUi(HttpCaseWithWebsiteUser):
     def test_14_carousel_snippet_content_removal(self):
         self.start_tour(self.env['website'].get_client_action_url('/'), 'carousel_content_removal', login='admin')
 
-    @unittest.skip
+    # TODO master-mysterious-egg fix error
+    @unittest.skip("prepare mysterious-egg for merging")
     def test_15_website_link_tools(self):
         self.start_tour(self.env['website'].get_client_action_url('/'), 'link_tools', login="admin")
 
-    @unittest.skip
+    # TODO master-mysterious-egg fix error
+    @unittest.skip("prepare mysterious-egg for merging")
     def test_16_website_edit_megamenu(self):
         self.start_tour(self.env['website'].get_client_action_url('/'), 'edit_megamenu', login='admin')
 
@@ -466,11 +478,13 @@ class TestUi(HttpCaseWithWebsiteUser):
     def test_18_website_snippets_menu_tabs(self):
         self.start_tour('/', 'website_snippets_menu_tabs', login='admin')
 
-    @unittest.skip
+    # TODO master-mysterious-egg fix error
+    @unittest.skip("prepare mysterious-egg for merging")
     def test_19_website_page_options(self):
         self.start_tour("/odoo", "website_page_options", login="admin")
 
-    @unittest.skip
+    # TODO master-mysterious-egg fix error
+    @unittest.skip("prepare mysterious-egg for merging")
     def test_20_snippet_editor_panel_options(self):
         self.start_tour('/@/', 'snippet_editor_panel_options', login='admin')
 
@@ -483,7 +497,8 @@ class TestUi(HttpCaseWithWebsiteUser):
     def test_23_website_multi_edition(self):
         self.start_tour('/@/', 'website_multi_edition', login='admin')
 
-    @unittest.skip
+    # TODO master-mysterious-egg fix error
+    @unittest.skip("prepare mysterious-egg for merging")
     def test_24_snippet_cache_across_websites(self):
         default_website = self.env.ref('website.default_website')
         website = self.env['website'].create({
@@ -536,11 +551,13 @@ class TestUi(HttpCaseWithWebsiteUser):
         self.assertFalse(menu_root.action, 'The top menu should not have an action (or the test/tour will not test anything).')
         self.start_tour('/', 'website_backend_menus_redirect', login='admin')
 
-    @unittest.skip
+    # TODO master-mysterious-egg fix error
+    @unittest.skip("prepare mysterious-egg for merging")
     def test_30_website_text_animations(self):
         self.start_tour("/", 'text_animations', login='admin')
 
-    @unittest.skip
+    # TODO master-mysterious-egg fix error
+    @unittest.skip("prepare mysterious-egg for merging")
     def test_31_website_edit_megamenu_big_icons_subtitles(self):
         self.start_tour(self.env['website'].get_client_action_url('/'), 'edit_megamenu_big_icons_subtitles', login='admin')
 
@@ -559,7 +576,8 @@ class TestUi(HttpCaseWithWebsiteUser):
     def test_update_column_count(self):
         self.start_tour(self.env['website'].get_client_action_url('/'), 'website_update_column_count', login="admin")
 
-    @unittest.skip
+    # TODO master-mysterious-egg fix error
+    @unittest.skip("prepare mysterious-egg for merging")
     def test_website_text_highlights(self):
         self.start_tour("/", 'text_highlights', login='admin')
 
@@ -614,7 +632,8 @@ class TestUi(HttpCaseWithWebsiteUser):
         })
         self.start_tour(self.env['website'].get_client_action_url('/'), 'interaction_lifecycle', login='admin')
 
-    @unittest.skip
+    # TODO master-mysterious-egg fix error
+    @unittest.skip("prepare mysterious-egg for merging")
     def test_drop_404_ir_attachment_url(self):
         website_snippets = self.env.ref('website.snippets')
         self.env['ir.ui.view'].create([{

--- a/addons/website/tests/test_website_form_editor.py
+++ b/addons/website/tests/test_website_form_editor.py
@@ -21,7 +21,8 @@ class TestWebsiteFormEditor(HttpCaseWithUserPortal):
             'phone': "+1 555-555-5555",
         })
 
-    @unittest.skip
+    # TODO master-mysterious-egg fix error
+    @unittest.skip("prepare mysterious-egg for merging")
     def test_tour(self):
         self.start_tour(self.env['website'].get_client_action_url('/'), 'website_form_editor_tour', login='admin', timeout=120)
         self.start_tour('/', 'website_form_editor_tour_submit')
@@ -60,8 +61,8 @@ class TestWebsiteFormEditor(HttpCaseWithUserPortal):
     def test_website_form_editable_content(self):
         self.start_tour('/', 'website_form_editable_content', login="admin")
 
-    # TODO @mysterious-egg: new tour
-    @unittest.skip
+    # TODO master-mysterious-egg fix error
+    @unittest.skip("prepare mysterious-egg for merging")
     def test_website_form_special_characters(self):
         self.start_tour('/', 'website_form_special_characters', login='admin')
         mail = self.env['mail.mail'].search([], order='id desc', limit=1)


### PR DESCRIPTION
The purpose of this commit is to add the message
"prepare mysterious-egg for merging" for all tours that have been skipped due to the website builder refactoring, to make it easier to identify and reactivate them.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
