### PR TITLE
[FIX] html_builder: fix check for duplicate ids of builder action

### DIFF
--- a/addons/html_builder/static/src/core/builder_actions_plugin.js
+++ b/addons/html_builder/static/src/core/builder_actions_plugin.js
@@ -15,19 +15,15 @@ export class BuilderActionsPlugin extends Plugin {
     setup() {
         this.actions = {};
         for (const actions of this.getResource("builder_actions")) {
-            for (const [actionKey, Action] of Object.entries(actions)) {
-                if (actionKey in this.actions) {
-                    throw new Error(`Duplicate builder action id: ${actionKey}`);
+            for (const Action of Object.values(actions)) {
+                if (Action.id in this.actions) {
+                    throw new Error(`Duplicate builder action id: ${Action.id}`);
                 }
-                if (Action.constructor.name === "Function") {
-                    const deps = {};
-                    for (const depName of Action.dependencies) {
-                        deps[depName] = this.config.getShared()[depName];
-                    }
-                    this.actions[Action.id] = new Action(this, deps);
-                } else {
-                    this.actions[actionKey] = { id: actionKey, ...Action };
+                const deps = {};
+                for (const depName of Action.dependencies) {
+                    deps[depName] = this.config.getShared()[depName];
                 }
+                this.actions[Action.id] = new Action(this, deps);
             }
         }
         Object.freeze(this.actions);


### PR DESCRIPTION
With the changes of b4b215325db61fbbe9793545293c8b6fbc99f310, some actions are declared as classes with their id as a static field instead of an object for which th id is the key in the resource `builder_actions`. The check for unique action id has not been adapted and only checked if the key is not the id of another action. But for classes the key is not the id, which could lead to duplicates.

It also introduced an inconsistency between the actions declared with objects and classes: the id field was added to the object, but not the other. As this field is not used, this commit removes it for both.

task-4367641
