### PR TITLE
[FIX] point_of_sale: fix shipping date set to previous day in specific timezones

### DIFF
--- a/addons/point_of_sale/static/src/app/models/pos_order.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order.js
@@ -7,7 +7,7 @@ import { roundCurrency } from "@point_of_sale/app/models/utils/currency";
 import { computeComboItems } from "./utils/compute_combo_items";
 import { accountTaxHelpers } from "@account/helpers/account_tax";
 import { localization } from "@web/core/l10n/localization";
-import { formatDate } from "@web/core/l10n/dates";
+import { formatDate, deserializeDate } from "@web/core/l10n/dates";
 
 const formatCurrency = registry.subRegistries.formatters.content.monetary[1];
 const { DateTime } = luxon;
@@ -947,7 +947,11 @@ export class PosOrder extends Base {
     /* ---- Ship later --- */
     //FIXME remove this
     setShippingDate(shippingDate) {
-        this.shipping_date = shippingDate;
+        if (shippingDate) {
+            this.shipping_date = deserializeDate(shippingDate, { zone: "utc" });
+        } else {
+            this.shipping_date = shippingDate;
+        }
     }
     //FIXME remove this
     getShippingDate() {

--- a/addons/point_of_sale/static/tests/pos/tours/shipping_date_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/shipping_date_tour.js
@@ -1,0 +1,50 @@
+import * as Chrome from "@point_of_sale/../tests/pos/tours/utils/chrome_util";
+import * as Dialog from "@point_of_sale/../tests/generic_helpers/dialog_util";
+import * as ProductScreen from "@point_of_sale/../tests/pos/tours/utils/product_screen_util";
+import { registry } from "@web/core/registry";
+
+registry.category("web_tour.tours").add("test_pos_order_shipping_date", {
+    steps: () =>
+        [
+            ProductScreen.setTimeZone("America/New_York"),
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            ProductScreen.addOrderline("Whiteboard Pen", "1"),
+            ProductScreen.clickPayButton(),
+            {
+                content: "click ship later button",
+                trigger: ".button:contains('Ship Later')",
+                run: "click",
+            },
+            {
+                content: "pick a date",
+                trigger: '.modal-body input[type="date"]',
+                run: () => {
+                    const input = document.querySelector('.modal-body input[type="date"]');
+                    const nextYear = new Date().getFullYear() + 1;
+                    input.value = `${nextYear}-05-30`;
+                    input.dispatchEvent(new Event("input", { bubbles: true }));
+                    input.dispatchEvent(new Event("change", { bubbles: true }));
+                },
+            },
+            {
+                content: "click confirm button",
+                trigger: ".btn:contains('Confirm')",
+                run: "click",
+            },
+            {
+                content: "Assert shipping date was set",
+                trigger: ".payment-buttons .d-flex .btn span",
+                run: () => {
+                    const spans = [
+                        ...document.querySelectorAll(".payment-buttons .d-flex .btn span"),
+                    ];
+                    const nextYear = new Date().getFullYear() + 1;
+                    const expectedDate = `05/30/${nextYear}`;
+                    if (!spans.some((span) => span.innerText === expectedDate)) {
+                        throw new Error("Expected shipping date is not set");
+                    }
+                },
+            },
+        ].flat(),
+});

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -2319,6 +2319,15 @@ class TestUi(TestPointOfSaleHttpCommon):
         self.assertEqual(load_product_from_pos_stats['items']['orange'], 2, "Orange should have 2 pricelist items")
         self.assertEqual(load_product_from_pos_stats['items']['kiwi'], 1, "Kiwi should have 1 pricelist item")
 
+    def test_pos_order_shipping_date(self):
+        self.main_pos_config.write({'ship_later': True})
+        self.main_pos_config.with_user(self.pos_user).open_ui()
+        self.start_tour(
+            f"/pos/ui?config_id={self.main_pos_config.id}",
+            "test_pos_order_shipping_date",
+            login="pos_user",
+        )
+
 
 # This class just runs the same tests as above but with mobile emulation
 class MobileTestUi(TestUi):


### PR DESCRIPTION
This is a fix to the bug when a shipping date in picked in specific timezones, the previous day is set.
The steps to reproduce:
1- Setup a database with point_of_sale app installed
2- In configuration -> Setting, check Allow Ship Later option for a pos shop.
3- Change the browser timezone to a US timezone. In chrome it can be in Console -> Sensors -> Location.
4- Open POS register, select a product, choose payment and use Ship Later, to pick a date.
5- The previous day is picked which is the bug.

The reason is that the shippingDate is parsed into shipping_date which is an object. We now manually deserialize and serialize the date to avoid automatic timezone handling.

opw-4853757
