### PR TITLE
[REF] iot_drivers: move supported logic to printer interface

### DIFF
--- a/addons/iot_drivers/iot_handlers/drivers/printer_driver_W.py
+++ b/addons/iot_drivers/iot_handlers/drivers/printer_driver_W.py
@@ -52,8 +52,7 @@ class PrinterDriver(PrinterDriverBase):
 
     @classmethod
     def supported(cls, device):
-        # discard virtual printers (like "Microsoft Print to PDF") as they will trigger dialog boxes prompt
-        return device['port'] != 'PORTPROMPT:'
+        return True
 
     @staticmethod
     def _compute_device_connection(device):

--- a/addons/iot_drivers/iot_handlers/interfaces/printer_interface_W.py
+++ b/addons/iot_drivers/iot_handlers/interfaces/printer_interface_W.py
@@ -34,6 +34,10 @@ class PrinterInterface(Interface):
                     _logger.warning('Printer "%s" has no port name. Used dummy port', identifier)
                     printer_port = 'IOT_DUMMY_PORT'
 
+                if printer_port == "PORTPROMPT:":
+                    # discard virtual printers (like "Microsoft Print to PDF") as they will trigger dialog boxes prompt
+                    continue
+
                 printer_devices[identifier] = {
                     'identifier': identifier,
                     'printer_handle': handle_printer,


### PR DESCRIPTION
Interfaces are used to detect connected devices. We used a `supported` method on drivers to filter detected devices and instantiate only supported ones.

This made it hard to read and understand as we were filtering some criteria from the interface, and others from the driver.

This commit moves the supported logic from the driver to the interface, regarding printers only.

Task: 4866280
