### PR TITLE
[FIX] web_editor: make background overlay have full height

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -9012,10 +9012,17 @@ registry.BackgroundPosition = SnippetOptionWidget.extend({
 
         this.$overlayContent.offset(targetOffset);
 
-        this.$bgDragger.css({
-            width: `${this.$target.innerWidth()}px`,
-            height: `${this.$target.innerHeight()}px`,
-        });
+        this.$bgDragger[0].style.setProperty(
+            "width",
+            `${this.$target.innerWidth()}px`,
+            "important"
+        );
+
+        this.$bgDragger[0].style.setProperty(
+            "height",
+            `${this.$target.innerHeight()}px`,
+            "important"
+        );
 
         const topPos = Math.max(0, $(window).scrollTop() - this.$target.offset().top);
         this.$overlayContent.find('.o_we_overlay_buttons').css('top', `${topPos}px`);


### PR DESCRIPTION
Before this commit in some snippets background overlay wouldn't have
proper height and/or width because of the snippets `h-{}, w-{}` classes.
This commit overrides it with `!important`.
To reproduce the issue:
- open website and start editing
- drop columns snippet, add background image to one of the cards, click
on it
- Click on the background position option to change it(the one with
a crosshair icon)
- the overlay isn't shown properly, which also breaks the tooltip
position

This should be forward-ported up to 18.3 inclusive, and from 18.4 on, `background_position_overlay.js L135` should be changed because of the [html_builder refactoring].
task-4930050

[html_builder refactoring]: https://github.com/odoo/odoo/commit/9fe45e2b7ddb