### PR TITLE
[FIX] stock: Prevent the overlapping of rows in reception reports

### DIFF
--- a/addons/stock/static/src/scss/report_stock_reception.scss
+++ b/addons/stock/static/src/scss/report_stock_reception.scss
@@ -27,6 +27,9 @@
         $-safe-text-color: color-contrast(mix($-bg-color, $o-view-background-color));
         @include bg-variant(".bg-#{$-name}-light", rgba(map-get($theme-colors, $-name), 0.5), $-safe-text-color);
     }
+    & thead{
+        display: table-row-group;
+    }
 }
 
 .o_label_page {


### PR DESCRIPTION
## Short functional explanation of the error
When printing a reception report containing a lot of products, the top row of the pages after the first one is overlapped with its corresponding header in the resulting PDF.

## Reproduction Steps
1. Open the settings. In the inventory section, enable "Reception Report".
2. Create a new quotation and add at least 40 different products. Each product should have at least 1 copy in stock, and the quantity to order must be greater than the quantity we have of this product in stock.
3. Confirm the sales order.
4. Create a new purchase order and add the exact same products you added in the quotation.
5. Confirm the order and click on the "Recept" smart button.
6. Click on the "Allocation" smart button and click on the "Assign all" gray button.
7. Click on print and open the PDF once it finishes downloading.

### Expected behavior
Each row (corresponding to the reception of a product) and its corresponding header is printed properly,  regardless of how many pages constitute the report.

### Unexpected behavior
The PDF has more than one page, and on the top of the second page, the product row is overlapped with the header of its corresponding section.

## Origin of the issue
It comes from an issue with WKHtmltopdf itself:
https://github.com/wkhtmltopdf/wkhtmltopdf/issues/1524
The report uses the "thead" tag for the headers. However, in some cases, when the header is linked to a table dynamically (with for-each, for
 example), WebKit ignores or breaks the "Thead" behavior.

## Explanation of the fix
I override the default behavior of thead, which repeats the header automatically at each new page, with a new style. Now, the "Thead" special behavior is ignored and treated like ordinary lines. The header isn't shown at each new page anymore, avoiding the overlapping of product rows.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
