### PR TITLE
[FIX] html_builder: style and debounce keydown on BuildeRange

### DIFF
--- a/addons/html_builder/static/src/core/building_blocks/builder_number_input.js
+++ b/addons/html_builder/static/src/core/building_blocks/builder_number_input.js
@@ -4,6 +4,7 @@ import {
     basicContainerBuilderComponentProps,
     useInputBuilderComponent,
     useBuilderComponent,
+    useInputDebouncedCommit,
 } from "../utils";
 import { BuilderComponent } from "./builder_component";
 import {
@@ -12,7 +13,6 @@ import {
 } from "@html_builder/core/building_blocks/builder_text_input_base";
 import { useChildRef } from "@web/core/utils/hooks";
 import { pick } from "@web/core/utils/objects";
-import { useDebounced } from "@web/core/utils/timing";
 
 export class BuilderNumberInput extends Component {
     static template = "html_builder.BuilderNumberInput";
@@ -51,14 +51,7 @@ export class BuilderNumberInput extends Component {
         this.state = state;
 
         this.inputRef = useChildRef();
-        this.debouncedCommitValue = useDebounced(() => {
-            const normalizedDisplayValue = this.commit(this.inputRef.el.value);
-            this.inputRef.el.value = normalizedDisplayValue;
-        }, 550);
-        // ↑ 500 is the delay when holding keydown between the 1st and 2nd event
-        // fired. Some additional delay by the browser may add another ~5-10ms.
-        // We debounce above that threshold to keep a single history step when
-        // holding up/down on a number input.
+        this.debouncedCommitValue = useInputDebouncedCommit(this.inputRef);
     }
 
     /**

--- a/addons/html_builder/static/src/core/building_blocks/builder_range.js
+++ b/addons/html_builder/static/src/core/building_blocks/builder_range.js
@@ -1,9 +1,10 @@
-import { Component } from "@odoo/owl";
+import { Component, useRef } from "@odoo/owl";
 import {
     basicContainerBuilderComponentProps,
     useActionInfo,
     useBuilderComponent,
     useInputBuilderComponent,
+    useInputDebouncedCommit,
 } from "../utils";
 import { BuilderComponent } from "./builder_component";
 
@@ -36,6 +37,9 @@ export class BuilderRange extends Component {
             parseDisplayValue: this.parseDisplayValue.bind(this),
         });
 
+        this.inputRef = useRef("inputRef");
+        this.debouncedCommitValue = useInputDebouncedCommit(this.inputRef);
+
         this.commit = commit;
         this.preview = preview;
         this.state = state;
@@ -67,6 +71,22 @@ export class BuilderRange extends Component {
         if (this.props.displayRangeValue) {
             this.state.value = this.parseDisplayValue(e.target.value);
         }
+    }
+
+    onKeydown(e) {
+        if (!["ArrowLeft", "ArrowUp", "ArrowDown", "ArrowRight"].includes(e.key)) {
+            return;
+        }
+        e.preventDefault();
+        let value = parseInt(e.target.value);
+        if (e.key === "ArrowLeft" || e.key === "ArrowDown") {
+            value = Math.max(this.min, value - this.props.step);
+        } else {
+            value = Math.min(this.max, value + this.props.step);
+        }
+        e.target.value = value;
+        this.onInput(e);
+        this.debouncedCommitValue();
     }
 
     get rangeInputValue() {

--- a/addons/html_builder/static/src/core/building_blocks/builder_range.scss
+++ b/addons/html_builder/static/src/core/building_blocks/builder_range.scss
@@ -26,6 +26,17 @@
             &::-moz-range-thumb     { box-shadow: none; }
             &::-ms-thumb            { box-shadow: none; }
         }
+        &:focus-visible {
+            &::-webkit-slider-thumb {
+                box-shadow: 0 0 0 1px $o-we-bg-dark, 0 0 0 3px $o-we-sidebar-content-field-progress-active-color;
+            }
+            &::-moz-range-thumb {
+                box-shadow: 0 0 0 1px $o-we-bg-dark, 0 0 0 3px $o-we-sidebar-content-field-progress-active-color;
+            }
+            &::-ms-thumb {
+                box-shadow: 0 0 0 1px $o-we-bg-dark, 0 0 0 3px $o-we-sidebar-content-field-progress-active-color;
+            }
+        }
         &::-moz-focus-outer {
             border: 0;
         }

--- a/addons/html_builder/static/src/core/building_blocks/builder_range.xml
+++ b/addons/html_builder/static/src/core/building_blocks/builder_range.xml
@@ -15,13 +15,15 @@
             <input
             type="range"
             class="o-hb-rangeInput"
+            t-ref="inputRef"
             t-att-class="className"
             t-att-min="min"
             t-att-max="max"
             t-att-step="props.step"
             t-att-value="rangeInputValue"
             t-on-change="onChange"
-            t-on-input="onInput" />
+            t-on-input="onInput"
+            t-on-keydown="onKeydown" />
             <output t-if="props.displayRangeValue" t-out="displayValue" class="ms-1"/>
         </div>
     </BuilderComponent>

--- a/addons/html_builder/static/src/core/utils.js
+++ b/addons/html_builder/static/src/core/utils.js
@@ -749,6 +749,18 @@ export function useVisibilityObserver(contentName, callback) {
     );
 }
 
+export function useInputDebouncedCommit(ref) {
+    const comp = useComponent();
+    return useDebounced(() => {
+        const normalizedDisplayValue = comp.commit(ref.el.value);
+        ref.el.value = normalizedDisplayValue;
+    }, 550);
+    // ↑ 500 is the delay when holding keydown between the 1st and 2nd event
+    // fired. Some additional delay by the browser may add another ~5-10ms.
+    // We debounce above that threshold to keep a single history step when
+    // holding up/down on a number or range input.
+}
+
 export const basicContainerBuilderComponentProps = {
     id: { type: String, optional: true },
     applyTo: { type: String, optional: true },


### PR DESCRIPTION
1) This commit adds proper styling on focus-visible on the BuilderRange.

2) When using the arrows to modify its value, it commited after every keydown. If the action relies on a load, the behavior is buggy. This is for instance the case on image optimization options:
- Select an image
- Set a filter on top > the "Quality" option appears
- Use tab to focus it
- Press an arrow and stay pressed for a while => The sidebar options are wrongly computed.

To avoid that, we debounce the commit just like what was already done in the BuilderNumberInput.
Note that while it prevents unwanted UI flickers and doesn't commit until after you let go of the key, the preview doesn't happen: this is due to the fact that each preview is cancelled by the next, preventing the load to ever complete, and thus the apply from happening.

task-4367641