### PR TITLE
[FIX] base: condense code in web/stacktrace for compare by position functions

### DIFF
--- a/doc/cla/individual/elibowlby.md
+++ b/doc/cla/individual/elibowlby.md
@@ -1,0 +1,11 @@
+United States, 2025-06-20
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Elijah Bowlby elijahbowlby@gmail.com https://github.com/elibowlby


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
Extract shared logic into `compareByFields(...)` within `addons\web\static\lib\stacktracejs\stacktrace.js`.

**Current behavior before PR:**
`compareByOriginalPositions(...)`, `compareByGeneratedPositionsDeflated(...)`, and `compareByGeneratedPositionsInflated(...)` each contain shared code.

**Desired behavior after PR is merged:**
Introduce a helper `compareByFields(...)` that handles comparing by positions with optional parameters.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
