### PR TITLE
[FIX] base_import: prevent crash on invalid utf-8 in csv import

### DIFF
--- a/addons/base_import/models/base_import.py
+++ b/addons/base_import/models/base_import.py
@@ -578,7 +578,7 @@ class Base_ImportImport(models.TransientModel):
             if bom and csv_data.startswith(bom):
                 encoding = options['encoding'] = encoding[:-2]
 
-        csv_text = csv_data.decode(encoding)
+        csv_text = csv_data.decode(encoding, errors='replace')
 
         separator = options.get('separator')
         if not separator:


### PR DESCRIPTION
The system will crash when importing CSV files that contain non-UTF-8 characters (e.g., 0xA0 ).

**Steps to produce:-**
1. Install `Documents`.
2. Upload this [file](https://drive.google.com/file/d/1BDQKvpVv-LuSImMnuCDMvywhob_HTNN7/view?usp=sharing).
3. Click on the uploaded file and click `Open with Odoo Spreadsheet`.

**Error:-**
`UnicodeDecodeError: 'utf-8' codec can't decode byte 0xa0 in position 13:
 invalid start byte`

**Root cause:-**
- When an imported CSV file contains a non-breaking space or any other non-UTF-8 characters, then the line below gives an error.

https://github.com/odoo/odoo/blob/4200b8b4101372e30678331f5e2b7fe891676cb2/addons/base_import/models/base_import.py#L581

**Solution:-**
- From this commit, now when decoding, when a byte is found that can’t be decoded, replace it with � (Unicode replacement character).

**Sentry - 6695651974**

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
