### PR TITLE
[FIX] html_builder, *: fix reload and loadOnClean in action classes

### DIFF
--- a/addons/html_builder/static/src/core/builder_action.js
+++ b/addons/html_builder/static/src/core/builder_action.js
@@ -18,7 +18,6 @@ export class BuilderAction {
         this.getValue = this.getValue.bind(this);
         this.clean = this.clean.bind(this);
         this.load = this.load.bind(this);
-        this.loadOnClean = this.loadOnClean.bind(this);
         this.prepare = this.prepare.bind(this);
         this.setup();
     }
@@ -71,8 +70,6 @@ export class BuilderAction {
      * @param {HTMLElement} context.editingElement
      */
     async load(context) {}
-
-    loadOnClean(context) {}
 
     /**
      * Check if a method has been overridden.

--- a/addons/html_builder/static/src/core/composite_action_plugin.js
+++ b/addons/html_builder/static/src/core/composite_action_plugin.js
@@ -21,6 +21,7 @@ export class CompositeActionPlugin extends Plugin {
 class CompositeAction extends BuilderAction {
     static id = "composite";
     static dependencies = ["builderActions"];
+    loadOnClean = true;
     async prepare({ actionParam: { mainParam: actions }, actionValue }) {
         const proms = [];
         for (const actionDef of actions) {
@@ -131,9 +132,6 @@ class CompositeAction extends BuilderAction {
             }
         }
     }
-    loadOnClean() {
-        return true;
-    }
     clean({
         editingElement,
         params: { mainParam: actions },
@@ -194,5 +192,7 @@ class CompositeAction extends BuilderAction {
 
 class ReloadCompositeAction extends CompositeAction {
     static id = "reloadComposite";
-    reload() {}
+    setup() {
+        this.reload = {};
+    }
 }

--- a/addons/website_event/static/src/website_builder/event_page_option_plugin.js
+++ b/addons/website_event/static/src/website_builder/event_page_option_plugin.js
@@ -37,6 +37,9 @@ class DisplaySubMenuAction extends BuilderAction {
         this.orm = this.services.orm;
         this.currentWebsiteUrl = this.document.location.pathname;
         this.eventId = this.getEventObjectId();
+        this.reload = {
+            getReloadUrl: () => this.eventData["website_url"],
+        }
     }
 
     async toggleWebsiteMenu(value) {
@@ -59,12 +62,6 @@ class DisplaySubMenuAction extends BuilderAction {
         }
         const objectIds = this.currentWebsiteUrl.match(/\d+(?![-\w])/);
         return parseInt(objectIds[0]) | 0;
-    }
-
-    reload() {
-        return {
-            getReloadUrl: () => this.eventData["website_url"],
-        };
     }
 
     async prepare() {

--- a/addons/website_sale/static/src/website_builder/products_list_page_option_plugin.js
+++ b/addons/website_sale/static/src/website_builder/products_list_page_option_plugin.js
@@ -87,7 +87,7 @@ class SetDefaultSortAction extends BuilderAction {
         this.reload = {};
     }
     isApplied({ editingElement, value }) {
-        editingElement.dataset.defaultSort === value;
+        return editingElement.dataset.defaultSort === value;
     }
     apply({ value }) {
         return rpc("/shop/config/website", { shop_default_sort: value });


### PR DESCRIPTION
Following the refactoring of actions into class-based structures [1], some properties such as `reload` and `loadOnClean` were inadvertently omitted. Additionally, a missing `return` statement was identified in an `isApplied` method.

[1]: https://github.com/odoo/odoo/commit/b4b215325db61fbbe9793545293c8b6fbc99f310

