### PR TITLE
[IMP] website, *: Prevent sales of product for categories and zero-price products

### DIFF
--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -110,7 +110,7 @@ class Website(models.CachedModel):
     # website module and accesses website.default_lang_id.
     #
     # Here, we cache the needed fields only to avoid prefetching any
-    # translatable field, such as contact_us_button_url by website_sale, as
+    # translatable field, such as contact_us_link_url by website_sale, as
     # translating to an invalid language would result in an error.
     _clear_cache_name = 'default'
     _cached_data_fields = (

--- a/addons/website_sale/controllers/comparison.py
+++ b/addons/website_sale/controllers/comparison.py
@@ -34,7 +34,7 @@ class ProductComparison(Controller):
                 'website_url': product.website_url,
                 'image_url': product._get_image_1024_url(),
                 'price': combination_info['price'],
-                'prevent_zero_price_sale': combination_info['prevent_zero_price_sale'],
+                'hide_price': combination_info['hide_price'],
                 'currency_id': combination_info['currency'].id,
             }
             if combination_info['has_discounted_price']:

--- a/addons/website_sale/controllers/product_configurator.py
+++ b/addons/website_sale/controllers/product_configurator.py
@@ -132,7 +132,8 @@ class WebsiteSaleProductConfiguratorController(SaleProductConfiguratorController
                 basic_product_information['price'], precision_rounding=currency.rounding
             )
             basic_product_information['can_be_sold'] = not (
-                request.website.prevent_zero_price_sale and has_zero_price
+                request.website.prevent_sale
+                and request.website._prevent_product_sale(product_or_template, has_zero_price)
             )
             # Don't compute the strikethrough price if there's a custom price (i.e. if `price_info`
             # is populated).

