### PR TITLE
[FIX] point_of_sale: display salesperson in pos

### DIFF
--- a/addons/point_of_sale/static/src/app/missing_fields.js
+++ b/addons/point_of_sale/static/src/app/missing_fields.js
@@ -8,5 +8,13 @@ class DefaultField extends Component {
     static template = xml``;
     static props = ["*"];
 }
-registry.category("fields").add("list.many2one_avatar_user", { component: DefaultField });
+
+class SalesPersonField extends Component {
+    static template = xml`
+        <span t-if="props.record.data[props.name]">
+            <t t-esc="props.record.data[props.name].display_name"/>
+        </span>`;
+    static props = ["*"];
+}
+registry.category("fields").add("list.many2one_avatar_user", { component: SalesPersonField });
 registry.category("fields").add("list.list_activity", { component: DefaultField });

--- a/addons/pos_sale/static/tests/tours/pos_sale_tour.js
+++ b/addons/pos_sale/static/tests/tours/pos_sale_tour.js
@@ -459,3 +459,27 @@ registry.category("web_tour.tours").add("test_down_payment_displayed", {
             }),
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("test_salesperson_in_quotation_dialog", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            ProductScreen.clickControlButton("Quotation/Order"),
+            {
+                content: "Select the quotation with the correct salesperson",
+                trigger: '.modal .o_list_view .o_data_row:contains("Because I am accountman!") td',
+                run: "click",
+            },
+            {
+                content: `Choose to settle the order`,
+                trigger: `.modal:not(.o_inactive_modal) .selection-item:contains('Settle the order')`,
+                run: "click",
+            },
+            Order.hasLine({
+                productName: "product_a",
+                quantity: "1.0",
+                price: "115.0",
+            }),
+        ].flat(),
+});

--- a/addons/pos_sale/tests/test_pos_sale_flow.py
+++ b/addons/pos_sale/tests/test_pos_sale_flow.py
@@ -1334,3 +1334,19 @@ class TestPoSSale(TestPointOfSaleHttpCommon):
         pos_order_id = self.env['pos.order'].sync_from_ui([pos_order])['pos.order'][0]['id']
         pos_order = self.env['pos.order'].browse(pos_order_id)
         self.assertFalse(pos_order.account_move.invoice_payment_term_id)
+
+    def test_salesperson_in_quotation_dialog(self):
+        self.env['sale.order'].sudo().create({
+            'partner_id': self.partner_a.id,
+            'user_id': self.env.uid,
+            'state': 'draft',
+            'order_line': [Command.create({
+                    'name': 'Test Product',
+                    'product_id': self.product_a.id,
+                    'product_uom_qty': 1,
+                    'price_unit': 100,
+                })
+            ],
+        })
+        self.main_pos_config.open_ui()
+        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'test_salesperson_in_quotation_dialog', login="accountman")


### PR DESCRIPTION
**Problem:**
When clicking on Quotation/order in PoS, it will display a Dialog,
which has a *Salesperson* column. However, the column will always
be empty. When in debug mode, the tooltip will display the name,
but the column is still empty.

**Steps to reproduce:**
- Make a quotation in the sales app
- Go to PoS, click on action and then Quotation/order
- The Salesperson column is empty

**Why the fix:**

In PoS, all components that have the many2one_avatar_user widget will
be replaced by a DefaultField. This means that it wouldn't be displayed
as it should. This was done to remove a warning in the console. We now
diplay the name of the SalesPerson with a new class, instead of
using the DefaultField.

opw-4866597