### PR TITLE
[IMP] im_livechat: operators dropdown include only livechat group user

### DIFF
--- a/addons/im_livechat/views/im_livechat_expertise_views.xml
+++ b/addons/im_livechat/views/im_livechat_expertise_views.xml
@@ -7,7 +7,7 @@
             <field name="arch" type="xml">
                 <list editable="bottom">
                     <field name="name"/>
-                    <field name="user_ids" widget="many2many_tags" options="{'no_create': True}"/>
+                    <field name="user_ids" widget="many2many_tags" options="{'no_create': True}" domain="[['all_group_ids', 'in', %(im_livechat.im_livechat_group_user)d]]"/>
                 </list>
             </field>
         </record>
@@ -20,7 +20,7 @@
                     <sheet>
                         <group>
                             <field name="name"/>
-                            <field name="user_ids" widget="many2many_tags" options="{'no_create': True}"/>
+                            <field name="user_ids" widget="many2many_tags" options="{'no_create': True}" domain="[['all_group_ids', 'in', %(im_livechat.im_livechat_group_user)d]]"/>
                         </group>
                     </sheet>
                 </form>


### PR DESCRIPTION
**Purpose of this PR:**

Currently, the Operators dropdown in the expertise views displays all users. However, expertise is a livechat-specific feature, used only in livechat flows. Therefore, it doesn't make sense to add non-livechat users to expertise.

**Current behavior before PR:**

Any user can be linked to expertise from expertise list and form view.

**Desired behavior after PR is merged:**

In both the expertise list and form views, the Operators dropdown now shows only users who belong to the livechat user group.

task-4872629

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
