### PR TITLE
[FIX] website: make background overlay have full height

### DIFF
--- a/addons/website/static/src/builder/plugins/background_option/background_position_overlay.js
+++ b/addons/website/static/src/builder/plugins/background_option/background_position_overlay.js
@@ -132,8 +132,16 @@ export class BackgroundPositionOverlay extends Component {
         const targetRect = this.props.editingElement.getBoundingClientRect();
         overlayContentEl.style.left = `${targetRect.left + window.scrollX}px`;
 
-        this.bgDraggerEl.style.width = `${this.props.editingElement.clientWidth}px`;
-        this.bgDraggerEl.style.height = `${this.props.editingElement.clientHeight}px`;
+        this.bgDraggerEl.style.setProperty(
+            "width",
+            `${this.props.editingElement.clientWidth}px`,
+            "important"
+        );
+        this.bgDraggerEl.style.setProperty(
+            "height",
+            `${this.props.editingElement.clientHeight}px`,
+            "important"
+        );
 
         const topPos = Math.max(
             0,


### PR DESCRIPTION
Before this commit in some snippets background overlay wouldn't have proper height because of the parent elements' height. This commit overrides it with `!important`.
To reproduce the issue:
- open website and start editing
- drop columns snippet, add background image to one of the columns, click on it
- Click on the background position option to change it(the one with a crosshair icon)
- the overlay isn't shown properly, which also breaks the tooltip position
Commit follows [the html_builder refactoring]. Copy of https://github.com/odoo/odoo/pull/215377

[the html_builder refactoring]: odoo/odoo@9fe45e2b7ddb

Related to task-4367641