### PR TITLE
[FIX] mail: correctly notify email-to-email discussions

### DIFF
--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -42,7 +42,8 @@ from odoo.tools import (
 from odoo.tools.mail import (
     append_content_to_html, decode_message_header,
     email_normalize, email_normalize_all, email_split,
-    email_split_and_format, formataddr, html_sanitize,
+    email_split_and_format, email_split_and_format_normalize,
+    formataddr, html_sanitize,
     generate_tracking_message_id,
     unfold_references,
 )
@@ -3755,15 +3756,29 @@ class MailThread(models.AbstractModel):
         if additional_values:
             base_mail_values.update(additional_values)
 
-        # prepare headers (as sudo as accessing mail.alias.domain, restricted)
+        # prepare headers
         headers = {}
-        # prepare external emails to modify Msg[To] and enable Reply-All including external people
+        # prepare external emails to modify Msg[To] and enable Reply-All by
+        # including external people (aka share partners to notify + emails
+        # notified by incoming email (incoming_email_cc and incoming_email_to)
+        # that were not transformed into partners to notify
         external_emails = [
             formataddr((r['name'], r['email_normalized']))
             for r in recipients_data if r['id'] and r['active'] and r['email_normalized'] and r['share']
         ]
+        external_emails_normalized = [
+            r['email_normalized']
+            for r in recipients_data if r['id'] and r['active'] and r['email_normalized'] and r['share']
+        ]
+        external_emails += list({
+            email for email in email_split_and_format_normalize(
+                f"{message_sudo.incoming_email_to or ''},{message_sudo.incoming_email_cc or ''}"
+            )
+            if email_normalize(email) not in external_emails_normalized
+        })
         if external_emails and len(external_emails) < self._CUSTOMER_HEADERS_LIMIT_COUNT:  # more than threshold = considered as public record (slide, forum, ...) -> do not leak
             headers['X-Msg-To-Add'] = ','.join(external_emails)
+        # sudo: access to mail.alias.domain, restricted
         if message_sudo.record_alias_domain_id.bounce_email:
             headers['Return-Path'] = message_sudo.record_alias_domain_id.bounce_email
         headers = self._notify_by_email_get_headers(headers=headers)

--- a/addons/mail/tests/common.py
+++ b/addons/mail/tests/common.py
@@ -263,7 +263,7 @@ class MockEmail(common.BaseCase, MockSmtplibCase):
         )
 
     def gateway_mail_reply_from_smtp_email(self, template, source_smtp_to_list,
-                                           reply_all=False, cc=False,
+                                           reply_all=False, add_to_lst=False, cc=False,
                                            force_email_from=False, force_return_path=False,
                                            extra=False, use_references=True, extra_references=False, use_in_reply_to=False,
                                            debug_log=False,
@@ -296,6 +296,8 @@ class MockEmail(common.BaseCase, MockSmtplibCase):
                 email for email in email_split_and_format_normalize(smtp_email['msg_to'])
                 if email_normalize(email) not in source_smtp_to_list]
             )
+        if add_to_lst:
+            replying_to = f'{replying_to},{",".join(add_to_lst)}'
         with RecordCapturer(self.env['mail.message'], []) as capture_messages, \
              self.mock_mail_gateway():
             self._gateway_mail_reply(
@@ -306,7 +308,7 @@ class MockEmail(common.BaseCase, MockSmtplibCase):
                 debug_log=debug_log,
                 target_model=target_model,
             )
-        return capture_messages
+        return capture_messages.records
 
     def gateway_mail_reply_last_email(self, template, force_email_to=False, debug_log=False):
         """ Tool to automatically reply to last outgoing mail. """

--- a/addons/project/tests/test_project_mail_features.py
+++ b/addons/project/tests/test_project_mail_features.py
@@ -116,6 +116,7 @@ class TestProjectMailFeatures(TestProjectCommon, MailCommon):
 
         incoming_cc = f'"New Cc" <new.cc@test.agrolait.com>, {self.partner_2.email_formatted}'
         incoming_to = f'{self.project_followers_alias.alias_full_name}, {self.partner_1.email_formatted}, "New Customer" <new.customer@test.agrolait.com>'
