### PR TITLE
html_builder, website: remove *.inside.scss from bundle, split bundle

### DIFF
--- a/addons/html_builder/__manifest__.py
+++ b/addons/html_builder/__manifest__.py
@@ -64,7 +64,7 @@
         ],
         'web.assets_unit_tests': [
             'html_builder/static/tests/**/*',
-            ('include', 'html_builder.assets'),
+            ('include', 'website.website_builder_assets'),
         ],
     },
     'license': 'LGPL-3',

--- a/addons/html_builder/__manifest__.py
+++ b/addons/html_builder/__manifest__.py
@@ -36,6 +36,7 @@
             'web/static/lib/bootstrap/scss/_maps.scss',
             'web/static/fonts/fonts.scss',
             'html_builder/static/src/**/*',
+            ('remove', 'html_builder/static/src/**/*.inside.scss'),
             ('remove', 'html_builder/static/src/**/*.dark.scss'),
         ],
         'web.assets_web_dark': [

--- a/addons/html_builder/tests/__init__.py
+++ b/addons/html_builder/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_html_builder_assets_bundle

--- a/addons/html_builder/tests/test_html_builder_assets_bundle.py
+++ b/addons/html_builder/tests/test_html_builder_assets_bundle.py
@@ -1,0 +1,19 @@
+
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+import odoo.tests
+from odoo.tests.common import HttpCase
+
+
+@odoo.tests.tagged('-at_install', 'post_install')
+class TestHtmlBuilderAssetsBundle(HttpCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.bundle = cls.env["ir.qweb"]._get_asset_bundle("html_builder.assets", True)
+
+    def test_html_builder_assets_bundle_no_inside_scss(self):
+        for file in self.bundle.files:
+            filename = file["filename"]
+            self.assertFalse(filename.endswith("inside.scss"), msg="html_builder.assets must not contain *.inside.scss files. Remove " + filename)

--- a/addons/website/__manifest__.py
+++ b/addons/website/__manifest__.py
@@ -493,7 +493,8 @@
             # Don't include dark mode files in light mode
             ('remove', 'website/static/src/components/dialog/*.dark.scss'),
         ],
-        'html_builder.assets': [
+        'website.website_builder_assets': [
+            ('include', 'html_builder.assets'),
             'website/static/src/scss/website_common.scss',
             'website/static/src/builder/**/*',
             ('remove', 'website/static/src/builder/**/*.inside.scss'),

--- a/addons/website/__manifest__.py
+++ b/addons/website/__manifest__.py
@@ -494,9 +494,9 @@
             ('remove', 'website/static/src/components/dialog/*.dark.scss'),
         ],
         'html_builder.assets': [
-
             'website/static/src/scss/website_common.scss',
             'website/static/src/builder/**/*',
+            ('remove', 'website/static/src/builder/**/*.inside.scss'),
         ],
         'html_builder.iframe_add_dialog': [
             'website/static/src/snippets/**/*.edit.scss',

--- a/addons/website/static/src/client_actions/website_preview/website_builder_action.js
+++ b/addons/website/static/src/client_actions/website_preview/website_builder_action.js
@@ -113,7 +113,7 @@ export class WebsiteBuilderClientAction extends Component {
             }
             if (!this.ui.isSmall) {
                 // preload builder and snippets so clicking on "edit" is faster
-                loadBundle("html_builder.assets").then(() => {
+                loadBundle("website.website_builder_assets").then(() => {
                     this.env.services["html_builder.snippets"].load();
                 });
             }

--- a/addons/website/static/src/client_actions/website_preview/website_builder_action.xml
+++ b/addons/website/static/src/client_actions/website_preview/website_builder_action.xml
@@ -17,7 +17,7 @@
         <LocalOverlayContainer localOverlay="overlayRef" identifier="env.localOverlayContainerKey"/>
         <div t-att-class="{'o_builder_sidebar_open': state.isEditing and state.showSidebar, 'o_is_microsoft_edge': isMicrosoftEdge}"
             class="o-website-builder_sidebar border-start border-dark">
-            <LazyComponent  t-if="state.isEditing" Component="'website.WebsiteBuilder'" props="() => this.websiteBuilderProps" bundle="'html_builder.assets'" t-key="state.key"/>
+            <LazyComponent  t-if="state.isEditing" Component="'website.WebsiteBuilder'" props="() => this.websiteBuilderProps" bundle="'website.website_builder_assets'" t-key="state.key"/>
         </div>
     </div>
 </t>

--- a/addons/website/static/tests/builder/website_helpers.js
+++ b/addons/website/static/tests/builder/website_helpers.js
@@ -236,7 +236,7 @@ export async function setupWebsiteBuilder(
 
 async function openBuilderSidebar(editAssetsLoaded) {
     // The next line allow us to await asynchronous fetches and cache them before it is used
-    await Promise.all([getWebsiteSnippets(), loadBundle("html_builder.assets")]);
+    await Promise.all([getWebsiteSnippets(), loadBundle("website.website_builder_assets")]);
 
     await click(".o-website-btn-custo-primary");
     await editAssetsLoaded;

--- a/addons/website/tests/__init__.py
+++ b/addons/website/tests/__init__.py
@@ -37,3 +37,4 @@ from . import test_website_favicon
 from . import test_website_form_editor
 from . import test_website_reset_password
 from . import test_website_visitor
+from . import test_website_website_builder_assets_bundle

--- a/addons/website/tests/test_website_website_builder_assets_bundle.py
+++ b/addons/website/tests/test_website_website_builder_assets_bundle.py
@@ -1,0 +1,19 @@
+
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+import odoo.tests
+from odoo.tests.common import HttpCase
+
+
+@odoo.tests.tagged('-at_install', 'post_install')
+class TestWebsiteWebsiteBuilderAssetsBundle(HttpCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.bundle = cls.env["ir.qweb"]._get_asset_bundle("website.website_builder_assets", True)
+
+    def test_website_builder_assets_bundle_no_inside_scss(self):
+        for file in self.bundle.files:
+            filename = file["filename"]
+            self.assertFalse(filename.endswith("inside.scss"), msg="website.website_builder_assets must not contain *.inside.scss files. Remove " + filename)

--- a/addons/website_blog/__manifest__.py
+++ b/addons/website_blog/__manifest__.py
@@ -51,7 +51,7 @@
             'website_blog/static/src/scss/website_blog.scss',
             'website_blog/static/src/snippets/**/*.js',
         ],
-        'html_builder.assets': [
+        'website.website_builder_assets': [
             'website_blog/static/src/website_builder/**/*',
         ],
     },

--- a/addons/website_crm/__manifest__.py
+++ b/addons/website_crm/__manifest__.py
@@ -25,7 +25,7 @@ This module includes contact phone and mobile numbers validation.""",
     'installable': True,
     'auto_install': True,
     'assets': {
-        'html_builder.assets': [
+        'website.website_builder_assets': [
             'website_crm/static/src/js/website_crm_editor.js',
         ],
         'web.assets_tests': [

--- a/addons/website_crm_partner_assign/__manifest__.py
+++ b/addons/website_crm_partner_assign/__manifest__.py
@@ -50,7 +50,7 @@ The automatic assignment is figured from the weight of partner levels and the ge
         'web.assets_frontend': [
             'website_crm_partner_assign/static/src/interactions/**/*',
         ],
-        'html_builder.assets': [
+        'website.website_builder_assets': [
             'website_crm_partner_assign/static/src/website_builder/**/*',
         ],
         'web.assets_tests': [

--- a/addons/website_customer/__manifest__.py
+++ b/addons/website_customer/__manifest__.py
@@ -28,7 +28,7 @@ Publish your customers as business references on your website to attract new pot
     'author': 'Odoo S.A.',
     'license': 'LGPL-3',
     'assets': {
-        'html_builder.assets': [
+        'website.website_builder_assets': [
             'website_customer/static/src/website_builder/**/*',
         ],
     },

--- a/addons/website_event/__manifest__.py
+++ b/addons/website_event/__manifest__.py
@@ -79,7 +79,7 @@
         'website.assets_editor': [
             'website_event/static/src/js/systray_items/*.js',
         ],
-        'html_builder.assets': [
+        'website.website_builder_assets': [
             'website_event/static/src/website_builder/**/*',
         ],
     },

--- a/addons/website_event_exhibitor/__manifest__.py
+++ b/addons/website_event_exhibitor/__manifest__.py
@@ -41,7 +41,7 @@
         'web.report_assets_common': [
             '/website_event_exhibitor/static/src/scss/event_full_page_ticket_report.scss',
         ],
-        'html_builder.assets': [
+        'website.website_builder_assets': [
             'website_event_exhibitor/static/src/website_builder/**/*',
         ],
     },

--- a/addons/website_event_track/__manifest__.py
+++ b/addons/website_event_track/__manifest__.py
@@ -57,7 +57,7 @@
         'web.assets_tests': [
             'website_event_track/static/tests/tours/*.js',
         ],
-        'html_builder.assets': [
+        'website.website_builder_assets': [
             'website_event_track/static/src/website_builder/**/*',
         ],
     },

--- a/addons/website_forum/__manifest__.py
+++ b/addons/website_forum/__manifest__.py
@@ -88,7 +88,7 @@ Ask questions, get answers, no distractions
             'website_forum/static/src/interactions/website_forum_spam.js',
             'website_forum/static/src/xml/public_templates.xml',
         ],
-        'html_builder.assets': [
+        'website.website_builder_assets': [
             'website_forum/static/src/website_builder/**/*',
         ],
     },

--- a/addons/website_hr_recruitment/__manifest__.py
+++ b/addons/website_hr_recruitment/__manifest__.py
@@ -35,7 +35,7 @@
             'website_hr_recruitment/static/src/js/widgets/copy_link_menuitem.xml',
             'website_hr_recruitment/static/src/fields/**/*',
         ],
-        'html_builder.assets': [
+        'website.website_builder_assets': [
             'website_hr_recruitment/static/src/js/website_hr_recruitment_editor.js',
             'website_hr_recruitment/static/src/website_builder/**/*',
         ],

--- a/addons/website_mail_group/__manifest__.py
+++ b/addons/website_mail_group/__manifest__.py
@@ -25,7 +25,7 @@
         'website.assets_edit_frontend': [
             'website_mail_group/static/src/**/*.edit.js',
         ],
-        'html_builder.assets': [
+        'website.website_builder_assets': [
             'website_mail_group/static/src/website_builder/**/*',
         ],
     },

--- a/addons/website_mass_mailing/__manifest__.py
+++ b/addons/website_mass_mailing/__manifest__.py
@@ -25,7 +25,7 @@ On a simple click, your visitors can subscribe to mailing lists managed in the E
             'website_mass_mailing/static/src/js/website_mass_mailing.js',
             'website_mass_mailing/static/src/xml/*.xml',
         ],
-        'html_builder.assets': [
+        'website.website_builder_assets': [
             'website_mass_mailing/static/src/js/mass_mailing_form_editor.js',
             'website_mass_mailing/static/src/website_builder/**/*',
             ('remove', 'website_mass_mailing/static/src/website_builder/**/*.inside.scss'),

--- a/addons/website_mass_mailing/__manifest__.py
+++ b/addons/website_mass_mailing/__manifest__.py
@@ -28,6 +28,7 @@ On a simple click, your visitors can subscribe to mailing lists managed in the E
         'html_builder.assets': [
             'website_mass_mailing/static/src/js/mass_mailing_form_editor.js',
             'website_mass_mailing/static/src/website_builder/**/*',
+            ('remove', 'website_mass_mailing/static/src/website_builder/**/*.inside.scss'),
         ],
         'website.assets_edit_frontend': [
             'website_mass_mailing/static/src/website_builder/mailing_list_subscribe_option.inside.scss',

--- a/addons/website_mass_mailing_sms/__manifest__.py
+++ b/addons/website_mass_mailing_sms/__manifest__.py
@@ -19,7 +19,7 @@ your visitors to subscribe with their phone number.
     'author': 'Odoo S.A.',
     'license': 'LGPL-3',
     'assets': {
-        'html_builder.assets': [
+        'website.website_builder_assets': [
             'website_mass_mailing_sms/static/src/website_builder/**/*',
         ],
     },

--- a/addons/website_payment/__manifest__.py
+++ b/addons/website_payment/__manifest__.py
@@ -40,7 +40,7 @@ This is a bridge module that adds multi-website support for payment providers.
         'web.assets_tests': [
             'website_payment/static/tests/tours/donation.js',
         ],
-        'html_builder.assets': [
+        'website.website_builder_assets': [
             'website_payment/static/src/website_builder/**/*',
         ],
     },

--- a/addons/website_project/__manifest__.py
+++ b/addons/website_project/__manifest__.py
@@ -18,7 +18,7 @@ Generate tasks in Project app from a form published on your website. This module
     'installable': True,
     'auto_install': True,
     'assets': {
-        'html_builder.assets': [
+        'website.website_builder_assets': [
             'website_project/static/src/js/website_project_editor.js',
         ],
         'project.webclient': [

--- a/addons/website_sale/__manifest__.py
+++ b/addons/website_sale/__manifest__.py
@@ -154,7 +154,7 @@
             'website_sale/static/src/xml/website_sale.xml',
             'website_sale/static/src/scss/kanban_record.scss',
         ],
-        'html_builder.assets': [
+        'website.website_builder_assets': [
             'website_sale/static/src/js/website_sale_form_editor.js',
             'website_sale/static/src/website_builder/**/*',
         ],

--- a/addons/website_sale_comparison/__manifest__.py
+++ b/addons/website_sale_comparison/__manifest__.py
@@ -33,7 +33,7 @@ Finally, the module comes with an option to display an attribute summary table i
         'web.assets_tests': [
             'website_sale_comparison/static/tests/**/*',
         ],
-        'html_builder.assets': [
+        'website.website_builder_assets': [
             'website_sale_comparison/static/src/website_builder/**/*',
         ],
     },

--- a/addons/website_sale_loyalty/__manifest__.py
+++ b/addons/website_sale_loyalty/__manifest__.py
@@ -35,7 +35,7 @@ Coupon & promotion programs can be edited in the Catalog menu of the Website app
         'web.assets_tests': [
             'website_sale_loyalty/static/tests/**/*',
         ],
-        'html_builder.assets': [
+        'website.website_builder_assets': [
             'website_sale_loyalty/static/src/website_builder/**/*',
         ],
     },

--- a/addons/website_sale_slides/__manifest__.py
+++ b/addons/website_sale_slides/__manifest__.py
@@ -32,7 +32,7 @@
         'web.assets_tests': [
             'website_sale_slides/static/tests/tours/*.js',
         ],
-        'html_builder.assets': [
+        'website.website_builder_assets': [
             'website_sale_slides/static/src/website_builder/**/*',
         ],
     },

--- a/addons/website_sale_wishlist/__manifest__.py
+++ b/addons/website_sale_wishlist/__manifest__.py
@@ -23,7 +23,7 @@ Allow shoppers of your eCommerce store to create personalized collections of pro
         'web.assets_tests': [
             'website_sale_wishlist/static/tests/**/*',
         ],
-        'html_builder.assets': [
+        'website.website_builder_assets': [
             'website_sale_wishlist/static/src/website_builder/**/*',
         ],
     },

--- a/addons/website_slides/__manifest__.py
+++ b/addons/website_slides/__manifest__.py
@@ -189,7 +189,7 @@ Featuring
             'website_slides/static/src/interactions/**/*',
             'website_slides/static/src/js/public/**/*',
         ],
-        'html_builder.assets': [
+        'website.website_builder_assets': [
             'website_slides/static/src/website_builder/**/*',
         ],
         'portal.assets_chatter': [

--- a/addons/website_slides_forum/__manifest__.py
+++ b/addons/website_slides_forum/__manifest__.py
@@ -30,7 +30,7 @@
     'author': 'Odoo S.A.',
     'license': 'LGPL-3',
     'assets': {
-        'html_builder.assets': [
+        'website.website_builder_assets': [
             'website_slides_forum/static/src/website_builder/**/*',
         ],
     },


### PR DESCRIPTION
~~Enterprise PR https://github.com/odoo/enterprise/pull/88162~~
Enterprise PR: https://github.com/odoo/enterprise/pull/88346

------

[[FIX] html_builder, *: remove *.inside.scss from html_builder.assets](https://github.com/odoo/odoo/pull/215218/commits/794370219cb9f4ddff2d771d21f5c03220382ac1)
*: website, website_mass_mailing

In commit [1], the website builder was rewritten in owl. The concept of
`*.inside.scss` files was introduced: style that is loaded on pages,
inside the iframe only during edition.

The `html_builder.assets` bundle was not supposed to have those. We fix
this issue and potential future issues by adding a remove on all modules
that include all files within `static/src/website_builder`.

This commit also adds a test to verify the `html_builder.assets` doesn't
contain *.inside.scss files to prevent potential future mistakes.

[1]: https://github.com/odoo-dev/odoo/commit/9fe45e2b7ddbbfd0445ffe25a859e67a316d02b2

------

[[REF] website, *: add website.website_builder_assets bundle](https://github.com/odoo/odoo/pull/215218/commits/5e7c43d0694c27171ba5ce17d61717f6346084b1)
*: website_blog, website_crm, website_crm_partner_assign,
website_customer, website_event, website_event_exhibitor,
website_event_track, website_forum, website_hr_recruitment,
website_mail_group, website_mass_mailing, website_mass_mailing_sms,
website_payment, website_project, website_sale, website_sale_comparison,
website_sale_loyalty, website_sale_slides, website_sale_wishlist,
website_slides, website_slides_forum

This commit adds the `website.website_builder_assets` bundle which
includes `html_builder.assets` and is used by the website builder
editor. This will allow mass_mailing to have its own bundle too, without
the need to load everything from the website builder.