### PR TITLE
[FIX] l10n_account_withholding_tax: rectify default account and tax domain

### DIFF
--- a/addons/l10n_account_withholding_tax/i18n/id.po
+++ b/addons/l10n_account_withholding_tax/i18n/id.po
@@ -1,221 +1,207 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
-# 	* l10n_account_withholding
+# 	* l10n_account_withholding_tax
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 18.4a1+e\n"
+"Project-Id-Version: Odoo Server 18.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-06-12 02:39+0000\n"
-"PO-Revision-Date: 2025-06-12 15:59+0800\n"
+"POT-Creation-Date: 2025-06-25 05:29+0000\n"
+"PO-Revision-Date: 2025-06-25 05:29+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
+"Content-Transfer-Encoding: \n"
 "Plural-Forms: \n"
 
-#. module: l10n_account_withholding
+#. module: l10n_account_withholding_tax
 #. odoo-python
-#: code:addons/l10n_account_withholding/models/product_template.py:0
+#: code:addons/l10n_account_withholding_tax/models/product_template.py:0
 msgid "%(amount)s Excl. Taxes"
 msgstr "%(amount)s Sebelum Pajak"
 
-#. module: l10n_account_withholding
+#. module: l10n_account_withholding_tax
 #. odoo-python
-#: code:addons/l10n_account_withholding/models/product_template.py:0
+#: code:addons/l10n_account_withholding_tax/models/product_template.py:0
 msgid "%(amount)s Incl. Taxes"
 msgstr "%(amount)s Termasuk Pajak"
 
-#. module: l10n_account_withholding
+#. module: l10n_account_withholding_tax
 #. odoo-python
-#: code:addons/l10n_account_withholding/models/product_template.py:0
+#: code:addons/l10n_account_withholding_tax/models/product_template.py:0
 msgid "%(amount)s Tax Withheld"
 msgstr "%(amount)s Pajak Dipotong"
 
-#. module: l10n_account_withholding
-#: model_terms:ir.ui.view,arch_db:l10n_account_withholding.report_payment_receipt_document
+#. module: l10n_account_withholding_tax
+#: model_terms:ir.ui.view,arch_db:l10n_account_withholding_tax.report_payment_receipt_document
 msgid "<span>Amount</span>"
 msgstr "<span>Jumlah</span>"
 
-#. module: l10n_account_withholding
-#: model_terms:ir.ui.view,arch_db:l10n_account_withholding.report_payment_receipt_document
+#. module: l10n_account_withholding_tax
+#: model_terms:ir.ui.view,arch_db:l10n_account_withholding_tax.report_payment_receipt_document
 msgid "<span>Base</span>"
 msgstr "<span>Pokok</span>"
 
-#. module: l10n_account_withholding
-#: model_terms:ir.ui.view,arch_db:l10n_account_withholding.report_payment_receipt_document
+#. module: l10n_account_withholding_tax
+#: model_terms:ir.ui.view,arch_db:l10n_account_withholding_tax.report_payment_receipt_document
 msgid "<span>Tax</span>"
 msgstr "<span>Pajak</span>"
 
-#. module: l10n_account_withholding
-#: model_terms:ir.ui.view,arch_db:l10n_account_withholding.report_payment_receipt_document
+#. module: l10n_account_withholding_tax
+#: model_terms:ir.ui.view,arch_db:l10n_account_withholding_tax.report_payment_receipt_document
 msgid "<span>Withholding number</span>"
 msgstr "<span>Angka pemotongan</span>"
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_register_withholding_line__account_id
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_withholding_line__account_id
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_withholding_line__account_id
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_register_withholding_line__account_id
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_withholding_line__account_id
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_withholding_line__account_id
 msgid "Account"
 msgstr "Akun"
 
-#. module: l10n_account_withholding
+#. module: l10n_account_withholding_tax
 #. odoo-python
-#: code:addons/l10n_account_withholding/wizards/account_payment_register_withholding_line.py:0
+#: code:addons/l10n_account_withholding_tax/wizards/account_payment_register_withholding_line.py:0
 msgid "All withholding lines in self must have the same payment register."
 msgstr "Semua baris pemotongan harus memiliki daftar pembayaran yang sama."
 
-#. module: l10n_account_withholding
+#. module: l10n_account_withholding_tax
 #. odoo-python
-#: code:addons/l10n_account_withholding/models/account_payment_withholding_line.py:0
+#: code:addons/l10n_account_withholding_tax/models/account_payment_withholding_line.py:0
 msgid "All withholding lines in self must have the same payment."
 msgstr "Semua baris pemotongan harus memiliki pembayaran yang sama."
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_register_withholding_line__analytic_distribution
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_withholding_line__analytic_distribution
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_withholding_line__analytic_distribution
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_register_withholding_line__analytic_distribution
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_withholding_line__analytic_distribution
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_withholding_line__analytic_distribution
 msgid "Analytic Distribution"
 msgstr "Distribusi Analitik"
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_register_withholding_line__analytic_precision
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_withholding_line__analytic_precision
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_withholding_line__analytic_precision
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_register_withholding_line__analytic_precision
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_withholding_line__analytic_precision
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_withholding_line__analytic_precision
 msgid "Analytic Precision"
 msgstr "Ketepatan Analitik"
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_register_withholding_line__comodel_currency_id
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_withholding_line__comodel_currency_id
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_withholding_line__comodel_currency_id
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_register_withholding_line__comodel_currency_id
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_withholding_line__comodel_currency_id
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_withholding_line__comodel_currency_id
 msgid "Comodel Currency"
 msgstr "Mata Uang Comodel"
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_register_withholding_line__comodel_date
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_withholding_line__comodel_date
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_withholding_line__comodel_date
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_register_withholding_line__comodel_date
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_withholding_line__comodel_date
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_withholding_line__comodel_date
 msgid "Comodel Date"
 msgstr "Tanggal Comodel"
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_register_withholding_line__comodel_payment_type
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_withholding_line__comodel_payment_type
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_withholding_line__comodel_payment_type
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_register_withholding_line__comodel_payment_type
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_withholding_line__comodel_payment_type
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_withholding_line__comodel_payment_type
 msgid "Comodel Payment Type"
 msgstr "Tipe Pembayaran Comodel"
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_register_withholding_line__comodel_percentage_paid_factor
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_withholding_line__comodel_percentage_paid_factor
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_withholding_line__comodel_percentage_paid_factor
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_register_withholding_line__comodel_percentage_paid_factor
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_withholding_line__comodel_percentage_paid_factor
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_withholding_line__comodel_percentage_paid_factor
 msgid "Comodel Percentage Paid Factor"
 msgstr "Faktor Persentase Pembayaran Comodel"
 
-#. module: l10n_account_withholding
-#: model:ir.model,name:l10n_account_withholding.model_res_company
+#. module: l10n_account_withholding_tax
+#: model:ir.model,name:l10n_account_withholding_tax.model_res_company
 msgid "Companies"
 msgstr "Perusahaan-Perusahaan"
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_register_withholding_line__company_id
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_withholding_line__company_id
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_withholding_line__company_id
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_register_withholding_line__company_id
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_withholding_line__company_id
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_withholding_line__company_id
 msgid "Company"
 msgstr "Perusahaan"
 
-#. module: l10n_account_withholding
-#: model:ir.model,name:l10n_account_withholding.model_res_config_settings
+#. module: l10n_account_withholding_tax
+#: model:ir.model,name:l10n_account_withholding_tax.model_res_config_settings
 msgid "Config Settings"
 msgstr "Pengaturan Konfigurasi"
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_register_withholding_line__create_uid
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_withholding_line__create_uid
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_register_withholding_line__create_uid
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_withholding_line__create_uid
 msgid "Created by"
 msgstr "Dibuat oleh"
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_register_withholding_line__create_date
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_withholding_line__create_date
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_register_withholding_line__create_date
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_withholding_line__create_date
 msgid "Created on"
 msgstr "Dibuat pada"
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_register_withholding_line__comodel_company_currency_id
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_withholding_line__comodel_company_currency_id
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_withholding_line__comodel_company_currency_id
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_register_withholding_line__comodel_company_currency_id
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_withholding_line__comodel_company_currency_id
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_withholding_line__comodel_company_currency_id
 msgid "Currency"
 msgstr "Mata Uang"
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_register__withholding_default_account_id
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_register__withholding_default_account_id
 msgid "Default Account"
 msgstr "Akun Default"
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment__display_name
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_register__display_name
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_register_withholding_line__display_name
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_withholding_line__display_name
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_tax__display_name
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_withholding_line__display_name
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_product_template__display_name
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_res_company__display_name
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_res_config_settings__display_name
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_register_withholding_line__display_name
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_withholding_line__display_name
 msgid "Display Name"
 msgstr "Nama Tampilan"
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment__display_withholding
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_register__display_withholding
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment__display_withholding
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_register__display_withholding
 msgid "Display Withholding"
 msgstr "Tampilan Pemotongan"
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_register_withholding_line__distribution_analytic_account_ids
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_withholding_line__distribution_analytic_account_ids
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_withholding_line__distribution_analytic_account_ids
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_register_withholding_line__distribution_analytic_account_ids
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_withholding_line__distribution_analytic_account_ids
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_withholding_line__distribution_analytic_account_ids
 msgid "Distribution Analytic Account"
 msgstr "Akun Distribusi Analitik"
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields.selection,name:l10n_account_withholding.selection__account_payment_register_withholding_line__placeholder_type__given_by_name
-#: model:ir.model.fields.selection,name:l10n_account_withholding.selection__account_payment_register_withholding_line__previous_placeholder_type__given_by_name
-#: model:ir.model.fields.selection,name:l10n_account_withholding.selection__account_payment_withholding_line__placeholder_type__given_by_name
-#: model:ir.model.fields.selection,name:l10n_account_withholding.selection__account_payment_withholding_line__previous_placeholder_type__given_by_name
-#: model:ir.model.fields.selection,name:l10n_account_withholding.selection__account_withholding_line__placeholder_type__given_by_name
-#: model:ir.model.fields.selection,name:l10n_account_withholding.selection__account_withholding_line__previous_placeholder_type__given_by_name
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields.selection,name:l10n_account_withholding_tax.selection__account_payment_register_withholding_line__placeholder_type__given_by_name
+#: model:ir.model.fields.selection,name:l10n_account_withholding_tax.selection__account_payment_register_withholding_line__previous_placeholder_type__given_by_name
+#: model:ir.model.fields.selection,name:l10n_account_withholding_tax.selection__account_payment_withholding_line__placeholder_type__given_by_name
+#: model:ir.model.fields.selection,name:l10n_account_withholding_tax.selection__account_payment_withholding_line__previous_placeholder_type__given_by_name
+#: model:ir.model.fields.selection,name:l10n_account_withholding_tax.selection__account_withholding_line__placeholder_type__given_by_name
+#: model:ir.model.fields.selection,name:l10n_account_withholding_tax.selection__account_withholding_line__previous_placeholder_type__given_by_name
 msgid "Given By the Name"
 msgstr "Diberikan Berdasarkan Nama"
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields.selection,name:l10n_account_withholding.selection__account_payment_register_withholding_line__placeholder_type__given_by_sequence
-#: model:ir.model.fields.selection,name:l10n_account_withholding.selection__account_payment_register_withholding_line__previous_placeholder_type__given_by_sequence
-#: model:ir.model.fields.selection,name:l10n_account_withholding.selection__account_payment_withholding_line__placeholder_type__given_by_sequence
-#: model:ir.model.fields.selection,name:l10n_account_withholding.selection__account_payment_withholding_line__previous_placeholder_type__given_by_sequence
-#: model:ir.model.fields.selection,name:l10n_account_withholding.selection__account_withholding_line__placeholder_type__given_by_sequence
-#: model:ir.model.fields.selection,name:l10n_account_withholding.selection__account_withholding_line__previous_placeholder_type__given_by_sequence
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields.selection,name:l10n_account_withholding_tax.selection__account_payment_register_withholding_line__placeholder_type__given_by_sequence
+#: model:ir.model.fields.selection,name:l10n_account_withholding_tax.selection__account_payment_register_withholding_line__previous_placeholder_type__given_by_sequence
+#: model:ir.model.fields.selection,name:l10n_account_withholding_tax.selection__account_payment_withholding_line__placeholder_type__given_by_sequence
+#: model:ir.model.fields.selection,name:l10n_account_withholding_tax.selection__account_payment_withholding_line__previous_placeholder_type__given_by_sequence
+#: model:ir.model.fields.selection,name:l10n_account_withholding_tax.selection__account_withholding_line__placeholder_type__given_by_sequence
+#: model:ir.model.fields.selection,name:l10n_account_withholding_tax.selection__account_withholding_line__previous_placeholder_type__given_by_sequence
 msgid "Given By the Sequence"
 msgstr "Diberikan Berdasarkan Urutan"
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment__id
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_register__id
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_register_withholding_line__id
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_withholding_line__id
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_tax__id
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_withholding_line__id
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_product_template__id
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_res_company__id
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_res_config_settings__id
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_register_withholding_line__id
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_withholding_line__id
 msgid "ID"
 msgstr "ID"
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,help:l10n_account_withholding.field_account_tax__is_withholding_tax_on_payment
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,help:l10n_account_withholding_tax.field_account_tax__is_withholding_tax_on_payment
 msgid ""
 "If enabled, this tax will not affect your accounts until the registration of"
 " payments."
@@ -223,236 +209,246 @@ msgstr ""
 "Bila diaktifkan, pajak ini tidak akan berdampak ke akun Anda sampai pendaftaran "
 "pembayaran."
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_register_withholding_line__write_uid
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_withholding_line__write_uid
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_register_withholding_line__write_uid
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_withholding_line__write_uid
 msgid "Last Updated by"
 msgstr "Terakhir Diupdate oleh"
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_register_withholding_line__write_date
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_withholding_line__write_date
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_register_withholding_line__write_date
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_withholding_line__write_date
 msgid "Last Updated on"
 msgstr "Terakhir Diupdate pada"
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_register__withholding_net_amount
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_register__withholding_net_amount
 msgid "Net Amount"
 msgstr "Jumlah Bersih"
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,help:l10n_account_withholding.field_account_payment_register__withholding_net_amount
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,help:l10n_account_withholding_tax.field_account_payment_register__withholding_net_amount
 msgid "Net amount after deducting the withholding lines"
 msgstr "Jumlah bersih setelah dikurangi baris pemotongan"
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields.selection,name:l10n_account_withholding.selection__account_payment_register_withholding_line__placeholder_type__not_defined
-#: model:ir.model.fields.selection,name:l10n_account_withholding.selection__account_payment_register_withholding_line__previous_placeholder_type__not_defined
-#: model:ir.model.fields.selection,name:l10n_account_withholding.selection__account_payment_withholding_line__placeholder_type__not_defined
-#: model:ir.model.fields.selection,name:l10n_account_withholding.selection__account_payment_withholding_line__previous_placeholder_type__not_defined
-#: model:ir.model.fields.selection,name:l10n_account_withholding.selection__account_withholding_line__placeholder_type__not_defined
-#: model:ir.model.fields.selection,name:l10n_account_withholding.selection__account_withholding_line__previous_placeholder_type__not_defined
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields.selection,name:l10n_account_withholding_tax.selection__account_payment_register_withholding_line__placeholder_type__not_defined
+#: model:ir.model.fields.selection,name:l10n_account_withholding_tax.selection__account_payment_register_withholding_line__previous_placeholder_type__not_defined
+#: model:ir.model.fields.selection,name:l10n_account_withholding_tax.selection__account_payment_withholding_line__placeholder_type__not_defined
+#: model:ir.model.fields.selection,name:l10n_account_withholding_tax.selection__account_payment_withholding_line__previous_placeholder_type__not_defined
+#: model:ir.model.fields.selection,name:l10n_account_withholding_tax.selection__account_withholding_line__placeholder_type__not_defined
+#: model:ir.model.fields.selection,name:l10n_account_withholding_tax.selection__account_withholding_line__previous_placeholder_type__not_defined
 msgid "Not defined"
 msgstr "Tidak didefinisikan"
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_register_withholding_line__original_base_amount
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_withholding_line__original_base_amount
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_withholding_line__original_base_amount
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_register_withholding_line__original_base_amount
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_withholding_line__original_base_amount
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_withholding_line__original_base_amount
 msgid "Original Base Amount"
 msgstr "Jumlah Pokok Awal"
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_register_withholding_line__original_tax_amount
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_withholding_line__original_tax_amount
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_withholding_line__original_tax_amount
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_register_withholding_line__original_tax_amount
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_withholding_line__original_tax_amount
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_withholding_line__original_tax_amount
 msgid "Original Tax Amount"
 msgstr "Jumlah Pajak Awal"
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment__outstanding_account_id
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_register__withholding_outstanding_account_id
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment__outstanding_account_id
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_register__withholding_outstanding_account_id
 msgid "Outstanding Account"
 msgstr "Akun Piutang"
 
