### PR TITLE
[IMP] hr_timesheet: remove `is_timesheet` field from analytic line

### DIFF
--- a/addons/hr_timesheet/static/tests/hr_timesheet_models.js
+++ b/addons/hr_timesheet/static/tests/hr_timesheet_models.js
@@ -11,7 +11,6 @@ export class HRTimesheet extends models.Model {
     project_id = fields.Many2one({ relation: "project.project", required: true });
     task_id = fields.Many2one({ relation: "project.task" });
     unit_amount = fields.Float();
-    is_timesheet = fields.Boolean();
 
     _records = [
         {


### PR DESCRIPTION
- Removed `is_timesheet` field from mock models in testcases.


task-4759383

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
