### PR TITLE
[IMP] mail: allow to copy alias email

### DIFF
--- a/addons/account/views/account_journal_views.xml
+++ b/addons/account/views/account_journal_views.xml
@@ -169,9 +169,13 @@
                                             </a>
                                         </div>
                                         <div class="o_row" colspan="2" dir="ltr" invisible="not display_alias_fields">
-                                            <label string="Email Alias" for="alias_name"/>
-                                            <field name="alias_name" placeholder="alias"/>@
-                                            <field name="alias_domain_id" placeholder="e.g. mycompany.com" options="{'no_create': True, 'no_open': True}"/>
+                                            <label string="Email Alias" for="alias_name" class="fw-medium"/>
+                                            <field name="alias_name" placeholder="alias" class="o_field_highlight"/>@
+                                            <field name="alias_domain_id" placeholder="e.g. mycompany.com" options="{'no_create': True, 'no_open': True}" class="o_field_highlight"/>
+                                            <div class="w-25">
+                                                <field name="alias_email" widget="CopyClipboardButton" invisible="not alias_email"
+                                                    class="copy_alias_email" options="{'btn_class': 'link'}" string=""/>
+                                            </div>
                                         </div>
                                         <field name="incoming_einvoice_notification_email" invisible="type != 'purchase'" placeholder="Enter an email to get notified"/>
                                     </group>

--- a/addons/crm/views/crm_team_views.xml
+++ b/addons/crm/views/crm_team_views.xml
@@ -163,10 +163,16 @@
                            invisible="not use_leads and not use_opportunities"/>
                     <div name="alias_def" invisible="not use_leads and not use_opportunities">
                         <field name="alias_id" string="Email Alias" class="oe_read_only" required="0"/>
-                        <div class="oe_edit_only" name="edit_alias" dir="ltr">
-                            <field name="alias_name" placeholder="alias" class="oe_inline"/>@
-                            <field name="alias_domain_id" class="oe_inline" placeholder="e.g. mycompany.com"
+                        <div class="oe_edit_only row" name="edit_alias" dir="ltr">
+                            <div class="d-flex col-10 p-0">
+                                <field name="alias_name" placeholder="alias" class="o_field_highlight"/>@
+                                <field name="alias_domain_id" class="o_field_highlight" placeholder="e.g. mycompany.com"
                                    options="{'no_create': True, 'no_open': True}"/>
+                            </div>
+                            <div class="col-2 p-0" invisible="not alias_email">
+                                <field name="alias_email" widget="CopyClipboardButton"
+                                    class="copy_alias_email" options="{'btn_class': 'link'}" string=""/>
+                            </div>
                         </div>
                     </div>
                     <field name="alias_contact"

--- a/addons/hr_recruitment/views/hr_job_views.xml
+++ b/addons/hr_recruitment/views/hr_job_views.xml
@@ -245,10 +245,16 @@
                     <div name="alias_def">
                         <field name="alias_id" class="oe_read_only" string="Email Alias" required="0"
                             groups="hr_recruitment.group_hr_recruitment_interviewer"/>
-                        <div class="oe_edit_only" name="edit_alias">
-                            <field name="alias_name" class="oe_inline o_job_alias" placeholder="e.g. sales-manager"/>@
-                            <field name="alias_domain_id" class="oe_inline" placeholder="e.g. mycompany.com"
-                                   options="{'no_create': True, 'no_open': True}"/>
+                        <div class="oe_edit_only row" name="edit_alias">
+                            <div class="d-flex col-10 col-md-5 p-0">
+                                <field name="alias_name" class="o_job_alias o_field_highlight" placeholder="e.g. sales-manager"/>@
+                                <field name="alias_domain_id" class="o_field_highlight" placeholder="e.g. mycompany.com"
+                                    options="{'no_create': True, 'no_open': True}"/>
+                            </div>
+                            <div class="col-2" invisible="not alias_email">
+                                <field name="alias_email" widget="CopyClipboardButton"
+                                    class="copy_alias_email" options="{'btn_class': 'link'}" string=""/>
+                            </div>
                         </div>
                         <div class="text-muted">Incoming emails create applications automatically. Use it for direct applications or when posting job opportunities on LinkedIn, Monster, etc.</div>
                     </div>
