### PR TITLE
[FIX] mrp: prevent error on clicking on BoM overview

### DIFF
--- a/addons/mrp/report/mrp_report_bom_structure.py
+++ b/addons/mrp/report/mrp_report_bom_structure.py
@@ -19,7 +19,10 @@ class ReportBomStructure(models.AbstractModel):
 
     @api.model
     def get_warehouses(self):
-        return self.env['stock.warehouse'].search_read([('company_id', 'in', self.env.companies.ids)], fields=['id', 'name'])
+        return self.env['stock.warehouse'].with_context(active_test=False).search_read(
+            [('company_id', 'in', self.env.companies.ids)],
+            fields=['id', 'name']
+        )
 
     @api.model
     def _compute_current_production_capacity(self, bom_data):

--- a/addons/mrp/tests/test_bom.py
+++ b/addons/mrp/tests/test_bom.py
@@ -1219,6 +1219,17 @@ class TestBoM(TestMrpCommon):
         line_values = report_values['lines']['components'][0]
         self.assertEqual(line_values['availability_state'], 'unavailable', 'The merged components should be unavailable')
 
+    def test_report_bom_structure_with_archived_warehouse(self):
+        """
+        Test bom structure report with all warehouses are archived.
+        """
+        if self.env['mrp.production'].search([]):
+            self.skipTest("Cannot run this test with data in 'mrp.production'.")
+        self.env['stock.warehouse'].search([]).action_archive()
+        bom = self.bom_4
+        report_values = self.env['report.mrp.report_bom_structure']._get_report_data(bom_id=bom.id)
+        self.assertIn('lines', report_values)
+
     def test_report_data_bom_with_0_qty(self):
         """
         Test that a bom with a child-bom set with a zero qty will still have have 0 qty for the child-bom on the report.


### PR DESCRIPTION
Currently, an error is encountered when a user tries to open the BoM Overview when all warehouses are archived.

**steps to Reproduce:**
- Install MRP without demo
- Archive the warehouses from the inventory configuration
- Now create a BOM from MRP/products and try to open the overview

**Error:**
`IndexError: list index out of range`

**Root Cause:**
When the user clicks on BoM Overview, the system tries to fetch all warehouses at [1]. At [2], the system tries to fetch all active warehouses, and since they are archived, we get a traceback here.

[1]- https://github.com/odoo/odoo/blob/a8fdf26ee138b1f71e0534cbef73efd95bb2445d/addons/mrp/report/mrp_report_bom_structure.py#L114 [2]- https://github.com/odoo/odoo/blob/a8fdf26ee138b1f71e0534cbef73efd95bb2445d/addons/mrp/report/mrp_report_bom_structure.py#L21-L22

**Solution:**
This commit prevent error by ensuring that all the warehouses are available for computation at [2].

sentry-**6379275060**
