### PR TITLE
[IMP] mrp: update work order search view

### DIFF
--- a/addons/mrp/models/mrp_workorder.py
+++ b/addons/mrp/models/mrp_workorder.py
@@ -38,6 +38,7 @@ class MrpWorkorder(models.Model):
     product_id = fields.Many2one(related='production_id.product_id')
     product_tracking = fields.Selection(related="product_id.tracking")
     product_uom_id = fields.Many2one(related='production_id.product_uom_id')
+    product_variant_attributes = fields.Many2many('product.template.attribute.value', related='product_id.product_template_attribute_value_ids')
     production_id = fields.Many2one('mrp.production', 'Manufacturing Order', required=True, check_company=True, readonly=True, index='btree')
     production_availability = fields.Selection(
         string='Stock Availability', readonly=True,

--- a/addons/mrp/views/mrp_workorder_views.xml
+++ b/addons/mrp/views/mrp_workorder_views.xml
@@ -280,6 +280,8 @@
                 <field name="production_id"/>
                 <field name="product_id"/>
                 <field name="finished_lot_id"/>
+                <field name="product_variant_attributes"/>
+                <field name="move_raw_ids" string="Component" filter_domain="[('move_raw_ids.product_id', 'ilike', self)]"/>
                 <filter string="In Progress" name="progress" domain="[('state', '=', 'progress')]"/>
                 <filter string="To Do" name="ready" domain="[('state', '=', 'ready')]"/>
                 <filter string="Blocked" name="blocked" domain="[('state', '=', 'blocked')]"/>


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**

- To plan work orders effectively, you might need to process them in a specific order. It might be based on a specific variant or a component, Therefore search in workorder view was updated to allow you to search a workorder by attributes values (variants) or components. To facilitate the organization of your workorders view.
Task:4869056




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
