### PR TITLE
[FIX] im_livechat: improved livechat status feature

### DIFF
--- a/addons/im_livechat/static/src/core/web/chat_bubble_patch.xml
+++ b/addons/im_livechat/static/src/core/web/chat_bubble_patch.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
-    <t t-inherit="mail.ChatWindow.headerContent" t-inherit-mode="extension">
-        <xpath expr="//*[@name='threadAvatar']" position="before">
+    <t t-inherit="mail.ChatBubble" t-inherit-mode="extension">
+        <xpath expr="//*[@t-ref='root']" position="inside">
             <t t-if="props.chatWindow.thread" t-call="im_livechat.LivechatStatusLabelOfThread">
                 <t t-set="livechatThread" t-value="props.chatWindow.thread"/>
             </t>

--- a/addons/im_livechat/static/src/core/web/discuss_sidebar_category_patch.xml
+++ b/addons/im_livechat/static/src/core/web/discuss_sidebar_category_patch.xml
@@ -1,23 +1,84 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-inherit="mail.DiscussSidebarChannel.main" t-inherit-mode="extension">
-        <xpath expr="//t[@t-call='mail.discuss_badge']" position="before">
-            <t t-call="im_livechat.LivechatStatusLabel">
+        <xpath expr="//*[@name='threadAvatar']" position="before">
+            <t t-call="im_livechat.LivechatStatusLabelOfThread">
                 <t t-set="livechatThread" t-value="props.thread"/>
             </t>
         </xpath>
     </t>
 
     <t t-name="im_livechat.LivechatStatusLabel">
-        <span t-if="livechatThread.channel_type === 'livechat' and ['waiting', 'need_help'].includes(livechatThread.livechat_status)" t-att-title="livechatThread.livechatStatusLabel" t-att-class="{
-            'me-2': env.inDiscussApp,
-            'me-1': env.inChatWindow,
+        <t t-set="btn" t-value="templateParams.btn"/>
+        <t t-set="inThreadActions" t-value="templateParams.inThreadActions"/>
+        <span class="o-livechat-LivechatStatusLabel fa fa-stack" t-att-title="btn.label" t-att-class="{
+            'ms-n1': inThreadActions,
+            'o-warning': btn.status === 'waiting',
+            'o-info': btn.status === 'need_help',
         }">
-            <i class="fa fa-circle" t-att-class="{
+            <i class="fa fa-circle o-livechat-LivechatStatusLabel-bubble fa-stack-1x" t-att-class="{
+                'o-warning': btn.status === 'waiting',
+                'o-info': btn.status === 'need_help',
+                'o-text-white o-white': !btn.icon or btn.status === 'in_progress',
+            }"/>
+            <i t-if="btn.icon" class="fa-stack-1x o-livechat-LivechatStatusLabel-icon" t-attf-class="{{ btn.icon }}" t-att-class="{
+                'o-warning': btn.status === 'waiting',
+                'o-info': btn.status === 'need_help',
+                'o-white': !btn.icon or btn.status === 'in_progress',
+            }"/>
+        </span>
+    </t>
+
+    <t t-name="im_livechat.LivechatStatusLabelOfThread">
+        <span t-if="livechatThread.channel_type === 'livechat' and ['waiting', 'need_help'].includes(livechatThread.livechat_status)" class="o-livechat-LivechatStatusLabel fa fa-stack" t-att-title="livechatThread.livechatStatusLabel" t-att-class="{
+            'position-absolute top-0 start-0 z-1': env.inDiscussSidebar or env.inChatBubble,
+            'm-n1': env.inDiscussSidebar,
+            'm-n2': env.inChatBubble,
+            'o-warning': livechatThread.livechat_status === 'waiting',
+            'o-info': livechatThread.livechat_status === 'need_help',
+        }">
+            <i class="fa fa-circle o-livechat-LivechatStatusLabel-bubble fa-stack-1x" t-att-class="{
                 'o-warning': livechatThread.livechat_status === 'waiting',
                 'o-info': livechatThread.livechat_status === 'need_help',
             }"/>
+            <i class="fa-stack-1x o-livechat-LivechatStatusLabel-icon" t-attf-class="{{ store.livechatStatusButtons.find(btn => btn.status === livechatThread.livechat_status)?.icon }}" t-att-class="{
+                'o-warning': livechatThread.livechat_status === 'waiting',
+                'o-info': livechatThread.livechat_status === 'need_help',
+                'o-white': livechatThread.livechat_status === 'in_progress',
+            }"/>
         </span>
