### PR TITLE
[FIX] stock_landed_costs: split the landed cost correctly with lots/SN

### DIFF
--- a/addons/stock_landed_costs/models/stock_landed_cost.py
+++ b/addons/stock_landed_costs/models/stock_landed_cost.py
@@ -134,8 +134,10 @@ class StockLandedCost(models.Model):
                     vals_list = []
                     if line.move_id.product_id.lot_valuated:
                         for lot_id, sml in line.move_id.move_line_ids.grouped('lot_id').items():
+                            if not lot_id.quantity_svl:
+                                continue
                             lot_layer = linked_layer.filtered(lambda l: l.lot_id == lot_id)[:1]
-                            value = cost_to_add * sum(sml.mapped('quantity')) / line.move_id.quantity
+                            value = cost_to_add * lot_id.quantity_svl / remaining_qty
                             if product.cost_method in ['average', 'fifo']:
                                 cost_to_add_bylot[product][lot_id] += value
                             vals_list.append({


### PR DESCRIPTION
**Problem:**
the split of the landed cost between lots doesn't
take into account if a lot has no quantity left
or if it has less than it's initial quantity

**Steps to reproduce:**
- enable the "lot & Serial Numbers" and "landed costs" settings
- create a storable product, tracked by lot
- in general information activate "valuation by Lot/Serial Number"
- select FIFO as the category
- create a request for quotation for this product for a quantity of 5 and a unit price of 10.000
- confirm and click on the receipt smart button
- on the move line click on the Lots/serial number widget on the right
- create 4 lots (L1 with 1 units, L2 with 2 units, L3 and L4 with 1)
- save and validate the picking
- create a sale order for a quantity of 2 of this product, confirm it and validate the picking
- create a new service product, in "purchase" check "is a landed cost"
- open accounting/vendors/bills, create a new one for the same vendor as the purhase order
- add a line with the landed cost and a price of 5000 (quantity of 1)
- set a bill date and save
- clik on "create landed costs"
- in the "transfers" field write the refernce of the receipt of the PO
- open inventory/reporting/valuation and type your product in the search bar

**Current behavior:**
4 lines were created :
a line of 600 for L1
a line of 1200 for L2
a line of 600 for L3
a line of 600 for L4

an additional issue, is that if we now sell the 3 remaining quantity and search our product in inventory/reporting/valuation the quantity will be zero but total value will be 600

**Expected behavior:**
the spliting should adapt to the remaining quantities like it does when lots are not involved
(for instance when there is a landed cost linked to a PO with a quantity of 5 but only 4 of those products are still in stock the value of the landed cost valuation line linked to this product is 4/5 of the landed cost)

So here it should be :
no line for L1 (no remaining quantity in L1)
a line of 1000 for L2 (only 1 remaining, so a third of the 3000 (3/5 * 5000)) a line of 1000 for L3
a line of 1000 for l4

**Cause of the issue:**
the quantity used is the one of the initial stock move line so it doesn't take into account the current number of product in the lot

opw-4828963