### PR TITLE
[FIX] website: ensure element is out of screen

### DIFF
--- a/addons/website/static/tests/tours/snippet_popup_and_animations.js
+++ b/addons/website/static/tests/tours/snippet_popup_and_animations.js
@@ -1,5 +1,6 @@
 /** @odoo-module */
 
+import { waitUntil } from "@odoo/hoot-dom";
 import {
     changeOption,
     clickOnEditAndWaitEditMode,
@@ -75,16 +76,13 @@ registerWebsitePreviewTour("snippet_popup_and_animations", {
     },
     {
         content: "Wait for the page to be scrolled to the top.",
-        trigger: ":iframe .s_three_columns .row > :last-child:not(.o_animating)",
-        run() {
-            // If the column has been animated successfully, the animation delay
-            // should be set to approximately zero when it is not visible.
-            // The main goal of the following condition is to verify if the
-            // animation delay is being updated as expected.
-            if (Math.round(parseFloat(this.anchor.style.animationDelay)) !== 0) {
-                throw new Error("The scroll animation in the page did not end properly with the cookies bar open.");
-            }
-        },
+        trigger: ":iframe .s_three_columns .row > .o_animating:last-child",
+        isActive: [`:iframe .s_three_columns .row > .o_animating:last-child`],
+        run: (helpers) =>
+            waitUntil(
+                () => !helpers.anchor.classList.contains(`o_animating`),
+                { timeout: 10000 }
+            ),
     },
     {
         content: "Close the Cookies Bar.",
@@ -127,14 +125,13 @@ registerWebsitePreviewTour("snippet_popup_and_animations", {
     },
     {
         content: "Wait until the column is no longer animated/visible.",
-        trigger: ":iframe .s_popup .s_three_columns .row > :last-child:not(.o_animating):hidden",
-        async run() {
-            // If the column has been animated successfully, the animation delay
-            // should be set to approximately zero when it is not visible.
-            if (Math.round(parseFloat(this.anchor.style.animationDelay)) !== 0) {
-                throw new Error("The scroll animation in the modal did not end properly.");
-            }
-        },
+        trigger: ":iframe .s_three_columns .row > .o_animating:last-child",
+        isActive: [`:iframe .s_three_columns .row > .o_animating:last-child`],
+        run: (helpers) =>
+            waitUntil(
+                () => !helpers.anchor.classList.contains(`o_animating`),
+                { timeout: 10000 }
+            ),
     },
     {
         content: "Close the Popup",


### PR DESCRIPTION
## Version
18.0+

## Issue
The tour `snippet_popup_and_animations` times out when trying to wait for the last column to become "not animated and hidden". This happens because the element never actually becomes `hidden` after the scroll-triggered animation ends — it remains in the DOM and visible.

## Cause
Commit 7e85f88214b6b57db87a6c1964286f0b7813f6ff attempted to fix a selector that was always true by adding `:hidden`, assuming the element would be hidden once the scroll animation completed. But since the element’s visibility is never changed via `display: none` or `visibility: hidden`, the `:hidden` condition never matches, blocking the tour.

## Fix
Remove the `:hidden` pseudo-class from the trigger.
Instead, wait for the `.o_animating` class to be removed (indicating the end of the animation), then:
- Add a short delay to ensure animation processing is complete.
- Check that the element is outside of the viewport (scrolled out).
- Verify that `animation-delay` is approximately 0.


runbot-227077