--- a/addons/website_sale/models/product_feed.py
+++ b/addons/website_sale/models/product_feed.py
@@ -289,10 +289,10 @@ class ProductFeed(models.Model):
     def _prepare_gmc_price_info(self, product):
         """Prepare price-related information for Google Merchant Center.
 
-        Note: If the product is flagged to prevent zero price sales, an empty dictionary is
-        returned.
+        Note: If the product is not sellable on the website, an empty dictionary is returned
+        and the product is excluded from the feed.
 
-        :return: A dictionary containing nothing if the product is "prevent zero price sale", or:
+        :return: A dictionary containing nothing if sale is prevented (zero price or specific category), or:
             - List price,
             - Sale price (if applicable), and
             - Comparison prices (e.g., $100 / ml) if "Product Reference Price" is enabled.
@@ -310,7 +310,7 @@ class ProductFeed(models.Model):
             date=fields.Date.context_today(self),
             website=self.website_id,
         )
-        if combination_info['prevent_zero_price_sale']:
+        if combination_info['prevent_sale']:
             return {}
 
         price_info = {

--- a/addons/website_sale/models/product_product.py
+++ b/addons/website_sale/models/product_product.py
@@ -137,7 +137,11 @@ class ProductProduct(models.Model):
         self.ensure_one()
         if not self.filtered_domain(self.env['website']._product_domain()):
             return False
-        return not request.website.prevent_zero_price_sale or self._get_contextual_price()
+        website = self.env['website'].get_current_website()
+        return not (
+            website.prevent_sale
+            and website._prevent_product_sale(self, not self._get_contextual_price())
+        )
 
     def _is_add_to_cart_allowed(self):
         self.ensure_one()
@@ -147,9 +151,13 @@ class ProductProduct(models.Model):
             return False
         if not self.filtered_domain(self.env['website']._product_domain()):
             return False
-        if request.website.prevent_zero_price_sale and not self._get_contextual_price():
+        website = self.env['website'].get_current_website()
+        if (
+            website.prevent_sale
+            and website._prevent_product_sale(self, not self._get_contextual_price())
+        ):
             return False
-        return request.website.has_ecommerce_access()
+        return website.has_ecommerce_access()
 
     @api.onchange('public_categ_ids')
     def _onchange_public_categ_ids(self):

--- a/addons/website_sale/models/res_config_settings.py
+++ b/addons/website_sale/models/res_config_settings.py
@@ -50,16 +50,13 @@ class ResConfigSettings(models.TransientModel):
         readonly=False,
     )
     salesteam_id = fields.Many2one(related='website_id.salesteam_id', readonly=False)
-    website_sale_prevent_zero_price_sale = fields.Boolean(
-        string="Prevent Sale of Zero Priced Product",
-        related='website_id.prevent_zero_price_sale',
+    prevent_sale = fields.Boolean(related='website_id.prevent_sale', readonly=False)
+    prevent_sale_for = fields.Selection(related='website_id.prevent_sale_for', readonly=False)
+    prevent_sale_for_categories = fields.Many2many(
+        related='website_id.prevent_sale_for_categories',
         readonly=False,
     )
-    website_sale_contact_us_button_url = fields.Char(
-        string="Button Url",
-        related='website_id.contact_us_button_url',
-        readonly=False,
-    )
+    contact_us_link_url = fields.Char(related='website_id.contact_us_link_url', readonly=False)
     show_line_subtotals_tax_selection = fields.Selection(
         related='website_id.show_line_subtotals_tax_selection',
         readonly=False,

--- a/addons/website_sale/models/sale_order.py
+++ b/addons/website_sale/models/sale_order.py
@@ -704,9 +704,9 @@ class SaleOrder(models.Model):
                     and product._website_show_quick_add()
                     and product.filtered_domain(self.env['product.product']._check_company_domain(line.company_id))
                     and product._is_variant_possible()
-                    and (
-                        not self.website_id.prevent_zero_price_sale
-                        or product._get_contextual_price()
+                    and not (
+                        self.website_id.prevent_sale
+                        and self.website_id._prevent_product_sale(product, not product._get_contextual_price())
                     )
                 )
 

--- a/addons/website_sale/static/src/interactions/product_page.js
+++ b/addons/website_sale/static/src/interactions/product_page.js
@@ -582,24 +582,28 @@ export class ProductPage extends Interaction {
         const contactUsButton = parent.closest('#product_details')
             ?.querySelector('#contact_us_wrapper');
         const quantity = parent.querySelector('.css_quantity');
-        const productUnavailable = parent.querySelector('#product_unavailable');
+        const boxedPriceWrapper = parent.querySelector('#o_wsale_cta_wrapper_boxed_price');
 
-        const preventSale = combination.prevent_zero_price_sale;
-        productPrice?.classList?.toggle('d-inline-block', !preventSale);
-        productPrice?.classList?.toggle('d-none', preventSale);
+        const preventSale = combination.prevent_sale;
+        const hidePrice = combination.hide_price;
+        productPrice?.classList.toggle('d-inline-block', !hidePrice);
+        productPrice?.classList.toggle('d-none', hidePrice);
+        boxedPriceWrapper?.classList.toggle('d-flex', !hidePrice);
+        boxedPriceWrapper?.classList.toggle('d-none', hidePrice);
         quantity?.classList?.toggle('d-inline-flex', !preventSale);
         quantity?.classList?.toggle('d-none', preventSale);
-        addToCart?.classList?.toggle('d-inline-flex', !preventSale);
-        addToCart?.classList?.toggle('d-none', preventSale);
+        addToCart?.classList.toggle('d-inline-flex', !preventSale);
+        addToCart?.classList.toggle('d-none', preventSale);
         contactUsButton?.classList?.toggle('d-none', !preventSale);
         contactUsButton?.classList?.toggle('d-flex', preventSale);
-        productUnavailable?.classList?.toggle('d-none', !preventSale);
-        productUnavailable?.classList?.toggle('d-flex', preventSale);
 
         if (contactUsButton) {
-            const contactUsButtonLink = contactUsButton.querySelector('a');
-            const url = contactUsButtonLink.getAttribute('data-url');
-            contactUsButtonLink.setAttribute('href', `${url}?subject=${combination.display_name}`);
+            const link = contactUsButton.querySelector('a');
+            if (link && combination.display_name) {
+                const linkUrl = new URL(link.href, window.location.origin);
+                linkUrl.searchParams.set('subject', combination.display_name);
+                link.href = linkUrl.toString();
+            }
         }
 
         const price = parent.querySelector('.oe_price')?.querySelector('.oe_currency_value');

--- a/addons/website_sale/static/src/js/product_row/product_row.js
+++ b/addons/website_sale/static/src/js/product_row/product_row.js
@@ -11,7 +11,7 @@ export class ProductRow extends Component {
         image_url: String,
         price: Number,
         strikethrough_price: { type: Number, optional: true },
-        prevent_zero_price_sale: Boolean,
+        hide_price: Boolean,
         currency_id: Number,
     };
 

--- a/addons/website_sale/static/src/js/product_row/product_row.xml
+++ b/addons/website_sale/static/src/js/product_row/product_row.xml
@@ -16,7 +16,7 @@
                 />
                 <h6 class="flex-grow-1 mb-0 text-truncate">
                     <span t-out="props.display_name" class="d-block mb-0 small text-truncate"/>
-                    <small t-if="!props.prevent_zero_price_sale" class="mb-0 text-body">
+                    <small t-if="!props.hide_price" class="mb-0 text-body">
                         <span t-out="formattedPrice" class="me-1 text-nowrap"/>
                         <del
                             t-if="props.strikethrough_price"

--- a/addons/website_sale/static/tests/tours/zero_priced_product.js
+++ b/addons/website_sale/static/tests/tours/zero_priced_product.js
@@ -8,10 +8,6 @@ registry.category('web_tour.tours').add('website_sale.contact_us_button', {
             trigger: '.js_attribute_value:has([checked]):contains(red)',
         },
         {
-            content: "Zero-priced product should be unavailable",
-            trigger: '#product_unavailable',
-        },
-        {
             content: "Price should be hidden",
             trigger: '.product_price:not(:visible)',
         },

--- a/addons/website_sale/templates/comparison_templates.xml
+++ b/addons/website_sale/templates/comparison_templates.xml
@@ -42,7 +42,7 @@
                                                     t-out="combination_info['display_name']"
                                                 />
                                                 <div
-                                                    t-if="not combination_info['prevent_zero_price_sale']"
+                                                    t-if="not combination_info['hide_price']"
                                                     class="text-wrap"
                                                 >
                                                     <small
@@ -119,7 +119,7 @@
                                         <a t-att-href="product.website_url">
                                             <h6 t-out="product.display_name"/>
                                         </a>
-                                        <span t-if="not combination_info['prevent_zero_price_sale']">
+                                        <span t-if="not combination_info['hide_price']">
                                             <span t-out="combination_info['price']"
                                                   t-options="{'widget': 'monetary', 'display_currency': website.currency_id}"/>
                                             <del
@@ -142,8 +142,8 @@
                                         </span>
                                         <div class="mt-auto pt-3">
                                             <a
-                                                t-if="combination_info['prevent_zero_price_sale']"
-                                                t-att-href="website.contact_us_button_url + '?subject=' + combination_info['display_name']"
+                                                t-if="combination_info['prevent_sale']"
+                                                t-att-href="website._get_contact_us_url(combination_info['display_name'])"
                                                 class="btn btn-primary btn_cta"
                                             >
                                                Contact Us

--- a/addons/website_sale/templates/product_page_templates.xml
+++ b/addons/website_sale/templates/product_page_templates.xml
@@ -156,31 +156,6 @@
                                     >
                                         <t t-call="website_sale.product_accordion"/>
                                     </div>
-
-                                    <div
-                                        t-if="combination_info['prevent_zero_price_sale']"
-                                        class="o_wsale_product_details_content_section o_wsale_product_details_content_section_contact mb-4"
-                                    >
-                                        <div
-                                            id="contact_us_wrapper"
-                                            t-attf-class="d-flex oe_structure oe_structure_solo #{_div_classes}"
-                                        >
-                                            <section
-                                                class="s_text_block"
-                                                data-snippet="s_text_block"
-                                                data-name="Text">
-                                                <div class="container">
-                                                    <a
-                                                        t-att-href="website.contact_us_button_url"
-                                                        t-att-data-url="website.contact_us_button_url"
-                                                        class="btn btn-primary btn_cta"
-                                                    >
-                                                        Contact Us
-                                                    </a>
-                                                </div>
-                                            </section>
-                                        </div>
-                                    </div>
                                     <t
                                         t-set="single_value_attributes"
                                         t-value="product.valid_product_template_attribute_line_ids._prepare_single_value_for_display()"
@@ -573,7 +548,7 @@
         >
             <div
                 id="add_to_cart_wrap"
-                t-attf-class="{{'d-none' if combination_info['prevent_zero_price_sale'] else 'd-flex'}} flex-grow-1 flex-lg-grow-0 flex-wrap align-items-center gap-2 {{'' if is_50_pc else ' w-100'}}"
+                t-attf-class="{{'d-none' if combination_info['prevent_sale'] else 'd-flex'}} flex-grow-1 flex-lg-grow-0 flex-wrap align-items-center gap-2 {{'' if is_50_pc else ' w-100'}}"
             >
                 <!-- data-action="add_to_cart" is the default, but it's needed to distinguish this
                 button from the "buy now" button in xpaths. -->
@@ -591,6 +566,17 @@
                     <i class="fa fa-shopping-cart me-2"/>
                     Add to cart
                 </button>
+            </div>
+            <div
+                id="contact_us_wrapper"
+                t-attf-class="{{'d-flex' if combination_info['prevent_sale'] else 'd-none'}} flex-grow-1 flex-lg-grow-0 flex-wrap align-items-center gap-2 {{'' if is_50_pc else 'w-100'}}"
+            >
+                <a
+                    t-att-href="website._get_contact_us_url(combination_info.get('display_name', ''))"
+                    class="btn btn-primary flex-grow-1 w-100"
+                >
+                    Contact Us
+                </a>
             </div>
             <div
                 id="product_option_block"
@@ -616,11 +602,17 @@
         <xpath expr="//div[@id='add_to_cart_wrap']" position="attributes">
             <attribute name="t-attf-class" remove="flex-lg-grow-0" separator=" "/>
         </xpath>
+        <div id="contact_us_wrapper" position="attributes">
+            <attribute name="t-attf-class" remove="flex-lg-grow-0" separator=" "/>
+        </div>
         <xpath expr="//div[@id='product_option_block']" position="attributes">
             <attribute name="t-att-class" remove="flex-lg-grow-0" separator=" "/>
         </xpath>
         <xpath expr="//div[@id='o_wsale_cta_wrapper']" position="inside">
-            <div class="d-flex gap-5 flex-grow-1 justify-content-between align-items-center order-first w-100 mb-3 pb-3 border-bottom">
+            <div
+                class="d-none gap-5 flex-grow-1 justify-content-between align-items-center order-first w-100 mb-3 pb-3 border-bottom"
+                id="o_wsale_cta_wrapper_boxed_price"
+            >
                 <span name="o_wsale_cta_wrapper_boxed_price_label" class="text-muted">Price</span>
                 <t t-call="website_sale.product_price"/>
             </div>
@@ -637,6 +629,12 @@
         </xpath>
         <xpath expr="//div[@id='add_to_cart_wrap']" position="attributes">
             <attribute name="t-attf-class" remove="flex-lg-grow-0" separator=" "/>
+        </xpath>
+        <div id="contact_us_wrapper" position="attributes">
+            <attribute name="t-attf-class" remove="flex-lg-grow-0" separator=" "/>
+        </div>
+        <xpath expr="//div[@id='contact_us_wrapper']/a" position="attributes">
+            <attribute name="class" add="btn-lg" separator=" "/>
         </xpath>
         <xpath expr="//div[@id='product_option_block']" position="attributes">
             <attribute name="t-att-class" remove="flex-lg-grow-0" separator=" "/>
@@ -848,7 +846,7 @@
     >
         <div id="add_to_cart_wrap" position="inside">
             <div
-                t-attf-class="css_quantity input-group {{'d-none' if combination_info['prevent_zero_price_sale'] else 'd-inline-flex order-first'}} align-middle border"
+                t-attf-class="css_quantity input-group {{'d-none' if combination_info['prevent_sale'] else 'd-inline-flex order-first'}} align-middle border"
                 contenteditable="false"
             >
                 <a
@@ -940,7 +938,7 @@
     <template id="website_sale.product_price">
         <div
             name="product_price"
-            t-attf-class="product_price {{'d-none' if combination_info['prevent_zero_price_sale'] else 'd-inline-block'}}"
+            t-attf-class="product_price {{'d-none' if combination_info['hide_price'] else 'd-inline-block'}}"
         >
             <div
                 name="product_price_container"
@@ -993,9 +991,6 @@
             <small t-if="combination_info.get('tax_disclaimer')" class="text-muted">
                 <t t-out="combination_info['tax_disclaimer']"/>
             </small>
-        </div>
-        <div id="product_unavailable" t-attf-class="{{'d-flex' if combination_info['prevent_zero_price_sale'] else 'd-none'}}">
-            <br/>
         </div>
     </template>
 

--- a/addons/website_sale/templates/product_tile_templates.xml
+++ b/addons/website_sale/templates/product_tile_templates.xml
@@ -178,15 +178,24 @@
                 <t t-else="">
                     <t t-set="template_price_vals" t-value="get_product_prices(product)"/>
                     <div class="product_price" aria-label="Price information">
+                        <t t-set="hide_price" t-value="(
+                            not template_price_vals['price_reduce']
+                            and website.prevent_sale
+                            and website._prevent_product_sale(product, True)
+                        )"/>
                         <span
                             class="mb-0 fw-bold"
                             aria-label="Sale price"
-                            t-if="template_price_vals['price_reduce'] or not website.prevent_zero_price_sale"
+                            t-if="not hide_price"
                             t-out="template_price_vals['price_reduce']"
                             t-options="{'widget': 'monetary', 'display_currency': website.currency_id}"
                         />
                         <t
-                            t-if="'base_price' in template_price_vals and (template_price_vals['base_price'] &gt; template_price_vals['price_reduce']) and (template_price_vals['price_reduce'] or not website.prevent_zero_price_sale)"
+                            t-if="(
+                                'base_price' in template_price_vals
+                                and (template_price_vals['base_price'] &gt; template_price_vals['price_reduce'])
+                                and not hide_price
+                            )"
                             name="product_base_price"
                         >
                             <del
@@ -236,6 +245,19 @@
                     <i class="fa fa-fw fa-shopping-cart o_not-animable" role="presentation"/>
                     <span class="o_label small ms-1">Add to Cart</span>
                 </button>
+            </t>
+            <t t-elif="website.prevent_sale and website._prevent_product_sale(
+                product, not template_price_vals['price_reduce']
+            )">
+                <a
+                    title="Contact us"
+                    aria-label="Contact us"
+                    t-att-href="website._get_contact_us_url(product.with_context(display_default_code=False).display_name)"
+                    class="o_wsale_product_btn_primary btn btn-outline-primary"
+                >
+                    <i class="fa fa-fw fa-envelope o_not-animable" role="presentation"/>
+                    <span class="o_label small ms-1">Contact Us</span>
+                </a>
             </t>
         </div>
     </t>

--- a/addons/website_sale/templates/snippets/product_snippet_template_data.xml
+++ b/addons/website_sale/templates/snippets/product_snippet_template_data.xml
@@ -108,6 +108,17 @@
                                             <i class="fa fa-shopping-cart fa-fw" role="presentation"/><span class="o_label small ms-1">Add to Cart</span>
                                         </button>
                                     </t>
+                                    <t t-elif="data.get('prevent_sale')">
+                                        <a
+                                            title="Contact us"
+                                            aria-label="Contact us"
+                                            t-att-href="website._get_contact_us_url(product.display_name)"
+                                            class="o_wsale_product_btn_primary btn btn-outline-primary"
+                                        >
+                                            <i class="fa fa-envelope fa-fw" role="presentation"/>
+                                            <span class="o_label small ms-1">Contact Us</span>
+                                        </a>
+                                    </t>
                                 </div>
                             </div>
                         </div>
@@ -117,7 +128,7 @@
         </template>
 
         <template id="website_sale.price_dynamic_filter_template_product_product" name="Dynamic Product Filter Price">
-            <t t-if="not data.get('prevent_zero_price_sale') and not data.get('is_sample')">
+            <t t-if="not data.get('hide_price') and not data.get('is_sample')">
                 <span t-out="data['price']"
                       class="mb-0 fw-bold"
                       name="product_price"

--- a/addons/website_sale/templates/wishlist_templates.xml
+++ b/addons/website_sale/templates/wishlist_templates.xml
@@ -46,7 +46,7 @@
                                     t-att-data-product-id="product_variant.id"
                                 >
                                     <t t-set="product_price">
-                                        <br t-if="combination_info['prevent_zero_price_sale']"/>
+                                        <br t-if="combination_info['hide_price']"/>
                                         <div t-else="" class="align-middle o_wish_price">
                                             <span aria-label="Sale price">
                                                 <t t-out="combination_info['price']"
@@ -70,10 +70,11 @@
                                     <t t-set="product_actions">
                                         <div class="o_wsale_product_action_row">
                                             <a
-                                                t-if="combination_info['prevent_zero_price_sale']"
-                                                t-att-href="website.contact_us_button_url + '?subject=' + combination_info['display_name']"
-                                                class="btn btn-primary btn_cta"
+                                                t-if="combination_info['prevent_sale']"
+                                                t-att-href="website._get_contact_us_url(combination_info['display_name'])"
+                                                class="o_wsale_product_btn_primary btn btn-primary"
                                             >
+                                                <i class="fa fa-fw fa-envelope o_not-animable me-2" role="presentation"/>
                                                 Contact Us
                                             </a>
                                             <button
@@ -86,11 +87,8 @@
                                                 t-att-data-ptav-ids="json.dumps(product_variant.product_template_attribute_value_ids.ids)"
                                                 t-att-data-show-quantity="is_view_active('website_sale.product_quantity')"
                                             >
-                                                <i
-                                                    class="fa fa-fw fa-shopping-cart o_not-animable"
-                                                    role="presentation"
-                                                />
-                                                <span class="o_label small ms-1">Add to Cart</span>
+                                                <i class="fa fa-fw fa-shopping-cart o_not-animable me-2" role="presentation"/>
+                                                Add to Cart
                                             </button>
                                             <t t-if="is_view_active('website_sale.add_to_compare')">
                                                 <button

--- a/addons/website_sale/tests/test_cart.py
+++ b/addons/website_sale/tests/test_cart.py
@@ -89,7 +89,7 @@ class TestWebsiteSaleCart(ProductVariantsCommon, WebsiteSaleCommon):
 
     def test_zero_price_product_rule(self):
         """
