### PR TITLE
[FIX] point_of_sale: display access denied popup when loading POS sample data

### DIFF
--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -2052,8 +2052,12 @@ export class PosStore extends WithLazyGetterTrap {
         );
     }
     async loadSampleData() {
-        const isPosManager = await user.hasGroup("point_of_sale.group_pos_manager");
-        if (!isPosManager) {
+        const [isPosManager, isAdmin] = await Promise.all([
+            user.hasGroup("point_of_sale.group_pos_manager"),
+            user.hasGroup("base.group_system"),
+        ]);
+
+        if (!(isPosManager && isAdmin)) {
             this.dialog.add(AlertDialog, {
                 title: _t("Access Denied"),
                 body: _t("It seems like you don't have enough rights to load data."),

--- a/addons/point_of_sale/static/src/backend/pos_kanban_view/pos_kanban_view.js
+++ b/addons/point_of_sale/static/src/backend/pos_kanban_view/pos_kanban_view.js
@@ -80,8 +80,12 @@ export class PosKanbanRenderer extends KanbanRenderer {
 
     async callWithViewUpdate(func) {
         try {
-            const isPosManager = await user.hasGroup("point_of_sale.group_pos_manager");
-            if (!isPosManager) {
+            const [isPosManager, isAdmin] = await Promise.all([
+                user.hasGroup("point_of_sale.group_pos_manager"),
+                user.hasGroup("base.group_system"),
+            ]);
+
+            if (!(isPosManager && isAdmin)) {
                 this.dialog.add(AlertDialog, {
                     title: _t("Access Denied"),
                     body: _t(

--- a/addons/point_of_sale/static/tests/pos/tours/product_screen_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/product_screen_tour.js
@@ -929,6 +929,21 @@ registry.category("web_tour.tours").add("test_load_pos_demo_data_by_pos_user", {
         ].flat(),
 });
 
+registry.category("web_tour.tours").add("test_load_pos_demo_data_with_member_role", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            clickLoadSampleButton(),
+            {
+                trigger:
+                    '.modal-content:has(.modal-title:contains("Access Denied")) .modal-footer .btn.btn-primary:contains("Ok")',
+                content: "Click Ok on the Access Denied dialog box",
+                run: "click",
+            },
+            Chrome.endTour(),
+        ].flat(),
+});
+
 registry.category("web_tour.tours").add("test_only_existing_lots", {
     steps: () =>
         [

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -2631,6 +2631,20 @@ class TestUi(TestPointOfSaleHttpCommon):
         products = self.env['product.template'].search_count([('available_in_pos', '=', True)])
         self.assertFalse(products, 'Demo data should not be loaded by user.')
 
+        # Member role with POS Administrator access
+        self.pos_user.write({'group_ids': [
+            Command.set(
+                [
+                    self.env.ref('base.group_user').id,
+                    self.env.ref('point_of_sale.group_pos_manager').id,
+                    self.env.ref('account.group_account_manager').id,
+                ]
+            )
+        ]})
+        self.start_pos_tour('test_load_pos_demo_data_with_member_role', login='pos_user')
+        products = self.env['product.template'].search_count([('available_in_pos', '=', True)])
+        self.assertFalse(products, 'Demo data should not be loaded by user with member role.')
+
     def test_combo_variant_mix(self):
         color_attribute = self.env['product.attribute'].create({
             'name': 'Color',


### PR DESCRIPTION
Currently, an error occurs when a new user with the Member role and Administrator rights for the Point of Sale app attempts to open POS Category.

Steps to reproduce:
---
- Install the `point_of_sale` module (without demo data).
- Create a new User and give Administrator rights for POS & Accounting
- Now log in with a new user in a different browser
- Open the pos session(Clothes or bar)

Traceback:
---
```py
AccessError: You are not allowed to modify 'Product Category' (product.category) records.

This operation is allowed for the following groups:
	- Products/Admin en Products / Create

Contact your administrator to request access if necessary.

ParseError:while parsing /home/odoo/src/odoo/saas-18.3/addons/point_of_sale/data/scenarios/clothes_category_data.xml:5, somewhere inside <record id="product_category_clothes" model="product.category">
            <field name="name">Clothes</field>
        </record>
```

This commit prevents the error by displaying an "Access Denied" pop-up when a user with the "Member" role and Administrator rights attempts to open the POS Category.

sentry-6683335275, 6679363278, 6823710988

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
