### PR TITLE
[IMP] website, website_sale:  add a shop_btn_href variable to snippets

### DIFF
--- a/addons/website/views/snippets/s_banner_categories.xml
+++ b/addons/website/views/snippets/s_banner_categories.xml
@@ -20,7 +20,7 @@
                         <br/>
                     </p>
                     <p style="text-align: center;">
-                        <a t-att-href="cta_btn_href" class="o_translate_inline btn btn-lg btn-secondary">
+                        <a t-att-href="shop_btn_href" class="o_translate_inline btn btn-lg btn-secondary">
                             <t t-out="cta_btn_text">Buy Now</t>
                         </a>
                     </p>

--- a/addons/website/views/snippets/s_banner_product.xml
+++ b/addons/website/views/snippets/s_banner_product.xml
@@ -19,7 +19,7 @@
                 </div>
                 <div class="o_grid_item g-height-4 g-col-lg-4 col-lg-4"
                         style="z-index: 2; grid-area: 12 / 9 / 16 / 13; text-align: right;">
-                    <a href="#" class="btn btn-lg btn-secondary">Buy Now</a>
+                    <a t-att-href="shop_btn_href" class="btn btn-lg btn-secondary">Buy Now</a>
                 </div>
             </div>
         </div>

--- a/addons/website/views/snippets/s_bento_banner.xml
+++ b/addons/website/views/snippets/s_bento_banner.xml
@@ -18,7 +18,7 @@
                                 <br/><br/>
                             </p>
                             <p style="text-align: center;">
-                                <a href="#"
+                                <a t-att-href="shop_btn_href"
                                     role="button"
                                     class="btn btn-lg btn-secondary o_translate_inline">
                                     Buy now

--- a/addons/website/views/snippets/s_bento_block.xml
+++ b/addons/website/views/snippets/s_bento_block.xml
@@ -18,7 +18,7 @@
                         </div>
                         <div class="o_grid_item g-height-3 g-col-lg-4 col-lg-4"
                                 style="z-index: 2; --grid-item-padding-x: 48px; --grid-item-padding-y: 0px; grid-area: 8 / 9 / 11 / 13; text-align: right;">
-                            <a href="#"
+                            <a t-att-href="shop_btn_href"
                                     class="btn btn-lg btn-secondary o_animate o_anim_fade_in o_animated"
                                     style="--wanim-intensity: 30; animation-play-state: running;">
                                 Buy Now

--- a/addons/website/views/snippets/s_bento_grid.xml
+++ b/addons/website/views/snippets/s_bento_grid.xml
@@ -28,7 +28,7 @@
                     <h2 class="h3-fs">30% Off Your First Purchase</h2>
                     <p class="lead">Shop today and unlock an exclusive discount!</p>
                     <p>
-                        <a class="o_translate_inline btn btn-secondary" t-att-href="cta_btn_href">
+                        <a class="o_translate_inline btn btn-secondary" t-att-href="shop_btn_href">
                             Shop Now
                         </a>
                         <br/>

--- a/addons/website/views/snippets/s_floating_blocks.xml
+++ b/addons/website/views/snippets/s_floating_blocks.xml
@@ -24,7 +24,7 @@
                                 </div>
 
                                 <div class="o_grid_item g-height-2 g-col-lg-4 col-lg-4" style="z-index: 2; --grid-item-padding-y: 0px; --grid-item-padding-x: 0px; grid-area: 7 / 1 / 9 / 5;">
-                                    <a href="" title="" role="button" class="btn btn-lg btn-secondary">Shop Desks</a>
+                                    <a t-att-href="shop_btn_href" title="" role="button" class="btn btn-lg btn-secondary">Shop Desks</a>
                                 </div>
                             </div>
                         </div>
@@ -48,7 +48,7 @@
                                     </h2>
                                 </div>
                                 <div class="o_grid_item g-height-2 g-col-lg-4 col-lg-4" style="z-index: 2; --grid-item-padding-y: 0px; --grid-item-padding-x: 0px; grid-area: 7 / 1 / 9 / 5;">
-                                    <a href="#" title="" role="button" class="btn btn-lg btn-secondary">Shop Sofas</a>
+                                    <a t-att-href="shop_btn_href" title="" role="button" class="btn btn-lg btn-secondary">Shop Sofas</a>
                                 </div>
                             </div>
                         </div>

--- a/addons/website/views/snippets/snippets.xml
+++ b/addons/website/views/snippets/snippets.xml
@@ -6,6 +6,7 @@
     <t id="default_snippets">
         <t t-set="cta_btn_text" t-value="False"/>
         <t t-set="cta_btn_href">/contactus</t>
+        <t t-set="shop_btn_href">#</t>
 
         <!-- Snippet groups -->
         <snippets id="snippet_groups" string="Categories">

--- a/addons/website_sale/templates/snippets/snippets.xml
+++ b/addons/website_sale/templates/snippets/snippets.xml
@@ -9,6 +9,9 @@
     <xpath expr="//t[@id='snippet_add_to_cart_hook']" position="replace">
         <t t-snippet="website_sale.s_add_to_cart" string="Add to Cart Button" t-thumbnail="/website/static/src/img/snippets_thumbs/s_add_to_cart.svg" t-grid-column-span="3"/>
     </xpath>
+    <xpath expr="//t[@t-set='shop_btn_href']" position="replace">
+        <t t-set="shop_btn_href">/shop</t>
+    </xpath>
 </template>
 
 </odoo>


### PR DESCRIPTION
Before this PR, we only had cta_btn_href, now shop_btn_href has been created and its value is by default empty until website-sale is installed and its value becomes "/shop". 

shop_btn_href has been added to these following "catalog" snippets' CTA :
- s_bento_grid
- s_floating_blocks

task-4807681

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
