### PR TITLE
[FIX] point_of_sale: set default tax return journal in tests

### DIFF
--- a/addons/account/tests/common.py
+++ b/addons/account/tests/common.py
@@ -392,6 +392,12 @@ class AccountTestInvoicingCommon(ProductCommon):
             }),
             'default_tax_sale': company.account_sale_tax_id,
             'default_tax_purchase': company.account_purchase_tax_id,
+            'default_tax_return_journal': cls.env['account.journal'].create({
+                'name': 'Tax Return Journal',
+                'type': 'general',
+                'code': 'TXRET',
+                'company_id': company.id,
+            }),
         }
 
     @classmethod

--- a/addons/point_of_sale/tests/common.py
+++ b/addons/point_of_sale/tests/common.py
@@ -160,6 +160,7 @@ class TestPoSCommon(ValuationReconciliationTestCommon):
         })
 
         # Set basic defaults
+        cls.account_tax_return_journal = cls.company_data['default_tax_return_journal']
         cls.sales_account = cls.company_data['default_account_revenue']
         cls.invoice_journal = cls.company_data['default_journal_sale']
         cls.receivable_account = cls.company_data['default_account_receivable']

--- a/addons/point_of_sale/tests/test_res_config_settings.py
+++ b/addons/point_of_sale/tests/test_res_config_settings.py
@@ -48,6 +48,7 @@ class TestConfigureShops(TestPoSCommon):
             form.pos_config_id = pos_config1
             form.pos_is_header_or_footer = True
             form.pos_receipt_header = 'xxxxx'
+            form.account_tax_return_journal_id = self.account_tax_return_journal
 
         self.assertEqual(pos_config1.receipt_header, 'xxxxx')
         self.assertEqual(pos_config2.receipt_header, False)


### PR DESCRIPTION
The PoS test `test_should_not_affect_other_pos_config` was failing due to a missing required field `account_tax_return_journal_id` when using the res.config.settings form.

To resolve this, we now explicitly create a general journal in `collect_company_accounting_data()` and assign it to the company's `account_tax_return_journal_id` during test setup.

build_error-226813
