### PR TITLE
[FIX] sale: hide the radio input on ecommerce product page

### DIFF
--- a/addons/sale/static/src/scss/product_configurator.scss
+++ b/addons/sale/static/src/scss/product_configurator.scss
@@ -189,6 +189,7 @@ label.css_attribute_color.css_not_available {
             -webkit-appearance: none;
             appearance: none;
             opacity: 0;
+            position: absolute !important;
         }
     }
 


### PR DESCRIPTION
Before this commit, the pills attributes on a eCommerce product page on iOS has misaligned text That was caused by an iOS inconstancy with 'appearance: none;'

A 'position: aboslute !important;' was added to force hiding the input like in saas-18.4

Expected:
![image](https://github.com/user-attachments/assets/650ec531-f0cc-44d8-95ef-7aa4bb5634cf)

Issue:
![image](https://github.com/user-attachments/assets/b1802be2-78b4-42e8-8d7d-4c789f4a1ab6)

## Steps to reproduce:
- Add a product with attributes in eCommerce
- Set the Attribute's Display Type to Pills
- Go to the eCommerce product's page
- Open the page on iPhone or iPad (using BrowserStack)
- The selection for the attributes have a space before option's name


opw-4854158