### PR TITLE
[FIX] website: discard skipHistoryHack elements when saving a snippet

### DIFF
--- a/addons/html_builder/static/src/builder.js
+++ b/addons/html_builder/static/src/builder.js
@@ -131,8 +131,12 @@ export class Builder extends Component {
                     key: this.env.localOverlayContainerKey,
                     ref: this.props.overlayRef,
                 },
-                saveSnippet: (snippetEl, cleanForSaveHandlers) =>
-                    this.snippetModel.saveSnippet(snippetEl, cleanForSaveHandlers),
+                saveSnippet: (snippetEl, cleanForSaveHandlers, wrapWithSaveSnippetHandlers) =>
+                    this.snippetModel.saveSnippet(
+                        snippetEl,
+                        cleanForSaveHandlers,
+                        wrapWithSaveSnippetHandlers
+                    ),
                 getShared: () => this.editor.shared,
                 updateInvisibleElementsPanel: () => this.updateInvisibleEls(),
                 allowCustomStyle: true,

--- a/addons/html_builder/static/src/snippets/snippet_service.js
+++ b/addons/html_builder/static/src/snippets/snippet_service.js
@@ -354,10 +354,17 @@ export class SnippetModel extends Reactive {
      *
      * @param {HTMLElement} snippetEl the snippet we want to save
      * @param {Array<Function>} cleanForSaveHandlers all the hanlders of the
-     *     clean_for_save_handlers` resources
+     *     `clean_for_save_handlers` resources
+     * @param {Function} wrapWithSaveSnippetHandlers a function that processes the snippet
+     * before and/or after the cloning. E.g. stopping the interactions before
+     * cloning and restarting them after cloning.
      * @returns
      */
-    saveSnippet(snippetEl, cleanForSaveHandlers) {
+    saveSnippet(
+        snippetEl,
+        cleanForSaveHandlers,
+        wrapWithSaveSnippetHandlers = (_, callback) => callback()
+    ) {
         return new Promise((resolve) => {
             this.dialog.add(
                 ConfirmationDialog,
@@ -371,7 +378,10 @@ export class SnippetModel extends Reactive {
                         const snippetKey = isButton ? "s_button" : snippetEl.dataset.snippet;
                         const thumbnailURL = this.getSnippetThumbnailURL(snippetKey);
 
-                        const snippetCopyEl = snippetEl.cloneNode(true);
+                        const snippetCopyEl = wrapWithSaveSnippetHandlers(snippetEl, () =>
+                            snippetEl.cloneNode(true)
+                        );
+
                         // "CleanForSave" the snippet copy (only its children in
                         // the case of a popup, or it will be saved as invisible
                         // and will not be visible in the "add snippet" dialog).

--- a/addons/website/static/src/builder/plugins/edit_interaction_plugin.js
+++ b/addons/website/static/src/builder/plugins/edit_interaction_plugin.js
@@ -18,6 +18,12 @@ export class EditInteractionPlugin extends Plugin {
             // The clonedEl is implicitly started because it is a newly
             // inserted content.
         },
+        on_will_save_snippet_handlers: ({ snippetEl }) => {
+            this.stopInteractions(snippetEl);
+        },
+        on_saved_snippet_handlers: ({ snippetEl }) => {
+            this.restartInteractions(snippetEl);
+        },
     };
 
     setup() {


### PR DESCRIPTION
**Problem**
Before this commit, custom snippets were saved including elements inserted by
interactions (marked with `data-skip-history-hack`). These elements are not
intended to be saved, and their presence in the custom snippet could disrupt
the normal functioning of an interaction (see `s_countdown` example below).
This happened because interactions were not stopped before saving a snippet.

**How to reproduce**
1. Save a custom snippet including `s_countdown`. E.g. insert `s_text_block`,
   then insert `s_countdown` in it, and finally save it as custom snippet.
2. Place the newly generated custom snippet on the page.
3. PROBLEM: the countdown rings are not centered anymore. Inspecting  the page,
   one can see that `s_countdown` includes 8 canvas, the first 4 being invisible.

**Solution**
This commit introduces two new resources: `on_will_save_snippet_handlers` and
`on_saved_snippet_handlers`, which are called by `saveSnippet` before and after
cloning a snippet for saving. `EditInteractionPlugin` installs two handlers which
stop the interactions before saving a custom snippet and restart the interactions
after saving it. This way: 1. snippets are saved correctly; 2. we have a system
that can be used in future to do other processing before and/or after the saving;
and 3. interactions are not directly touched by `saveSnippet`.

task-4367641