### PR TITLE
[PERF] stock: Batching get_rules_from_location

### DIFF
--- a/addons/stock/models/product.py
+++ b/addons/stock/models/product.py
@@ -594,24 +594,59 @@ class Product(models.Model):
     def _get_quantity_in_progress(self, location_ids=False, warehouse_ids=False):
         return defaultdict(float), defaultdict(float)
 
+    @api.model
+    def _get_rules_for_combinations(self, combinations, route_ids=False, result_dict=None, base_location_dict=None):
+        """ Return stock.rules related to combinations and route_ids.
+        Batched-like version of _get_rules_from_location with a different return type.
+
+        :param combinations: list of (product, location) pairs to find rules.
+        :param route_ids: stock.routes recordset used to filter rules.
+        :param result_dct: a dictionary mapping (product, location) -> rules
+        :param base_location_dict: a dictionary mapping (product, location) -> location
+        This param serves to store the root location (value) that led to the
+        current location (key) for the same product (key) following rule.location_src_id tree.
+
+        :return result dict: a dictionary mapping (product, location) -> rules
+        """
+        result_dict = result_dict or defaultdict(lambda: self.env['stock.rule'])
+        base_location_dict = base_location_dict or {}
+        unique_combinations = {(
+                product,
+                location,
+                location.warehouse_id or result_dict[product, location].propagate_warehouse_id
+            )
+            for product, location in combinations
+        }
+        rule_dict = self.env['procurement.group'].with_context(active_test=True)._get_rules_for_combinations(
+            unique_combinations,
+            {'route_ids': route_ids}
+        )
+        next_combinations = []
+        for product, location, warehouse in unique_combinations:
+            candidate_rule = rule_dict.get((product, location, warehouse), self.env['stock.rule'])
+            base_location = base_location_dict.get((product, location), location)
+            base_location_dict[product, candidate_rule.location_src_id] = base_location
+            # Check for rules that are not bound to a specific warehouse
+            candidate_rule = candidate_rule or rule_dict.get(
+                (product, location, self.env["stock.warehouse"]),
+                self.env["stock.rule"],
+            )
+            if candidate_rule in result_dict[product, base_location]:
+                raise UserError(_("Invalid rule's configuration, the following rule causes an endless loop: %s", candidate_rule.display_name))
+            if not candidate_rule:
+                continue
+            if candidate_rule.procure_method == 'make_to_stock' or candidate_rule.action not in ('pull_push', 'pull'):
+                result_dict[product, base_location] |= candidate_rule
+            else:
+                result_dict[product, base_location] |= candidate_rule
+                next_combinations.append((product, candidate_rule.location_src_id))
+        if not next_combinations:
+            return result_dict
+        return self._get_rules_for_combinations(next_combinations, route_ids, result_dict, base_location_dict)
+
     def _get_rules_from_location(self, location, route_ids=False, seen_rules=False):
-        if not seen_rules:
-            seen_rules = self.env['stock.rule']
-        warehouse = location.warehouse_id
-        if not warehouse and seen_rules:
-            warehouse = seen_rules[-1].propagate_warehouse_id
-        rule = self.env['procurement.group'].with_context(active_test=True)._get_rule(self, location, {
-            'route_ids': route_ids,
-            'warehouse_id': warehouse,
-        })
-        if rule in seen_rules:
-            raise UserError(_("Invalid rule's configuration, the following rule causes an endless loop: %s", rule.display_name))
-        if not rule:
-            return seen_rules
-        if rule.procure_method == 'make_to_stock' or rule.action not in ('pull_push', 'pull'):
-            return seen_rules | rule
-        else:
-            return self._get_rules_from_location(rule.location_src_id, seen_rules=seen_rules | rule)
+        rule_dict = self._get_rules_for_combinations([(self, location)], route_ids=route_ids)
+        return rule_dict[self, location]
 
     def _get_dates_info(self, date, location, route_ids=False):
         rules = self._get_rules_from_location(location, route_ids=route_ids)

