### PR TITLE
[FIX] html_builder: background filters corner radius fixed

### DIFF
--- a/addons/html_builder/static/src/core/border_radius_style_plugin.js
+++ b/addons/html_builder/static/src/core/border_radius_style_plugin.js
@@ -1,40 +1,81 @@
 import { Plugin } from "@html_editor/plugin";
 import { registry } from "@web/core/registry";
-import { applyNeededCss } from "@html_builder/utils/utils_css";
 
+/*
+ * This plugin makes background layers border radius follow
+ * the radius of their parent element.
+ *
+ * Example: if a div has border 50 and border-radius 60, its
+ * child element containing the background should have radius
+ * 60 (parent border-radius) - 50 (parent border) = 10
+ *
+ * It also works with multiple border or radius values, so an
+ * element with border 20 30 40 10 and radius 50 80 60 70 will have
+ * a child element with radius
+ * 50 - max(20, 10) = 30
+ * 80 - max(30, 20) = 50
+ * 60 - max(40, 30) = 20
+ * 70 - max(10, 40) = 30
+ */
 class BorderRadiusStylePlugin extends Plugin {
     static id = "borderRadiusStyle";
     resources = {
-        builder_style_actions: this.getStyleActions(),
         step_added_handlers: () => {
-            this.document.querySelectorAll(".o_grid_item").forEach((gridEl) => {
-                this.calculateAndSetRadius(gridEl);
+            this.getChildBackgroundEls(this.document).forEach((element) => {
+                this.calculateAndSetRadius(element);
             });
         },
     };
 
-    getStyleActions() {
-        return {
-            "border-radius": {
-                getValue: (el, styleName) => window.getComputedStyle(el)[styleName],
-                apply: (el, styleValue) => {
-                    applyNeededCss(el, "border-radius", styleValue);
-                    this.calculateAndSetRadius(el);
-                },
-            },
-        };
+    calculateAndSetRadius(backgroundEl) {
+        const parentElement = backgroundEl.parentElement;
+        const parentRadius = this.getBorderValues(parentElement, "border-radius");
+        const parentWidth = this.getBorderValues(parentElement, "border-width");
+        backgroundEl.style.borderRadius = parentRadius
+            .map(
+                (radius, index) =>
+                    Math.max(
+                        0,
+                        (radius || 0) -
+                            Math.max(
+                                parentWidth[index] || 0,
+                                parentWidth[index === 0 ? 3 : index - 1] || 0
+                            )
+                    ) + "px"
+            )
+            .join(" ");
     }
 
-    calculateAndSetRadius(parentElement) {
-        const backgroundEls = parentElement.querySelectorAll(":scope > [class*='_bg']");
-        backgroundEls.forEach((backgroundEl) => {
-            backgroundEl.style.borderRadius =
-                Math.max(
-                    0,
-                    (parseInt(parentElement.style.borderRadius) || 0) -
-                        (parseInt(parentElement.style.borderWidth) || 0)
-                ) + "px";
-        });
+    getChildBackgroundEls(element) {
+        return element.querySelectorAll(".o_we_bg_filter, .s_parallax_bg");
+    }
+
+    getBorderValues(parentElement, styleName) {
+        const borderValuesArray = this.window
+            .getComputedStyle(parentElement)
+            [styleName].split(" ")
+            .map((val) => parseInt(val));
+
+        switch (borderValuesArray.length) {
+            case 0:
+                borderValuesArray.push(0);
+                break;
+            case 1:
+                borderValuesArray.push(
+                    borderValuesArray[0],
+                    borderValuesArray[0],
+                    borderValuesArray[0]
+                );
+                break;
+            case 2:
+                borderValuesArray.push(borderValuesArray[0], borderValuesArray[1]);
+                break;
+            case 3:
+                borderValuesArray.push(borderValuesArray[1]);
+                break;
+        }
+
+        return borderValuesArray;
     }
 }
 registry.category("website-plugins").add(BorderRadiusStylePlugin.id, BorderRadiusStylePlugin);


### PR DESCRIPTION
This commit fixes the border radius style plugin to allow it to work on every background element instead of grid items only, and it also fixes a bug where elements with variables for border-width or border-radius would not have their background layer radius calculated.

task-3358501
