### PR TITLE
[IMP] sale_, project: generalize same-field check for selected tasks

### DIFF
--- a/addons/project/static/src/views/project_task_list/project_task_list_renderer.js
+++ b/addons/project/static/src/views/project_task_list/project_task_list_renderer.js
@@ -13,16 +13,16 @@ export class ProjectTaskListRenderer extends ListRenderer {
      * rendering the list. Indeed, `selection` is a getter which browses all
      * records, so computing it for each cell slows down the rendering a lot on
      * large tables. Moreover, it also prevents from iterating over the selection
-     * to compare tasks' projects.
+     * to compare tasks' projects or partners.
      *
-     * It returns true iff the selected tasks are all in the same project.
+     * Returns true if all selected tasks have the same value for the specified field.
      */
-    areSelectedTasksInSameProject() {
+    haveAllSelectedTasksSameField(field) {
         if (this._areSelectedTasksInSameProject === undefined) {
             const selection = this.props.list.selection;
-            const projectId = selection.length && getRawValue(selection[0], "project_id");
+            const projectId = selection.length && getRawValue(selection[0], field);
             this._areSelectedTasksInSameProject = selection.every(
-                (task) => getRawValue(task, "project_id") === projectId
+                (task) => getRawValue(task, field) === projectId
             );
             Promise.resolve().then(() => {
                 delete this._areSelectedTasksInSameProject;
@@ -33,7 +33,7 @@ export class ProjectTaskListRenderer extends ListRenderer {
     isCellReadonly(column, record) {
         let readonly = false;
         if (column.name === "stage_id") {
-            readonly = !this.areSelectedTasksInSameProject();
+            readonly = !this.haveAllSelectedTasksSameField('project_id');
         }
         return readonly || super.isCellReadonly(column, record);
     }

--- a/addons/sale_project/static/src/views/project_task_list/project_task_list_sale_line.js
+++ b/addons/sale_project/static/src/views/project_task_list/project_task_list_sale_line.js
@@ -1,35 +1,11 @@
 import { patch } from "@web/core/utils/patch";
 import { ProjectTaskListRenderer } from "@project/views/project_task_list/project_task_list_renderer";
-import { getRawValue } from "@web/views/kanban/kanban_record";
 
 patch(ProjectTaskListRenderer.prototype, {
-    /**
-     * This method prevents from computing the selection once for each cell when
-     * rendering the list. Indeed, `selection` is a getter which browses all
-     * records, so computing it for each cell slows down the rendering a lot on
-     * large tables. Moreover, it also prevents from iterating over the selection
-     * to compare tasks' partners.
-     *
-     * It returns true iff the selected tasks all have the same partner.
-     */
-    haveSelectedTasksSamePartner() {
-        if (this._haveSelectedTasksSamePartner === undefined) {
-            const selection = this.props.list.selection;
-            const partnerId = selection.length && getRawValue(selection[0], "partner_id");
-            this._haveSelectedTasksSamePartner = selection.every(
-                (task) => getRawValue(task, "partner_id") === partnerId
-            );
-            Promise.resolve().then(() => {
-                delete this._haveSelectedTasksSamePartner;
-            });
-        }
-        return this._haveSelectedTasksSamePartner;
-    },
-
     isCellReadonly(column, record) {
         let readonly = false;
         if (column.name === "sale_line_id") {
-            readonly = !this.haveSelectedTasksSamePartner();
+            readonly = !this.haveAllSelectedTasksSameField('partner_id');
         }
         return readonly || super.isCellReadonly(column, record);
     }


### PR DESCRIPTION
- Merged `haveSelectedTasksSamePartner` and `areSelectedTasksInSameProject` into a single reusable method `areSelectedTasksInSameValue(field)`.

- This avoids duplication and improves maintainability by allowing the same logic to be reused for different fields.

- Also retains caching logic to avoid repeated computation during list rendering.

task-4775290
