### PR TITLE
[IMP] base: remove unnecessary index on ir.rule name field

### DIFF
--- a/odoo/addons/base/models/ir_rule.py
+++ b/odoo/addons/base/models/ir_rule.py
@@ -19,7 +19,7 @@ class IrRule(models.Model):
     _MODES = ['read', 'write', 'create', 'unlink']
     _allow_sudo_commands = False
 
-    name = fields.Char(index=True)
+    name = fields.Char()
     active = fields.Boolean(default=True, help="If you uncheck the active field, it will disable the record rule without deleting it (if you delete a native record rule, it may be re-created when you reload the module).")
     model_id = fields.Many2one('ir.model', string='Model', index=True, required=True, ondelete="cascade")
     groups = fields.Many2many('res.groups', 'rule_group_rel', 'rule_group_id', 'group_id', ondelete='restrict')


### PR DESCRIPTION
[[IMP] base: remove unnecessary index on ir.rule name field](https://github.com/odoo/odoo/pull/215331/commits/20a2b1005409fb74c7fb837647220c1148e0e939)
* The name field of ir.rule is rarely used in search operations or WHERE
clauses
* Security rules are typically queried by model_id, active status, and
permissions (perm_read, perm_write, etc.)


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
