### PR TITLE
[FIX] html_editor: traceback post removing captions

### DIFF
--- a/addons/html_editor/static/src/others/embedded_components/backend/caption/caption.js
+++ b/addons/html_editor/static/src/others/embedded_components/backend/caption/caption.js
@@ -3,7 +3,7 @@ import {
     getEmbeddedProps,
     StateChangeManager,
 } from "@html_editor/others/embedded_component_utils";
-import { Component, useState, useRef, onMounted } from "@odoo/owl";
+import { Component, useState, useRef, onMounted, onWillDestroy } from "@odoo/owl";
 
 export class EmbeddedCaptionComponent extends Component {
     static template = "html_editor.EmbeddedCaption";
@@ -30,18 +30,17 @@ export class EmbeddedCaptionComponent extends Component {
         }
         // Ensure the state, the attribute and the placeholder are in sync.
         this.updateCaption();
-        this.observer = new MutationObserver((mutations) => {
+        const observer = new MutationObserver((mutations) => {
             for (const mutation of mutations) {
                 if (mutation.type === "attributes" && mutation.attributeName === "data-caption") {
                     this.updateCaption();
                 }
             }
         });
-        this.observer.observe(this.props.image, { attributes: true });
-    }
-
-    destroy() {
-        this.observer.disconnect();
+        observer.observe(this.props.image, { attributes: true });
+        onWillDestroy(() => {
+            observer.disconnect();
+        });
     }
 
     updateCaption(caption = this.props.image.getAttribute("data-caption")) {

--- a/addons/html_editor/static/src/others/embedded_components/plugins/caption_plugin/caption_plugin.js
+++ b/addons/html_editor/static/src/others/embedded_components/plugins/caption_plugin/caption_plugin.js
@@ -4,7 +4,7 @@ import { closestBlock } from "@html_editor/utils/blocks";
 import { renderToElement } from "@web/core/utils/render";
 import { fillEmpty, unwrapContents } from "@html_editor/utils/dom";
 import { closestElement } from "@html_editor/utils/dom_traversal";
-import { EDITABLE_MEDIA_CLASS } from "@html_editor/utils/dom_info";
+import { EDITABLE_MEDIA_CLASS, isShrunkBlock } from "@html_editor/utils/dom_info";
 import { boundariesOut, rightPos } from "@html_editor/utils/position";
 import { findInSelection } from "@html_editor/utils/selection";
 import { isHtmlContentSupported } from "@html_editor/core/selection_plugin";
@@ -141,11 +141,15 @@ export class CaptionPlugin extends Plugin {
             const baseContainer = this.dependencies.baseContainer.createBaseContainer();
             block.before(baseContainer);
             fillEmpty(baseContainer);
+        } else if (isShrunkBlock(block.previousSibling)) {
+            fillEmpty(block.previousSibling);
         }
         if (!block.nextSibling) {
             const baseContainer = this.dependencies.baseContainer.createBaseContainer();
             block.after(baseContainer);
             fillEmpty(baseContainer);
+        } else if (isShrunkBlock(block.nextSibling)) {
+            fillEmpty(block.nextSibling);
         }
         // Add the caption component.
         // => <p><figure><img/><figcaption>...</figcaption></figure></p>

--- a/addons/html_editor/static/src/others/embedded_components/plugins/caption_plugin/caption_plugin.js
+++ b/addons/html_editor/static/src/others/embedded_components/plugins/caption_plugin/caption_plugin.js
@@ -250,11 +250,11 @@ export class CaptionPlugin extends Plugin {
     onImageReplaced(media) {
         const figure = closestElement(media, "figure");
         if (media.nodeName === "IMG" && figure) {
-            const caption = figure.querySelector("[data-embedded='caption'] input")?.value;
-            if (caption) {
-                media.setAttribute("data-caption", caption);
-            }
             const [anchorNode, anchorOffset] = rightPos(figure);
+            const caption = figure.querySelector("[data-embedded='caption'] input")?.value;
+            figure.before(media);
+            figure.remove();
+            this.addImageCaption(media, caption, false);
             this.dependencies.selection.setSelection({ anchorNode, anchorOffset });
         }
     }


### PR DESCRIPTION
**Current behavior before PR:**

- Replacing an image that has a caption, then editing the caption and clicking outside it, would result in a traceback.
- When a caption was added to an image, the previous sibling block of the image became empty. As a result, the tooltip of that   empty block could appear hovering above the image.

**Desired behavior after PR is merged:**

- A traceback no longer occurs when the image is replaced and the caption is edited before clicking outside.
- If the previous sibling block is found to be empty when a caption is added, a `<br>` element is inserted into it. This ensures the block is no longer considered empty, preventing the tooltip from appearing above the image.

task: 4876199
