### PR TITLE
[FIX] html_builder: added tooltip popover when clicking on an image

### DIFF
--- a/addons/html_builder/static/src/core/media_website_plugin.js
+++ b/addons/html_builder/static/src/core/media_website_plugin.js
@@ -4,6 +4,8 @@ import { closestElement } from "@html_editor/utils/dom_traversal";
 import { shouldEditableMediaBeEditable } from "@html_builder/utils/utils_css";
 import { _t } from "@web/core/l10n/translation";
 import { isHtmlContentSupported } from "@html_editor/core/selection_plugin";
+import { Tooltip } from "@web/core/tooltip/tooltip";
+
 
 export class MediaWebsitePlugin extends Plugin {
     static id = "media_website";
@@ -65,14 +67,52 @@ export class MediaWebsitePlugin extends Plugin {
                 this.onDblClickEditableMedia(targetEl);
             }
         });
+
+        this.popover = this.services.popover;
+        this.tooltipTimeouts = [];
+        this.removeCurrentTooltip = () => {};
+
+        this.addDomListener(this.editable, "click", (ev) => {
+            const targetEl = ev.target.closest(mediaSelector);
+            if (!targetEl) {
+                return;
+            }
+            let isEditable = (targetEl.parentElement && targetEl.parentElement.isContentEditable);
+
+            if (!isEditable && targetEl.classList.contains("o_editable_media")) {
+                isEditable = shouldEditableMediaBeEditable(targetEl);
+            }
+            if (
+                isEditable &&
+                !isProtected(this.dependencies.selection.getEditableSelection().anchorNode)
+            ) {
+                this.openImageTooltip(targetEl);
+            }
+        });
     }
 
     onDblClickEditableMedia(mediaEl) {
+        this.removeCurrentTooltip();
+
         const params = { node: mediaEl };
         const sel = this.dependencies.selection.getEditableSelection();
 
         const editableEl =
             closestElement(params.node || sel.startContainer, ".o_editable") || this.editable;
         this.dependencies.media.openMediaDialog(params, editableEl);
+    }
+
+    openImageTooltip(mediaEl) {
+        //delete last tooltip if it's still displayed
+        this.removeCurrentTooltip();
+        
+        const removeTooltip = this.popover.add(mediaEl, Tooltip, { tooltip: _t('Double-click to edit')});
+        setTimeout(() => { removeTooltip() }, 1500);
+        this.removeCurrentTooltip = removeTooltip.bind(this);
+    }
+
+    destroy() {
+        super.destroy();
+        this.removeCurrentTooltip();
     }
 }

--- a/addons/website/static/tests/builder/images.test.js
+++ b/addons/website/static/tests/builder/images.test.js
@@ -1,9 +1,11 @@
 import { setSelection } from "@html_editor/../tests/_helpers/selection";
 import { describe, expect, test } from "@odoo/hoot";
 import {
-    manuallyDispatchProgrammaticEvent,
+    advanceTime,
     animationFrame,
+    click,
     dblclick,
+    manuallyDispatchProgrammaticEvent,
     queryAll,
     queryFirst,
     waitFor,
@@ -36,7 +38,18 @@ test("double click on Image", async () => {
     await dblclick(":iframe img.a_nice_img");
     await animationFrame();
     expect(".modal-content:contains(Select a media) .o_upload_media_button").toHaveCount(1);
+    expect("div.o-tooltip").toHaveCount(0);
 });
+
+test("simple click on Image", async () => {
+    await setupWebsiteBuilder(`<div><img class=a_nice_img src='${dummyBase64Img}'></div>`);
+    await click(":iframe img.a_nice_img");
+    await waitFor("div.o-tooltip");
+    expect("div.o-tooltip").toHaveCount(1);
+    await advanceTime(1600);
+    expect("div.o-tooltip").toHaveCount(0);
+});
+
 
 test("double click on text", async () => {
     await setupWebsiteBuilder("<div><p class=text_class>Text</p></div>");


### PR DESCRIPTION
problem:
The "Double-click to edit" popover tooltip when clicking once 
on an image was not displayed anymore.

to reproduce:
- In the website app, open the editor
- Click on any editable image
- The "Double-click to edit" popover is not displayed

why:
It has not been transferred in the new builder

desired behavior:
When clicking once on an editable image, a popover tooltip should
be displayed below the image with "Double-click to edit" message.
