### PR TITLE
[IMP] base: use cron progress for attachment gc

### DIFF
--- a/odoo/addons/base/models/ir_autovacuum.py
+++ b/odoo/addons/base/models/ir_autovacuum.py
@@ -19,6 +19,11 @@ def is_autovacuum(func):
     return callable(func) and getattr(func, '_autovacuum', False)
 
 
+def is_autovacuum_progress(value):
+    return isinstance(value, tuple) and len(value) == 2
+assert is_autovacuum_progress(api.autovacuum.Progress)  # noqa: E305
+
+
 class IrAutovacuum(models.AbstractModel):
     """ Helper model to the ``@api.autovacuum`` method decorator. """
     _name = 'ir.autovacuum'
@@ -48,7 +53,7 @@ class IrAutovacuum(models.AbstractModel):
                 start_time = time.monotonic()
                 result = func(model)
                 self.env['ir.cron']._commit_progress(1)
-                if isinstance(result, tuple) and len(result) == 2:
+                if is_autovacuum_progress(result):
                     func_done, func_remaining = result
                     _logger.debug(
                         '%s.%s  vacuumed %r records, remaining %r',

--- a/odoo/addons/base/models/ir_cron.py
+++ b/odoo/addons/base/models/ir_cron.py
@@ -465,17 +465,13 @@ class IrCron(models.Model):
                     else:
                         status = CompletionStatus.FAILED
                 else:
-                    if not progress.remaining:
-                        status = CompletionStatus.FULLY_DONE
-                    elif not progress.done:
-                        # assume the server action doesn't use the progress API
-                        # and that there is nothing left to process
-                        status = CompletionStatus.FULLY_DONE
-                    else:
-                        status = CompletionStatus.PARTIALLY_DONE
 
-                    if status == CompletionStatus.FULLY_DONE and progress.deactivate:
-                        job['active'] = False
+                    if progress.remaining:
+                        status = CompletionStatus.PARTIALLY_DONE
+                    else:
+                        status = CompletionStatus.FULLY_DONE
+                        if progress.deactivate:
+                            job['active'] = False
                 finally:
                     done, remaining = progress.done, progress.remaining
                     loop_count += 1

--- a/odoo/orm/decorators.py
+++ b/odoo/orm/decorators.py
@@ -276,6 +276,14 @@ def autovacuum(method: C) -> C:
     return method
 
 
+class AutovacuumProgress(typing.NamedTuple):
+    done: int
+    remaining: int | bool
+
+
+autovacuum.Progress = AutovacuumProgress
+
+
 def model(method: C) -> C:
     """ Decorate a record-style method where ``self`` is a recordset, but its
         contents is not relevant, only the model is. Such a method::


### PR DESCRIPTION
On very large databases, with attachments in the millions, the file gc can run uninterrupted and exhaust a cron worker. It is not has bad as it sounds: the file gc doesn't write anything on the database, it only does file operation on the file-system, and those operations persist even if the transaction rollbacks.

Still, that a single function is able to exhaust the system is pretty bad. No other `@api.autovacuum` is able to run while the file gc run.

In this work we leverage the cron progress API to achieve better fairness. The file gc now only collects up to 10,000 files at once, and then yield so other jobs can run too. As long as the file gc reports that there are remaining files to check, the system (autovacuum and cron) gives the guarantee to run the file gc again quickly.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
