### PR TITLE
[FIX] point_of_sale: log access error when loading data

### DIFF
--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -3,6 +3,7 @@ from collections import defaultdict
 from datetime import timedelta
 from itertools import groupby, starmap
 from markupsafe import Markup
+import logging
 
 from odoo import api, fields, models, _, Command
 from odoo.exceptions import AccessError, UserError, ValidationError
@@ -10,6 +11,8 @@ from odoo.tools import float_is_zero, float_compare, plaintext2html, split_every
 from odoo.tools.constants import PREFETCH_MAX
 from odoo.service.common import exp_version
 from odoo.osv.expression import AND
+
+_logger = logging.getLogger(__name__)
 
 
 class PosSession(models.Model):
@@ -179,8 +182,9 @@ class PosSession(models.Model):
 
             try:
                 response[model] = self.env[model].with_context(config_id=self.config_id.id)._post_read_pos_data(self.env[model]._load_pos_data(response))
-            except AccessError:
+            except AccessError as e:
                 response[model] = []
+                _logger.info("Could not load model %s due to AccessError: %s", model, e)
 
         return response
 


### PR DESCRIPTION
Previously, an access error during PoS data loading would silently fail, leading to unresolved issues and poor traceability.

This commit introduces logging for access errors that occur when a model's data is loaded in the PoS. This provides better insight and simplifies investigation of such issues.

opw-4801774

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
