### PR TITLE
[FIX web: race condition in waitUntil test

### DIFF
--- a/addons/web/static/lib/hoot/tests/hoot-dom/time.test.js
+++ b/addons/web/static/lib/hoot/tests/hoot-dom/time.test.js
@@ -1,8 +1,15 @@
 /** @odoo-module */
 
 import { describe, expect, test } from "@odoo/hoot";
-import { animationFrame, delay, microTick, waitUntil } from "@odoo/hoot-dom";
-import { Deferred, advanceTime, runAllTimers, tick } from "@odoo/hoot-mock";
+import {
+    Deferred,
+    advanceTime,
+    animationFrame,
+    microTick,
+    runAllTimers,
+    tick,
+    waitUntil,
+} from "@odoo/hoot-dom";
 import { parseUrl } from "../local_helpers";
 
 // timeout of 1 second to ensure all timeouts are actually mocked
@@ -101,18 +108,7 @@ describe(parseUrl(import.meta.url), () => {
     });
 
     test("waitUntil: rejects", async () => {
-        const promise = waitUntil(() => false, { timeout: 1 }).catch(() => expect.step("rejected"));
-
-        expect.verifySteps([]);
-        expect(promise).toBeInstanceOf(Promise);
-
-        await delay(1);
-
-        expect.verifySteps([]);
-
-        await animationFrame();
-
-        expect.verifySteps(["rejected"]);
+        await expect(waitUntil(() => false, { timeout: 0 })).rejects.toThrow();
     });
 
     test("waitUntil: lazy", async () => {


### PR DESCRIPTION
This commit fixes a race condition in one of Hoot's internal tests.

The fix simplifies the failing test since the previous manipulations were redundant and fragile.

runbot [223471](https://runbot.odoo.com/odoo/runbot.build.error/223471)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
