### PR TITLE
[FIX] web_editor: self-closing t elements

### DIFF
--- a/addons/html_editor/static/src/editor.js
+++ b/addons/html_editor/static/src/editor.js
@@ -4,6 +4,7 @@ import { fillShrunkPhrasingParent, removeClass } from "./utils/dom";
 import { isEmpty } from "./utils/dom_info";
 import { resourceSequenceSymbol, withSequence } from "./utils/resource";
 import { fixInvalidHTML, initElementForEdition } from "./utils/sanitize";
+import { setElementContent } from "@web/core/utils/html";
 
 /**
  * @typedef { import("./plugin_sets").SharedMethods } SharedMethods
@@ -96,7 +97,7 @@ export class Editor {
         this.editable = editable;
         this.document = editable.ownerDocument;
         if (this.config.content) {
-            editable.innerHTML = fixInvalidHTML(this.config.content);
+            setElementContent(editable, fixInvalidHTML(this.config.content));
             if (isEmpty(editable)) {
                 const baseContainer = createBaseContainer(this.config.baseContainer, this.document);
                 fillShrunkPhrasingParent(baseContainer);

--- a/addons/html_editor/static/src/fields/property_value.js
+++ b/addons/html_editor/static/src/fields/property_value.js
@@ -13,16 +13,17 @@ import { useState, onWillStart, onWillUpdateProps } from "@odoo/owl";
 patch(PropertyValue.prototype, {
     setup() {
         this.htmlUpgradeManager = new HtmlUpgradeManager();
-        this.lastHtmlValue = this.propertyValue;
+        this.lastHtmlValue = this.propertyValue?.toString();
         onWillStart(async () => {
             this.htmlState.isPortalUser = await user.hasGroup("base.group_portal");
         });
         this.htmlState = useState({ isPortalUser: false, key: 0 });
 
         onWillUpdateProps((newProps) => {
-            if (newProps.type === "html" && newProps.value !== this.lastHtmlValue) {
+            const newValueStr = newProps.value?.toString();
+            if (newProps.type === "html" && newValueStr !== this.lastHtmlValue) {
                 this.htmlState.key += 1;
-                this.lastHtmlValue = newProps.value;
+                this.lastHtmlValue = newValueStr;
             }
         });
 

--- a/addons/html_editor/static/src/html_migrations/html_upgrade_manager.js
+++ b/addons/html_editor/static/src/html_migrations/html_upgrade_manager.js
@@ -1,3 +1,4 @@
+import { markup } from "@odoo/owl";
 import {
     compareVersions,
     VERSION_SELECTOR,
@@ -57,7 +58,7 @@ export class HtmlUpgradeManager {
         }
         this.originalValue = value;
         this.upgradedValue = value;
-        this.element = this.parser.parseFromString(fixInvalidHTML(value.toString()), "text/html")[
+        this.element = this.parser.parseFromString(fixInvalidHTML(value), "text/html")[
             this.containsComplexHTML ? "documentElement" : "body"
         ];
         const versionNode = this.element.querySelector(VERSION_SELECTOR);
@@ -93,6 +94,6 @@ export class HtmlUpgradeManager {
                 migrate(this.element, this.env);
             }
         }
-        return this.element[this.containsComplexHTML ? "outerHTML" : "innerHTML"];
+        return markup(this.element[this.containsComplexHTML ? "outerHTML" : "innerHTML"]);
     }
 }

--- a/addons/html_editor/static/src/public/html_migrations/html_migrations_interaction.js
+++ b/addons/html_editor/static/src/public/html_migrations/html_migrations_interaction.js
@@ -2,6 +2,7 @@ import { registry } from "@web/core/registry";
 import { Interaction } from "@web/public/interaction";
 import { VERSION_SELECTOR } from "@html_editor/html_migrations/html_migrations_utils";
 import { HtmlUpgradeManager } from "@html_editor/html_migrations/html_upgrade_manager";
+import { markup } from "@odoo/owl";
 
 const upgradeElementToInteractionMap = new Map();
 
@@ -40,7 +41,7 @@ export class HtmlMigrationsInteraction extends Interaction {
         this.isUpgrading = true;
         this.services["public.interactions"].stopInteractions(this.container);
         const htmlUpgradeManager = new HtmlUpgradeManager();
-        const initialValue = this.container.innerHTML;
+        const initialValue = markup(this.container.innerHTML);
         const upgradedValue = htmlUpgradeManager.processForUpgrade(initialValue);
         if (initialValue !== upgradedValue) {
             this.container.innerHTML = upgradedValue;

--- a/addons/html_editor/static/tests/_helpers/editor.js
+++ b/addons/html_editor/static/tests/_helpers/editor.js
@@ -1,7 +1,7 @@
 import { Wysiwyg } from "@html_editor/wysiwyg";
 import { expect, getFixture } from "@odoo/hoot";
 import { queryOne } from "@odoo/hoot-dom";
-import { Component, xml } from "@odoo/owl";
+import { Component, markup, xml } from "@odoo/owl";
 import { mountWithCleanup } from "@web/../tests/web_test_helpers";
 import { getContent, getSelection, setContent } from "./selection";
 import { animationFrame, tick } from "@odoo/hoot-mock";
@@ -95,7 +95,9 @@ export async function setupEditor(content, options = {}) {
     const styleContent = options.styleContent || "";
     await mountWithCleanup(TestEditor, {
         props: {
-            content,
+            // TODO: Move the markup call up the chain and call markup at source.
+            // markup: Not the correct place to call markup as content can be anything but would be okay for the tests.
+            content: markup(content),
             wysiwygProps,
             styleContent,
             onMounted: options.onMounted,

--- a/addons/html_editor/static/tests/_helpers/selection.js
+++ b/addons/html_editor/static/tests/_helpers/selection.js
@@ -114,7 +114,7 @@ export function setContent(el, content) {
     if (configSelection) {
         setSelection(configSelection);
     }
-    if (getContent(el) !== content) {
+    if (getContent(el) !== content.toString()) {
         throw new Error("error in setContent/getContent helpers");
     }
 }

--- a/addons/html_editor/static/tests/odoo_collaboration.test.js
+++ b/addons/html_editor/static/tests/odoo_collaboration.test.js
@@ -2,10 +2,11 @@ import { stripHistoryIds } from "@html_editor/others/collaboration/collaboration
 import { HISTORY_SNAPSHOT_INTERVAL } from "@html_editor/others/collaboration/collaboration_plugin";
 import { COLLABORATION_PLUGINS, MAIN_PLUGINS } from "@html_editor/plugin_sets";
 import { normalizeHTML } from "@html_editor/utils/html";
+import { htmlReplaceAll } from "@web/core/utils/html";
 import { Wysiwyg } from "@html_editor/wysiwyg";
 import { beforeEach, describe, expect, test } from "@odoo/hoot";
 import { advanceTime, animationFrame, tick, waitUntil } from "@odoo/hoot-dom";
-import { Component, xml } from "@odoo/owl";
+import { Component, xml, markup } from "@odoo/owl";
 import { mountWithCleanup, onRpc } from "@web/../tests/web_test_helpers";
 import { Mutex } from "@web/core/utils/concurrency";
 import { patch } from "@web/core/utils/patch";
@@ -116,7 +117,7 @@ class PeerTest {
     }
 }
 
-const initialValue = '<p data-last-history-steps="1">a[]</p>';
+const initialValue = markup`<p data-last-history-steps="1">a[]</p>`;
 
 class Wysiwygs extends Component {
     static template = xml`
@@ -163,7 +164,7 @@ class Wysiwygs extends Component {
         };
         return {
             Plugins: [...MAIN_PLUGINS, ...COLLABORATION_PLUGINS],
-            content: content.replaceAll("[]", ""),
+            content: htmlReplaceAll(content, "[]", ""),
             collaboration: {
                 peerId,
                 busService,
@@ -1150,7 +1151,7 @@ describe("History steps Ids", () => {
 
 describe("Indent List", () => {
     test("should sync `li` indent properly", async () => {
-        const pool = await createPeers(["p1", "p2"], `<ul><li>a[]</li></ul>`);
+        const pool = await createPeers(["p1", "p2"], markup`<ul><li>a[]</li></ul>`);
         const peers = pool.peers;
 
         await peers.p1.focus();

--- a/addons/html_editor/static/tests/sanitize.test.js
+++ b/addons/html_editor/static/tests/sanitize.test.js
@@ -1,5 +1,9 @@
 import { expect, test } from "@odoo/hoot";
+import { markup } from "@odoo/owl";
 import { setupEditor, testEditor } from "./_helpers/editor";
+import { fixInvalidHTML } from "@html_editor/utils/sanitize";
+
+const Markup = markup().constructor;
 
 test("sanitize should remove nasty elements", async () => {
     const { editor } = await setupEditor("");
@@ -34,4 +38,81 @@ test("sanitize plugin should handle aria-label attribute with data-oe-aria-label
         contentAfterEdit: `<p data-oe-aria-label="status" aria-label="status">a[]</p>`,
         contentAfter: `<p data-oe-aria-label="status">a[]</p>`,
     });
+});
+
+test("fixInvalidHTML should close self-closing elements", () => {
+    expect(fixInvalidHTML(markup`<t/>`).toString()).toBe("<t></t>");
+    expect(fixInvalidHTML(markup`<t class="test"/>`).toString()).toBe('<t class="test"></t>');
+    expect(fixInvalidHTML(markup`<a/>`).toString()).toBe("<a></a>");
+    expect(fixInvalidHTML(markup`<a href="#"/>`).toString()).toBe('<a href="#"></a>');
+    expect(fixInvalidHTML(markup`<strong/>`).toString()).toBe("<strong></strong>");
+    expect(fixInvalidHTML(markup`<strong class="bold"/>`).toString()).toBe(
+        '<strong class="bold"></strong>'
+    );
+    expect(fixInvalidHTML(markup`<span/>`).toString()).toBe("<span></span>");
+    expect(fixInvalidHTML(markup`<span id="test"/>`).toString()).toBe('<span id="test"></span>');
+    expect(
+        fixInvalidHTML(
+            markup`<t t-out="object.name"/>asdf<t t-out="object.parner_id.name"/>`
+        ).toString()
+    ).toBe('<t t-out="object.name"></t>asdf<t t-out="object.parner_id.name"></t>');
+});
+
+test("fixInvalidHTML escapes string input", () => {
+    expect(fixInvalidHTML("<t/>").toString()).toBe("&lt;t/&gt;");
+    expect(fixInvalidHTML('<a href="?param=value&other=test"/>').toString()).toBe(
+        "&lt;a href=&quot;?param=value&amp;other=test&quot;/&gt;"
+    );
+});
+
+test("fixInvalidHTML should return markup", () => {
+    expect(fixInvalidHTML(markup`<t/>`)).toBeInstanceOf(Markup);
+    expect(fixInvalidHTML("<t/>")).toBeInstanceOf(Markup);
+});
+
+test("fixInvalidHTML handles nested self-closing tags correctly", () => {
+    expect(fixInvalidHTML(markup`<t><t/><t><t/></t></t>`).toString()).toBe(
+        "<t><t></t><t><t></t></t></t>"
+    );
+    expect(fixInvalidHTML(markup`<span><span class="inner"/></span>`).toString()).toBe(
+        '<span><span class="inner"></span></span>'
+    );
+});
+
+test("fixInvalidHTML preserves escaped content in attributes and text", () => {
+    expect(fixInvalidHTML(markup`<span title="quoted &amp; special"/>`).toString()).toBe(
+        `<span title="quoted &amp; special"></span>`
+    );
+    expect(fixInvalidHTML(markup`<p>Text with &lt;escaped&gt; content</p>`).toString()).toBe(
+        `<p>Text with &lt;escaped&gt; content</p>`
+    );
+});
+
+test("fixInvalidHTML attribute", () => {
+    // Properly quoted attributes should work
+    expect(fixInvalidHTML(markup`<t onclick="alert('test')"/>`).toString()).toBe(
+        `<t onclick="alert('test')"></t>`
+    );
+
+    // Unclosed quotes should NOT be converted (security protection)
+    expect(fixInvalidHTML(markup`<t class="unclosed/>`).toString()).toBe(`<t class="unclosed/>`);
+
+    // Mismatched quotes should NOT be converted (security protection)
+    expect(fixInvalidHTML(markup`<t class="test'/>`).toString()).toBe(`<t class="test'/>`);
+
+    // Valid data attributes with special characters should work
+    expect(fixInvalidHTML(markup`<span data-config='{"key": "value"}'/>`).toString()).toBe(
+        `<span data-config='{"key": "value"}'></span>`
+    );
+
+    // Attributes with invalid characters in unquoted values should NOT match
+    expect(fixInvalidHTML(markup`<t class=test>value/>`).toString()).toBe(`<t class=test>value/>`);
+
+    // Attributes containing < or > characters in quoted values should work
+    expect(fixInvalidHTML(markup`<t data-rule="value < 10"/>`).toString()).toBe(
+        `<t data-rule="value < 10"></t>`
+    );
+    expect(fixInvalidHTML(markup`<span title="score > 100"/>`).toString()).toBe(
+        `<span title="score > 100"></span>`
+    );
 });

--- a/addons/html_editor/static/tests/wysiwyg.test.js
+++ b/addons/html_editor/static/tests/wysiwyg.test.js
@@ -4,6 +4,9 @@ import { animationFrame } from "@odoo/hoot-mock";
 import { setupWysiwyg } from "./_helpers/editor";
 import { getContent, setContent, setSelection } from "./_helpers/selection";
 import { expectElementCount } from "./_helpers/ui_expectations";
+import { range } from "@web/core/utils/numbers";
+import { htmlJoin } from "@web/core/utils/html";
+import { markup } from "@odoo/owl";
 
 describe("Wysiwyg Component", () => {
     test("Wysiwyg component can be instantiated", async () => {
@@ -22,7 +25,7 @@ describe("Wysiwyg Component", () => {
 
     test("Wysiwyg component can be instantiated with initial content", async () => {
         const { el } = await setupWysiwyg({
-            config: { content: "<p>hello rodolpho</p>" },
+            config: { content: markup`<p>hello rodolpho</p>` },
         });
         expect(el.innerHTML).toBe(`<p>hello rodolpho</p>`);
     });
@@ -40,7 +43,11 @@ describe("Wysiwyg Component", () => {
         const CLOSE_ENOUGH = 10;
         const { el } = await setupWysiwyg({
             iframe: true,
-            config: { content: "<p>editable text inside the iframe</p>".repeat(30) },
+            config: {
+                content: htmlJoin(
+                    range(0, 30).map(() => markup`<p>editable text inside the iframe</p>`)
+                ),
+            },
         });
 
         // Add some content before the iframe to make sure it's top does not

--- a/addons/web_editor/static/tests/html_field_tests.js
+++ b/addons/web_editor/static/tests/html_field_tests.js
@@ -367,6 +367,27 @@ QUnit.module("WebEditor.HtmlField", ({ beforeEach }) => {
         assert.containsN(target, '#codeview-btn-group > button', 0, 'Codeview toggle should not be possible in readonly mode.');
     });
 
+    QUnit.test("readonly sandboxed preview: properly close self-closing t-tags", async (assert) => {
+        assert.expect(1);
+        serverData.models.partner.records.push({
+            id: 1,
+            txt: `<div>foo<t t-out="object.id"/>bar <t t-out="object.id"/></div>`,
+        });
+        await makeView({
+            type: "form",
+            resId: 1,
+            resModel: "partner",
+            serverData,
+            arch: `
+                <form>
+                    <field name="txt" widget="html_legacy" readonly="1" options="{'sandboxedPreview': true}"/>
+                </form>`,
+        });
+        const readonlyIframe = target.querySelector('.o_field_html_legacy[name="txt"] iframe[sandbox="allow-same-origin allow-popups allow-popups-to-escape-sandbox"]');
+        await iframeReady(readonlyIframe);
+        assert.strictEqual(readonlyIframe.contentDocument.body.innerHTML, `<div>foo<t t-out="object.id" contenteditable="false" data-oe-t-inline="true"></t>bar <t t-out="object.id" contenteditable="false" data-oe-t-inline="true"></t></div>`);
+    });
+
     QUnit.test("sandboxed preview display and editing", async (assert) => {
         let codeViewState = false;
         const togglePromises = [makeDeferred(), makeDeferred()];


### PR DESCRIPTION
Self-closing t elements become nested when they're supposed to be siblings.
Issue found while testing Task-ID: 4762393

Steps to reproduce:

1. Install sale_management and mass_mailing modules.
2. Modify the email template for sale quotations to have consecutive dynamic
placeholder contents like so:
`object.name foo object.name bar object.name` which in html is approximate the following
`<t t-out"object.name"/> foo <t t-out="object.name"/> bar <t t-out="object.name"/>`
3. Go to the list of sale orders and make a selection.
4. Find the send email action and click it, a composer will appear.
5. Select the template in 2.
6. Before sending the email, fill-in the Mass Mailing field at the top of the composer.
7. Main send button becomes Send Mass Mail, click it.
8. Go Email Marketing app.
9. Find the sent mass mail and check the body and notice that it's not properly rendered.

For better visualization, watch in https://youtu.be/V_iM7rUSaFM.

The issue occurs when setting innerHTML with the html-string saved in the db. We
need to manually close these self-closing tags before setting the html string to
the iframe element.

The fix calls `fixInvalidHTML` on the field value before setting it as innerHTML
in the iframe. This required modifying the function signature from string -> string
to (string | Markup) -> Markup. The function now always returns a Markup object:
string inputs are escaped and converted to Markup, while Markup inputs return a
new Markup with properly closed elements.

Multiple components that use fixInvalidHTML have been updated to handle the new
Markup return type.