### PR TITLE
[IMP] survey: manage conditionals in post submit flow

### DIFF
--- a/addons/survey/controllers/main.py
+++ b/addons/survey/controllers/main.py
@@ -332,8 +332,7 @@ class Survey(http.Controller):
                     values = {'survey_last': survey_last}
                     # On the last survey page, get the suggested answers which are triggering questions on the following pages
                     # to dynamically update the survey button to "submit" or "continue" depending on the selected answers.
-                    # NB: Not in the skipped questions flow as conditionals aren't handled.
-                    if not answer_sudo.survey_first_submitted and survey_last and survey_sudo.questions_layout != 'one_page':
+                    if survey_last and survey_sudo.questions_layout != 'one_page':
                         pages_or_questions = survey_sudo._get_pages_or_questions(answer_sudo)
                         following_questions = pages_or_questions.filtered(lambda page_or_question: page_or_question.sequence > next_page_or_question.sequence)
                         next_page_questions_suggested_answers = next_page_or_question.suggested_answer_ids
@@ -590,8 +589,7 @@ class Survey(http.Controller):
                 else:
                     next_page = survey_sudo._get_next_page_or_question(answer_sudo, page_or_question_id)
                 if not next_page:
-                    if survey_sudo.users_can_go_back and answer_sudo.user_input_line_ids.filtered(
-                            lambda a: a.skipped and a.question_id.constr_mandatory):
+                    if survey_sudo.users_can_go_back and answer_sudo._get_skipped_questions():
                         answer_sudo.write({
                             'last_displayed_page_id': page_or_question_id,
                             'survey_first_submitted': True,

--- a/addons/survey/static/src/interactions/survey_form.js
+++ b/addons/survey/static/src/interactions/survey_form.js
@@ -272,10 +272,10 @@ export class SurveyForm extends Interaction {
             }
         }
 
-        // Update survey button to "continue" if the current page/question is the last (without accounting for
+        // Update survey button label to next page if the current page/question is the last (without accounting for
         // its own conditional questions) but a selected answer is triggering a conditional question on a next page.
-        const surveyLastTriggeringAnswers = this.el.querySelector(".o_survey_form_content_data")
-            .dataset.surveyLastTriggeringAnswers;
+        const surveyContentData = this.el.querySelector(".o_survey_form_content_data");
+        const surveyLastTriggeringAnswers = surveyContentData.dataset.surveyLastTriggeringAnswers;
         if (surveyLastTriggeringAnswers) {
             const currentSelectedAnswers = Array.from(
                 this.el.querySelectorAll(`
@@ -289,9 +289,10 @@ export class SurveyForm extends Interaction {
                     surveyLastTriggeringAnswers.includes(answerId)
                 )
             ) {
-                // change to continue
-                submitButton.value = "next";
-                submitButton.textContent = _t("Continue");
+                // change to next
+                const firstSubmitted = surveyContentData.dataset.surveyFirstSubmitted;
+                submitButton.value = firstSubmitted ? "next_skipped" : "next";
+                submitButton.textContent = firstSubmitted ? _t("Next Skipped") : _t("Continue");
                 submitButton.classList.replace("btn-secondary", "btn-primary");
             } else {
                 // change to submit

--- a/addons/survey/static/src/interactions/survey_form.js
+++ b/addons/survey/static/src/interactions/survey_form.js
@@ -221,7 +221,7 @@ export class SurveyForm extends Interaction {
             }
             this.submitForm({
                 isFinish: !!this.el.querySelector("button[value='finish']"),
-                nextSkipped: this.el.querySelector("button[value='next_skipped']")
+                showNextPostSubmitPage: this.el.querySelector("button[value='next_post_submit']")
                     ? ev.key === "Enter"
                     : false,
             });
@@ -291,8 +291,8 @@ export class SurveyForm extends Interaction {
             ) {
                 // change to next
                 const firstSubmitted = surveyContentData.dataset.surveyFirstSubmitted;
-                submitButton.value = firstSubmitted ? "next_skipped" : "next";
-                submitButton.textContent = firstSubmitted ? _t("Next Skipped") : _t("Continue");
+                submitButton.value = firstSubmitted ? "next_post_submit" : "next";
+                submitButton.textContent = _t("Continue");
                 submitButton.classList.replace("btn-secondary", "btn-primary");
             } else {
                 // change to submit
@@ -320,7 +320,7 @@ export class SurveyForm extends Interaction {
             targetEl.closest(".js_question-wrapper").querySelector(".o_survey_comment");
         if (!questionHasComment) {
             await this.submitForm({
-                nextSkipped: !!questionEl.dataset.isSkippedQuestion,
+                showNextPostSubmitPage: !!questionEl.dataset.isPostSubmitQuestion,
             });
         }
     }
@@ -411,8 +411,8 @@ export class SurveyForm extends Interaction {
         const targetEl = ev.currentTarget;
         if (targetEl.value === "previous") {
             this.submitForm({ previousPageId: parseInt(targetEl.dataset.previousPageId) });
-        } else if (targetEl.value === "next_skipped") {
-            this.submitForm({ nextSkipped: true });
+        } else if (targetEl.value === "next_post_submit") {
+            this.submitForm({ showNextPostSubmitPage: true });
         } else if (targetEl.value === "finish" && !this.options.sessionInProgress) {
             // Adding pop-up before the survey is submitted when not in live session
             this.dialog.add(ConfirmationDialog, {
@@ -526,7 +526,7 @@ export class SurveyForm extends Interaction {
      *
      * @param {Array} [options]
      * @param {Integer} [options.previousPageId] navigates to page id
-     * @param {Boolean} [options.nextSkipped] navigates to next skipped page or question
+     * @param {Boolean} [options.showNextPostSubmitPage] navigates to next post submit page or question
      * @param {Boolean} [options.skipValidation] skips JS validation
      * @param {Boolean} [options.initTime] will force the re-init of the timer after next
      *   screen transition
@@ -541,8 +541,8 @@ export class SurveyForm extends Interaction {
         if (options.previousPageId) {
             params.previous_page_id = options.previousPageId;
         }
-        if (options.nextSkipped) {
-            params.next_skipped_page_or_question = true;
+        if (options.showNextPostSubmitPage) {
+            params.next_post_submit_page_or_question = true;
         }
         let route = "/survey/submit";
         if (this.options.isStartScreen) {
@@ -604,10 +604,9 @@ export class SurveyForm extends Interaction {
      */
     async nextScreen(nextScreenPromise, options) {
         const selectorsToFadeout = [".o_survey_form_content"];
-        if (options.isFinish && !this.nextScreenResult?.has_skipped_questions) {
+        if (options.isFinish && !this.nextScreenResult?.has_post_submit_questions) {
             // Fade out the top title
             document.querySelector('.o_survey_main_title_fade')?.classList.replace("opacity-100", "opacity-0");
-            
             selectorsToFadeout.push(".breadcrumb", ".o_survey_timer");
             cookie.delete(`survey_${this.options.surveyToken}`);
         }
@@ -640,7 +639,7 @@ export class SurveyForm extends Interaction {
     onNextScreenDone(options) {
         const result = this.nextScreenResult;
         if (
-            (!(options && options.isFinish) || result.has_skipped_questions) &&
+            (!(options && options.isFinish) || result.has_post_submit_questions) &&
             !this.options.sessionInProgress
         ) {
             this.preventEnterSubmit = false;
@@ -694,7 +693,7 @@ export class SurveyForm extends Interaction {
                 this.removeTimer();
             }
         }
-        if (options && options.isFinish && !result.has_skipped_questions) {
+        if (options && options.isFinish && !result.has_post_submit_questions) {
             if (this.breadcrumbEl) {
                 this.showBreadcrumb = false;
                 this.breadcrumbEl.replaceChildren();

--- a/addons/survey/static/tests/tours/survey_roaming_mandatory_questions.js
+++ b/addons/survey/static/tests/tours/survey_roaming_mandatory_questions.js
@@ -73,6 +73,20 @@ registry.category('web_tour.tours').add('test_survey_roaming_mandatory_questions
         trigger: 'div.js_question-wrapper:contains("Q2") label:contains("Answer 3")',
         run: "click",
     }, {
+        content: 'Check if the visible question is the indirectly skipped mandatory conditional question Q4',
+        trigger: 'div.js_question-wrapper:contains("Q4")',
+    }, {
+        content: 'Answer Q4',
+        trigger: 'div.js_question-wrapper:contains("Q4") label:contains("Answer 1")',
+        run: "click",
+    }, {
+        content: 'Check if the visible question is the indirectly skipped non-mandatory conditional question Q5',
+        trigger: 'div.js_question-wrapper:contains("Q5")',
+    }, {
+        content: 'Answer Q5',
+        trigger: 'div.js_question-wrapper:contains("Q5") label:contains("Answer 1")',
+        run: "click",
+    }, {
         content: 'Click on Submit',
         trigger: 'button.btn:contains("Submit")',
         run: "click",

--- a/addons/survey/static/tests/tours/survey_roaming_mandatory_questions.js
+++ b/addons/survey/static/tests/tours/survey_roaming_mandatory_questions.js
@@ -48,15 +48,15 @@ registry.category('web_tour.tours').add('test_survey_roaming_mandatory_questions
         content: 'Check if question is Q1',
         trigger: 'div.js_question-wrapper:contains("Q1")',
     }, {
-        content: 'Click on "Next Skipped" button',
-        trigger: 'button.btn:contains("Next Skipped")',
+        content: 'Click on "Continue" button',
+        trigger: 'button.btn:contains("Continue")',
         run: "click",
     }, {
         content: 'Check if question is Q2',
         trigger: 'div.js_question-wrapper:contains("Q2")',
     }, {
-        content: 'Click on "Next Skipped" button',
-        trigger: 'button.btn:contains("Next Skipped")',
+        content: 'Click on "Continue" button',
+        trigger: 'button.btn:contains("Continue")',
         run: "click",
     }, {
         content: 'Check if question is Q1 again (should loop on skipped questions)',

--- a/addons/survey/tests/test_survey_ui_feedback.py
+++ b/addons/survey/tests/test_survey_ui_feedback.py
@@ -295,15 +295,9 @@ class TestUiFeedback(HttpCaseWithUserDemo):
                 }),
             ]
         })
-
-        q1 = survey_with_trigger_on_different_page.question_ids.filtered(lambda q: q.title == 'Q1')
+        q1, q2, q3 = survey_with_trigger_on_different_page.question_ids
         q1_a1 = q1.suggested_answer_ids.filtered(lambda a: a.value == 'Answer 1')
-
-        q2 = survey_with_trigger_on_different_page.question_ids.filtered(lambda q: q.title == 'Q2')
         q2_a1 = q2.suggested_answer_ids.filtered(lambda a: a.value == 'Answer 1')
-
-        q3 = survey_with_trigger_on_different_page.question_ids.filtered(lambda q: q.title == 'Q3')
-
         q3.triggering_answer_ids = q1_a1 | q2_a1
 
         access_token = survey_with_trigger_on_different_page.access_token
@@ -351,9 +345,31 @@ class TestUiFeedback(HttpCaseWithUserDemo):
                         Command.create({'value': 'Answer 1'}),
                         Command.create({'value': 'Answer 2'}),
                     ],
+                }), Command.create({
+                    'title': 'Q4',
+                    'sequence': 4,
+                    'question_type': 'simple_choice',
+                    'constr_mandatory': True,
+                    'suggested_answer_ids': [
+                        Command.create({'value': 'Answer 1'}),
+                        Command.create({'value': 'Answer 2'}),
+                    ],
+                }), Command.create({
+                    'title': 'Q5',
+                    'sequence': 5,
+                    'question_type': 'simple_choice',
+                    'constr_mandatory': False,
+                    'suggested_answer_ids': [
+                        Command.create({'value': 'Answer 1'}),
+                        Command.create({'value': 'Answer 2'}),
+                    ],
                 }),
             ]
         })
+        _, q2, _, q4, q5 = survey_with_mandatory_questions.question_ids
+        q2_a3 = q2.suggested_answer_ids.filtered(lambda a: a.value == 'Answer 3')
+        q4.triggering_answer_ids = q2_a3
+        q5.triggering_answer_ids = q2_a3
 
         access_token = survey_with_mandatory_questions.access_token
         self.start_tour("/survey/start/%s" % access_token, 'test_survey_roaming_mandatory_questions')

--- a/addons/survey/views/survey_templates.xml
+++ b/addons/survey/views/survey_templates.xml
@@ -182,6 +182,7 @@
             t-att-data-has-answered="bool(has_answered)"
             t-att-data-is-page-description="bool(question and question.is_page and not is_html_empty(question.description))"
             t-att-data-server-time="server_time"
+            t-att-data-survey-first-submitted="answer.survey_first_submitted"
             t-att-data-survey-last-triggering-answers="survey_last_triggering_answers"
             t-att-data-timer="timer_start"
             t-att-data-time-limit-minutes="time_limit_minutes"/>

--- a/addons/survey/views/survey_templates.xml
+++ b/addons/survey/views/survey_templates.xml
@@ -224,11 +224,10 @@
 
             <div class="row">
                 <div class="col-12 text-center mt16">
-                    <t t-set="submit_value" t-value="'finish' if survey_last or answer.is_session_answer else 'next_skipped'
-                        if answer.survey_first_submitted and skipped_questions.page_id and page in skipped_questions.page_id else 'next'"/>
+                    <t t-set="submit_value" t-value="'finish' if survey_last or answer.is_session_answer else 'next_post_submit'
+                        if answer.survey_first_submitted and post_submit_questions.page_id and page in post_submit_questions.page_id else 'next'"/>
                     <button type="submit" t-att-value="submit_value" t-attf-class="btn #{'btn-secondary' if survey_last else 'btn-primary'} disabled">
                         <t t-if="submit_value == 'finish'">Submit</t>
-                        <t t-elif="submit_value == 'next_skipped'">Next Skipped</t>
                         <t t-else="">Continue</t>
                     </button>
                     <button id="next_page" t-attf-class="btn #{'btn-secondary' if survey_last else 'btn-primary'} d-none">Next</button>
@@ -265,10 +264,9 @@
                 <div class="row">
                     <div class="col-12 text-center mt16">
                         <t t-set="submit_value" t-value="'finish' if survey_last or answer.is_session_answer else
-                            'next_skipped' if answer.survey_first_submitted and skipped_questions and question in skipped_questions else 'next'"/>
+                            'next_post_submit' if answer.survey_first_submitted and post_submit_questions and question in post_submit_questions else 'next'"/>
                         <button type="submit" t-att-value="submit_value" t-attf-class="btn #{'btn-secondary' if survey_last else 'btn-primary'} disabled">
                             <t t-if="submit_value == 'finish'">Submit</t>
-                            <t t-elif="submit_value == 'next_skipped'">Next Skipped</t>
                             <t t-else="">Continue</t>
                         </button>
                         <button id="next_page" t-attf-class="btn #{'btn-secondary' if survey_last else 'btn-primary'} d-none">Next</button>
@@ -352,7 +350,7 @@
         <t t-set="default_constr_error_msg">This question requires an answer.</t>
         <t t-set="default_validation_error_msg">The answer you entered is not valid.</t>
         <t t-set="default_comments_message">If other, please specify:</t>
-        <t t-set="is_skipped_question" t-value="skipped_questions and question in skipped_questions"/>
+        <t t-set="is_post_submit_question" t-value="post_submit_questions and question in post_submit_questions"/>
         <div t-attf-class="js_question-wrapper pb-4
                            #{'d-none' if not display_question else ''}
                            #{'me-2' if extra_right_margin else ''}"
@@ -377,8 +375,8 @@
             <t t-if="question.question_type == 'multiple_choice'" t-call="survey.question_multiple_choice"/>
             <t t-if="question.question_type == 'matrix'" t-call="survey.question_matrix"/>
             <div t-attf-class="o_survey_question_error d-flex align-items-center justify-content-between overflow-hidden
-                 border-0 py-0 px-3 alert alert-danger mt-2 #{'slide_in' if is_skipped_question else ''}" role="alert">
-                <span t-if="is_skipped_question" t-out="question.constr_error_msg or default_constr_error_msg"/>
+                 border-0 py-0 px-3 alert alert-danger mt-2 #{'slide_in' if is_post_submit_question else ''}" role="alert">
+                <span t-if="is_post_submit_question" t-out="question.constr_error_msg or default_constr_error_msg"/>
             </div>
         </div>
     </template>
@@ -420,7 +418,7 @@
         <t t-set="answer_line" t-value="answer_lines and not answer_lines[0].skipped and answer_lines[0]"/>
         <div class="o_survey_answer_wrapper o_survey_form_choice"
              t-att-data-name="question.id"
-             t-att-data-is-skipped-question="is_skipped_question or None"
+             t-att-data-is-post-submit-question="is_post_submit_question or None"
              data-question-type="scale">
             <div role="radiogroup" class="btn-group d-flex mb-2" t-att-aria-label="">
                 <t t-foreach="range(question.scale_min, question.scale_max + 1)" t-as="value">
@@ -503,7 +501,7 @@
         <t t-set="comment_line" t-value="answer_lines.filtered(lambda line: line.value_char_box)"/>
         <div class="row g-2 o_survey_answer_wrapper o_survey_form_choice"
              t-att-data-name="question.id"
-             t-att-data-is-skipped-question="is_skipped_question or None"
+             t-att-data-is-post-submit-question="is_post_submit_question or None"
              data-question-type="simple_choice_radio">
             <t t-set="item_idx" t-value="0"/>
             <t t-set="has_correct_answer" t-value="scoring_display_correction and any(label.is_correct for label in question.suggested_answer_ids)"/>
@@ -638,7 +636,7 @@
                t-att-data-name="question.id"
                t-att-data-question-type="question.question_type"
                t-att-data-sub-questions="question.matrix_row_ids.ids"
-               t-att-data-is-skipped-question="is_skipped_question or None">
+               t-att-data-is-post-submit-question="is_post_submit_question or None">
             <thead>
                 <tr>
                     <th> </th>


### PR DESCRIPTION
Purpose
=======
Manage mandatory conditional questions in the skipped questions flow,
now renamed "post submit" flow as it doesn't only contains skipped questions anymore.

Specification
=============
Currently, conditional questions aren't taken into account in the post submit questions flow.
Meaning that, when picking an answer triggering a conditional, this conditional won't be displayed.

=> Updating the flow so that, if the skipped mandatory question triggers conditional questions which weren't displayed yet, those questions are added to the flow so that the user actually have a chance to answer them.
NB: Skipping a non-mandatory conditional question by clicking on "Next Skipped" won't propose it again.
=> Renaming the flow from "skipped questions" flow to "post submit" flow as it doesn't only includes the skipped mandatory questions anymore.

Task-4778398

