### PR TITLE
[FIX] stock: freeze time for the quantity reports tests

### DIFF
--- a/addons/stock/tests/test_report_stock_quantity.py
+++ b/addons/stock/tests/test_report_stock_quantity.py
@@ -5,6 +5,7 @@ from datetime import datetime, timedelta
 
 from odoo import fields, tests
 from odoo.tests.common import Form
+from freezegun import freeze_time
 
 
 class TestReportStockQuantity(tests.TransactionCase):
@@ -12,6 +13,9 @@ class TestReportStockQuantity(tests.TransactionCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+        # freeze time to avoid test errors due to the class being initialized before 00:00:00 and the test run after
+        cls.fake_today = fields.Date.today()
+        cls.startClassPatcher(freeze_time(cls.fake_today))
         cls.product1 = cls.env['product.product'].create({
             'name': 'Mellohi',
             'default_code': 'C418',


### PR DESCRIPTION
The tests:
- `test_report_stock_quantity`
- `test_report_stock_quantity_with_product_qty_filter` can fail if the test class was instantiate at midnight and the tests launched at 00:01.

The issue has been explained extensively in d1e11dc2b41e66709ddd89beded32872af4118b9

Here is a modest retranscription of its holy analysis: The Test class `TestReportStockQuantity` inherit from `TransactionCase`. So, once initialized, a SQL transaction is started and is the same for all the tests of the class:
https://github.com/odoo/odoo/blob/d86409d93e096126b32cbb35f442db332628375d/odoo/tests/common.py#L775-L778

Also, in a SQL request, the method `now()` does not really return the current date:
> Notice that NOW() and its related functions return the start time of
the current transaction. In other words, the return values of the function calls are the same within a transaction.
(https://www.postgresqltutorial.com/postgresql-date-functions/postgresql-now/)

So, if we we start all the tests of the class `TestReportStockQuantity` at the end of D01. The SQL transaction is created and the tests are executed one by one with a NOW() corresponding to D01. However, certain indiviual tests might be launched on the following day D02 because it takes time to run the rest of the tests of the class: In particular, the python "today()" will notgive the same date as the SQL NOW and the queries of the test will simply not perform the expected. E.g: https://github.com/odoo/odoo/blob/d86409d93e096126b32cbb35f442db332628375d/addons/stock/tests/test_report_stock_quantity.py#L105-L110

runbot-226726
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
