### PR TITLE
[FIX] hr,hr_*: check existence of menu

### DIFF
--- a/addons/hr/models/ir_ui_menu.py
+++ b/addons/hr/models/ir_ui_menu.py
@@ -9,6 +9,7 @@ class IrUiMenu(models.Model):
 
     def _load_menus_blacklist(self):
         res = super()._load_menus_blacklist()
-        if self.env.user.has_group('hr.group_hr_user'):
-            res.append(self.env.ref('hr.menu_hr_employee').id)
+        emp_menu = self.env.ref('hr.menu_hr_employee', raise_if_not_found=False)
+        if emp_menu and self.env.user.has_group('hr.group_hr_user'):
+            res.append(emp_menu.id)
         return res

--- a/addons/hr_attendance/models/ir_ui_menu.py
+++ b/addons/hr_attendance/models/ir_ui_menu.py
@@ -9,6 +9,7 @@ class IrUiMenu(models.Model):
 
     def _load_menus_blacklist(self):
         res = super()._load_menus_blacklist()
-        if self.env.user.has_group('hr_attendance.group_hr_attendance_user'):
-            res.append(self.env.ref('hr_attendance.menu_hr_attendance_attendances_overview').id)
+        att_menu = self.env.ref('hr_attendance.menu_hr_attendance_attendances_overview', raise_if_not_found=False)
+        if att_menu and self.env.user.has_group('hr_attendance.group_hr_attendance_user'):
+            res.append(att_menu.id)
         return res

--- a/addons/hr_recruitment/models/ir_ui_menu.py
+++ b/addons/hr_recruitment/models/ir_ui_menu.py
@@ -9,6 +9,7 @@ class IrUiMenu(models.Model):
 
     def _load_menus_blacklist(self):
         res = super()._load_menus_blacklist()
-        if self.env.user.has_group('hr_recruitment.group_hr_recruitment_interviewer'):
-            res.append(self.env.ref('hr_recruitment.menu_hr_job_position').id)
+        job_menu = self.env.ref('hr_recruitment.menu_hr_job_position', raise_if_not_found=False)
+        if job_menu and self.env.user.has_group('hr_recruitment.group_hr_recruitment_interviewer'):
+            res.append(job_menu.id)
         return res

--- a/addons/hr_timesheet/models/ir_ui_menu.py
+++ b/addons/hr_timesheet/models/ir_ui_menu.py
@@ -9,6 +9,7 @@ class IrUiMenu(models.Model):
 
     def _load_menus_blacklist(self):
         res = super()._load_menus_blacklist()
-        if self.env.user.has_group('hr_timesheet.group_hr_timesheet_approver'):
-            res.append(self.env.ref('hr_timesheet.timesheet_menu_activity_user').id)
+        time_menu = self.env.ref('hr_timesheet.timesheet_menu_activity_user', raise_if_not_found=False)
+        if time_menu and self.env.user.has_group('hr_timesheet.group_hr_timesheet_approver'):
+            res.append(time_menu.id)
         return res

--- a/addons/hr_timesheet_attendance/models/ir_ui_menu.py
+++ b/addons/hr_timesheet_attendance/models/ir_ui_menu.py
@@ -9,6 +9,7 @@ class IrUiMenu(models.Model):
 
     def _load_menus_blacklist(self):
         res = super()._load_menus_blacklist()
-        if not (self.env.user.has_group('hr_attendance.group_hr_attendance_user') and self.env.user.has_group('hr_timesheet.group_hr_timesheet_user')):
-            res.append(self.env.ref('hr_timesheet_attendance.menu_hr_timesheet_attendance_report').id)
+        att_menu = self.env.ref('hr_timesheet_attendance.menu_hr_timesheet_attendance_report', raise_if_not_found=False)
+        if att_menu and not (self.env.user.has_group('hr_attendance.group_hr_attendance_user') and self.env.user.has_group('hr_timesheet.group_hr_timesheet_user')):
+            res.append(att_menu.id)
         return res


### PR DESCRIPTION
To Reproduce:
1) make a database in 16.0 and go to developer mode. 2) Delete the menus
3) I mocked the views with upgrade mockcrawler.

it failed for these xmlids:
```
hr_attendance.menu_hr_attendance_attendances_overview
hr_timesheet.timesheet_menu_activity_use
hr.menu_hr_employee
```
but we should have a check anyways.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
