### PR TITLE
[FIX] mail, im_livechat: make (live)chat create more deterministic

### DIFF
--- a/addons/im_livechat/models/im_livechat_channel.py
+++ b/addons/im_livechat/models/im_livechat_channel.py
@@ -243,6 +243,7 @@ class Im_LivechatChannel(models.Model):
 
         return {
             'channel_member_ids': members_to_add,
+            "last_interest_dt": last_interest_dt,
             'livechat_active': True,
             'livechat_operator_id': operator_partner_id,
             'livechat_channel_id': self.id,

--- a/addons/mail/models/discuss/discuss_channel.py
+++ b/addons/mail/models/discuss/discuss_channel.py
@@ -1132,6 +1132,7 @@ class DiscussChannel(models.Model):
                         for partner in partners
                     ],
                     "channel_type": "chat",
+                    "last_interest_dt": last_interest_dt,
                     "name": ", ".join(partners.mapped("name")),
                 }
             )


### PR DESCRIPTION
runbot-112917
runbot-112998

Follow up of https://github.com/odoo/odoo/pull/214559

The issue is still happening after the previous fix, because the issue does not only happen with the `last_interest_dt` of the member, but also with the `last_interest_dt` of the channel.