### PR TITLE
[FIX] website_sale_stock: don't include price in availability email

### DIFF
--- a/addons/website_sale_stock/data/template_email.xml
+++ b/addons/website_sale_stock/data/template_email.xml
@@ -18,7 +18,7 @@
                     />)
                 </p>
                 <p style="margin-left: 0.5em; margin-right: 0.5em">-</p>
-                <p t-esc="product.list_price" t-options="{'widget': 'monetary', 'display_currency': product.currency_id}"/>
+                <p t-esc="product.list_price" t-options="{'widget': 'monetary', 'display_currency': product.currency_id}" hidden=""/>
             </div>
             <p t-esc="product.description_sale"/>
             <div style="display: flex; justify-content: center; width: 100%;">


### PR DESCRIPTION
Versions
--------
- 17.0+

Steps
-----
1. Configure website to display prices tax-included;
2. disable selling out-of-stock products;
3. go to an out-of-stock product page;
4. request a reminder email;
5. replenish product stock;
6. run the `_send_availability_email` action;
7. check email that was sent.

Issue
-----
The price display in the email does not include taxes.

Cause
-----
The email only checks the `list_price` defined on the product.

Solution
--------
Don't include the price in the email:
  - On stable: hide the element to avoid breaking xpaths
  - On master: remove the price element from the email template

opw-4712613