### PR TITLE
[IMP] mail: busy behavior

### DIFF
--- a/addons/mail/models/discuss/discuss_channel.py
+++ b/addons/mail/models/discuss/discuss_channel.py
@@ -702,7 +702,7 @@ class DiscussChannel(models.Model):
             [("partner_id", "!=", author_id)],
             [("partner_id.active", "=", True)],
             [("mute_until_dt", "=", False)],
-            [("partner_id.user_ids.res_users_settings_ids.mute_until_dt", "=", False)],
+            [("partner_id.user_ids.manual_im_status", "!=", "busy")],
             Domain.OR([
                 [("channel_id.channel_type", "!=", "channel")],
                 Domain.AND([

--- a/addons/mail/models/discuss/discuss_channel_member.py
+++ b/addons/mail/models/discuss/discuss_channel_member.py
@@ -429,10 +429,14 @@ class DiscussChannelMember(models.Model):
         :param list member_ids: List of the partner ids to invite.
         """
         self.ensure_one()
-        domain = Domain([
-            ('channel_id', '=', self.channel_id.id),
-            ('rtc_inviting_session_id', '=', False),
-            ('rtc_session_ids', '=', False),
+        domain = Domain.AND([
+            [('channel_id', '=', self.channel_id.id)],
+            [('rtc_inviting_session_id', '=', False)],
+            [('rtc_session_ids', '=', False)],
+            Domain.OR([
+                [("partner_id", "=", False)],
+                [("partner_id.user_ids.manual_im_status", "!=", "busy")],
+            ]),
         ])
         if member_ids:
             domain &= Domain('id', 'in', member_ids)

--- a/addons/mail/static/src/core/common/im_status_dropdown.xml
+++ b/addons/mail/static/src/core/common/im_status_dropdown.xml
@@ -4,11 +4,14 @@
         <Dropdown>
             <button><ImStatus persona='store.self'/> <span t-esc="readableImStatus"/></button>
             <t t-set-slot="content">
-                <DropdownItem onSelected="() => this.setManualImStatus('online')"><i class="fa fa-circle text-success me-1" title="Online" role="img"/> Online</DropdownItem>
+                <DropdownItem class="{ 'active': this.store.self.im_status.includes('online') }" onSelected="() => this.setManualImStatus('online')"><i class="fa fa-circle text-success me-1" title="Online" role="img"/> Online</DropdownItem>
                 <hr class="my-1"/>
-                <DropdownItem onSelected="() => this.setManualImStatus('away')"><i class="fa fa-circle o-yellow me-1" title="Away" role="img"/> Away</DropdownItem>
-                <DropdownItem onSelected="() => this.setManualImStatus('busy')"><span><i class="fa fa-minus-circle text-danger me-1" title="Busy" role="img"/> Do Not Disturb</span></DropdownItem>
-                <DropdownItem onSelected="() => this.setManualImStatus('offline')"><i class="fa fa-circle-o text-700 opacity-75 me-1" title="Offline" role="img"/> Offline</DropdownItem>
+                <DropdownItem class="{ 'active': this.store.self.im_status.includes('away') }" onSelected="() => this.setManualImStatus('away')"><i class="fa fa-circle o-yellow me-1" title="Away" role="img"/> Away</DropdownItem>
+                <DropdownItem class="{ 'active': this.store.self.im_status.includes('busy') }" onSelected="() => this.setManualImStatus('busy')">
+                    <i class="fa fa-minus-circle text-danger me-1" title="Busy" role="img"/> Do Not Disturb
+                    <div class="small text-muted">You will not receive any notifications</div>
+                </DropdownItem>
+                <DropdownItem class="{ 'active': this.store.self.im_status.includes('offline') }" onSelected="() => this.setManualImStatus('offline')"><i class="fa fa-circle-o text-700 opacity-75 me-1" title="Offline" role="img"/> Offline</DropdownItem>
             </t>
         </Dropdown>
     </t>

--- a/addons/mail/static/src/core/common/settings_model.js
+++ b/addons/mail/static/src/core/common/settings_model.js
@@ -57,7 +57,6 @@ export class Settings extends Record {
             }
         },
     });
-    mute_until_dt = fields.Datetime();
 
     // Voice settings
     // DeviceId of the audio input selected by the user

--- a/addons/mail/static/src/core/common/thread_model.js
+++ b/addons/mail/static/src/core/common/thread_model.js
@@ -323,7 +323,7 @@ export class Thread extends Record {
     }
 
     get isMuted() {
-        return this.mute_until_dt || this.store.settings.mute_until_dt;
+        return this.mute_until_dt;
     }
 
     get typesAllowingCalls() {

--- a/addons/mail/static/src/core/public_web/thread_model_patch.js
+++ b/addons/mail/static/src/core/public_web/thread_model_patch.js
@@ -22,7 +22,7 @@ patch(Thread.prototype, {
             this.custom_notifications || this.store.settings.channel_notifications;
         if (
             !this.mute_until_dt &&
-            !this.store.settings.mute_until_dt &&
+            !this.store.self.im_status.includes("busy") &&
             (this.channel_type !== "channel" ||
                 (this.channel_type === "channel" &&
                     (channel_notifications === "all" ||

--- a/addons/mail/static/src/core/web/messaging_menu_patch.xml
+++ b/addons/mail/static/src/core/web/messaging_menu_patch.xml
@@ -6,7 +6,7 @@
                 <Dropdown state="dropdown" beforeOpen.bind="beforeOpen" position="'bottom-end'" menuClass="discussSystray.menuClass">
                     <button>
                         <i class="fa fa-lg fa-comments" role="img" aria-label="Messages" t-on-click="() => store.discuss.activeTab = ui.isSmall and store.discuss.activeTab === 'main' ? 'main' : store.discuss.activeTab"></i>
-                        <span t-if="!store.settings.mute_until_dt and counter" class="o-mail-MessagingMenu-counter badge rounded-pill"><t t-esc="counter"/></span>
+                        <span t-if="counter" class="o-mail-MessagingMenu-counter badge rounded-pill"><t t-esc="counter"/></span>
                     </button>
                     <t t-set-slot="content">
                         <t t-call="mail.MessagingMenu.content"/>

--- a/addons/mail/static/src/discuss/core/common/discuss_notification_settings.js
+++ b/addons/mail/static/src/discuss/core/common/discuss_notification_settings.js
@@ -12,26 +12,7 @@ export class DiscussNotificationSettings extends Component {
         });
     }
 
-    onChangeDisplayMuteDetails() {
-        // set the default mute duration to forever when opens the mute details
-        if (!this.store.settings.mute_until_dt) {
-            const FOREVER = this.store.settings.MUTES.find((m) => m.label === "forever").value;
-            this.store.settings.setMuteDuration(FOREVER);
-            this.state.selectedDuration = FOREVER;
-        } else {
-            this.store.settings.setMuteDuration(false);
-        }
-    }
-
     onChangeMessageSound() {
         this.store.settings.messageSound = !this.store.settings.messageSound;
-    }
-
-    onChangeMuteDuration(ev) {
-        if (ev.target.value === "default") {
-            return;
-        }
-        this.store.settings.setMuteDuration(parseInt(ev.target.value));
-        this.state.selectedDuration = parseInt(ev.target.value);
     }
 }

--- a/addons/mail/static/src/discuss/core/common/discuss_notification_settings.xml
+++ b/addons/mail/static/src/discuss/core/common/discuss_notification_settings.xml
@@ -4,29 +4,6 @@
     <t t-name="mail.DiscussNotificationSettings">
         <div class="o-mail-DiscussNotificationSettings d-flex flex-column">
             <div class="d-flex flex-column my-1">
-                <label class="cursor-pointer d-flex align-items-center">
-                    <h5>Mute all conversations</h5>
-                    <div class="flex-grow-1"/>
-                    <div class="form-check form-switch">
-                        <input class="form-check-input" type="checkbox" role="switch" t-att-checked="store.settings.mute_until_dt" t-on-change="onChangeDisplayMuteDetails"/>
-                    </div>
-                </label>
-                <span class="mt-1 text-muted small">Muting prevents unread indicators and notifications from appearing.</span>
-            </div>
-            <label t-if="store.settings.mute_until_dt" class="d-flex align-items-baseline my-1">
-                <div class="d-flex flex-column">
-                    <h6 class="flex-shrink-0 mb-1">Mute duration</h6>
-                    <span class="text-muted smaller" t-esc="store.settings.getMuteUntilText(store.settings.mute_until_dt)"/>
-                </div>
-                <div class="flex-grow-1"/>
-                <select class="form-select w-auto d-flex" t-on-change="onChangeMuteDuration">
-                    <t t-foreach="store.settings.MUTES" t-as="mute" t-key="mute.label">
-                        <option t-att-value="mute.value" t-esc="mute.name" t-att-selected="mute.value === state.selectedDuration"/>
-                    </t>
-                </select>
-            </label>
-            <hr class="o-discuss-separator my-1"/>
-            <div class="d-flex flex-column my-1">
                 <h5>Channel Notifications</h5>
                 <span class="mb-1 text-muted small">This setting will be applied to all channels using the default notification settings.</span>
                 <t t-foreach="store.settings.NOTIFICATIONS" t-as="notif" t-key="notif.label">

--- a/addons/mail/static/src/discuss/core/common/notification_settings.xml
+++ b/addons/mail/static/src/discuss/core/common/notification_settings.xml
@@ -4,9 +4,6 @@
     <t t-name="discuss.NotificationSettings">
         <ActionPanel title.translate="Notification Settings" resizable="false" icon="'fa fa-bell'">
             <div class="o-discuss-NotificationSettings">
-                <div t-if="store.settings.mute_until_dt" class="d-flex flex-column alert alert-warning">
-                    <span><i class="fa fa-exclamation-triangle"/> <a href="#" t-on-click="onClickAllConversationsMuted">All conversations have been muted</a></span>
-                </div>
                 <t t-if="props.thread.mute_until_dt">
                     <button class="btn w-100 d-flex p-1 opacity-75 border-0" t-on-click="()=>this.setMute(false)">
                         <div class="d-flex flex-column flex-grow-1 px-2 py-1 w-100 rounded">
@@ -15,7 +12,7 @@
                         </div>
                     </button>
                 </t>
-                <div t-elif="!store.settings.mute_until_dt" class="d-flex">
+                <div class="d-flex">
                     <Dropdown position="ui.isSmall ? 'bottom-end' : 'right-start'" menuClass="'o-mail-NotificationSettings-submenu d-flex flex-column py-0 my-0 bg-100 border-secondary'">
                         <button class="btn w-100 d-flex p-1 opacity-75 border-0">
                             <div class="d-flex flex-grow-1 align-items-center px-0 py-1 w-100 rounded">
@@ -31,7 +28,7 @@
                         </t>
                     </Dropdown>
                 </div>
-                <t t-if="props.thread.channel_type === 'channel' and !store.settings.mute_until_dt">
+                <t t-if="props.thread.channel_type === 'channel'">
                     <hr class="solid mx-1 my-2"/>
                     <button class="btn d-flex w-100 p-0 border-0" t-on-click="() => store.settings.setCustomNotifications(false, props.thread)">
                         <div class="d-flex flex-grow-1 align-items-center px-2 rounded">

--- a/addons/mail/static/tests/mock_server/mail_mock_server.js
+++ b/addons/mail/static/tests/mock_server/mail_mock_server.js
@@ -345,8 +345,6 @@ async function discuss_settings_mute(request) {
     const BusBus = this.env["bus.bus"];
     /** @type {import("mock_models").DiscussChannel} */
     const DiscussChannel = this.env["discuss.channel"];
-    /** @type {import("mock_models").ResUsersSettings} */
-    const ResUsersSettings = this.env["res.users.settings"];
     /** @type {import("mock_models").DiscussChannelMember} */
     const DiscussChannelMember = this.env["discuss.channel.member"];
     /** @type {import("mock_models").ResPartner} */
@@ -361,21 +359,16 @@ async function discuss_settings_mute(request) {
     } else {
         mute_until_dt = false;
     }
-    if (channel_id) {
-        const member = DiscussChannel._find_or_create_member_for_self(channel_id);
-        DiscussChannelMember.write([member.id], { mute_until_dt });
-        const [partner] = ResPartner.read(this.env.user.partner_id);
-        BusBus._sendone(
-            partner,
-            "mail.record/insert",
-            new mailDataHelpers.Store(DiscussChannel.browse(member.channel_id), {
-                mute_until_dt,
-            }).get_result()
-        );
-    } else {
-        const settings = ResUsersSettings._find_or_create_for_user(this.env.user.id);
-        ResUsersSettings.set_res_users_settings(settings.id, { mute_until_dt });
-    }
+    const member = DiscussChannel._find_or_create_member_for_self(channel_id);
+    DiscussChannelMember.write([member.id], { mute_until_dt });
+    const [partner] = ResPartner.read(this.env.user.partner_id);
+    BusBus._sendone(
+        partner,
+        "mail.record/insert",
+        new mailDataHelpers.Store(DiscussChannel.browse(member.channel_id), {
+            mute_until_dt,
+        }).get_result()
+    );
     return "dummy";
 }
 

--- a/addons/mail/static/tests/mock_server/mock_models/mail_guest.js
+++ b/addons/mail/static/tests/mock_server/mock_models/mail_guest.js
@@ -29,6 +29,7 @@ export class MailGuest extends models.ServerModel {
                 data.write_date = guest.write_date;
             }
             if (fields.includes("im_status")) {
+                data.im_status = "offline";
                 data.im_status_access_token = guest.id;
             }
             store.add(this.browse(guest.id), data);

--- a/addons/mail/static/tests/mock_server/mock_models/res_partner.js
+++ b/addons/mail/static/tests/mock_server/mock_models/res_partner.js
@@ -188,7 +188,7 @@ export class ResPartner extends webModels.ResPartner {
         if (partner.id === serverState.odoobotId) {
             return "bot";
         }
-        return partner.im_status;
+        return partner.im_status || "offline";
     }
     /**
      * @param {Array} domain

--- a/addons/mail/static/tests/tours/discuss_configuration_tour.js
+++ b/addons/mail/static/tests/tours/discuss_configuration_tour.js
@@ -18,10 +18,6 @@ registry.category("web_tour.tours").add("discuss_configuration_tour", {
             run: "click",
         },
         {
-            trigger: ".o-mail-DiscussNotificationSettings label:contains('Mute')",
-            run: "click",
-        },
-        {
             trigger: "button:contains('All Messages')",
             run: "click",
         },

--- a/addons/test_discuss_full/tests/test_performance.py
+++ b/addons/test_discuss_full/tests/test_performance.py
@@ -431,7 +431,6 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
                 "self_partner": {"id": self.users[0].partner_id.id, "type": "partner"},
                 "settings": {
                     "channel_notifications": False,
-                    "mute_until_dt": False,
                     "id": self.env["res.users.settings"]._find_or_create_for_user(self.users[0]).id,
                     "is_discuss_sidebar_category_channel_open": True,
                     "is_discuss_sidebar_category_chat_open": True,


### PR DESCRIPTION
This commit adds behavior to the busy IM status.
This status replaces the "mute all" behavior, with the exception of hiding counters and the addition of rejecting incoming calls and muting sound alerts.

task-4889586
