### PR TITLE
[FIX] hr: fix sms wizard

### DIFF
--- a/addons/sms/models/models.py
+++ b/addons/sms/models/models.py
@@ -53,6 +53,8 @@ class BaseModel(models.AbstractModel):
                     'number': record[fname],
                     'partner_store': False,
                     'field_store': fname,
+                    'force_field':force_field,
+                    'tocheck_fields':tocheck_fields,
                 }
             elif all_partners and partner_fallback:
                 partner = self.env['res.partner']
@@ -71,6 +73,9 @@ class BaseModel(models.AbstractModel):
                     'number': partner[fname],
                     'partner_store': True,
                     'field_store': fname,
+                    'force_field':force_field,
+                    'tocheck_fields':tocheck_fields,
+
                 }
             else:
                 # did not find any sanitized number -> take first set value as fallback;
@@ -84,6 +89,8 @@ class BaseModel(models.AbstractModel):
                     'sanitized': False,
                     'number': value,
                     'partner_store': False,
-                    'field_store': fname
+                    'field_store': fname,
+                    'force_field':force_field,
+                    'tocheck_fields':tocheck_fields,
                 }
         return result

--- a/addons/sms/wizard/sms_composer.py
+++ b/addons/sms/wizard/sms_composer.py
@@ -29,6 +29,8 @@ class SmsComposer(models.TransientModel):
         return result
 
     # documents
+    recipient_info_string = fields.Char(string="Computed String", compute='_compute_recipient_single_stored', compute_sudo=False, store=True)
+
     composition_mode = fields.Selection([
         ('numbers', 'Send to numbers'),
         ('comment', 'Post on a document'),
@@ -125,6 +127,9 @@ class SmsComposer(models.TransientModel):
                 composer.recipient_single_number_itf = res[records.id]['sanitized'] or res[records.id]['number'] or ''
             if not composer.number_field_name:
                 composer.number_field_name = res[records.id]['field_store']
+            recipient_dict = res.get(records.id, {})
+            string_repr = ", ".join(f"{k}: {v}" for k, v in recipient_dict.items())
+            composer.recipient_info_string = string_repr
 
     @api.depends('res_model', 'number_field_name')
     def _compute_recipient_single_non_stored(self):

--- a/addons/sms/wizard/sms_composer_views.xml
+++ b/addons/sms/wizard/sms_composer_views.xml
@@ -43,6 +43,7 @@
                             class="fw-bold"
                             invisible="not comment_single_recipient"/>
                         <div invisible="not comment_single_recipient">
+                            <field name='recipient_info_string'/>
                             <field name="recipient_single_description" class="oe_inline" invisible="not recipient_single_description"/>
                             <field name="recipient_single_number_itf" class="oe_inline" nolabel="1" onchange_on_keydown="True" placeholder="e.g. +1 415 555 0100"/>
                         </div>


### PR DESCRIPTION
When clicking the 'SMS' button beside the employee's work phone, the sms wizard opens pre-filled with the mobile phone number instead. 
The issue has been solved