-        With the `prevent_zero_price_sale` that we have on website, we can't add free products
+        With the `prevent_sale` that we have on website, we can't add free products
         to our cart.
         There is an exception for certain product types specified by the
         `_get_product_types_allow_zero_price` method, so this test ensures that it works
@@ -97,7 +97,7 @@ class TestWebsiteSaleCart(ProductVariantsCommon, WebsiteSaleCommon):
         """
         website_prevent_zero_price = self.env['website'].create({
             'name': 'Prevent zero price sale',
-            'prevent_zero_price_sale': True,
+            'prevent_sale': True,
         })
         product_consu = self.env['product.product'].create({
             'name': 'Cannot be zero price',

--- a/addons/website_sale/tests/test_product_configurator.py
+++ b/addons/website_sale/tests/test_product_configurator.py
@@ -376,7 +376,7 @@ class TestWebsiteSaleProductConfigurator(HttpCase, WebsiteSaleCommon):
 
     def test_product_configurator_zero_priced(self):
         """Test that the product configurator prevents the sale of zero-priced products."""
-        self.website.prevent_zero_price_sale = True
+        self.website.prevent_sale = True
         price_attribute = self.env['product.attribute'].create({
             'name': "Price",
             'value_ids': [

--- a/addons/website_sale/tests/test_product_page.py
+++ b/addons/website_sale/tests/test_product_page.py
@@ -22,7 +22,7 @@ class TestWebsiteSaleProductPage(HttpCase, ProductVariantsCommon, WebsiteSaleCom
         - is hidden for other products
         - is not displayed at the same time as the "Add to Cart" button
         """
