### PR TITLE
[FIX] crm: show lost leads in activities for crm

### DIFF
--- a/addons/crm/static/src/activity_menu_patch.js
+++ b/addons/crm/static/src/activity_menu_patch.js
@@ -33,6 +33,7 @@ patch(ActivityMenu.prototype, {
             // Necessary because activity_ids of mail.activity.mixin has auto_join
             // So, duplicates are faking the count and "Load more" doesn't show up
             context["force_search_count"] = 1;
+            context["active_test"] = 0; // to show lost leads in the activity
             this.action.doAction("crm.crm_lead_action_my_activities", {
                 additionalContext: context,
                 clearBreadcrumbs: true,


### PR DESCRIPTION
**Steps to reproduce:**

1) Install CRM
2) Create a crm lead and mark it as lost
3) Create a new activity for the lost lead for today 
4) Go to the activity button in the top right corner 
5) Click on today's activity for crm leads

**Issue:**

If you click activity for crm, it will only show 
the active lead's activities, not the lost ones.

You need to click on the filter 'lost', to see the lost leads

**Cause:**

When the lead is marked as lost, we archive the lead record. 
Indeed, we won't see the lost leads by default when opening activities, 
since they are not active.
https://github.com/odoo/odoo/blob/8111009f6a8888db80f9afaa145a4c64272370e7/addons/crm/models/crm_lead.py#L1013-L1016

**Solution:**

Add `active_test` to the context to show the archived/lost activities.

opw-4866692
