### PR TITLE
[FIX] base,rating,tools: prevent unnecessary wrapping of last word in rating feedback

### DIFF
--- a/addons/rating/models/mail_thread.py
+++ b/addons/rating/models/mail_thread.py
@@ -141,7 +141,7 @@ class MailThread(models.AbstractModel):
                 subtype_id = self._rating_apply_get_default_subtype_id()
             else:
                 subtype_id = False
-            feedback = tools.plaintext2html(feedback or '')
+            feedback = tools.plaintext2html(feedback or '', with_paragraph=False)
 
             scheduled_datetime = (
                 fields.Datetime.now() + datetime.timedelta(hours=2)

--- a/odoo/addons/base/tests/test_mail.py
+++ b/odoo/addons/base/tests/test_mail.py
@@ -372,13 +372,15 @@ class TestHtmlTools(BaseCase):
 
     def test_plaintext2html(self):
         cases = [
-            ("First \nSecond \nThird\n \nParagraph\n\r--\nSignature paragraph", 'div',
+            ("First \nSecond \nThird\n \nParagraph\n\r--\nSignature paragraph", 'div', True,
              "<div><p>First <br/>Second <br/>Third</p><p>Paragraph</p><p>--<br/>Signature paragraph</p></div>"),
-            ("First<p>It should be escaped</p>\nSignature", False,
-             "<p>First&lt;p&gt;It should be escaped&lt;/p&gt;<br/>Signature</p>")
+            ("First<p>It should be escaped</p>\nSignature", False, True,
+             "<p>First&lt;p&gt;It should be escaped&lt;/p&gt;<br/>Signature</p>"),
+            ("First \nSecond \nThird", False, False,
+             "First <br/>Second <br/>Third"),
         ]
-        for content, container_tag, expected in cases:
-            html = plaintext2html(content, container_tag)
+        for content, container_tag, with_paragraph, expected in cases:
+            html = plaintext2html(content, container_tag, with_paragraph)
             self.assertEqual(html, expected, 'plaintext2html is broken')
 
     def test_html_html_to_inner_content(self):

--- a/odoo/tools/mail.py
+++ b/odoo/tools/mail.py
@@ -471,18 +471,19 @@ def html2plaintext(html, body_id=None, encoding='utf-8', include_references=True
 
     return html.strip()
 
-def plaintext2html(text, container_tag=None):
+
+def plaintext2html(text, container_tag=None, with_paragraph=True):
     r"""Convert plaintext into html. Content of the text is escaped to manage
     html entities, using :func:`~odoo.tools.misc.html_escape`.
 
     - all ``\n``, ``\r`` are replaced by ``<br/>``
-    - enclose content into ``<p>``
     - convert url into clickable link
-    - 2 or more consecutive ``<br/>`` are considered as paragraph breaks
 
     :param str text: plaintext to convert
     :param str container_tag: container of the html; by default the content is
         embedded into a ``<div>``
+    :param with_paragraph: whether or not considering 2 or more consecutive ``<br/>``
+        as paragraph breaks and enclosing content in ``<p>``
     :rtype: markupsafe.Markup
     """
     text = misc.html_escape(ustr(text))
@@ -494,13 +495,15 @@ def plaintext2html(text, container_tag=None):
     text = html_keep_url(text)
 
     # 3-4: form paragraphs
-    idx = 0
-    final = '<p>'
-    br_tags = re.compile(r'(([<]\s*[bB][rR]\s*/?[>]\s*){2,})')
-    for item in re.finditer(br_tags, text):
-        final += text[idx:item.start()] + '</p><p>'
-        idx = item.end()
-    final += text[idx:] + '</p>'
+    final = text
+    if with_paragraph:
+        idx = 0
+        final = '<p>'
+        br_tags = re.compile(r'(([<]\s*[bB][rR]\s*/?[>]\s*){2,})')
+        for item in re.finditer(br_tags, text):
+            final += text[idx:item.start()] + '</p><p>'
+            idx = item.end()
+        final += text[idx:] + '</p>'
 
     # 5. container
     if container_tag: # FIXME: validate that container_tag is just a simple tag?


### PR DESCRIPTION
**Current behavior before PR:**

- Short feedback wraps the last word unnecessary.
![image](https://github.com/user-attachments/assets/89c9c615-36b8-40b5-847e-cfd1461989c1)

**Desired behavior after PR is merged:**

- Short messages wrapped unnecessarily due to block-level element
 conflicting with floated rating image. This fix ensures cleaner inline layout.
![image](https://github.com/user-attachments/assets/b4b53179-96c5-44c0-ad5f-c0cb3dcb99f4)

Backport of this: [Commit](https://github.com/odoo/odoo/commit/52a1913ea7082655009c9eca1201c8c42e4e4037) 

task-[4788428](https://www.odoo.com/odoo/project/1519/tasks/4788428)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
