### PR TITLE
[FIX] website_sale_wishlist: redirect to cart on empty wishlist

### DIFF
--- a/addons/website_sale_wishlist/static/src/js/website_sale_wishlist.js
+++ b/addons/website_sale_wishlist/static/src/js/website_sale_wishlist.js
@@ -192,6 +192,9 @@ publicWidget.registry.ProductWishlist = publicWidget.Widget.extend(VariantMixin,
         const quantity = await addToCart;
         if (quantity > 0 && !document.getElementById('b2b_wish').checked) {
             this._removeWish(ev, false);
+            if (this.wishlistProductIDs.length === 0) {
+                this._redirectNoWish();
+            }
         }
         return addToCart;
     },


### PR DESCRIPTION
Versions
--------
- saas-18.2
- saas-18.3

Fix on master in FW.

Steps
-----
1. Add 1 item to your wishlist;
2. go to wishlist;
3. add item to cart.

Issue
-----
You don't get redirected to the cart.

Cause
-----
Commit c0f411cc7cf17 fixed an issue where products were removed from the wishlist before they were added to the cart via the product configurator by not passing a deferred redirect to `_removeWish`. An unintended side-effect is that the user no longer gets redirected when the wishlist is empty.

Solution
--------
After calling `_removeWish`, check if the wishlist is empty, and if so, call `_redirectNoWish` to restore previous behavior.

runbot-227042