### PR TITLE
[IMP] core: id as required

### DIFF
--- a/odoo/addons/test_orm/tests/test_fields.py
+++ b/odoo/addons/test_orm/tests/test_fields.py
@@ -5217,3 +5217,20 @@ class TestModifiedPerformance(TransactionCase):
         self.assertEqual(self.modified_line_a_child.total_price_quantity, 30)
         self.assertEqual(self.modified_line_a.total_price_quantity, 35)
         self.assertEqual(self.modified_line_a.total_price, 7)
+
+
+@tagged('post_install', '-at_install')
+class PostInstallQueryResult(TransactionCase):
+
+    def test_not_null_id_query(self):
+        # Test at post_install since not_null_fields is only loaded at the end of the registry
+        Model = self.env['test_orm.model_active_field'].with_context(active_test=False)
+
+        with self.assertQueries(["""
+            SELECT "test_orm_model_active_field"."id"
+            FROM "test_orm_model_active_field"
+            WHERE "test_orm_model_active_field"."id" NOT IN %s
+            ORDER BY "test_orm_model_active_field"."id"
+        """]):
+            Model.search([('id', '!=', 1)])
+            Model.search([('id', '=', False)])  # No query

--- a/odoo/orm/domains.py
+++ b/odoo/orm/domains.py
@@ -1259,7 +1259,7 @@ def _optimize_in_required(condition, model):
     field = condition._field(model)
     if (
         field.falsy_value is None
-        and field.required
+        and (field.required or field.name == 'id')
         and field in model.env.registry.not_null_fields
         # only optimize if there are no NewId's
         and all(model._ids)

--- a/odoo/orm/registry.py
+++ b/odoo/orm/registry.py
@@ -753,16 +753,20 @@ class Registry(Mapping[str, type["BaseModel"]]):
             JOIN pg_namespace n ON c.relnamespace = n.oid
             WHERE n.nspname = 'public'
             AND a.attnotnull = true
-            AND a.attnum > 0;
+            AND a.attnum > 0
+            AND a.attname != 'id';
         ''')
         not_null_columns = set(cr.fetchall())
 
         self.not_null_fields.clear()
         for Model in self.models.values():
             if Model._auto and not Model._abstract:
-                for field in Model._fields.values():
+                for field_name, field in Model._fields.items():
+                    if field_name == 'id':
+                        self.not_null_fields.add(field)
+                        continue
                     if field.column_type and field.store and field.required:
-                        if (Model._table, field.name) in not_null_columns:
+                        if (Model._table, field_name) in not_null_columns:
                             self.not_null_fields.add(field)
                         else:
                             _schema.warning("Missing not-null constraint on %s", field)


### PR DESCRIPTION
Since https://github.com/odoo/odoo/pull/191236, we avoid useless condition IS NOT null for required field. But Field.Id is not flag as required, that means this opimisation doesn't apply on it.

An intuitive solution is to put id as required=True in the class but it means that Id will be flag as required for the webclient which may lead to different issue (same for export feature by example). Moreover it means that all id field will be in `registry.not_null_fields` (only valid at the end of the installation).

Choose a more safe change: modify condition of the `can_be_null` and the optimisation in domains.py for id field. Add a test.