### PR TITLE
[FIX] website, html_editor: cleanup highlight in DOM

### DIFF
--- a/addons/html_editor/static/src/core/format_plugin.js
+++ b/addons/html_editor/static/src/core/format_plugin.js
@@ -568,7 +568,7 @@ export class FormatPlugin extends Plugin {
      */
     mergeAdjacentInlines(root, { preserveSelection = true } = {}) {
         let selectionToRestore = null;
-        for (const node of descendants(root)) {
+        for (const node of [root, ...descendants(root)]) {
             if (this.shouldBeMergedWithPreviousSibling(node)) {
                 if (preserveSelection) {
                     selectionToRestore ??= this.dependencies.selection.preserveSelection();

--- a/addons/html_editor/static/tests/color.test.js
+++ b/addons/html_editor/static/tests/color.test.js
@@ -1,7 +1,8 @@
-import { after, before, describe, test } from "@odoo/hoot";
-import { testEditor } from "./_helpers/editor";
+import { after, before, describe, expect, test } from "@odoo/hoot";
+import { setupEditor, testEditor } from "./_helpers/editor";
 import { unformat } from "./_helpers/format";
 import { setColor } from "./_helpers/user_actions";
+import { getContent } from "./_helpers/selection";
 
 const redToBlueGradient = "linear-gradient(rgb(255, 0, 0), rgb(0, 0, 255))";
 const greenToBlueGradient = "linear-gradient(rgb(0, 255, 0), rgb(0, 0, 255))";
@@ -513,6 +514,17 @@ test("should apply gradient text color on selected text", async () => {
             '<div style="background-image:none"><p><font class="text-gradient" style="background-image: linear-gradient(135deg, rgb(255, 174, 127) 0%, rgb(109, 204, 0) 100%);">[ab<strong>cd</strong>ef]</font></p></div>',
     });
 });
+
+test("should merge adjacent font with the same text color when mutations common root is <font>", async () => {
+    // This test should not execute clean for save as the bug will no longer exists
+    const { el, editor } = await setupEditor(
+        '<p><font style="color: rgb(255, 0, 0);">first </font><font style="color: rgb(0, 255, 0);">[second]</font></p>'
+    );
+    await setColor("rgb(255, 0, 0)", "color")(editor);
+    const expected = '<p><font style="color: rgb(255, 0, 0);">first [second]</font></p>';
+    expect(getContent(el)).toBe(expected);
+});
+
 describe("colorElement", () => {
     test("should apply o_cc1 class to the element when a color wasn't defined", async () => {
         await testEditor({

--- a/addons/website/static/src/builder/plugins/highlight/highlight_plugin.js
+++ b/addons/website/static/src/builder/plugins/highlight/highlight_plugin.js
@@ -65,6 +65,14 @@ export class HighlightPlugin extends Plugin {
         selectionchange_handlers: this.updateSelectedHighlight.bind(this),
         collapsed_selection_toolbar_predicate: (selectionData) =>
             !!closestElement(selectionData.editableSelection.anchorNode, ".o_text_highlight"),
+        remove_format_handlers: () => {
+            const highlightedNodes = this.getSelectedHighlightNodes();
+            for (const node of new Set(highlightedNodes)) {
+                for (const svg of node.querySelectorAll(".o_text_highlight_svg")) {
+                    svg.remove();
+                }
+            }
+        },
     };
 
     setup() {
@@ -168,10 +176,7 @@ export class HighlightPlugin extends Plugin {
     getSelectedHighlightNodes() {
         return this.dependencies.selection
             .getTargetedNodes()
-            .map((n) => {
-                const el = n.nodeType === Node.ELEMENT_NODE ? n : n.parentElement;
-                return el.closest(".o_text_highlight");
-            })
+            .map((n) => closestElement(n, ".o_text_highlight"))
             .filter(Boolean);
     }
     /**

--- a/addons/website/static/src/builder/plugins/highlight/highlight_plugin.js
+++ b/addons/website/static/src/builder/plugins/highlight/highlight_plugin.js
@@ -8,7 +8,7 @@ import { HighlightConfigurator } from "./highlight_configurator";
 import { StackingComponent, useStackingComponentState } from "./stacking_component";
 import { formatsSpecs } from "@html_editor/utils/formatting";
 import { closestElement, descendants } from "@html_editor/utils/dom_traversal";
-import { removeStyle } from "@html_editor/utils/dom";
+import { removeClass, removeStyle } from "@html_editor/utils/dom";
 import { isTextNode } from "@html_editor/utils/dom_info";
 import { getCurrentTextHighlight } from "@website/js/highlight_utils";
 import { isCSSColor, rgbaToHex } from "@web/core/utils/colors";
@@ -237,7 +237,7 @@ formatsSpecs.highlight = {
     addStyle: (node, { highlightId, thicknessToRestore, colorToRestore }) => {
         node.dispatchEvent(new Event("text_highlight_added", { bubbles: true }));
         node.classList.add("o_text_highlight", `o_text_highlight_${highlightId}`);
-        if (colorToRestore) {
+        if (colorToRestore && colorToRestore !== "currentColor") {
             node.style.setProperty("--text-highlight-color", colorToRestore);
         }
         if (thicknessToRestore) {
@@ -251,7 +251,8 @@ formatsSpecs.highlight = {
         }
     },
     removeStyle: (node) => {
-        node.classList.remove(
+        removeClass(
+            node,
             ...[...node.classList].filter((cls) => cls.startsWith("o_text_highlight"))
         );
         removeStyle(node, "--text-highlight-width");

--- a/addons/website/static/tests/builder/website_builder/highlight.test.js
+++ b/addons/website/static/tests/builder/website_builder/highlight.test.js
@@ -7,6 +7,7 @@ import { expandToolbar } from "@html_editor/../tests/_helpers/toolbar";
 import { HighlightPlugin } from "@website/builder/plugins/highlight/highlight_plugin";
 import { MAIN_PLUGINS } from "@html_editor/plugin_sets";
 import { contains } from "@web/../tests/web_test_helpers";
+import { closestElement } from "@html_editor/utils/dom_traversal";
 
 defineMailModels();
 
@@ -121,4 +122,24 @@ test("Similar adjacent highlights are merged", async () => {
     await contains(".o_popover .o_text_highlight_freehand_2").click();
     expect("p>.o_text_highlight_freehand_2").toHaveCount(1);
     expect("p>.o_text_highlight_freehand_1").toHaveCount(0);
+});
+
+test("Remove format on highlight does not create an empty node", async () => {
+    const { editor } = await setupEditor(
+        `<p>
+            <span class="o_text_highlight o_text_highlight_freehand_2" style="--text-highlight-color: #E79C9C; --text-highlight-width: 2px;">highligh[t]<svg class="o_text_highlight_svg"></svg></span>
+        </p>`,
+        { config: { Plugins: [...MAIN_PLUGINS, HighlightPlugin] } }
+    );
+    await expandToolbar();
+    const selectedHighlights = (editor) =>
+        editor.shared.selection
+            .getTargetedNodes()
+            .map((n) => closestElement(n, ".o_text_highlight"))
+            .filter(Boolean);
+    expect("p>.o_text_highlight_freehand_2").toHaveCount(1);
+    expect(selectedHighlights(editor)).toHaveLength(1);
+    await contains(".o-we-toolbar .fa-eraser").click();
+    expect("p>.o_text_highlight_freehand_2").toHaveCount(1);
+    expect(selectedHighlights(editor)).toHaveLength(0);
 });

--- a/addons/website/static/tests/builder/website_builder/highlight.test.js
+++ b/addons/website/static/tests/builder/website_builder/highlight.test.js
@@ -103,3 +103,22 @@ test("Can remove an highlight with the trash button", async () => {
     await click("button[title='Reset']");
     expect(".o_text_highlight").toHaveCount(0);
 });
+
+test("Similar adjacent highlights are merged", async () => {
+    await setupEditor(
+        `<p>
+            <span class="o_text_highlight o_text_highlight_freehand_2" style="--text-highlight-width: 1px;">highlight</span><span class="o_text_highlight o_text_highlight_freehand_1">[highlight2]</span>
+        </p>`,
+        { config: { Plugins: [...MAIN_PLUGINS, HighlightPlugin] } }
+    );
+    await expandToolbar();
+    expect(".o-select-highlight").toHaveCount(1);
+    await contains(".o-we-toolbar .o-select-highlight").click();
+
+    expect("p>.o_text_highlight_freehand_2").toHaveCount(1);
+    expect("p>.o_text_highlight_freehand_1").toHaveCount(1);
+    await contains("#highlightPicker").click();
+    await contains(".o_popover .o_text_highlight_freehand_2").click();
+    expect("p>.o_text_highlight_freehand_2").toHaveCount(1);
+    expect("p>.o_text_highlight_freehand_1").toHaveCount(0);
+});


### PR DESCRIPTION
This PR has a few commits to clean up the DOM when the user performs operations on highlights. 
Some cases were not handled, which meant that similar highlights were not merged leading to a messy DOM.

[[FIX] website: fix similar highlight merging](https://github.com/odoo/odoo/pull/214852/commits/128587261494921ca64d55745345d8a70d2578b9)
Steps to reproduce:
- Go to the website builder in edit mode
- Write "test1Test2"
- Select "test1" and put an underline highlight
- Select "Test2" and put another highlight
- Select "Test2" and change the highlight to underline

Expected Behaviour
test1 and Test2 are merged into the same highlight

Current Behaviour
test1 and Test2 are not merged into the same highlight.

[[FIX] html_editor: ensure similar adjacent node are merged](https://github.com/odoo/odoo/pull/214852/commits/f516c8243ea0a79ded73db4c89134b58036a655d)
Steps to reproduce:
- Go to a project task
- Type "test1 test2" in the editor
- Color "test1" in red
- Color " test2" in orange
- Color " test2" in red

Current behaviour:
"test1" and " test2" are not merged into the same `<font>` node.

Expected behaviour:
"test1" and "test2" are merged in the same `<font>` node.

Technical explanation:
When applying the color to "<font ...> test2</font>",
the common ancestor mutation node is the `font` node itself.
The `normalize` and then `mergeAdjacentInlines` methods are therefore
 called with this node as the `root`. The problem is that
`mergeAdjacentInlines` does not check if the root should be merged
with adjacent nodes.

While it is not a visual bug for colors, it matters for highlights
who's impacted by the same bug.
e.g. Two unmerged "circle" highlight is not visually the same than
one merged "circle" highlight.

[[FIX] website: avoid empty node when removing highlight format](https://github.com/odoo/odoo/pull/214852/commits/6e056598d3ca33cb45308fe0e6b4c35ff8ac2211)
Steps to reproduce:
- Go to the website builder in edit mode
- Select a text
- Put a highlight with the highlight button in the toolbar
- Select the end of the highlight
- Click on "Remove Format" in the toolbar (eraser button)

Current behaviour:
The highlight is removed but an empty highlight node is created.
It's not visible but it pollutes the DOM.

![image](https://github.com/user-attachments/assets/d40ad37f-8705-48fa-bfce-706fd45cafea)

Expected behaviour:
The highlight is removed without pollution in the DOM.
