### PR TITLE
[FIX] l10n_es_edi_tbai_pos: default 'manual' origin

### DIFF
--- a/addons/l10n_es_edi_tbai_pos/models/pos_order.py
+++ b/addons/l10n_es_edi_tbai_pos/models/pos_order.py
@@ -165,7 +165,7 @@ class PosOrder(models.Model):
             'delivery_date': None,
             **self._l10n_es_tbai_get_attachment_values(),
             **self._l10n_es_tbai_get_credit_note_values(),
-            'invoice_origin': False,
+            'origin': 'manual',
             'taxes': self.lines.tax_ids,
             'rate': self.currency_rate,
             'base_lines': base_lines,


### PR DESCRIPTION
Before PR #187439, the field DescripcionFactura defaulted to `manual` when the origin was False.

That PR removed the fallback and moved the default assignment to `_l10n_es_tbai_get_invoice_values` in `l10n_es_edi_tbai` module, but forgot to apply the same logic in `_l10n_es_tbai_get_values`.

Steps to reproduce:
- Create a new TBAI POS order
- Try to submit it
- You’ll get an error:
```cvc-complex-type.2.4.a: Invalid content was found starting
with element 'DetallesFactura'. One of '{FechaOperacion,
DescripcionFactura}' is expected.
```

This fix restores the fallback value 'manual' for POS invoices
to ensure schema compliance.

opw-4834333