### PR TITLE
[FIX] sale_project: prevent error when creating a milestone

### DIFF
--- a/addons/sale_project/views/project_task_views.xml
+++ b/addons/sale_project/views/project_task_views.xml
@@ -307,7 +307,7 @@
                             widget="percentage" decoration-danger="quantity_percentage &lt; 0 or 1 &lt; quantity_percentage" readonly="0"/>
                         <span>
                             (<field name="product_uom_qty" class="mw-25"  decoration-danger="quantity_percentage &lt; 0 or 1 &lt; quantity_percentage"/>
-                            <field name="product_uom_id" class="w-auto text-end" groups="uom.group_uom" widget="many2one_uom" options="{'no_open': True}"/>
+                            <field name="product_uom_id" class="w-auto text-end" groups="uom.group_uom" options="{'no_open': True}"/>
                             <span>)</span>
                         </span>
                     </div>


### PR DESCRIPTION
**Issue:**

When editing or creating a milestone from a task (linked to a sale order) form of a billable project, an error is caught

**Steps to Reproduce:**

 - Enable "Milestones" in Settings > Project.
 - Create a billable project.
 - From Sales, create a sales order using a service product and generate a task in the same project.
 - In the task form, attempt to create and edit a new milestone.

an error is caught due to the use of the widget 'Many2OneUomField'

The fix is about removing the widget as the view has no product field (also the widget might be useless here, as we're only displaying the sale line's UoM )

opw-4852849