### PR TITLE
[FIX] purchase_stock: fix po suggestion wizard on actual demand

### DIFF
--- a/addons/purchase_stock/wizard/purchase_order_suggest.py
+++ b/addons/purchase_stock/wizard/purchase_order_suggest.py
@@ -168,7 +168,7 @@ class PurchaseOrderSuggest(models.TransientModel):
         self.ensure_one()
         if self.based_on == 'actual_demand':
             context = {
-                'from_date': fields.Datetime.now(),
+                'from_date': datetime(1970, 1, 1),
                 'to_date': fields.Datetime.now() + relativedelta(days=self.number_of_days),
             }
         else:

--- a/addons/purchase_stock/wizard/purchase_order_suggest_views.xml
+++ b/addons/purchase_stock/wizard/purchase_order_suggest_views.xml
@@ -27,11 +27,11 @@
                     </div>
                 </group>
                 <footer>
-                    <button invisible="estimated_price"
+                    <button invisible="product_count"
                             class="btn-secondary disabled"
                             name="action_purchase_order_suggest"
                             string="Compute" type="object"/>
-                    <button invisible="not estimated_price"
+                    <button invisible="not product_count"
                             class="btn-primary"
                             name="action_purchase_order_suggest"
                             string="Compute" type="object"


### PR DESCRIPTION
This commit fixes 2 bugs in the purchase order suggestion wizard
when it's based on actual demand:

1- it now allows the suggestion wizard to add products without
prices to the PO.
2- it now takes into account outgoing deliveries with scheduled date
in the past, as long as it's not validated yet.

Task-4877088