### PR TITLE
[FIX] base_import_module: avoid `to upgrade` imported modules

### DIFF
--- a/addons/base_import_module/models/ir_module.py
+++ b/addons/base_import_module/models/ir_module.py
@@ -439,6 +439,12 @@ class IrModuleModule(models.Model):
         except requests.exceptions.ConnectionError:
             return []
 
+    def button_upgrade(self):
+        res = super().button_upgrade()
+        # revert states for imported modules since they cannot be upgraded
+        self.search([('imported', '=', True), ('state', '=', 'to upgrade')]).state = 'installed'
+        return res
+
     def button_immediate_install_app(self):
         if not self.env.is_admin():
             raise AccessDenied()


### PR DESCRIPTION
Since PR #203952, module operations are rejected if any module is in a `to install`, `to upgrade`, or `to remove` state. This has unintentionally exposed a subtle issue where certain imported modules can be left in an inconsistent `to upgrade` state, preventing further module management actions.

Steps to Reproduce:
1. Install a imported module, e.g., automobile.
2. Upgrade one of its dependency modules, e.g., purchase_product_matrix.
3. After the upgrade, the imported module is erroneously marked as `to upgrade`
4. The system log for ir.cron then repeatedly shows warnings like: “Skipping database <dbname> because of modules to install/upgrade/remove.”
5. From the Odoo App interface, the user cannot directly install/upgrade/uninstall modules
6. This situation persists until:
    (a) The user manually clicks “Cancel Upgrade” for every `to upgrade` imported module, or
    (b) The system auto-resets these states after `MAX_FAIL_TIME` (5 hours), reverting them to `installed`.

This fix reverts such modules to `installed` during `button_upgrade`

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
