### PR TITLE
[FIX] im_livechat: fix demo data

### DIFF
--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_chatbot_session_1.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_chatbot_session_1.xml
@@ -20,10 +20,16 @@
         <record id="livechat_channel_chatbot_session_1_guest_demo" model="mail.guest">
             <field name="name">Visitor #234</field>
         </record>
+        <record id="livechat_channel_chatbot_session_1_history_guest_demo" model="im_livechat.channel.member.history">
+            <field name="channel_id" ref="livechat_channel_chatbot_session_1_demo"/>
+            <field name="guest_id" ref="livechat_channel_chatbot_session_1_guest_demo"/>
+            <field name="livechat_member_type">visitor</field>
+            <field name="create_date" eval="DateTime.today() + relativedelta(months=-1)"/>
+        </record>
         <record id="livechat_channel_chatbot_session_1_member_guest_demo" model="discuss.channel.member">
             <field name="guest_id" ref="livechat_channel_chatbot_session_1_guest_demo"/>
             <field name="channel_id" ref="livechat_channel_chatbot_session_1_demo"/>
-            <field name="livechat_member_type">visitor</field>
+            <field name="livechat_member_history_ids" eval="[(4, ref('livechat_channel_chatbot_session_1_history_guest_demo'))]"/>
         </record>
 
         <record id="livechat_channel_chatbot_session_1_message_1_demo" model="mail.message">

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_chatbot_session_2.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_chatbot_session_2.xml
@@ -20,10 +20,16 @@
         <record id="livechat_channel_chatbot_session_2_guest_demo" model="mail.guest">
             <field name="name">Visitor #235</field>
         </record>
+        <record id="livechat_channel_chatbot_session_2_history_guest_demo" model="im_livechat.channel.member.history">
+            <field name="channel_id" ref="livechat_channel_chatbot_session_2_demo"/>
+            <field name="guest_id" ref="livechat_channel_chatbot_session_2_guest_demo"/>
+            <field name="livechat_member_type">visitor</field>
+            <field name="create_date" eval="DateTime.today() + relativedelta(months=-1)"/>
+        </record>
         <record id="livechat_channel_chatbot_session_2_member_guest_demo" model="discuss.channel.member">
             <field name="guest_id" ref="livechat_channel_chatbot_session_2_guest_demo"/>
             <field name="channel_id" ref="livechat_channel_chatbot_session_2_demo"/>
-            <field name="livechat_member_type">visitor</field>
+            <field name="livechat_member_history_ids" eval="[(4, ref('livechat_channel_chatbot_session_2_history_guest_demo'))]"/>
         </record>
 
         <record id="livechat_channel_chatbot_session_2_message_1_demo" model="mail.message">

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_chatbot_session_3.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_chatbot_session_3.xml
@@ -20,10 +20,16 @@
         <record id="livechat_channel_chatbot_session_3_guest_demo" model="mail.guest">
             <field name="name">Visitor #236</field>
         </record>
-        <record id="livechat_channel_chatbot_session_3_member_guest_demo" model="discuss.channel.member">
+        <record id="livechat_channel_chatbot_session_3_history_guest_demo" model="im_livechat.channel.member.history">
             <field name="guest_id" ref="livechat_channel_chatbot_session_3_guest_demo"/>
             <field name="channel_id" ref="livechat_channel_chatbot_session_3_demo"/>
             <field name="livechat_member_type">visitor</field>
+            <field name="create_date" eval="DateTime.today() + relativedelta(months=-1)"/>
+        </record>
+        <record id="livechat_channel_chatbot_session_3_member_guest_demo" model="discuss.channel.member">
+            <field name="guest_id" ref="livechat_channel_chatbot_session_3_guest_demo"/>
+            <field name="channel_id" ref="livechat_channel_chatbot_session_3_demo"/>
+            <field name="livechat_member_history_ids" eval="[(4, ref('livechat_channel_chatbot_session_3_history_guest_demo'))]"/>
         </record>
 
         <record id="livechat_channel_chatbot_session_3_message_1_demo" model="mail.message">

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_1.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_1.xml
@@ -10,20 +10,32 @@
             <field name="anonymous_name">Visitor #234</field>
             <field name="create_date" eval="DateTime.today() + relativedelta(months=-1)"/>
         </record>
+        <record id="livechat_channel_session_1_history_member_admin" model="im_livechat.channel.member.history">
+            <field name="channel_id" ref="livechat_channel_session_1"/>
+            <field name="partner_id" ref="base.partner_admin"/>
+            <field name="livechat_member_type">agent</field>
+            <field name="create_date" eval="DateTime.today() + relativedelta(months=-1)"/>
+        </record>
         <record id="im_livechat.livechat_channel_session_1_member_admin" model="discuss.channel.member">
             <field name="partner_id" ref="base.partner_admin"/>
             <field name="channel_id" ref="im_livechat.livechat_channel_session_1"/>
             <field name="unpin_dt" eval="DateTime.today()"/>
             <field name="last_interest_dt" eval="DateTime.today() + relativedelta(months=-1)"/>
-            <field name="livechat_member_type">agent</field>
+            <field name="livechat_member_history_ids" eval="[(4, ref('livechat_channel_session_1_history_member_admin'))]"/>
         </record>
         <record id="im_livechat.livechat_channel_session_1_guest" model="mail.guest">
             <field name="name">Visitor #234</field>
         </record>
