### PR TITLE
[IMP] account,point_of_sale,sale: adjust storno flows

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -156,10 +156,7 @@ class AccountMove(models.Model):
         index=True,
         default="entry",
     )
-    is_storno = fields.Boolean(
-        compute='_compute_is_storno', store=True, readonly=False,
-        copy=False,
-    )
+    is_storno = fields.Boolean(compute='_compute_is_storno')
     journal_id = fields.Many2one(
         'account.journal',
         string='Journal',
@@ -895,7 +892,9 @@ class AccountMove(models.Model):
     @api.depends('move_type')
     def _compute_is_storno(self):
         for move in self:
-            move.is_storno = move.is_storno or (move.move_type in ('out_refund', 'in_refund') and move.company_id.account_storno)
+            move.is_storno = move.is_storno or (
+                move.company_id.account_storno and move.move_type in ('out_refund', 'in_refund')
+            )
 
     @api.depends('company_id', 'invoice_filter_type_domain')
     def _compute_suitable_journal_ids(self):
@@ -5163,6 +5162,7 @@ class AccountMove(models.Model):
             Command.update(line.id, {
                 'balance': -line.balance,
                 'amount_currency': -line.amount_currency,
+                **({'is_storno': not line.is_storno} if line.company_id.account_storno else {}),
             })
             for line in reverse_moves.line_ids
             if line.move_id.move_type == 'entry' or line.display_type == 'cogs'

--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -83,7 +83,7 @@ class AccountMoveLine(models.Model):
     )
     is_storno = fields.Boolean(
         string="Company Storno Accounting",
-        related='move_id.is_storno',
+        compute='_compute_is_storno', store=True, readonly=False, precompute=True,
         help="Utility field to express whether the journal item is subject to storno accounting",
     )
     sequence = fields.Integer(compute='_compute_sequence', store=True, readonly=False, precompute=True)
@@ -696,6 +696,18 @@ class AccountMoveLine(models.Model):
 
         return [('account_id', operator, value)]
 
+    @api.depends('move_id.is_storno', 'price_unit', 'quantity')
+    def _compute_is_storno(self):
+        for line in self:
+            if not line.company_id.account_storno:
+                continue
+            line.is_storno = line.is_storno or line.move_id.is_storno
+
+            # For invoice lines, we want to set is_storno based on the sign of the line if the entire move is not storno (not refund)
+            # This allows setting is_storno to true or false depending on quantity and price_unit
+            if not line.move_id.is_storno and line in line.move_id.invoice_line_ids and line.quantity * line.price_unit:
+                line.is_storno = line.quantity * line.price_unit < 0
+
     @api.depends('move_id')
     def _compute_balance(self):
         for line in self:
@@ -715,7 +727,7 @@ class AccountMoveLine(models.Model):
             else:
                 line.balance = 0
 
-    @api.depends('balance', 'move_id.is_storno')
+    @api.depends('balance')
     def _compute_debit_credit(self):
         for line in self:
             if not line.is_storno:
@@ -1318,6 +1330,7 @@ class AccountMoveLine(models.Model):
     @api.onchange('debit')
     def _inverse_debit(self):
         for line in self:
+            line.is_storno = line.debit < 0
             if line.debit:
                 line.credit = 0
             line.balance = line.debit - line.credit
@@ -1325,6 +1338,7 @@ class AccountMoveLine(models.Model):
     @api.onchange('credit')
     def _inverse_credit(self):
         for line in self:
+            line.is_storno = line.credit < 0
             if line.credit:
                 line.debit = 0
             line.balance = line.debit - line.credit
@@ -1584,11 +1598,15 @@ class AccountMoveLine(models.Model):
     def _sanitize_vals(self, vals):
         if 'debit' in vals or 'credit' in vals:
             vals = vals.copy()
