### PR TITLE
[FIX] website: fix shadow on mobile preview

### DIFF
--- a/addons/website/static/src/scss/website.backend.scss
+++ b/addons/website/static/src/scss/website.backend.scss
@@ -96,7 +96,8 @@
     box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15),
                 16px 12px 32px rgba(0, 0, 0, 0.15),
                 64px 0 64px rgba(0, 0, 0, 0.15);
-    border-radius: 2rem;
+    border-radius: 3.5vh;
+    background-color: white;
 
     iframe {
         height: 87%;
@@ -108,9 +109,11 @@
     @for $max-height from 800 through 600 {
         @if $max-height % 25 == 0 {
             $scale: 0.0016 * $max-height - 0.37;
+            $adjusted-radius: 3.5vh / $scale;
             @media (max-height: #{$max-height}px) {
                 height: (90 / $scale) * 1%;
                 transform: translate(-50%, -50%) scale($scale);
+                border-radius: $adjusted-radius;
                 // Add min-height for 600px only.
                 @if $max-height == 600 {
                     min-height: 740px;


### PR DESCRIPTION
This PR aims to fix an issue about the shadow around the device in the mobile preview, specifically in the corners, when the height of the viewport is bigger than 1080px.

Prior to this, the border-radius property was not correctly aligned with the radius of the mobile device image (in `.o_mobile_preview_layout`). 

| Before | After |
|--------|--------|
| <img width="468" alt="image" src="https://github.com/user-attachments/assets/1d8aaba4-2e8f-45fd-a6b8-853c82051a51" /> | <img width="468" alt="image" src="https://github.com/user-attachments/assets/b3a10e9b-ac53-429d-8780-a03120316df4" /> | 

task-4795450


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
