### PR TITLE
[IMP] project: dispatch tasks based on project roles

### DIFF
--- a/addons/hr_timesheet/models/project_project.py
+++ b/addons/hr_timesheet/models/project_project.py
@@ -284,7 +284,7 @@ class ProjectProject(models.Model):
         action['context']['allow_timesheets'] = self.allow_timesheets
         return action
 
-    def action_create_from_template(self, values=None):
-        project = super().action_create_from_template(values)
+    def action_create_from_template(self, values=None, role_to_users_mapping=None):
+        project = super().action_create_from_template(values, role_to_users_mapping)
         project._create_analytic_account()
         return project

--- a/addons/project/__manifest__.py
+++ b/addons/project/__manifest__.py
@@ -35,6 +35,7 @@
         'views/project_task_type_views.xml',
         'views/project_project_views.xml',
         'views/project_task_views.xml',
+        'views/project_role_views.xml',
         'views/project_tags_views.xml',
         'views/project_milestone_views.xml',
         'views/res_partner_views.xml',

--- a/addons/project/models/__init__.py
+++ b/addons/project/models/__init__.py
@@ -9,6 +9,7 @@ from . import project_task_recurrence
 from . import project_task_stage_personal
 from . import project_milestone
 from . import project_project
+from . import project_role
 from . import project_task
 from . import project_task_type
 from . import project_tags

--- a/addons/project/models/project_role.py
+++ b/addons/project/models/project_role.py
@@ -1,0 +1,20 @@
+from random import randint
+
+from odoo import fields, models
+
+
+class ProjectRole(models.Model):
+    _name = 'project.role'
+    _description = 'Project Role'
+
+    def _get_default_color(self):
+        return randint(1, 11)
+
+    active = fields.Boolean(default=True)
+    name = fields.Char(required=True, translate=True)
+    color = fields.Integer(default=_get_default_color)
+    sequence = fields.Integer(export_string_translation=False)
+
+    def copy_data(self, default=None):
+        vals_list = super().copy_data(default=default)
+        return [dict(vals, name=self.env._('%s (copy)', role.name)) for role, vals in zip(self, vals_list)]

--- a/addons/project/models/project_task.py
+++ b/addons/project/models/project_task.py
@@ -186,6 +186,7 @@ class ProjectTask(models.Model):
     allocated_hours = fields.Float("Allocated Time", tracking=True)
     subtask_allocated_hours = fields.Float("Sub-tasks Allocated Time", compute='_compute_subtask_allocated_hours', export_string_translation=False,
         help="Sum of the hours allocated for all the sub-tasks (and their own sub-tasks) linked to this task. Usually less than or equal to the allocated hours of this task.")
+    role_ids = fields.Many2many('project.role', string='Project Roles')
     # Tracking of this field is done in the write function
     user_ids = fields.Many2many('res.users', relation='project_task_user_rel', column1='task_id', column2='user_id',
         string='Assignees', context={'active_test': False}, tracking=True, default=_default_user_ids, domain="[('share', '=', False), ('active', '=', True)]", falsy_value_label=_lt("👤 Unassigned"))
@@ -1938,6 +1939,7 @@ class ProjectTask(models.Model):
     def action_undo_convert_to_template(self):
         self.ensure_one()
         self.is_template = False