-#. module: l10n_account_withholding
-#: model:ir.model,name:l10n_account_withholding.model_account_payment_register
+#. module: l10n_account_withholding_tax
+#: model:ir.model,name:l10n_account_withholding_tax.model_account_payment_register
 msgid "Pay"
 msgstr "Bayar"
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_withholding_line__payment_id
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_withholding_line__payment_id
 msgid "Payment"
 msgstr "Pembayaran"
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment__withholding_payment_account_id
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_register__withholding_payment_account_id
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment__withholding_payment_account_id
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_register__withholding_payment_account_id
 msgid "Payment Account"
 msgstr "Akun Pembayaran"
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_register_withholding_line__payment_register_id
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_register_withholding_line__payment_register_id
 msgid "Payment Register"
 msgstr "Daftar Pembayaran"
 
-#. module: l10n_account_withholding
-#: model:ir.model,name:l10n_account_withholding.model_account_payment_register_withholding_line
+#. module: l10n_account_withholding_tax
+#: model:ir.model,name:l10n_account_withholding_tax.model_account_payment_register_withholding_line
 msgid "Payment register withholding line"
 msgstr "Baris pemotongan daftar pembayaran"
 
-#. module: l10n_account_withholding
-#: model:ir.model,name:l10n_account_withholding.model_account_payment_withholding_line
+#. module: l10n_account_withholding_tax
+#: model:ir.model,name:l10n_account_withholding_tax.model_account_payment_withholding_line
 msgid "Payment withholding line"
 msgstr "Baris pemotongan pembayaran"
 
-#. module: l10n_account_withholding
-#: model:ir.model,name:l10n_account_withholding.model_account_payment
+#. module: l10n_account_withholding_tax
+#: model:ir.model,name:l10n_account_withholding_tax.model_account_payment
 msgid "Payments"
 msgstr "Pembayaran-Pembayaran"
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_register_withholding_line__placeholder_type
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_withholding_line__placeholder_type
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_withholding_line__placeholder_type
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_register_withholding_line__placeholder_type
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_withholding_line__placeholder_type
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_withholding_line__placeholder_type
 msgid "Placeholder Type"
 msgstr "Tipe Placeholder"
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_register_withholding_line__placeholder_value
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_withholding_line__placeholder_value
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_withholding_line__placeholder_value
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_register_withholding_line__placeholder_value
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_withholding_line__placeholder_value
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_withholding_line__placeholder_value
 msgid "Placeholder Value"
 msgstr "Nilai Placeholder"
 
-#. module: l10n_account_withholding
+#. module: l10n_account_withholding_tax
 #. odoo-python
-#: code:addons/l10n_account_withholding/models/account_withholding_line.py:0
+#: code:addons/l10n_account_withholding_tax/models/account_withholding_line.py:0
 msgid "Please enter the withholding number for the tax %(tax_name)s"
 msgstr "Silakan masukkan angka pemotongan untuk pajak %(tax_name)s"
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,help:l10n_account_withholding.field_account_payment_register_withholding_line__placeholder_value
-#: model:ir.model.fields,help:l10n_account_withholding.field_account_payment_withholding_line__placeholder_value
-#: model:ir.model.fields,help:l10n_account_withholding.field_account_withholding_line__placeholder_value
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,help:l10n_account_withholding_tax.field_account_payment_register_withholding_line__placeholder_value
+#: model:ir.model.fields,help:l10n_account_withholding_tax.field_account_payment_withholding_line__placeholder_value
+#: model:ir.model.fields,help:l10n_account_withholding_tax.field_account_withholding_line__placeholder_value
 msgid "Populated by the comodel during edition of the line."
 msgstr "Silakan masukkan angka pemotongan untuk pajak %(tax_name)s."
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_register_withholding_line__previous_placeholder_type
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_withholding_line__previous_placeholder_type
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_withholding_line__previous_placeholder_type
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_register_withholding_line__previous_placeholder_type
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_withholding_line__previous_placeholder_type
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_withholding_line__previous_placeholder_type
 msgid "Previous Placeholder Type"
 msgstr "Tipe Placeholder Sebelumnya"
 
-#. module: l10n_account_withholding
-#: model:ir.model,name:l10n_account_withholding.model_product_template
+#. module: l10n_account_withholding_tax
+#: model:ir.model,name:l10n_account_withholding_tax.model_product_template
 msgid "Product"
 msgstr "Produk"
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields.selection,name:l10n_account_withholding.selection__account_payment_register_withholding_line__comodel_payment_type__inbound
-#: model:ir.model.fields.selection,name:l10n_account_withholding.selection__account_payment_withholding_line__comodel_payment_type__inbound
-#: model:ir.model.fields.selection,name:l10n_account_withholding.selection__account_withholding_line__comodel_payment_type__inbound
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields.selection,name:l10n_account_withholding_tax.selection__account_payment_register_withholding_line__comodel_payment_type__inbound
+#: model:ir.model.fields.selection,name:l10n_account_withholding_tax.selection__account_payment_withholding_line__comodel_payment_type__inbound
+#: model:ir.model.fields.selection,name:l10n_account_withholding_tax.selection__account_withholding_line__comodel_payment_type__inbound
 msgid "Receive Money"
 msgstr "Terima Uang"
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields.selection,name:l10n_account_withholding.selection__account_payment_register_withholding_line__comodel_payment_type__outbound
-#: model:ir.model.fields.selection,name:l10n_account_withholding.selection__account_payment_withholding_line__comodel_payment_type__outbound
-#: model:ir.model.fields.selection,name:l10n_account_withholding.selection__account_withholding_line__comodel_payment_type__outbound
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields.selection,name:l10n_account_withholding_tax.selection__account_payment_register_withholding_line__comodel_payment_type__outbound
+#: model:ir.model.fields.selection,name:l10n_account_withholding_tax.selection__account_payment_withholding_line__comodel_payment_type__outbound
+#: model:ir.model.fields.selection,name:l10n_account_withholding_tax.selection__account_withholding_line__comodel_payment_type__outbound
 msgid "Send Money"
 msgstr "Kirim Uang"
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_register_withholding_line__name
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_withholding_line__name
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_withholding_line__name
-#: model_terms:ir.ui.view,arch_db:l10n_account_withholding.view_account_payment_form
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_register_withholding_line__name
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_withholding_line__name
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_withholding_line__name
+#: model_terms:ir.ui.view,arch_db:l10n_account_withholding_tax.view_account_payment_form
 msgid "Sequence Number"
 msgstr "Nomor Urut"
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_register_withholding_line__source_base_amount
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_withholding_line__source_base_amount
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_withholding_line__source_base_amount
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_register_withholding_line__source_base_amount
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_withholding_line__source_base_amount
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_withholding_line__source_base_amount
 msgid "Source Base Amount"
 msgstr "Jumlah Pokok Sumber"
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_register_withholding_line__source_base_amount_currency
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_withholding_line__source_base_amount_currency
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_withholding_line__source_base_amount_currency
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_register_withholding_line__source_base_amount_currency
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_withholding_line__source_base_amount_currency
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_withholding_line__source_base_amount_currency
 msgid "Source Base Amount Currency"
 msgstr "Mata Uang Jumlah Pokok Sumber"
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_register_withholding_line__source_currency_id
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_withholding_line__source_currency_id
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_withholding_line__source_currency_id
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_register_withholding_line__source_currency_id
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_withholding_line__source_currency_id
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_withholding_line__source_currency_id
 msgid "Source Currency"
 msgstr "Mata Uang Sumber"
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_register_withholding_line__source_tax_id
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_withholding_line__source_tax_id
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_withholding_line__source_tax_id
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_register_withholding_line__source_tax_id
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_withholding_line__source_tax_id
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_withholding_line__source_tax_id
 msgid "Source Tax"
 msgstr "Pajak Sumber"
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_register_withholding_line__source_tax_amount
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_withholding_line__source_tax_amount
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_withholding_line__source_tax_amount
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_register_withholding_line__source_tax_amount
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_withholding_line__source_tax_amount
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_withholding_line__source_tax_amount
 msgid "Source Tax Amount"
 msgstr "Jumlah Pajak Sumber"
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_register_withholding_line__source_tax_amount_currency
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_withholding_line__source_tax_amount_currency
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_withholding_line__source_tax_amount_currency
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_register_withholding_line__source_tax_amount_currency
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_withholding_line__source_tax_amount_currency
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_withholding_line__source_tax_amount_currency
 msgid "Source Tax Amount Currency"
 msgstr "Mata Uang Jumlah Pajak Sumber"
 
-#. module: l10n_account_withholding
-#: model:ir.model,name:l10n_account_withholding.model_account_tax
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_register_withholding_line__tax_id
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_withholding_line__tax_id
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_withholding_line__tax_id
-#: model_terms:ir.ui.view,arch_db:l10n_account_withholding.view_account_payment_form
+#. module: l10n_account_withholding_tax
+#: model:ir.model,name:l10n_account_withholding_tax.model_account_tax
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_register_withholding_line__tax_id
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_withholding_line__tax_id
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_withholding_line__tax_id
+#: model_terms:ir.ui.view,arch_db:l10n_account_withholding_tax.view_account_payment_form
 msgid "Tax"
 msgstr "Pajak"
 
-#. module: l10n_account_withholding
+#. module: l10n_account_withholding_tax
 #. odoo-python
-#: code:addons/l10n_account_withholding/models/account_withholding_line.py:0
+#: code:addons/l10n_account_withholding_tax/models/account_withholding_line.py:0
 msgid "The account \"%(account_name)s\" is not valid to use on withholding lines."
 msgstr ""
 "Akun \"%(account_name)s\" tidak valid untuk digunakan pada baris pemotongan."
 
-#. module: l10n_account_withholding
+#. module: l10n_account_withholding_tax
 #. odoo-python
-#: code:addons/l10n_account_withholding/models/account_withholding_line.py:0
+#: code:addons/l10n_account_withholding_tax/models/account_withholding_line.py:0
 msgid "The base amount of a withholding tax line must be above 0."
 msgstr "Jumlah pokok baris pemotongan pajak harus di atas 0."
 
-#. module: l10n_account_withholding
+#. module: l10n_account_withholding_tax
 #. odoo-python
-#: code:addons/l10n_account_withholding/wizards/account_payment_register.py:0
+#: code:addons/l10n_account_withholding_tax/models/account_withholding_line.py:0
+msgid ""
+"The tax '%(tax_name)s' used on withholding lines does not have an account "
+"set on its tax repartition line."
+msgstr ""
+"Pajak '%(tax_name)s' yang digunakan pada baris pemotongan tidak memiliki akun "
+"yang ditetapkan pada baris alokasi pajaknya."
+
+#. module: l10n_account_withholding_tax
+#. odoo-python
+#: code:addons/l10n_account_withholding_tax/wizards/account_payment_register.py:0
 msgid "The withholding net amount cannot be negative."
 msgstr "Jumlah bersih pemotongan tidak bisa negatif."
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,help:l10n_account_withholding.field_res_company__withholding_tax_base_account_id
-#: model:ir.model.fields,help:l10n_account_withholding.field_res_config_settings__withholding_tax_base_account_id
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,help:l10n_account_withholding_tax.field_res_company__withholding_tax_base_account_id
+#: model:ir.model.fields,help:l10n_account_withholding_tax.field_res_config_settings__withholding_tax_base_account_id
 msgid "This account will be set on withholding tax base lines."
 msgstr "Akun ini akan ditetapkan pada baris pokok pemotongan pajak."
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,help:l10n_account_withholding.field_account_payment_register_withholding_line__withholding_sequence_id
-#: model:ir.model.fields,help:l10n_account_withholding.field_account_payment_withholding_line__withholding_sequence_id
-#: model:ir.model.fields,help:l10n_account_withholding.field_account_tax__withholding_sequence_id
-#: model:ir.model.fields,help:l10n_account_withholding.field_account_withholding_line__withholding_sequence_id
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,help:l10n_account_withholding_tax.field_account_payment_register_withholding_line__withholding_sequence_id
+#: model:ir.model.fields,help:l10n_account_withholding_tax.field_account_payment_withholding_line__withholding_sequence_id
+#: model:ir.model.fields,help:l10n_account_withholding_tax.field_account_tax__withholding_sequence_id
+#: model:ir.model.fields,help:l10n_account_withholding_tax.field_account_withholding_line__withholding_sequence_id
 msgid ""
 "This sequence will be used to generate default numbers on payment "
 "withholding lines."
@@ -460,79 +456,79 @@ msgstr ""
 "Urutan ini akan digunakan untuk membuat angka-angka default di baris pemotongan "
 "pembayaran."
 
-#. module: l10n_account_withholding
-#: model_terms:ir.ui.view,arch_db:l10n_account_withholding.view_account_payment_form
-#: model_terms:ir.ui.view,arch_db:l10n_account_withholding.view_account_payment_register_form
+#. module: l10n_account_withholding_tax
+#: model_terms:ir.ui.view,arch_db:l10n_account_withholding_tax.view_account_payment_form
+#: model_terms:ir.ui.view,arch_db:l10n_account_withholding_tax.view_account_payment_register_form
 msgid "Total Withheld Amount"
 msgstr "Jumlah Total Pemotongan"
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_register_withholding_line__type_tax_use
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_withholding_line__type_tax_use
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_withholding_line__type_tax_use
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_register_withholding_line__type_tax_use
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_withholding_line__type_tax_use
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_withholding_line__type_tax_use
 msgid "Type Tax Use"
 msgstr "Tipe Pajak yang Digunakan"
 
-#. module: l10n_account_withholding
+#. module: l10n_account_withholding_tax
 #. odoo-python
-#: code:addons/l10n_account_withholding/models/account_withholding_line.py:0
+#: code:addons/l10n_account_withholding_tax/models/account_withholding_line.py:0
 msgid "WH Base Counterpart: %(names)s"
 msgstr "Counterpart Pokok Pemotongan: %(names)s"
 
-#. module: l10n_account_withholding
+#. module: l10n_account_withholding_tax
 #. odoo-python
-#: code:addons/l10n_account_withholding/models/account_withholding_line.py:0
+#: code:addons/l10n_account_withholding_tax/models/account_withholding_line.py:0
 msgid "WH Base: %(names)s"
 msgstr "Pokok Pemotongan: %(names)s"
 
-#. module: l10n_account_withholding
+#. module: l10n_account_withholding_tax
 #. odoo-python
