### PR TITLE
[FIX] web: fixed traceback on clicking view button in x2many records

### DIFF
--- a/addons/web/static/src/views/fields/x2many/x2many_field.js
+++ b/addons/web/static/src/views/fields/x2many/x2many_field.js
@@ -118,6 +118,7 @@ export class X2ManyField extends Component {
             return selectCreate(p);
         };
         this.action = useService("action");
+        this.notificationService = useService("notification");
     }
 
     get activeField() {


### PR DESCRIPTION
Steps to reproduce:

- Open Project go to a task.
- Go to Sub-Tasks sub setting page.
- Don't fill anything click on view.

Issue:

- A trace-back instead of a sticky notification.

Reason:

- Missing notification service initialization.

Fix:

- Add the notification service initialization.

Issue from PR: https://github.com/odoo/odoo/pull/197629

task-4891134
