### PR TITLE
[FIX] base,irQweb: When in dev-xml mode, the attributes have been consumed

### DIFF
--- a/odoo/addons/base/models/ir_qweb.py
+++ b/odoo/addons/base/models/ir_qweb.py
@@ -381,6 +381,7 @@ import psycopg2.errors
 from markupsafe import Markup, escape
 from collections import defaultdict
 from collections.abc import Sized, Mapping, Sequence
+from copy import deepcopy
 from itertools import count, chain
 from lxml import etree
 from dateutil.relativedelta import relativedelta
@@ -889,8 +890,10 @@ class IrQweb(models.AbstractModel):
         if value.get('error'):
             raise value['error']
 
+        # In dev mode `_generate_code_cached` is not cached and the tree can be processed several times
+        value_tree = deepcopy(value['tree']) if 'xml' in tools.config['dev_mode'] else value['tree']
         # return etree, document and ref
-        return (value['tree'], value['template'], value['ref'])
+        return (value_tree, value['template'], value['ref'])
 
     @api.model
     def _get_preload_attribute_xmlids(self):


### PR DESCRIPTION
This causes some t-calls to not be made, and some attributes to disappear if the templates are used twice in a request.

Issue:

Odoo Client Error
UncaughtPromiseError > TypeError

Uncaught Promise > snippetEl.children[0] is undefined

Occured on localhost:8069 on 2025-06-19 07:34:46 GMT

TypeError: snippetEl.children[0] is undefined
    computeSnippetTemplates@http://localhost:8069/web/assets/9ed6d90/html_builder.assets.min.js:1096:67
    load/this.loadProm<@http://localhost:8069/web/assets/9ed6d90/html_builder.assets.min.js:1093:186
    async*load@http://localhost:8069/web/assets/9ed6d90/html_builder.assets.min.js:1093:268
    setup/</<@http://localhost:8069/web/assets/3ec822d/web.assets_web.min.js:21059:109

