### PR TITLE
[FIX] project: remove unwanted fields from domain

### DIFF
--- a/addons/project/static/src/views/project_task_analysis_renderer_mixin.js
+++ b/addons/project/static/src/views/project_task_analysis_renderer_mixin.js
@@ -1,8 +1,18 @@
+import { Domain } from "@web/core/domain";
+
 export const ProjectTaskAnalysisRendererMixin = (T) => class ProjectTaskAnalysisRendererMixin extends T {
     openView(domain, views, context) {
+        for (const leaf of domain) {
+            if (Array.isArray(leaf) && leaf[0] === "task_id") {
+                leaf[0] = "id";
+            }
+        }
+        const fieldsNotInBaseModel = ["nbr", "rating_last_value", "rating_avg", "delay_endings_days"];
+        const newDomain = Domain.removeDomainLeaves(domain, fieldsNotInBaseModel).toList();
+
         this.actionService.doAction({
             context,
-            domain,
+            domain: newDomain,
             name: "Tasks",
             res_model: "project.task",
             target: "current",

--- a/addons/project/static/tests/project_task_analysis.test.js
+++ b/addons/project/static/tests/project_task_analysis.test.js
@@ -19,6 +19,8 @@ describe.current.tags("desktop");
 class ReportProjectTaskUser extends models.Model {
     _name = "report.project.task.user";
     project_id = fields.Many2one({ relation: "project.project" });
+    task_id = fields.Many2one({ relation: "project.task" });
+    nbr = fields.Integer({ string: "# of Tasks" });
 
     _records = [
         { id: 4, project_id: 1 },
@@ -47,7 +49,7 @@ projectModels.ProjectTask._views = {
 defineProjectModels();
 setupChartJsForTests();
 
-async function mountView(viewName) {
+async function mountView(viewName, ctx = {}) {
     const view = await mountWithCleanup(WebClient);
     await getService("action").doAction({
         id: 1,
@@ -55,6 +57,7 @@ async function mountView(viewName) {
         res_model: "report.project.task.user",
         type: "ir.actions.act_window",
         views: [[false, viewName]],
+        context: ctx,
     });
     return view;
 }
@@ -97,4 +100,34 @@ test("report.project.task.user (pivot): clicking on a cell leads to project.task
     });
     // The model of the list view that is opened consequently should be "project.task"
     expect.verifySteps(["report.project.task.user", "project.task"]);
+});
+
+test("report.project.task.user: fix the domain, in case field is not present in main model", async () => {
+    mockService("action", {
+        doAction({ domain, res_model }) {
+            if (res_model === "project.task") {
+                expect(domain).toEqual(["&", [1, "=", 1], ["id", "=", 1]]);
+            }
+            return super.doAction(...arguments);
+        },
+    });
+
+    ReportProjectTaskUser._records = [
+        { id: 1, nbr: 1, task_id: 1 },
+        { id: 2, nbr: 1, task_id: 2 },
+    ];
+    ReportProjectTaskUser._views = {
+        graph: /* xml */ `
+            <graph string="Tasks Analysis" sample="1" js_class="project_task_analysis_graph">
+                <field name="task_id"/>
+                <field name="nbr"/>
+            </graph>
+        `
+    };
+
+    const view = await mountView("graph", { group_by: ["task_id", "nbr"] });
+    await animationFrame();
+    await clickOnDataset(view);
+    await animationFrame();
+    expect(`.o_list_renderer .o_data_row`).toHaveCount(1);
 });


### PR DESCRIPTION
Step to reproduce
- Go to Project
- Go to Reporting > Task Analysis
- Group by Tasks (not Task)
- Click on any of the blue bars

Issue:
since odoo/odoo@c36ad1896 we now allow user to drill down to base model from report view, this causes issue when a field which is present in report model but not in base/main model.
For now we directly pass the domain created for report view to base model.

FIx:
we only open the view, when the such fields are not present in domain

opw-4798353

related : https://github.com/odoo/enterprise/pull/88356

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
