### PR TITLE
[FIX] im_livechat: use prettifyMessageContent for note

### DIFF
--- a/addons/im_livechat/static/src/core/web/livechat_channel_info_list.js
+++ b/addons/im_livechat/static/src/core/web/livechat_channel_info_list.js
@@ -1,10 +1,10 @@
 import { ActionPanel } from "@mail/discuss/core/common/action_panel";
+import { prettifyMessageContent } from "@mail/utils/common/format";
 
 import { Component } from "@odoo/owl";
 
 import { rpc } from "@web/core/network/rpc";
 import { useService } from "@web/core/utils/hooks";
-import { htmlEscape } from "@web/core/utils/html";
 
 export class LivechatChannelInfoList extends Component {
     static components = { ActionPanel };
@@ -17,9 +17,8 @@ export class LivechatChannelInfoList extends Component {
     }
 
     onBlurNote() {
-        rpc("/im_livechat/session/update_note", {
-            channel_id: this.props.thread.id,
-            note: htmlEscape(this.props.thread.livechatNoteText),
+        prettifyMessageContent(this.props.thread.livechatNoteText).then((note) => {
+            rpc("/im_livechat/session/update_note", { channel_id: this.props.thread.id, note });
         });
     }
 }


### PR DESCRIPTION
`htmlEscape` was used to escape html entities so they properly display as text.

However the intent here is going from text to HTML, which should fully convert the text to HTML, not just escape it.

`prettifyMessageContent` does a better job at this, in particular by also converting newlines to `<br>` tags, among other things.

There was no display issue when showing back the edited note in a textarea, as `\n` would be "restored" in that context, however if displaying the note anywhere else (as HTML) the new lines would be lost.