-        self.website.prevent_zero_price_sale = True
+        self.website.prevent_sale = True
 
         self.product_template_sofa.list_price = 0
         red_sofa, blue_sofa = self.product_template_sofa.product_variant_ids[:2]

--- a/addons/website_sale/tests/test_reorder_from_portal.py
+++ b/addons/website_sale/tests/test_reorder_from_portal.py
@@ -16,7 +16,7 @@ class TestWebsiteSaleReorderFromPortal(HttpCaseWithUserPortal):
 
         cls.website = cls.env['website'].get_current_website()
         cls.website.write({
-            'prevent_zero_price_sale': False,
+            'prevent_sale': False,
         })
         cls.empty_cart = cls.env['sale.order'].create({
             'partner_id': cls.partner_portal.id,

--- a/addons/website_sale/views/res_config_settings_views.xml
+++ b/addons/website_sale/views/res_config_settings_views.xml
@@ -162,17 +162,36 @@
                 </setting>
                 <setting
                     id="hide_add_to_cart_setting"
-                    help="If product price equals 0, replace 'Add to Cart' by 'Contact us'."
+                    help="Show &quot;Contact Us&quot; for zero-priced products or specific categories."
                 >
-                    <field name="website_sale_prevent_zero_price_sale"/>
-                    <div class="content-group" invisible="not website_sale_prevent_zero_price_sale">
+                    <field name="prevent_sale"/>
+                    <div class="content-group" invisible="not prevent_sale">
                         <div class="row mt16">
                             <label
-                                string="Button URL"
-                                for="website_sale_contact_us_button_url"
+                                string="For"
+                                for="prevent_sale_for"
                                 class="o_light_label col-lg-3"
                             />
-                            <field name="website_sale_contact_us_button_url"/>
+                            <field name="prevent_sale_for" required="prevent_sale"/>
+                        </div>
+                        <div
+                            class="row mt16"
+                            invisible="prevent_sale_for != 'specific_categories'"
+                        >
+                            <label
+                                for="prevent_sale_for_categories"
+                                class="o_light_label col-lg-3"
+                            />
+                            <field
+                                name="prevent_sale_for_categories"
+                                widget="many2many_tags"
+                                options="{'no_create': True}"
+                                required="prevent_sale_for == 'specific_categories'"
+                            />
+                        </div>
+                        <div class="row mt16">
+                            <label for="contact_us_link_url" class="o_light_label col-lg-3"/>
+                            <field name="contact_us_link_url"/>
                         </div>
                     </div>
                 </setting>

--- a/addons/website_sale_stock/static/src/interactions/product_page.js
+++ b/addons/website_sale_stock/static/src/interactions/product_page.js
@@ -121,7 +121,7 @@ patch(ProductPage.prototype, {
                     addQtyInput.value = addQtyInput.dataset.max;
                 }
             }
-            if (combination.free_qty < 1) {
+            if (combination.free_qty < 1 && !combination.prevent_sale) {
                 ctaWrapper.classList.replace('d-flex', 'd-none');
                 ctaWrapper.classList.add('out_of_stock');
             }
@@ -132,7 +132,7 @@ patch(ProductPage.prototype, {
                     addQtyInput.value = addQtyInput.dataset.max;
                 }
             }
-            if (combination.max_combo_quantity < 1) {
+            if (combination.max_combo_quantity < 1 && !combination.prevent_sale) {
                 ctaWrapper.classList.replace('d-flex', 'd-none');
                 ctaWrapper.classList.add('out_of_stock');
             }

--- a/addons/website_sale_stock/static/src/xml/website_sale_stock_product_availability.xml
+++ b/addons/website_sale_stock/static/src/xml/website_sale_stock_product_availability.xml
@@ -3,7 +3,7 @@
 <templates>
     <t t-name="website_sale_stock.product_availability">
         <div
-            t-if="is_storable and !prevent_zero_price_sale"
+            t-if="is_storable and !prevent_sale"
             id="product_stock_availability"
         >
             <div t-if="free_qty lte 0 and !cart_qty" t-attf-class="availability_message_#{product_template} d-flex flex-column gap-2">
@@ -77,7 +77,7 @@
     </t>
     <t t-name="website_sale_stock.product_availability_wishlist">
         <div
-            t-if="is_storable and !free_qty and !allow_out_of_stock_order and !prevent_zero_price_sale"
+            t-if="is_storable and !free_qty and !allow_out_of_stock_order and !prevent_sale"
             id="stock_wishlist_message"
             t-attf-class="availability_message_#{product_template} my-2 d-flex align-items-center flex-column flex-md-row"
         >


### PR DESCRIPTION
    *  = [website_sale , website_sale_comparison , website_sale_wishlist, website_sale_stock, website_sale_stock_wishlist]
 -  Added configuration option to select specific product categories for which
    sales are blocked.
 - Replaced "Add to Cart" with "Contact Us" button for products in restricted
   categories.
 - Updated naming from `prevent_zero_price_sale` to `prevent_sale` for
    logic and naming consistency.
 -  Adjusted price and button visibility when restriction is active:
      • Hide price if product has zero price in restricted categories.
      • Show "Contact Us" when price = 0 or category is restricted and sale is blocked.
      • Show price if product has a positive price but sale is blocked.
      • Keep "Add to Cart" available for non-restricted products.

 task-4819657
SEE ALSO:

Upgrade PR: https://github.com/odoo/upgrade/pull/7928
Documentation PR:https://github.com/odoo/documentation/pull/13908
Enterprise PR:https://github.com/odoo/enterprise/pull/93675
Documentation PR(BY Documentation team): https://github.com/odoo/documentation/pull/15740

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
