### PR TITLE
[IMP] spreadsheet{_dashboard}: add filter search dialog in spreadsheet

### DIFF
--- a/addons/spreadsheet/static/src/global_filters/components/filter_value/filter_value.xml
+++ b/addons/spreadsheet/static/src/global_filters/components/filter_value/filter_value.xml
@@ -32,7 +32,7 @@
                                  update.bind="(value) => this.onDateInput(filter.id, value)"/>
             </div>
             <i t-if="props.showClear and getters.isGlobalFilterActive(filter.id)"
-                class="fa fa-times btn btn-link text-muted o_side_panel_filter_icon ms-1 mt-1"
+                class="fa fa-times btn btn-link text-muted ms-1 mt-1"
                 title="Clear"
                 t-on-click="() => this.clear(filter.id)"/>
         </div>

--- a/addons/spreadsheet/static/src/global_filters/components/filters_search_dialog/filters_search_dialog.js
+++ b/addons/spreadsheet/static/src/global_filters/components/filters_search_dialog/filters_search_dialog.js
@@ -7,11 +7,11 @@ import { _t } from "@web/core/l10n/translation";
 
 /**
  * This component is used to display a dialog with the global filters of a
- * dashboard. It allows the user to select the values of the filters and
- * confirm or discard the changes.
+ * spreadsheet/dashboard. It allows the user to select the values of the filters
+ * and confirm or discard the changes.
  */
