### PR TITLE
[FIX] account_edi_ubl_cii: use `deferred_start/end_date` in FacturX XML

### DIFF
--- a/addons/account_edi_ubl_cii/data/cii_22_templates.xml
+++ b/addons/account_edi_ubl_cii/data/cii_22_templates.xml
@@ -69,6 +69,16 @@
                             </ram:ApplicableTradeTax>
                         </t>
 
+                        <!-- Billing Period -->
+                        <ram:BillingSpecifiedPeriod t-if="line_vals.get('billing_start') and line_vals.get('billing_end')"> 
+                            <ram:StartDateTime>
+                                <udt:DateTimeString format="102" t-out="format_date(line_vals['billing_start'])"/>
+                            </ram:StartDateTime>
+                            <ram:EndDateTime>
+                                <udt:DateTimeString format="102" t-out="format_date(line_vals['billing_end'])"/>
+                            </ram:EndDateTime>
+                        </ram:BillingSpecifiedPeriod>
+
                         <!-- Allowance/Charge on the line -->
                         <t t-foreach="line_vals.get('allowance_charge_vals_list')" t-as="allowance_charge_vals">
                             <ram:SpecifiedTradeAllowanceCharge>

--- a/addons/account_edi_ubl_cii/tests/test_ubl_cii.py
+++ b/addons/account_edi_ubl_cii/tests/test_ubl_cii.py
@@ -8,6 +8,7 @@ from odoo import fields, Command
 from odoo.addons.account.tests.common import AccountTestInvoicingCommon
 from odoo.tests import tagged
 from odoo.tools import file_open
+from odoo.tools.safe_eval import datetime
 
 
 @tagged('post_install', '-at_install')
@@ -31,6 +32,12 @@ class TestAccountEdiUblCii(AccountTestInvoicingCommon):
             'uom_id': cls.uom_units.id,
             'standard_price': 80.0,
         })
+
+        cls.namespaces = {
+            'rsm': "urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100",
+            'ram': "urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100",
+            'udt': "urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100"
+        }
 
     def import_attachment(self, attachment, journal=None):
         journal = journal or self.company_data["default_journal_purchase"]
@@ -286,11 +293,7 @@ class TestAccountEdiUblCii(AccountTestInvoicingCommon):
             'name': 'test_invoice.xml',
         })
         xml_tree = etree.fromstring(xml_attachment.raw)
-        actual_delivery_date = xml_tree.find('.//ram:ActualDeliverySupplyChainEvent/ram:OccurrenceDateTime/udt:DateTimeString', {
-            'rsm': "urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100",
-            'ram': "urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100",
-            'udt': "urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100"
-        })
+        actual_delivery_date = xml_tree.find('.//ram:ActualDeliverySupplyChainEvent/ram:OccurrenceDateTime/udt:DateTimeString', self.namespaces)
         self.assertEqual(actual_delivery_date.text, '20241231')
 
     def test_billing_date_in_cii_xml(self):
@@ -309,18 +312,84 @@ class TestAccountEdiUblCii(AccountTestInvoicingCommon):
             'name': 'test_invoice.xml',
         })
         xml_tree = etree.fromstring(xml_attachment.raw)
-        start_date = xml_tree.find('.//ram:BillingSpecifiedPeriod/ram:StartDateTime/udt:DateTimeString', {
-            'rsm': "urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100",
-            'ram': "urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100",
-            'udt': "urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100"
-        })
-        end_date = xml_tree.find('.//ram:BillingSpecifiedPeriod/ram:EndDateTime/udt:DateTimeString', {
-            'rsm': "urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100",
-            'ram': "urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100",
-            'udt': "urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100"
-        })
+        start_date = xml_tree.find('.//ram:ApplicableHeaderTradeSettlement/ram:BillingSpecifiedPeriod/ram:StartDateTime/udt:DateTimeString', self.namespaces)
+        end_date = xml_tree.find('.//ram:ApplicableHeaderTradeSettlement/ram:BillingSpecifiedPeriod/ram:EndDateTime/udt:DateTimeString', self.namespaces)
         self.assertEqual(start_date.text, '20241201')
         self.assertEqual(end_date.text, '20241231')
