### PR TITLE
[IMP] orm: use MappingProxyType to expose _fields

### DIFF
--- a/odoo/orm/models.py
+++ b/odoo/orm/models.py
@@ -77,6 +77,7 @@ from .utils import (
 
 if typing.TYPE_CHECKING:
     from collections.abc import Collection, Iterable, Iterator, Reversible, Sequence
+    from types import MappingProxyType
     from .table_objects import TableObject
     from .environments import Environment
     from .registry import Registry, TriggerTree
@@ -356,7 +357,9 @@ class BaseModel(metaclass=MetaModel):
     pool: Registry  # all registry classes have a registry on the class
     # TODO replace most usages with self.env.registry; pool is reserved for class instance
 
-    _fields: dict[str, Field]
+    _fields__: dict[str, Field]
+    _fields: MappingProxyType[str, Field]
+
     _auto: bool = False
     """Whether a database table should be created.
     If set to ``False``, override :meth:`~odoo.models.BaseModel.init`


### PR DESCRIPTION
Currently, the `_fields` attribute in the model is an instance of a `ReadonlyDict`.  For performance reasons, we had to expose its internal dictionary in a way that is not completely satisfactory.  Also, the methods `values()` and `items()`, which are frequently used by the ORM, are less efficient than a plain dict.

This commit adds a `_fields__` attribute, which is the mutable structure containing the fields.  It is safely exposed as a `MappingProxyType` in attribute `_fields`.  This new strategy has the advantage of removing the performance overhead introduced by the former `ReadonlyDict`.

task-4808836