### PR TITLE
[IMP] spreadsheet: add selection filters

### DIFF
--- a/addons/spreadsheet/static/src/@types/global_filter.d.ts
+++ b/addons/spreadsheet/static/src/@types/global_filter.d.ts
@@ -74,6 +74,15 @@ declare module "@spreadsheet" {
         defaultValue?: string[];
     }
 
+    export interface SelectionGlobalFilter {
+        type: "selection";
+        id: string;
+        label: string;
+        resModel: string;
+        selectionField: string;
+        defaultValue?: string[];
+    }
+
     export interface CmdTextGlobalFilter extends TextGlobalFilter {
         rangesOfAllowedValues?: RangeData[];
     }
@@ -102,6 +111,6 @@ declare module "@spreadsheet" {
         defaultValue?: boolean[];
     }
 
-    export type GlobalFilter = TextGlobalFilter | DateGlobalFilter | RelationalGlobalFilter | BooleanGlobalFilter;
-    export type CmdGlobalFilter = CmdTextGlobalFilter | DateGlobalFilter | RelationalGlobalFilter | BooleanGlobalFilter;
+    export type GlobalFilter = TextGlobalFilter | DateGlobalFilter | RelationalGlobalFilter | BooleanGlobalFilter | SelectionGlobalFilter;
+    export type CmdGlobalFilter = CmdTextGlobalFilter | DateGlobalFilter | RelationalGlobalFilter | BooleanGlobalFilter | SelectionGlobalFilter;
 }

--- a/addons/spreadsheet/static/src/global_filters/components/filter_value/filter_value.js
+++ b/addons/spreadsheet/static/src/global_filters/components/filter_value/filter_value.js
@@ -12,6 +12,7 @@ import { user } from "@web/core/user";
 import { TextFilterValue } from "../filter_text_value/filter_text_value";
 import { getFields, ModelNotFoundError } from "@spreadsheet/data_sources/data_source";
 import { BooleanMultiSelector } from "../boolean_multi_selector/boolean_multi_selector";
+import { SelectionFilterValue } from "../selection_filter_value/selection_filter_value";
 
 const { ValidationMessages } = components;
 
