### PR TITLE
[FIX] l10n_eg_edi_eta: duplicate compute

### DIFF
--- a/addons/l10n_eg_edi_eta/models/account_move.py
+++ b/addons/l10n_eg_edi_eta/models/account_move.py
@@ -57,11 +57,9 @@ class AccountMove(models.Model):
             if response_data:
                 rec.l10n_eg_uuid = response_data.get('l10n_eg_uuid')
                 rec.l10n_eg_submission_number = response_data.get('l10n_eg_submission_number')
-                rec.l10n_eg_long_id = response_data.get('l10n_eg_long_id')
             else:
                 rec.l10n_eg_uuid = False
                 rec.l10n_eg_submission_number = False
-                rec.l10n_eg_long_id = False
 
     def button_draft(self):
         self.l10n_eg_eta_json_doc_id = False


### PR DESCRIPTION
`l10n_eg_long_edi` is set by two different computes. This is completely useless as it will trigger a write and the actual compute will still be called when the field is read.
