### PR TITLE
[FIX] l10n_sa, l10n_sa_edi, l10n_gcc_invoice: Fixed issue date on rep…

### DIFF
--- a/addons/l10n_gcc_invoice/views/report_invoice.xml
+++ b/addons/l10n_gcc_invoice/views/report_invoice.xml
@@ -501,10 +501,10 @@
 
                 <p t-if="o.invoice_payment_term_id" name="payment_term">
                     <div class="row">
-                        <div class="col-4 text-start">
+                        <div class="col-3 text-start">
                             <span t-out="o.invoice_payment_term_id.note"/>
                         </div>
-                        <div class="col-4 text-start">
+                        <div class="col-3 text-end">
                             <span t-if="o.invoice_payment_term_id.note != o_sec.invoice_payment_term_id.note" dir="rtl" t-out="o_sec.invoice_payment_term_id.note"/>
                         </div>
                     </div>
@@ -544,20 +544,20 @@
                 <p t-if="o.narration" name="comment">
                     <div class="row">
                         <div class="col-6 text-start">
-                            <span t-if="o.narration != o_sec.narration" t-out="o.narration"/>
+                            <span t-out="o.narration"/>
                         </div>
                         <div class="col-6 text-end">
-                            <span dir="rtl" t-out="o_sec.narration"/>
+                            <span t-if="o.narration != o_sec.narration" dir="rtl" t-out="o_sec.narration"/>
                         </div>
                     </div>
                 </p>
                 <p t-if="o.fiscal_position_id.note" name="note">
                     <div class="row">
                         <div class="col-6 text-start">
-                            <span t-if="o.fiscal_position_id.note != o_sec.fiscal_position_id.note" t-out="o.fiscal_position_id.note"/>
+                            <span t-out="o.fiscal_position_id.note"/>
                         </div>
                         <div class="col-6 text-end">
-                            <span dir="rtl" t-out="o_sec.fiscal_position_id.note"/>
+                            <span t-if="o.fiscal_position_id.note != o_sec.fiscal_position_id.note" dir="rtl" t-out="o_sec.fiscal_position_id.note"/>
                         </div>
                     </div>
                 </p>

--- a/addons/l10n_sa/__manifest__.py
+++ b/addons/l10n_sa/__manifest__.py
@@ -30,6 +30,7 @@ Activates:
         'data/account_tax_report_data.xml',
         'data/report_paperformat_data.xml',
         'views/report_invoice.xml',
