### PR TITLE
[IMP] web, *: replace o_object_fit(_contain,_cover) occurences

### DIFF
--- a/addons/html_editor/static/src/others/collaboration/collaboration_selection_avatar_plugin.js
+++ b/addons/html_editor/static/src/others/collaboration/collaboration_selection_avatar_plugin.js
@@ -96,7 +96,7 @@ export class CollaborationSelectionAvatarPlugin extends Plugin {
             avatarElement.append(image);
             image.onload = () => avatarElement.style.removeProperty("display");
             image.setAttribute("src", avatarUrl);
-            image.classList.add("o_object_fit_cover");
+            image.classList.add("object-fit-cover");
         }
         // Avoid re-appending the element in the dom.
         if (!avatarElement.parentElement) {

--- a/addons/mail/static/src/chatter/web/scheduled_message.xml
+++ b/addons/mail/static/src/chatter/web/scheduled_message.xml
@@ -6,7 +6,7 @@
         <div class="o-mail-Message-core position-relative d-flex flex-shrink-0">
             <div class="o-mail-Message-sidebar d-flex flex-shrink-0">
                 <div class="o-mail-Message-avatarContainer position-relative bg-view" t-on-click="ev => this.onClickAuthor(ev)">
-                    <img class="o-mail-Message-avatar w-100 h-100 rounded o_redirect cursor-pointer o_object_fit_cover" t-att-src="props.scheduledMessage.author_id.avatarUrl"/>
+                    <img class="o-mail-Message-avatar w-100 h-100 rounded o_redirect cursor-pointer object-fit-cover" t-att-src="props.scheduledMessage.author_id.avatarUrl"/>
                 </div>
             </div>
             <div class="w-100 o-min-width-0">

--- a/addons/mail/static/src/core/common/chat_bubble.xml
+++ b/addons/mail/static/src/core/common/chat_bubble.xml
@@ -15,7 +15,7 @@
             </ImStatus>
             <CountryFlag t-if="thread?.showCorrespondentCountry" country="thread.correspondentCountry" class="'o-mail-ChatBubble-country position-absolute bottom-0 border shadow-sm'"/>
             <button class="o-mail-ChatHub-bubbleBtn btn shadow">
-                <img class="o-mail-ChatBubble-avatar bg-view rounded-circle o_object_fit_cover" t-att-class="{ 'o-big': env.embedLivechat }" t-att-src="thread?.avatarUrl" alt="Thread image" draggable="false"/>
+                <img class="o-mail-ChatBubble-avatar bg-view rounded-circle object-fit-cover" t-att-class="{ 'o-big': env.embedLivechat }" t-att-src="thread?.avatarUrl" alt="Thread image" draggable="false"/>
             </button>
         </div>
     </t>

--- a/addons/mail/static/src/core/common/chat_hub.xml
+++ b/addons/mail/static/src/core/common/chat_hub.xml
@@ -61,7 +61,7 @@
             <ul class="m-0 p-0 overflow-auto o-scrollbar-thin" role="menu" t-ref="more-menu">
                 <t t-foreach="chatHub.folded.slice(chatHub.maxFolded)" t-as="cw" t-key="cw.localId">
                     <li class="o-mail-ChatHub-hiddenItem gap-2 px-2 py-1" role="menuitem" t-att-name="cw.displayName" t-on-click="() => cw.open({ focus: true })">
-                        <img class="o-mail-ChatHub-hiddenAvatar rounded-circle o_object_fit_cover" t-att-src="cw.thread?.avatarUrl" alt="Thread image" draggable="false"/>
+                        <img class="o-mail-ChatHub-hiddenAvatar rounded-circle object-fit-cover" t-att-src="cw.thread?.avatarUrl" alt="Thread image" draggable="false"/>
                         <p class="text-truncate fw-bold mb-0" t-esc="cw.displayName"/>
                         <div t-if="cw.thread?.importantCounter > 0" class="o-mail-ChatHub-hiddenCounter badge rounded-pill fw-bold o-discuss-badge" style="padding: 3px 6px">
                             <t t-out="cw.thread?.importantCounter"/>

--- a/addons/mail/static/src/core/common/chat_window.xml
+++ b/addons/mail/static/src/core/common/chat_window.xml
@@ -57,7 +57,7 @@
             </div>
             <t t-if="this.store.inPublicPage and this.store.self.type === 'guest'">
                 <button class="btn ps-1" t-if="!state.editingGuestName">
-                    <img class="o-mail-Discuss-selfAvatar rounded-circle o_object_fit_cover flex-shrink-0" alt="Avatar" t-att-src="store.self.avatarUrl" t-on-click="() => state.editingGuestName = true"/>
+                    <img class="o-mail-Discuss-selfAvatar rounded-circle object-fit-cover flex-shrink-0" alt="Avatar" t-att-src="store.self.avatarUrl" t-on-click="() => state.editingGuestName = true"/>
                 </button>
                 <AutoresizeInput
                     t-if="state.editingGuestName"
@@ -99,7 +99,7 @@
         'ms-3': !thread,
         'ps-2': !hasActionsMenu,
     }" name="threadAvatar">
