### PR TITLE
[FIX] purchase{_requisition}: fix single app tests

### DIFF
--- a/addons/purchase/tests/test_purchase_invoice.py
+++ b/addons/purchase/tests/test_purchase_invoice.py
@@ -14,6 +14,7 @@ class TestPurchaseToInvoiceCommon(AccountTestInvoicingCommon):
     def setUpClass(cls):
         super(TestPurchaseToInvoiceCommon, cls).setUpClass()
         cls.other_currency = cls.setup_other_currency('EUR')
+        cls.env.user.group_ids += cls.env.ref('uom.group_uom')
         uom_unit = cls.env.ref('uom.product_uom_unit')
         uom_hour = cls.env.ref('uom.product_uom_hour')
         cls.product_order = cls.env['product.product'].create({

--- a/addons/purchase_requisition/tests/common.py
+++ b/addons/purchase_requisition/tests/common.py
@@ -9,6 +9,8 @@ class TestPurchaseRequisitionCommon(common.TransactionCase):
     def setUpClass(cls):
         super(TestPurchaseRequisitionCommon, cls).setUpClass()
 
+        cls.env.user.group_ids += cls.env.ref('uom.group_uom')
+
         # Fetch purchase related user groups
         user_group_purchase_manager = cls.env.ref('purchase.group_purchase_manager')
         user_group_purchase_user = cls.env.ref('purchase.group_purchase_user')


### PR DESCRIPTION
This commit fixes tests failure caused by odoo/odoo#212098. The mentioned PR removed all occurrences of uom fields without the uom group. That led to failing any test that tried to access uom field without having the uom group. This commit ensures that the uom group is applied on the test user before accessing uom field.

