### PR TITLE
[IMP] website: enable test_07_image_gallery test

### DIFF
--- a/addons/website/tests/test_snippets.py
+++ b/addons/website/tests/test_snippets.py
@@ -84,8 +84,6 @@ class TestSnippets(HttpCase):
     def test_06_snippet_popup_add_remove(self):
         self.start_tour(self.env['website'].get_client_action_url('/'), 'snippet_popup_add_remove', login='admin')
 
-    # TODO master-mysterious-egg fix error
-    @unittest.skip("prepare mysterious-egg for merging")
     def test_07_image_gallery(self):
         self.start_tour(self.env['website'].get_client_action_url('/'), 'snippet_image_gallery', login='admin')
 


### PR DESCRIPTION
`test_07_image_gallery` test was disabled after the new website builder changes. This commit re-enables this test.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
