### PR TITLE
[REV] base: don't use `MappingProxyType`

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -3,7 +3,6 @@
 import ast
 import calendar
 from collections import Counter, defaultdict
-from collections.abc import Mapping
 from contextlib import ExitStack, contextmanager
 from datetime import date, timedelta
 from dateutil.relativedelta import relativedelta
@@ -4462,7 +4461,7 @@ class AccountMove(models.Model):
             for grouping_key, values in aggregated_values.items():
                 if not grouping_key:
                     continue
-                if isinstance(grouping_key, Mapping):
+                if isinstance(grouping_key, dict):
                     values.update(grouping_key)
                 tax_details[grouping_key] = values
 
@@ -4471,7 +4470,7 @@ class AccountMove(models.Model):
         for grouping_key, values in values_per_grouping_key.items():
             if not grouping_key:
                 continue
-            if isinstance(grouping_key, Mapping):
+            if isinstance(grouping_key, dict):
                 values.update(grouping_key)
             tax_details[grouping_key] = values
 

--- a/addons/account/wizard/account_automatic_entry_wizard.py
+++ b/addons/account/wizard/account_automatic_entry_wizard.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 from odoo import api, fields, models, _
 from odoo.exceptions import UserError, ValidationError
-from odoo.tools.json import json_default
 from odoo.tools.misc import format_date, formatLang
 from odoo.tools.float_utils import float_repr
 from odoo.tools import groupby
@@ -366,9 +365,9 @@ class AccountAutomaticEntryWizard(models.TransientModel):
                 if any(line.account_id.account_type != record.move_line_ids[0].account_id.account_type for line in record.move_line_ids):
                     raise UserError(_('All accounts on the lines must be of the same type.'))
             if record.action == 'change_period':
-                record.move_data = json.dumps(record._get_move_dict_vals_change_period(), default=json_default)
+                record.move_data = json.dumps(record._get_move_dict_vals_change_period())
             elif record.action == 'change_account':
-                record.move_data = json.dumps(record._get_move_dict_vals_change_account(), default=json_default)
+                record.move_data = json.dumps(record._get_move_dict_vals_change_account())
 
     @api.depends('move_data')
     def _compute_preview_move_data(self):

--- a/addons/rpc/controllers.py
+++ b/addons/rpc/controllers.py
@@ -4,12 +4,12 @@ import xmlrpc.client
 from datetime import date, datetime
 from collections import defaultdict
 from markupsafe import Markup
-from types import MappingProxyType
 
 import odoo.exceptions
 from odoo.http import Controller, route, dispatch_rpc, request, Response
 from odoo.fields import Date, Datetime, Command
 from odoo.tools import lazy
+from odoo.tools.misc import frozendict
 
 # ==========================================================
 # XML-RPC helpers
@@ -97,7 +97,7 @@ class OdooMarshaller(xmlrpc.client.Marshaller):
         # XML 1.0 disallows control characters, remove them otherwise they break clients
         return super().dump_unicode(value.translate(CONTROL_CHARACTERS), write)
 
-    dispatch[MappingProxyType] = dump_frozen_dict
+    dispatch[frozendict] = dump_frozen_dict
     dispatch[bytes] = dump_bytes
     dispatch[datetime] = dump_datetime
     dispatch[date] = dump_date

--- a/odoo/orm/model_classes.py
+++ b/odoo/orm/model_classes.py
@@ -6,7 +6,6 @@ import logging
 import typing
 
 from collections import defaultdict
-from types import MappingProxyType
 
 from . import models
 from . import fields  # must be imported after models
@@ -19,6 +18,7 @@ from odoo.tools import (
     frozendict,
     sql,
 )
+from odoo.tools.misc import ReadonlyDict
 
 if typing.TYPE_CHECKING:
     from odoo.api import Environment
@@ -183,10 +183,9 @@ def add_to_registry(registry: Registry, model_def: type[BaseModel]) -> type[Base
             '_inherit_module': {},                  # map parent to introducing module
             '_inherit_children': OrderedSet(),      # names of children models
             '_inherits_children': set(),            # names of children models
-            '_fields__': {},                        # populated in _setup()
+            '_fields': ReadonlyDict({}),            # populated in _setup()
             '_table_objects': frozendict(),         # populated in _setup()
         })