-        <img t-if="thread" class="rounded-3 o_object_fit_cover" t-att-src="thread.parent_channel_id?.avatarUrl ?? thread.avatarUrl" alt="Thread Image"/>
+        <img t-if="thread" class="rounded-3 object-fit-cover" t-att-src="thread.parent_channel_id?.avatarUrl ?? thread.avatarUrl" alt="Thread Image"/>
         <ImStatus t-if="showImStatus" className="'o-mail-ChatWindow-imStatus position-absolute'" member="thread.correspondent" size="'sm'"/>
     </div>
     <t t-if="thread?.parent_channel_id">

--- a/addons/mail/static/src/core/common/link_preview.xml
+++ b/addons/mail/static/src/core/common/link_preview.xml
@@ -27,7 +27,7 @@
                 </div>
                 <div class="o-mail-LinkPreviewCard-imageLinkWrap col-4 d-block">
                     <a t-att-href="props.linkPreview.source_url" target="_blank">
-                        <img t-if="props.linkPreview.og_image" class="w-100 h-100 o_object_fit_cover" t-att-src="props.linkPreview.og_image" t-att-alt="props.linkPreview.og_title" t-on-load="onImageLoaded"/>
+                        <img t-if="props.linkPreview.og_image" class="w-100 h-100 object-fit-cover" t-att-src="props.linkPreview.og_image" t-att-alt="props.linkPreview.og_title" t-on-load="onImageLoaded"/>
                         <span t-else="" class="d-flex align-items-center justify-content-center w-100 h-100 bg-100 text-300">
                             <i class="fa fa-camera fa-2x"/>
                         </span>
@@ -88,7 +88,7 @@
 
     <t t-name="mail.LinkPreviewVideo.preview">
         <div  class="o-mail-LinkPreviewVideo-overlay position-relative h-100 rounded-bottom" t-att-class="{'bg-dark': !props.linkPreview.og_image}">
-            <img t-if="props.linkPreview.og_image" class="img-fluid h-100 o_object_fit_cover" t-att-src="props.linkPreview.og_image" t-att-alt="props.linkPreview.og_title" t-on-load="onImageLoaded"/>
+            <img t-if="props.linkPreview.og_image" class="img-fluid h-100 object-fit-cover" t-att-src="props.linkPreview.og_image" t-att-alt="props.linkPreview.og_title" t-on-load="onImageLoaded"/>
             <i t-elif="props.linkPreview.videoURL" class="fa fa-television fa-8x position-absolute top-50 start-50 translate-middle"/>
             <span t-else="" class="d-flex align-items-center justify-content-center w-100 h-100 bg-100 text-300">
                 <i class="fa fa-camera fa-2x"/>

--- a/addons/mail/static/src/core/common/message.js
+++ b/addons/mail/static/src/core/common/message.js
@@ -237,8 +237,8 @@ export class Message extends Component {
 
     get authorAvatarAttClass() {
         return {
-            o_object_fit_contain: this.props.message.author?.is_company,
-            o_object_fit_cover: !this.props.message.author?.is_company,
+            "object-fit-contain": this.props.message.author?.is_company,
+            "object-fit-cover": !this.props.message.author?.is_company,
         };
     }
 

--- a/addons/mail/static/src/core/common/message_in_reply.xml
+++ b/addons/mail/static/src/core/common/message_in_reply.xml
@@ -9,7 +9,7 @@
             }">
                 <span class="d-inline-flex align-items-center text-muted opacity-75" t-att-class="{ 'cursor-pointer opacity-100-hover': props.onClick }" t-on-click="() => this.props.onClick?.()">
                     <t t-if="!props.message.parent_id.isEmpty">
-                        <img class="o-mail-MessageInReply-avatar me-2 rounded o_object_fit_cover" t-att-src="authorAvatarUrl" t-att-title="props.message.parent_id.author?.name ?? props.message.parent_id.email_from" alt="Avatar"/>
+                        <img class="o-mail-MessageInReply-avatar me-2 rounded object-fit-cover" t-att-src="authorAvatarUrl" t-att-title="props.message.parent_id.author?.name ?? props.message.parent_id.email_from" alt="Avatar"/>
                         <span class="o-mail-MessageInReply-content overflow-hidden smaller">
                             <b class="o-mail-MessageInReply-author"><t t-out="props.message.parent_id.author?.name ?? props.message.parent_id.email_from"/></b>:
                             <span class="o-mail-MessageInReply-message ms-1 text-break">

--- a/addons/mail/static/src/core/common/message_reaction_menu.xml
+++ b/addons/mail/static/src/core/common/message_reaction_menu.xml
@@ -14,7 +14,7 @@
                 </div>
                 <div class="d-flex overflow-auto o-scrollbar-thin flex-column flex-grow-1 bg-view p-2 h-100">
                     <div t-foreach="state.reaction.personas" t-as="persona" t-key="persona.id" class="o-mail-MessageReactionMenu-persona d-flex p-1 align-items-center" t-att-class="{ 'o-isDeviceSmall': ui.isSmall }">
