### PR TITLE
[FIX] stock: prevent crash when confirmation template is removed before validate

### DIFF
--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -1004,6 +1004,8 @@ class Picking(models.Model):
         subtype_id = self.env['ir.model.data']._xmlid_to_res_id('mail.mt_comment')
         for stock_pick in self.filtered(lambda p: p.company_id.stock_move_email_validation and p.picking_type_id.code == 'outgoing'):
             delivery_template = stock_pick.company_id.stock_mail_confirmation_template_id
+            if not delivery_template:
+                continue
             stock_pick.with_context(force_send=True).message_post_with_source(
                 delivery_template,
                 email_layout_xmlid='mail.mail_notification_light',


### PR DESCRIPTION
The system will crash when we try to validate the order when email template is missing.

**Steps to produce:-**
1. Install the `Inventory` module.
2. Navigate to `Settings > Technical > Email > Email Templates`.
3. Delete `Shipping: Send by Email` template.
4. Go to `Inventory > Configuration > Settings > enable Email Confirmation and then save the changes`.
5. Then go to `Inventory > Deliveries > Open any record which is ready > Try to validate`.

**Error:-**
`ValueError: Mailing or posting with a source should not be called with an empty
 template`

**Root cause:-**
- When [1] is executed, it retrieves `mail.template()`, which means there is no template because we removed it previously.
- It then attempts to send the email, resulting in a crash.
- Also, this error also comes when `_default_confirmation_mail_template`
  is executed from [2].
- The field `stock_mail_confirmation_template_id` is assigned `False` because the
  XML reference `stock.mail_template_data_delivery_confirmation` could not be found.

    [1]
    https://github.com/odoo/odoo/blob/8111009f6a8888db80f9afaa145a4c64272370e7/addons/stock/models/stock_picking.py#L1006-L1011

    [2]
    https://github.com/odoo/odoo/blob/8111009f6a8888db80f9afaa145a4c64272370e7/addons/stock/models/res_company.py#L21-L24


**Solution:-**
- This commit verifies whether the email template exists before trying to send .

**Sentry - 6692097406,6686050082**

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
