### PR TITLE
[FIX] html_editor: areSimilarElements order-insensitive class/style

### DIFF
--- a/addons/html_editor/static/src/utils/dom_info.js
+++ b/addons/html_editor/static/src/utils/dom_info.js
@@ -707,7 +707,15 @@ export function areSimilarElements(node, node2) {
         return false; // The nodes aren't the same type of element.
     }
     for (const name of new Set([...node.getAttributeNames(), ...node2.getAttributeNames()])) {
-        if (node.getAttribute(name) !== node2.getAttribute(name)) {
+        if (name === "style") {
+            if (!hasSameStyleAttributes(node, node2)) {
+                return false;
+            }
+        } else if (name === "class") {
+            if (!hasSameClasses(node, node2)) {
+                return false; // The nodes don't have the same classes.
+            }
+        } else if (node.getAttribute(name) !== node2.getAttribute(name)) {
             return false; // The nodes don't have the same attributes.
         }
     }
@@ -728,6 +736,29 @@ export function areSimilarElements(node, node2) {
         !+node2Style.padding.replace(NOT_A_NUMBER, "") &&
         !+nodeStyle.margin.replace(NOT_A_NUMBER, "") &&
         !+node2Style.margin.replace(NOT_A_NUMBER, "")
+    );
+}
+
+export function hasSameStyleAttributes(node, node2) {
+    const getNodeStyles = (node) =>
+        node
+            .getAttribute("style")
+            .split(";")
+            .map((style) => style.trim())
+            .filter(Boolean);
+    const [nodeStyles, node2Styles] = [node, node2].map(getNodeStyles);
+    return (
+        nodeStyles.length === node2Styles.length &&
+        nodeStyles.every((style) => node2Styles.includes(style))
+    );
+}
+
+export function hasSameClasses(node, node2) {
+    const getNodeClasses = (node) => node.getAttribute("class")?.trim()?.split(/\s+/);
+    const [nodeClasses, node2Classes] = [node, node2].map(getNodeClasses);
+    return (
+        nodeClasses.length === node2Classes.length &&
+        nodeClasses.every((cls) => node2Classes.includes(cls))
     );
 }
 
@@ -787,22 +818,12 @@ export function isRedundantElement(node) {
 
         if (attrName === "class") {
             // All classes on the node must exist in closest element.
-            const nodeClasses = nodeAttrVal.trim().split(/\s+/);
-            const closestElClasses = closestElAttrVal.trim().split(/\s+/);
-            if (!nodeClasses.every((cls) => closestElClasses.includes(cls))) {
+            if (!hasSameClasses(node, closestEl)) {
                 return false;
             }
         } else if (attrName === "style") {
             // All inline styles on the node must exist in closest element.
-            const nodeStyles = nodeAttrVal
-                .split(";")
-                .map((style) => style.trim())
-                .filter(Boolean);
-            const closestElStyles = closestElAttrVal
-                .split(";")
-                .map((style) => style.trim())
-                .filter(Boolean);
-            if (!nodeStyles.every((style) => closestElStyles.includes(style))) {
+            if (!hasSameStyleAttributes(node, closestEl)) {
                 return false;
             }
         } else {

--- a/addons/html_editor/static/tests/utils/dom_info.test.js
+++ b/addons/html_editor/static/tests/utils/dom_info.test.js
@@ -1,4 +1,5 @@
 import {
+    areSimilarElements,
     getDeepestPosition,
     isEmptyBlock,
     isShrunkBlock,
@@ -442,6 +443,44 @@ describe("isShrunkBlock", () => {
     test("should not consider a block containing a canvas as a shrunk block", () => {
         const [canvas] = insertTestHtml("<canvas></canvas>");
         const result = isShrunkBlock(canvas);
+        expect(result).toBe(false);
+    });
+});
+
+describe("areSimilarElements", () => {
+    test("should consider elements with same classes and styles in different orders as similar", () => {
+        const [span1, span2] = insertTestHtml(
+            "<span class='first second' style='color: red; color2: blue'>hello</span><span class='second first' style='color2: blue; color: red'>world</span>"
+        );
+        const result = areSimilarElements(span1, span2);
+        expect(result).toBe(true);
+    });
+    test("return false when the number of styles are different", () => {
+        const [span1, span2] = insertTestHtml(
+            "<span class='first second' style='color: red; color2: blue'>hello</span><span class='second first' style='color2: blue;'>world</span>"
+        );
+        const result = areSimilarElements(span1, span2);
+        expect(result).toBe(false);
+    });
+    test("return false when the number of classes are different", () => {
+        const [span1, span2] = insertTestHtml(
+            "<span class='first' style='color: red; color2: blue'>hello</span><span class='second first' style='color2: blue;'>world</span>"
+        );
+        const result = areSimilarElements(span1, span2);
+        expect(result).toBe(false);
+    });
+    test("return false when classes are different", () => {
+        const [span1, span2] = insertTestHtml(
+            "<span class='first' style='color: red; color2: blue'>hello</span><span class='second' style='color2: blue;'>world</span>"
+        );
+        const result = areSimilarElements(span1, span2);
+        expect(result).toBe(false);
+    });
+    test("return false when styles are different", () => {
+        const [span1, span2] = insertTestHtml(
+            "<span class='first second' style='color2: blue'>hello</span><span class='second first' style='color2: blue; color: red'>world</span>"
+        );
+        const result = areSimilarElements(span1, span2);
         expect(result).toBe(false);
     });
 });


### PR DESCRIPTION
`areSimilarElements` is used by `mergeAdjacentInline` function to
merge similar node and having a clean DOM.

In website, highlights use this function but highlights node can have
two similar node but with different style order.

This commit make `areSimilarElements` compare class and style attributes
without considering order.