### PR TITLE
[FIX] pos_self_order: redirect to product page on empty cart

### DIFF
--- a/addons/pos_self_order/static/src/app/pages/cart_page/cart_page.js
+++ b/addons/pos_self_order/static/src/app/pages/cart_page/cart_page.js
@@ -161,6 +161,7 @@ export class CartPage extends Component {
         } else {
             this.selfOrder.removeLine(line);
         }
+        !this.lines.length && this.router.back();
     }
 
     async _changeQuantity(line, increase) {

--- a/addons/pos_self_order/static/tests/tours/self_order_kiosk_tour.js
+++ b/addons/pos_self_order/static/tests/tours/self_order_kiosk_tour.js
@@ -43,6 +43,11 @@ registry.category("web_tour.tours").add("self_kiosk_each_table_takeaway_in", {
         Utils.checkIsNoBtn("My Order"),
         ...clickOrderNowAndWaitLocation("Eat In"),
         Utils.checkIsDisabledBtn("Order"),
+        ProductPage.clickProduct("Coca-Cola"),
+        Utils.clickBtn("Order"),
+        CartPage.checkProduct("Coca-Cola", "2.53", "1"),
+        CartPage.removeLine("Coca-Cola"),
+        ProductPage.isShown(),
     ],
 });
 

--- a/addons/pos_self_order/static/tests/tours/self_order_mobile_tour.js
+++ b/addons/pos_self_order/static/tests/tours/self_order_mobile_tour.js
@@ -25,6 +25,13 @@ registry.category("web_tour.tours").add("self_mobile_each_table_takeaway_in", {
         ...CartPage.cancelOrder(),
         Utils.checkBtn("Order Now"),
         Utils.checkBtn("My Orders"),
+        Utils.clickBtn("Order Now"),
+        LandingPage.selectLocation("Eat In"),
+        ProductPage.clickProduct("Coca-Cola"),
+        Utils.clickBtn("Order"),
+        CartPage.checkProduct("Coca-Cola", "2.53", "1"),
+        CartPage.removeLine("Coca-Cola"),
+        ProductPage.isShown(),
     ],
 });
 

--- a/addons/pos_self_order/static/tests/tours/utils/cart_page_util.js
+++ b/addons/pos_self_order/static/tests/tours/utils/cart_page_util.js
@@ -93,3 +93,11 @@ export function cancelOrder() {
         },
     ];
 }
+
+export function removeLine(productName) {
+    return {
+        content: `remove orderline with name ${productName}`,
+        trigger: `.product-card-item:has(.product-info strong:contains(${productName})) .product-controllers button:eq(0)`,
+        run: "click",
+    };
+}

--- a/addons/pos_self_order/static/tests/tours/utils/product_page_util.js
+++ b/addons/pos_self_order/static/tests/tours/utils/product_page_util.js
@@ -114,3 +114,10 @@ export function setupCombo(products, addToCart = true) {
 
     return steps;
 }
+
+export function isShown() {
+    return {
+        content: `product page is shown`,
+        trigger: `.product-list`,
+    };
+}


### PR DESCRIPTION
Before this commit:
================
Users could attempt to proceed with payment even when the cart had no orderlines

After this commit:
===============
If the cart is empty, the user is automatically redirected back to the product
page, preventing the error and ensuring a smoother user experience.

Task-4880984