-#: code:addons/l10n_account_withholding/models/account_withholding_line.py:0
+#: code:addons/l10n_account_withholding_tax/models/account_withholding_line.py:0
 msgid "WH Tax: %(name)s"
 msgstr "Pemotongan Pajak: %(name)s"
 
-#. module: l10n_account_withholding
-#: model_terms:ir.ui.view,arch_db:l10n_account_withholding.view_account_payment_form
+#. module: l10n_account_withholding_tax
+#: model_terms:ir.ui.view,arch_db:l10n_account_withholding_tax.view_account_payment_form
 msgid "Withheld Amount"
 msgstr "Jumlah yang Dipotong"
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_tax__is_withholding_tax_on_payment
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_tax__is_withholding_tax_on_payment
 msgid "Withhold On Payment"
 msgstr "Potong Pada Pembayaran"
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment__should_withhold_tax
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_register__should_withhold_tax
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment__should_withhold_tax
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_register__should_withhold_tax
 msgid "Withhold Tax Amounts"
 msgstr "Jumlah Pajak yang Dipotong"
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,help:l10n_account_withholding.field_account_payment__should_withhold_tax
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,help:l10n_account_withholding_tax.field_account_payment__should_withhold_tax
 msgid "Withhold tax amounts from the payment amount."
 msgstr "Jumlah pajak yang dipotong dari jumlah pembayaran."
 
-#. module: l10n_account_withholding
-#: model_terms:ir.ui.view,arch_db:l10n_account_withholding.view_account_payment_form
-#: model_terms:ir.ui.view,arch_db:l10n_account_withholding.view_account_payment_register_form
+#. module: l10n_account_withholding_tax
+#: model_terms:ir.ui.view,arch_db:l10n_account_withholding_tax.view_account_payment_form
+#: model_terms:ir.ui.view,arch_db:l10n_account_withholding_tax.view_account_payment_register_form
 msgid "Withholding"
 msgstr "Pemotongan"
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment__withholding_hide_tax_base_account
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_register__withholding_hide_tax_base_account
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment__withholding_hide_tax_base_account
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_register__withholding_hide_tax_base_account
 msgid "Withholding Hide Tax Base Account"
 msgstr "Sembunyikan Akun Pokok Pemotongan Pajak"
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment__withholding_line_ids
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_register__withholding_line_ids
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment__withholding_line_ids
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_register__withholding_line_ids
 msgid "Withholding Lines"
 msgstr "Baris-Baris Pemotongan"
 
-#. module: l10n_account_withholding
+#. module: l10n_account_withholding_tax
 #. odoo-python
-#: code:addons/l10n_account_withholding/models/account_tax.py:0
+#: code:addons/l10n_account_withholding_tax/models/account_tax.py:0
 msgid ""
 "Withholding On Payment taxes cannot use the 'Group of Taxes' or the "
 "'Percentage Tax Included' computations."
@@ -540,40 +536,40 @@ msgstr ""
 "Pajak Pemotongan Pada Pembayaran tidak dapat menggunakan komputasi 'Kelompok "
 "Pajak-Pajak' atau 'Termasuk Persentase Pajak'."
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_register_withholding_line__withholding_sequence_id
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_withholding_line__withholding_sequence_id
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_tax__withholding_sequence_id
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_withholding_line__withholding_sequence_id
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_register_withholding_line__withholding_sequence_id
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_withholding_line__withholding_sequence_id
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_tax__withholding_sequence_id
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_withholding_line__withholding_sequence_id
 msgid "Withholding Sequence"
 msgstr "Urutan Pemotongan"
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_res_company__withholding_tax_base_account_id
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_res_config_settings__withholding_tax_base_account_id
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_res_company__withholding_tax_base_account_id
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_res_config_settings__withholding_tax_base_account_id
 msgid "Withholding Tax Base"
 msgstr "Pokok Pemotongan Pajak"
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_register_withholding_line__amount
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_withholding_line__amount
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_withholding_line__amount
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_register_withholding_line__amount
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_withholding_line__amount
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_withholding_line__amount
 msgid "Withholding amount"
 msgstr "Jumlah pemotongan"
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_register_withholding_line__base_amount
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_withholding_line__base_amount
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_withholding_line__base_amount
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_register_withholding_line__base_amount
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_withholding_line__base_amount
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_withholding_line__base_amount
 msgid "Withholding base"
 msgstr "Pokok pemotongan"
 
-#. module: l10n_account_withholding
-#: model_terms:ir.ui.view,arch_db:l10n_account_withholding.res_config_settings_form
+#. module: l10n_account_withholding_tax
+#: model_terms:ir.ui.view,arch_db:l10n_account_withholding_tax.res_config_settings_form
 msgid "Withholding:"
 msgstr "Pemotongan:"
 
-#. module: l10n_account_withholding
-#: model:ir.model,name:l10n_account_withholding.model_account_withholding_line
+#. module: l10n_account_withholding_tax
+#: model:ir.model,name:l10n_account_withholding_tax.model_account_withholding_line
 msgid "withholding line"
 msgstr "baris pemotongan"

--- a/addons/l10n_account_withholding_tax/i18n/l10n_account_withholding.pot
+++ b/addons/l10n_account_withholding_tax/i18n/l10n_account_withholding.pot
@@ -1,13 +1,13 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
-# 	* l10n_account_withholding
+# 	* l10n_account_withholding_tax
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 18.4a1+e\n"
+"Project-Id-Version: Odoo Server 18.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-06-12 02:38+0000\n"
-"PO-Revision-Date: 2025-06-12 02:38+0000\n"
+"POT-Creation-Date: 2025-06-24 12:44+0000\n"
+"PO-Revision-Date: 2025-06-24 12:44+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -15,558 +15,552 @@ msgstr ""
 "Content-Transfer-Encoding: \n"
 "Plural-Forms: \n"
 
-#. module: l10n_account_withholding
+#. module: l10n_account_withholding_tax
 #. odoo-python
-#: code:addons/l10n_account_withholding/models/product_template.py:0
+#: code:addons/l10n_account_withholding_tax/models/product_template.py:0
 msgid "%(amount)s Excl. Taxes"
 msgstr ""
 
-#. module: l10n_account_withholding
+#. module: l10n_account_withholding_tax
 #. odoo-python
-#: code:addons/l10n_account_withholding/models/product_template.py:0
+#: code:addons/l10n_account_withholding_tax/models/product_template.py:0
 msgid "%(amount)s Incl. Taxes"
 msgstr ""
 
-#. module: l10n_account_withholding
+#. module: l10n_account_withholding_tax
 #. odoo-python
-#: code:addons/l10n_account_withholding/models/product_template.py:0
+#: code:addons/l10n_account_withholding_tax/models/product_template.py:0
 msgid "%(amount)s Tax Withheld"
 msgstr ""
 
-#. module: l10n_account_withholding
-#: model_terms:ir.ui.view,arch_db:l10n_account_withholding.report_payment_receipt_document
+#. module: l10n_account_withholding_tax
+#: model_terms:ir.ui.view,arch_db:l10n_account_withholding_tax.report_payment_receipt_document
 msgid "<span>Amount</span>"
 msgstr ""
 
-#. module: l10n_account_withholding
-#: model_terms:ir.ui.view,arch_db:l10n_account_withholding.report_payment_receipt_document
+#. module: l10n_account_withholding_tax
+#: model_terms:ir.ui.view,arch_db:l10n_account_withholding_tax.report_payment_receipt_document
 msgid "<span>Base</span>"
 msgstr ""
 
-#. module: l10n_account_withholding
-#: model_terms:ir.ui.view,arch_db:l10n_account_withholding.report_payment_receipt_document
+#. module: l10n_account_withholding_tax
+#: model_terms:ir.ui.view,arch_db:l10n_account_withholding_tax.report_payment_receipt_document
 msgid "<span>Tax</span>"
 msgstr ""
 
-#. module: l10n_account_withholding
-#: model_terms:ir.ui.view,arch_db:l10n_account_withholding.report_payment_receipt_document
+#. module: l10n_account_withholding_tax
+#: model_terms:ir.ui.view,arch_db:l10n_account_withholding_tax.report_payment_receipt_document
 msgid "<span>Withholding number</span>"
 msgstr ""
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_register_withholding_line__account_id
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_withholding_line__account_id
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_withholding_line__account_id
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_register_withholding_line__account_id
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_withholding_line__account_id
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_withholding_line__account_id
 msgid "Account"
 msgstr ""
 
-#. module: l10n_account_withholding
+#. module: l10n_account_withholding_tax
 #. odoo-python
-#: code:addons/l10n_account_withholding/wizards/account_payment_register_withholding_line.py:0
+#: code:addons/l10n_account_withholding_tax/wizards/account_payment_register_withholding_line.py:0
 msgid "All withholding lines in self must have the same payment register."
 msgstr ""
 
-#. module: l10n_account_withholding
+#. module: l10n_account_withholding_tax
 #. odoo-python
-#: code:addons/l10n_account_withholding/models/account_payment_withholding_line.py:0
+#: code:addons/l10n_account_withholding_tax/models/account_payment_withholding_line.py:0
 msgid "All withholding lines in self must have the same payment."
 msgstr ""
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_register_withholding_line__analytic_distribution
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_withholding_line__analytic_distribution
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_withholding_line__analytic_distribution
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_register_withholding_line__analytic_distribution
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_withholding_line__analytic_distribution
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_withholding_line__analytic_distribution
 msgid "Analytic Distribution"
 msgstr ""
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_register_withholding_line__analytic_precision
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_withholding_line__analytic_precision
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_withholding_line__analytic_precision
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_register_withholding_line__analytic_precision
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_withholding_line__analytic_precision
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_withholding_line__analytic_precision
 msgid "Analytic Precision"
 msgstr ""
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_register_withholding_line__comodel_currency_id
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_withholding_line__comodel_currency_id
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_withholding_line__comodel_currency_id
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_register_withholding_line__comodel_currency_id
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_withholding_line__comodel_currency_id
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_withholding_line__comodel_currency_id
 msgid "Comodel Currency"
 msgstr ""
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_register_withholding_line__comodel_date
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_withholding_line__comodel_date
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_withholding_line__comodel_date
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_register_withholding_line__comodel_date
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_withholding_line__comodel_date
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_withholding_line__comodel_date
 msgid "Comodel Date"
 msgstr ""
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_register_withholding_line__comodel_payment_type
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_withholding_line__comodel_payment_type
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_withholding_line__comodel_payment_type
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_register_withholding_line__comodel_payment_type
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_withholding_line__comodel_payment_type
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_withholding_line__comodel_payment_type
 msgid "Comodel Payment Type"
 msgstr ""
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_register_withholding_line__comodel_percentage_paid_factor
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_withholding_line__comodel_percentage_paid_factor
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_withholding_line__comodel_percentage_paid_factor
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_register_withholding_line__comodel_percentage_paid_factor
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_withholding_line__comodel_percentage_paid_factor
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_withholding_line__comodel_percentage_paid_factor
 msgid "Comodel Percentage Paid Factor"
 msgstr ""
 
-#. module: l10n_account_withholding
-#: model:ir.model,name:l10n_account_withholding.model_res_company
+#. module: l10n_account_withholding_tax
+#: model:ir.model,name:l10n_account_withholding_tax.model_res_company
 msgid "Companies"
 msgstr ""
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_register_withholding_line__company_id
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_withholding_line__company_id
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_withholding_line__company_id
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_register_withholding_line__company_id
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_withholding_line__company_id
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_withholding_line__company_id
 msgid "Company"
 msgstr ""
 
