### PR TITLE
[FIX] website: highlight selection on text translation

### DIFF
--- a/addons/html_builder/__manifest__.py
+++ b/addons/html_builder/__manifest__.py
@@ -42,6 +42,7 @@
 
             'web/static/src/scss/bootstrap_overridden.scss',
             'html_builder/static/src/**/*.inside.scss',
+            'html_editor/static/src/main/chatgpt/chatgpt_plugin.scss',
             'html_editor/static/src/main/link/link.scss',
         ],
         'html_builder.assets_edit_frontend': [


### PR DESCRIPTION
The bundle didn't include a CSS file responsible for highlighting the text you selected, translated and inserted.

**Steps to see the issue:** 
- Start editing website in a multilingual website environment
- Drop any snippet that has text in it
- Select text, expand the toolbar above, and select "Translate with AI"
- Select language, wait for the translation and click Insert

=> Text is inserted, and the highlighting `div` is inserted above, but the style isn't applied.
This commit follows [the html_builder refactoring].

[the html_builder refactoring]: odoo/odoo@9fe45e2b7ddb

Related to task-4367641