### PR TITLE
[FIX] hr_holidays : Force employee in context as False

### DIFF
--- a/addons/hr_holidays/models/hr_leave_type.py
+++ b/addons/hr_holidays/models/hr_leave_type.py
@@ -629,6 +629,7 @@ class HolidaysType(models.Model):
             ('holiday_status_id', 'in', self.ids),
         ]
         action['context'] = {
+            'employee_id': False,
             'default_holiday_type': 'department',
             'default_holiday_status_id': self.ids[0],
             'search_default_approved_state': 1,


### PR DESCRIPTION
### Steps to reproduce:
	- Create a Time off type
	- Create allocations for some employees with the created type
	- Navigate to an allocation for a specific employee
	- Click on the time off type in the allocation form
	- Click on the smart button 'Allocations'
	- Notice each record showing the same time off type (X remaining out of Y)

### Cause:
This is happening because when going through the allocation of a specific employee we add him in the context 'employee_id' so we compute the display name of the leave type and set it for each record as the same value as we compute leaves depending on the contextual employee.

### Fix:
We are preventing the computation of the display name by forcing the employee_id in the context to force when we are using the smart button for allocations in the time off type form view

opw-4841096