### PR TITLE
[FIX] mail: vals get shadowed

### DIFF
--- a/addons/mail/models/discuss/discuss_channel.py
+++ b/addons/mail/models/discuss/discuss_channel.py
@@ -407,9 +407,9 @@ class DiscussChannel(models.Model):
         result = super().write(vals)
         for channel in self:
             new_subchannel_vals = get_vals(channel)
-            for subchannel, vals in new_subchannel_vals.items():
+            for subchannel, values in new_subchannel_vals.items():
                 diff = []
-                for field_name, (value, field_description) in vals.items():
+                for field_name, (value, field_description) in values.items():
                     if value != old_vals[channel][subchannel][field_name][0]:
                         diff.append(field_description)
                 if diff:


### PR DESCRIPTION
This commit fixes a bug where the `vals` variable in the `write` method of `discuss_channel.py` was being shadowed by a local variable of the same name. This caused the method to not behave as expected, leading to issues on the runbot.

ticket-227049

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
