### PR TITLE
[IMP] account: Make invoice legal notes translatable

### DIFF
--- a/addons/account/models/account_tax.py
+++ b/addons/account/models/account_tax.py
@@ -220,7 +220,7 @@ class AccountTax(models.Model):
     country_code = fields.Char(related='country_id.code', readonly=True)
     is_used = fields.Boolean(string="Tax used", compute='_compute_is_used')
     repartition_lines_str = fields.Char(string="Repartition Lines", tracking=True, compute='_compute_repartition_lines_str')
-    invoice_legal_notes = fields.Html(string="Legal Notes", help="Legal mentions that have to be printed on the invoices.")
+    invoice_legal_notes = fields.Html(string="Legal Notes", translate=True, help="Legal mentions that have to be printed on the invoices.")
     # Technical field depicting if the tax has at least one repartition line with a percentage below 0.
     # Used for the taxes computation to manage the reverse charge taxes having a repartition +100 -100.
     has_negative_factor = fields.Boolean(compute='_compute_has_negative_factor')


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
The invoice legal notes on account.tax is not translatable.

Current behavior before PR:
Legal notes can only be configured in one language.

Desired behavior after PR is merged:
Legal notes can be translated.




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
