### PR TITLE
[FIX] mail sanitize: allow button if sanitize_form=True


### DIFF
--- a/odoo/tools/mail.py
+++ b/odoo/tools/mail.py
@@ -330,7 +330,7 @@ def html_sanitize(src, silent=True, sanitize_tags=True, sanitize_attributes=Fals
             'page_structure': True,
             'style': strip_style,              # True = remove style tags/attrs
             'sanitize_style': sanitize_style,  # True = sanitize styling
-            'forms': sanitize_form,            # True = remove form tags
+            'forms': False,
             'remove_unknown_tags': False,
             'comments': False,
             'conditional_comments': sanitize_conditional_comments,   # True = remove conditional comments
@@ -338,6 +338,11 @@ def html_sanitize(src, silent=True, sanitize_tags=True, sanitize_attributes=Fals
         }
         if sanitize_tags:
             kwargs.update(SANITIZE_TAGS)
+        if sanitize_form:
+            kwargs['remove_tags'] = list(kwargs.get('remove_tags', []))
+            kwargs['remove_tags'].append('form')
+            kwargs['kill_tags'] = list(kwargs.get('kill_tags', []))
+            kwargs['kill_tags'].extend(['input', 'select', 'textarea'])
 
         if sanitize_attributes:  # We keep all attributes in order to keep "style"
             if strip_classes:


### PR DESCRIPTION

Scenario:
- in 18.0, insert a slideshow in sanitize_form=True (the default) html
  field, for example an appointment description
- reload the page

Result: the slideshow button have disappeared and a traceback appear

Issue:

Since 3deb8050831c69ca1e32039622b322ffa38cc497 the slideshow uses BUTTON
tags instead of LI.

The "sanitize_form" field options enable the lxml cleaner "forms" option
which removes FORM tags, and kill BUTTON, INPUT, SELECT, TEXTAREA tags.

So the buttons used for navigation are removed which causes an issue
with the code not expecting it.

Fix:

We could:

- switch buttons to other tags: but not very stable and bootstrap is
  using buttons itself for similar widget

- have a code that refill the button on page display if they
  disappeared: it's lot of code and we need to be hacky with bootstrap
  to remove previous carousel and start on the new one we rendered
  dynamically

- allow button in sanitization: they are removed to remove forms, but
  button can be used anywhere in the page, and they should be as risky
  as link (which are allowed) for XSS.

This fix change the sanitization of forms to allow BUTTON tags.

opw-4844700
