### PR TITLE
[FIX] website_sale_mass_mailing: newsletter button in website settings

### DIFF
--- a/addons/website_sale_mass_mailing/models/res_config_settings.py
+++ b/addons/website_sale_mass_mailing/models/res_config_settings.py
@@ -6,19 +6,31 @@ from odoo import api, fields, models
 class ResConfigSettings(models.TransientModel):
     _inherit = 'res.config.settings'
 
-    is_newsletter_enabled = fields.Boolean()
+    is_newsletter_enabled = fields.Boolean(
+        compute='_compute_is_newsletter_enabled', store=True, readonly=False,
+    )
     newsletter_id = fields.Many2one(related='website_id.newsletter_id', readonly=False)
+
+    # === COMPUTE METHODS ===#
+
+    @api.depends('website_id')
+    def _compute_is_newsletter_enabled(self):
+        """
+        Computing newsletter setting when changing the website in the res.config.settings page to
+        show the correct value in the checkbox.
+        """
+        for record in self:
+            website = record.with_context(website_id=record.website_id.id).website_id
+            record.is_newsletter_enabled = website.is_view_active(
+                'website_sale_mass_mailing.newsletter'
+            )
 
     # === CRUD METHODS ===#
 
-    @api.model
-    def get_values(self):
-        res = super().get_values()
-        res['is_newsletter_enabled'] = self.env.ref('website_sale_mass_mailing.newsletter').active
-        return res
-
     def set_values(self):
         super().set_values()
-        newsletter_view = self.env.ref('website_sale_mass_mailing.newsletter')
-        if newsletter_view.active != self.is_newsletter_enabled:
-            newsletter_view.active = self.is_newsletter_enabled
+        if self.website_id:
+            website = self.with_context(website_id=self.website_id.id).website_id
+            website_newsletter_view = website.viewref('website_sale_mass_mailing.newsletter')
+            if website_newsletter_view.active != self.is_newsletter_enabled:
+                website_newsletter_view.active = self.is_newsletter_enabled

--- a/addons/website_sale_mass_mailing/tests/__init__.py
+++ b/addons/website_sale_mass_mailing/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_res_config_settings

--- a/addons/website_sale_mass_mailing/tests/test_res_config_settings.py
+++ b/addons/website_sale_mass_mailing/tests/test_res_config_settings.py
@@ -1,0 +1,59 @@
+from odoo.tests.common import TransactionCase, tagged
+
+
+@tagged('post_install', '-at_install')
+class TestResConfigSettings(TransactionCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        Website = cls.env['website']
+        MailingList = cls.env['mailing.list']
+
+        cls.mailing_list = MailingList.search([], limit=1)
+        assert cls.mailing_list, "No mailing list found for the test."
+
+        cls.site_one = Website.create({'name': 'Site 1'})
+        cls.site_two = Website.create({'name': 'Site 2'})
+
+        cls.site_one_settings = cls._create_settings_for_website(cls.site_one, False)
+        cls.site_two_settings = cls._create_settings_for_website(cls.site_two, False)
+
+    @classmethod
+    def _create_settings_for_website(cls, website, enable_newsletter):
+        """Create and execute settings for a given website."""
+        settings = cls.env['res.config.settings'].with_context(website_id=website.id).create({
+            'newsletter_id': cls.mailing_list.id,
+            'is_newsletter_enabled': enable_newsletter,
+            'website_id': website.id,
+        })
+        settings.execute()
+        return settings
+
+    def _get_newsletter_view_for_website(self, website_setting, website):
+        """Return the newsletter view associated with a specific website."""
+        website = website_setting.with_context(website_id=website.id).website_id
+        return website.viewref('website_sale_mass_mailing.newsletter')
+
+    def test_newsletter_enabled_per_website(self):
+        """Test newsletter enablement per website and its effect on view activation."""
+        # Ensure initial state: newsletter is disabled for both websites
+        self.assertFalse(self.site_one_settings.is_newsletter_enabled)
+        self.assertFalse(self.site_two_settings.is_newsletter_enabled)
+
+        # Enable newsletter for site one
+        self.site_one_settings.is_newsletter_enabled = True
+        self.site_one_settings.execute()
+
+        site_one_newsletter_view = self._get_newsletter_view_for_website(self.site_one_settings, self.site_one)
+        self.assertTrue(site_one_newsletter_view.active, "Newsletter view should be active for Site One")
+        self.assertTrue(self.site_one_settings.is_newsletter_enabled)
+        self.assertFalse(self.site_two_settings.is_newsletter_enabled)
+
+        # Enable newsletter for site two
+        self.site_two_settings.is_newsletter_enabled = True
+        self.site_two_settings.execute()
+
+        site_two_newsletter_view = self._get_newsletter_view_for_website(self.site_two_settings, self.site_two)
+        self.assertTrue(site_two_newsletter_view.active, "Newsletter view should be active for Site Two")
+        self.assertTrue(self.site_two_settings.is_newsletter_enabled)


### PR DESCRIPTION
Reproduction Steps:
---------------------------------------------------
To reproduce the issue first we need to create cowed view, follow the steps below:

- Ensure that the website and website_sale_mass_mailing modules are installed. 
- Navigate to Website > Shop.
- Select any product and add it to the cart.
- click on Proceed to checkout then checkout.
- On the checkout page, you will see the address form.
- Click on "Add a new address".
- Now "Edit" the website page (e.g., make the City label bold).

This will create a cowed view for the address page.
Now, follow the final steps to reproduce the actual issue:

- Enable the "Newsletter" option from Website Settings.
- Log out of the database.
- Go to the website shop, add a product to the cart, and proceed to checkout.
- On the address page, the subscription checkbox is not visible for a "Guest"  user.

Root Cause:
--------------------------------------------
The subscription checkbox does not appear because the cowed view of the newsletter is not activated.

Solution:
---------------------------------------
As of SaaS 17.3, a new module `website_sale_mass_mailing` was introduced, which adds the "Newsletter" option in Website Settings. When this option is enabled, the newsletter view is automatically activated. However, the corresponding cowed views are not automatically activated, causing the subscription checkbox to be missing during guest checkout.
To fix this, we ensure that the corresponding cowed view is also activated when the "Newsletter" option is enabled.

Related Link:
https://github.com/odoo/odoo/pull/154604/files

OPW-4860002
UPG-2978748



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
