### PR TITLE
[FIX] web: correctly activate companies after access error

### DIFF
--- a/addons/web/static/src/core/user.js
+++ b/addons/web/static/src/core/user.js
@@ -256,7 +256,7 @@ export function _makeUser(session) {
                 for (const companyId of companyIds) {
                     if (!newCompanyIds.includes(companyId)) {
                         newCompanyIds.push(companyId);
-                        addCompanies(allowedCompanies[companyId].child_ids);
+                        addCompanies(allowedCompanies.find((c) => c.id === companyId).child_ids);
                     }
                 }
             }

--- a/addons/web/static/tests/core/user.test.js
+++ b/addons/web/static/tests/core/user.test.js
@@ -117,3 +117,36 @@ test("company evalContext", async () => {
     expect(companyEvalContext.has(false, "country_code", "AR")).toBe(false);
     expect(companyEvalContext.has(4, "country_code", "AR")).toBe(false);
 });
+
+test("activate company branches after access error", async () => {
+    cookie.set("cids", "1")
+    serverState.companies = [
+        {
+            id: 1,
+            name: "Company 1",
+            sequence: 1,
+            parent_id: false,
+            child_ids: [2, 3],
+        },
+        {
+            id: 2,
+            name: "Company 1 Branch 1",
+            sequence: 2,
+            parent_id: 1,
+            child_ids: [],
+        },
+        {
+            id: 3,
+            name: "Company 1 Branch 2",
+            sequence: 3,
+            parent_id: 1,
+            child_ids: [],
+        },
+    ];
+
+    const activeCompanyIds = user.activeCompanies.map((c) => c.id);
+    activeCompanyIds.push(2);
+    user.activateCompanies(activeCompanyIds);
+    // Activating the first branch should activate all branches
+    expect(cookie.get("cids")).toBe("1-2-3");
+})


### PR DESCRIPTION
When we get an access error due to multi-company rules, odoo will try to set the appropriate company in the company switcher. If any company has branches, these will also be set. However, currently, if we have multiple branches and we try to access a record that belongs to any branch but the last one, we get a traceback.

Steps to reproduce:
1. Create 2 branches of a company
2. Create an employee in the first branch (copy the link to employee)
3. Uncheck the branches in the company selector
4. Try to access the employee created in step 2 via a link > Traceback

This is because we are trying to access an index that is out of range of `allowedCompanies`.

To fix this, we use `find()` to find the appropriate company by its id.

opw-4846979