### PR TITLE
[FIX] website: allow visibility attributes on root tag


### DIFF
--- a/addons/website/models/ir_ui_view.py
+++ b/addons/website/models/ir_ui_view.py
@@ -493,10 +493,13 @@ class View(models.Model):
     @api.model
     def _get_allowed_root_attrs(self):
         # Related to these options:
-        # background-video, background-shapes, parallax
+        # background-video, background-shapes, parallax, visibility
         return super()._get_allowed_root_attrs() + [
             'data-bg-video-src', 'data-shape', 'data-scroll-background-ratio',
-        ]
+            'data-visibility', 'data-visibility-id', 'data-visibility-selectors',
+        ] + ['data-visibility-value-' + suffix for suffix in (
+            'country', 'lang', 'logged', 'utm-campaign', 'utm-medium', 'utm-source',
+        )]
 
     def _get_combined_arch(self):
         root = super()._get_combined_arch()


### PR DESCRIPTION

Scenario:
- install website_sale
- go in settings and enable "extra steps"
- go to configure extra steps
- get in edit mode and add any visibility condition for the form
- save

Result: the form is hidden in all conditions, even when it should be
shown.

Why:

In 0750eb6315fe9c2d1f1de36b9b756b5097ed11e0 17.0 redesign of the
checkout flow, the structure of extra steps changed so now the root
element when editing became the section tag of the form.

This means that when we set a visibility on it, the form will be hidden
by default then shown based on attributes such as
data-visibility-selectors.

But on the root tag, we only allow to modify only a very restricted list
of tags, so we saved the hiding of the form, but didn't save the
attributes that made it visibile based on a condition.

Fix: add the attributes used for visibility in the authorized list on
the root tag.

opw-4765026