+
+    def test_export_import_billing_dates(self):
+        if self.env.ref('base.module_account_accountant').state != 'installed':
+            self.skipTest("payment_custom module is not installed")
+
+        invoice = self.env['account.move'].create({
+            'partner_id': self.partner_a.id,
+            'move_type': 'out_invoice',
+            'invoice_date': "2024-12-01",
+            'invoice_date_due': "2024-12-31",
+            'invoice_line_ids': [
+                Command.create({
+                    'product_id': self.product_a.id,
+                    'deferred_start_date': "2024-11-19",
+                    'deferred_end_date': "2024-12-11",
+                }),
+                Command.create({
+                    'product_id': self.product_a.id,
+                    'deferred_end_date': "2024-12-26",
+                }),
+                Command.create({
+                    'product_id': self.product_a.id,
+                }),
+                Command.create({
+                    'product_id': self.product_a.id,
+                    'deferred_start_date': "2024-11-29",
+                    'deferred_end_date': "2024-12-15",
+                }),
+            ],
+        })
+        invoice.action_post()
+
+        xml_attachment = self.env['ir.attachment'].create({
+            'raw': self.env['account.edi.xml.cii']._export_invoice(invoice)[0],
+            'name': 'test_invoice.xml',
+        })
+        xml_tree = etree.fromstring(xml_attachment.raw)
+
+        line_start_dates = xml_tree.findall('.//ram:SpecifiedLineTradeSettlement/ram:BillingSpecifiedPeriod/ram:StartDateTime/udt:DateTimeString', self.namespaces)
+        self.assertEqual([date.text for date in line_start_dates], ['20241119', '20241201', '20241129'])
+
+        line_end_dates = xml_tree.findall('.//ram:SpecifiedLineTradeSettlement/ram:BillingSpecifiedPeriod/ram:EndDateTime/udt:DateTimeString', self.namespaces)
+        self.assertEqual([value.text for value in line_end_dates], ['20241211', '20241226', '20241215'])
+
+        global_start_date = xml_tree.find('.//ram:ApplicableHeaderTradeSettlement/ram:BillingSpecifiedPeriod/ram:StartDateTime/udt:DateTimeString', self.namespaces)
+        self.assertEqual(global_start_date.text, '20241119')
+
+        global_end_date = xml_tree.find('.//ram:ApplicableHeaderTradeSettlement/ram:BillingSpecifiedPeriod/ram:EndDateTime/udt:DateTimeString', self.namespaces)
+        self.assertEqual(global_end_date.text, '20241226')
+
+        line_vals = [
+            {
+                'product_id': self.product_a.id,
+                'deferred_start_date': datetime.date(2024, 11, 19),
+                'deferred_end_date': datetime.date(2024, 12, 11),
+            },
+            {
+                'product_id': self.product_a.id,
+                'deferred_start_date': datetime.date(2024, 12, 1),
+                'deferred_end_date': datetime.date(2024, 12, 26),
+            },
+            {
+                'product_id': self.product_a.id,
+                'deferred_start_date': False,
+                'deferred_end_date': False,
+            },
+            {
+                'product_id': self.product_a.id,
+                'deferred_start_date': datetime.date(2024, 11, 29),
+                'deferred_end_date': datetime.date(2024, 12, 15),
+            },
+        ]
+        new_invoice = invoice.journal_id._create_document_from_attachment(xml_attachment.ids)
+        self.assertRecordValues(new_invoice.invoice_line_ids, line_vals)
 
     def test_import_partner_fields(self):
         """ We are going to import the e-invoice and check partner is correctly imported."""


### PR DESCRIPTION
### Issue:
The FacturX XML has a field `BillingSpecifiedPeriod`, it should depend on `deferred_start/end_date` if they are there. Currently, it only outputs the invoice date as start date and the due date as end date.

### Steps to reproduce:
- Install "l10n_de" and switch to a German company
- Go to a contact, in the page Accounting > Electronic Invoicing change the format to "Factur-X (CII)"
- Create an invoice for this contact
- Add a start date and end date on the line of this invoice (`deferred_start/end_date`)
- Confirm and send to Factur-X
- In the generated XML the dates used are the invoice date and the due date

### Cause:
As the `deferred_start/end_date` fields are defined in enterprise and the XML generation is in community, this [commit](https://github.com/odoo/odoo/commit/f0c5d5b46444a289bf55ad5846623d48ac3a3b71) set dates defined in community instead of the deferred ones.

### Solution:
Mimicking [the way it's done for UBL20](https://github.com/odoo/odoo/blob/638268a81ed5a292a02d7fc353c4954159de54e1/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_20.py#L846) we check if  `deferred_start/end_date` are defined (i.e. account_accountant is installed). If it's the case, we use the min/max of the `deferred_start/end_date` as start/end date of the `BillingSpecifiedPeriod` in the XML.

To include as much info as we can this commit also adds the `deferred_start_date` and `deferred_end_date` on lines.

opw-4874370