### PR TITLE
[FIX] mail: proper camera settings in discuss call

### DIFF
--- a/addons/mail/static/src/discuss/call/common/rtc_service.js
+++ b/addons/mail/static/src/discuss/call/common/rtc_service.js
@@ -32,12 +32,7 @@ const SCREEN_CONFIG = {
     },
 };
 const CAMERA_CONFIG = {
-    width: { max: 1280 },
-    height: { max: 720 },
-    aspectRatio: 16 / 9,
-    frameRate: {
-        max: 30,
-    },
+    width: 1280,
 };
 const INVALID_ICE_CONNECTION_STATES = new Set(["disconnected", "failed", "closed"]);
 const IS_CLIENT_RTC_COMPATIBLE = Boolean(window.RTCPeerConnection && window.MediaStream);


### PR DESCRIPTION
Before this commit, when using discuss call, using some usb camera would lead to wrong camera settings:

```
aspectRatio: 1.7777777777777777
frameRate: 20,
height: 360,
resizeMode: "crop-and-scale",
width: 640,
```

This happens because of the camera config constraints that are not well understood by some usb cameras, such as `max` for width and height.
Another problem is that `frameRate` was set to 30 but a camera can stream 30.0003 frames per seconds which is slightly higher. Because of the 30 value, it forces camera to stream a much lower framerate. Also somehow the camera panics and crop the content when this is not wanted.

This commit fixes the issue by simplifying constraints to only asking for explicit width. This is well understood by many cameras and it just works. Framerate is managed by camera and bandwidth constraints, aspect-ratio has no reason to be limited by constraints and instead the source decides and call view managed the layout like it does now.

With the same usb camera that give the results before, with the new contraints this become:

```
aspectRatio: 1.7777777777777777
frameRate: 30.000030517578125
height: 720
resizeMode: "none"
width: 1280
```