+    </t>
+
+    <t t-name="im_livechat.LivechatStatusSelection">
+        <div class="o-livechat-LivechatStatusSelection btn-group d-flex flex-column o-rounded-bubble o-outline-secondary shadow-sm" t-ref="livechat-status-selection">
+            <t t-foreach="store.livechatStatusButtons" t-as="btn" t-key="btn.status">
+                <button
+                    class="flex btn btn-sm btn-group-item px-2 btn-secondary d-flex align-items-center text-start m-0"
+                    t-att-class="{
+                        'o-inProgress': btn.status === 'in_progress',
+                        'active': livechatThread.livechat_status === btn.status,
+                        'fw-normal': livechatThread.livechat_status !== btn.status,
+                        'btn-warning': livechatThread.livechat_status === btn.status and btn.status === 'waiting',
+                        'btn-info': livechatThread.livechat_status === btn.status and btn.status === 'need_help',
+                        'rounded-0': !btn_first and !btn_last,
+                        'o-rounded-top-bubble rounded-bottom-0': btn_first,
+                        'o-rounded-bottom-bubble rounded-top-0': btn_last,
+                    }"
+                    t-on-click="() => livechatThread.updateLivechatStatus(btn.status)"
+                >
+                    <t t-call="im_livechat.LivechatStatusLabel">
+                        <t t-set="templateParams" t-value="{ btn }"/>
+                    </t>
+                    <span class="ms-2 text-truncate" t-esc="btn.label"/>
+                </button>
+            </t>
+        </div>
+    </t>
+
+    <t t-name="im_livechat.LivechatStatusAction">
+        <t t-call="im_livechat.LivechatStatusSelection">
+            <t t-set="livechatThread" t-value="thread"/>
+        </t>
     </t>
 
 </templates>

--- a/addons/im_livechat/static/src/core/web/livechat_channel_info_list.js
+++ b/addons/im_livechat/static/src/core/web/livechat_channel_info_list.js
@@ -2,52 +2,23 @@ import { ActionPanel } from "@mail/discuss/core/common/action_panel";
 import { prettifyMessageContent } from "@mail/utils/common/format";
 
 import { Component } from "@odoo/owl";
-import { _t } from "@web/core/l10n/translation";
 
 import { rpc } from "@web/core/network/rpc";
+import { useService } from "@web/core/utils/hooks";
 
 export class LivechatChannelInfoList extends Component {
     static components = { ActionPanel };
-    static template = "im_livechat.channelInfoList";
+    static template = "im_livechat.LivechatChannelInfoList";
     static props = ["thread"];
 
     setup() {
         super.setup();
-    }
-
-    get statusButtons() {
-        return [
-            {
-                label: _t("In progress"),
-                status: "in_progress",
-                icon: "fa fa-circle-o",
-            },
-            {
-                label: _t("Waiting for customer"),
-                status: "waiting",
-                icon: "fa fa-check",
-            },
-            {
-                label: _t("Looking for help"),
-                status: "need_help",
-                icon: "fa fa-times",
-            },
-        ];
+        this.store = useService("mail.store");
     }
 
     onBlurNote() {
         prettifyMessageContent(this.props.thread.livechatNoteText).then((note) => {
             rpc("/im_livechat/session/update_note", { channel_id: this.props.thread.id, note });
-        });
-    }
-
-    updateLivechatStatus(livechat_status) {
-        if (this.props.thread.livechat_status === livechat_status) {
-            return;
-        }
-        rpc("/im_livechat/session/update_status", {
-            channel_id: this.props.thread.id,
-            livechat_status,
         });
     }
 }

