### PR TITLE
[FIX] web_editor, website: fix undo behaviour of dynamic snippet

### DIFF
--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
@@ -247,6 +247,7 @@ export class OdooEditor extends EventTarget {
                     }
                 },
                 preHistoryUndo: () => {},
+                postHistoryUndo: () => {},
                 beforeAnyCommand: () => {},
                 isHintBlacklisted: () => false,
                 filterMutationRecords: (records) => records,
@@ -1473,6 +1474,7 @@ export class OdooEditor extends EventTarget {
             this.historyStep(true, { stepId });
             this.dispatchEvent(new Event('historyUndo'));
         }
+        this.options.postHistoryUndo();
     }
     /**
      * Redo a step of the history.

--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -493,6 +493,7 @@ export class Wysiwyg extends Component {
             preHistoryUndo: () => {
                 this.destroyLinkTools();
             },
+            postHistoryUndo: this.postHistoryUndo.bind(this),
             beforeAnyCommand: this._beforeAnyCommand.bind(this),
             commands: powerboxOptions.commands,
             categories: powerboxOptions.categories,
@@ -1181,6 +1182,10 @@ export class Wysiwyg extends Component {
     redo() {
         this.odooEditor.historyRedo();
     }
+    /**
+     * This is automatically triggered after undo()
+     */
+    postHistoryUndo() { }
     /**
      * Focus inside the editor.
      *

--- a/addons/website/static/src/components/wysiwyg_adapter/wysiwyg_adapter.js
+++ b/addons/website/static/src/components/wysiwyg_adapter/wysiwyg_adapter.js
@@ -334,6 +334,17 @@ export class WysiwygAdapterComponent extends Wysiwyg {
     _getBannerCategory() {
         return [];
     }
+    postHistoryUndo() {
+        super.postHistoryUndo();
+        // Re-initialized all dynamic elements which were added by undo.
+        const dynamicEls = this.$root[0].querySelectorAll(".s_dynamic");
+        for (const element of dynamicEls) {
+            this._websiteRootEvent("widgets_start_request", {
+                $target: $(element),
+                editableMode: true,
+            });
+        }
+    }
     /**
      * Stop the widgets and save the content.
      *

--- a/addons/website/static/tests/tours/dynamic_snippet_undo_after_deletion.js
+++ b/addons/website/static/tests/tours/dynamic_snippet_undo_after_deletion.js
@@ -1,0 +1,48 @@
+/** @odoo-module */
+
+import wTourUtils from '@website/js/tours/tour_utils';
+
+wTourUtils.registerWebsitePreviewTour("dynamic_snippet_undo_removal",
+    {
+        test: true,
+        edition: true,
+        url: "/?debug=1",
+    },
+    () => [
+        wTourUtils.dragNDrop({
+            id: "s_dynamic_snippet",
+            name: "Dynamic Snippet",
+        }),
+        wTourUtils.clickOnSnippet({
+            id: "s_dynamic_snippet",
+            name: "Dynamic Snippet",
+        }),
+        {
+            content: "Remove the dynamic snippet",
+            trigger: "iframe .oe_overlay.oe_active .oe_snippet_remove",
+        },
+        {
+            content: "Check that the dynamic snippet is removed",
+            trigger: "iframe:not('.s_dynamic_snippet')",
+            isCheck: true,
+        },
+        {
+            content: "Undo the deletion",
+            trigger: "button[data-action='undo']",
+        },
+        {
+            content: "Check that the dynamic snippet is back",
+            trigger: "iframe .s_dynamic_snippet",
+            isCheck: true,
+        },
+        {
+            content: "Undo Again to remove the dynamic snippet",
+            trigger: "button[data-action='undo']",
+        },
+        {
+            content: "Check that the dynamic snippet is not present anymore",
+            trigger: "iframe:not('.s_dynamic_snippet')",
+            isCheck: true,
+        }
+    ]
+);

--- a/addons/website/tests/test_snippets.py
+++ b/addons/website/tests/test_snippets.py
@@ -147,3 +147,6 @@ class TestSnippets(HttpCase):
 
     def test_tabs_snippet(self):
         self.start_tour(self.env["website"].get_client_action_url("/"), "snippet_tabs", login="admin")
+
+    def test_dynamic_snippet_undo_removal(self):
+        self.start_tour(self.env["website"].get_client_action_url("/?debug=1"), "dynamic_snippet_undo_removal", login="admin")


### PR DESCRIPTION
This commit resolves an issue related to loading dynamic snippets that were reinserted into the DOM via the undo action after deletion.

**Steps to reproduce the issue:**
1. Add any dynamic snippet (e.g., Products, Events, Blog Posts).
2. Delete the snippet using the tooltip.
3. Perform the UNDO action.

Currently, the dynamic snippet does not reappear after the undo action.

With this commit, the dynamic snippet will be reinitialised and will be visible again after following the steps above.

**Task:** 3601449

---
I confirm that I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr.
