### PR TITLE
[FIX] website: fix popup options

### DIFF
--- a/addons/website/static/src/builder/plugins/options/popup_option.xml
+++ b/addons/website/static/src/builder/plugins/options/popup_option.xml
@@ -21,14 +21,14 @@
     </BuilderRow>
     <BuilderRow label.translate="Backdrop">
         <BuilderCheckbox id="'popup_backdrop_opt'" action="'setBackdrop'" preview="false"/>
-        <BuilderColorPicker t-if="isActiveItem('popup_backdrop_opt')" styleAction="'background-color'"/>
+        <BuilderColorPicker t-if="isActiveItem('popup_backdrop_opt')" styleAction="'background-color'" enabledTabs="['solid', 'custom']"/>
     </BuilderRow>
 </t>
 
 <t t-name="website.PopupOption">
     <t t-call="website.base_popup_options"/>
     <BuilderRow label.translate="Close Button Color">
-        <BuilderColorPicker styleAction="'color'" applyTo="'.s_popup_close'"/>
+        <BuilderColorPicker styleAction="'color'" applyTo="'.s_popup_close'" enabledTabs="['solid', 'custom']"/>
     </BuilderRow>
     <BuilderRow label.translate="Display">
         <BuilderSelect dataAttributeAction="'display'" preview="false">

--- a/addons/website/static/src/builder/plugins/options/popup_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/popup_option_plugin.js
@@ -105,8 +105,7 @@ class MoveBlockAction extends BuilderAction {
 class SetBackdropAction extends BuilderAction {
     static id = "setBackdrop";
     isApplied({ editingElement }) {
-        const hasBackdropColor =
-            editingElement.style.getPropertyValue("background-color").trim() === "var(--black-50)";
+        const hasBackdropColor = !!editingElement.style.getPropertyValue("background-color").trim();
         const hasNoBackdropClass = editingElement.classList.contains("s_popup_no_backdrop");
         return hasBackdropColor && !hasNoBackdropClass;
     }


### PR DESCRIPTION
Steps to reproduce:
- Drop a popup snippet
- Change the backdrop color => The backdrop option is disabled (even though the background is still on the element).

This commit fixes this and limits the available colorpicker tabs to solid and custom.

task-4367641