### PR TITLE
[IMP] html_builder; *: migrate legacy action tests to class-based action tests

### DIFF
--- a/addons/html_builder/static/src/core/builder_action.js
+++ b/addons/html_builder/static/src/core/builder_action.js
@@ -18,7 +18,6 @@ export class BuilderAction {
         this.getValue = this.getValue.bind(this);
         this.clean = this.clean.bind(this);
         this.load = this.load.bind(this);
-        this.loadOnClean = this.loadOnClean.bind(this);
         this.prepare = this.prepare.bind(this);
         this.setup();
     }
@@ -71,8 +70,6 @@ export class BuilderAction {
      * @param {HTMLElement} context.editingElement
      */
     async load(context) {}
-
-    loadOnClean(context) {}
 
     /**
      * Check if a method has been overridden.

--- a/addons/html_builder/static/src/core/composite_action_plugin.js
+++ b/addons/html_builder/static/src/core/composite_action_plugin.js
@@ -21,11 +21,12 @@ export class CompositeActionPlugin extends Plugin {
 class CompositeAction extends BuilderAction {
     static id = "composite";
     static dependencies = ["builderActions"];
+    loadOnClean = true;
     async prepare({ actionParam: { mainParam: actions }, actionValue }) {
         const proms = [];
         for (const actionDef of actions) {
             const action = this.dependencies.builderActions.getAction(actionDef.action);
-            if (action.prepare) {
+            if (action.has("prepare")) {
                 const actionDescr = { actionId: actionDef.action };
                 if (actionDef.actionParam) {
                     actionDescr.actionParam = convertParamToObject(actionDef.actionParam);
@@ -42,7 +43,7 @@ class CompositeAction extends BuilderAction {
         const results = [];
         for (const actionDef of actions) {
             const action = this.dependencies.builderActions.getAction(actionDef.action);
-            if (action.getPriority) {
+            if (action.has("getPriority")) {
                 const actionDescr = this._getActionDescription({ ...actionDef, value });
                 results.push(action.getPriority(actionDescr));
             }
@@ -56,7 +57,7 @@ class CompositeAction extends BuilderAction {
         let actionGetValue;
         const actionDef = actions.find((actionDef) => {
             const action = this.dependencies.builderActions.getAction(actionDef.action);
-            if (action.getValue) {
+            if (action.has("getValue")) {
                 actionGetValue = action.getValue;
             }
             return !!action.getValue;
@@ -73,7 +74,7 @@ class CompositeAction extends BuilderAction {
         const results = [];
         for (const actionDef of actions) {
             const action = this.dependencies.builderActions.getAction(actionDef.action);
-            if (action.isApplied) {
+            if (action.has("isApplied")) {
                 const actionDescr = this._getActionDescription({
                     editingElement,
                     ...actionDef,
@@ -89,7 +90,7 @@ class CompositeAction extends BuilderAction {
         const loadResults = [];
         for (const actionDef of actions) {
             const action = this.dependencies.builderActions.getAction(actionDef.action);
-            if (action.load) {
+            if (action.has("load")) {
                 const actionDescr = this._getActionDescription({
                     editingElement,
                     ...actionDef,
@@ -118,7 +119,7 @@ class CompositeAction extends BuilderAction {
     }) {
         for (const actionDef of actions) {
             const action = this.dependencies.builderActions.getAction(actionDef.action);
-            if (action.apply) {
+            if (action.has("apply")) {
                 const actionDescr = this._getActionDescription({
                     editingElement,
                     value,
@@ -130,9 +131,6 @@ class CompositeAction extends BuilderAction {
                 await action.apply(actionDescr);
             }
         }
-    }
-    loadOnClean() {
-        return true;
     }
     clean({
         editingElement,
@@ -154,10 +152,9 @@ class CompositeAction extends BuilderAction {
                 selectableContext,
                 nextAction,
             });
-
-            if (action.clean) {
+            if (action.has("clean")) {
                 action.clean(actionDescr);
-            } else if (action.apply) {
+            } else if (action.has("apply")) {
                 if (loadResult && loadResult[actionDef.action]) {
                     actionDescr.loadResult = loadResult[actionDef.action];
                 }
@@ -194,5 +191,7 @@ class CompositeAction extends BuilderAction {
 
 class ReloadCompositeAction extends CompositeAction {
     static id = "reloadComposite";
-    reload() {}
+    setup() {
+        this.reload = {};
+    }
 }

--- a/addons/html_builder/static/src/core/utils.js
+++ b/addons/html_builder/static/src/core/utils.js
@@ -362,7 +362,7 @@ function usePrepareAction(getAllActions) {
     for (const descr of getAllActions()) {
         if (descr.actionId) {
             const action = getAction(descr.actionId);
-            if (action.prepare) {
+            if (action.has("prepare")) {
                 asyncActions.push({ action, descr });
             }
         }

--- a/addons/website/static/tests/builder/builder_action.test.js
+++ b/addons/website/static/tests/builder/builder_action.test.js
@@ -10,6 +10,7 @@ import {
     addBuilderOption,
     setupHTMLBuilder,
 } from "@html_builder/../tests/helpers";
+import { BuilderAction } from "@html_builder/core/builder_action";
 
 describe("website tests", () => {
     beforeEach(defineWebsiteModels);
@@ -41,15 +42,19 @@ describe("website tests", () => {
 
 describe.tags("desktop");
 describe("HTML builder tests", () => {
+    class TestAction extends BuilderAction {
+        static id = "testAction";
+        isApplied({ editingElement }) {
+            return editingElement.classList.contains("applied");
+        }
+        apply({ editingElement }) {
+            editingElement.classList.toggle("applied");
+            expect.step("apply");
+        }
+    }
     beforeEach(() => {
         addBuilderAction({
-            testAction: {
-                isApplied: ({ editingElement }) => editingElement.classList.contains("applied"),
-                apply: ({ editingElement }) => {
-                    editingElement.classList.toggle("applied");
-                    expect.step("apply");
-                },
-            },
+            TestAction,
         });
     });
 
@@ -97,14 +102,16 @@ describe("HTML builder tests", () => {
                 });
             }
         }
+        class CustomAction extends BuilderAction {
+            static id = "customAction";
+            async prepare() {
+                await prepareDeferred;
+                expect.step("prepare");
+            }
+            apply() {}
+        }
         addBuilderAction({
-            customAction: {
-                prepare: async () => {
-                    await prepareDeferred;
-                    expect.step("prepare");
-                },
-                apply: () => {},
-            },
+            CustomAction,
         });
         addBuilderOption({
             OptionComponent: TestOption,

--- a/addons/website/static/tests/builder/builder_option.test.js
+++ b/addons/website/static/tests/builder/builder_option.test.js
@@ -7,15 +7,17 @@ import {
     setupWebsiteBuilder,
 } from "./website_helpers";
 import { xml } from "@odoo/owl";
+import { BuilderAction } from "@html_builder/core/builder_action";
 
 defineWebsiteModels();
 
 test("Undo/Redo correctly restores the stored container target", async () => {
     addActionOption({
-        customAction: {
-            apply: ({ editingElement }) => {
+        customAction: class extends BuilderAction {
+            static id = "customAction";
+            apply({ editingElement }) {
                 editingElement.remove();
-            },
+            }
         },
     });
     addOption({
@@ -46,10 +48,11 @@ test("Undo/Redo correctly restores the stored container target", async () => {
 
 test("Undo/Redo multiple actions always restores the action container target", async () => {
     addActionOption({
-        customAction: {
-            apply: ({ editingElement }) => {
+        customAction: class extends BuilderAction {
+            static id = "customAction";
+            apply({ editingElement }) {
                 editingElement.classList.add("test");
-            },
+            }
         },
     });
     addOption({
@@ -90,11 +93,12 @@ test("Undo/Redo multiple actions always restores the action container target", a
 test("Undo/Redo an action that activates another target restores the old one on undo and the new one on redo", async () => {
     let editor;
     addActionOption({
-        customAction: {
-            apply: ({ editingElement }) => {
+        customAction: class extends BuilderAction {
+            static id = "customAction";
+            apply({ editingElement }) {
                 editingElement.classList.add("test");
-                editor.shared["builderOptions"].setNextTarget(editingElement.nextElementSibling);
-            },
+                editor.shared.builderOptions.setNextTarget(editingElement.nextElementSibling);
+            }
         },
     });
     addOption({
@@ -125,15 +129,17 @@ test("Undo/Redo an action that activates another target restores the old one on 
 
 test("Containers fallback to a valid ancestor if the target disappears and restore it on undo", async () => {
     addActionOption({
-        targetAction: {
-            apply: ({ editingElement }) => {
+        targetAction: class extends BuilderAction {
+            static id = "targetAction";
+            apply({ editingElement }) {
                 editingElement.remove();
-            },
+            }
         },
-        ancestorAction: {
-            apply: ({ editingElement }) => {
+        ancestorAction: class extends BuilderAction {
+            static id = "ancestorAction";
+            apply({ editingElement }) {
                 editingElement.remove();
-            },
+            }
         },
     });
     addOption({

--- a/addons/website/static/tests/builder/composite_action.test.js
+++ b/addons/website/static/tests/builder/composite_action.test.js
@@ -6,29 +6,36 @@ import {
     addBuilderOption,
     setupHTMLBuilder,
 } from "@html_builder/../tests/helpers";
+import { BuilderAction } from "@html_builder/core/builder_action";
 
 // TODO: test composite with each spec: prepare, load, getValue
 // TODO: test reloadComposite
 
 describe.current.tags("desktop");
 test("can call 2 separate actions with composite action", async () => {
+    class Action1 extends BuilderAction {
+        static id = "action1";
+        isApplied({ editingElement, params: { mainParam: cls } }) {
+            return editingElement.classList.contains(cls);
+        }
+        apply({ editingElement, params: { mainParam: cls } }) {
+            editingElement.classList.toggle(cls);
+            expect.step(`action1: ${cls}`);
+        }
+    }
+    class Action2 extends BuilderAction {
+        static id = "action2";
+        isApplied({ editingElement, params: { mainParam: cls } }) {
+            return editingElement.classList.contains(cls);
+        }
+        apply({ editingElement, params: { mainParam: cls } }) {
+            editingElement.classList.toggle(cls);
+            expect.step(`action2: ${cls}`);
+        }
+    }
     addBuilderAction({
-        action1: {
-            isApplied: ({ editingElement, params: { mainParam: cls } }) =>
-                editingElement.classList.contains(cls),
-            apply: ({ editingElement, params: { mainParam: cls } }) => {
-                editingElement.classList.toggle(cls);
-                expect.step(`action1: ${cls}`);
-            },
-        },
-        action2: {
-            isApplied: ({ editingElement, params: { mainParam: cls } }) =>
-                editingElement.classList.contains(cls),
-            apply: ({ editingElement, params: { mainParam: cls } }) => {
-                editingElement.classList.toggle(cls);
-                expect.step(`action2: ${cls}`);
-            },
-        },
+        Action1,
+        Action2,
     });
     addBuilderOption({
         selector: ".s_test",
@@ -57,15 +64,18 @@ test("can call 2 separate actions with composite action", async () => {
 });
 
 test("can call the same action twice with composite action", async () => {
+    class Action1 extends BuilderAction {
+        static id = "action1";
+        isApplied({ editingElement, params: { mainParam: cls } }) {
+            return editingElement.classList.contains(cls);
+        }
+        apply({ editingElement, params: { mainParam: cls } }) {
+            editingElement.classList.toggle(cls);
+            expect.step(`action1: ${cls}`);
+        }
+    }
     addBuilderAction({
-        action1: {
-            isApplied: ({ editingElement, params: { mainParam: cls } }) =>
-                editingElement.classList.contains(cls),
-            apply: ({ editingElement, params: { mainParam: cls } }) => {
-                editingElement.classList.toggle(cls);
-                expect.step(`action1: ${cls}`);
-            },
-        },
+        Action1,
     });
     addBuilderOption({
         selector: ".s_test",
@@ -94,12 +104,14 @@ test("can call the same action twice with composite action", async () => {
 });
 
 test("composite action's isApplied returns false if no action defined it", async () => {
+    class Action1 extends BuilderAction {
+        static id = "action1";
+        apply({ params: { mainParam: cls } }) {
+            expect.step(`action: ${cls}`);
+        }
+    }
     addBuilderAction({
-        action1: {
-            apply: ({ params: { mainParam: cls } }) => {
-                expect.step(`action: ${cls}`);
-            },
-        },
+        Action1,
     });
     addBuilderOption({
         selector: ".s_test",
@@ -115,9 +127,9 @@ test("composite action's isApplied returns false if no action defined it", async
     });
     await setupHTMLBuilder(`<section class="s_test">Test</section>`);
     await contains(":iframe .s_test").click();
-    expect("[data-action-id='composite'").not.toHaveClass("active");
+    expect("[data-action-id='composite']").not.toHaveClass("active");
     await contains("[data-action-id='composite']").click();
-    expect("[data-action-id='composite'").not.toHaveClass("active");
+    expect("[data-action-id='composite']").not.toHaveClass("active");
     expect.verifySteps([
         "action: class1", // preview
         "action: class2", // preview
@@ -126,18 +138,22 @@ test("composite action's isApplied returns false if no action defined it", async
     ]);
 });
 test("composite action's isApplied returns true if at least one action defined it", async () => {
+    class Action1 extends BuilderAction {
+        static id = "action1";
+        apply() {}
+    }
+    class Action2 extends BuilderAction {
+        static id = "action2";
+        isApplied({ editingElement, params: { mainParam: cls } }) {
+            return editingElement.classList.contains(cls);
+        }
+        apply({ editingElement, params: { mainParam: cls } }) {
+            editingElement.classList.add(cls);
+        }
+    }
     addBuilderAction({
-        action1: {
-            apply: () => {},
-        },
-        action2: {
-            isApplied: ({ editingElement, params: { mainParam: cls } }) => {
-                return editingElement.classList.contains(cls);
-            },
-            apply: ({ editingElement, params: { mainParam: cls } }) => {
-                editingElement.classList.add(cls);
-            },
-        },
+        Action1,
+        Action2,
     });
     addBuilderOption({
         selector: ".s_test",
@@ -153,7 +169,7 @@ test("composite action's isApplied returns true if at least one action defined i
     });
     await setupHTMLBuilder(`<section class="s_test">Test</section>`);
     await contains(":iframe .s_test").click();
-    expect("[data-action-id='composite'").not.toHaveClass("active");
+    expect("[data-action-id='composite']").not.toHaveClass("active");
     await contains("[data-action-id='composite']").click();
-    expect("[data-action-id='composite'").toHaveClass("active");
+    expect("[data-action-id='composite']").toHaveClass("active");
 });

--- a/addons/website/static/tests/builder/custom_tab/builder_components/builder_button_group.test.js
+++ b/addons/website/static/tests/builder/custom_tab/builder_components/builder_button_group.test.js
@@ -7,16 +7,19 @@ import {
     addBuilderOption,
     setupHTMLBuilder,
 } from "@html_builder/../tests/helpers";
+import { BuilderAction } from "@html_builder/core/builder_action";
 
 describe.current.tags("desktop");
 
 test("change the editingElement of sub widget through `applyTo` prop", async () => {
+    class CustomAction extends BuilderAction {
+        static id = "customAction";
+        apply({ editingElement }) {
+            expect.step(`customAction ${editingElement.className}`);
+        }
+    }
     addBuilderAction({
-        customAction: {
-            apply: ({ editingElement }) => {
-                expect.step(`customAction ${editingElement.className}`);
-            },
-        },
+        CustomAction,
     });
     addBuilderOption({
         selector: ".test-options-target",
@@ -36,12 +39,14 @@ test("change the editingElement of sub widget through `applyTo` prop", async () 
     expect.verifySteps(["customAction a o-paragraph"]);
 });
 test("should propagate actionParam in the context", async () => {
+    class CustomAction extends BuilderAction {
+        static id = "customAction";
+        apply({ params: { mainParam: testParam } }) {
+            expect.step(`customAction ${testParam}`);
+        }
+    }
     addBuilderAction({
-        customAction: {
-            apply: ({ params: { mainParam: testParam } }) => {
-                expect.step(`customAction ${testParam}`);
-            },
-        },
+        CustomAction,
     });
     addBuilderOption({
         selector: ".test-options-target",
@@ -75,19 +80,35 @@ test("prevent preview of all buttons", async () => {
                         <BuilderButton action="'customAction4'"/>
                     </BuilderButtonGroup>`,
     });
+    class CustomAction1 extends BuilderAction {
+        static id = "customAction1";
+        apply() {
+            return expect.step(`customAction1`);
+        }
+    }
+    class CustomAction2 extends BuilderAction {
+        static id = "customAction2";
+        apply() {
+            return expect.step(`customAction2`);
+        }
+    }
+    class CustomAction3 extends BuilderAction {
+        static id = "customAction3";
+        apply() {
+            return expect.step(`customAction3`);
+        }
+    }
+    class CustomAction4 extends BuilderAction {
+        static id = "customAction4";
+        apply() {
+            return expect.step(`customAction4`);
+        }
+    }
     addBuilderAction({
-        customAction1: {
-            apply: () => expect.step(`customAction1`),
-        },
-        customAction2: {
-            apply: () => expect.step(`customAction2`),
-        },
-        customAction3: {
-            apply: () => expect.step(`customAction3`),
-        },
-        customAction4: {
-            apply: () => expect.step(`customAction4`),
-        },
+        CustomAction1,
+        CustomAction2,
+        CustomAction3,
+        CustomAction4,
     });
     await setupHTMLBuilder(`
                 <div class="test-options-target">

--- a/addons/website/static/tests/builder/custom_tab/builder_components/builder_colorpicker.test.js
+++ b/addons/website/static/tests/builder/custom_tab/builder_components/builder_colorpicker.test.js
@@ -9,6 +9,7 @@ import {
     defineWebsiteModels,
     setupWebsiteBuilder,
 } from "../../website_helpers";
+import { BuilderAction } from "@html_builder/core/builder_action";
 
 defineWebsiteModels();
 
@@ -103,15 +104,16 @@ test("apply color to a different style than color or backgroundColor", async () 
 test("apply custom action", async () => {
     const styleName = "border-top-color";
     addActionOption({
-        customAction: {
-            load: async () => {
+        customAction: class extends BuilderAction {
+            static id = "customAction";
+            async load() {
                 expect.step("load");
-            },
-            apply: async ({ editingElement }) => {
+            }
+            async apply({ editingElement }) {
                 expect.step(
                     `apply ${getComputedStyle(editingElement).getPropertyValue(styleName)}`
                 );
-            },
+            }
         },
     });
     addOption({
@@ -129,12 +131,15 @@ test("apply custom action", async () => {
 test("apply custom async action", async () => {
     const def = new Deferred();
     addActionOption({
-        customAction: {
-            getValue: () => "",
-            apply: async ({ editingElement }) => {
+        customAction: class extends BuilderAction {
+            static id = "customAction";
+            getValue() {
+                return "";
+            }
+            async apply({ editingElement }) {
                 await def;
                 editingElement.classList.add("applied");
-            },
+            }
         },
     });
     addOption({
@@ -185,14 +190,15 @@ test("should revert preview on escape", async () => {
 
 test("should apply transparent color if no color is defined", async () => {
     addActionOption({
-        customAction: {
-            getValue: ({ editingElement }) => {
+        customAction: class extends BuilderAction {
+            static id = "customAction";
+            getValue({ editingElement }) {
                 expect.step("getValue");
                 return editingElement.dataset.color;
-            },
-            apply: ({ editingElement, value }) => {
+            }
+            apply({ editingElement, value }) {
                 editingElement.dataset.color = value;
-            },
+            }
         },
     });
     addOption({

--- a/addons/website/static/tests/builder/custom_tab/builder_components/builder_context.test.js
+++ b/addons/website/static/tests/builder/custom_tab/builder_components/builder_context.test.js
@@ -7,15 +7,17 @@ import {
     defineWebsiteModels,
     setupWebsiteBuilder,
 } from "../../website_helpers";
+import { BuilderAction } from "@html_builder/core/builder_action";
 
 defineWebsiteModels();
 
 test("should pass the context", async () => {
     addActionOption({
-        customAction: {
-            apply: ({ params: { mainParam: testParam }, value }) => {
+        customAction: class extends BuilderAction {
+            static id = "customAction";
+            apply({ params: { mainParam: testParam }, value }) {
                 expect.step(`customAction ${testParam} ${value}`);
-            },
+            }
         },
     });
     addOption({

--- a/addons/website/static/tests/builder/custom_tab/builder_components/builder_many2many.test.js
+++ b/addons/website/static/tests/builder/custom_tab/builder_components/builder_many2many.test.js
@@ -9,6 +9,7 @@ import {
     defineWebsiteModels,
     setupWebsiteBuilder,
 } from "../../website_helpers";
+import { BuilderAction } from "@html_builder/core/builder_action";
 
 class Test extends models.Model {
     _name = "test";
@@ -83,17 +84,20 @@ test("many2many: async load", async () => {
         [3, "Third"],
     ]);
     addActionOption({
-        testAction: {
-            load: async ({ value }) => {
+        testAction: class extends BuilderAction {
+            static id = "testAction";
+            async load({ value }) {
                 expect.step("load");
                 await defWillLoad;
                 return value;
-            },
-            apply: ({ editingElement, value }) => {
+            }
+            apply({ editingElement, value }) {
                 editingElement.dataset.test = value;
                 defDidApply.resolve();
-            },
-            getValue: ({ editingElement }) => editingElement.dataset.test,
+            }
+            getValue({ editingElement }) {
+                return editingElement.dataset.test;
+            }
         },
     });
     addOption({

--- a/addons/website/static/tests/builder/custom_tab/builder_components/builder_many2one.test.js
+++ b/addons/website/static/tests/builder/custom_tab/builder_components/builder_many2one.test.js
@@ -8,6 +8,7 @@ import {
     defineWebsiteModels,
     setupWebsiteBuilder,
 } from "../../website_helpers";
+import { BuilderAction } from "@html_builder/core/builder_action";
 
 class Test extends models.Model {
     _name = "test";
@@ -31,17 +32,20 @@ test("many2one: async load", async () => {
         [3, "Third"],
     ]);
     addActionOption({
-        testAction: {
-            load: async ({ value }) => {
+        testAction: class extends BuilderAction {
+            static id = "testAction";
+            async load({ value }) {
                 expect.step("load");
                 await defWillLoad;
                 return value;
-            },
-            apply: ({ editingElement, value }) => {
+            }
+            apply({ editingElement, value }) {
                 editingElement.dataset.test = value;
                 defDidApply.resolve();
-            },
-            getValue: ({ editingElement }) => editingElement.dataset.test,
+            }
+            getValue({ editingElement }) {
+                return editingElement.dataset.test;
+            }
         },
     });
     addOption({

--- a/addons/website/static/tests/builder/custom_tab/builder_components/builder_number_input.test.js
+++ b/addons/website/static/tests/builder/custom_tab/builder_components/builder_number_input.test.js
@@ -9,16 +9,20 @@ import {
     defineWebsiteModels,
     setupWebsiteBuilder,
 } from "../../website_helpers";
+import { BuilderAction } from "@html_builder/core/builder_action";
 
 defineWebsiteModels();
 
 test("should get the initial value of the input", async () => {
     addActionOption({
-        customAction: {
-            getValue: ({ editingElement }) => editingElement.innerHTML,
-            apply: ({ params }) => {
+        customAction: class extends BuilderAction {
+            static id = "customAction";
+            getValue({ editingElement }) {
+                return editingElement.innerHTML;
+            }
+            apply({ params }) {
                 expect.step(`customAction ${params}`);
-            },
+            }
         },
     });
     addOption({
@@ -43,8 +47,11 @@ test("hide/display base on applyTo", async () => {
         template: xml`<BuilderNumberInput applyTo="'.my-custom-class'" action="'customAction'"/>`,
     });
     addActionOption({
-        customAction: {
-            getValue: () => "10",
+        customAction: class extends BuilderAction {
+            static id = "customAction";
+            getValue() {
+                return "10";
+            }
         },
     });
 
@@ -86,11 +93,14 @@ test("input with classAction and styleAction", async () => {
 describe("default value", () => {
     test("should use the default value when there is no value onChange", async () => {
         addActionOption({
-            customAction: {
-                getValue: ({ editingElement }) => editingElement.innerHTML,
-                apply: ({ value }) => {
+            customAction: class extends BuilderAction {
+                static id = "customAction";
+                getValue({ editingElement }) {
+                    return editingElement.innerHTML;
+                }
+                apply({ value }) {
                     expect.step(`customAction ${value}`);
-                },
+                }
             },
         });
         addOption({
@@ -112,11 +122,14 @@ describe("default value", () => {
     });
     test("clear BuilderNumberInput without default value", async () => {
         addActionOption({
-            customAction: {
-                getValue: ({ editingElement }) => editingElement.innerHTML,
-                apply: ({ editingElement, value }) => {
+            customAction: class extends BuilderAction {
+                static id = "customAction";
+                getValue({ editingElement }) {
+                    return editingElement.innerHTML;
+                }
+                apply({ editingElement, value }) {
                     editingElement.innerHTML = value;
-                },
+                }
             },
         });
         addOption({
@@ -137,11 +150,14 @@ describe("default value", () => {
     });
     test("clear BuilderNumberInput with default value", async () => {
         addActionOption({
-            customAction: {
-                getValue: ({ editingElement }) => editingElement.innerHTML,
-                apply: ({ editingElement, value }) => {
+            customAction: class extends BuilderAction {
+                static id = "customAction";
+                getValue({ editingElement }) {
+                    return editingElement.innerHTML;
+                }
+                apply({ editingElement, value }) {
                     editingElement.innerHTML = value;
-                },
+                }
             },
         });
         addOption({
@@ -164,12 +180,15 @@ describe("default value", () => {
 describe("operations", () => {
     test("should preview changes", async () => {
         addActionOption({
-            customAction: {
-                getValue: ({ editingElement }) => editingElement.innerHTML,
-                apply: ({ editingElement, value }) => {
+            customAction: class extends BuilderAction {
+                static id = "customAction";
+                getValue({ editingElement }) {
+                    return editingElement.innerHTML;
+                }
+                apply({ editingElement, value }) {
                     expect.step(`customAction ${value}`);
                     editingElement.innerHTML = value;
-                },
+                }
             },
         });
         addOption({
@@ -190,12 +209,15 @@ describe("operations", () => {
     });
     test("should commit changes", async () => {
         addActionOption({
-            customAction: {
-                getValue: ({ editingElement }) => editingElement.innerHTML,
-                apply: ({ editingElement, value }) => {
+            customAction: class extends BuilderAction {
+                static id = "customAction";
+                getValue({ editingElement }) {
+                    return editingElement.innerHTML;
+                }
+                apply({ editingElement, value }) {
                     expect.step(`customAction ${value}`);
                     editingElement.innerHTML = value;
-                },
+                }
             },
         });
         addOption({
@@ -219,12 +241,15 @@ describe("operations", () => {
     });
     test("should commit changes after an undo", async () => {
         addActionOption({
-            customAction: {
-                getValue: ({ editingElement }) => editingElement.innerHTML,
-                apply: ({ editingElement, value }) => {
+            customAction: class extends BuilderAction {
+                static id = "customAction";
+                getValue({ editingElement }) {
+                    return editingElement.innerHTML;
+                }
+                apply({ editingElement, value }) {
                     expect.step(`customAction ${value}`);
                     editingElement.innerHTML = value;
-                },
+                }
             },
         });
         addOption({
@@ -252,12 +277,15 @@ describe("operations", () => {
     });
     test("should not commit on input if no preview", async () => {
         addActionOption({
-            customAction: {
-                getValue: ({ editingElement }) => editingElement.innerHTML,
-                apply: ({ editingElement, value }) => {
+            customAction: class extends BuilderAction {
+                static id = "customAction";
+                getValue({ editingElement }) {
+                    return editingElement.innerHTML;
+                }
+                apply({ editingElement, value }) {
                     expect.step(`customAction ${value}`);
                     editingElement.innerHTML = value;
-                },
+                }
             },
         });
         addOption({
@@ -279,12 +307,15 @@ describe("operations", () => {
 describe("keyboard triggers", () => {
     test("input should step up or down from by the step prop", async () => {
         addActionOption({
-            customAction: {
-                getValue: ({ editingElement }) => editingElement.innerHTML,
-                apply: ({ editingElement, value }) => {
+            customAction: class extends BuilderAction {
+                static id = "customAction";
+                getValue({ editingElement }) {
+                    return editingElement.innerHTML;
+                }
+                apply({ editingElement, value }) {
                     expect.step(`customAction ${value}`);
                     editingElement.innerHTML = value;
-                },
+                }
             },
         });
         addOption({
@@ -310,12 +341,15 @@ describe("keyboard triggers", () => {
     });
     test("multi values: apply change on each value with up or down", async () => {
         addActionOption({
-            customAction: {
-                getValue: ({ editingElement }) => editingElement.innerHTML,
-                apply: ({ editingElement, value }) => {
+            customAction: class extends BuilderAction {
+                static id = "customAction";
+                getValue({ editingElement }) {
+                    return editingElement.innerHTML;
+                }
+                apply({ editingElement, value }) {
                     expect.step(`customAction ${value}`);
                     editingElement.innerHTML = value;
-                },
+                }
             },
         });
         addOption({
@@ -342,11 +376,14 @@ describe("keyboard triggers", () => {
     });
     test("up on empty BuilderNumberInput gives 1", async () => {
         addActionOption({
-            customAction: {
-                getValue: ({ editingElement }) => editingElement.dataset.number,
-                apply: ({ editingElement, value }) => {
+            customAction: class extends BuilderAction {
+                static id = "customAction";
+                getValue({ editingElement }) {
+                    return editingElement.dataset.number;
+                }
+                apply({ editingElement, value }) {
                     editingElement.dataset.number = value;
-                },
+                }
             },
         });
         addOption({
@@ -364,11 +401,14 @@ describe("keyboard triggers", () => {
     });
     test("down on empty BuilderNumberInput gives -1", async () => {
         addActionOption({
-            customAction: {
-                getValue: ({ editingElement }) => editingElement.dataset.number,
-                apply: ({ editingElement, value }) => {
+            customAction: class extends BuilderAction {
+                static id = "customAction";
+                getValue({ editingElement }) {
+                    return editingElement.dataset.number;
+                }
+                apply({ editingElement, value }) {
                     editingElement.dataset.number = value;
-                },
+                }
             },
         });
         addOption({
@@ -387,12 +427,15 @@ describe("keyboard triggers", () => {
     });
     test("apply preview on keydown and debounce commit operation", async () => {
         addActionOption({
-            customAction: {
-                getValue: ({ editingElement }) => editingElement.innerHTML,
-                apply: ({ editingElement, value }) => {
+            customAction: class extends BuilderAction {
+                static id = "customAction";
+                getValue({ editingElement }) {
+                    return editingElement.innerHTML;
+                }
+                apply({ editingElement, value }) {
                     expect.step(`customAction ${value}`);
                     editingElement.innerHTML = value;
-                },
+                }
             },
         });
         addOption({
@@ -422,12 +465,15 @@ describe("keyboard triggers", () => {
 describe("unit & saveUnit", () => {
     test("should handle unit", async () => {
         addActionOption({
-            customAction: {
-                getValue: ({ editingElement }) => editingElement.innerHTML,
-                apply: ({ editingElement, value }) => {
+            customAction: class extends BuilderAction {
+                static id = "customAction";
+                getValue({ editingElement }) {
+                    return editingElement.innerHTML;
+                }
+                apply({ editingElement, value }) {
                     expect.step(`customAction ${value}`);
                     editingElement.innerHTML = value;
-                },
+                }
             },
         });
         addOption({
@@ -448,12 +494,15 @@ describe("unit & saveUnit", () => {
     });
     test("should handle saveUnit", async () => {
         addActionOption({
-            customAction: {
-                getValue: ({ editingElement }) => editingElement.innerHTML,
-                apply: ({ editingElement, value }) => {
+            customAction: class extends BuilderAction {
+                static id = "customAction";
+                getValue({ editingElement }) {
+                    return editingElement.innerHTML;
+                }
+                apply({ editingElement, value }) {
                     expect.step(`customAction ${value}`);
                     editingElement.innerHTML = value;
-                },
+                }
             },
         });
         addOption({
@@ -474,12 +523,15 @@ describe("unit & saveUnit", () => {
     });
     test("should handle empty saveUnit", async () => {
         addActionOption({
-            customAction: {
-                getValue: ({ editingElement }) => editingElement.innerHTML,
-                apply: ({ editingElement, value }) => {
+            customAction: class extends BuilderAction {
+                static id = "customAction";
+                getValue({ editingElement }) {
+                    return editingElement.innerHTML;
+                }
+                apply({ editingElement, value }) {
                     expect.step(`customAction ${value}`);
                     editingElement.innerHTML = value;
-                },
+                }
             },
         });
         addOption({
@@ -502,11 +554,14 @@ describe("unit & saveUnit", () => {
 describe("sanitized values", () => {
     test("don't allow multi values by default", async () => {
         addActionOption({
-            customAction: {
-                getValue: ({ editingElement }) => editingElement.innerHTML,
-                apply: ({ editingElement, value }) => {
+            customAction: class extends BuilderAction {
+                static id = "customAction";
+                getValue({ editingElement }) {
+                    return editingElement.innerHTML;
+                }
+                apply({ editingElement, value }) {
                     editingElement.innerHTML = value;
-                },
+                }
             },
         });
         addOption({
@@ -523,11 +578,14 @@ describe("sanitized values", () => {
     });
     test("use min when the given value is smaller", async () => {
         addActionOption({
-            customAction: {
-                getValue: ({ editingElement }) => editingElement.innerHTML,
-                apply: ({ value }) => {
+            customAction: class extends BuilderAction {
+                static id = "customAction";
+                getValue({ editingElement }) {
+                    return editingElement.innerHTML;
+                }
+                apply({ value }) {
                     expect.step(`customAction ${value}`);
-                },
+                }
             },
         });
         addOption({
@@ -544,11 +602,14 @@ describe("sanitized values", () => {
     });
     test("use max when the given value is bigger", async () => {
         addActionOption({
-            customAction: {
-                getValue: ({ editingElement }) => editingElement.innerHTML,
-                apply: ({ value }) => {
+            customAction: class extends BuilderAction {
+                static id = "customAction";
+                getValue({ editingElement }) {
+                    return editingElement.innerHTML;
+                }
+                apply({ value }) {
                     expect.step(`customAction ${value}`);
-                },
+                }
             },
         });
         addOption({
@@ -566,11 +627,14 @@ describe("sanitized values", () => {
     });
     test("multi values: trailing space in BuilderNumberInput is ignored", async () => {
         addActionOption({
-            customAction: {
-                getValue: ({ editingElement }) => editingElement.innerHTML,
-                apply: ({ value }) => {
+            customAction: class extends BuilderAction {
+                static id = "customAction";
+                getValue({ editingElement }) {
+                    return editingElement.innerHTML;
+                }
+                apply({ value }) {
                     expect.step(`customAction ${value}`);
-                },
+                }
             },
         });
         addOption({

--- a/addons/website/static/tests/builder/custom_tab/builder_components/builder_range.test.js
+++ b/addons/website/static/tests/builder/custom_tab/builder_components/builder_range.test.js
@@ -9,17 +9,21 @@ import {
     defineWebsiteModels,
     setupWebsiteBuilder,
 } from "../../website_helpers";
+import { BuilderAction } from "@html_builder/core/builder_action";
 
 defineWebsiteModels();
 
 test("should commit changes", async () => {
     addActionOption({
-        customAction: {
-            getValue: ({ editingElement }) => editingElement.innerHTML,
-            apply: ({ editingElement, value }) => {
+        customAction: class extends BuilderAction {
+            static id = "customAction";
+            getValue({ editingElement }) {
+                return editingElement.innerHTML;
+            }
+            apply({ editingElement, value }) {
                 expect.step(`customAction ${value}`);
                 editingElement.innerHTML = value;
-            },
+            }
         },
     });
     addOption({

--- a/addons/website/static/tests/builder/custom_tab/builder_components/builder_select_item.test.js
+++ b/addons/website/static/tests/builder/custom_tab/builder_components/builder_select_item.test.js
@@ -17,15 +17,17 @@ import {
     defineWebsiteModels,
     setupWebsiteBuilder,
 } from "../../website_helpers";
+import { BuilderAction } from "@html_builder/core/builder_action";
 
 defineWebsiteModels();
 
 test("call a specific action with some params and value (BuilderSelectItem)", async () => {
     addActionOption({
-        customAction: {
-            apply: ({ params: { mainParam: testParam }, value }) => {
+        customAction: class extends BuilderAction {
+            static id = "customAction";
+            apply({ params: { mainParam: testParam }, value }) {
                 expect.step(`customAction ${testParam} ${value}`);
-            },
+            }
         },
     });
     addOption({
@@ -315,11 +317,11 @@ test("revert a preview selected with the keyboard when cancelling with escape", 
 
 test("isApplied shouldn't be called when the element is removed from the DOM", async () => {
     addActionOption({
-        customAction: {
-            isApplied: ({ editingElement: el }) => {
+        customAction: class extends BuilderAction {
+            static id = "customAction";
+            isApplied({ editingElement: el }) {
                 expect(el.isConnected).toBe(true);
-            },
-            apply: () => {},
+            }
         },
     });
     addOption({

--- a/addons/website/static/tests/builder/custom_tab/builder_components/builder_text_input.test.js
+++ b/addons/website/static/tests/builder/custom_tab/builder_components/builder_text_input.test.js
@@ -7,6 +7,7 @@ import {
     defineWebsiteModels,
     setupWebsiteBuilder,
 } from "../../website_helpers";
+import { BuilderAction } from "@html_builder/core/builder_action";
 
 defineWebsiteModels();
 
@@ -20,8 +21,11 @@ test("hide/display base on applyTo", async () => {
         template: xml`<BuilderTextInput applyTo="'.my-custom-class'" action="'customAction'"/>`,
     });
     addActionOption({
-        customAction: {
-            getValue: () => "customValue",
+        customAction: class extends BuilderAction {
+            static id = "customAction";
+            getValue() {
+                return "customValue";
+            }
         },
     });
 

--- a/addons/website/static/tests/builder/custom_tab/container_buttons.test.js
+++ b/addons/website/static/tests/builder/custom_tab/container_buttons.test.js
@@ -16,6 +16,7 @@ import { contains, onRpc } from "@web/../tests/web_test_helpers";
 import { animationFrame, Deferred, queryText, tick } from "@odoo/hoot-dom";
 import { undo } from "@html_editor/../tests/_helpers/user_actions";
 import { Plugin } from "@html_editor/plugin";
+import { BuilderAction } from "@html_builder/core/builder_action";
 
 defineWebsiteModels();
 
@@ -299,11 +300,14 @@ test("applying option container button should wait for actions in progress", asy
     addPlugin(TestPlugin);
     const customActionDef = new Deferred();
     addActionOption({
-        customAction: {
-            load: () => customActionDef,
-            apply: ({ editingElement }) => {
+        customAction: class extends BuilderAction {
+            static id = "customAction";
+            load() {
+                return customActionDef;
+            }
+            apply({ editingElement }) {
                 editingElement.classList.add("customAction");
-            },
+            }
         },
     });
     addOption({

--- a/addons/website/static/tests/builder/custom_tab/misc.test.js
+++ b/addons/website/static/tests/builder/custom_tab/misc.test.js
@@ -12,6 +12,7 @@ import {
     defineWebsiteModels,
     setupWebsiteBuilder,
 } from "../website_helpers";
+import { BuilderAction } from "@html_builder/core/builder_action";
 
 defineWebsiteModels();
 
@@ -432,14 +433,15 @@ test("useDomState callback shouldn't be called when the editingElement is remove
         template: xml`<BuilderButton action="'addTestSnippet'">Add</BuilderButton>`,
     });
     addActionOption({
-        addTestSnippet: {
-            apply: ({ editingElement }) => {
+        addTestSnippet: class extends BuilderAction {
+            static id = "addTestSnippet";
+            apply({ editingElement }) {
                 const testEl = document.createElement("div");
                 testEl.classList.add("s_test", "alert-info");
                 testEl.textContent = "test";
                 editingElement.after(testEl);
                 editor.shared["builderOptions"].setNextTarget(testEl);
-            },
+            }
         },
     });
 
@@ -463,12 +465,13 @@ test("useDomState callback shouldn't be called when the editingElement is remove
 
 test("Update editing elements at dom change with multiple levels of applyTo", async () => {
     addActionOption({
-        customAction: {
-            apply: ({ editingElement }) => {
+        customAction: class extends BuilderAction {
+            static id = "customAction";
+            apply({ editingElement }) {
                 const createdEl = editingElement.cloneNode(true);
                 const parentEl = editingElement.parentElement;
                 parentEl.appendChild(createdEl);
-            },
+            }
         },
     });
     addOption({

--- a/addons/website/static/tests/builder/edit_interaction.test.js
+++ b/addons/website/static/tests/builder/edit_interaction.test.js
@@ -12,6 +12,7 @@ import {
 } from "./website_helpers";
 import { waitFor } from "@odoo/hoot-dom";
 import { xml } from "@odoo/owl";
+import { BuilderAction } from "@html_builder/core/builder_action";
 
 defineWebsiteModels();
 
@@ -37,14 +38,15 @@ test("dropping a new snippet starts its interaction", async () => {
 
 test("ensure order of operations when hovering an option", async () => {
     addActionOption({
-        customAction: {
-            load: async () => {
+        customAction: class extends BuilderAction {
+            static id = "customAction";
+            async load() {
                 expect.step("load");
-            },
-            apply: ({ editingElement }) => {
+            }
+            apply({ editingElement }) {
                 editingElement.classList.add("new_class");
                 expect.step("apply");
-            },
+            }
         },
     });
     addOption({

--- a/addons/website/static/tests/builder/overlay_buttons.test.js
+++ b/addons/website/static/tests/builder/overlay_buttons.test.js
@@ -12,6 +12,7 @@ import {
     defineWebsiteModels,
     setupWebsiteBuilder,
 } from "./website_helpers";
+import { BuilderAction } from "@html_builder/core/builder_action";
 
 defineWebsiteModels();
 
@@ -225,11 +226,14 @@ test("Applying an overlay button action should wait for the actions in progress"
     addPlugin(TestPlugin);
     const customActionDef = new Deferred();
     addActionOption({
-        customAction: {
-            load: () => customActionDef,
-            apply: ({ editingElement }) => {
+        customAction: class extends BuilderAction {
+            static id = "customAction";
+            load() {
+                return customActionDef;
+            }
+            apply({ editingElement }) {
                 editingElement.classList.add("customAction");
-            },
+            }
         },
     });
     addOption({

--- a/addons/website_mass_mailing/static/src/website_builder/mailing_list_subscribe_option_plugin.js
+++ b/addons/website_mass_mailing/static/src/website_builder/mailing_list_subscribe_option_plugin.js
@@ -6,28 +6,16 @@ import { _t } from "@web/core/l10n/translation";
 import { NewsletterSubscribeCommonOption } from "./newsletter_subscribe_common_option";
 import { getSelectorParams } from "@html_builder/utils/utils";
 import { applyFunDependOnSelectorAndExclude } from "@website/builder/plugins/utils";
+import { BuilderAction } from "@html_builder/core/builder_action";
 
 class MailingListSubscribeOptionPlugin extends Plugin {
     static id = "mailingListSubscribeOption";
     static dependencies = ["remove", "savePlugin"];
     static shared = ["fetchMailingLists"];
     resources = {
-        builder_actions: [
-            {
-                toggleThanksMessage: {
-                    apply: ({ editingElement }) => {
-                        this.setThanksMessageVisibility(editingElement, true);
-                    },
-                    clean: ({ editingElement }) => {
-                        this.setThanksMessageVisibility(editingElement, false);
-                    },
-                    isApplied: ({ editingElement }) =>
-                        editingElement
-                            .querySelector(".js_subscribed_wrap")
-                            ?.classList.contains("o_enable_preview"),
-                },
-            },
-        ],
+        builder_actions: {
+            ToggleThanksMessageAction,
+        },
         on_snippet_dropped_handlers: this.onSnippetDropped.bind(this),
         clean_for_save_handlers: this.cleanForSave.bind(this),
     };
@@ -37,15 +25,6 @@ class MailingListSubscribeOptionPlugin extends Plugin {
             this.getResource("builder_options"),
             NewsletterSubscribeCommonOption
         );
-    }
-
-    setThanksMessageVisibility(editingElement, isVisible) {
-        const toSubscribeEl = editingElement.querySelector(".js_subscribe_wrap");
-        const thanksMessageEl = editingElement.querySelector(".js_subscribed_wrap");
-        thanksMessageEl.classList.toggle("o_enable_preview", isVisible);
-        thanksMessageEl.classList.toggle("o_disable_preview", !isVisible);
-        toSubscribeEl.classList.toggle("o_enable_preview", !isVisible);
-        toSubscribeEl.classList.toggle("o_disable_preview", isVisible);
     }
 
     async onSnippetDropped({ snippetEl }) {
@@ -123,6 +102,27 @@ class MailingListSubscribeOptionPlugin extends Plugin {
         for (const toCleanEl of toCleanEls) {
             toCleanEl.classList.remove(...previewClasses);
         }
+    }
+}
+
+class ToggleThanksMessageAction extends BuilderAction {
+    static id = "toggleThanksMessage";
+    apply({ editingElement }) {
+        this.setThanksMessageVisibility(editingElement, true);
+    }
+    clean({ editingElement }) {
+        this.setThanksMessageVisibility(editingElement, false);
+    }
+    isApplied({ editingElement }) {
+        return editingElement.querySelector(".js_subscribed_wrap")?.classList.contains("o_enable_preview");
+    }
+    setThanksMessageVisibility(editingElement, isVisible) {
+        const toSubscribeEl = editingElement.querySelector(".js_subscribe_wrap");
+        const thanksMessageEl = editingElement.querySelector(".js_subscribed_wrap");
+        thanksMessageEl.classList.toggle("o_enable_preview", isVisible);
+        thanksMessageEl.classList.toggle("o_disable_preview", !isVisible);
+        toSubscribeEl.classList.toggle("o_enable_preview", !isVisible);
+        toSubscribeEl.classList.toggle("o_disable_preview", isVisible);
     }
 }
 

--- a/addons/website_mass_mailing/static/src/website_builder/recaptcha_subscribe_option_plugin.js
+++ b/addons/website_mass_mailing/static/src/website_builder/recaptcha_subscribe_option_plugin.js
@@ -1,3 +1,4 @@
+import { BuilderAction } from "@html_builder/core/builder_action";
 import { Plugin } from "@html_editor/plugin";
 import { registry } from "@web/core/registry";
 import { renderToElement } from "@web/core/utils/render";
@@ -7,26 +8,27 @@ class RecaptchaSubscribeOptionPlugin extends Plugin {
     static dependencies = ["websiteSession"];
     static shared = ["hasRecaptcha"];
     resources = {
-        builder_actions: [
-            {
-                toggleRecaptchaLegal: {
-                    apply: ({ editingElement }) => {
-                        const template = document.createElement("template");
-                        template.content.append(
-                            renderToElement("google_recaptcha.recaptcha_legal_terms")
-                        );
-                        editingElement.appendChild(template.content.firstElementChild);
-                    },
-                    clean: ({ editingElement }) => {
-                        editingElement.querySelector(".o_recaptcha_legal_terms").remove();
-                    },
-                },
-            },
-        ],
+        builder_actions: {
+            ToggleRecaptchaLegalAction,
+        }
     };
 
     hasRecaptcha() {
         return !!this.dependencies.websiteSession.getSession().recaptcha_public_key;
+    }
+}
+
+class ToggleRecaptchaLegalAction extends BuilderAction {
+    static id = "toggleRecaptchaLegal";
+    apply({ editingElement }) {
+        const template = document.createElement("template");
+        template.content.append(
+            renderToElement("google_recaptcha.recaptcha_legal_terms")
+        );
+        editingElement.appendChild(template.content.firstElementChild);
+    }
+    clean({ editingElement }) {
+        editingElement.querySelector(".o_recaptcha_legal_terms").remove();
     }
 }
 


### PR DESCRIPTION
*: website

Following the introduction of class-based actions [1], the existing tests needed to be updated accordingly. This commit performs that migration.

[1]: https://github.com/odoo/odoo/commit/b4b215325db61fbbe9793545293c8b6fbc99f310
