### PR TITLE
[IMP] hr_expense: change expense manager access rights

### DIFF
--- a/addons/hr_expense/models/hr_employee.py
+++ b/addons/hr_expense/models/hr_employee.py
@@ -46,11 +46,15 @@ class Employee(models.Model):
     expense_manager_id = fields.Many2one(
         comodel_name='res.users',
         string='Expense',
-        compute='_compute_expense_manager', store=True, readonly=False,
-        domain=_group_hr_expense_user_domain,
+        store=True,
+        readonly=False,
+        domain="[('id', 'in', expense_approver_ids)]",
         help='Select the user responsible for approving "Expenses" of this employee.\n'
              'If empty, the approval is done by an Administrator or Approver (determined in settings/users).',
     )
+
+    parent_ids = fields.Many2many('hr.employee', compute="_compute_parent_ids")
+    expense_approver_ids = fields.Many2many('res.users', compute="_compute_expense_approver_ids")
 
     @api.depends('parent_id')
     def _compute_expense_manager(self):
@@ -62,6 +66,22 @@ class Employee(models.Model):
                 employee.expense_manager_id = manager
             elif not employee.expense_manager_id:
                 employee.expense_manager_id = False
+
+    @api.depends('parent_id')
+    def _compute_parent_ids(self):
+        for employee in self:
+            parents = employee.env['hr.employee']
+            parent = employee.parent_id
+            while parent and parent not in parents:
+                # The while condition should avoid the loops because of orphans (parent_id = False)
+                # and cycles where A is its own ancestor (A == A.parent_id. ... .parent_id)
+                parents += parent
+                parent = parent.parent_id
+            employee.parent_ids = parents
+
+    def _compute_expense_approver_ids(self):
+        for employee in self:
+            employee.expense_approver_ids = employee.user_id.expense_approver_ids
 
     def _get_user_m2o_to_empty_on_archived_employees(self):
         return super()._get_user_m2o_to_empty_on_archived_employees() + ['expense_manager_id']
@@ -76,8 +96,50 @@ class EmployeePublic(models.Model):
 class User(models.Model):
     _inherit = ['res.users']
 
-    expense_manager_id = fields.Many2one(related='employee_id.expense_manager_id', readonly=False)
+    def _get_expense_approver_domain(self):
+        return [('id', 'in', self.expense_approver_ids.ids)]
+
+    expense_approver_ids = fields.Many2many(
+        'res.users',
+        'user_expense_approver_rel',
+        'user_id',
+        'approver_id',
+        compute="_compute_expense_approver_ids",
+    )
+
+    expense_manager_id = fields.Many2one(
+        related='employee_id.expense_manager_id',
+        domain="[('id', 'in', expense_approver_ids)]",
+        readonly=False,
+    )
+
+    @api.depends('employee_id', 'employee_id.parent_id')
+    def _compute_expense_approver_ids(self):
+        team_approvers_group = self.env.ref('hr_expense.group_hr_expense_team_approver', raise_if_not_found=False)
+        approvers = team_approvers_group.users if team_approvers_group else self.env["res.users"]
+        for user in self:
+            user.expense_approver_ids = approvers & user.employee_id.parent_ids.mapped("user_id")
+
+    @api.onchange('employee_parent_id', 'expense_approver_ids')
+    def _check_expense_approver_in_domain(self):
+        for user in self:
+            if user.expense_manager_id not in user.expense_approver_ids:
+                user.expense_manager_id = False
+
+    def write(self, vals):
+        """ If 'Expense/Team Approver' has been removed from the access rights, we recompute the field user_id of the
+        expense sheets having this user as approver. """
+        res = True
+        for user in self:
+            user_was_approver = user.has_group('hr_expense.group_hr_expense_team_approver')
+            res &= super().write(vals)
+            if user_was_approver and not user.has_group('hr_expense.group_hr_expense_team_approver'):
+                expense_children = user.env['res.users'].search([('expense_manager_id', '=', self.id)])
+                expense_children.write({'expense_manager_id': False})
+                expense_sheets = self.env['hr.expense.sheet'].search([('user_id', '=', self.id), ('state', 'in', ['draft', 'submit'])])
+                expense_sheets._compute_from_employee_id()
+        return res
 
     @property
     def SELF_READABLE_FIELDS(self):
-        return super().SELF_READABLE_FIELDS + ['expense_manager_id']
+        return super().SELF_READABLE_FIELDS + ['expense_manager_id', 'expense_approver_ids']

--- a/addons/hr_expense/views/hr_expense_views.xml
+++ b/addons/hr_expense/views/hr_expense_views.xml
@@ -7,7 +7,8 @@
             <field name="inherit_id" ref="hr.view_employee_form"/>
             <field name="arch" type="xml">
                 <xpath expr="//group[@name='managers']" position="inside">
-                    <field name="expense_manager_id" context="{'default_company_id': company_id}" widget="many2one_avatar_user"/>
+                    <field name="expense_approver_ids" invisible="1"/>
+                    <field name="expense_manager_id" domain="[('id', 'in', expense_approver_ids)]" context="{'default_company_id': company_id}" widget="many2one_avatar_user"/>
                 </xpath>
                  <xpath expr="//group[@name='managers']" position="attributes">
                     <attribute name="invisible">0</attribute>
@@ -21,6 +22,7 @@
             <field name="inherit_id" ref="hr.view_employee_tree"/>
             <field name="arch" type="xml">
                 <xpath expr="//field[@name='work_location_id']" position="after">
+                    <field name="expense_approver_ids" invisible="1"/>
                     <field name="expense_manager_id" optional="hide" string="Expense Approver" widget="many2one_avatar_user"/>
                 </xpath>
             </field>
@@ -32,7 +34,8 @@
             <field name="inherit_id" ref="hr.res_users_view_form_profile" />
             <field name="arch" type="xml">
                 <xpath expr="//group[@name='managers']" position="inside">
-                    <field name="expense_manager_id" readonly="not can_edit" context="{'default_company_id': company_id}"/>
+                    <field name="expense_approver_ids" invisible="1"/>
+                    <field name="expense_manager_id" readonly="not can_edit" domain="[('id', 'in', expense_approver_ids)]" context="{'default_company_id': company_id}"/>
                 </xpath>
                  <xpath expr="//group[@name='managers']" position="attributes">
                     <attribute name="invisible">0</attribute>


### PR DESCRIPTION
Currently, the parent_id of an employee can be assigned as manager to an expense report even without having team approver access rights. In this cas, that means that the expense cannot be approved.
To avoid that, we add a domain to the expense approvers. 

task-4300192