### PR TITLE
[FIX] html_builder: make visibility work while translating

### DIFF
--- a/addons/html_builder/static/src/core/builder_options_plugin_translate.js
+++ b/addons/html_builder/static/src/core/builder_options_plugin_translate.js
@@ -3,10 +3,11 @@ import { registry } from "@web/core/registry";
 
 export class BuilderOptionsPlugin extends Plugin {
     static id = "builderOptions";
-    static shared = ["deactivateContainers", "getTarget"];
+    static shared = ["deactivateContainers", "getTarget", "updateContainers"];
 
     deactivateContainers() {}
     getTarget() {}
+    updateContainers() {}
 }
 
 registry.category("translation-plugins").add(BuilderOptionsPlugin.id, BuilderOptionsPlugin);

--- a/addons/website/static/tests/builder/translation.test.js
+++ b/addons/website/static/tests/builder/translation.test.js
@@ -61,6 +61,16 @@ test("invisible elements in translate mode", async () => {
     ).toHaveCount(1);
 });
 
+test("show invisible elements in translate mode", async () => {
+    await setupSidebarBuilderForTranslation({ websiteContent: invisibleEl });
+
+    expect(":iframe .o_snippet_invisible").toHaveAttribute("data-invisible", "1");
+    await contains(
+        ".o_we_invisible_el_panel  .o_we_invisible_entry:contains('Invisible Element') i.fa-eye-slash"
+    ).click();
+    expect(":iframe .o_snippet_invisible").not.toHaveAttribute("data-invisible");
+});
+
 test("translate text", async () => {
     const resultSave = [];
     onRpc("/web_editor/field/translation/update", async (data) => {


### PR DESCRIPTION
Before this commit it would crash when you clicked on the visibility button in the invisible elements section while translating a website. To reproduce the issue:
1. Create a multilingual website
2. Drop a popup snippet
3. Switch to a secondary language, click edit and select "translate"
4. Click on the eye in the invisible elements panel below

=> We have an error.
This commit follows [the html_builder refactoring].

[the html_builder refactoring]: odoo/odoo@9fe45e2b7ddb