### PR TITLE
[IMP] hr: add a smaller max width for employee image

### DIFF
--- a/addons/hr/views/hr_employee_public_views.xml
+++ b/addons/hr/views/hr_employee_public_views.xml
@@ -43,7 +43,7 @@
                         <div class="row align-items-center">
                             <div class="o_employee_avatar ms-2 p-0 h-100 mw-25">
                                 <field name="hr_icon_display" invisible="not show_hr_icon_display or not id" widget="hr_presence_status"/>
-                                <field name="image_1920" widget='image' class="m-0" options='{"zoom": true, "preview_image":"avatar_128"}'/>
+                                <field name="image_1920" widget='image' class="m-0" options='{"size": [128,158], "zoom": true, "preview_image":"avatar_128"}'/>
                                 <field name="show_hr_icon_display" invisible="1" />
                             </div>
                             <div class="col">

--- a/addons/hr/views/hr_employee_views.xml
+++ b/addons/hr/views/hr_employee_views.xml
@@ -111,7 +111,7 @@
                         <div class="row align-items-center">
                             <div class="o_employee_avatar ms-2 p-0 h-100 mw-25">
                                 <field name="hr_icon_display" invisible="not show_hr_icon_display or not id" widget="hr_presence_status"/>
-                                <field name="image_1920" widget='image' class="m-0" options='{"zoom": true, "preview_image":"avatar_128"}'/>
+                                <field name="image_1920" widget='image' class="m-0" options='{"size": [128,158], "zoom": true, "preview_image":"avatar_128"}'/>
                                 <field name="show_hr_icon_display" invisible="1" />
                             </div>
                             <div class="col">


### PR DESCRIPTION
Problem: the employee image avatar placeholder when creating a new employee is larger than the default image when saving the record. This commit adds a max width for the employee avatar image so that the default image is the same size as the placeholder before saving the record.

task-4879346

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
