### PR TITLE
[IMP] l10n_jo_edi: Made reason for return mandatory in credit notes

### DIFF
--- a/addons/l10n_jo_edi/models/account_move.py
+++ b/addons/l10n_jo_edi/models/account_move.py
@@ -234,6 +234,9 @@ class AccountMove(models.Model):
             elif self.currency_id != self.reversed_entry_id.currency_id:
                 error_msgs.append(_("Please make sure the currency of the credit note is the same as the related invoice"))
 
+            if not self.ref:
+                error_msgs.append(_('Please make sure the "Customer Reference" contains the reason for the return'))
+
         if any(
             line.display_type not in ('line_note', 'line_section')
             and (line.quantity < 0 or line.price_unit < 0)


### PR DESCRIPTION
For Jordan E-invoicing, the reason for return of a credit note is mandatory in the XML.

Before this commit, if the return reason (`ref`) was empty in a credit note, an error from JoFotara pops up during validation.
This commit makes sure the user is notified of missing `ref` before submitting the XML to JoFotara.

task-4869028



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
