### PR TITLE
[IMP] *: adapt tours for the new website builder

### DIFF
--- a/addons/html_builder/static/src/snippets/snippet_service.js
+++ b/addons/html_builder/static/src/snippets/snippet_service.js
@@ -398,7 +398,7 @@ registry.category("services").add("html_builder.snippets", {
     start(env, { orm, dialog, website }) {
         const services = { orm, dialog, website };
         const context = {
-            lang: website.currentWebsite?.metadata.lang,
+            lang: website.currentWebsite?.default_lang_id.code,
             user_lang: user.context.lang,
         };
 

--- a/addons/html_builder/static/src/snippets/snippet_service.js
+++ b/addons/html_builder/static/src/snippets/snippet_service.js
@@ -145,6 +145,23 @@ export class SnippetModel extends Reactive {
         return this.loadProm;
     }
 
+    /**
+     * Reloads the snippet data, optionally updating the context.
+     *
+     * @param {Object} context - Optional context to override or extend the
+     *                           current context.
+     * @returns {Promise<void>} A promise that resolves once the snippets are
+     *                          reloaded.
+     */
+    reload(context = {}) {
+        this.loadProm = null;
+        this.context = {
+            ...this.context,
+            ...context,
+        };
+        return this.load();
+    }
+
     computeSnippetTemplates(snippetsDocument) {
         const snippetsBody = snippetsDocument.body;
         this.snippetsByCategory = {};
@@ -260,8 +277,7 @@ export class SnippetModel extends Reactive {
             template_key: this.snippetsName,
         });
         // Reload snippet to have updated name.
-        this.loadProm = null;
-        await this.load();
+        await this.reload();
     }
 
     setSnippetName(snippetsDocument) {
@@ -380,9 +396,8 @@ export class SnippetModel extends Reactive {
                             context,
                         });
 
-                        this.loadProm = null;
                         // Reload the snippets so the sidebar is up to date.
-                        await this.load();
+                        await this.reload();
                         resolve(savedName);
                     },
                 },

--- a/addons/website/static/src/client_actions/website_preview/website_builder_action.js
+++ b/addons/website/static/src/client_actions/website_preview/website_builder_action.js
@@ -135,7 +135,9 @@ export class WebsiteBuilderClientAction extends Component {
             if (!this.ui.isSmall) {
                 // preload builder and snippets so clicking on "edit" is faster
                 loadBundle("website.website_builder_assets").then(() => {
-                    this.env.services["html_builder.snippets"].load();
+                    this.env.services["html_builder.snippets"].reload({
+                        lang: this.websiteService.currentWebsite?.default_lang_id.code,
+                    });
                 });
             }
         });

--- a/addons/website/static/src/services/website_service.js
+++ b/addons/website/static/src/services/website_service.js
@@ -271,7 +271,17 @@ export const websiteService = {
                 ]);
             },
             async fetchWebsites() {
-                websites = [...(await orm.searchRead('website', [], ['domain', 'id', 'name', 'language_ids']))];
+                websites = (
+                    await orm.webSearchRead("website", [], {
+                        specification: {
+                            domain: {},
+                            id: {},
+                            name: {},
+                            language_ids: {},
+                            default_lang_id: { fields: { code: {} } },
+                        },
+                    })
+                ).records;
             },
             async loadWysiwyg() {
                 await ensureJQuery();

--- a/addons/website/static/tests/builder/translation.test.js
+++ b/addons/website/static/tests/builder/translation.test.js
@@ -18,6 +18,9 @@ const websiteServiceInTranslateMode = {
             translatable: true,
             defaultLangName: "English (US)",
         },
+        default_lang_id: {
+            code: "en_US",
+        },
     },
     // Minimal context to avoid crashes.
     context: { showNewContentModal: false },
@@ -38,6 +41,9 @@ test("systray in translate mode", async () => {
                     langName: " Français (BE)",
                     translatable: true,
                     defaultLangName: "English (US)",
+                },
+                default_lang_id: {
+                    code: "en_US",
                 },
             };
         },

