### PR TITLE
[FIX] sale_project: subtask should keep sale line according to milestone

### DIFF
--- a/addons/sale_project/models/project_task.py
+++ b/addons/sale_project/models/project_task.py
@@ -108,9 +108,11 @@ class ProjectTask(models.Model):
                 sale_line = False
                 if task.parent_id.sale_line_id and task.parent_id.partner_id.commercial_partner_id == task.partner_id.commercial_partner_id:
                     sale_line = task.parent_id.sale_line_id
+                elif task.milestone_id.sale_line_id:
+                    sale_line = task.milestone_id.sale_line_id
                 elif task.project_id.sale_line_id and task.project_id.partner_id.commercial_partner_id == task.partner_id.commercial_partner_id:
                     sale_line = task.project_id.sale_line_id
-                task.sale_line_id = sale_line or task.milestone_id.sale_line_id
+                task.sale_line_id = sale_line
 
     @api.depends('sale_order_id')
     def _compute_display_sale_order_button(self):


### PR DESCRIPTION
**Step to reprocduce :**
1. Install sale_project module
2. Create a product
        - type: Service
        - Invoice policy: based on the milestones
        - Create on order: Project & Task.
3. Create a sale order with that product and add two SO lines with different descriptions.
4. Confirm the sale order.
5. Click on the Tasks smart button in the sale order to open the generated tasks.
6. From one of the tasks (e.g., m1)
7. Manually remove the existing milestone and sales order item from the task.
8. Then assign a different milestone (e.g., m2) to the task.
9. The sale order item set different (e.g., m1) instead of the newly set milestone.

**Issue:**

When a task has its `milestone_id` and `sale_line_id` manually cleared, and a new milestone
is later assigned, the task does not get the correct Sales Order Item.

**Cause:**
In the `_compute_sale_line` method, the logic priority the parent task and project when
computing the `sale_line_id`, and only uses the `milestone_id.sale_line_id` as a fallback.

https://github.com/odoo/odoo/blob/259f7eafb15882807640a00cf6939129f27c8fbb/addons/sale_project/models/project_task.py#L109-L113

**Solution :** 

To fix this `_compute_sale_line` method to priority the milestone's `sale_line_id` 
when a milestone is explicitly set. This ensures that if the task’s milestone 
changes, its sale line reflects the one from the milestone, even for subtasks.

opw-4701106
