### PR TITLE
[FIX] html_editor: fix non-deterministic expect assertion

### DIFF
--- a/addons/html_editor/static/tests/image.test.js
+++ b/addons/html_editor/static/tests/image.test.js
@@ -103,12 +103,10 @@ test("can undo a shape", async () => {
     await waitFor(".o-we-toolbar");
 
     await click(".o-we-toolbar button[name='shape_rounded']");
-    await animationFrame();
-    expect(".o-we-toolbar button[name='shape_rounded']").toHaveClass("active");
+    await expectElementCount(".o-we-toolbar button[name='shape_rounded'].active", 1);
     expect("img").toHaveClass("rounded");
     undo(editor);
-    await animationFrame();
-    expect(".o-we-toolbar button[name='shape_rounded']").not.toHaveClass("active");
+    await expectElementCount(".o-we-toolbar button[name='shape_rounded'].active", 0);
     expect("img").not.toHaveClass("rounded");
 });
 


### PR DESCRIPTION
The expect assertion does not wait, and waiting one animation frame is not enough for popovers, like the toolbar, as explained in [1].

[1]: https://github.com/odoo/odoo/pull/211426/commits/54da715df84789f9a1acc0cfc91be41dcdbab140
