### PR TITLE
[FIX] website: accept class colors on header

### DIFF
--- a/addons/website/static/src/builder/plugins/options/website_page_config_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/website_page_config_option_plugin.js
@@ -78,8 +78,8 @@ class WebsitePageConfigOptionPlugin extends Plugin {
         const item = this.getVisibilityItem();
         const pageOptions = {
             header_overlay: () => item === "overTheContent",
-            header_color: () => this.getColorValue("background-color", "bg-o-color-"),
-            header_text_color: () => this.getColorValue("color", "text-o-color-"),
+            header_color: () => this.getColorValue("background-color", "bg-"),
+            header_text_color: () => this.getColorValue("color", "text-"),
             header_visible: () => item !== "hidden",
             footer_visible: () => !this.getFooterVisibility(),
         };


### PR DESCRIPTION
Steps to reproduce:
- Open website builder and click on header
- Set "Header Position" to "Over The Content"
- Set the "Background" color to one of the suggestion (not from the arbitrary picker)
- Set the "Text Color" to one of the suggestion from the "Custom tab"
- Save
- Bug: The colors of the header are reset to default

This issue was introduced during the initial refactor of website builder

Website refactor: 9fe45e2b7ddbbfd0445ffe25a859e67a316d02b2
task-4367641