-export class DashboardSearchDialog extends Component {
-    static template = "spreadsheet_dashboard.DashboardSearchDialog";
+export class FiltersSearchDialog extends Component {
+    static template = "spreadsheet_dashboard.FiltersSearchDialog";
     static components = {
         Dialog,
         Dropdown,
@@ -22,6 +22,7 @@ export class DashboardSearchDialog extends Component {
     static props = {
         close: Function,
         model: Object,
+        openFiltersEditor: { type: Function, optional: true },
     };
 
     setup() {

--- a/addons/spreadsheet/static/src/global_filters/components/filters_search_dialog/filters_search_dialog.xml
+++ b/addons/spreadsheet/static/src/global_filters/components/filters_search_dialog/filters_search_dialog.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <templates xml:space="preserve">
 
-    <t t-name="spreadsheet_dashboard.DashboardSearchDialog">
+    <t t-name="spreadsheet_dashboard.FiltersSearchDialog">
         <Dialog title.translate="Global Filters" size="md">
-            <div class="d-flex flex-column o-dashboard-search-dialog">
+            <div class="d-flex flex-column o-filters-search-dialog">
                 <div t-foreach="state.activeFilters" t-as="item" t-key="item_index" class="d-flex o-filter-item align-items-center">
                     <div class="me-1 w-25">
                         <t t-esc="getTranslatedFilterLabel(item.globalFilter)"/>
@@ -18,17 +18,21 @@
                 </div>
                 <div class="d-flex">
                     <Dropdown t-if="hasUnusedGlobalFilters">
-                        <a href="#" class="pt-2">
+                        <a href="#" class="pt-2 o-add-global-filter">
                             Add filter
                         </a>
                         <t t-set-slot="content">
                             <t t-foreach="unusedGlobalFilters" t-as="filter" t-key="filter.id">
                                 <DropdownItem onSelected="() => this.activateFilter(filter)">
-                                    <span t-esc="getTranslatedFilterLabel(filter)"/>
+                                    <span class="o-add-global-filter-label" t-esc="getTranslatedFilterLabel(filter)"/>
                                 </DropdownItem>
                             </t>
                         </t>
                     </Dropdown>
+                    <a href="#" t-if="props.openFiltersEditor" class="pt-2 ps-4 o-edit-global-filters" t-on-click="() => this.props.openFiltersEditor()">
+                        <i class="fa fa-pencil"/>
+                        Edit filters
+                    </a>
                 </div>
             </div>
             <t t-set-slot="footer">

--- a/addons/spreadsheet/static/src/global_filters/helpers.js
+++ b/addons/spreadsheet/static/src/global_filters/helpers.js
@@ -572,3 +572,31 @@ export function getDateDomain(from, to, field, fieldType) {
     }
     return new Domain();
 }
+
+export async function getFacetInfo(filter, filterValues, nameService) {
+    let values;
+    const separator = _t("or");
+    switch (filter.type) {
+        case "boolean":
+        case "text":
+            values = [filterValues];
+            break;
+        case "date": {
+            if (!filterValues) {
+                throw new Error("Should be defined at this point");
+            }
+            values = [dateFilterValueToString(filterValues)];
+            break;
+        }
+        case "relation":
+            values = await nameService.loadDisplayNames(filter.modelName, filterValues);
+            values = Object.values(values);
+            break;
+    }
+    return {
+        title: filter.label,
+        values,
+        id: filter.id,
+        separator,
+    };
+}

--- a/addons/spreadsheet/static/tests/global_filters/filter_search_dialog.test.js
+++ b/addons/spreadsheet/static/tests/global_filters/filter_search_dialog.test.js
@@ -1,0 +1,272 @@
+import { describe, expect, test } from "@odoo/hoot";
+import { queryAllTexts } from "@odoo/hoot-dom";
+import { defineSpreadsheetModels } from "@spreadsheet/../tests/helpers/data";
+import { contains, makeMockEnv, mountWithCleanup } from "@web/../tests/web_test_helpers";
+
+import { Model } from "@odoo/o-spreadsheet";
+import { addGlobalFilter } from "@spreadsheet/../tests/helpers/commands";
+
+import { OdooDataProvider } from "@spreadsheet/data_sources/odoo_data_provider";
+import { Component, onWillUnmount, xml } from "@odoo/owl";
+import { FiltersSearchDialog } from "@spreadsheet/global_filters/components/filters_search_dialog/filters_search_dialog";
+
+describe.current.tags("headless");
+defineSpreadsheetModels();
+
+class FiltersSearchDialogWrapper extends Component {
+    static template = xml`<FiltersSearchDialog t-props="props" />`;
+    static components = { FiltersSearchDialog };
+    static props = {
+        ...FiltersSearchDialog.props,
+        close: { type: Function, optional: true },
+    };
+    static defaultProps = {
+        close: () => {},
+    };
+
+    setup() {
+        this.props.model.on("update", this, () => this.render(true));
+        onWillUnmount(() => this.props.model.off("update", this));
+    }
+}
+
+/**
+ *
+ * @param {object} env
+ * @param {{ model: Model }} props
+ */
+async function mountFiltersSearchDialog(env, props) {
+    //@ts-ignore
+    env.dialogData = {
+        isActive: true,
+        close: () => {},
+    };
+    await mountWithCleanup(FiltersSearchDialogWrapper, { props });
+}
+
+test("basic text filter", async function () {
+    const env = await makeMockEnv();
+    const model = new Model({}, { custom: { odooDataProvider: new OdooDataProvider(env) } });
+    await addGlobalFilter(model, {
+        id: "42",
+        type: "text",
+        label: "Text Filter",
+    });
+    await mountFiltersSearchDialog(env, { model });
+    expect(".o-filters-search-dialog").toHaveCount(1);
+    expect(".fa-pencil").toHaveCount(0);
+});
+
+test("Edit filter is displayed when the props openFiltersEditor is set", async function () {
+    const env = await makeMockEnv();
+    const model = new Model({}, { custom: { odooDataProvider: new OdooDataProvider(env) } });
+    await mountFiltersSearchDialog(env, {
+        model,
+        openFiltersEditor: () => {},
+    });
+    expect(".o-filters-search-dialog .fa-pencil").toHaveCount(1);
+});
+
+test("filter search dialog with no active filters", async function () {
+    const env = await makeMockEnv();
+    const model = new Model({}, { custom: { odooDataProvider: new OdooDataProvider(env) } });
+    await addGlobalFilter(model, {
+        id: "42",
+        type: "text",
+        label: "Text Filter",
+    });
+    await mountFiltersSearchDialog(env, { model });
+    expect(".o-filters-search-dialog .o-filter-item").toHaveCount(0);
+    expect(".o-filters-search-dialog .o-add-global-filter").toHaveCount(1);
+});
+
+test("filter search dialog with active filters", async function () {
+    const env = await makeMockEnv();
+    const model = new Model({}, { custom: { odooDataProvider: new OdooDataProvider(env) } });
+    await addGlobalFilter(model, {
+        id: "42",
+        type: "text",
+        label: "Text Filter",
+        defaultValue: ["foo"],
+    });
+    await mountFiltersSearchDialog(env, { model });
+    expect(".o-filters-search-dialog .o-filter-item").toHaveCount(1);
+    expect(".o-filters-search-dialog .o-add-global-filter").toHaveCount(0);
+});
+
+test("New filter dropdown only shows inactive filters", async function () {
+    const env = await makeMockEnv();
+    const model = new Model({}, { custom: { odooDataProvider: new OdooDataProvider(env) } });
+    await addGlobalFilter(model, {
+        id: "42",
+        type: "text",
+        label: "Text Filter",
+        defaultValue: ["foo"],
+    });
+    await addGlobalFilter(model, {
+        id: "43",
+        type: "text",
+        label: "Inactive Filter",
+    });
+    await mountFiltersSearchDialog(env, { model });
+    await contains(".o-add-global-filter").click();
+    expect(".o-add-global-filter-label").toHaveCount(1);
+    expect(queryAllTexts(".o-add-global-filter-label")).toEqual(["Inactive Filter"]);
+});
+
+test("Can set a text filter value", async function () {
+    const env = await makeMockEnv();
+    const model = new Model({}, { custom: { odooDataProvider: new OdooDataProvider(env) } });
+    await addGlobalFilter(model, {
+        id: "42",
+        type: "text",
+        label: "Text Filter",
+    });
+    await mountFiltersSearchDialog(env, { model });
+    await contains(".o-add-global-filter").click();
+    await contains(".o-add-global-filter-label").click();
+    await contains(".o-filters-search-dialog .o-filter-item .o-autocomplete input").edit("foo");
+    await contains(".o-filters-search-dialog .o-filter-item .o-autocomplete input").press("Enter");
+    expect(model.getters.getGlobalFilterValue("42")).toBe(undefined, {
+        message: "value is not directly set",
+    });
+    await contains(".btn-primary").click();
+    expect(model.getters.getGlobalFilterValue("42")).toEqual(["foo"], { message: "value is set" });
+});
+
+test("Can set a relation filter value", async function () {
+    const env = await makeMockEnv();
+    const model = new Model({}, { custom: { odooDataProvider: new OdooDataProvider(env) } });
+    await addGlobalFilter(model, {
+        id: "42",
+        type: "relation",
+        modelName: "product",
+        label: "Relation Filter",
+    });
+    await mountFiltersSearchDialog(env, { model });
+    await contains(".o-add-global-filter").click();
+    await contains(".o-add-global-filter-label").click();
+    await contains("input.o-autocomplete--input").click();
+    await contains(".o-autocomplete--dropdown-item:first").click();
+    expect(".o_tag").toHaveCount(1);
+    await contains(".btn-primary").click();
+    expect(model.getters.getGlobalFilterValue("42")).toEqual([37], {
+        message: "value is set",
+    });
+    await contains(".o_tag .o_delete").click();
+    await contains(".btn-primary").click();
+    expect(model.getters.getGlobalFilterValue("42")).toBe(undefined);
+});
+
+test("Can remove a default relation filter value", async function () {
+    const env = await makeMockEnv();
+    const model = new Model({}, { custom: { odooDataProvider: new OdooDataProvider(env) } });
+    await addGlobalFilter(model, {
+        id: "42",
+        type: "relation",
+        modelName: "product",
+        label: "Relation Filter",
+        defaultValue: [37],
+    });
+    await mountFiltersSearchDialog(env, { model });
+    expect(".o_tag").toHaveCount(1);
+    await contains(".o_tag .o_delete").click();
+    expect(".o_tag").toHaveCount(0);
+    await contains(".btn-primary").click();
+    expect(model.getters.getGlobalFilterValue("42")).toBe(undefined);
+});
+
+test("Default value for relation filter is correctly displayed", async function () {
+    const env = await makeMockEnv();
+    const model = new Model({}, { custom: { odooDataProvider: new OdooDataProvider(env) } });
+    await addGlobalFilter(model, {
+        id: "42",
+        type: "relation",
+        modelName: "product",
+        label: "Relation Filter",
+        defaultValue: [37],
+    });
+    await mountFiltersSearchDialog(env, { model });
+    expect(".o_tag").toHaveCount(1);
+    expect(queryAllTexts(".o_tag")).toEqual(["xphone"]);
+});
+
+test("Can set a boolean filter value", async function () {
+    const env = await makeMockEnv();
+    const model = new Model({}, { custom: { odooDataProvider: new OdooDataProvider(env) } });
+    await addGlobalFilter(model, {
+        id: "42",
+        type: "boolean",
+        label: "Boolean Filter",
+    });
+    await mountFiltersSearchDialog(env, { model });
+    await contains(".o-add-global-filter").click();
+    await contains(".o-add-global-filter-label").click();
+    await contains("input.o-autocomplete--input").click();
+    await contains(".o-autocomplete--dropdown-item:first").click();
+    expect(".o_tag").toHaveCount(1);
+    expect(queryAllTexts(".o_tag")).toEqual(["Is set"]);
+    await contains(".btn-primary").click();
+    expect(model.getters.getGlobalFilterValue("42")).toEqual([true], {
+        message: "value is set",
+    });
+});
+
+test("Can set a date filter value", async function () {
+    const env = await makeMockEnv();
+    const model = new Model({}, { custom: { odooDataProvider: new OdooDataProvider(env) } });
+    const label = "Date Filter";
+    await addGlobalFilter(model, {
+        id: "42",
+        type: "date",
+        label,
+    });
+    await mountFiltersSearchDialog(env, { model });
+    await contains(".o-add-global-filter").click();
+    await contains(".o-add-global-filter-label").click();
+    await contains(".o-date-filter-input").click();
+    await contains(".o-dropdown-item[data-id='last_7_days']").click();
+    expect(".o-date-filter-input").toHaveValue("Last 7 Days");
+    await contains(".btn-primary").click();
+    expect(model.getters.getGlobalFilterValue("42")).toEqual({
+        period: "last_7_days",
+        type: "relative",
+    });
+});
+
+test("Readonly user can update a filter value", async function () {
+    const env = await makeMockEnv();
+    const model = new Model({}, { custom: { odooDataProvider: new OdooDataProvider(env) } });
+    await addGlobalFilter(model, {
+        id: "42",
+        type: "text",
+        label: "Text Filter",
+    });
+    model.updateMode("readonly");
+    await mountFiltersSearchDialog(env, { model });
+    await contains(".o-add-global-filter").click();
+    await contains(".o-add-global-filter-label").click();
+    await contains(".o-filters-search-dialog .o-filter-item .o-autocomplete input").edit("foo");
+    await contains(".o-filters-search-dialog .o-filter-item .o-autocomplete input").press("Enter");
+    await contains(".btn-primary").click();
+    expect(model.getters.getGlobalFilterValue("42")).toEqual(["foo"], { message: "value is set" });
+});
+
+test("Can clear a filter value", async function () {
+    const env = await makeMockEnv();
+    const model = new Model({}, { custom: { odooDataProvider: new OdooDataProvider(env) } });
+    await addGlobalFilter(model, {
+        id: "42",
+        type: "text",
+        label: "Text Filter",
+        defaultValue: ["foo"],
+    });
+    await mountFiltersSearchDialog(env, { model });
+    expect(".o-filters-search-dialog .o-filter-item .o_tag").toHaveCount(1);
+    await contains(".o-filters-search-dialog .o-filter-item .o_tag .o_delete").click();
+    expect(".o-filters-search-dialog .o-filter-item .o_tag").toHaveCount(0);
+    await contains(".btn-primary").click();
+    expect(model.getters.getGlobalFilterValue("42")).toBe(undefined, {
+        message: "value is cleared",
+    });
+});

--- a/addons/spreadsheet_dashboard/static/src/bundle/dashboard_action/dashboard_action.scss
+++ b/addons/spreadsheet_dashboard/static/src/bundle/dashboard_action/dashboard_action.scss
@@ -57,10 +57,6 @@
         }
     }
 
-    .o_side_panel_filter_icon {
-        padding: 0;
-    }
-
     .dashboard-loading-status {
         margin: auto;
     }

--- a/addons/spreadsheet_dashboard/static/src/bundle/dashboard_action/dashboard_search_bar/dashboard_search_bar.js
+++ b/addons/spreadsheet_dashboard/static/src/bundle/dashboard_action/dashboard_search_bar/dashboard_search_bar.js
@@ -2,10 +2,9 @@ import { Component, onWillUpdateProps, onWillStart } from "@odoo/owl";
 import { DashboardFacet } from "../dashboard_facet/dashboard_facet";
 import { useService } from "@web/core/utils/hooks";
 import { useDropdownState } from "@web/core/dropdown/dropdown_hooks";
-import { _t } from "@web/core/l10n/translation";
-import { DashboardSearchDialog } from "../dashboard_search_dialog/dashboard_search_dialog";
-import { dateFilterValueToString } from "@spreadsheet/global_filters/helpers";
 import { DashboardDateFilter } from "../dashboard_date_filter/dashboard_date_filter";
+import { getFacetInfo } from "@spreadsheet/global_filters/helpers";
+import { FiltersSearchDialog } from "@spreadsheet/global_filters/components/filters_search_dialog/filters_search_dialog";
 
 export class DashboardSearchBar extends Component {
     static template = "spreadsheet_dashboard.DashboardSearchBar";
@@ -27,7 +26,7 @@ export class DashboardSearchBar extends Component {
     }
 
     openDialog() {
-        this.dialog.add(DashboardSearchDialog, {
+        this.dialog.add(FiltersSearchDialog, {
             model: this.props.model,
         });
     }
@@ -69,30 +68,6 @@ export class DashboardSearchBar extends Component {
 
     async getFacetFor(filter) {
         const filterValues = this.props.model.getters.getGlobalFilterValue(filter.id);
-        let values;
-        const separator = _t("or");
-        switch (filter.type) {
-            case "boolean":
-            case "text":
-                values = [filterValues];
-                break;
-            case "date": {
-                if (!filterValues) {
-                    throw new Error("Should be defined at this point");
-                }
-                values = [dateFilterValueToString(filterValues)];
-                break;
-            }
-            case "relation":
-                values = await this.nameService.loadDisplayNames(filter.modelName, filterValues);
-                values = Object.values(values);
-                break;
-        }
-        return {
-            title: filter.label,
-            values,
-            id: filter.id,
-            separator,
-        };
+        return getFacetInfo(filter, filterValues, this.nameService);
     }
 }

--- a/addons/spreadsheet_dashboard/static/tests/dashboard/dashboard_action.test.js
+++ b/addons/spreadsheet_dashboard/static/tests/dashboard/dashboard_action.test.js
@@ -359,7 +359,7 @@ test("Global filter with same id is not shared between dashboards", async functi
     expect(".o_searchview_facet").toHaveCount(0);
     await contains(".o_spreadsheet_dashboard_action .dropdown-toggle").click();
 
-    await contains(".o-dashboard-search-dialog a.dropdown-toggle").click();
+    await contains(".o-filters-search-dialog a.dropdown-toggle").click();
     await contains(".o-dropdown-item").click();
 
     await contains(".o-autocomplete--input.o_input").click();
@@ -399,11 +399,11 @@ test("Can add a new global filter from the search bar", async function () {
     await createSpreadsheetDashboard({ serverData });
 
     await contains(".o_spreadsheet_dashboard_action .dropdown-toggle").click();
-    expect(".o-dashboard-search-dialog a.dropdown-toggle").toHaveText("Add filter");
-    await contains(".o-dashboard-search-dialog a.dropdown-toggle").click();
+    expect(".o-filters-search-dialog a.dropdown-toggle").toHaveText("Add filter");
+    await contains(".o-filters-search-dialog a.dropdown-toggle").click();
     await contains(".o-dropdown-item").click();
 
-    expect(".o-dashboard-search-dialog a.dropdown-toggle").toHaveCount(0);
+    expect(".o-filters-search-dialog a.dropdown-toggle").toHaveCount(0);
 
     expect(".o-autocomplete--input.o_input").toHaveCount(1);
     expect(".o-autocomplete--input.o_input").toHaveValue("");
@@ -459,7 +459,7 @@ test("Can open the dialog by clicking on a facet", async function () {
 
     expect(".o_searchview_facet").toHaveCount(1);
     await contains(".o_searchview_facet").click();
-    expect(".o-dashboard-search-dialog").toHaveCount(1);
+    expect(".o-filters-search-dialog").toHaveCount(1);
 });
 
 test("Can open the dialog by clicking on the search bar", async function () {
@@ -478,7 +478,7 @@ test("Can open the dialog by clicking on the search bar", async function () {
     await createSpreadsheetDashboard({ serverData });
 
     await contains(".o_searchview").click();
-    expect(".o-dashboard-search-dialog").toHaveCount(1);
+    expect(".o-filters-search-dialog").toHaveCount(1);
 });
 
 test("Changes of global filters are not dispatched while inside the dialog", async function () {
@@ -498,7 +498,7 @@ test("Changes of global filters are not dispatched while inside the dialog", asy
     expect(model.getters.getGlobalFilterValue("1")).toBe(undefined);
 
     await contains(".o_spreadsheet_dashboard_action .dropdown-toggle").click();
-    await contains(".o-dashboard-search-dialog a.dropdown-toggle").click();
+    await contains(".o-filters-search-dialog a.dropdown-toggle").click();
     await contains(".o-dropdown-item").click();
 
     await contains(".o-autocomplete--input.o_input").click();


### PR DESCRIPTION
This commit changes the behavior of the filter component (top right corner of the spreadsheet) to open the filter search dialog instead of the side panel to configure filters. Filters can still be created and edited in the side panel, but the search dialog provides a more efficient way to search and apply filters directly from the spreadsheet.

Task: 4816193

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
