### PR TITLE
[FIX] website: indeterministic popup closing test

### DIFF
--- a/addons/website/static/tests/builder/website_builder/popup_option.test.js
+++ b/addons/website/static/tests/builder/website_builder/popup_option.test.js
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, test } from "@odoo/hoot";
-import { advanceTime } from "@odoo/hoot-dom";
+import { advanceTime, waitFor } from "@odoo/hoot-dom";
 import { contains } from "@web/../tests/web_test_helpers";
 import {
     defineWebsiteModels,
@@ -55,6 +55,8 @@ describe("Popup options: popup in page before edit", () => {
     test("closing s_popup with the X button updates the invisible elements panel", async () => {
         await contains(".o_we_invisible_entry .fa-eye-slash").click();
         expect(".o_we_invisible_entry .fa").toHaveClass("fa-eye");
+        // Sometimes bootstrap.js takes a bit of time to close the popup.
+        await waitFor(":iframe .s_popup div.js_close_popup", { timeout: 500 });
         await contains(":iframe .s_popup div.js_close_popup").click();
         expect(":iframe .s_popup").not.toBeVisible();
         expect(".o_we_invisible_entry .fa").toHaveClass("fa-eye-slash");


### PR DESCRIPTION
PR: https://github.com/odoo/odoo/pull/217521

Before to this commit, the ‘closing s_popup with the X button updates the invisible elements panel’ test failed from sometimes on runbot. We think boostrap.js takes longer than normal to close the popup.

Solution:
We're going to increase the waiting timeout so that the crash doesn't recur. We've taken this decision because the problem is very specific and probably link to bootsta.js.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
