### PR TITLE
[FIX] l10n_jo_edi: Unit price not matched

### DIFF
--- a/addons/l10n_jo_edi/models/account_edi_xml_ubl_21_jo.py
+++ b/addons/l10n_jo_edi/models/account_edi_xml_ubl_21_jo.py
@@ -27,9 +27,16 @@ class AccountEdiXmlUBL21JO(models.AbstractModel):
         return float_round(value, JO_MAX_DP)
 
     def _get_line_amount_before_discount_jod(self, line):
-        if line.discount < 100:
-            amount_after_discount = line.price_subtotal
-            return (amount_after_discount / (1 - line.discount / 100))
+        if line.discount < 100 and line.tax_ids:
+            taxes_res = line.tax_ids.with_context({'round_base': False}).compute_all(
+                line.price_unit,
+                quantity=line.quantity,
+                currency=line.currency_id,
+                product=line.product_id,
+                partner=line.partner_id,
+                is_refund=line.is_refund,
+            )
+            return taxes_res['total_excluded']
         else:
             # reported numbers won't matter if discount is 100%
             return line.price_unit * line.quantity

--- a/addons/l10n_jo_edi/tests/jo_edi_common.py
+++ b/addons/l10n_jo_edi/tests/jo_edi_common.py
@@ -81,8 +81,8 @@ class JoEdiCommon(AccountTestInvoicingCommon):
         move.action_post()
         return move
 
-    def _l10n_jo_create_refund(self, invoice_vals, return_reason, refund_vals):
-        invoice = self._l10n_jo_create_invoice(invoice_vals)
+    def _l10n_jo_create_refund(self, invoice, return_reason, refund_vals):
+        invoice = self._l10n_jo_create_invoice(invoice) if isinstance(invoice, dict) else invoice
         reversal = self.env['account.move.reversal'].with_context(active_model="account.move", active_ids=invoice.ids).create({
             'reason': return_reason,
             'journal_id': invoice.journal_id.id,

--- a/addons/l10n_jo_edi/tests/test_jo_edi_precision.py
+++ b/addons/l10n_jo_edi/tests/test_jo_edi_precision.py
@@ -345,3 +345,67 @@ class TestJoEdiPrecision(JoEdiCommon):
                 }),
             ],
         })
+
+    def test_jo_credit_notes_price_unit(self):
+        def get_price_units(xml_string):
+            root = self.get_xml_tree_from_string(xml_string)
+            for xml_line in root.findall('./{*}InvoiceLine'):
+                yield float(xml_line.findtext('{*}Price/{*}PriceAmount'))
+        self.company.l10n_jo_edi_taxpayer_type = 'sales'
+        self.company.l10n_jo_edi_sequence_income_source = '16683693'
+        invoice = self._l10n_jo_create_invoice({
+            'name': 'TestEIN014',
+            'invoice_date': '2023-11-10',
+            'invoice_line_ids': [
+                Command.create({
+                    'product_id': self.product_b.id,
+                    'price_unit': 11.11,
+                    'quantity': 9833,
+                    'discount': 3.12,
+                    'tax_ids': [Command.set((self.jo_general_tax_16_included).ids)],
+                }),
+                Command.create({
+                    'product_id': self.product_a.id,
+                    'price_unit': 10000.01,
+                    'quantity': 93333,
+                    'discount': 99.71,
+                    'tax_ids': [Command.set((self.jo_general_tax_16_included).ids)],
+                }),
+                Command.create({
+                    'product_id': self.product_a.id,
+                    'price_unit': 0.01,
+                    'quantity': 0.11,
+                    'discount': 2,
+                    'tax_ids': [Command.set((self.jo_general_tax_16_included).ids)],
+                }),
+            ],
+        })
+        refund = self._l10n_jo_create_refund(invoice, 'return reason', {
+            'invoice_line_ids': [
+                Command.create({
+                    'product_id': self.product_b.id,
+                    'price_unit': 11.11,
+                    'quantity': 3.11,
+                    'discount': 3.12,
+                    'tax_ids': [Command.set((self.jo_general_tax_16_included).ids)],
+                }),
+                Command.create({
+                    'product_id': self.product_a.id,
+                    'price_unit': 10000.01,
+                    'quantity': 2.02,
+                    'discount': 99.71,
+                    'tax_ids': [Command.set((self.jo_general_tax_16_included).ids)],
+                }),
+                Command.create({
+                    'product_id': self.product_a.id,
+                    'price_unit': 0.01,
+                    'quantity': 0.1,
+                    'discount': 2,
+                    'tax_ids': [Command.set((self.jo_general_tax_16_included).ids)],
+                }),
+            ],
+        })
+        invoice_file = self.env['account.edi.xml.ubl_21.jo']._export_invoice(invoice)[0]
+        refund_file = self.env['account.edi.xml.ubl_21.jo']._export_invoice(refund)[0]
+        for invoice_price_unit, refund_price_unit in zip(get_price_units(invoice_file), get_price_units(refund_file)):
+            self.assertEqual(invoice_price_unit, refund_price_unit)


### PR DESCRIPTION
In certain cases, the unit price value on a partial credit note does not match the unit price on the corresponding invoice
This commit solves this issue by using a more precise price subtotal in XML numbers calculations

task-4877278




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