+        <record id="im_livechat.livechat_channel_session_1_history_guest" model="im_livechat.channel.member.history">
+            <field name="channel_id" ref="livechat_channel_session_1"/>
+            <field name="guest_id" ref="im_livechat.livechat_channel_session_1_guest"/>
+            <field name="livechat_member_type">visitor</field>
+            <field name="create_date" eval="DateTime.today() + relativedelta(months=-1)"/>
+        </record>
         <record id="im_livechat.livechat_channel_session_1_member_guest" model="discuss.channel.member">
             <field name="guest_id" ref="im_livechat.livechat_channel_session_1_guest"/>
             <field name="channel_id" ref="im_livechat.livechat_channel_session_1"/>
-            <field name="livechat_member_type">visitor</field>
+            <field name="livechat_member_history_ids" eval="[(4, ref('im_livechat.livechat_channel_session_1_history_guest'))]"/>
         </record>
 
         <record id="livechat_channel_session_1_message_1" model="mail.message">

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_10.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_10.xml
@@ -12,20 +12,32 @@
             <field name="anonymous_name">Visiteur</field>
             <field name="country_id" ref="base.be"/>
         </record>
+        <record id="im_livechat.livechat_channel_session_10_history_member_admin" model="im_livechat.channel.member.history">
+            <field name="channel_id" ref="livechat_channel_session_10"/>
+            <field name="partner_id" ref="base.partner_admin"/>
+            <field name="livechat_member_type">agent</field>
+            <field name="create_date" eval="datetime.now() - timedelta(days=1)"/>
+        </record>
         <record id="im_livechat.livechat_channel_session_10_member_admin" model="discuss.channel.member">
             <field name="partner_id" ref="base.partner_admin"/>
             <field name="channel_id" ref="im_livechat.livechat_channel_session_10"/>
             <field name="unpin_dt" eval="DateTime.today()"/>
             <field name="last_interest_dt" eval="DateTime.today() + relativedelta(months=-1)"/>
-            <field name="livechat_member_type">agent</field>
+            <field name="livechat_member_history_ids" eval="[(4, ref('im_livechat.livechat_channel_session_10_history_member_admin'))]"/>
         </record>
         <record id="im_livechat.livechat_channel_session_10_guest" model="mail.guest">
             <field name="name">Visiteur</field>
         </record>
+        <record id="im_livechat.livechat_channel_session_10_history_member_guest" model="im_livechat.channel.member.history">
+            <field name="channel_id" ref="livechat_channel_session_10"/>
+            <field name="guest_id" ref="im_livechat.livechat_channel_session_10_guest"/>
+            <field name="livechat_member_type">visitor</field>
+            <field name="create_date" eval="datetime.now() - timedelta(days=1)"/>
+        </record>
         <record id="im_livechat.livechat_channel_session_10_member_guest" model="discuss.channel.member">
             <field name="guest_id" ref="im_livechat.livechat_channel_session_10_guest"/>
             <field name="channel_id" ref="im_livechat.livechat_channel_session_10"/>
-            <field name="livechat_member_type">visitor</field>
+            <field name="livechat_member_history_ids" eval="[(4, ref('im_livechat.livechat_channel_session_10_history_member_guest'))]"/>
         </record>
 
         <record id="livechat_channel_session_10_message_1" model="mail.message">

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_11.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_11.xml
@@ -12,18 +12,28 @@
             <field name="anonymous_name">Visitor</field>
             <field name="country_id" ref="base.us"/>
         </record>
+        <record id="im_livechat.livechat_channel_session_11_history_member_admin" model="im_livechat.channel.member.history">
+            <field name="channel_id" ref="livechat_channel_session_11"/>
+            <field name="partner_id" ref="base.partner_admin"/>
+            <field name="livechat_member_type">agent</field>
+        </record>
         <record id="im_livechat.livechat_channel_session_11_member_admin" model="discuss.channel.member">
             <field name="partner_id" ref="base.partner_admin"/>
             <field name="channel_id" ref="im_livechat.livechat_channel_session_11"/>
-            <field name="livechat_member_type">agent</field>
+            <field name="livechat_member_history_ids" eval="[(4, ref('im_livechat.livechat_channel_session_11_history_member_admin'))]"/>
         </record>
         <record id="im_livechat.livechat_channel_session_11_guest" model="mail.guest">
             <field name="name">Visitor</field>
         </record>
+        <record id="im_livechat.livechat_channel_session_11_history_member_guest" model="im_livechat.channel.member.history">
+            <field name="channel_id" ref="livechat_channel_session_11"/>
+            <field name="guest_id" ref="im_livechat.livechat_channel_session_11_guest"/>
+            <field name="livechat_member_type">visitor</field>
+        </record>
         <record id="im_livechat.livechat_channel_session_11_member_guest" model="discuss.channel.member">
             <field name="guest_id" ref="im_livechat.livechat_channel_session_11_guest"/>
             <field name="channel_id" ref="im_livechat.livechat_channel_session_11"/>
-            <field name="livechat_member_type">visitor</field>
+            <field name="livechat_member_history_ids" eval="[(4, ref('im_livechat.livechat_channel_session_11_history_member_guest'))]"/>
         </record>
 
         <record id="livechat_channel_session_11_message_1" model="mail.message">

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_12.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_12.xml
@@ -12,18 +12,28 @@
             <field name="anonymous_name">Visitor</field>
             <field name="country_id" ref="base.us"/>
         </record>
