### PR TITLE
[IMP] website_event_sale: hide the "Sign In" button on the "No available seats" modal 

### DIFF
--- a/addons/website_event_sale/views/website_event_templates.xml
+++ b/addons/website_event_sale/views/website_event_templates.xml
@@ -86,19 +86,15 @@
     <!-- Change 'continue' button to use the website login settings -->
     <xpath expr="//div[hasclass('modal-footer')]//button[hasclass('btn-primary')]" position="replace">
         <t t-if="availability_check">
-            <t t-if="website.account_on_checkout == 'mandatory' and website.is_public_user()">
-                <button class="btn btn-primary" type="submit">
-                    <span>Sign In</span>
-                    <span class="fa fa-sign-in"/>
-                </button>
-            </t>
-            <t t-else="">
-                <t t-set="has_paying_ticket" t-value="any(ticket.get('price', 0) > 0 for ticket in tickets)"/>
-                <button type="submit" class="btn btn-primary">
-                    <span t-if="has_paying_ticket">Go to Payment</span>
-                    <span t-else="">Confirm Registration</span>
-                </button>
-            </t>
+            <t t-set="has_paying_ticket" t-value="any(ticket.get('price', 0) > 0 for ticket in tickets)"/>
+            <button t-if="website.account_on_checkout == 'mandatory' and website.is_public_user() and has_paying_ticket" class="btn btn-primary" type="submit">
+                <span>Sign In</span>
+                <span class="fa fa-sign-in"/>
+            </button>
+            <button t-else="" type="submit" class="btn btn-primary">
+                <span t-if="has_paying_ticket">Go to Payment</span>
+                <span t-else="">Confirm Registration</span>
+            </button>
         </t>
     </xpath>
 </template>

--- a/addons/website_event_sale/views/website_event_templates.xml
+++ b/addons/website_event_sale/views/website_event_templates.xml
@@ -85,18 +85,20 @@
 <template id="registration_attendee_details" inherit_id="website_event.registration_attendee_details">
     <!-- Change 'continue' button to use the website login settings -->
     <xpath expr="//div[hasclass('modal-footer')]//button[hasclass('btn-primary')]" position="replace">
-        <t t-if="website.account_on_checkout == 'mandatory' and website.is_public_user()">
-            <button class="btn btn-primary" type="submit">
-                <span>Sign In</span>
-                <span class="fa fa-sign-in"/>
-            </button>
-        </t>
-        <t t-else="">
-            <t t-set="has_paying_ticket" t-value="any(ticket.get('price', 0) > 0 for ticket in tickets)"/>
-            <button t-if="availability_check" type="submit" class="btn btn-primary">
-                <span t-if="has_paying_ticket">Go to Payment</span>
-                <span t-else="">Confirm Registration</span>
-            </button>
+        <t t-if="availability_check">
+            <t t-if="website.account_on_checkout == 'mandatory' and website.is_public_user()">
+                <button class="btn btn-primary" type="submit">
+                    <span>Sign In</span>
+                    <span class="fa fa-sign-in"/>
+                </button>
+            </t>
+            <t t-else="">
+                <t t-set="has_paying_ticket" t-value="any(ticket.get('price', 0) > 0 for ticket in tickets)"/>
+                <button type="submit" class="btn btn-primary">
+                    <span t-if="has_paying_ticket">Go to Payment</span>
+                    <span t-else="">Confirm Registration</span>
+                </button>
+            </t>
         </t>
     </xpath>
 </template>


### PR DESCRIPTION
This commit fixes two bugs related to the "Sign in" in button of the registration form.

First bug:
------------
If there is more ordered seats than available seats, an error modal is displayed with a "Sign In" button. This button shouldn't be present. On click, a 500 error is triggered. Now, the button does not appeared on this modal.

Reproduce:
Check "Mandatory" for "Sign in/up at checkout" in the settings. In the event form, add a limit of 1 available seat and add two tickets with each one 1 seat. With a public user, on the website page of the event, click on "Register" to open the registration modal. In the tickets form, select the maximum number of registrations for each tickets. The error modal with the "Sign In" button should appear. Clicking on this button trigger the 500 error.

Second bug:
----------------
The "Sign in" button is displayed even if the tickets have no price. So the label of the button is wrong because public users are not redirected to the checkout. Now, the "Confirm Registration" button is displayed in this case.

Reproduce:
With the same settings as for the first bug, create an event without tickets. Order a registration with an public user. Click on the "Sign In" button of the attendee details form. The confirmation page appears instead of the sign in page.

task-4797022