-#. module: l10n_account_withholding
-#: model:ir.model,name:l10n_account_withholding.model_res_config_settings
+#. module: l10n_account_withholding_tax
+#: model:ir.model,name:l10n_account_withholding_tax.model_res_config_settings
 msgid "Config Settings"
 msgstr ""
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_register_withholding_line__create_uid
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_withholding_line__create_uid
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_register_withholding_line__create_uid
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_withholding_line__create_uid
 msgid "Created by"
 msgstr ""
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_register_withholding_line__create_date
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_withholding_line__create_date
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_register_withholding_line__create_date
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_withholding_line__create_date
 msgid "Created on"
 msgstr ""
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_register_withholding_line__comodel_company_currency_id
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_withholding_line__comodel_company_currency_id
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_withholding_line__comodel_company_currency_id
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_register_withholding_line__comodel_company_currency_id
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_withholding_line__comodel_company_currency_id
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_withholding_line__comodel_company_currency_id
 msgid "Currency"
 msgstr ""
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_register__withholding_default_account_id
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_register__withholding_default_account_id
 msgid "Default Account"
 msgstr ""
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment__display_name
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_register__display_name
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_register_withholding_line__display_name
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_withholding_line__display_name
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_tax__display_name
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_withholding_line__display_name
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_product_template__display_name
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_res_company__display_name
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_res_config_settings__display_name
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_register_withholding_line__display_name
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_withholding_line__display_name
 msgid "Display Name"
 msgstr ""
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment__display_withholding
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_register__display_withholding
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment__display_withholding
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_register__display_withholding
 msgid "Display Withholding"
 msgstr ""
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_register_withholding_line__distribution_analytic_account_ids
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_withholding_line__distribution_analytic_account_ids
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_withholding_line__distribution_analytic_account_ids
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_register_withholding_line__distribution_analytic_account_ids
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_withholding_line__distribution_analytic_account_ids
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_withholding_line__distribution_analytic_account_ids
 msgid "Distribution Analytic Account"
 msgstr ""
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields.selection,name:l10n_account_withholding.selection__account_payment_register_withholding_line__placeholder_type__given_by_name
-#: model:ir.model.fields.selection,name:l10n_account_withholding.selection__account_payment_register_withholding_line__previous_placeholder_type__given_by_name
-#: model:ir.model.fields.selection,name:l10n_account_withholding.selection__account_payment_withholding_line__placeholder_type__given_by_name
-#: model:ir.model.fields.selection,name:l10n_account_withholding.selection__account_payment_withholding_line__previous_placeholder_type__given_by_name
-#: model:ir.model.fields.selection,name:l10n_account_withholding.selection__account_withholding_line__placeholder_type__given_by_name
-#: model:ir.model.fields.selection,name:l10n_account_withholding.selection__account_withholding_line__previous_placeholder_type__given_by_name
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields.selection,name:l10n_account_withholding_tax.selection__account_payment_register_withholding_line__placeholder_type__given_by_name
+#: model:ir.model.fields.selection,name:l10n_account_withholding_tax.selection__account_payment_register_withholding_line__previous_placeholder_type__given_by_name
+#: model:ir.model.fields.selection,name:l10n_account_withholding_tax.selection__account_payment_withholding_line__placeholder_type__given_by_name
+#: model:ir.model.fields.selection,name:l10n_account_withholding_tax.selection__account_payment_withholding_line__previous_placeholder_type__given_by_name
+#: model:ir.model.fields.selection,name:l10n_account_withholding_tax.selection__account_withholding_line__placeholder_type__given_by_name
+#: model:ir.model.fields.selection,name:l10n_account_withholding_tax.selection__account_withholding_line__previous_placeholder_type__given_by_name
 msgid "Given By the Name"
 msgstr ""
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields.selection,name:l10n_account_withholding.selection__account_payment_register_withholding_line__placeholder_type__given_by_sequence
-#: model:ir.model.fields.selection,name:l10n_account_withholding.selection__account_payment_register_withholding_line__previous_placeholder_type__given_by_sequence
-#: model:ir.model.fields.selection,name:l10n_account_withholding.selection__account_payment_withholding_line__placeholder_type__given_by_sequence
-#: model:ir.model.fields.selection,name:l10n_account_withholding.selection__account_payment_withholding_line__previous_placeholder_type__given_by_sequence
-#: model:ir.model.fields.selection,name:l10n_account_withholding.selection__account_withholding_line__placeholder_type__given_by_sequence
-#: model:ir.model.fields.selection,name:l10n_account_withholding.selection__account_withholding_line__previous_placeholder_type__given_by_sequence
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields.selection,name:l10n_account_withholding_tax.selection__account_payment_register_withholding_line__placeholder_type__given_by_sequence
+#: model:ir.model.fields.selection,name:l10n_account_withholding_tax.selection__account_payment_register_withholding_line__previous_placeholder_type__given_by_sequence
+#: model:ir.model.fields.selection,name:l10n_account_withholding_tax.selection__account_payment_withholding_line__placeholder_type__given_by_sequence
+#: model:ir.model.fields.selection,name:l10n_account_withholding_tax.selection__account_payment_withholding_line__previous_placeholder_type__given_by_sequence
+#: model:ir.model.fields.selection,name:l10n_account_withholding_tax.selection__account_withholding_line__placeholder_type__given_by_sequence
+#: model:ir.model.fields.selection,name:l10n_account_withholding_tax.selection__account_withholding_line__previous_placeholder_type__given_by_sequence
 msgid "Given By the Sequence"
 msgstr ""
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment__id
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_register__id
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_register_withholding_line__id
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_withholding_line__id
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_tax__id
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_withholding_line__id
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_product_template__id
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_res_company__id
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_res_config_settings__id
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_register_withholding_line__id
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_withholding_line__id
 msgid "ID"
 msgstr ""
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,help:l10n_account_withholding.field_account_tax__is_withholding_tax_on_payment
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,help:l10n_account_withholding_tax.field_account_tax__is_withholding_tax_on_payment
 msgid ""
 "If enabled, this tax will not affect your accounts until the registration of"
 " payments."
 msgstr ""
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_register_withholding_line__write_uid
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_withholding_line__write_uid
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_register_withholding_line__write_uid
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_withholding_line__write_uid
 msgid "Last Updated by"
 msgstr ""
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_register_withholding_line__write_date
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_withholding_line__write_date
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_register_withholding_line__write_date
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_withholding_line__write_date
 msgid "Last Updated on"
 msgstr ""
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_register__withholding_net_amount
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_register__withholding_net_amount
 msgid "Net Amount"
 msgstr ""
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,help:l10n_account_withholding.field_account_payment_register__withholding_net_amount
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,help:l10n_account_withholding_tax.field_account_payment_register__withholding_net_amount
 msgid "Net amount after deducting the withholding lines"
 msgstr ""
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields.selection,name:l10n_account_withholding.selection__account_payment_register_withholding_line__placeholder_type__not_defined
-#: model:ir.model.fields.selection,name:l10n_account_withholding.selection__account_payment_register_withholding_line__previous_placeholder_type__not_defined
-#: model:ir.model.fields.selection,name:l10n_account_withholding.selection__account_payment_withholding_line__placeholder_type__not_defined
-#: model:ir.model.fields.selection,name:l10n_account_withholding.selection__account_payment_withholding_line__previous_placeholder_type__not_defined
-#: model:ir.model.fields.selection,name:l10n_account_withholding.selection__account_withholding_line__placeholder_type__not_defined
-#: model:ir.model.fields.selection,name:l10n_account_withholding.selection__account_withholding_line__previous_placeholder_type__not_defined
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields.selection,name:l10n_account_withholding_tax.selection__account_payment_register_withholding_line__placeholder_type__not_defined
+#: model:ir.model.fields.selection,name:l10n_account_withholding_tax.selection__account_payment_register_withholding_line__previous_placeholder_type__not_defined
+#: model:ir.model.fields.selection,name:l10n_account_withholding_tax.selection__account_payment_withholding_line__placeholder_type__not_defined
+#: model:ir.model.fields.selection,name:l10n_account_withholding_tax.selection__account_payment_withholding_line__previous_placeholder_type__not_defined
+#: model:ir.model.fields.selection,name:l10n_account_withholding_tax.selection__account_withholding_line__placeholder_type__not_defined
+#: model:ir.model.fields.selection,name:l10n_account_withholding_tax.selection__account_withholding_line__previous_placeholder_type__not_defined
 msgid "Not defined"
 msgstr ""
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_register_withholding_line__original_base_amount
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_withholding_line__original_base_amount
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_withholding_line__original_base_amount
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_register_withholding_line__original_base_amount
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_withholding_line__original_base_amount
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_withholding_line__original_base_amount
 msgid "Original Base Amount"
 msgstr ""
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_register_withholding_line__original_tax_amount
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_withholding_line__original_tax_amount
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_withholding_line__original_tax_amount
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_register_withholding_line__original_tax_amount
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_withholding_line__original_tax_amount
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_withholding_line__original_tax_amount
 msgid "Original Tax Amount"
 msgstr ""
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment__outstanding_account_id
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_register__withholding_outstanding_account_id
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment__outstanding_account_id
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_register__withholding_outstanding_account_id
 msgid "Outstanding Account"
 msgstr ""
 
-#. module: l10n_account_withholding
-#: model:ir.model,name:l10n_account_withholding.model_account_payment_register
+#. module: l10n_account_withholding_tax
+#: model:ir.model,name:l10n_account_withholding_tax.model_account_payment_register
 msgid "Pay"
 msgstr ""
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_withholding_line__payment_id
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_withholding_line__payment_id
 msgid "Payment"
 msgstr ""
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment__withholding_payment_account_id
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_register__withholding_payment_account_id
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment__withholding_payment_account_id
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_register__withholding_payment_account_id
 msgid "Payment Account"
 msgstr ""
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_register_withholding_line__payment_register_id
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_register_withholding_line__payment_register_id
 msgid "Payment Register"
 msgstr ""
 
-#. module: l10n_account_withholding
-#: model:ir.model,name:l10n_account_withholding.model_account_payment_register_withholding_line
+#. module: l10n_account_withholding_tax
+#: model:ir.model,name:l10n_account_withholding_tax.model_account_payment_register_withholding_line
 msgid "Payment register withholding line"
 msgstr ""
 
-#. module: l10n_account_withholding
-#: model:ir.model,name:l10n_account_withholding.model_account_payment_withholding_line
+#. module: l10n_account_withholding_tax
+#: model:ir.model,name:l10n_account_withholding_tax.model_account_payment_withholding_line
 msgid "Payment withholding line"
 msgstr ""
 
-#. module: l10n_account_withholding
-#: model:ir.model,name:l10n_account_withholding.model_account_payment
+#. module: l10n_account_withholding_tax
+#: model:ir.model,name:l10n_account_withholding_tax.model_account_payment
 msgid "Payments"
 msgstr ""
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_register_withholding_line__placeholder_type
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_withholding_line__placeholder_type
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_withholding_line__placeholder_type
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_register_withholding_line__placeholder_type
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_withholding_line__placeholder_type
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_withholding_line__placeholder_type
 msgid "Placeholder Type"
 msgstr ""
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_register_withholding_line__placeholder_value
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_withholding_line__placeholder_value
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_withholding_line__placeholder_value
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_register_withholding_line__placeholder_value
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_withholding_line__placeholder_value
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_withholding_line__placeholder_value
 msgid "Placeholder Value"
 msgstr ""
 
-#. module: l10n_account_withholding
+#. module: l10n_account_withholding_tax
 #. odoo-python
-#: code:addons/l10n_account_withholding/models/account_withholding_line.py:0
+#: code:addons/l10n_account_withholding_tax/models/account_withholding_line.py:0
 msgid "Please enter the withholding number for the tax %(tax_name)s"
 msgstr ""
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,help:l10n_account_withholding.field_account_payment_register_withholding_line__placeholder_value
-#: model:ir.model.fields,help:l10n_account_withholding.field_account_payment_withholding_line__placeholder_value
-#: model:ir.model.fields,help:l10n_account_withholding.field_account_withholding_line__placeholder_value
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,help:l10n_account_withholding_tax.field_account_payment_register_withholding_line__placeholder_value
+#: model:ir.model.fields,help:l10n_account_withholding_tax.field_account_payment_withholding_line__placeholder_value
+#: model:ir.model.fields,help:l10n_account_withholding_tax.field_account_withholding_line__placeholder_value
 msgid "Populated by the comodel during edition of the line."
 msgstr ""
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_register_withholding_line__previous_placeholder_type
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_withholding_line__previous_placeholder_type
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_withholding_line__previous_placeholder_type
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_register_withholding_line__previous_placeholder_type
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_withholding_line__previous_placeholder_type
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_withholding_line__previous_placeholder_type
 msgid "Previous Placeholder Type"
 msgstr ""
 
-#. module: l10n_account_withholding
-#: model:ir.model,name:l10n_account_withholding.model_product_template
+#. module: l10n_account_withholding_tax
+#: model:ir.model,name:l10n_account_withholding_tax.model_product_template
 msgid "Product"
 msgstr ""
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields.selection,name:l10n_account_withholding.selection__account_payment_register_withholding_line__comodel_payment_type__inbound
-#: model:ir.model.fields.selection,name:l10n_account_withholding.selection__account_payment_withholding_line__comodel_payment_type__inbound
-#: model:ir.model.fields.selection,name:l10n_account_withholding.selection__account_withholding_line__comodel_payment_type__inbound
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields.selection,name:l10n_account_withholding_tax.selection__account_payment_register_withholding_line__comodel_payment_type__inbound
+#: model:ir.model.fields.selection,name:l10n_account_withholding_tax.selection__account_payment_withholding_line__comodel_payment_type__inbound
+#: model:ir.model.fields.selection,name:l10n_account_withholding_tax.selection__account_withholding_line__comodel_payment_type__inbound
 msgid "Receive Money"
 msgstr ""
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields.selection,name:l10n_account_withholding.selection__account_payment_register_withholding_line__comodel_payment_type__outbound
-#: model:ir.model.fields.selection,name:l10n_account_withholding.selection__account_payment_withholding_line__comodel_payment_type__outbound
-#: model:ir.model.fields.selection,name:l10n_account_withholding.selection__account_withholding_line__comodel_payment_type__outbound
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields.selection,name:l10n_account_withholding_tax.selection__account_payment_register_withholding_line__comodel_payment_type__outbound
+#: model:ir.model.fields.selection,name:l10n_account_withholding_tax.selection__account_payment_withholding_line__comodel_payment_type__outbound
+#: model:ir.model.fields.selection,name:l10n_account_withholding_tax.selection__account_withholding_line__comodel_payment_type__outbound
 msgid "Send Money"
 msgstr ""
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_register_withholding_line__name
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_withholding_line__name
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_withholding_line__name
-#: model_terms:ir.ui.view,arch_db:l10n_account_withholding.view_account_payment_form
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_register_withholding_line__name
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_withholding_line__name
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_withholding_line__name
+#: model_terms:ir.ui.view,arch_db:l10n_account_withholding_tax.view_account_payment_form
 msgid "Sequence Number"
 msgstr ""
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_register_withholding_line__source_base_amount
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_withholding_line__source_base_amount
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_withholding_line__source_base_amount
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_register_withholding_line__source_base_amount
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_withholding_line__source_base_amount
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_withholding_line__source_base_amount
 msgid "Source Base Amount"
 msgstr ""
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_register_withholding_line__source_base_amount_currency
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_withholding_line__source_base_amount_currency
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_withholding_line__source_base_amount_currency
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_register_withholding_line__source_base_amount_currency
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_withholding_line__source_base_amount_currency
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_withholding_line__source_base_amount_currency
 msgid "Source Base Amount Currency"
 msgstr ""
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_register_withholding_line__source_currency_id
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_withholding_line__source_currency_id
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_withholding_line__source_currency_id
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_register_withholding_line__source_currency_id
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_withholding_line__source_currency_id
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_withholding_line__source_currency_id
 msgid "Source Currency"
 msgstr ""
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_register_withholding_line__source_tax_id
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_withholding_line__source_tax_id
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_withholding_line__source_tax_id
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_register_withholding_line__source_tax_id
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_withholding_line__source_tax_id
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_withholding_line__source_tax_id
 msgid "Source Tax"
 msgstr ""
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_register_withholding_line__source_tax_amount
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_withholding_line__source_tax_amount
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_withholding_line__source_tax_amount
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_register_withholding_line__source_tax_amount
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_withholding_line__source_tax_amount
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_withholding_line__source_tax_amount
 msgid "Source Tax Amount"
 msgstr ""
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_register_withholding_line__source_tax_amount_currency
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_withholding_line__source_tax_amount_currency
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_withholding_line__source_tax_amount_currency
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_register_withholding_line__source_tax_amount_currency
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_withholding_line__source_tax_amount_currency
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_withholding_line__source_tax_amount_currency
 msgid "Source Tax Amount Currency"
 msgstr ""
 
-#. module: l10n_account_withholding
-#: model:ir.model,name:l10n_account_withholding.model_account_tax
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_register_withholding_line__tax_id
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_withholding_line__tax_id
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_withholding_line__tax_id
-#: model_terms:ir.ui.view,arch_db:l10n_account_withholding.view_account_payment_form
+#. module: l10n_account_withholding_tax
+#: model:ir.model,name:l10n_account_withholding_tax.model_account_tax
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_register_withholding_line__tax_id
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_withholding_line__tax_id
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_withholding_line__tax_id
+#: model_terms:ir.ui.view,arch_db:l10n_account_withholding_tax.view_account_payment_form
 msgid "Tax"
 msgstr ""
 
-#. module: l10n_account_withholding
+#. module: l10n_account_withholding_tax
 #. odoo-python
-#: code:addons/l10n_account_withholding/models/account_withholding_line.py:0
+#: code:addons/l10n_account_withholding_tax/models/account_withholding_line.py:0
 msgid "The account \"%(account_name)s\" is not valid to use on withholding lines."
 msgstr ""
 
-#. module: l10n_account_withholding
+#. module: l10n_account_withholding_tax
 #. odoo-python
-#: code:addons/l10n_account_withholding/models/account_withholding_line.py:0
+#: code:addons/l10n_account_withholding_tax/models/account_withholding_line.py:0
 msgid "The base amount of a withholding tax line must be above 0."
 msgstr ""
 
-#. module: l10n_account_withholding
+#. module: l10n_account_withholding_tax
 #. odoo-python
-#: code:addons/l10n_account_withholding/wizards/account_payment_register.py:0
+#: code:addons/l10n_account_withholding_tax/models/account_withholding_line.py:0
+msgid ""
+"The tax '%(tax_name)s' used on withholding lines does not have an account "
+"set on its tax repartition line."
+msgstr ""
+
+#. module: l10n_account_withholding_tax
+#. odoo-python
+#: code:addons/l10n_account_withholding_tax/wizards/account_payment_register.py:0
 msgid "The withholding net amount cannot be negative."
 msgstr ""
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,help:l10n_account_withholding.field_res_company__withholding_tax_base_account_id
-#: model:ir.model.fields,help:l10n_account_withholding.field_res_config_settings__withholding_tax_base_account_id
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,help:l10n_account_withholding_tax.field_res_company__withholding_tax_base_account_id
+#: model:ir.model.fields,help:l10n_account_withholding_tax.field_res_config_settings__withholding_tax_base_account_id
 msgid "This account will be set on withholding tax base lines."
 msgstr ""
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,help:l10n_account_withholding.field_account_payment_register_withholding_line__withholding_sequence_id
-#: model:ir.model.fields,help:l10n_account_withholding.field_account_payment_withholding_line__withholding_sequence_id
-#: model:ir.model.fields,help:l10n_account_withholding.field_account_tax__withholding_sequence_id
-#: model:ir.model.fields,help:l10n_account_withholding.field_account_withholding_line__withholding_sequence_id
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,help:l10n_account_withholding_tax.field_account_payment_register_withholding_line__withholding_sequence_id
+#: model:ir.model.fields,help:l10n_account_withholding_tax.field_account_payment_withholding_line__withholding_sequence_id
+#: model:ir.model.fields,help:l10n_account_withholding_tax.field_account_tax__withholding_sequence_id
+#: model:ir.model.fields,help:l10n_account_withholding_tax.field_account_withholding_line__withholding_sequence_id
 msgid ""
 "This sequence will be used to generate default numbers on payment "
 "withholding lines."
 msgstr ""
 
