### PR TITLE
[IMP] delivery, *: rename 'Shipping Methods' to 'Delivery Methods'

### DIFF
--- a/addons/delivery/data/neutralize.sql
+++ b/addons/delivery/data/neutralize.sql
@@ -1,7 +1,7 @@
--- disable prod environment in all delivery carriers
+-- disable prod environment in all delivery methods
 UPDATE delivery_carrier
    SET prod_environment = false;
--- disable delivery carriers from external providers
+-- disable delivery methods from external providers
 UPDATE delivery_carrier
    SET active = false
    WHERE delivery_type NOT IN ('fixed', 'base_on_rule');

--- a/addons/delivery/models/delivery_carrier.py
+++ b/addons/delivery/models/delivery_carrier.py
@@ -69,7 +69,7 @@ class DeliveryCarrier(models.Model):
     state_ids = fields.Many2many('res.country.state', 'delivery_carrier_state_rel', 'carrier_id', 'state_id', 'States')
     zip_prefix_ids = fields.Many2many(
         'delivery.zip.prefix', 'delivery_zip_prefix_rel', 'carrier_id', 'zip_prefix_id', 'Zip Prefixes',
-        help="Prefixes of zip codes that this carrier applies to. Note that regular expressions can be used to support countries with varying zip code lengths, i.e. '$' can be added to end of prefix to match the exact zip (e.g. '100$' will only match '100' and not '1000')")
+        help="Prefixes of zip codes that this delivery method applies to. Note that regular expressions can be used to support countries with varying zip code lengths, i.e. '$' can be added to end of prefix to match the exact zip (e.g. '100$' will only match '100' and not '1000')")
 
     max_weight = fields.Float('Max Weight', help="If the total weight of the order is over this weight, the method won't be available.")
     weight_uom_name = fields.Char(string='Weight unit of measure label', compute='_compute_weight_uom_name')
@@ -81,7 +81,7 @@ class DeliveryCarrier(models.Model):
                                         help="The method is NOT available if at least one product of the order has one of these tags.")
 
     carrier_description = fields.Text(
-        'Carrier Description', translate=True,
+        'Description', translate=True,
         help="A description of the delivery method that you want to communicate to your customers on the Sales Order and sales confirmation email."
              "E.g. instructions for customers to follow.")
 
@@ -122,7 +122,7 @@ class DeliveryCarrier(models.Model):
     def _check_tags(self):
         for carrier in self:
             if carrier.must_have_tag_ids & carrier.excluded_tag_ids:
-                raise UserError(_("Carrier %s cannot have the same tag in both Must Have Tags and Excluded Tags.") % carrier.name)
+                raise UserError(_("Delivery method %(name)s cannot have the same tag in both Must Have Tags and Excluded Tags."), name=carrier.name)
 
     def _compute_weight_uom_name(self):
         self.weight_uom_name = self.env['product.template']._get_weight_uom_name_from_ir_config_parameter()
@@ -286,7 +286,7 @@ class DeliveryCarrier(models.Model):
     def _get_delivery_type(self):
         """Return the delivery type.
 
-        This method needs to be overridden by a delivery carrier module if the delivery type is not
+        This method needs to be overridden by a delivery method module if the delivery type is not
         stored on the field `delivery_type`.
         """
         self.ensure_one()

--- a/addons/delivery/models/delivery_carrier.py
+++ b/addons/delivery/models/delivery_carrier.py
@@ -12,7 +12,7 @@ from odoo.tools.safe_eval import safe_eval
 
 class DeliveryCarrier(models.Model):
     _name = 'delivery.carrier'
