### PR TITLE
[FIX] web: fix the default many2one property

### DIFF
--- a/addons/web/static/src/model/relational_model/record.js
+++ b/addons/web/static/src/model/relational_model/record.js
@@ -617,22 +617,23 @@ export class Record extends DataPoint {
                 : false;
         } else if (fieldType === "properties") {
             return value.map((property) => {
-                let value;
-                if (property.type === "many2one") {
-                    value = property.value;
-                } else if (
-                    (property.type === "date" || property.type === "datetime") &&
-                    typeof property.value === "string"
-                ) {
-                    // TO REMOVE: need refactoring PropertyField to use the same format as the server
-                    value = property.value;
-                } else if (property.value !== undefined) {
-                    value = this._formatServerValue(property.type, property.value);
+                property = { ...property };
+                for (const key of ["value", "default"]) {
+                    let value;
+                    if (property.type === "many2one") {
+                        value = property[key];
+                    } else if (
+                        (property.type === "date" || property.type === "datetime") &&
+                        typeof property[key] === "string"
+                    ) {
+                        // TO REMOVE: need refactoring PropertyField to use the same format as the server
+                        value = property[key];
+                    } else if (property[key] !== undefined) {
+                        value = this._formatServerValue(property.type, property[key]);
+                    }
+                    property[key] = value;
                 }
-                return {
-                    ...property,
-                    value,
-                };
+                return property;
             });
         }
         return value;

--- a/addons/web/static/src/model/relational_model/utils.js
+++ b/addons/web/static/src/model/relational_model/utils.js
@@ -519,6 +519,9 @@ export function parseServerValue(field, value) {
                       if (property.value !== undefined) {
                           property.value = parseServerValue(property, property.value ?? false);
                       }
+                      if (property.default !== undefined) {
+                          property.default = parseServerValue(property, property.default ?? false);
+                      }
                       return property;
                   })
                 : [];

--- a/addons/web/static/src/views/fields/many2one_avatar/many2one_avatar_field.xml
+++ b/addons/web/static/src/views/fields/many2one_avatar/many2one_avatar_field.xml
@@ -6,7 +6,7 @@
         <t t-set="value" t-value="props.record.data[props.name]"/>
         <div class="d-flex align-items-center gap-1">
             <span class="o_avatar o_m2o_avatar">
-                <t t-if="value !== false">
+                <t t-if="value">
                     <img class="rounded" t-attf-src="/web/image/{{relation}}/{{value.id}}/avatar_128"/>
                 </t>
                 <t t-elif="!props.readonly">


### PR DESCRIPTION
Bug
===
Create a many2one property with a default value, it will crash when saving. Since f79b2edb614fd08b19b18beeb16be38743f637b2 , the way many2one are represented in the client changed. We adapted the code for the property value, but not for the default value in the definition.

When adding a many2one property in a list view, if some values are falsy, then a traceback is raised.

Task-4865894