+        self.role_ids = False
         self.message_post(body=_("Template converted back to regular task"))
         return {
             'type': 'ir.actions.client',

--- a/addons/project/security/ir.model.access.csv
+++ b/addons/project/security/ir.model.access.csv
@@ -48,3 +48,7 @@ access_mail_activity_plan_project_manager,mail.activity.plan.project.manager,mai
 access_mail_activity_plan_template_project_manager,mail.activity.plan.template.project.manager,mail.model_mail_activity_plan_template,project.group_project_manager,1,1,1,1
 access_project_template_create_wizard_user,project.template.create.wizard.user,project.model_project_template_create_wizard,project.group_project_user,1,1,0,0
 access_project_template_create_wizard_manager,project.template.create.wizard.manager,project.model_project_template_create_wizard,project.group_project_manager,1,1,1,1
+access_project_template_role_to_users_map_user,project.template.role.to.users.map.user,project.model_project_template_role_to_users_map,project.group_project_user,1,1,0,0
+access_project_template_role_to_users_map_manager,project.template.role.to.users.map.manager,project.model_project_template_role_to_users_map,project.group_project_manager,1,1,1,1
+access_project_role_user,project.role.user,model_project_role,project.group_project_user,1,0,0,0
+access_project_role_manager,project.role.manager,model_project_role,project.group_project_manager,1,1,1,1

--- a/addons/project/tests/test_project_template.py
+++ b/addons/project/tests/test_project_template.py
@@ -1,4 +1,5 @@
 from odoo.exceptions import UserError
+from odoo import Command
 from odoo.addons.project.tests.test_project_base import TestProjectCommon
 
 
@@ -49,3 +50,121 @@ class TestProjectTemplates(TestProjectCommon):
         self.task_inside_template.is_template = True
         with self.assertRaises(UserError, msg="A UserError should be raised when attempting to revert a template task to a regular one."):
             self.task_inside_template.action_convert_to_template()
+
+    def test_tasks_dispatching_from_template(self):
+        """
+        The tasks of a project template should be dispatched to the new project according to the role-to-users mapping defined
+        on the project template wizard.
+        """
+        role1, role2, role3, role4, role5 = self.env['project.role'].create([
+            {'name': 'Developer'},
+            {'name': 'Designer'},
+            {'name': 'Project Manager'},
+            {'name': 'Tester'},
+            {'name': 'Product Owner'},
+        ])
+        project_template = self.env['project.project'].create({
+            'name': 'Project template',
+            'is_template': True,
+            'task_ids': [
+                Command.create({
+                    'name': 'Task 1',
+                    'role_ids': [role1.id, role3.id],
+                }),
+                Command.create({
+                    'name': 'Task 2',
+                    'role_ids': [role5.id, role4.id],
+                }),
+                Command.create({
+                    'name': 'Task 3',
+                    'role_ids': [role2.id, role5.id],
+                }),
+                Command.create({
+                    'name': 'Task 4',
+                    'role_ids': [role3.id],
+                }),
+                Command.create({
+                    'name': 'Task 5',
+                    'role_ids': [role5.id],
+                }),
+                Command.create({
+                    'name': 'Task 6',
+                }),
+                Command.create({
+                    'name': 'Task 7',
+                    'role_ids': [role2.id, role3.id],
+                    'user_ids': [self.user_projectuser.id, self.user_projectmanager.id],
+                }),
+            ],
+        })
+        user1, user2 = self.env['res.users'].create([
+            {
+                'name': 'Test User 1',
+                'login': 'test1',
+                'password': 'testuser1',
+                'email': 'test1.test@example.com',
+            },
+            {
+                'name': 'Test User 2',
+                'login': 'test2',
+                'password': 'testuser2',
+                'email': 'test2.test@example.com',
+            }
+        ])
+        wizard = self.env['project.template.create.wizard'].create({
+            'template_id': project_template.id,
+            'name': 'New Project from Template',
+            'role_to_users_ids': [
+                Command.create({
+                    'role_id': role1.id,
+                    'user_ids': [self.user_projectuser.id, self.user_projectmanager.id],
+                }),
+                Command.create({
+                    'role_id': role2.id,
+                    'user_ids': [user1.id],
+                }),
+                Command.create({
+                    'role_id': role3.id,
+                    'user_ids': [user2.id],
+                }),
+                Command.create({
+                    'role_id': role4.id,
+                    'user_ids': [self.user_projectuser.id],
+                }),
+            ],
+        })
+        new_project = wizard._create_project_from_template()
+
+        self.assertEqual(
+            new_project.task_ids.filtered(lambda t: t.name == 'Task 1').user_ids,
+            self.user_projectuser + self.user_projectmanager + user2,
+            'Task 1 should be assigned to the users mapped to `role1` and `role3`.',
+        )
+        self.assertEqual(
+            new_project.task_ids.filtered(lambda t: t.name == 'Task 2').user_ids,
+            self.user_projectuser,
+            'Task 2 should be assigned to the users mapped to `role4`. As `role5` is not in the mapping.',
+        )
+        self.assertEqual(
+            new_project.task_ids.filtered(lambda t: t.name == 'Task 3').user_ids,
+            user1,
+            'Task 3 should be assigned to the users mapped to `role2`. As `role5` is not in the mapping.',
+        )
+        self.assertEqual(
+            new_project.task_ids.filtered(lambda t: t.name == 'Task 4').user_ids,
+            user2,
+            'Task 4 should be assigned to the users mapped to `role3`.'
+        )
+        self.assertFalse(
+            new_project.task_ids.filtered(lambda t: t.name == 'Task 5').user_ids,
+            'Task 5 should not be assigned to any user as `role5` is not in the mapping.',
+        )
+        self.assertFalse(
+            new_project.task_ids.filtered(lambda t: t.name == 'Task 6').user_ids,
+            'Task 6 should not be assigned to any user as it has no role.',
+        )
+        self.assertEqual(
+            new_project.task_ids.filtered(lambda t: t.name == 'Task 7').user_ids,
+            self.user_projectuser + self.user_projectmanager + user1 + user2,
+            'Task 7 should be assigned to the users mapped to `role2` and `role3`, plus the users who were already assigned to the task.'
+        )

--- a/addons/project/views/project_menus.xml
+++ b/addons/project/views/project_menus.xml
@@ -114,6 +114,11 @@
                 action="project_task_templates_action"
             />
             <menuitem
+                name="Project Roles"
+                id="project_menu_config_project_roles"
+                action="project_roles_action"
+            />
+            <menuitem
                 name="Activity Types"
                 id="project_menu_config_activity_type"
                 action="mail_activity_type_action_config_project_types"

--- a/addons/project/views/project_project_views.xml
+++ b/addons/project/views/project_project_views.xml
@@ -728,6 +728,7 @@
                 <kanban position="attributes">
                     <attribute name="js_class"></attribute>
                 </kanban>
+                <span name="partner_name" position="replace"/>
             </field>
         </record>
 

--- a/addons/project/views/project_role_views.xml
+++ b/addons/project/views/project_role_views.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="project_role_view_list" model="ir.ui.view">
+        <field name="name">project.role.list</field>
+        <field name="model">project.role</field>
+        <field name="arch" type="xml">
+            <list editable="bottom" multi_edit="1">
+                <field name="sequence" widget="handle"/>
+                <field name="name" placeholder="e.g. Developer"/>
+                <field name="color" widget="color_picker" optional="show"/>
+            </list>
+        </field>
+    </record>
+
+    <record id="project_role_view_form" model="ir.ui.view">
+        <field name="name">project.role.form</field>
+        <field name="model">project.role</field>
+        <field name="arch" type="xml">
+            <form>
+                <sheet>
+                    <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" invisible="active"/>
+                    <group>
+                        <field name="active" invisible="1"/>
+                        <field name="name"/>
+                        <field name="color" widget="color_picker"/>
+                    </group>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+    <record id="project_role_view_kanban" model="ir.ui.view">
+        <field name="name">project.role.kanban</field>
+        <field name="model">project.role</field>
+        <field name="arch" type="xml">
+            <kanban highlight_color="color">
+                <templates>
+                    <t t-name="menu">
+                        <a t-if="widget.editable" role="menuitem" type="open" class="dropdown-item">Edit</a>
+                        <a t-if="widget.deletable" role="menuitem" type="delete" class="dropdown-item">Delete</a>
+                        <field name="color" widget="kanban_color_picker"/>
+                    </t>
+                    <t t-name="card">
+                        <field name="name" class="fw-bold fs-4 ms-1"/>
+                    </t>
+                </templates>
+            </kanban>
+        </field>
+    </record>
+
+    <record id="project_role_view_search" model="ir.ui.view">
+        <field name="name">project.role.search</field>
+        <field name="model">project.role</field>
+        <field name="arch" type="xml">
+            <search>
+                <field name="name"/>
+                <filter name="archived" string="Archived" domain="[('active', '=', False)]"/>
+            </search>
+        </field>
+    </record>
+
+    <record id="project_roles_action" model="ir.actions.act_window">
+        <field name="name">Project Roles</field>
+        <field name="res_model">project.role</field>
+        <field name="view_mode">list,kanban,form</field>
+        <field name="search_view_id" ref="project_role_view_search"/>
+        <field name="help" type="html">
+            <p class="o_view_nocontent_smiling_face">
+                No project role found. Let's create one!
+            </p>
+        </field>
+    </record>
+
+    <record id="project_roles_action_list" model="ir.actions.act_window.view">
+        <field name="act_window_id" ref="project_roles_action"/>
+        <field name="view_mode">list</field>
+        <field name="view_id" ref="project.project_role_view_list"/>
+    </record>
+
+    <record id="project_roles_action_kanban" model="ir.actions.act_window.view">
+        <field name="act_window_id" ref="project_roles_action"/>
+        <field name="view_mode">kanban</field>
+        <field name="view_id" ref="project.project_role_view_kanban"/>
+    </record>
+</odoo>

--- a/addons/project/views/project_task_views.xml
+++ b/addons/project/views/project_task_views.xml
@@ -419,6 +419,7 @@
                                 class="o_task_user_field"
                                 options="{'no_open': True, 'no_quick_create': True}"
                                 widget="many2many_avatar_user"/>
+                            <field name="role_ids" invisible="not (is_template and has_project_template)" widget="many2many_tags" options="{'color_field': 'color', 'no_create_edit': True}" placeholder="Assign at project creation"/>
                             <field name="priority" widget="priority_switch"/>
                             <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color', 'no_create_edit': True}" context="{'project_id': project_id}"/>
                         </group>
@@ -1320,6 +1321,9 @@
                     <attribute name="required">is_template</attribute>
                 </field>
                 <field name="partner_id" position="replace"/>
+                <field name="user_ids" position="after">
+                    <field name="role_ids" optional="hide" widget="many2many_tags" options="{'color_field': 'color', 'no_create_edit': True}" invisible="not (is_template and has_project_template)"/>
+                </field>
             </field>
         </record>
 
@@ -1348,6 +1352,9 @@
                 <filter name="unassigned" position="after">
                     <filter name="task_templates" string="Task Templates" domain="[('has_project_template', '=', False)]" invisible="1"/>
                 </filter>
+                <field name="user_ids" position="after">
+                   <field name="role_ids"/>
+                </field>
             </field>
         </record>
 

--- a/addons/project/wizard/project_template_create_wizard.py
+++ b/addons/project/wizard/project_template_create_wizard.py
@@ -17,7 +17,6 @@ class ProjectTemplateCreateWizard(models.TransientModel):
     date = fields.Date(string='Expiration Date')
     alias_name = fields.Char(string="Alias Name")
     alias_domain_id = fields.Many2one("mail.alias.domain", string="Alias Domain")
-    partner_id = fields.Many2one("res.partner")
     template_id = fields.Many2one("project.project", default=lambda self: self._context.get('template_id'))
     role_to_users_ids = fields.One2many('project.template.role.to.users.map', 'wizard_id', default=_default_role_to_users_ids)
 
@@ -25,7 +24,7 @@ class ProjectTemplateCreateWizard(models.TransientModel):
         """
         Whitelist of fields of this wizard that will be used when creating a project from a template.
         """
-        return ["name", "date_start", "date", "alias_name", "alias_domain_id", "partner_id"]
+        return ["name", "date_start", "date", "alias_name", "alias_domain_id"]
 
     def _create_project_from_template(self):
         # Dictionary with all whitelist fields and their values
@@ -52,9 +51,12 @@ class ProjectTemplateCreateWizard(models.TransientModel):
             'view_mode': 'form',
             'views': [(view.id, 'form')],
             'res_model': 'project.template.create.wizard',
-            'res_id': self.id,
             'target': 'new',
-            'context': self.env.context,
+            'context': {
+                key: value
+                for key, value in self.env.context.items()
+                if not key.startswith('default_')
+            },
         }
 
 