-            if 'balance' in vals:
-                vals.pop('debit', None)
-                vals.pop('credit', None)
-            else:
-                vals['balance'] = vals.pop('debit', 0) - vals.pop('credit', 0)
+
+            # This is used for negative amounts in debit/credit for manual inputs (to stay in same debit/credit as input)
+            if vals.get('move_id') and self.env['account.move'].browse(vals['move_id']).company_id.account_storno:
+                vals['is_storno'] = vals.get('is_storno', False) or (vals.get('debit', 0) < 0 or vals.get('credit', 0) < 0)
+
+            debit = vals.pop('debit', 0)
+            credit = vals.pop('credit', 0)
+            if 'balance' not in vals:
+                vals['balance'] = debit - credit
         if (
             vals.get('matching_number')
             and not vals['matching_number'].startswith('I')

--- a/addons/account/models/res_config_settings.py
+++ b/addons/account/models/res_config_settings.py
@@ -150,6 +150,7 @@ class ResConfigSettings(models.TransientModel):
 
     # Storno Accounting
     account_storno = fields.Boolean(string="Storno accounting", readonly=False, related='company_id.account_storno')
+    display_account_storno = fields.Boolean(related='company_id.display_account_storno')
 
     # Allows for the use of a different delivery address
     group_sale_delivery_address = fields.Boolean("Customer Addresses", implied_group='account.group_delivery_invoice_address')

--- a/addons/account/views/res_config_settings_views.xml
+++ b/addons/account/views/res_config_settings_views.xml
@@ -370,7 +370,7 @@
                                 </div>
                             </div>
                         </block>
-                        <block title="Storno Accounting" id="storno" groups="account.group_account_user">
+                        <block title="Storno Accounting" id="storno" groups="account.group_account_user" invisible="not display_account_storno">
                             <setting id="enable_storno_accounting" company_dependent="1" help="Use negative numbers to reverse original entries">
                                 <field name="account_storno"/>
                             </setting>

--- a/addons/point_of_sale/models/account_move.py
+++ b/addons/point_of_sale/models/account_move.py
@@ -90,6 +90,14 @@ class AccountMove(models.Model):
     def _compute_tax_totals(self):
         return super(AccountMove, self.with_context(linked_to_pos=bool(self.sudo().pos_order_ids)))._compute_tax_totals()
 
+    def _compute_is_storno(self):
+        # EXTENDS 'account'
+        super()._compute_is_storno()
+        for move in self:
+            move.is_storno = move.is_storno or (
+                move.company_id.account_storno and move.reversed_pos_order_id
+            )
+
     def action_view_source_pos_orders(self):
         self.ensure_one()
         action = self.env['ir.actions.act_window']._for_xml_id('point_of_sale.action_pos_pos_form')


### PR DESCRIPTION
This PR changes entry reversals when storno accounting is enabled, which required changes in how debit/credit amounts are computed.

A `account.move` is now considered `is_storno` if it's a refund or a reversal of previous entry. In some cases, some moves lines could be considered a reversal, not the entire move, like when creating an invoice for the remaining sale that had a previous downpayment. So, a new `is_storno` field is added in `account.move.line`. The `is_storno` field is kept in `account.move` as a non-stored computed field for convenience of setting all move lines as storno without having to set each move line separately.

The `is_storno` flag in `account.move.line` is used to set the correct debit and credit amounts in the move line. `is_storno` is set in the compute function (`_compute_is_storno`), in the inverse debit/credit functions, or manually. Other modules extend the `_compute_is_storno` function to add relevant logic.

Storno accounting option is enabled by default in several countries and can be optionally enabled in other countries. By default, any other country has storno accounting not enabled with no option to enable it.

Meant by storno accounting: any reversal of a previous entry shall be considered a negative amount in the original debit/credit position rather than a positive amount in the opposite column. 

task-4845062

Current behavior before PR:
When reversing an entry with Storno accounting enabled, the reversal entry is created with amounts in opposite debit/credit position.

Desired behavior after PR is merged:
When reversing an entry with Storno accounting enabled, the reversal entry is created with opposite sign amounts in the original debit/credit position.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
