### PR TITLE
[IMP] mail: replace anchors with buttons in edit-composer

### DIFF
--- a/addons/mail/static/src/core/common/composer.js
+++ b/addons/mail/static/src/core/common/composer.js
@@ -29,9 +29,9 @@ import {
 
 import { _t } from "@web/core/l10n/translation";
 import { useService } from "@web/core/utils/hooks";
-import { createElementWithContent } from "@web/core/utils/html";
+import { createElementWithContent, htmlJoin } from "@web/core/utils/html";
 import { FileUploader } from "@web/views/fields/file_handler";
-import { escape, isEmail } from "@web/core/utils/strings";
+import { isEmail } from "@web/core/utils/strings";
 import { isDisplayStandalone, isIOS, isMobileOS } from "@web/core/browser/feature_detection";
 import { Dropdown } from "@web/core/dropdown/dropdown";
 import { DropdownItem } from "@web/core/dropdown/dropdown_item";
@@ -93,8 +93,9 @@ export class Composer extends Component {
         this.isIosPwa = isIOS() && isDisplayStandalone();
         this.composerActions = useComposerActions();
         this.OR_PRESS_SEND_KEYBIND = _t("or press %(send_keybind)s", {
-            send_keybind: markup(
-                this.sendKeybinds.map((key) => `<samp>${escape(key)}</samp>`).join(" + ")
+            send_keybind: htmlJoin(
+                this.sendKeybinds.map((key) => markup`<samp>${key}</samp>`),
+                " + "
             ),
         });
         this.store = useService("mail.store");
@@ -227,7 +228,7 @@ export class Composer extends Component {
             if (this.thread.channel_type === "channel") {
                 const threadName = this.thread.displayName;
                 if (this.thread.parent_channel_id) {
-                    return _t(`Message "%(subChannelName)s"`, {
+                    return _t('Message "%(subChannelName)s"', {
                         subChannelName: threadName,
                     });
                 }
@@ -243,7 +244,6 @@ export class Composer extends Component {
     }
 
     onClickCancelOrSaveEditText(ev) {
-        ev.preventDefault();
         const composer = toRaw(this.props.composer);
         if (composer.message && ev.target.dataset?.type === EDIT_CLICK_TYPE.CANCEL) {
             this.props.onDiscardCallback(ev);
@@ -258,35 +258,23 @@ export class Composer extends Component {
             return _t(
                 "%(open_button)s%(icon)s%(open_em)sDiscard editing%(close_em)s%(close_button)s",
                 {
-                    open_button: markup(
-                        `<button class='btn px-1 py-0' data-type="${escape(
-                            EDIT_CLICK_TYPE.CANCEL
-                        )}">`
-                    ),
-                    close_button: markup("</button>"),
-                    icon: markup(
-                        `<i class='fa fa-times-circle pe-1' data-type="${escape(
-                            EDIT_CLICK_TYPE.CANCEL
-                        )}"></i>`
-                    ),
-                    open_em: markup(`<em data-type="${escape(EDIT_CLICK_TYPE.CANCEL)}">`),
-                    close_em: markup("</em>"),
+                    open_button: markup`<button class='btn px-1 py-0' data-type="${EDIT_CLICK_TYPE.CANCEL}">`,
+                    close_button: markup`</button>`,
+                    icon: markup`<i class='fa fa-times-circle pe-1' data-type="${EDIT_CLICK_TYPE.CANCEL}"></i>`,
+                    open_em: markup`<em data-type="${EDIT_CLICK_TYPE.CANCEL}">`,
+                    close_em: markup`</em>`,
                 }
             );
         } else {
             const tags = {
-                open_samp: markup("<samp>"),
-                close_samp: markup("</samp>"),
-                open_em: markup("<em>"),
-                close_em: markup("</em>"),
-                open_cancel: markup(
-                    `<a role="button" href="#" data-type="${escape(EDIT_CLICK_TYPE.CANCEL)}">`
-                ),
-                close_cancel: markup("</a>"),
-                open_save: markup(
-                    `<a role="button" href="#" data-type="${escape(EDIT_CLICK_TYPE.SAVE)}">`
-                ),
-                close_save: markup("</a>"),
+                open_samp: markup`<samp>`,
+                close_samp: markup`</samp>`,
+                open_em: markup`<em>`,
+                close_em: markup`</em>`,
+                open_cancel: markup`<button class="btn btn-link fst-italic p-0 align-baseline" data-type="${EDIT_CLICK_TYPE.CANCEL}">`,
+                close_cancel: markup`</button>`,
+                open_save: markup`<button class="btn btn-link fst-italic p-0 align-baseline" data-type="${EDIT_CLICK_TYPE.SAVE}">`,
+                close_save: markup`</button>`,
             };
             return this.env.inChatter
                 ? _t(

--- a/addons/mail/static/tests/message/message.test.js
+++ b/addons/mail/static/tests/message/message.test.js
@@ -54,7 +54,7 @@ test("Start edition on click edit", async () => {
     await openDiscuss(channelId);
     await click(".o-mail-Message [title='Edit']");
     await contains(".o-mail-Message .o-mail-Composer-input", { value: "Hello world" });
-    await click("a[role='button']", { text: "cancel" });
+    await click("button", { text: "cancel" });
     await contains(".o-mail-Message .o-mail-Composer-input", { count: 0 });
 });
 
@@ -168,7 +168,7 @@ test("Editing message keeps the mentioned channels", async () => {
     await click(".o-mail-Message [title='Edit']");
     await contains(".o-mail-Message .o-mail-Composer-input", { value: "#other" });
     await insertText(".o-mail-Message .o-mail-Composer-input", "#other bye", { replace: true });
-    await click(".o-mail-Message a", { text: "save" });
+    await click(".o-mail-Message button", { text: "save" });
     await contains(".o-mail-Message-content", { text: "other bye (edited)" });
     await click(".o_channel_redirect", { text: "other" });
     await contains(".o-mail-Discuss-threadName", { value: "other" });
@@ -188,7 +188,7 @@ test("Can edit message comment in chatter", async () => {
     await openFormView("res.partner", partnerId);
     await click(".o-mail-Message [title='Edit']");
     await insertText(".o-mail-Message .o-mail-Composer-input", "edited message", { replace: true });
-    await click(".o-mail-Message a", { text: "save" });
+    await click(".o-mail-Message button", { text: "save" });
     await contains(".o-mail-Message-content", { text: "edited message (edited)" });
     await click(".o-mail-Message [title='Edit']");
     await contains(".o-mail-Message:contains('Escape to cancel, CTRL-Enter to save')");
@@ -264,7 +264,7 @@ test("Stop edition on click cancel", async () => {
     await start();
     await openDiscuss(channelId);
     await click(".o-mail-Message [title='Edit']");
-    await click(".o-mail-Message a", { text: "cancel" });
+    await click(".o-mail-Message button", { text: "cancel" });
     await contains(".o-mail-Message.o-editing .o-mail-Composer", { count: 0 });
 });
 
@@ -304,7 +304,7 @@ test("Stop edition on click save", async () => {
     await start();
     await openDiscuss(channelId);
     await click(".o-mail-Message [title='Edit']");
-    await click(".o-mail-Message a", { text: "save" });
+    await click(".o-mail-Message button", { text: "save" });
     await contains(".o-mail-Message.o-editing .o-mail-Composer", { count: 0 });
 });
 
@@ -366,7 +366,7 @@ test("Edit and click save", async () => {
     await openDiscuss(channelId);
     await click(".o-mail-Message [title='Edit']");
     await insertText(".o-mail-Message .o-mail-Composer-input", "Goodbye World", { replace: true });
-    await click(".o-mail-Message a", { text: "save" });
+    await click(".o-mail-Message button", { text: "save" });
     await contains(".o-mail-Message-body", { text: "Goodbye World (edited)" });
 });
 
@@ -387,7 +387,7 @@ test("Do not call server on save if no changes", async () => {
     await start();
     await openDiscuss(channelId);
     await click(".o-mail-Message [title='Edit']");
-    await click(".o-mail-Message a", { text: "save" });
+    await click(".o-mail-Message button", { text: "save" });
     await waitForSteps([]);
 });
 
@@ -411,7 +411,7 @@ test("Update the link previews when a message is edited", async () => {
     await insertText(".o-mail-Message .o-mail-Composer-input", "http://odoo.com", {
         replace: true,
     });
-    await click(".o-mail-Message a", { text: "save" });
+    await click(".o-mail-Message button", { text: "save" });
     await contains(".o-mail-Message-body", { text: "http://odoo.com" });
     await waitForSteps(["link_preview"]);
 });
@@ -458,7 +458,7 @@ test("mentions are kept when editing message", async () => {
     await insertText(".o-mail-Message .o-mail-Composer-input", "Hi @Mitchell Admin", {
         replace: true,
     });
-    await click(".o-mail-Message a", { text: "save" });
+    await click(".o-mail-Message button", { text: "save" });
     await contains(".o-mail-Message", {
         text: "Hi @Mitchell Admin (edited)",
         contains: ["a.o_mail_redirect", { text: "@Mitchell Admin" }],
@@ -493,7 +493,7 @@ test("can add new mentions when editing message", async () => {
     await insertText(".o-mail-Message .o-mail-Composer-input", " @");
     await click(".o-mail-Composer-suggestion strong", { text: "TestPartner" });
     await contains(".o-mail-Composer-input", { value: "Hello @TestPartner " });
-    await click(".o-mail-Message a", { text: "save" });
+    await click(".o-mail-Message button", { text: "save" });
     await contains(".o-mail-Message", {
         text: "Hello @TestPartner (edited)",
         contains: ["a.o_mail_redirect", { text: "@TestPartner" }],
@@ -607,7 +607,7 @@ test("Can open emoji picker after edit mode", async () => {
     await start();
     await openDiscuss(channelId);
     await click(".o-mail-Message [title='Edit']");
-    await click(".o-mail-Message a", { text: "save" });
+    await click(".o-mail-Message button", { text: "save" });
     await contains(".o-mail-Message", { text: "Hello world" });
     await click("[title='Add a Reaction']");
     await click(".o-mail-QuickReactionMenu [title='Toggle Emoji Picker']");

--- a/addons/mail/static/tests/tours/discuss_channel_public_tour.js
+++ b/addons/mail/static/tests/tours/discuss_channel_public_tour.js
@@ -170,7 +170,7 @@ registry.category("web_tour.tours").add("discuss_channel_public_tour.js", {
         },
         {
             content: "Save edited message",
-            trigger: ".o-mail-Message a:contains(save)",
+            trigger: ".o-mail-Message button:contains(save)",
             run: "click",
         },
         {

--- a/addons/website_slides/static/tests/tours/slides_course_reviews_comment.js
+++ b/addons/website_slides/static/tests/tours/slides_course_reviews_comment.js
@@ -38,7 +38,7 @@ registry.category("web_tour.tours").add("course_reviews_comment", {
         },
         // Send the comment
         {
-            trigger: "#chatterRoot:shadow .o-mail-Message a:contains('save')",
+            trigger: "#chatterRoot:shadow .o-mail-Message button:contains('save')",
             run: "click",
         },
         {


### PR DESCRIPTION
**Current behavior before PR:**

"Cancel" and "Save" actions in the edit-composer were implemented using `<a>` elements, which is semantically incorrect for button-like behavior.

**Desired behavior after PR is merged:**

These actions are now rendered as `<button>` elements, improving semantic correctness.

**task**-[4826935](https://www.odoo.com/odoo/my-tasks/4826935)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