+        <record id="im_livechat.livechat_channel_session_12_history_member_admin" model="im_livechat.channel.member.history">
+            <field name="channel_id" ref="livechat_channel_session_12"/>
+            <field name="partner_id" ref="base.partner_admin"/>
+            <field name="livechat_member_type">agent</field>
+        </record>
         <record id="im_livechat.livechat_channel_session_12_member_admin" model="discuss.channel.member">
             <field name="partner_id" ref="base.partner_admin"/>
             <field name="channel_id" ref="im_livechat.livechat_channel_session_12"/>
-            <field name="livechat_member_type">agent</field>
+            <field name="livechat_member_history_ids" eval="[(4, ref('im_livechat.livechat_channel_session_12_history_member_admin'))]"/>
         </record>
         <record id="im_livechat.livechat_channel_session_12_guest" model="mail.guest">
             <field name="name">Visitor</field>
         </record>
+        <record id="im_livechat.livechat_channel_session_12_history_member_guest" model="im_livechat.channel.member.history">
+            <field name="channel_id" ref="livechat_channel_session_12"/>
+            <field name="guest_id" ref="im_livechat.livechat_channel_session_12_guest"/>
+            <field name="livechat_member_type">visitor</field>
+        </record>
         <record id="im_livechat.livechat_channel_session_12_member_guest" model="discuss.channel.member">
             <field name="guest_id" ref="im_livechat.livechat_channel_session_12_guest"/>
             <field name="channel_id" ref="im_livechat.livechat_channel_session_12"/>
-            <field name="livechat_member_type">visitor</field>
+            <field name="livechat_member_history_ids" eval="[(4, ref('im_livechat.livechat_channel_session_12_history_member_guest'))]"/>
         </record>
 
         <record id="livechat_channel_session_12_message_1" model="mail.message">

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_13.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_13.xml
@@ -12,20 +12,32 @@
             <field name="anonymous_name">Visiteur</field>
             <field name="country_id" ref="base.be"/>
         </record>
+        <record id="im_livechat.livechat_channel_session_13_history_member_admin" model="im_livechat.channel.member.history">
+            <field name="channel_id" ref="livechat_channel_session_13"/>
+            <field name="partner_id" ref="base.partner_admin"/>
+            <field name="livechat_member_type">agent</field>
+            <field name="create_date" eval="datetime.now() - timedelta(days=1)"/>
+        </record>
         <record id="im_livechat.livechat_channel_session_13_member_admin" model="discuss.channel.member">
             <field name="partner_id" ref="base.partner_admin"/>
             <field name="channel_id" ref="im_livechat.livechat_channel_session_13"/>
             <field name="unpin_dt" eval="DateTime.today()"/>
             <field name="last_interest_dt" eval="DateTime.today() + relativedelta(months=-1)"/>
-            <field name="livechat_member_type">agent</field>
+            <field name="livechat_member_history_ids" eval="[(4, ref('im_livechat.livechat_channel_session_13_history_member_admin'))]"/>
         </record>
         <record id="im_livechat.livechat_channel_session_13_guest" model="mail.guest">
             <field name="name">Visiteur</field>
         </record>
+        <record id="im_livechat.livechat_channel_session_13_history_member_guest" model="im_livechat.channel.member.history">
+            <field name="channel_id" ref="livechat_channel_session_13"/>
+            <field name="guest_id" ref="im_livechat.livechat_channel_session_13_guest"/>
+            <field name="livechat_member_type">visitor</field>
+            <field name="create_date" eval="datetime.now() - timedelta(days=1)"/>
+        </record>
         <record id="im_livechat.livechat_channel_session_13_member_guest" model="discuss.channel.member">
             <field name="guest_id" ref="im_livechat.livechat_channel_session_13_guest"/>
             <field name="channel_id" ref="im_livechat.livechat_channel_session_13"/>
-            <field name="livechat_member_type">visitor</field>
+            <field name="livechat_member_history_ids" eval="[(4, ref('im_livechat.livechat_channel_session_13_history_member_guest'))]"/>
         </record>
 
         <record id="livechat_channel_session_13_message_1" model="mail.message">

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_14.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_14.xml
@@ -12,20 +12,32 @@
             <field name="anonymous_name">Visiteur</field>
             <field name="country_id" ref="base.be"/>
         </record>
+        <record id="im_livechat.livechat_channel_session_14_history_member_admin" model="im_livechat.channel.member.history">
+            <field name="channel_id" ref="livechat_channel_session_14"/>
+            <field name="partner_id" ref="base.partner_admin"/>
+            <field name="livechat_member_type">agent</field>
+            <field name="create_date" eval="datetime.now() - timedelta(minutes=1)"/>
+        </record>
         <record id="im_livechat.livechat_channel_session_14_member_admin" model="discuss.channel.member">
             <field name="partner_id" ref="base.partner_admin"/>
             <field name="channel_id" ref="im_livechat.livechat_channel_session_14"/>
             <field name="unpin_dt" eval="DateTime.today()"/>
             <field name="last_interest_dt" eval="DateTime.today() - timedelta(minutes=1)"/>
-            <field name="livechat_member_type">agent</field>
+            <field name="livechat_member_history_ids" eval="[(4, ref('im_livechat.livechat_channel_session_14_history_member_admin'))]"/>
         </record>
         <record id="im_livechat.livechat_channel_session_14_guest" model="mail.guest">
             <field name="name">Visiteur</field>
         </record>
