### PR TITLE
[FIX] web: fix daterange selection when clicking start date

### DIFF
--- a/addons/web/static/src/core/datetime/datetimepicker_service.js
+++ b/addons/web/static/src/core/datetime/datetimepicker_service.js
@@ -356,7 +356,7 @@ export const datetimePickerService = {
                     const previousValue = pickerProps.value;
                     pickerProps.value = value;
 
-                    if (areDatesEqual(previousValue, pickerProps.value)) {
+                    if (source === "input" && areDatesEqual(previousValue, pickerProps.value)) {
                         return;
                     }
 

--- a/addons/web/static/tests/core/components/datetime/datetime_input.test.js
+++ b/addons/web/static/tests/core/components/datetime/datetime_input.test.js
@@ -92,7 +92,6 @@ describe("DateTimeInput (date)", () => {
         await contains(getPickerCell("8")).click();
 
         expect(".o_datetime_input").toHaveValue("08/02/1997");
-        // the onchange is called twice (when clicking and whe the popover is closing)
         expect.verifySteps(["datetime-changed"]);
     });
 

--- a/addons/web/static/tests/views/fields/daterange_field.test.js
+++ b/addons/web/static/tests/views/fields/daterange_field.test.js
@@ -128,6 +128,31 @@ test("Datetime field - interaction with the datepicker", async () => {
     expect("input[data-field=datetime_end]").toHaveValue("02/09/2017 05:30:00");
 });
 
+test("Datetime field - interaction with the datepicker (same initial dates)", async () => {
+    Partner._records[0].datetime_end = "2017-02-08 15:00:00";
+
+    await mountView({
+        type: "form",
+        resModel: "partner",
+        resId: 1,
+        arch: `
+            <form>
+                <field name="datetime" widget="daterange" options="{'end_date_field': 'datetime_end'}"/>
+            </form>`,
+    });
+    expect("input[data-field=datetime]").toHaveValue("02/08/2017 15:30:00");
+    expect("input[data-field=datetime_end]").toHaveValue("02/08/2017 20:30:00");
+    await contains("input[data-field=datetime]").click();
+    expect(".o_date_item_cell.o_select_start").toHaveText("8");
+    expect(".o_date_item_cell.o_select_end").toHaveText("8");
+    expect("input[data-field=datetime]").toBeFocused();
+    await contains(getPickerCell("8").at(0)).click();
+    expect("input[data-field=datetime_end]").toBeFocused();
+    await contains(getPickerCell("10").at(0)).click();
+    expect("input[data-field=datetime]").toHaveValue("02/08/2017 15:30:00");
+    expect("input[data-field=datetime_end]").toHaveValue("02/10/2017 20:30:00");
+});
+
 test.tags("desktop");
 test("Date field - interaction with the datepicker", async () => {
     Partner._fields.date_end = fields.Date({ string: "Date end" });


### PR DESCRIPTION
This commit fixes an issue in the datetime_picker where clicking on an already selected start date would not initiate the selection of an end date. As a result, users were forced to select a different date first before being able to reselect the same start date.

With this fix, clicking the start date again now correctly triggers the end date selection phase, improving the overall usability of the daterange picker.

task-4845373