--- a/addons/im_livechat/static/src/core/web/livechat_channel_info_list.scss
+++ b/addons/im_livechat/static/src/core/web/livechat_channel_info_list.scss
@@ -1,0 +1,37 @@
+.o-livechat-LivechatStatusSelection {
+    button {
+        border-color: transparent !important;
+        &:not(.active):not(:hover) {
+            span, i {
+                opacity: 65%;
+            }
+        }
+        &.o-inProgress {
+            --btn-active-border-color: #{rgba($o-action, .5)};
+            --btn-active-bg: #{$o-view-background-color};
+        }
+    }
+}
+
+.o-livechat-LivechatStatusLabel-bubble {
+    --oi-font-size: 1.75em;
+    &.o-info {
+        text-shadow: 1px 1px 3px rgba(0, 0, 0, .75), 0px 0px 1px $o-info;
+    }
+    &.o-warning {
+        text-shadow: 1px 1px 3px rgba(0, 0, 0, .75), 0px 0px 1px $o-warning;
+    }
+    &.o-white {
+        text-shadow: 1px 1px 3px rgba(0, 0, 0, .75), 0px 0px 1px $o-view-background-color;
+    }
+}
+
+.o-livechat-LivechatStatusLabel-icon {
+    &.o-info {
+        color: white !important;
+        text-shadow: 0px 0px 3px rgba(0, 0, 0, .5) !important;
+    }
+    &.o-warning, &.o-white {
+        color: rgba(0, 0, 0, .75) !important;
+    }
+}

--- a/addons/im_livechat/static/src/core/web/livechat_channel_info_list.xml
+++ b/addons/im_livechat/static/src/core/web/livechat_channel_info_list.xml
@@ -1,22 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
-    <t t-name="im_livechat.channelInfoList">
+    <t t-name="im_livechat.LivechatChannelInfoList">
         <ActionPanel title.translate="Information" minWidth="200" initialWidth="250" icon="'fa fa-info'">
-            <div t-if="!props.thread.livechat_end_dt or props.thread.livechat_status" class="d-flex flex-column bg-inherit gap-1">
+            <div t-if="!props.thread.livechat_end_dt" class="o-livechat-LivechatChannelInfoList d-flex flex-column bg-inherit gap-1">
                 <h3 class="pt-3">Status</h3>
-                <t t-foreach="statusButtons" t-as="btn" t-key="btn.status">
-                    <button
-                        class="flex btn btn-sm px-1 btn-secondary rounded-3 gap-1"
-                        t-att-class="{
-                            'active': props.thread.livechat_status === btn.status,
-                            'btn-warning': props.thread.livechat_status === btn.status and btn.status === 'waiting',
-                            'btn-info': props.thread.livechat_status === btn.status and btn.status === 'need_help',
-                        }"
-                        t-on-click="() => this.updateLivechatStatus(btn.status)"
-                    >
-                        <i t-att-class="btn.icon"/>
-                        <span class="ms-2 text-truncate" t-esc="btn.label"/>
-                    </button>
+                <t t-call="im_livechat.LivechatStatusSelection">
+                    <t t-set="livechatThread" t-value="props.thread"/>
                 </t>
             </div>
             <div class="d-flex flex-column bg-inherit gap-1">

--- a/addons/im_livechat/static/src/core/web/store_service_patch.js
+++ b/addons/im_livechat/static/src/core/web/store_service_patch.js
@@ -1,5 +1,6 @@
 import { Store } from "@mail/core/common/store_service";
 import { compareDatetime } from "@mail/utils/common/misc";
+import { _t } from "@web/core/l10n/translation";
 
 import { patch } from "@web/core/utils/patch";
 
@@ -41,6 +42,25 @@ const storePatch = {
             chatWindow.open({ focus: true, jumpToNewMessage: true });
         });
         return true;
