### PR TITLE
[FIX] point_of_sale: fix incorrect sorting logic on ticket screen

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.js
@@ -426,7 +426,7 @@ export class TicketScreen extends Component {
                 const dateA = a.date_order;
                 const dateB = b.date_order;
 
-                if (a.date_order !== b.date_order) {
+                if (!dateA.equals(dateB)) {
                     return ascending ? dateA - dateB : dateB - dateA;
                 } else {
                     const nameA = parseInt(a.pos_reference.replace(/\D/g, "")) || 0;


### PR DESCRIPTION
Before:
=
- Orders were compared using full date objects, which caused incorrect sorting when the dates were the same.

After:
=
- Sorting now uses numeric timestamps for accurate date comparison.
- If timestamps are equal, it falls back to sorting by order number.

Task: 4881605
Runbot Error: [odoo/error#226754](https://runbot.odoo.com/odoo/error/226754)