-                        <img class="rounded o_object_fit_cover o-mail-MessageReactionMenu-avatar" t-att-src="persona.avatarUrl"/>
+                        <img class="rounded object-fit-cover o-mail-MessageReactionMenu-avatar" t-att-src="persona.avatarUrl"/>
                         <span class="d-flex flex-grow-1 align-items-center">
                             <span class="mx-2 text-truncate fs-6" t-esc="props.message.getPersonaName(persona)"/>
                             <div class="flex-grow-1"/>

--- a/addons/mail/static/src/core/common/thread.xml
+++ b/addons/mail/static/src/core/common/thread.xml
@@ -107,7 +107,7 @@
             'mt-1': props.thread.parent_channel_id,
         }">
             <div class="o-mail-Thread-avatar d-inline" t-att-class="{'o-mail-Thread-avatarChatWindow': env.inChatWindow }">
-                <img t-if="!props.thread.parent_channel_id" class="rounded-3 o_object_fit_cover" t-att-src="props.thread?.avatarUrl" alt="Thread Image"/>
+                <img t-if="!props.thread.parent_channel_id" class="rounded-3 object-fit-cover" t-att-src="props.thread?.avatarUrl" alt="Thread Image"/>
                 <i t-else="" class="fa fa-comments-o opacity-75"/>
             </div>
             <h1 class="opacity-75" t-att-class="{ 'fs-3': env.inChatWindow, 'mb-0': env.inChatWindow, 'mb-1': !env.inChatWindow }" t-esc="startMessageTitle"/>

--- a/addons/mail/static/src/core/public_web/discuss.xml
+++ b/addons/mail/static/src/core/public_web/discuss.xml
@@ -9,7 +9,7 @@
             <div class="o-mail-Discuss-header px-2 d-flex flex-shrink-0 align-items-center border-bottom border-secondary z-1 flex-grow-0" t-ref="header">
                 <t t-if="thread">
                     <div t-if="['channel', 'group', 'chat'].includes(thread.channel_type)" class="o-mail-Discuss-threadAvatar position-relative align-self-center align-items-center mx-2 my-1 bg-inherit">
-                        <img class="rounded-3 o_object_fit_cover" t-att-src="thread.parent_channel_id?.avatarUrl ?? thread.avatarUrl" alt="Thread Image"/>
+                        <img class="rounded-3 object-fit-cover" t-att-src="thread.parent_channel_id?.avatarUrl ?? thread.avatarUrl" alt="Thread Image"/>
                         <FileUploader t-if="!thread.parent_channel_id and thread.is_editable and thread.channel_type !== 'chat'" acceptedFileExtensions="'.bmp, .jpg, .jpeg, .png, .svg'" showUploadingText="false" multiUpload="false" onUploaded.bind="(data) => this.onFileUploaded(data)">
                             <t t-set-slot="toggler">
                                 <a href="#" class="position-absolute z-1 h-100 w-100 rounded-3 start-0 bottom-0" title="Upload Avatar">
@@ -72,7 +72,7 @@
                             <span t-if="!group_last" class="text-muted align-self-stretch ms-2 me-1"/>
                         </t>
                         <div t-if="store.inPublicPage and !ui.isSmall" class="d-flex align-items-center">
-                            <img class="o-mail-Discuss-selfAvatar ms-3 me-1 rounded-3 o_object_fit_cover flex-shrink-0 smaller" alt="Avatar" t-att-src="store.self.avatarUrl"/>
+                            <img class="o-mail-Discuss-selfAvatar ms-3 me-1 rounded-3 object-fit-cover flex-shrink-0 smaller" alt="Avatar" t-att-src="store.self.avatarUrl"/>
                             <div class="fw-bold flex-shrink-1 text-dark">
                                 <t t-if="store.self.type === 'partner'" t-esc="store.self.name"/>
                                 <t t-else="">

--- a/addons/mail/static/src/core/web/activity.xml
+++ b/addons/mail/static/src/core/web/activity.xml
@@ -5,7 +5,7 @@
     <div class="o-mail-Activity d-flex py-1 mb-2" t-on-click="onClick">
         <div class="o-mail-Activity-sidebar d-flex flex-shrink-0 position-relative align-items-start justify-content-center">
             <div class="o-mail-Activity-avatarContainer position-relative d-flex align-items-center justify-content-center" t-att-role="props.activity.persona ? 'button' : 'img'" t-on-click="onClickAvatar">
-                <img t-if="props.activity.persona" class="w-100 h-100 rounded o_object_fit_cover" t-att-src="props.activity.persona.avatarUrl" />
+                <img t-if="props.activity.persona" class="w-100 h-100 rounded object-fit-cover" t-att-src="props.activity.persona.avatarUrl" />
                 <div
                     class="o-mail-Activity-iconContainer rounded-circle d-flex align-items-center justify-content-center"
                     t-att-class="{

--- a/addons/mail/static/src/core/web/activity_list_popover_item.xml
+++ b/addons/mail/static/src/core/web/activity_list_popover_item.xml
@@ -29,7 +29,7 @@
                 </button>
             </div>
             <div class="d-flex align-items-center flex-wrap mx-3">
