### PR TITLE
[REF] html_builder, *: pass isPreviewing to action's apply and clean

### DIFF
--- a/addons/html_builder/static/src/core/builder_action.js
+++ b/addons/html_builder/static/src/core/builder_action.js
@@ -34,6 +34,7 @@ export class BuilderAction {
     /**
      * Apply the action on the editing element.
      * @param {Object} context
+     * @param {boolean} context.isPreviewing
      * @param {HTMLElement} context.editingElement
      * @param {any} context.value
      * @param {Object} [context.params]
@@ -60,6 +61,7 @@ export class BuilderAction {
     /**
      * Clean/reset the value if needed.
      * @param {Object} context
+     * @param {boolean} context.isPreviewing
      * @param {HTMLElement} context.editingElement
      */
     clean(context) {}

--- a/addons/html_builder/static/src/core/builder_action.js
+++ b/addons/html_builder/static/src/core/builder_action.js
@@ -46,6 +46,7 @@ export class BuilderAction {
      * @param {Object} context
      * @param {HTMLElement} context.editingElement
      * @param {Object} [context.params]
+     * @returns {any}
      */
     getValue(context) {}
 
@@ -55,14 +56,17 @@ export class BuilderAction {
      * @param {HTMLElement} context.editingElement
      * @param {any} context.value
      * @param {Object} [context.params]
+     * @returns {boolean}
      */
-    isApplied() {}
+    isApplied(context) {}
 
     /**
      * Clean/reset the value if needed.
      * @param {Object} context
      * @param {boolean} context.isPreviewing
      * @param {HTMLElement} context.editingElement
+     * @param {any} context.value
+     * @param {Object} [context.params]
      */
     clean(context) {}
 
@@ -76,6 +80,7 @@ export class BuilderAction {
     /**
      * Check if a method has been overridden.
      * @param {string} method
+     * @returns {boolean}
      */
     has(method) {
         const baseMethod = BuilderAction.prototype[method];

--- a/addons/html_builder/static/src/core/building_blocks/builder_colorpicker.js
+++ b/addons/html_builder/static/src/core/building_blocks/builder_colorpicker.js
@@ -72,6 +72,7 @@ export function useColorPickerBuilderComponent() {
         }
         preventNextPreview = true;
         callOperation(applyOperation.preview, {
+            preview: true,
             userInputValue: getColor(colorValue),
             operationParams: {
                 cancellable: true,

--- a/addons/html_builder/static/src/core/utils.js
+++ b/addons/html_builder/static/src/core/utils.js
@@ -490,6 +490,7 @@ export function useClickableBuilderComponent() {
             }
             preventNextPreview = true;
             callOperation(applyOperation.preview, {
+                preview: true,
                 operationParams: {
                     cancellable: true,
                     cancelPrevious: () => applyOperation.revert(),
@@ -508,11 +509,12 @@ export function useClickableBuilderComponent() {
         operation.preview = () => {};
     }
 
-    function clean(nextApplySpecs) {
+    function clean(nextApplySpecs, isPreviewing) {
         for (const { actionId, actionParam, actionValue } of getAllActions()) {
             for (const editingElement of comp.env.getEditingElements()) {
                 let nextAction;
                 getAction(actionId).clean?.({
+                    isPreviewing,
                     editingElement,
                     params: actionParam,
                     value: actionValue,
@@ -531,13 +533,13 @@ export function useClickableBuilderComponent() {
         }
     }
 
-    async function callApply(applySpecs) {
-        comp.env.selectableContext?.cleanSelectedItem(applySpecs);
+    async function callApply(applySpecs, isPreviewing) {
+        comp.env.selectableContext?.cleanSelectedItem(applySpecs, isPreviewing);
         const cleans = inheritedActionIds
             .map((actionId) => comp.env.dependencyManager.get(actionId).cleanSelectedItem)
             .filter(Boolean);
         for (const clean of new Set(cleans)) {
-            clean(applySpecs);
+            clean(applySpecs, isPreviewing);
         }
         const proms = [];
         const isAlreadyApplied = isApplied();
@@ -547,6 +549,7 @@ export function useClickableBuilderComponent() {
             if (shouldClean) {
                 proms.push(
                     applySpec.clean({
+                        isPreviewing,
                         editingElement: applySpec.editingElement,
                         params: applySpec.actionParam,
                         value: applySpec.actionValue,
@@ -558,6 +561,7 @@ export function useClickableBuilderComponent() {
             } else {
                 proms.push(
                     applySpec.apply({
+                        isPreviewing,
                         editingElement: applySpec.editingElement,
                         params: applySpec.actionParam,
                         value: applySpec.actionValue,
@@ -619,11 +623,12 @@ export function useInputBuilderComponent({
 
     const withLoadingEffect = useWithLoadingEffect(getAllActions);
 
-    async function callApply(applySpecs) {
+    async function callApply(applySpecs, isPreviewing) {
         const proms = [];
         for (const applySpec of applySpecs) {
             proms.push(
                 applySpec.apply({
+                    isPreviewing,
                     editingElement: applySpec.editingElement,
                     params: applySpec.actionParam,
                     value: applySpec.actionValue,
@@ -675,6 +680,7 @@ export function useInputBuilderComponent({
     function preview(userInputValue) {
         if (shouldPreview) {
             callOperation(applyOperation.preview, {
+                preview: true,
                 userInputValue: parseDisplayValue(userInputValue),
                 operationParams: {
                     cancellable: true,
@@ -861,8 +867,10 @@ export function getAllActionsAndOperations(comp) {
         return actions.concat(inheritedActions || []);
     }
     function callOperation(fn, params = {}) {
+        const isPreviewing = !!params.preview;
         const actionsSpecs = getActionsSpecs(getAllActions(), params.userInputValue);
-        comp.env.editor.shared.operation.next(() => fn(actionsSpecs), {
+
+        comp.env.editor.shared.operation.next(() => fn(actionsSpecs, isPreviewing), {
             load: async () =>
                 Promise.all(
                     actionsSpecs.map(async (applySpec) => {

--- a/addons/website/static/src/builder/plugins/content_width_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/content_width_option_plugin.js
@@ -6,7 +6,7 @@ import { ClassAction } from "@html_builder/core/core_builder_action_plugin";
 
 class ContentWidthOptionPlugin extends Plugin {
     static id = "contentWidthOption";
-    static dependencies = ["builderActions", "history"];
+    static dependencies = ["builderActions"];
     resources = {
         builder_options: [
             withSequence(CONTAINER_WIDTH, {
@@ -26,11 +26,9 @@ class ContentWidthOptionPlugin extends Plugin {
 
 class SetContainerWidthAction extends ClassAction {
     static id = "setContainerWidth";
-    static dependencies = ["history"];
-    apply({ editingElement }) {
+    apply({ isPreviewing, editingElement }) {
         super.apply(...arguments);
-        const isPreviewMode = this.dependencies.history.getIsPreviewing();
-        editingElement.classList.toggle("o_container_preview", isPreviewMode);
+        editingElement.classList.toggle("o_container_preview", isPreviewing);
     }
 }
 

--- a/addons/website/static/src/builder/plugins/options/image_gallery_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/image_gallery_option_plugin.js
@@ -54,8 +54,8 @@ class ImageGalleryOption extends Plugin {
         }
     }
 
-    restoreSelection(imageToSelect) {
-        if (imageToSelect && !this.dependencies.history.getIsPreviewing()) {
+    restoreSelection(imageToSelect, isPreviewing) {
+        if (imageToSelect && !isPreviewing) {
             // We want to update the container to the equivalent cloned image.
             // This has to be done in the new step so we manually add a step
             this.dependencies.history.addStep();
@@ -119,7 +119,7 @@ class ImageGalleryOption extends Plugin {
      * @param {String('slideshow'|'masonry'|'grid'|'nomode')} mode
      * @param {Element[]} images
      */
-    async setImages(imageGalleryElement, mode, images) {
+    setImages(imageGalleryElement, mode, images) {
         if (mode !== this.getMode(imageGalleryElement)) {
             imageGalleryElement.classList.remove("o_nomode", "o_masonry", "o_grid", "o_slideshow");
             imageGalleryElement.classList.add(`o_${mode}`);
@@ -436,10 +436,13 @@ class SetImageGalleryLayoutAction extends BuilderAction {
     load({ editingElement }) {
         return this.dependencies.imageGalleryOption.processImages(editingElement);
     }
-    apply({ editingElement, params: { mainParam: mode }, loadResult }) {
+    apply({ isPreviewing, editingElement, params: { mainParam: mode }, loadResult }) {
         if (mode !== this.dependencies.imageGalleryOption.getMode(editingElement)) {
             this.dependencies.imageGalleryOption.setImages(editingElement, mode, loadResult.images);
-            this.dependencies.imageGalleryOption.restoreSelection(loadResult.imageToSelect);
+            this.dependencies.imageGalleryOption.restoreSelection(
+                loadResult.imageToSelect,
+                isPreviewing
+            );
         }
     }
     isApplied({ editingElement, params: { mainParam: mode } }) {
@@ -452,7 +455,7 @@ class SetImageGalleryColumnsAction extends BuilderAction {
     load({ editingElement }) {
         return this.dependencies.imageGalleryOption.processImages(editingElement);
     }
-    apply({ editingElement, params: { mainParam: columns }, loadResult }) {
+    apply({ isPreviewing, editingElement, params: { mainParam: columns }, loadResult }) {
         if (columns !== this.dependencies.imageGalleryOption.getColumns(editingElement)) {
             editingElement.dataset.columns = columns;
             this.dependencies.imageGalleryOption.setImages(
@@ -460,7 +463,10 @@ class SetImageGalleryColumnsAction extends BuilderAction {
                 this.dependencies.imageGalleryOption.getMode(editingElement),
                 loadResult.images
             );
-            this.dependencies.imageGalleryOption.restoreSelection(loadResult.imageToSelect);
+            this.dependencies.imageGalleryOption.restoreSelection(
+                loadResult.imageToSelect,
+                isPreviewing
+            );
         }
     }
     isApplied({ editingElement, params: { mainParam: columns } }) {

--- a/addons/website/static/tests/builder/builder_action.test.js
+++ b/addons/website/static/tests/builder/builder_action.test.js
@@ -1,3 +1,4 @@
+import { BuilderAction } from "@html_builder/core/builder_action";
 import { beforeEach, describe, expect, test } from "@odoo/hoot";
 import { animationFrame, Deferred } from "@odoo/hoot-dom";
 import { useState, xml } from "@odoo/owl";
@@ -10,7 +11,6 @@ import {
     addBuilderOption,
     setupHTMLBuilder,
 } from "@html_builder/../tests/helpers";
-import { BuilderAction } from "@html_builder/core/builder_action";
 
 describe("website tests", () => {
     beforeEach(defineWebsiteModels);
@@ -128,5 +128,66 @@ describe("HTML builder tests", () => {
         prepareDeferred.resolve();
         await animationFrame();
         expect.verifySteps(["prepare"]);
+    });
+
+    describe("isPreviewing is passed to action's apply and clean", () => {
+        beforeEach(async () => {
+            addBuilderAction({
+                IsPreviewingAction: class extends BuilderAction {
+                    static id = "isPreviewing";
+                    isApplied({ editingElement }) {
+                        return editingElement.classList.contains("o_applied");
+                    }
+
+                    getValue({ editingElement }) {
+                        return editingElement.dataset.value;
+                    }
+
+                    apply({ isPreviewing, editingElement, value }) {
+                        expect.step(`apply ${isPreviewing}`);
+                        editingElement.classList.add("o_applied");
+                        editingElement.dataset.value = value;
+                    }
+
+                    clean({ isPreviewing, editingElement }) {
+                        expect.step(`clean ${isPreviewing}`);
+                        editingElement.classList.remove("o_applied");
+                    }
+                },
+            });
+        });
+
+        test("useClickableBuilderComponent", async () => {
+            addBuilderOption({
+                selector: ".test-options-target",
+                template: xml`<BuilderButton action="'isPreviewing'" actionValue="true">Toggle</BuilderButton>`,
+            });
+            await setupHTMLBuilder(`<section class="test-options-target">Homepage</section>`);
+            await contains(":iframe .test-options-target").click();
+
+            // apply
+            await contains("[data-action-id='isPreviewing']").click();
+            expect.verifySteps(["apply true", "apply false"]);
+
+            // Hover something else, making sure we have a preview on next click
+            await contains(":iframe .test-options-target").click();
+
+            // clean
+            await contains("[data-action-id='isPreviewing']").click();
+            expect.verifySteps(["clean true", "clean false"]);
+        });
+
+        test("useInputBuilderComponent", async () => {
+            addBuilderOption({
+                selector: ".test-options-target",
+                template: xml`<BuilderTextInput action="'isPreviewing'"/>`,
+            });
+            await setupHTMLBuilder(`<section class="test-options-target">Homepage</section>`);
+            await contains(":iframe .test-options-target").click();
+
+            // apply
+            await contains("[data-action-id='isPreviewing'] input").edit("truthy");
+            expect.verifySteps(["apply true", "apply false"]);
+        });
     });
 });

--- a/addons/website_sale/static/src/website_builder/products_item_option_plugin.js
+++ b/addons/website_sale/static/src/website_builder/products_item_option_plugin.js
@@ -9,7 +9,6 @@ import { BuilderAction } from "@html_builder/core/builder_action";
 
 class ProductsItemOptionPlugin extends Plugin {
     static id = "productsItemOptionPlugin";
-    static dependencies = ["history"];
     static shared = [
         "setItemSize",
         "setProductTemplateID",
@@ -369,12 +368,11 @@ class ChangeSequenceAction extends BuilderAction {
 }
 class SetRibbonAction extends BuilderAction {
     static id = "setRibbon";
-    static dependencies = ["productsItemOptionPlugin", "history"];
+    static dependencies = ["productsItemOptionPlugin"];
     isApplied({ editingElement, value }) {
         return (parseInt(editingElement.dataset.ribbonId) || "") === value;
     }
-    apply({ editingElement, value }) {
-        const isPreviewMode = this.dependencies.history.getIsPreviewing();
+    apply({ isPreviewing, editingElement, value }) {
         this.dependencies.productsItemOptionPlugin.setProductTemplateID(parseInt(
             editingElement
                 .querySelector('[data-oe-model="product.template"]')
@@ -394,7 +392,7 @@ class SetRibbonAction extends BuilderAction {
             position: "left",
         };
 
-        return this.dependencies.productsItemOptionPlugin._setRibbon(editingElement, ribbon, !isPreviewMode);
+        return this.dependencies.productsItemOptionPlugin._setRibbon(editingElement, ribbon, !isPreviewing);
     }
 }
 class CreateRibbonAction extends BuilderAction {
@@ -425,7 +423,7 @@ class CreateRibbonAction extends BuilderAction {
 }
 class ModifyRibbonAction extends BuilderAction {
     static id = "modifyRibbon";
-    static dependencies = ["productsItemOptionPlugin", "history"];
+    static dependencies = ["productsItemOptionPlugin"];
     setup() {
         this.piop = this.dependencies.productsItemOptionPlugin
     }
@@ -452,8 +450,7 @@ class ModifyRibbonAction extends BuilderAction {
         }
         return this.dependencies.productsItemOptionPlugin.getRibbonsObject()[ribbonId][field] === value;
     }
-    apply({ editingElement, params, value }) {
-        const isPreviewMode = this.dependencies.history.getIsPreviewing();
+    apply({ isPreviewing, editingElement, params, value }) {
         const setting = params.mainParam;
         const ribbonId = parseInt(editingElement.dataset.ribbonId);
         this.dependencies.productsItemOptionPlugin.getRibbonsObject()[ribbonId][setting] = value;
@@ -461,7 +458,7 @@ class ModifyRibbonAction extends BuilderAction {
         const ribbon = this.dependencies.productsItemOptionPlugin.getRibbons().find((ribbon) => ribbon.id == ribbonId);
         ribbon[setting] = value;
 
-        return this.plugin._setRibbon(editingElement, ribbon, !isPreviewMode);
+        return this.plugin._setRibbon(editingElement, ribbon, !isPreviewing);
     }
 }
 class DeleteRibbonAction extends BuilderAction {


### PR DESCRIPTION
*: website, website_sale

Remove unnecessary dependency on `history` plugin just to know whether we're previewing or not. This makes more sense because previewing is done at the level of Builder components behaviors, which are defined in `utils.js`.