-#. module: l10n_account_withholding
-#: model_terms:ir.ui.view,arch_db:l10n_account_withholding.view_account_payment_form
-#: model_terms:ir.ui.view,arch_db:l10n_account_withholding.view_account_payment_register_form
+#. module: l10n_account_withholding_tax
+#: model_terms:ir.ui.view,arch_db:l10n_account_withholding_tax.view_account_payment_form
+#: model_terms:ir.ui.view,arch_db:l10n_account_withholding_tax.view_account_payment_register_form
 msgid "Total Withheld Amount"
 msgstr ""
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_register_withholding_line__type_tax_use
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_withholding_line__type_tax_use
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_withholding_line__type_tax_use
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_register_withholding_line__type_tax_use
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_withholding_line__type_tax_use
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_withholding_line__type_tax_use
 msgid "Type Tax Use"
 msgstr ""
 
-#. module: l10n_account_withholding
+#. module: l10n_account_withholding_tax
 #. odoo-python
-#: code:addons/l10n_account_withholding/models/account_withholding_line.py:0
+#: code:addons/l10n_account_withholding_tax/models/account_withholding_line.py:0
 msgid "WH Base Counterpart: %(names)s"
 msgstr ""
 
-#. module: l10n_account_withholding
+#. module: l10n_account_withholding_tax
 #. odoo-python
-#: code:addons/l10n_account_withholding/models/account_withholding_line.py:0
+#: code:addons/l10n_account_withholding_tax/models/account_withholding_line.py:0
 msgid "WH Base: %(names)s"
 msgstr ""
 
-#. module: l10n_account_withholding
+#. module: l10n_account_withholding_tax
 #. odoo-python
-#: code:addons/l10n_account_withholding/models/account_withholding_line.py:0
+#: code:addons/l10n_account_withholding_tax/models/account_withholding_line.py:0
 msgid "WH Tax: %(name)s"
 msgstr ""
 
-#. module: l10n_account_withholding
-#: model_terms:ir.ui.view,arch_db:l10n_account_withholding.view_account_payment_form
+#. module: l10n_account_withholding_tax
+#: model_terms:ir.ui.view,arch_db:l10n_account_withholding_tax.view_account_payment_form
 msgid "Withheld Amount"
 msgstr ""
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_tax__is_withholding_tax_on_payment
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_tax__is_withholding_tax_on_payment
 msgid "Withhold On Payment"
 msgstr ""
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment__should_withhold_tax
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_register__should_withhold_tax
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment__should_withhold_tax
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_register__should_withhold_tax
 msgid "Withhold Tax Amounts"
 msgstr ""
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,help:l10n_account_withholding.field_account_payment__should_withhold_tax
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,help:l10n_account_withholding_tax.field_account_payment__should_withhold_tax
 msgid "Withhold tax amounts from the payment amount."
 msgstr ""
 
-#. module: l10n_account_withholding
-#: model_terms:ir.ui.view,arch_db:l10n_account_withholding.view_account_payment_form
-#: model_terms:ir.ui.view,arch_db:l10n_account_withholding.view_account_payment_register_form
+#. module: l10n_account_withholding_tax
+#: model_terms:ir.ui.view,arch_db:l10n_account_withholding_tax.view_account_payment_form
+#: model_terms:ir.ui.view,arch_db:l10n_account_withholding_tax.view_account_payment_register_form
 msgid "Withholding"
 msgstr ""
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment__withholding_hide_tax_base_account
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_register__withholding_hide_tax_base_account
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment__withholding_hide_tax_base_account
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_register__withholding_hide_tax_base_account
 msgid "Withholding Hide Tax Base Account"
 msgstr ""
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment__withholding_line_ids
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_register__withholding_line_ids
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment__withholding_line_ids
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_register__withholding_line_ids
 msgid "Withholding Lines"
 msgstr ""
 
-#. module: l10n_account_withholding
+#. module: l10n_account_withholding_tax
 #. odoo-python
-#: code:addons/l10n_account_withholding/models/account_tax.py:0
+#: code:addons/l10n_account_withholding_tax/models/account_tax.py:0
 msgid ""
 "Withholding On Payment taxes cannot use the 'Group of Taxes' or the "
 "'Percentage Tax Included' computations."
 msgstr ""
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_register_withholding_line__withholding_sequence_id
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_withholding_line__withholding_sequence_id
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_tax__withholding_sequence_id
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_withholding_line__withholding_sequence_id
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_register_withholding_line__withholding_sequence_id
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_withholding_line__withholding_sequence_id
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_tax__withholding_sequence_id
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_withholding_line__withholding_sequence_id
 msgid "Withholding Sequence"
 msgstr ""
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_res_company__withholding_tax_base_account_id
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_res_config_settings__withholding_tax_base_account_id
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_res_company__withholding_tax_base_account_id
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_res_config_settings__withholding_tax_base_account_id
 msgid "Withholding Tax Base"
 msgstr ""
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_register_withholding_line__amount
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_withholding_line__amount
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_withholding_line__amount
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_register_withholding_line__amount
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_withholding_line__amount
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_withholding_line__amount
 msgid "Withholding amount"
 msgstr ""
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_register_withholding_line__base_amount
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_withholding_line__base_amount
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_withholding_line__base_amount
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_register_withholding_line__base_amount
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_withholding_line__base_amount
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_withholding_line__base_amount
 msgid "Withholding base"
 msgstr ""
 
-#. module: l10n_account_withholding
-#: model_terms:ir.ui.view,arch_db:l10n_account_withholding.res_config_settings_form
+#. module: l10n_account_withholding_tax
+#: model_terms:ir.ui.view,arch_db:l10n_account_withholding_tax.res_config_settings_form
 msgid "Withholding:"
 msgstr ""
 
-#. module: l10n_account_withholding
-#: model:ir.model,name:l10n_account_withholding.model_account_withholding_line
+#. module: l10n_account_withholding_tax
+#: model:ir.model,name:l10n_account_withholding_tax.model_account_withholding_line
 msgid "withholding line"
 msgstr ""

--- a/addons/l10n_account_withholding_tax/i18n/th.po
+++ b/addons/l10n_account_withholding_tax/i18n/th.po
@@ -1,13 +1,13 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
-# 	* l10n_account_withholding
+# 	* l10n_account_withholding_tax
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 18.4a1+e\n"
+"Project-Id-Version: Odoo Server 18.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-06-12 02:39+0000\n"
-"PO-Revision-Date: 2025-06-12 02:39+0000\n"
+"POT-Creation-Date: 2025-06-25 05:14+0000\n"
+"PO-Revision-Date: 2025-06-25 05:14+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -15,558 +15,553 @@ msgstr ""
 "Content-Transfer-Encoding: \n"
 "Plural-Forms: \n"
 
-#. module: l10n_account_withholding
+#. module: l10n_account_withholding_tax
 #. odoo-python
-#: code:addons/l10n_account_withholding/models/product_template.py:0
+#: code:addons/l10n_account_withholding_tax/models/product_template.py:0
 msgid "%(amount)s Excl. Taxes"
 msgstr ""
 
-#. module: l10n_account_withholding
+#. module: l10n_account_withholding_tax
 #. odoo-python
-#: code:addons/l10n_account_withholding/models/product_template.py:0
+#: code:addons/l10n_account_withholding_tax/models/product_template.py:0
 msgid "%(amount)s Incl. Taxes"
 msgstr ""
 
-#. module: l10n_account_withholding
+#. module: l10n_account_withholding_tax
 #. odoo-python
-#: code:addons/l10n_account_withholding/models/product_template.py:0
+#: code:addons/l10n_account_withholding_tax/models/product_template.py:0
 msgid "%(amount)s Tax Withheld"
 msgstr ""
 
-#. module: l10n_account_withholding
-#: model_terms:ir.ui.view,arch_db:l10n_account_withholding.report_payment_receipt_document
+#. module: l10n_account_withholding_tax
+#: model_terms:ir.ui.view,arch_db:l10n_account_withholding_tax.report_payment_receipt_document
 msgid "<span>Amount</span>"
 msgstr ""
 
-#. module: l10n_account_withholding
-#: model_terms:ir.ui.view,arch_db:l10n_account_withholding.report_payment_receipt_document
+#. module: l10n_account_withholding_tax
+#: model_terms:ir.ui.view,arch_db:l10n_account_withholding_tax.report_payment_receipt_document
 msgid "<span>Base</span>"
 msgstr ""
 
-#. module: l10n_account_withholding
-#: model_terms:ir.ui.view,arch_db:l10n_account_withholding.report_payment_receipt_document
+#. module: l10n_account_withholding_tax
+#: model_terms:ir.ui.view,arch_db:l10n_account_withholding_tax.report_payment_receipt_document
 msgid "<span>Tax</span>"
 msgstr ""
 
-#. module: l10n_account_withholding
-#: model_terms:ir.ui.view,arch_db:l10n_account_withholding.report_payment_receipt_document
+#. module: l10n_account_withholding_tax
+#: model_terms:ir.ui.view,arch_db:l10n_account_withholding_tax.report_payment_receipt_document
 msgid "<span>Withholding number</span>"
 msgstr ""
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_register_withholding_line__account_id
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_withholding_line__account_id
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_withholding_line__account_id
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_register_withholding_line__account_id
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_withholding_line__account_id
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_withholding_line__account_id
 msgid "Account"
 msgstr ""
 
-#. module: l10n_account_withholding
+#. module: l10n_account_withholding_tax
 #. odoo-python
-#: code:addons/l10n_account_withholding/wizards/account_payment_register_withholding_line.py:0
+#: code:addons/l10n_account_withholding_tax/wizards/account_payment_register_withholding_line.py:0
 msgid "All withholding lines in self must have the same payment register."
 msgstr ""
 
-#. module: l10n_account_withholding
+#. module: l10n_account_withholding_tax
 #. odoo-python
-#: code:addons/l10n_account_withholding/models/account_payment_withholding_line.py:0
+#: code:addons/l10n_account_withholding_tax/models/account_payment_withholding_line.py:0
 msgid "All withholding lines in self must have the same payment."
 msgstr ""
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_register_withholding_line__analytic_distribution
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_withholding_line__analytic_distribution
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_withholding_line__analytic_distribution
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_register_withholding_line__analytic_distribution
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_withholding_line__analytic_distribution
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_withholding_line__analytic_distribution
 msgid "Analytic Distribution"
 msgstr ""
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_register_withholding_line__analytic_precision
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_withholding_line__analytic_precision
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_withholding_line__analytic_precision
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_register_withholding_line__analytic_precision
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_withholding_line__analytic_precision
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_withholding_line__analytic_precision
 msgid "Analytic Precision"
 msgstr ""
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_register_withholding_line__comodel_currency_id
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_withholding_line__comodel_currency_id
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_withholding_line__comodel_currency_id
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_register_withholding_line__comodel_currency_id
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_withholding_line__comodel_currency_id
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_withholding_line__comodel_currency_id
 msgid "Comodel Currency"
 msgstr ""
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_register_withholding_line__comodel_date
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_withholding_line__comodel_date
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_withholding_line__comodel_date
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_register_withholding_line__comodel_date
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_withholding_line__comodel_date
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_withholding_line__comodel_date
 msgid "Comodel Date"
 msgstr ""
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_register_withholding_line__comodel_payment_type
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_withholding_line__comodel_payment_type
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_withholding_line__comodel_payment_type
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_register_withholding_line__comodel_payment_type
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_withholding_line__comodel_payment_type
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_withholding_line__comodel_payment_type
 msgid "Comodel Payment Type"
 msgstr ""
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_register_withholding_line__comodel_percentage_paid_factor
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_withholding_line__comodel_percentage_paid_factor
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_withholding_line__comodel_percentage_paid_factor
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_register_withholding_line__comodel_percentage_paid_factor
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_withholding_line__comodel_percentage_paid_factor
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_withholding_line__comodel_percentage_paid_factor
 msgid "Comodel Percentage Paid Factor"
 msgstr ""
 
-#. module: l10n_account_withholding
-#: model:ir.model,name:l10n_account_withholding.model_res_company
+#. module: l10n_account_withholding_tax
+#: model:ir.model,name:l10n_account_withholding_tax.model_res_company
 msgid "Companies"
 msgstr "บริษัท"
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_register_withholding_line__company_id
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_withholding_line__company_id
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_withholding_line__company_id
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_register_withholding_line__company_id
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_withholding_line__company_id
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_withholding_line__company_id
 msgid "Company"
 msgstr ""
 
