### PR TITLE
[FIX] l10n_in_ewaybill: hide E-Waybill print action if it is not generated

### DIFF
--- a/addons/l10n_in_ewaybill/report/ewaybill_report_views.xml
+++ b/addons/l10n_in_ewaybill/report/ewaybill_report_views.xml
@@ -27,6 +27,7 @@
             <field name="paperformat_id" ref="l10n_in_ewaybill.paperformat_ewaybill"/>
             <field name="binding_model_id" ref="model_l10n_in_ewaybill"/>
             <field name="binding_type">report</field>
+            <field name="domain" eval="[('state', '=', 'generated')]"/>
         </record>
     </data>
 </odoo>


### PR DESCRIPTION
Currently, an error occurs when users print the E-Waybill without generating it.

Steps to replicate:
- Install `l10n_in_ewaybill` and switch to IN company.
- Change the `Zipcode` on IN company to `aa`.
- Go to `Invoicing > Customer > Invoices`.
- Create an invoice, confirm and click Send E-WayBill.
- Click on the Gear icon and Click on the report `Ewaybill`.

Error:
`ValueError: invalid literal for int() with base 10: ''....`
`QWebException: Error while render the template
ValueError: invalid literal for int() with base 10: '' Template: ir.ui.view(2614,)
Path: /t/t/t/t/div/t[3]
Node: <t t-if='doc.state in ewaybill_states'/>`

The error occurs because the report printing is available even when the `E-Waybill` is not yet generated. This causes the execution flow to skip all the necessary validations, leading to a `ValueError` at line [1].

[1] - https://github.com/odoo/odoo/blob/aa7dac87a3eebce1b300e1e3d04398d680325b5d/addons/l10n_in_ewaybill/models/l10n_in_ewaybill.py#L640

This commit solves this issue by adding a domain to the report, so that it appears only after the EwayBill is generated.

sentry-6695761066

https://github.com/user-attachments/assets/81e5a8eb-4c0c-4dc5-a65b-e22bc11098d2

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