--- a/addons/project/wizard/project_template_create_wizard.xml
+++ b/addons/project/wizard/project_template_create_wizard.xml
@@ -12,18 +12,21 @@
                         <field name="name" class="o_project_name" placeholder="e.g. Office Party"/>
                     </h1>
                 </div>
-                <div class="mb-2">
-                    <label for="date_start" string="Planned Date" class="pe-2"/>
-                    <field name="date_start" widget="daterange" options='{"end_date_field": "date", "always_range": "1"}'/>
-                </div>
-                <div class="mt-2" colspan="2">
-                    <label for="alias_name" string="Create tasks by sending an email to" class="pe-2"/>
-                    <span>
-                        <field name="alias_name" placeholder="e.g. office-party"/>@
-                        <field name="alias_domain_id" class="oe_inline" placeholder="e.g. mycompany.com"
-                               options="{'no_create': True, 'no_open': True}"/>
-                    </span>
-                </div>
+                <group>
+                    <group>
+                        <field name="date_start" string="Planned Date" widget="daterange" options='{"end_date_field": "date", "always_range": "1"}'/>
+                        <label for="alias_name" string="Create tasks by sending an email to" class="pe-2"/>
+                        <div class="d-inline-flex">
+                            <field name="alias_name" placeholder="e.g. office-party"/>@ <field name="alias_domain_id" placeholder="e.g. mycompany.com" options="{'no_create': True, 'no_open': True}"/>
+                        </div>
+                    </group>
+                </group>
+                <field name="role_to_users_ids" invisible="not role_to_users_ids">
+                    <list create="0" delete="0" no_open="1" editable="bottom">
+                        <field name="role_id" force_save="1" readonly="1" options="{'no_open': True}"/>
+                        <field name="user_ids" widget="many2many_avatar_user" options="{'no_open': True, 'no_quick_create': True}"/>
+                    </list>
+                </field>
                 <footer>
                     <button string="Create project" name="create_project_from_template" type="object" class="btn-primary o_open_tasks" data-hotkey="q"/>
                     <button string="Discard" class="btn-secondary" special="cancel" data-hotkey="x"/>