+        <record id="im_livechat.livechat_channel_session_14_history_member_guest" model="im_livechat.channel.member.history">
+            <field name="channel_id" ref="livechat_channel_session_14"/>
+            <field name="guest_id" ref="im_livechat.livechat_channel_session_14_guest"/>
+            <field name="livechat_member_type">visitor</field>
+            <field name="create_date" eval="datetime.now() - timedelta(minutes=1)"/>
+        </record>
         <record id="im_livechat.livechat_channel_session_14_member_guest" model="discuss.channel.member">
             <field name="guest_id" ref="im_livechat.livechat_channel_session_14_guest"/>
             <field name="channel_id" ref="im_livechat.livechat_channel_session_14"/>
-            <field name="livechat_member_type">visitor</field>
+            <field name="livechat_member_history_ids" eval="[(4, ref('im_livechat.livechat_channel_session_14_history_member_guest'))]"/>
         </record>
 
         <record id="livechat_channel_session_14_message_1" model="mail.message">

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_2.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_2.xml
@@ -10,20 +10,31 @@
             <field name="anonymous_name">Visitor #323</field>
             <field name="create_date" eval="DateTime.today() + relativedelta(months=-1, days=-1)"/>
         </record>
+        <record id="livechat_channel_session_2_history_member_demo" model="im_livechat.channel.member.history">
+            <field name="channel_id" ref="livechat_channel_session_2"/>
+            <field name="partner_id" ref="base.partner_demo"/>
+            <field name="livechat_member_type">agent</field>
+            <field name="create_date" eval="DateTime.today() + relativedelta(months=-1, days=-1)"/>
+        </record>
         <record id="im_livechat.livechat_channel_session_2_member_demo" model="discuss.channel.member">
             <field name="partner_id" ref="base.partner_demo"/>
             <field name="channel_id" ref="im_livechat.livechat_channel_session_2"/>
             <field name="unpin_dt" eval="DateTime.today()"/>
             <field name="last_interest_dt" eval="DateTime.today() + relativedelta(months=-1)"/>
-            <field name="livechat_member_type">agent</field>
+            <field name="livechat_member_history_ids" eval="[(4, ref('livechat_channel_session_2_history_member_demo'))]"/>
         </record>
         <record id="im_livechat.livechat_channel_session_2_guest" model="mail.guest">
             <field name="name">Visitor #323</field>
         </record>
+        <record id="im_livechat.livechat_channel_session_2_history_guest" model="im_livechat.channel.member.history">
+            <field name="channel_id" ref="livechat_channel_session_2"/>
+            <field name="guest_id" ref="im_livechat.livechat_channel_session_2_guest"/>
+            <field name="livechat_member_type">visitor</field>
+        </record>
         <record id="im_livechat.livechat_channel_session_2_member_guest" model="discuss.channel.member">
             <field name="guest_id" ref="im_livechat.livechat_channel_session_2_guest"/>
             <field name="channel_id" ref="im_livechat.livechat_channel_session_2"/>
-            <field name="livechat_member_type">visitor</field>
+            <field name="livechat_member_history_ids" eval="[(4, ref('im_livechat.livechat_channel_session_2_history_guest'))]"/>
         </record>
 
         <record id="livechat_channel_session_2_message_1" model="mail.message">

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_3.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_3.xml
@@ -10,17 +10,29 @@
             <field name="anonymous_name">Joel Willis</field>
             <field name="create_date" eval="DateTime.today() + relativedelta(months=-1, days=-2)"/>
         </record>
+        <record id="im_livechat.livechat_channel_session_3_history_member_admin" model="im_livechat.channel.member.history">
+            <field name="channel_id" ref="livechat_channel_session_3"/>
+            <field name="partner_id" ref="base.partner_admin"/>
+            <field name="livechat_member_type">agent</field>
+            <field name="create_date" eval="DateTime.today() + relativedelta(months=-1, days=-2)"/>
+        </record>
         <record id="im_livechat.livechat_channel_session_3_member_admin" model="discuss.channel.member">
             <field name="partner_id" ref="base.partner_admin"/>
             <field name="channel_id" ref="im_livechat.livechat_channel_session_3"/>
             <field name="unpin_dt" eval="DateTime.today()"/>
             <field name="last_interest_dt" eval="DateTime.today() + relativedelta(months=-1)"/>
-            <field name="livechat_member_type">agent</field>
+            <field name="livechat_member_history_ids" eval="[(4, ref('im_livechat.livechat_channel_session_3_history_member_admin'))]"/>
+        </record>
+        <record id="im_livechat.livechat_channel_session_3_history_member_portal" model="im_livechat.channel.member.history">
+            <field name="channel_id" ref="livechat_channel_session_3"/>
+            <field name="partner_id" ref="base.partner_demo_portal"/>
+            <field name="livechat_member_type">visitor</field>
+            <field name="create_date" eval="DateTime.today() + relativedelta(months=-1, days=-2)"/>
         </record>
         <record id="im_livechat.livechat_channel_session_3_member_portal" model="discuss.channel.member">
             <field name="partner_id" ref="base.partner_demo_portal"/>
             <field name="channel_id" ref="im_livechat.livechat_channel_session_3"/>
-            <field name="livechat_member_type">visitor</field>
+            <field name="livechat_member_history_ids" eval="[(4, ref('im_livechat.livechat_channel_session_3_history_member_portal'))]"/>
         </record>
 
         <record id="livechat_channel_session_3_message_1" model="mail.message">

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_4.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_4.xml
@@ -11,17 +11,29 @@
             <field name="anonymous_name">Joel Willis</field>
             <field name="create_date" eval="DateTime.today() + relativedelta(months=-2, days=-3)"/>
         </record>
