### PR TITLE
[FIX] html_editor: prevent focus loss when rotating large images

### DIFF
--- a/addons/html_editor/static/src/main/media/image_transformation.js
+++ b/addons/html_editor/static/src/main/media/image_transformation.js
@@ -40,6 +40,7 @@ export class ImageTransformation extends Component {
     };
 
     setup() {
+        this.isCurrentlyTransforming = false;
         this.document = this.props.document;
         this.image = this.props.image;
         this.transfoContainer = useRef("transfoContainer");
@@ -62,7 +63,11 @@ export class ImageTransformation extends Component {
             }
         });
         useHotkey("escape", () => this.props.destroy());
-        usePositionHook({ el: this.props.editable }, this.document, this.resetHandlers);
+        usePositionHook({ el: this.props.editable }, this.document, () => {
+            if (!this.isCurrentlyTransforming) {
+                this.resetHandlers();
+            }
+        });
     }
 
     mouseMove(ev) {
@@ -177,6 +182,7 @@ export class ImageTransformation extends Component {
     }
 
     mouseUp() {
+        this.isCurrentlyTransforming = false;
         this.transfo.active = null;
     }
 
@@ -184,6 +190,7 @@ export class ImageTransformation extends Component {
         if (this.transfo.active) {
             return;
         }
+        this.isCurrentlyTransforming = true;
         let type = "position";
         const target = ev.target.closest("div");
 


### PR DESCRIPTION
Problem:
When a user rotates an image, certain image sizes can cause the editable area to become scrollable. This triggers `resetHandlers` from `usePositionHook`, resulting in loss of focus on the rotate controller.

Solution:
Add a flag to detect when the user is actively transforming (`mousedown`). Delay the reset until interaction ends (`mouseup`), preventing premature handler reset.

Steps to reproduce:
- Add a long image
- Transform > Rotate until a scrollbar appears
- You lose focus on the rotate controller

opw-4890029

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
