### PR TITLE
[FIX] hr_expense: only remove account.move ref when expense present

### DIFF
--- a/addons/hr_expense/models/account_move.py
+++ b/addons/hr_expense/models/account_move.py
@@ -99,5 +99,7 @@ class AccountMove(models.Model):
         # We need to override this method to remove the link with the move, else we cannot reimburse them anymore.
         # And cancelling the move != cancelling the expense
         res = super().button_cancel()
-        self.write({'expense_sheet_id': False, 'ref': False})
+        with_expense = self.filtered('expense_sheet_id')
+        # Only clear reference for moves with expense sheets.
+        with_expense.write({'expense_sheet_id': False, 'ref': False})
         return res


### PR DESCRIPTION
### Issue:
On 18.0 and 18.1, cancelling an `account.move` will clear the `ref` value in all situations if `hr_expense` is installed. While clearing the `ref` is necessary if unlinking an expense, this isn't the case for unrelated records.

### Solution:
Check to see if the `expense_sheet_id` is set on the `account.move` to determine if the `ref` should also be removed.

### Additional Note:
This flow was reworked in 18.2 via #189701, so we only need to adjust this for the affected versions.

opw-4853903