+        'views/report_templates_views.xml'
     ],
     'demo': [
         'demo/demo_company.xml',

--- a/addons/l10n_sa/i18n_extra/ar.po
+++ b/addons/l10n_sa/i18n_extra/ar.po
@@ -349,3 +349,21 @@ msgstr "هللة"
 #: model:account.tax.group,name:l10n_sa.sa_tax_group_taxes_15
 msgid "VAT Taxes"
 msgstr "ضريبة القيمة المضافة"
+
+#. module: l10n_sa
+#: model:ir.model.fields,field_description:l10n_sa.field_account_bank_statement_line__l10n_sa_confirmation_datetime
+#: model:ir.model.fields,field_description:l10n_sa.field_account_move__l10n_sa_confirmation_datetime
+#: model:ir.model.fields,field_description:l10n_sa.field_account_payment__l10n_sa_confirmation_datetime
+msgid "Confirmation Date"
+msgstr "تاريخ التأكيد"
+
+#. module: l10n_sa
+#: model:ir.model.fields,help:l10n_sa.field_account_bank_statement_line__l10n_sa_confirmation_datetime
+#: model:ir.model.fields,help:l10n_sa.field_account_move__l10n_sa_confirmation_datetime
+#: model:ir.model.fields,help:l10n_sa.field_account_payment__l10n_sa_confirmation_datetime
+msgid ""
+"Date when the invoice is confirmed and posted.\n"
+"                                                    In other words, it is the date on which the invoice is generated as final document (after securing all internal approvals)."
+msgstr ""
+"تاريخ تأكيد وتسجيل الفاتورة.\n"
+"بعبارة أخرى، هو التاريخ الذي يتم فيه إصدار الفاتورة كوثيقة نهائية (بعد الحصول على جميع الموافقات الداخلية)."

--- a/addons/l10n_sa/i18n_extra/l10n_sa.pot
+++ b/addons/l10n_sa/i18n_extra/l10n_sa.pot
@@ -339,3 +339,19 @@ msgstr ""
 #: model:account.tax.group,name:l10n_sa.sa_tax_group_taxes_15
 msgid "VAT Taxes"
 msgstr ""
+
+#. module: l10n_sa
+#: model:ir.model.fields,field_description:l10n_sa.field_account_bank_statement_line__l10n_sa_confirmation_datetime
+#: model:ir.model.fields,field_description:l10n_sa.field_account_move__l10n_sa_confirmation_datetime
+#: model:ir.model.fields,field_description:l10n_sa.field_account_payment__l10n_sa_confirmation_datetime
+msgid "Confirmation Date"
+msgstr ""
+
+#. module: l10n_sa
+#: model:ir.model.fields,help:l10n_sa.field_account_bank_statement_line__l10n_sa_confirmation_datetime
+#: model:ir.model.fields,help:l10n_sa.field_account_move__l10n_sa_confirmation_datetime
+#: model:ir.model.fields,help:l10n_sa.field_account_payment__l10n_sa_confirmation_datetime
+msgid ""
+"Date when the invoice is confirmed and posted.\n"
+"                                                    In other words, it is the date on which the invoice is generated as final document (after securing all internal approvals)."
+msgstr ""

--- a/addons/l10n_sa/views/report_invoice.xml
+++ b/addons/l10n_sa/views/report_invoice.xml
@@ -5,15 +5,15 @@
             <div class="row" t-if="o.delivery_date" name="delivery_date">
                 <div class="col-6"></div>
                 <div class="col-2">
-                    <strong style="white-space:nowrap">Delivery Date:
+                    <strong style="white-space:nowrap">Supply Date:
                     </strong>
                 </div>
                 <div class="col-2">
-                    <span t-field="o.delivery_date"/>
+                    <span t-out="o.delivery_date.strftime('%Y-%m-%d')"/>
                 </div>
                 <div class="col-2 text-end">
                     <strong style="white-space:nowrap">:
-                        تاريخ التوصيل
+                        تاريخ التوريد
                     </strong>
                 </div>
             </div>
@@ -102,14 +102,19 @@
                 إجمالي قيمة الفاتورة شامل ضريبة القيمة المضافة
             </strong>
         </xpath>
-        <xpath expr="//div[@name='invoice_date']//span" position="before">
-            <span t-if="o.l10n_sa_confirmation_datetime" t-field="o.l10n_sa_confirmation_datetime"/>
+        <xpath expr="//span[@t-field='o.invoice_date']" position="attributes">
+            <attribute name="t-field"></attribute>
+            <attribute name="t-out">o.invoice_date.strftime('%Y-%m-%d')</attribute>
         </xpath>
-        <xpath expr="//div[@name='invoice_date']//span[@t-field='o.invoice_date']" position="attributes">
-            <attribute name="t-if">not o.l10n_sa_confirmation_datetime</attribute>
+        <xpath expr="//span[@t-field='o.invoice_date_due']" position="attributes">
+            <attribute name="t-field"></attribute>
+            <attribute name="t-out">o.invoice_date_due.strftime('%Y-%m-%d')</attribute>
         </xpath>
         <xpath expr="//div[hasclass('clearfix')]" position="attributes">
             <attribute name="class">clearfix pt-2 pb-2</attribute>
+        </xpath>
+        <xpath expr="//div[hasclass('page')]">
+            <t t-set="additional_footer_text" t-value="o.get_l10n_sa_confirmation_datetime_sa_tz()"/> <!-- This is to show the issue date on the footer of all layouts. -->
         </xpath>
     </template>
 </odoo>

--- a/addons/l10n_sa/views/report_templates_views.xml
+++ b/addons/l10n_sa/views/report_templates_views.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <template id="l10n_sa_additional_footer">
+        <span t-if="report_type == 'pdf' and additional_footer_text" class="text-muted text-center" t-out="additional_footer_text"/><br/>
+    </template>
+    <template id="l10n_sa_external_layout_standard" inherit_id="web.external_layout_standard">
+        <xpath expr="//span[hasclass('page')]/.." position="before">
+            <t t-call="l10n_sa.l10n_sa_additional_footer"/>
+        </xpath>
+    </template>
+    <template id="l10n_sa_external_layout_boxed" inherit_id="web.external_layout_boxed">
+        <xpath expr="//span[hasclass('page')]/.." position="before">
+            <t t-call="l10n_sa.l10n_sa_additional_footer"/>
+        </xpath>
+    </template>
+    <template id="l10n_sa_external_layout_bold" inherit_id="web.external_layout_bold">
+        <xpath expr="//span[hasclass('page')]/.." position="before">
+            <t t-call="l10n_sa.l10n_sa_additional_footer"/>
+        </xpath>
+    </template>
+    <template id="l10n_sa_external_layout_striped" inherit_id="web.external_layout_striped">
+        <xpath expr="//span[hasclass('page')]/.." position="before">
+            <t t-call="l10n_sa.l10n_sa_additional_footer"/>
+        </xpath>
+    </template>
+    <template id="l10n_sa_external_layout_folder" inherit_id="web.external_layout_folder">
+        <xpath expr="//span[hasclass('page')]/.." position="before">
+            <t t-call="l10n_sa.l10n_sa_additional_footer"/>
+        </xpath>
+    </template>
+    <template id="l10n_sa_external_layout_wave" inherit_id="web.external_layout_wave">
+        <xpath expr="//span[hasclass('page')]/.." position="before">
+            <t t-call="l10n_sa.l10n_sa_additional_footer"/>
+        </xpath>
+    </template>
+    <template id="l10n_sa_external_layout_bubble" inherit_id="web.external_layout_bubble">
+        <xpath expr="//span[hasclass('page')]/.." position="before">
+            <t t-call="l10n_sa.l10n_sa_additional_footer"/>
+        </xpath>
+    </template>
+</odoo>

--- a/addons/l10n_sa_edi/views/report_invoice.xml
+++ b/addons/l10n_sa_edi/views/report_invoice.xml
@@ -6,7 +6,7 @@
 
             <!--    Add Currency Exchange rate if different currency than SAR    -->
             <xpath expr="//div[@name='exchange_rate']/.." position="attributes">
-                <attribute name="class">d-none</attribute>
+                <attribute name="t-att-class">'d-none' if o.company_id.country_id.code == 'SA' else ''</attribute>
             </xpath>
             <xpath expr="//div[hasclass('clearfix')]" position="after">
                 <table t-if="o.company_id.country_id.code == 'SA' and o.currency_id != o.company_id.currency_id"


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
The invoice date was printed as l10n_sa_confirmation_date on the report, causing confusion for users issuing backdated invoices. Additionally, the issue date was being converted to the partner's timezone, leading to inconsistencies.

Current behavior before PR:
The invoice date appears as l10n_sa_confirmation_date on the report.
The issue date is affected by the partner's timezone.

Desired behavior after PR is merged:
The report will display both the standard invoice date and l10n_sa_confirmation_date separately for clarity.
The issue date will always be passed in SA timezone to the report to ensure consistency, regardless of the partner's country.

task-4508551

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
