### PR TITLE
[FIX] point_of_sale: fix runbot 227554

### DIFF
--- a/addons/point_of_sale/static/tests/generic_helpers/utils.js
+++ b/addons/point_of_sale/static/tests/generic_helpers/utils.js
@@ -39,7 +39,11 @@ export function refresh() {
                 }
             };
 
-            checkTransaction();
+            // Wait indexedDB debouncer
+            setTimeout(() => {
+                checkTransaction();
+            }, 305);
+
             setTimeout(() => {
                 throw new Error("Timeout waiting indexedDB for transactions to finish");
             }, 2000);


### PR DESCRIPTION
Call to indexedDB is now debounced to avoid multiple calls, but when a tour refresh the page, the previous call is still pending and causes a failure in the test since the data are not in the database yet.

runbot error: 227554


