### PR TITLE
[FIX] spreadsheet_dashboard: fix searchbard toggler style

### DIFF
--- a/addons/spreadsheet_dashboard/static/src/bundle/dashboard_action/dashboard_search_bar/dashboard_search_bar.xml
+++ b/addons/spreadsheet_dashboard/static/src/bundle/dashboard_action/dashboard_search_bar/dashboard_search_bar.xml
@@ -12,7 +12,7 @@
                     </t>
                 </div>
             </div>
-            <button class="btn btn-outline-secondary o-dropdown-caret rounded-start-0 o-dropdown dropdown-toggle dropdown" t-on-click="openDialog"/>
+            <button class="o_searchview_dropdown_toggler btn btn-outline-secondary o-dropdown-caret rounded-start-0 o-dropdown dropdown-toggle dropdown" t-on-click="openDialog"/>
             <div class="o_sp_date_filter_button ms-2 d-flex" t-if="firstDateFilter">
                 <DashboardDateFilter value="firstDateFilterValue"
                                  update.bind="updateFirstDateFilter"/>


### PR DESCRIPTION
There was a missing class in the new searchbar to unify the border behaviour of both the input box and the dropdown button.

Task-4893891

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
