### PR TITLE
[IMP] sale,sale_stock,stock: show expected_date as placeholder

### DIFF
--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -84,10 +84,11 @@ class SaleOrder(models.Model):
     create_date = fields.Datetime(  # Override of default create_date field from ORM
         string="Creation Date", index=True, readonly=True)
     commitment_date = fields.Datetime(
-        string="Delivery Date", copy=False,
+        string="Promised Delivery", copy=False,
         help="This is the delivery date promised to the customer. "
              "If set, the delivery order will be scheduled based on "
              "this date rather than product lead times.")
+    delivery_date = fields.Datetime(string="Delivery Date", compute='_compute_delivery_date')
     date_order = fields.Datetime(
         string="Order Date",
         required=True, copy=False,
@@ -837,6 +838,11 @@ class SaleOrder(models.Model):
                 if product_msg := line.sale_line_warn_msg:
                     warnings.add(line.product_id.display_name + ' - ' + product_msg)
             order.sale_warning_text = '\n'.join(warnings)
+
+    @api.depends('commitment_date', 'expected_date')
+    def _compute_delivery_date(self):
+        for order in self:
+            order.delivery_date = order.commitment_date or order.expected_date
 
     #=== CONSTRAINT METHODS ===#
 

--- a/addons/sale/views/sale_order_views.xml
+++ b/addons/sale/views/sale_order_views.xml
@@ -129,8 +129,9 @@
 
                 <field name="name" string="Number" readonly="1" decoration-bf="1"/>
                 <field name="date_order" optional="show" readonly="state in ['cancel', 'sale']"/>
-                <field name="commitment_date" optional="hide"/>
-                <field name="expected_date" optional="hide"/>
+                <field name="delivery_date" string="Delivery Date" optional="hide"
+                    decoration-muted="not commitment_date"
+                    decoration-danger="(commitment_date and (expected_date &lt; commitment_date or commitment_date &lt; context_today().strftime('%Y-%m-%d'))) and state in ['draft', 'sent']"/>
                 <field name="partner_id" readonly="1"/>
                 <field name="user_id" widget="many2one_avatar_user" optional="show"/>
                 <field name="activity_ids" widget="list_activity" optional="show"/>

--- a/addons/sale_stock/models/sale_order.py
+++ b/addons/sale_stock/models/sale_order.py
@@ -113,6 +113,12 @@ class SaleOrder(models.Model):
                 picking.products_availability_state == 'late' for picking in order.picking_ids
             )
 
+    @api.depends('effective_date')
+    def _compute_delivery_date(self):
+        super()._compute_delivery_date()
+        for order in self:
+            order.delivery_date = order.effective_date or order.delivery_date
+
     def _search_late_availability(self, operator, value):
         if operator not in ('=', '!=') or not isinstance(value, bool):
             return NotImplemented

--- a/addons/sale_stock/views/sale_order_views.xml
+++ b/addons/sale_stock/views/sale_order_views.xml
@@ -32,9 +32,16 @@
                 <div class="o_row">
                     <field name="expected_date" invisible="1"/>  <!-- Needed for the placeholder widget -->
                     <field name="commitment_date" options="{'placeholder_field': 'expected_date'}"/>
+                    <field
+                        name="delivery_status"
+                        class="oe_inline"
+                        invisible="state != 'sale'"
+                        decoration-success="delivery_status == 'full'"
+                        decoration-warning="delivery_status == 'partial'"
+                        decoration-info="delivery_status in ['pending', 'started']"
+                        widget="badge"/>
                 </div>
                 <field name="effective_date" invisible="not effective_date"/>
-                <field name="delivery_status" invisible="state != 'sale'"/>
             </div>
             <xpath expr="//page[@name='other_information']//field[@name='commitment_date']" position="after">
                 <field string=" " name="json_popover" widget="stock_rescheduling_popover" invisible="not show_json_popover"/>
@@ -81,18 +88,19 @@
         <field name="model">sale.order</field>
         <field name="inherit_id" ref="sale.view_order_tree"/>
         <field name="arch" type="xml">
-            <field name="commitment_date" position="attributes">
+            <field name="delivery_date" position="attributes">
                 <attribute name="decoration-danger">
                     (
                         (
-                            commitment_date &lt; effective_date
-                            or commitment_date &lt; datetime.datetime.combine(
-                                datetime.date.today(),
-                                datetime.time(0,0,0)
-                            ).to_utc().strftime('%Y-%m-%d %H:%M:%S')
+                            (
+                                (commitment_date or expected_date) &lt; effective_date
+                                or (commitment_date or expected_date) &lt; datetime.datetime.combine(
+                                    datetime.date.today(),
+                                    datetime.time(0,0,0)
+                                ).to_utc().strftime('%Y-%m-%d %H:%M:%S')
+                            )
+                            and delivery_status in ['pending', 'started']
                         )
-                        and delivery_status in ['pending', 'started']
-                        and effective_date &lt;= commitment_date
                         or delivery_status == 'partial'
                     )
                 </attribute>

--- a/addons/stock/report/report_deliveryslip.xml
+++ b/addons/stock/report/report_deliveryslip.xml
@@ -58,8 +58,8 @@
                         </div>
                         <div t-if="o.state" class="col col-3 mw-100 mb-2" name="div_sched_date">
                             <strong>Shipping Date</strong>
-                            <div t-if="o.state == 'done'" t-field="o.date_done" class="m-0"/>
-                            <div t-else="" t-field="o.scheduled_date" class="m-0"/>
+                            <div t-if="o.state == 'done'" t-field="o.date_done" t-options='{"widget": "date"}' class="m-0"/>
+                            <div t-else="" t-field="o.scheduled_date" t-options='{"widget": "date"}' class="m-0"/>
                         </div>
                         <div t-if="o.user_id" class="col-auto" name="div_operator">
                             <strong>Operator:</strong>


### PR DESCRIPTION
Display the `expected_date` as a dynamic placeholder in the `commitment_date` field on the sales order form, to avoid confusion caused by showing both fields.
If the full delivery is completed, display the `effective_date` as the placeholder instead.
Show the placeholder and `commitment_date` in red for late or partially delivered orders to help users quickly spot delays.

Additionally, remove the time component from the shipping date displayed in the delivery slip to improve readability, as the time is often not relevant in most shipping contexts.
Also, `delivery_status` is now shown as a tag beside the delivery date instead of being displayed as a separate field.

Users will have a cleaner sales order form with contextual delivery dates and visual cues for late deliveries. This improves usability and allows sales teams to quickly identify and act on delayed shipments without manually checking delivery records.

Task ID: 4841669