### PR TITLE
[FIX] mail: handle error on uploading non-image file

### DIFF
--- a/addons/mail/models/discuss/discuss_channel.py
+++ b/addons/mail/models/discuss/discuss_channel.py
@@ -123,7 +123,7 @@ class Channel(models.Model):
     @api.depends('channel_type', 'image_128', 'uuid')
     def _compute_avatar_128(self):
         for record in self:
-            record.avatar_128 = record.image_128 or record._generate_avatar()
+            record.avatar_128 = record._origin.image_128 or record._generate_avatar()
 
     def _generate_avatar(self):
         if self.channel_type not in ('channel', 'group'):


### PR DESCRIPTION
Currently, an error is encountered on uploading non-image files(e.g .txt, .csv) rather than image file, in the discuss channel.

**Steps to reproduce:**
- Install Discuss module
- Navigate to Discuss channels.
- Create new Channel and upload [this](https://docs.google.com/spreadsheets/d/1k_s_V7Q-zA9uQUaQblsJtBHC4VlEFM-w/edit?usp=drive_link&ouid=101212513075316114369&rtpof=true&sd=true) file as group's profile image.

**Error:**
`ValueError: Compute method failed to assign discuss.channel(<NewId origin=4>,).avatar_128`

**Root Cause:**
On uploading a file compute method expects a `Id` and here we are receiving `temporary id` as `<NewId origin=4>`, on using this id at [1] raising an error.

[1]- https://github.com/odoo/odoo/blob/44a9831f125800743504a5cc55b395980ddc9ce7/addons/mail/models/discuss/discuss_channel.py#L126

**Solution:**
This commit handles error on uploading a corrupt image in the discuss channel.

Sentry- **6690968543**

