### PR TITLE
[FIX] l10n_in_ewaybill: prevent error due multiple ewaybills present

### DIFF
--- a/addons/l10n_in_ewaybill/models/account_move.py
+++ b/addons/l10n_in_ewaybill/models/account_move.py
@@ -40,7 +40,7 @@ class AccountMove(models.Model):
     def _compute_l10n_in_ewaybill_details(self):
         for move in self:
             ewaybill = move.l10n_in_ewaybill_ids and move.l10n_in_ewaybill_ids[0]
-            if move.country_code == 'IN' and move.l10n_in_ewaybill_ids.state == 'generated':
+            if move.country_code == 'IN' and ewaybill.state == 'generated':
                 move.l10n_in_ewaybill_name = ewaybill.name
                 move.l10n_in_ewaybill_expiry_date = ewaybill.ewaybill_expiry_date
             else:


### PR DESCRIPTION
Currently, an error occurs when users try to access invoices.

Steps to replicate:
- Install `l10n_in_ewaybill` without demo data.
- Load demo data and switch to IN company.
- Go to invoices and you will get the error.

Error:
`ValueError : Expected singleton: l10n.in.ewaybill(5, 20)`

This error occurs due to presence of multiple records at line [1] and the code tries to execute `move.l10n_in_ewaybill_ids.state` that will cause the error.

[1] - https://github.com/odoo/odoo/blob/0066944f545b0a8d2c81acbc1a12afb7c15ea009/addons/l10n_in_ewaybill/models/account_move.py#L43

This commit solves this issue by considering only the first ewaybill to avoid any errors.

sentry-6530655516
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
