### PR TITLE
[18.0][FIX] repair: Display lot when removing/recylcing parts

### DIFF
--- a/addons/repair/models/stock_move.py
+++ b/addons/repair/models/stock_move.py
@@ -217,3 +217,12 @@ class StockMove(models.Model):
         if self.repair_line_type == 'recycle':
             action['context'].update({'show_quant': False, 'show_destination_location': True})
         return action
+
+    @api.depends("repair_line_type")
+    def _compute_show_info(self):
+        repair_line_moves = self.filtered(lambda mv: mv.repair_line_type)
+        super(StockMove, self - repair_line_moves)._compute_show_info()
+        for move in repair_line_moves:
+            move.show_quant = move.repair_line_type == "add" and move.product_id.is_storable
+            move.show_lots_text = False
+            move.show_lots_m2o = not move.show_quant and move.has_tracking != 'none'


### PR DESCRIPTION
When removing or recycling parts in a repair order, we are effectively moving parts from the virtual production location to an internal one. In that case, there is no sense to display the quant_id field with the pick_from widget as the production location is virtual.

We should instead allow the user to define the lot he is removing or recycling, as it might not even exist
in the production location if the repaired product was bought and not assembled.

OPW-4892170

Description of the issue/feature this PR addresses:

On a runbot, create a finished product tracked by serial, and a component tracked by serial. Add a unit of finished product in stock (through inventory, purchase, receipt or whatever you prefer).
Create a repair order and add a line to remove or recycle a component. Confirm, start the repair and try to end the repair, you'll get an error message stating you must provide a serial number.
Open the move lines from the component move, you don't have the lot_id or lot_name field, but the quant selector. (what does not make sense as we are moving from the production location, that bypasses reservations, to an internal location. It's actually the same use case than byproducts in the MRP but there we can actually define the lot_id)

Current behavior before PR:

You cannot set on the move lines the lot_id or lot_name of the component you want to remove/recycle.

Desired behavior after PR is merged:

Have the lot_id displayed so that you can set the right lot/serial you want to remove / recycle


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
