### PR TITLE
[FIX] website_event: give access to event.question.answer to base.group_user

### DIFF
--- a/addons/test_event_full/tests/test_wevent_register.py
+++ b/addons/test_event_full/tests/test_wevent_register.py
@@ -4,6 +4,7 @@
 from freezegun import freeze_time
 
 from odoo import tests
+from odoo.addons.mail.tests.common import mail_new_test_user
 from odoo.addons.test_event_full.tests.common import TestWEventCommon
 
 
@@ -38,3 +39,14 @@ class TestWEventRegister(TestWEventCommon):
         self.assertEqual(visitor.partner_id, self.env['res.partner'])
         self.assertEqual(visitor.mobile, "0456112233")
         self.assertEqual(visitor.email, "raoulette@example.com")
+
+    def test_internal_user_register(self):
+        mail_new_test_user(
+            self.env,
+            name='User Internal Event',
+            login='user_internal_event',
+            email='user_internal_event@example.com',
+            groups='base.group_user',
+        )
+        with freeze_time(self.reference_now, tick=True):
+            self.start_tour('/event', 'wevent_register', login='user_internal_event')

--- a/addons/website_event/security/ir.model.access.csv
+++ b/addons/website_event/security/ir.model.access.csv
@@ -22,3 +22,4 @@ access_event_question_portal,event.question,event.model_event_question,base.grou
 access_event_question_user,event.question,event.model_event_question,base.group_user,1,0,0,0
 access_event_question_answer_public,event.question.answer,event.model_event_question_answer,base.group_public,1,0,0,0
 access_event_question_answer_portal,event.question.answer,event.model_event_question_answer,base.group_portal,1,0,0,0
+access_event_question_answer_user,event.question.answer,event.model_event_question_answer,base.group_user,1,0,0,0


### PR DESCRIPTION
A global rule for base.group_user is missing for the event.answer.model. This commit adds it.

A test has been added to check that internal users have all the permissions required to register for events.

Reproduce:
The administrator must create a new user and let empty the permissions for sales and for events. When trying to register for an event that has questions with options, this new user will trigger a 500 error.

task-