### PR TITLE
[IMP] hr_expense: improvements after farewell expense reports

### DIFF
--- a/addons/hr_expense/data/mail_message_subtype_data.xml
+++ b/addons/hr_expense/data/mail_message_subtype_data.xml
@@ -9,6 +9,13 @@
             <field name="description">Expense approved</field>
         </record>
 
+        <record id="mt_expense_posted" model="mail.message.subtype">
+            <field name="name">Posted</field>
+            <field name="res_model">hr.expense</field>
+            <field name="default" eval="True"/>
+            <field name="description">Expense posted</field>
+        </record>
+
         <record id="mt_expense_refused" model="mail.message.subtype">
             <field name="name">Refused</field>
             <field name="res_model">hr.expense</field>

--- a/addons/hr_expense/data/mail_templates.xml
+++ b/addons/hr_expense/data/mail_templates.xml
@@ -41,6 +41,13 @@
             <a t-att-href="'/odoo/expenses-to-process'" class="o_expense_button_mail">View expenses</a>
         </template>
 
+        <template id="hr_expense_template_posted_expenses">
+            <p>
+                Journal entry created:
+                <a href="#" t-att-data-oe-model="move._name" t-att-data-oe-id="move.id"><t t-esc="move.name"/></a>
+            </p>
+        </template>
+
         <template id="hr_expense_template_register_no_user">
             <div style="background:#F0F0F0;color:#515166;padding:10px 0px;font-family:Arial,Helvetica,sans-serif;font-size:14px;">
                 <table style="width:600px;margin:5px auto;" t-if="not expense.employee_id.company_id.uses_default_logo">

--- a/addons/hr_expense/models/__init__.py
+++ b/addons/hr_expense/models/__init__.py
@@ -8,6 +8,7 @@ from . import account_payment
 from . import account_tax
 from . import hr_department
 from . import hr_expense
+from . import hr_expense_group
 from . import product_product
 from . import product_template
 from . import res_config_settings

--- a/addons/hr_expense/models/hr_expense.py
+++ b/addons/hr_expense/models/hr_expense.py
@@ -241,7 +241,7 @@ class HrExpense(models.Model):
     )
     payment_mode = fields.Selection(
         selection=[
-            ('own_account', "Employee (to reimburse)"),
+            ('own_account', "Employee"),
             ('company_account', "Company")
         ],
         string="Paid By",

--- a/addons/hr_expense/models/hr_expense.py
+++ b/addons/hr_expense/models/hr_expense.py
@@ -258,6 +258,12 @@ class HrExpense(models.Model):
         domain="[('account_type', 'not in', ('asset_receivable', 'liability_payable', 'asset_cash', 'liability_credit_card'))]",
         help="An expense account is expected",
     )
