### PR TITLE
[FIX] html_builder: fix crash with mouse move on overlay

### DIFF
--- a/addons/html_builder/static/src/core/builder_overlay/builder_overlay_plugin.js
+++ b/addons/html_builder/static/src/core/builder_overlay/builder_overlay_plugin.js
@@ -48,16 +48,16 @@ export class BuilderOverlayPlugin extends Plugin {
 
         // On keydown, hide the overlay and then show it again when the mouse
         // moves.
-        const onMouseMoveOrDown = throttleForAnimation((ev) => {
+        const onMouseMoveOrDown = throttleForAnimation(() => {
             this.toggleOverlaysVisibility(true);
             this.refreshPositions();
-            ev.currentTarget.removeEventListener("mousemove", onMouseMoveOrDown);
-            ev.currentTarget.removeEventListener("mousedown", onMouseMoveOrDown);
+            this.editable.removeEventListener("mousemove", onMouseMoveOrDown);
+            this.editable.removeEventListener("mousedown", onMouseMoveOrDown);
         });
-        this.addDomListener(this.editable, "keydown", (ev) => {
+        this.addDomListener(this.editable, "keydown", () => {
             this.toggleOverlaysVisibility(false);
-            ev.currentTarget.addEventListener("mousemove", onMouseMoveOrDown);
-            ev.currentTarget.addEventListener("mousedown", onMouseMoveOrDown);
+            this.editable.addEventListener("mousemove", onMouseMoveOrDown);
+            this.editable.addEventListener("mousedown", onMouseMoveOrDown);
         });
 
         // Hide the overlay when scrolling. Show it again when the scroll is

--- a/addons/html_builder/static/src/core/overlay_buttons/overlay_buttons_plugin.js
+++ b/addons/html_builder/static/src/core/overlay_buttons/overlay_buttons_plugin.js
@@ -60,15 +60,15 @@ export class OverlayButtonsPlugin extends Plugin {
 
         // On keydown, hide the buttons and then show them again when the mouse
         // moves.
-        const onMouseMoveOrDown = throttleForAnimation((ev) => {
+        const onMouseMoveOrDown = throttleForAnimation(() => {
             this.showOverlayButtons();
-            ev.currentTarget.removeEventListener("mousemove", onMouseMoveOrDown);
-            ev.currentTarget.removeEventListener("mousedown", onMouseMoveOrDown);
+            this.editable.removeEventListener("mousemove", onMouseMoveOrDown);
+            this.editable.removeEventListener("mousedown", onMouseMoveOrDown);
         });
-        this.addDomListener(this.editable, "keydown", (ev) => {
+        this.addDomListener(this.editable, "keydown", () => {
             this.hideOverlayButtons();
-            ev.currentTarget.addEventListener("mousemove", onMouseMoveOrDown);
-            ev.currentTarget.addEventListener("mousedown", onMouseMoveOrDown);
+            this.editable.addEventListener("mousemove", onMouseMoveOrDown);
+            this.editable.addEventListener("mousedown", onMouseMoveOrDown);
         });
 
         // Hide the buttons when scrolling. Show them again when the scroll is

--- a/addons/website/static/tests/builder/builder_overlay.test.js
+++ b/addons/website/static/tests/builder/builder_overlay.test.js
@@ -167,3 +167,36 @@ test("Resize in grid mode (sizingGrid)", async () => {
     expect(":iframe .row").toHaveAttribute("data-row-count", "6");
     expect(".oe_overlay.oe_active").toHaveRect(":iframe .o_grid_item");
 });
+
+test("Mouse move on throttleForAnimation", async () => {
+    await setupWebsiteBuilder(`
+        <section>
+            <div class="container">
+                <div class="row">
+                    <div class="col-lg-3">
+                        <p>TEST</p>
+                    </div>
+                </div>
+            </div>
+        </section>
+    `);
+
+    await contains(":iframe .col-lg-3").click();
+    expect(".oe_overlay.oe_active").toHaveCount(1);
+
+    const keyDownEvent = new KeyboardEvent('keydown', { bubbles: true });
+    const mouseMoveEvent = new KeyboardEvent('mousemove', { bubbles: true });
+    const p = queryOne(":iframe p");
+
+    p.dispatchEvent(keyDownEvent);
+    expect(".oe_overlay.oe_active.o_overlay_hidden").toHaveCount(1);
+    p.dispatchEvent(mouseMoveEvent);
+    expect(".oe_overlay.oe_active:not(.o_overlay_hidden)").toHaveCount(1);
+    p.dispatchEvent(keyDownEvent);
+    expect(".oe_overlay.oe_active.o_overlay_hidden").toHaveCount(1);
+    p.dispatchEvent(mouseMoveEvent);
+    // Due to throttleForAnimation, the second mousemove event listener call 
+    // will be throttled at animationFrame time
+    await animationFrame();
+    expect(".oe_overlay.oe_active:not(.o_overlay_hidden)").toHaveCount(1);
+});


### PR DESCRIPTION
__Current behavior before commit:__
The `onMouseMoveOrDown` event listener is inside `throttleForAnimation` therefore it might be called asynchronously.

In this case `ev.currentTarget` is `null` and the following traceback appears when we move the mouse while pressing a key in the html builder:
```
TypeError: Cannot read properties of null (reading 'removeEventListener')
```

__Description of the fix:__
Replace `ev.currentTarget` by `this.editable` since the `onMouseMoveOrDown` event listener is always added on the latter.