-                <img class="me-2 rounded o_object_fit_cover" t-if="props.activity.persona" t-att-src="props.activity.persona.avatarUrl" style="max-width: 1.5rem; max-height: 1.5rem;"/>
+                <img class="me-2 rounded object-fit-cover" t-if="props.activity.persona" t-att-src="props.activity.persona.avatarUrl" style="max-width: 1.5rem; max-height: 1.5rem;"/>
                 <div class="mt-1">
                     <small t-if="props.activity.persona" class="text-truncate" t-esc="props.activity.persona.displayName"/>
                     <small t-if="props.activity.state !== 'today'" class="mx-1">-</small>

--- a/addons/mail/static/src/discuss/call/common/call_invitation.xml
+++ b/addons/mail/static/src/discuss/call/common/call_invitation.xml
@@ -6,13 +6,13 @@
             'o-cameraPreview': state.videoStream,
         }">
             <div class="position-relative d-flex justify-content-center position-absolute h-100 w-100 rounded-3">
-                <video class="shadow rounded h-100 w-100 o_object_fit_cover rounded-3" autoplay="" t-ref="video"/>
+                <video class="shadow rounded h-100 w-100 object-fit-cover rounded-3" autoplay="" t-ref="video"/>
             </div>
             <div t-if="props.thread.rtcInvitingSession" class="o-discuss-CallInvitation-correspondent d-flex justify-content-around align-items-center text-nowrap px-3 mb-2 z-1" t-att-class="{
                 'align-self-start mt-3': state.videoStream,
                 'flex-column mt-4': !state.videoStream,
             }">
-                <img class="o-discuss-CallInvitation-avatar mb-2 rounded-circle cursor-pointer o_object_fit_cover"
+                <img class="o-discuss-CallInvitation-avatar mb-2 rounded-circle cursor-pointer object-fit-cover"
                     t-att-src="props.thread.rtcInvitingSession.channel_member_id.persona.avatarUrl"
                     t-on-click="onClickAvatar"
                     alt="Avatar"/>

--- a/addons/mail/static/src/discuss/call/common/call_participant_card.xml
+++ b/addons/mail/static/src/discuss/call/common/call_participant_card.xml
@@ -30,7 +30,7 @@
             </t>
             <CallParticipantVideo t-elif="hasVideo" session="rtcSession" type="props.cardData.type" inset="props.inset"/>
             <div t-else="" class="o-discuss-CallParticipantCard-avatar d-flex align-items-center justify-content-center h-100 w-100 rounded-1" t-att-class="{ 'o-minimized': props.minimized, 'o-isRemoteVideo': isRemoteVideo }" draggable="false">
-                <img t-if="!showRemoteWarning" alt="Avatar" class="h-100 rounded-circle border-5 o_object_fit_cover" t-att-src="channelMember?.persona.avatarUrl" draggable="false" t-att-class="{
+                <img t-if="!showRemoteWarning" alt="Avatar" class="h-100 rounded-circle border-5 object-fit-cover" t-att-src="channelMember?.persona.avatarUrl" draggable="false" t-att-class="{
                     'o-isTalking': isTalking,
                     'o-isInvitation': !rtcSession,
                 }"/>

--- a/addons/mail/static/src/discuss/call/public_web/discuss_sidebar_call_participants.xml
+++ b/addons/mail/static/src/discuss/call/public_web/discuss_sidebar_call_participants.xml
@@ -67,7 +67,7 @@
     <t t-name="mail.DiscussSidebarCallParticipants.participant">
         <div class="o-mail-DiscussSidebarCallParticipants-participant d-flex text-reset overflow-hidden align-items-center" t-att-class="{ 'justify-content-center bg-inherit': isCompact }">
             <div class="bg-inherit position-relative d-flex flex-shrink-0" style="width:26px;height:26px;margin:1px;">
-                <img class="o-mail-DiscussSidebarCallParticipants-avatar w-100 h-100 rounded-circle o_object_fit_cover" t-att-src="session.channel_member_id.persona.avatarUrl" t-att-class="{'o-isTalking': !session.isMute and session.isTalking}" alt="Participant avatar" t-att-title="session.channel_member_id.name"/>
+                <img class="o-mail-DiscussSidebarCallParticipants-avatar w-100 h-100 rounded-circle object-fit-cover" t-att-src="session.channel_member_id.persona.avatarUrl" t-att-class="{'o-isTalking': !session.isMute and session.isTalking}" alt="Participant avatar" t-att-title="session.channel_member_id.name"/>
             </div>
             <span t-if="!isCompact" class="o-mail-DiscussSidebarCallParticipants-name mx-1 text-truncate fw-bold smaller user-select-none" t-att-title="session.channel_member_id.name" t-att-class="{ 'o-isTalking': !session.isMute and session.isTalking }">
                 <t t-esc="session.channel_member_id.name"/>

