### PR TITLE
[FIX] sale: remove default user context on confirm

### DIFF
--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -958,6 +958,7 @@ class SaleOrder(models.Model):
         # We don't need it and it creates issues in the creation of linked records.
         context = self._context.copy()
         context.pop('default_name', None)
+        context.pop('default_user_id', None)
 
         self.with_context(context)._action_confirm()
 


### PR DESCRIPTION
When creating a sale order through crm, default_user_id was being passed through the context. This was causing issues when confirming the sale orders when quality checks were enabled as the user on the quality checks would be set as the user from the CRM lead. Removing this from the context before confirming and thus creating any linked records avoids this issue.

opw-4658850
