### PR TITLE
[FIX] discuss: allow peer offer filtering

### DIFF
--- a/addons/mail/static/src/discuss/call/common/rtc_service.js
+++ b/addons/mail/static/src/discuss/call/common/rtc_service.js
@@ -1572,10 +1572,11 @@ export const rtcService = {
      * @param {Partial<import("services").Services>} services
      */
     start(env, services) {
-        const rtc = env.services["mail.store"].rtc;
+        const store = env.services["mail.store"];
+        const rtc = store.rtc;
         rtc.p2pService = services["discuss.p2p"];
         rtc.p2pService.acceptOffer = async (id, sequence) => {
-            const session = await this.store.RtcSession.getWhenReady(Number(id));
+            const session = await store.RtcSession.getWhenReady(Number(id));
             /**
              * We only accept offers for new connections (higher sequence),
              * or offers that renegotiate an existing connection (same sequence).


### PR DESCRIPTION
Before this commit, peer offer filtering was not working as the reference to the store was incorrect.

This wouldn't cause tracebacks or known connection issues as the error was caught and the filter was just ignored.
