### PR TITLE
[IMP] l10n_ma : Add ice number to invoicing

### DIFF
--- a/addons/l10n_ma/__manifest__.py
+++ b/addons/l10n_ma/__manifest__.py
@@ -17,6 +17,9 @@ This module has been built with the help of Caudigef.
     ],
     'data': [
         'data/account_tax_report_data.xml',
+        "views/res_partner_views.xml",
+        "views/res_company_views.xml",
+        'views/report_invoice.xml',
     ],
     'demo': [
         'demo/demo_company.xml',

--- a/addons/l10n_ma/i18n/fr.po
+++ b/addons/l10n_ma/i18n/fr.po
@@ -553,6 +553,16 @@ msgid "Companies"
 msgstr ""
 
 #. module: l10n_ma
+#: model:ir.model.fields,field_description:l10n_ma.field_base_document_layout__company_details
+msgid "Company Details"
+msgstr "Détails de la société"
+
+#. module: l10n_ma
+#: model:ir.model,name:l10n_ma.model_base_document_layout
+msgid "Company Document Layout"
+msgstr "Mise en page des documents de votre société"
+
+#. module: l10n_ma
 #: model:account.report.line,name:l10n_ma.tax_report_part_d
 msgid "D - Breakdown of deductions"
 msgstr "D - Ventilation des déductions"
@@ -561,6 +571,22 @@ msgstr "D - Ventilation des déductions"
 #: model:account.report.line,name:l10n_ma.tax_report_part_ded
 msgid "Deduction adjustments"
 msgstr "Ajustements des déductions"
+
+#. module: l10n_ma
+#: model:ir.model.fields,help:l10n_ma.field_base_document_layout__company_details
+msgid "Header text displayed at the top of all reports."
+msgstr "Texte d'en-tête affiché en haut de tous les rapports."
+
+#. module: l10n_ma
+#: model_terms:ir.ui.view,arch_db:l10n_ma.view_company_form
+#: model_terms:ir.ui.view,arch_db:l10n_ma.view_partner_property_form
+msgid "ICE"
+msgstr ""
+
+#. module: l10n_ma
+#: model_terms:ir.ui.view,arch_db:l10n_ma.report_invoice_document
+msgid "ICE:"
+msgstr ""
 
 #. module: l10n_ma
 #: model:account.report.line,name:l10n_ma.tax_report_part_d_1_2

--- a/addons/l10n_ma/i18n/l10n_ma.pot
+++ b/addons/l10n_ma/i18n/l10n_ma.pot
@@ -595,6 +595,16 @@ msgid "Companies"
 msgstr ""
 
 #. module: l10n_ma
+#: model:ir.model.fields,field_description:l10n_ma.field_base_document_layout__company_details
+msgid "Company Details"
+msgstr ""
+
+#. module: l10n_ma
+#: model:ir.model,name:l10n_ma.model_base_document_layout
+msgid "Company Document Layout"
+msgstr ""
+
+#. module: l10n_ma
 #: model:account.report.line,name:l10n_ma.tax_report_part_d
 msgid "D - Breakdown of deductions"
 msgstr ""
@@ -602,6 +612,22 @@ msgstr ""
 #. module: l10n_ma
 #: model:account.report.line,name:l10n_ma.tax_report_part_ded
 msgid "Deduction adjustments"
+msgstr ""
+
+#. module: l10n_ma
+#: model:ir.model.fields,help:l10n_ma.field_base_document_layout__company_details
+msgid "Header text displayed at the top of all reports."
+msgstr ""
+
+#. module: l10n_ma
+#: model_terms:ir.ui.view,arch_db:l10n_ma.view_company_form
+#: model_terms:ir.ui.view,arch_db:l10n_ma.view_partner_property_form
+msgid "ICE"
+msgstr ""
+
+#. module: l10n_ma
+#: model_terms:ir.ui.view,arch_db:l10n_ma.report_invoice_document
+msgid "ICE:"
 msgstr ""
 
 #. module: l10n_ma

--- a/addons/l10n_ma/models/__init__.py
+++ b/addons/l10n_ma/models/__init__.py
@@ -1,2 +1,3 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 from . import template_ma
+from . import base_document_layout

--- a/addons/l10n_ma/models/base_document_layout.py
+++ b/addons/l10n_ma/models/base_document_layout.py
@@ -1,0 +1,18 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from markupsafe import Markup
+
+from odoo import api, fields, models
+
+
+class BaseDocumentLayout(models.TransientModel):
+    _inherit = 'base.document.layout'
+
+    @api.model
+    def _default_company_details(self):
+        # OVERRIDE web/models/base_document_layout
+        company_details = super()._default_company_details()
+        if self.env.company.country_code == 'MA':
+            company_details += Markup('<br> ICE: %s') % self.env.company.company_registry
+        return company_details
+
+    company_details = fields.Html(default=_default_company_details)

--- a/addons/l10n_ma/views/report_invoice.xml
+++ b/addons/l10n_ma/views/report_invoice.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <template id="report_invoice_document" inherit_id="account.report_invoice_document">
+        <xpath expr="//div[@id='partner_vat_address_same_as_shipping']" position="after">
+            <div t-if="o.partner_id.country_id.code == 'MA' and o.partner_id.company_registry">
+                ICE: <a t-field="o.partner_id.company_registry"/>
+            </div>
+        </xpath>
+    </template>
+</odoo>

--- a/addons/l10n_ma/views/res_company_views.xml
+++ b/addons/l10n_ma/views/res_company_views.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record id="view_company_form" model="ir.ui.view">
+        <field name="name">res.company.form.inherit.l10n_ma</field>
+        <field name="model">res.company</field>
+        <field name="inherit_id" ref="account.view_company_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='company_registry']" position="attributes">
+                <attribute name="nolabel">1</attribute>
+            </xpath>
+            <field name="company_registry" position="before">
+                <label for="company_registry" invisible="country_code == 'MA'" />
+                <label for="company_registry" string="ICE" invisible="country_code != 'MA'" />
+            </field>
+        </field>
+    </record>
+</odoo>

--- a/addons/l10n_ma/views/res_partner_views.xml
+++ b/addons/l10n_ma/views/res_partner_views.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_partner_property_form" model="ir.ui.view">
+        <field name="name">res.partner.form.inherit.l10n_ma</field>
+        <field name="model">res.partner</field>
+        <field name="inherit_id" ref="account.view_partner_property_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='vat']" position="after">
+                <field name="company_registry" string="ICE" invisible="country_code != 'MA'"></field>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
The ICE number is now backported from 18.0 to 17.0 PR Backport from : https://github.com/odoo/odoo/pull/166531

This commit Add the ICE as 'company_registry' and Add the ICE number to the invoice report if it's a moroccan company

Reason: The ICE (Identifiant Commun de l'Entreprise) is an identification number assigned to businesses and legal entities for various administrative and legal purposes in Morocco. If the partner has one, it must be indicated on the invoice.

16.0 PR : https://github.com/odoo/odoo/pull/215353

opw-4876562