### PR TITLE
[FIX] l10n_it_edi: fix positive 'imposta' in XML for credit notes

### DIFF
--- a/addons/l10n_it_edi/models/account_move.py
+++ b/addons/l10n_it_edi/models/account_move.py
@@ -394,6 +394,8 @@ class AccountMove(models.Model):
             if float_is_zero(rounding, precision_digits=8):
                 rounding = None
 
+            if self.move_type in ('in_refund', 'out_refund') and values['base_amount'] < 0 and values['tax_amount'] > 0:
+                values['tax_amount'] = -values['tax_amount']
             tax_lines.append({
                 'aliquota_iva': grouping_key['tax_amount_field'],
                 'natura': grouping_key['l10n_it_exempt_reason'],


### PR DESCRIPTION
**Issue**
When generating the XML for a credit note, the <Imposta> field (tax amount) appears as a positive value, whereas it should be negative in compliance with Italian EDI standards.

**Steps to Reproduce**
1. Install the Accounting module and Italian localization.
2. Create and confirm a vendor bill using a service-type product.
3. Reverse the bill into a credit note.
4. On the credit note, go to the Journal Items tab.
5. Assign tax 22% S RC and confirm.
6. Click Send Tax Integration.
7. Inspect the generated XML: <Imposta> appears as positive.

**Root Cause**
The XML generation logic for tax lines does not consider the type of the accounting move. As a result, for credit notes (in_refund or out_refund), the tax amount (<Imposta>) remains positive, even though it should be negative to reflect the refund nature of the document.

**Fix**
The tax amount is inverted for credit notes to ensure the XML reflects the correct financial direction. This distinction prevents misreporting, as positive values in a refund context would contradict e-invoicing standards.

Ticket [link](https://www.odoo.com/odoo/project/967/tasks/4831091)
opw-4831091