### PR TITLE
[FIX] loyalty: prevent archiving pricelists linked to active loyalty programs

### DIFF
--- a/addons/loyalty/models/__init__.py
+++ b/addons/loyalty/models/__init__.py
@@ -6,6 +6,7 @@ from . import loyalty_mail
 from . import loyalty_reward
 from . import loyalty_rule
 from . import loyalty_program
+from . import product_pricelist
 from . import product_product
 from . import product_template
 from . import res_partner

--- a/addons/loyalty/models/product_pricelist.py
+++ b/addons/loyalty/models/product_pricelist.py
@@ -1,0 +1,19 @@
+from odoo import _, models
+from odoo.exceptions import UserError
+
+
+class ProductPricelist(models.Model):
+    _inherit = 'product.pricelist'
+
+    def action_archive(self):
+        loyalty_programs = self.env['loyalty.program'].search([
+            ('active', '=', True),
+            ('pricelist_ids', 'in', self.ids)
+        ])
+        if loyalty_programs:
+            raise UserError(_(
+                "This pricelist may not be archived. "
+                "It is being used for active promotion programs: %s",
+                ', '.join(loyalty_programs.mapped('name'))
+            ))
+        return super().action_archive()

--- a/addons/loyalty/tests/test_loyalty.py
+++ b/addons/loyalty/tests/test_loyalty.py
@@ -3,7 +3,7 @@
 
 from psycopg2 import IntegrityError
 
-from odoo.exceptions import ValidationError
+from odoo.exceptions import UserError, ValidationError
 from odoo.fields import Command
 from odoo.tests import tagged, TransactionCase, Form
 from odoo.tools import mute_logger
@@ -141,6 +141,15 @@ class TestLoyalty(TransactionCase):
         self.program.toggle_active()
         after_archived_reward_ids = self.program.reward_ids
         self.assertEqual(before_archived_reward_ids, after_archived_reward_ids)
+
+    def test_prevent_archive_pricelist_linked_to_program(self):
+        self.program.pricelist_ids = demo_pricelist = self.env['product.pricelist'].create({
+            'name': "Demo"
+        })
+        with self.assertRaises(UserError):
+            demo_pricelist.action_archive()
+        self.program.action_archive()
+        demo_pricelist.action_archive()
 
     def test_prevent_archiving_product_linked_to_active_loyalty_reward(self):
         self.program.program_type = 'promotion'


### PR DESCRIPTION
**Step to Reproduce:**
1. Install `sale_loyalty` and `sale`
2. Enable the `Pricelists` option in the settings.
3. Create a pricelist named demo.
4. Create a Discount & Loyalty named `test program` with type `Discount Code`,
5. Assign the demo pricelist to the loyalty program.
6. Copy the discount code from the program’s conditional rules.
7. Archive the demo pricelist.
8. create sale order for any product.
9. Try to apply the copied coupon code.

**Observation:**
- An error is shown: "This code is invalid".
- check loyalty program `test program` pricelist field is empty, that suggesting it's valid for all pricelists, but the coupon still fails.

**Issue:**
- When a linked pricelist is archived, it's hidden in the UI, but the relation still exists in the relational table.
```17_sale=# select id,name,active from product_pricelist;
 id |                name                | active 
----+------------------------------------+--------
  1 | {"en_US": "Default USD pricelist"} | t
  2 | {"en_US": "new"}                   | f
(2 rows)

17_sale=# select * from loyalty_program_product_pricelist_rel;
 loyalty_program_id | product_pricelist_id 
--------------------+----------------------
                  5 |                    2
(1 row)
```
- While filtering the domain for coupon, the condition is not satisfied due to the program's pricelist.

https://github.com/odoo/odoo/blob/94d727bd9ba38116d3e14188c730c7566744e9f0/addons/sale_loyalty/models/sale_order.py#L636-L647

**Solution:**
- Display a validation error to the user when trying to archive a pricelist
  that is linked to any active promotional programs.

opw-4841678



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
