### PR TITLE
[FIX] account_payment: traceback due to payment state computation

### DIFF
--- a/addons/account/models/account_payment.py
+++ b/addons/account/models/account_payment.py
@@ -399,7 +399,7 @@ class AccountPayment(models.Model):
                 liquidity, _counterpart, _writeoff = payment._seek_for_lines()
                 payment.state = (
                     'paid'
-                    if move.company_currency_id.is_zero(sum(liquidity.mapped('amount_residual'))) or not liquidity.account_id.reconcile else
+                    if move.company_currency_id.is_zero(sum(liquidity.mapped('amount_residual'))) or not any(liquidity.account_id.mapped('reconcile')) else
                     'in_process'
                 )
             if payment.state == 'in_process' and payment.invoice_ids and all(invoice.payment_state == 'paid' for invoice in payment.invoice_ids):


### PR DESCRIPTION
Previously, a traceback would occur during payment state computation if more than one liquidity line was present with different accounts. This issue was caused by the logic assuming a single account, which fails when multiple are involved.

This commit updates the computation to robustly handle scenarios with multiple liquidity lines, ensuring correct evaluation without raising errors

Traceback: https://pastebin.com/K2kuEaua


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
