### PR TITLE
[FIX] stock{,_account}, l10n_ar_stock: move country_code from stock to stock_account

### DIFF
--- a/addons/l10n_ar_stock/__manifest__.py
+++ b/addons/l10n_ar_stock/__manifest__.py
@@ -3,7 +3,7 @@
     'version': '1.0',
     'description': """Argentinean - Stock""",
     'category': 'Accounting/Localizations',
-    'depends': ['l10n_ar', 'stock'],
+    'depends': ['l10n_ar', 'stock_account'],
     'data': [
         # data
         'data/mail_template_data.xml',

--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -151,7 +151,6 @@ class StockPickingType(models.Model):
         ('direct', 'As soon as possible'), ('one', 'When all products are ready')],
         'Shipping Policy', default='direct', required=True,
         help="It specifies goods to be transferred partially or all at once")
-    country_code = fields.Char(related='company_id.account_fiscal_country_id.code')
 
     @api.model_create_multi
     def create(self, vals_list):

--- a/addons/stock_account/models/__init__.py
+++ b/addons/stock_account/models/__init__.py
@@ -11,6 +11,7 @@ from . import stock_location
 from . import stock_lot
 from . import stock_move_line
 from . import stock_picking
+from . import stock_picking_type
 from . import stock_quant
 from . import stock_valuation_layer
 from . import res_config_settings

--- a/addons/stock_account/models/stock_picking_type.py
+++ b/addons/stock_account/models/stock_picking_type.py
@@ -1,0 +1,9 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models, fields
+
+
+class StockPickingType(models.Model):
+    _inherit = 'stock.picking.type'
+
+    country_code = fields.Char(related='company_id.account_fiscal_country_id.code')


### PR DESCRIPTION
### Issue:

It is impossible to install stock without account.

### Cause of the issue:

The `country_code` field of the `stock.picking.type` model was added to the stock module in d9305a1a7af6c3e4a944d566530ae75837b5cfcc
The issue is that this field is a related field via the `account_fiscal_country_id` of the `res.company` model:
https://github.com/odoo/odoo/blob/919c5515d60b9c53faf56fa63907a1f0f5d87a64/addons/account/models/company.py#L209-L210
and hence can only be initialized if the account module is not installed.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
