### PR TITLE
[FIX] base: Prevent `_where_calc` on unstored models

### DIFF
--- a/odoo/addons/test_new_api/models/test_new_api.py
+++ b/odoo/addons/test_new_api/models/test_new_api.py
@@ -1953,3 +1953,11 @@ class ModelAutovacuumed(models.Model):
     @api.autovacuum
     def _gc(self):
         self.search([('expire_at', '<', datetime.datetime.now() - datetime.timedelta(days=1))]).unlink()
+
+class VolatileModel(models.Model):
+    _name = _description = 'test_new_api.volatile.model'
+
+    _auto = False
+    _table_query = "0"
+
+    name = fields.Char()

--- a/odoo/addons/test_new_api/tests/test_attributes.py
+++ b/odoo/addons/test_new_api/tests/test_attributes.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from odoo.exceptions import UserError
 from odoo.tests import common
 
 
@@ -10,3 +11,12 @@ class TestAttributes(common.TransactionCase):
 
         with self.assertRaises(AttributeError):
             instance.unknown = 42
+
+    def test_volatile_model_name_search(self):
+        Model = self.env['test_new_api.volatile.model']
+
+        with self.assertRaises(UserError):
+            Model.name_search("")
+
+        with self.assertRaises(UserError):
+            Model.search_count("")

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -5141,6 +5141,7 @@ class BaseModel(metaclass=MetaModel):
             ``active`` field set to ``False`` should be applied.
         :return: the query expressing the given domain as provided in domain
         :rtype: Query
+        :raise odoo.exceptions.UserError: in case _table_query is not None
         """
         # if the object has an active field ('active', 'x_active'), filter out all
         # inactive records unless they were explicitly asked for
@@ -5149,6 +5150,9 @@ class BaseModel(metaclass=MetaModel):
             # operators too
             if not any(item[0] == self._active_name for item in domain):
                 domain = [(self._active_name, '=', 1)] + domain
+
+        if self._table_query:
+            raise UserError(f"Unable to use {self._name!r} to perform this action.")
 
         if domain:
             return expression.expression(domain, self).query


### PR DESCRIPTION
To reproduce this issue, just try to perform a
name_search/search_count/etc.. on "bank_rec_widget" for example:
- Example of Steps in Knowledge:
- Open knowledge
- Create an article
- Create another article in the first one (child)
- Add a properties
- Select `Bank reconciliation widget` in Model
- Traceback

Some models use
```py
# _auto=False' & _table_query = "0" prevent the ORM to create the corresponding postgresql table.
_auto = False
_table_query = "0”
```
to avoid being stored in db.

This kind of model doesn't work with several methods of the model api, such as `search_count`, `name_search` etc...

This commit will raises an UserError in this case.

opw-4763713