### PR TITLE
[FIX] hr: add check company to employee calendar

### DIFF
--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -74,7 +74,7 @@ class HrEmployee(models.Model):
     name = fields.Char(string="Employee Name", related='resource_id.name', store=True, readonly=False, tracking=True)
     resource_id = fields.Many2one('resource.resource', required=True)
     # required because the mixin already creates it so it is not related to the version_id
-    resource_calendar_id = fields.Many2one(related='version_id.resource_calendar_id', index=False, store=False)
+    resource_calendar_id = fields.Many2one(related='version_id.resource_calendar_id', index=False, store=False, check_company=True)
     user_id = fields.Many2one(
         'res.users', 'User',
         related='resource_id.user_id',


### PR DESCRIPTION
The check_company of the resource_calendar field was only on the hr_version model but should also be on the hr_employee model as the two company fields are not necessarily related (ex: contract templates).


task-4894155

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
