### PR TITLE
[IMP] core: concat html value fields during import

### DIFF
--- a/addons/base_import/models/base_import.py
+++ b/addons/base_import/models/base_import.py
@@ -49,6 +49,13 @@ MIMETYPE_TO_READER = {
     'application/vnd.oasis.opendocument.spreadsheet': 'ods',
 }
 
+CONCAT_SEPARATOR_IMPORT = {
+    'char': ' ',
+    'text': '\n',
+    'html': '<br>',
+    'many2many': ',',
+}
+
 
 class ImportValidationError(Exception):
     """
@@ -1598,12 +1605,9 @@ class Base_ImportImport(models.TransientModel):
                 field_type = field.type if field else ''
 
                 # merge data if necessary
-                if field_type == 'char':
-                    new_record.append(' '.join(record[idx] for idx in indexes if record[idx]))
-                elif field_type == 'text':
-                    new_record.append('\n'.join(record[idx] for idx in indexes if record[idx]))
-                elif field_type == 'many2many':
-                    new_record.append(','.join(record[idx] for idx in indexes if record[idx]))
+                if field_type in CONCAT_SEPARATOR_IMPORT:
+                    separator = CONCAT_SEPARATOR_IMPORT[field_type]
+                    new_record.append(separator.join(record[idx] for idx in indexes if record[idx]))
                 else:
                     new_record.append(record[indexes[0]])
 

--- a/addons/base_import/static/src/import_model.js
+++ b/addons/base_import/static/src/import_model.js
@@ -264,8 +264,11 @@ export class BaseImportModel {
             const error = await this._executeImportStep(isTest, importRes);
             if (error) {
                 const errorData = error.data || {};
-                const message = errorData.arguments && (errorData.arguments[1] || errorData.arguments[0])
-                    || _t("An unknown issue occurred during import (possibly lost connection, data limit exceeded or memory limits exceeded). Please retry in case the issue is transient. If the issue still occurs, try to split the file rather than import it at once.");
+                const message =
+                    (errorData.arguments && (errorData.arguments[1] || errorData.arguments[0])) ||
+                    _t(
+                        "An unknown issue occurred during import (possibly lost connection, data limit exceeded or memory limits exceeded). Please retry in case the issue is transient. If the issue still occurs, try to split the file rather than import it at once."
+                    );
 
                 if (error.message) {
                     this._addMessage("danger", [error.message, message]);
@@ -606,16 +609,16 @@ export class BaseImportModel {
         }
 
         if (this.importOptions.has_headers && res.headers && res.preview.length > 0) {
-            return res.headers.flatMap((header, index) => {
-                return this._createColumn(
+            return res.headers.flatMap((header, index) =>
+                this._createColumn(
                     res,
                     getId(res, index),
                     header,
                     index,
                     res.preview[index],
                     res.preview[index][0]
-                );
-            });
+                )
+            );
         } else if (res.preview && res.preview.length >= 2) {
             return res.preview.flatMap((preview, index) =>
                 this._createColumn(
@@ -737,7 +740,7 @@ export class BaseImportModel {
 
             // Fields of type "char", "text" or "many2many" can be specified multiple
             // times and they will be concatenated, fields of other types must be unique.
-            if (["char", "text", "many2many"].includes(column.fieldInfo.type)) {
+            if (["char", "text", "html", "many2many"].includes(column.fieldInfo.type)) {
                 if (column.fieldInfo.type === "many2many") {
                     column.comments.push({
                         type: "info",

--- a/addons/test_import_export/models/models_import.py
+++ b/addons/test_import_export/models/models_import.py
@@ -112,6 +112,7 @@ class ImportComplex(models.Model):
     d = fields.Date()
     dt = fields.Datetime()
     parent_id = fields.Many2one('import.complex')
+    html = fields.Html()
 
 
 class ImportPropertiesDefinition(models.Model):

--- a/addons/test_import_export/tests/test_import.py
+++ b/addons/test_import_export/tests/test_import.py
@@ -886,6 +886,28 @@ foo3,US,0,persons\n""",
         self.assertEqual(tag3, partners[1].category_id)
         self.assertEqual(tag1 | tag3, partners[2].category_id)
 
+    def test_multi_mapping_hmtl(self):
+        import_wizard = self.env['base_import.import'].create({
+            'res_model': 'import.complex',
+            'file': 'html,html\n'
+                    '"<p>foo</p>","<p>bar</p>"\n',
+            'file_type': 'text/csv',
+        })
+
+        results = import_wizard.execute_import(
+            ['html', 'html'],
+            [],
+            {
+                'quoting': '"',
+                'separator': ',',
+                'has_headers': True,
+            },
+        )
+        self.assertItemsEqual(results['messages'], [])  # No error
+
+        last_record = self.env['import.complex'].search([], order='id DESC', limit=1)
+        self.assertItemsEqual(last_record.html, "<p>foo</p><br><p>bar</p>")
+
     @mute_logger('odoo.addons.base_import.models.base_import')
     @unittest.skipUnless(can_import('xlwt') and can_import('openpyxl'), "xlwt/openpyxl not available")
     def test_xls_datetime_values(self):


### PR DESCRIPTION
We can select the same text/char/many2many field mulitple times during
the import and the values will be merged together. But we cannot do it
for HTML field. Add the feature for HTML field too and use `<br>`
as separator.

task-4809478