### PR TITLE
[IMP] l10n_in: raise warning in case of exempt + taxable goods for b2b

### DIFF
--- a/addons/l10n_in/i18n/l10n_in.pot
+++ b/addons/l10n_in/i18n/l10n_in.pot
@@ -4,10 +4,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 19.0+e\n"
+"Project-Id-Version: Odoo Server 19.1a1+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-15 12:58+0000\n"
-"PO-Revision-Date: 2025-10-15 12:58+0000\n"
+"POT-Creation-Date: 2025-11-05 09:55+0000\n"
+"PO-Revision-Date: 2025-11-05 09:55+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -146,6 +146,11 @@ msgstr ""
 #. module: l10n_in
 #: model:ir.model.fields,field_description:l10n_in.field_l10n_in_pan_entity__activity_exception_decoration
 msgid "Activity Exception Decoration"
+msgstr ""
+
+#. module: l10n_in
+#: model:ir.model.fields,field_description:l10n_in.field_l10n_in_pan_entity__activity_plans_ids
+msgid "Activity Plans"
 msgstr ""
 
 #. module: l10n_in
@@ -420,10 +425,6 @@ msgstr ""
 
 #. module: l10n_in
 #: model:ir.model,name:l10n_in.model_res_company
-msgid "Companies"
-msgstr ""
-
-#. module: l10n_in
 #: model:ir.model.fields,field_description:l10n_in.field_l10n_in_withhold_wizard__company_id
 #: model:ir.model.fields.selection,name:l10n_in.selection__l10n_in_pan_entity__type__c
 msgid "Company"
@@ -1509,13 +1510,9 @@ msgid "Partners"
 msgstr ""
 
 #. module: l10n_in
+#: model:ir.model,name:l10n_in.model_account_payment
 #: model:ir.model.fields,field_description:l10n_in.field_l10n_in_withhold_wizard__related_payment_id
 msgid "Payment"
-msgstr ""
-
-#. module: l10n_in
-#: model:ir.model,name:l10n_in.model_account_payment
-msgid "Payments"
 msgstr ""
 
 #. module: l10n_in
@@ -2344,6 +2341,14 @@ msgstr ""
 #. odoo-python
 #: code:addons/l10n_in/models/res_partner.py:0
 msgid "The provided GSTIN is invalid. Please check the GSTIN and try again."
+msgstr ""
+
+#. module: l10n_in
+#. odoo-python
+#: code:addons/l10n_in/models/account_invoice.py:0
+msgid ""
+"This document includes both taxable and exempt goods. It is advisable to "
+"raise seperate document."
 msgstr ""
 
 #. module: l10n_in


### PR DESCRIPTION
**PURPOSE**
- Warn users when a GST-registered customer has both taxable and exempt goods in the same Invoice / Credit Note / Debit Note.
- Helps ensure compliance with CGST Rule 46 & 49.

**SPECIFICATION**
- Show a warning on Invoices / Credit Notes / Debit Notes when:
   - The customer is GST registered, and
   - The document contains both taxable and exempt products.

- The warning states:- 'This document includes both taxable and exempt goods. It is advisable to raise separate documents for clarity and compliance.'

task-4876400

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
