### PR TITLE
[FIX] l10n_my_edi: relax credit note check

### DIFF
--- a/addons/l10n_my_edi/models/account_edi_xml_ubl_my.py
+++ b/addons/l10n_my_edi/models/account_edi_xml_ubl_my.py
@@ -109,7 +109,8 @@ class AccountEdiXmlUBLMyInvoisMY(models.AbstractModel):
             # The current version is 1.1 (document with signature), the type code depends on the move type.
             'document_type_code_attrs': {'listVersionID': 1.1},
             'document_type_code': document_type_code,
-            # The issue time must be the current time set in the UTC time zone
+            # The issue date and time must be the current time set in the UTC time zone
+            'issue_date': datetime.now(tz=UTC).strftime("%Y-%m-%d"),
             'issue_time': datetime.now(tz=UTC).strftime("%H:%M:%SZ"),
             # Exchange rate information must be provided if applicable
             'tax_exchange_rate': self._l10n_my_edi_get_tax_exchange_rate(invoice),
@@ -134,11 +135,14 @@ class AccountEdiXmlUBLMyInvoisMY(models.AbstractModel):
         vals['vals']['accounting_customer_party_vals']['party_vals']['party_identification_vals'] = customer_identification_vals
 
         # Debit/Credit note original invoice ref.
-        if original_document:
+        # Applies to credit notes, debit notes, refunds for both invoices and self-billed invoices.
+        # The original document is mandatory; but in some specific cases it will be empty (sending a credit note for an invoice
+        # managed outside Odoo/...)
+        if document_type_code in ('02', '03', '04', '12', '13', '14'):
             vals['vals'].update({
                 'billing_reference_vals': {
-                    'id': original_document.name,
-                    'uuid': original_document.l10n_my_edi_external_uuid,
+                    'id': (original_document and original_document.name) or 'NA',
+                    'uuid': (original_document and original_document.l10n_my_edi_external_uuid) or 'NA',
                 },
             })
 
@@ -303,10 +307,6 @@ class AccountEdiXmlUBLMyInvoisMY(models.AbstractModel):
                 self._l10n_my_edi_make_validation_error(constraints, 'tax_ids_required', line.id, line.display_name)
             elif any(tax.l10n_my_tax_type == 'E' for tax in line.tax_ids) and not invoice.l10n_my_edi_exemption_reason:
                 self._l10n_my_edi_make_validation_error(constraints, 'tax_exemption_required', invoice.id, invoice.display_name)
-
-        document_type_code, original_document = self._l10n_my_edi_get_document_type_code(invoice)
-        if document_type_code != '01' and not original_document:
-            self._l10n_my_edi_make_validation_error(constraints, 'adjustment_origin', invoice.id, invoice.display_name)
 
         return constraints
 


### PR DESCRIPTION
So far, we have enforced that credit notes must be linked to an invoice that has been sent to MyInvois.

In real life, this is too strict. Users could be
issuing credit notes for invoices created before
MyInvois was used, in which case these must still
be reported to MyInvois even though the original
invoice isn't on the platform.

This also fixes a small issue with the issue date,
which was set to the invoice date up until now but
on their platform they explicitly ask for today in
UTC timezone.

task-4889022

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
