### PR TITLE
17.0 in stock ewb cancel fix hamo

### DIFF
--- a/addons/l10n_in_ewaybill_stock/models/l10n_in_ewaybill.py
+++ b/addons/l10n_in_ewaybill_stock/models/l10n_in_ewaybill.py
@@ -418,7 +418,7 @@ class Ewaybill(models.Model):
         cancel_json = {
             "ewbNo": int(self.name),
             "cancelRsnCode": int(self.cancel_reason),
-            "CnlRem": self.cancel_remarks,
+            "cancelRmrk": self.cancel_remarks,
         }
         ewb_api = EWayBillApi(self.company_id)
         self._lock_ewaybill()

--- a/addons/l10n_in_ewaybill_stock/models/l10n_in_ewaybill.py
+++ b/addons/l10n_in_ewaybill_stock/models/l10n_in_ewaybill.py
@@ -423,10 +423,11 @@ class Ewaybill(models.Model):
         ewb_api = EWayBillApi(self.company_id)
         self._lock_ewaybill()
         try:
-            ewb_api._ewaybill_cancel(cancel_json)
+            response = ewb_api._ewaybill_cancel(cancel_json)
         except EWayBillError as error:
             self._handle_error(error)
             return False
+        self._handle_internal_warning_if_present(response)  # In case of error 312
         self._write_successfully_response({'state': 'cancel'})
         self._cr.commit()
 

--- a/addons/l10n_in_ewaybill_stock/tools/ewaybill_api.py
+++ b/addons/l10n_in_ewaybill_stock/tools/ewaybill_api.py
@@ -142,15 +142,17 @@ class EWayBillApi:
             if operation_type == "cancel" and "312" in e.error_codes:
                 # E-waybill is already canceled
                 # this happens when timeout from the Government portal but IRN is generated
-                e.error_json['odoo_warning'].append({
-                    'message': Markup("%s<br/>%s:<br/>%s") % (
-                        self.DEFAULT_HELP_MESSAGE % 'cancelled',
-                        _("Error"),
-                        e.get_all_error_message()
-                    ),
-                    'message_post': True
-                })
-                raise
+                # Avoid raising error in this case, since it is already cancelled
+                return {
+                    'odoo_warning': [{
+                        'message': Markup("%s<br/>%s:<br/>%s") % (
+                            self.DEFAULT_HELP_MESSAGE % 'cancelled',
+                            _("Error"),
+                            e.get_all_error_message()
+                        ),
+                        'message_post': True
+                    }]
+                }
 
             if operation_type == "generate" and "604" in e.error_codes:
                 # Get E-waybill by details in case of E-waybill is already generated


### PR DESCRIPTION
This PR has following commit-
- **[FIX] l10n_in_ewaybill_stock:cancel remarks mandatory** (Already managed by https://github.com/odoo/odoo/pull/215523)
 Since it would more much better to handle the fw-port with different version this commit will be removed in saas-18.1 fw-port and will be surpassed by the above mention PR

- **[FIX] l10n_in_ewaybill_stock: Allow cancelation of E-waybill**

When canceling E-waybill if error `312` occurred it means
the E-waybill is already been cancelled but in that case
we raise warning while E-waybill stays in the state of
`Generated`.

In this commit we handle error `312`, we receive it,
we will log it on the E-waybill and cancel the E-waybill
as it is already being cancelled

opw-4882071

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
