### PR TITLE
[FIX] im_livechat: normalize the email before sending

### DIFF
--- a/addons/im_livechat/models/mail_channel.py
+++ b/addons/im_livechat/models/mail_channel.py
@@ -2,7 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import api, fields, models, _
-from odoo.tools import email_normalize, html_escape, html2plaintext, plaintext2html
+from odoo.tools import email_normalize, email_split, html_escape, html2plaintext, plaintext2html
 
 from markupsafe import Markup
 
@@ -140,7 +140,7 @@ class MailChannel(models.Model):
             'subject': _('Conversation with %s', self.livechat_operator_id.user_livechat_username or self.livechat_operator_id.name),
             'email_from': company.catchall_formatted or company.email_formatted,
             'author_id': self.env.user.partner_id.id,
-            'email_to': email,
+            'email_to': email_split(email)[0],
             'body_html': mail_body,
         })
         mail.send()


### PR DESCRIPTION
When there is invalid characters in the field, sending may lead to unexpected behaviour.
normalize and keep only the first one

Task-id: 4894083
