### PR TITLE
[FIX] hr_expense: make account admin able to create expense

### DIFF
--- a/addons/hr_expense/models/hr_employee.py
+++ b/addons/hr_expense/models/hr_employee.py
@@ -14,7 +14,7 @@ class HrEmployeeBase(models.AbstractModel):
         res = [('id', '=', 0)]  # Nothing accepted by domain, by default
         user = self.env.user
         employee = user.employee_id
-        if user.has_groups('hr_expense.group_hr_expense_user') or user.has_groups('account.group_account_user'):
+        if user.has_groups('hr_expense.group_hr_expense_user'):
             res = ['|', ('company_id', '=', False), ('company_id', 'child_of', self.env.company.root_id.id)]  # Then, domain accepts everything
         elif user.has_groups('hr_expense.group_hr_expense_team_approver') and user.employee_ids:
             res = [


### PR DESCRIPTION

- Create a user and its related employee without any expense access rights but with  accounting admin rights.
- With that user create a new expense.
- On the employee field select a different employee and save. 
- The following error appears:

Validation Error

The operation cannot be completed: Missing required value for the field 'Description' (name).
Model: 'Expense' (hr.expense)
- create/update: a mandatory field is not set
- delete: another model requires the record being deleted, you can archive it instead

Since b1ac6f52d37cd59fdb973ce87f93d1d0a69dd204, the field employee_id is no longer invisible for users without hr_expense rights. However, in the method _search_filter_for_expense, users without hr_expense rights but with account rights are able to select every employee (commit 87cca4a9ee64c890ccbd24e2d6766f9f8799a0c0).

But in hr_expense, the method _compute_is_editable only considered hr_expense rights, which meant that users trying to create a new expense with only accounting rights would get an error if they were not the approver of the employee they tried to create the expense for.

After this commit: If the user has no hr_expense rights but has account rights, they will only be able to create expenses for themselves. 

opw-4780218


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
