### PR TITLE
[IMP] mail,im_livechat: tests for info list

### DIFF
--- a/addons/im_livechat/static/tests/livechat_channel_info_list.test.js
+++ b/addons/im_livechat/static/tests/livechat_channel_info_list.test.js
@@ -1,0 +1,71 @@
+import { insertText, openDiscuss, start, startServer } from "@mail/../tests/mail_test_helpers";
+import { describe, test } from "@odoo/hoot";
+import { Command, serverState } from "@web/../tests/web_test_helpers";
+import { defineLivechatModels } from "@im_livechat/../tests/livechat_test_helpers";
+import { waitFor } from "@odoo/hoot-dom";
+
+describe.current.tags("desktop");
+defineLivechatModels();
+
+test("livechat note is loaded when opening the channel info list", async () => {
+    const pyEnv = await startServer();
+    const userId = pyEnv["res.users"].create({ name: "James" });
+    pyEnv["res.partner"].create({
+        name: "James",
+        user_ids: [userId],
+    });
+    const countryId = pyEnv["res.country"].create({ code: "be", name: "Belgium" });
+    const guestId = pyEnv["mail.guest"].create({
+        name: "Visitor #20",
+    });
+    const channelId = pyEnv["discuss.channel"].create({
+        anonymous_name: "Visitor #20",
+        channel_member_ids: [
+            Command.create({ partner_id: serverState.partnerId }),
+            Command.create({ guest_id: guestId }),
+        ],
+        country_id: countryId,
+        channel_type: "livechat",
+        livechat_operator_id: serverState.partnerId,
+        livechat_note: "<p>Initial note<br/>Second line</p>",
+    });
+    await start();
+    await openDiscuss(channelId);
+    await waitFor(".o-livechat-ChannelInfoList textarea:value('Initial note\nSecond line')");
+});
+
+test("editing livechat note is synced between tabs", async () => {
+    const pyEnv = await startServer();
+    const userId = pyEnv["res.users"].create({ name: "James" });
+    pyEnv["res.partner"].create({
+        name: "James",
+        user_ids: [userId],
+    });
+    const countryId = pyEnv["res.country"].create({ code: "be", name: "Belgium" });
+    const guestId = pyEnv["mail.guest"].create({
+        name: "Visitor #20",
+    });
+    const channelId = pyEnv["discuss.channel"].create({
+        anonymous_name: "Visitor #20",
+        channel_member_ids: [
+            Command.create({ partner_id: serverState.partnerId }),
+            Command.create({ guest_id: guestId }),
+        ],
+        country_id: countryId,
+        channel_type: "livechat",
+        livechat_operator_id: serverState.partnerId,
+        livechat_note: "<p>Initial note</p>",
+    });
+    const tab1 = await start({ asTab: true });
+    const tab2 = await start({ asTab: true });
+    await openDiscuss(channelId, { target: tab1 });
+    await openDiscuss(channelId, { target: tab2 });
+    await waitFor(".o-livechat-ChannelInfoList textarea:value('Initial note')", { target: tab1 });
+    await waitFor(".o-livechat-ChannelInfoList textarea:value('Initial note')", { target: tab2 });
+    await insertText(".o-livechat-ChannelInfoList textarea", "Updated note", {
+        target: tab1,
+        replace: true,
+    });
+    await document.querySelector(".o-livechat-ChannelInfoList textarea").blur(); // Trigger the blur event to save the note
+    await waitFor(".o-livechat-ChannelInfoList textarea:value('Updated note')", { target: tab1 }); // Note should be synced with bus
+});

--- a/addons/im_livechat/static/tests/mock_server/livechat_mock_server.js
+++ b/addons/im_livechat/static/tests/mock_server/livechat_mock_server.js
@@ -162,6 +162,25 @@ async function get_emoji_bundle(request) {
     return new Response();
 }
 