+        <record id="im_livechat.livechat_channel_session_4_history_member_demo" model="im_livechat.channel.member.history">
+            <field name="channel_id" ref="livechat_channel_session_4"/>
+            <field name="partner_id" ref="base.partner_demo"/>
+            <field name="livechat_member_type">agent</field>
+            <field name="create_date" eval="DateTime.today() + relativedelta(months=-2, days=-3)"/>
+        </record>
         <record id="im_livechat.livechat_channel_session_4_member_demo" model="discuss.channel.member">
             <field name="partner_id" ref="base.partner_demo"/>
             <field name="channel_id" ref="im_livechat.livechat_channel_session_4"/>
             <field name="unpin_dt" eval="DateTime.today()"/>
             <field name="last_interest_dt" eval="DateTime.today() + relativedelta(months=-1)"/>
-            <field name="livechat_member_type">agent</field>
+            <field name="livechat_member_history_ids" eval="[(4, ref('im_livechat.livechat_channel_session_4_history_member_demo'))]"/>
+        </record>
+        <record id="im_livechat.livechat_channel_session_4_history_member_portal" model="im_livechat.channel.member.history">
+            <field name="channel_id" ref="livechat_channel_session_4"/>
+            <field name="partner_id" ref="base.partner_demo_portal"/>
+            <field name="livechat_member_type">visitor</field>
+            <field name="create_date" eval="DateTime.today() + relativedelta(months=-2, days=-3)"/>
         </record>
         <record id="im_livechat.livechat_channel_session_4_member_portal" model="discuss.channel.member">
             <field name="partner_id" ref="base.partner_demo_portal"/>
             <field name="channel_id" ref="im_livechat.livechat_channel_session_4"/>
-            <field name="livechat_member_type">visitor</field>
+            <field name="livechat_member_history_ids" eval="[(4, ref('im_livechat.livechat_channel_session_4_history_member_portal'))]"/>
         </record>
 
         <record id="livechat_channel_session_4_message_1" model="mail.message">

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_5.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_5.xml
@@ -11,20 +11,32 @@
             <field name="anonymous_name">Visitor #532</field>
             <field name="create_date" eval="DateTime.today() + relativedelta(months=-2, days=-4)"/>
         </record>
+        <record id="im_livechat.livechat_channel_session_5_history_member_admin" model="im_livechat.channel.member.history">
+            <field name="channel_id" ref="livechat_channel_session_5"/>
+            <field name="partner_id" ref="base.partner_admin"/>
+            <field name="livechat_member_type">agent</field>
+            <field name="create_date" eval="DateTime.today() + relativedelta(months=-2, days=-4)"/>
+        </record>
         <record id="im_livechat.livechat_channel_session_5_member_admin" model="discuss.channel.member">
             <field name="partner_id" ref="base.partner_admin"/>
             <field name="channel_id" ref="im_livechat.livechat_channel_session_5"/>
             <field name="unpin_dt" eval="DateTime.today()"/>
             <field name="last_interest_dt" eval="DateTime.today() + relativedelta(months=-1)"/>
-            <field name="livechat_member_type">agent</field>
+            <field name="livechat_member_history_ids" eval="[(4, ref('im_livechat.livechat_channel_session_5_history_member_admin'))]"/>
         </record>
         <record id="im_livechat.livechat_channel_session_5_guest" model="mail.guest">
             <field name="name">Visitor #532</field>
         </record>
+        <record id="im_livechat.livechat_channel_session_5_history_member_guest" model="im_livechat.channel.member.history">
+            <field name="channel_id" ref="livechat_channel_session_5"/>
+            <field name="guest_id" ref="im_livechat.livechat_channel_session_5_guest"/>
+            <field name="livechat_member_type">visitor</field>
+            <field name="create_date" eval="DateTime.today() + relativedelta(months=-2, days=-4)"/>
+        </record>
         <record id="im_livechat.livechat_channel_session_5_member_guest" model="discuss.channel.member">
             <field name="guest_id" ref="im_livechat.livechat_channel_session_5_guest"/>
             <field name="channel_id" ref="im_livechat.livechat_channel_session_5"/>
-            <field name="livechat_member_type">visitor</field>
+            <field name="livechat_member_history_ids" eval="[(4, ref('im_livechat.livechat_channel_session_5_history_member_guest'))]"/>
         </record>
 
         <record id="livechat_channel_session_5_message_1" model="mail.message">

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_6.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_6.xml
@@ -11,20 +11,32 @@
             <field name="anonymous_name">Visitor #649</field>
             <field name="create_date" eval="DateTime.today() + relativedelta(months=-3, days=-5)"/>
         </record>
+        <record id="im_livechat.livechat_channel_session_6_history_member_admin" model="im_livechat.channel.member.history">
+            <field name="channel_id" ref="livechat_channel_session_6"/>
+            <field name="partner_id" ref="base.partner_admin"/>
+            <field name="livechat_member_type">agent</field>
+            <field name="create_date" eval="DateTime.today() + relativedelta(months=-3, days=-5)"/>
+        </record>
         <record id="im_livechat.livechat_channel_session_6_member_admin" model="discuss.channel.member">
             <field name="partner_id" ref="base.partner_admin"/>
             <field name="channel_id" ref="im_livechat.livechat_channel_session_6"/>
             <field name="unpin_dt" eval="DateTime.today()"/>
             <field name="last_interest_dt" eval="DateTime.today() + relativedelta(months=-1)"/>
