### PR TITLE
[FIX] point_of_sale: update deleted products when opening pos

### DIFF
--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -203,7 +203,12 @@ class PosSession(models.Model):
     def filter_local_data(self, models_to_filter):
         response = {}
         for model, ids in models_to_filter.items():
-            response[model] = self.env[model].browse(ids)._unrelevant_records()
+            existing_records = self.env[model].browse(ids).exists()
+
+            non_existent_ids = set(ids) - set(existing_records.ids)
+            inactive_ids = set(existing_records._unrelevant_records())
+
+            response[model] = list(non_existent_ids | inactive_ids)
 
         return response
 


### PR DESCRIPTION
### Problem:
This commit https://github.com/odoo/odoo/commit/3c87fdc363183c8ced5ff2952c90a6c371f73fa7 filters archived products loaded to pos session's cache. It sends\ the ids of the current loaded products to filter_local_data. This creates a bug when deleting a product. The sent deleted product id will raise a missing error in the function, and will block opening and closing the session, unless they are manually deleted from IndexedDB.
The solution here is to filter both archived and deleted products.

### How to reproduce:
    * Open a shop and close it (to store products in cache)
    * Delete any product from the previous shop
    * Open the shop again

opw-4864574
