### PR TITLE
[FIX] web: make the opacity slider's not transparent at the top

### DIFF
--- a/addons/web/static/src/core/color_picker/custom_color_picker/custom_color_picker.js
+++ b/addons/web/static/src/core/color_picker/custom_color_picker/custom_color_picker.js
@@ -159,7 +159,8 @@ export class CustomColorPicker extends Component {
             this.opacitySliderPointerRef.el.style.top = `${Math.round(z - 2)}px`;
 
             // Add gradient color on opacity slider
-            opacitySlider.style.background = `linear-gradient(${this.colorComponents.hex} 0%, transparent 100%)`;
+            const sliderColor = this.colorComponents.hex.slice(0, 7);
+            opacitySlider.style.background = `linear-gradient(${sliderColor} 0%, transparent 100%)`;
         }
     }
     /**


### PR DESCRIPTION
Before this commit the opacity slider in the custom color picker (
introduced in this [commit]) in the custom tab would change its
opacity at the top based on the opacity of the color you selected,
which isn't expected behaviour. To see the issue:
- go to any apps where you can edit text (for example, Knowledge)
- select any text and expand the toolbar to see the colors options
- click on "Apply font color" and navigate to the Custom tab
- slide the opacity slider down

=> slider's opacity changes, this happens because its style's linear
gradient goes from our colors opacity value to 0 instead of 100 to 0.

[commit]: https://github.com/odoo/odoo/commit/7bbe05b34541d641dd431662e835d2a26e1adfab