@@ -300,10 +306,17 @@
                     string="Email Alias"
                     help="Define a specific contact address for this job position. If you keep it empty, the default email address will be used which is in human resources settings"
                 />
-                <div class="o_wrap_label d-flex flex-row gap-1 align-items-baseline">
-                    <field name="alias_name" placeholder="e.g. jobs"/>
-                    <span>@</span>
-                    <field name="alias_domain_id" placeholder="e.g. domain.com" options="{'no_create': True, 'no_open': True}"/>
+                <div class="row">
+                    <div class="d-flex col-10 p-0">
+                        <field name="alias_name" placeholder="e.g. jobs" class="o_field_highlight"/>
+                        <span>@</span>
+                        <field name="alias_domain_id" placeholder="e.g. domain.com"
+                            options="{'no_create': True, 'no_open': True}" class="o_field_highlight"/>
+                    </div>
+                    <div class="col-2 p-0" invisible="not alias_email">
+                        <field name="alias_email" widget="CopyClipboardButton"
+                            class="copy_alias_email" options="{'btn_class': 'link'}" string=""/>
+                    </div>
                 </div>
             </group>
 

--- a/addons/mail/static/src/scss/copy_alias_email.scss
+++ b/addons/mail/static/src/scss/copy_alias_email.scss
@@ -1,0 +1,8 @@
+.copy_alias_email {
+    .fa-clipboard {
+        display: none;
+    }
+    .o_clipboard_button {
+        padding: 0;
+    }
+}

--- a/addons/mail/views/mail_alias_views.xml
+++ b/addons/mail/views/mail_alias_views.xml
@@ -26,11 +26,17 @@
                                     </div>
                             </button>
                         </div>
-                        <div class="d-flex">
-                            <h2 class="flex-grow-1" dir="ltr">
-                                <field name="alias_name" placeholder="alias" class="oe_inline"/>@
-                                <field name="alias_domain_id" class="oe_inline" placeholder="e.g. mycompany.com"
-                                       options="{'no_create': True, 'no_open': True}"/>
+                        <div class="d-flex justify-content-between">
+                            <h2 class="row" dir="ltr">
+                                <div class="d-flex col-8">
+                                    <field name="alias_name" placeholder="alias" class="o_field_highlight"/>@
+                                    <field name="alias_domain_id" class="o_field_highlight" placeholder="e.g. mycompany.com"
+                                        options="{'no_create': True, 'no_open': True}"/>
+                                </div>
+                                <div class="col-2 p-0" invisible="not alias_name or not alias_domain_id">
+                                    <field name="alias_full_name" widget="CopyClipboardButton"
+                                        class="copy_alias_email" options="{'btn_class': 'link'}" string=""/>
+                                </div>
                             </h2>
                             <field name="alias_status" widget="badge"
                                    decoration-success="alias_status == 'valid'"

--- a/addons/mail_group/views/mail_group_views.xml
+++ b/addons/mail_group/views/mail_group_views.xml
@@ -114,10 +114,16 @@
                             <div class="oe_inline" name="alias_def">
                                 <field name="alias_id" class="oe_read_only oe_inline" string="Email Alias" required="0"/>
                                 <div class="oe_inline" name="edit_alias" style="display: inline;">
