### PR TITLE
[FIX] point_of_sale: move overriden method _doneOrder to point_of_sale

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.js
@@ -368,6 +368,11 @@ export class TicketScreen extends Component {
         this.setSelectedOrder(this.pos.getOrder());
     }
 
+    // Used to override inside `pos_blackbox_be` and `pos_urban_piper`
+    async _doneOrder(order) {
+        return;
+    }
+
     postRefund(destinationOrder) {}
 
     setPartnerToRefundOrder(partner, destinationOrder) {

--- a/addons/pos_restaurant/static/src/app/screens/ticket_screen/ticket_screen.js
+++ b/addons/pos_restaurant/static/src/app/screens/ticket_screen/ticket_screen.js
@@ -106,10 +106,6 @@ patch(TicketScreen.prototype, {
         }
         return super.isDefaultOrderEmpty(...arguments);
     },
-    // Used to override inside `pos_blackbox_be` and `pos_urban_piper`
-    async _doneOrder(order) {
-        return;
-    },
 });
 
 export class TipCell extends Component {


### PR DESCRIPTION
Before this commit:
- If pos_restaurant is not installed, then placing an order as 'Mark As Ready' in food delivery will lead to a traceback in retail POS.

Following this commit:
- Overridden method is moved to point_of_sale from pos_restaurant

task-4889905