-            <field name="livechat_member_type">agent</field>
+            <field name="livechat_member_history_ids" eval="[(4, ref('im_livechat.livechat_channel_session_6_history_member_admin'))]"/>
         </record>
         <record id="im_livechat.livechat_channel_session_6_guest" model="mail.guest">
             <field name="name">Visitor #649</field>
         </record>
+        <record id="im_livechat.livechat_channel_session_6_history_member_guest" model="im_livechat.channel.member.history">
+            <field name="channel_id" ref="livechat_channel_session_6"/>
+            <field name="guest_id" ref="im_livechat.livechat_channel_session_6_guest"/>
+            <field name="livechat_member_type">visitor</field>
+            <field name="create_date" eval="DateTime.today() + relativedelta(months=-3, days=-5)"/>
+        </record>
         <record id="im_livechat.livechat_channel_session_6_member_guest" model="discuss.channel.member">
             <field name="guest_id" ref="im_livechat.livechat_channel_session_6_guest"/>
             <field name="channel_id" ref="im_livechat.livechat_channel_session_6"/>
-            <field name="livechat_member_type">visitor</field>
+            <field name="livechat_member_history_ids" eval="[(4, ref('im_livechat.livechat_channel_session_6_history_member_guest'))]"/>
         </record>
 
         <record id="livechat_channel_session_6_message_1" model="mail.message">

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_7.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_7.xml
@@ -11,17 +11,29 @@
             <field name="anonymous_name">Joel Willis</field>
             <field name="create_date" eval="DateTime.today() + relativedelta(months=-3, days=-6)"/>
         </record>
+        <record id="im_livechat.livechat_channel_session_7_history_member_admin" model="im_livechat.channel.member.history">
+            <field name="channel_id" ref="livechat_channel_session_7"/>
+            <field name="partner_id" ref="base.partner_admin"/>
+            <field name="livechat_member_type">agent</field>
+            <field name="create_date" eval="DateTime.today() + relativedelta(months=-3, days=-6)"/>
+        </record>
         <record id="im_livechat.livechat_channel_session_7_member_admin" model="discuss.channel.member">
             <field name="partner_id" ref="base.partner_admin"/>
             <field name="channel_id" ref="im_livechat.livechat_channel_session_7"/>
             <field name="unpin_dt" eval="DateTime.today()"/>
             <field name="last_interest_dt" eval="DateTime.today() + relativedelta(months=-1)"/>
-            <field name="livechat_member_type">agent</field>
+            <field name="livechat_member_history_ids" eval="[(4, ref('im_livechat.livechat_channel_session_7_history_member_admin'))]"/>
+        </record>
+        <record id="im_livechat.livechat_channel_session_7_history_member_portal" model="im_livechat.channel.member.history">
+            <field name="channel_id" ref="livechat_channel_session_7"/>
+            <field name="partner_id" ref="base.partner_demo_portal"/>
+            <field name="livechat_member_type">visitor</field>
+            <field name="create_date" eval="DateTime.today() + relativedelta(months=-3, days=-6)"/>
         </record>
         <record id="im_livechat.livechat_channel_session_7_member_portal" model="discuss.channel.member">
             <field name="partner_id" ref="base.partner_demo_portal"/>
             <field name="channel_id" ref="im_livechat.livechat_channel_session_7"/>
-            <field name="livechat_member_type">visitor</field>
+            <field name="livechat_member_history_ids" eval="[(4, ref('im_livechat.livechat_channel_session_7_history_member_portal'))]"/>
         </record>
 
         <record id="livechat_channel_session_7_message_1" model="mail.message">

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_8.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_8.xml
@@ -11,20 +11,32 @@
             <field name="anonymous_name">Visitor #722</field>
             <field name="create_date" eval="DateTime.today() + relativedelta(months=-3, days=-7)"/>
         </record>
+        <record id="im_livechat.livechat_channel_session_8_history_member_demo" model="im_livechat.channel.member.history">
+            <field name="channel_id" ref="livechat_channel_session_8"/>
+            <field name="partner_id" ref="base.partner_demo"/>
+            <field name="livechat_member_type">agent</field>
+            <field name="create_date" eval="DateTime.today() + relativedelta(months=-3, days=-7)"/>
+        </record>
         <record id="im_livechat.livechat_channel_session_8_member_demo" model="discuss.channel.member">
             <field name="partner_id" ref="base.partner_demo"/>
             <field name="channel_id" ref="im_livechat.livechat_channel_session_8"/>
             <field name="unpin_dt" eval="DateTime.today()"/>
             <field name="last_interest_dt" eval="DateTime.today() + relativedelta(months=-1)"/>
-            <field name="livechat_member_type">agent</field>
+            <field name="livechat_member_history_ids" eval="[(4, ref('im_livechat.livechat_channel_session_8_history_member_demo'))]"/>
         </record>
         <record id="im_livechat.livechat_channel_session_8_guest" model="mail.guest">
             <field name="name">Visitor #722</field>
         </record>
+        <record id="im_livechat.livechat_channel_session_8_history_member_guest" model="im_livechat.channel.member.history">
+            <field name="channel_id" ref="livechat_channel_session_8"/>
+            <field name="guest_id" ref="im_livechat.livechat_channel_session_8_guest"/>
+            <field name="livechat_member_type">visitor</field>
+            <field name="create_date" eval="DateTime.today() + relativedelta(months=-3, days=-7)"/>
+        </record>
         <record id="im_livechat.livechat_channel_session_8_member_guest" model="discuss.channel.member">
             <field name="guest_id" ref="im_livechat.livechat_channel_session_8_guest"/>
             <field name="channel_id" ref="im_livechat.livechat_channel_session_8"/>
