### PR TITLE
[IMP] sale: improve sales team notifications

### DIFF
--- a/addons/sale/data/mail_message_subtype_data.xml
+++ b/addons/sale/data/mail_message_subtype_data.xml
@@ -46,15 +46,16 @@
             <field name="parent_id" ref="sale.mt_order_confirmed"/>
             <field name="relation_field">team_id</field>
         </record>
-        <record id="mt_salesteam_invoice_created" model="mail.message.subtype">
-            <field name="name">Invoice Created</field>
+        <record id="mt_salesteam_invoice_paid" model="mail.message.subtype">
+            <field name="name">Invoice Paid</field>
             <field name="sequence">35</field>
             <field name="res_model">crm.team</field>
-            <field name="parent_id" ref="account.mt_invoice_created"/>
+            <field name="default" eval="True"/>
+            <field name="parent_id" ref="account.mt_invoice_paid"/>
             <field name="relation_field">team_id</field>
         </record>
-        <record id="mt_salesteam_invoice_confirmed" model="mail.message.subtype">
-            <field name="name">Invoice Confirmed</field>
+        <record id="mt_salesteam_invoice_posted" model="mail.message.subtype">
+            <field name="name">Invoice Posted</field>
             <field name="sequence">40</field>
             <field name="res_model">crm.team</field>
             <field name="parent_id" ref="account.mt_invoice_validated"/>


### PR DESCRIPTION
**Prior this commit:**
- Sales teams could opt to follow 'Invoice Created' and 'Invoice Confirmed'.

**Post this commit:**
- Removed 'Invoice Created' subtype from sales team follower options.
- Renamed 'Invoice Confirmed' to 'Invoice Posted'.
- Added new 'Invoice Paid' subtype, selected by default.

**Affected Version:** master
task-4783921