### PR TITLE
[IMP] web: allow opening graph view groups in new tab/window

### DIFF
--- a/addons/web/static/src/views/graph/graph_renderer.js
+++ b/addons/web/static/src/views/graph/graph_renderer.js
@@ -681,7 +681,11 @@ export class GraphRenderer extends Component {
      * If a group has been clicked on, display a view of its records.
      * @param {MouseEvent} ev
      */
-    onGraphClicked(ev) {
+    onGraphClicked(ev, isMiddleClick) {
+        const { disableLinking, mode } = this.model.metaData;
+        if (disableLinking || mode === "line") {
+            return;
+        }
         const [activeElement] = this.chart.getElementsAtEventForMode(
             ev,
             "nearest",
@@ -694,7 +698,7 @@ export class GraphRenderer extends Component {
         const { datasetIndex, index } = activeElement;
         const { domains } = this.chart.data.datasets[datasetIndex];
         if (domains) {
-            this.onGraphClickedFinal(domains[index]);
+            this.onGraphClickedFinal(domains[index], isMiddleClick);
         }
     }
 
@@ -760,7 +764,7 @@ export class GraphRenderer extends Component {
      * instantiate the chart.
      */
     prepareOptions() {
-        const { disableLinking, mode } = this.model.metaData;
+        const { mode } = this.model.metaData;
         const options = {
             maintainAspectRatio: false,
             scales: this.getScaleOptions(),
@@ -774,9 +778,6 @@ export class GraphRenderer extends Component {
             },
             animation: this.getAnimationOptions(),
         };
-        if (!disableLinking && mode !== "line") {
-            options.onClick = this.onGraphClicked.bind(this);
-        }
         if (mode === "line") {
             options.interaction = {
                 mode: "index",
@@ -848,7 +849,7 @@ export class GraphRenderer extends Component {
      * @param {Array} views
      * @param {Object} context
      */
-    openView(domain, views, context) {
+    openView(domain, views, context, newWindow) {
         this.actionService.doAction(
             {
                 context,
@@ -860,6 +861,7 @@ export class GraphRenderer extends Component {
                 views,
             },
             {
+                newWindow,
                 viewType: "list",
             }
         );
@@ -867,7 +869,7 @@ export class GraphRenderer extends Component {
     /**
      * @param {string} domain the domain of the clicked area
      */
-    onGraphClickedFinal(domain) {
+    onGraphClickedFinal(domain, isMiddleClick = false) {
         const { context } = this.model.metaData;
 
         Object.keys(context).forEach((x) => {
@@ -884,7 +886,7 @@ export class GraphRenderer extends Component {
             return [views[viewType] || false, viewType];
         }
         const actionViews = [getView("list"), getView("form")];
-        this.openView(domain, actionViews, context);
+        this.openView(domain, actionViews, context, isMiddleClick);
     }
 
     /**

--- a/addons/web/static/src/views/graph/graph_renderer.xml
+++ b/addons/web/static/src/views/graph/graph_renderer.xml
@@ -35,7 +35,7 @@
                 <t t-call="{{ props.buttonTemplate }}"/>
             </div>
             <div t-if="model.hasData()" class="o_graph_canvas_container flex-grow-1 position-relative px-3 pb-3" t-ref="container">
-                <canvas t-ref="canvas" />
+                <canvas t-custom-click="(ev, isMiddleClick) => this.onGraphClicked(ev, isMiddleClick)" t-ref="canvas" />
             </div>
         </div>
     </t>

--- a/addons/web/static/tests/views/graph/graph_test_helpers.js
+++ b/addons/web/static/tests/views/graph/graph_test_helpers.js
@@ -149,10 +149,10 @@ export function checkLegend(view, expectedLabels) {
 /**
  * @param {GraphView} view
  */
-export async function clickOnDataset(view) {
+export async function clickOnDataset(view, options = {}) {
     const chart = getChart(view);
     const point = chart.getDatasetMeta(0).data[0].getCenterPoint();
-    return contains(chart.canvas).click({ position: point, relative: true });
+    return contains(chart.canvas).click({ position: point, relative: true, ...options });
 }
 
 /**

--- a/addons/web/static/tests/views/graph/graph_view.test.js
+++ b/addons/web/static/tests/views/graph/graph_view.test.js
@@ -1853,7 +1853,7 @@ test("clicking on bar charts triggers a do_action", async () => {
                     [false, "form"],
                 ],
             });
-            expect(options).toEqual({ viewType: "list" });
+            expect(options).toEqual({ newWindow: false, viewType: "list" });
         },
     });
 
@@ -1875,6 +1875,45 @@ test("clicking on bar charts triggers a do_action", async () => {
     await clickOnDataset(view);
 });
 
+test("middle click on bar charts triggers a do_action", async () => {
+    expect.assertions(6);
+
+    mockService("action", {
+        doAction(actionRequest, options) {
+            expect(actionRequest).toEqual({
+                context: { allowed_company_ids: [1], lang: "en", tz: "taht", uid: 7 },
+                domain: [["bar", "=", false]],
+                name: "Foo Analysis",
+                res_model: "foo",
+                target: "current",
+                type: "ir.actions.act_window",
+                views: [
+                    [false, "list"],
+                    [false, "form"],
+                ],
+            });
+            expect(options).toEqual({ newWindow: true, viewType: "list" });
+        },
+    });
+
+    const view = await mountView({
+        type: "graph",
+        resModel: "foo",
+        arch: /* xml */ `
+            <graph string="Foo Analysis">
+                <field name="bar" />
+            </graph>
+        `,
+    });
+
+    checkModeIs(view, "bar");
+    checkDatasets(view, ["domains"], {
+        domains: [[["bar", "=", false]], [["bar", "=", true]]],
+    });
+
+    await clickOnDataset(view, { ctrlKey: true });
+});
+
 test("Clicking on bar charts removes group_by and search_default_* context keys", async () => {
     expect.assertions(2);
 
@@ -1892,7 +1931,7 @@ test("Clicking on bar charts removes group_by and search_default_* context keys"
                     [false, "form"],
                 ],
             });
-            expect(options).toEqual({ viewType: "list" });
+            expect(options).toEqual({ newWindow: false, viewType: "list" });
         },
     });
 
@@ -1933,7 +1972,7 @@ test("clicking on a pie chart trigger a do_action with correct views", async () 
                     [29, "form"],
                 ],
             });
-            expect(options).toEqual({ viewType: "list" });
+            expect(options).toEqual({ newWindow: false, viewType: "list" });
         },
     });
 
@@ -1959,6 +1998,54 @@ test("clicking on a pie chart trigger a do_action with correct views", async () 
     });
 
     await clickOnDataset(view);
+});
+
+test("middle click on a pie chart trigger a do_action with correct views", async () => {
+    expect.assertions(6);
+
+    Foo._views[["list", 364]] = /* xml */ `<list />`;
+    Foo._views[["form", 29]] = /* xml */ `<form />`;
+
+    mockService("action", {
+        doAction(actionRequest, options) {
+            expect(actionRequest).toEqual({
+                context: { allowed_company_ids: [1], lang: "en", tz: "taht", uid: 7 },
+                domain: [["bar", "=", false]],
+                name: "Foo Analysis",
+                res_model: "foo",
+                target: "current",
+                type: "ir.actions.act_window",
+                views: [
+                    [364, "list"],
+                    [29, "form"],
+                ],
+            });
+            expect(options).toEqual({ newWindow: true, viewType: "list" });
+        },
+    });
+
+    const view = await mountView({
+        type: "graph",
+        resModel: "foo",
+        arch: /* xml */ `
+            <graph string="Foo Analysis" type="pie">
+                <field name="bar" />
+            </graph>
+        `,
+        config: {
+            views: [
+                [364, "list"],
+                [29, "form"],
+            ],
+        },
+    });
+
+    checkModeIs(view, "pie");
+    checkDatasets(view, ["domains"], {
+        domains: [[["bar", "=", false]], [["bar", "=", true]]],
+    });
+
+    await clickOnDataset(view, { ctrlKey: true });
 });
 
 test('graph view with attribute disable_linking="1"', async () => {


### PR DESCRIPTION
This commit adds support for opening a graph view's group in a new tab or window via middle-click or Ctrl+click.

task-4373340