### PR TITLE
[FIX] web: Allow users to focus inputs with hotkey

### DIFF
--- a/addons/web/static/src/core/hotkeys/hotkey_service.js
+++ b/addons/web/static/src/core/hotkeys/hotkey_service.js
@@ -285,7 +285,8 @@ export const hotkeyService = {
                     if (document.activeElement) {
                         document.activeElement.blur();
                     }
-                    setTimeout(() => el.click());
+                    el.focus();
+                    browser.setTimeout(() => el.click());
                 },
             }));
         }

--- a/addons/web/static/tests/core/dropdown_tests.js
+++ b/addons/web/static/tests/core/dropdown_tests.js
@@ -14,6 +14,7 @@ import {
     click,
     getFixture,
     makeDeferred,
+    mockTimeout,
     mount,
     mouseEnter,
     nextTick,
@@ -816,6 +817,7 @@ QUnit.module("Components", ({ beforeEach }) => {
 
     QUnit.test("multi-level dropdown: keynav", async (assert) => {
         assert.expect(213);
+        const { execRegisteredTimeouts } = mockTimeout();
         class Parent extends Component {
             onItemSelected(value) {
                 assert.step(value);
@@ -893,6 +895,7 @@ QUnit.module("Components", ({ beforeEach }) => {
 
         for (const [stepIndex, step] of scenarioSteps.entries()) {
             triggerHotkey(step.hotkey);
+            execRegisteredTimeouts();
             await nextTick();
             if (step.highlighted !== undefined) {
                 let index = 0;

--- a/addons/web/static/tests/core/hotkeys/hotkey_service_tests.js
+++ b/addons/web/static/tests/core/hotkeys/hotkey_service_tests.js
@@ -252,6 +252,36 @@ QUnit.test("data-hotkey", async (assert) => {
     assert.verifySteps(["click"]);
 });
 
+QUnit.test("input with [accesskey] is correctly focused", async (assert) => {
+    const inputEl = document.createElement("input");
+    inputEl.className = "foo";
+    inputEl.accessKey = "a";
+    inputEl.onclick = () => assert.step("click");
+    inputEl.textContent = "foo";
+    target.appendChild(inputEl);
+
+    // div must only have [accesskey] attribute
+    assert.containsOnce(target, ".foo");
+    assert.containsOnce(target, ".foo[accesskey]");
+    assert.containsNone(target, ".foo[data-hotkey]");
+
+    // press any hotkey, i.e. the left arrow
+    triggerHotkey("arrowleft");
+    await nextTick();
+
+    // div should now only have [data-hotkey] attribute
+    assert.containsOnce(target, ".foo");
+    assert.containsOnce(target, ".foo[data-hotkey]");
+    assert.containsNone(target, ".foo[accesskey]");
+
+    // try to press the related hotkey, just to make sure it works
+    assert.verifySteps([]);
+    triggerHotkey("a", true);
+    await nextTick();
+    assert.verifySteps(["click"]);
+    assert.strictEqual(document.activeElement, inputEl);
+});
+
 QUnit.test("invisible data-hotkeys are not enabled. ", async (assert) => {
     assert.expect(3);
 


### PR DESCRIPTION
Steps:
- Open any views with a search bar
- Press ALT + Q (hotkey used to focus search input)
- Nothing happens

This behavior has been introduced by https://github.com/odoo/odoo/pull/185960

This commit just adds the focus that had previously been removed to enable the input to be correctly selected so that the user can write directly on it.

opw-4874194