### PR TITLE
[FIX] sale_management: prevent error adding optional product in unsaved SO

### DIFF
--- a/addons/sale_management/views/sale_order_views.xml
+++ b/addons/sale_management/views/sale_order_views.xml
@@ -30,7 +30,7 @@
                                     <div class="row">
                                         <field name="product_id" class="col-10 fw-bolder"/>
                                         <button name="button_add_to_order"
-                                            class="col-2 btn btn-link oe_link fa fa-shopping-cart"
+                                            t-att-class="'col-2 btn btn-link oe_link fa fa-shopping-cart ' + (record.id.raw_value ? '' : 'disabled')"
                                             title="Add to order lines"
                                             type="object"
                                             invisible="is_present"/>


### PR DESCRIPTION
Currently, an error is raised when a user tries to add an optional product to the order lines in a sale order or quotation **without saving the record**, particularly in **mobile view**.

**Steps to reproduce:**
- Install the `sale_management` module and switch to **mobile view**.
- Create a new quotation, select a customer, and add a product in the **Optional Products** tab. (Do not save the sale order.)
- Click the shopping **cart icon** to add the optional product to the order lines.

**Error:**
`ValueError - Expected singleton: sale.order.option()`

**Cause:**
This error occurs because the `button_add_to_order()` method at [1] attempts to access the id of `sale.order` record which hasn’t been saved yet.

[1] - https://github.com/odoo/odoo/blob/ef23c42b9742740d158c3cb83ea3b62d01eceb01/addons/sale_management/models/sale_order_option.py#L148-L149

This issue only occurs in the **kanban view** used in **mobile mode**. In contrast, the **list view** handles this scenario by triggering a client-side **pop-up** ([2]) when the user clicks the add button without saving.

[2] - https://github.com/odoo/odoo/blob/ef23c42b9742740d158c3cb83ea3b62d01eceb01/addons/web/static/src/views/list/list_renderer.js#L292-L296

In list view, each column has a specific field or button. This allows to find the button (column) and check whether the parent record is saved ([3]). If it’s not saved, this can prevent the button's action and show a "Please click on the 'save' button first" notification.

However, in the kanban view, the button is placed manually inside a `<div>` element using **HTML**. Unlike the list view, the kanban view does not have a built-in functionality for button actions.

[3] - https://github.com/odoo/odoo/blob/ef23c42b9742740d158c3cb83ea3b62d01eceb01/addons/web/static/src/views/list/list_renderer.xml#L285-L304

**Fix:**
This commit adds a condition in the kanban template to disable the "Add to order lines" button if the optional product record is not saved.

Sentry - 6700745738