### PR TITLE
[FIX] project: fix project_task_views priority width

### DIFF
--- a/addons/project/views/project_task_views.xml
+++ b/addons/project/views/project_task_views.xml
@@ -518,7 +518,7 @@
                                     <field name="subtask_count" column_invisible="True"/>
                                     <field name="closed_subtask_count" column_invisible="True"/>
                                     <field name="id" optional="hide" options="{'enable_formatting': False}"/>
-                                    <field name="priority" widget="priority" nolabel="1" width="20px"/>
+                                    <field name="priority" widget="priority" nolabel="1" width="70px"/>
                                     <field name="state" widget="project_task_state_selection" nolabel="1" width="20px"/>
                                     <field name="name" widget="name_with_subtask_count"/>
                                     <field name="project_id" optional="hide" options="{'no_open': 1}" />


### PR DESCRIPTION
This commit fixes the size of the priority field in the project_task_views form view's sub-tasks because it was not updated properly when the widget got 2 more stars.

task-4881973
