### PR TITLE
[FIX] hw_drivers: allow connection to multi-db backend

### DIFF
--- a/addons/hw_drivers/__init__.py
+++ b/addons/hw_drivers/__init__.py
@@ -14,6 +14,7 @@ from . import exception_logger
 from . import http
 from . import interface
 from . import main
+from . import tools
 from . import websocket_client
 
 _logger = logging.getLogger(__name__)
@@ -28,6 +29,10 @@ def set_user_agent(func):
     def wrapper(*args, **kwargs):
         headers = kwargs.pop('headers', None) or {}
         headers['User-Agent'] = 'OdooIoTBox/1.0'
+        server_url = tools.helpers.get_odoo_server_url()
+        db_name = tools.helpers.get_conf('db_name')
+        if server_url and db_name and args[0].startswith(server_url) and '/web/login?db=' not in args[0]:
+            headers['X-Odoo-Database'] = db_name
         return func(*args, headers=headers, **kwargs)
 
     return wrapper

--- a/addons/hw_drivers/server_logger.py
+++ b/addons/hw_drivers/server_logger.py
@@ -37,6 +37,7 @@ class AsyncHTTPHandler(logging.Handler):
         """
         super().__init__()
         self._odoo_server_url = odoo_server_url
+        self._db_name = helpers.get_conf('db_name') or ''
         self._log_queue = queue.Queue(self._MAX_QUEUE_SIZE)
         self._flush_thread = None
         self._active = None
@@ -95,6 +96,7 @@ class AsyncHTTPHandler(logging.Handler):
             odoo_session.post(
                 self._odoo_server_url + '/iot/log',
                 data=empty_queue(),
+                headers={'X-Odoo-Database': self._db_name},
                 timeout=self._REQUEST_TIMEOUT
             ).raise_for_status()
             self._next_disconnection_time = None

--- a/addons/hw_drivers/tools/helpers.py
+++ b/addons/hw_drivers/tools/helpers.py
@@ -157,19 +157,21 @@ def check_image():
     return {'major': version[0], 'minor': version[1]}
 
 
-def save_conf_server(url, token, db_uuid, enterprise_code):
+def save_conf_server(url, token, db_uuid, enterprise_code, db_name=None):
     """
     Save server configurations in odoo.conf
     :param url: The URL of the server
     :param token: The token to authenticate the server
     :param db_uuid: The database UUID
     :param enterprise_code: The enterprise code
+    :param db_name: The database name
     """
     update_conf({
         'remote_server': url,
         'token': token,
         'db_uuid': db_uuid,
         'enterprise_code': enterprise_code,
+        'db_name': db_name,
     })
     get_odoo_server_url.cache_clear()
 
@@ -482,6 +484,7 @@ def disconnect_from_server():
         'remote_server': '',
         'token': '',
         'db_uuid': '',
+        'db_name': '',
         'enterprise_code': '',
         'screen_orientation': '',
         'browser_url': '',


### PR DESCRIPTION
Enterprise PR: https://github.com/odoo/enterprise/pull/88029

Before this commit, if you tried to pair with a DB running in a multi-db environment, it would fail due to the requests to Odoo not specifying a DB to use.

After this commit, we add the `X-Odoo-Database` header to requests to the backend to fix the issue. This requires the IoT box receiving the database name when pairing, so it has been added to the connection token. It will not be present when pairing with a pairing code, so for now the token must be used for this situation.

The websocket connection does not work with this method due to it requiring a session. To fix this, a new `/iot/authenticate` endpoint has been added to retrieve a session (using the public user). The session ID can then be passed to the websocket with the DB correctly chosen via the session.

task-4815521

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
