### PR TITLE
[IMP] l10n_tr_nilvera_einvoice: Add Referance as tax office for UBL

### DIFF
--- a/addons/l10n_tr_nilvera_einvoice/i18n/l10n_tr_nilvera_einvoice.pot
+++ b/addons/l10n_tr_nilvera_einvoice/i18n/l10n_tr_nilvera_einvoice.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 17.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-03-26 15:09+0000\n"
-"PO-Revision-Date: 2025-03-26 15:09+0000\n"
+"POT-Creation-Date: 2025-06-20 15:07+0000\n"
+"PO-Revision-Date: 2025-06-20 15:07+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -25,6 +25,22 @@ msgstr ""
 #: code:addons/l10n_tr_nilvera_einvoice/wizard/account_move_send.py:0
 #, python-format
 msgid "Check data on Partner(s)"
+msgstr ""
+
+#. module: l10n_tr_nilvera_einvoice
+#. odoo-python
+#: code:addons/l10n_tr_nilvera_einvoice/wizard/account_move_send.py:0
+#, python-format
+msgid "Check reference on Partner(s)"
+msgstr ""
+
+#. module: l10n_tr_nilvera_einvoice
+#. odoo-python
+#: code:addons/l10n_tr_nilvera_einvoice/models/account_edi_xml_ubl_tr.py:0
+#, python-format
+msgid ""
+"E-Invoice customers must have a tax office name in the partner reference "
+"field."
 msgstr ""
 
 #. module: l10n_tr_nilvera_einvoice
@@ -134,8 +150,17 @@ msgstr ""
 #: code:addons/l10n_tr_nilvera_einvoice/wizard/account_move_send.py:0
 #, python-format
 msgid ""
-"The following partner(s) are either not Turkish or are missing one of those "
-"fields: city, state and street."
+"The following E-Invoice partner(s) must have the reference field set to the "
+"tax office name."
+msgstr ""
+
+#. module: l10n_tr_nilvera_einvoice
+#. odoo-python
+#: code:addons/l10n_tr_nilvera_einvoice/wizard/account_move_send.py:0
+#, python-format
+msgid ""
+"The following partner(s) are either not Turkish or are missing one of the "
+"following fields: city, state, or street."
 msgstr ""
 
 #. module: l10n_tr_nilvera_einvoice

--- a/addons/l10n_tr_nilvera_einvoice/i18n/tr.po
+++ b/addons/l10n_tr_nilvera_einvoice/i18n/tr.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 17.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-03-26 15:10+0000\n"
-"PO-Revision-Date: 2025-03-26 15:10+0000\n"
+"POT-Creation-Date: 2025-06-20 15:03+0000\n"
+"PO-Revision-Date: 2025-06-20 15:03+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -26,6 +26,24 @@ msgstr "Hesap Hareketi Yollandı"
 #, python-format
 msgid "Check data on Partner(s)"
 msgstr "Ortak(lar) hakkındaki verileri kontrol edin"
+
+#. module: l10n_tr_nilvera_einvoice
+#. odoo-python
+#: code:addons/l10n_tr_nilvera_einvoice/wizard/account_move_send.py:0
+#, python-format
+msgid "Check reference on Partner(s)"
+msgstr "Ortak(lar) üzerindeki referansı kontrol edin"
+
+#. module: l10n_tr_nilvera_einvoice
+#. odoo-python
+#: code:addons/l10n_tr_nilvera_einvoice/models/account_edi_xml_ubl_tr.py:0
+#, python-format
+msgid ""
+"E-Invoice customers must have a tax office name in the partner reference "
+"field."
+msgstr ""
+"E-Fatura müşterilerinin ortak referans alanında bir vergi dairesi adı "
+"bulunmalıdır."
 
 #. module: l10n_tr_nilvera_einvoice
 #: model:ir.model.fields.selection,name:l10n_tr_nilvera_einvoice.selection__account_move__l10n_tr_nilvera_send_status__error
