### PR TITLE
[IMP] core: fill column for required stored computed fields

### DIFF
--- a/odoo/orm/fields.py
+++ b/odoo/orm/fields.py
@@ -1163,6 +1163,12 @@ class Field(typing.Generic[T]):
                 field = model._fields[self.name]
                 if not field.required or not field.store:
                     return
+                if field.compute:
+                    records = model.browse(id_ for id_, in model.env.execute_query(SQL(
+                        "SELECT id FROM %s AS t WHERE %s IS NULL",
+                        SQL.identifier(model._table), model._field_to_sql('t', field.name),
+                    )))
+                    model.env.add_to_compute(field, records)
                 # Flush values before adding NOT NULL constraint.
                 model.flush_model([field.name])
                 model.pool.post_constraint(


### PR DESCRIPTION
When a required stored computed field doesn't have a default value we may fail to add its not null constraint if some records are created during an upgrade. This would then cause a warning once the registry is fully loaded.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