--- a/addons/stock/models/stock_rule.py
+++ b/addons/stock/models/stock_rule.py
@@ -563,84 +563,139 @@ class ProcurementGroup(models.Model):
         return res
 
     @api.model
-    def _get_rule(self, product_id, location_id, values):
-        """ Find a pull rule for the location_id, fallback on the parent
+    def _get_rules_for_combinations(self, combinations, values):
+        """ Find pull rules for the location_ids, fallback on the parent
         locations if it could not be found.
+        Batched version of _get_rule with a different return type.
+
+        :param combinations: list of (product_id, location_id, warehouse_id) triplets
+        :param values: kwargs type parameter. Common keys are route_ids and product_packaging_id
+
+        :return result_dict: a dict mapping (product, location, warehouse) -> stock.rule
         """
-        result = self.env['stock.rule']
-        if not location_id:
-            return result
-        locations = location_id
-        # Get the location hierarchy, starting from location_id up to its root location.
-        while locations[-1].location_id:
-            locations |= locations[-1].location_id
-        domain = self._get_rule_domain(locations, values)
+        result_dict = {}
+        # Replace False warehouses/products by empty recordset and uniquify combinations.
+        unique_combinations = {
+            (combination[0] or self.env['product.product'], combination[1], combination[2] or self.env['stock.warehouse'])
+            for combination in combinations
+        }
+        products, locations, warehouses = zip(*unique_combinations)
+        products = self.env['product.product'].union(*products)
+        locations = self.env['stock.location'].union(*locations)
+        warehouses = self.env['stock.warehouse'].union(*warehouses)
+        if not locations:
+            return result_dict
+        all_locations = self.env['stock.location']
+        for location in locations:
+            all_locations |= location
+            # Get the location hierarchy, starting from location_id up to its root location.
+            while all_locations[-1].location_id and all_locations[-1].location_id not in all_locations:
+                all_locations |= all_locations[-1].location_id
+        domain = self._get_rule_domain(all_locations, values)
         # Get a mapping (location_id, route_id) -> warehouse_id -> rule_id
         rule_dict = self._search_rule_for_warehouses(
             values.get("route_ids", False),
             values.get("product_packaging_id", False),
-            product_id,
-            values.get("warehouse_id", locations.warehouse_id),
+            products,
+            warehouses or all_locations.warehouse_id,
             domain,
         )
+        # Buid a mapping location-id -> is_intercomp_location
+        location_intercomp_dict = {
+            location.id: self._check_intercomp_location(location)
+            for location in all_locations
+        }
 
-        def extract_rule(rule_dict, route_ids, warehouse_id, location_dest_id):
+        def extract_rule(rule_dict, routes, warehouse, location_dest):
             rule = self.env['stock.rule']
-            for route_id in sorted(route_ids, key=lambda r: r.sequence):
-                sub_dict = rule_dict.get((location_dest_id.id, route_id.id))
+            for route in routes:
+                sub_dict = rule_dict.get((location_dest.id, route.id))
                 if not sub_dict:
                     continue
-                if not warehouse_id:
+                if not warehouse:
                     rule = sub_dict[next(iter(sub_dict))]
+                elif warehouse.id not in sub_dict and False not in sub_dict:
+                    continue
                 else:
-                    rule = sub_dict.get(warehouse_id.id)
+                    rule = sub_dict.get(warehouse.id)
                     rule = rule or sub_dict[False]
                 if rule:
                     break
             return rule
 
-        def get_rule_for_routes(rule_dict, route_ids, packaging_id, product_id, warehouse_id, location_dest_id):
-            res = self.env['stock.rule']
-            if route_ids:
-                res = extract_rule(rule_dict, route_ids, warehouse_id, location_dest_id)
-            if not res and packaging_id:
-                res = extract_rule(rule_dict, packaging_id.route_ids, warehouse_id, location_dest_id)
-            if not res:
-                res = extract_rule(rule_dict, product_id.route_ids | product_id.categ_id.total_route_ids, warehouse_id, location_dest_id)
-            if not res and warehouse_id:
-                res = extract_rule(rule_dict, warehouse_id.route_ids, warehouse_id, location_dest_id)
-            return res
+        def get_rule_for_tuple(rule_dict, product_routes, warehouse, routes_by_warehouse, location_dest, routes, packaging_routes, multi_company_user):
+            result = self.env['stock.rule']
+            location = location_dest
+            # Go through the location hierarchy again, this time breaking at the first valid stock.rule found
+            # in rules_by_location.
+            inter_comp_location_checked = False
+            while (not result) and location:
+                candidate_locations = location
+                if not inter_comp_location_checked and multi_company_user and location_intercomp_dict[location.id]:
+                    # Add the intercomp location to candidate_locations as the intercomp domain was added
+                    # above in the call to _get_rule_domain.
+                    inter_comp_location = self.env.ref('stock.stock_location_customers', raise_if_not_found=False)
+                    candidate_locations |= inter_comp_location
+                    inter_comp_location_checked = True
+                for candidate_location in candidate_locations:
+                    warehouse = warehouse or candidate_location.warehouse_id
+                    if routes:
+                        result = extract_rule(rule_dict, routes, warehouse, candidate_location)
+                    if not result and packaging_routes:
+                        result = extract_rule(rule_dict, packaging_routes, warehouse, candidate_location)
+                    if not result and product_routes:
+                        result = extract_rule(rule_dict, product_routes, warehouse, candidate_location)
+                    if not result and warehouse:
+                        result = extract_rule(rule_dict, routes_by_warehouse.get(warehouse.id), warehouse, candidate_location)
+                    if result:
+                        break
+                else:
+                    location = location.location_id
+            return result
 
-        location = location_id
-        # Go through the location hierarchy again, this time breaking at the first valid stock.rule found
-        # in rules_by_location.
-        inter_comp_location_checked = False
-        while (not result) and location:
-            candidate_locations = location
-            if not inter_comp_location_checked and self._check_intercomp_location(location):
-                # Add the intercomp location to candidate_locations as the intercomp domain was added
-                # above in the call to _get_rule_domain.
-                inter_comp_location = self.env.ref('stock.stock_location_customers', raise_if_not_found=False)
-                candidate_locations |= inter_comp_location
-                inter_comp_location_checked = True
-            for candidate_location in candidate_locations:
-                result = get_rule_for_routes(
-                    rule_dict,
-                    values.get("route_ids", self.env['stock.route']),
-                    values.get("product_packaging_id", self.env['product.packaging']),
-                    product_id,
-                    values.get("warehouse_id", candidate_location.warehouse_id),
-                    candidate_location,
-                )
-                if result:
-                    break
-            else:
-                location = location.location_id
-        return result
+        multi_company_user = self.env.user.has_group('base.group_multi_company')
+        intercomp_warehouse = self.env.ref('stock.stock_location_customers', raise_if_not_found=False).warehouse_id or self.env['stock.warehouse']
+        # Get routes in advance to avoid doing lots of One2many convert_to_record calls.
+        routes_by_product = {
+            p.id: sorted(p.route_ids | p.categ_id.total_route_ids, key=lambda r: r.sequence)
+            for p in products
+        }
+        routes_by_warehouse = {
+            w.id: sorted(w.route_ids, key=lambda r: r.sequence)
+            for w in (
+                warehouses
+                or locations.warehouse_id | intercomp_warehouse)
+        }
+        routes = sorted(values.get("route_ids") or self.env['stock.route'], key=lambda r: r.sequence)
+        packaging_routes = sorted((values.get('product_packaging_id') or self.env['product.packaging']).route_ids, key=lambda r: r.sequence)
+        for product, location, warehouse in unique_combinations:
+            result = get_rule_for_tuple(
+                rule_dict,
+                routes_by_product.get(product.id),
+                warehouse,
+                routes_by_warehouse,
+                location,
+                routes,
+                packaging_routes,
+                multi_company_user,
+            )
+            result_dict[product, location, warehouse] = result
+        return result_dict
+
+    @api.model
+    def _get_rule(self, product_id, location_id, values):
+        """ Find a pull rule for the location_id, fallback on the parent
+        locations if it could not be found.
+        """
+        if not location_id:
+            return self.env['stock.rule']
+        result_dict = self._get_rules_for_combinations([(product_id, location_id, values.get('warehouse_id', False))], values)
+        warehouse_id = values.get('warehouse_id') or self.env['stock.warehouse']
+        return result_dict[product_id, location_id, warehouse_id]
 
     @api.model
     def _check_intercomp_location(self, locations):
-        if self.env.user.has_group('base.group_multi_company') and locations.filtered(lambda location: location.usage == 'transit'):
+        if locations.filtered(lambda location: location.usage == 'transit'):
             inter_comp_location = self.env.ref('stock.stock_location_inter_company', raise_if_not_found=False)
             return inter_comp_location and inter_comp_location.id in locations.ids
 
@@ -649,7 +704,7 @@ class ProcurementGroup(models.Model):
         location_ids = locations.ids
         # If the method is called to find rules towards the Inter-company location, also add the 'Customer' location in the domain.
         # This is to avoid having to duplicate every rules that deliver to Customer to have the Inter-company part.
-        if self._check_intercomp_location(locations):
+        if self.env.user.has_group('base.group_multi_company') and self._check_intercomp_location(locations):
             location_ids.append(self.env.ref('stock.stock_location_customers', raise_if_not_found=False).id)
         domain = ['&', ('location_dest_id', 'in', location_ids), ('action', '!=', 'push')]
         # In case the method is called by the superuser, we need to restrict the rules to the


### PR DESCRIPTION
Currrently `product.product._get_rules_from_location` can become a performance bottleneck when it's called multiple times. Because the method finds a candidate stock.rule then call itself recursively with stock.rule.location_src_id, it's difficult to properly batch.

In this commit we introduce two methods, `product.product._get_rules_for_combinations` and
`procurement.group._get_rules_for_combinations`.

The second one is a batched version of `get_rule`. The idea is that given a list of (products, locations, warehouses), the method will call `search_rules_for_warehouses` only once and then distribute the fetched stock.rule to the correct `(product, location, warehouse)` triplet by building a dictionary.

This is then used by `product.product.get_rules_for_combinations` which takes a list of `(products, locations)` pairs and build a recordset of stock.rules for each one.

The way to use this workflow is the following:
 - The calling code creates the list of (product_id, location_id) it needs. E.g. `[(o.product_id, o.location_id) for o in orderpoints)]`
 - A single call to `product.product._get_rules_for_combinations`
 - stock.rules are then extracted by the calling code using the resulting dictionary.

Assuming the worst case, the current code does (n+k) calls to both `product.product._get_rules_from_location` and `procurement.group._get_rule`, with n being `len([(r.product_id, r.location_id) for r in records])` and k the total number of recursive calls in `product.product._get_rules_from_location`

After this commit, the worst case will be h calls to both methods, with h being the height of
`product.product._get_rules_for_combinations` recursive call tree.

#### speedup

Current iterative version product._get_rules_from_location 
| Total loops count |  Exec Time |
|:-------------------:|:------------:|
|        10         |     50ms   |
|        50         |     62ms   |
|       500         |     567ms  |
|     7 441         |     5.6s   |

Benchmark of product._get_rules_for_combinations
| combinations Nb | Exec Time |
|:-------------------:|:-----------:|
|       10        |   24 ms   |
|       50        |   23ms    |
|      500        |   93ms    |
|    7 441        |   1.23s   |

Average speedup calling both method from a shell: 2.4

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
