### PR TITLE
[FIX] point_of_sale: ensure only loading needed pta exclusion

### DIFF
--- a/addons/point_of_sale/models/product_attribute.py
+++ b/addons/point_of_sale/models/product_attribute.py
@@ -65,7 +65,8 @@ class ProductTemplateAttributeExclusion(models.Model):
     @api.model
     def _load_pos_data_domain(self, data):
         loaded_product_tmpl_ids = list({p['id'] for p in data['product.template']})
-        return [('product_tmpl_id', 'in', loaded_product_tmpl_ids), ('product_template_attribute_value_id.ptav_active', '=', True)]
+        loaded_ptav_ids = list({ptav['id'] for ptav in data['product.template.attribute.value']})
+        return [('product_tmpl_id', 'in', loaded_product_tmpl_ids), ('product_template_attribute_value_id', 'in', loaded_ptav_ids)]
 
     @api.model
     def _load_pos_data_fields(self, config_id):


### PR DESCRIPTION
Before this commit, if a product template attribute exclusion existed for a product template attribute value on a product not loaded in the PoS, but that exclusion was linked to a product is loaded into the PoS, it would unnecessarily load the exclusion, leading to errors.

opw-4875036

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