+        incoming_to_filtered = f'{self.partner_1.email_formatted}, "New Customer" <new.customer@test.agrolait.com>'
         with self.mock_mail_gateway():
             task = self.format_and_process(
                 MAIL_TEMPLATE,
@@ -141,7 +142,7 @@ class TestProjectMailFeatures(TestProjectCommon, MailCommon):
                         'email_from': self.user_portal.email_formatted,
                         # coming from incoming email
                         'incoming_email_cc': incoming_cc,
-                        'incoming_email_to': incoming_to,
+                        'incoming_email_to': incoming_to_filtered,
                         'mail_server_id': self.env['ir.mail_server'],
                         # followers of 'new task' subtype (but not original To as they
                         # already received the email)
@@ -172,6 +173,7 @@ class TestProjectMailFeatures(TestProjectCommon, MailCommon):
 
         incoming_cc = f'"New Cc" <new.cc@test.agrolait.com>, {self.partner_2.email_formatted}'
         incoming_to = f'{self.project_followers_alias.alias_full_name}, {self.partner_1.email_formatted}, "New Customer" <new.customer@test.agrolait.com>'
+        incoming_to_filtered = f'{self.partner_1.email_formatted}, "New Customer" <new.customer@test.agrolait.com>'
         for test_user in (self.user_employee, self.user_portal, False):
             with self.subTest(user_name=test_user.name if test_user else new_partner_email):
                 email_from = test_user.email_formatted if test_user else new_partner_email
@@ -228,7 +230,7 @@ class TestProjectMailFeatures(TestProjectCommon, MailCommon):
                                 'email_from': formataddr((author.name, author.email_normalized)),
                                 # coming from incoming email
                                 'incoming_email_cc': incoming_cc,
-                                'incoming_email_to': incoming_to,
+                                'incoming_email_to': incoming_to_filtered,
                                 'mail_server_id': self.env['ir.mail_server'],
                                 # followers of 'new task' subtype (but not original To as they
                                 # already received the email)
@@ -442,11 +444,8 @@ class TestProjectMailFeatures(TestProjectCommon, MailCommon):
                                 'email_from': author.email_formatted,
                                 # coming from incoming email
                                 'incoming_email_cc': f'"Another Cc" <another.cc@test.agrolait.com>, {self.partner_3.email}',
-                                # To: received email Msg-To - customer who replies + email Reply-To
-                                'incoming_email_to': ', '.join(
-                                    external_partners.mapped('email_formatted') +
-                                    [formataddr((self.user_projectuser.name, self.project_followers_alias.alias_full_name))]
-                                ),
+                                # To: received email Msg-To - customer who replies, without email Reply-To
+                                'incoming_email_to': ', '.join(external_partners.mapped('email_formatted')),
                                 'mail_server_id': self.env['ir.mail_server'],
                                 # notified: followers - already emailed, aka internal only
                                 'notified_partner_ids': internal_followers,

--- a/addons/test_mail/data/test_mail_data.py
+++ b/addons/test_mail/data/test_mail_data.py
@@ -135,6 +135,38 @@ Message-ID: {msg_id}
 </html>
 """
 
+MAIL_TEMPLATE_SHORT = """Return-Path: {return_path}
+To: {to}
+cc: {cc}
+Received: by mail1.openerp.com (Postfix, from userid 10002)
+    id 5DF9ABFB2A; Fri, 10 Aug 2012 16:16:39 +0200 (CEST)
+From: {email_from}
+Subject: {subject}
+MIME-Version: 1.0
+Content-Type: multipart/alternative;
+    boundary="----=_Part_4200734_24778174.1344608186754"
+Date: Fri, 10 Aug 2012 14:16:26 +0000
+Message-ID: {msg_id}
+{extra}
+------=_Part_4200734_24778174.1344608186754
+Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: quoted-printable
+
+Eli alla à l'eau
+
+--
+Signature
+------=_Part_4200734_24778174.1344608186754
+Content-Type: text/html; charset=utf-8
+Content-Transfer-Encoding: quoted-printable
+<div>Eli alla à l'eau<br/>
+--<br/>
+Sylvie
+</div>
+------=_Part_4200734_24778174.1344608186754--
+"""
+
+
 MAIL_MULTIPART_MIXED = """Return-Path: <ignasse.carambar@gmail.com>
 X-Original-To: raoul@grosbedon.fr
 Delivered-To: raoul@grosbedon.fr

--- a/addons/test_mail/models/mail_test_lead.py
+++ b/addons/test_mail/models/mail_test_lead.py
@@ -31,7 +31,7 @@ class MailTestTLead(models.Model):
         email_normalized_to_values = super()._get_customer_information()
 
         for lead in self:
-            email_key = lead.email_normalized or lead.email
+            email_key = lead.email_normalized or lead.email_from
             values = email_normalized_to_values.setdefault(email_key, {})
             values['lang'] = values.get('lang') or lead.lang_code
             values['name'] = values.get('name') or lead.customer_name or parse_contact_from_email(lead.email_from)[0] or lead.email_from

--- a/addons/test_mail/tests/test_mail_flow.py
+++ b/addons/test_mail/tests/test_mail_flow.py
@@ -174,8 +174,8 @@ class TestMailFlow(MailCommon, TestRecipients):
             ),
             smtp_from=self.mail_server_notification.from_filter,
             smtp_to_list=[self.user_employee.email_normalized],
