### PR TITLE
[FIX] mail: allow drag in mobile (discuss call PiP)

### DIFF
--- a/addons/mail/static/src/discuss/call/common/call_pip.js
+++ b/addons/mail/static/src/discuss/call/common/call_pip.js
@@ -321,7 +321,9 @@ export class CallPip extends Component {
 
     onTouchMove(event) {
         this.onMouseMove(event);
-        event.preventDefault();
+        if (this.state.isDragging) {
+            event.preventDefault();
+        }
     }
 
     onMouseUp() {


### PR DESCRIPTION
Before this commit, scrolling in mobile with touch interaction didn't work.

This happens because the `CallPip` component, i.e. the application-based PiP, is always mounted in
main component, and was preventing the default behaviour of all touch move.

This preventDefault is intended to cover touch outside of `CallPip` when dragging the size of PiP.

This commit fixes the issue by limiting the prevent default only when dragging on the `CallPip` component.