### PR TITLE
[FIX] hw_drivers: mount point busy while remounting ro

### DIFF
--- a/addons/hw_drivers/main.py
+++ b/addons/hw_drivers/main.py
@@ -124,8 +124,11 @@ class Manager(Thread):
 
         # Set scheduled actions
         schedule and schedule.every().day.at("00:00").do(helpers.get_certificate_status)
+        # if mount point was held busy by a background process (e.g. apt upgrade)
+        # we need to ensure the system is remounted r/o later.
+        schedule and schedule.every(30).minutes.do(helpers.remount_ro)
 
-        #Setup the websocket connection
+        # Set up the websocket connection
         if server_url:
             iot_client.start()
         # Check every 3 secondes if the list of connected devices has changed and send the updated


### PR DESCRIPTION
If a process was holding the filesystem in r/w mode (e.g. apt upgrade), we were getting a "mount point is busy" error polluting logs.

We now check the filesystem mount mode (r/w or r/o) before trying to remount it. Also, we removed the lock, allowing multiple threads to use the context manager at the same time. This avoids many unnecessary `subprocess` calls, unnecessary remount r/o if another thread needs to write on the system, and avoids polluting the logs.

To ensure system is remounted r/o after the background process is done, we now check and remount every 30 minutes.

Task: 4551009