### PR TITLE
[FIX] web: ask less aggregates when select progressbar

### DIFF
--- a/addons/web/static/src/views/kanban/progress_bar_hook.js
+++ b/addons/web/static/src/views/kanban/progress_bar_hook.js
@@ -195,7 +195,7 @@ class ProgressBarState {
         );
         const { context, fields, groupBy, resModel } = this.model.root;
         const kwargs = { context };
-        const aggregateSpecs = getAggregateSpecifications(fields);
+        const aggregateSpecs = getAggregateSpecifications(this._aggregateFields);
         const domain = filterDomain
             ? Domain.and([group.groupDomain, filterDomain]).toList()
             : group.groupDomain;

--- a/addons/web/static/tests/views/kanban/kanban_view.test.js
+++ b/addons/web/static/tests/views/kanban/kanban_view.test.js
@@ -3442,7 +3442,7 @@ test("kanban grouped by stage_id: move record from to the None column", async ()
     // Set up a record with no stage initially
     Partner._records = [
         { id: 1, foo: "Task A", stage_id: false },
-        { id: 2, foo: "Task B", stage_id: 10},
+        { id: 2, foo: "Task B", stage_id: 10 },
     ];
     Partner._fields.stage_id = fields.Many2one({ relation: "partner.stage" });
 
@@ -3463,9 +3463,9 @@ test("kanban grouped by stage_id: move record from to the None column", async ()
     expect(queryAll(".o_kanban_group")).toHaveCount(2); // None and New
 
     await click(".o_kanban_group:first .o_kanban_header");
-    
+
     // Drag a record to the "None" column
-    let dragActions = await contains(".o_kanban_record:contains(Task B)").drag();
+    const dragActions = await contains(".o_kanban_record:contains(Task B)").drag();
     await dragActions.moveTo(".o_kanban_group:nth-child(1) .o_kanban_header");
     await dragActions.drop();
 
@@ -9504,10 +9504,16 @@ test("progress bar with aggregates: activate bars (grouped by many2one)", async 
                 <templates>
                     <t t-name="card">
                         <field name="foo"/>
+                        <field name="float_field"/>
                     </t>
                 </templates>
             </kanban>`,
         groupBy: ["product_id"],
+    });
+
+    onRpc("partner", "web_read_group", ({ kwargs }) => {
+        // float_field is not in the progressbar, then never ask his aggregation
+        expect(kwargs.aggregates).not.toInclude("float_field:sum");
     });
 
     expect(getKanbanColumnTooltips(0)).toEqual(["2 yop", "1 gnap", "1 blip"]);


### PR DESCRIPTION
When a progress bar is clicked, its aggregates should be refreshed.
However, a change introduced in https://github.com/odoo/odoo/pull/163300
inadvertently caused the webclient to request all available aggregates,
leading to unnecessarily complex queries (for related field by example).

This commit corrects this behavior by ensuring that only the necessary
aggregates are requested when a progress bar is selected.