--- a/addons/mail/static/src/discuss/core/common/avatar_stack.xml
+++ b/addons/mail/static/src/discuss/core/common/avatar_stack.xml
@@ -4,7 +4,7 @@
         <div t-if="props.personas.length > 0" class="bg-inherit" t-att-class="props.containerClass" t-on-click="props.onClick">
             <div class="d-flex bg-inherit" t-att-class="{'flex-column': props.direction === 'v'}">
                 <span t-foreach="props.personas.slice(0, props.max)" t-as="persona" t-key="persona.localId" class="bg-inherit rounded-circle position-relative" t-attf-style="{{getStyle(persona_index)}}">
-                    <img t-att-src="persona.avatarUrl" t-att-title="persona.displayName" class="w-100 h-100 rounded-circle o_object_fit_cover" t-attf-class="{{props.avatarClass(persona)}}"/>
+                    <img t-att-src="persona.avatarUrl" t-att-title="persona.displayName" class="w-100 h-100 rounded-circle object-fit-cover" t-attf-class="{{props.avatarClass(persona)}}"/>
                     <t t-slot="avatarExtraInfo" persona="persona"/>
                 </span>
                 <span t-if="props.personas.length > props.max" class="rounded-circle bg-secondary smaller d-flex justify-content-center align-items-center user-select-none" t-attf-style="{{getStyle(props.personas.length)}}; font-weight: 450;">+<t t-esc="props.personas.length - props.max"/></span>

--- a/addons/mail/static/src/discuss/core/common/channel_invitation.xml
+++ b/addons/mail/static/src/discuss/core/common/channel_invitation.xml
@@ -19,10 +19,10 @@
                     </div>
                     <div t-if="state.searchResultCount > selectablePartners.length" class="smaller text-muted mx-1 fst-italic" t-esc="showingResultNarrowText"/>
                     <t t-foreach="selectablePartners" t-as="selectablePartner" t-key="selectablePartner.id">
-                        <li class="o-discuss-ChannelInvitation-selectable o_object_fit_cover d-flex align-items-center px-1 py-0 btn list-group-item border-0 rounded-0" t-att-class="{ 'o-odd': selectablePartner_index % 2 === 1, 'o-selected': selectablePartner.in(selectedPartners) }" t-on-click="() => this.onClickSelectablePartner(selectablePartner)">
+                        <li class="o-discuss-ChannelInvitation-selectable object-fit-cover d-flex align-items-center px-1 py-0 btn list-group-item border-0 rounded-0" t-att-class="{ 'o-odd': selectablePartner_index % 2 === 1, 'o-selected': selectablePartner.in(selectedPartners) }" t-on-click="() => this.onClickSelectablePartner(selectablePartner)">
                             <div class="d-flex align-items-center p-1 bg-inherit">
                                 <div class="o-discuss-ChannelInvitation-avatar position-relative d-flex flex-shrink-0 bg-inherit">
-                                    <img class="w-100 h-100 rounded-3 o_object_fit_cover" t-att-src="selectablePartner.avatarUrl"/>
+                                    <img class="w-100 h-100 rounded-3 object-fit-cover" t-att-src="selectablePartner.avatarUrl"/>
                                     <ImStatus persona="selectablePartner" className="'position-absolute top-100 start-100 translate-middle mt-n1 ms-n1'" size="'md'"/>
                                 </div>
                             </div>

--- a/addons/mail/static/src/discuss/core/common/channel_member_list.xml
+++ b/addons/mail/static/src/discuss/core/common/channel_member_list.xml
@@ -37,7 +37,7 @@
     <t t-name="discuss.channel_member">
         <div class="o-discuss-ChannelMember d-flex align-items-center p-1 bg-inherit rounded-3" t-att-class="{ 'cursor-pointer': canOpenChatWith(member), 'o-offline': offline }" t-on-click.stop="(ev) => this.onClickAvatar(ev, member)">
             <div class="bg-inherit o-discuss-ChannelMember-avatar position-relative d-flex flex-shrink-0 rounded-3">
-                <img class="w-100 h-100 rounded-3 o_object_fit_cover" t-att-src="member.persona.avatarUrl"/>
+                <img class="w-100 h-100 rounded-3 object-fit-cover" t-att-src="member.persona.avatarUrl"/>
                 <ImStatus member="member" className="'position-absolute top-100 start-100 translate-middle mt-n1 ' + (member.isTyping ? 'ms-n2' : 'ms-n1')" size="'md'"/>
             </div>
             <div t-ref="displayName" class="d-flex overflow-hidden flex-column">

--- a/addons/mail/static/src/discuss/core/common/message_seen_indicator.xml
+++ b/addons/mail/static/src/discuss/core/common/message_seen_indicator.xml
@@ -12,7 +12,7 @@
     <t t-name="mail.MessageSeenIndicatorPopover.card">
         <div class="o-mail-MessageSeenIndicatorPopover-card d-flex align-items-center gap-2">
             <span class="o_avatar position-relative o_card_avatar" style="width: 30px;height:30px;">
-                <img t-att-src="member.persona.avatarUrl" class="w-100 h-100 rounded o_object_fit_cover" />
+                <img t-att-src="member.persona.avatarUrl" class="w-100 h-100 rounded object-fit-cover" />
             </span>
             <span class="fw-bold" t-esc="member.name"/>
             <span t-if="member.lastSeenDt" class="ms-auto text-muted small" t-out="member.lastSeenDt"/>

