### PR TITLE
[FIX] microsoft_calendar: call code only when the module is used

### DIFF
--- a/addons/calendar/models/calendar_event.py
+++ b/addons/calendar/models/calendar_event.py
@@ -756,13 +756,14 @@ class CalendarEvent(models.Model):
             attendee_update_events.attendee_ids.filtered(lambda att: self.user_id.partner_id == att.partner_id).write({'state': 'needsAction'})
 
         current_attendees = self.filtered('active').attendee_ids
-        if 'partner_ids' in values:
+        skip_attendee_notification = self.env.context.get('skip_attendee_notification')
+        if not skip_attendee_notification and 'partner_ids' in values:
             # we send to all partners and not only the new ones
             (current_attendees - previous_attendees)._notify_attendees(
                 self.env.ref('calendar.calendar_template_meeting_invitation', raise_if_not_found=False),
                 force_send=True,
             )
-        if not self.env.context.get('is_calendar_event_new') and 'start' in values:
+        if not skip_attendee_notification and not self.env.context.get('is_calendar_event_new') and 'start' in values:
             start_date = fields.Datetime.to_datetime(values.get('start'))
             # Only notify on future events
             if start_date and start_date >= fields.Datetime.now():
@@ -1397,7 +1398,7 @@ class CalendarEvent(models.Model):
             # Archive all events and delete recurrence, reactivate base event and apply updated values.
             base_event.action_mass_archive("all_events")
             base_event.recurrence_id.unlink()
-            base_event.write({
+            base_event.with_context(skip_attendee_notification=True).write({
                 'active': True,
                 'recurrence_id': False,
                 **values, **time_values

--- a/addons/calendar/tests/test_calendar_activity.py
+++ b/addons/calendar/tests/test_calendar_activity.py
@@ -53,14 +53,8 @@ class TestCalendarActivity(ActivityScheduleCase):
             'start': now + timedelta(days=-2),
             'user_id': self.user_employee.id,
         })
-        # TDE FIXME: currently failing if microsoft_calendar is installed as it
-        # creates a copy of the event (organizer change) and therefore copies
-        # activities also, see '_recreate_event_different_organizer'. Waiting
-        # proper investigation of behavior by calendar people.
-        if len(test_record.activity_ids) == 2:
-            activity = test_record.activity_ids[1]
-        else:
-            activity = test_record.activity_ids[0]
+
+        activity = test_record.activity_ids[0]
         self.assertEqual(activity.summary, '%s2' % test_name)
         self.assertEqual(activity.note, test_note2)
         self.assertEqual(activity.user_id, self.user_employee)

--- a/addons/microsoft_calendar/models/calendar.py
+++ b/addons/microsoft_calendar/models/calendar.py
@@ -180,8 +180,9 @@ class CalendarEvent(models.Model):
         # Updates from Microsoft must skip this check since changing the organizer on their side is not possible.
         change_from_microsoft = self.env.context.get('dont_notify', False)
         deactivated_events_ids = []
+        new_user_id = values.get('user_id')
         for event in self:
-            if values.get('user_id') and event.user_id.id != values['user_id'] and not change_from_microsoft:
+            if new_user_id and event.user_id.id != new_user_id and not change_from_microsoft and event.microsoft_id:
                 sender_user, partner_ids = event._get_organizer_user_change_info(values)
                 partner_included = sender_user.partner_id in event.attendee_ids.partner_id or sender_user.partner_id.id in partner_ids
                 event._check_organizer_validation(sender_user, partner_included)

--- a/addons/microsoft_calendar/tests/test_update_events.py
+++ b/addons/microsoft_calendar/tests/test_update_events.py
@@ -1363,6 +1363,9 @@ class TestUpdateEvents(TestCommon):
         self.simple_event_values['user_id'] = self.organizer_user.id
         self.simple_event_values['partner_ids'] = [Command.set([self.organizer_user.partner_id.id])]
         event = self.env['calendar.event'].with_user(self.organizer_user).create(self.simple_event_values)
+        # Simulate sync where the api update the microsoft_id field
+        event.ms_universal_event_id = "test_id_for_event"
+        event.microsoft_id = "test_id_for_organizer"
 
         # Deactivate user B's calendar synchronization. Try changing the event organizer to user B.
         # A ValidationError must be thrown because user B's calendar is not synced.
@@ -1383,8 +1386,6 @@ class TestUpdateEvents(TestCommon):
         mock_get_events.return_value = ([], None)
 
         # Change the event organizer: user B (the organizer) is synced and now listed as an attendee.
-        event.ms_universal_event_id = "test_id_for_event"
-        event.microsoft_id = "test_id_for_organizer"
         event.with_user(self.organizer_user).write({
             'user_id': self.attendee_user.id,
             'partner_ids': [Command.set([self.organizer_user.partner_id.id, self.attendee_user.partner_id.id])]


### PR DESCRIPTION
Before this commit, when the module was installed but not used, events would be duplicated even if it was not useful.

As a result the following code would duplicate the activities linked to the events as _recreate_event_different_organizer would be called even if both user would not sync their calendar.

```py
test_event = self.env['calendar.event'].with_user(test_user).with_context(
    default_res_model=test_record._name,
    default_res_id=test_record.id,
).create({
    'name': test_name,
    'description': test_description,
    'start': fields.Datetime.to_string(now + timedelta(days=-1)),
    'stop': fields.Datetime.to_string(now + timedelta(hours=2)),
    'user_id': self.env.user.id,
})

test_event.write({
    'name': '%s2' % test_name,
    'description': test_description2,
    'start': fields.Datetime.to_string(now + timedelta(days=-2)),
    'user_id': test_user.id,
})
```

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
