### PR TITLE
[FIX] point_of_sale: traceback paid self order

### DIFF
--- a/addons/point_of_sale/models/pos_load_mixin.py
+++ b/addons/point_of_sale/models/pos_load_mixin.py
@@ -37,4 +37,7 @@ class PosLoadMixin(models.AbstractModel):
 
     def _read_pos_record(self, ids, config_id):
         fields = self._load_pos_data_fields(self.id)
-        return self.with_context(config_id=config_id)._post_read_pos_data(self.browse(ids).read(fields, load=False))
+        record_ids = self.browse(ids).exists()
+        if not record_ids:
+            return []
+        return self.with_context(config_id=config_id)._post_read_pos_data(record_ids.read(fields, load=False))


### PR DESCRIPTION
Step to reproduce:
- Make an order in self order mode
- Pay it, while the linked pos config is open
- A traceback will be shown in the pos config

Issue:
When printing the ticket on the pos config, notify_synchronisation function is called with no records in the session model. _post_read_pos_data will be called with empty data array.

Fix:
Prevent calling _post_read_pos_data with empty records.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
