### PR TITLE
[FIX] test_website: update timeout for testing

### DIFF
--- a/addons/test_website/static/tests/tours/website_page_properties.js
+++ b/addons/test_website/static/tests/tours/website_page_properties.js
@@ -140,6 +140,7 @@ function testCommonProperties(url, canPublish, modifiedUrl = undefined) {
             {
                 content: "Verify is not in menu",
                 trigger: `:visible :iframe #top_menu:not(:has(a[href="${url}"]))`,
+                timeout: 30000,
             },
             stepUtils.goToUrl(getClientActionUrl("/")),
             ...assertPageCanonicalUrlIs("/"),


### PR DESCRIPTION
## Version
18.0+

## Issue
Task 4141409 introduced long tests to simulate complete flow. As this test relies on many iframe checks and these iframes being slow to load, the test time limit is reached. The test fails on Single App and Community but not with Enterprise might be related to performances linked to modules interactions.

runbot-223225