### PR TITLE
[FIX] hr_timesheet : Keep x_plan_id when saving timesheet

### DIFF
--- a/addons/hr_timesheet/models/hr_timesheet.py
+++ b/addons/hr_timesheet/models/hr_timesheet.py
@@ -197,7 +197,11 @@ class AccountAnalyticLine(models.Model):
 
             company = task.company_id or project.company_id or self.env['res.company'].browse(vals.get('company_id'))
             vals['company_id'] = company.id
-            vals.update(self._timesheet_preprocess_get_accounts(vals))
+            vals.update({
+                fname: account_id
+                for fname, account_id in self._timesheet_preprocess_get_accounts(vals).items()
+                if fname not in vals
+            })
 
             if not vals.get('product_uom_id'):
                 vals['product_uom_id'] = company.project_time_mode_id.id
@@ -290,7 +294,11 @@ class AccountAnalyticLine(models.Model):
             raise ValidationError(_('Timesheets cannot be created on a private task.'))
         if project or task:
             values['company_id'] = task.company_id.id or project.company_id.id
-        values.update(self._timesheet_preprocess_get_accounts(values))
+        values.update({
+            fname: account_id
+            for fname, account_id in self._timesheet_preprocess_get_accounts(values).items()
+            if fname not in values
+        })
 
         if values.get('employee_id'):
             employee = self.env['hr.employee'].browse(values['employee_id'])


### PR DESCRIPTION
### Steps to reproduce:
	- Navigate to a Project > View (Timesheets)
	- Open studio and add x_plan2_id for example to the view
	- Try creating a new timesheet and set a value for the field we added using studio
	- Save and notice the field doesn't keep its value

### Cause:
This is mainly happening because when getting the plan_ids for the account we are gonna fill we just get the account in the distribution and ignore if the user is setting another value

### Fix:
We check the create vals_list if a plan has value we set it before setting the account in the distribution

opw-4716041