### PR TITLE
[FIX] mail: detect hardware acceleration status via WebGL renderer

### DIFF
--- a/addons/mail/static/src/core/common/settings_model.js
+++ b/addons/mail/static/src/core/common/settings_model.js
@@ -1,3 +1,4 @@
+import { hasHardwareAcceleration } from "@mail/utils/common/misc";
 import { _t } from "@web/core/l10n/translation";
 import { browser } from "@web/core/browser/browser";
 import { fields, Record } from "./record";
@@ -77,6 +78,15 @@ export class Settings extends Record {
     edgeBlurAmount = 10;
     showOnlyVideo = false;
     useBlur = false;
+    blurPerformanceWarning = fields.Attr(false, {
+        compute() {
+            const rtc = this.store.rtc;
+            if (!rtc || !this.useBlur) {
+                return false;
+            }
+            return this.useBlur && rtc.state?.cameraTrack && !hasHardwareAcceleration();
+        },
+    });
 
     logRtc = false;
     /**

--- a/addons/mail/static/src/discuss/call/common/blur_performance_warning.js
+++ b/addons/mail/static/src/discuss/call/common/blur_performance_warning.js
@@ -1,0 +1,19 @@
+import { CallPopover } from "@mail/discuss/call/common/call_popover";
+
+import { Component } from "@odoo/owl";
+
+import { useService } from "@web/core/utils/hooks";
+
+export class BlurPerformanceWarning extends Component {
+    static template = "discuss.BlurPerformanceWarning";
+    static props = {};
+    static components = { CallPopover };
+
+    setup() {
+        this.store = useService("mail.store");
+    }
+
+    onClickClose() {
+        this.store.settings.blurPerformanceWarning = false;
+    }
+}

--- a/addons/mail/static/src/discuss/call/common/blur_performance_warning.xml
+++ b/addons/mail/static/src/discuss/call/common/blur_performance_warning.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates>
+    <t t-name="discuss.BlurPerformanceWarning">
+        <CallPopover class="'position-absolute top-0 start-0 z-2'" contentClass="'o-discuss-BlurPerformanceWarning'" openByDefault="true">
+            <div class="o-discuss-BlurPerformanceWarning-button btn bg-warning-subtle p-1 rounded-circle" title="Background Blur Performance Warning">
+                <i class="fa fa-exclamation-triangle fa-fw"/>
+            </div>
+            <t t-set-slot="content">
+                <div class="position-relative p-3 shadow rounded bg-warning-subtle text-dark" style="min-width:275px;">
+                    <div class="position-absolute top-0 end-0 m-2 cursor-pointer" t-on-click="onClickClose" title="Dismiss warning">
+                        <i class="oi oi-close"/>
+                    </div>
+                    <div>
+                        <strong>Performance Warning:</strong><br/>
+                        Hardware acceleration is disabled. Blur effect impacts performance significantly.
+                    </div>
+                </div>
+            </t>
+        </CallPopover>
+    </t>
+</templates>

--- a/addons/mail/static/src/discuss/call/common/call.js
+++ b/addons/mail/static/src/discuss/call/common/call.js
@@ -1,3 +1,4 @@
+import { BlurPerformanceWarning } from "@mail/discuss/call/common/blur_performance_warning";
 import { CallActionList } from "@mail/discuss/call/common/call_action_list";
 import { CallParticipantCard } from "@mail/discuss/call/common/call_participant_card";
 import { PttAdBanner } from "@mail/discuss/call/common/ptt_ad_banner";
@@ -25,8 +26,13 @@ import { useHotkey } from "@web/core/hotkeys/hotkey_hook";
  * @extends {Component<Props, Env>}
  */
 export class Call extends Component {
-    static components = { CallActionList, CallParticipantCard, PttAdBanner };
-    static props = ["thread?", "compact?", "isPip?"];
+    static components = {
+        BlurPerformanceWarning,
+        CallActionList,
+        CallParticipantCard,
+        PttAdBanner,
+    };
+    static props = ["thread", "compact?", "isPip?"];
     static template = "discuss.Call";
 
     overlayTimeout;

--- a/addons/mail/static/src/discuss/call/common/call.xml
+++ b/addons/mail/static/src/discuss/call/common/call.xml
@@ -12,6 +12,7 @@
             'o-selfInCall': isActiveCall,
         }">
             <div class="o-discuss-Call-main d-flex flex-grow-1 flex-column align-items-center justify-content-center position-relative overflow-auto o-scrollbar-thin" t-on-mouseleave="onMouseleaveMain">
+                <BlurPerformanceWarning t-if="store.settings.blurPerformanceWarning"/>
                 <div
                     class="o-discuss-Call-mainCards d-flex align-items-center overflow-hidden h-100 w-100 flex-wrap justify-content-center"
                     t-att-class="{'mt-1': minimized}"

--- a/addons/mail/static/src/discuss/call/common/call_popover.js
+++ b/addons/mail/static/src/discuss/call/common/call_popover.js
@@ -13,19 +13,21 @@ export class CallPopover extends Component {
         contentClass: { type: String, optional: true },
         clickToClose: { type: Boolean, optional: true },
         slots: { optional: true },
+        openByDefault: { type: Boolean, optional: true },
     };
     static defaultProps = {
         position: "bottom",
         class: "",
         contentClass: "",
         clickToClose: false,
+        openByDefault: false,
     };
 
     setup() {
         super.setup();
         this.triggerRef = useRef("trigger");
         this.contentRef = useRef("content");
-        this.state = useState({ isOpen: false });
+        this.state = useState({ isOpen: this.props.openByDefault });
         usePosition("content", () => this.triggerRef.el, {
             position: this.props.position,
             margin: 4,

--- a/addons/mail/static/src/utils/common/misc.js
+++ b/addons/mail/static/src/utils/common/misc.js
@@ -1,4 +1,5 @@
 import { reactive } from "@odoo/owl";
+import { memoize } from "@web/core/utils/functions";
 import { rpc } from "@web/core/network/rpc";
 
 export function assignDefined(obj, data, keys = Object.keys(data)) {
@@ -191,3 +192,29 @@ export function convertToEmbedURL(url) {
     }
     return { url: null, provider: null };
 }
+
+/**
+ * Checks if the browser supports hardware acceleration for video processing.
+ *
+ * @returns {boolean} True if hardware acceleration is supported, false otherwise.
+ */
+export const hasHardwareAcceleration = memoize(() => {
+    const canvas = document.createElement("canvas");
+    const gl =
+        canvas.getContext("webgl2") ||
+        canvas.getContext("webgl") ||
+        canvas.getContext("experimental-webgl");
+    if (!gl) {
+        // WebGL support is typically required for hardware acceleration.
+        return false;
+    }
+    const debugInfo = gl.getExtension("WEBGL_debug_renderer_info");
+    if (debugInfo) {
+        const renderer = gl.getParameter(debugInfo.UNMASKED_RENDERER_WEBGL);
+        if (/swiftshader|llvmpipe|software/i.test(renderer)) {
+            // These renderers indicate software-based rendering instead of hardware acceleration.
+            return false;
+        }
+    }
+    return true;
+});


### PR DESCRIPTION
When background blur is enabled during a video call, lack of hardware acceleration can significantly degrade performance or causes visual frame drops making an effect of glitches in the video streams. Users may not be aware that their devices is falling back to software rendering, especially on the desktops.

This commit introduces a warning dialog that informs users when the hardware acceleration is not available while blur is enabled. The warning appears:

-  As a banner in the discuss main call interface
![image](https://github.com/user-attachments/assets/d1037d54-09f9-4435-abaa-dcfd854b37c3)

- As a popover in the chat window interface.
 ![image](https://github.com/user-attachments/assets/2601cd46-64d8-4f55-9302-484dac0942ae)

For more info about why WebGL is required, read this: https://developer.mozilla.org/en-US/docs/Web/API/WebGL_API

task-4781216
