### PR TITLE
[FIX] web: make searchbar focus on first load in kanban view

### DIFF
--- a/addons/web/static/src/views/kanban/kanban_controller.js
+++ b/addons/web/static/src/views/kanban/kanban_controller.js
@@ -24,6 +24,7 @@ import { SelectionBox } from "@web/views/view_components/selection_box";
 
 import {
     Component,
+    onMounted,
     onWillStart,
     reactive,
     useEffect,
@@ -191,6 +192,10 @@ export class KanbanController extends Component {
             }
         });
         this.searchBarToggler = useSearchBarToggler();
+        this.firstLoad = true;
+        onMounted(() => {
+            this.firstLoad = false;
+        });
         useEffect(
             () => {
                 this.onSelectionChanged();

--- a/addons/web/static/src/views/kanban/kanban_controller.xml
+++ b/addons/web/static/src/views/kanban/kanban_controller.xml
@@ -76,7 +76,7 @@
                     </CogMenu>
                 </t>
                 <t t-set-slot="layout-actions">
-                    <SearchBar toggler="searchBarToggler"/>
+                    <SearchBar toggler="searchBarToggler" autofocus="firstLoad"/>
                 </t>
                 <t t-set-slot="control-panel-navigation-additional">
                     <t t-if="!hasSelectedRecords" t-component="searchBarToggler.component" t-props="searchBarToggler.props"/>

--- a/addons/web/static/tests/views/kanban/kanban_view.test.js
+++ b/addons/web/static/tests/views/kanban/kanban_view.test.js
@@ -13049,6 +13049,31 @@ test("searchbar filters are displayed directly (with progressbar)", async () => 
 });
 
 test.tags("desktop");
+test(`searchbar in kanban view doesn't take focus after unselected all items`, async () => {
+    await mountView({
+        resModel: "partner",
+        type: "kanban",
+        arch: `
+            <kanban>
+                <templates>
+                    <t t-name="card">
+                        <field name="foo"/>
+                    </t>
+                </templates>
+            </kanban>`,
+    });
+    expect(`.o_searchview_input`).toBeFocused({
+        message: "The search input should have the focus",
+    });
+
+    await contains(`.o_kanban_record`).click({ altKey: true });
+    await contains(`.o_kanban_record.o_record_selected`).click();
+    expect(`.o_searchview_input`).not.toBeFocused({
+        message: "The search input shouldn't have the focus",
+    });
+});
+
+test.tags("desktop");
 test("group by properties and drag and drop", async () => {
     expect.assertions(7);
 


### PR DESCRIPTION
Before this commit, when deselecting multiple records in kanban view the focus is set on the searchbar. Like the list view it should take focus on first load but not each time it's displayed.

Task-4813624