### PR TITLE
[IMP] l10n_sa_edi: generating serial number on journal and fixing the…

### DIFF
--- a/addons/l10n_sa_edi/__manifest__.py
+++ b/addons/l10n_sa_edi/__manifest__.py
@@ -4,7 +4,7 @@
 {
     'name': 'Saudi Arabia - E-invoicing',
     'icon': '/l10n_sa/static/description/icon.png',
-    'version': '0.1',
+    'version': '0.2',
     'depends': [
         'account_edi_ubl_cii',
         'account_debit_note',

--- a/addons/l10n_sa_edi/i18n/ar.po
+++ b/addons/l10n_sa_edi/i18n/ar.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 15.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-06-14 10:53+0000\n"
-"PO-Revision-Date: 2023-06-15 14:10+0400\n"
+"POT-Creation-Date: 2025-06-26 10:46+0000\n"
+"PO-Revision-Date: 2025-06-26 14:58+0400\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "Language: ar\n"
@@ -15,9 +15,10 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: \n"
-"X-Generator: Poedit 3.3.1\n"
+"X-Generator: Poedit 3.4.2\n"
 
 #. module: l10n_sa_edi
+#. odoo-python
 #: code:addons/l10n_sa_edi/models/res_config_settings.py:0
 #, python-format
 msgid ""
@@ -30,54 +31,63 @@ msgstr ""
 "الحي: %s"
 
 #. module: l10n_sa_edi
+#. odoo-python
 #: code:addons/l10n_sa_edi/models/account_edi_format.py:0
 #, python-format
 msgid "- Finish the Onboarding procees for journal %s by requesting the CSIDs and completing the checks."
 msgstr "- قم بإنهاء إجراءات الإعداد لدفتر اليومية %s عن طريق طلب معرّفات CSID واستكمال عمليات التحقق."
 
 #. module: l10n_sa_edi
+#. odoo-python
 #: code:addons/l10n_sa_edi/models/account_edi_format.py:0
 #, python-format
 msgid "- Invoice lines should have at least one Tax applied."
 msgstr "- يجب تطبيق ضريبة واحدة على الأقل في بنود الفاتورة."
 
 #. module: l10n_sa_edi
+#. odoo-python
 #: code:addons/l10n_sa_edi/models/account_edi_format.py:0
 #, python-format
 msgid "- No Private Key was generated for company %s. A Private Key is mandatory in order to generate Certificate Signing Requests (CSR)."
 msgstr "- لم يتم إنشاء مفتاح خاص للشركة %s. يعد المفتاح الخاص إلزاميًا لإنشاء طلبات توقيع الشهادة (CSR)."
 
 #. module: l10n_sa_edi
+#. odoo-python
 #: code:addons/l10n_sa_edi/models/account_edi_format.py:0
 #, python-format
 msgid "- No Serial Number was assigned for journal %s. A Serial Number is mandatory in order to generate Certificate Signing Requests (CSR)."
 msgstr "- لم يتم تعيين رقم تسلسلي للمجلة %s. الرقم التسلسلي إلزامي لإنشاء طلبات توقيع الشهادة (CSR)."
 
 #. module: l10n_sa_edi
+#. odoo-python
 #: code:addons/l10n_sa_edi/models/account_edi_format.py:0
 #, python-format
-msgid "- Please, make sure both the Reversed Entry and the Reversal Reason are specified when confirming a Credit/Debit note"
-msgstr "- يرجى التأكد من أن البند المعكوس وسبب العكس محددان عند تأكيد الإشعار الدائن/المدين"
+msgid "- Please, make sure either the Reversed Entry or the Reversal Reason are specified when confirming a Credit/Debit note"
+msgstr ""
 
 #. module: l10n_sa_edi
+#. odoo-python
 #: code:addons/l10n_sa_edi/models/account_edi_format.py:0
 #, python-format
 msgid "- Please, make sure the invoice date is set to either the same as or before Today."
 msgstr "- يُرجى التأكد من ضبط تاريخ الفاتورة على نفس تاريخ اليوم أو قبله."
 
 #. module: l10n_sa_edi
+#. odoo-python
 #: code:addons/l10n_sa_edi/models/account_edi_format.py:0
 #, python-format
 msgid "- Please, set the following fields on the %s: %s"
 msgstr "- يرجى تعيين الحقول التالية على %s: %s"
 
 #. module: l10n_sa_edi
+#. odoo-python
 #: code:addons/l10n_sa_edi/models/account_edi_format.py:0
 #, python-format
 msgid "- The company VAT identification must contain 15 digits, with the first and last digits being '3' as per the BR-KSA-39 and BR-KSA-40 of ZATCA KSA business rule."
 msgstr "- يجب أن يحتوي معرف ضريبة القيمة المضافة للشركة على 15 رقمًا، على أن يكون الرقمان الأول والأخير \"3\" وفقًا لقواعد الأعمال BR-KSA-39 و BR-KSA-40 لهيئة الزكاة والضريبة والجمارك (زاتكا) في المملكة العربية السعودية."
 
 #. module: l10n_sa_edi
+#. odoo-python
 #: code:addons/l10n_sa_edi/models/account_edi_format.py:0
 #, python-format
 msgid "- You cannot post invoices where the Seller is the Buyer"
@@ -101,8 +111,28 @@ msgstr ""
 
 #. module: l10n_sa_edi
 #: model_terms:ir.ui.view,arch_db:l10n_sa_edi.res_config_settings_view_form
-msgid "<i class=\"fa fa-warning mr-2\"/> Warning"
-msgstr "<i class=\"fa fa-warning mr-2\"/> تحذير"
+msgid "<i class=\"fa fa-warning me-2\"/> Warning"
+msgstr ""
+
+#. module: l10n_sa_edi
+#: model_terms:ir.ui.view,arch_db:l10n_sa_edi.arabic_english_invoice
+msgid "<span class=\"fw-bold\">Exchange Rate</span>"
+msgstr ""
+
+#. module: l10n_sa_edi
+#: model_terms:ir.ui.view,arch_db:l10n_sa_edi.arabic_english_invoice
+msgid "<span class=\"fw-bold\">Subtotal</span>"
+msgstr ""
+
+#. module: l10n_sa_edi
+#: model_terms:ir.ui.view,arch_db:l10n_sa_edi.arabic_english_invoice
+msgid "<span class=\"fw-bold\">Total</span>"
+msgstr ""
+
+#. module: l10n_sa_edi
+#: model_terms:ir.ui.view,arch_db:l10n_sa_edi.arabic_english_invoice
+msgid "<span class=\"fw-bold\">VAT Amount</span>"
+msgstr ""
 
 #. module: l10n_sa_edi
 #: model_terms:ir.ui.view,arch_db:l10n_sa_edi.res_config_settings_view_form
@@ -115,23 +145,23 @@ msgstr ""
 
 #. module: l10n_sa_edi
 #: model_terms:ir.ui.view,arch_db:l10n_sa_edi.arabic_english_invoice
-msgid "<strong>Exchange Rate</strong>"
-msgstr "<strong>سعر الصرف</strong>"
+msgid "<strong>الإجمالي الفرعي بالريال السعودي</strong>"
+msgstr ""
 
 #. module: l10n_sa_edi
 #: model_terms:ir.ui.view,arch_db:l10n_sa_edi.arabic_english_invoice
-msgid "<strong>Subtotal (SAR)</strong>"
-msgstr "<strong>الإجمالي الفرعي بالريال السعودي</strong>"
+msgid "<strong>الإجمالي بالريال السعودي</strong>"
+msgstr ""
 
 #. module: l10n_sa_edi
 #: model_terms:ir.ui.view,arch_db:l10n_sa_edi.arabic_english_invoice
-msgid "<strong>Total (SAR)</strong>"
-msgstr "<strong>الإجمالي بالريال السعودي</strong>"
+msgid "<strong>سعر الصرف</strong>"
+msgstr ""
 
 #. module: l10n_sa_edi
 #: model_terms:ir.ui.view,arch_db:l10n_sa_edi.arabic_english_invoice
-msgid "<strong>VAT Amount (SAR)</strong>"
-msgstr "<strong>مبلغ ضريبة القيمة المضافة بالريال السعودي</strong>"
+msgid "<strong>مبلغ ضريبة القيمة المضافة بالريال السعودي</strong>"
+msgstr ""
 
 #. module: l10n_sa_edi
 #: model_terms:ir.ui.view,arch_db:l10n_sa_edi.res_config_settings_view_form
@@ -149,31 +179,36 @@ msgid "Add Debit Note wizard"
 msgstr "إضافة مُعالج إشعار المدين "
 
 #. module: l10n_sa_edi
-#: model:ir.model.fields,help:l10n_sa_edi.field_res_company__l10n_sa_additional_identification_number model:ir.model.fields,help:l10n_sa_edi.field_res_partner__l10n_sa_additional_identification_number
+#: model:ir.model.fields,help:l10n_sa_edi.field_res_company__l10n_sa_additional_identification_number
+#: model:ir.model.fields,help:l10n_sa_edi.field_res_partner__l10n_sa_additional_identification_number
 #: model:ir.model.fields,help:l10n_sa_edi.field_res_users__l10n_sa_additional_identification_number
 msgid "Additional Identification Number for Seller/Buyer"
 msgstr "رقم التعريف الإضافي للبائع/المشتري"
 
 #. module: l10n_sa_edi
+#. odoo-python
 #: code:addons/l10n_sa_edi/models/account_edi_format.py:0
 #, python-format
 msgid "Additional Identification Number is required for commercial partners"
 msgstr "رقم التعريف الإضافي مطلوب للشركاء التجاريين"
 
 #. module: l10n_sa_edi
+#. odoo-python
 #: code:addons/l10n_sa_edi/models/account_edi_format.py:0
 #, python-format
 msgid "Additional Identification Scheme is required for the Buyer if tax exemption reason is either VATEX-SA-HEA or VATEX-SA-EDU, and its value must be NAT"
 msgstr "خطة التعريف الإضافي مطلوب للمشتري إذا كان سبب الإعفاء الضريبي إما VATEX-SA-HEA أو VATEX-SA-EDU، ويجب أن تكون قيمته NAT"
 
 #. module: l10n_sa_edi
+#. odoo-python
 #: code:addons/l10n_sa_edi/models/account_edi_format.py:0
 #, python-format
 msgid "Additional Identification Scheme is required for the Seller, and must be one of CRN, MOM, MLS, SAG or OTH"
 msgstr "خطة التعريف الإضافي مطلوب للبائع، ويج أن يكون إما CRN، MOM، MLS، SAG، أو OTH"
 
 #. module: l10n_sa_edi
-#: model:ir.model.fields,help:l10n_sa_edi.field_res_company__l10n_sa_additional_identification_scheme model:ir.model.fields,help:l10n_sa_edi.field_res_partner__l10n_sa_additional_identification_scheme
+#: model:ir.model.fields,help:l10n_sa_edi.field_res_company__l10n_sa_additional_identification_scheme
+#: model:ir.model.fields,help:l10n_sa_edi.field_res_partner__l10n_sa_additional_identification_scheme
 #: model:ir.model.fields,help:l10n_sa_edi.field_res_users__l10n_sa_additional_identification_scheme
 msgid "Additional Identification scheme for Seller/Buyer"
 msgstr "خطة التعريف الإضافي للبائع/المشتري"
@@ -184,12 +219,20 @@ msgid "Are you sure you wish to re-onboard the Journal?"
 msgstr "هل أنت متأكد من أنك ترغب في إعادة تجهيز دفتر اليومية؟"
 
 #. module: l10n_sa_edi
-#: model:ir.model.fields,field_description:l10n_sa_edi.field_res_partner__l10n_sa_edi_building_number model:ir.model.fields,field_description:l10n_sa_edi.field_res_users__l10n_sa_edi_building_number
-#: model_terms:ir.ui.view,arch_db:l10n_sa_edi.sa_partner_address_form model_terms:ir.ui.view,arch_db:l10n_sa_edi.view_company_form
+#: model:ir.model,name:l10n_sa_edi.model_ir_attachment
+msgid "Attachment"
+msgstr ""
+
+#. module: l10n_sa_edi
+#: model:ir.model.fields,field_description:l10n_sa_edi.field_res_partner__l10n_sa_edi_building_number
+#: model:ir.model.fields,field_description:l10n_sa_edi.field_res_users__l10n_sa_edi_building_number
+#: model_terms:ir.ui.view,arch_db:l10n_sa_edi.sa_partner_address_form
+#: model_terms:ir.ui.view,arch_db:l10n_sa_edi.view_company_form
 msgid "Building Number"
 msgstr "رقم المبنى"
 
 #. module: l10n_sa_edi
+#. odoo-python
 #: code:addons/l10n_sa_edi/models/account_edi_format.py:0
 #, python-format
 msgid "Building Number for the Buyer is required on Standard Invoices"
@@ -206,18 +249,21 @@ msgid "Cancel"
 msgstr "إلغاء"
 
 #. module: l10n_sa_edi
+#. odoo-python
 #: code:addons/l10n_sa_edi/models/account_journal.py:0
 #, python-format
 msgid "Cannot request a Production CSID before completing the Compliance Checks"
 msgstr "لا يمكن طلب CSID الإنتاج قبل إتمام فحوصات الامتثال"
 
 #. module: l10n_sa_edi
+#. odoo-python
 #: code:addons/l10n_sa_edi/models/account_journal.py:0
 #, python-format
 msgid "Cannot request a Production CSID before requesting a CCSID first"
 msgstr "لا يمكن طلب CSID الإنتاج قبل طلب CCSID أولاً"
 
 #. module: l10n_sa_edi
+#. odoo-python
 #: code:addons/l10n_sa_edi/models/account_tax.py:0
 #, python-format
 msgid "Cannot set a tax to Retention if the amount is greater than or equal 0"
@@ -227,6 +273,13 @@ msgstr "لا يمكن تعيين الضريبة للاحتفاظ إذا كان �
 #: model_terms:ir.ui.view,arch_db:l10n_sa_edi.sa_partner_address_form
 msgid "City"
 msgstr "المدينة"
+
+#. module: l10n_sa_edi
+#. odoo-python
+#: code:addons/l10n_sa_edi/models/account_journal.py:0
+#, python-format
+msgid "Clearance and reporting seem to have been mixed up. "
+msgstr ""
 
 #. module: l10n_sa_edi
 #: model:ir.model.fields.selection,name:l10n_sa_edi.selection__res_partner__l10n_sa_additional_identification_scheme__crn
@@ -242,10 +295,8 @@ msgstr "الشركات "
 #: model_terms:ir.ui.view,arch_db:l10n_sa_edi.view_account_journal_form
 msgid ""
 "Complete the Compliance Checks\n"
-"                                    <i class=\"fa fa-check text-success ml-1\" attrs=\"{'invisible': [('l10n_sa_compliance_checks_passed', '=', False)]}\"/>"
+"                                    <i class=\"fa fa-check text-success ms-1\" attrs=\"{'invisible': [('l10n_sa_compliance_checks_passed', '=', False)]}\"/>"
 msgstr ""
-"إكمال فحوصات الامتثال\n"
-"                                    <i class=\"fa fa-check text-success ml-1\" attrs=\"{'invisible': [('l10n_sa_compliance_checks_passed', '=', False)]}\"/>"
 
 #. module: l10n_sa_edi
 #: model:ir.model.fields,help:l10n_sa_edi.field_account_journal__l10n_sa_compliance_csid_json
@@ -258,6 +309,7 @@ msgid "Compliance Checks Done"
 msgstr "فحوصات الامتثال المنجزة"
 
 #. module: l10n_sa_edi
+#. odoo-python
 #: code:addons/l10n_sa_edi/models/account_journal.py:0
 #, python-format
 msgid "Compliance checks can only be run for companies operating from KSA"
@@ -274,36 +326,42 @@ msgid "Contact"
 msgstr "جهة الاتصال"
 
 #. module: l10n_sa_edi
+#. odoo-python
 #: code:addons/l10n_sa_edi/models/account_journal.py:0
 #, python-format
 msgid "Could not complete Compliance Checks for the following file:"
 msgstr "تعذر إجراء فحوصات الامتثال للملف التالي:"
 
 #. module: l10n_sa_edi
+#. odoo-python
 #: code:addons/l10n_sa_edi/models/account_edi_format.py:0
 #, python-format
 msgid "Could not generate Invoice UBL content: %s"
 msgstr "تعذر إنشاء محتوى فاتورة UBL: %s"
 
 #. module: l10n_sa_edi
+#. odoo-python
 #: code:addons/l10n_sa_edi/models/account_edi_format.py:0
 #, python-format
 msgid "Could not generate PCSID values: \n"
 msgstr "تعذر إنشاء قيم PCSID: \n"
 
 #. module: l10n_sa_edi
+#. odoo-python
 #: code:addons/l10n_sa_edi/models/account_edi_format.py:0
 #, python-format
 msgid "Could not generate signed XML values: \n"
 msgstr "تعذر إنشاء قيم XML موقعة: \n"
 
 #. module: l10n_sa_edi
+#. odoo-python
 #: code:addons/l10n_sa_edi/models/account_journal.py:0
 #, python-format
 msgid "Could not obtain Compliance CSID: %s"
 msgstr "تعذر الحصول على CSID للامتثال: %s"
 
 #. module: l10n_sa_edi
+#. odoo-python
 #: code:addons/l10n_sa_edi/models/account_journal.py:0
 #, python-format
 msgid "Could not obtain Production CSID: %s"
@@ -325,13 +383,15 @@ msgid "Created on"
 msgstr "أنشئ في"
 
 #. module: l10n_sa_edi
+#. odoo-python
 #: code:addons/l10n_sa_edi/models/account_edi_format.py:0
 #, python-format
 msgid "Customer"
 msgstr "العميل"
 
 #. module: l10n_sa_edi
-#: model:ir.model.fields,help:l10n_sa_edi.field_account_tax__l10n_sa_is_retention model:ir.model.fields,help:l10n_sa_edi.field_account_tax_template__l10n_sa_is_retention
+#: model:ir.model.fields,help:l10n_sa_edi.field_account_tax__l10n_sa_is_retention
+#: model:ir.model.fields,help:l10n_sa_edi.field_account_tax_template__l10n_sa_is_retention
 msgid "Determines whether or not a tax counts as a Withholding Tax"
 msgstr "يحدد ما إذا كانت الضريبة تُحسب كضريبة احتجاز أم لا"
 
@@ -341,7 +401,8 @@ msgid "Display Name"
 msgstr "اسم العرض"
 
 #. module: l10n_sa_edi
-#: model:ir.model.fields,field_description:l10n_sa_edi.field_account_bank_statement_line__l10n_sa_uuid model:ir.model.fields,field_description:l10n_sa_edi.field_account_move__l10n_sa_uuid
+#: model:ir.model.fields,field_description:l10n_sa_edi.field_account_bank_statement_line__l10n_sa_uuid
+#: model:ir.model.fields,field_description:l10n_sa_edi.field_account_move__l10n_sa_uuid
 #: model:ir.model.fields,field_description:l10n_sa_edi.field_account_payment__l10n_sa_uuid
 msgid "Document UUID (SA)"
 msgstr "UUID الخاص بالمستند (المملكة العربية السعودية)"
@@ -352,23 +413,27 @@ msgid "EDI format"
 msgstr "صيغة EDI "
 
 #. module: l10n_sa_edi
+#. odoo-python
 #: code:addons/l10n_sa_edi/models/account_journal.py:0
 #, python-format
 msgid "Errors:"
 msgstr "الأخطاء:"
 
 #. module: l10n_sa_edi
-#: model:ir.model.fields,field_description:l10n_sa_edi.field_account_tax__l10n_sa_exemption_reason_code model:ir.model.fields,field_description:l10n_sa_edi.field_account_tax_template__l10n_sa_exemption_reason_code
+#: model:ir.model.fields,field_description:l10n_sa_edi.field_account_tax__l10n_sa_exemption_reason_code
+#: model:ir.model.fields,field_description:l10n_sa_edi.field_account_tax_template__l10n_sa_exemption_reason_code
 msgid "Exemption Reason Code"
 msgstr "كود سبب الإعفاء"
 
 #. module: l10n_sa_edi
+#. odoo-python
 #: code:addons/l10n_sa_edi/wizard/account_move_reversal.py:0
 #, python-format
 msgid "For Credit/Debit notes issued in Saudi Arabia, you need to specify a Reason"
 msgstr "للإشعارات الدائنة/المدينة المصدرة في المملكة العربية السعودية، تحتاج إلى تحديد السبب"
 
 #. module: l10n_sa_edi
+#. odoo-python
 #: code:addons/l10n_sa_edi/wizard/account_debit_note.py:0
 #, python-format
 msgid "For debit notes issued in Saudi Arabia, you need to specify a Reason"
@@ -409,12 +474,14 @@ msgid "Identification Scheme"
 msgstr "خطة التعريف"
 
 #. module: l10n_sa_edi
+#. odoo-python
 #: code:addons/l10n_sa_edi/models/account_move.py:0
 #, python-format
 msgid "Invoice Successfully Submitted to ZATCA"
 msgstr "تم إرسال الفاتورة بنجاح إلى زاتكا"
 
 #. module: l10n_sa_edi
+#. odoo-python
 #: code:addons/l10n_sa_edi/models/account_edi_format.py:0
 #, python-format
 msgid ""
@@ -425,6 +492,7 @@ msgstr ""
 " %s "
 
 #. module: l10n_sa_edi
+#. odoo-python
 #: code:addons/l10n_sa_edi/models/account_edi_format.py:0
 #, python-format
 msgid ""
@@ -435,24 +503,28 @@ msgstr ""
 " %s "
 
 #. module: l10n_sa_edi
-#: model:ir.model.fields,help:l10n_sa_edi.field_account_bank_statement_line__l10n_sa_chain_index model:ir.model.fields,help:l10n_sa_edi.field_account_move__l10n_sa_chain_index
+#: model:ir.model.fields,help:l10n_sa_edi.field_account_bank_statement_line__l10n_sa_chain_index
+#: model:ir.model.fields,help:l10n_sa_edi.field_account_move__l10n_sa_chain_index
 #: model:ir.model.fields,help:l10n_sa_edi.field_account_payment__l10n_sa_chain_index
 msgid "Invoice index in chain, set if and only if an in-chain XML was submitted and did not error"
 msgstr "مؤشر الفاتورة في السلسلة. يتم إعداده فقط إذا تم إرسال ملف XML في سلسلة ولم يحدث أي خطأ"
 
 #. module: l10n_sa_edi
+#. odoo-python
 #: code:addons/l10n_sa_edi/models/account_journal.py:0
 #, python-format
 msgid "Invoice submission to ZATCA returned errors"
 msgstr "حدثت أخطاء عند إرسال الفواتير إلى زاتكا"
 
 #. module: l10n_sa_edi
+#. odoo-python
 #: code:addons/l10n_sa_edi/models/account_move.py:0
 #, python-format
 msgid "Invoice was Accepted by ZATCA (with Warnings)"
 msgstr "تم قبول الفاتورة من قِبَل زاتكا (مع تحذيرات)"
 
 #. module: l10n_sa_edi
+#. odoo-python
 #: code:addons/l10n_sa_edi/models/account_move.py:0
 #, python-format
 msgid "Invoice was rejected by ZATCA"
@@ -464,18 +536,21 @@ msgid "Iqama Number"
 msgstr "رقم إقامة "
 
 #. module: l10n_sa_edi
-#: model:ir.model.fields,field_description:l10n_sa_edi.field_account_tax__l10n_sa_is_retention model:ir.model.fields,field_description:l10n_sa_edi.field_account_tax_template__l10n_sa_is_retention
+#: model:ir.model.fields,field_description:l10n_sa_edi.field_account_tax__l10n_sa_is_retention
+#: model:ir.model.fields,field_description:l10n_sa_edi.field_account_tax_template__l10n_sa_is_retention
 msgid "Is Retention"
 msgstr "احتفاظ"
 
 #. module: l10n_sa_edi
+#. odoo-python
 #: code:addons/l10n_sa_edi/models/account_journal.py:0
 #, python-format
 msgid "JSON response from ZATCA could not be decoded"
 msgstr "تعذر فك تشفير رد JSON من زاتكا"
 
 #. module: l10n_sa_edi
-#: model:ir.model,name:l10n_sa_edi.model_account_journal model:ir.model.fields,field_description:l10n_sa_edi.field_l10n_sa_edi_otp_wizard__journal_id
+#: model:ir.model,name:l10n_sa_edi.model_account_journal
+#: model:ir.model.fields,field_description:l10n_sa_edi.field_l10n_sa_edi_otp_wizard__journal_id
 msgid "Journal"
 msgstr "دفتر اليومية"
 
@@ -485,6 +560,12 @@ msgid "Journal Entry"
 msgstr "قيد اليومية"
 
 #. module: l10n_sa_edi
+#: model:ir.model,name:l10n_sa_edi.model_account_move_line
+msgid "Journal Item"
+msgstr ""
+
+#. module: l10n_sa_edi
+#. odoo-python
 #: code:addons/l10n_sa_edi/models/account_journal.py:0
 #, python-format
 msgid "Journal could not be onboarded"
@@ -496,7 +577,22 @@ msgid "Journal could not be onboarded. Please make sure the Company VAT/Identifi
 msgstr "تعذر تجهيز دفتر اليومية. يرجى التأكد من أن رقمي ضريبة القيمة المضافة/رقم التعريف صحيحين."
 
 #. module: l10n_sa_edi
-#: model:ir.model.fields,field_description:l10n_sa_edi.field_res_company__l10n_sa_api_mode model:ir.model.fields,field_description:l10n_sa_edi.field_res_config_settings__l10n_sa_api_mode
+#. odoo-python
+#: code:addons/l10n_sa_edi/models/account_journal.py:0
+#, python-format
+msgid "Journal onboarded with ZATCA successfully"
+msgstr ""
+
+#. module: l10n_sa_edi
+#. odoo-python
+#: code:addons/l10n_sa_edi/models/account_journal.py:0
+#, python-format
+msgid "Journal re-onboarded with ZATCA successfully"
+msgstr ""
+
+#. module: l10n_sa_edi
+#: model:ir.model.fields,field_description:l10n_sa_edi.field_res_company__l10n_sa_api_mode
+#: model:ir.model.fields,field_description:l10n_sa_edi.field_res_config_settings__l10n_sa_api_mode
 msgid "L10N Sa Api Mode"
 msgstr "L10N Sa Api Mode"
 
@@ -561,12 +657,14 @@ msgid "Neighborhood"
 msgstr "الحي"
 
 #. module: l10n_sa_edi
+#. odoo-python
 #: code:addons/l10n_sa_edi/models/account_edi_format.py:0
 #, python-format
 msgid "Neighborhood for the Buyer is required on Standard Invoices"
 msgstr "الحي الخاص بالمشتري مطلوب في الفواتير القياسية"
 
 #. module: l10n_sa_edi
+#. odoo-python
 #: code:addons/l10n_sa_edi/models/account_edi_format.py:0
 #, python-format
 msgid "Neighborhood for the Seller is required on Standard Invoices"
@@ -609,6 +707,13 @@ msgstr ""
 "                                وقد تؤدي إلى <strong>الغرامات &amp; العقوبات</strong>."
 
 #. module: l10n_sa_edi
+#. odoo-python
+#: code:addons/l10n_sa_edi/models/account_journal.py:0
+#, python-format
+msgid "Oops! The journal is stuck. Please submit the pending invoices to ZATCA and try again."
+msgstr ""
+
+#. module: l10n_sa_edi
 #: model:ir.model.fields.selection,name:l10n_sa_edi.selection__res_partner__l10n_sa_additional_identification_scheme__oth
 msgid "Other ID"
 msgstr "المعرف الآخر"
@@ -639,24 +744,35 @@ msgid "Passport ID"
 msgstr "معرف جواز السفر"
 
 #. module: l10n_sa_edi
+#. odoo-python
+#: code:addons/l10n_sa_edi/migrations/0.2/post-migrate.py:0
+#, python-format
+msgid "Please Re-Onboard the Journal for a new serial number"
+msgstr "يرجى إعادة تجهيز دفتر اليومية للحصول على رقم تسلسلي جديد."
+
+#. module: l10n_sa_edi
+#. odoo-python
 #: code:addons/l10n_sa_edi/models/account_journal.py:0
 #, python-format
 msgid "Please, generate a CSR before requesting a CCSID"
 msgstr "يرجى إنشاء CSR قبل طلب CCSID"
 
 #. module: l10n_sa_edi
+#. odoo-python
 #: code:addons/l10n_sa_edi/models/account_journal.py:0
 #, python-format
 msgid "Please, make a request to obtain the Compliance CSID and Production CSID before sending documents to ZATCA"
 msgstr "يرجى إنشاء طلب للحصول على CSID للامتثال وCSID للإنتاج قبل إرسال المستندات إلى زاتكا"
 
 #. module: l10n_sa_edi
+#. odoo-python
 #: code:addons/l10n_sa_edi/models/account_journal.py:0
 #, python-format
 msgid "Please, make sure all the following fields have been correctly set on the Company: \n"
 msgstr "يرجى التأكد من أن كافة الحقول التالية قد تم إعدادها بشكل صحيح في الشركة: \n"
 
 #. module: l10n_sa_edi
+#. odoo-python
 #: code:addons/l10n_sa_edi/models/account_journal.py:0
 #, python-format
 msgid "Please, set a valid OTP to be used for Onboarding"
@@ -668,8 +784,10 @@ msgid "Please, set the OTP you received from ZATCA in the input below then valid
 msgstr "يرجى إعداد كلمة السر لمرة واحدة التي قمت باستلامها من زاتكا في المدخل أدناه، ثم قم بالتصديق."
 
 #. module: l10n_sa_edi
-#: model:ir.model.fields,field_description:l10n_sa_edi.field_res_partner__l10n_sa_edi_plot_identification model:ir.model.fields,field_description:l10n_sa_edi.field_res_users__l10n_sa_edi_plot_identification
-#: model_terms:ir.ui.view,arch_db:l10n_sa_edi.sa_partner_address_form model_terms:ir.ui.view,arch_db:l10n_sa_edi.view_company_form
+#: model:ir.model.fields,field_description:l10n_sa_edi.field_res_partner__l10n_sa_edi_plot_identification
+#: model:ir.model.fields,field_description:l10n_sa_edi.field_res_users__l10n_sa_edi_plot_identification
+#: model_terms:ir.ui.view,arch_db:l10n_sa_edi.sa_partner_address_form
+#: model_terms:ir.ui.view,arch_db:l10n_sa_edi.view_company_form
 msgid "Plot Identification"
 msgstr "معرّف قطعة الأرض"
 
@@ -689,6 +807,7 @@ msgid "Production CSID expiration date"
 msgstr "تاريخ انتهاء CSID الإنتاج"
 
 #. module: l10n_sa_edi
+#. odoo-python
 #: code:addons/l10n_sa_edi/models/account_journal.py:0
 #, python-format
 msgid "Production certificate has expired, please renew the PCSID before proceeding"
@@ -703,6 +822,11 @@ msgstr "QR"
 #: model_terms:ir.ui.view,arch_db:l10n_sa_edi.view_account_journal_form
 msgid "Re-Onboard"
 msgstr "إعادة التجهيز"
+
+#. module: l10n_sa_edi
+#: model_terms:ir.ui.view,arch_db:l10n_sa_edi.view_account_move_reversal_inherit_l10n_sa_edi
+msgid "Reason"
+msgstr ""
 
 #. module: l10n_sa_edi
 #: model_terms:ir.ui.view,arch_db:l10n_sa_edi.view_account_journal_form
@@ -728,19 +852,15 @@ msgstr "طلب CSID"
 #: model_terms:ir.ui.view,arch_db:l10n_sa_edi.view_account_journal_form
 msgid ""
 "Request a Compliance Certificate (CCSID)\n"
-"                                    <i class=\"fa fa-check text-success ml-1\" attrs=\"{'invisible': [('l10n_sa_compliance_csid_json', '=', False)]}\"/>"
+"                                    <i class=\"fa fa-check text-success ms-1\" groups=\"base.group_system\" attrs=\"{'invisible': [('l10n_sa_compliance_csid_json', '=', False)]}\"/>"
 msgstr ""
-"طلب شهادة امتثال (CCSID)\n"
-"                                    <i class=\"fa fa-check text-success ml-1\" attrs=\"{'invisible': [('l10n_sa_compliance_csid_json', '=', False)]}\"/>"
 
 #. module: l10n_sa_edi
 #: model_terms:ir.ui.view,arch_db:l10n_sa_edi.view_account_journal_form
 msgid ""
 "Request a Production Certificate (PCSID)\n"
-"                                    <i class=\"fa fa-check text-success ml-1\" attrs=\"{'invisible': [('l10n_sa_production_csid_json', '=', False)]}\"/>"
+"                                    <i class=\"fa fa-check text-success ms-1\" groups=\"base.group_system\" attrs=\"{'invisible': [('l10n_sa_production_csid_json', '=', False)]}\"/>"
 msgstr ""
-"طلب شهادة إنتاج (PCSID)\n"
-"                                    <i class=\"fa fa-check text-success ml-1\" attrs=\"{'invisible': [('l10n_sa_production_csid_json', '=', False)]}\"/>"
 
 #. module: l10n_sa_edi
 #: model:ir.model.fields.selection,name:l10n_sa_edi.selection__res_partner__l10n_sa_additional_identification_scheme__sag
@@ -758,19 +878,18 @@ msgid "Serial Number"
 msgstr "الرقم التسلسلي"
 
 #. module: l10n_sa_edi
+#. odoo-python
 #: code:addons/l10n_sa_edi/models/account_journal.py:0
 #, python-format
-msgid "Server returned an unexpected error: "
-msgstr "حدث خطأ غير متوقع في الخادم"
+msgid "Server returned an unexpected error: %(error)s"
+msgstr ""
 
 #. module: l10n_sa_edi
 #: model_terms:ir.ui.view,arch_db:l10n_sa_edi.view_account_journal_form
 msgid ""
 "Set a Serial Number for your device\n"
-"                                    <i class=\"fa fa-check text-success ml-1\" attrs=\"{'invisible': [('l10n_sa_serial_number', '=', False)]}\"/>"
+"                                    <i class=\"fa fa-check text-success ms-1\" attrs=\"{'invisible': [('l10n_sa_serial_number', '=', False)]}\"/>"
 msgstr ""
-"قم بإعداد رقم تسلسلي لجهازك\n"
-"                                    <i class=\"fa fa-check text-success ml-1\" attrs=\"{'invisible': [('l10n_sa_serial_number', '=', False)]}\"/>"
 
 #. module: l10n_sa_edi
 #: model_terms:ir.ui.view,arch_db:l10n_sa_edi.res_config_settings_view_form
@@ -793,11 +912,13 @@ msgid "Specifies if the Compliance Checks have been completed successfully"
 msgstr "يحدد ما إذا كان قد تم إكمال فحوصات الامتثال بنجاح أم لا"
 
 #. module: l10n_sa_edi
-#: model:ir.model.fields,help:l10n_sa_edi.field_res_company__l10n_sa_api_mode model:ir.model.fields,help:l10n_sa_edi.field_res_config_settings__l10n_sa_api_mode
+#: model:ir.model.fields,help:l10n_sa_edi.field_res_company__l10n_sa_api_mode
+#: model:ir.model.fields,help:l10n_sa_edi.field_res_config_settings__l10n_sa_api_mode
 msgid "Specifies which API the system should use"
 msgstr "يحدد نظام الواجهة البرمجية الذي يجب استخدامه"
 
 #. module: l10n_sa_edi
+#. odoo-python
 #: code:addons/l10n_sa_edi/models/account_edi_format.py:0
 #, python-format
 msgid "State / Country subdivision"
@@ -814,6 +935,7 @@ msgid "Street"
 msgstr "الشارع"
 
 #. module: l10n_sa_edi
+#. odoo-python
 #: code:addons/l10n_sa_edi/models/account_edi_format.py:0
 #, python-format
 msgid "Supplier"
@@ -825,7 +947,8 @@ msgid "Tax"
 msgstr "الضريبة"
 
 #. module: l10n_sa_edi
-#: model:ir.model.fields,help:l10n_sa_edi.field_account_tax__l10n_sa_exemption_reason_code model:ir.model.fields,help:l10n_sa_edi.field_account_tax_template__l10n_sa_exemption_reason_code
+#: model:ir.model.fields,help:l10n_sa_edi.field_account_tax__l10n_sa_exemption_reason_code
+#: model:ir.model.fields,help:l10n_sa_edi.field_account_tax_template__l10n_sa_exemption_reason_code
 msgid "Tax Exemption Reason Code (ZATCA)"
 msgstr "كود سبب الإعفاء (زاتكا)"
 
@@ -850,6 +973,7 @@ msgid "The Certificate Signing Request that is submitted to the Compliance API"
 msgstr "طلب توقيع الشهادة المرسل إلى الواجهة البرمجية للامتثال"
 
 #. module: l10n_sa_edi
+#. odoo-python
 #: code:addons/l10n_sa_edi/models/account_journal.py:0
 #, python-format
 msgid "The Production CSID is still valid. You can only renew it once it has expired."
@@ -861,12 +985,14 @@ msgid "The Production certificate is valid until"
 msgstr "شهادة الإنتاج سارية حتى"
 
 #. module: l10n_sa_edi
+#. odoo-python
 #: code:addons/l10n_sa_edi/models/account_move.py:0
 #, python-format
 msgid "The invoice was accepted by ZATCA, but returned warnings. Please, check the response below:"
 msgstr "تم قبول الفاتورة من قِبَل زاتكا، ولكن ظهرت تحذيرات. يرجى إلقاء نظرة على الرد أدناه:"
 
 #. module: l10n_sa_edi
+#. odoo-python
 #: code:addons/l10n_sa_edi/models/account_move.py:0
 #, python-format
 msgid "The invoice was rejected by ZATCA. Please, check the response below:"
@@ -878,23 +1004,25 @@ msgid "The private key used to generate the CSR and obtain certificates"
 msgstr "المفتاح الخاص المستخدَم لإنشاء CSR والحصول على الشهادات"
 
 #. module: l10n_sa_edi
-#: model:ir.model.fields,help:l10n_sa_edi.field_account_journal__l10n_sa_serial_number
-msgid "The serial number of the Taxpayer solution unit. Provided by ZATCA"
-msgstr "الرقم التسلسلي لوحدة حل دافع الضريبة. مقدم من قِبَل زاتكا"
-
-#. module: l10n_sa_edi
 #: model:ir.model,name:l10n_sa_edi.model_account_edi_xml_ubl_21_zatca
 msgid "UBL 2.1 (ZATCA)"
 msgstr "UBL 2.1 (زاتكا)"
 
 #. module: l10n_sa_edi
-#: model:ir.model.fields,help:l10n_sa_edi.field_account_bank_statement_line__l10n_sa_uuid model:ir.model.fields,help:l10n_sa_edi.field_account_move__l10n_sa_uuid
+#: model:ir.model.fields,help:l10n_sa_edi.field_account_journal__l10n_sa_serial_number
+msgid "Unique Serial Number automatically filled when the journal is onboarded"
+msgstr "الرقم التسلسلي الفريد يتم تعبئته تلقائيًا عند إعداد دفتر اليومية."
+
+#. module: l10n_sa_edi
+#: model:ir.model.fields,help:l10n_sa_edi.field_account_bank_statement_line__l10n_sa_uuid
+#: model:ir.model.fields,help:l10n_sa_edi.field_account_move__l10n_sa_uuid
 #: model:ir.model.fields,help:l10n_sa_edi.field_account_payment__l10n_sa_uuid
 msgid "Universally unique identifier of the Invoice"
 msgstr "المعرف الفريد عالمياً للفاتورة"
 
 #. module: l10n_sa_edi
-#: model:ir.model.fields,field_description:l10n_sa_edi.field_account_bank_statement_line__l10n_sa_invoice_signature model:ir.model.fields,field_description:l10n_sa_edi.field_account_move__l10n_sa_invoice_signature
+#: model:ir.model.fields,field_description:l10n_sa_edi.field_account_bank_statement_line__l10n_sa_invoice_signature
+#: model:ir.model.fields,field_description:l10n_sa_edi.field_account_move__l10n_sa_invoice_signature
 #: model:ir.model.fields,field_description:l10n_sa_edi.field_account_payment__l10n_sa_invoice_signature
 msgid "Unsigned XML Signature"
 msgstr "توقيع XML غير مسند"
@@ -910,6 +1038,7 @@ msgid "Used to decide whether we should call the PCSID renewal API or the CCSID 
 msgstr "يُستخدَم لتحديد ما إذا كان يجب استدعاء الواجهة البرمجية لتجديد PCSID أو الواجهة البرمجية لـCCSID"
 
 #. module: l10n_sa_edi
+#. odoo-python
 #: code:addons/l10n_sa_edi/models/account_edi_format.py:0
 #, python-format
 msgid "VAT is required when Identification Scheme is set to Tax Identification Number"
@@ -1000,6 +1129,13 @@ msgid "VATEX-SA-HEA Private healthcare to citizen."
 msgstr "VATEX-SA-HEA رعاية صحية خاصة للمواطن."
 
 #. module: l10n_sa_edi
+#: model:ir.model.fields.selection,name:l10n_sa_edi.selection__account_tax__l10n_sa_exemption_reason_code__vatex-sa-oos
+#: model:ir.model.fields.selection,name:l10n_sa_edi.selection__account_tax_template__l10n_sa_exemption_reason_code__vatex-sa-oos
+msgid "VATEX-SA-OOS Not subject to VAT."
+msgstr ""
+
+#. module: l10n_sa_edi
+#. odoo-python
 #: code:addons/l10n_sa_edi/models/account_journal.py:0
 #, python-format
 msgid "Warnings:"
@@ -1015,12 +1151,28 @@ msgstr ""
 "                                بمجرد أن تقوم بتحديد الواجهة البرمجية الصحيحة، يمكنك بدء عملية التجهيز عن طريق الذهاب إلى دفاتر اليومية وتحديد الخيارات تحت علامة تبويب زاتكا."
 
 #. module: l10n_sa_edi
+#. odoo-python
+#: code:addons/l10n_sa_edi/models/ir_attachment.py:0
+#, python-format
+msgid "You can't unlink an attachment being an EDI document refused by the government."
+msgstr ""
+
+#. module: l10n_sa_edi
+#. odoo-python
+#: code:addons/l10n_sa_edi/models/res_company.py:0
+#, python-format
+msgid "You cannot change the ZATCA Submission Mode once it has been set to Production"
+msgstr ""
+
+#. module: l10n_sa_edi
+#. odoo-python
 #: code:addons/l10n_sa_edi/wizard/l10n_sa_edi_otp_wizard.py:0
 #, python-format
 msgid "You need to provide an OTP to be able to request a CCSID"
 msgstr "عليك تقديم كلمة مرور لمرة واحدة قبل طلب CCSID "
 
 #. module: l10n_sa_edi
+#. odoo-python
 #: code:addons/l10n_sa_edi/models/account_journal.py:0
 #, python-format
 msgid "You need to request the CCSID first before you can proceed"
@@ -1030,12 +1182,6 @@ msgstr "عليك طلب CCSID أولاً قبل الاستمرار"
 #: model_terms:ir.ui.view,arch_db:l10n_sa_edi.view_account_journal_form
 msgid "ZATCA"
 msgstr "زاتكا"
-
-#. module: l10n_sa_edi
-#: code:addons/l10n_sa_edi/models/account_edi_format.py:0
-#, python-format
-msgid "ZATCA Compliance Checks need to be completed for the current journal before invoices can be submitted to the Authority"
-msgstr "يجب أن يتم احتساب فحوصات امتثال زاتكا لدفتر اليومية الحالي حتى يتم إرسال الفواتير إلى الهيئة"
 
 #. module: l10n_sa_edi
 #: model_terms:ir.ui.view,arch_db:l10n_sa_edi.res_config_settings_view_form
@@ -1053,7 +1199,8 @@ msgid "ZATCA account.move chain sequence"
 msgstr "تسلسل سلسلة account.move لزاتكا"
 
 #. module: l10n_sa_edi
-#: model:ir.model.fields,field_description:l10n_sa_edi.field_account_bank_statement_line__l10n_sa_chain_index model:ir.model.fields,field_description:l10n_sa_edi.field_account_move__l10n_sa_chain_index
+#: model:ir.model.fields,field_description:l10n_sa_edi.field_account_bank_statement_line__l10n_sa_chain_index
+#: model:ir.model.fields,field_description:l10n_sa_edi.field_account_move__l10n_sa_chain_index
 #: model:ir.model.fields,field_description:l10n_sa_edi.field_account_payment__l10n_sa_chain_index
 msgid "ZATCA chain index"
 msgstr "مؤشر سلسلة زاتكا"
@@ -1079,7 +1226,8 @@ msgid "not(//ancestor-or-self::ext:UBLExtensions)"
 msgstr "not(//ancestor-or-self::ext:UBLExtensions)"
 
 #. module: l10n_sa_edi
-#: model_terms:ir.ui.view,arch_db:l10n_sa_edi.export_sa_zatca_ubl_extensions model_terms:ir.ui.view,arch_db:l10n_sa_edi.ubl_21_InvoiceType_zatca
+#: model_terms:ir.ui.view,arch_db:l10n_sa_edi.export_sa_zatca_ubl_extensions
+#: model_terms:ir.ui.view,arch_db:l10n_sa_edi.ubl_21_InvoiceType_zatca
 msgid "urn:oasis:names:specification:ubl:dsig:enveloped:xades"
 msgstr "urn:oasis:names:specification:ubl:dsig:enveloped:xades"
 
@@ -1089,7 +1237,8 @@ msgid "urn:oasis:names:specification:ubl:signature:1"
 msgstr "urn:oasis:names:specification:ubl:signature:1"
 
 #. module: l10n_sa_edi
-#: model_terms:ir.ui.view,arch_db:l10n_sa_edi.export_sa_zatca_ubl_extensions model_terms:ir.ui.view,arch_db:l10n_sa_edi.ubl_21_InvoiceType_zatca
+#: model_terms:ir.ui.view,arch_db:l10n_sa_edi.export_sa_zatca_ubl_extensions
+#: model_terms:ir.ui.view,arch_db:l10n_sa_edi.ubl_21_InvoiceType_zatca
 msgid "urn:oasis:names:specification:ubl:signature:Invoice"
 msgstr "urn:oasis:names:specification:ubl:signature:Invoice"
 

--- a/addons/l10n_sa_edi/i18n/l10n_sa_edi.pot
+++ b/addons/l10n_sa_edi/i18n/l10n_sa_edi.pot
@@ -4,10 +4,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 15.0\n"
+"Project-Id-Version: Odoo Server 16.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-06-14 10:53+0000\n"
-"PO-Revision-Date: 2023-06-15 14:10+0400\n"
+"POT-Creation-Date: 2025-06-26 10:46+0000\n"
+"PO-Revision-Date: 2025-06-26 10:46+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -16,6 +16,7 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: l10n_sa_edi
+#. odoo-python
 #: code:addons/l10n_sa_edi/models/res_config_settings.py:0
 #, python-format
 msgid ""
@@ -25,6 +26,7 @@ msgid ""
 msgstr ""
 
 #. module: l10n_sa_edi
+#. odoo-python
 #: code:addons/l10n_sa_edi/models/account_edi_format.py:0
 #, python-format
 msgid ""
@@ -33,12 +35,14 @@ msgid ""
 msgstr ""
 
 #. module: l10n_sa_edi
+#. odoo-python
 #: code:addons/l10n_sa_edi/models/account_edi_format.py:0
 #, python-format
 msgid "- Invoice lines should have at least one Tax applied."
 msgstr ""
 
 #. module: l10n_sa_edi
+#. odoo-python
 #: code:addons/l10n_sa_edi/models/account_edi_format.py:0
 #, python-format
 msgid ""
@@ -47,6 +51,7 @@ msgid ""
 msgstr ""
 
 #. module: l10n_sa_edi
+#. odoo-python
 #: code:addons/l10n_sa_edi/models/account_edi_format.py:0
 #, python-format
 msgid ""
@@ -55,14 +60,16 @@ msgid ""
 msgstr ""
 
 #. module: l10n_sa_edi
+#. odoo-python
 #: code:addons/l10n_sa_edi/models/account_edi_format.py:0
 #, python-format
 msgid ""
-"- Please, make sure both the Reversed Entry and the Reversal Reason are "
+"- Please, make sure either the Reversed Entry or the Reversal Reason are "
 "specified when confirming a Credit/Debit note"
 msgstr ""
 
 #. module: l10n_sa_edi
+#. odoo-python
 #: code:addons/l10n_sa_edi/models/account_edi_format.py:0
 #, python-format
 msgid ""
@@ -71,12 +78,14 @@ msgid ""
 msgstr ""
 
 #. module: l10n_sa_edi
+#. odoo-python
 #: code:addons/l10n_sa_edi/models/account_edi_format.py:0
 #, python-format
 msgid "- Please, set the following fields on the %s: %s"
 msgstr ""
 
 #. module: l10n_sa_edi
+#. odoo-python
 #: code:addons/l10n_sa_edi/models/account_edi_format.py:0
 #, python-format
 msgid ""
@@ -86,6 +95,7 @@ msgid ""
 msgstr ""
 
 #. module: l10n_sa_edi
+#. odoo-python
 #: code:addons/l10n_sa_edi/models/account_edi_format.py:0
 #, python-format
 msgid "- You cannot post invoices where the Seller is the Buyer"
@@ -106,7 +116,27 @@ msgstr ""
 
 #. module: l10n_sa_edi
 #: model_terms:ir.ui.view,arch_db:l10n_sa_edi.res_config_settings_view_form
-msgid "<i class=\"fa fa-warning mr-2\"/> Warning"
+msgid "<i class=\"fa fa-warning me-2\"/> Warning"
+msgstr ""
+
+#. module: l10n_sa_edi
+#: model_terms:ir.ui.view,arch_db:l10n_sa_edi.arabic_english_invoice
+msgid "<span class=\"fw-bold\">Exchange Rate</span>"
+msgstr ""
+
+#. module: l10n_sa_edi
+#: model_terms:ir.ui.view,arch_db:l10n_sa_edi.arabic_english_invoice
+msgid "<span class=\"fw-bold\">Subtotal</span>"
+msgstr ""
+
+#. module: l10n_sa_edi
+#: model_terms:ir.ui.view,arch_db:l10n_sa_edi.arabic_english_invoice
+msgid "<span class=\"fw-bold\">Total</span>"
+msgstr ""
+
+#. module: l10n_sa_edi
+#: model_terms:ir.ui.view,arch_db:l10n_sa_edi.arabic_english_invoice
+msgid "<span class=\"fw-bold\">VAT Amount</span>"
 msgstr ""
 
 #. module: l10n_sa_edi
@@ -118,22 +148,22 @@ msgstr ""
 
 #. module: l10n_sa_edi
 #: model_terms:ir.ui.view,arch_db:l10n_sa_edi.arabic_english_invoice
-msgid "<strong>Exchange Rate</strong>"
+msgid "<strong>الإجمالي الفرعي بالريال السعودي</strong>"
 msgstr ""
 
 #. module: l10n_sa_edi
 #: model_terms:ir.ui.view,arch_db:l10n_sa_edi.arabic_english_invoice
-msgid "<strong>Subtotal (SAR)</strong>"
+msgid "<strong>الإجمالي بالريال السعودي</strong>"
 msgstr ""
 
 #. module: l10n_sa_edi
 #: model_terms:ir.ui.view,arch_db:l10n_sa_edi.arabic_english_invoice
-msgid "<strong>Total (SAR)</strong>"
+msgid "<strong>سعر الصرف</strong>"
 msgstr ""
 
 #. module: l10n_sa_edi
 #: model_terms:ir.ui.view,arch_db:l10n_sa_edi.arabic_english_invoice
-msgid "<strong>VAT Amount (SAR)</strong>"
+msgid "<strong>مبلغ ضريبة القيمة المضافة بالريال السعودي</strong>"
 msgstr ""
 
 #. module: l10n_sa_edi
@@ -159,12 +189,14 @@ msgid "Additional Identification Number for Seller/Buyer"
 msgstr ""
 
 #. module: l10n_sa_edi
+#. odoo-python
 #: code:addons/l10n_sa_edi/models/account_edi_format.py:0
 #, python-format
 msgid "Additional Identification Number is required for commercial partners"
 msgstr ""
 
 #. module: l10n_sa_edi
+#. odoo-python
 #: code:addons/l10n_sa_edi/models/account_edi_format.py:0
 #, python-format
 msgid ""
@@ -173,6 +205,7 @@ msgid ""
 msgstr ""
 
 #. module: l10n_sa_edi
+#. odoo-python
 #: code:addons/l10n_sa_edi/models/account_edi_format.py:0
 #, python-format
 msgid ""
@@ -193,6 +226,11 @@ msgid "Are you sure you wish to re-onboard the Journal?"
 msgstr ""
 
 #. module: l10n_sa_edi
+#: model:ir.model,name:l10n_sa_edi.model_ir_attachment
+msgid "Attachment"
+msgstr ""
+
+#. module: l10n_sa_edi
 #: model:ir.model.fields,field_description:l10n_sa_edi.field_res_partner__l10n_sa_edi_building_number
 #: model:ir.model.fields,field_description:l10n_sa_edi.field_res_users__l10n_sa_edi_building_number
 #: model_terms:ir.ui.view,arch_db:l10n_sa_edi.sa_partner_address_form
@@ -201,6 +239,7 @@ msgid "Building Number"
 msgstr ""
 
 #. module: l10n_sa_edi
+#. odoo-python
 #: code:addons/l10n_sa_edi/models/account_edi_format.py:0
 #: code:addons/l10n_sa_edi/models/account_edi_format.py:0
 #, python-format
@@ -218,6 +257,7 @@ msgid "Cancel"
 msgstr ""
 
 #. module: l10n_sa_edi
+#. odoo-python
 #: code:addons/l10n_sa_edi/models/account_journal.py:0
 #, python-format
 msgid ""
@@ -225,12 +265,14 @@ msgid ""
 msgstr ""
 
 #. module: l10n_sa_edi
+#. odoo-python
 #: code:addons/l10n_sa_edi/models/account_journal.py:0
 #, python-format
 msgid "Cannot request a Production CSID before requesting a CCSID first"
 msgstr ""
 
 #. module: l10n_sa_edi
+#. odoo-python
 #: code:addons/l10n_sa_edi/models/account_tax.py:0
 #, python-format
 msgid "Cannot set a tax to Retention if the amount is greater than or equal 0"
@@ -239,6 +281,13 @@ msgstr ""
 #. module: l10n_sa_edi
 #: model_terms:ir.ui.view,arch_db:l10n_sa_edi.sa_partner_address_form
 msgid "City"
+msgstr ""
+
+#. module: l10n_sa_edi
+#. odoo-python
+#: code:addons/l10n_sa_edi/models/account_journal.py:0
+#, python-format
+msgid "Clearance and reporting seem to have been mixed up. "
 msgstr ""
 
 #. module: l10n_sa_edi
@@ -255,7 +304,7 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:l10n_sa_edi.view_account_journal_form
 msgid ""
 "Complete the Compliance Checks\n"
-"                                    <i class=\"fa fa-check text-success ml-1\" attrs=\"{'invisible': [('l10n_sa_compliance_checks_passed', '=', False)]}\"/>"
+"                                    <i class=\"fa fa-check text-success ms-1\" attrs=\"{'invisible': [('l10n_sa_compliance_checks_passed', '=', False)]}\"/>"
 msgstr ""
 
 #. module: l10n_sa_edi
@@ -271,6 +320,7 @@ msgid "Compliance Checks Done"
 msgstr ""
 
 #. module: l10n_sa_edi
+#. odoo-python
 #: code:addons/l10n_sa_edi/models/account_journal.py:0
 #, python-format
 msgid "Compliance checks can only be run for companies operating from KSA"
@@ -287,6 +337,7 @@ msgid "Contact"
 msgstr ""
 
 #. module: l10n_sa_edi
+#. odoo-python
 #: code:addons/l10n_sa_edi/models/account_journal.py:0
 #: code:addons/l10n_sa_edi/models/account_journal.py:0
 #, python-format
@@ -294,30 +345,35 @@ msgid "Could not complete Compliance Checks for the following file:"
 msgstr ""
 
 #. module: l10n_sa_edi
+#. odoo-python
 #: code:addons/l10n_sa_edi/models/account_edi_format.py:0
 #, python-format
 msgid "Could not generate Invoice UBL content: %s"
 msgstr ""
 
 #. module: l10n_sa_edi
+#. odoo-python
 #: code:addons/l10n_sa_edi/models/account_edi_format.py:0
 #, python-format
 msgid "Could not generate PCSID values: \n"
 msgstr ""
 
 #. module: l10n_sa_edi
+#. odoo-python
 #: code:addons/l10n_sa_edi/models/account_edi_format.py:0
 #, python-format
 msgid "Could not generate signed XML values: \n"
 msgstr ""
 
 #. module: l10n_sa_edi
+#. odoo-python
 #: code:addons/l10n_sa_edi/models/account_journal.py:0
 #, python-format
 msgid "Could not obtain Compliance CSID: %s"
 msgstr ""
 
 #. module: l10n_sa_edi
+#. odoo-python
 #: code:addons/l10n_sa_edi/models/account_journal.py:0
 #, python-format
 msgid "Could not obtain Production CSID: %s"
@@ -339,6 +395,7 @@ msgid "Created on"
 msgstr ""
 
 #. module: l10n_sa_edi
+#. odoo-python
 #: code:addons/l10n_sa_edi/models/account_edi_format.py:0
 #, python-format
 msgid "Customer"
@@ -368,6 +425,7 @@ msgid "EDI format"
 msgstr ""
 
 #. module: l10n_sa_edi
+#. odoo-python
 #: code:addons/l10n_sa_edi/models/account_journal.py:0
 #, python-format
 msgid "Errors:"
@@ -380,6 +438,7 @@ msgid "Exemption Reason Code"
 msgstr ""
 
 #. module: l10n_sa_edi
+#. odoo-python
 #: code:addons/l10n_sa_edi/wizard/account_move_reversal.py:0
 #, python-format
 msgid ""
@@ -387,6 +446,7 @@ msgid ""
 msgstr ""
 
 #. module: l10n_sa_edi
+#. odoo-python
 #: code:addons/l10n_sa_edi/wizard/account_debit_note.py:0
 #, python-format
 msgid "For debit notes issued in Saudi Arabia, you need to specify a Reason"
@@ -429,12 +489,14 @@ msgid "Identification Scheme"
 msgstr ""
 
 #. module: l10n_sa_edi
+#. odoo-python
 #: code:addons/l10n_sa_edi/models/account_move.py:0
 #, python-format
 msgid "Invoice Successfully Submitted to ZATCA"
 msgstr ""
 
 #. module: l10n_sa_edi
+#. odoo-python
 #: code:addons/l10n_sa_edi/models/account_edi_format.py:0
 #, python-format
 msgid ""
@@ -443,6 +505,7 @@ msgid ""
 msgstr ""
 
 #. module: l10n_sa_edi
+#. odoo-python
 #: code:addons/l10n_sa_edi/models/account_edi_format.py:0
 #, python-format
 msgid ""
@@ -460,18 +523,21 @@ msgid ""
 msgstr ""
 
 #. module: l10n_sa_edi
+#. odoo-python
 #: code:addons/l10n_sa_edi/models/account_journal.py:0
 #, python-format
 msgid "Invoice submission to ZATCA returned errors"
 msgstr ""
 
 #. module: l10n_sa_edi
+#. odoo-python
 #: code:addons/l10n_sa_edi/models/account_move.py:0
 #, python-format
 msgid "Invoice was Accepted by ZATCA (with Warnings)"
 msgstr ""
 
 #. module: l10n_sa_edi
+#. odoo-python
 #: code:addons/l10n_sa_edi/models/account_move.py:0
 #, python-format
 msgid "Invoice was rejected by ZATCA"
@@ -489,6 +555,7 @@ msgid "Is Retention"
 msgstr ""
 
 #. module: l10n_sa_edi
+#. odoo-python
 #: code:addons/l10n_sa_edi/models/account_journal.py:0
 #, python-format
 msgid "JSON response from ZATCA could not be decoded"
@@ -506,6 +573,12 @@ msgid "Journal Entry"
 msgstr ""
 
 #. module: l10n_sa_edi
+#: model:ir.model,name:l10n_sa_edi.model_account_move_line
+msgid "Journal Item"
+msgstr ""
+
+#. module: l10n_sa_edi
+#. odoo-python
 #: code:addons/l10n_sa_edi/models/account_journal.py:0
 #, python-format
 msgid "Journal could not be onboarded"
@@ -516,6 +589,20 @@ msgstr ""
 msgid ""
 "Journal could not be onboarded. Please make sure the Company "
 "VAT/Identification Number are correct."
+msgstr ""
+
+#. module: l10n_sa_edi
+#. odoo-python
+#: code:addons/l10n_sa_edi/models/account_journal.py:0
+#, python-format
+msgid "Journal onboarded with ZATCA successfully"
+msgstr ""
+
+#. module: l10n_sa_edi
+#. odoo-python
+#: code:addons/l10n_sa_edi/models/account_journal.py:0
+#, python-format
+msgid "Journal re-onboarded with ZATCA successfully"
 msgstr ""
 
 #. module: l10n_sa_edi
@@ -585,12 +672,14 @@ msgid "Neighborhood"
 msgstr ""
 
 #. module: l10n_sa_edi
+#. odoo-python
 #: code:addons/l10n_sa_edi/models/account_edi_format.py:0
 #, python-format
 msgid "Neighborhood for the Buyer is required on Standard Invoices"
 msgstr ""
 
 #. module: l10n_sa_edi
+#. odoo-python
 #: code:addons/l10n_sa_edi/models/account_edi_format.py:0
 #, python-format
 msgid "Neighborhood for the Seller is required on Standard Invoices"
@@ -632,6 +721,15 @@ msgid ""
 msgstr ""
 
 #. module: l10n_sa_edi
+#. odoo-python
+#: code:addons/l10n_sa_edi/models/account_journal.py:0
+#, python-format
+msgid ""
+"Oops! The journal is stuck. Please submit the pending invoices to ZATCA and "
+"try again."
+msgstr ""
+
+#. module: l10n_sa_edi
 #: model:ir.model.fields.selection,name:l10n_sa_edi.selection__res_partner__l10n_sa_additional_identification_scheme__oth
 msgid "Other ID"
 msgstr ""
@@ -662,12 +760,21 @@ msgid "Passport ID"
 msgstr ""
 
 #. module: l10n_sa_edi
+#. odoo-python
+#: code:addons/l10n_sa_edi/migrations/0.2/post-migrate.py:0
+#, python-format
+msgid "Please Re-Onboard the Journal for a new serial number"
+msgstr ""
+
+#. module: l10n_sa_edi
+#. odoo-python
 #: code:addons/l10n_sa_edi/models/account_journal.py:0
 #, python-format
 msgid "Please, generate a CSR before requesting a CCSID"
 msgstr ""
 
 #. module: l10n_sa_edi
+#. odoo-python
 #: code:addons/l10n_sa_edi/models/account_journal.py:0
 #, python-format
 msgid ""
@@ -676,6 +783,7 @@ msgid ""
 msgstr ""
 
 #. module: l10n_sa_edi
+#. odoo-python
 #: code:addons/l10n_sa_edi/models/account_journal.py:0
 #, python-format
 msgid ""
@@ -684,6 +792,7 @@ msgid ""
 msgstr ""
 
 #. module: l10n_sa_edi
+#. odoo-python
 #: code:addons/l10n_sa_edi/models/account_journal.py:0
 #, python-format
 msgid "Please, set a valid OTP to be used for Onboarding"
@@ -722,6 +831,7 @@ msgid "Production CSID expiration date"
 msgstr ""
 
 #. module: l10n_sa_edi
+#. odoo-python
 #: code:addons/l10n_sa_edi/models/account_journal.py:0
 #, python-format
 msgid ""
@@ -736,6 +846,11 @@ msgstr ""
 #. module: l10n_sa_edi
 #: model_terms:ir.ui.view,arch_db:l10n_sa_edi.view_account_journal_form
 msgid "Re-Onboard"
+msgstr ""
+
+#. module: l10n_sa_edi
+#: model_terms:ir.ui.view,arch_db:l10n_sa_edi.view_account_move_reversal_inherit_l10n_sa_edi
+msgid "Reason"
 msgstr ""
 
 #. module: l10n_sa_edi
@@ -762,14 +877,14 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:l10n_sa_edi.view_account_journal_form
 msgid ""
 "Request a Compliance Certificate (CCSID)\n"
-"                                    <i class=\"fa fa-check text-success ml-1\" attrs=\"{'invisible': [('l10n_sa_compliance_csid_json', '=', False)]}\"/>"
+"                                    <i class=\"fa fa-check text-success ms-1\" groups=\"base.group_system\" attrs=\"{'invisible': [('l10n_sa_compliance_csid_json', '=', False)]}\"/>"
 msgstr ""
 
 #. module: l10n_sa_edi
 #: model_terms:ir.ui.view,arch_db:l10n_sa_edi.view_account_journal_form
 msgid ""
 "Request a Production Certificate (PCSID)\n"
-"                                    <i class=\"fa fa-check text-success ml-1\" attrs=\"{'invisible': [('l10n_sa_production_csid_json', '=', False)]}\"/>"
+"                                    <i class=\"fa fa-check text-success ms-1\" groups=\"base.group_system\" attrs=\"{'invisible': [('l10n_sa_production_csid_json', '=', False)]}\"/>"
 msgstr ""
 
 #. module: l10n_sa_edi
@@ -788,16 +903,17 @@ msgid "Serial Number"
 msgstr ""
 
 #. module: l10n_sa_edi
+#. odoo-python
 #: code:addons/l10n_sa_edi/models/account_journal.py:0
 #, python-format
-msgid "Server returned an unexpected error: "
+msgid "Server returned an unexpected error: %(error)s"
 msgstr ""
 
 #. module: l10n_sa_edi
 #: model_terms:ir.ui.view,arch_db:l10n_sa_edi.view_account_journal_form
 msgid ""
 "Set a Serial Number for your device\n"
-"                                    <i class=\"fa fa-check text-success ml-1\" attrs=\"{'invisible': [('l10n_sa_serial_number', '=', False)]}\"/>"
+"                                    <i class=\"fa fa-check text-success ms-1\" attrs=\"{'invisible': [('l10n_sa_serial_number', '=', False)]}\"/>"
 msgstr ""
 
 #. module: l10n_sa_edi
@@ -827,6 +943,7 @@ msgid "Specifies which API the system should use"
 msgstr ""
 
 #. module: l10n_sa_edi
+#. odoo-python
 #: code:addons/l10n_sa_edi/models/account_edi_format.py:0
 #, python-format
 msgid "State / Country subdivision"
@@ -843,6 +960,7 @@ msgid "Street"
 msgstr ""
 
 #. module: l10n_sa_edi
+#. odoo-python
 #: code:addons/l10n_sa_edi/models/account_edi_format.py:0
 #, python-format
 msgid "Supplier"
@@ -881,6 +999,7 @@ msgid ""
 msgstr ""
 
 #. module: l10n_sa_edi
+#. odoo-python
 #: code:addons/l10n_sa_edi/models/account_journal.py:0
 #, python-format
 msgid ""
@@ -894,6 +1013,7 @@ msgid "The Production certificate is valid until"
 msgstr ""
 
 #. module: l10n_sa_edi
+#. odoo-python
 #: code:addons/l10n_sa_edi/models/account_move.py:0
 #, python-format
 msgid ""
@@ -902,6 +1022,7 @@ msgid ""
 msgstr ""
 
 #. module: l10n_sa_edi
+#. odoo-python
 #: code:addons/l10n_sa_edi/models/account_move.py:0
 #, python-format
 msgid "The invoice was rejected by ZATCA. Please, check the response below:"
@@ -913,13 +1034,14 @@ msgid "The private key used to generate the CSR and obtain certificates"
 msgstr ""
 
 #. module: l10n_sa_edi
-#: model:ir.model.fields,help:l10n_sa_edi.field_account_journal__l10n_sa_serial_number
-msgid "The serial number of the Taxpayer solution unit. Provided by ZATCA"
+#: model:ir.model,name:l10n_sa_edi.model_account_edi_xml_ubl_21_zatca
+msgid "UBL 2.1 (ZATCA)"
 msgstr ""
 
 #. module: l10n_sa_edi
-#: model:ir.model,name:l10n_sa_edi.model_account_edi_xml_ubl_21_zatca
-msgid "UBL 2.1 (ZATCA)"
+#: model:ir.model.fields,help:l10n_sa_edi.field_account_journal__l10n_sa_serial_number
+msgid ""
+"Unique Serial Number automatically filled when the journal is onboarded"
 msgstr ""
 
 #. module: l10n_sa_edi
@@ -948,6 +1070,7 @@ msgid ""
 msgstr ""
 
 #. module: l10n_sa_edi
+#. odoo-python
 #: code:addons/l10n_sa_edi/models/account_edi_format.py:0
 #: code:addons/l10n_sa_edi/models/account_edi_format.py:0
 #, python-format
@@ -1050,6 +1173,13 @@ msgid "VATEX-SA-HEA Private healthcare to citizen."
 msgstr ""
 
 #. module: l10n_sa_edi
+#: model:ir.model.fields.selection,name:l10n_sa_edi.selection__account_tax__l10n_sa_exemption_reason_code__vatex-sa-oos
+#: model:ir.model.fields.selection,name:l10n_sa_edi.selection__account_tax_template__l10n_sa_exemption_reason_code__vatex-sa-oos
+msgid "VATEX-SA-OOS Not subject to VAT."
+msgstr ""
+
+#. module: l10n_sa_edi
+#. odoo-python
 #: code:addons/l10n_sa_edi/models/account_journal.py:0
 #, python-format
 msgid "Warnings:"
@@ -1064,6 +1194,15 @@ msgstr ""
 
 #. module: l10n_sa_edi
 #. odoo-python
+#: code:addons/l10n_sa_edi/models/ir_attachment.py:0
+#, python-format
+msgid ""
+"You can't unlink an attachment being an EDI document refused by the "
+"government."
+msgstr ""
+
+#. module: l10n_sa_edi
+#. odoo-python
 #: code:addons/l10n_sa_edi/models/res_company.py:0
 #, python-format
 msgid ""
@@ -1072,12 +1211,14 @@ msgid ""
 msgstr ""
 
 #. module: l10n_sa_edi
+#. odoo-python
 #: code:addons/l10n_sa_edi/wizard/l10n_sa_edi_otp_wizard.py:0
 #, python-format
 msgid "You need to provide an OTP to be able to request a CCSID"
 msgstr ""
 
 #. module: l10n_sa_edi
+#. odoo-python
 #: code:addons/l10n_sa_edi/models/account_journal.py:0
 #, python-format
 msgid "You need to request the CCSID first before you can proceed"
@@ -1086,14 +1227,6 @@ msgstr ""
 #. module: l10n_sa_edi
 #: model_terms:ir.ui.view,arch_db:l10n_sa_edi.view_account_journal_form
 msgid "ZATCA"
-msgstr ""
-
-#. module: l10n_sa_edi
-#: code:addons/l10n_sa_edi/models/account_edi_format.py:0
-#, python-format
-msgid ""
-"ZATCA Compliance Checks need to be completed for the current journal before "
-"invoices can be submitted to the Authority"
 msgstr ""
 
 #. module: l10n_sa_edi

--- a/addons/l10n_sa_edi/migrations/0.2/post-migrate.py
+++ b/addons/l10n_sa_edi/migrations/0.2/post-migrate.py
@@ -1,0 +1,14 @@
+from odoo import _, api, SUPERUSER_ID
+
+
+def migrate(cr, version):
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    zatca_format = env.ref('l10n_sa_edi.edi_sa_zatca')
+    journals = env["account.journal"].search([
+        ("edi_format_ids", "in", zatca_format.id),
+        ("l10n_sa_compliance_checks_passed", "=", True),
+        ("l10n_sa_production_csid_json", "!=", False)])
+    journals.activity_schedule(
+        act_type_xmlid='mail.mail_activity_data_warning',
+        user_id=env.ref("base.user_admin").id,
+        note=_('Please Re-Onboard the Journal for a new serial number'))

--- a/addons/l10n_sa_edi/models/account_journal.py
+++ b/addons/l10n_sa_edi/models/account_journal.py
@@ -86,7 +86,7 @@ class AccountJournal(models.Model):
                                                 readonly=True, copy=False)
 
     l10n_sa_serial_number = fields.Char("Serial Number", copy=False,
-                                        help="The serial number of the Taxpayer solution unit. Provided by ZATCA")
+                                        help="Unique Serial Number automatically filled when the journal is onboarded")
 
     l10n_sa_latest_submission_hash = fields.Char("Latest Submission Hash", copy=False,
                                                  help="Hash of the latest submitted invoice to be used as the Previous Invoice Hash (KSA-13)")
