### PR TITLE
[FIX] website: reset and copy formInfo data

### DIFF
--- a/addons/website/static/src/builder/plugins/form/form_action_fields_option.js
+++ b/addons/website/static/src/builder/plugins/form/form_action_fields_option.js
@@ -21,6 +21,14 @@ export class FormActionFieldsOption extends BaseOptionComponent {
     async getFormInfo(props = this.props) {
         const el = this.env.getEditingElement();
         const formInfo = await props.prepareFormModel(el, props.activeForm);
-        this.state.formInfo.fields = formInfo.fields || [];
+        Object.assign(
+            this.state.formInfo,
+            {
+                fields: [],
+                formFields: [],
+                successPage: undefined,
+            },
+            formInfo
+        );
     }
 }


### PR DESCRIPTION
Since [1] when resetting `formInfo.fields` was introduced, an error could be thrown if `formInfo` was missing for the current model.

This commit restores the previous assignment while also resetting the various fields that can be part of a `formInfo`.

Steps to reproduce:
- Install website_studio (enterprise)
- Drop a form
- Pick the "More models" action
- Select any model

=> There was an error because no formInfo is defined for that model.

[1]: https://github.com/odoo/odoo/commit/7021cc3acc540dc18d2219ec6adb2dd96d9da484#diff-d912c919f66b88171110ab7eca663c705c6e0dbeb4ed259a38e9839fd28d1295L24-R24

task-4367641
