### PR TITLE
[IMP] html_editor: allow converting first table row to header

### DIFF
--- a/addons/html_editor/__manifest__.py
+++ b/addons/html_editor/__manifest__.py
@@ -41,11 +41,7 @@ This addon provides an extensible, maintainable editor.
             'html_editor/static/src/others/qweb_picker*',
             'html_editor/static/src/others/qweb_plugin*',
             'html_editor/static/src/services/**/*',
-            ('remove', 'html_editor/static/src/components/history_dialog/history_dialog.dark.scss'),
-            ('remove', 'html_editor/static/src/main/movenode.dark.scss'),
-            ('remove', 'html_editor/static/src/main/toolbar/toolbar.dark.scss'),
-            ('remove', 'html_editor/static/src/main/chatgpt/language_selector.dark.scss'),
-            ('remove', 'html_editor/static/src/main/table/table_align_selector.dark.scss'),
+            ('remove', 'html_editor/static/src/**/*.dark.scss'),
         ],
         'html_editor.assets_media_dialog': [
             # Bundle to use the media dialog in the backend and the frontend
@@ -65,11 +61,7 @@ This addon provides an extensible, maintainable editor.
             'html_editor/static/src/utils/**/*',
         ],
         "web.assets_web_dark": [
-            'html_editor/static/src/components/history_dialog/history_dialog.dark.scss',
-            'html_editor/static/src/main/movenode.dark.scss',
-            'html_editor/static/src/main/toolbar/toolbar.dark.scss',
-            'html_editor/static/src/main/chatgpt/language_selector.dark.scss',
-            'html_editor/static/src/main/table/table_align_selector.dark.scss',
+            'html_editor/static/src/**/*.dark.scss',
         ],
         'web.assets_tests': [
             'html_editor/static/tests/tours/**/*',

--- a/addons/html_editor/static/src/main/power_buttons_plugin.js
+++ b/addons/html_editor/static/src/main/power_buttons_plugin.js
@@ -127,7 +127,7 @@ export class PowerButtonsPlugin extends Plugin {
             editableRect.bottom > blockRect.top &&
             isEmptyBlock(block) &&
             !this.services.ui.isSmall &&
-            !closestElement(editableSelection.anchorNode, "td, li") &&
+            !closestElement(editableSelection.anchorNode, "td, th, li") &&
             !block.style.textAlign &&
             this.getResource("power_buttons_visibility_predicates").every((predicate) =>
                 predicate(editableSelection)

--- a/addons/html_editor/static/src/main/table/table.dark.scss
+++ b/addons/html_editor/static/src/main/table/table.dark.scss
@@ -1,0 +1,4 @@
+th.o_table_header {
+    background-color: #1B1D26;
+    font-weight: 900;
+}

--- a/addons/html_editor/static/src/main/table/table.scss
+++ b/addons/html_editor/static/src/main/table/table.scss
@@ -1,0 +1,4 @@
+th.o_table_header {
+    background-color: #F7F7F7;
+    font-weight: 900;
+}

--- a/addons/html_editor/static/src/main/table/table_menu.js
+++ b/addons/html_editor/static/src/main/table/table_menu.js
@@ -14,6 +14,8 @@ export class TableMenu extends Component {
         moveRow: Function,
         addRow: Function,
         removeRow: Function,
+        turnIntoHeader: Function,
+        turnIntoRow: Function,
         resetRowHeight: Function,
         resetColumnWidth: Function,
         resetTableSize: Function,
@@ -35,6 +37,7 @@ export class TableMenu extends Component {
             const tr = this.props.target.parentElement;
             this.isFirst = !tr.previousElementSibling;
             this.isLast = !tr.nextElementSibling;
+            this.isTableHeader = [...tr.children][0].nodeName === "TH";
         }
         this.items = this.props.type === "column" ? this.colItems() : this.rowItems();
     }
@@ -123,6 +126,20 @@ export class TableMenu extends Component {
 
     rowItems() {
         return [
+            this.isFirst &&
+                !this.isTableHeader && {
+                    name: "make_header",
+                    icon: "fa-th-large",
+                    text: _t("Turn into header"),
+                    action: (target) => this.props.turnIntoHeader(target.parentElement),
+                },
+            this.isFirst &&
+                this.isTableHeader && {
+                    name: "remove_header",
+                    icon: "fa-table",
+                    text: _t("Turn into row"),
+                    action: (target) => this.props.turnIntoRow(target.parentElement),
+                },
             !this.isFirst && {
                 name: "move_up",
                 icon: "fa-chevron-up",
@@ -135,7 +152,7 @@ export class TableMenu extends Component {
                 text: _t("Move down"),
                 action: (target) => this.props.moveRow("down", target.parentElement),
             },
-            {
+            !this.isTableHeader && {
                 name: "insert_above",
                 icon: "fa-plus",
                 text: _t("Insert above"),

--- a/addons/html_editor/static/src/main/table/table_resize_plugin.js
+++ b/addons/html_editor/static/src/main/table/table_resize_plugin.js
@@ -6,6 +6,7 @@ import {
 } from "@html_editor/utils/dom_traversal";
 import { getColumnIndex } from "@html_editor/utils/table";
 import { BORDER_SENSITIVITY } from "@html_editor/main/table/table_plugin";
+import { isTableCell } from "@html_editor/utils/dom_info";
 
 export class TableResizePlugin extends Plugin {
     static id = "tableResize";
@@ -28,7 +29,7 @@ export class TableResizePlugin extends Plugin {
      */
     isHoveringTdBorder(ev) {
         const target = /** @type {HTMLElement} */ (ev.target);
-        if (ev.target && target.nodeName === "TD" && target.isContentEditable) {
+        if (ev.target && isTableCell(target) && target.isContentEditable) {
             const targetRect = target.getBoundingClientRect();
             if (ev.clientX <= targetRect.x + BORDER_SENSITIVITY) {
                 return "left";
@@ -98,11 +99,11 @@ export class TableResizePlugin extends Plugin {
         // TD widths should only be applied in the first row. Change targets and
         // clean the rest.
         if (direction === "col") {
-            let hostCell = closestElement(table, "td");
+            let hostCell = closestElement(table, isTableCell);
             const hostCells = [];
             while (hostCell) {
                 hostCells.push(hostCell);
-                hostCell = closestElement(hostCell.parentElement, "td");
+                hostCell = closestElement(hostCell.parentElement, isTableCell);
             }
             const nthColumn = getColumnIndex(item);
             const firstRow = [...table.querySelector("tr").children];
@@ -141,7 +142,7 @@ export class TableResizePlugin extends Plugin {
                 if (newMargin >= 0 && newSize > MIN_SIZE) {
                     const tableRect = table.getBoundingClientRect();
                     // Check if a nested table would overflow its parent cell.
-                    const hostCell = closestElement(table.parentElement, "td");
+                    const hostCell = closestElement(table.parentElement, isTableCell);
                     const childTable = item.querySelector("table");
                     const endProp = isRTL ? "left" : "right";
                     if (
@@ -221,7 +222,7 @@ export class TableResizePlugin extends Plugin {
                 if ((newSize >= 0 || direction === "row") && newSize > MIN_SIZE) {
                     const tableRect = table.getBoundingClientRect();
                     // Check if a nested table would overflow its parent cell.
-                    const hostCell = closestElement(table.parentElement, "td");
+                    const hostCell = closestElement(table.parentElement, isTableCell);
                     const childTable = item.querySelector("table");
                     const endProp = isRTL ? "left" : "right";
                     if (
@@ -262,7 +263,7 @@ export class TableResizePlugin extends Plugin {
             const table = closestElement(cell, "table");
             const currentColumnIndex = getColumnIndex(cell);
             const currentColumnCells = table.querySelectorAll(
-                `tr td:nth-of-type(${currentColumnIndex + 1})`
+                `tr :is(td, th):nth-of-type(${currentColumnIndex + 1})`
             );
             this.dependencies.table.resetColumnWidth(currentColumnCells[0]);
             const isLeftSideClick = isHoveringTdBorder === "left";
@@ -274,7 +275,7 @@ export class TableResizePlugin extends Plugin {
                     ? currentColumnIndex - 1
                     : currentColumnIndex + 1;
                 const siblingColumnCells = table.querySelectorAll(
-                    `tr td:nth-of-type(${siblingColumnIndex + 1})`
+                    `tr :is(td, th):nth-of-type(${siblingColumnIndex + 1})`
                 );
                 this.dependencies.table.resetColumnWidth(siblingColumnCells[0]);
             }
@@ -308,15 +309,11 @@ export class TableResizePlugin extends Plugin {
                 target2 = closestElement(ev.target, "tr");
             } else if (isHoveringTdBorder === "right") {
                 if (isRTL) {
-                    target1 = getAdjacentPreviousSiblings(ev.target).find(
-                        (node) => node.nodeName === "TD"
-                    );
+                    target1 = getAdjacentPreviousSiblings(ev.target).find(isTableCell);
                     target2 = ev.target;
                 } else {
                     target1 = ev.target;
-                    target2 = getAdjacentNextSiblings(ev.target).find(
-                        (node) => node.nodeName === "TD"
-                    );
+                    target2 = getAdjacentNextSiblings(ev.target).find(isTableCell);
                 }
             } else if (isHoveringTdBorder === "bottom" && column) {
                 target1 = closestElement(ev.target, "tr");
@@ -324,13 +321,9 @@ export class TableResizePlugin extends Plugin {
             } else if (isHoveringTdBorder === "left") {
                 if (isRTL) {
                     target1 = ev.target;
-                    target2 = getAdjacentNextSiblings(ev.target).find(
-                        (node) => node.nodeName === "TD"
-                    );
+                    target2 = getAdjacentNextSiblings(ev.target).find(isTableCell);
                 } else {
-                    target1 = getAdjacentPreviousSiblings(ev.target).find(
-                        (node) => node.nodeName === "TD"
-                    );
+                    target1 = getAdjacentPreviousSiblings(ev.target).find(isTableCell);
                     target2 = ev.target;
                 }
             }

--- a/addons/html_editor/static/src/main/table/table_ui_plugin.js
+++ b/addons/html_editor/static/src/main/table/table_ui_plugin.js
@@ -156,6 +156,8 @@ export class TableUIPlugin extends Plugin {
             moveRow: withAddStep(this.dependencies.table.moveRow),
             addRow: withAddStep(this.dependencies.table.addRow),
             removeRow: withAddStep(this.dependencies.table.removeRow),
+            turnIntoHeader: withAddStep(this.dependencies.table.turnIntoHeader),
+            turnIntoRow: withAddStep(this.dependencies.table.turnIntoRow),
             resetRowHeight: withAddStep(this.dependencies.table.resetRowHeight),
             resetColumnWidth: withAddStep(this.dependencies.table.resetColumnWidth),
             resetTableSize: withAddStep(this.dependencies.table.resetTableSize),

--- a/addons/html_editor/static/src/utils/dom_info.js
+++ b/addons/html_editor/static/src/utils/dom_info.js
@@ -553,6 +553,10 @@ export function isListElement(node) {
 
 export const listElementSelector = [...listContainers].join(",");
 
+export function isTableCell(node) {
+    return ["TH", "TD"].includes(node.nodeName);
+}
+
 /**
  * @param {Element} parentBlock
  * @param {Node[]} nodes

--- a/addons/html_editor/static/src/utils/table.js
+++ b/addons/html_editor/static/src/utils/table.js
@@ -31,5 +31,7 @@ export function getColumnIndex(td) {
  * @returns {Array<HTMLTableCellElement>}
  */
 export function getTableCells(table) {
-    return [...table.querySelectorAll("td")].filter((td) => closestElement(td, "table") === table);
+    return [...table.querySelectorAll("td, th")].filter(
+        (cell) => closestElement(cell, "table") === table
+    );
 }


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

- When users create tables, there was no built-in option to define a semantic header row using `<th>` elements.

Current behavior before PR:

- Tables were created with only `<td>` cells, even for the first row.
- There was no way to mark a row as a header.

Desired behavior after PR is merged:

- Users can toggle the first row of a table as a header using "Make header" / "Remove header" options.
- Header rows use `<th>` tags, apply bold styling, and a background color for visibility.
- If a header row is moved from the first position, it automatically converts back to a regular `<td>` row.
- Inserting new rows above a header row is disabled to preserve its positioning.
- All formatting remains user-editable.

task-4610605

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