@@ -117,6 +117,16 @@ class AccountJournal(models.Model):
         stuck_moves = [move for move in move_ids if not move._l10n_sa_is_in_chain()]
         if stuck_moves:
             raise UserError(_("Oops! The journal is stuck. Please submit the pending invoices to ZATCA and try again."))
+
+    def _l10n_sa_edi_set_csr_fields(self):
+        '''
+            Sets default values for CSR generation fields in Odoo, if their values do not exist
+        '''
+        self.ensure_one()
+        # Avoid unnecessary write calls
+        if self.l10n_sa_serial_number != str(self.id):
+            self.l10n_sa_serial_number = self.id
+
     # ====== CSR Generation =======
 
     def _l10n_sa_csr_required_fields(self):
@@ -140,8 +150,8 @@ class AccountJournal(models.Model):
             (NameOID.ORGANIZATIONAL_UNIT_NAME, (company_id.vat or '')[:10]),
             # Organization Name
             (NameOID.ORGANIZATION_NAME, company_id.name),
-            # Subject Common Name
-            (NameOID.COMMON_NAME, company_id.name),
+            # Subject Common Name (Short Code - Journal Name - Company Name)
+            (NameOID.COMMON_NAME, "%s-%s-%s" % (self.code, self.name, company_id.name)),
             # Organization Identifier
             (ObjectIdentifier('2.5.4.97'), company_id.vat),
             # State/Province Name
