### PR TITLE
[FIX] l10n_in_edi_ewaybill: cancel remarks mandatory

### DIFF
--- a/addons/l10n_in_edi_ewaybill/models/account_edi_format.py
+++ b/addons/l10n_in_edi_ewaybill/models/account_edi_format.py
@@ -133,7 +133,7 @@ class AccountEdiFormat(models.Model):
         cancel_json = {
             "ewbNo": ewaybill_response_json.get("ewayBillNo") or ewaybill_response_json.get("EwbNo"),
             "cancelRsnCode": int(invoices.l10n_in_edi_cancel_reason),
-            "CnlRem": invoices.l10n_in_edi_cancel_remarks,
+            "cancelRmrk": invoices.l10n_in_edi_cancel_remarks,
         }
         response = self._l10n_in_edi_ewaybill_cancel(invoices.company_id, cancel_json)
         if response.get("error"):


### PR DESCRIPTION
Due to historical error, the key mapped for cancel remarks seems to be incorrect. Due to which while
cancelling the E-waybill we receive the error code `[659] Remark is mandatory`. In this commit,
we make sure the keys are mapped correctly as
per https://docs.ewaybillgst.gov.in/apidocs/version1.03/cancel-eway-bill.html

Though as per the schema validation the remark is
not mandatory after receiving the ticket it doesn't seems like that :)

opw-4882071


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
