### PR TITLE
[FIX] product: add uom.group_uom group to the user

### DIFF
--- a/addons/product/tests/test_seller.py
+++ b/addons/product/tests/test_seller.py
@@ -151,6 +151,7 @@ class TestSeller(TransactionCase):
             "Setting the product_id to False shouldn't affect seller_ids.")
 
     def test_supplierinfo_without_uom_and_product_template(self):
+        self.env.user.groups_id += self.env.ref('uom.group_uom')
         supplier_info = self.env['product.supplierinfo'].create({
             'partner_id': self.asustec.id,
         })


### PR DESCRIPTION
The ``test_supplierinfo_without_uom_and_product_template`` test is failing
in the single app tests on runbot nightly builds.

error:
```
AssertionError: 'product_uom_id' was not found in the view
```

The issue is that the ``product_uom_id`` field is included in the view with the ``uom.group_uom`` group.
However, the test case does not assign the ``uom.group_uom`` group to the user.

This commit fixes tests failure caused by https://github.com/odoo/odoo/pull/213497

runbot-226816

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