@@ -236,6 +246,7 @@ class AccountJournal(models.Model):
         # we want to perform sanity checks to ensure that the journal is ready to be onboarded
         # If the check fails, we do not want to revoke the existing PCSID because the user might still need it to post hanging invoices
         self._l10n_sa_api_onboard_sanity_checks()
+        self._l10n_sa_edi_set_csr_fields()
 
         try:
             # If the company does not have a private key, we generate it.

--- a/addons/l10n_sa_edi/views/account_journal_views.xml
+++ b/addons/l10n_sa_edi/views/account_journal_views.xml
@@ -15,7 +15,7 @@
                     <page name="zatca_einvoicing" string="ZATCA" attrs="{'invisible': ['|', ('country_code', '!=', 'SA'), ('type', '!=', 'sale')]}">
                         <group>
                             <group>
-                                <field name="l10n_sa_serial_number"/>
+                                <field name="l10n_sa_serial_number" readonly="1" groups="base.group_no_one"/>
                             </group>
                         </group>
                         <p groups="base.group_system">


### PR DESCRIPTION
… common name to be unique per journal

Previously, the company name was used as the common name when onboarding the journal. However, the common name has to be unique.
The fix changes the common name to use the journal's short code, journal name, and company name to ensure uniquness.

Additionally, an improvement is applied to the serial number on journals. Previously, users inputted this field manually.
Now, the system uses the journal's id as the serial number to ensure uniqueness.

A post-migration script was added to notify users that they need to re-onboard their journals.
This is done in case users previously onboarded journals with non-unique serial numbers.

task-4797124

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
