### PR TITLE
[IMP] core, *: dead load_data stuff

### DIFF
--- a/addons/base_import_module/models/ir_module.py
+++ b/addons/base_import_module/models/ir_module.py
@@ -116,7 +116,7 @@ class IrModuleModule(models.Model):
         for pattern in terp.get('cloc_exclude', []):
             exclude_list.update(str(p.relative_to(base_dir)) for p in base_dir.glob(pattern) if p.is_file())
 
-        kind_of_files = ['data', 'init_xml', 'update_xml']
+        kind_of_files = ['data', 'init_xml']
         if with_demo:
             kind_of_files.append('demo')
         for kind in kind_of_files:
@@ -126,9 +126,7 @@ class IrModuleModule(models.Model):
                     _logger.info("module %s: skip unsupported file %s", module, filename)
                     continue
                 _logger.info("module %s: loading %s", module, filename)
-                noupdate = False
-                if ext == '.csv' and kind in ('init', 'init_xml'):
-                    noupdate = True
+                noupdate = ext == '.csv' and kind == 'init_xml'
                 pathname = opj(path, filename)
                 idref = {}
                 with file_open(pathname, 'rb', env=self.env) as fp:

--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -867,9 +867,9 @@ class HrEmployee(models.Model):
         }
         if dep_rd:
             return action_reload
-        convert.convert_file(env=self.env, module='hr', filename='data/scenarios/hr_scenario.xml', idref=None, mode='init', kind="data")
+        convert.convert_file(env=self.env, module='hr', filename='data/scenarios/hr_scenario.xml', idref=None, mode='init')
         if 'resume_line_ids' in self:
-            convert.convert_file(env=self.env, module='hr_skills', filename='data/scenarios/hr_skills_scenario.xml', idref=None, mode='init', kind="data")
+            convert.convert_file(env=self.env, module='hr_skills', filename='data/scenarios/hr_skills_scenario.xml', idref=None, mode='init')
         return action_reload
 
     def get_formview_id(self, access_uid=None):
@@ -1122,7 +1122,7 @@ class HrEmployee(models.Model):
         demo_tag = self.env.ref('hr.employee_category_demo', raise_if_not_found=False)
         if demo_tag:
             return
-        convert.convert_file(self.env, 'hr', 'data/scenarios/hr_scenario.xml', None, mode='init', kind='data')
+        convert.convert_file(self.env, 'hr', 'data/scenarios/hr_scenario.xml', None, mode='init')
 
     # ---------------------------------------------------------
     # Business Methods

--- a/addons/hr_attendance/models/hr_attendance.py
+++ b/addons/hr_attendance/models/hr_attendance.py
@@ -513,7 +513,7 @@ class HrAttendance(models.Model):
             return
         self.env['hr.employee']._load_scenario()
         # Load employees, schedules, departments and partners
-        convert.convert_file(self.env, 'hr_attendance', 'data/scenarios/hr_attendance_scenario.xml', None, mode='init', kind='data')
+        convert.convert_file(self.env, 'hr_attendance', 'data/scenarios/hr_attendance_scenario.xml', None, mode='init')
 
         employee_sj = self.env.ref('hr.employee_sj')
         employee_mw = self.env.ref('hr.employee_mw')

--- a/addons/hr_recruitment/models/hr_job.py
+++ b/addons/hr_recruitment/models/hr_job.py
@@ -375,7 +375,6 @@ class HrJob(models.Model):
             "data/scenarios/hr_recruitment_scenario.xml",
             None,
             mode="init",
-            kind="data",
         )
 
         return {

--- a/addons/hr_skills/models/hr_employee.py
+++ b/addons/hr_skills/models/hr_employee.py
@@ -65,5 +65,5 @@ class HrEmployee(models.Model):
         demo_tag = self.env.ref('hr_skills.employee_resume_line_emp_eg_1', raise_if_not_found=False)
         if demo_tag:
             return
-        convert.convert_file(self.env, 'hr', 'data/scenarios/hr_scenario.xml', None, mode='init', kind='data')
-        convert.convert_file(self.env, 'hr_skills', 'data/scenarios/hr_skills_scenario.xml', None, mode='init', kind='data')
+        convert.convert_file(self.env, 'hr', 'data/scenarios/hr_scenario.xml', None, mode='init')
+        convert.convert_file(self.env, 'hr_skills', 'data/scenarios/hr_skills_scenario.xml', None, mode='init')

--- a/addons/mail/tests/test_mail_template.py
+++ b/addons/mail/tests/test_mail_template.py
@@ -389,7 +389,7 @@ class TestMailTemplateReset(MailCommon):
         # pylint: disable=no-value-for-parameter
         convert_file(self.env, module='mail',
                      filename=filepath,
-                     idref={}, mode='init', noupdate=False, kind='test')
+                     idref={}, mode='init', noupdate=False)
 
     def test_mail_template_reset(self):
         self._load('mail', 'tests/test_mail_template.xml')

--- a/addons/sms/tests/test_sms_template.py
+++ b/addons/sms/tests/test_sms_template.py
@@ -114,9 +114,7 @@ class TestSMSTemplateReset(TransactionCase):
 
     def _load(self, module, filepath):
         # pylint: disable=no-value-for-parameter
-        convert_file(self.env, module='sms',
-                     filename=filepath,
-                     idref={}, mode='init', noupdate=False, kind='test')
+        convert_file(self.env, module='sms', filename=filepath, idref={}, mode='init', noupdate=False)
 
     def test_sms_template_reset(self):
         self._load('sms', 'tests/test_sms_template.xml')

--- a/addons/test_website/tests/test_qweb.py
+++ b/addons/test_website/tests/test_qweb.py
@@ -10,11 +10,7 @@ from odoo.addons.base.tests.common import TransactionCaseWithUserDemo
 
 class TestQweb(TransactionCaseWithUserDemo):
     def _load(self, module, filepath):
-        tools.convert_file(
-            self.env, module,
-            filepath,
-            {}, 'init', False, 'test'
-        )
+        tools.convert_file(self.env, module, filepath, {}, 'init')
 
     def test_qweb_cdn(self):
         self._load('test_website', 'tests/template_qweb_test.xml')


### PR DESCRIPTION
- `init` kind doesn't exist (has it ever?)
- deprecate key `init_xml` since it never did what it was kept un-deprecated for, so it's useless
- deprecate `convert_file`'s `kind`, it's unused and useless

Consideration: maybe an actual way to create `noupdate` records via CSV should be added back in since it's apparently not worked for a decade?

Ideally it should be mixed in `data` and / or `demo` in order to intersperse update and noupdate content as with XML files. One motivation for that is XML files can't bulk-create, which can make them inefficient when creating records with complex but batch-able post-processing (stumbled on it looking at a profile where `_generate_payroll_report_fields` on `hr.salary.rule` turns out quite expensive, and though I didn't dig to the end to confirm it kinda looks like that's because it has to create the fields one by one then re-create the view every time as the rule creations can't be batched)