### PR TITLE
[FIX] spreadsheet: handle empty filters default value

### DIFF
--- a/addons/spreadsheet/static/src/global_filters/components/filter_value/filter_value.js
+++ b/addons/spreadsheet/static/src/global_filters/components/filter_value/filter_value.js
@@ -91,10 +91,18 @@ export class FilterValue extends Component {
     }
 
     onTextInput(id, value) {
+        if (Array.isArray(value) && value.length === 0) {
+            this.clear(id);
+            return;
+        }
         this.props.setGlobalFilterValue(id, value);
     }
 
     onBooleanInput(id, value) {
+        if (Array.isArray(value) && value.length === 0) {
+            this.clear(id);
+            return;
+        }
         this.props.setGlobalFilterValue(id, value);
     }
 

--- a/addons/spreadsheet/static/src/global_filters/helpers.js
+++ b/addons/spreadsheet/static/src/global_filters/helpers.js
@@ -129,7 +129,7 @@ export function checkFilterValueIsValid(filter, value) {
  * @returns {boolean}
  */
 function isTextFilterValueValid(value) {
-    return Array.isArray(value) && value.every((text) => typeof text === "string");
+    return Array.isArray(value) && value.length && value.every((text) => typeof text === "string");
 }
 
 /**
@@ -147,7 +147,7 @@ function isRelationFilterDefaultValueValid(value) {
  * @returns {boolean}
  */
 function isRelationFilterValueValid(value) {
-    return Array.isArray(value) && value.every((v) => typeof v === "number");
+    return Array.isArray(value) && value.length && value.every((v) => typeof v === "number");
 }
 
 /**
@@ -156,7 +156,7 @@ function isRelationFilterValueValid(value) {
  * @returns {boolean}
  */
 function isBooleanFilterValueValid(value) {
-    return Array.isArray(value) && value.every((v) => typeof v === "boolean");
+    return Array.isArray(value) && value.length && value.every((v) => typeof v === "boolean");
 }
 
 /**

--- a/addons/spreadsheet/static/tests/global_filters/global_filters_core_view.test.js
+++ b/addons/spreadsheet/static/tests/global_filters/global_filters_core_view.test.js
@@ -53,6 +53,13 @@ test("Value of text filter", () => {
     });
     expect(result.isSuccessful).toBe(false);
     expect(result.reasons).toEqual(["InvalidValueTypeCombination"]);
+
+    result = setGlobalFilterValueWithoutReload(model, {
+        id: "1",
+        value: [],
+    });
+    expect(result.isSuccessful).toBe(false);
+    expect(result.reasons).toEqual(["InvalidValueTypeCombination"]);
 });
 
 test("Value of date filter", () => {
@@ -219,6 +226,13 @@ test("Value of relation filter", () => {
     });
     expect(result.isSuccessful).toBe(false);
     expect(result.reasons).toEqual(["InvalidValueTypeCombination"]);
+
+    result = setGlobalFilterValueWithoutReload(model, {
+        id: "1",
+        value: [],
+    });
+    expect(result.isSuccessful).toBe(false);
+    expect(result.reasons).toEqual(["InvalidValueTypeCombination"]);
 });
 
 test("Value of boolean filter", () => {
@@ -257,6 +271,13 @@ test("Value of boolean filter", () => {
     result = setGlobalFilterValueWithoutReload(model, {
         id: "1",
         value: false,
+    });
+    expect(result.isSuccessful).toBe(false);
+    expect(result.reasons).toEqual(["InvalidValueTypeCombination"]);
+
+    result = setGlobalFilterValueWithoutReload(model, {
+        id: "1",
+        value: [],
     });
     expect(result.isSuccessful).toBe(false);
     expect(result.reasons).toEqual(["InvalidValueTypeCombination"]);

--- a/addons/spreadsheet/static/tests/global_filters/global_filters_model.test.js
+++ b/addons/spreadsheet/static/tests/global_filters/global_filters_model.test.js
@@ -1121,7 +1121,6 @@ test("ODOO.FILTER.VALUE relation filter", async function () {
         type: "relation",
         label: "Relation Filter",
         modelName: "partner",
-        defaultValue: [],
     });
     await animationFrame();
     const [filter] = model.getters.getGlobalFilters();
@@ -2277,7 +2276,6 @@ test("getFiltersMatchingPivot return correctly matching filter according to cell
         {
             id: "42",
             type: "relation",
-            defaultValue: [],
         },
         { pivot: { "PIVOT#1": { chain: "product_id", type: "many2one" } } }
     );
@@ -2304,7 +2302,6 @@ test("getFiltersMatchingPivot return correctly matching filter according to cell
         {
             id: "42",
             type: "relation",
-            defaultValue: [],
         },
         { pivot: { "PIVOT#1": { chain: "product_id", type: "many2one" } } }
     );
@@ -2328,7 +2325,6 @@ test("getFiltersMatchingPivot return correctly matching filter when there is a f
     await addGlobalFilter(model, {
         id: "42",
         type: "relation",
-        defaultValue: [],
     });
     const filters = getFiltersMatchingPivot(model, getCellFormula(model, "B3"));
     expect(filters).toEqual([]);
@@ -2348,7 +2344,6 @@ test("getFiltersMatchingPivot return empty filter for cell formula without any a
         {
             id: "42",
             type: "relation",
-            defaultValue: [],
         },
         { pivot: { "PIVOT#1": { chain: "product_id", type: "many2one" } } }
     );
@@ -2460,7 +2455,6 @@ test("getFiltersMatchingPivot return correctly matching filter with the 'measure
         id: "42",
         label: "fake",
         type: "relation",
-        defaultValue: [],
     });
     const filters = getFiltersMatchingPivot(model, getCellFormula(model, "B2"));
     expect(filters).toEqual([]);
@@ -2727,7 +2721,6 @@ test("Can add a boolean filter", async () => {
         id: "42",
         label: "test",
         type: "boolean",
-        defaultValue: [],
     };
     model.dispatch("ADD_GLOBAL_FILTER", { filter });
     model.dispatch("SET_GLOBAL_FILTER_VALUE", { id: "42", value: [true] });
@@ -2752,7 +2745,6 @@ test("Can set a boolean filter with both true and false", async () => {
         id: "42",
         label: "test",
         type: "boolean",
-        defaultValue: [],
     };
     model.dispatch("ADD_GLOBAL_FILTER", { filter });
     model.dispatch("SET_GLOBAL_FILTER_VALUE", { id: "42", value: [true, false] });
@@ -2765,7 +2757,6 @@ test("Check boolean filter domain", async () => {
         id: "42",
         label: "test",
         type: "boolean",
-        defaultValue: [],
     };
     model.dispatch("ADD_GLOBAL_FILTER", { filter });
     model.dispatch("SET_GLOBAL_FILTER_VALUE", { id: "42", value: [] });
@@ -2866,6 +2857,15 @@ test("Default value of text filter", () => {
         type: "text",
         label: "Default value cannot be a boolean",
         defaultValue: false,
+    });
+    expect(result.isSuccessful).toBe(false);
+    expect(result.reasons).toEqual(["InvalidValueTypeCombination"]);
+
+    result = addGlobalFilterWithoutReload(model, {
+        id: "6",
+        type: "text",
+        label: "Default value cannot be an empty array",
+        defaultValue: [],
     });
     expect(result.isSuccessful).toBe(false);
     expect(result.reasons).toEqual(["InvalidValueTypeCombination"]);
@@ -2983,6 +2983,15 @@ test("Default value of relation filter", () => {
     });
     expect(result.isSuccessful).toBe(false);
     expect(result.reasons).toEqual(["InvalidValueTypeCombination"]);
+
+    result = addGlobalFilterWithoutReload(model, {
+        id: "8",
+        type: "relation",
+        label: "Default value cannot be an empty array",
+        defaultValue: [],
+    });
+    expect(result.isSuccessful).toBe(false);
+    expect(result.reasons).toEqual(["InvalidValueTypeCombination"]);
 });
 
 test("Default value of boolean filter", () => {
@@ -3025,6 +3034,15 @@ test("Default value of boolean filter", () => {
         type: "boolean",
         label: "Default value cannot be a boolean",
         defaultValue: false,
+    });
+    expect(result.isSuccessful).toBe(false);
+    expect(result.reasons).toEqual(["InvalidValueTypeCombination"]);
+
+    result = addGlobalFilterWithoutReload(model, {
+        id: "6",
+        type: "boolean",
+        label: "Default value cannot be an empty array",
+        defaultValue: [],
     });
     expect(result.isSuccessful).toBe(false);
     expect(result.reasons).toEqual(["InvalidValueTypeCombination"]);


### PR DESCRIPTION
Since 7ca4daf9afb1dd7621c47b00d19d9c5c4b123582, an empty default value for global filter is represented with `undefined`. However, the code still set the default value to an empty array for relational and boolean filters, which is not correct.

This commit fixes the issue by setting the default value to `undefined` for relational and boolean filters when the global filter is empty.

Note that the migration was already done, so there was no impact on existing filters. (See fecd2d4ffc9adfa75b8ccc9604817476ea5af44f)

Task: 4886119

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
