### PR TITLE
[FIX] mail: fix retained memory in discuss call tests

### DIFF
--- a/addons/mail/static/src/discuss/call/common/rtc_service.js
+++ b/addons/mail/static/src/discuss/call/common/rtc_service.js
@@ -57,9 +57,9 @@ const CAMERA_CONFIG = {
     width: 1280,
 };
 const IS_CLIENT_RTC_COMPATIBLE = Boolean(window.RTCPeerConnection && window.MediaStream);
-const DEFAULT_ICE_SERVERS = [
-    { urls: ["stun:stun1.l.google.com:19302", "stun:stun2.l.google.com:19302"] },
-];
+function GET_DEFAULT_ICE_SERVERS() {
+    return [{ urls: ["stun:stun1.l.google.com:19302", "stun:stun2.l.google.com:19302"] }];
+}
 export const CROSS_TAB_HOST_MESSAGE = {
     PING: "PING", // signals that the host is still active
     UPDATE_REMOTE: "UPDATE_REMOTE", // sent with updated state of the remote rtc sessions of the call
@@ -222,7 +222,7 @@ export class Rtc extends Record {
     /** @type {{urls: string[]}[]} */
     iceServers = fields.Attr(undefined, {
         compute() {
-            return this.iceServers ? this.iceServers : DEFAULT_ICE_SERVERS;
+            return this.iceServers ? this.iceServers : GET_DEFAULT_ICE_SERVERS();
         },
     });
     /**


### PR DESCRIPTION
Before this commit, discuss call HOOT tests retained the window object after test ended.

Retained memory was about 2.5Mb-4Mb per test.

An earlier PR [1] fixed a similar issue from a `const` object being used in field default value. This was a problem because JS models internal code is keeping a reference to this object, and since HOOT suite test reuses the same window object, the window of each test were retained. The PR [1] fixed the issue by not setting object as default value of the field.

Note that the default value and its presence in internal code of JS models happened for all tests that use `@mail` static files. That means this PR `[1]` fixed a retained memory for all `@mail` and related tests.

While this fixed many tests, we still observed this retained memory on all discuss call tests. This happens because while the default value no longer uses this shared object, the computed value still does. Therefore call tests were sharing the const and thus retaining the window object. Note that the computed method is implicitly lazy, so this is only invoked in code that actually uses this `iceServers` field, hence why only discuss call tests were still affected by the issue.

This commit fixes the issue by replacing the DEFAULT_ICE_SERVERS object by GET_DEFAULT_ICE_SERVERS function. This ensures each test use a different object, thus preventing retaining the window object after test has ended.

[1]: https://github.com/odoo/odoo/pull/204521

X-original-commit: dd3679b2c0be105a470654a1e1e7aab08796913e