### PR TITLE
[IMP] account:  Allow to have more than one reco model with same name

### DIFF
--- a/addons/account/models/account_reconcile_model.py
+++ b/addons/account/models/account_reconcile_model.py
@@ -84,11 +84,6 @@ class AccountReconcileModel(models.Model):
     _order = 'sequence, id'
     _check_company_auto = True
 
-    _name_unique = models.Constraint(
-        'unique(name, company_id)',
-        'A reconciliation model already bears this name.',
-    )
-
     # Base fields.
     active = fields.Boolean(default=True)
     name = fields.Char(string='Name', required=True, translate=True)


### PR DESCRIPTION
- Before this pr: User can not create more than one reconciliation model for different Label and Label Parameter

- After this pr: The unique SQL constraint on the name and company is removed, and a new python constraint is added for the unique combination of name, company_id, match_label, and match_label_param. So now user can create multiple reconciliation models with the  same name but different matching parameters in the same company

Related Enterprise PR: https://github.com/odoo/enterprise/pull/89358

Task: 4876374