-#. module: l10n_account_withholding
-#: model:ir.model,name:l10n_account_withholding.model_res_config_settings
+#. module: l10n_account_withholding_tax
+#: model:ir.model,name:l10n_account_withholding_tax.model_res_config_settings
 msgid "Config Settings"
 msgstr "ตั้งค่าการกำหนดค่า"
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_register_withholding_line__create_uid
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_withholding_line__create_uid
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_register_withholding_line__create_uid
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_withholding_line__create_uid
 msgid "Created by"
 msgstr ""
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_register_withholding_line__create_date
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_withholding_line__create_date
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_register_withholding_line__create_date
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_withholding_line__create_date
 msgid "Created on"
 msgstr ""
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_register_withholding_line__comodel_company_currency_id
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_withholding_line__comodel_company_currency_id
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_withholding_line__comodel_company_currency_id
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_register_withholding_line__comodel_company_currency_id
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_withholding_line__comodel_company_currency_id
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_withholding_line__comodel_company_currency_id
 msgid "Currency"
 msgstr ""
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_register__withholding_default_account_id
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_register__withholding_default_account_id
 msgid "Default Account"
 msgstr ""
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment__display_name
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_register__display_name
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_register_withholding_line__display_name
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_withholding_line__display_name
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_tax__display_name
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_withholding_line__display_name
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_product_template__display_name
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_res_company__display_name
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_res_config_settings__display_name
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_register_withholding_line__display_name
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_withholding_line__display_name
 msgid "Display Name"
 msgstr "แสดงชื่อ"
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment__display_withholding
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_register__display_withholding
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment__display_withholding
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_register__display_withholding
 msgid "Display Withholding"
 msgstr ""
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_register_withholding_line__distribution_analytic_account_ids
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_withholding_line__distribution_analytic_account_ids
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_withholding_line__distribution_analytic_account_ids
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_register_withholding_line__distribution_analytic_account_ids
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_withholding_line__distribution_analytic_account_ids
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_withholding_line__distribution_analytic_account_ids
 msgid "Distribution Analytic Account"
 msgstr ""
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields.selection,name:l10n_account_withholding.selection__account_payment_register_withholding_line__placeholder_type__given_by_name
-#: model:ir.model.fields.selection,name:l10n_account_withholding.selection__account_payment_register_withholding_line__previous_placeholder_type__given_by_name
-#: model:ir.model.fields.selection,name:l10n_account_withholding.selection__account_payment_withholding_line__placeholder_type__given_by_name
-#: model:ir.model.fields.selection,name:l10n_account_withholding.selection__account_payment_withholding_line__previous_placeholder_type__given_by_name
-#: model:ir.model.fields.selection,name:l10n_account_withholding.selection__account_withholding_line__placeholder_type__given_by_name
-#: model:ir.model.fields.selection,name:l10n_account_withholding.selection__account_withholding_line__previous_placeholder_type__given_by_name
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields.selection,name:l10n_account_withholding_tax.selection__account_payment_register_withholding_line__placeholder_type__given_by_name
+#: model:ir.model.fields.selection,name:l10n_account_withholding_tax.selection__account_payment_register_withholding_line__previous_placeholder_type__given_by_name
+#: model:ir.model.fields.selection,name:l10n_account_withholding_tax.selection__account_payment_withholding_line__placeholder_type__given_by_name
+#: model:ir.model.fields.selection,name:l10n_account_withholding_tax.selection__account_payment_withholding_line__previous_placeholder_type__given_by_name
+#: model:ir.model.fields.selection,name:l10n_account_withholding_tax.selection__account_withholding_line__placeholder_type__given_by_name
+#: model:ir.model.fields.selection,name:l10n_account_withholding_tax.selection__account_withholding_line__previous_placeholder_type__given_by_name
 msgid "Given By the Name"
 msgstr ""
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields.selection,name:l10n_account_withholding.selection__account_payment_register_withholding_line__placeholder_type__given_by_sequence
-#: model:ir.model.fields.selection,name:l10n_account_withholding.selection__account_payment_register_withholding_line__previous_placeholder_type__given_by_sequence
-#: model:ir.model.fields.selection,name:l10n_account_withholding.selection__account_payment_withholding_line__placeholder_type__given_by_sequence
-#: model:ir.model.fields.selection,name:l10n_account_withholding.selection__account_payment_withholding_line__previous_placeholder_type__given_by_sequence
-#: model:ir.model.fields.selection,name:l10n_account_withholding.selection__account_withholding_line__placeholder_type__given_by_sequence
-#: model:ir.model.fields.selection,name:l10n_account_withholding.selection__account_withholding_line__previous_placeholder_type__given_by_sequence
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields.selection,name:l10n_account_withholding_tax.selection__account_payment_register_withholding_line__placeholder_type__given_by_sequence
+#: model:ir.model.fields.selection,name:l10n_account_withholding_tax.selection__account_payment_register_withholding_line__previous_placeholder_type__given_by_sequence
+#: model:ir.model.fields.selection,name:l10n_account_withholding_tax.selection__account_payment_withholding_line__placeholder_type__given_by_sequence
+#: model:ir.model.fields.selection,name:l10n_account_withholding_tax.selection__account_payment_withholding_line__previous_placeholder_type__given_by_sequence
+#: model:ir.model.fields.selection,name:l10n_account_withholding_tax.selection__account_withholding_line__placeholder_type__given_by_sequence
+#: model:ir.model.fields.selection,name:l10n_account_withholding_tax.selection__account_withholding_line__previous_placeholder_type__given_by_sequence
 msgid "Given By the Sequence"
 msgstr ""
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment__id
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_register__id
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_register_withholding_line__id
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_withholding_line__id
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_tax__id
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_withholding_line__id
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_product_template__id
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_res_company__id
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_res_config_settings__id
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_register_withholding_line__id
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_withholding_line__id
 msgid "ID"
 msgstr "ไอดี"
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,help:l10n_account_withholding.field_account_tax__is_withholding_tax_on_payment
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,help:l10n_account_withholding_tax.field_account_tax__is_withholding_tax_on_payment
 msgid ""
 "If enabled, this tax will not affect your accounts until the registration of"
 " payments."
 msgstr ""
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_register_withholding_line__write_uid
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_withholding_line__write_uid
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_register_withholding_line__write_uid
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_withholding_line__write_uid
 msgid "Last Updated by"
 msgstr ""
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_register_withholding_line__write_date
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_withholding_line__write_date
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_register_withholding_line__write_date
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_withholding_line__write_date
 msgid "Last Updated on"
 msgstr ""
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_register__withholding_net_amount
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_register__withholding_net_amount
 msgid "Net Amount"
 msgstr ""
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,help:l10n_account_withholding.field_account_payment_register__withholding_net_amount
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,help:l10n_account_withholding_tax.field_account_payment_register__withholding_net_amount
 msgid "Net amount after deducting the withholding lines"
 msgstr ""
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields.selection,name:l10n_account_withholding.selection__account_payment_register_withholding_line__placeholder_type__not_defined
-#: model:ir.model.fields.selection,name:l10n_account_withholding.selection__account_payment_register_withholding_line__previous_placeholder_type__not_defined
-#: model:ir.model.fields.selection,name:l10n_account_withholding.selection__account_payment_withholding_line__placeholder_type__not_defined
-#: model:ir.model.fields.selection,name:l10n_account_withholding.selection__account_payment_withholding_line__previous_placeholder_type__not_defined
-#: model:ir.model.fields.selection,name:l10n_account_withholding.selection__account_withholding_line__placeholder_type__not_defined
-#: model:ir.model.fields.selection,name:l10n_account_withholding.selection__account_withholding_line__previous_placeholder_type__not_defined
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields.selection,name:l10n_account_withholding_tax.selection__account_payment_register_withholding_line__placeholder_type__not_defined
+#: model:ir.model.fields.selection,name:l10n_account_withholding_tax.selection__account_payment_register_withholding_line__previous_placeholder_type__not_defined
+#: model:ir.model.fields.selection,name:l10n_account_withholding_tax.selection__account_payment_withholding_line__placeholder_type__not_defined
+#: model:ir.model.fields.selection,name:l10n_account_withholding_tax.selection__account_payment_withholding_line__previous_placeholder_type__not_defined
+#: model:ir.model.fields.selection,name:l10n_account_withholding_tax.selection__account_withholding_line__placeholder_type__not_defined
+#: model:ir.model.fields.selection,name:l10n_account_withholding_tax.selection__account_withholding_line__previous_placeholder_type__not_defined
 msgid "Not defined"
 msgstr ""
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_register_withholding_line__original_base_amount
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_withholding_line__original_base_amount
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_withholding_line__original_base_amount
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_register_withholding_line__original_base_amount
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_withholding_line__original_base_amount
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_withholding_line__original_base_amount
 msgid "Original Base Amount"
 msgstr ""
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_register_withholding_line__original_tax_amount
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_withholding_line__original_tax_amount
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_withholding_line__original_tax_amount
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_register_withholding_line__original_tax_amount
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_withholding_line__original_tax_amount
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_withholding_line__original_tax_amount
 msgid "Original Tax Amount"
 msgstr ""
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment__outstanding_account_id
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_register__withholding_outstanding_account_id
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment__outstanding_account_id
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_register__withholding_outstanding_account_id
 msgid "Outstanding Account"
 msgstr ""
 
-#. module: l10n_account_withholding
-#: model:ir.model,name:l10n_account_withholding.model_account_payment_register
+#. module: l10n_account_withholding_tax
+#: model:ir.model,name:l10n_account_withholding_tax.model_account_payment_register
 msgid "Pay"
 msgstr "จ่าย"
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_withholding_line__payment_id
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_withholding_line__payment_id
 msgid "Payment"
 msgstr ""
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment__withholding_payment_account_id
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_register__withholding_payment_account_id
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment__withholding_payment_account_id
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_register__withholding_payment_account_id
 msgid "Payment Account"
 msgstr ""
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_register_withholding_line__payment_register_id
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_register_withholding_line__payment_register_id
 msgid "Payment Register"
 msgstr ""
 
-#. module: l10n_account_withholding
-#: model:ir.model,name:l10n_account_withholding.model_account_payment_register_withholding_line
+#. module: l10n_account_withholding_tax
+#: model:ir.model,name:l10n_account_withholding_tax.model_account_payment_register_withholding_line
 msgid "Payment register withholding line"
 msgstr ""
 
-#. module: l10n_account_withholding
-#: model:ir.model,name:l10n_account_withholding.model_account_payment_withholding_line
+#. module: l10n_account_withholding_tax
+#: model:ir.model,name:l10n_account_withholding_tax.model_account_payment_withholding_line
 msgid "Payment withholding line"
 msgstr ""
 
-#. module: l10n_account_withholding
-#: model:ir.model,name:l10n_account_withholding.model_account_payment
+#. module: l10n_account_withholding_tax
+#: model:ir.model,name:l10n_account_withholding_tax.model_account_payment
 msgid "Payments"
 msgstr "การชำระเงิน"
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_register_withholding_line__placeholder_type
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_withholding_line__placeholder_type
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_withholding_line__placeholder_type
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_register_withholding_line__placeholder_type
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_withholding_line__placeholder_type
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_withholding_line__placeholder_type
 msgid "Placeholder Type"
 msgstr ""
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_register_withholding_line__placeholder_value
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_withholding_line__placeholder_value
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_withholding_line__placeholder_value
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_register_withholding_line__placeholder_value
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_withholding_line__placeholder_value
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_withholding_line__placeholder_value
 msgid "Placeholder Value"
 msgstr ""
 
-#. module: l10n_account_withholding
+#. module: l10n_account_withholding_tax
 #. odoo-python
-#: code:addons/l10n_account_withholding/models/account_withholding_line.py:0
+#: code:addons/l10n_account_withholding_tax/models/account_withholding_line.py:0
 msgid "Please enter the withholding number for the tax %(tax_name)s"
 msgstr ""
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,help:l10n_account_withholding.field_account_payment_register_withholding_line__placeholder_value
-#: model:ir.model.fields,help:l10n_account_withholding.field_account_payment_withholding_line__placeholder_value
-#: model:ir.model.fields,help:l10n_account_withholding.field_account_withholding_line__placeholder_value
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,help:l10n_account_withholding_tax.field_account_payment_register_withholding_line__placeholder_value
+#: model:ir.model.fields,help:l10n_account_withholding_tax.field_account_payment_withholding_line__placeholder_value
+#: model:ir.model.fields,help:l10n_account_withholding_tax.field_account_withholding_line__placeholder_value
 msgid "Populated by the comodel during edition of the line."
 msgstr ""
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_register_withholding_line__previous_placeholder_type
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_withholding_line__previous_placeholder_type
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_withholding_line__previous_placeholder_type
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_register_withholding_line__previous_placeholder_type
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_withholding_line__previous_placeholder_type
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_withholding_line__previous_placeholder_type
 msgid "Previous Placeholder Type"
 msgstr ""
 
-#. module: l10n_account_withholding
-#: model:ir.model,name:l10n_account_withholding.model_product_template
+#. module: l10n_account_withholding_tax
+#: model:ir.model,name:l10n_account_withholding_tax.model_product_template
 msgid "Product"
 msgstr "สินค้า"
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields.selection,name:l10n_account_withholding.selection__account_payment_register_withholding_line__comodel_payment_type__inbound
-#: model:ir.model.fields.selection,name:l10n_account_withholding.selection__account_payment_withholding_line__comodel_payment_type__inbound
-#: model:ir.model.fields.selection,name:l10n_account_withholding.selection__account_withholding_line__comodel_payment_type__inbound
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields.selection,name:l10n_account_withholding_tax.selection__account_payment_register_withholding_line__comodel_payment_type__inbound
+#: model:ir.model.fields.selection,name:l10n_account_withholding_tax.selection__account_payment_withholding_line__comodel_payment_type__inbound
+#: model:ir.model.fields.selection,name:l10n_account_withholding_tax.selection__account_withholding_line__comodel_payment_type__inbound
 msgid "Receive Money"
 msgstr ""
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields.selection,name:l10n_account_withholding.selection__account_payment_register_withholding_line__comodel_payment_type__outbound
-#: model:ir.model.fields.selection,name:l10n_account_withholding.selection__account_payment_withholding_line__comodel_payment_type__outbound
-#: model:ir.model.fields.selection,name:l10n_account_withholding.selection__account_withholding_line__comodel_payment_type__outbound
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields.selection,name:l10n_account_withholding_tax.selection__account_payment_register_withholding_line__comodel_payment_type__outbound
+#: model:ir.model.fields.selection,name:l10n_account_withholding_tax.selection__account_payment_withholding_line__comodel_payment_type__outbound
+#: model:ir.model.fields.selection,name:l10n_account_withholding_tax.selection__account_withholding_line__comodel_payment_type__outbound
 msgid "Send Money"
 msgstr ""
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_register_withholding_line__name
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_withholding_line__name
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_withholding_line__name
-#: model_terms:ir.ui.view,arch_db:l10n_account_withholding.view_account_payment_form
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_register_withholding_line__name
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_withholding_line__name
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_withholding_line__name
+#: model_terms:ir.ui.view,arch_db:l10n_account_withholding_tax.view_account_payment_form
 msgid "Sequence Number"
 msgstr ""
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_register_withholding_line__source_base_amount
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_withholding_line__source_base_amount
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_withholding_line__source_base_amount
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_register_withholding_line__source_base_amount
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_withholding_line__source_base_amount
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_withholding_line__source_base_amount
 msgid "Source Base Amount"
 msgstr ""
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_register_withholding_line__source_base_amount_currency
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_withholding_line__source_base_amount_currency
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_withholding_line__source_base_amount_currency
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_register_withholding_line__source_base_amount_currency
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_withholding_line__source_base_amount_currency
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_withholding_line__source_base_amount_currency
 msgid "Source Base Amount Currency"
 msgstr ""
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_register_withholding_line__source_currency_id
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_withholding_line__source_currency_id
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_withholding_line__source_currency_id
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_register_withholding_line__source_currency_id
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_withholding_line__source_currency_id
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_withholding_line__source_currency_id
 msgid "Source Currency"
 msgstr ""
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_register_withholding_line__source_tax_id
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_withholding_line__source_tax_id
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_withholding_line__source_tax_id
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_register_withholding_line__source_tax_id
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_withholding_line__source_tax_id
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_withholding_line__source_tax_id
 msgid "Source Tax"
 msgstr ""
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_register_withholding_line__source_tax_amount
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_withholding_line__source_tax_amount
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_withholding_line__source_tax_amount
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_register_withholding_line__source_tax_amount
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_withholding_line__source_tax_amount
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_withholding_line__source_tax_amount
 msgid "Source Tax Amount"
 msgstr ""
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_register_withholding_line__source_tax_amount_currency
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_withholding_line__source_tax_amount_currency
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_withholding_line__source_tax_amount_currency
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_register_withholding_line__source_tax_amount_currency
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_withholding_line__source_tax_amount_currency
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_withholding_line__source_tax_amount_currency
 msgid "Source Tax Amount Currency"
 msgstr ""
 
-#. module: l10n_account_withholding
-#: model:ir.model,name:l10n_account_withholding.model_account_tax
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_register_withholding_line__tax_id
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_withholding_line__tax_id
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_withholding_line__tax_id
-#: model_terms:ir.ui.view,arch_db:l10n_account_withholding.view_account_payment_form
+#. module: l10n_account_withholding_tax
+#: model:ir.model,name:l10n_account_withholding_tax.model_account_tax
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_register_withholding_line__tax_id
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_withholding_line__tax_id
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_withholding_line__tax_id
+#: model_terms:ir.ui.view,arch_db:l10n_account_withholding_tax.view_account_payment_form
 msgid "Tax"
 msgstr "ภาษี"
 
-#. module: l10n_account_withholding
+#. module: l10n_account_withholding_tax
 #. odoo-python
-#: code:addons/l10n_account_withholding/models/account_withholding_line.py:0
+#: code:addons/l10n_account_withholding_tax/models/account_withholding_line.py:0
 msgid "The account \"%(account_name)s\" is not valid to use on withholding lines."
 msgstr ""
 
-#. module: l10n_account_withholding
+#. module: l10n_account_withholding_tax
 #. odoo-python
