### PR TITLE
[IMP] website: media manager enhancement

### DIFF
--- a/addons/html_builder/static/src/core/media_website_plugin.js
+++ b/addons/html_builder/static/src/core/media_website_plugin.js
@@ -14,6 +14,7 @@ export class MediaWebsitePlugin extends Plugin {
         on_replaced_media_handlers: ({ newMediaEl }) =>
             // Activate the new media options.
             this.dependencies.builderOptions.setNextTarget(newMediaEl),
+        on_snippet_dropped_handlers: this.onSnippetDropped.bind(this),
     };
 
     setup() {
@@ -104,5 +105,26 @@ export class MediaWebsitePlugin extends Plugin {
             tooltip: _t("Double-click to edit"),
         });
         setTimeout(this.removeCurrentTooltip, 1500);
+    }
+
+    async onSnippetDropped({ snippetEl }) {
+        if (!snippetEl.matches(".media_iframe_video")) {
+            return;
+        }
+        let isVideoSelected = false;
+        await new Promise((resolve) => {
+            const onClose = this.dependencies.media.openMediaDialog({
+                activeTab: "VIDEOS",
+                save: async (selectedVideoEl) => {
+                    isVideoSelected = true;
+                    snippetEl.insertAdjacentElement("afterend", selectedVideoEl);
+                    snippetEl.remove();
+                },
+            });
+            onClose.then(() => {
+                resolve();
+            });
+        });
+        return !isVideoSelected;
     }
 }

--- a/addons/html_builder/static/src/plugins/image/replace_media_option.js
+++ b/addons/html_builder/static/src/plugins/image/replace_media_option.js
@@ -1,4 +1,5 @@
 import { BaseOptionComponent, useDomState } from "@html_builder/core/utils";
+import { _t } from "@web/core/l10n/translation";
 
 export class ReplaceMediaOption extends BaseOptionComponent {
     static template = "html_builder.ReplaceMediaOption";
@@ -6,6 +7,7 @@ export class ReplaceMediaOption extends BaseOptionComponent {
     setup() {
         super.setup();
         this.state = useDomState((editingElement) => ({
+            tooltipName: this.getTooltipName(editingElement),
             canSetLink: this.canSetLink(editingElement),
             hasHref: this.hasHref(editingElement),
         }));
@@ -20,6 +22,21 @@ export class ReplaceMediaOption extends BaseOptionComponent {
     hasHref(editingElement) {
         const parentEl = searchSupportedParentLinkEl(editingElement);
         return parentEl.tagName === "A" && parentEl.hasAttribute("href");
+    }
+    getTooltipName(editingElement) {
+        const classes = editingElement.classList;
+        if (classes.contains("media_iframe_video")) {
+            return _t("Replace Video");
+        } else if (classes.contains("img")) {
+            return _t("Replace Image");
+        } else if (
+            classes.contains("fa") ||
+            Array.from(classes).some((cls) => cls.startsWith("s_share_"))
+        ) {
+            return _t("Replace Icon");
+        } else {
+            return _t("Replace Media");
+        }
     }
 }
 

--- a/addons/html_builder/static/src/plugins/image/replace_media_option.xml
+++ b/addons/html_builder/static/src/plugins/image/replace_media_option.xml
@@ -5,7 +5,7 @@
     <BuilderRow label.translate="Media">
         <BuilderButton
             action="'replaceMedia'"
-            title.translate="Replace image"
+            title="state.tooltipName"
             className="'flex-grow-1'"
             type="'success'"
             preview="false"


### PR DESCRIPTION
When dropping an inner video snippet, the media manager will now open
on the video tab, ensuring a smoother experience when adding videos to
the website.

The replace button now shows meaningfull tooltips:
- "Replace Image" for images
- "Replace Video" for videos
- "Replace Icon" for icons

task-4876092