### PR TITLE
[IMP] web: replace dot by underscore in model selector class

### DIFF
--- a/addons/web/static/src/core/model_selector/model_selector.js
+++ b/addons/web/static/src/core/model_selector/model_selector.js
@@ -31,15 +31,16 @@ export class ModelSelector extends Component {
             }
 
             this.models = this.models.map((record) => ({
-                cssClass: `o_model_selector_${record.model}`,
+                cssClass: `o_model_selector_${record.model.replaceAll(".", "_")}`,
                 data: {
                     technical: record.model,
                 },
                 label: record.display_name,
-                onSelect: () => this.props.onModelSelected({
-                    label: record.display_name,
-                    technical: record.model,
-                }),
+                onSelect: () =>
+                    this.props.onModelSelected({
+                        label: record.display_name,
+                        technical: record.model,
+                    }),
             }));
         });
     }

--- a/addons/web/static/tests/core/model_selector.test.js
+++ b/addons/web/static/tests/core/model_selector.test.js
@@ -27,16 +27,16 @@ class IrModel extends models.Model {
     name = fields.Char({ string: "Model Name" });
     model = fields.Char();
     _records = [
-        { id: 1, name: "Model 1", model: "model_1" },
-        { id: 2, name: "Model 2", model: "model_2" },
-        { id: 3, name: "Model 3", model: "model_3" },
-        { id: 4, name: "Model 4", model: "model_4" },
-        { id: 5, name: "Model 5", model: "model_5" },
-        { id: 6, name: "Model 6", model: "model_6" },
-        { id: 7, name: "Model 7", model: "model_7" },
-        { id: 8, name: "Model 8", model: "model_8" },
-        { id: 9, name: "Model 9", model: "model_9" },
-        { id: 10, name: "Model 10", model: "model_10" },
+        { id: 1, name: "Model 1", model: "model.1" },
+        { id: 2, name: "Model 2", model: "model.2" },
+        { id: 3, name: "Model 3", model: "model.3" },
+        { id: 4, name: "Model 4", model: "model.4" },
+        { id: 5, name: "Model 5", model: "model.5" },
+        { id: 6, name: "Model 6", model: "model.6" },
+        { id: 7, name: "Model 7", model: "model.7" },
+        { id: 8, name: "Model 8", model: "model.8" },
+        { id: 9, name: "Model 9", model: "model.9" },
+        { id: 10, name: "Model 10", model: "model.10" },
     ];
 }
 
@@ -60,7 +60,7 @@ test("model_selector: with no model", async () => {
 });
 
 test("model_selector: displays model display names", async () => {
-    await mountModelSelector(["model_1", "model_2", "model_3"]);
+    await mountModelSelector(["model.1", "model.2", "model.3"]);
     await contains(".o-autocomplete--input").click();
     expect("li.o-autocomplete--dropdown-item").toHaveCount(3);
     const items = queryAll("li.o-autocomplete--dropdown-item");
@@ -71,14 +71,14 @@ test("model_selector: displays model display names", async () => {
 
 test("model_selector: with 8 models", async () => {
     await mountModelSelector([
-        "model_1",
-        "model_2",
-        "model_3",
-        "model_4",
-        "model_5",
-        "model_6",
-        "model_7",
-        "model_8",
+        "model.1",
+        "model.2",
+        "model.3",
+        "model.4",
+        "model.5",
+        "model.6",
+        "model.7",
+        "model.8",
     ]);
     await contains(".o-autocomplete--input").click();
     expect("li.o-autocomplete--dropdown-item").toHaveCount(8);
@@ -86,16 +86,16 @@ test("model_selector: with 8 models", async () => {
 
 test("model_selector: with more than 8 models", async () => {
     await mountModelSelector([
-        "model_1",
-        "model_2",
-        "model_3",
-        "model_4",
-        "model_5",
-        "model_6",
-        "model_7",
-        "model_8",
-        "model_9",
-        "model_10",
+        "model.1",
+        "model.2",
+        "model.3",
+        "model.4",
+        "model.5",
+        "model.6",
+        "model.7",
+        "model.8",
+        "model.9",
+        "model.10",
     ]);
     await contains(".o-autocomplete--input").click();
     expect("li.o-autocomplete--dropdown-item").toHaveCount(9);
@@ -103,22 +103,22 @@ test("model_selector: with more than 8 models", async () => {
 });
 
 test("model_selector: search content is not applied when opening the autocomplete", async () => {
-    await mountModelSelector(["model_1", "model_2"], "_2");
+    await mountModelSelector(["model.1", "model.2"], "_2");
     await contains(".o-autocomplete--input").click();
     expect("li.o-autocomplete--dropdown-item").toHaveCount(2);
 });
 
 test("model_selector: with search matching some records on technical name", async () => {
-    await mountModelSelector(["model_1", "model_2"]);
+    await mountModelSelector(["model.1", "model.2"]);
     await contains(".o-autocomplete--input").click();
-    await contains(".o-autocomplete--input").edit("_2", { confirm: false });
+    await contains(".o-autocomplete--input").edit(".2", { confirm: false });
     await runAllTimers();
     expect("li.o-autocomplete--dropdown-item").toHaveCount(1);
     expect("li.o-autocomplete--dropdown-item").toHaveText("Model 2");
 });
 
 test("model_selector: with search matching some records on business name", async () => {
-    await mountModelSelector(["model_1", "model_2"]);
+    await mountModelSelector(["model.1", "model.2"]);
     await contains(".o-autocomplete--input").click();
     await contains(".o-autocomplete--input").edit(" 2", { confirm: false });
     await runAllTimers();
@@ -127,7 +127,7 @@ test("model_selector: with search matching some records on business name", async
 });
 
 test("model_selector: with search matching no record", async () => {
-    await mountModelSelector(["model_1", "model_2"]);
+    await mountModelSelector(["model.1", "model.2"]);
     await contains(".o-autocomplete--input").edit("a random search query", { confirm: false });
     await runAllTimers();
     expect("li.o-autocomplete--dropdown-item").toHaveCount(1);
@@ -135,11 +135,11 @@ test("model_selector: with search matching no record", async () => {
 });
 
 test("model_selector: select a model", async () => {
-    await mountModelSelector(["model_1", "model_2", "model_3"], "Model 1", (selected) => {
+    await mountModelSelector(["model.1", "model.2", "model.3"], "Model 1", (selected) => {
         expect.step("model selected");
         expect(selected).toEqual({
             label: "Model 2",
-            technical: "model_2",
+            technical: "model.2",
         });
     });
     await contains(".o-autocomplete--input").click();
@@ -148,6 +148,6 @@ test("model_selector: select a model", async () => {
 });
 
 test("model_selector: with an initial value", async () => {
-    await mountModelSelector(["model_1", "model_2", "model_3"], "Model 1");
+    await mountModelSelector(["model.1", "model.2", "model.3"], "Model 1");
     expect(".o-autocomplete--input").toHaveValue("Model 1");
 });


### PR DESCRIPTION
Before this commit, the class names generated by the model selector could contains dots (as it's the technical name of the model). However, it means that this class name could not be used, for example, in querySelector, as it would be interpreted as two classes.

This commit replaces the dots by underscores, so that the class names can be used in querySelector.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
