### PR TITLE
[FIX] account: Fix display of invoice

### DIFF
--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -1268,11 +1268,13 @@
                                             <field name="invoice_payments_widget" colspan="2" nolabel="1" widget="payment"/>
                                             <field name="amount_residual" class="oe_subtotal_footer_separator" invisible="state == 'draft'"/>
                                         </group>
-                                        <group class="oe_subtotal_footer px-4">
+                                        <group
+                                            class="oe_subtotal_footer px-4"
+                                            invisible="state != 'posted' or not invoice_has_outstanding"
+                                            groups="account.group_account_invoice,account.group_account_readonly">
                                             <field name="invoice_outstanding_credits_debits_widget"
                                                 class="oe_invoice_outstanding_credits_debits py-3"
-                                                colspan="2" nolabel="1" widget="payment"
-                                                invisible="state != 'posted' or not invoice_has_outstanding"/>
+                                                colspan="2" nolabel="1" widget="payment"/>
                                         </group>
                                     </group>
                                 </group>


### PR DESCRIPTION
Repro steps:
Navigate to the form view of an invoice that is either
1. not posted
2. does not have outstanding debits/credits

Problem spotted:
next to the invoice amounts, a weird line and margin to the right can be seen

Cause:
The field invoice_outstanding_credits_debits_widget of an invoice may be invisible with this condition invisible="state != 'posted' or not invoice_has_outstanding" and in that case, it's containing group would still be visible (showing the aforementioned margin).

Fix:
This commit fixes this issue by moving the invisible condition to the group containing the field invoice_outstanding_credits_debits_widget instead of the condition being on the field itself.

task-4882509





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
