### PR TITLE
[16.0][FIX] pos_daily_sales_reports total discount

### DIFF
--- a/addons/pos_daily_sales_reports/models/pos_daily_sales_reports.py
+++ b/addons/pos_daily_sales_reports/models/pos_daily_sales_reports.py
@@ -317,10 +317,14 @@ class ReportSaleDetails(models.AbstractModel):
         def get_total_discount(self):
             amount = 0
             for line in self.env['pos.order.line'].search([('order_id', 'in', self.order_ids.ids), ('discount', '>', 0)]):
-                normal_price = line.qty * line.price_unit
-                normal_price = normal_price + (normal_price / 100 * line.tax_ids.amount)
-                amount += normal_price - line.price_subtotal_incl
-
+                taxes = line.tax_ids.compute_all(
+                    line.price_unit,
+                    line.order_id.currency_id,
+                    line.qty,
+                    product=line.product_id,
+                    partner=line.order_id.partner_id,
+                )
+                amount += taxes["total_included"] - line.price_subtotal
             return amount
 
         def _get_invoice_total_list(self):

--- a/addons/pos_daily_sales_reports/tests/__init__.py
+++ b/addons/pos_daily_sales_reports/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_pos_daily_sales_report

--- a/addons/pos_daily_sales_reports/tests/test_pos_daily_sales_report.py
+++ b/addons/pos_daily_sales_reports/tests/test_pos_daily_sales_report.py
@@ -1,0 +1,54 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+import odoo
+from odoo.addons.point_of_sale.tests.common import TestPoSCommon
+
+
+@odoo.tests.tagged('post_install', '-at_install')
+class TestPoSDailySalesReports(TestPoSCommon):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.config = cls.basic_config
+        cls.PosOrder = cls.env["pos.order"]
+        cls.partner_01 = cls.env["res.partner"].create({"name": "Test partner 1"})
+        cls.tax_15 = cls.env["account.tax"].create(
+            {
+                "name": "TAX 15%",
+                "amount_type": "percent",
+                "type_tax_use": "sale",
+                "amount": 15.0,
+            }
+        )
+        cls.tax_5 = cls.env["account.tax"].create(
+            {
+                "name": "TAX 5%",
+                "amount_type": "percent",
+                "type_tax_use": "sale",
+                "amount": 5.0,
+            }
+        )
+        cls.tax = cls.env["account.tax"].create(
+            {
+                "name": "TAX 15%",
+                "amount_type": "percent",
+                "type_tax_use": "sale",
+                "amount": 15.0,
+            }
+        )
+        cls.product1 = cls.env["product.product"].create(
+            {"name": "Test Product 1",
+            "list_price": 10.0,
+            "taxes_id": [(6, 0, (cls.tax_15 | cls.tax_5).ids)],
+            }
+        )
+
+    def test_pos_total_discount(self):
+        """Test that the total discount is correctly calculated in the POS daily sales report."""
+        pos_session = self.open_new_session()
+
+        orders = [
+            self.create_ui_order_data(
+                [(self.product1, 3, 10)], False)
+        ]
+        self.env["pos.order"].create_from_ui(orders)
+        self.assertEqual(pos_session.get_total_discount(), 9.0)


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
**Traceback printing POS Daily Report**
1. Set product xxx with 2 sales taxes and available in POS
2. In POS shop, sell product xxx and apply a discount via "%Disc" button
3. Pay order and close session
4. Go to POS => Sales Details report and print orders from Shop where previous pos.order was create

Current behavior before PR:
```
File "/data/build/odoo/odoo/addons/base/models/ir_actions_report.py", line 996, in _get_rendering_context
data.update(report_model._get_report_values(docids, data=data))
File "/data/build/odoo/addons/point_of_sale/models/pos_order.py", line 1588, in _get_report_values
data.update(self.get_sale_details(data['date_start'], data['date_stop'], configs.ids, data['session_ids']))
File "/data/build/enterprise/pos_blackbox_be/models/report_sale_details.py", line 12, in get_sale_details
data = super(ReportSaleDetails, self).get_sale_details(date_start, date_stop, config_ids, session_ids)
File "/data/build/odoo/addons/pos_daily_sales_reports/models/pos_daily_sales_reports.py", line 236, in get_sale_details
discount_amount += session.get_total_discount()
File "/data/build/odoo/addons/pos_daily_sales_reports/models/pos_daily_sales_reports.py", line 321, in get_total_discount
normal_price = normal_price + (normal_price / 100 * line.tax_ids.amount)
File "/data/build/odoo/odoo/fields.py", line 1154, in __get__
record.ensure_one()
File "/data/build/odoo/odoo/models.py", line 5222, in ensure_one
raise ValueError("Expected singleton: %s" % self)
ValueError: Expected singleton: account.tax(1, 260)
```


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