--- a/addons/mail/static/src/discuss/core/public_web/discuss_command_palette.xml
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_command_palette.xml
@@ -5,7 +5,7 @@
         <div class="o-mail-DiscussCommand o_command_default d-flex align-items-center ps-3 pe-4" t-att-class="{ 'o-uiSmall': ui.isSmall }">
             <i t-if="props.channel" class="fa-fw opacity-50 text-muted me-2" t-att-class="props.channel.parent_channel_id ? 'fa fa-comments-o' : props.channel.discussAppCategory?.icon ?? 'fa fa-user opacity-0'"/>
             <i t-elif="props.persona" class="fa fa-fw fa-user opacity-50 text-muted me-2"/>
-            <img class="rounded-3 me-2 o_object_fit_cover shadow-sm" t-if="props.imgUrl" t-att-src="props.imgUrl"  style="width: 32px; height: 32px"/>
+            <img class="rounded-3 me-2 object-fit-cover shadow-sm" t-if="props.imgUrl" t-att-src="props.imgUrl"  style="width: 32px; height: 32px"/>
             <ImStatus t-if="props.persona" className="'me-1'" persona="props.persona"/>
             <span class="pe-1 text-ellipsis d-flex align-items-center fw-bold" t-att-class="{ 'o-action': props.action }">
                 <t t-if="props.channel?.parent_channel_id">

--- a/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.xml
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.xml
@@ -158,7 +158,7 @@
         >
             <div class="o-mail-DiscussSidebarChannel-itemMain border-0 rounded-start-2 text-reset d-flex align-items-center p-0" t-att-class="{ 'overflow-hidden': !store.discuss.isSidebarCompact }" t-att-title="store.discuss.isSidebarCompact ? undefined : thread.displayName">
                 <div class="bg-inherit position-relative d-flex flex-shrink-0 o-my-0_5 rounded-3" style="width:32px;height:32px;" t-att-class="{ 'ms-2': !store.discuss.isSidebarCompact }">
-                    <img class="w-100 h-100 rounded-3 o_object_fit_cover shadow-sm" t-att-src="thread.avatarUrl" alt="Thread Image"/>
+                    <img class="w-100 h-100 rounded-3 object-fit-cover shadow-sm" t-att-src="thread.avatarUrl" alt="Thread Image"/>
                     <ThreadIcon t-if="thread.channel_type?.includes('chat') or (thread.channel_type === 'channel' and !thread.group_public_id)" thread="thread" size="'small'" className="'o-mail-DiscussSidebarChannel-threadIcon position-absolute top-100 start-100 translate-middle mt-n1 ms-n1 d-flex align-items-center justify-content-center rounded-circle bg-inherit'"/>
                     <CountryFlag t-if="thread.showCorrespondentCountry" country="thread.correspondentCountry" class="'position-absolute o-mail-DiscussSidebarChannel-country border shadow-sm'"/>
                 </div>

--- a/addons/point_of_sale/static/src/app/components/product_card/product_card.xml
+++ b/addons/point_of_sale/static/src/app/components/product_card/product_card.xml
@@ -9,7 +9,7 @@
             t-att-data-product-id="props.productId"
             t-attf-aria-labelledby="article_product_{{props.productId}}">
             <div t-if="props.imageUrl" class="product-img ratio ratio-4x3 rounded-top rounded-3">
-                <img class="w-100 o_object_fit_cover bg-200 pe-none" t-att-src="props.imageUrl" t-att-alt="props.name" draggable="false"/>
+                <img class="w-100 object-fit-cover bg-200 pe-none" t-att-src="props.imageUrl" t-att-alt="props.name" draggable="false"/>
             </div>
             <div class="product-content h-100 px-2 rounded-bottom-3 flex-shrink-1"
                 t-att-class="{'d-flex' : !props.isComboPopup, 'my-1': !(props.isComboPopup and !props.imageUrl)}">

--- a/addons/portal/views/portal_templates.xml
+++ b/addons/portal/views/portal_templates.xml
@@ -120,7 +120,7 @@
                 <a href="#" role="button" data-bs-toggle="dropdown" t-attf-class="#{'' if _no_caret else 'dropdown-toggle'} #{_link_class}">
                     <t t-if="_avatar">
                         <t t-set="avatar_source" t-value="image_data_uri(user_id.avatar_256)"/>
-                        <img t-att-src="avatar_source" t-attf-class="rounded-circle o_object_fit_cover #{_avatar_class}" width="24" height="24" alt="" loading="eager"/>
+                        <img t-att-src="avatar_source" t-attf-class="rounded-circle object-fit-cover #{_avatar_class}" width="24" height="24" alt="" loading="eager"/>
                     </t>
                     <div t-if="_icon" t-attf-class="#{_icon_wrap_class}">
                         <i t-attf-class="fa fa-1x fa-fw fa-user #{_icon_class}"/>
@@ -742,7 +742,7 @@
         </div>
         <div t-attf-class="{{'offcanvas-body' if isOffcanvas else 'mt-3 mw-100'}}">
             <div class="d-flex justify-content-start align-items-start gap-3 mb-4">