-        model_cls._fields = MappingProxyType(model_cls._fields__)
 
     # determine all the classes the model should inherit from
     bases = LastOrderedSet([model_def])
@@ -363,7 +362,7 @@ def _setup(model_cls: type[BaseModel], env: Environment):
     # avoid clashes with inheritance between different models
     for name in model_cls._fields:
         discardattr(model_cls, name)
-    model_cls._fields__.clear()
+    model_cls._fields._data__.clear()
 
     # collect the definitions of each field (base definition + overrides)
     definitions = defaultdict(list)
@@ -386,7 +385,7 @@ def _setup(model_cls: type[BaseModel], env: Environment):
                 _logger.debug("Patching %s.%s with translate=True", model_cls._name, name)
                 fields_.append(type(fields_[0])(translate=True))
         if len(fields_) == 1 and fields_[0]._direct and fields_[0].model_name == model_cls._name:
-            model_cls._fields__[name] = fields_[0]
+            model_cls._fields._data__[name] = fields_[0]
         else:
             Field = type(fields_[-1])
             add_field(model_cls, name, Field(_base_fields__=tuple(fields_)))
@@ -586,13 +585,13 @@ def add_field(model_cls: type[BaseModel], name: str, field: Field):
     setattr(model_cls, name, field)
     field._toplevel = True
     field.__set_name__(model_cls, name)
-    # add field as an attribute and in model_cls._fields__ (for reflection)
-    model_cls._fields__[name] = field
+    # add field as an attribute and in model_cls._fields (for reflection)
+    model_cls._fields._data__[name] = field
 
 
 def pop_field(model_cls: type[BaseModel], name: str) -> Field | None:
     """ Remove the field with the given ``name`` from the model class of ``model``. """
-    field = model_cls._fields__.pop(name, None)
+    field = model_cls._fields._data__.pop(name, None)
     discardattr(model_cls, name)
     if model_cls._rec_name == name:
         # fixup _rec_name and display_name's dependencies

