### PR TITLE
[IMP] web: datetime_picker: redesign footer

### DIFF
--- a/addons/web/static/src/core/datetime/datetime_picker.xml
+++ b/addons/web/static/src/core/datetime/datetime_picker.xml
@@ -47,21 +47,25 @@
                 </div>
             </t>
         </div>
-        <div t-attf-class="position-relative d-flex flex-column flex-md-row gap-4 gap-md-3 {{ props.type === 'datetime' ? 'justify-content-center' : 'justify-content-end' }}">
-            <div t-attf-class="d-flex gap-3 w-100 {{ props.type === 'datetime' ? 'justify-content-around' : 'd-none' }}">
-                <t t-if="props.type === 'datetime'">
-                    <t t-foreach="state.timeValues" t-as="timeValue" t-key="timeValue_index">
-                        <TimePicker
-                            t-if="timeValue"
-                            value="timeValue"
-                            onChange="(newTime) => this.onTimeChange(timeValue_index, newTime)"
-                            minutesRounding="props.rounding"
-                            showSeconds="props.rounding === 0"
-                        />
-                    </t>
-                </t>
+        <div t-if="props.type === 'datetime'" class="d-flex gap-3 justify-content-between">
+            <div class="d-flex gap-1 align-items-center">
+                <TimePicker
+                    t-if="state.timeValues[0]"
+                    value="state.timeValues[0]"
+                    onChange="(newTime) => this.onTimeChange(0, newTime)"
+                    minutesRounding="props.rounding"
+                    showSeconds="props.rounding === 0"
+                />
+                <i t-if="state.timeValues[0] and state.timeValues[1]" class="fa fa-long-arrow-right"/>
+                <TimePicker
+                    t-if="state.timeValues[1]"
+                    value="state.timeValues[1]"
+                    onChange="(newTime) => this.onTimeChange(1, newTime)"
+                    minutesRounding="props.rounding"
+                    showSeconds="props.rounding === 0"
+                />
             </div>
-            <div t-attf-class="o_datetime_buttons {{ props.type === 'datetime' ? 'position-md-absolute h-100 end-0' : '' }}">
+            <div class="o_datetime_buttons d-flex gap-2">
                 <t t-slot="buttons" />
             </div>
         </div>

--- a/addons/web/static/src/core/datetime/datetime_picker_popover.xml
+++ b/addons/web/static/src/core/datetime/datetime_picker_popover.xml
@@ -4,12 +4,18 @@
         <DateTimePicker t-props="props.pickerProps">
             <t t-set-slot="buttons">
                 <button
-                    class="btn btn-secondary btn-sm h-100 w-100 w-md-auto d-flex align-items-center justify-content-center gap-1"
+                    class="btn btn-sm btn-secondary"
                     tabindex="-1"
                     t-on-click="() => props.pickerProps.range || props.pickerProps.focusedDateIndex ? props.pickerProps.onSelect([false, false]) : props.pickerProps.onSelect(false)"
                 >
                     <i class="fa fa-eraser" />
-                    <span>Clear</span>
+                </button>
+                <button
+                    class="btn btn-sm btn-primary"
+                    tabindex="-1"
+                    t-on-click="props.close"
+                >
+                    <span>Apply</span>
                 </button>
             </t>
         </DateTimePicker>

--- a/addons/web/static/src/core/time_picker/time_picker.xml
+++ b/addons/web/static/src/core/time_picker/time_picker.xml
@@ -18,7 +18,7 @@
                 <input
                     type="text"
                     t-ref="inputRef"
-                    class="o_time_picker_input o_input cursor-pointer fs-6 fw-normal"
+                    class="o_time_picker_input form-control"
                     t-att-class="{ o_invalid: !state.isValid }"
                     t-model="state.inputValue"
                     t-on-input="onInput"

--- a/addons/web/static/tests/core/components/datetime/datetime_input.test.js
+++ b/addons/web/static/tests/core/components/datetime/datetime_input.test.js
@@ -514,6 +514,20 @@ describe("DateTimeInput (datetime)", () => {
         expect(".o_datetime_picker").toHaveCount(1);
     });
 
+    test("Clicking apply button closes datetime picker", async () => {
+        await mountWithCleanup(DateTimeInputComp, {
+            props: {
+                value: DateTime.fromFormat("09/01/1997 12:30:01", "dd/MM/yyyy HH:mm:ss"),
+                type: "datetime",
+                format: "dd MMM, yyyy HH:mm:ss",
+            },
+        });
+        await contains(".o_datetime_input").click();
+        await contains(".o_datetime_picker .o_datetime_buttons .btn-primary").click();
+
+        expect(".o_datetime_picker").toHaveCount(0);
+    });
+
     test("check datepicker in localization with textual month format", async () => {
         defineParams({
             lang_parameters: {

--- a/addons/web/static/tests/core/datetime/datetime_test_helpers.js
+++ b/addons/web/static/tests/core/datetime/datetime_test_helpers.js
@@ -43,12 +43,11 @@ export function assertDateTimePicker(expectedParams) {
         expect(".o_time_picker").toHaveCount(time.length);
         for (let i = 0; i < time.length; i++) {
             const expectedTime = time[i];
-            expect(`.o_time_picker:nth-child(${i + 1}) .o_time_picker_input`).toHaveValue(
-                expectedTime,
-                {
-                    message: `time values should be [${expectedTime}]`,
-                }
-            );
+            expect(
+                `.o_time_picker:nth-child(${i + 1} of .o_time_picker) .o_time_picker_input`
+            ).toHaveValue(expectedTime, {
+                message: `time values should be [${expectedTime}]`,
+            });
         }
     } else {
         expect(".o_time_picker").toHaveCount(0);

--- a/addons/web/static/tests/views/fields/daterange_field.test.js
+++ b/addons/web/static/tests/views/fields/daterange_field.test.js
@@ -1178,7 +1178,7 @@ test("update the selected input datetime after clearing the existing date", asyn
         resId: 1,
     });
     await contains("input[data-field=datetime]").click();
-    await contains(".o_datetime_buttons button.btn-secondary:contains('Clear')").click();
+    await contains(".o_datetime_buttons button.btn-secondary > .fa-eraser").click();
     expect(".o_time_picker_input").toHaveCount(1);
 
     await contains(getPickerCell("12")).click();


### PR DESCRIPTION
This commit redesign the footer of the datetime picker popover. We now have a safe zone with a save button to close it. We also moved time pickers to the left.

task-4613140

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
