### PR TITLE
[IMP] web: hide daterange separator when only one date is set

### DIFF
--- a/addons/web/static/src/views/fields/datetime/datetime_field.xml
+++ b/addons/web/static/src/views/fields/datetime/datetime_field.xml
@@ -5,7 +5,7 @@
         <div class="d-flex gap-2 align-items-center" t-ref="root">
             <!-- Start date -->
             <t t-if="props.readonly">
-                <span class="text-truncate" t-esc="getFormattedValue(0)" />
+                <span t-if="!isEmpty(startDateField)" class="text-truncate" t-esc="getFormattedValue(0)" />
             </t>
             <t t-elif="!props.required and !props.alwaysRange and isEmpty(startDateField) and !isEmpty(endDateField)">
                 <button

--- a/addons/web/static/src/views/fields/datetime/list_datetime_field.js
+++ b/addons/web/static/src/views/fields/datetime/list_datetime_field.js
@@ -9,14 +9,6 @@ export class ListDateTimeField extends DateTimeField {
         const startDateRef = useRef("start-date");
         useAutoresize(startDateRef, { offset: -5 });
     }
-    /**
-     * @override
-     */
-    shouldShowSeparator() {
-        return this.props.readonly
-            ? this.relatedField && this.values.some(Boolean)
-            : super.shouldShowSeparator();
-    }
 }
 
 export const listDateField = { ...dateField, component: ListDateTimeField };

--- a/addons/web/static/tests/views/fields/daterange_field.test.js
+++ b/addons/web/static/tests/views/fields/daterange_field.test.js
@@ -812,20 +812,8 @@ test("list daterange with start date and empty end date", async () => {
             </list>`,
     });
 
-    const arrowIcon = queryFirst(".fa-long-arrow-right");
-    const textSiblings = [...arrowIcon.parentNode.childNodes]
-        .map((node) => {
-            if (node === arrowIcon) {
-                return "->";
-            } else if (node.nodeType === Node.TEXT_NODE) {
-                return node.nodeValue.trim();
-            } else {
-                return node.innerText?.trim();
-            }
-        })
-        .filter(Boolean);
-
-    expect(textSiblings).toEqual(["02/03/2017", "->"]);
+    expect(".o_field_daterange").toHaveText("02/03/2017");
+    expect(".o_field_daterange .fa-long-arrow-right").toHaveCount(0);
 });
 
 test("list daterange with empty start date and end date", async () => {
@@ -842,20 +830,8 @@ test("list daterange with empty start date and end date", async () => {
             </list>`,
     });
 
-    const arrowIcon = queryFirst(".fa-long-arrow-right");
-    const textSiblings = [...arrowIcon.parentNode.childNodes]
-        .map((node) => {
-            if (node === arrowIcon) {
-                return "->";
-            } else if (node.nodeType === Node.TEXT_NODE) {
-                return node.nodeValue.trim();
-            } else {
-                return node.innerText?.trim();
-            }
-        })
-        .filter(Boolean);
-
-    expect(textSiblings).toEqual(["->", "02/03/2017"]);
+    expect(".o_field_daterange").toHaveText("02/03/2017");
+    expect(".o_field_daterange .fa-long-arrow-right").toHaveCount(0);
 });
 
 test("list daterange: column widths", async () => {

--- a/addons/web/static/tests/views/list/list_view.test.js
+++ b/addons/web/static/tests/views/list/list_view.test.js
@@ -10755,7 +10755,6 @@ test(`list daterange with empty start date and end date`, async () => {
         `,
     });
     expect(queryAllTexts(`.o_data_row:eq(0) .o_field_widget[name=date] span`)).toEqual([
-        "",
         "01/25/2017",
     ]);
 });


### PR DESCRIPTION
This commit removes the override introduced in https://github.com/odoo/odoo/pull/125184/commits/5c02831e87e4f275e10c31d4e9e070f2c7ece152, which forced the display of the daterange separator in list views even when only one of the two dates was set.

With this change, the separator will no longer be shown in readonly mode unless both start and end dates have a value.

task-4868827
