### PR TITLE
[IMP] profiler: Time limit to commit profile

### DIFF
--- a/addons/web/static/src/core/debug/profiling/profiling_item.xml
+++ b/addons/web/static/src/core/debug/profiling/profiling_item.xml
@@ -33,6 +33,10 @@
                                 <option value="0.1" t-att-selected="interval === '0.1'">0.1</option>
                                 <option value="1" t-att-selected="interval === '1'">1</option>
                             </select>
+                            <div class="input-group input-group-sm mt-2">
+                                <div class="input-group-text">Time Limit (seconds)</div>
+                                <input type="number" class="form-control" t-on-click.stop.prevent="" t-on-change="(ev) => this.changeParam('time_limit', ev)" t-att-value="profiling.state.params.time_limit || '0'" placeholder="None"/>
+                            </div>
                         </div>
                         <div class="input-group input-group-sm mt-2">
                             <div class="input-group-text">Entry Count</div>


### PR DESCRIPTION
Modify the query collector so that it add an entry before the query runs and updates the time after it runs.

use the async collector periodic sampling to commit the profiler after a time limit.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