+    expense_group_ids = fields.Many2many(
+        comodel_name='hr.expense.group',
+        string="Expense Groups",
+        help="Groups of expenses",
+    )
+
     tax_ids = fields.Many2many(
         comodel_name='account.tax',
         relation='expense_tax',

--- a/addons/hr_expense/models/hr_expense_group.py
+++ b/addons/hr_expense/models/hr_expense_group.py
@@ -1,0 +1,20 @@
+from odoo import fields, models
+
+
+class HrExpense(models.Model):
+    _name = 'hr.expense.group'
+    _description = 'Expense Group'
+    _order = 'sequence desc'
+
+    name = fields.Char(string='Name')
+    sequence = fields.Integer(string='Sequence', default=100)
+    parent_id = fields.Many2one(
+        'hr.expense.group',
+        string='Super Group',
+        help='Expense group containing this one',
+    )
+    expense_ids = fields.Many2many(
+        comodel_name='hr.expense',
+        string='Expenses',
+        help='Expenses grouped',
+    )

--- a/addons/hr_expense/security/ir.model.access.csv
+++ b/addons/hr_expense/security/ir.model.access.csv
@@ -13,3 +13,4 @@ access_hr_expense_approve_duplicate,access.hr.expense.approve.duplicate,model_hr
 access_hr_expense_split_wizard_manager,access.hr.expense.split.wizard.manager,model_hr_expense_split_wizard,base.group_user,1,1,1,0
 access_hr_expense_split_manager,access.hr.expense.split.manager,model_hr_expense_split,base.group_user,1,1,1,1
 access_hr_expense_post,access.hr.expense.post.wizard,model_hr_expense_post_wizard,account.group_account_invoice,1,1,1,1
+access_hr_expense_group,access.hr.expense.group,model_hr_expense_group,base.group_user,1,1,1,1

--- a/addons/hr_expense/static/src/components/attachment_view.js
+++ b/addons/hr_expense/static/src/components/attachment_view.js
@@ -1,5 +1,7 @@
 import { patch } from "@web/core/utils/patch";
 import { AttachmentView } from "@mail/core/common/attachment_view";
+import { onMounted } from "@odoo/owl";
+import { useBus } from "@web/core/utils/hooks";
 
 patch(AttachmentView.prototype, {
     get displayName() {
@@ -9,3 +11,18 @@ patch(AttachmentView.prototype, {
         return super.displayName;
     }
 });
+
+export class ExpenseAttachment extends AttachmentView {
+    static props = [...AttachmentView.props, "openInPopout"];
+    static components = { AttachmentView };
+
+    setup() {
+        super.setup();
+        if (this.props.openInPopout) {
+            onMounted(this.onClickPopout);
+        }
+        // In the mail_popout_service.js the function pollClosedWindow will trigger a resize event on the main window
+        // when the external window is closed. It allows us to know when to hide the preview for small screens.
+        useBus(this.uiService.bus, "resize", () => this.env.setPopout(false));
+    }
+}

--- a/addons/hr_expense/static/src/scss/hr_expense.scss
+++ b/addons/hr_expense/static/src/scss/hr_expense.scss
@@ -1,3 +1,80 @@
+.o_expense_list_view {
+    &.o_view_controller > .o_content {
+        overflow: hidden;
+        display: block;
+
+        .o_attachment_list {
+            @include media-only(screen) {
+                display: flex;
+                overflow: hidden;
+                height: 100%;
+                flex: 1 1 100%;
+            }
+            .o_list_renderer {
+                overflow: scroll;
+                height: 100%;
+                flex: 1 1 100%;
+            }
+        }
+    }
+
+    .o_attachment_preview {
+        height: 100%;
+        width: 30%;
+        border-left: $border-width solid $border-color;
+
+        .o_attachment_control.toggle {
+            margin-top: 10%;
+            border-radius: 0 30px 30px 0;
+            padding: 15px 15px 15px 5px;
+            &::after {
+                color: white;
+                content: '>>';
+            }
+        }
+
+        &.hidden {
+            width: 0;
+            .o_attachment_control.toggle {
+                right: 0;
+                border-radius: 30px 0 0 30px;
+                padding: 15px 0 15px 15px;
+                &::after {
+                    content: '<';
+                }
+                &:hover {
+                    padding-right: 5px;
+                    ::after {
+                        content: '<<';
+                    }
+                }
+            }
+        }
+    }
+
+    .o_popout_icon {
+        position: absolute;
+        top: 8%;
+        background-color: black;
+        opacity: 0.3;
+        margin-top: -15px;
+        transition: all 0.3s;
+        z-index: $zindex-dropdown; // due to the absolute position in o-mail-Attachment-imgContainer
+        right: 0;
+        border-radius: 30px 0 0 30px;
+        padding: 15px 0 15px 15px;
+        &:hover {
+            padding-right: 15px;
+        }
+    }
+
+    @include media-only(print) {
+        .o_search_panel {
+            display: none;
+        }
+    }
+}
+
 .hr_expense {
     @include media-breakpoint-up(md) {
         &.o_list_view, &.o_kanban_view .o_kanban_renderer {

--- a/addons/hr_expense/static/src/views/list.js
+++ b/addons/hr_expense/static/src/views/list.js
@@ -1,15 +1,17 @@
+import { ExpenseAttachment } from "../components/attachment_view";
 import { ExpenseDashboard } from '../components/expense_dashboard';
 import { ExpenseMobileQRCode } from '../mixins/qrcode';
 import { ExpenseDocumentUpload, ExpenseDocumentDropZone } from '../mixins/document_upload';
 
 import { registry } from '@web/core/registry';
+import { SIZES } from "@web/core/ui/ui_service";
 import { useService } from '@web/core/utils/hooks';
 import { user } from "@web/core/user";
 import { listView } from "@web/views/list/list_view";
 
 import { ListController } from "@web/views/list/list_controller";
 import { ListRenderer } from "@web/views/list/list_renderer";
-import { onWillStart } from "@odoo/owl";
+import { useChildSubEnv, useState, onWillStart } from "@odoo/owl";
 
 export class ExpenseListController extends ExpenseDocumentUpload(ListController) {
     static template = `hr_expense.ListView`;
@@ -70,21 +72,122 @@ export class ExpenseListRenderer extends ExpenseDocumentDropZone(
     static template = "hr_expense.ListRenderer";
 }
 
-export class ExpenseDashboardListRenderer extends ExpenseListRenderer {
-    static components = { ...ExpenseDashboardListRenderer.components, ExpenseDashboard };
-    static template = "hr_expense.DashboardListRenderer";
+export const ExpenseListView = {
+    ...listView,
+    buttonTemplate: 'hr_expense.ListButtons',
+    Renderer: ExpenseListRenderer,
+    Controller: ExpenseListController,
+};
+
+export class ExpenseOverviewListController extends ExpenseListController {
+    static template = "hr_expense.OverviewListView";
+    static components = { ...ExpenseListController.components, ExpenseAttachment };
+    setup() {
+        super.setup();
+        this.store = useService("mail.store");
+        this.ui = useService("ui");
+        this.mailPopoutService = useService("mail.popout");
+        this.attachmentPreviewState = useState({
+            displayAttachment: localStorage.getItem(this.previewerStorageKey) !== "false",
+            focusedRecord: false,
+            thread: null,
+        });
+
+        this.popout = useState({ active: false });
+
+        useChildSubEnv({
+            setPopout: this.setPopout.bind(this),
+        });
+    }
+
+    get previewerStorageKey() {
+        return "hr_expense.expense_previewer_hidden";
+    }
+
+    previewEnabled() {
+        return (
+            !this.env.searchModel.context.disable_preview &&
+            (this.ui.size >= SIZES.XXL || this.mailPopoutService.externalWindow)
+        );
+    }
+
+    togglePreview() {
+        this.attachmentPreviewState.displayAttachment = !this.attachmentPreviewState.displayAttachment;
+        localStorage.setItem(
+            this.previewerStorageKey,
+            this.attachmentPreviewState.displayAttachment
+        );
+    }
+
+    setPopout(value) {
+        if (this.attachmentPreviewState.thread?.attachmentsInWebClientView.length) {
+            this.popout.active = value;
+        }
+    }
+
+    async setThread(lineData) {
+        const attachmentField = "attachment_ids"
+        const attachments = lineData?.data[attachmentField]?.records || [];
+        if (!lineData || !attachments.length) {
+            this.attachmentPreviewState.thread = null;
+            return;
+        }
+        const thread = this.store.Thread.insert({
+            attachments: attachments.map((attachment) => ({
+                id: attachment.resId,
+                mimetype: attachment.data.mimetype,
+            })),
+            id: lineData.resId,
+            model: lineData.resModel,
+        });
+        if (!thread.message_main_attachment_id && thread.attachmentsInWebClientView.length > 0){
+            thread.update({message_main_attachment_id: thread.attachmentsInWebClientView[0]});
+        }
+        this.attachmentPreviewState.thread = thread;
+    }
+
+    async setFocusedRecord(ExpenseData) {
+        this.attachmentPreviewState.focusedRecord = ExpenseData;
+        await this.setThread(ExpenseData, "attachment_ids", "id");
+    }
 }
 
-registry.category('views').add('hr_expense_tree', {
-    ...listView,
-    buttonTemplate: 'hr_expense.ListButtons',
-    Controller: ExpenseListController,
-    Renderer: ExpenseListRenderer,
-});
 
-registry.category('views').add('hr_expense_dashboard_tree', {
+export class ExpenseOverviewListRenderer extends ExpenseListRenderer {
+    static components = { ...ExpenseListRenderer.components, ExpenseDashboard, ExpenseAttachment };
+    static template = "hr_expense.OverviewListRenderer";
+    static props = [
+        ...ExpenseListRenderer.props,
+        "attachmentPreviewState",
+        "previewEnabled",
+        "popout",
+        "setFocusedRecord",
+        "togglePreview",
+    ];
+
+    findFocusFutureCell(cell, cellIsInGroupRow, direction) {
+        const futureCell = super.findFocusFutureCell(cell, cellIsInGroupRow, direction);
+        if (futureCell) {
+            const dataPointId = futureCell.closest("tr").dataset.id;
+            const record = this.props.list.records.filter((x) => x.id === dataPointId)[0];
+            this.props.setFocusedRecord(record);
+        }
+        return futureCell;
+    }
+
+    toggleRecordSelection(record) {
+        super.toggleRecordSelection(record);
+        if (record){this.props.setFocusedRecord(record);}
+    }
+}
+
+export const ExpenseOverviewListView = {
     ...listView,
     buttonTemplate: 'hr_expense.ListButtons',
-    Controller: ExpenseListController,
-    Renderer: ExpenseDashboardListRenderer,
-});
+    Renderer: ExpenseOverviewListRenderer,
+    Controller: ExpenseOverviewListController,
+};
+
+registry.category('views').add('hr_expense_tree', ExpenseListView);
+
+registry.category('views').add('hr_expense_overview_tree', ExpenseOverviewListView);

--- a/addons/hr_expense/static/src/views/list.xml
+++ b/addons/hr_expense/static/src/views/list.xml
@@ -49,9 +49,60 @@
     </t>
 
 
-    <t t-name="hr_expense.DashboardListRenderer" t-inherit="hr_expense.ListRenderer" t-inherit-mode="primary">
+    <t t-name="hr_expense.OverviewListRenderer" t-inherit="hr_expense.ListRenderer" t-inherit-mode="primary">
         <xpath expr="//div[hasclass('o_list_renderer')]" position="before">
             <ExpenseDashboard/>
+            <div class="o_attachment_list"/>
+        </xpath>
+        <xpath expr="//div[hasclass('o_attachment_list')]" position="inside">
+            <xpath expr="//div[hasclass('o_list_renderer')]" position="move"/>
+            <div t-if="this.props.previewEnabled" class="o_attachment_preview d-print-none" t-att-class="{'hidden': !props.attachmentPreviewState.displayAttachment}">
+                <t t-if="this.props.attachmentPreviewState.displayAttachment">
+                    <t t-if="this.props.attachmentPreviewState.thread and this.props.attachmentPreviewState.thread.attachmentsInWebClientView.length > 0">
+                        <ExpenseAttachment
+                            threadId="this.props.attachmentPreviewState.thread.id"
+                            threadModel="this.props.attachmentPreviewState.thread.model"
+                            openInPopout="0"
+                        />
+                    </t>
+                    <t t-elif="!this.props.attachmentPreviewState.focusedRecord">
+                        <p class="text-center">Choose a line to preview its attachments.</p>
+                    </t>
+                    <t t-else="">
+                        <p class="text-center">No attachments linked.</p>
+                    </t>
+                </t>
+                <div class="o_attachment_control toggle" t-on-click="props.togglePreview"/>
+            </div>
+            <t t-else="">
+                <div class="o_popout_icon" t-on-click="() => this.setPopout(true)">
+                    <i class="fa fa-window-restore" title="Open attachment in pop out"/>
+                </div>
+                <t t-if="this.props.popout.active">
+                    <div class="o_attachment_preview d-print-none"
+                         t-if="this.props.attachmentPreviewState.thread?.attachmentsInWebClientView.length"
+                    >
+                        <ExpenseAttachment
+                            threadId="this.props.attachmentPreviewState.thread.id"
+                            threadModel="this.props.attachmentPreviewState.thread.model"
+                            openInPopout="1"
+                        />
+                    </div>
+                </t>
+            </t>
+        </xpath>
+    </t>
+
+    <t t-name="hr_expense.OverviewListView" t-inherit="hr_expense.ListView">
+        <xpath expr="//div[@t-ref='root']" position="attributes" type="add">
+            <attribute name="class" add="o_expense_list_view" separator=" "/>
+        </xpath>
+        <xpath expr="//t[@t-component='props.Renderer']" position="attributes">
+            <attribute name="attachmentPreviewState">this.attachmentPreviewState</attribute>
+            <attribute name="popout">this.popout</attribute>
+            <attribute name="previewEnabled.bind">this.previewEnabled</attribute>
+            <attribute name="setFocusedRecord.bind">this.setFocusedRecord</attribute>
+            <attribute name="togglePreview.bind">this.togglePreview</attribute>
         </xpath>
     </t>
 </templates>

--- a/addons/hr_expense/views/hr_expense_views.xml
+++ b/addons/hr_expense/views/hr_expense_views.xml
@@ -22,6 +22,11 @@
                     <field name="is_editable" column_invisible="True"/>
                     <field name="company_id" column_invisible="True"/>
                     <field name="company_currency_id" column_invisible="True"/>
+                    <field name="attachment_ids">
+                        <list>
+                            <field name="mimetype"/>
+                        </list>
+                    </field>
                     <field name="nb_attachment" column_invisible="True"/>
                     <field name="is_multiple_currency" column_invisible="True"/>
                     <field name="product_has_cost" column_invisible="True"/>
@@ -35,8 +40,8 @@
                     <field name="department_id" optional="hide" readonly="True"/>
                     <field name="date" optional="show" readonly="not is_editable"/>
                     <field name="product_id" optional="show" readonly="not is_editable" required="1"/>
-                    <field name="payment_mode" optional="show" readonly="not is_editable"/>
-                    <field name="activity_ids" widget="list_activity" optional="show"/>
+                    <field name="payment_mode" optional="show" readonly="not is_editable" invisible="payment_mode=='company_account'"/>
+                    <field name="activity_ids" widget="list_activity" optional="hide"/>
                     <field name="analytic_distribution" widget="analytic_distribution"
                            optional="show"
                            groups="analytic.group_analytic_accounting"
@@ -91,7 +96,7 @@
             <field name="arch" type="xml">
                 <xpath expr="//list" position="attributes">
                     <!-- Display the tree dashboard view with the header -->
-                    <attribute name="js_class">hr_expense_dashboard_tree</attribute>
+                    <attribute name="js_class">hr_expense_overview_tree</attribute>
                 </xpath>
             </field>
         </record>
@@ -105,7 +110,7 @@
             <field name="arch" type="xml">
                 <xpath expr="//list" position="attributes">
                     <!-- Display the tree dashboard view with the header -->
-                    <attribute name="js_class">hr_expense_dashboard_tree</attribute>
+                    <attribute name="js_class">hr_expense_overview_tree</attribute>
                 </xpath>
             </field>
         </record>

--- a/addons/hr_expense/views/hr_expense_views.xml
+++ b/addons/hr_expense/views/hr_expense_views.xml
@@ -481,6 +481,7 @@
                         <filter string="Company" name="company" domain="[]" context="{'group_by': 'company_id'}"
                                 groups="base.group_multi_company"/>
                         <filter string="Department" name="department" domain="[]" context="{'group_by': 'department_id'}"/>
+                        <filter string="Expense Group" name="group" domain="[]" context="{'group_by': 'expense_group_ids'}"/>
                     </group>
                 </search>
             </field>
@@ -651,6 +652,27 @@
             </field>
         </record>
 
+        <record id="hr_expense_group" model="ir.actions.act_window">
+            <field name="name">Expense Groups</field>
+            <field name="res_model">hr.expense.group</field>
+            <field name="view_mode">list,form</field>
+            <field name="help" type="html">
+                <p class="o_view_nocontent_smiling_face">No expense group found. Let's create one!</p>
+            </field>
+        </record>
+
+        <record id="hr_expense_group_tree" model="ir.actions.act_window.view">
+            <field name="sequence" eval="1"/>
+            <field name="view_mode">list</field>
+            <field name="act_window_id" ref="hr_expense_group"/>
+        </record>
+
+        <record id="hr_expense_group_form" model="ir.actions.act_window.view">
+            <field name="sequence" eval="2"/>
+            <field name="view_mode">form</field>
+            <field name="act_window_id" ref="hr_expense_group"/>
+        </record>
+
         <menuitem id="menu_hr_expense_root" name="Expenses" sequence="230" web_icon="hr_expense,static/description/icon.png"/>
 
         <menuitem id="menu_hr_expense_my_expenses" name="My Expenses" sequence="1" parent="menu_hr_expense_root" groups="base.group_user"/>
@@ -668,6 +690,9 @@
             sequence="100"/>
         <menuitem id="menu_hr_product" name="Expense Categories" parent="menu_hr_expense_configuration"
             action="hr_expense_product" groups="hr_expense.group_hr_expense_manager" sequence="10"/>
+
+        <menuitem id="menu_hr_expense_group" name="Expense Groups" parent="menu_hr_expense_configuration"
+            action="hr_expense_group" sequence="11"/>
 
         <menuitem id="menu_hr_expense_account_employee_expenses" name="Employee Expenses" sequence="22"
                   parent="account.menu_finance_payables" groups="hr_expense.group_hr_expense_user"


### PR DESCRIPTION
Some improvements to match the previous behavior or simply the new one:

- hide activity_ids by default on the list view
- the column "Paid By" contains "Employee" or nothing
- a document preview is displayed aside the list
- when an entry is created, we put a link to the entry in the chatter
- we can group expenses by expense groups (they can replace the reports)

task-id: 4492474