### PR TITLE
[FIX] website, html_builder: fix look of animated and highlighted text

### DIFF
--- a/addons/html_builder/__manifest__.py
+++ b/addons/html_builder/__manifest__.py
@@ -36,6 +36,10 @@
             'web/static/lib/bootstrap/scss/_maps.scss',
             'web/static/fonts/fonts.scss',
             'html_builder/static/src/**/*',
+            ('remove', 'html_builder/static/src/**/*.dark.scss'),
+        ],
+        'web.assets_web_dark': [
+            'html_builder/static/src/**/*.dark.scss',
         ],
         'html_builder.inside_builder_style': [
             ('include', 'web._assets_helpers'),

--- a/addons/html_builder/static/src/core/building_blocks/builder_number_input.dark.scss
+++ b/addons/html_builder/static/src/core/building_blocks/builder_number_input.dark.scss
@@ -1,0 +1,6 @@
+.o-hb-input-field-number {
+    .popover & {
+        --o-hb-field-input-bg-popover: #{$o-we-sidebar-content-field-input-bg};
+        --o-hb-field-color-popover: #{$o-we-sidebar-content-field-color};
+    }
+}

--- a/addons/html_builder/static/src/core/building_blocks/builder_number_input.scss
+++ b/addons/html_builder/static/src/core/building_blocks/builder_number_input.scss
@@ -1,14 +1,18 @@
 .o-hb-input-field-number {
+    .popover & {
+        --o-hb-field-input-bg: var(--o-hb-field-input-bg-popover, #{$o-we-fg-lighter});
+        --o-hb-field-color: var(--o-hb-field-color-popover, #{$o-we-bg-lightest});
+    }
     font-family: $o-we-font-monospace;
     border: $o-we-sidebar-content-field-border-width solid $o-we-sidebar-content-field-border-color;
     border-radius: $o-we-sidebar-content-field-border-radius;
-    background-color: $o-we-sidebar-content-field-input-bg;
+    background-color: var(--o-hb-field-input-bg, #{$o-we-sidebar-content-field-input-bg});
     padding: 0.15rem $o-we-sidebar-content-field-clickable-spacing;
     flex: 0 1 calc(50% - calc(var(--hb-row-content-gap) * 0.5));
 
     &:focus, &:focus-within {
         border-color: var(--o-hb-input-active-border, #{$o-we-sidebar-content-field-input-border-color});
-        color: $o-we-fg-lighter;
+        color: var(--o-hb-row-color-active, #{$o-we-fg-lighter});
     }
 
     .o-hb-input-number {
@@ -21,7 +25,7 @@
     }
 
     .o-hb-input-field-unit {
-        color: $o-we-sidebar-content-field-color;
+        color: var(--o-hb-field-color, #{$o-we-sidebar-content-field-color});
         font-size: $o-we-font-size-xs;
     }
 }

--- a/addons/html_builder/static/src/core/building_blocks/builder_range.dark.scss
+++ b/addons/html_builder/static/src/core/building_blocks/builder_range.dark.scss
@@ -1,0 +1,3 @@
+.popover .o-hb-range {
+    --o-hb-range-thumb-color-popover: #{$o-we-fg-lighter};
+}

--- a/addons/html_builder/static/src/core/building_blocks/builder_range.scss
+++ b/addons/html_builder/static/src/core/building_blocks/builder_range.scss
@@ -1,4 +1,7 @@
 .o-hb-range {
+    .popover & {
+        --o-hb-range-thumb-color: var(--o-hb-range-thumb-color-popover, #{$o-we-bg-darkest});
+    }
     &:has(output) {
         .o-hb-rangeInput {
             // Needed because without it the output overflows to the right
@@ -32,7 +35,7 @@
             margin-top: ($o-we-sidebar-content-field-progress-height - $o-we-sidebar-content-field-progress-control-height) / 2;
             border: none;
             border-radius: 10rem;
-            background-color: $o-we-fg-lighter;
+            background-color: var(--o-hb-range-thumb-color, #{$o-we-fg-lighter});
             box-shadow: none;
             appearance: none;
 
@@ -57,7 +60,7 @@
             height: $o-we-sidebar-content-field-progress-control-height;
             border: none;
             border-radius: 10rem;
-            background-color: $o-we-fg-lighter;
+            background-color: var(--o-hb-range-thumb-color, #{$o-we-fg-lighter});
             box-shadow: none;
             appearance: none;
 
@@ -87,7 +90,7 @@
             margin-left: 0;
             border: none;
             border-radius: 10rem;
-            background-color: $o-we-fg-lighter;
+            background-color: var(--o-hb-range-thumb-color, #{$o-we-fg-lighter});
             box-shadow: none;
             appearance: none;
 

--- a/addons/html_builder/static/src/core/building_blocks/builder_row.dark.scss
+++ b/addons/html_builder/static/src/core/building_blocks/builder_row.dark.scss
@@ -1,0 +1,11 @@
+.hb-row {
+    .popover & {
+        --o-hb-row-active-bg-color-popover: #{mix($o-we-color-accent, $o-we-bg-dark, 20%)};
+        --o-hb-row-color-popover: #{$o-we-fg-dark};
+        --o-hb-row-color-active-popover: #{$o-we-fg-lighter};
+        --o-hb-row-sublevel-color-popover: #{mix($o-we-bg-lighter, $o-we-fg-light)};
+        .btn.btn-secondary {
+            --btn-border-color: #{$o-we-bg-light};
+        }
+    }
+}

--- a/addons/html_builder/static/src/core/building_blocks/builder_row.scss
+++ b/addons/html_builder/static/src/core/building_blocks/builder_row.scss
@@ -1,18 +1,35 @@
 .hb-row {
+    .popover & {
+        --o-hb-row-bg-color: var(--o-hb-row-bg-color-popover, --popover-bg);
+        --o-hb-row-active-bg-color: var(--o-hb-row-active-bg-color-popover, #{mix($o-we-color-accent, $o-we-fg-lighter, 20%)});
+        --o-hb-row-color: var(--o-hb-row-color-popover, #{$o-we-bg-lightest});
+        --o-hb-row-color-active: var(--o-hb-row-color-active-popover, #{$o-we-bg-darkest});
+        --o-hb-row-sublevel-color: var(--o-hb-row-sublevel-color-popover, #{mix($o-we-bg-lighter, $o-we-fg-light)});
+        .hb-row-content:has(button.fa-trash) {
+            align-items: stretch;
+        }
+        .hb-row-label {
+            flex: 0 0 38%;
+        }
+        .hb-row-content {
+            flex: 0 0 62%;
+        }
+    }
+
     --o-hb-btn-minHeight: #{$o-hb-row-min-height - ($o-hb-row-spacing * 0.5)};
 
     min-height: $o-hb-row-min-height;
     padding-top: $o-hb-row-spacing;
     box-sizing: content-box;
     align-items: center;
-    color: $o-we-fg-dark;
+    color: var(--o-hb-row-color, #{$o-we-fg-dark});
 
     .hb-row-label {
         min-width: 0;
         flex: 0 0 44%;
         z-index: 4;
         position: relative;
-        background-color: $o-we-bg-lighter;
+        background-color: var(--o-hb-row-bg-color, #{$o-we-bg-lighter});
         padding: $o-hb-row-spacing 0 $o-hb-row-spacing $o-hb-row-padding-left;
         align-self: baseline;
     }
@@ -42,20 +59,20 @@
     // ==== States
     &:hover, &.active {
         .hb-row-content {
-            color: $o-we-fg-lighter;
+            color: var(--o-hb-row-color-active, #{$o-we-fg-lighter});
         }
     }
 
     &:has(.hb-row-content:hover) {
-        color: $o-we-fg-lighter;
+        color: var(--o-hb-row-color-active, #{$o-we-fg-lighter});
     }
 
     &:has(.hb-row-label-actionable:hover) .o_hb_collapse_toggler {
-        color: $o-we-fg-lighter;
+        color: var(--o-hb-row-color-active, #{$o-we-fg-lighter});
     }
 
     &.active {
-        background-color: mix($o-we-color-accent, $o-we-bg-dark, 20%);
+        background-color: var(--o-hb-row-active-bg-color, #{mix($o-we-color-accent, $o-we-bg-dark, 20%)});
 
         .hb-row-label {
             background-color: inherit;
@@ -66,13 +83,13 @@
     // presence of a collapsable icon. Should be improved using states.
     .o_hb_collapse_toggler:where(:not(.d-none)) + .hb-row-label-actionable:hover {
         cursor: pointer;
-        color: $o-we-fg-lighter;
+        color: var(--o-hb-row-color-active, #{$o-we-fg-lighter});
     }
 
     // ==== Sublevels
     &.hb-row-sublevel:after {
         position: absolute;
-        border: $o-we-border-width solid mix($o-we-bg-lighter, $o-we-fg-light);
+        border: $o-we-border-width solid var(--o-hb-row-sublevel-color, #{mix($o-we-bg-lighter, $o-we-fg-light)});
         border-width: 0 0 $o-we-border-width $o-we-border-width;
         height: 100%;
         transform: translate(-$o-we-border-width, ($o-hb-row-min-height * -0.5) - $o-we-border-width);

--- a/addons/html_builder/static/src/core/building_blocks/builder_text_input_base.dark.scss
+++ b/addons/html_builder/static/src/core/building_blocks/builder_text_input_base.dark.scss
@@ -1,0 +1,5 @@
+.o-hb-input-base {
+    .popover & {
+        --o-hb-field-input-bg-popover: #{$o-we-sidebar-content-field-input-bg};
+    }
+}

--- a/addons/html_builder/static/src/core/building_blocks/builder_text_input_base.scss
+++ b/addons/html_builder/static/src/core/building_blocks/builder_text_input_base.scss
@@ -1,12 +1,15 @@
 .o-hb-input-base {
+    .popover & {
+        --o-hb-field-input-bg: var(--o-hb-field-input-bg-popover, #{$o-we-fg-lighter});
+    }
     border: $o-we-sidebar-content-field-border-width solid $o-we-sidebar-content-field-border-color;
     border-radius: $o-we-sidebar-content-field-border-radius;
-    background-color: $o-we-sidebar-content-field-input-bg;
+    background-color: var(--o-hb-field-input-bg, #{$o-we-sidebar-content-field-input-bg});
     padding: 0.15rem $o-we-sidebar-content-field-clickable-spacing;
     color: inherit;
 
     &:focus, &:focus-within {
         border-color: var(--o-hb-input-active-border, #{$o-we-sidebar-content-field-input-border-color});
-        color: $o-we-fg-lighter;
+        color: var(--o-hb-row-color-active, #{$o-we-fg-lighter});
     }
 }

--- a/addons/website/static/src/builder/plugins/highlight/highlight_configurator.js
+++ b/addons/website/static/src/builder/plugins/highlight/highlight_configurator.js
@@ -81,7 +81,7 @@ export class HighlightConfigurator extends Component {
                         normalizeColor(color)
                     ),
                 applyColorResetPreview: this.props.revertHighlightStyle,
-                className: "w-100",
+                className: "d-contents",
             },
             "Select a color",
             true

--- a/addons/website/static/src/builder/plugins/highlight/highlight_configurator.xml
+++ b/addons/website/static/src/builder/plugins/highlight/highlight_configurator.xml
@@ -2,28 +2,40 @@
 <templates xml:space="preserve">
 
 <t t-name="website.highlightConfigurator">
-    <div class="p-2">
-        <div class="d-flex align-items-center mb-3">
-            <label for="highlightPicker" class="flex-grow-1">Highlight:</label>
-            <button id="highlightPicker" title="highlightPicker" class="btn btn-secondary" t-on-click="openHighlightPicker">
-                 <t t-if="this.state.highlightId === 'multiple'">
+    <div class="hb-row d-flex position-relative pe-2">
+        <div class="hb-row-label d-flex align-items-center">
+            <label for="highlightPicker" class="text-nowrap text-truncate">Highlight</label>
+        </div>
+        <div class="hb-row-content d-flex">
+            <button id="highlightPicker" title="highlightPicker" class="o-hb-btn btn btn-secondary" t-on-click="openHighlightPicker">
+                <t t-if="this.state.highlightId === 'multiple'">
                     <span class="mx-3 d-inline-block"></span>
                 </t>
                 <t t-else="" t-out="this.highlightIdToName[this.state.highlightId]"/>
             </button>
             <button class="btn btn-sm btn-light fa fa-trash" title="Reset" t-on-click="deleteHighlight"/>
         </div>
+    </div>
 
-        <div class="d-flex align-items-center mb-3">
-            <label for="colorButton" class="flex-grow-1">Color:</label>
-                <button id="colorButton" title="color" class="o_we_color_preview btn btn-outline-secondary" t-attf-style="background-color:{{this.state.color}}" t-on-click="openColorPicker">
+    <div class="hb-row d-flex position-relative pe-2">
+        <div class="hb-row-label d-flex align-items-center">
+            <label for="colorButton" class="text-nowrap text-truncate">Color</label>
+        </div>
+        <div class="hb-row-content d-flex">
+            <button id="colorButton" title="color" class="o_we_color_preview" t-attf-style="background-color:{{this.state.color}}" t-on-click="openColorPicker">
             </button>
         </div>
+    </div>
 
-        <div class="d-flex align-items-center">
-            <label for="thicknessInput" class="flex-grow-1">Thickness:</label>
-            <input type="number" id="thicknessInput" class="text-end w-25" t-att-value="this.state.thickness" t-on-input="onThicknessChange" />
-            <span class="ms-1">px</span>
+    <div class="hb-row d-flex position-relative pe-2">
+        <div class="hb-row-label d-flex align-items-center">
+            <label for="thicknessInput" class="text-nowrap text-truncate">Thickness</label>
+        </div>
+        <div class="hb-row-content d-flex">
+            <div class="d-flex flex-row flex-nowrap align-items-center o-hb-input-field-number justify-content-end">
+                <input type="number" id="thicknessInput" class="o-hb-input-base o-hb-input-number text-end" t-att-value="this.state.thickness" t-on-input="onThicknessChange"/>
+                <span class="o-hb-input-field-unit">px</span>
+            </div>
         </div>
     </div>
 </t>

--- a/addons/website/static/src/builder/plugins/highlight/highlight_plugin.js
+++ b/addons/website/static/src/builder/plugins/highlight/highlight_plugin.js
@@ -306,8 +306,8 @@ class HighlightToolbarButton extends Component {
         this.props.onClick();
         this.configuratorPopover.open(this.root.el, {
             stackState: this.componentStack,
-            style: "max-height: 275px; width: 262px",
-            class: "d-flex flex-column",
+            style: "max-height: 300px; width: 262px",
+            class: "d-flex flex-column p-2",
         });
     }
 }

--- a/addons/website/static/src/builder/plugins/options/animate_option.js
+++ b/addons/website/static/src/builder/plugins/options/animate_option.js
@@ -9,6 +9,7 @@ export class AnimateOption extends BaseOptionComponent {
         getEffectsItems: Function,
         canHaveHoverEffect: Function,
         requireAnimation: { type: Boolean, optional: true },
+        slots: { type: Object, optional: true },
     };
     static defaultProps = { requireAnimation: false };
 

--- a/addons/website/static/src/builder/plugins/options/animate_option.xml
+++ b/addons/website/static/src/builder/plugins/options/animate_option.xml
@@ -1,6 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
+<t t-name="website.animateOnScrollInOut">
+    <BuilderButtonGroup t-if="isActiveItem('animation_on_scroll_opt')" preview="false" action="'forceAnimation'">
+        <BuilderButton classAction="''">In</BuilderButton>
+        <BuilderButton classAction="'o_animate_out'">Out</BuilderButton>
+    </BuilderButtonGroup>
+</t>
+
 <t t-name="website.AnimateOption">
     <t t-if="this.state.isOptionActive">
         <BuilderRow label.translate="Animation">
@@ -23,10 +30,11 @@
                             id="'animation_on_hover_opt'"
                             t-if="state.canHover">On Hover</BuilderSelectItem>
             </BuilderSelect>
-            <BuilderButtonGroup t-if="isActiveItem('animation_on_scroll_opt')" preview="false" action="'forceAnimation'">
-                <BuilderButton classAction="''">In</BuilderButton>
-                <BuilderButton classAction="'o_animate_out'">Out</BuilderButton>
-            </BuilderButtonGroup>
+            <t t-if="!!props.slots?.animationRowTrailing" t-slot="animationRowTrailing"/>
+            <t t-else="" t-call="website.animateOnScrollInOut"/> 
+        </BuilderRow>
+        <BuilderRow label.translate="On Scroll" level="1" t-if="!!props.slots?.animationRowTrailing">
+            <t t-call="website.animateOnScrollInOut"/>
         </BuilderRow>
         <BuilderRow label.translate="Effect" level="1">
             <BuilderSelect id="'animation_effect_opt'"

--- a/addons/website/static/src/builder/plugins/options/animate_text.xml
+++ b/addons/website/static/src/builder/plugins/options/animate_text.xml
@@ -6,12 +6,12 @@
     </t>
 
     <t t-name="website_builder.AnimateTextPopover">
-        <div class="o_animate_text_popover" data-prevent-closing-overlay="true" t-ref="content">
-            <div class="my-1 d-flex">
-                <div class="flex-grow-1"/>
-                <button class="btn btn-sm btn-light fa fa-trash me-1" title="Reset" t-on-click="props.onReset"/>
-            </div>
-            <AnimateOption t-props="props.animateOptionProps"/>
+        <div class="o_animate_text_popover p-2" data-prevent-closing-overlay="true" t-ref="content">
+            <AnimateOption t-props="props.animateOptionProps">
+                <t t-set-slot="animationRowTrailing">
+                    <button class="btn btn-sm btn-light fa fa-trash" title="Reset" t-on-click="props.onReset"/>
+                </t>
+            </AnimateOption>
         </div>
     </t>
 </templates>


### PR DESCRIPTION
With the redesign after the initial website builder refactor, the appearance of option for animated text was broken: it mixed light on dark and dark on light elements.

After the initial website builder refactor, the appearance of the option for highlighted text was a bit weird. This commit changes it to be closer to the animated text option.


Redesign commit: 0bbf24a4b0d6d6160e1964f18391f86b4513fc72
Website refactor: 9fe45e2b7ddbbfd0445ffe25a859e67a316d02b2
task-4367641