-            <field name="livechat_member_type">visitor</field>
+            <field name="livechat_member_history_ids" eval="[(4, ref('im_livechat.livechat_channel_session_8_history_member_guest'))]"/>
         </record>
 
         <record id="livechat_channel_session_8_message_1" model="mail.message">

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_9.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_9.xml
@@ -11,20 +11,32 @@
             <field name="channel_type">livechat</field>
             <field name="anonymous_name">Visitor</field>
         </record>
+        <record id="im_livechat.livechat_channel_session_9_history_member_admin" model="im_livechat.channel.member.history">
+            <field name="channel_id" ref="livechat_channel_session_9"/>
+            <field name="partner_id" ref="base.partner_admin"/>
+            <field name="livechat_member_type">agent</field>
+            <field name="create_date" eval="datetime.now() - timedelta(days=1)"/>
+        </record>
         <record id="im_livechat.livechat_channel_session_9_member_admin" model="discuss.channel.member">
             <field name="partner_id" ref="base.partner_admin"/>
             <field name="channel_id" ref="im_livechat.livechat_channel_session_9"/>
             <field name="unpin_dt" eval="DateTime.today()"/>
             <field name="last_interest_dt" eval="DateTime.today() + relativedelta(months=-1)"/>
-            <field name="livechat_member_type">agent</field>
+            <field name="livechat_member_history_ids" eval="[(4, ref('im_livechat.livechat_channel_session_9_history_member_admin'))]"/>
         </record>
         <record id="im_livechat.livechat_channel_session_9_guest" model="mail.guest">
             <field name="name">Visitor</field>
         </record>
+        <record id="im_livechat.livechat_channel_session_9_history_member_guest" model="im_livechat.channel.member.history">
+            <field name="channel_id" ref="livechat_channel_session_9"/>
+            <field name="guest_id" ref="im_livechat.livechat_channel_session_9_guest"/>
+            <field name="livechat_member_type">visitor</field>
+            <field name="create_date" eval="datetime.now() - timedelta(days=1)"/>
+        </record>
         <record id="im_livechat.livechat_channel_session_9_member_guest" model="discuss.channel.member">
             <field name="guest_id" ref="im_livechat.livechat_channel_session_9_guest"/>
             <field name="channel_id" ref="im_livechat.livechat_channel_session_9"/>
-            <field name="livechat_member_type">visitor</field>
+            <field name="livechat_member_history_ids" eval="[(4, ref('im_livechat.livechat_channel_session_9_history_member_guest'))]"/>
         </record>
 
         <record id="livechat_channel_session_9_message_1" model="mail.message">

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_support_bot_session_1.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_support_bot_session_1.xml
@@ -20,10 +20,16 @@
         <record id="support_bot_session_1_guest_demo" model="mail.guest">
             <field name="name">Visiteur #301</field>
         </record>
+        <record id="support_bot_session_1_history_member_guest_demo" model="im_livechat.channel.member.history">
+            <field name="channel_id" ref="support_bot_session_1_demo"/>
+            <field name="guest_id" ref="support_bot_session_1_guest_demo"/>
+            <field name="livechat_member_type">visitor</field>
+            <field name="create_date" eval="datetime.now() - timedelta(minutes=5)"/>
+        </record>
         <record id="support_bot_session_1_member_guest_demo" model="discuss.channel.member">
             <field name="guest_id" ref="support_bot_session_1_guest_demo"/>
             <field name="channel_id" ref="support_bot_session_1_demo"/>
-            <field name="livechat_member_type">visitor</field>
+            <field name="livechat_member_history_ids" eval="[(4, ref('support_bot_session_1_history_member_guest_demo'))]"/>
         </record>
         <record id="support_bot_session_1_message_1" model="mail.message">
             <field name="model">discuss.channel</field>

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_support_bot_session_2.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_support_bot_session_2.xml
@@ -20,10 +20,16 @@
         <record id="support_bot_session_2_guest_demo" model="mail.guest">
             <field name="name">Visitatore #302</field>
         </record>
+        <record id="support_bot_session_2_history_member_guest_demo" model="im_livechat.channel.member.history">
+            <field name="channel_id" ref="support_bot_session_2_demo"/>
+            <field name="guest_id" ref="support_bot_session_2_guest_demo"/>
+            <field name="livechat_member_type">visitor</field>
+            <field name="create_date" eval="DateTime.today() + relativedelta(weeks=-2)"/>
+        </record>
         <record id="support_bot_session_2_member_guest_demo" model="discuss.channel.member">
             <field name="guest_id" ref="support_bot_session_2_guest_demo"/>
             <field name="channel_id" ref="support_bot_session_2_demo"/>
-            <field name="livechat_member_type">visitor</field>
+            <field name="livechat_member_history_ids" eval="[(4, ref('support_bot_session_2_history_member_guest_demo'))]"/>
         </record>
         <record id="support_bot_session_2_message_1" model="mail.message">
             <field name="model">discuss.channel</field>

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_support_bot_session_3.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_support_bot_session_3.xml
@@ -20,10 +20,16 @@
         <record id="support_bot_session_3_guest_demo" model="mail.guest">
             <field name="name">Visitatore #303</field>
         </record>
