### PR TITLE
[FIX] pos_restaurant: add function used to be overridden

### DIFF
--- a/addons/pos_restaurant/static/src/app/screens/ticket_screen/ticket_screen.js
+++ b/addons/pos_restaurant/static/src/app/screens/ticket_screen/ticket_screen.js
@@ -106,6 +106,10 @@ patch(TicketScreen.prototype, {
         }
         return super.isDefaultOrderEmpty(...arguments);
     },
+    // Used to override inside `pos_blackbox_be` and `pos_urban_piper`
+    async _doneOrder(order) {
+        return;
+    },
 });
 
 export class TipCell extends Component {


### PR DESCRIPTION
We added a function in the ticket screen in order to override it in the modules `pos_urban_piper` and `pos_blackbox_be`.

task-id: 4781945

enterprise PR: https://github.com/odoo/enterprise/pull/87989




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
