### PR TITLE
[FIX] html_builder: resolve various issues in BuilderDateTimePicker

### DIFF
--- a/addons/html_builder/static/src/core/building_blocks/builder_datetimepicker.xml
+++ b/addons/html_builder/static/src/core/building_blocks/builder_datetimepicker.xml
@@ -6,6 +6,7 @@
         <div t-ref="root">
             <BuilderTextInputBase
                     t-props="textInputBaseProps"
+                    inputRef="inputRef"
                     commit="commit"
                     preview="preview"
                     onFocus.bind="onFocus"


### PR DESCRIPTION
This commit addresses several regressions that were introduced during the website refactor [1].
The primary goal is to restore and improve the functionality of the `BuilderDateTimePicker`.

The following issues have been resolved (to reproduce: drop an
`s_countdown` snippet on the page, use `Due Date` option):
- Empty input fields now correctly default to the current date and time
- Clicking the "Clear" button now resets the input to the current date
  and time (previously, it only emptied the input)
- Invalid date or time inputs now revert to the last valid input (to
  reproduce: choose a valid date, then type `INVALID` in the input
field)
- `NaN` is no longer displayed on the snippet while the user is typing
  (previously, `NaN` appeared on the snippet for invalid or empty inputs,
even in preview)

Additionally, the `default` props have been removed as the component now
consistently defaults to the current time.
The input field is now synchronized with the `DateTimePicker` to provide
a more seamless user experience (the field displays the same date while
using the `DateTimePicker` in preview).

[1]: https://github.com/odoo/odoo/commit/9fe45e2b7ddbbfd0445ffe25a859e67a316d02b2

Related to task-4367641