-#: code:addons/l10n_account_withholding/models/account_withholding_line.py:0
+#: code:addons/l10n_account_withholding_tax/models/account_withholding_line.py:0
 msgid "The base amount of a withholding tax line must be above 0."
 msgstr ""
 
-#. module: l10n_account_withholding
+#. module: l10n_account_withholding_tax
 #. odoo-python
-#: code:addons/l10n_account_withholding/wizards/account_payment_register.py:0
+#: code:addons/l10n_account_withholding_tax/models/account_withholding_line.py:0
+msgid ""
+"The tax '%(tax_name)s' used on withholding lines does not have an account "
+"set on its tax repartition line."
+msgstr ""
+"ภาษี '%(tax_name)s' ที่ใช้ในรายการหักภาษี ณ ที่จ่ายยังไม่มีการกำหนดบัญชีในบรรทัดการจัดสรรภาษี"
+
+#. module: l10n_account_withholding_tax
+#. odoo-python
+#: code:addons/l10n_account_withholding_tax/wizards/account_payment_register.py:0
 msgid "The withholding net amount cannot be negative."
 msgstr ""
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,help:l10n_account_withholding.field_res_company__withholding_tax_base_account_id
-#: model:ir.model.fields,help:l10n_account_withholding.field_res_config_settings__withholding_tax_base_account_id
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,help:l10n_account_withholding_tax.field_res_company__withholding_tax_base_account_id
+#: model:ir.model.fields,help:l10n_account_withholding_tax.field_res_config_settings__withholding_tax_base_account_id
 msgid "This account will be set on withholding tax base lines."
 msgstr ""
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,help:l10n_account_withholding.field_account_payment_register_withholding_line__withholding_sequence_id
-#: model:ir.model.fields,help:l10n_account_withholding.field_account_payment_withholding_line__withholding_sequence_id
-#: model:ir.model.fields,help:l10n_account_withholding.field_account_tax__withholding_sequence_id
-#: model:ir.model.fields,help:l10n_account_withholding.field_account_withholding_line__withholding_sequence_id
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,help:l10n_account_withholding_tax.field_account_payment_register_withholding_line__withholding_sequence_id
+#: model:ir.model.fields,help:l10n_account_withholding_tax.field_account_payment_withholding_line__withholding_sequence_id
+#: model:ir.model.fields,help:l10n_account_withholding_tax.field_account_tax__withholding_sequence_id
+#: model:ir.model.fields,help:l10n_account_withholding_tax.field_account_withholding_line__withholding_sequence_id
 msgid ""
 "This sequence will be used to generate default numbers on payment "
 "withholding lines."
 msgstr ""
 
-#. module: l10n_account_withholding
-#: model_terms:ir.ui.view,arch_db:l10n_account_withholding.view_account_payment_form
-#: model_terms:ir.ui.view,arch_db:l10n_account_withholding.view_account_payment_register_form
+#. module: l10n_account_withholding_tax
+#: model_terms:ir.ui.view,arch_db:l10n_account_withholding_tax.view_account_payment_form
+#: model_terms:ir.ui.view,arch_db:l10n_account_withholding_tax.view_account_payment_register_form
 msgid "Total Withheld Amount"
 msgstr ""
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_register_withholding_line__type_tax_use
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_withholding_line__type_tax_use
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_withholding_line__type_tax_use
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_register_withholding_line__type_tax_use
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_withholding_line__type_tax_use
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_withholding_line__type_tax_use
 msgid "Type Tax Use"
 msgstr ""
 
-#. module: l10n_account_withholding
+#. module: l10n_account_withholding_tax
 #. odoo-python
-#: code:addons/l10n_account_withholding/models/account_withholding_line.py:0
+#: code:addons/l10n_account_withholding_tax/models/account_withholding_line.py:0
 msgid "WH Base Counterpart: %(names)s"
 msgstr ""
 
-#. module: l10n_account_withholding
+#. module: l10n_account_withholding_tax
 #. odoo-python
-#: code:addons/l10n_account_withholding/models/account_withholding_line.py:0
+#: code:addons/l10n_account_withholding_tax/models/account_withholding_line.py:0
 msgid "WH Base: %(names)s"
 msgstr ""
 
-#. module: l10n_account_withholding
+#. module: l10n_account_withholding_tax
 #. odoo-python
-#: code:addons/l10n_account_withholding/models/account_withholding_line.py:0
+#: code:addons/l10n_account_withholding_tax/models/account_withholding_line.py:0
 msgid "WH Tax: %(name)s"
 msgstr ""
 
-#. module: l10n_account_withholding
-#: model_terms:ir.ui.view,arch_db:l10n_account_withholding.view_account_payment_form
+#. module: l10n_account_withholding_tax
+#: model_terms:ir.ui.view,arch_db:l10n_account_withholding_tax.view_account_payment_form
 msgid "Withheld Amount"
 msgstr ""
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_tax__is_withholding_tax_on_payment
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_tax__is_withholding_tax_on_payment
 msgid "Withhold On Payment"
 msgstr ""
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment__should_withhold_tax
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_register__should_withhold_tax
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment__should_withhold_tax
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_register__should_withhold_tax
 msgid "Withhold Tax Amounts"
 msgstr ""
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,help:l10n_account_withholding.field_account_payment__should_withhold_tax
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,help:l10n_account_withholding_tax.field_account_payment__should_withhold_tax
 msgid "Withhold tax amounts from the payment amount."
 msgstr ""
 
-#. module: l10n_account_withholding
-#: model_terms:ir.ui.view,arch_db:l10n_account_withholding.view_account_payment_form
-#: model_terms:ir.ui.view,arch_db:l10n_account_withholding.view_account_payment_register_form
+#. module: l10n_account_withholding_tax
+#: model_terms:ir.ui.view,arch_db:l10n_account_withholding_tax.view_account_payment_form
+#: model_terms:ir.ui.view,arch_db:l10n_account_withholding_tax.view_account_payment_register_form
 msgid "Withholding"
 msgstr ""
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment__withholding_hide_tax_base_account
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_register__withholding_hide_tax_base_account
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment__withholding_hide_tax_base_account
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_register__withholding_hide_tax_base_account
 msgid "Withholding Hide Tax Base Account"
 msgstr ""
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment__withholding_line_ids
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_register__withholding_line_ids
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment__withholding_line_ids
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_register__withholding_line_ids
 msgid "Withholding Lines"
 msgstr ""
 
-#. module: l10n_account_withholding
+#. module: l10n_account_withholding_tax
 #. odoo-python
-#: code:addons/l10n_account_withholding/models/account_tax.py:0
+#: code:addons/l10n_account_withholding_tax/models/account_tax.py:0
 msgid ""
 "Withholding On Payment taxes cannot use the 'Group of Taxes' or the "
 "'Percentage Tax Included' computations."
 msgstr ""
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_register_withholding_line__withholding_sequence_id
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_withholding_line__withholding_sequence_id
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_tax__withholding_sequence_id
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_withholding_line__withholding_sequence_id
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_register_withholding_line__withholding_sequence_id
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_withholding_line__withholding_sequence_id
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_tax__withholding_sequence_id
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_withholding_line__withholding_sequence_id
 msgid "Withholding Sequence"
 msgstr ""
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_res_company__withholding_tax_base_account_id
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_res_config_settings__withholding_tax_base_account_id
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_res_company__withholding_tax_base_account_id
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_res_config_settings__withholding_tax_base_account_id
 msgid "Withholding Tax Base"
 msgstr ""
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_register_withholding_line__amount
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_withholding_line__amount
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_withholding_line__amount
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_register_withholding_line__amount
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_withholding_line__amount
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_withholding_line__amount
 msgid "Withholding amount"
 msgstr ""
 
-#. module: l10n_account_withholding
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_register_withholding_line__base_amount
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_payment_withholding_line__base_amount
-#: model:ir.model.fields,field_description:l10n_account_withholding.field_account_withholding_line__base_amount
+#. module: l10n_account_withholding_tax
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_register_withholding_line__base_amount
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_payment_withholding_line__base_amount
+#: model:ir.model.fields,field_description:l10n_account_withholding_tax.field_account_withholding_line__base_amount
 msgid "Withholding base"
 msgstr ""
 
-#. module: l10n_account_withholding
-#: model_terms:ir.ui.view,arch_db:l10n_account_withholding.res_config_settings_form
+#. module: l10n_account_withholding_tax
+#: model_terms:ir.ui.view,arch_db:l10n_account_withholding_tax.res_config_settings_form
 msgid "Withholding:"
 msgstr ""
 
-#. module: l10n_account_withholding
-#: model:ir.model,name:l10n_account_withholding.model_account_withholding_line
+#. module: l10n_account_withholding_tax
+#: model:ir.model,name:l10n_account_withholding_tax.model_account_withholding_line
 msgid "withholding line"
 msgstr ""

--- a/addons/l10n_account_withholding_tax/models/account_withholding_line.py
+++ b/addons/l10n_account_withholding_tax/models/account_withholding_line.py
@@ -48,7 +48,8 @@ class AccountWithholdingLine(models.AbstractModel):
         comodel_name='account.tax',
         check_company=True,
         required=True,
-        domain="[('type_tax_use', '=', type_tax_use), ('is_withholding_tax_on_payment', '=', True)]",
+        domain="[('type_tax_use', '=', type_tax_use), '|', ('is_withholding_tax_on_payment', '=', True), "
+                "'&', ('amount_type', '=', 'group'), ('children_tax_ids.is_withholding_tax_on_payment', '=', True),]"
     )
     withholding_sequence_id = fields.Many2one(related='tax_id.withholding_sequence_id')
     source_base_amount_currency = fields.Monetary(currency_field='source_currency_id')

--- a/addons/l10n_account_withholding_tax/tests/test_account_withholding_flows.py
+++ b/addons/l10n_account_withholding_tax/tests/test_account_withholding_flows.py
@@ -36,11 +36,28 @@ class TestL10nAccountWithholdingTaxesFlows(TestTaxCommon, AnalyticCommon):
             'reconcile': False,  # On purpose for testing.
             'account_type': 'asset_current'
         })
+        cls.tax_received_account = cls.env['account.account'].create({
+            'code': '2510',
+            'name': 'Tax Received',
+            'account_type': 'liability_current',
+        })
 
     def test_no_withholding_tax_invoice_but_included_one_on_payment(self):
         """ Test a flow where not withholding tax is set on the invoice line, but one is added to the payment register. """
         invoice_tax = self.percent_tax(15)
