### PR TITLE
[IMP] web: calendar view add support for x2many fields

### DIFF
--- a/doc/cla/individual/mkoeck.md
+++ b/doc/cla/individual/mkoeck.md
@@ -1,0 +1,11 @@
+Austria, 2025-06-26
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Michael Köck mkoeck@elektroshopkoeck.com https://github.com/mkoeck


### PR DESCRIPTION
**Impacted versions:**

- `master`

---

### **Steps to Reproduce:**

1. In a custom module, create or inherit a calendar view.
2. Add a `many2many` field (e.g., `user_ids`) to the view with the `filters="1"` attribute:

    ```xml
    <record id="project_task_calendar_view" model="ir.ui.view">
        <field name="name">project.task.calendar.filter.inherit</field>
        <field name="model">project.task</field>
        <field name="inherit_id" ref="project.view_task_calendar"/>
        <field name="arch" type="xml">
            <xpath expr="//calendar" position="inside">
                <field name="user_ids" filters="1"/>
            </xpath>
        </field>
    </record>
    ```

3. Install or upgrade the module.
4. Open the Calendar view.

---

### **Current Behavior:**

The calendar view fails to render. A JavaScript `TypeError` is thrown:

```javascript
UncaughtPromiseError > TypeError
Uncaught TypeError: Cannot read properties of undefined (reading 'length')
    at formatX2many (formatters.js:295:36)
    at CalendarModel.makeFilterDynamic (calendar_model.js:773:28)
    at calendar_model.js:717:23
    at Array.map (<anonymous>)
    at CalendarModel.loadDynamicFilterSection (calendar_model.js:713:34)
    at async CalendarModel.loadDynamicFilters (calendar_model.js:661:21)
    at async CalendarModel.updateData (calendar_model.js:335:13)
```

---

### **Expected Behavior:**

- The calendar view should load successfully.
- The dynamic filters sidebar should correctly display options for the x2many field (e.g., "Assignees" from `user_ids`).
- Filters should behave consistently with `many2one`-like selection and formatting.

---

### **Root Cause Analysis:**

- The dynamic filter system attempts to use the `formatX2many` formatter based on the provided field being x2many
- This formatter expects a value structure (`{ currentIds: [...] }`), but is being passed a single id due to the formatting of `rawFilters` in `loadDynamicFilterSection`
- The resulting `TypeError` breaks view rendering.

---

### **Solution:**

This PR modifies the CalendarModel logic to properly support `x2many` fields:

- When loading dynamic filters, fetch related records via `searchRead` to build correctly formatted options.
- In `makeFilterDynamic`, force usage of the `many2one` formatter for `x2many` fields, similar to `makeFilterRecord`.
- Update filter matching logic to work with arrays when comparing filter values to field values.
