### PR TITLE
[FIX] website_sale: test combo product tax disclaimer

### DIFF
--- a/addons/website_sale/static/tests/tours/website_sale_combo_configurator.js
+++ b/addons/website_sale/static/tests/tours/website_sale_combo_configurator.js
@@ -20,6 +20,10 @@ registry
             ...productConfiguratorTourUtils.saveConfigurator(),
             comboConfiguratorTourUtils.selectComboItem("Product B2"),
             comboConfiguratorTourUtils.assertFooterButtonsEnabled(),
+            {
+                content: "Check that the tax disclaimer gets displayed",
+                trigger: '.js_main_product small:contains(Final price may vary based on selection)',
+            },
             // Assert that the cart's content is correct.
             {
                 content: "Proceed to checkout",
@@ -41,8 +45,8 @@ registry
                 ),
             },
             {
-                content: "Verify the combo product's price",
-                trigger: 'div[name="website_sale_cart_line_price"]:contains(93.00)',
+                content: "Verify the combo product's price (tax included)",
+                trigger: 'div[name="website_sale_cart_line_price"]:contains(106.95)',
             },
             {
                 content: "Verify the order's total price",
@@ -58,7 +62,7 @@ registry
             wsTourUtils.assertCartContains({ productName: "2 x Product B2" }),
             {
                 content: "Verify the combo product's price",
-                trigger: 'div[name="website_sale_cart_line_price"]:contains(62.00)',
+                trigger: 'div[name="website_sale_cart_line_price"]:contains(71.31)',
             },
         ],
    });

--- a/addons/website_sale/tests/test_website_sale_combo_configurator.py
+++ b/addons/website_sale/tests/test_website_sale_combo_configurator.py
@@ -51,6 +51,7 @@ class TestWebsiteSaleComboConfigurator(HttpCase, WebsiteSaleCommon):
                 Command.link(combo_b.id),
             ],
         )
+        self.website.show_line_subtotals_tax_selection = 'tax_included'
         self.start_tour('/', 'website_sale_combo_configurator')
 
     def test_website_sale_combo_configurator_single_configuration(self):


### PR DESCRIPTION
Modifies a test to check the tax disclaimer added by 4ec8d2198a1a0 (and fixed by 3d4027b6ab115) to prevent regression.

opw-4454112