--- a/addons/sale_project/wizard/project_template_create_wizard.py
+++ b/addons/sale_project/wizard/project_template_create_wizard.py
@@ -4,4 +4,11 @@ from odoo import fields, models
 class ProjectTemplateCreateWizard(models.TransientModel):
     _inherit = 'project.template.create.wizard'
 
+    partner_id = fields.Many2one("res.partner")
     allow_billable = fields.Boolean(related="template_id.allow_billable")
+
+    def _get_template_whitelist_fields(self):
+        res = super()._get_template_whitelist_fields()
+        if self.allow_billable:
+            res.append("partner_id")
+        return res

--- a/addons/sale_project/wizard/project_template_create_wizard.xml
+++ b/addons/sale_project/wizard/project_template_create_wizard.xml
@@ -6,16 +6,16 @@
         <field name="model">project.template.create.wizard</field>
         <field name="inherit_id" ref="project.project_project_view_form_simplified_template"/>
         <field name="arch" type="xml">
-            <xpath expr="//div[hasclass('oe_title')]" position="after">
-                <field name="allow_billable" invisible="1"/>
-                <div name="partner_def" class="mb-2" invisible="not allow_billable">
-                    <label for="partner_id" string="Customer" class="pe-2"/>
-                    <span>
-                        <field name="partner_id" placeholder="Select who to bill..." class="ms-1" widget="res_partner_many2one"
-                            options="{'no_create_edit': True, 'no_open': True}"/>
-                    </span>
-                </div>
-            </xpath>
+            <field name="date_start" position="before">
+                <field
+                    name="partner_id"
+                    string="Customer"
+                    invisible="not allow_billable"
+                    placeholder="Select who to bill..."
+                    widget="res_partner_many2one"
+                    options="{'no_create_edit': True, 'no_open': True}"
+                />
+            </field>
         </field>
     </record>
 


### PR DESCRIPTION
In this PR, we add a new feature allowing project tasks to be dispatched automatically based on:
- The roles we have defined in the tasks of a project template
- And a role-to-users mapping showing up when creating a new project from a project template

This feature enhances task management by ensuring that tasks are assigned to the appropriate team members according to their roles, improving efficiency and clarity in project execution.

More precisely, we add a new model: 'Project Roles' that we can link to tasks templates (as long as they belong to a project template).
We can link multiples roles to a single task template, and a role can be linked to different tasks too. A menu item for 'Project Roles' has been added.

When creating a new project from a project template, the user can select in the wizard which users are going to be assigned to the task if some roles match.
This mapping is only visible if at least one role has been defined in any task of the project template, and the available roles in that mapping are only the roles defined in those tasks.
If multiple roles match, all the users matching those roles will be assigned to the task. If a task already contains some assignees, they will not be overridden but the matching users will be added to the existing assignees.

task-4700746
