### PR TITLE
[FIX] pos_restaurant: fix release table button

### DIFF
--- a/addons/pos_restaurant/static/src/app/product_screen/order_summary/order_summary.js
+++ b/addons/pos_restaurant/static/src/app/product_screen/order_summary/order_summary.js
@@ -22,9 +22,8 @@ patch(OrderSummary.prototype, {
     },
     async unbookTable() {
         const order = this.pos.get_order();
-        await this.pos._onBeforeDeleteOrder(order);
-        order.state = "cancel";
-        this.pos.showScreen("FloorScreen");
+        await this.pos.deleteOrders([order]);
+        this.pos.showScreen(this.pos.firstScreen);
     },
     showUnbookButton() {
         if (this.pos.selectedTable) {


### PR DESCRIPTION
Before this commit, release table wasn't calling the correct method (deleteOrders) it was just changing the state of the order and waiting for calling syncAllOrders method to update the order on the server.

But if the order didn't have any line it was never synched.

Now the release table button calls the deleteOrders method directly and the order is removed from the server.

