### PR TITLE
[FIX] hw_drivers: error on git checkout

### DIFF
--- a/addons/hw_drivers/tools/helpers.py
+++ b/addons/hw_drivers/tools/helpers.py
@@ -217,7 +217,7 @@ def check_git_branch(server_url=None, get_db_branch=False):
             db_branch,
         )
         if db_branch != local_branch:
-            update_conf({'database_version', db_branch})
+            update_conf({'database_version': db_branch})
             try:
                 with writable():
                     subprocess.run(git + ['branch', '-m', db_branch], check=True)


### PR DESCRIPTION
Introduced in odoo/odoo#213177.

A simple typo meant the `update_conf` method was being called with a set instead of a dict, leading to an error being thrown and preventing the git checkout. This commit fixes the typo.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
