### PR TITLE
[FIX] mail: reply-to composer recover doesn't crash

### DIFF
--- a/addons/mail/static/src/core/common/composer.xml
+++ b/addons/mail/static/src/core/common/composer.xml
@@ -36,7 +36,7 @@
                 <span class="cursor-pointer" t-on-click="() => env.messageHighlight?.highlightMessage(props.composer.replyToMessage, props.composer.thread)">
                     Replying to <b t-esc="props.composer.replyToMessage.author?.name ?? props.composer.replyToMessage.email_from"/>
                 </span>
-                <span t-if="props.composer.replyToMessage.thread.notEq(props.composer.thread)">
+                <span t-if="props.composer.replyToMessage.thread?.notEq(props.composer.thread)">
                     on: <b><t t-esc="props.composer.replyToMessage.thread.displayName"/></b>
                 </span>
                 <i class="fa fa-lg fa-times-circle rounded-circle p-0 ms-1 cursor-pointer" title="Stop replying" t-on-click="() => (props.composer.replyToMessage = undefined)"/>


### PR DESCRIPTION
Before this commit, when a composer had a reply-to on a message. Reloading the page would lead to the following crash:

```
TypeError" undefined is not an object
(evaluating 'ctx['props'].composer.replyToMessage.thread.notEq')
```

Steps to reproduce:
- post 2 messages in conversation
- start replying to the oldest message
- page reload => crash

This happens because when page reloading the composer is recovering its content, including the reply-to message. The reply-to composer recovery only contains the `messageId`, hence the crash above.

When the reply-to message of composer is the last one this would not crash thanks to thread fetched data that also contains the last message data, which has proper link of message to thread.

This commit fixes the issue by guarding message.thread relation in template, as the UI must be robust against partial knowledge of data.