+registerRoute("/im_livechat/session/update_note", session_update_note);
+/** @type {RouteCallback} */
+async function session_update_note(request) {
+    /** @type {import("mock_models").DiscussChannel} */
+    const DiscussChannel = this.env["discuss.channel"];
+    const { channel_id, note } = await parseRequestParams(request);
+    if (this.env.user.share) {
+        return false;
+    }
+    const [channel] = DiscussChannel.search_read([["id", "=", channel_id]]);
+    if (!channel) {
+        return false;
+    }
+    DiscussChannel.write([channel_id], {
+        livechat_note: note,
+    });
+    return true;
+}
+
 patch(mailDataHelpers, {
     _process_request_for_internal_user(store, name, params) {
         super._process_request_for_internal_user(...arguments);

--- a/addons/im_livechat/static/tests/mock_server/mock_models/discuss_channel.js
+++ b/addons/im_livechat/static/tests/mock_server/mock_models/discuss_channel.js
@@ -7,6 +7,7 @@ import { ensureArray } from "@web/core/utils/arrays";
 
 export class DiscussChannel extends mailModels.DiscussChannel {
     livechat_channel_id = fields.Many2one({ relation: "im_livechat.channel", string: "Channel" }); // FIXME: somehow not fetched properly
+    livechat_note = fields.Html({ sanitize: true });
 
     action_unfollow(idOrIds) {
         /** @type {import("mock_models").BusBus} */
@@ -28,6 +29,11 @@ export class DiscussChannel extends mailModels.DiscussChannel {
         }
         return super.action_unfollow(...arguments);
     }
+
+    _channel_basic_info_fields() {
+        return super._channel_basic_info_fields().concat(["livechat_note"]);
+    }
+
     /**
      * @override
      * @type {typeof mailModels.DiscussChannel["prototype"]["_to_store"]}
@@ -64,6 +70,7 @@ export class DiscussChannel extends mailModels.DiscussChannel {
                     channelInfo.livechat_operator_id = false;
                 }
                 channelInfo["livechat_end_dt"] = channel.livechat_end_dt;
+                channelInfo["livechat_note"] = ["markup", channel.livechat_note];
                 channelInfo.livechat_channel_id = mailDataHelpers.Store.one(
                     this.env["im_livechat.channel"].browse(channel.livechat_channel_id),
                     makeKwArgs({ fields: ["name"] })

--- a/addons/im_livechat/tests/test_discuss_channel.py
+++ b/addons/im_livechat/tests/test_discuss_channel.py
@@ -1,9 +1,10 @@
 from odoo.tests import new_test_user, tagged
 from odoo.addons.im_livechat.tests.common import TestImLivechatCommon
+from odoo.addons.mail.tests.common import MailCase
 
 
 @tagged("-at_install", "post_install")
-class TestDiscussChannel(TestImLivechatCommon):
+class TestDiscussChannel(TestImLivechatCommon, MailCase):
     def test_unfollow_from_non_member_does_not_close_livechat(self):
         bob_user = new_test_user(
             self.env, "bob_user", groups="base.group_user,im_livechat.im_livechat_group_manager"
@@ -76,3 +77,34 @@ class TestDiscussChannel(TestImLivechatCommon):
             subtype_xmlid="mail.mt_comment",
         )
         self.assertEqual(chat.livechat_failure, "no_failure")
+
+    def test_livechat_note_sync_to_internal_user_bus(self):
+        """Test that a livechat note is sent to the internal user bus."""
+        data = self.make_jsonrpc_request(
+            "/im_livechat/get_session",
+            {
+                "channel_id": self.livechat_channel.id,
+                "anonymous_name": "Visitor",
+            },
+        )
+        channel = self.env["discuss.channel"].browse(data["channel_id"])
+        with self.assertBus(
+            [(self.cr.dbname, "discuss.channel", channel.id, "internal_users")],
+            [
+                {
+                    "type": "mail.record/insert",
+                    "payload": {
+                        "discuss.channel": [
+                            {
+                                "id": channel.id,
+                                "livechat_note": [
+                                    "markup",
+                                    "<p>This is a note for the internal user.</p>",
+                                ],
+                            }
+                        ]
+                    },
+                }
+            ],
+        ):
+            channel.livechat_note = "This is a note for the internal user."

--- a/addons/mail/static/tests/mock_server/mock_models/discuss_channel.js
+++ b/addons/mail/static/tests/mock_server/mock_models/discuss_channel.js
@@ -222,6 +222,20 @@ export class DiscussChannel extends models.ServerModel {
         return DiscussChannel.browse(id);
     }
 
+    _channel_basic_info_fields() {
+        return [
+            "avatar_cache_key",
+            "channel_type",
+            "create_uid",
+            "default_display_mode",
+            "description",
+            "group_public_id",
+            "last_interest_dt",
+            "name",
+            "uuid",
+        ];
+    }
+
     /** @param {number[]} ids */
     _channel_basic_info(ids) {
         const kwargs = getKwArgs(arguments, "ids");
@@ -231,21 +245,7 @@ export class DiscussChannel extends models.ServerModel {
         /** @type {import("mock_models").DiscussChannelMember} */
         const DiscussChannelMember = this.env["discuss.channel.member"];
 
-        const [data] = this._read_format(
-            ids,
-            [
-                "avatar_cache_key", // mock server simplification
-                "channel_type",
-                "create_uid",
-                "default_display_mode",
-                "description",
-                "group_public_id",
-                "last_interest_dt",
-                "name",
-                "uuid",
-            ],
-            false
-        );
+        const [data] = this._read_format(ids, this._channel_basic_info_fields(), false);
         const [channel] = this.browse(ids);
         const memberOfCurrentUser = this._find_or_create_member_for_self(channel.id);
         Object.assign(data, {


### PR DESCRIPTION
Adding tests for the info list in the livechat channel info panel.

followup to https://github.com/odoo/odoo/pull/215014

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
