### PR TITLE
[FIX] website: prevent error when creating a new page on the website

### DIFF
--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -876,8 +876,8 @@ class Website(models.Model):
 
         template_record = self.env.ref(template)
         arch = template_record.arch
-        if sections_arch:
-            tree = html.fromstring(arch)
+        tree = html.fromstring(arch)
+        if sections_arch and tree.xpath('//div[@id="wrap"]'):
             wrap = tree.xpath('//div[@id="wrap"]')[0]
             for section in html.fromstring(f'<wrap>{sections_arch}</wrap>'):
                 wrap.append(section)


### PR DESCRIPTION
Currently, an error occurs when creating a new page on the website.

Steps to Reproduce:

 - Install the `website` module.
 - Go to `Pages` on website.
 - Click `New` and choose any template except Blank.
 - Enter demo.xml as the page title and click Create.

`IndexError: list index out of range`

This error occurs when creating a new page and the title includes a file extension. The _guess_mimetype function [1] uses the extension to determine and return the related template name. In [2], if the template does not contain a 'div' with id="wrap", the XPath query returns an empty list. When it tries to access the first element of this empty list, it raises an error.

[1]
https://github.com/odoo/odoo/blob/8ddc065c5d75750d8fe0736c2232888a543424fd/addons/website/controllers/main.py#L640

[2]
https://github.com/odoo/odoo/blob/8ddc065c5d75750d8fe0736c2232888a543424fd/addons/website/models/website.py#L881

This commit ensures that it accesses the first XPath only if there is an element present in the list.

sentry-6696313055


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
