### PR TITLE
[FIX] im_livechat: ongoing history session duration

### DIFF
--- a/addons/im_livechat/views/im_livechat_channel_member_history_views.xml
+++ b/addons/im_livechat/views/im_livechat_channel_member_history_views.xml
@@ -24,6 +24,7 @@
                     <field name="partner_id"/>
                     <field name="chatbot_script_id"/>
                     <field name="guest_id"/>
+                    <field name="session_duration_hour" widget="float_time" options="{'displaySeconds': True}"/>
                     <field name="livechat_member_type" string="Member Type"/>
                 </list>
             </field>


### PR DESCRIPTION
This commit fixes the "session_duration_hour" computation for the member history model. This compute is stored and based on "livechat_end_dt" of the channel and "create_date" of the history. However, when the live chat is still ongoing, there is no end date and the current time is used. This is not updated and leads to incorrect duration.

This commit fixes this issue by adding channel's messages to the dependencies. When the chat is still ongoing, last message is used to compute the duration.

follow up of https://github.com/odoo/odoo/pull/214176

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