@@ -136,11 +154,22 @@ msgstr "Başarılı"
 #: code:addons/l10n_tr_nilvera_einvoice/wizard/account_move_send.py:0
 #, python-format
 msgid ""
-"The following partner(s) are either not Turkish or are missing one of those "
-"fields: city, state and street."
+"The following E-Invoice partner(s) must have the reference field set to the "
+"tax office name."
 msgstr ""
-"Aşağıdaki ortak(lar) ya Türkçe değildir ya da bu alanlardan biri eksiktir: "
-"şehir, eyalet ve cadde."
+"Aşağıdaki E-Fatura ortaklarının referans alanı vergi dairesi adına ayarlanmış "
+"olmalıdır."
+
+#. module: l10n_tr_nilvera_einvoice
+#. odoo-python
+#: code:addons/l10n_tr_nilvera_einvoice/wizard/account_move_send.py:0
+#, python-format
+msgid ""
+"The following partner(s) are either not Turkish or are missing one of the "
+"following fields: city, state, or street."
+msgstr ""
+"Aşağıdaki ortaklar ya Türk değil ya da şu alanlardan bir veya daha "
+"fazlası eksik: şehir, eyalet veya sokak."
 
 #. module: l10n_tr_nilvera_einvoice
 #. odoo-python

--- a/addons/l10n_tr_nilvera_einvoice/wizard/account_move_send.py
+++ b/addons/l10n_tr_nilvera_einvoice/wizard/account_move_send.py
@@ -39,19 +39,40 @@ class AccountMoveSend(models.TransientModel):
 
     def _l10n_tr_nilvera_check_invoices(self):
         moves_to_check = self.move_ids.filtered(self._get_default_l10n_tr_nilvera_einvoice_enable_einvoice)
-        invalid_records = moves_to_check.partner_id.filtered(
+
+        partners = moves_to_check.partner_id
+
+        invalid_records = partners.filtered(
             lambda p: p.country_code != 'TR' or not p.city or not p.state_id or not p.street
         )
-        if invalid_records:
-            return {
-                "partner_data_missing": {
-                    "message": _("The following partner(s) are either not Turkish or are missing one of those fields: city, state and street."),
+        critical_invalid_records = partners.filtered(
+            lambda p: p.l10n_tr_nilvera_customer_status == 'einvoice' and not p.ref
+        )
+
+        if invalid_records or critical_invalid_records:
+            result = {}
+            if invalid_records:
+                result["partner_data_missing"] = {
+                    "message": _(
+                        "The following partner(s) are either not Turkish or are missing one of the following fields: city, state, or street."
+                    ),
                     "action_text": _("View Partner(s)"),
                     "action": invalid_records._get_records_action(
-                        name=_("Check data on Partner(s)"),
+                        name=_("Check data on Partner(s)")
                     ),
                 }
-            }
+            if critical_invalid_records:
+                result["critical_partner_data_missing"] = {
+                    "message": _(
+                        "The following E-Invoice partner(s) must have the reference field set to the tax office name."
+                    ),
+                    "action_text": _("View Partner(s)"),
+                    "action": critical_invalid_records._get_records_action(
+                        name=_("Check reference on Partner(s)")
+                    ),
+                    "critical": True
+                }
+            return result
 
         return {}
 


### PR DESCRIPTION
### Description of the issue/feature this PR addresses

This PR adds a validation to ensure that E-Invoice partners in Turkey have the `reference` field filled with their registered tax office name, as required by GİB regulations.

### Current behavior before PR

Partners marked as E-Invoice customers can be used in invoicing without a value in the `reference` field, which may lead to non-compliant UBL documents.

### Desired behavior after PR is merged

The account move send wizard critically warns the user about partners that should contain the tax office name in the reference field. If the critical warning is ignored, a validation error is raised, prompting the user to complete the required reference field on the partner. Once the field is filled, it is sent via the UBL under the reference field, and the name is passed to tax_scheme_vals if the partner has a TR e-invoicing Nilvera status.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
