### PR TITLE
[FIX] mail, im_livechat: avoid creating chat bubble when discuss is open

### DIFF
--- a/addons/im_livechat/static/src/core/public_web/thread_model_patch.js
+++ b/addons/im_livechat/static/src/core/public_web/thread_model_patch.js
@@ -71,6 +71,10 @@ patch(Thread.prototype, {
         return super.avatarUrl;
     },
 
+    get inChathubOnNewMessage() {
+        return this.channel_type === "livechat" || super.inChathubOnNewMessage;
+    },
+
     /**
      * @override
      * @param {boolean} pushState

--- a/addons/im_livechat/static/tests/chat_window_patch.test.js
+++ b/addons/im_livechat/static/tests/chat_window_patch.test.js
@@ -1,7 +1,16 @@
-import { click, contains, start, startServer } from "@mail/../tests/mail_test_helpers";
+import {
+    click,
+    contains,
+    openDiscuss,
+    openFormView,
+    start,
+    startServer,
+} from "@mail/../tests/mail_test_helpers";
 import { test } from "@odoo/hoot";
 import { Command, serverState } from "@web/../tests/web_test_helpers";
 import { defineLivechatModels } from "./livechat_test_helpers";
+import { withGuest } from "@mail/../tests/mock_server/mail_mock_server";
+import { rpc } from "@web/core/network/rpc";
 
 defineLivechatModels();
 
@@ -28,4 +37,54 @@ test("closing a chat window with no message from admin side unpins it", async ()
         parent: [".o-mail-ChatWindow", { text: "Demo" }],
     });
     await contains(".o_notification", { text: "You unpinned your conversation with Demo" });
+});
+
+test.tags("desktop");
+test("Show livechats with new message in chat hub even when in discuss app)", async () => {
+    // Chat hub show conversations with new message only when outside of discuss app by default.
+    // Live chats are special in that agents are expected to see their ongoing conversations at all
+    // time. Closing chat window ends the conversation. Hence the livechat always are shown on chat hub.
+    const pyEnv = await startServer();
+    const guestId = pyEnv["mail.guest"].create({ name: "Visitor 11" });
+    const [livechatId, channelId] = pyEnv["discuss.channel"].create([
+        {
+            anonymous_name: "Visitor 11",
+            channel_member_ids: [
+                Command.create({ partner_id: serverState.partnerId }),
+                Command.create({ guest_id: guestId }),
+            ],
+            channel_type: "livechat",
+            livechat_operator_id: serverState.partnerId,
+        },
+        {
+            channel_member_ids: [Command.create({ partner_id: serverState.partnerId })],
+            channel_type: "channel",
+            name: "general",
+        },
+    ]);
+    pyEnv["mail.message"].create({
+        author_id: serverState.partnerId,
+        body: "<p>Test</p>",
+        message_type: "comment",
+        model: "discuss.channel",
+        res_id: channelId,
+    });
+    await start();
+    await openDiscuss(channelId);
+    await contains(".o-mail-Message:contains('Test')");
+    // simulate livechat visitor sending a message
+    await withGuest(guestId, () =>
+        rpc("/mail/message/post", {
+            post_data: {
+                body: "Hello, I need help!",
+                message_type: "comment",
+                subtype_xmlid: "mail.mt_comment",
+            },
+            thread_id: livechatId,
+            thread_model: "discuss.channel",
+        })
+    );
+    await contains(".o-mail-DiscussSidebar-item:contains('Visitor 11') .badge", { text: "1" });
+    await openFormView("res.partner", serverState.partnerId);
+    await contains(".o-mail-ChatWindow-header:contains('Visitor 11')");
 });

--- a/addons/mail/static/src/core/public_web/thread_model_patch.js
+++ b/addons/mail/static/src/core/public_web/thread_model_patch.js
@@ -45,13 +45,12 @@ patch(Thread.prototype, {
                         (channel_notifications === "mentions" &&
                             message.recipients?.includes(this.store.self)))))
         ) {
-            if (this.model === "discuss.channel") {
+            if (this.model === "discuss.channel" && this.inChathubOnNewMessage) {
                 let chatWindow = this.store.ChatWindow.get({ thread: this });
                 if (!chatWindow) {
                     chatWindow = this.store.ChatWindow.insert({ thread: this });
                     if (
                         this.autoOpenChatWindowOnNewMessage &&
-                        !this.store.discuss.isActive &&
                         this.store.chatHub.opened.length < this.store.chatHub.maxOpened
                     ) {
                         chatWindow.open();
@@ -62,6 +61,10 @@ patch(Thread.prototype, {
             }
             this.store.env.services["mail.out_of_focus"].notify(message, this);
         }
+    },
+    /** Condition for whether the conversation should become present in chat hub on new message */
+    get inChathubOnNewMessage() {
+        return !this.store.discuss.isActive;
     },
     get autoOpenChatWindowOnNewMessage() {
         return false;

--- a/addons/mail/static/tests/messaging/messaging.test.js
+++ b/addons/mail/static/tests/messaging/messaging.test.js
@@ -56,44 +56,63 @@ test("Receiving a new message out of discuss app should open a chat bubble", asy
     await contains(".o-mail-ChatBubble[name='Dumbledore']");
 });
 
-test("Receiving a new message in discuss app should open a chat bubble after leaving discuss app", async () => {
+test("Show conversations with new message in chat hub (outside of discuss app)", async () => {
     const pyEnv = await startServer();
     const partnerId = pyEnv["res.partner"].create({ name: "Dumbledore" });
     const userId = pyEnv["res.users"].create({ partner_id: partnerId });
-    const channelId = pyEnv["discuss.channel"].create({
-        channel_member_ids: [
-            Command.create({ partner_id: serverState.partnerId }),
-            Command.create({ partner_id: partnerId }),
-        ],
-        channel_type: "chat",
-    });
-    onRpcBefore("/mail/data", (args) => {
-        if (args.init_messaging) {
-            step(`/mail/data - ${JSON.stringify(args)}`);
-        }
-    });
-    await start();
-    await assertSteps([
-        `/mail/data - ${JSON.stringify({
-            init_messaging: {},
-            failures: true,
-            systray_get_activities: true,
-            context: { lang: "en", tz: "taht", uid: serverState.userId, allowed_company_ids: [1] },
-        })}`,
+    const [chatId, groupChatId] = pyEnv["discuss.channel"].create([
+        {
+            channel_member_ids: [
+                Command.create({ partner_id: serverState.partnerId }),
+                Command.create({ partner_id: partnerId }),
+            ],
+            channel_type: "chat",
+        },
+        {
+            channel_member_ids: [
+                Command.create({ partner_id: serverState.partnerId }),
+                Command.create({ partner_id: partnerId }),
+            ],
+            channel_type: "group",
+            name: "GroupChat",
+        },
     ]);
-    // send after init_messaging because bus subscription is done after init_messaging
-    await openDiscuss();
-    // simulate receiving new message
+    await start();
+    // simulate receiving new message (chat, outside discuss app)
     await withUser(userId, () =>
         rpc("/mail/message/post", {
-            post_data: { body: "Tricky", message_type: "comment" },
-            thread_id: channelId,
+            post_data: { body: "Chat Message 1", message_type: "comment" },
+            thread_id: chatId,
             thread_model: "discuss.channel",
         })
     );
-    // leaving discuss.
+    await click(".o-mail-ChatBubble[name='Dumbledore']");
+    await contains(".o-mail-ChatWindow-header:contains('Dumbledore')");
+    await click(".o-mail-ChatWindow [title*='Close Chat Window']");
+    // simulate receiving new message (group chat, outside discuss app)
+    await withUser(userId, () =>
+        rpc("/mail/message/post", {
+            post_data: { body: "GroupChat Message", message_type: "comment" },
+            thread_id: groupChatId,
+            thread_model: "discuss.channel",
+        })
+    );
+    await contains(".o-mail-ChatBubble[name='GroupChat']");
+    await openDiscuss();
+    // simulate receiving new message (chat, inside discuss app)
+    await withUser(userId, () =>
+        rpc("/mail/message/post", {
+            post_data: { body: "Tricky", message_type: "comment" },
+            thread_id: chatId,
+            thread_model: "discuss.channel",
+        })
+    );
+    await contains(".o-mail-DiscussSidebar-item:contains('Dumbledore') .badge", { text: "1" });
+    // check no new chat window/bubble while in discuss app
     await openFormView("res.partner", partnerId);
-    await contains(".o-mail-ChatBubble[name='Dumbledore']");
+    await contains(".o-mail-ChatBubble[name='GroupChat']");
+    await contains(".o-mail-ChatBubble[name='Dumbledore']", { count: 0 });
+    await contains(".o-mail-ChatWindow-header:contains('Dumbledore')", { count: 0 });
 });
 
 test("Posting a message in discuss app should not open a chat window after leaving discuss app", async () => {


### PR DESCRIPTION
**Current behavior before PR:**
Receiving a new message while the Discuss app is open creates a chat bubble in the background. These bubbles become visible after leaving the Discuss app.

**Desired behavior after PR is merged:**
Chat bubbles are no longer created while the Discuss app is open, except for livechat messages. Messages still trigger notifications, but no background bubbles are inserted.

task-[4752392](https://www.odoo.com/odoo/project/1519/tasks/4752392)


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
