### PR TITLE
[FIX] account: use sudo() to compute journal's display name

### DIFF
--- a/addons/account/models/account_journal.py
+++ b/addons/account/models/account_journal.py
@@ -901,7 +901,7 @@ class AccountJournal(models.Model):
     def _compute_display_name(self):
         for journal in self:
             name = journal.name
-            if journal.currency_id and journal.currency_id != journal.company_id.currency_id:
+            if journal.currency_id and journal.currency_id != journal.company_id.sudo().currency_id:
                 name = f"{name} ({journal.currency_id.name})"
             journal.display_name = name
 


### PR DESCRIPTION
### Steps to reproduce:
- Create a branch to a company
- Create a journal on the parent company with a different currency from the company
- Create a user that can access both the parent company and the branch, but can't change the settings of Odoo
- Log as this user, select only the branch as current company
- Accounting > Reporting > Profit & Loss
- Access Error

### Cause:
`_compute_display_name` on the journal reads `journal.company_id.currency_id` without sudo. The current user cannot read on `company_id` because of the rule `res_company_rule_employee`.

### Solution:
Use `sudo()` to read the currency of the company.

opw-4847500