@@ -22,6 +23,7 @@ export class FilterValue extends Component {
         DateFilterValue,
         MultiRecordSelector,
         BooleanMultiSelector,
+        SelectionFilterValue,
         ValidationMessages,
     };
     static props = {
@@ -99,6 +101,14 @@ export class FilterValue extends Component {
     }
 
     onBooleanInput(id, value) {
+        if (Array.isArray(value) && value.length === 0) {
+            this.clear(id);
+            return;
+        }
+        this.props.setGlobalFilterValue(id, value);
+    }
+
+    onSelectionInput(id, value) {
         if (Array.isArray(value) && value.length === 0) {
             this.clear(id);
             return;

--- a/addons/spreadsheet/static/src/global_filters/components/filter_value/filter_value.xml
+++ b/addons/spreadsheet/static/src/global_filters/components/filter_value/filter_value.xml
@@ -15,6 +15,14 @@
                     onValueChanged="(value) => this.onTextInput(filter.id, value)"
                 />
             </div>
+            <div t-if="filter.type === 'selection'" class="w-100">
+                <SelectionFilterValue
+                    resModel="filter.resModel"
+                    field="filter.selectionField"
+                    value="filterValue"
+                    onValueChanged="(value) => this.onSelectionInput(filter.id, value)"
+                />
+            </div>
             <span t-if="filter.type === 'relation'" class="w-100">
                 <MultiRecordSelector
                     t-if="isValid"

--- a/addons/spreadsheet/static/src/global_filters/components/selection_filter_value/selection_filter_value.js
+++ b/addons/spreadsheet/static/src/global_filters/components/selection_filter_value/selection_filter_value.js
@@ -1,0 +1,71 @@
+/** @ts-check */
+
+import { Component, onWillStart, onWillUpdateProps, useEffect } from "@odoo/owl";
+import { useChildRef, useService } from "@web/core/utils/hooks";
+
+import { TagsList } from "@web/core/tags_list/tags_list";
+import { AutoComplete } from "@web/core/autocomplete/autocomplete";
+
+export class SelectionFilterValue extends Component {
+    static template = "spreadsheet.SelectionFilterValue";
+    static components = {
+        TagsList,
+        AutoComplete,
+    };
+    static props = {
+        resModel: String,
+        field: String,
+        value: { type: Array, optional: true },
+        onValueChanged: Function,
+    };
+    static defaultProps = {
+        value: [],
+    };
+
+    setup() {
+        this.inputRef = useChildRef();
+        useEffect(
+            () => {
+                if (this.inputRef.el) {
+                    // Prevent the user from typing free-text by setting the maxlength to 0
+                    this.inputRef.el.setAttribute("maxlength", 0);
+                }
+            },
+            () => [this.inputRef.el]
+        );
+        this.tags = [];
+        this.sources = [];
+        this.fields = useService("field");
+        onWillStart(() => this._computeTagsAndSources(this.props));
+        onWillUpdateProps((nextProps) => this._computeTagsAndSources(nextProps));
+    }
+
+    async _computeTagsAndSources(props) {
+        const fields = await this.fields.loadFields(props.resModel);
+        const field = fields[props.field];
+        if (!field) {
+            throw new Error(`Field "${props.field}" not found in model "${props.resModel}"`);
+        }
+        const selection = field.selection;
+        this.tags = props.value.map((value) => ({
+            id: value,
+            text: selection.find((option) => option[0] === value)?.[1] ?? value,
+            onDelete: () => {
+                props.onValueChanged(props.value.filter((v) => v !== value));
+            },
+        }));
+        const alreadySelected = new Set(props.value);
+        this.sources = [
+            {
+                options: selection
+                    .filter((option) => !alreadySelected.has(option[0]))
+                    .map(([value, formattedValue]) => ({
+                        label: formattedValue,
+                        onSelect: () => {
+                            props.onValueChanged([...props.value, value]);
+                        },
+                    })),
+            },
+        ];
+    }
+}

--- a/addons/spreadsheet/static/src/global_filters/components/selection_filter_value/selection_filter_value.xml
+++ b/addons/spreadsheet/static/src/global_filters/components/selection_filter_value/selection_filter_value.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<templates>
+    <t t-name="spreadsheet.SelectionFilterValue">
+        <div class="o_input o-global-filter-selection-value d-flex flex-wrap gap-1">
+            <TagsList tags="tags"/>
+            <AutoComplete input="inputRef" sources="sources"/>
+        </div>
+    </t>
+</templates>

--- a/addons/spreadsheet/static/src/global_filters/helpers.js
+++ b/addons/spreadsheet/static/src/global_filters/helpers.js
@@ -89,7 +89,8 @@ export function checkFilterDefaultValueIsValid(filter, defaultValue) {
     }
     switch (filter.type) {
         case "text":
-            return isTextFilterValueValid(defaultValue);
+        case "selection":
+            return isTextSelectionFilterValueValid(defaultValue);
         case "date":
             return isDateFilterDefaultValueValid(defaultValue);
         case "relation":
@@ -112,7 +113,8 @@ export function checkFilterValueIsValid(filter, value) {
     }
     switch (filter.type) {
         case "text":
-            return isTextFilterValueValid(value);
+        case "selection":
+            return isTextSelectionFilterValueValid(value);
         case "date":
             return isDateFilterValueValid(value);
         case "relation":
@@ -124,11 +126,11 @@ export function checkFilterValueIsValid(filter, value) {
 }
 
 /**
- * A text filter value is valid if it is an array of strings. It's the same
- * for the default value.
+ * A text or selection filter value is valid if it is an array of strings. It's
+ * the same for the default value.
  * @returns {boolean}
  */
-function isTextFilterValueValid(value) {
+function isTextSelectionFilterValueValid(value) {
     return Array.isArray(value) && value.length && value.every((text) => typeof text === "string");
 }
 
@@ -596,6 +598,20 @@ export async function getFacetInfo(filter, filterValues, nameService) {
                 typeof value === "string" ? value : _t("Inaccessible/missing record ID")
             );
             break;
+        case "selection": {
+            const fields = await this.fields.loadFields(filter.resModel);
+            const field = fields[filter.selectionField];
+            if (!field) {
+                throw new Error(
+                    `Field ${filter.selectionField} not found in model ${filter.resModel}`
+                );
+            }
+            values = filterValues.map((value) => {
+                const option = field.selection.find((option) => option[0] === value);
+                return option ? option[1] : value;
+            });
+            break;
+        }
     }
     return {
         title: filter.label,

--- a/addons/spreadsheet/static/src/global_filters/plugins/global_filters_core_view_plugin.js
+++ b/addons/spreadsheet/static/src/global_filters/plugins/global_filters_core_view_plugin.js
@@ -132,6 +132,8 @@ export class GlobalFiltersCoreViewPlugin extends OdooCoreViewPlugin {
                 return this._getRelationDomain(filter, fieldMatching);
             case "boolean":
                 return this._getBooleanDomain(filter, fieldMatching);
+            case "selection":
+                return this._getSelectionDomain(filter, fieldMatching);
         }
     }
 
@@ -156,6 +158,7 @@ export class GlobalFiltersCoreViewPlugin extends OdooCoreViewPlugin {
         switch (filter.type) {
             case "text":
             case "boolean":
+            case "selection":
                 return filter.defaultValue;
             case "date":
                 return this._getDateValueFromDefaultValue(filter.defaultValue);
@@ -198,6 +201,7 @@ export class GlobalFiltersCoreViewPlugin extends OdooCoreViewPlugin {
         switch (filter.type) {
             case "text":
             case "boolean":
+            case "selection":
                 return [[{ value: value?.length ? value.join(", ") : "" }]];
             case "date":
                 return this._getDateFilterDisplayValue(filter);
@@ -439,6 +443,15 @@ export class GlobalFiltersCoreViewPlugin extends OdooCoreViewPlugin {
             return new Domain([[field, "=", toBoolean(value[0])]]);
         }
         return new Domain([[field, "in", [toBoolean(value[0]), toBoolean(value[1])]]]);
+    }
+
+    _getSelectionDomain(filter, fieldMatching) {
+        const values = this.getGlobalFilterValue(filter.id);
+        if (!values || !values.length || !fieldMatching.chain) {
+            return new Domain();
+        }
+        const field = fieldMatching.chain;
+        return new Domain([[field, "in", values]]);
     }
 
     /**

--- a/addons/spreadsheet/static/tests/global_filters/filter_value_component.test.js
+++ b/addons/spreadsheet/static/tests/global_filters/filter_value_component.test.js
@@ -259,3 +259,19 @@ test("boolean filter", async function () {
     await contains("a:first").click();
     expect(model.getters.getGlobalFilterValue("42")).toEqual([true], { message: "value is set" });
 });
+
+test("selection filter", async function () {
+    const env = await makeMockEnv();
+    const model = new Model({}, { custom: { odooDataProvider: new OdooDataProvider(env) } });
+    await addGlobalFilter(model, {
+        id: "42",
+        type: "selection",
+        label: "Selection Filter",
+        resModel: "res.currency",
+        selectionField: "position",
+    });
+    await mountFilterValueComponent({ model, filter: model.getters.getGlobalFilter("42") });
+    await contains("input").click();
+    await contains("a:first").click();
+    expect(model.getters.getGlobalFilterValue("42")).toEqual(["after"]);
+});

--- a/addons/spreadsheet/static/tests/global_filters/global_filters_core_view.test.js
+++ b/addons/spreadsheet/static/tests/global_filters/global_filters_core_view.test.js
@@ -62,6 +62,53 @@ test("Value of text filter", () => {
     expect(result.reasons).toEqual(["InvalidValueTypeCombination"]);
 });
 
+test("Value of selection filter", () => {
+    const model = new Model();
+    addGlobalFilterWithoutReload(model, {
+        id: "1",
+        type: "selection",
+        label: "selection Filter",
+        resModel: "res.currency",
+        selectionField: "position",
+    });
+
+    let result = setGlobalFilterValueWithoutReload(model, {
+        id: "1",
+        value: "test",
+    });
+    expect(result.isSuccessful).toBe(false);
+    expect(result.reasons).toEqual(["InvalidValueTypeCombination"]);
+
+    result = addGlobalFilterWithoutReload(model, {
+        id: "2",
+        type: "selection",
+        label: "Default value is an array",
+        resModel: "res.currency",
+        selectionField: "position",
+        defaultValue: ["default value"],
+    });
+    expect(result.isSuccessful).toBe(true);
+
+    result = setGlobalFilterValueWithoutReload(model, {
+        id: "1",
+    });
+    expect(result.isSuccessful).toBe(true);
+
+    result = setGlobalFilterValueWithoutReload(model, {
+        id: "1",
+        value: 5,
+    });
+    expect(result.isSuccessful).toBe(false);
+    expect(result.reasons).toEqual(["InvalidValueTypeCombination"]);
+
+    result = setGlobalFilterValueWithoutReload(model, {
+        id: "1",
+        value: false,
+    });
+    expect(result.isSuccessful).toBe(false);
+    expect(result.reasons).toEqual(["InvalidValueTypeCombination"]);
+});
+
 test("Value of date filter", () => {
     const model = new Model();
     addGlobalFilterWithoutReload(model, {

--- a/addons/spreadsheet/static/tests/global_filters/global_filters_model.test.js
+++ b/addons/spreadsheet/static/tests/global_filters/global_filters_model.test.js
@@ -2799,6 +2799,62 @@ test("Check boolean filter domain", async () => {
     );
 });
 
+test("Can add a selection filter", async () => {
+    const model = new Model();
+    const filter = {
+        id: "42",
+        label: "test",
+        type: "selection",
+        resModel: "res.currency",
+        selectionField: "position",
+    };
+    addGlobalFilterWithoutReload(model, filter);
+    await setGlobalFilterValue(model, {
+        id: "42",
+        value: ["after"],
+    });
+    expect(model.getters.getGlobalFilterValue("42")).toEqual(["after"]);
+});
+
+test("Check selection filter domain", async () => {
+    const model = new Model();
+    const filter = {
+        id: "42",
+        label: "test",
+        type: "selection",
+        resModel: "res.currency",
+        selectionField: "position",
+    };
+    addGlobalFilterWithoutReload(model, filter);
+    await setGlobalFilterValue(model, {
+        id: "42",
+        value: [],
+    });
+    const fieldMatching = { chain: "position", type: "selection" };
+    expect(model.getters.getGlobalFilterDomain("42", fieldMatching).toString()).toEqual("[]");
+    await setGlobalFilterValue(model, {
+        id: "42",
+        value: ["after"],
+    });
+    expect(model.getters.getGlobalFilterDomain("42", fieldMatching).toString()).toEqual(
+        `[("position", "in", ["after"])]`
+    );
+    await setGlobalFilterValue(model, {
+        id: "42",
+        value: ["before"],
+    });
+    expect(model.getters.getGlobalFilterDomain("42", fieldMatching).toString()).toEqual(
+        `[("position", "in", ["before"])]`
+    );
+    await setGlobalFilterValue(model, {
+        id: "42",
+        value: ["after", "before"],
+    });
+    expect(model.getters.getGlobalFilterDomain("42", fieldMatching).toString()).toEqual(
+        `[("position", "in", ["after", "before"])]`
+    );
+});
+
 test("Undo/Redo of global filter update", async () => {
     const { model, pivotId } = await createSpreadsheetWithPivot();
     const filter = {
@@ -2889,6 +2945,61 @@ test("Default value of text filter", () => {
         type: "text",
         label: "Default value cannot be an empty array",
         defaultValue: [],
+    });
+    expect(result.isSuccessful).toBe(false);
+    expect(result.reasons).toEqual(["InvalidValueTypeCombination"]);
+});
+
+test("Default value of selection filter", () => {
+    const model = new Model();
+    let result = addGlobalFilterWithoutReload(model, {
+        id: "1",
+        type: "selection",
+        label: "Default value cannot be a string, should be an array",
+        resModel: "res.currency",
+        selectionField: "position",
+        defaultValue: "default value",
+    });
+    expect(result.isSuccessful).toBe(false);
+    expect(result.reasons).toEqual(["InvalidValueTypeCombination"]);
+
+    result = addGlobalFilterWithoutReload(model, {
+        id: "2",
+        type: "selection",
+        label: "Default value is an array",
+        resModel: "res.currency",
+        selectionField: "position",
+        defaultValue: ["default value"],
+    });
+    expect(result.isSuccessful).toBe(true);
+
+    result = addGlobalFilterWithoutReload(model, {
+        id: "3",
+        type: "selection",
+        label: "Default value is empty",
+        resModel: "res.currency",
+        selectionField: "position",
+    });
+    expect(result.isSuccessful).toBe(true);
+
+    result = addGlobalFilterWithoutReload(model, {
+        id: "4",
+        type: "selection",
+        label: "Default value cannot be a number",
+        resModel: "res.currency",
+        selectionField: "position",
+        defaultValue: 5,
+    });
+    expect(result.isSuccessful).toBe(false);
+    expect(result.reasons).toEqual(["InvalidValueTypeCombination"]);
+
+    result = addGlobalFilterWithoutReload(model, {
+        id: "5",
+        type: "selection",
+        label: "Default value cannot be a boolean",
+        resModel: "res.currency",
+        selectionField: "position",
+        defaultValue: false,
     });
     expect(result.isSuccessful).toBe(false);
     expect(result.reasons).toEqual(["InvalidValueTypeCombination"]);

--- a/addons/spreadsheet/static/tests/global_filters/selection_filter_value.test.js
+++ b/addons/spreadsheet/static/tests/global_filters/selection_filter_value.test.js
@@ -1,0 +1,73 @@
+import { describe, expect, test, getFixture } from "@odoo/hoot";
+import { makeMockEnv, contains, mountWithCleanup } from "@web/../tests/web_test_helpers";
+import { defineSpreadsheetModels } from "@spreadsheet/../tests/helpers/data";
+import { getTemplate } from "@web/core/templates";
+import { SelectionFilterValue } from "@spreadsheet/global_filters/components/selection_filter_value/selection_filter_value";
+
+describe.current.tags("desktop");
+defineSpreadsheetModels();
+
+/**
+ *
+ * @param {{ model: Model, filter: object}} props
+ */
+async function mountSelectionFilterValue(env, props) {
+    await mountWithCleanup(SelectionFilterValue, { props, env, getTemplate });
+}
+
+/**
+ * res.currency.position is a selection field with 2 options:
+ * - after (A)
+ * - before (B)
+ */
+
+test("basic selection filter value", async function () {
+    const env = await makeMockEnv();
+    await mountSelectionFilterValue(env, {
+        value: [],
+        resModel: "res.currency",
+        field: "position",
+        onValueChanged: (values) => {
+            expect(values).toEqual(["after"]);
+            expect.step("onValueChanged");
+        },
+    });
+    expect.verifySteps([]);
+    await contains("input").click();
+    const options = getFixture().querySelectorAll(".o-autocomplete a");
+    expect(options.length).toBe(2);
+    expect(options[0].textContent).toBe("A");
+    expect(options[1].textContent).toBe("B");
+    await contains("a:first").click();
+    expect.verifySteps(["onValueChanged"]);
+});
+
+test("Autocomplete only provide values that are not selected", async function () {
+    const env = await makeMockEnv();
+    await mountSelectionFilterValue(env, {
+        value: ["after"],
+        resModel: "res.currency",
+        field: "position",
+        onValueChanged: () => {},
+    });
+    await contains("input").click();
+    const options = getFixture().querySelectorAll(".o-autocomplete a");
+    expect(options.length).toBe(1);
+    expect(options[0].textContent).toBe("B");
+});
+
+test("Can click on delete", async function () {
+    const env = await makeMockEnv();
+    await mountSelectionFilterValue(env, {
+        value: ["after", "before"],
+        resModel: "res.currency",
+        field: "position",
+        onValueChanged: (values) => {
+            expect(values).toEqual(["before"]);
+            expect.step("onValueChanged");
+        },
+    });
+    expect.verifySteps([]);
+    await contains(".o_badge:first .o_delete").click();
+    expect.verifySteps(["onValueChanged"]);
+});

--- a/addons/web/static/src/core/model_field_selector/model_field_selector_popover.js
+++ b/addons/web/static/src/core/model_field_selector/model_field_selector_popover.js
@@ -176,9 +176,9 @@ export class ModelFieldSelectorPopover extends Component {
         return fieldDef.relation;
     }
 
-    filter(fieldDefs, path) {
+    filter(fieldDefs, path, resModel) {
         const filteredKeys = Object.keys(fieldDefs).filter((k) =>
-            this.props.filter(fieldDefs[k], path)
+            this.props.filter(fieldDefs[k], path, resModel)
         );
         return Object.fromEntries(filteredKeys.map((k) => [k, fieldDefs[k]]));
     }
@@ -193,7 +193,7 @@ export class ModelFieldSelectorPopover extends Component {
         this.state.page.selectedName = fieldDef.name;
         const { resModel, fieldDefs } = modelsInfo.at(-1);
         this.openPage(
-            new Page(resModel, this.filter(fieldDefs, this.state.page.path), {
+            new Page(resModel, this.filter(fieldDefs, this.state.page.path, resModel), {
                 previousPage: this.state.page,
                 isDebugMode: this.props.isDebugMode,
                 readProperty: this.props.readProperty,
@@ -215,7 +215,7 @@ export class ModelFieldSelectorPopover extends Component {
     async loadPages(resModel, path) {
         if (typeof path !== "string" || !path.length) {
             const fieldDefs = await this.fieldService.loadFields(resModel);
-            return new Page(resModel, this.filter(fieldDefs, path), {
+            return new Page(resModel, this.filter(fieldDefs, path, resModel), {
                 isDebugMode: this.props.isDebugMode,
                 readProperty: this.props.readProperty,
                 sortFn: this.props.sort,
@@ -227,7 +227,7 @@ export class ModelFieldSelectorPopover extends Component {
                 throw new Error(`Invalid model name: ${resModel}`);
             case "path": {
                 const { resModel, fieldDefs } = modelsInfo[0];
-                return new Page(resModel, this.filter(fieldDefs, path), {
+                return new Page(resModel, this.filter(fieldDefs, path, resModel), {
                     selectedName: path,
                     isDebugMode: this.props.isDebugMode,
                     readProperty: this.props.readProperty,
@@ -239,7 +239,7 @@ export class ModelFieldSelectorPopover extends Component {
                 for (let index = 0; index < names.length; index++) {
                     const name = names[index];
                     const { resModel, fieldDefs } = modelsInfo[index];
-                    page = new Page(resModel, this.filter(fieldDefs, path), {
+                    page = new Page(resModel, this.filter(fieldDefs, path, resModel), {
                         previousPage: page,
                         selectedName: name,
                         isDebugMode: this.props.isDebugMode,

--- a/addons/web/static/tests/core/model_field_selector.test.js
+++ b/addons/web/static/tests/core/model_field_selector.test.js
@@ -173,11 +173,18 @@ test("use the filter option", async () => {
             readonly: false,
             path: "",
             resModel: "partner",
-            filter: (field) => field.type === "many2one" && field.searchable,
+            filter: (field, path, resModel) => {
+                const result = field.type === "many2one" && field.searchable;
+                if (result) {
+                    expect.step(resModel);
+                }
+                return result;
+            },
         },
     });
     await openModelFieldSelectorPopover();
     expect(getDisplayedFieldNames()).toEqual(["Product"]);
+    expect.verifySteps(["partner"]);
 });
 
 test("use the sort option", async () => {


### PR DESCRIPTION
This commit introduces selection filters to the available global filters. This allows users to filter data based on `selection` fields.

Selection filters are a bit tricky, as they are not shared across models unlike relation fields. Therefore, we need to handle them with some restrictions:
- Users have to select the combination of model and field on which they want to filter.
- Field matching has to be done on the same model as the one selected in the filter configuration.

Task: 3619413

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
