### PR TITLE
[FIX] website: fix typo in instagram page action

### DIFF
--- a/addons/website/static/src/builder/plugins/options/instagram_option.xml
+++ b/addons/website/static/src/builder/plugins/options/instagram_option.xml
@@ -6,7 +6,7 @@
         Your instagram page must be public to be integrated into an Odoo website.
     </div>
     <BuilderRow label.translate="Instagram Page">
-        <BuilderTextInput action="'instagramPageAction'" placeholder="'odoo.official'" preview="false"/>
+        <BuilderTextInput action="'instagramPage'" placeholder="'odoo.official'" preview="false"/>
     </BuilderRow>
 </t>
 


### PR DESCRIPTION
Since [1] a typo was introduced in the instagramPageAction call.

[1]: https://github.com/odoo/odoo/commit/b4b215325db61fbbe9793545293c8b6fbc99f310
