### PR TITLE
[IMP] hw_drivers: allow updating server URL via WS

### DIFF
--- a/addons/hw_drivers/websocket_client.py
+++ b/addons/hw_drivers/websocket_client.py
@@ -69,6 +69,11 @@ class WebsocketClient(Thread):
                 case 'server_clear':
                     helpers.disconnect_from_server()
                     close_server_log_sender_handler()
+                case 'server_update':
+                    helpers.update_conf({
+                        'remote_server': payload['server_url']
+                    })
+                    helpers.get_odoo_server_url.cache_clear()
                 case 'restart_odoo':
                     ws.close()
                     helpers.odoo_restart()


### PR DESCRIPTION
Before this commit, if a client renamed their SaaS database to use a different URL, it would cause paired IoT boxes to fail as they would try to contact the old URL to send devices etc.

After this commit, when the `web.base.url` parameter is updated (which will happen the first time an admin logs in from the new URL), we send a websocket message to all IoT boxes informing them of the new URL.

task-4879313

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