-                                    <div class="oe_edit_only" dir="ltr">
-                                        <field name="alias_name" placeholder="alias" class="oe_inline"/>@
-                                        <field name="alias_domain_id" class="oe_inline" placeholder="e.g. mycompany.com"
-                                               options="{'no_create': True, 'no_open': True}"/>
+                                    <div class="oe_edit_only row" dir="ltr">
+                                        <div class="d-flex col-10 p-0">
+                                            <field name="alias_name" placeholder="alias" class="o_field_highlight"/>@
+                                            <field name="alias_domain_id" class="o_field_highlight" placeholder="e.g. mycompany.com"
+                                                options="{'no_create': True, 'no_open': True}"/>
+                                        </div>
+                                        <div class="col-2 p-0" invisible="not alias_email">
+                                            <field name="alias_email" widget="CopyClipboardButton"
+                                                class="copy_alias_email" options="{'btn_class': 'link'}" string=""/>
+                                        </div>
                                     </div>
                                     <button icon="oi-arrow-right" type="action" name="%(base_setup.action_general_configuration)d"
                                             string="Choose or configure a custom domain" class="p-0 btn-link"

--- a/addons/maintenance/views/maintenance_views.xml
+++ b/addons/maintenance/views/maintenance_views.xml
@@ -757,10 +757,16 @@
                         <label for="alias_name" string="Email Alias"/>
                         <div name="alias_def">
                             <field name="alias_id" class="oe_read_only oe_inline" string="Email Alias" required="0"/>
-                            <div class="oe_edit_only oe_inline" name="edit_alias" style="display: inline;" dir="ltr">
-                                <field name="alias_name" placeholder="alias" class="oe_inline"/>@
-                                <field name="alias_domain_id" class="oe_inline" placeholder="e.g. mycompany.com"
-                                    options="{'no_create': True, 'no_open': True}"/>
+                            <div class="oe_edit_only row" name="edit_alias" dir="ltr">
+                                <div class="d-flex col-10 p-0">
+                                    <field name="alias_name" placeholder="alias" class="o_field_highlight"/>@
+                                    <field name="alias_domain_id" class="o_field_highlight" placeholder="e.g. mycompany.com"
+                                        options="{'no_create': True, 'no_open': True}"/>
+                                </div>
+                                <div class="col-2 p-0" invisible="not alias_email">
+                                    <field name="alias_email" widget="CopyClipboardButton"
+                                        class="copy_alias_email" options="{'btn_class': 'link'}" string=""/>
+                                </div>
                             </div>
                         </div>
                     </group>

--- a/addons/project/views/project_project_views.xml
+++ b/addons/project/views/project_project_views.xml
@@ -93,10 +93,16 @@
                                     <field name="alias_id" invisible="1"/>
                                     <label for="alias_name" string="Email Alias" invisible="is_template"/>
                                     <field name="alias_email" widget="email" readonly="1" nolabel="1" groups="!project.group_project_manager" invisible="is_template"/>
-                                    <div class="d-inline-flex" groups="project.group_project_manager" invisible="is_template">
-                                        <field name="alias_name" placeholder="alias"/>@
-                                        <field name="alias_domain_id" placeholder="e.g. mycompany.com"
-                                            options="{'no_create': True, 'no_open': True}"/>
+                                    <div class="row" groups="project.group_project_manager" invisible="is_template">
+                                        <div class="d-flex col-10 p-0">
+                                            <field name="alias_name" placeholder="alias" class="o_field_highlight"/>@
+                                            <field name="alias_domain_id" class="o_field_highlight" placeholder="e.g. mycompany.com"
+                                                options="{'no_create': True, 'no_open': True}"/>
+                                        </div>
+                                        <div class="col-2 p-0" invisible="not alias_email">
+                                           <field name="alias_email" widget="CopyClipboardButton"
+                                                class="copy_alias_email" options="{'btn_class': 'link'}" string=""/>
+                                        </div>
                                     </div>
                                     <!-- the alias contact must appear when the user start typing and it must disappear
                                         when the string is deleted. -->


### PR DESCRIPTION
This PR  made the following changes:
- Add the alias_email field to the view, using the
  `CopyClipboardButton` widget to enable copying the alias email
  to the clipboard.
- Added the custom CSS using the `copy_alias_email` class to hide the copy icon
  provided by the `CopyClipboardButton`.
- Also, make sure that alias_name, alias_domain_id, and the copy button appear
  on the same line.
- Also removed some classes from the field and div, and used row col instead of
  them to align fields properly in a single line.

Task-4812573