### PR TITLE
[FIX] pos_restaurant: add test for booking and release table

### DIFF
--- a/addons/pos_restaurant/static/src/app/product_screen/order_summary/order_summary.xml
+++ b/addons/pos_restaurant/static/src/app/product_screen/order_summary/order_summary.xml
@@ -2,7 +2,7 @@
 <templates id="template" xml:space="preserve">
     <t t-name="pos_restaurant.OrderSummary" t-inherit="point_of_sale.OrderSummary" t-inherit-mode="extension">
         <xpath expr="//OrderWidget/t[@t-set-slot='details']" position="inside">
-            <div class="d-flex flex-column align-items-center gap-2">
+            <div class="d-flex flex-column align-items-center gap-2 table-booking">
                 <button t-if="showBookButton()" class="btn btn-primary btn-lg py-2 book-table" style="border:none; font-size: 20px;" t-on-click="bookTable">Book table</button>
                 <button t-if="showUnbookButton()" class="btn btn-primary btn-lg py-2 unbook-table" style="border:none; font-size: 20px;" t-on-click="unbookTable">
                     <t t-if="pos.selectedTable">Release table</t>

--- a/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
@@ -13,7 +13,7 @@ import * as ProductScreenPos from "@point_of_sale/../tests/tours/utils/product_s
 import * as ProductScreenResto from "@pos_restaurant/../tests/tours/utils/product_screen_util";
 import * as Order from "@point_of_sale/../tests/tours/utils/generic_components/order_widget_util";
 import * as TicketScreen from "@point_of_sale/../tests/tours/utils/ticket_screen_util";
-import { inLeftSide, negateStep } from "@point_of_sale/../tests/tours/utils/common";
+import { inLeftSide, negateStep, waitForLoading } from "@point_of_sale/../tests/tours/utils/common";
 import { registry } from "@web/core/registry";
 import * as Numpad from "@point_of_sale/../tests/tours/utils/numpad_util";
 import { delay } from "@odoo/hoot-dom";
@@ -730,5 +730,30 @@ registry.category("web_tour.tours").add("test_combo_preparation_receipt_layout",
                     }
                 },
             },
+        ].flat(),
+});
+
+registry.category("web_tour.tours").add("test_book_and_release_table", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            FloorScreen.clickTable("5"),
+            ProductScreen.bookOrReleaseTable(),
+            waitForLoading(),
+            {
+                content: "Check if order has a server ID",
+                trigger: "body",
+                run: () => {
+                    const order = posmodel.models["pos.order"].getFirst();
+
+                    if (typeof order.id !== "number") {
+                        throw new Error("Order does not have a valid server ID");
+                    }
+                },
+            },
+            FloorScreen.clickTable("5"),
+            ProductScreen.bookOrReleaseTable(),
+            waitForLoading(),
         ].flat(),
 });

--- a/addons/pos_restaurant/static/tests/tours/utils/product_screen_util.js
+++ b/addons/pos_restaurant/static/tests/tours/utils/product_screen_util.js
@@ -53,3 +53,13 @@ export function OrderButtonNotContain(data) {
     ];
     return steps;
 }
+
+export function bookOrReleaseTable() {
+    return [
+        {
+            content: "click book or release table button",
+            trigger: ".table-booking button",
+            run: "click",
+        },
+    ];
+}

--- a/addons/pos_restaurant/tests/test_frontend.py
+++ b/addons/pos_restaurant/tests/test_frontend.py
@@ -519,3 +519,9 @@ class TestFrontend(TestFrontendCommon):
         })
         self.pos_config.with_user(self.pos_admin).open_ui()
         self.start_tour(f"/pos/ui?config_id={self.pos_config.id}", 'test_combo_preparation_receipt_layout', login="pos_admin")
+
+    def test_book_and_release_table(self):
+        self.pos_config.with_user(self.pos_user).open_ui()
+        self.start_pos_tour('test_book_and_release_table', login="pos_user")
+        order = self.env['pos.order'].search([], limit=1, order='id desc')
+        self.assertEqual(order.state, "cancel", "The order should be in cancel state after releasing the table")


### PR DESCRIPTION
Following this commit: 9448836cb0307161d829f28bda0bdb5bf50f3a10

This commit adds a test to ensure that the booking and release table functionality works correctly in the POS Restaurant module. The test verifies that when a table is booked the order is correctly sent to the server.

