### PR TITLE
[IMP] base: handle neutralization with OCA multi-company modules

### DIFF
--- a/odoo/addons/base/data/neutralize.sql
+++ b/odoo/addons/base/data/neutralize.sql
@@ -18,10 +18,20 @@ UPDATE ir_cron
 );
 
 -- neutralization flag for the database
-INSERT INTO ir_config_parameter (key, value)
-VALUES ('database.is_neutralized', true)
-    ON CONFLICT (key) DO
-       UPDATE SET value = true;
+DO $$
+BEGIN
+   IF NOT EXISTS (
+       SELECT 1 FROM ir_config_parameter
+       WHERE key = 'database.is_neutralized'
+   ) THEN
+      INSERT INTO ir_config_parameter (key, value)
+      VALUES ('database.is_neutralized', 'true');
+   ELSE
+      UPDATE ir_config_parameter
+      SET value = 'true'
+      WHERE key = 'database.is_neutralized';
+   END IF;
+END $$;
 
 -- deactivate webhooks
 UPDATE ir_act_server


### PR DESCRIPTION
The previous INSERT ... ON CONFLICT approach for setting the neutralization flag fails when OCA modules like ir_config_parameter_multi_company are installed, as they add unique constraints on (key, company_id) rather than just (key).

This commit replaces the INSERT ... ON CONFLICT with a DO block that explicitly checks for existence before inserting or updating, ensuring compatibility with modules that modify the ir_config_parameter constraints.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