--- a/odoo/orm/models.py
+++ b/odoo/orm/models.py
@@ -78,7 +78,6 @@ from .utils import (
 
 if typing.TYPE_CHECKING:
     from collections.abc import Collection, Iterable, Iterator, Reversible, Sequence
-    from types import MappingProxyType
     from .table_objects import TableObject
     from .environments import Environment
     from .registry import Registry, TriggerTree
@@ -358,9 +357,7 @@ class BaseModel(metaclass=MetaModel):
     pool: Registry  # all registry classes have a registry on the class
     # TODO replace most usages with self.env.registry; pool is reserved for class instance
 
-    _fields__: dict[str, Field]
-    _fields: MappingProxyType[str, Field]
-
+    _fields: dict[str, Field]
     _auto: bool = False
     """Whether a database table should be created.
     If set to ``False``, override :meth:`~odoo.models.BaseModel.init`

--- a/odoo/tools/json.py
+++ b/odoo/tools/json.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
 from datetime import date, datetime
-from types import MappingProxyType
 import json as json_
 import re
 
 import markupsafe
 from .func import lazy
+from .misc import ReadonlyDict
 
 JSON_SCRIPTSAFE_MAPPER = {
     '&': r'\u0026',
@@ -54,8 +54,6 @@ class JSON:
 
         Cf https://code.djangoproject.com/ticket/17419#comment:27
         """
-        if 'default' not in kwargs:
-            kwargs['default'] = json_default
         return _ScriptSafe(json_.dumps(*args, **kwargs))
 scriptsafe = JSON()
 
@@ -68,7 +66,7 @@ def json_default(obj):
         return fields.Date.to_string(obj)
     if isinstance(obj, lazy):
         return obj._value
-    if isinstance(obj, MappingProxyType):
+    if isinstance(obj, ReadonlyDict):
         return dict(obj)
     if isinstance(obj, bytes):
         return obj.decode()

--- a/odoo/tools/misc.py
+++ b/odoo/tools/misc.py
@@ -32,7 +32,6 @@ from difflib import HtmlDiff
 from functools import reduce, wraps
 from itertools import islice, groupby as itergroupby
 from operator import itemgetter
-from types import MappingProxyType
 
 import babel
 import babel.dates
@@ -934,7 +933,7 @@ def freehash(arg: typing.Any) -> int:
         return hash(arg)
     except Exception:
         if isinstance(arg, Mapping):
-            return hash(_HashDict(arg))
+            return hash(frozendict(arg))
         elif isinstance(arg, Iterable):
             return hash(frozenset(freehash(item) for item in arg))
         else:
@@ -946,6 +945,35 @@ def clean_context(context: dict[str, typing.Any]) -> dict[str, typing.Any]:
     starting with ``default_``
     """
     return {k: v for k, v in context.items() if not k.startswith('default_')}
+
+
+class frozendict(dict[K, T], typing.Generic[K, T]):
+    """ An implementation of an immutable dictionary. """
+    __slots__ = ()
+
+    def __delitem__(self, key):
+        raise NotImplementedError("'__delitem__' not supported on frozendict")
+
+    def __setitem__(self, key, val):
+        raise NotImplementedError("'__setitem__' not supported on frozendict")
+
+    def clear(self):
+        raise NotImplementedError("'clear' not supported on frozendict")
+
+    def pop(self, key, default=None):
+        raise NotImplementedError("'pop' not supported on frozendict")
+
+    def popitem(self):
+        raise NotImplementedError("'popitem' not supported on frozendict")
+
+    def setdefault(self, key, default=None):
+        raise NotImplementedError("'setdefault' not supported on frozendict")
+
+    def update(self, *args, **kwargs):
+        raise NotImplementedError("'update' not supported on frozendict")
+
+    def __hash__(self) -> int:  # type: ignore
+        return hash(frozenset((key, freehash(val)) for key, val in self.items()))
 
 
 class Collector(dict[K, tuple[T, ...]], typing.Generic[K, T]):
@@ -1618,29 +1646,43 @@ def format_duration(value: float) -> str:
 consteq = hmac_lib.compare_digest
 
 
-class _HashDict(dict):
-    """ Simple extension of ``dict`` that provides a hash function.
-        For the hash to be correct, one should not modify the dict's content.
+class ReadonlyDict(Mapping[K, T], typing.Generic[K, T]):
+    """Helper for an unmodifiable dictionary, not even updatable using `dict.update`.
+
+    This is similar to a `frozendict`, with one drawback and one advantage:
+
+    - `dict.update` works for a `frozendict` but not for a `ReadonlyDict`.
+    - `json.dumps` works for a `frozendict` by default but not for a `ReadonlyDict`.
+
+    This comes from the fact `frozendict` inherits from `dict`
+    while `ReadonlyDict` inherits from `collections.abc.Mapping`.
+
+    So, depending on your needs,
+    whether you absolutely must prevent the dictionary from being updated (e.g., for security reasons)
+    or you require it to be supported by `json.dumps`, you can choose either option.
+
+        E.g.
+          data = ReadonlyDict({'foo': 'bar'})
+          data['baz'] = 'xyz' # raises exception
+          data.update({'baz', 'xyz'}) # raises exception
+          dict.update(data, {'baz': 'xyz'}) # raises exception
     """
-    __slots__ = ()
+    __slots__ = ('_data__',)
 
-    def __hash__(self):
-        return hash(frozenset((key, freehash(val)) for key, val in self.items()))
+    def __init__(self, data):
+        self._data__ = dict(data)
 
+    def __contains__(self, key: K):
+        return key in self._data__
 
-def frozendict(mapping=(), /, **kw) -> MappingProxyType:
-    """ Return an immutable copy of a mapping.
+    def __getitem__(self, key: K) -> T:
+        return self._data__[key]
 
-        The proxied internal dictionary is an instance of ``_HashDict``.
-        This allows the returned proxy mapping to be hashed.
-        The reference to the newly created internal dictionary is not
-        accessible, which guarantees immutability.
-    """
-    return MappingProxyType(_HashDict(mapping, **kw))
+    def __len__(self):
+        return len(self._data__)
 
-
-# TODO deprecate ``ReadonlyDict``
-ReadonlyDict = frozendict
+    def __iter__(self):
+        return iter(self._data__)
 
 
 class DotDict(dict):


### PR DESCRIPTION
Before 3.12, `MappingProxyType` is not hashable.

Revert:
91df1a41d3e3e2caa7f007e95342267633367f00
496b3f4c5feff63edbb428c4d826f7b86cd7a18a
bda5a78e8ebe9899c15cd7319a013a3257e1ee01