--- a/addons/website/static/tests/builder/website_builder/menu_data.test.js
+++ b/addons/website/static/tests/builder/website_builder/menu_data.test.js
@@ -162,6 +162,9 @@ describe("EditMenuDialog", () => {
             get currentWebsite() {
                 return {
                     id: 1,
+                    default_lang_id: {
+                        code: "en_US",
+                    },
                     metadata: {
                         lang: "en_EN",
                     },

--- a/addons/website/static/tests/builder/website_helpers.js
+++ b/addons/website/static/tests/builder/website_helpers.js
@@ -65,6 +65,17 @@ export function defineWebsiteModels() {
     defineMailModels();
     defineModels([Website, IrUiView]);
     onRpc("/website/theme_customize_data_get", () => []);
+    onRpc("website", "web_search_read", () => ({
+        length: 1,
+        records: [
+            {
+                id: 1,
+                default_lang_id: {
+                    code: "en_US",
+                },
+            },
+        ],
+    }));
 }
 
 /**
@@ -474,6 +485,9 @@ export async function setupWebsiteBuilderWithSnippet(snippetName, options = {}) 
                     defaultLangName: "English (US)",
                 },
                 id: 1,
+                default_lang_id: {
+                    code: "en_US",
+                },
             };
         },
     });

--- a/addons/website/static/tests/tours/snippet_translation.js
+++ b/addons/website/static/tests/tours/snippet_translation.js
@@ -7,6 +7,7 @@ import {
     insertSnippet,
     registerWebsitePreviewTour,
 } from '@website/js/tours/tour_utils';
+import { stepUtils } from "@web_tour/tour_service/tour_utils";
 
 registerWebsitePreviewTour('snippet_translation', {
     url: '/',
@@ -36,6 +37,7 @@ registerWebsitePreviewTour('snippet_translation', {
 registerWebsitePreviewTour('snippet_translation_changing_lang', {
     url: '/',
 }, () => [
+    stepUtils.waitIframeIsReady(),
     {
         content: "Open dropdown language selector",
         trigger: ':iframe .js_language_selector button',

--- a/addons/website/static/tests/tours/snippet_translation.js
+++ b/addons/website/static/tests/tours/snippet_translation.js
@@ -89,3 +89,39 @@ registerWebsitePreviewTour('snippet_translation_changing_lang', {
         trigger: ':iframe .s_cover .btn-outline-secondary:contains("Contact us in Parseltongue")',
     },
 ]);
+registerWebsitePreviewTour(
+    "snippet_translation_switching_website",
+    {
+        url: "/",
+    },
+    () => [
+        ...clickOnEditAndWaitEditModeInTranslatedPage(),
+        ...insertSnippet({ id: "s_cover", name: "Cover", groupName: "Intro" }),
+        {
+            content: "Check that contact us contain Parseltongue",
+            trigger:
+                ":iframe .s_cover .btn-outline-secondary:contains('Contact us in Parseltongue')",
+        },
+        ...clickOnSave(),
+        {
+            content: "Open website switcher dropdown",
+            trigger: ".o_website_switcher_container button",
+            run: "click",
+        },
+        {
+            content: "Switch to website fu_GB",
+            trigger: ".o-dropdown--menu .o-dropdown-item:contains('website fu_GB')",
+            run: "click",
+        },
+        {
+            content: "Wait for website fu_GB",
+            trigger: ":iframe .o_homepage_editor_welcome_message",
+        },
+        ...clickOnEditAndWaitEditMode(),
+        ...insertSnippet({ id: "s_cover", name: "Cover", groupName: "Intro" }),
+        {
+            content: "Check that contact us contain Fake User Lang",
+            trigger: ":iframe .s_cover .btn-outline-secondary:contains('Fake User Lang')",
+        },
+    ]
+);

--- a/addons/website/tests/test_ui.py
+++ b/addons/website/tests/test_ui.py
@@ -251,8 +251,6 @@ class TestUiTranslate(odoo.tests.HttpCase):
 
         self.start_tour(self.env['website'].get_client_action_url('/'), 'translate_text_options', login='admin')
 
-    # TODO master-mysterious-egg fix error
-    @unittest.skip("prepare mysterious-egg for merging")
     def test_snippet_translation(self):
         ResLang = self.env['res.lang']
         parseltongue, fake_user_lang = ResLang.create([{

--- a/addons/website/tests/test_ui.py
+++ b/addons/website/tests/test_ui.py
@@ -271,6 +271,9 @@ class TestUiTranslate(odoo.tests.HttpCase):
             parseltongue.code: {
                 # See contact_us_label
                 'Contact us': 'Contact us in Parseltongue'
+            },
+            fake_user_lang.code: {
+                'Contact us': 'Contact us in Fake User Lang'
             }
         })
         website = self.env['website'].create({
@@ -283,9 +286,15 @@ class TestUiTranslate(odoo.tests.HttpCase):
             'language_ids': [(6, 0, [self.env.ref('base.lang_en').id, parseltongue.id])],
             'default_lang_id': parseltongue.id,
         })
+        self.env['website'].create({
+            'name': 'website fu_GB',
+            'language_ids': [Command.set([fake_user_lang.id])],
+            'default_lang_id': fake_user_lang.id,
+        })
 
         self.start_tour(f"/website/force/{website.id}", 'snippet_translation', login='admin')
         self.start_tour(f"/website/force/{website_2.id}", 'snippet_translation_changing_lang', login='admin')
+        self.start_tour(f"/website/force/{website_2.id}", 'snippet_translation_switching_website', login='admin')
 
 
 @odoo.tests.common.tagged('post_install', '-at_install')


### PR DESCRIPTION
\* = html_builder, website

This PR re-enable the `test_snippet_translation` test that were broken and skipped after the DOM changes introduced by the new Website Builder and adapts it's tour selectors. (commit 2)

It also fixes some translation related issues that were introduced by the new Website Builder. (see commit 1 and 3)