### PR TITLE
[FIX] pos_self_order: allow custom color configuration for self ui

### DIFF
--- a/addons/pos_self_order/static/src/app/kiosk_style.js
+++ b/addons/pos_self_order/static/src/app/kiosk_style.js
@@ -37,6 +37,10 @@ function generateKioskCSS(primaryBg, primaryText = "#fff") {
   --btn-disabled-border-color: ${primaryBg};
 }
 
+.bg-primary {
+    --background-color: ${primaryBg};
+}
+
 .text-primary {
   --color: rgba(${primaryRGB}, var(--text-opacity, 1));
 }

--- a/addons/pos_self_order/static/src/app/pages/confirmation_page/confirmation_page.xml
+++ b/addons/pos_self_order/static/src/app/pages/confirmation_page/confirmation_page.xml
@@ -8,7 +8,7 @@
                 </div>
             </div>
         </div>
-        <div t-else="" class="confirmation-page d-flex justify-content-center align-items-center flex-column h-100 p-3 text-center" t-attf-style="background-image:#{selfOrder.kioskBackgroundImage};background-size: cover; background-position: center;">
+        <div t-else="" class="confirmation-page d-flex justify-content-center align-items-center flex-column h-100 p-3 text-center o_self_background" t-attf-style="background-image:#{selfOrder.kioskBackgroundImage};background-size: cover; background-position: center;">
             <div class="d-flex flex-column align-items-center justify-content-center w-100 h-100">
                 <div class="mb-4">
                     <h1 t-if="state.payment and selfOrder.config.self_ordering_pay_after !== 'each'" class="fw-bold" style="text-wrap: pretty;">

--- a/addons/pos_self_order/static/src/app/self_order_index.js
+++ b/addons/pos_self_order/static/src/app/self_order_index.js
@@ -47,12 +47,13 @@ export class selfOrderIndex extends Component {
         }
 
         if (this.selfOrder.kioskMode) {
-            const styleConfig = this.selfOrder.config._self_ordering_style;
-            if (styleConfig) {
-                const { primaryBgColor, primaryTextColor } = styleConfig;
-                insertKioskStyle(primaryBgColor, primaryTextColor);
-            }
             document.documentElement.classList.add("kiosk");
+        }
+
+        const styleConfig = this.selfOrder.config._self_ordering_style;
+        if (styleConfig) {
+            const { primaryBgColor, primaryTextColor } = styleConfig;
+            insertKioskStyle(primaryBgColor, primaryTextColor);
         }
 
         if (this.env.debug) {


### PR DESCRIPTION
This modification allows customization of the color of the self-service ordering interface, as is the case for the kiosk.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
