### PR TITLE
[IMP] web: kanban ask only needed aggregates

### DIFF
--- a/addons/web/static/src/model/relational_model/dynamic_group_list.js
+++ b/addons/web/static/src/model/relational_model/dynamic_group_list.js
@@ -232,6 +232,7 @@ export class DynamicGroupList extends DynamicList {
             resModel: this.config.resModel,
             fields: this.config.fields,
             activeFields: this.config.activeFields,
+            fieldsToAggregate: this.config.fieldsToAggregate,
         };
         const context = {
             ...this.context,

--- a/addons/web/static/src/model/relational_model/relational_model.js
+++ b/addons/web/static/src/model/relational_model/relational_model.js
@@ -45,6 +45,7 @@ import { FetchRecordError } from "./errors";
  * @typedef {SearchParams & {
  *  fields: Record<string, Field>;
  *  activeFields: Record<string, FieldInfo>;
+ *  fieldsToAggregate: string[];
  *  isMonoRecord: boolean;
  *  isRoot: boolean;
  *  resIds?: number[];
@@ -135,6 +136,7 @@ export class RelationalModel extends Model {
         this.config = {
             isMonoRecord: false,
             context: {},
+            fieldsToAggregate: Object.keys(params.config.activeFields), // active fields by default
             ...params.config,
             isRoot: true,
         };
@@ -444,6 +446,7 @@ export class RelationalModel extends Model {
             resModel: config.resModel,
             fields: config.fields,
             activeFields: config.activeFields,
+            fieldsToAggregate: config.fieldsToAggregate,
             offset: 0,
         };
 
@@ -775,9 +778,8 @@ export class RelationalModel extends Model {
                 }
             });
         }
-
         const aggregates = getAggregateSpecifications(
-            pick(config.fields, ...Object.keys(config.activeFields))
+            pick(config.fields, ...config.fieldsToAggregate)
         );
         const currentGroupInfos = getGroupInfo(config.groups);
         const { activeFields, fields } = config;

--- a/addons/web/static/src/views/kanban/kanban_controller.js
+++ b/addons/web/static/src/views/kanban/kanban_controller.js
@@ -278,19 +278,12 @@ export class KanbanController extends Component {
             addFieldDependencies(activeFields, fields, [{ name: cardColorField, type: "integer" }]);
         }
 
-        // Remove fields aggregator unused to avoid asking them for no reason
-        const aggregateFieldNames = this.progressBarAggregateFields.map((field) => field.name);
-        for (const [key, value] of Object.entries(activeFields)) {
-            if (!aggregateFieldNames.includes(key)) {
-                value.aggregator = null;
-            }
-        }
-
         addFieldDependencies(activeFields, fields, this.progressBarAggregateFields);
         const modelConfig = this.props.state?.modelState?.config || {
             resModel,
             activeFields,
             fields,
+            fieldsToAggregate: this.progressBarAggregateFields.map((field) => field.name),
             openGroupsByDefault: true,
         };
 

--- a/addons/web/static/tests/views/kanban/kanban_view.test.js
+++ b/addons/web/static/tests/views/kanban/kanban_view.test.js
@@ -13226,7 +13226,7 @@ test("Correct values for progress bar with toggling filter and slow RPC", async 
 test("group by numeric field (with aggregator)", async () => {
     onRpc("web_read_group", ({ kwargs }) => {
         expect(kwargs.groupby).toEqual(["int_field"]);
-        expect(kwargs.aggregates).toEqual(["int_field:sum", "float_field:sum"]);
+        expect(kwargs.aggregates).toEqual([]); // No progressbar - no aggregate needed
         expect.step("web_read_group");
     });
     await mountView({


### PR DESCRIPTION
Currently, the Kanban view requests all active field aggregates, but only the ones used in the progress bar are necessary.

To simplify the final SQL query performed by _read_group and improve its performance, change the behavior to request only the aggregates of the fields used in the progress bar.