### PR TITLE
[FIX] stock: center barcode label text below image

### DIFF
--- a/addons/stock/report/report_package_barcode.xml
+++ b/addons/stock/report/report_package_barcode.xml
@@ -128,7 +128,7 @@
                         <div class="row">
                             <div class="text-center col-12">
                                 <span t-field="o.name" t-options="{'widget': 'barcode', 'width': 600, 'height': 100, 'img_style': 'width:600px;height:100px;'}">Name Demo</span>
-                                <span t-field="o.name" style="font-size:20px; margin:100px;">Name Demo</span>
+                                <span t-field="o.name" style="font-size:20px; margin:100px; white-space: nowrap;">Name Demo</span>
                             </div>
                         </div>
                         <div t-if="o.pack_date" class="col-12 text-center" style="font-size:24px; font-weight:bold;">Pack Date: <span t-field="o.pack_date">2023-01-01</span></div>


### PR DESCRIPTION
<b>Steps to Reproduce:</b>
1. Navigate to Inventory → Configuration
2. Search for packages and check
3. Products → Packages
4. Click or create a Package (With at least 15-20 Char).
5. Print > Package Barcode (PDF)

<b>Issue:</b>
- Package names containing dashes (e.g., A101-101-110-1910) or spaces 
(e.g., A192 2932 2039) were breaking, affecting alignment and readability.

<b>Solution:</b>
- Applied `white-space: nowrap` style to the text span to prevent line wrapping
and ensure consistent alignment across all package name formats.


<b>opw-4872595</b>

Before FIX:
![image](https://github.com/user-attachments/assets/510fb131-90a5-4975-a75b-3e6bab247c3e)
After FIX :
![image](https://github.com/user-attachments/assets/acb96e4d-d7e7-4fe1-8ad0-6fee8de3dda6)

