### PR TITLE
[IMP] hw_drivers: ensure identifier if no mb uuid

### DIFF
--- a/addons/hw_drivers/tools/helpers.py
+++ b/addons/hw_drivers/tools/helpers.py
@@ -212,11 +212,16 @@ def get_identifier():
     # On windows, get motherboard's uuid (serial number isn't reliable as it's not always present)
     command = ['powershell', '-Command', "(Get-CimInstance Win32_ComputerSystemProduct).UUID"]
     p = subprocess.run(command, stdout=subprocess.PIPE, check=False)
-    if p.returncode != 0:
-        _logger.error("Failed to get Windows IoT serial number")
-        return False
+    identifier = get_conf('generated_identifier')  # Fallback identifier if windows does not return mb UUID
+    if p.returncode == 0 and p.stdout.decode().strip():
+        return p.stdout.decode().strip()
 
-    return p.stdout.decode().strip() or False
+    _logger.error("Failed to get Windows IoT serial number, defaulting to a random identifier")
+    if not identifier:
+        identifier = secrets.token_hex()
+        update_conf({'generated_identifier': identifier})
+
+    return identifier
 
 
 def get_path_nginx():


### PR DESCRIPTION
On Windows IoT Boxes, we use the motherboard uuid as identifier. If it's not found, it returns `False`, making it impossible to create a record in the database.

We now fallback to a generated identifier that we store in `odoo.conf`, to ensure it always has a value.

Task: 4852469
