### PR TITLE
[IMP] html_builder, *: allow user to select next article manually

### DIFF
--- a/addons/html_builder/static/src/core/building_blocks/builder_many2one.js
+++ b/addons/html_builder/static/src/core/building_blocks/builder_many2one.js
@@ -7,6 +7,8 @@ import {
     useDependencyDefinition,
     useDomState,
     useHasPreview,
+    useOperationWithReload,
+    useReloadAction,
 } from "../utils";
 import { BuilderComponent } from "./builder_component";
 import { SelectMany2X } from "./select_many2x";
@@ -22,6 +24,7 @@ export class BuilderMany2One extends Component {
         limit: { type: Number, optional: true },
         id: { type: String, optional: true },
         allowUnselect: { type: Boolean, optional: true },
+        unselectBtnTitle: { type: String, optional: true },
         defaultMessage: { type: String, optional: true },
         createAction: { type: String, optional: true },
         nullText: { type: String, optional: true },
@@ -29,6 +32,7 @@ export class BuilderMany2One extends Component {
     static defaultProps = {
         ...BuilderComponent.defaultProps,
         allowUnselect: true,
+        unselectBtnTitle: "Unselect",
     };
     static components = { BuilderComponent, SelectMany2X };
 
@@ -41,6 +45,10 @@ export class BuilderMany2One extends Component {
         this.applyOperation = this.env.editor.shared.history.makePreviewableAsyncOperation(
             this.callApply.bind(this)
         );
+        // Detect if any action requires a reload.
+        const { reload } = useReloadAction(getAllActions);
+        this.reload = reload;
+        this.operationWithReload = useOperationWithReload(this.callApply.bind(this), reload);
         const getAction = this.env.editor.shared.builderActions.getAction;
         const actionWithGetValue = getAllActions().find(
             ({ actionId }) => getAction(actionId).getValue
@@ -113,9 +121,12 @@ export class BuilderMany2One extends Component {
         return Promise.all(proms);
     }
     select(newSelected) {
-        this.callOperation(this.applyOperation.commit, {
-            userInputValue: newSelected && JSON.stringify(newSelected),
-        });
+        const args = { userInputValue: newSelected && JSON.stringify(newSelected) };
+        if (this.reload) {
+            this.callOperation(this.operationWithReload, args);
+        } else {
+            this.callOperation(this.applyOperation.commit, args);
+        }
     }
     preview(newSelected) {
         this.callOperation(this.applyOperation.preview, {

--- a/addons/html_builder/static/src/core/building_blocks/builder_many2one.xml
+++ b/addons/html_builder/static/src/core/building_blocks/builder_many2one.xml
@@ -20,6 +20,7 @@
         <button type="button"
                 t-if="domState.selected and props.allowUnselect"
                 class="o-hb-btn o-hb-btn-has-icon btn btn-secondary"
+                t-att-title="props.unselectBtnTitle"
                 t-on-click="() => this.select()"
                 t-on-pointerenter="hasPreview ? () => this.preview() : () => {}"
                 t-on-pointerleave="revert"

--- a/addons/html_builder/static/src/core/utils.js
+++ b/addons/html_builder/static/src/core/utils.js
@@ -414,7 +414,7 @@ function usePrepareAction(getAllActions) {
     return onReady;
 }
 
-function useReloadAction(getAllActions) {
+export function useReloadAction(getAllActions) {
     const env = useEnv();
     const getAction = env.editor.shared.builderActions.getAction;
     let reload = false;
@@ -651,7 +651,7 @@ export function useClickableBuilderComponent() {
         onReady,
     };
 }
-function useOperationWithReload(callApply, reload) {
+export function useOperationWithReload(callApply, reload) {
     const env = useEnv();
     return async (...args) => {
         const { editingElement } = args[0][0];

--- a/addons/website_blog/controllers/main.py
+++ b/addons/website_blog/controllers/main.py
@@ -311,12 +311,20 @@ class WebsiteBlog(http.Controller):
         if blog_post not in all_post:
             return request.redirect("/blog/%s" % (request.env['ir.http']._slug(blog_post.blog_id)))
 
-        # should always return at least the current post
-        all_post_ids = all_post.ids
-        current_blog_post_index = all_post_ids.index(blog_post.id)
-        nb_posts = len(all_post_ids)
-        next_post_id = all_post_ids[(current_blog_post_index + 1) % nb_posts] if nb_posts > 1 else None
-        next_post = next_post_id and BlogPost.browse(next_post_id) or False
+        next_post = blog_post.recommended_next_post_id
+        is_next_post_recommended = True
+        if (
+            not next_post
+            or not next_post.sudo().is_published
+            or next_post.website_id.id not in (False, request.website.id)
+        ):
+            # Fallback to the next post in the list.
+            all_post_ids = all_post.ids
+            current_blog_post_index = all_post_ids.index(blog_post.id)
+            nb_posts = len(all_post_ids)
+            next_post_id = all_post_ids[(current_blog_post_index + 1) % nb_posts] if nb_posts > 1 else None
+            next_post = next_post_id and BlogPost.browse(next_post_id) or False
+            is_next_post_recommended = False
 
         values = {
             'tags': tags,
@@ -328,6 +336,7 @@ class WebsiteBlog(http.Controller):
             'nav_list': self.nav_list(blog),
             'enable_editor': enable_editor,
             'next_post': next_post,
+            'is_next_post_recommended': is_next_post_recommended,
             'date': date_begin,
             'blog_url': blog_url,
         }

--- a/addons/website_blog/models/website_blog.py
+++ b/addons/website_blog/models/website_blog.py
@@ -192,6 +192,8 @@ class BlogPost(models.Model):
     author_name = fields.Char(related='author_id.display_name', string="Author Name", readonly=False, store=True)
     active = fields.Boolean('Active', default=True)
     blog_id = fields.Many2one('blog.blog', 'Blog', required=True, index=True, ondelete='cascade', default=lambda self: self.env['blog.blog'].search([], limit=1))
+    recommended_next_post_id = fields.Many2one('blog.post', string="Recommended Next Post",
+        help="Next blog post that will be shown as the next article to users at the bottom of the blog post.")
     tag_ids = fields.Many2many('blog.tag', string='Tags')
     content = fields.Html('Content', default=_default_content, translate=html_translate, sanitize=False)
     teaser = fields.Text('Teaser', compute='_compute_teaser', inverse='_set_teaser', translate=True)

--- a/addons/website_blog/static/src/website_builder/blog_page_option.xml
+++ b/addons/website_blog/static/src/website_builder/blog_page_option.xml
@@ -44,10 +44,28 @@
             <BuilderCheckbox actionParam="{views: ['website_blog.opt_blog_post_breadcrumb']}"/>
         </BuilderRow>
 
+        <BuilderRow label.translate="Comments" tooltip.translate="Toggle comments">
+            <BuilderCheckbox actionParam="{views: ['website_blog.opt_blog_post_comment']}"/>
+        </BuilderRow>
+
         <BuilderRow label.translate="Bottom">
-            <BuilderButton label.translate="Next Article" actionParam="{views: ['website_blog.opt_blog_post_read_next']}"/>
-            <BuilderButton label.translate="Comments" actionParam="{views: ['website_blog.opt_blog_post_comment']}"/>
+            <BuilderCheckbox actionParam="{views: ['website_blog.opt_blog_post_read_next']}" id="'next_article_opt'"/>
         </BuilderRow>
     </BuilderContext>
+
+    <BuilderRow label.translate="Recommended Post" tooltip.translate="Promote a post" level="1" t-if="isActiveItem('next_article_opt')">
+        <BuilderMany2One
+            action="'setRecommendedNextPost'"
+            applyTo="'#o_wblog_post_footer'"
+            model="'blog.post'"
+            domain="[
+                ['is_published', '=', true],
+                ['id', '!=', this.services.website.currentWebsite.metadata.mainObject.id],
+                ['website_id', 'in', [false, this.services.website.currentWebsite.id]],
+            ]"
+            allowUnselect="state.isNextPostRecommended"
+            unselectBtnTitle.translate="Reset to default post"
+        />
+    </BuilderRow>
 </t>
 </templates>

--- a/addons/website_blog/static/src/website_builder/blog_page_option_plugin.js
+++ b/addons/website_blog/static/src/website_builder/blog_page_option_plugin.js
@@ -1,4 +1,5 @@
-import { BaseOptionComponent } from "@html_builder/core/utils";
+import { BuilderAction } from "@html_builder/core/builder_action";
+import { BaseOptionComponent, useDomState } from "@html_builder/core/utils";
 import { Plugin } from "@html_editor/plugin";
 import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
@@ -9,6 +10,15 @@ export class BlogPageOption extends BaseOptionComponent {
     static title = _t("Blog Page");
     static groups = ["website.group_website_designer"];
     static editableOnly = false;
+
+    setup() {
+        super.setup();
+        this.state = useDomState((editingElement) => ({
+            isNextPostRecommended: !!editingElement.querySelector(
+                "[data-is-next-post-recommended]"
+            ),
+        }));
+    }
 }
 
 export class BlogPageOptionPlugin extends Plugin {
@@ -17,7 +27,46 @@ export class BlogPageOptionPlugin extends Plugin {
     resources = {
         builder_options: [BlogPageOption],
         content_not_editable_selectors: [".o_list_cover"],
+        builder_actions: {
+            SetRecommendedNextPostAction,
+        },
     };
+}
+
+export class SetRecommendedNextPostAction extends BuilderAction {
+    static id = "setRecommendedNextPost";
+    static dependencies = ["savePlugin"];
+
+    setup() {
+        this.reload = {};
+    }
+
+    /**
+     * Updates the recommended next post and reloads the editor.
+     *
+     * @param {number|false} id - ID of the recommended post, or false to unset
+     */
+    async updateRecommendedNextPost(id) {
+        const { website, orm } = this.services;
+        const { mainObject } = website.currentWebsite.metadata;
+
+        await orm.write(mainObject.model, [mainObject.id], {
+            recommended_next_post_id: id,
+        });
+    }
+
+    getValue({ editingElement }) {
+        return JSON.stringify({ id: parseInt(editingElement.dataset.nextPostId) || 0 });
+    }
+
+    async apply({ value }) {
+        const { id } = JSON.parse(value);
+        await this.updateRecommendedNextPost(id);
+    }
+
+    async clean() {
+        await this.updateRecommendedNextPost(false);
+    }
 }
 
 registry.category("website-plugins").add(BlogPageOptionPlugin.id, BlogPageOptionPlugin);

--- a/addons/website_blog/static/tests/website_builder/many2one_option.test.js
+++ b/addons/website_blog/static/tests/website_builder/many2one_option.test.js
@@ -1,11 +1,72 @@
+import { Builder } from "@html_builder/builder";
+import { startServer } from "@mail/../tests/mail_test_helpers";
 import { expect, test } from "@odoo/hoot";
-import { contains, onRpc } from "@web/../tests/web_test_helpers";
+import {
+    contains,
+    defineModels,
+    fields,
+    mockService,
+    models,
+    onRpc,
+    patchWithCleanup,
+} from "@web/../tests/web_test_helpers";
 import {
     defineWebsiteModels,
     setupWebsiteBuilder,
 } from "@website/../tests/builder/website_helpers";
 
+class BlogBlog extends models.Model {
+    _name = "blog.blog";
+    name = fields.Char();
+    website_id = fields.Many2one({ relation: "website" });
+}
+class BlogPost extends models.Model {
+    _name = "blog.post";
+    name = fields.Char();
+    blog_id = fields.Many2one({ relation: "blog.blog" });
+    recommended_next_post_id = fields.Many2one({ relation: "blog.post" });
+    website_id = fields.Many2one({
+        relation: "website",
+        related: "blog_id.website_id",
+    });
+    is_published = fields.Boolean();
+}
 defineWebsiteModels();
+
+/**
+ * Generates HTML markup for a blog post with recommended next article section.
+ *
+ * @param {number} postId - ID of the blog post to render
+ * @param {Object} pyEnv - Python environment containing blog post data
+ * @returns {string} HTML markup for the blog post
+ */
+function getBlogPostMarkup(postId, pyEnv) {
+    const post = pyEnv["blog.post"].read(postId)[0];
+    const nextPostId = post.recommended_next_post_id;
+    const nextPost = nextPostId ? pyEnv["blog.post"].read(nextPostId)[0] : null;
+
+    return `
+        <main>
+            <section id="o_wblog_post_main">
+                <div id="wrap" class="js_blog website_blog">
+                    <div class="o_record_cover_container" data-res-model="blog.post" data-res-id="${
+                        post.id
+                    }">
+                        <h1>${post.name}</h1>
+                        ${
+                            nextPost
+                                ? `
+                                <section id="o_wblog_post_footer" data-next-post-id="${nextPost.id}" data-is-next-post-recommended="True">
+                                    ${nextPost.name}
+                                </section>`
+                                : ""
+                        }
+                    </div>
+                </div>
+            </section>
+        </main>
+    `;
+}
 
 test("Change contact oe-many2one-id of a blog author changes other instance of same contact and avatar", async () => {
     onRpc(
@@ -41,4 +102,53 @@ test("Change contact oe-many2one-id of a blog author changes other instance of s
     expect(":iframe span.span-3 > span").toHaveText("The Address of 3"); // author of other post is not changed
     expect(":iframe span.span-4").toHaveText("Hermit");
     expect(":iframe div > img").toHaveAttribute("src", "/web/image/res.partner/1/avatar_1024");
+});
+
+test("Editing the recommended next post option updates recommended_next_post_id", async () => {
+    defineModels([BlogBlog, BlogPost]);
+    onRpc("/website/theme_customize_data_get", () => ["website_blog.opt_blog_post_read_next"]);
+    onRpc("blog.post", "write", ({ args }) => {
+        expect.step(`write ${args[1].recommended_next_post_id}`);
+    });
+    patchWithCleanup(Builder.prototype, {
+        setup() {
+            super.setup();
+            this.editor.config.reloadEditor = () => {
+                expect.step("reload");
+            };
+        },
+    });
+
+    const pyEnv = await startServer();
+    const websiteId = pyEnv["website"].create({});
+    const blogId = pyEnv["blog.blog"].create({ name: "Blog Test", website_id: websiteId });
+    const blogData = { blog_id: blogId, is_published: true };
+    const [post1, post2, post3] = pyEnv["blog.post"].create([
+        { name: "Post 1", ...blogData },
+        { name: "Post 2", ...blogData },
+        { name: "Post 3", ...blogData },
+    ]);
+    pyEnv["blog.post"].write(post3, { recommended_next_post_id: post1 });
+
+    mockService("website", {
+        get currentWebsite() {
+            return {
+                id: websiteId,
+                default_lang_id: { code: "en_US" },
+                metadata: {
+                    mainObject: { id: post3, model: "blog.post" },
+                },
+            };
+        },
+    });
+
+    await setupWebsiteBuilder(getBlogPostMarkup(post3, pyEnv), { hasToCreateWebsite: false });
+
+    await contains("[data-name='customize']").click();
+    await contains("[data-label='Recommended Post'] .o_select_menu_toggler").click();
+    await contains(".o-dropdown-item:contains('Post 2')").click();
+    expect.verifySteps([`write ${post2}`, "reload"]);
+
+    await contains(".o-hb-btn[aria-label='Unselect']").click();
+    expect.verifySteps([`write ${false}`, "reload"]);
 });

--- a/addons/website_blog/tests/test_ui.py
+++ b/addons/website_blog/tests/test_ui.py
@@ -3,6 +3,8 @@
 
 import odoo.tests
 import re
+from odoo.addons.http_routing.tests.common import MockRequest
+from odoo.addons.website_blog.controllers.main import WebsiteBlog
 from odoo.addons.website_blog.tests.common import TestWebsiteBlogCommon
 from datetime import datetime
 
@@ -161,3 +163,37 @@ class TestWebsiteBlogUi(odoo.tests.HttpCase, TestWebsiteBlogCommon):
         homepage_view_arch_misconfigured = re.sub(r'data-filter-id="\d+"', 'data-filter-id="-1"', homepage_view.arch_db)
         homepage_view.write({'arch': homepage_view_arch_misconfigured})
         self.start_tour(self.env['website'].get_client_action_url('/'), 'blog_posts_dynamic_snippet_misconfigured', login='admin')
+
+    def test_next_article(self):
+        blog1, blog2 = self.env['blog.blog'].create([
+            {'name': "Blog Test"},
+            {'name': "Blog Test 2", 'website_id': self.env['website'].create({'name': 'Website Test 2'}).id},
+        ])
+        post1, post2, post3, post4, post5, post6 = self.env['blog.post'].create([
+            {'name': "Post Test 1", 'blog_id': blog1.id, 'is_published': True},
+            {'name': "Post Test 2", 'blog_id': blog1.id, 'is_published': True},
+            {'name': "Post Test 3", 'blog_id': blog1.id, 'is_published': False},
+            {'name': "Post Test 4", 'blog_id': blog1.id, 'is_published': True},
+            {'name': "Post Test 5", 'blog_id': blog1.id, 'is_published': True},
+            {'name': "Post Test 6", 'blog_id': blog2.id, 'is_published': True},
+        ])
+        post2.recommended_next_post_id = post4
+        post4.recommended_next_post_id = post3
+        post5.recommended_next_post_id = post6
+
+        website = self.env.ref('website.default_website')
+        controller = WebsiteBlog()
+
+        cases = [(self.env, post1, post5, "Next post should be Post5 according to chronological order"),
+            (self.env, post2, post4, "Next post should be Post4 as it is set manually"),
+            (self.env(user=self.env.ref('base.public_user')), post4, post2, "Fallback to next published post when recommended post is not published"),
+            (self.env, post5, post4, "Next post should be Post4 as Post6 is not in the same blog")]
+
+        for env, current_post, expected_post, message in cases:
+            with MockRequest(env, website=website) as mock_request:
+                def fake_render(_, values):
+                    self.assertEqual(values['next_post'], expected_post, message)
+
+                mock_request.session.touch = lambda: None
+                mock_request.render = fake_render
+                controller.blog_post(blog1, current_post)

--- a/addons/website_blog/views/website_blog_templates.xml
+++ b/addons/website_blog/views/website_blog_templates.xml
@@ -326,6 +326,10 @@ list of filtered posts (by date or tag).
     Show 'read next' banner at the bottom of the page
 -->
 <template id="opt_blog_post_read_next" name="Read Next Article" inherit_id="website_blog.blog_post_complete" active="True">
+    <xpath expr="//section[@id='o_wblog_post_footer']" position="attributes">
+        <attribute name="t-att-data-next-post-id">next_post and next_post.id</attribute>
+        <attribute name="t-att-data-is-next-post-recommended">is_next_post_recommended</attribute>
+    </xpath>
     <xpath expr="//section[@id='o_wblog_post_footer']" position="inside">
         <div t-if="next_post" class="mt-5">
             <t t-if="opt_blog_post_regular_cover">


### PR DESCRIPTION
`*`: website_blog

Before this commit, the blog post bottom section could only show the
next article based on the post order.

With this commit, website editors can manually select which post is to
be recommended at the bottom of blog articles.

Enabling the "Bottom" option displays a `Many2one` dropdown where users
can choose from published blog posts belonging to blogs allowed to be
visible in the current website.

And a separate section was added to toggle the comments using a
`BuilderCheckbox` labeled "Comments".


task-[3916105](https://www.odoo.com/odoo/project/974/tasks/3916105)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr