### PR TITLE
[IMP] hw_drivers: allow saving db_name to conf

### DIFF
--- a/addons/hw_drivers/tools/helpers.py
+++ b/addons/hw_drivers/tools/helpers.py
@@ -204,19 +204,21 @@ def check_image():
     return {'major': version[0], 'minor': version[1]}
 
 
-def save_conf_server(url, token, db_uuid, enterprise_code):
+def save_conf_server(url, token, db_uuid, enterprise_code, db_name=None):
     """
     Save server configurations in odoo.conf
     :param url: The URL of the server
     :param token: The token to authenticate the server
     :param db_uuid: The database UUID
     :param enterprise_code: The enterprise code
+    :param db_name: The database name
     """
     update_conf({
         'remote_server': url,
         'token': token,
         'db_uuid': db_uuid,
         'enterprise_code': enterprise_code,
+        'db_name': db_name,
     })
 
 
@@ -606,6 +608,7 @@ def disconnect_from_server():
         'remote_server': '',
         'token': '',
         'db_uuid': '',
+        'db_name': '',
         'screen_orientation': '',
         'browser_url': '',
         'iot_handlers_etag': '',


### PR DESCRIPTION
See odoo/odoo#214960 (master)

The PR mentioned above adds fixes to connect to a DB that is part of a multi-DB instance. This includes saving a new configuration key, `db_name`, to keep track of the current database name.

This commit backports just this functionality, making older versions compatible with the new pairing token that includes to DB name. This prevents a potential traceback if using this new token format.

task-4815521

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
