### PR TITLE
[IMP] im_livechat: deduplicate member history

### DIFF
--- a/addons/im_livechat/models/im_livechat_channel_member_history.py
+++ b/addons/im_livechat/models/im_livechat_channel_member_history.py
@@ -37,6 +37,18 @@ class ImLivechatChannelMemberHistory(models.Model):
     _member_id_unique = models.Constraint(
         "UNIQUE(member_id)", "Members can only be linked to one history"
     )
+    _channel_id_partner_id_unique = models.UniqueIndex(
+        "(channel_id, partner_id) WHERE partner_id IS NOT NULL",
+        "One partner can only be linked to one history on a channel",
+    )
+    _channel_id_guest_id_unique = models.UniqueIndex(
+        "(channel_id, guest_id) WHERE guest_id IS NOT NULL",
+        "One guest can only be linked to one history on a channel",
+    )
+    _partner_id_or_guest_id_constraint = models.Constraint(
+        "CHECK(partner_id IS NULL OR guest_id IS NULL)",
+        "History should either be linked to a partner or a guest but not both",
+    )
 
     @api.constrains("channel_id")
     def _constraint_channel_id(self):


### PR DESCRIPTION
Before this commit, joining/leaving a live chat multiple times would lead to several member history creation. However, it would be better to replace the existing member by the new one in order to ease the history model for live chat agent reports. This way, we have only one row for a given (partner_id, channel_id).

An history record will hold every information about the partner/guest in this conversation, regardless of whether multiple members where created.

part of task-4796793

upgrade: https://github.com/odoo/upgrade/pull/7908