-        withholding_tax = self.percent_tax(-1, is_withholding_tax_on_payment=True, withholding_sequence_id=self.withholding_sequence.id)
+        withholding_tax = self.percent_tax(
+            amount=-1,
+            is_withholding_tax_on_payment=True,
+            withholding_sequence_id=self.withholding_sequence.id,
+            invoice_repartition_line_ids=[
+                Command.create({'repartition_type': 'base', 'factor_percent': 100.0}),
+                Command.create({'repartition_type': 'tax', 'factor_percent': 100.0, 'account_id': self.tax_received_account.id}),
+            ],
+            refund_repartition_line_ids=[
+                Command.create({'repartition_type': 'base', 'factor_percent': 100.0}),
+                Command.create({'repartition_type': 'tax', 'factor_percent': 100.0, 'account_id': self.tax_received_account.id}),
+            ],
+        )
 
         invoice = self.env['account.move'].create({
             'move_type': 'out_invoice',
@@ -86,7 +103,19 @@ class TestL10nAccountWithholdingTaxesFlows(TestTaxCommon, AnalyticCommon):
         Afterward, register the payment separately.
         """
         invoice_tax = self.percent_tax(15)
-        withholding_tax = self.percent_tax(-1, is_withholding_tax_on_payment=True, withholding_sequence_id=self.withholding_sequence.id)
+        withholding_tax = self.percent_tax(
+            amount=-1,
+            is_withholding_tax_on_payment=True,
+            withholding_sequence_id=self.withholding_sequence.id,
+            invoice_repartition_line_ids=[
+                Command.create({'repartition_type': 'base', 'factor_percent': 100.0}),
+                Command.create({'repartition_type': 'tax', 'factor_percent': 100.0, 'account_id': self.tax_received_account.id}),
+            ],
+            refund_repartition_line_ids=[
+                Command.create({'repartition_type': 'base', 'factor_percent': 100.0}),
+                Command.create({'repartition_type': 'tax', 'factor_percent': 100.0, 'account_id': self.tax_received_account.id}),
+            ],
+        )
 
         invoice = self.env['account.move'].create({
             'move_type': 'out_invoice',
@@ -172,11 +201,27 @@ class TestL10nAccountWithholdingTaxesFlows(TestTaxCommon, AnalyticCommon):
             amount=-1,
             is_withholding_tax_on_payment=True,
             withholding_sequence_id=self.withholding_sequence.id,
+            invoice_repartition_line_ids=[
+                Command.create({'repartition_type': 'base', 'factor_percent': 100.0}),
+                Command.create({'repartition_type': 'tax', 'factor_percent': 100.0, 'account_id': self.tax_received_account.id}),
+            ],
+            refund_repartition_line_ids=[
+                Command.create({'repartition_type': 'base', 'factor_percent': 100.0}),
+                Command.create({'repartition_type': 'tax', 'factor_percent': 100.0, 'account_id': self.tax_received_account.id}),
+            ],
         )
         withholding_tax2 = self.percent_tax(
             amount=-2,
             is_withholding_tax_on_payment=True,
             withholding_sequence_id=self.withholding_sequence.id,
+            invoice_repartition_line_ids=[
+                Command.create({'repartition_type': 'base', 'factor_percent': 100.0}),
+                Command.create({'repartition_type': 'tax', 'factor_percent': 100.0, 'account_id': self.tax_received_account.id}),
+            ],
+            refund_repartition_line_ids=[
+                Command.create({'repartition_type': 'base', 'factor_percent': 100.0}),
+                Command.create({'repartition_type': 'tax', 'factor_percent': 100.0, 'account_id': self.tax_received_account.id}),
+            ],
         )
 
         invoice = self.env['account.move'].create({
@@ -382,7 +427,19 @@ class TestL10nAccountWithholdingTaxesFlows(TestTaxCommon, AnalyticCommon):
     def test_withholding_not_payment_account_on_method_line(self):
         """ Test that when no payment account is set on the payment method line, the one from the wizard is used. """
         invoice_tax = self.percent_tax(15)
-        withholding_tax = self.percent_tax(-1, is_withholding_tax_on_payment=True, withholding_sequence_id=self.withholding_sequence.id)
+        withholding_tax = self.percent_tax(
+            amount=-1,
+            is_withholding_tax_on_payment=True,
+            withholding_sequence_id=self.withholding_sequence.id,
+            invoice_repartition_line_ids=[
+                Command.create({'repartition_type': 'base', 'factor_percent': 100.0}),
+                Command.create({'repartition_type': 'tax', 'factor_percent': 100.0, 'account_id': self.tax_received_account.id}),
+            ],
+            refund_repartition_line_ids=[
+                Command.create({'repartition_type': 'base', 'factor_percent': 100.0}),
+                Command.create({'repartition_type': 'tax', 'factor_percent': 100.0, 'account_id': self.tax_received_account.id}),
+            ],
+        )
         self.company_data['default_journal_bank'].inbound_payment_method_line_ids.payment_account_id = False
 
         invoice = self.env['account.move'].create({
@@ -417,7 +474,7 @@ class TestL10nAccountWithholdingTaxesFlows(TestTaxCommon, AnalyticCommon):
             # Receivable line:
             {'balance': -1150.0,    'account_id': receivable.id},
             # withholding line:
-            {'balance': 10.0,       'account_id': withholding_account.id},
+            {'balance': 10.0,       'account_id': self.tax_received_account.id},
             # base lines:
             {'balance': 1000.0,     'account_id': withholding_account.id},
             {'balance': -1000.0,    'account_id': withholding_account.id},
@@ -449,11 +506,11 @@ class TestL10nAccountWithholdingTaxesFlows(TestTaxCommon, AnalyticCommon):
             withholding_sequence_id=self.withholding_sequence.id,
             invoice_repartition_line_ids=[
                 Command.create({'repartition_type': 'base', 'factor_percent': 100.0, 'tag_ids': base_tag_1.ids}),
-                Command.create({'repartition_type': 'tax', 'factor_percent': 100.0, 'tag_ids': tax_tag_1.ids}),
+                Command.create({'repartition_type': 'tax', 'factor_percent': 100.0, 'account_id': self.tax_received_account.id, 'tag_ids': tax_tag_1.ids}),
             ],
             refund_repartition_line_ids=[
                 Command.create({'repartition_type': 'base', 'factor_percent': 100.0, 'tag_ids': base_tag_1.ids}),
-                Command.create({'repartition_type': 'tax', 'factor_percent': 100.0, 'tag_ids': tax_tag_1.ids}),
+                Command.create({'repartition_type': 'tax', 'factor_percent': 100.0, 'account_id': self.tax_received_account.id, 'tag_ids': tax_tag_1.ids}),
             ],
         )
         withholding_tax_2 = self.percent_tax(
@@ -462,11 +519,11 @@ class TestL10nAccountWithholdingTaxesFlows(TestTaxCommon, AnalyticCommon):
             withholding_sequence_id=self.withholding_sequence.id,
             invoice_repartition_line_ids=[
                 Command.create({'repartition_type': 'base', 'factor_percent': 100.0, 'tag_ids': base_tag_2.ids}),
-                Command.create({'repartition_type': 'tax', 'factor_percent': 100.0, 'tag_ids': tax_tag_2.ids}),
+                Command.create({'repartition_type': 'tax', 'factor_percent': 100.0, 'account_id': self.tax_received_account.id, 'tag_ids': tax_tag_2.ids}),
             ],
             refund_repartition_line_ids=[
                 Command.create({'repartition_type': 'base', 'factor_percent': 100.0, 'tag_ids': base_tag_2.ids}),
-                Command.create({'repartition_type': 'tax', 'factor_percent': 100.0, 'tag_ids': tax_tag_2.ids}),
+                Command.create({'repartition_type': 'tax', 'factor_percent': 100.0, 'account_id': self.tax_received_account.id, 'tag_ids': tax_tag_2.ids}),
             ],
         )
 
@@ -517,6 +574,14 @@ class TestL10nAccountWithholdingTaxesFlows(TestTaxCommon, AnalyticCommon):
             amount=-3,
             is_withholding_tax_on_payment=True,
             withholding_sequence_id=self.withholding_sequence.id,
+            invoice_repartition_line_ids=[
+                Command.create({'repartition_type': 'base', 'factor_percent': 100.0}),
+                Command.create({'repartition_type': 'tax', 'factor_percent': 100.0, 'account_id': self.tax_received_account.id}),
+            ],
+            refund_repartition_line_ids=[
+                Command.create({'repartition_type': 'base', 'factor_percent': 100.0}),
+                Command.create({'repartition_type': 'tax', 'factor_percent': 100.0, 'account_id': self.tax_received_account.id}),
+            ],
         )
         self.product_a.taxes_id = withholding_tax
 
@@ -566,13 +631,13 @@ class TestL10nAccountWithholdingTaxesFlows(TestTaxCommon, AnalyticCommon):
             withholding_sequence_id=self.withholding_sequence.id,
             invoice_repartition_line_ids=[
                 Command.create({'repartition_type': 'base', 'factor_percent': 100.0}),
-                Command.create({'repartition_type': 'tax', 'factor_percent': 60.0}),
-                Command.create({'repartition_type': 'tax', 'factor_percent': 40.0}),
+                Command.create({'repartition_type': 'tax', 'factor_percent': 60.0, 'account_id': self.tax_received_account.id}),
+                Command.create({'repartition_type': 'tax', 'factor_percent': 40.0, 'account_id': self.tax_received_account.id}),
             ],
             refund_repartition_line_ids=[
                 Command.create({'repartition_type': 'base', 'factor_percent': 100.0}),
-                Command.create({'repartition_type': 'tax', 'factor_percent': 60.0}),
-                Command.create({'repartition_type': 'tax', 'factor_percent': 40.0}),
+                Command.create({'repartition_type': 'tax', 'factor_percent': 60.0, 'account_id': self.tax_received_account.id}),
+                Command.create({'repartition_type': 'tax', 'factor_percent': 40.0, 'account_id': self.tax_received_account.id}),
             ],
         )
         self.product_b.taxes_id = withholding_tax
@@ -615,6 +680,61 @@ class TestL10nAccountWithholdingTaxesFlows(TestTaxCommon, AnalyticCommon):
             {'balance': -200.0},
         ])
 
+    def test_withholding_tax_with_no_account(self):
+        """
+        Ensure that when no account is set on the tax repartition line,
+        the invoice line account is used for the withholding tax line.
+        """
+        account_sale = self.env['account.account'].create({
+            'name': 'Product Sales',
+            'code': '4200000',
+            'account_type': 'income',
+            'reconcile': False,
+        })
+
+        withholding_tax = self.percent_tax(
+            amount=-1,
+            is_withholding_tax_on_payment=True,
+            withholding_sequence_id=self.withholding_sequence.id,
+        )
+        self.product_b.taxes_id = withholding_tax
+
+        invoice = self.env['account.move'].create({
+            'move_type': 'out_invoice',
+            'partner_id': self.partner_a.id,
+            'invoice_line_ids': [Command.create({
+                'account_id': account_sale.id,
+                'product_id': self.product_a.id,
+                'price_unit': 1000.0,
+                'tax_ids': [Command.set(withholding_tax.ids)],
+            })],
+        })
+        invoice.action_post()
+
+        payment_register = self.env['account.payment.register']\
+            .with_context(active_model='account.move', active_ids=invoice.ids)\
+            .create({
+                'withholding_outstanding_account_id': self.outstanding_account.id
+            })
+
+        payment = payment_register._create_payments()
+
+        outstanding = self.outstanding_account
+        receivable = self.company_data['default_account_receivable']
+        withholding_account = self.env.company.withholding_tax_base_account_id
+
+        self.assertRecordValues(payment.move_id.line_ids, [
+            # Liquidity line
+            {'balance': 990.0,     'account_id': outstanding.id},
+            # Receivable line
+            {'balance': -1000.0,   'account_id': receivable.id},
+            # Withholding tax line (uses invoice line account)
+            {'balance': 10.0,      'account_id': account_sale.id},
+            # Withholding base lines
+            {'balance': 1000.0,    'account_id': withholding_account.id},
+            {'balance': -1000.0,   'account_id': withholding_account.id},
+        ])
+
     def test_withholding_analytic_distribution(self):
         """ Ensure that the analytic distribution set on an invoice line is correctly applied to the final entry if the
         withholding tax is set to affect analytics.
@@ -624,6 +744,14 @@ class TestL10nAccountWithholdingTaxesFlows(TestTaxCommon, AnalyticCommon):
             is_withholding_tax_on_payment=True,
             withholding_sequence_id=self.withholding_sequence.id,
             analytic=True,
+            invoice_repartition_line_ids=[
+                Command.create({'repartition_type': 'base', 'factor_percent': 100.0}),
+                Command.create({'repartition_type': 'tax', 'factor_percent': 100.0, 'account_id': self.tax_received_account.id}),
+            ],
+            refund_repartition_line_ids=[
+                Command.create({'repartition_type': 'base', 'factor_percent': 100.0}),
+                Command.create({'repartition_type': 'tax', 'factor_percent': 100.0, 'account_id': self.tax_received_account.id}),
+            ],
         )
         invoice = self.env['account.move'].create({
             'move_type': 'out_invoice',
@@ -686,6 +814,14 @@ class TestL10nAccountWithholdingTaxesFlows(TestTaxCommon, AnalyticCommon):
             is_withholding_tax_on_payment=True,
             withholding_sequence_id=self.withholding_sequence.id,
             analytic=True,
+            invoice_repartition_line_ids=[
+                Command.create({'repartition_type': 'base', 'factor_percent': 100.0}),
+                Command.create({'repartition_type': 'tax', 'factor_percent': 100.0, 'account_id': self.tax_received_account.id}),
+            ],
+            refund_repartition_line_ids=[
+                Command.create({'repartition_type': 'base', 'factor_percent': 100.0}),
+                Command.create({'repartition_type': 'tax', 'factor_percent': 100.0, 'account_id': self.tax_received_account.id}),
+            ],
         )
         invoice = self.env['account.move'].create({
             'move_type': 'out_invoice',
@@ -792,7 +928,19 @@ class TestL10nAccountWithholdingTaxesFlows(TestTaxCommon, AnalyticCommon):
     def test_payment_synchronize_to_moves(self):
         """ Test that the payment and the journal entry behind it are synchronized as expected when the payment record is updated. """
         invoice_tax = self.percent_tax(15)
-        withholding_tax = self.percent_tax(-1, is_withholding_tax_on_payment=True, withholding_sequence_id=self.withholding_sequence.id)
+        withholding_tax = self.percent_tax(
+            amount=-1,
+            is_withholding_tax_on_payment=True,
+            withholding_sequence_id=self.withholding_sequence.id,
+            invoice_repartition_line_ids=[
+                Command.create({'repartition_type': 'base', 'factor_percent': 100.0}),
+                Command.create({'repartition_type': 'tax', 'factor_percent': 100.0, 'account_id': self.tax_received_account.id}),
+            ],
+            refund_repartition_line_ids=[
+                Command.create({'repartition_type': 'base', 'factor_percent': 100.0}),
+                Command.create({'repartition_type': 'tax', 'factor_percent': 100.0, 'account_id': self.tax_received_account.id}),
+            ],
+        )
 
         invoice = self.env['account.move'].create({
             'move_type': 'out_invoice',
@@ -897,6 +1045,14 @@ class TestL10nAccountWithholdingTaxesFlows(TestTaxCommon, AnalyticCommon):
             amount=-1,
             is_withholding_tax_on_payment=True,
             withholding_sequence_id=self.withholding_sequence.id,
+            invoice_repartition_line_ids=[
+                Command.create({'repartition_type': 'base', 'factor_percent': 100.0}),
+                Command.create({'repartition_type': 'tax', 'factor_percent': 100.0, 'account_id': self.tax_received_account.id}),
+            ],
+            refund_repartition_line_ids=[
+                Command.create({'repartition_type': 'base', 'factor_percent': 100.0}),
+                Command.create({'repartition_type': 'tax', 'factor_percent': 100.0, 'account_id': self.tax_received_account.id}),
+            ],
         )
 
         invoice = self.env['account.move'].create({
@@ -926,7 +1082,19 @@ class TestL10nAccountWithholdingTaxesFlows(TestTaxCommon, AnalyticCommon):
 
     def test_cannot_register_negative_payment(self):
         """ Test that you cannot register a payment where the withholding amount is higher than the payment amount. """
-        withholding_tax = self.percent_tax(-1, is_withholding_tax_on_payment=True, withholding_sequence_id=self.withholding_sequence.id)
+        withholding_tax = self.percent_tax(
+            amount=-1,
+            is_withholding_tax_on_payment=True,
+            withholding_sequence_id=self.withholding_sequence.id,
+            invoice_repartition_line_ids=[
+                Command.create({'repartition_type': 'base', 'factor_percent': 100.0}),
+                Command.create({'repartition_type': 'tax', 'factor_percent': 100.0, 'account_id': self.tax_received_account.id}),
+            ],
+            refund_repartition_line_ids=[
+                Command.create({'repartition_type': 'base', 'factor_percent': 100.0}),
+                Command.create({'repartition_type': 'tax', 'factor_percent': 100.0, 'account_id': self.tax_received_account.id}),
+            ],
+        )
 
         invoice = self.env['account.move'].create({
             'move_type': 'out_invoice',
@@ -952,9 +1120,17 @@ class TestL10nAccountWithholdingTaxesFlows(TestTaxCommon, AnalyticCommon):
     def test_placeholder_computation(self):
         """ Ensure that the placeholder computation is working as expected when changed in the form view.. """
         withholding_tax = self.percent_tax(
-            -1,
+            amount=-1,
             is_withholding_tax_on_payment=True,
             withholding_sequence_id=self.withholding_sequence.id,
+            invoice_repartition_line_ids=[
+                Command.create({'repartition_type': 'base', 'factor_percent': 100.0}),
+                Command.create({'repartition_type': 'tax', 'factor_percent': 100.0, 'account_id': self.tax_received_account.id}),
+            ],
+            refund_repartition_line_ids=[
+                Command.create({'repartition_type': 'base', 'factor_percent': 100.0}),
+                Command.create({'repartition_type': 'tax', 'factor_percent': 100.0, 'account_id': self.tax_received_account.id}),
+            ],
         )
         withholding_tax_2 = self.percent_tax(
             -2,
@@ -1010,7 +1186,19 @@ class TestL10nAccountWithholdingTaxesFlows(TestTaxCommon, AnalyticCommon):
 
     def test_manual_adjustments(self):
         """ Ensure that when manually adjusting the base or tax amount of a line, the manually set amount is saved. """
-        withholding_tax = self.percent_tax(-2, is_withholding_tax_on_payment=True, withholding_sequence_id=self.withholding_sequence.id)
+        withholding_tax = self.percent_tax(
+            amount=-2,
+            is_withholding_tax_on_payment=True,
+            withholding_sequence_id=self.withholding_sequence.id,
+            invoice_repartition_line_ids=[
+                Command.create({'repartition_type': 'base', 'factor_percent': 100.0}),
+                Command.create({'repartition_type': 'tax', 'factor_percent': 100.0, 'account_id': self.tax_received_account.id}),
+            ],
+            refund_repartition_line_ids=[
+                Command.create({'repartition_type': 'base', 'factor_percent': 100.0}),
+                Command.create({'repartition_type': 'tax', 'factor_percent': 100.0, 'account_id': self.tax_received_account.id}),
+            ],
+        )
 
         invoice = self.env['account.move'].create({
             'move_type': 'out_invoice',


### PR DESCRIPTION
**FIX - 1 : rectify default account on tax line**
Before this **PR**:

The Withholding Tax (WTH) base account, if set on the company, was being used as the default account. This account overrode the expected behavior and was applied not just to the base and counterpart lines, but also to the tax line, when the tax repartition line had no account defined.

After this **PR**:

If the tax repartition line has no account set, the system now uses the account from the invoice line (typically an income or expense account) instead of the WTH base account. Additionally, in cases where withholding is added directly on a payment or payment registration, a constraint has been added on the tax_id field in account_withholding_line to prevent users from selecting a tax that lacks an account on its repartition line.

**Technical background**:
Previously, when a WTH base account was available, it was used in the creation of withholding lines. These lines, created during payment processing via _prepare_withholding_amls_create_values, inherited the WTH base account on the base line. Later, _add_accounting_data_in_base_lines_tax_details used this base account for tax line creation if the tax lacked its own repartition line account, resulting in incorrect account assignment.

**Solution**:
Always use the invoice line’s account (e.g., income/expense) when creating withholding lines. This ensures that the tax lines use the appropriate account. If a WTH base account is configured, it will only be applied to the base and base counterpart lines, not the tax lines in the
_prepare_withholding_amls_create_values.

**FIX - 2 : rectify domain on tax_id**
With this commit, the domain for account_id in the account_withholding_line model correctly includes group taxes that contain at least one withholding tax.

**task**-4883286
