### PR TITLE
[FIX] l10n_latam_check: fix currency when paying with existing check

### DIFF
--- a/addons/l10n_latam_check/i18n/es_419.po
+++ b/addons/l10n_latam_check/i18n/es_419.po
@@ -770,6 +770,16 @@ msgstr ""
 "%s"
 
 #. module: l10n_latam_check
+#. odoo-python
+#: code:addons/l10n_latam_check/wizards/account_payment_register.py:0
+msgid ""
+"You can't mix checks of different currencies in one payment, and you can't change the payment's currency if checks are already created in that currency.\n"
+"Please create separate payments for each currency."
+msgstr ""
+"No se pueden mezclar cheques de distintas monedas en un mismo pago, y no se puede cambiar la moneda del pago si los cheques seleccionados están creados en esa moneda.\n"
+"Por favor, crea pagos separados para cada moneda."
+
+#. module: l10n_latam_check
 #: model_terms:ir.ui.view,arch_db:l10n_latam_check.view_account_payment_register_form
 msgid ""
 "You can't use checks when paying invoices of different partners or same "

--- a/addons/l10n_latam_check/i18n/l10n_latam_check.pot
+++ b/addons/l10n_latam_check/i18n/l10n_latam_check.pot
@@ -737,6 +737,14 @@ msgid ""
 msgstr ""
 
 #. module: l10n_latam_check
+#. odoo-python
+#: code:addons/l10n_latam_check/wizards/account_payment_register.py:0
+msgid ""
+"You can't mix checks of different currencies in one payment, and you can't change the payment's currency if checks are already created in that currency.\n"
+"Please create separate payments for each currency."
+msgstr ""
+
+#. module: l10n_latam_check
 #: model_terms:ir.ui.view,arch_db:l10n_latam_check.view_account_payment_register_form
 msgid ""
 "You can't use checks when paying invoices of different partners or same "


### PR DESCRIPTION
**Steps to reproduce:**
- Install accountant, l10n_ar and l10n_latam_check
- Switch to an Argentinian company (e.g. (AR) Responsable Inscripto)

- Make sure that USD currency has a rate different than 1

- Create a journal:
  * Journal Name: Checks journal
  * Type: Cash
- Save the journal
=> a Cash Account should be automatically created
- In "Incoming Payments" tab of the journal, set:
  * "New Third Party Checks" with the Cash Account
  * "Existing Third Party Checks" with the Cash Account
- In "Outgoing Payments" tab of the journal, set:
  * "Existing Third Party Checks" with the Cash Account

- Create an invoice:
  * Customer: [an Argentinian customer] (e.g. ADHOC SA)
  * Currency: ARS
  * Invoice Lines:
    - Quantity: 1
    - Price: 150000.00
    - Taxes: VAT 21%
- Confirm the invoice
- Pay the invoice:
  * Journal: [the created Checks journal]
  * Currency: ARS
  * Checks: [add a line with the amount of the invoice]

- Create a bill:
  * Vendor: [an Argentinian customer] (e.g. ADHOC SA)
  * Currency: USD
  * Invoice Lines:
    - Quantity: 1
    - Price: 500.00
    - Taxes: VAT 21%
- Pay the bill:
  * Journal: [the created Checks journal]
  * Payment Method: Existing Third Party Checks
  * Checks: [add a line and select the check used to pay the invoice]

**Issue:**
When the check (from the invoice) is selected to pay the bill, the original amount (in ARS) is used but the currency stays in USD, which is not correct.
If the currency is changed to ARS, the currency rate is applied on the amount that is already the amount in ARS, which generates a higher incorrect amount.

**Solution:**
Use the currency set on the existing check by default.
Also prevent adding several checks with different currencies. 

opw-4741607




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