+    },
+    get livechatStatusButtons() {
+        return [
+            {
+                label: _t("In progress"),
+                status: "in_progress",
+                icon: "fa fa-commenting-o",
+            },
+            {
+                label: _t("Waiting for customer"),
+                status: "waiting",
+                icon: "fa fa-hourglass-o",
+            },
+            {
+                label: _t("Looking for help"),
+                status: "need_help",
+                icon: "fa fa-exclamation",
+            },
+        ];
     },
     /**
      * @override

--- a/addons/im_livechat/static/src/core/web/thread_actions.js
+++ b/addons/im_livechat/static/src/core/web/thread_actions.js
@@ -3,17 +3,64 @@ import { threadActionsRegistry } from "@mail/core/common/thread_actions";
 import { _t } from "@web/core/l10n/translation";
 import { LivechatChannelInfoList } from "@im_livechat/core/web/livechat_channel_info_list";
 
-threadActionsRegistry.add("livechat-info", {
-    component: LivechatChannelInfoList,
-    condition(component) {
-        return component.thread?.channel_type === "livechat";
-    },
-    panelOuterClass: "o-livechat-ChannelInfoList bg-inherit",
-    icon: "fa fa-fw fa-info",
-    iconLarge: "fa fa-fw fa-lg fa-info",
-    name: _t("Information"),
-    nameActive: _t("Close Information"),
-    sequence: 10,
-    sequenceGroup: 7,
-    toggle: true,
-});
+threadActionsRegistry
+    .add("livechat-info", {
+        component: LivechatChannelInfoList,
+        condition(component) {
+            return component.thread?.channel_type === "livechat";
+        },
+        panelOuterClass: "o-livechat-ChannelInfoList bg-inherit",
+        icon: "fa fa-fw fa-info",
+        iconLarge: "fa fa-fw fa-lg fa-info",
+        name: _t("Information"),
+        nameActive: _t("Close Information"),
+        sequence: 10,
+        sequenceGroup: 7,
+        toggle: true,
+    })
+    .add("livechat-status", {
+        component: LivechatChannelInfoList,
+        condition(component) {
+            return (
+                component.thread?.channel_type === "livechat" && !component.thread.livechat_end_dt
+            );
+        },
+        dropdown: {
+            template: "im_livechat.LivechatStatusAction",
+            menuClass: "p-0 m-0 o-rounded-bubble",
+        },
+        panelOuterClass: "o-livechat-ChannelInfoList bg-inherit",
+        icon: (component) => {
+            const btn = component.store.livechatStatusButtons.find(
+                (btn) => btn.status === component.thread.livechat_status
+            );
+            if (!btn) {
+                return undefined;
+            }
+            return {
+                template: "im_livechat.LivechatStatusLabel",
+                params: { btn, inThreadActions: true },
+            };
+        },
+        iconLarge: (component) => {
+            const btn = component.store.livechatStatusButtons.find(
+                (btn) => btn.status === component.thread.livechat_status
+            );
+            if (!btn) {
+                return undefined;
+            }
+            return {
+                template: "im_livechat.LivechatStatusLabel",
+                params: { btn, inThreadActions: true },
+            };
+        },
+        name: (component) => component.thread.livechatStatusLabel,
+        nameClass: "fst-italic small mx-2",
+        partition: (component) => !component.env.inDiscussApp,
+        sequence: 5,
+        sequenceGroup: 7,
+        sidebar: true,
+        sidebarSequence: 10,
+        sidebarSequenceGroup: 5,
+        toggle: true,
+    });

--- a/addons/im_livechat/static/src/core/web/thread_model_patch.js
+++ b/addons/im_livechat/static/src/core/web/thread_model_patch.js
@@ -2,6 +2,7 @@ import { Thread } from "@mail/core/common/thread_model";
 import { fields } from "@mail/model/misc";
 import { convertBrToLineBreak } from "@mail/utils/common/format";
 import { _t } from "@web/core/l10n/translation";
+import { rpc } from "@web/core/network/rpc";
 
 import { patch } from "@web/core/utils/patch";
 
@@ -26,6 +27,12 @@ patch(Thread.prototype, {
         } else if (status === "need_help") {
             return _t("Looking for help");
         }
-        return "";
+        return _t("In progress");
+    },
+    updateLivechatStatus(status) {
+        if (this.livechat_status === status) {
+            return;
+        }
+        rpc("/im_livechat/session/update_status", { channel_id: this.id, livechat_status: status });
     },
 });

--- a/addons/mail/static/src/core/common/chat_hub.js
+++ b/addons/mail/static/src/core/common/chat_hub.js
@@ -26,7 +26,7 @@ export class ChatHub extends Component {
         this.ui = useService("ui");
         this.busMonitoring = useService("bus.monitoring_service");
         this.bubblesHover = useHover("bubbles");
-        this.moreHover = useHover(["more-button", "more-menu*"], {
+        this.moreHover = useHover(["more-button", "more-menu"], {
             onHover: () => (this.more.isOpen = true),
             onAway: () => (this.more.isOpen = false),
         });

--- a/addons/mail/static/src/core/common/chat_window.xml
+++ b/addons/mail/static/src/core/common/chat_window.xml
@@ -150,9 +150,24 @@
 </t>
 
 <t t-name="mail.ThreadActionsAsDropdownContent.action">
-    <DropdownItem class="'btn d-flex align-items-baseline m-0 ' + (env.inChatWindow ? 'o-mail-ChatWindow-command rounded-0 p-2' : ('rounded-3 px-2 py-1 bg-200 ' + (!action_first ? 'rounded-top-0' : !action_last ? 'rounded-bottom-0' : '')))" onSelected="() => action.onSelect()">
-        <i t-att-class="action.icon"/>
-        <span t-att-class="{ 'mx-2': env.inChatWindow, 'mx-1': !env.inChatWindow }" t-attf-class="{{ action.nameClass }}" t-out="action.name"/>
+    <t t-if="action.dropdown">
+        <Dropdown menuClass="action.dropdown.menuClass">
+            <t t-call="mail.ThreadActionsAsDropdownContent.actionMain"/>
+            <t t-set-slot="content">
+                <t t-call="{{ action.dropdown.template }}"/>
+            </t>
+        </Dropdown>
+    </t>
+    <t t-else="" t-call="mail.ThreadActionsAsDropdownContent.actionMain"/>
+</t>
+
+<t t-name="mail.ThreadActionsAsDropdownContent.actionMain">
+    <DropdownItem class="'btn d-flex align-items-center m-0 gap-0 ' + (env.inChatWindow ? 'o-mail-ChatWindow-command rounded-0 p-2' : ('rounded-3 px-2 py-1 bg-200 ' + (!action_first ? 'rounded-top-0' : !action_last ? 'rounded-bottom-0' : '')))" onSelected="() => action.onSelect()">
+        <t t-if="action.icon?.template" t-call="{{ action.icon.template }}">
+            <t t-set="templateParams" t-value="action.icon.params"/>
+        </t>
+        <i t-else="" class="me-1" t-att-class="action.icon"/>
+        <span t-att-class="{ 'ms-1 me-2': env.inChatWindow, 'mx-1': !env.inChatWindow }" t-attf-class="{{ action.nameClass }}" t-out="action.name"/>
     </DropdownItem>
 </t>
 

--- a/addons/mail/static/src/core/common/core.scss
+++ b/addons/mail/static/src/core/common/core.scss
@@ -73,6 +73,10 @@ $o-discuss-talkingColor: lighten($success, 10%);
     opacity: 35%;
 }
 
+.o-outline-secondary {
+    outline: 1px solid $o-gray-300;
+}
+
 .o-gap-0_5 {
     gap: map-get($spacers, 1) / 2;
 }

--- a/addons/mail/static/src/core/common/message_reaction_list.js
+++ b/addons/mail/static/src/core/common/message_reaction_list.js
@@ -18,7 +18,7 @@ export class MessageReactionList extends Component {
         this.store = useService("mail.store");
         this.ui = useService("ui");
         this.preview = useDropdownState();
-        this.hover = useHover(["reactionButton", "reactionList*"], {
+        this.hover = useHover(["reactionButton", "reactionList"], {
             onHover: () => (this.preview.isOpen = true),
             onAway: () => (this.preview.isOpen = false),
             stateObserver: () => [this.preview?.isOpen],

--- a/addons/mail/static/src/core/common/thread_actions.js
+++ b/addons/mail/static/src/core/common/thread_actions.js
@@ -112,11 +112,23 @@ function transformAction(component, id, action) {
         get disabledCondition() {
             return action.disabledCondition?.(component);
         },
-        /** Icon for the button this action. */
+        /** Determines whether this action opens a dropdown on selection. Value is shaped { template, menuClass } */
+        dropdown: action.dropdown,
+        /**
+         * Icon for the button this action.
+         * - When a string, this is considered an icon as classname (.fa and .oi).
+         * - When an object with property `template`, this is an icon rendered in template.
+         *   Template params are provided in `params` and passed to template as a `t-set="templateParams"`
+         */
         get icon() {
             return typeof action.icon === "function" ? action.icon(component) : action.icon;
         },
