### PR TITLE
[FIX] hw_posbox_homepage: server url is not reactive

### DIFF
--- a/addons/hw_posbox_homepage/static/src/app/components/dialog/ServerDialog.js
+++ b/addons/hw_posbox_homepage/static/src/app/components/dialog/ServerDialog.js
@@ -4,14 +4,14 @@ import useStore from "../../hooks/useStore.js";
 import { BootstrapDialog } from "./BootstrapDialog.js";
 import { LoadingFullScreen } from "../LoadingFullScreen.js";
 
-const { Component, xml, useState, toRaw } = owl;
+const { Component, xml, useState } = owl;
 
 export class ServerDialog extends Component {
     static props = {};
     static components = { BootstrapDialog, LoadingFullScreen };
 
     setup() {
-        this.store = toRaw(useStore());
+        this.store = useStore();
         this.state = useState({ waitRestart: false, loading: false, error: null });
         this.form = useState({ token: "" });
     }
@@ -38,14 +38,11 @@ export class ServerDialog extends Component {
     }
 
     async clearConfiguration() {
+        this.state.waitRestart = true;
         try {
-            const data = await this.store.rpc({
+            await this.store.rpc({
                 url: "/hw_posbox_homepage/server_clear",
             });
-
-            if (data.status === "success") {
-                this.state.waitRestart = true;
-            }
         } catch {
             console.warn("Error while clearing configuration");
         }


### PR DESCRIPTION
We store the server url in `store.base`, which was made unreactive by using owl `toRaw` method. This made the `disconnect from current` button not being displayed right after connecting to a database, without reloading the page.

We removed this call to fix this behavior.

We also called `waitRestart` before calling the disconnect method from the back end, in order to remove the delay before displaying the loader.