-            msg_to_lst=[self.user_employee.email_formatted],
-            # FIXME: missing customer in CC of reply -> will get out of discussion
+            # customers in To/Cc of reply added in envelope to keep them in discussions
+            msg_to_lst=[self.user_employee.email_formatted, self.test_emails[0], self.test_emails[1]],
             msg_cc_lst=[],
         )
 
@@ -194,8 +194,8 @@ class TestMailFlow(MailCommon, TestRecipients):
                         'author_id': self.partner_employee,
                         'email_from': self.partner_employee.email_formatted,
                         'incoming_email_cc': self.partner_employee_2.email_formatted,
-                        # be sure not to have catchall reply-to !
-                        'incoming_email_to': False,
+                        # be sure not to have catchall reply-to ! customers are in 'To' due to Reply-All
+                        'incoming_email_to': f'{self.test_emails[0]}, {self.test_emails[1]}',
                         'notified_partner_ids': self.customer_zboing,
                         # only recognized partners
                         'partner_ids': self.partner_employee_2,
@@ -207,7 +207,6 @@ class TestMailFlow(MailCommon, TestRecipients):
                 },
             ],
         )
-        # FIXME: additional recipients are out of discussion
         self.assertSMTPEmailsSent(
             mail_server=self.mail_server_notification,
             msg_from=formataddr(
@@ -215,7 +214,9 @@ class TestMailFlow(MailCommon, TestRecipients):
             ),
             smtp_from=self.mail_server_notification.from_filter,
             smtp_to_list=[self.customer_zboing.email_normalized],
-            msg_to_lst=[self.customer_zboing.email_formatted],
+            # customers are still in discussion
+            msg_to_lst=[self.customer_zboing.email_formatted, self.partner_employee_2.email_formatted, self.test_emails[0], self.test_emails[1]],
+            msg_cc_lst=[],
         )
 
     def test_lead_mailgateway(self):

--- a/addons/test_mail/tests/test_mail_flow.py
+++ b/addons/test_mail/tests/test_mail_flow.py
@@ -196,29 +196,27 @@ class TestMailFlow(MailCommon, TestRecipients):
                         'incoming_email_cc': self.partner_employee_2.email_formatted,
                         # be sure not to have catchall reply-to !
                         'incoming_email_to': False,
-                        'notified_partner_ids': self.env['res.partner'],
+                        'notified_partner_ids': self.customer_zboing,
                         # only recognized partners
                         'partner_ids': self.partner_employee_2,
                         'subject': 'Re: Re: False',
                         'subtype_id': self.env.ref('mail.mt_comment'),
                     },
                     # partner_employee_2 received an email, hence no duplicate notification
-                    'notif': [],
+                    'notif': [{'partner': self.customer_zboing, 'type': 'email'}],
                 },
             ],
         )
-        # FIXME: customer + additional recipients are out of discussion
-        self.assertEqual(emp_reply.notified_partner_ids, self.env['res.partner'])
-        self.assertFalse(self.emails)
-        # self.assertSMTPEmailsSent(
-        #     mail_server=self.mail_server_notification,
-        #     msg_from=formataddr(
-        #         (self.partner_employee.name, f'{self.default_from}@{self.alias_domain}')
-        #     ),
-        #     smtp_from=self.mail_server_notification.from_filter,
-        #     smtp_to_list=[],
-        #     msg_to_lst=[],
-        # )
+        # FIXME: additional recipients are out of discussion
+        self.assertSMTPEmailsSent(
+            mail_server=self.mail_server_notification,
+            msg_from=formataddr(
+                (self.partner_employee.name, f'{self.default_from}@{self.alias_domain}')
+            ),
+            smtp_from=self.mail_server_notification.from_filter,
+            smtp_to_list=[self.customer_zboing.email_normalized],
+            msg_to_lst=[self.customer_zboing.email_formatted],
+        )
 
     def test_lead_mailgateway(self):
         """ Flow of this test


### PR DESCRIPTION
Purpose

Improve email to email discussions, aka discussion on Odoo records
between people using emails.

See individual commit for more details.
 * be sure to include external recipients in email headers
 * be sure to include author when they are not followers
 * avoid adding aliases as external recipients

Task-4873049
