### PR TITLE
[IMP] iot_box_image: download logs from 502 page

### DIFF
--- a/addons/iot_box_image/configuration/odoo.conf
+++ b/addons/iot_box_image/configuration/odoo.conf
@@ -7,3 +7,4 @@ limit_time_cpu = 600
 limit_time_real = 1200
 max_cron_threads = 0
 server_wide_modules=hw_drivers,hw_posbox_homepage,web
+list_db = False

--- a/addons/iot_box_image/overwrite_after_init/var/www/html/502.html
+++ b/addons/iot_box_image/overwrite_after_init/var/www/html/502.html
@@ -1,89 +1,89 @@
 <!DOCTYPE html>
-<html>
-<head>
-    <style>
-        body {
-            width: 600px;
-            margin: 30px auto;
-            font-family: sans-serif;
-            text-align: justify;
-            color: #6B6B6B;
-            background-color: #f1f1f1;
-        }
-
-        a {
-            text-decoration: none;
-            color: #00a09d;
-        }
-
-        a:hover {
-            color: #006d6b;
-        }
-
-        .container {
-            padding: 10px 20px;
-            background: #ffffff;
-            border-radius: 8px;
-            box-shadow: 0 1px 1px 0 rgba(0, 0, 0, 0.17);
-        }
-
-        input[type="text"], input[type="password"] {
-            padding: 6px 12px;
-            font-size: 1rem;
-            border: 1px solid #ccc;
-            border-radius: 3px;
-            color: inherit;
-        }
-
-        input::placeholder {
-            color: #ccc;
-            opacity: 1; /* Firefox */
-        }
-
-        select {
-            padding: 6px 12px;
-            font-size: 1rem;
-            border: 1px solid #ccc;
-            border-radius: 3px;
-            color: inherit;
-            background: #ffffff;
-            width: 100%;
-        }
-
-        .footer {
-            margin-top: 12px;
-            text-align: right;
-        }
-
-        .footer a {
-            margin-left: 8px;
-        }
-
-        @keyframes spin {
-            from {
-                transform: rotate(0deg);
+<html lang="en">
+    <head>
+        <style>
+            body {
+                width: 100vw;
+                height: 100vh;
+                font-family: system-ui;
+                background-color: #f1f1f1;
+                color: #212529;
+                display: flex;
+                flex-direction: column;
+                justify-content: center;
+                align-items: center;
             }
-            to {
-                transform: rotate(360deg);
+
+            .header {
+                display: flex;
+                justify-content: space-between;
+                align-items: center;
+
             }
-        }
-    </style>
-</head>
-<body>
-<div class="container">
-        <h1 style="color: red">IoT Box is down</h1>
-        <h2>502 Bad Gateway</h2>
-        <p>The IoT Box received the request but was not able to handle it. You can try to refresh the page to see if the request can now be handled.</p>
-        <p>If the error persist for more than 5 minutes:</p>
-        <ol>
-            <li>Force restart the IoT box by plug off the IoT power supply then on again</li>
-            <li>Re-flash the SD card of the IoT box, see: <a
-                href="https://www.odoo.com/documentation/18.0/applications/general/iot/config/updating_iot.html#flashing-the-sd-card-on-iot-box" target="_blank">documentation</a></li>
-        </ol>
-</div>
-<div class="footer">
-    <a href='https://www.odoo.com/help'>Help</a>
-    <a href='https://www.odoo.com/documentation/18.0/applications/productivity/iot.html'>Documentation</a>
-</div>
-</body>
+
+            .header a {
+                color: white;
+                background-color: #714b67;
+                padding: 8px 16px;
+                border-radius: 4px;
+                text-decoration: none;
+                font-weight: 500;
+            }
+
+            .header a:hover {
+                background-color: #52374B;
+                color: white;
+            }
+
+            h2 {
+                color: #6c757d;
+                font-weight: normal;
+                margin-top: 0;
+            }
+
+            a {
+                font-weight: bold;
+                color: #714b67;
+            }
+
+            a:hover {
+                color: blue;
+            }
+
+            .container {
+                max-width: 600px;
+                padding: 10px 20px;
+                background: #ffffff;
+                border-radius: 8px;
+            }
+
+            .footer {
+                display: flex;
+                gap: 1rem;
+                margin-top: 12px;
+            }
+        </style>
+        <title>IoT Box is down</title>
+    </head>
+    <body>
+        <div class="container">
+            <div class="header">
+                <h1>IoT Box is down</h1>
+                <a href="/odoo-logs/odoo-server.log">Download logs</a>
+            </div>
+            <h2>(502 Bad Gateway)</h2>
+            <p>The IoT Box received the request but was not able to handle it. You can try to refresh the page to see if the request can now be handled.</p>
+            <p>If the error persists for more than 5 minutes:</p>
+            <ol>
+                <li>Force restart the IoT Box by unplugging the IoT power supply then plugging it in again</li>
+                <li>Re-flash the SD card of the IoT Box, see:
+                    <a href="https://www.odoo.com/documentation/18.0/applications/general/iot/config/updating_iot.html#flashing-the-sd-card-on-iot-box" target="_blank">documentation</a>
+                </li>
+            </ol>
+        </div>
+        <div class="footer">
+            <a target="_blank" href="https://www.odoo.com/help">Help</a>
+            <a target="_blank" href="https://www.odoo.com/documentation/18.0/applications/productivity/iot.html">Documentation</a>
+        </div>
+    </body>
 </html>


### PR DESCRIPTION
We add a button to ease logs downloading from the IoT Box http 502 error page. We also update the design to match the homepage's one.

This commit also sets the configuration param `list_db = False` to avoid displaying the form when the user is redirected to `/web/database/selector` (which should not happen).
