### PR TITLE
[IMP] fleet: warnings on contract type specific

### DIFF
--- a/addons/fleet/models/fleet_vehicle_log_contract.py
+++ b/addons/fleet/models/fleet_vehicle_log_contract.py
@@ -72,7 +72,7 @@ class FleetVehicleLogContract(models.Model):
                 name = record.cost_subtype_id.name + ' ' + name
             record.name = name
 
-    @api.depends('vehicle_id')
+    @api.depends('vehicle_id', 'cost_subtype_id')
     def _compute_has_open_contract(self):
         today = fields.Date.today()
         open_contracts = self.env['fleet.vehicle.log.contract'].search([
@@ -80,8 +80,9 @@ class FleetVehicleLogContract(models.Model):
             ('state', '=', 'open'),
             ('expiration_date', '>=', today)
         ])
+        open_contract_keys = {(c.vehicle_id.id, c.cost_subtype_id.id) for c in open_contracts}
         for log_contract in self:
-            log_contract.has_open_contract = log_contract.vehicle_id in open_contracts.vehicle_id
+            log_contract.has_open_contract = (log_contract.vehicle_id.id, log_contract.cost_subtype_id.id) in open_contract_keys
 
     @api.depends('expiration_date', 'state')
     def _compute_days_left(self):

--- a/addons/fleet/views/fleet_vehicle_cost_views.xml
+++ b/addons/fleet/views/fleet_vehicle_cost_views.xml
@@ -75,8 +75,10 @@
                 <field name="active" column_invisible="True"/>
                 <field name="expires_today" column_invisible="True"/>
                 <field name="name" class="fw-bold" />
+                <field name="cost_subtype_id" />
                 <field name="start_date" />
-                <field name="expiration_date" widget="remaining_days"/>
+                <field name="expiration_date" widget="remaining_days"
+                    options="{'classes': {'danger': 'record.days_left==0 and not record.expires_today and not record.has_open_contract'}}"/>
                 <field name="days_left" column_invisible="True"/>
                 <field name="vehicle_id"/>
                 <field name="insurer_id" />


### PR DESCRIPTION
In this PR,
Before:
- The contract expiration warning logic does not differentiate between contract types.
- A contract line turns red when it is expired and has no subsequent contracts.
- The line returns to gray if any new contract is added, regardless of type.
- This can result in prematurely removed warnings, especially when the new contract is of a different type (e.g., Omnium vs Leasing).
- The "type" column is not shown in the list view.

After:
- Added "type" column to the list view (default visible).
- A contract line now turns red only if it is expired and there are no future contracts of the same type.
- Contracts with no type are treated as a separate type category.
- When a valid future contract of the same type exists, the color is cleared from the line.
- Ensured outdated red warnings are properly removed (e.g., "Yesterday" no longer stays red once warning condition is cleared).

Task-4885171