### PR TITLE
[PERF] account: avoid O(n²) in tax detail with tax groups

### DIFF
--- a/addons/account/models/account_move_line_tax_details.py
+++ b/addons/account/models/account_move_line_tax_details.py
@@ -103,42 +103,7 @@ class AccountMoveLine(models.Model):
             tax_line_4      5                                                       275         base_line_2/3
             */
 
-            WITH affecting_base_tax_ids AS (
-
-                /*
-                This CTE builds a reference table based on the tax_ids field, with the following changes:
-                  - flatten the group of taxes
-                  - exclude the taxes having 'is_base_affected' set to False.
-                Those allow to match only base_line_1 when finding the base lines of tax_line_1, as we need to find
-                base lines having a 'affecting_base_tax_ids' ending with [10_affect_base, 20], not only containing
-                '10_affect_base'. Otherwise, base_line_2/3 would also be matched.
-                In our example, as all the taxes are set to be affected by previous ones affecting the base, the
-                result is similar to the table 'account_move_line_account_tax_rel':
-                Id                 Tax_ids
-                -------------------------------------------
-                base_line_1        [10_affect_base, 20]
-                base_line_2        [10_affect_base, 5]
-                base_line_3        [10_affect_base, 5]
-                */
-
-                SELECT
-                    sub.line_id AS id,
-                    ARRAY_AGG(sub.tax_id ORDER BY sub.sequence, sub.tax_id) AS tax_ids
-                FROM (
-                    SELECT
-                        tax_rel.account_move_line_id AS line_id,
-                        {group_taxes_query} AS tax_id,
-                        tax.sequence
-                    FROM {tables}
-                    JOIN account_move_line_account_tax_rel tax_rel ON account_move_line.id = tax_rel.account_move_line_id
-                    JOIN account_tax tax ON tax.id = tax_rel.account_tax_id
-                    WHERE tax.is_base_affected
-                    AND {where_clause}
-                ) AS sub
-                GROUP BY sub.line_id
-            ),
-
-            base_tax_line_mapping AS (
+            WITH base_tax_line_mapping AS (
 
                 /*
                 Create the mapping of each tax lines with their corresponding base lines.
@@ -194,12 +159,49 @@ class AccountMoveLine(models.Model):
                     curr.id = account_move_line.currency_id
                 JOIN res_currency comp_curr ON
                     comp_curr.id = account_move_line.company_currency_id
-                LEFT JOIN affecting_base_tax_ids tax_line_tax_ids ON tax_line_tax_ids.id = account_move_line.id
-                JOIN affecting_base_tax_ids base_line_tax_ids ON base_line_tax_ids.id = base_line.id
+                LEFT JOIN LATERAL (
+                    /*
+                        This table builds a reference table based on the tax_ids field, with the following changes:
+                          - flatten the group of taxes
+                          - exclude the taxes having 'is_base_affected' set to False.
+                        Those allow to match only base_line_1 when finding the base lines of tax_line_1, as we need to find
+                        base lines having a 'affecting_base_tax_ids' ending with [10_affect_base, 20], not only containing
+                        '10_affect_base'. Otherwise, base_line_2/3 would also be matched.
+                        In our example, as all the taxes are set to be affected by previous ones affecting the base, the
+                        result is similar to the table 'account_move_line_account_tax_rel':
+                        Id                 Tax_ids
+                        -------------------------------------------
+                        base_line_1        [10_affect_base, 20]
+                        base_line_2        [10_affect_base, 5]
+                        base_line_3        [10_affect_base, 5]
+                    */
+                    SELECT ARRAY_AGG(sub.tax_id ORDER BY sub.sequence, sub.tax_id) AS tax_ids
+                    FROM (
+                        SELECT
+                            {group_taxes_query} AS tax_id,
+                            tax.sequence
+                        FROM account_move_line_account_tax_rel tax_rel
+                        JOIN account_tax tax ON tax.id = tax_rel.account_tax_id
+                        WHERE tax.is_base_affected
+                        AND tax_rel.account_move_line_id = account_move_line.id
+                    ) AS sub
+                ) tax_line_tax_ids ON TRUE
+                LEFT JOIN LATERAL (
+                    SELECT ARRAY_AGG(sub.tax_id ORDER BY sub.sequence, sub.tax_id) AS tax_ids
+                    FROM (
+                        SELECT
+                            {group_taxes_query} AS tax_id,
+                            tax.sequence
+                        FROM account_move_line_account_tax_rel tax_rel
+                        JOIN account_tax tax ON tax.id = tax_rel.account_tax_id
+                        WHERE tax.is_base_affected
+                        AND tax_rel.account_move_line_id = base_line.id
+                    ) AS sub
+                ) base_line_tax_ids ON TRUE
                 WHERE account_move_line.tax_repartition_line_id IS NOT NULL
                     AND {where_clause}
                     AND (
-                        -- keeping only the rows from affecting_base_tax_lines that end with the same taxes applied (see comment in affecting_base_tax_ids)
+                        -- keeping only the rows from affecting_base_tax_lines that end with the same taxes applied (see comment in tax_line_tax_ids)
                         NOT tax.include_base_amount
                         OR base_line_tax_ids.tax_ids[ARRAY_LENGTH(base_line_tax_ids.tax_ids, 1) - COALESCE(ARRAY_LENGTH(tax_line_tax_ids.tax_ids, 1), 0):ARRAY_LENGTH(base_line_tax_ids.tax_ids, 1)]
                             = ARRAY[account_move_line.tax_line_id] || COALESCE(tax_line_tax_ids.tax_ids, ARRAY[]::INTEGER[])
@@ -507,4 +509,4 @@ class AccountMoveLine(models.Model):
                     0.0
                 ) AS tax_amount_currency
             FROM base_tax_matching_all_amounts sub
-        ''', group_taxes_params + where_params + where_params + where_params + fallback_params
+        ''', group_taxes_params + group_taxes_params + where_params + where_params + fallback_params

--- a/addons/spreadsheet/models/res_lang.py
+++ b/addons/spreadsheet/models/res_lang.py
@@ -22,7 +22,7 @@ class Lang(models.Model):
     @api.model
     def _get_user_spreadsheet_locale(self):
         """Convert the odoo lang to a spreadsheet locale."""
-        lang = self._lang_get(self.env.user.lang)
+        lang = self._lang_get(self.env.user.lang or 'en_US')
         return lang._odoo_lang_to_spreadsheet_locale()
 
     def _odoo_lang_to_spreadsheet_locale(self):


### PR DESCRIPTION
When building `base_tax_line_mapping`, the JOIN on
`affecting_base_tax_ids` was effectively scanning the CTE as many times
as there were tax lines in the domain. This lead to computing a number
of rows equivalent to the number of base lines times the number of tax
lines; so O(n²).
Using a LATERAL JOIN helps in avoiding that behavior and only getting
the lines needed in each loop.Description of the issue/feature this PR addresses:
