### PR TITLE
[FIX] account_edi_ubl_cii: restrict XML export to posted invoices only

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_move.py
+++ b/addons/account_edi_ubl_cii/models/account_move.py
@@ -73,7 +73,7 @@ class AccountMove(models.Model):
             for partner in self.commercial_partner_id
             if (suggested_format := partner ._get_suggested_ubl_cii_edi_format())
         }
-        if self.ubl_cii_xml_id or suggested_edi_formats:
+        if self.state == 'posted' and (self.ubl_cii_xml_id or suggested_edi_formats):
             print_items.append({
                 'key': 'download_ubl',
                 'description': _('Export XML'),


### PR DESCRIPTION
Currently, an error is raised when attempting to export the XML for a draft invoice.

**Steps to Reproduce:**
- Install the `account_edi_ubl_cii` module.
- Create an invoice with customer **OpenWood**.
- Without confirming the invoice, go to `Print > Export XML`.

**Error:**
`AttributeError - 'bool' object has no attribute 'replace'`

**Cause:**
In draft state, the invoice name is `False`, leading to an `AttributeError` when calling `replace()` on bolean value. - [1]

[1] - https://github.com/odoo/odoo/blob/8bc24feca01a7d0e45606ac97e45ddf442670392/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_bis3.py#L32-L33

Restrict the XML export feature to only allow export for posted invoices, where the name is always defined.

Sentry - 6695898207