### PR TITLE
[IMP] website_sale: adapt and re-enable tours

### DIFF
--- a/addons/website_sale/static/tests/tours/website_sale_remove_product_image.js
+++ b/addons/website_sale/static/tests/tours/website_sale_remove_product_image.js
@@ -60,7 +60,7 @@ registerWebsitePreviewTour("add_and_remove_main_product_image_no_variant", {
     },
     {
         content: "Check that the snippet editor of the clicked image has been loaded",
-        trigger: "we-customizeblock-options:has(we-title:contains('Re-order'))",
+        trigger: ".o_customize_tab [data-container-title='Image']",
     },
     ...removeImg,
 ]);

--- a/addons/website_sale/tests/test_website_sale_image.py
+++ b/addons/website_sale/tests/test_website_sale_image.py
@@ -8,8 +8,6 @@ from PIL import Image
 from odoo.fields import Command
 from odoo.tests import HttpCase, tagged
 from odoo.addons.website.tests.common import HttpCaseWithWebsiteUser
-import unittest
-
 
 @tagged('post_install', '-at_install')
 class TestWebsiteSaleImage(HttpCaseWithWebsiteUser):
@@ -388,8 +386,6 @@ class TestWebsiteSaleRemoveImage(HttpCase):
             'image_1920': blue_image,
         })
 
-    # TODO master-mysterious-egg fix error
-    @unittest.skip("prepare mysterious-egg for merging")
     def test_website_sale_add_and_remove_main_product_image_no_variant(self):
         self.product = self.env['product.product'].create({
             'product_tmpl_id': self.template.id,


### PR DESCRIPTION
The `add_and_remove_main_product_image_no_variant` tour was previously broken due to DOM structure changes introduced by the new website builder and was consequently disabled.

This PR updates the tour steps to align with the new DOM and re-enables the associated test.