### PR TITLE
[IMP] hr_expense: Improvements after removing the expense reports

### DIFF
--- a/addons/hr_expense/i18n/hr_expense.pot
+++ b/addons/hr_expense/i18n/hr_expense.pot
@@ -633,11 +633,6 @@ msgid "Employee"
 msgstr ""
 
 #. module: hr_expense
-#: model:ir.model.fields.selection,name:hr_expense.selection__hr_expense__payment_mode__own_account
-msgid "Employee (to reimburse)"
-msgstr ""
-
-#. module: hr_expense
 #: model_terms:ir.ui.view,arch_db:hr_expense.res_config_settings_view_form
 msgid "Employee Expense Journal"
 msgstr ""

--- a/addons/hr_expense/models/hr_expense.py
+++ b/addons/hr_expense/models/hr_expense.py
@@ -235,7 +235,7 @@ class HrExpense(models.Model):
     )
     payment_mode = fields.Selection(
         selection=[
-            ('own_account', "Employee (to reimburse)"),
+            ('own_account', "Employee"),
             ('company_account', "Company")
         ],
         string="Paid By",

--- a/addons/hr_expense/static/src/components/expense_attachment.js
+++ b/addons/hr_expense/static/src/components/expense_attachment.js
@@ -1,0 +1,18 @@
+import { AttachmentView } from "@mail/core/common/attachment_view";
+import { onMounted } from "@odoo/owl";
+import { useBus } from "@web/core/utils/hooks";
+
+export class ExpenseAttachment extends AttachmentView {
+    static props = [...AttachmentView.props, "openInPopout"];
+    static components = { AttachmentView };
+
+    setup() {
+        super.setup();
+        if (this.props.openInPopout) {
+            onMounted(this.onClickPopout);
+        }
+        // In the mail_popout_service.js the function pollClosedWindow will trigger a resize event on the main window
+        // when the external window is closed. It allows us to know when to hide the preview for small screens.
+        useBus(this.uiService.bus, "resize", () => this.env.setPopout(false));
+    }
+}

--- a/addons/hr_expense/static/src/scss/hr_expense.scss
+++ b/addons/hr_expense/static/src/scss/hr_expense.scss
@@ -1,3 +1,80 @@
+.o_expense_list_view {
+    &.o_view_controller > .o_content {
+        overflow: hidden;
+        display: block;
+
+        .o_attachment_list {
+            @include media-only(screen) {
+                display: flex;
+                overflow: hidden;
+                height: 100%;
+                flex: 1 1 100%;
+            }
+            .o_list_renderer {
+                overflow: scroll;
+                height: 100%;
+                flex: 1 1 100%;
+            }
+        }
+    }
+
+    .o_attachment_preview {
+        height: 100%;
+        width: 30%;
+        border-left: $border-width solid $border-color;
+
+        .o_attachment_control.toggle {
+            margin-top: 10%;
+            border-radius: 0 30px 30px 0;
+            padding: 15px 15px 15px 5px;
+            &::after {
+                color: white;
+                content: '>>';
+            }
+        }
+
+        &.hidden {
+            width: 0;
+            .o_attachment_control.toggle {
+                right: 0;
+                border-radius: 30px 0 0 30px;
+                padding: 15px 0 15px 15px;
+                &::after {
+                    content: '<';
+                }
+                &:hover {
+                    padding-right: 5px;
+                    ::after {
+                        content: '<<';
+                    }
+                }
+            }
+        }
+    }
+
+    .o_popout_icon {
+        position: absolute;
+        top: 8%;
+        background-color: black;
+        opacity: 0.3;
+        margin-top: -15px;
+        transition: all 0.3s;
+        z-index: $zindex-dropdown; // due to the absolute position in o-mail-Attachment-imgContainer
+        right: 0;
+        border-radius: 30px 0 0 30px;
+        padding: 15px 0 15px 15px;
+        &:hover {
+            padding-right: 15px;
+        }
+    }
+
+    @include media-only(print) {
+        .o_search_panel {
+            display: none;
+        }
+    }
+}
+
 .hr_expense {
     @include media-breakpoint-up(md) {
         &.o_list_view, &.o_kanban_view .o_kanban_renderer {

--- a/addons/hr_expense/static/src/views/list.js
+++ b/addons/hr_expense/static/src/views/list.js
@@ -1,15 +1,18 @@
+import { ExpenseAttachment } from "../components/expense_attachment";
 import { ExpenseDashboard } from '../components/expense_dashboard';
 import { ExpenseMobileQRCode } from '../mixins/qrcode';
 import { ExpenseDocumentUpload, ExpenseDocumentDropZone } from '../mixins/document_upload';
 
 import { registry } from '@web/core/registry';
+import { SIZES } from "@web/core/ui/ui_service";
 import { useService } from '@web/core/utils/hooks';
 import { user } from "@web/core/user";
 import { listView } from "@web/views/list/list_view";
 
 import { ListController } from "@web/views/list/list_controller";
 import { ListRenderer } from "@web/views/list/list_renderer";
-import { onWillStart } from "@odoo/owl";
+import { useChildSubEnv, useState, onWillStart } from "@odoo/owl";
+
 
 export class ExpenseListController extends ExpenseDocumentUpload(ListController) {
     static template = `hr_expense.ListView`;
@@ -64,27 +67,126 @@ export class ExpenseListController extends ExpenseDocumentUpload(ListController)
     }
 }
 
-export class ExpenseListRenderer extends ExpenseDocumentDropZone(
-    ExpenseMobileQRCode(ListRenderer)
-) {
+export class ExpenseListRenderer extends ExpenseDocumentDropZone(ExpenseMobileQRCode(ListRenderer)) {
     static template = "hr_expense.ListRenderer";
 }
 
-export class ExpenseDashboardListRenderer extends ExpenseListRenderer {
-    static components = { ...ExpenseDashboardListRenderer.components, ExpenseDashboard };
-    static template = "hr_expense.DashboardListRenderer";
+export const ExpenseListView = {
+    ...listView,
+    buttonTemplate: 'hr_expense.ListButtons',
+    Renderer: ExpenseListRenderer,
+    Controller: ExpenseListController,
+};
+
+export class ExpenseOverviewListController extends ExpenseListController {
+    static template = "hr_expense.OverviewListView";
+    static components = { ...ExpenseListController.components, ExpenseAttachment };
+    setup() {
+        super.setup();
+        this.store = useService("mail.store");
+        this.ui = useService("ui");
+        this.mailPopoutService = useService("mail.popout");
+        this.attachmentPreviewState = useState({
+            displayAttachment: localStorage.getItem(this.previewerStorageKey) !== "false",
+            focusedRecord: false,
+            thread: null,
+        });
+
+        this.popout = useState({ active: false });
+
+        useChildSubEnv({
+            setPopout: this.setPopout.bind(this),
+        });
+    }
+
+    get previewerStorageKey() {
+        return "hr_expense.expense_previewer_hidden";
+    }
+
+    previewEnabled() {
+        return (
+            !this.env.searchModel.context.disable_preview &&
+            (this.ui.size >= SIZES.XXL || this.mailPopoutService.externalWindow)
+        );
+    }
+
+    togglePreview() {
+        this.attachmentPreviewState.displayAttachment = !this.attachmentPreviewState.displayAttachment;
+        localStorage.setItem(
+            this.previewerStorageKey,
+            this.attachmentPreviewState.displayAttachment
+        );
+    }
+
+    setPopout(value) {
+        if (this.attachmentPreviewState.thread?.attachmentsInWebClientView.length) {
+            this.popout.active = value;
+        }
+    }
+
+    async setThread(lineData) {
+        const attachmentField = "attachment_ids"
+        const attachments = lineData?.data[attachmentField]?.records || [];
+        if (!lineData || !attachments.length) {
+            this.attachmentPreviewState.thread = null;
+            return;
+        }
+        const thread = this.store.Thread.insert({
+            attachments: attachments.map((attachment) => ({
+                id: attachment.resId,
+                mimetype: attachment.data.mimetype,
+            })),
+            id: lineData.resId,
+            model: lineData.resModel,
+        });
+        if (!thread.mainAttachment && thread.attachmentsInWebClientView.length > 0){
+            thread.update({mainAttachment: thread.attachmentsInWebClientView[0]});
+        }
+        this.attachmentPreviewState.thread = thread;
+    }
+
+    async setFocusedRecord(ExpenseData) {
+        this.attachmentPreviewState.focusedRecord = ExpenseData;
+        await this.setThread(ExpenseData, "attachment_ids", "id");
+    }
 }
 
-registry.category('views').add('hr_expense_tree', {
-    ...listView,
-    buttonTemplate: 'hr_expense.ListButtons',
-    Controller: ExpenseListController,
-    Renderer: ExpenseListRenderer,
-});
 
-registry.category('views').add('hr_expense_dashboard_tree', {
+export class ExpenseOverviewListRenderer extends ExpenseListRenderer {
+    static components = { ...ExpenseListRenderer.components, ExpenseDashboard, ExpenseAttachment };
+    static template = "hr_expense.OverviewListRenderer";
+    static props = [
+        ...ExpenseListRenderer.props,
+        "attachmentPreviewState",
+        "previewEnabled",
+        "popout",
+        "setFocusedRecord",
+        "togglePreview",
+    ];
+
+    findFocusFutureCell(cell, cellIsInGroupRow, direction) {
+        const futureCell = super.findFocusFutureCell(cell, cellIsInGroupRow, direction);
+        if (futureCell) {
+            const dataPointId = futureCell.closest("tr").dataset.id;
+            const record = this.props.list.records.filter((x) => x.id === dataPointId)[0];
+            this.props.setFocusedRecord(record);
+        }
+        return futureCell;
+    }
+
+    toggleRecordSelection(record) {
+        super.toggleRecordSelection(record);
+        if (record){this.props.setFocusedRecord(record);}
+    }
+}
+
+export const ExpenseOverviewListView = {
     ...listView,
     buttonTemplate: 'hr_expense.ListButtons',
-    Controller: ExpenseListController,
-    Renderer: ExpenseDashboardListRenderer,
-});
+    Renderer: ExpenseOverviewListRenderer,
+    Controller: ExpenseOverviewListController,
+};
+
+registry.category('views').add('hr_expense_tree', ExpenseListView);
+
+registry.category('views').add('hr_expense_overview_tree', ExpenseOverviewListView);

--- a/addons/hr_expense/static/src/views/list.xml
+++ b/addons/hr_expense/static/src/views/list.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
-    <t t-name="hr_expense.ListButtons" t-inherit="web.ListView.Buttons" t-inherit-mode="primary">
+    <t t-name="hr_expense.ListButtons" t-inherit="web.ListView.Buttons">
 
        <!-- hr.expense -->
         <xpath expr="//div[hasclass('o_list_buttons')]" position="attributes">
@@ -37,7 +37,7 @@
         </xpath>
     </t>
 
-    <t t-name="hr_expense.ListRenderer" t-inherit="web.ListRenderer" t-inherit-mode="primary">
+    <t t-name="hr_expense.ListRenderer" t-inherit="web.ListRenderer">
         <xpath expr="//div[hasclass('o_list_renderer')]" position="before">
             <div t-if="dragState.showDragZone" class="o_dropzone">
                 <i class="fa fa-upload fa-10x"></i>
@@ -48,10 +48,60 @@
         </xpath>
     </t>
 
-
-    <t t-name="hr_expense.DashboardListRenderer" t-inherit="hr_expense.ListRenderer" t-inherit-mode="primary">
+    <t t-name="hr_expense.OverviewListRenderer" t-inherit="hr_expense.ListRenderer" t-inherit-mode="primary">
         <xpath expr="//div[hasclass('o_list_renderer')]" position="before">
             <ExpenseDashboard/>
+            <div class="o_attachment_list"/>
+        </xpath>
+        <xpath expr="//div[hasclass('o_attachment_list')]" position="inside">
+            <xpath expr="//div[hasclass('o_list_renderer')]" position="move"/>
+            <div t-if="this.props.previewEnabled" class="o_attachment_preview d-print-none" t-att-class="{'hidden': !props.attachmentPreviewState.displayAttachment}">
+                <t t-if="this.props.attachmentPreviewState.displayAttachment">
+                    <t t-if="this.props.attachmentPreviewState.thread and this.props.attachmentPreviewState.thread.attachmentsInWebClientView.length > 0">
+                        <ExpenseAttachment
+                            threadId="this.props.attachmentPreviewState.thread.id"
+                            threadModel="this.props.attachmentPreviewState.thread.model"
+                            openInPopout="0"
+                        />
+                    </t>
+                    <t t-elif="!this.props.attachmentPreviewState.focusedRecord">
+                        <p class="text-center">Choose a line to preview its attachments.</p>
+                    </t>
+                    <t t-else="">
+                        <p class="text-center">No attachments linked.</p>
+                    </t>
+                </t>
+                <div class="o_attachment_control toggle" t-on-click="props.togglePreview"/>
+            </div>
+            <t t-else="">
+                <div class="o_popout_icon" t-on-click="() => this.setPopout(true)">
+                    <i class="fa fa-window-restore" title="Open attachment in pop out"/>
+                </div>
+                <t t-if="this.props.popout.active">
+                    <div class="o_attachment_preview d-print-none"
+                         t-if="this.props.attachmentPreviewState.thread?.attachmentsInWebClientView.length"
+                    >
+                        <ExpenseAttachment
+                            threadId="this.props.attachmentPreviewState.thread.id"
+                            threadModel="this.props.attachmentPreviewState.thread.model"
+                            openInPopout="1"
+                        />
+                    </div>
+                </t>
+            </t>
+        </xpath>
+    </t>
+
+    <t t-name="hr_expense.OverviewListView" t-inherit="hr_expense.ListView" t-inherit-mode="primary">
+        <xpath expr="//div[@t-ref='root']" position="attributes" type="add">
+            <attribute name="class" add="o_expense_list_view" separator=" "/>
+        </xpath>
+        <xpath expr="//t[@t-component='props.Renderer']" position="attributes">
+            <attribute name="attachmentPreviewState">this.attachmentPreviewState</attribute>
+            <attribute name="popout">this.popout</attribute>
+            <attribute name="previewEnabled.bind">this.previewEnabled</attribute>
+            <attribute name="setFocusedRecord.bind">this.setFocusedRecord</attribute>
+            <attribute name="togglePreview.bind">this.togglePreview</attribute>
         </xpath>
     </t>
 </templates>

--- a/addons/hr_expense/views/hr_expense_views.xml
+++ b/addons/hr_expense/views/hr_expense_views.xml
@@ -22,6 +22,11 @@
                     <field name="is_editable" column_invisible="True"/>
                     <field name="company_id" column_invisible="True"/>
                     <field name="company_currency_id" column_invisible="True"/>
+                    <field name="attachment_ids">
+                        <list>
+                            <field name="mimetype"/>
+                        </list>
+                    </field>
                     <field name="nb_attachment" column_invisible="True"/>
                     <field name="is_multiple_currency" column_invisible="True"/>
                     <field name="product_has_cost" column_invisible="True"/>
@@ -35,8 +40,8 @@
                     <field name="department_id" optional="hide" readonly="True"/>
                     <field name="date" optional="show" readonly="not is_editable"/>
                     <field name="product_id" optional="show" readonly="not is_editable" required="1"/>
-                    <field name="payment_mode" optional="show" readonly="not is_editable"/>
-                    <field name="activity_ids" widget="list_activity" optional="show"/>
+                    <field name="payment_mode" optional="show" readonly="not is_editable" invisible="payment_mode == 'company_account'"/>
+                    <field name="activity_ids" widget="list_activity" optional="hide"/>
                     <field name="analytic_distribution" widget="analytic_distribution"
                            optional="show"
                            groups="analytic.group_analytic_accounting"
@@ -91,7 +96,7 @@
             <field name="arch" type="xml">
                 <xpath expr="//list" position="attributes">
                     <!-- Display the tree dashboard view with the header -->
-                    <attribute name="js_class">hr_expense_dashboard_tree</attribute>
+                    <attribute name="js_class">hr_expense_overview_tree</attribute>
                 </xpath>
             </field>
         </record>
@@ -105,8 +110,11 @@
             <field name="arch" type="xml">
                 <xpath expr="//list" position="attributes">
                     <!-- Display the tree dashboard view with the header -->
-                    <attribute name="js_class">hr_expense_dashboard_tree</attribute>
+                    <attribute name="js_class">hr_expense_overview_tree</attribute>
                 </xpath>
+<!--                <xpath expr="//div[hasclass('o_jond')]" position="inside">-->
+<!--                    <xpath expr="//div[hasclass('o_attachment_preview')]" position="move"/>-->
+<!--                </xpath>-->
             </field>
         </record>
 


### PR DESCRIPTION
Some improvements to match the previous behavior or simply the new one:
- hide activity_ids by default on the list view
- the column "Paid By" contains "Employee" or nothing
- a document preview is displayed aside the list
- when an entry is created, we put a link to the entry in the chatter

task-id: 4492474
