### PR TITLE
[FIX] website: fix background color of mega menu mobile navbar

### DIFF
--- a/addons/website/static/src/scss/website.scss
+++ b/addons/website/static/src/scss/website.scss
@@ -1709,7 +1709,7 @@ header {
     .o_mega_nav {
         padding-left: $grid-gutter-width * .5;
         height: $o-mega-menu-nav-height;
-        background-color: inherit;
+        background-color: o-color('menu-custom') or o-color('menu');
     }
 
     // Div needed for selector specificity to apply mh


### PR DESCRIPTION
Steps to reproduce:

- Install the "Website" app.
- Go to the homepage.
- Click on "Site > Menu Editor" in the backend navbar.
- Create a submenu.
- Add a "Mega Menu Item" to the menu.
- Save the dialog.
- Enter edit mode.
- Click on the header.
- Select the "sidebar" template in the options.
- Open the "Mega Menu".
- Bug -> the website logo is visible under the left arrow icon.

The bug has appeared since commit [1], where an "inherit" value was added to the background color property of the mega menu nav. The goal was to apply the header's background color to the mega menu nav, but the chosen method was incorrect.

Indeed, "inherit" only takes the background color from the immediate parent, and does not search up the tree until it finds one with a defined background color.

In this case, since the parent had no background color set, the value ends up as "transparent".

[1]: https://github.com/odoo/odoo/commit/b975377fe688f10497b75598c0c50bd7b0758367