### PR TITLE
[FIX] account: Prevent sequence gaps when enabling hash on journals with canceled moves

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -3995,7 +3995,10 @@ class AccountMove(models.Model):
         """
         common_domain = expression.AND([
             common_domain or [],
-            [('state', '=', 'posted')],
+            expression.OR([
+                [('state', '=', 'posted')],
+                [('sequence_number', '!=', False)],
+            ])
         ])
         if force_hash:
             return common_domain

--- a/addons/account/tests/test_account_inalterable_hash.py
+++ b/addons/account/tests/test_account_inalterable_hash.py
@@ -350,7 +350,7 @@ class TestAccountMoveInalterableHash(AccountTestInvoicingCommon):
         move3 = self.init_invoice("out_invoice", self.partner_a, "2024-01-02", amounts=[1000], post=True)
 
         move2.button_draft()  # Create hole in the middle of unhashed chain [move1, move2, move3]
-
+        move2.sequence_number = False
         self.company_data['default_journal_sale'].restrict_mode_hash_table = True
 
         with self.assertRaisesRegex(UserError, "An error occurred when computing the inalterability. A gap has been detected in the sequence."), self.env.cr.savepoint():


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
When enabling the restrict_mode_hash_table on journals that previously operated without hash, the posting of new moves could fail with the following error:

    "An error occurred when computing the inalterability. A gap has been detected in the sequence."

This happened because the domain used to compute the hash only considered posted moves, ignoring moves that were posted, assigned a sequence number, and later canceled.

As a result, gaps were detected because moves with assigned sequence numbers were missing from the hash table computation.

This commit fixes the issue by adjusting the hash domain to also include any moves that have a sequence_number assigned. This ensures that all used sequence numbers are taken into account, regardless of the current move state.

This allows activating restrict_mode_hash_table on existing journals without generating gaps due to previously canceled moves.

Steps to reproduce:
1. Operate with a journal without hash enabled.
2. Post moves → cancel some of them → they retain sequence numbers.
3. Enable hash → try to post a new move → gap error due to ignored canceled moves.

After this fix, such gaps will no longer occur.

Current behavior before PR:
- Enabling restrict_mode_hash_table on journals that previously operated without hash fails
  with a "gap detected in the sequence" error when canceled moves with sequence numbers exist.

Desired behavior after PR is merged:
- All moves that ever had a sequence number (posted or later canceled) are considered when
  computing the hash table, preventing gaps and allowing the posting of new moves normally.

Video of expected behavior (as it worked in v17):  
https://drive.google.com/file/d/19EtZNeVDkm3VR3qBke3B4ggemCQoDNRv/view

This video shows how, in v17, canceling moves with sequence numbers did not cause errors when continuing the sequence, even when enabling hash afterward.

Video of current behavior (v18):  
https://drive.google.com/file/d/1uRKHtWnQa2ZPllYzdHN-aUNoNLvQSibQ/view


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
