### PR TITLE
[FIX] l10n_ph: Improve BIR 2307 XLS export format

### DIFF
--- a/addons/l10n_ph/wizard/generate_2307_wizard.py
+++ b/addons/l10n_ph/wizard/generate_2307_wizard.py
@@ -18,7 +18,8 @@ COLUMN_HEADER_MAP = {
     "firstName": "first_name",
     "middleName": "middle_name",
     "address": "address",
-    "nature": "product_name",
+    "zip_code": "zip",
+    "nature": "tax_description",
     "ATC": "atc",
     "income_payment": "price_subtotal",
     "ewt_rate": "amount",
@@ -43,17 +44,23 @@ class Generate2307Wizard(models.TransientModel):
         worksheet_row = 0
         for move in moves:
             worksheet_row += 1
-            partner = move.partner_id
+            partner = move.commercial_partner_id
             partner_address_info = [partner.street, partner.street2, partner.city, partner.state_id.name, partner.country_id.name]
+            first_name = middle_name = last_name = ''
+            if partner.company_type == 'person':
+                first_name = partner.first_name or ''
+                middle_name = partner.middle_name or ''
+                last_name = partner.last_name or ''
             values = {
                 'invoice_date': format_date(self.env, move.invoice_date, date_format="MM/dd/yyyy"),
                 'vat': re.sub(r'\-', '', partner.vat)[:9] if partner.vat else '',
                 'branch_code': partner.branch_code or '000',
-                'company_name': partner.commercial_partner_id.name,
-                'first_name': partner.first_name or '',
-                'middle_name': partner.middle_name or '',
-                'last_name': partner.last_name or '',
-                'address': ', '.join([val for val in partner_address_info if val])
+                'company_name': partner.name if partner.company_type == 'company' else '',
+                'first_name': first_name,
+                'middle_name': middle_name,
+                'last_name': last_name,
+                'address': ', '.join([val for val in partner_address_info if val]),
+                'zip': partner.zip or '',
             }
             aggregated_taxes = move._prepare_invoice_aggregated_taxes()
             for invoice_line, tax_details_for_line in aggregated_taxes['tax_details_per_record'].items():
@@ -61,9 +68,7 @@ class Generate2307Wizard(models.TransientModel):
                     tax = tax_detail['tax']
                     if not tax.l10n_ph_atc:
                         continue
-
-                    product_name = invoice_line.product_id.name or invoice_line.name
-                    values['product_name'] = re.sub(r'[\(\)]', '', product_name) if product_name else ""
+                    values['tax_description'] = tax.description or ''
                     values['atc'] = tax.l10n_ph_atc
                     values['price_subtotal'] = tax_detail['base_amount']
                     values['amount'] = tax.amount


### PR DESCRIPTION
The BIR 2307 XLS export was missing the `ZIP_code` and incorrectly showing the `nature` of payment from the invoice line instead of the tax description.

In this commit:
---
- Added a new column `zip_code` to show the ZIP from the `partner`.
- Changed the `nature` column to use the `tax-description` instead of `product-name`.
- Displaying `companyName` only when the commercial partner is a company.
- Displaying `surName`, `firstName`, and `middleName` only when the commercial partner is an individual.

enterprise-PR- odoo/enterprise#91120

task-4880921

