### PR TITLE
[FIX] link selected contract template to employee version on load

### DIFF
--- a/addons/hr/wizard/hr_contract_template_wizard.py
+++ b/addons/hr/wizard/hr_contract_template_wizard.py
@@ -26,4 +26,5 @@ class HrDepartureWizard(models.TransientModel):
                 if field in whitelist and not self.env['hr.version']._fields[field].related
         }
         employee.write(val_list)
+        employee.version_id.contract_template_id = self.contract_template_id
         return


### PR DESCRIPTION
Issue:
When trying to submit the salary configurator form, the error "No signature template defined on this version .." occurs.

This is fixed by assigning the `contract_template_id` to `version.contract_template_id` when it's loaded and assigned to `hr.employee.contract_template_id`

task-4873800