+        <record id="support_bot_session_3_history_member_guest_demo" model="im_livechat.channel.member.history">
+            <field name="channel_id" ref="support_bot_session_3_demo"/>
+            <field name="guest_id" ref="support_bot_session_3_guest_demo"/>
+            <field name="livechat_member_type">visitor</field>
+            <field name="create_date" eval="DateTime.today() + relativedelta(days=-10)"/>
+        </record>
         <record id="support_bot_session_3_member_guest_demo" model="discuss.channel.member">
             <field name="guest_id" ref="support_bot_session_3_guest_demo"/>
             <field name="channel_id" ref="support_bot_session_3_demo"/>
-            <field name="livechat_member_type">visitor</field>
+            <field name="livechat_member_history_ids" eval="[(4, ref('support_bot_session_3_history_member_guest_demo'))]"/>
         </record>
         <record id="support_bot_session_3_message_1" model="mail.message">
             <field name="model">discuss.channel</field>

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_support_bot_session_4.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_support_bot_session_4.xml
@@ -20,10 +20,16 @@
         <record id="support_bot_session_4_guest_demo" model="mail.guest">
             <field name="name">Visitatore #304</field>
         </record>
+        <record id="support_bot_session_4_history_member_guest_demo" model="im_livechat.channel.member.history">
+            <field name="channel_id" ref="support_bot_session_4_demo"/>
+            <field name="guest_id" ref="support_bot_session_4_guest_demo"/>
+            <field name="livechat_member_type">visitor</field>
+            <field name="create_date" eval="datetime.now() - timedelta(seconds=30)"/>
+        </record>
         <record id="support_bot_session_4_member_guest_demo" model="discuss.channel.member">
             <field name="guest_id" ref="support_bot_session_4_guest_demo"/>
             <field name="channel_id" ref="support_bot_session_4_demo"/>
-            <field name="livechat_member_type">visitor</field>
+            <field name="livechat_member_history_ids" eval="[(4, ref('support_bot_session_4_history_member_guest_demo'))]"/>
         </record>
         <record id="support_bot_session_4_message_1" model="mail.message">
             <field name="model">discuss.channel</field>

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_support_bot_session_5.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_support_bot_session_5.xml
@@ -19,10 +19,16 @@
         <record id="support_bot_session_5_guest_demo" model="mail.guest">
             <field name="name">Visitor #305</field>
         </record>
+        <record id="support_bot_session_5_history_member_guest_demo" model="im_livechat.channel.member.history">
+            <field name="channel_id" ref="support_bot_session_5_demo"/>
+            <field name="guest_id" ref="support_bot_session_5_guest_demo"/>
+            <field name="livechat_member_type">visitor</field>
+            <field name="create_date" eval="DateTime.today() + relativedelta(days=-5)"/>
+        </record>
         <record id="support_bot_session_5_member_guest_demo" model="discuss.channel.member">
             <field name="guest_id" ref="support_bot_session_5_guest_demo"/>
             <field name="channel_id" ref="support_bot_session_5_demo"/>
-            <field name="livechat_member_type">visitor</field>
+            <field name="livechat_member_history_ids" eval="[(4, ref('support_bot_session_5_history_member_guest_demo'))]"/>
         </record>
         <record id="support_bot_session_5_message_1" model="mail.message">
             <field name="model">discuss.channel</field>

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_support_bot_session_6.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_support_bot_session_6.xml
@@ -19,10 +19,16 @@
         <record id="support_bot_session_6_guest_demo" model="mail.guest">
             <field name="name">Visitor #306</field>
         </record>
-        <record id="support_bot_session_6_member_guest_demo" model="discuss.channel.member">
+        <record id="support_bot_session_6_history_member_guest_demo" model="im_livechat.channel.member.history">
             <field name="guest_id" ref="support_bot_session_6_guest_demo"/>
             <field name="channel_id" ref="support_bot_session_6_demo"/>
             <field name="livechat_member_type">visitor</field>
+            <field name="create_date" eval="datetime.now() - timedelta(minutes=6)"/>
+        </record>
+        <record id="support_bot_session_6_member_guest_demo" model="discuss.channel.member">
+            <field name="guest_id" ref="support_bot_session_6_guest_demo"/>
+            <field name="channel_id" ref="support_bot_session_6_demo"/>
+            <field name="livechat_member_history_ids" eval="[(4, ref('support_bot_session_6_history_member_guest_demo'))]"/>
         </record>
         <record id="support_bot_session_6_message_1" model="mail.message">
             <field name="model">discuss.channel</field>

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_support_bot_session_7.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_support_bot_session_7.xml
@@ -19,6 +19,12 @@
         <record id="support_bot_session_7_guest_demo" model="mail.guest">
             <field name="name">Visitor #307</field>
         </record>
+        <record id="support_bot_session_7_history_member_guest_demo" model="im_livechat.channel.member.history">
+            <field name="channel_id" ref="support_bot_session_7_demo"/>
+            <field name="guest_id" ref="support_bot_session_7_guest_demo"/>
+            <field name="livechat_member_type">visitor</field>
+            <field name="create_date" eval="DateTime.today() + relativedelta(days=-6)"/>
+        </record>
         <record id="support_bot_session_7_member_guest_demo" model="discuss.channel.member">
             <field name="guest_id" ref="support_bot_session_7_guest_demo"/>
             <field name="channel_id" ref="support_bot_session_7_demo"/>


### PR DESCRIPTION
Live chat demo data set some conversations in the past. However, some statistics such as session duration is computed from the member history create date, which is not correctly set in the past. This commit fixes this issue.

part of task-4796793

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
