### PR TITLE
[DRAFT][FIX] hr_skills: Add/delete button hiding if table has more content in resume

### DIFF
--- a/addons/hr_skills/static/src/fields/resume_one2many/resume_one2many.js
+++ b/addons/hr_skills/static/src/fields/resume_one2many/resume_one2many.js
@@ -18,7 +18,11 @@ export class ResumeListRenderer extends CommonSkillsListRenderer {
         this.linkRef = useRef("link-target-blank");
         onMounted(this._setLinksToOpenInNewTab);
         onPatched(this._setLinksToOpenInNewTab);
+
+        onMounted(this._setResumeLineDescMaxSize);
+        onPatched(this._setResumeLineDescMaxSize);
     }
+
     get groupBy() {
         return "line_type_id";
     }
@@ -46,6 +50,25 @@ export class ResumeListRenderer extends CommonSkillsListRenderer {
             });
         }
     }
+
+    _setResumeLineDescMaxSize() {
+        const parentContainer = document.getElementById("o_employee_left");
+        if (parentContainer) {
+            const resumeLineDescs = document.querySelectorAll('.o_resume_line_title + .o_resume_line_desc');
+            const parentContainerWidth = parentContainer?.clientWidth;
+
+            resumeLineDescs.forEach(resumeLine => {
+                if (resumeLine.clientWidth > parentContainerWidth - 120) {
+                    resumeLine.style.width = `${parentContainerWidth - 120}px`;
+                    resumeLine.style.wordWrap = 'break-word'
+                    if (resumeLine.innerHTML.includes('<table')) {
+                        resumeLine.style.overflow = 'auto'
+                    }
+                }
+            });
+        }
+    }
+
 }
 
 export class ResumeX2ManyField extends SkillsX2ManyField {

--- a/addons/hr_skills/views/hr_views.xml
+++ b/addons/hr_skills/views/hr_views.xml
@@ -127,7 +127,7 @@
         <field name="arch" type="xml">
             <page name="resume" position="inside">
                 <div class="row">
-                    <div class="o_hr_skills_editable o_hr_skills_group o_group_resume col-lg-7 d-flex flex-column">
+                    <div id="o_employee_left" class="o_hr_skills_editable o_hr_skills_group o_group_resume col-lg-7 d-flex flex-column">
                         <separator string="Resume" class="mb-4"/>
                         <!-- This field uses a custom list view rendered by the 'resume_one2many' widget.
                             Adding fields in the list arch below makes them accessible to the widget


### PR DESCRIPTION
When the Description field in the Resume section is too wide, it causes horizontal overflow, pushing the Add and Delete buttons out of view

task-4881917

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
