### PR TITLE
[FIX] point_of_sale: display correct cashier in receipt

### DIFF
--- a/addons/point_of_sale/static/tests/tours/utils/receipt_screen_util.js
+++ b/addons/point_of_sale/static/tests/tours/utils/receipt_screen_util.js
@@ -201,3 +201,12 @@ export function shippingDateIsToday() {
         },
     ];
 }
+
+export function cashierNameExists(name) {
+    return [
+        {
+            content: `Cashier ${name} exists on the receipt`,
+            trigger: `.pos-receipt-contact .cashier:contains(Served by):contains(${name})`,
+        },
+    ];
+}

--- a/addons/pos_hr/static/src/overrides/components/payment_screen/payment_screen.js
+++ b/addons/pos_hr/static/src/overrides/components/payment_screen/payment_screen.js
@@ -3,7 +3,7 @@ import { patch } from "@web/core/utils/patch";
 
 patch(PaymentScreen.prototype, {
     async validateOrder(isForceValidate) {
-        if (this.pos.config.module_pos_hr && this.pos.get_cashier() === null) {
+        if (this.pos.config.module_pos_hr) {
             this.currentOrder.update({ employee_id: this.pos.get_cashier() });
         }
 

--- a/addons/pos_hr/static/tests/tours/pos_hr_tour.js
+++ b/addons/pos_hr/static/tests/tours/pos_hr_tour.js
@@ -1,6 +1,8 @@
 import * as PosHr from "@pos_hr/../tests/tours/utils/pos_hr_helpers";
 import * as ProductScreen from "@point_of_sale/../tests/tours/utils/product_screen_util";
 import * as TicketScreen from "@point_of_sale/../tests/tours/utils/ticket_screen_util";
+import * as ReceiptScreen from "@point_of_sale/../tests/tours/utils/receipt_screen_util";
+import * as PaymentScreen from "@point_of_sale/../tests/tours/utils/payment_screen_util";
 import * as Chrome from "@point_of_sale/../tests/tours/utils/chrome_util";
 import * as NumberPopup from "@point_of_sale/../tests/tours/utils/number_popup_util";
 import * as Dialog from "@point_of_sale/../tests/tours/utils/dialog_util";
@@ -153,5 +155,24 @@ registry.category("web_tour.tours").add("test_basic_user_can_change_price", {
             SelectionPopup.has("Test Employee 3", { run: "click" }),
             Dialog.confirm("Open Register"),
             ProductScreen.addOrderline("Desk Pad", "1", "10", "10"),
+        ].flat(),
+});
+
+registry.category("web_tour.tours").add("test_cashier_changed_in_receipt", {
+    steps: () =>
+        [
+            Chrome.clickBtn("Open Register"),
+            PosHr.loginScreenIsShown(),
+            PosHr.clickLoginButton(),
+            SelectionPopup.has("Mitchell Admin", { run: "click" }),
+            Dialog.confirm("Open Register"),
+            ProductScreen.addOrderline("product_a", "1"),
+            ProductScreen.clickPayButton(),
+            PaymentScreen.clickPaymentMethod("Bank"),
+            PosHr.clickCashierName(),
+            SelectionPopup.has("Test Employee 3", { run: "click" }),
+            PaymentScreen.clickValidate(),
+            ReceiptScreen.cashierNameExists("Test Employee 3"),
+            ReceiptScreen.clickNextOrder(),
         ].flat(),
 });

--- a/addons/pos_hr/tests/test_frontend.py
+++ b/addons/pos_hr/tests/test_frontend.py
@@ -121,3 +121,23 @@ class TestUi(TestPosHrHttpCommon):
             "test_basic_user_can_change_price",
             login="pos_user",
         )
+
+    def test_cashier_changed_in_receipt(self):
+        """
+        Checks that when the cashier is changed during the order,
+        the receipts displays the employee that concluded the order,
+        meaning the one that was at the register when the customer was paying.
+        Also checks that the order has the right cashier and employee in the same
+        use case.
+        """
+        self.product_a.available_in_pos = True
+        self.main_pos_config.with_user(self.pos_admin).open_ui()
+
+        self.start_tour(
+            "/pos/ui?config_id=%d" % self.main_pos_config.id,
+            "test_cashier_changed_in_receipt",
+            login="pos_admin",
+        )
+        order = self.main_pos_config.current_session_id.order_ids[0]
+        self.assertEqual(order.cashier, "Test Employee 3")
+        self.assertEqual(order.employee_id.display_name, "Test Employee 3")


### PR DESCRIPTION
**Problem:**
When cashier A is assigned to an order, then changed during the payment
screen process to cashier B, the receipt will display Served by cashier A.
It should be Served by cashier B as this is the one that closed the order.
This used to work until 18.0.

**Steps to reproduce:**
- Add some employees to your PoS, using pos_hr
- Select one of them, then change to another one during the payment screen, before paying
- Pay for it, the receipt screen still displays the first cashier

**Why the fix:**
The receipt should first display the current cashier, not the order's
cashier. It was done the other way around before this commit. We now
first display the session's cashier, then if not available we display
the order's cashier.

opw-4868038