### PR TITLE
[REV] tools: reimplement frozendict

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -3,7 +3,6 @@
 import ast
 import calendar
 from collections import Counter, defaultdict
-from collections.abc import Mapping
 from contextlib import ExitStack, contextmanager
 from datetime import date, timedelta
 from dateutil.relativedelta import relativedelta
@@ -4462,7 +4461,7 @@ class AccountMove(models.Model):
             for grouping_key, values in aggregated_values.items():
                 if not grouping_key:
                     continue
-                if isinstance(grouping_key, Mapping):
+                if isinstance(grouping_key, dict):
                     values.update(grouping_key)
                 tax_details[grouping_key] = values
 
@@ -4471,7 +4470,7 @@ class AccountMove(models.Model):
         for grouping_key, values in values_per_grouping_key.items():
             if not grouping_key:
                 continue
-            if isinstance(grouping_key, Mapping):
+            if isinstance(grouping_key, dict):
                 values.update(grouping_key)
             tax_details[grouping_key] = values
 

--- a/addons/account/wizard/account_automatic_entry_wizard.py
+++ b/addons/account/wizard/account_automatic_entry_wizard.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 from odoo import api, fields, models, _
 from odoo.exceptions import UserError, ValidationError
-from odoo.tools.json import json_default
 from odoo.tools.misc import format_date, formatLang
 from odoo.tools.float_utils import float_repr
 from odoo.tools import groupby
@@ -366,9 +365,9 @@ class AccountAutomaticEntryWizard(models.TransientModel):
                 if any(line.account_id.account_type != record.move_line_ids[0].account_id.account_type for line in record.move_line_ids):
                     raise UserError(_('All accounts on the lines must be of the same type.'))
             if record.action == 'change_period':
-                record.move_data = json.dumps(record._get_move_dict_vals_change_period(), default=json_default)
+                record.move_data = json.dumps(record._get_move_dict_vals_change_period())
             elif record.action == 'change_account':
-                record.move_data = json.dumps(record._get_move_dict_vals_change_account(), default=json_default)
+                record.move_data = json.dumps(record._get_move_dict_vals_change_account())
 
     @api.depends('move_data')
     def _compute_preview_move_data(self):

--- a/addons/rpc/controllers.py
+++ b/addons/rpc/controllers.py
@@ -4,12 +4,12 @@ import xmlrpc.client
 from datetime import date, datetime
 from collections import defaultdict
 from markupsafe import Markup
-from types import MappingProxyType
 
 import odoo.exceptions
 from odoo.http import Controller, route, dispatch_rpc, request, Response
 from odoo.fields import Date, Datetime, Command
 from odoo.tools import lazy
+from odoo.tools.misc import frozendict
 
 # ==========================================================
 # XML-RPC helpers
@@ -97,7 +97,7 @@ class OdooMarshaller(xmlrpc.client.Marshaller):
         # XML 1.0 disallows control characters, remove them otherwise they break clients
         return super().dump_unicode(value.translate(CONTROL_CHARACTERS), write)
 
-    dispatch[MappingProxyType] = dump_frozen_dict
+    dispatch[frozendict] = dump_frozen_dict
     dispatch[bytes] = dump_bytes
     dispatch[datetime] = dump_datetime
     dispatch[date] = dump_date

--- a/odoo/tools/misc.py
+++ b/odoo/tools/misc.py
@@ -32,7 +32,6 @@ from difflib import HtmlDiff
 from functools import reduce, wraps
 from itertools import islice, groupby as itergroupby
 from operator import itemgetter
-from types import MappingProxyType
 
 import babel
 import babel.dates
@@ -934,7 +933,7 @@ def freehash(arg: typing.Any) -> int:
         return hash(arg)
     except Exception:
         if isinstance(arg, Mapping):
-            return hash(_HashDict(arg))
+            return hash(frozendict(arg))
         elif isinstance(arg, Iterable):
             return hash(frozenset(freehash(item) for item in arg))
         else:
