### PR TITLE
[FIX] mass_mailing: fix link tracker external call

### DIFF
--- a/addons/link_tracker/tests/test_tracker_http_requests.py
+++ b/addons/link_tracker/tests/test_tracker_http_requests.py
@@ -21,7 +21,8 @@ class TestTrackerHttpRequests(MockLinkTracker, common.HttpCase):
             link,
             headers={
                 'User-Agent': 'Mozilla/5.0 MicrosoftPreview/2.0 +https://aka.ms/MicrosoftPreview',
-            }
+            },
+            allow_redirects=False,
         )
         self.assertEqual(len(link_tracker.link_click_ids), 0)
 
@@ -30,7 +31,8 @@ class TestTrackerHttpRequests(MockLinkTracker, common.HttpCase):
             link,
             headers={
                 'User-Agent': 'Mozilla/5.0 Google-PageRenderer Google (+https://developers.google.com/+/web/snippet/)'
-            }
+            },
+            allow_redirects=False,
         )
         self.assertEqual(len(link_tracker.link_click_ids), 0)
 
@@ -39,6 +41,7 @@ class TestTrackerHttpRequests(MockLinkTracker, common.HttpCase):
             link,
             headers={
                 'User-Agent': 'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:126.0) Gecko/20100101 Firefox/126.0'
-            }
+            },
+            allow_redirects=False,
         )
         self.assertEqual(len(link_tracker.link_click_ids), 1)

--- a/addons/mass_mailing/tests/test_mailing_controllers.py
+++ b/addons/mass_mailing/tests/test_mailing_controllers.py
@@ -58,7 +58,8 @@ class TestMailingControllers(MassMailCommon, HttpCase):
             f'r/{link_tracker_code.code}/m/{mailing_trace.id}'
         )
         with freeze_time(self._reference_now):
-            _response = self.url_open(short_link_url)
+            response = self.url_open(short_link_url, allow_redirects=False)
+            self.assertEqual(response.headers['Location'], 'https://www.example.com/foo/bar?baz=qux&utm_source=TestMailing&utm_medium=Email')
 
         self.assertEqual(link_tracker_code.link_id.count, 1)
         self.assertEqual(mailing_trace.links_click_datetime, self._reference_now)


### PR DESCRIPTION
Calling external resources can lead to random failures in tests

test_tracking_short_code calls a tracked url to check the side effect of this call, but we actually don't need to follow the redirect.

Fixes the test by not following the 301 and checking the target instead.