-        /** Large icon for the button this action. */
+        /**
+         * Large icon for the button this action.
+         * - When a string, this is considered an icon as classname (.fa and .oi).
+         * - When an object with property `template`, this is an icon rendered in template.
+         *   Template params are provided in `params` and passed to template as a `t-set="templateParams"`
+         */
         get iconLarge() {
             return typeof action.iconLarge === "function"
                 ? action.iconLarge(component)

--- a/addons/mail/static/src/core/public_web/discuss_sidebar.js
+++ b/addons/mail/static/src/core/public_web/discuss_sidebar.js
@@ -1,4 +1,4 @@
-import { Component } from "@odoo/owl";
+import { Component, useSubEnv } from "@odoo/owl";
 import { Dropdown } from "@web/core/dropdown/dropdown";
 import { DropdownItem } from "@web/core/dropdown/dropdown_item";
 
@@ -19,6 +19,7 @@ export class DiscussSidebar extends Component {
     setup() {
         super.setup();
         this.store = useService("mail.store");
+        useSubEnv({ inDiscussSidebar: true });
     }
 
     get discussSidebarItems() {

--- a/addons/mail/static/src/core/web/discuss_sidebar_mailboxes.js
+++ b/addons/mail/static/src/core/web/discuss_sidebar_mailboxes.js
@@ -17,7 +17,7 @@ export class Mailbox extends Component {
     setup() {
         super.setup();
         this.store = useService("mail.store");
-        this.hover = useHover(["root", "floating*"], {
+        this.hover = useHover(["root", "floating"], {
             onHover: () => {
                 if (this.store.discuss.isSidebarCompact) {
                     this.floating.isOpen = true;

--- a/addons/mail/static/src/core/web/discuss_sidebar_patch.js
+++ b/addons/mail/static/src/core/web/discuss_sidebar_patch.js
@@ -9,7 +9,7 @@ patch(DiscussSidebar.prototype, {
     setup() {
         super.setup();
         this.ui = useService("ui");
-        this.meetingHover = useHover(["meeting-btn", "meeting-floating*"], {
+        this.meetingHover = useHover(["meeting-btn", "meeting-floating"], {
             onHover: () => {
                 if (this.store.discuss.isSidebarCompact) {
                     this.meetingFloating.isOpen = true;

--- a/addons/mail/static/src/discuss/call/public_web/discuss_sidebar_call_participants.js
+++ b/addons/mail/static/src/discuss/call/public_web/discuss_sidebar_call_participants.js
@@ -22,7 +22,7 @@ export class DiscussSidebarCallParticipants extends Component {
         super.setup();
         this.store = useService("mail.store");
         this.rtc = useService("discuss.rtc");
-        this.hover = useHover(["root", "floating*"], {
+        this.hover = useHover(["root", "floating"], {
             onHover: () => (this.floating.isOpen = true),
             onAway: () => (this.floating.isOpen = false),
         });

--- a/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.js
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.js
@@ -3,7 +3,7 @@ import { ImStatus } from "@mail/core/common/im_status";
 import { ThreadIcon } from "@mail/core/common/thread_icon";
 import { discussSidebarItemsRegistry } from "@mail/core/public_web/discuss_sidebar";
 import { DiscussSidebarChannelActions } from "@mail/discuss/core/public_web/discuss_sidebar_channel_actions";
-import { useHover } from "@mail/utils/common/hooks";
+import { useHover, UseHoverOverlay } from "@mail/utils/common/hooks";
 
 import { Component, useSubEnv } from "@odoo/owl";
 
@@ -21,12 +21,12 @@ export const discussSidebarChannelIndicatorsRegistry = registry.category(
 export class DiscussSidebarSubchannel extends Component {
     static template = "mail.DiscussSidebarSubchannel";
     static props = ["thread", "isFirst?"];
-    static components = { DiscussSidebarChannelActions, Dropdown };
+    static components = { DiscussSidebarChannelActions, Dropdown, UseHoverOverlay };
 
     setup() {
         super.setup();
         this.store = useService("mail.store");
-        this.hover = useHover(["root", "floating*"], {
+        this.hover = useHover(["root"], {
             onHover: () => {
                 if (this.store.discuss.isSidebarCompact) {
                     this.floating.isOpen = true;
@@ -68,12 +68,13 @@ export class DiscussSidebarChannel extends Component {
         Dropdown,
         ImStatus,
         ThreadIcon,
+        UseHoverOverlay,
     };
 
     setup() {
         super.setup();
         this.store = useService("mail.store");
-        this.hover = useHover(["root", "floating*"], {
+        this.hover = useHover(["root"], {
             onHover: () => {
                 if (this.store.discuss.isSidebarCompact) {
                     this.floating.isOpen = true;
@@ -173,7 +174,7 @@ export class DiscussSidebarCategory extends Component {
         super.setup();
         this.store = useService("mail.store");
         this.discusscorePublicWebService = useService("discuss.core.public.web");
-        this.hover = useHover(["root", "floating*"], {
+        this.hover = useHover(["root", "floating"], {
             onHover: () => {
                 if (this.store.discuss.isSidebarCompact) {
                     this.onHover(true);
@@ -230,7 +231,7 @@ export class DiscussSidebarCategories extends Component {
         this.orm = useService("orm");
         this.ui = useService("ui");
         this.command = useService("command");
-        this.searchHover = useHover(["search-btn", "search-floating*"], {
+        this.searchHover = useHover(["search-btn", "search-floating"], {
             onHover: () => {
                 if (this.store.discuss.isSidebarCompact) {
                     this.searchFloating.isOpen = true;

--- a/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.xml
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.xml
@@ -86,10 +86,12 @@
                 <Dropdown t-if="store.discuss.isSidebarCompact" state="floating" position="'right-start'" menuClass="'o-mail-DiscussSidebar-floatingMenu rounded-3 bg-100 border border-secondary p-0 mx-2 my-0 min-w-0 shadow-sm o-rounded-bubble'" manual="true">
                     <t t-call="mail.DiscussSidebarChannel.main"/>
                     <t t-set-slot="content">
-                        <div class="overflow-hidden d-flex flex-column" t-ref="floating">
-                            <span class="fw-bolder user-select-none text-truncate d-inline-block p-2 pb-0" t-esc="thread.displayName"/>
-                            <DiscussSidebarChannelActions thread="thread"/>
-                        </div>
+                        <UseHoverOverlay hover="hover">
+                            <div class="overflow-hidden d-flex flex-column" t-ref="floating">
+                                <span class="fw-bolder user-select-none text-truncate d-inline-block p-2 pb-0" t-esc="thread.displayName"/>
+                                <DiscussSidebarChannelActions thread="thread"/>
+                            </div>
+                        </UseHoverOverlay>
                     </t>
                 </Dropdown>
                 <t t-else="" t-call="mail.DiscussSidebarChannel.main"/>
@@ -106,10 +108,12 @@
         <Dropdown t-if="store.discuss.isSidebarCompact" state="floating" position="'right-start'" menuClass="'o-mail-DiscussSidebar-floatingMenu rounded-3 bg-100 border border-secondary p-0 mx-2 my-0 min-w-0 shadow-sm o-rounded-bubble'" manual="true">
             <t t-call="mail.DiscussSidebarSubchannel.main"/>
             <t t-set-slot="content">
-                <div class="overflow-hidden d-flex flex-column" t-ref="floating">
-                    <span class="fw-bolder user-select-none text-truncate d-inline-block p-2 pb-0" t-esc="thread.displayName"/>
-                    <DiscussSidebarChannelActions thread="thread"/>
-                </div>
+                <UseHoverOverlay hover="hover">
+                    <div class="overflow-hidden d-flex flex-column" t-ref="floating">
+                        <span class="fw-bolder user-select-none text-truncate d-inline-block p-2 pb-0" t-esc="thread.displayName"/>
+                        <DiscussSidebarChannelActions thread="thread"/>
+                    </div>
+                </UseHoverOverlay>
             </t>
         </Dropdown>
         <t t-else="" t-call="mail.DiscussSidebarSubchannel.main"/>
@@ -157,7 +161,8 @@
             t-ref="root"
         >
             <div class="o-mail-DiscussSidebarChannel-itemMain border-0 rounded-start-2 text-reset d-flex align-items-center p-0" t-att-class="{ 'overflow-hidden': !store.discuss.isSidebarCompact }" t-att-title="store.discuss.isSidebarCompact ? undefined : thread.displayName">
-                <div class="bg-inherit position-relative d-flex flex-shrink-0 o-my-0_5 rounded-3" style="width:32px;height:32px;" t-att-class="{ 'ms-2': !store.discuss.isSidebarCompact }">
+                <span t-if="!store.discuss.isSidebarCompact" class="ms-1"/>
+                <div class="bg-inherit position-relative d-flex flex-shrink-0 ms-1 o-my-0_5 rounded-3" style="width:32px;height:32px;" name="threadAvatar">
                     <img class="w-100 h-100 rounded-3 o_object_fit_cover shadow-sm" t-att-src="thread.avatarUrl" alt="Thread Image"/>
                     <ThreadIcon t-if="thread.channel_type?.includes('chat') or (thread.channel_type === 'channel' and !thread.group_public_id)" thread="thread" size="'small'" className="'o-mail-DiscussSidebarChannel-threadIcon position-absolute top-100 start-100 translate-middle mt-n1 ms-n1 d-flex align-items-center justify-content-center rounded-circle bg-inherit'"/>
                     <CountryFlag t-if="thread.showCorrespondentCountry" country="thread.correspondentCountry" class="'position-absolute o-mail-DiscussSidebarChannel-country border shadow-sm'"/>

--- a/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_channel_actions.js
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_channel_actions.js
@@ -1,6 +1,7 @@
 import { useThreadActions } from "@mail/core/common/thread_actions";
 
 import { Component } from "@odoo/owl";
+import { Dropdown } from "@web/core/dropdown/dropdown";
 import { DropdownItem } from "@web/core/dropdown/dropdown_item";
 import { useService } from "@web/core/utils/hooks";
 /**
@@ -12,7 +13,7 @@ import { useService } from "@web/core/utils/hooks";
 export class DiscussSidebarChannelActions extends Component {
     static template = "mail.DiscussSidebarChannelActions";
     static props = ["thread"];
-    static components = { DropdownItem };
+    static components = { Dropdown, DropdownItem };
 
     setup() {
         this.store = useService("mail.store");


### PR DESCRIPTION
Before this commit, new livechat status feature has some usability issues:

- icons of status were poor: `.fa-circle` is not unique enough and looks like IM status
- icons were inconsistent: info panel uses different icons
- info panel buttons do not look good: text not aligned, border too harsh with strange spacing, etc.
- feature is cumbersome to use: can only be changed in panel, so lots of clicks when not in discuss app and conversation not selected.
- feature was not displayed in some contexts like chat bubbles
- livechat status not easy to see in discuss sidebar when next to unread counter

This commit makes the following improvements to livechat status feature:
- new icons for livechat status
- better button style in panel
- livechat status is visible in all context with proper style
- can quickly change livechat status from thread actions, including discuss sidebar more actions
- livechat icon is floating in top-left of avatar for better visibility of status (exception: chat window is before avatar for space constraints)

Before 
<img width="901" alt="before" src="https://github.com/user-attachments/assets/4b5919c8-32bc-4db6-aa92-82d6b0dcf54f" />

After
<img width="896" alt="Screenshot 2025-06-25 at 16 30 52" src="https://github.com/user-attachments/assets/2bf20825-f3a7-4ea4-a1f8-2e63b882dfde" />
<img width="67" alt="Screenshot 2025-06-24 at 17 45 55" src="https://github.com/user-attachments/assets/0d1fd50f-30d7-4b5a-a473-255bccf1e4c0" />


----

With the addition of quick action to change livechat status, this commit adds these new features:

1. thread action icons can be defined in dedicate templates, for more creativity in making icon than `.fa` and `.oi` classnames.
2. useHover() now works with nested overlay: this works by warping dropdown content in a `<UseHoverOverlay hover="hover">` component.

---

Technical details of useHover nested overlay improvement:
To make it work, the content of 1st dropdown should be wrapped in a `<UseHoverOverlay>` component and provide the `hover` object of `useHover()`. The overlay content is put in slot of this component.

This `<UseHoverOverlay>` component works by helping `hover` object to make use of `contains()` function of overlay, which tells precisely if a target is inside the overlay including nested dropdowns.

Note that sub-dropdowns menu can optionally have `<UseHoverOverlay>`:
- without it, they are persistently displayed until click away or mouseleave from parented dropdown (if has `useHoverOverlay`)
- with it: mouse-leave on it outside of whole overlay closes all the related overlays.

This commit also do some related code-cleaning with useHover:
- "*" suffix syntax is removed. This was used as a way to get the direct parent element of ref. Floating menu were disappearing immediately `onAway`, but there's a global 100ms now so we don't need 2 hover triggers to be exactly next to each other
