### PR TITLE
[FIX] sale: remove unnecessary assert

### DIFF
--- a/addons/sale/tests/test_sale_prices.py
+++ b/addons/sale/tests/test_sale_prices.py
@@ -902,6 +902,9 @@ class TestSalePrices(SaleCommon):
         """When adding a discount on a SO line, this test ensures that the untaxed amount to invoice is
         equal to the untaxed subtotal"""
         self.product.invoice_policy = 'delivery'
+        
+        self.product.write({'invoice_policy': 'delivery'})
+
         order = self.empty_order
 
         order.order_line = [Command.create({


### PR DESCRIPTION
steps to reproduce:
1- install l10n_ke_edi_oscu_mrp
2- run test test_discount_and_untaxed_subtotal

the assert is not needed and wrong in the test , as you can see there is another 2 asserts that checks

```
        self.assertEqual(line.price_subtotal, 17527.41)
        self.assertEqual(line.untaxed_amount_to_invoice, line.price_subtotal)
```

which indicates that `untaxed_amount_to_invoice` is equal to `price_subtotal` which is equal to 17527.41 not 0.

build_error-70728


