### PR TITLE
[IMP] bus, mail, survey: new master tab election mechanism

### DIFF
--- a/addons/bus/static/src/outdated_page_watcher_service.js
+++ b/addons/bus/static/src/outdated_page_watcher_service.js
@@ -35,7 +35,7 @@ export class OutdatedPageWatcherService {
             }
             wasBusAlreadyConnected = true;
         });
-        bus_service.addEventListener("reconnect", () => this.checkHasMissedNotifications());
+        bus_service.addEventListener("reconnect", async () => this.checkHasMissedNotifications());
         multi_tab.bus.addEventListener("shared_value_updated", ({ detail: { key } }) => {
             if (key === "bus.has_missed_notifications") {
                 this.showOutdatedPageNotification();
@@ -44,7 +44,7 @@ export class OutdatedPageWatcherService {
     }
 
     async checkHasMissedNotifications() {
-        if (!this.multi_tab.isOnMainTab() || !this.lastNotificationId) {
+        if (!(await this.multi_tab.isOnMainTab()) || !this.lastNotificationId) {
             return;
         }
         const hasMissedNotifications = await rpc(

--- a/addons/bus/static/tests/bus_service.test.js
+++ b/addons/bus/static/tests/bus_service.test.js
@@ -420,14 +420,13 @@ test("remove from main tab candidates when version is outdated", async () => {
         ["disconnect", () => asyncStep("disconnect")]
     );
     await makeMockEnv();
-    patchWithCleanup(getService("multi_tab"), { isOnMainTab: () => true });
     patchWithCleanup(console, { warn: (message) => asyncStep(message) });
     getService("multi_tab").bus.addEventListener("no_longer_main_tab", () =>
         asyncStep("no_longer_main_tab")
     );
     startBusService();
     await waitForSteps(["connect"]);
-    expect(getService("multi_tab").isOnMainTab()).toBe(true);
+    expect(await getService("multi_tab").isOnMainTab()).toBe(true);
     MockServer.env["bus.bus"]._simulateDisconnection(
         WEBSOCKET_CLOSE_CODES.CLEAN,
         "OUTDATED_VERSION"

--- a/addons/bus/static/tests/multi_tab_service.test.js
+++ b/addons/bus/static/tests/multi_tab_service.test.js
@@ -1,11 +1,5 @@
 import { describe, expect, test } from "@odoo/hoot";
-import {
-    asyncStep,
-    makeMockEnv,
-    patchWithCleanup,
-    restoreRegistry,
-    waitForSteps,
-} from "@web/../tests/web_test_helpers";
+import { makeMockEnv, patchWithCleanup, restoreRegistry } from "@web/../tests/web_test_helpers";
 import { browser } from "@web/core/browser/browser";
 import { registry } from "@web/core/registry";
 
@@ -13,7 +7,7 @@ describe.current.tags("desktop");
 
 test("multi tab service elects new main on pagehide", async () => {
     const firstTabEnv = await makeMockEnv();
-    expect(firstTabEnv.services.multi_tab.isOnMainTab()).toBe(true);
+    expect(await firstTabEnv.services.multi_tab.isOnMainTab()).toBe(true);
     // Prevent second tab from receiving pagehide event.
     patchWithCleanup(browser, {
         addEventListener(eventName, callback) {
@@ -24,21 +18,21 @@ test("multi tab service elects new main on pagehide", async () => {
     });
     restoreRegistry(registry);
     const secondTabEnv = await makeMockEnv(null, { makeNew: true });
-    expect(secondTabEnv.services.multi_tab.isOnMainTab()).toBe(false);
+    expect(await secondTabEnv.services.multi_tab.isOnMainTab()).toBe(false);
     firstTabEnv.services.multi_tab.bus.addEventListener("no_longer_main_tab", () =>
-        asyncStep("tab1 no_longer_main_tab")
+        expect.step("tab1 no_longer_main_tab")
     );
     secondTabEnv.services.multi_tab.bus.addEventListener("no_longer_main_tab", () =>
-        asyncStep("tab2 no_longer_main_tab")
+        expect.step("tab2 no_longer_main_tab")
     );
     secondTabEnv.services.multi_tab.bus.addEventListener("become_main_tab", () =>
-        asyncStep("tab2 become_main_tab")
+        expect.step("tab2 become_main_tab")
     );
     browser.dispatchEvent(new Event("pagehide"));
 
-    await waitForSteps(["tab1 no_longer_main_tab", "tab2 become_main_tab"]);
-    expect(firstTabEnv.services.multi_tab.isOnMainTab()).toBe(false);
-    expect(secondTabEnv.services.multi_tab.isOnMainTab()).toBe(true);
+    await expect.waitForSteps(["tab1 no_longer_main_tab", "tab2 become_main_tab"]);
+    expect(await firstTabEnv.services.multi_tab.isOnMainTab()).toBe(false);
+    expect(await secondTabEnv.services.multi_tab.isOnMainTab()).toBe(true);
 });
 
 test("multi tab allow to share values between tabs", async () => {
@@ -58,10 +52,10 @@ test("multi tab triggers shared_value_updated", async () => {
     restoreRegistry(registry);
     const secondTabEnv = await makeMockEnv(null, { makeNew: true });
     secondTabEnv.services.multi_tab.bus.addEventListener("shared_value_updated", ({ detail }) => {
-        asyncStep(`${detail.key} - ${JSON.parse(detail.newValue)}`);
+        expect.step(`${detail.key} - ${JSON.parse(detail.newValue)}`);
     });
     firstTabEnv.services.multi_tab.setSharedValue("foo", "bar");
     firstTabEnv.services.multi_tab.setSharedValue("foo", "foo");
     firstTabEnv.services.multi_tab.removeSharedValue("foo");
-    await waitForSteps(["foo - bar", "foo - foo", "foo - null"]);
+    await expect.waitForSteps(["foo - bar", "foo - foo", "foo - null"]);
 });

--- a/addons/mail/static/src/core/common/out_of_focus_service.js
+++ b/addons/mail/static/src/core/common/out_of_focus_service.js
@@ -54,7 +54,7 @@ export class OutOfFocusService {
         const notificationContent = message.previewText
             .toString()
             .substring(0, PREVIEW_MSG_MAX_SIZE);
-        this.sendNotification({
+        await this.sendNotification({
             message: notificationContent,
             sound: message.thread?.model === "discuss.channel",
             title: notificationTitle,
@@ -89,15 +89,15 @@ export class OutOfFocusService {
      * @param {string} [param0.icon] The icon to be displayed in the
      * notification.
      */
-    sendNotification({ message, sound = true, title, type, icon }) {
-        if (!this.canSendNativeNotification || !this.multiTab.isOnMainTab()) {
+    async sendNotification({ message, sound = true, title, type, icon }) {
+        if (!this.canSendNativeNotification || !(await this.multiTab.isOnMainTab())) {
             if (sound) {
                 this._playSound();
             }
             return;
         }
         try {
-            this.sendNativeNotification(title, message, icon, { sound });
+            await this.sendNativeNotification(title, message, icon, { sound });
         } catch (error) {
             // Notification without Serviceworker in Chrome Android doesn't works anymore
             // So we fallback to the notification service in this case
@@ -130,7 +130,7 @@ export class OutOfFocusService {
      * @param {string} title
      * @param {string} message
      */
-    sendNativeNotification(title, message, icon, { sound = true } = {}) {
+    async sendNativeNotification(title, message, icon, { sound = true } = {}) {
         const notification = new Notification(title, {
             body: message,
             icon,
@@ -144,8 +144,12 @@ export class OutOfFocusService {
         }
     }
 
-    _playSound() {
-        if (this.canPlayAudio && this.multiTab.isOnMainTab() && this.store.settings.messageSound) {
+    async _playSound() {
+        if (
+            this.canPlayAudio &&
+            this.store.settings.messageSound &&
+            (await this.multiTab.isOnMainTab())
+        ) {
             this.soundEffectService.play("new-message");
         }
     }

--- a/addons/mail/static/src/discuss/call/common/thread_model_patch.js
+++ b/addons/mail/static/src/discuss/call/common/thread_model_patch.js
@@ -52,7 +52,7 @@ const ThreadPatch = {
                 this.store.env.services["discuss.rtc"].deleteSession(r.id);
             },
             /** @this {import("models").Thread} */
-            onUpdate() {
+            async onUpdate() {
                 const hadSelfSession = this.hadSelfSession;
                 const lastSessionIds = this.lastSessionIds;
                 this.hadSelfSession = Boolean(this.store.rtc.selfSession?.in(this.rtc_session_ids));
@@ -60,7 +60,7 @@ const ThreadPatch = {
                 if (
                     !hadSelfSession || // sound for self-join is played instead
                     !this.hadSelfSession || // sound for self-leave is played instead
-                    !this.store.env.services["multi_tab"].isOnMainTab() // another tab playing sound
+                    !(await this.store.env.services["multi_tab"].isOnMainTab()) // another tab playing sound
                 ) {
                     return;
                 }

--- a/addons/mail/static/src/discuss/core/web/discuss_core_web_service.js
+++ b/addons/mail/static/src/discuss/core/web/discuss_core_web_service.js
@@ -27,7 +27,7 @@ export class DiscussCoreWeb {
                 { user: username }
             );
             this.notificationService.add(notification, { type: "info" });
-            if (!this.multiTab.isOnMainTab()) {
+            if (!(await this.multiTab.isOnMainTab())) {
                 return;
             }
             const chat = await this.store.getChat({ partnerId });

--- a/addons/survey/static/src/js/survey_form.js
+++ b/addons/survey/static/src/js/survey_form.js
@@ -1061,8 +1061,8 @@ publicWidget.registry.SurveyFormWidget = publicWidget.Widget.extend(SurveyPreloa
     *
     * @private
     */
-    _checkisOnMainTab: function () {
-        var isOnMainTab = this.call('multi_tab', 'isOnMainTab');
+    _checkisOnMainTab: async function () {
+        var isOnMainTab = await this.call('multi_tab', 'isOnMainTab');
         var $errorModal = this.$('#MasterTabErrorModal');
         if (isOnMainTab) {
             // Force reload the page when survey is ready to be followed, to force restart long polling


### PR DESCRIPTION
A new master tab election mechanism by sending messages between tabs using BroadcastChannel.

When electing a new master tab, each tab will broadcast its own uid. Every tab will compare all the uids it gets to elect the biggest one.

To prove the master tab is still alive, the master tab should broadcast heartbeat messages. Any tab that misses a heartbeat message will start a new election.

To shorten the waiting time for new tab to decide if there is a master, the new tab will broadcast a connect message, and if a master exist, it should send heartbeat immediately.

`isOnMainTab` is now async func. The function will give the result after a master tab is elected. This is to ensure the reliablity of the result.





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
