### PR TITLE
[FIX] point_of_sale: correctly determine if the browser is offline

### DIFF
--- a/addons/point_of_sale/controllers/main.py
+++ b/addons/point_of_sale/controllers/main.py
@@ -99,6 +99,10 @@ class PosController(PortalAccount):
         response.headers['Cache-Control'] = 'no-store'
         return response
 
+    @http.route(['/pos/ping'], type='jsonrpc', auth='user')
+    def pos_ping(self):
+        return {'response': 'pong'}
+
     @http.route('/pos/sale_details_report', type='http', auth='user')
     def print_sale_details(self, date_start=False, date_stop=False, **kw):
         r = request.env['report.point_of_sale.report_saledetails']

--- a/addons/point_of_sale/static/src/app/main.js
+++ b/addons/point_of_sale/static/src/app/main.js
@@ -30,7 +30,7 @@ whenReady(() => {
         props: { disableLoader: () => (loader.isShown = false) },
     });
     window.addEventListener("beforeunload", function (event) {
-        if (!navigator.onLine) {
+        if (app.env.services.pos_data.network.offline) {
             var confirmationMessage = _t(
                 "You are currently offline. Reloading the page may cause you to lose unsaved data."
             );

--- a/addons/pos_hr/static/src/app/services/pos_store.js
+++ b/addons/pos_hr/static/src/app/services/pos_store.js
@@ -57,7 +57,7 @@ patch(PosStore.prototype, {
         super.setCashier(employee);
 
         if (this.config.module_pos_hr) {
-            if (navigator.onLine) {
+            if (!this.data.network.offline) {
                 this.data.write("pos.session", [this.config.current_session_id.id], {
                     employee_id: employee.id,
                 });


### PR DESCRIPTION
Runbot tests will soon be run in dockers with no access to the outside
world, so all their interfaces will be disconnected. The problem is that
the browser considers itself offline when no interface is connected.
However, in this case, if the Odoo server is still accessible.

This method also makes it possible to run local tests when no connection
is available and an Odoo server is running locally.

A ping is required to verify that the connection to the server is not
possible.