-                <img class="rounded o_object_fit_cover" t-att-src="image_data_uri(user_id.partner_id.avatar_128)" alt="Contact" width="50"/>
+                <img class="rounded object-fit-cover" t-att-src="image_data_uri(user_id.partner_id.avatar_128)" alt="Contact" width="50"/>
                 <div class="d-flex flex-column justify-content-center">
                     <h5 class="mb-0" t-out="user_id.name"/>
                     <p class="mb-0 text-muted" t-out="user_id.company_name"/>

--- a/addons/web/static/src/scss/ui.scss
+++ b/addons/web/static/src/scss/ui.scss
@@ -131,16 +131,6 @@ span.o_force_ltr {
 }
 */
 
-// To fill the available space while keeping aspect ratio (crop).
-// Assuming the important part of the image is its center.
-.o_object_fit_cover {
-    object-fit: cover;
-}
-
-.o_object_fit_contain {
-    object-fit: contain;
-}
-
 .o_image_24_cover {
     width: 24px;
     height: 24px;

--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
@@ -2003,7 +2003,7 @@ export class OdooEditor extends EventTarget {
             avatarElement.append(image);
             image.onload = () => avatarElement.style.removeProperty('display');
             image.setAttribute('src', clientAvatarUrl);
-            image.classList.add('o_object_fit_cover');
+            image.classList.add('object-fit-cover');
         }
         // Avoid re-appending the element in the dom.
         if (!avatarElement.parentElement) {

--- a/addons/website_event_track_quiz/views/event_leaderboard_templates.xml
+++ b/addons/website_event_track_quiz/views/event_leaderboard_templates.xml
@@ -75,7 +75,7 @@
         <span t-out="visitor['position']"/>
     </td>
     <td class="align-middle d-none d-sm-table-cell">
-        <img class="o_object_fit_cover rounded-circle o_wprofile_img_small"
+        <img class="object-fit-cover rounded-circle o_wprofile_img_small"
         width="30"
         height="30"
         t-att-src="image_data_uri(visitor['visitor'].partner_image) if visitor['visitor'].partner_image else '/web/static/img/user_placeholder.jpg'"/>

--- a/addons/website_forum/views/forum_forum_templates_layout.xml
+++ b/addons/website_forum/views/forum_forum_templates_layout.xml
@@ -278,7 +278,7 @@
         <a t-attf-href="/forum/user/#{ uid }?forum_id=#{ forum.id if forum else '' }&amp;forum_origin=#{ request.httprequest.path }"
             class="btn w-100 py-1 text-start d-flex align-items-center" data-bs-toggle="tooltip" data-trigger="hover"
             title="My profile">
-            <img class="o_wforum_avatar rounded-circle o_object_fit_cover" t-att-src="request.website.image_url(user, 'avatar_128', '60x60')" alt="Avatar"/>
+            <img class="o_wforum_avatar rounded-circle object-fit-cover" t-att-src="request.website.image_url(user, 'avatar_128', '60x60')" alt="Avatar"/>
             <div class="d-flex flex-column justify-content-center ms-2">
                 <span class="mt-0 mb-1 h6-fs fw-bold" t-out="user_id.name"/>
                 <span class="fs-6 text-reset opacity-50"><t t-out="user_id.karma"/> XP</span>

--- a/addons/website_forum/views/forum_forum_templates_tools.xml
+++ b/addons/website_forum/views/forum_forum_templates_tools.xml
@@ -148,7 +148,7 @@
             <t t-set="user_profile_url" t-valuef="/forum/user/#{ object.create_uid.id }?forum_id=#{ object.forum_id.id }&amp;forum_origin=#{ request.httprequest.path }"/>
         </t>
         <a t-if="show_image" t-att-href="user_profile_url or '#'" t-attf-class="o_wforum_author_pic position-relative #{ 'pe-none' if not user_profile_url else '' }">
-            <img t-attf-class="o_wforum_avatar rounded-circle o_object_fit_cover #{'me-2' if show_name or show_date or show_karma else '' } #{_image_classes}" t-att-src="website.image_url(object.create_uid, 'avatar_128', '60x60')" alt="Avatar"/>
+            <img t-attf-class="o_wforum_avatar rounded-circle object-fit-cover #{'me-2' if show_name or show_date or show_karma else '' } #{_image_classes}" t-att-src="website.image_url(object.create_uid, 'avatar_128', '60x60')" alt="Avatar"/>
         </a>
         <div t-if="show_name or show_date or show_karma" t-attf-class="d-flex #{ 'align-items-baseline' if compact else 'flex-column justify-content-around' } #{ 'ms-2' if show_image else '' }">
             <a t-att-href="user_profile_url" t-attf-class="my-0 text-reset h6 #{ 'small' if compact else ''}" t-field="object.create_uid" t-options='{"widget": "contact", "fields": ["name"]}'/>

--- a/addons/website_livechat/static/src/web/thread_patch.xml
+++ b/addons/website_livechat/static/src/web/thread_patch.xml
@@ -5,7 +5,7 @@
             <t t-set="visitor" t-value="props.thread.livechat_visitor_id"/>
             <div t-if="visitor and !env.inChatWindow" class="o-website_livechat-VisitorBanner py-4 px-2 d-flex border-bottom">
                 <div t-if="props.thread.correspondent" class="o-website_livechat-VisitorBanner-sidebar me-2 d-flex justify-content-center">
-                    <img class="rounded o-website_livechat-VisitorBanner-avatar o_object_fit_cover" t-att-src="props.thread.correspondent.persona.avatarUrl" alt="Avatar"/>
+                    <img class="rounded o-website_livechat-VisitorBanner-avatar object-fit-cover" t-att-src="props.thread.correspondent.persona.avatarUrl" alt="Avatar"/>
                 </div>
                 <div>
                     <div class="d-flex align-items-baseline">

--- a/addons/website_profile/views/website_profile.xml
+++ b/addons/website_profile/views/website_profile.xml
@@ -138,7 +138,7 @@
                         <div class="o_wprofile_sidebar_top d-flex justify-content-between">
                             <div t-if="user.rank_id" class="d-flex align-items-center">
                                 <small class="fw-bold me-2">Current rank:</small>
-                                <img t-att-src="website.image_url(user.rank_id, 'image_128')" width="16" height="16" alt="" class="o_object_fit_cover me-1"/>
+                                <img t-att-src="website.image_url(user.rank_id, 'image_128')" width="16" height="16" alt="" class="object-fit-cover me-1"/>
                                 <a t-attf-href="/profile/ranks_badges?url_origin=#{request.httprequest.path}&amp;name_origin=#{user.name}" t-field="user.rank_id"/>
                             </div>
                             <button class="btn btn-sm d-md-none bg-white border" type="button" data-bs-toggle="collapse" data-bs-target="#o_wprofile_sidebar_collapse" aria-expanded="false" aria-controls="o_wprofile_sidebar_collapse">More info</button>
@@ -263,11 +263,11 @@
                             <div class="card-body p-2 pe-3">
                                 <div class="d-flex align-items-center">
                                     <div t-if="badge.badge_id.image_1920 and badge.badge_id.level" t-field="badge.badge_id.image_1920"
-                                        t-options="{'widget': 'image', 'preview_image': 'image_128', 'class': 'o_object_fit_cover me-0', 'style': 'height: 38px; width: 38px'}"/>
+                                        t-options="{'widget': 'image', 'preview_image': 'image_128', 'class': 'object-fit-cover me-0', 'style': 'height: 38px; width: 38px'}"/>
                                     <img t-else=""
                                         width="38" height="38"
                                         t-attf-src="/website_profile/static/src/img/badge_#{badge.badge_id.level}.svg"
-                                        class="o_object_fit_cover me-0"
+                                        class="object-fit-cover me-0"
                                         t-att-alt="badge.badge_id.name"/>
                                     <div class="flex-grow-1 col-md-10 p-0">
                                         <h6 class="my-0 ps-1 text-truncate" t-field="badge.badge_id.name"/>
@@ -499,7 +499,7 @@
             <span t-esc="user['position']"/>
         </td>
         <td class="align-middle d-none d-sm-table-cell">
-            <img class="o_object_fit_cover rounded-circle o_wprofile_img_small" width="30" height="30" t-att-src="'/profile/avatar/%s?field=avatar_128%s' % (user['id'], '&amp;res_model=%s&amp;res_id=%s' % (record._name, record.id) if record else '')"/>
+            <img class="object-fit-cover rounded-circle o_wprofile_img_small" width="30" height="30" t-att-src="'/profile/avatar/%s?field=avatar_128%s' % (user['id'], '&amp;res_model=%s&amp;res_id=%s' % (record._name, record.id) if record else '')"/>
         </td>
         <td class="align-middle w-md-75">
             <span class="fw-bold" t-esc="user['name']"/><br/>

--- a/addons/website_slides/views/website_slides_templates_homepage.xml
+++ b/addons/website_slides/views/website_slides_templates_homepage.xml
@@ -477,7 +477,7 @@
     <div class="o_wslides_home_aside">
         <div t-if="user.rank_id" class="d-flex align-items-center">
             <span class="fw-bold text-muted me-2">Current rank:</span>
-            <img t-att-src="website.image_url(user.rank_id, 'image_128')" width="16" height="16" alt="" class="o_object_fit_cover me-1"/>
+            <img t-att-src="website.image_url(user.rank_id, 'image_128')" width="16" height="16" alt="" class="object-fit-cover me-1"/>
             <a href="/profile/ranks_badges" t-field="user.rank_id"/>
         </div>
         <t t-set="next_rank_id" t-value="user._get_next_rank()"/>


### PR DESCRIPTION
*: html_editor, mail, point_of_sale, portal, web_editor, website_event_track_quiz, website_forum, website_livechat, website_profile, website_slides.

This commit replaces all occurrences of `o_object_fit_contain` and `o_object_fit_cover` CSS classes with their Bootstrap (v5.3) equivalent : `object-fit-contain` and `object-fit-cover`.
It also removes said classes from the repo since they are no longer of use. 

Requires: 
- https://github.com/odoo/enterprise/pull/88152

task-4703046


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
