### PR TITLE
[IMP] html_builder, website: remove website dependency from snippet_service

### DIFF
--- a/addons/html_builder/static/src/builder.js
+++ b/addons/html_builder/static/src/builder.js
@@ -32,7 +32,7 @@ export class Builder extends Component {
     static props = {
         closeEditor: { type: Function },
         reloadEditor: { type: Function, optional: true },
-        snippetsName: { type: String },
+        snippetModel: { type: Object },
         toggleMobile: { type: Function },
         overlayRef: { type: Function },
         isTranslation: { type: Boolean },
@@ -65,6 +65,8 @@ export class Builder extends Component {
         this.dialog = useService("dialog");
         this.ui = useService("ui");
         this.notification = useService("notification");
+        this.snippetModel = useState(this.props.snippetModel);
+        this.snippetModel.registerBeforeReload(this.save.bind(this));
 
         const editorBus = new EventBus();
 
@@ -146,8 +148,7 @@ export class Builder extends Component {
                     key: this.env.localOverlayContainerKey,
                     ref: this.props.overlayRef,
                 },
-                saveSnippet: (snippetEl, cleanForSaveHandlers) =>
-                    this.snippetModel.saveSnippet(snippetEl, cleanForSaveHandlers),
+                snippetModel: this.snippetModel,
                 getShared: () => this.editor.shared,
                 updateInvisibleElementsPanel: () => this.updateInvisibleEls(),
                 allowCustomStyle: true,
@@ -156,9 +157,6 @@ export class Builder extends Component {
             },
             this.env.services
         );
-
-        this.snippetModel = useState(useService("html_builder.snippets"));
-        this.snippetModel.registerBeforeReload(this.save.bind(this));
 
         onWillStart(async () => {
             await this.snippetModel.load();

--- a/addons/html_builder/static/src/builder.xml
+++ b/addons/html_builder/static/src/builder.xml
@@ -34,7 +34,7 @@
         </div>
         <div class="o-tab-content overflow-y-auto overflow-x-hidden flex-grow-1">
             <t t-if="state.activeTab === 'blocks'">
-                <BlockTab />
+                <BlockTab snippetModel="snippetModel"/>
             </t>
             <t t-if="state.activeTab === 'customize'">
                 <t t-if="props.isTranslation" t-call="html_builder.CustomizeTranslationTab"/>

--- a/addons/html_builder/static/src/core/disable_snippets_plugin.js
+++ b/addons/html_builder/static/src/core/disable_snippets_plugin.js
@@ -14,7 +14,7 @@ export class DisableSnippetsPlugin extends Plugin {
     };
 
     setup() {
-        this.snippetModel = this.services["html_builder.snippets"];
+        this.snippetModel = this.config.snippetModel;
         this._disableSnippets = this.disableUndroppableSnippets.bind(this);
 
         // TODO only for website ?

--- a/addons/html_builder/static/src/core/drop_zone_plugin.js
+++ b/addons/html_builder/static/src/core/drop_zone_plugin.js
@@ -15,7 +15,7 @@ export class DropZonePlugin extends Plugin {
     ];
 
     setup() {
-        this.snippetModel = this.services["html_builder.snippets"];
+        this.snippetModel = this.config.snippetModel;
         this.dropzoneSelectors = this.getResource("dropzone_selector");
         this.iframe = this.document.defaultView.frameElement;
     }

--- a/addons/html_builder/static/src/core/save_snippet_plugin.js
+++ b/addons/html_builder/static/src/core/save_snippet_plugin.js
@@ -38,7 +38,7 @@ export class SaveSnippetPlugin extends Plugin {
 
     async saveSnippet(el) {
         const cleanForSaveHandlers = this.getResource("clean_for_save_handlers");
-        const savedName = await this.config.saveSnippet(el, cleanForSaveHandlers);
+        const savedName = await this.config.snippetModel.saveSnippet(el, cleanForSaveHandlers);
         if (savedName) {
             const message = markup(
                 _t(

--- a/addons/html_builder/static/src/core/version_control_plugin.js
+++ b/addons/html_builder/static/src/core/version_control_plugin.js
@@ -14,7 +14,7 @@ export class VersionControlPlugin extends Plugin {
             return this.accessPerOutdatedEl.get(el);
         }
         const snippetKey = el.dataset.snippet;
-        const snippet = this.services["html_builder.snippets"].getOriginalSnippet(snippetKey);
+        const snippet = this.config.snippetModel.getOriginalSnippet(snippetKey);
         let isUpToDate = true;
         if (snippet) {
             const {
@@ -34,7 +34,7 @@ export class VersionControlPlugin extends Plugin {
     }
     replaceWithNewVersion(el) {
         const snippetKey = el.dataset.snippet;
-        const snippet = this.services["html_builder.snippets"].getOriginalSnippet(snippetKey);
+        const snippet = this.config.snippetModel.getOriginalSnippet(snippetKey);
         const cloneEl = snippet.content.cloneNode(true);
         el.replaceWith(cloneEl);
         this.dependencies["builderOptions"].updateContainers(cloneEl);

--- a/addons/html_builder/static/src/sidebar/block_tab.js
+++ b/addons/html_builder/static/src/sidebar/block_tab.js
@@ -13,13 +13,15 @@ import { CustomInnerSnippet } from "./custom_inner_snippet";
 export class BlockTab extends Component {
     static template = "html_builder.BlockTab";
     static components = { Snippet, CustomInnerSnippet };
-    static props = {};
+    static props = {
+        snippetModel: { type: Object },
+    };
 
     setup() {
         this.dialog = useService("dialog");
         this.orm = useService("orm");
         this.popover = useService("popover");
-        this.snippetModel = useState(useService("html_builder.snippets"));
+        this.snippetModel = useState(this.props.snippetModel);
         this.blockTabRef = useRef("block-tab");
         // Needed to avoid race condition in tours.
         this.state = useState({ ongoingInsertion: false });

--- a/addons/html_builder/static/tests/helpers.js
+++ b/addons/html_builder/static/tests/helpers.js
@@ -17,6 +17,7 @@ import {
 import { isBrowserFirefox } from "@web/core/browser/feature_detection";
 import { registry } from "@web/core/registry";
 import { uniqueId } from "@web/core/utils/functions";
+import { useService } from "@web/core/utils/hooks";
 
 export function patchWithCleanupImg() {
     const defaultImg =
@@ -93,6 +94,7 @@ class BuilderContainer extends Component {
         useSubEnv({
             builderRef: useRef("container"),
         });
+        this.snippetModel = useService("html_builder.snippets").makeSnippetModel("");
     }
 
     onLoad() {
@@ -102,7 +104,7 @@ class BuilderContainer extends Component {
     getBuilderProps() {
         return {
             closeEditor: () => {},
-            snippetsName: "",
+            snippetModel: this.snippetModel,
             toggleMobile: () => {
                 this.state.isMobile = !this.state.isMobile;
             },

--- a/addons/website/static/src/builder/plugins/snippets_powerbox_plugin.js
+++ b/addons/website/static/src/builder/plugins/snippets_powerbox_plugin.js
@@ -128,10 +128,7 @@ class SnippetsPowerboxPlugin extends Plugin {
     };
 
     insertSnippet(name) {
-        const snippet = this.services["html_builder.snippets"].getSnippetByName(
-            "snippet_content",
-            name
-        );
+        const snippet = this.config.snippetModel.getSnippetByName("snippet_content", name);
         const content = snippet.content.cloneNode(true);
         this.dependencies.dom.insert(content);
         this.dependencies.history.addStep();


### PR DESCRIPTION
In order to be able to use the `snippet_service` for `mass_mailing`, it can not
depends on `website`. This commit removes that dependency and adjust impacted
files.

It is now possible to use different `snippetName` depending on the desired
snippets bundle.

task-4247642
