### PR TITLE
[FIX] website_event: fix traceback when creating a menu in website

### DIFF
--- a/addons/website_event/models/website_menu.py
+++ b/addons/website_event/models/website_menu.py
@@ -81,7 +81,9 @@ class WebsiteMenu(models.Model):
 
         menus_by_parent_id = {}
         for menu in data['data']:
-            if menu.get('parent_id') and not menus_by_parent_id.get(menu['parent_id']):
+            if not menu.get('parent_id'):
+                continue
+            if not menus_by_parent_id.get(menu['parent_id']):
                 menus_by_parent_id[menu['parent_id']] = []
 
             menus_by_parent_id[menu['parent_id']].append(menu)


### PR DESCRIPTION
A traceback occurs when a user attempts to create a 
menu item from the Website Editor.

**To reproduce this issue:**

1) Install the website_event module and enable debug mode.
2) Delete all existing menus for a website from the Website Configuration.
3) Now, add a menu item from the website/Site/Menu editor.
4) Save the record

**Error:-** 
```
KeyError: False
```

**Cause:**
When there are no existing menus on a website and a new menu is created,
the value of parent_id in the data dictionary is False.

Although the `parent_id` key is present, using `.get("parent_id")` returns False,
which leads to a `KeyError` in the following code line:

https://github.com/odoo/odoo/blob/d6db9f910288e69ecd8e26addd20ea34bda81f15/addons/website_event/models/website_menu.py#L83-L88

**Solution:**

We can check the `parent_id` in the data using `in` to solve the issue 
if the value of the `parent_id` is False.

opw-4869138
