### PR TITLE
[IMP] web: Add context support to the name_search call in many2many_checkboxes

### DIFF
--- a/addons/web/static/src/views/fields/many2many_checkboxes/many2many_checkboxes_field.js
+++ b/addons/web/static/src/views/fields/many2many_checkboxes/many2many_checkboxes_field.js
@@ -15,12 +15,13 @@ export class Many2ManyCheckboxesField extends Component {
     static props = {
         ...standardFieldProps,
         domain: { type: Array, optional: true },
+        context: { type: Object, optional: true },
     };
 
     setup() {
         this.specialData = useSpecialData((orm, props) => {
             const { relation } = props.record.fields[props.name];
-            return orm.call(relation, "name_search", ["", props.domain]);
+            return orm.call(relation, "name_search", ["", props.domain], {context: this.props.context || {}});
         });
         // these two sets track pending changes in the relation, and allow us to
         // batch consecutive changes into a single replaceWith, thus saving
@@ -79,6 +80,7 @@ export const many2ManyCheckboxesField = {
     extractProps(fieldInfo, dynamicInfo) {
         return {
             domain: dynamicInfo.domain(),
+            context: dynamicInfo.context,
         };
     },
 };

--- a/doc/cla/corporate/tecnativa.md
+++ b/doc/cla/corporate/tecnativa.md
@@ -27,3 +27,4 @@ Carlos Roca carlos.roca@tecnativa.com https://github.com/CarlosRoca13
 Pilar Vargas pilar.vargas@tecnativa.com https://github.com/pilarvargas-tecnativa
 Carolina Fernández carolina.fernandez@tecnativa.com https://github.com/carolinafernandez-tecnativa
 Josep Guardiola josep.guardiola@tecnativa.com https://github.com/josep-tecnativa
+Carlos Lopez carlos.lopez@tecnativa.com https://github.com/carlos-lopez-tecnativa


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
When `name_search` is called, the `context` is not passed to the method. In some cases, this is necessary, for example, if the field is related to `ir.attachment` and you want to pass `skip_res_field_check` in the context (see https://github.com/OCA/social/pull/1672).

**Current behavior before PR:**
The `context` is not passed to `name_search`.

**Desired behavior after PR is merged:**

Ability to pass context to name_search.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr

TT56840
@Tecnativa @pedrobaeza 