### PR TITLE
[FIX] website_payment: fix error when clicking on donate now button

### DIFF
--- a/addons/website_payment/static/src/snippets/s_donation/options.js
+++ b/addons/website_payment/static/src/snippets/s_donation/options.js
@@ -99,7 +99,7 @@ options.registry.Donation = options.Class.extend({
         const donationAmounts = [];
         delete this.$target[0].dataset.donationAmounts;
         valueList.forEach((value) => {
-            donationAmounts.push(value.display_name);
+            donationAmounts.push(value.display_name || '0');
         });
         this.$target[0].dataset.donationAmounts = JSON.stringify(donationAmounts);
         this._rebuildPrefilledOptions();


### PR DESCRIPTION
When the user clicks the ``Donate Now`` button and one of the pre-filled options
has a null amount, A traceback will appear.

Steps to reproduce the error:
- Go to Website > drag and drop donation button > Edit > Click on Donate Now button
- Add new pre-filled option with Null amount > Save
- Click on Donate Now button

Traceback:
```
ValueError: could not convert string to float: ''
```

https://github.com/odoo/odoo/blob/638268a81ed5a292a02d7fc353c4954159de54e1/addons/website_payment/views/payment_form_templates.xml#L86
Here, ``donation_amount`` will be an ``empty string('')``.
So, It will lead to the above traceback.

This commit will add a fallback value for a null amount.

sentry-6703335051

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
