### PR TITLE
[FIX] core: compute_sudo for Properties

### DIFF
--- a/odoo/orm/fields_properties.py
+++ b/odoo/orm/fields_properties.py
@@ -60,6 +60,7 @@ class Properties(Field):
     store = True
     readonly = False
     precompute = True
+    compute_sudo = True  # properties are stored, _compute needs to run in sudo
 
     definition = None
     definition_record = None         # field on the current model that point to the definition record


### PR DESCRIPTION
If the definition of the properties changes, the Properties fields is computed to add the default values from its definition. This is done in the `_compute` method when flushing data (because the field is stored). We need to run that method in sudo, because the default environment may have a user that doesn't have permissions to read the parent record or update the current record.

Example with `env` with public user which is the default_env for the transaction.
```
lead = env['crm.lead'].sudo().create({'name': 'test'})
lead.team_id = 2
```

Current behavior before PR:
Access error in:
```
  File "/opt/odoo/odoo/orm/fields_properties.py", line 294, in _compute
    {self.name: record[self.name], self.definition_record: record[self.definition_record]},
                ~~~~~~^^^^^^^^^^^
```

Desired behavior after PR is merged:
`lead` flushed correctly.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
