### PR TITLE
[FIX] stock, mrp: avoid rounding errors in merge moves float comparaisons

### DIFF
--- a/addons/mrp/tests/test_byproduct.py
+++ b/addons/mrp/tests/test_byproduct.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from odoo.fields import Command
 from odoo.tests import Form
 from odoo.tests import common
 from odoo.exceptions import ValidationError
@@ -529,3 +530,27 @@ class TestMrpByProduct(common.TransactionCase):
         self.assertEqual(len(postprod_picking.move_ids), 2)
         self.assertEqual(postprod_picking.move_ids.product_id, final_product + byproduct)
         self.assertEqual(postprod_picking.location_dest_id, self.warehouse.lot_stock_id)
+
+    def test_over_produce_by_products_with_cost_share(self):
+        """
+        Tests that overproducing by-products with a set cost share
+        behaves as expected (as it should rely on the merge move) for
+        the extra move.
+        """
+        # Create new MO
+        self.env.user.groups_id = [Command.link(self.ref('mrp.group_mrp_byproducts'))]
+        self.bom_byproduct.byproduct_ids.cost_share = 3.3
+        mo = self.env['mrp.production'].create({
+            'product_id': self.product_a.id,
+            'product_qty': 1.0,
+        })
+        mo.action_confirm()
+
+        with Form(mo) as mo_form:
+            mo_form.qty_producing = 1.0
+            with mo_form.move_byproduct_ids.edit(0) as by_product_move:
+                by_product_move.quantity = 10.0
+        mo.button_mark_done()
+        self.assertRecordValues(mo.move_byproduct_ids, [
+            {'quantity': 10.0, 'state': 'done'},
+        ])

--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -1027,25 +1027,25 @@ Please change the quantity done or the rounding precision of your unit of measur
             candidate_moves_set.add(picking.move_ids)
 
     def _merge_move_itemgetter(self, distinct_fields, excluded_fields=None):
-        field_names = [
-            f_name for f_name in distinct_fields
-            if f_name != 'price_unit' and (excluded_fields is None or f_name not in excluded_fields)
-        ]
-        base_getter = itemgetter(*field_names)
+        fields = set(distinct_fields or []) - set(excluded_fields or [])
+        float_fields = {f_name for f_name in fields if self.env['stock.move']._fields[f_name].type == 'float'}
+        base_getter = itemgetter(*fields - float_fields)
 
-        if 'price_unit' not in distinct_fields:
+        if not float_fields:
             return base_getter
 
-        price_unit_prec = self.env['decimal.precision'].precision_get('Product Price')
-        currency_prec = self.company_id.currency_id.decimal_places
-        price_precision = min(currency_prec, price_unit_prec)
+        float_precision = {f_name: (self.env['stock.move']._fields[f_name].get_digits(self.env) or (False, 2))[1] for f_name in float_fields}
+        if 'price_unit' in float_fields:
+            price_unit_prec = self.env['decimal.precision'].precision_get('Product Price')
+            currency_precision = self.company_id.currency_id.decimal_places
+            float_precision['price_unit'] = min(currency_precision, price_unit_prec) if currency_precision else price_unit_prec
 
-        def _get_formatted_price_unit(move):
-            # Round and Cast the price_unit into a string so that rounding errors do not prevent the merge
-            rounded_price_unit = float_round(move.price_unit, precision_digits=price_precision)
-            return "{:.{p}f}".format(rounded_price_unit, p=price_precision)
+        def _get_formatted_float_fields(move, f_name, precision):
+            # Round and cast the value of move.f_name into a string so that rounding errors do not prevent the merge
+            rounded_value = float_round(move[f_name], precision_digits=precision[f_name])
+            return "{:.{precision}f}".format(rounded_value, precision=precision[f_name])
 
-        return lambda move: base_getter(move) + (_get_formatted_price_unit(move),)
+        return lambda move: base_getter(move) + tuple(_get_formatted_float_fields(move, f_name, float_precision) for f_name in float_fields)
 
     def _merge_moves(self, merge_into=False):
         """ This method will, for each move in `self`, go up in their linked picking and try to


### PR DESCRIPTION
### Steps to reproduce:
- In the settings enable by-products
- Create a product FP with a bill of material:
	- 1 operation: op 1
	- 1 By-product line: cost share 3.3%, produced in op 1
- Create aand confirm an MO for 1 unit of FP
- On the by product line produce 10 instead of 1
- Produce All
#### > 19 units of by products were produced: The initial by-product move was validated for 10 units and an extra move with a quantity of 9 was automatically created and validated aswell.

### Cause of the issue:

Since the quantity of the by-product move exceed its initial demand, its validation will create an extra move that is expected to be merge into the main move during its confirmation:
https://github.com/odoo/odoo/blob/474ac02d03c17af0274422ecb1e97ca14a3e80e7/addons/stock/models/stock_move.py#L1922 https://github.com/odoo/odoo/blob/474ac02d03c17af0274422ecb1e97ca14a3e80e7/addons/stock/models/stock_move.py#L1844-L1865 However, while `cost_share` value of the original move floats is correctly encoded as 3.3, the copied value of the extra is 3.3000000000000003. This discrepency is a well known issue of the way the orm handles float and convert them to cache as it calls the `float_round` method, which can effectively change its value: https://github.com/odoo/odoo/blob/8c22e358840f02c5b1596e1fbe0d6cf7315754f7/odoo/fields.py#L1553-L1557 In particular, the `cost_share` of both moves differs in terms of strict equality and the move will not be merged with its extra move.

### Note:

The issue should not be reproducible in saas17.4+ because the float_round issues have been erased by
commit 784f1511acc4352905a61f9bd90aecb78e8558ec

opw-4846289
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
