### PR TITLE
[FIX] base: remove blank spaces from report address block

### DIFF
--- a/odoo/addons/base/models/res_partner.py
+++ b/odoo/addons/base/models/res_partner.py
@@ -1006,7 +1006,8 @@ class ResPartner(models.Model):
                 if partner._context.get('show_email') and partner.email:
                     name = f"{name} <{partner.email}>"
                 if partner._context.get('show_address'):
-                    name = name + "\n" + partner._display_address(without_company=True)
+                    address = name + "\n" + partner._display_address(without_company=True)
+                    name = "\n".join(line for line in address.splitlines() if line.strip())
 
                 if partner._context.get('show_vat') and partner.vat:
                     if partner._context.get('show_address'):

--- a/odoo/addons/base/tests/test_res_partner.py
+++ b/odoo/addons/base/tests/test_res_partner.py
@@ -1008,11 +1008,17 @@ class TestPartnerAddressCompany(TransactionCase):
         Check display_name correctly return name with context. """
         test_partner_jetha = self.env['res.partner'].create({'name': 'Jethala', 'street': 'Powder gali', 'street2': 'Gokuldham Society'})
         test_partner_bhide = self.env['res.partner'].create({'name': 'Atmaram Bhide'})
+        test_partner_bagha = self.env['res.partner'].create({'name': 'Bagha', 'street': '', 'street2': '', 'city': 'Mumbai'})
+        test_partner_nattu_kaka = self.env['res.partner'].create({'name': 'Nattu Kaka', 'street': 'Gada Electronics', 'street2': '', 'city': 'Mumbai'})
 
         res_jetha = test_partner_jetha.with_context(show_address=1).display_name
         self.assertEqual(res_jetha, "Jethala\nPowder gali\nGokuldham Society", "name should contain comma separated name and address")
         res_bhide = test_partner_bhide.with_context(show_address=1).display_name
         self.assertEqual(res_bhide, "Atmaram Bhide", "name should contain only name if address is not available, without extra commas")
+        res_bagha = test_partner_bagha.with_context(show_address=True).display_name
+        self.assertEqual(res_bagha, 'Bagha\nMumbai')
+        res_nattu_kaka = test_partner_nattu_kaka.with_context(show_address=True).display_name
+        self.assertEqual(res_nattu_kaka, 'Nattu Kaka\nGada Electronics\nMumbai')
 
     def test_accessibility_of_company_partner_from_branch(self):
         """ Check accessibility of company partner from branch. """


### PR DESCRIPTION
<b>Steps to Reproduce:</b>
1. Navigate to Invoice → Keep street2 or State value of customer address empty.
2. Print button.

<b>Issue:</b>
- There will be blank space in display of the address if you didn't complete Street2 field or the State field.

<b>Cause:</b>
- In cause is mentioned PR : [29f7475](https://github.com/odoo/odoo/commit/29f7475437586363e473955315d74aef7d80028c#diff-c4cf79d0ff0cb8f7ca865fdfac774ce8fd95c800471a0932d126acb6fd8e7c27L992)
where Line `name = re.sub(r'\s+\n', '\n', name)` is removed.

<b>Solution:</b>
- Improved the `_compute_display_name` method to strip empty lines from the final address string.

<b>opw-4879069</b>