@@ -946,6 +945,35 @@ def clean_context(context: dict[str, typing.Any]) -> dict[str, typing.Any]:
     starting with ``default_``
     """
     return {k: v for k, v in context.items() if not k.startswith('default_')}
+
+
+class frozendict(dict[K, T], typing.Generic[K, T]):
+    """ An implementation of an immutable dictionary. """
+    __slots__ = ()
+
+    def __delitem__(self, key):
+        raise NotImplementedError("'__delitem__' not supported on frozendict")
+
+    def __setitem__(self, key, val):
+        raise NotImplementedError("'__setitem__' not supported on frozendict")
+
+    def clear(self):
+        raise NotImplementedError("'clear' not supported on frozendict")
+
+    def pop(self, key, default=None):
+        raise NotImplementedError("'pop' not supported on frozendict")
+
+    def popitem(self):
+        raise NotImplementedError("'popitem' not supported on frozendict")
+
+    def setdefault(self, key, default=None):
+        raise NotImplementedError("'setdefault' not supported on frozendict")
+
+    def update(self, *args, **kwargs):
+        raise NotImplementedError("'update' not supported on frozendict")
+
+    def __hash__(self) -> int:  # type: ignore
+        return hash(frozenset((key, freehash(val)) for key, val in self.items()))
 
 
 class Collector(dict[K, tuple[T, ...]], typing.Generic[K, T]):
@@ -1618,29 +1646,43 @@ def format_duration(value: float) -> str:
 consteq = hmac_lib.compare_digest
 
 
-class _HashDict(dict):
-    """ Simple extension of ``dict`` that provides a hash function.
-        For the hash to be correct, one should not modify the dict's content.
+class ReadonlyDict(Mapping[K, T], typing.Generic[K, T]):
+    """Helper for an unmodifiable dictionary, not even updatable using `dict.update`.
+
+    This is similar to a `frozendict`, with one drawback and one advantage:
+
+    - `dict.update` works for a `frozendict` but not for a `ReadonlyDict`.
+    - `json.dumps` works for a `frozendict` by default but not for a `ReadonlyDict`.
+
+    This comes from the fact `frozendict` inherits from `dict`
+    while `ReadonlyDict` inherits from `collections.abc.Mapping`.
+
+    So, depending on your needs,
+    whether you absolutely must prevent the dictionary from being updated (e.g., for security reasons)
+    or you require it to be supported by `json.dumps`, you can choose either option.
+
+        E.g.
+          data = ReadonlyDict({'foo': 'bar'})
+          data['baz'] = 'xyz' # raises exception
+          data.update({'baz', 'xyz'}) # raises exception
+          dict.update(data, {'baz': 'xyz'}) # raises exception
     """
-    __slots__ = ()
+    __slots__ = ('_data__',)
 
-    def __hash__(self):
-        return hash(frozenset((key, freehash(val)) for key, val in self.items()))
+    def __init__(self, data):
+        self._data__ = dict(data)
 
+    def __contains__(self, key: K):
+        return key in self._data__
 
-def frozendict(mapping=(), /, **kw) -> MappingProxyType:
-    """ Return an immutable copy of a mapping.
+    def __getitem__(self, key: K) -> T:
+        return self._data__[key]
 
-        The proxied internal dictionary is an instance of ``_HashDict``.
-        This allows the returned proxy mapping to be hashed.
-        The reference to the newly created internal dictionary is not
-        accessible, which guarantees immutability.
-    """
-    return MappingProxyType(_HashDict(mapping, **kw))
+    def __len__(self):
+        return len(self._data__)
 
-
-# TODO deprecate ``ReadonlyDict``
-ReadonlyDict = frozendict
+    def __iter__(self):
+        return iter(self._data__)
 
 
 class DotDict(dict):


### PR DESCRIPTION
To avoid breaking all dev environment of dev using 3.10/11. Revert for now., we will add it properly soon.

This reverts commit 91df1a41d3e3e2caa7f007e95342267633367f00.


Errors:
> TypeError: unhashable type: 'mappingproxy'

https://runbot.odoo.com/runbot/build/83004303
