### PR TITLE
[IMP] im_livechat: group channels by start minutes

### DIFF
--- a/addons/im_livechat/report/im_livechat_report_channel.py
+++ b/addons/im_livechat/report/im_livechat_report_channel.py
@@ -19,6 +19,7 @@ class Im_LivechatReportChannel(models.Model):
     livechat_channel_id = fields.Many2one('im_livechat.channel', 'Channel', readonly=True)
     start_date = fields.Datetime('Start Date of session', readonly=True)
     start_hour = fields.Char('Start Hour of session', readonly=True)
+    start_date_minutes = fields.Char("Start Date of session, truncated to minutes", readonly=True)
     day_number = fields.Selection(
         selection=[
             ("0", "Sunday"),
@@ -101,6 +102,7 @@ class Im_LivechatReportChannel(models.Model):
                 channel_member_history.visitor_partner_id AS visitor_partner_id,
                 to_char(date_trunc('hour', C.create_date), 'YYYY-MM-DD HH24:MI:SS') as start_date_hour,
                 to_char(date_trunc('hour', C.create_date), 'HH24') as start_hour,
+                to_char(date_trunc('minute', C.create_date), 'YYYY-MM-DD HH:MI:SS') AS start_date_minutes,
                 EXTRACT(dow from C.create_date)::text AS day_number,
                 EXTRACT('epoch' FROM message_vals.last_message_dt - c.create_date)/60 AS duration,
                 CASE


### PR DESCRIPTION
This commit adds the "start_date_minutes" field which will allow to group by minute in the ongoing session dashboard.

part of task-4805308

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
