### PR TITLE
[REV] project_todo: converting to-do into a task, keep breadcrumbs

### DIFF
--- a/addons/project_todo/models/project_task.py
+++ b/addons/project_todo/models/project_task.py
@@ -49,9 +49,10 @@ class ProjectTask(models.Model):
         self.ensure_one()
         self.company_id = self.project_id.company_id
         return {
-            'type': 'ir.actions.act_url',
-            'target': 'self',
-            'url': f'/odoo/project/{self.project_id.id}/tasks/{self.id}',
+            'view_mode': 'form',
+            'res_model': 'project.task',
+            'res_id': self.id,
+            'type': 'ir.actions.act_window',
         }
 
     @api.model

--- a/addons/project_todo/static/tests/tours/project_todo_main_functions.js
+++ b/addons/project_todo/static/tests/tours/project_todo_main_functions.js
@@ -163,10 +163,9 @@ registry.category("web_tour.tours").add('project_todo_main_functions', {
     trigger: 'button[name="action_convert_to_task"]',
     content: 'Convert the todo to a task',
     run: "click",
-    expectUnloadPage: true,
 }, {
-    trigger: ".o_form_view .breadcrumb-item:last-child",
-    content: markup`Let's go back to the <b>kanban view</b> to have an overview of tasks linked to project chosen.`,
+    trigger: ".o_form_view .breadcrumb-item:nth-child(1)",
+    content: markup`Let's go back to the <b>kanban view</b> to have an overview of your next tasks.`,
     run: "click",
 }, {
     trigger: ".o_kanban_view",


### PR DESCRIPTION
When converting a to-do into a task, the breadcrumb is kept to return to the to-do.

Before: the breadcrumbs are switched to the `project` app after a to-do is converted to a task.

After: the breadcrumbs are kept, leading to the `to-do` app to return to the to-dos

Reverting old commit c6e5ef2ce887f662f52317ede3fbb5e6ac241a73

---

task-4781811