### PR TITLE
[FIX] point_of_sale, pos_restaurant: track finalized order on screens

### DIFF
--- a/addons/point_of_sale/static/src/app/hooks/use_tracked_finalized_order.js
+++ b/addons/point_of_sale/static/src/app/hooks/use_tracked_finalized_order.js
@@ -1,0 +1,29 @@
+import { useEffect } from "@odoo/owl";
+import { _t } from "@web/core/l10n/translation";
+import { usePos } from "../store/pos_hook";
+
+export const useTrackedFinalizedOrder = (
+    orderUuid,
+    targetScreen = null,
+    recreateOrder = false,
+    isLocked = () => false
+) => {
+    const pos = usePos();
+    const order = pos.models["pos.order"].getBy("uuid", orderUuid);
+
+    useEffect(
+        (state) => {
+            if (state !== "draft" && recreateOrder) {
+                pos.add_new_order();
+            }
+
+            if (state !== "draft" && !isLocked()) {
+                pos.showScreen(targetScreen || pos.firstScreen);
+                pos.notification.add(_t("Order has been cancelled from another devices."), {
+                    type: "warning",
+                });
+            }
+        },
+        () => [order.state]
+    );
+};

--- a/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
@@ -3,7 +3,7 @@ import { useService } from "@web/core/utils/hooks";
 import { useBarcodeReader } from "@point_of_sale/app/barcode/barcode_reader_hook";
 import { _t } from "@web/core/l10n/translation";
 import { usePos } from "@point_of_sale/app/store/pos_hook";
-import { Component, onMounted, useEffect, useState, reactive, onWillRender } from "@odoo/owl";
+import { Component, onMounted, useEffect, useState, reactive } from "@odoo/owl";
 import { CategorySelector } from "@point_of_sale/app/generic_components/category_selector/category_selector";
 import { Input } from "@point_of_sale/app/generic_components/inputs/input/input";
 import {
@@ -25,6 +25,7 @@ import {
 import { pick } from "@web/core/utils/objects";
 import { unaccent } from "@web/core/utils/strings";
 import { CameraBarcodeScanner } from "@point_of_sale/app/screens/product_screen/camera_barcode_scanner";
+import { useTrackedFinalizedOrder } from "@point_of_sale/app/hooks/use_tracked_finalized_order";
 
 export class ProductScreen extends Component {
     static template = "point_of_sale.ProductScreen";
@@ -63,15 +64,9 @@ export class ProductScreen extends Component {
             this.numberBuffer.reset();
         });
 
-        onWillRender(() => {
-            // If its a shared order it can be paid from another POS
-            if (this.currentOrder?.state !== "draft") {
-                this.pos.add_new_order();
-            }
-        });
-
         this.barcodeReader = useService("barcode_reader");
 
+        useTrackedFinalizedOrder(this.currentOrder.uuid, false, true, () => true);
         useBarcodeReader({
             product: this._barcodeProductAction,
             quantity: this._barcodeProductAction,

--- a/addons/pos_restaurant/static/src/app/split_bill_screen/split_bill_screen.js
+++ b/addons/pos_restaurant/static/src/app/split_bill_screen/split_bill_screen.js
@@ -3,6 +3,7 @@ import { usePos } from "@point_of_sale/app/store/pos_hook";
 import { Component, useState } from "@odoo/owl";
 import { Orderline } from "@point_of_sale/app/generic_components/orderline/orderline";
 import { OrderWidget } from "@point_of_sale/app/generic_components/order_widget/order_widget";
+import { useTrackedFinalizedOrder } from "@point_of_sale/app/hooks/use_tracked_finalized_order";
 
 export class SplitBillScreen extends Component {
     static template = "pos_restaurant.SplitBillScreen";
@@ -13,6 +14,8 @@ export class SplitBillScreen extends Component {
         this.pos = usePos();
         this.qtyTracker = useState({});
         this.priceTracker = useState({});
+
+        useTrackedFinalizedOrder(this.currentOrder.uuid, this.pos.firstScreen, false, () => false);
     }
 
     get currentOrder() {


### PR DESCRIPTION
Before this commit, if two devices were working on the same order and one of them finalized the order, the other device would not be aware of this change. This was leading to error, since a finalized order is not editable anymore.

This commit adds a hook to track the finalized order on the product, payment and split bill screens. When the finalized order is detected, the user is redirected to another screen or a new draft order is created, depending on the screen.

taskId: 4788430

