### PR TITLE
[IMP] account: don't allow to send invoice if partner has no email

### DIFF
--- a/addons/account/models/account_move_send.py
+++ b/addons/account/models/account_move_send.py
@@ -107,16 +107,30 @@ class AccountMoveSend(models.AbstractModel):
         - action the action to run when the link is clicked
         """
         alerts = {}
-        if len(moves) > 1 and (partners_without_mail := moves.filtered(
-                lambda m: 'email' in moves_data[m]['sending_methods'] and not m.partner_id.email).partner_id
-        ):
-            # should only appear in mass invoice sending
-            alerts['account_missing_email'] = {
-                'level': 'warning',
-                'message': _("Partner(s) should have an email address."),
-                'action_text': _("View Partner(s)"),
-                'action': partners_without_mail._get_records_action(name=_("Check Partner(s) Email(s)")),
-            }
+
+        # Filter moves that are trying to send via email
+        email_moves = moves.filtered(lambda m: 'email' in moves_data[m]['sending_methods'])
+        if email_moves:
+            # Identify partners without email depending on batch/single send
+            if is_batch := len(moves) > 1:
+                # Batch sending
+                partners_without_mail = email_moves.filtered(lambda m: not m.partner_id.email).mapped('partner_id')
+            else:
+                # Single sending
+                partners_without_mail = moves_data[email_moves]['mail_partner_ids'].filtered(lambda p: not p.email)
+
+            # If there are partners without email, add an alert
+            if partners_without_mail:
+                alerts['account_missing_email'] = {
+                    'level': 'warning' if is_batch else 'danger',
+                    'message': _("Partner(s) should have an email address."),
+                    'action_text': _("View Partner(s)") if is_batch else False,
+                    'action': (
+                        partners_without_mail._get_records_action(name=_("Check Partner(s) Email(s)"))
+                        if is_batch else False
+                    ),
+                }
+
         return alerts
 
     # -------------------------------------------------------------------------

--- a/addons/account/wizard/account_move_send_wizard.py
+++ b/addons/account/wizard/account_move_send_wizard.py
@@ -98,7 +98,7 @@ class AccountMoveSendWizard(models.TransientModel):
     # COMPUTE METHODS
     # -------------------------------------------------------------------------
 
-    @api.depends('sending_methods', 'extra_edis')
+    @api.depends('sending_methods', 'extra_edis', 'mail_partner_ids')
     def _compute_alerts(self):
         for wizard in self:
             move_data = {
@@ -106,6 +106,7 @@ class AccountMoveSendWizard(models.TransientModel):
                     'sending_methods': wizard.sending_methods or {},
                     'invoice_edi_format': wizard.invoice_edi_format,
                     'extra_edis': wizard.extra_edis or {},
+                    'mail_partner_ids': wizard.mail_partner_ids
                 }
             }
             wizard.alerts = self._get_alerts(wizard.move_id, move_data)


### PR DESCRIPTION
On send and print, When a partner has no email a popup prompts the user to add one but the `Send` button remains active. As a result, the email is sent to an invalid address, and the invoice is incorrectly marked as sent.

We should block sending invoices by email if the partner has no email (same behavior as on Sales Orders).

Task [link](https://www.odoo.com/odoo/project.task/4882552)
task-4882552