### PR TITLE
[FIX] l10n_ar: 5614/2024: Tax Breakdown on B2C (0.0 taxes)

### DIFF
--- a/addons/l10n_ar/models/account_move.py
+++ b/addons/l10n_ar/models/account_move.py
@@ -403,7 +403,6 @@ class AccountMove(models.Model):
             if (
                 grouping_key
                 and not grouping_key['skip']
-                and not self.currency_id.is_zero(values['tax_amount_currency'])
             ):
                 results.append({
                     'name': grouping_key['name'],

--- a/addons/l10n_ar/tests/test_manual.py
+++ b/addons/l10n_ar/tests/test_manual.py
@@ -255,7 +255,7 @@ class TestManual(common.TestAr):
     def test_19_invoice_b_tax_breakdown_2(self):
         """ Display only Other Taxes (VAT taxes are 0) """
         invoice = self._create_invoice_from_dict({
-            'ref': 'test_invoice_21:  inal Consumer Invoice B with 0 tax and internal tax',
+            'ref': 'test_invoice_21: Final Consumer Invoice B with 0 tax and internal tax',
             "move_type": 'out_invoice',
             "partner_id": self.partner_cf,
             "company_id": self.company_ri,
@@ -270,8 +270,14 @@ class TestManual(common.TestAr):
             {
                 'tax_amount_currency': 300.00,
                 'formatted_tax_amount_currency': '300.00',
-                'name': 'Other National Ind. Taxes $',
+                'name': 'Other National Ind. Taxes $'
             },
+            {
+                'formatted_tax_amount_currency': '0.00',
+                'name': 'VAT Content $',
+                'tax_amount_currency': 0.0
+            }
+
         ])
         self._assert_tax_totals_summary(invoice._l10n_ar_get_invoice_totals_for_report(), {
             'same_tax_base': True,
@@ -279,6 +285,36 @@ class TestManual(common.TestAr):
             'base_amount_currency': 10300.0,
             'tax_amount_currency': 0.0,
             'total_amount_currency': 10300.0,
+            'subtotals': [],
+        })
+
+    def test_20_invoice_b_tax_breakdown_3(self):
+        """ Display only Other Taxes (VAT taxes are 0 and non other taxes) """
+        invoice = self._create_invoice_from_dict({
+            'ref': 'test_invoice_22: Final Consumer Invoice B with only 0 tax',
+            "move_type": 'out_invoice',
+            "partner_id": self.partner_cf,
+            "company_id": self.company_ri,
+            "invoice_date": "2021-03-20",
+            "invoice_line_ids": [
+                {'product_id': self.product_iva_105_perc, 'price_unit': 10000.0, 'quantity': 1,
+                    'tax_ids': [(6, 0, [self.tax_no_gravado.id])]},
+            ],
+        })
+        results = invoice._l10n_ar_get_invoice_custom_tax_summary_for_report()
+        self.assertEqual(results, [
+            {
+                'tax_amount_currency': 0.0,
+                'formatted_tax_amount_currency': '0.00',
+                'name': 'VAT Content $'
+            },
+        ])
+        self._assert_tax_totals_summary(invoice._l10n_ar_get_invoice_totals_for_report(), {
+            'same_tax_base': True,
+            'currency_id': self.currency.id,
+            'base_amount_currency': 10000.0,
+            'tax_amount_currency': 0.0,
+            'total_amount_currency': 10000.0,
             'subtotals': [],
         })
 


### PR DESCRIPTION
### **Description of the issue/feature this PR addresses:**
When doing an Invoice B to exempts customer we have a problem the RG Legend new table is not showing: this because if the VAT Content or other taxes sum is 0.0 (we are not showing any information if sums 0.0)

After checking with ARCA Online PDF sxampels, and some feedback of Argentinen users, we found out that the Legend should be always present. event if the totals of theTax Breakdown are shown with 0.0

### **Steps to reproduce**
Go to an Argentina Company
Create a new invoice for "Final Consumer" with document type "Invoice B"
Create a product line with tax 0 (could use either VAT Exempt, VAT 0, VAT Not Taxed)
Print the PDF

### **Current behavior before PR:**
The PDF is NOT showing the Tax Breakdown table

![image](https://github.com/user-attachments/assets/ae51cd41-0bc0-478f-8781-b05f0b13b3de)

### **Desired behavior after PR is merged:**
The PDF is showing the Tax Breakdown with the line VAT Content 0.0

![image](https://github.com/user-attachments/assets/9780eeb0-943b-4755-a5c1-7e1e5eafdf5c)



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
Manual Forward-Port-Of: https://github.com/odoo/odoo/pull/207367