### PR TITLE
[FIX] point_of_sale: prevent traceback after completing online payment

### DIFF
--- a/addons/pos_self_order/models/pos_session.py
+++ b/addons/pos_self_order/models/pos_session.py
@@ -18,6 +18,8 @@ class PosSession(models.Model):
         return [('config_id', '=', data['pos.config'][0]['id']), ('state', '=', 'opened')]
 
     def _post_read_pos_data(self, data):
+        if not data:
+            return data
         data[0]['_self_ordering'] = (
             self.env["pos.config"]
             .sudo()


### PR DESCRIPTION
Currently, an error occurs when attempting to make an online payment.

Steps to reproduce:
---
- Install the `pos_restaurant` module.
- Activate Demo Payment and create an Online payment
- In POS Settings, Enable `QR menu + Ordering` and add Online Payment
- Create an order and make an Online payment

Error:
---
`IndexError: list index out of range`

This commit resolves the issue by ensuring an empty list is returned when no data is present.

sentry-6542024953


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
