### PR TITLE
[FIX] stock: fix showing product name in move description

### DIFF
--- a/addons/stock/models/product.py
+++ b/addons/stock/models/product.py
@@ -297,8 +297,8 @@ class ProductProduct(models.Model):
         """
         self.ensure_one()
         if picking_type_id.code == 'outgoing':
-            return self.name
-        return html2plaintext(self.description) if not is_html_empty(self.description) else self.name
+            return self.display_name
+        return html2plaintext(self.description) if not is_html_empty(self.description) else self.display_name
 
     def _get_picking_description(self, picking_type_id):
         """

--- a/addons/stock_dropshipping/models/product.py
+++ b/addons/stock_dropshipping/models/product.py
@@ -8,6 +8,6 @@ class ProductProduct(models.Model):
 
     def _get_description(self, picking_type_id):
         if picking_type_id.code == 'dropship':
-            return self.description_pickingout or self.name
+            return self.description_pickingout or self.display_name
         else:
             return super()._get_description(picking_type_id)


### PR DESCRIPTION
This commit makes sure that product name is not shown in the move description if exists at all. The new description widget applied in odoo/odoo#177390 looks for product's `display_name` to hide it. This commit makes `display_name` the fallback value for the description instead of `name` so that it's properly hidden in the picking form.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
