### PR TITLE
[FIX] html_editor: areSimilarElements order-insensitive class/style

### DIFF
--- a/addons/html_editor/static/tests/utils/dom_info.test.js
+++ b/addons/html_editor/static/tests/utils/dom_info.test.js
@@ -1,4 +1,5 @@
 import {
+    areSimilarElements,
     getDeepestPosition,
     isEmptyBlock,
     isShrunkBlock,
@@ -442,6 +443,44 @@ describe("isShrunkBlock", () => {
     test("should not consider a block containing a canvas as a shrunk block", () => {
         const [canvas] = insertTestHtml("<canvas></canvas>");
         const result = isShrunkBlock(canvas);
+        expect(result).toBe(false);
+    });
+});
+
+describe("areSimilarElements", () => {
+    test("should consider elements with same classes and styles in different orders as similar", () => {
+        const [span1, span2] = insertTestHtml(
+            "<span class='first second' style='color: red; color2: blue'>hello</span><span class='second first' style='color2: blue; color: red'>world</span>"
+        );
+        const result = areSimilarElements(span1, span2);
+        expect(result).toBe(true);
+    });
+    test("return false when the number of styles are different", () => {
+        const [span1, span2] = insertTestHtml(
+            "<span class='first second' style='color: red; color2: blue'>hello</span><span class='second first' style='color2: blue;'>world</span>"
+        );
+        const result = areSimilarElements(span1, span2);
+        expect(result).toBe(false);
+    });
+    test("return false when the number of classes are different", () => {
+        const [span1, span2] = insertTestHtml(
+            "<span class='first' style='color: red; color2: blue'>hello</span><span class='second first' style='color2: blue;'>world</span>"
+        );
+        const result = areSimilarElements(span1, span2);
+        expect(result).toBe(false);
+    });
+    test("return false when classes are different", () => {
+        const [span1, span2] = insertTestHtml(
+            "<span class='first' style='color: red; color2: blue'>hello</span><span class='second' style='color2: blue;'>world</span>"
+        );
+        const result = areSimilarElements(span1, span2);
+        expect(result).toBe(false);
+    });
+    test("return false when styles are different", () => {
+        const [span1, span2] = insertTestHtml(
+            "<span class='first second' style='color2: blue'>hello</span><span class='second first' style='color2: blue; color: red'>world</span>"
+        );
+        const result = areSimilarElements(span1, span2);
         expect(result).toBe(false);
     });
 });


### PR DESCRIPTION
The `areSimilarElements` is used by `mergeAdjacentInline` function to merge similar node and having a clean DOM.

In website, highlights use this function but highlights node can have two similar node but with different style order.

This commit make `areSimilarElements` compare class and style attributes without considering order.
