### PR TITLE
[FIX] mrp,sale_mrp: kit adapt qty when packaging changed before valid…

### DIFF
--- a/addons/mrp/models/stock_move.py
+++ b/addons/mrp/models/stock_move.py
@@ -83,6 +83,30 @@ class StockMoveLine(models.Model):
         aggregated_properties['line_key'] += f'_{bom.id if bom else ""}'
         return aggregated_properties
 
+    def _compute_product_packaging_qty(self):
+        # we catch kit lines where the packaging is still the one from the final product (it has
+        # not been changed to a packaging of a component)
+        kit_lines = self.filtered(lambda move_line: move_line.move_id.bom_line_id.bom_id.type == 'phantom' and
+        move_line.product_id != move_line.move_id.product_packaging_id.product_id)
+        for move_line in kit_lines:
+            move = move_line.move_id
+            bom_line = move.bom_line_id
+            kit_bom = bom_line.bom_id
+
+            # Convert the move line quantity to the product's move uom
+            qty_move_uom = move_line.product_uom_id._compute_quantity(move_line.quantity, move_line.move_id.product_uom)
+            # Convert the product's move uom to the bom line's uom
+            qty_bom_uom = move.product_uom._compute_quantity(qty_move_uom, bom_line.product_uom_id)
+            # calculate the bom's kit qty in kit product uom qty
+            bom_qty_product_uom = kit_bom.product_uom_id._compute_quantity(kit_bom.product_qty, kit_bom.product_tmpl_id.uom_id)
+            # calculate the comp/final_prod ratio of the BOM
+            kit_ratio = bom_line.product_qty / bom_qty_product_uom
+            # calculate the number of kit on the move line according to the number of comp
+            kit_qty = qty_bom_uom / kit_ratio
+            # calculate the quantity needed of packaging
+            move_line.product_packaging_qty = kit_qty / move_line.move_id.product_packaging_id.qty
+        super(StockMoveLine, self - kit_lines)._compute_product_packaging_qty()
+
     @api.model
     def _compute_packaging_qtys(self, aggregated_move_lines):
         non_kit_ml = {}

--- a/addons/sale_mrp/tests/test_sale_mrp_kit_bom.py
+++ b/addons/sale_mrp/tests/test_sale_mrp_kit_bom.py
@@ -714,6 +714,7 @@ class TestSaleMrpKitBom(TransactionCase):
         """
         Test that when selling a kit, and changing the packaging on the stock move
         to the packaging of the comp, the correct quantity is computed when printing
+        before and after validating
         """
         grp_pack = self.env.ref('product.group_stock_packaging')
         self.env.user.write({'groups_id': [(4, grp_pack.id, 0)]})
@@ -755,9 +756,13 @@ class TestSaleMrpKitBom(TransactionCase):
             })],
         })
         so.action_confirm()
-        so.picking_ids.move_ids.product_packaging_id = packaging_comp
+        # check that before validating, the product packaging quantity is good, both if we keep the final product packages
+        # and if we change to a packages of the component
         so.picking_ids.move_ids.write({'quantity': 0.9})
-
+        self.assertEqual(so.picking_ids.move_ids.move_line_ids[0].product_packaging_qty, 1)
+        so.picking_ids.move_ids.product_packaging_id = packaging_comp
+        self.assertEqual(so.picking_ids.move_ids.move_line_ids[0].product_packaging_qty, 2)
+        # check that after validating, if the packages was changed to a package of the component the quantity is good
         so.picking_ids.button_validate()
         aggr_prod_qty = so.picking_ids.move_ids.move_line_ids[0]._get_aggregated_product_quantities(kit_name='Kit')
         key = f"{comp_product.id}_{comp_product.display_name}__{comp_product.uom_id.id}_{packaging_comp}_{kit_product.bom_ids.id}"


### PR DESCRIPTION
…ating

**Steps to reproduce:**
- Inside Settings/Sales activate the "Product Packagings" setting
- Create a new product (the final product)
- Inside the inventory tab add a packaging line for a pack of 9 units
- Create a new product (the comp product)
- In the general information tab, set a unit of mesure of g
- In the inventory tab add a packaging line for a pack of 0.9 g
- Set an on hand quantity for the comp product
- Create a new BOM for the final product
- Add a a line with the comp product for a quantity of 0.1 g
- Select kit
- Create a new quotation and select your kit product
- Select your packaging > Confirm
- Click on the delivery smart button
- print without validating

**Current behavior:**
traceback with error message :
"The unit of measure g defined on the order line
doesn't belong to the same category as the unit
of measure Units defined on the product."

**Cause of the issue:**
https://github.com/odoo/odoo/blob/57282becdeab5cdd7f581e149dede683fc352abe/addons/stock/models/stock_move_line.py#L136 line.move_id.product_packaging_id is the packaging of the final product whose uom is unit.
ine.product_uom_id is grams so _compute_quantity will fail

**fix**
the fix is a backport of https://github.com/odoo/odoo/pull/201580 with an adaptation of the filtering so that the lines where the packaging was changed on the line to a packaging of the component are sent to super (it otherwise results in a wrong quantity computation)

related to opw-4781180
