### PR TITLE
[FIX] pos_self_order: cancel only draft orders in test case

### DIFF
--- a/addons/pos_self_order/tests/test_self_order_mobile.py
+++ b/addons/pos_self_order/tests/test_self_order_mobile.py
@@ -52,7 +52,7 @@ class TestSelfOrderMobile(SelfOrderCommonTest):
         self.start_tour(self_route, "self_mobile_each_counter_takeaway_in")
         self.start_tour(self_route, "self_mobile_each_counter_takeaway_out")
 
-        self.env['pos.order'].search([]).write({'state': 'cancel'})
+        self.env['pos.order'].search([('state', '=', 'draft')]).write({'state': 'cancel'})
         self.pos_config.write({
             'self_ordering_pay_after': 'meal',
             'self_ordering_service_mode': 'table',
@@ -62,7 +62,7 @@ class TestSelfOrderMobile(SelfOrderCommonTest):
         self.start_tour(self_route, "self_mobile_meal_table_takeaway_in")
         self.start_tour(self_route, "self_mobile_meal_table_takeaway_out")
 
-        self.env['pos.order'].search([]).write({'state': 'cancel'})
+        self.env['pos.order'].search([('state', '=', 'draft')]).write({'state': 'cancel'})
         self.pos_config.write({
             'self_ordering_service_mode': 'counter',
         })
@@ -74,7 +74,7 @@ class TestSelfOrderMobile(SelfOrderCommonTest):
         # Cancel in meal
         self.start_tour(self_route, "self_order_mobile_meal_cancel")
 
-        self.env['pos.order'].search([]).write({'state': 'cancel'})
+        self.env['pos.order'].search([('state', '=', 'draft')]).write({'state': 'cancel'})
         self.pos_config.write({
             'self_ordering_pay_after': 'each',
         })


### PR DESCRIPTION
Before this commit:
=
- Previously, `test_self_order_mobile` set all orders to cancel, causing errors with finalized orders (e.g., paid orders from demo data).

After this commit:
=
- Only draft orders are cancelled, preventing errors and ensuring correct test behavior.

Runboat Error: 224197
