### PR TITLE
[FIX] point_of_sale: prevent error refunding multiple lines

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -1533,8 +1533,8 @@ class PosOrderLine(models.Model):
             product = line.product_id
             if line._is_product_storable_fifo_avco() and stock_moves:
                 product_cost = product._compute_average_price(0, line.qty, line._get_stock_moves_to_consider(stock_moves, product))
-                if (product.cost_currency_id.is_zero(product_cost) and self.order_id.shipping_date and self.refunded_orderline_id):
-                    product_cost = self.refunded_orderline_id.total_cost / self.refunded_orderline_id.qty
+                if (product.cost_currency_id.is_zero(product_cost) and line.order_id.shipping_date and line.refunded_orderline_id):
+                    product_cost = line.refunded_orderline_id.total_cost / line.refunded_orderline_id.qty
             else:
                 product_cost = product.standard_price
             line.total_cost = line.qty * product.cost_currency_id._convert(


### PR DESCRIPTION
Before this commit, refunding multiple order lines with the Ship Later option enabled would result in an error.

opw-4862064

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