-    _description = "Shipping Method"
+    _description = "Delivery Method"
     _order = 'sequence, id'
 
     ''' A Shipping Provider

--- a/addons/delivery/models/product_category.py
+++ b/addons/delivery/models/product_category.py
@@ -11,4 +11,4 @@ class ProductCategory(models.Model):
     def _unlink_except_delivery_category(self):
         delivery_category = self.env.ref('delivery.product_category_deliveries', raise_if_not_found=False)
         if delivery_category and delivery_category in self:
-            raise UserError(_("You cannot delete the deliveries product category as it is used on the delivery carriers products."))
+            raise UserError(_("You cannot delete this product category as it is used on the products linked to delivery methods."))

--- a/addons/delivery/models/sale_order.py
+++ b/addons/delivery/models/sale_order.py
@@ -129,7 +129,7 @@ class SaleOrder(models.Model):
         if self.env.context.get('carrier_recompute'):
             name = _('Update shipping cost')
         else:
-            name = _('Add a shipping method')
+            name = _('Add a delivery method')
         return {
             'name': name,
             'type': 'ir.actions.act_window',

--- a/addons/delivery/report/ir_actions_report_templates.xml
+++ b/addons/delivery/report/ir_actions_report_templates.xml
@@ -4,7 +4,7 @@
     <template id="delivery_report_saleorder_document" inherit_id="sale.report_saleorder_document">
         <span name="order_note" position="before">
             <p t-if="doc.carrier_id.carrier_description" id="carrier_description">
-                <strong>Shipping Description</strong>
+                <strong>Delivery Description</strong>
                 <span class="d-block" t-out="doc.carrier_id.carrier_description"/>
             </p>
         </span>

--- a/addons/delivery/security/ir_rules.xml
+++ b/addons/delivery/security/ir_rules.xml
@@ -2,7 +2,7 @@
 <odoo noupdate="1">
 
     <record model="ir.rule" id="delivery_carrier_comp_rule">
-        <field name="name">Delivery Carrier multi-company</field>
+        <field name="name">Delivery Method multi-company</field>
         <field name="model_id" ref="model_delivery_carrier"/>
         <field name="domain_force">[('company_id', 'in', company_ids + [False])]</field>
     </record>

--- a/addons/delivery/tests/test_delivery_availability.py
+++ b/addons/delivery/tests/test_delivery_availability.py
@@ -111,7 +111,7 @@ class TestDeliveryAvailability(DeliveryCommon, SaleCommon):
             'default_carrier_id': self.non_restricted_carrier.id,
         }))
         choose_delivery_carrier = delivery_wizard.save()
-        self.assertFalse(self.carrier.id in choose_delivery_carrier.available_carrier_ids.ids, "Carrier must have tag is not set on any product in the order")
+        self.assertFalse(self.carrier.id in choose_delivery_carrier.available_carrier_ids.ids, "Delivery method's must have tag is not set on any product in the order")
 
         self.product.write({
             'product_tag_ids': [self.must_have_tag.id],
@@ -124,7 +124,7 @@ class TestDeliveryAvailability(DeliveryCommon, SaleCommon):
         self.assertIn(
             self.carrier,
             choose_delivery_carrier.available_carrier_ids,
-            "Carrier should be available if at least one must-have tag is present in the products",
+            "Delivery method should be available if at least one must-have tag is present in the products",
         )
 
     def test_05_check_excluded_tag(self):
@@ -137,7 +137,7 @@ class TestDeliveryAvailability(DeliveryCommon, SaleCommon):
             'default_carrier_id': self.non_restricted_carrier.id,
         }))
         choose_delivery_carrier = delivery_wizard.save()
-        self.assertTrue(self.carrier.id in choose_delivery_carrier.available_carrier_ids.ids, "Carrier excluded tag is not set on any product in the order")
+        self.assertTrue(self.carrier.id in choose_delivery_carrier.available_carrier_ids.ids, "Delivery method's excluded tag is not set on any product in the order")
 
         self.product.write({
             'product_tag_ids': [self.exclude_tag.id],
@@ -147,7 +147,7 @@ class TestDeliveryAvailability(DeliveryCommon, SaleCommon):
             'default_carrier_id': self.non_restricted_carrier.id,
         }))
         choose_delivery_carrier = delivery_wizard.save()
-        self.assertFalse(self.carrier.id in choose_delivery_carrier.available_carrier_ids.ids, "Carrier excluded tag is set on one product in the order")
+        self.assertFalse(self.carrier.id in choose_delivery_carrier.available_carrier_ids.ids, "Delivery method's excluded tag is set on one product in the order")
 
     def test_06_check_tags_complex(self):
         self.carrier.write({
@@ -160,7 +160,7 @@ class TestDeliveryAvailability(DeliveryCommon, SaleCommon):
             'default_carrier_id': self.non_restricted_carrier.id,
         }))
         choose_delivery_carrier = delivery_wizard.save()
-        self.assertFalse(self.carrier.id in choose_delivery_carrier.available_carrier_ids.ids, "Carrier must have tag is not set on any product in the order")
+        self.assertFalse(self.carrier.id in choose_delivery_carrier.available_carrier_ids.ids, "Delivery method's must have tag is not set on any product in the order")
 
         self.product.write({
             'product_tag_ids': [self.must_have_tag.id],
@@ -170,7 +170,7 @@ class TestDeliveryAvailability(DeliveryCommon, SaleCommon):
             'default_carrier_id': self.non_restricted_carrier.id,
         }))
         choose_delivery_carrier = delivery_wizard.save()
-        self.assertTrue(self.carrier.id in choose_delivery_carrier.available_carrier_ids.ids, "Carrier must have tag is set on one product in the order")
+        self.assertTrue(self.carrier.id in choose_delivery_carrier.available_carrier_ids.ids, "Delivery method's must have tag is set on one product in the order")
 
         self.product.write({
             'product_tag_ids': [self.exclude_tag.id, self.must_have_tag.id],
@@ -180,7 +180,7 @@ class TestDeliveryAvailability(DeliveryCommon, SaleCommon):
             'default_carrier_id': self.non_restricted_carrier.id,
         }))
         choose_delivery_carrier = delivery_wizard.save()
-        self.assertFalse(self.carrier.id in choose_delivery_carrier.available_carrier_ids.ids, "Carrier excluded tag is set on one product in the order")
+        self.assertFalse(self.carrier.id in choose_delivery_carrier.available_carrier_ids.ids, "Delivery method's excluded tag is set on one product in the order")
 
         self.product.write({
             'product_tag_ids': [self.must_have_tag.id],
@@ -193,4 +193,4 @@ class TestDeliveryAvailability(DeliveryCommon, SaleCommon):
             'default_carrier_id': self.non_restricted_carrier.id,
         }))
         choose_delivery_carrier = delivery_wizard.save()
-        self.assertFalse(self.carrier.id in choose_delivery_carrier.available_carrier_ids.ids, "Carrier excluded tag is set on one product in the order")
+        self.assertFalse(self.carrier.id in choose_delivery_carrier.available_carrier_ids.ids, "Delivery method's excluded tag is set on one product in the order")

--- a/addons/delivery/tests/test_delivery_cost.py
+++ b/addons/delivery/tests/test_delivery_cost.py
@@ -274,7 +274,7 @@ class TestDeliveryCost(DeliveryCommon, SaleCommon):
     def test_estimated_weight(self):
         """
         Test that negative qty SO lines are not included in the estimated weight calculation
-        of delivery carriers (since it's used when calculating their rates).
+        of delivery method (since it's used when calculating their rates).
         """
         sale_order = self.env['sale.order'].create({
             'partner_id': self.partner.id,

--- a/addons/delivery/tests/test_delivery_cost.py
+++ b/addons/delivery/tests/test_delivery_cost.py
@@ -139,9 +139,9 @@ class TestDeliveryCost(DeliveryCommon, SaleCommon):
 
     def test_01_delivery_cost_from_pricelist(self):
         """ This test aims to validate the use of a pricelist to compute the delivery cost in the case the associated
-            product of the shipping method is defined in the pricelist """
+            product of the delivery method is defined in the pricelist """
 
-        # Create pricelist with a custom price for the standard shipping method
+        # Create pricelist with a custom price for the standard delivery method
         my_pricelist = self.env['product.pricelist'].create({
             'name': 'shipping_cost_change',
             'item_ids': [Command.create({
@@ -178,9 +178,9 @@ class TestDeliveryCost(DeliveryCommon, SaleCommon):
 
     def test_02_delivery_cost_from_different_currency(self):
         """ This test aims to validate the use of a pricelist using a different currency to compute the delivery cost in
-            the case the associated product of the shipping method is defined in the pricelist """
+            the case the associated product of the delivery method is defined in the pricelist """
 
-        # Create pricelist with a custom price for the standard shipping method
+        # Create pricelist with a custom price for the standard delivery method
         my_pricelist = self.env['product.pricelist'].create({
             'name': 'shipping_cost_change',
             'item_ids': [Command.create({
@@ -543,7 +543,7 @@ class TestDeliveryCost(DeliveryCommon, SaleCommon):
                 'inverse_company_rate': 2,
             })
 
-        # Company less shipping method
+        # Company less delivery method
         product_delivery_rule = self.env['product.product'].with_company(nook_inc).create({
             'name': 'rule delivery charges',
             'type': 'service',
@@ -565,7 +565,7 @@ class TestDeliveryCost(DeliveryCommon, SaleCommon):
             'fixed_margin': 10,
         })
 
-        # Create sale using the shipping method
+        # Create sale using the delivery method
         so = self.env['sale.order'].with_company(nook_inc).create({
             'partner_id': self.partner_4.id,
             'partner_invoice_id': self.partner_4.id,

--- a/addons/delivery/views/delivery_carrier_views.xml
+++ b/addons/delivery/views/delivery_carrier_views.xml
@@ -5,7 +5,7 @@
         <field name="name">delivery.carrier.list</field>
         <field name="model">delivery.carrier</field>
         <field name="arch" type="xml">
-            <list string="Carrier">
+            <list string="Delivery Method">
                 <field name="sequence" widget="handle"/>
                 <field name="name"/>
                 <field name="delivery_type"/>
@@ -23,8 +23,8 @@
         <field name="name">delivery.carrier.search</field>
         <field name="model">delivery.carrier</field>
         <field name="arch" type="xml">
-            <search string="Delivery Carrier">
-                <field name="name" string="Carrier" />
+            <search string="Delivery Method">
+                <field name="name" string="Delivery Method" />
                 <field name="delivery_type"/>
                 <separator/>
                 <filter string="Archived" name="inactive" domain="[('active', '=', False)]"/>
@@ -39,7 +39,7 @@
         <field name="name">delivery.carrier.form</field>
         <field name="model">delivery.carrier</field>
         <field name="arch" type="xml">
-            <form string="Carrier">
+            <form string="Delivery Method">
                 <sheet>
                     <div class="oe_button_box" name="button_box">
                         <button name="toggle_prod_environment"

--- a/addons/delivery/views/delivery_carrier_views.xml
+++ b/addons/delivery/views/delivery_carrier_views.xml
@@ -148,7 +148,7 @@
                         <page string="Availability" name="destination">
                             <group col="1">
                                 <p name="availability_description">
-                                    Filling this form allows you to make the shipping method available according to the content of the order or its destination.
+                                    Filling this form allows you to make the delivery method available according to the content of the order or its destination.
                                 </p>
                                 <group>
                                     <group name="country_details" string="Destination">
@@ -192,7 +192,7 @@
                             </group>
                         </page>
                         <page string="Description" name="description">
-                            <field name="carrier_description" placeholder="Shipping method details to be included at bottom sales orders and their confirmation emails. E.g. Instructions for customers to follow."/>
+                            <field name="carrier_description" placeholder="Delivery method details to be included at bottom sales orders and their confirmation emails. E.g. Instructions for customers to follow."/>
                         </page>
                     </notebook>
                 </sheet>

--- a/addons/delivery/views/delivery_zip_prefix_views.xml
+++ b/addons/delivery/views/delivery_zip_prefix_views.xml
@@ -10,7 +10,7 @@
             <p class="o_view_nocontent_smiling_face">
             Manage delivery zip prefixes
             </p><p>
-            Delivery zip prefixes are assigned to delivery carriers to restrict
+            Delivery zip prefixes are assigned to delivery methods to restrict
             which zips it is available to.
             </p>
         </field>

--- a/addons/delivery/wizard/choose_delivery_carrier.py
+++ b/addons/delivery/wizard/choose_delivery_carrier.py
@@ -15,7 +15,7 @@ class ChooseDeliveryCarrier(models.TransientModel):
     partner_id = fields.Many2one('res.partner', related='order_id.partner_id', required=True)
     carrier_id = fields.Many2one(
         'delivery.carrier',
-        string="Shipping Method",
+        string="Delivery Method",
         required=True,
         domain="[('id', 'in', available_carrier_ids)]",
     )
@@ -79,7 +79,7 @@ class ChooseDeliveryCarrier(models.TransientModel):
         if vals.get('error_message'):
             raise UserError(vals.get('error_message'))
         return {
-            'name': _('Add a shipping method'),
+            'name': _('Add a delivery method'),
             'type': 'ir.actions.act_window',
             'view_mode': 'form',
             'res_model': 'choose.delivery.carrier',

--- a/addons/delivery/wizard/choose_delivery_carrier.py
+++ b/addons/delivery/wizard/choose_delivery_carrier.py
@@ -6,7 +6,7 @@ from odoo.exceptions import UserError
 
 class ChooseDeliveryCarrier(models.TransientModel):
     _name = 'choose.delivery.carrier'
-    _description = 'Delivery Carrier Selection Wizard'
+    _description = 'Delivery Method Selection Wizard'
 
     def _get_default_weight_uom(self):
         return self.env['product.template']._get_weight_uom_name_from_ir_config_parameter()

--- a/addons/delivery/wizard/res_config_settings_views.xml
+++ b/addons/delivery/wizard/res_config_settings_views.xml
@@ -13,7 +13,7 @@
                                 type="action"
                                 class="btn-link"
                                 icon="oi-arrow-right"
-                                string="Shipping Methods"/>
+                                string="Delivery Methods"/>
                     </div>
                  </div>
             </setting>

--- a/addons/sale/data/mail_template_data.xml
+++ b/addons/sale/data/mail_template_data.xml
@@ -317,7 +317,7 @@
         <table t-if="hasattr(object, 'carrier_id') and object.carrier_id" width="100%" style="color: #454748; font-size: 12px;">
             <tr>
                 <td>
-                    <span style="font-weight:bold;">Shipping Method:</span>
+                    <span style="font-weight:bold;">Delivery Method:</span>
                     <t t-out="object.carrier_id.name or ''"></t>
                     <t t-if="object.amount_delivery == 0.0">
                         (Free)
@@ -329,7 +329,7 @@
             </tr>
             <tr t-if="object.carrier_id.carrier_description">
                 <td>
-                    <strong>Shipping Description:</strong>
+                    <strong>Delivery Description:</strong>
                     <t t-out="object.carrier_id.carrier_description"/>
                 </td>
             </tr>

--- a/addons/sale_loyalty_delivery/tests/test_loyalty_delivery.py
+++ b/addons/sale_loyalty_delivery/tests/test_loyalty_delivery.py
@@ -94,7 +94,7 @@ class TestLoyaltyDeliveryCost(common.TransactionCase):
 
     def test_free_delivery_cost_with_ewallet(self):
         """
-        Automatic free shipping of a delivery carrier should not be affected by the
+        Automatic free shipping of a delivery method should not be affected by the
         use of an ewallet when paying.
         Paying for an order of value 200 with an ewallet should still trigger the
         free shipping of the selected carrier if the free shipping is for amounts

--- a/addons/stock_delivery/models/stock_move.py
+++ b/addons/stock_delivery/models/stock_move.py
@@ -8,7 +8,7 @@ from odoo.tools.sql import column_exists, create_column
 class StockRoute(models.Model):
     _inherit = "stock.route"
 
-    shipping_selectable = fields.Boolean("Applicable on Shipping Methods")
+    shipping_selectable = fields.Boolean("Applicable on Delivery Methods")
 
 
 class StockMove(models.Model):

--- a/addons/stock_delivery/tests/test_carrier_propagation.py
+++ b/addons/stock_delivery/tests/test_carrier_propagation.py
@@ -130,7 +130,7 @@ class TestCarrierPropagation(TransactionCase):
     def test_route_based_on_carrier_delivery(self):
         """
             Check that the route on the sale order line is selected as per the first priority even if route on shipping mehod is present
-            Also, Check that the route on the shipping method is selected if there is no route selected on sale order line
+            Also, Check that the route on the delivery method is selected if there is no route selected on sale order line
         """
         route1 = self.env['stock.route'].create({
             'name': 'Route1',

--- a/addons/stock_delivery/tests/test_delivery_stock_move.py
+++ b/addons/stock_delivery/tests/test_delivery_stock_move.py
@@ -185,7 +185,7 @@ class TestStockMoveInvoice(TestSaleCommon):
         self.assertEqual(so.invoice_status, 'no', 'The status should still be "Nothing To Invoice"')
 
     def test_delivery_carrier_from_confirmed_so(self):
-        """Test if adding shipping method in sale order after confirmation
+        """Test if adding delivery method in sale order after confirmation
            will add it in pickings too"""
 
         sale_order = self.SaleOrder.create({
@@ -231,11 +231,11 @@ class TestStockMoveInvoice(TestSaleCommon):
 
         # Check the carrier in picking after confirm sale order
         delivery_for_product_11 = sale_order.picking_ids.filtered(lambda p: self.product_11 in p.move_ids.product_id)
-        self.assertEqual(delivery_for_product_11.carrier_id, self.normal_delivery, "The shipping method should be set in pending deliveries.")
+        self.assertEqual(delivery_for_product_11.carrier_id, self.normal_delivery, "The delivery method should be set in pending deliveries.")
 
         done_delivery = sale_order.picking_ids.filtered(lambda p: p.state == "done")
-        self.assertFalse(done_delivery.carrier_id.id, "The shipping method should not be set in done deliveries.")
-        self.assertFalse(return_picking.carrier_id.id, "The shipping method should not set in return pickings")
+        self.assertFalse(done_delivery.carrier_id.id, "The delivery method should not be set in done deliveries.")
+        self.assertFalse(return_picking.carrier_id.id, "The delivery method should not set in return pickings")
 
     def test_picking_weight(self):
         """Test if the picking weight is correctly computed when the product of the move changes."""

--- a/addons/stock_delivery/tests/test_packing_delivery.py
+++ b/addons/stock_delivery/tests/test_packing_delivery.py
@@ -204,7 +204,7 @@ class TestPackingDelivery(TestPackingCommon):
         picking_ship.move_ids.picked = True
         picking_ship.button_validate()
 
-        # Mock carrier shipping method
+        # Mock carrier delivery method
         with patch(
             'odoo.addons.stock_delivery.models.delivery_carrier.DeliveryCarrier.fixed_send_shipping',
             return_value=[{'exact_price': 0, 'tracking_number': "666"}]

--- a/addons/stock_delivery/views/report_shipping.xml
+++ b/addons/stock_delivery/views/report_shipping.xml
@@ -12,10 +12,6 @@
                 <span t-field="o.shipping_weight"/>
                 <span t-field="o.weight_uom_name"/>
             </div>
-            <div t-if="o.carrier_id" class="col" name="div_shipping_method">
-                <strong>Delivery Method:</strong>
-                <p t-field="o.carrier_id">FedEx</p>
-            </div>
         </xpath>
     </template>
 </odoo>

--- a/addons/stock_delivery/views/report_shipping.xml
+++ b/addons/stock_delivery/views/report_shipping.xml
@@ -13,7 +13,7 @@
                 <span t-field="o.weight_uom_name"/>
             </div>
             <div t-if="o.carrier_id" class="col" name="div_shipping_method">
-                <strong>Shipping Method:</strong>
+                <strong>Delivery Method:</strong>
                 <p t-field="o.carrier_id">FedEx</p>
             </div>
         </xpath>

--- a/addons/stock_delivery/views/stock_move_line_views.xml
+++ b/addons/stock_delivery/views/stock_move_line_views.xml
@@ -6,7 +6,7 @@
         <field name="inherit_id" ref="stock.stock_location_route_form_view"/>
         <field name="arch" type="xml">
             <xpath expr="//group[@name='route_selector']/group" position="inside">
-                <field name="shipping_selectable" string="Shipping Methods"/>
+                <field name="shipping_selectable" string="Delivery Methods"/>
             </xpath>
         </field>
     </record>

--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -1561,7 +1561,7 @@ class WebsiteSale(payment_portal.PaymentPortal):
         if order._has_deliverable_products() and not order._get_delivery_methods():
             errors.append((
                 _("Sorry, we are unable to ship your order."),
-                _("No shipping method is available for your current order and shipping address."
+                _("No delivery method is available for your current order and shipping address."
                   " Please contact us for more information."),
             ))
         return errors

--- a/addons/website_sale/models/sale_order.py
+++ b/addons/website_sale/models/sale_order.py
@@ -891,7 +891,7 @@ class SaleOrder(models.Model):
             ))
 
         if not self.only_services and not self.carrier_id:
-            raise ValidationError(_("No shipping method is selected."))
+            raise ValidationError(_("No delivery method is selected."))
 
     def _recompute_cart(self):
         """Recompute taxes and prices for the current cart."""

--- a/addons/website_sale/static/src/interactions/payment_button.js
+++ b/addons/website_sale/static/src/interactions/payment_button.js
@@ -7,7 +7,7 @@ patch(PaymentButton.prototype, {
      * Verify that the payment button is ready to be enabled.
      *
      * The conditions are that:
-     * - a delivery carrier is selected and ready (the price is computed) if deliveries are enabled;
+     * - a delivery method is selected and ready (the price is computed) if deliveries are enabled;
      * - the "Terms and Conditions" checkbox is ticked if it is present.
      *
      * @override method from @payment/interactions/payment_button

--- a/addons/website_sale/tests/test_delivery_controller.py
+++ b/addons/website_sale/tests/test_delivery_controller.py
@@ -15,7 +15,7 @@ class TestWebsiteSaleDeliveryController(PaymentCommon, WebsiteSaleCommon):
         super().setUp()
         self.Controller = Delivery()
 
-    # test that changing the carrier while there is a pending transaction raises an error
+    # test that changing the delivery method while there is a pending transaction raises an error
     def test_controller_change_carrier_when_transaction(self):
         website = self.website.with_env(self.env)
         self.empty_cart.transaction_ids = self._create_transaction(flow='redirect', state='pending')
@@ -23,7 +23,7 @@ class TestWebsiteSaleDeliveryController(PaymentCommon, WebsiteSaleCommon):
             request.cart = self.empty_cart
             self.Controller.shop_set_delivery_method(dm_id='1')
 
-    # test that changing the carrier while there is a draft transaction doesn't raise an error
+    # test that changing the delivery method while there is a draft transaction doesn't raise an error
     def test_controller_change_carrier_when_draft_transaction(self):
         website = self.website.with_env(self.env)
         self.empty_cart.transaction_ids = self._create_transaction(flow='redirect', state='draft')

--- a/addons/website_sale_loyalty/static/tests/tours/shipping_discount.js
+++ b/addons/website_sale_loyalty/static/tests/tours/shipping_discount.js
@@ -31,7 +31,7 @@ registry.category("web_tour.tours").add("website_sale_loyalty.check_shipping_dis
         ...wsTourUtils.assertCartAmounts({ delivery: "5.00" }),
         ...assertRewardAmounts({ discount: "- 300.00", shipping: "- 5.00" }),
         {
-            content: "confirm shipping method",
+            content: "confirm delivery method",
             trigger: ".o_total_card a[name=website_sale_main_button]",
             run: "click",
             expectUnloadPage: true,

--- a/addons/website_sale_loyalty/tests/test_website_sale_loyalty_delivery.py
+++ b/addons/website_sale_loyalty/tests/test_website_sale_loyalty_delivery.py
@@ -134,7 +134,7 @@ class TestWebsiteSaleDelivery(HttpCase, WebsiteSaleCommon):
         }])
 
     def test_shop_sale_gift_card_keep_delivery(self):
-        # Get admin user and set his preferred shipping method to normal delivery
+        # Get admin user and set his preferred delivery method to normal delivery
         # This test also tests that we can indeed pay delivery fees with gift cards/ewallet
         self.partner_admin.property_delivery_carrier_id = self.normal_delivery
         self.start_tour(

--- a/addons/website_sale_mondialrelay/controllers/controllers.py
+++ b/addons/website_sale_mondialrelay/controllers/controllers.py
@@ -19,7 +19,7 @@ class MondialRelay(http.Controller):
 
         if order_sudo.carrier_id.country_ids:
             country_is_allowed = data['Pays'][:2].upper() in order_sudo.carrier_id.country_ids.mapped(lambda c: c.code.upper())
-            assert country_is_allowed, _("%s is not allowed for this delivery carrier.", data['Pays'])
+            assert country_is_allowed, _("%s is not allowed for this delivery method.", data['Pays'])
 
         partner_shipping = order_sudo.partner_id.sudo()._mondialrelay_search_or_create({
             'id': data['ID'],


### PR DESCRIPTION
_* = stock_delivery, website_sale, sale, website_sale_loyalty, sale_loyalty_delivery,
website_sale_mondialrelay

With this PR:
---
1. Renamed 'Shipping Methods' to 'Delivery Methods'
   * Renamed all user-facing labels of "Shipping Method(s)" to "Delivery Method(s)"
for consistent terminology across apps and improved user clarity, without
altering terminology used by specific delivery providers or third-party
integrations.
2. Renamed 'Delivery Carrier'/ 'Carrier' to 'Delivery Methods'
   * A `Carrier` label is used at the stock level, while `Delivery Method` is used at
  the sales level.
   * A Delivery Method represents the complete carrier process along with the
  required parameters defined at the sales level, whereas a Delivery Carrier
  (or Carrier) is used at the transfer/picking level, where the focus is on
  which carrier actually ships the goods rather than the full delivery
  configuration.
   * Therefore, all relevant occurrences of Delivery Carrier have been updated to
  Delivery Method.
   * The remaining occurrences of Carrier/Delivery Carrier refer either to
  stock-level usage, delivery provider's internal labels, or
  localization-specific terminology.
   * Removed the extra "Delivery Method" column from the "Picking Operations"
  report, as it duplicates the "Carrier" column. At the transfer level, we
  primarily refer to the "Carrier" used, so having both columns would only cause
  confusion and redundancy.

Impact:
-------
- This avoids confusion between "Shipping Method" and "Delivery Method", as
"Delivery Method" better reflects how an order is handed over to the customer,
making the terminology clearer and more contextual.
- Clarifies when "Delivery Method" vs. "Carrier" should be used by keeping "Carrier"
terminology where it correctly reflects stock-level operations, while ensuring sales-level 
terminology remains consistent.

task-4720174