### PR TITLE
[FIX] web: avoid beforeUnload event when download

### DIFF
--- a/addons/web/static/src/webclient/actions/action_service.js
+++ b/addons/web/static/src/webclient/actions/action_service.js
@@ -1110,8 +1110,10 @@ export function makeActionManager(env, router = _router) {
         if (url && !(url.startsWith("http") || url.startsWith("/"))) {
             url = "/" + url;
         }
-        if (action.target === "download" || action.target === "self") {
+        if (action.target === "self") {
             browser.location.assign(url);
+        } else if (action.target === "download") {
+            browser.open(url, "_blank");
         } else {
             const w = browser.open(url, "_blank");
             if (!w || w.closed || typeof w.closed === "undefined") {

--- a/addons/web/static/tests/webclient/actions/url_action.test.js
+++ b/addons/web/static/tests/webclient/actions/url_action.test.js
@@ -45,8 +45,8 @@ test("execute an 'ir.actions.act_url' action with url javascript:", async () => 
 });
 
 test("execute an 'ir.actions.act_url' action with target 'download'", async () => {
-    patchWithCleanup(browser.location, {
-        assign: (url) => {
+    patchWithCleanup(browser, {
+        open: (url) => {
             expect.step(url);
         },
     });


### PR DESCRIPTION
In this commit, we use browser.open(url, "_blank") when the action is a download instead of window.location.assign(url). This latest dispatch a "beforeUnload" event and we want to avoid it.