### PR TITLE
[FIX] mail, rating, im_livechat: rating image background in dark mode

### DIFF
--- a/addons/im_livechat/views/discuss_channel_views.xml
+++ b/addons/im_livechat/views/discuss_channel_views.xml
@@ -35,7 +35,7 @@
                     <field name="country_id"/>
                     <field name="duration" widget="float_time" options="{'displaySeconds': True}"/>
                     <field name="message_ids" string="# Messages"/>
-                    <field name="rating_last_image" string="Rating" widget="image" options='{"size": [20, 20]}' class="bg-view"/>
+                    <field name="rating_last_image" string="Rating" widget="image" options='{"size": [20, 20], "img_class": "bg-transparent"}'/>
                 </list>
             </field>
         </record>
@@ -53,7 +53,7 @@
                                     <span class="fw-bold">Duration: <field class="d-inline fw-normal" name="duration" widget="float_time" options="{'displaySeconds': True}"/></span>
                                     <span class="fw-bold">Date: <field name="create_date" class="fw-normal"/></span>
                                 </div>
-                                <field name="rating_last_image" string="Rating" widget="image" options='{"size": [40, 40]}' class="ms-auto"/>
+                                <field name="rating_last_image" string="Rating" widget="image" options='{"size": [40, 40], "img_class": "bg-transparent"}' class="ms-auto"/>
                             </div>
                             <footer class="pt-0">
                                 <t t-if="record.country_id.raw_value">
@@ -74,7 +74,7 @@
                 <form string="Session Form" create="false" edit="false">
                     <sheet>
                         <div style="width:50%" class="float-end">
-                            <field name="rating_last_image" widget="image" class="float-end bg-view" readonly="1" nolabel="1"/>
+                            <field name="rating_last_image" widget="image" options='{"img_class": "bg-transparent"}' class="float-end bg-view" readonly="1" nolabel="1"/>
                             <field name="rating_last_feedback" nolabel="1"/>
                         </div>
                         <div style="width:50%" class="float-start">

--- a/addons/mail/views/discuss_channel_views.xml
+++ b/addons/mail/views/discuss_channel_views.xml
@@ -15,7 +15,7 @@
                         <t t-name="card" class="row g-0">
                             <widget name="web_ribbon" class="d-flex" title="Archived" bg_color="text-bg-danger" invisible="active"/>
                             <aside class="col-2 my-auto">
-                                <field name="avatar_128" widget="image" options="{'size': [50, 50]}" alt="Channel"/>
+                                <field name="avatar_128" widget="image" options="{'size': [50, 50], 'img_class': 'bg-transparent'}" alt="Channel"/>
                             </aside>
                             <main class="col me-4 ms-2">
                                 <span class="fw-bold fs-5">#<field name="name"/></span>

--- a/addons/rating/views/rating_rating_views.xml
+++ b/addons/rating/views/rating_rating_views.xml
@@ -35,7 +35,7 @@
                             <group>
                                 <field name="partner_id"/>
                                 <div colspan="2" class="text-center" name="rating_image_container">
-                                    <field name="rating_image" widget='image'/>
+                                    <field name="rating_image" widget='image' options='{"img_class": "bg-transparent"}'/>
                                     <div class="mt4">
                                         <strong><field name="rating_text"/></strong>
                                     </div>
@@ -89,7 +89,7 @@
                     <templates>
                         <t t-name="card" class="row g-0">
                             <aside class="col-4 my-auto align-self-center">
-                                <field name="rating_image" widget="image" class="bg-view ms-3" />
+                                <field name="rating_image" widget="image" options='{"img_class": "bg-transparent"}' class="bg-view ms-3" />
                             </aside>
                             <main class="col ps-2">
                                 <field name="rated_partner_name" class="fw-bolder"/>


### PR DESCRIPTION
**Current behavior before PR:**
The rating images have an unintended white background in dark mode.

**Steps to Reproduce:**
- Turn on Dark Mode
- Go to livechat
- Go to Report > Sessions History  

**Desired behavior after PR is merged:**
This PR fixes the issue by applying a transparent background to rating images through the `img_class` option in image widget.

The change is applied to:
- discuss.channel (kanban, list, form views)
- rating.rating (form, kanban views)

---
**Before:**
<img width="372" height="202" alt="image" src="https://github.com/user-attachments/assets/d573ab3e-62be-4ab2-9c7f-e39bf97cb542" />

**After:**
<img width="394" height="141" alt="image" src="https://github.com/user-attachments/assets/6133c231-c634-4afd-a99f-5440ecfe72be" />

task-[4689867](https://www.odoo.com/odoo/project/1519/tasks/4689867)


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
