### PR TITLE
[IMP] purchase: hide 0 qty PO order_lines

### DIFF
--- a/addons/purchase/report/purchase_order_templates.xml
+++ b/addons/purchase/report/purchase_order_templates.xml
@@ -66,7 +66,7 @@
                 </thead>
                 <tbody>
                     <t t-set="current_subtotal" t-value="0"/>
-                    <t t-foreach="o.order_line" t-as="line">
+                    <t t-foreach="o.order_line.filtered(lambda l: l.display_type or l.product_qty != 0)" t-as="line">
                         <t t-set="current_subtotal" t-value="current_subtotal + line.price_subtotal"/>
 
                         <tr t-att-class="'fw-bold o_line_section' if line.display_type == 'line_section' else 'fst-italic o_line_note' if line.display_type == 'line_note' else ''">

--- a/addons/purchase/report/purchase_quotation_templates.xml
+++ b/addons/purchase/report/purchase_quotation_templates.xml
@@ -34,7 +34,7 @@
                     </tr>
                 </thead>
                 <tbody>
-                    <t t-foreach="o.order_line" t-as="order_line">
+                    <t t-foreach="o.order_line.filtered(lambda l: l.display_type or l.product_qty != 0)" t-as="order_line">
                         <tr t-att-class="'fw-bold o_line_section' if order_line.display_type == 'line_section' else 'fst-italic o_line_note' if order_line.display_type == 'line_note' else ''">
                             <t t-if="not order_line.display_type">
                                 <td id="product">

--- a/addons/purchase/views/portal_templates.xml
+++ b/addons/purchase/views/portal_templates.xml
@@ -300,7 +300,7 @@
 
                           <t t-set="current_subtotal" t-value="0"/>
 
-                          <t t-foreach="order.order_line" t-as="line">
+                          <t t-foreach="order.order_line.filtered(lambda l: l.display_type or l.product_qty != 0)" t-as="line">
 
                               <t t-set="current_subtotal" t-value="current_subtotal + line.price_subtotal"/>
 


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

When choosing a vendor among atlernative RFQ for a specific lines (using compare lines), it updates the quantity to 0 for the unselected lines but these lines are still sent in the PO/RFQ late

Current behavior before PR:

Print and portal templates render all PO lines, regardless of qty resulting in receivers of RFQ seeing 0 qty order lines

Desired behavior after PR is merged:

Hide 0 qty orderlines from the PDF and portal

task: [4638313](https://www.odoo.com/odoo/project/966/tasks/4638313)


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
