### PR TITLE
[IMP] html_editor: add support for facebook video embedding

### DIFF
--- a/addons/html_editor/tests/__init__.py
+++ b/addons/html_editor/tests/__init__.py
@@ -1,1 +1,2 @@
 from . import test_controller
+from . import test_tools

--- a/addons/html_editor/tests/test_tools.py
+++ b/addons/html_editor/tests/test_tools.py
@@ -1,0 +1,26 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+import re
+
+from odoo.tests import common, tagged
+from odoo.addons.html_editor import tools
+
+
+@tagged("post_install", "-at_install")
+class TestVideoUtils(common.BaseCase):
+    urls = {
+        "facebook_video": "http://www.facebook.com/watch?v=2206239373151307",
+        "facebook_reel": "https://www.facebook.com/reel/568986686120283",
+    }
+
+    def test_player_regexes(self):
+        # facebook
+        self.assertIsNotNone(re.search(tools.player_regexes["facebook"], TestVideoUtils.urls["facebook_video"]))
+        self.assertIsNotNone(re.search(tools.player_regexes["facebook"], TestVideoUtils.urls["facebook_reel"]))
+
+    def test_get_video_source_data(self):
+        # facebook
+        self.assertEqual("facebook", tools.get_video_source_data(TestVideoUtils.urls["facebook_video"])[0])
+        self.assertEqual("2206239373151307", tools.get_video_source_data(TestVideoUtils.urls["facebook_video"])[1])
+        self.assertEqual("facebook", tools.get_video_source_data(TestVideoUtils.urls["facebook_reel"])[0])
+        self.assertEqual("568986686120283", tools.get_video_source_data(TestVideoUtils.urls["facebook_reel"])[1])

--- a/addons/html_editor/tools.py
+++ b/addons/html_editor/tools.py
@@ -19,6 +19,7 @@ player_regexes = {
     'dailymotion': r'(https?:\/\/)(www\.)?(dailymotion\.com\/(embed\/video\/|embed\/|video\/|hub\/.*#video=)|dai\.ly\/)(?P<id>[A-Za-z0-9]{6,7})',
     'instagram': r'(?:(.*)instagram.com|instagr\.am)/p/(.[a-zA-Z0-9-_\.]*)',
     'youku': r'(?:(https?:\/\/)?(v\.youku\.com/v_show/id_|player\.youku\.com/player\.php/sid/|player\.youku\.com/embed/|cloud\.youku\.com/services/sharev\?vid=|video\.tudou\.com/v/)|youku:)(?P<id>[A-Za-z0-9]+)(?:\.html|/v\.swf|)',
+    "facebook": r'^(?:(?:https?:)?//)?(?:www\.)?facebook\.com(?:/(?:[^/]+/)?videos/|/watch/?\?v=|/reel/|/plugins/video\.php\?[^ ]*?href=.*?(?:videos|reel)%2[Ff])(?P<id>\d+)',
 }
 
 
@@ -45,6 +46,9 @@ def get_video_source_data(video_url):
         youku_match = re.search(player_regexes['youku'], video_url)
         if youku_match:
             return ('youku', youku_match.group("id"), youku_match)
+        facebook_match = re.search(player_regexes["facebook"], video_url)
+        if facebook_match:
+            return ("facebook", facebook_match.group("id"), facebook_match)
     return None
 
 
@@ -106,6 +110,8 @@ def get_video_url_data(video_url, autoplay=False, loop=False, hide_controls=Fals
         embed_url = f'//www.instagram.com/p/{video_id}/embed/'
     elif platform == 'youku':
         embed_url = f'//player.youku.com/embed/{video_id}'
+    elif platform == "facebook":
+        embed_url = f"//facebook.com/plugins/video.php?href=https://www.facebook.com/username/videos/{video_id}/"
 
     if params:
         embed_url = f'{embed_url}?{url_encode(params)}'


### PR DESCRIPTION
Specification:
- Support embedding Facebook videos, reels in media_dialog component.

After this commit:
- The media dialog component will support embedding Facebook videos and
reels.

- Example of supported URLs:
  - Facebook video: `http://www.facebook.com/watch?v={video_id}`
  - Facebook reel: `https://www.facebook.com/reel/{video_id}`
  - Facebook reel: `https://www.facebook.com/odoo/videos/{video_id}`
- Example of embedded code:

      video: ```<iframe
                  src={source_link}
                  width="560"
                  height="314"
                  style="border:none;overflow:hidden"
                  scrolling="no" frameborder="0"
                  allowfullscreen="true"
                  allow="autoplay; clipboard-write; encrypted-media; picture-in-picture; web-share"
                  allowFullScreen="true">
              </iframe>```

      reel: ```<iframe
                  src={source_link}
                  width="267"
                  height="476"
                  style="border:none;overflow:hidden"
                  scrolling="no"
                  frameborder="0"
                  allowfullscreen="true"
                  allow="autoplay; clipboard-write; encrypted-media; picture-in-picture; web-share"
                  allowFullScreen="true">
              </iframe>```
task-4869099

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
