### PR TITLE
[FIX] mail, *: remove _to_store_(defaults) of partner,channel,member

### DIFF
--- a/addons/crm_livechat/models/crm_lead.py
+++ b/addons/crm_livechat/models/crm_lead.py
@@ -37,5 +37,7 @@ class CrmLead(models.Model):
 
     def action_open_livechat(self):
         self.env.user._bus_send_store(
-            self.origin_channel_id, extra_fields={"open_chat_window": True}
+            self.origin_channel_id,
+            self.origin_channel_id._to_store_defaults(for_current_user=True)
+            + [{"open_chat_window": True}],
         )

--- a/addons/hr_holidays/models/res_partner.py
+++ b/addons/hr_holidays/models/res_partner.py
@@ -34,8 +34,8 @@ class ResPartner(models.Model):
     def _get_on_leave_ids(self):
         return self.env['res.users']._get_on_leave_ids(partner=True)
 
-    def _to_store_defaults(self):
-        return super()._to_store_defaults() + [
+    def _get_store_default_fields(self, *, for_current_user):
+        return super()._get_store_default_fields(for_current_user=for_current_user) + [
             Store.One(
                 "main_user_id",
                 [Store.Attr("leave_date_to", lambda u: u.leave_date_to if u.active else False)],

--- a/addons/im_livechat/controllers/main.py
+++ b/addons/im_livechat/controllers/main.py
@@ -166,13 +166,14 @@ class LivechatController(http.Controller):
         # Make sure not to send "isLoaded" value on the guest bus, otherwise it
         # could be overwritten.
         if channel:
-             store.add(
-                 channel,
-                 extra_fields={
-                     "isLoaded": not chatbot_script,
-                     "scrollUnread": False,
-                 },
-             )
+            store.add(
+                channel,
+                channel._to_store_defaults(for_current_user=True)
+                + [
+                    Store.Attr("isLoaded", not chatbot_script),
+                    Store.Attr("scrollUnread", False),
+                ],
+            )
         return {
             "store_data": store.get_result(),
             "channel_id": channel_id,

--- a/addons/im_livechat/models/discuss_channel.py
+++ b/addons/im_livechat/models/discuss_channel.py
@@ -312,7 +312,7 @@ class DiscussChannel(models.Model):
         """Return the standard fields to include in Store for livechat_operator_id."""
         return ["avatar_128", *self.env["res.partner"]._get_store_livechat_username_fields()]
 
-    def _to_store_defaults(self, for_current_user=True):
+    def _get_store_default_fields(self, *, for_current_user):
         fields = [
             "anonymous_name",
             "chatbot_current_step",
@@ -331,7 +331,7 @@ class DiscussChannel(models.Model):
                 Store.Attr("livechat_note", predicate=lambda c: c.channel_type == "livechat"),
                 Store.Attr("livechat_status", predicate=lambda c: c.channel_type == "livechat"),
             ])
-        return super()._to_store_defaults(for_current_user=for_current_user) + fields
+        return super()._get_store_default_fields(for_current_user=for_current_user) + fields
 
     def _to_store(self, store: Store, fields):
         """Extends the channel header by adding the livechat operator and the 'anonymous' profile"""

--- a/addons/im_livechat/tests/test_chatbot_internals.py
+++ b/addons/im_livechat/tests/test_chatbot_internals.py
@@ -210,9 +210,10 @@ class ChatbotCase(MailCommon, chatbot_common.ChatbotCase):
             channel_data_join = json.loads(
                 json_dump(
                     Store(
-                        discuss_channel, discuss_channel._to_store_defaults(for_current_user=False)
-                    ).get_result()
-                )
+                        discuss_channel,
+                        discuss_channel._get_store_default_fields(for_current_user=False),
+                    ).get_result(),
+                ),
             )
             channel_data_join["discuss.channel"][0]["chatbot"]["currentStep"]["message"] = messages[1].id
             channel_data_join["discuss.channel"][0]["chatbot"]["steps"][0]["message"] = messages[1].id

--- a/addons/mail/controllers/attachment.py
+++ b/addons/mail/controllers/attachment.py
@@ -74,7 +74,8 @@ class AttachmentController(ThreadController):
             # sudo: ir.attachment - posting a new attachment on an accessible thread
             attachment = request.env["ir.attachment"].sudo().create(vals)
             attachment._post_add_create(**kwargs)
-            res = {"data": Store(attachment, extra_fields="access_token").get_result()}
+            store = Store(attachment, attachment._to_store_defaults() + ["access_token"])
+            res = {"data": store.get_result()}
         except AccessError:
             res = {"error": _("You are not allowed to upload an attachment here.")}
         return request.make_json_response(res)

--- a/addons/mail/controllers/discuss/channel.py
+++ b/addons/mail/controllers/discuss/channel.py
@@ -23,7 +23,7 @@ class DiscussChannelWebclientController(WebclientController):
         super()._process_request_loop(store, fetch_params)
         channels = request.env.context["channels"]
         if channels:
-            store.add(channels)
+            store.add(channels, channels._get_store_default_fields(for_current_user=True))
         if request.env.context["add_channels_last_message"]:
             # fetch channels data before messages to benefit from prefetching (channel info might
             # prefetch a lot of data that message format could use)

--- a/addons/mail/controllers/discuss/rtc.py
+++ b/addons/mail/controllers/discuss/rtc.py
@@ -140,7 +140,16 @@ class RtcController(http.Controller):
             channel_member_sudo.channel_id.rtc_session_ids.filtered_domain(domain).write({})  # update write_date
         current_rtc_sessions, outdated_rtc_sessions = channel_member_sudo._rtc_sync_sessions(check_rtc_session_ids)
         return (
-            Store(member.channel_id, {"rtc_session_ids": Store.Many(current_rtc_sessions, mode="ADD")})
+            Store(
+                member.channel_id,
+                {
+                    "rtc_session_ids": Store.Many(
+                        current_rtc_sessions,
+                        current_rtc_sessions._get_store_default_fields(for_current_user=True),
+                        mode="ADD",
+                    ),
+                },
+            )
             .add(
                 member.channel_id,
                 {"rtc_session_ids": Store.Many(outdated_rtc_sessions, [], mode="DELETE")},

--- a/addons/mail/models/discuss/discuss_channel.py
+++ b/addons/mail/models/discuss/discuss_channel.py
@@ -5,6 +5,7 @@ from collections import defaultdict
 from hashlib import sha512
 from secrets import choice
 from markupsafe import Markup
+import logging
 from datetime import timedelta
 
 from odoo import _, api, fields, models, tools, Command
@@ -25,6 +26,8 @@ group_avatar = '''<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 530.06 53
 <circle cx="265.03" cy="265.03" r="265.03" fill="#875a7b"/>
 <path d="m184.356059,265.030004c-23.740561,0.73266 -43.157922,10.11172 -58.252302,28.136961l-29.455881,0c-12.0169,0 -22.128621,-2.96757 -30.335161,-8.90271s-12.309921,-14.618031 -12.309921,-26.048671c0,-51.730902 9.08582,-77.596463 27.257681,-77.596463c0.87928,0 4.06667,1.53874 9.56217,4.61622s12.639651,6.19167 21.432451,9.34235s17.512401,4.72613 26.158581,4.72613c9.8187,0 19.563981,-1.68536 29.236061,-5.05586c-0.73266,5.4223 -1.0991,10.25834 -1.0991,14.508121c0,20.370061 5.93514,39.127962 17.805421,56.273922zm235.42723,140.025346c0,17.585601 -5.34888,31.470971 -16.046861,41.655892s-24.912861,15.277491 -42.645082,15.277491l-192.122688,0c-17.732221,0 -31.947101,-5.09257 -42.645082,-15.277491s-16.046861,-24.070291 -16.046861,-41.655892c0,-7.7669 0.25653,-15.350691 0.76937,-22.751371s1.53874,-15.387401 3.07748,-23.960381s3.48041,-16.523211 5.82523,-23.850471s5.4955,-14.471411 9.45226,-21.432451s8.49978,-12.89618 13.628841,-17.805421c5.12906,-4.90924 11.393931,-8.82951 18.794611,-11.76037s15.570511,-4.3964 24.509931,-4.3964c1.46554,0 4.61622,1.57545 9.45226,4.72613s10.18492,6.6678 16.046861,10.55136c5.86194,3.88356 13.702041,7.40068 23.520741,10.55136s19.710601,4.72613 29.675701,4.72613s19.857001,-1.57545 29.675701,-4.72613s17.658801,-6.6678 23.520741,-10.55136c5.86194,-3.88356 11.21082,-7.40068 16.046861,-10.55136s7.98672,-4.72613 9.45226,-4.72613c8.93942,0 17.109251,1.46554 24.509931,4.3964s13.665551,6.85113 18.794611,11.76037c5.12906,4.90924 9.67208,10.844381 13.628841,17.805421s7.10744,14.105191 9.45226,21.432451s4.28649,15.277491 5.82523,23.850471s2.56464,16.559701 3.07748,23.960381s0.76937,14.984471 0.76937,22.751371zm-225.095689,-280.710152c0,15.534021 -5.4955,28.796421 -16.486501,39.787422s-24.253401,16.486501 -39.787422,16.486501s-28.796421,-5.4955 -39.787422,-16.486501s-16.486501,-24.253401 -16.486501,-39.787422s5.4955,-28.796421 16.486501,-39.787422s24.253401,-16.486501 39.787422,-16.486501s28.796421,5.4955 39.787422,16.486501s16.486501,24.253401 16.486501,39.787422zm154.753287,84.410884c0,23.300921 -8.24325,43.194632 -24.729751,59.681133s-36.380212,24.729751 -59.681133,24.729751s-43.194632,-8.24325 -59.681133,-24.729751s-24.729751,-36.380212 -24.729751,-59.681133s8.24325,-43.194632 24.729751,-59.681133s36.380212,-24.729751 59.681133,-24.729751s43.194632,8.24325 59.681133,24.729751s24.729751,36.380212 24.729751,59.681133zm126.616325,49.459502c0,11.43064 -4.10338,20.113531 -12.309921,26.048671s-18.318261,8.90271 -30.335161,8.90271l-29.455881,0c-15.094381,-18.025241 -34.511741,-27.404301 -58.252302,-28.136961c11.87028,-17.145961 17.805421,-35.903862 17.805421,-56.273922c0,-4.24978 -0.36644,-9.08582 -1.0991,-14.508121c9.67208,3.3705 19.417361,5.05586 29.236061,5.05586c8.64618,0 17.365781,-1.57545 26.158581,-4.72613s15.936951,-6.26487 21.432451,-9.34235s8.68289,-4.61622 9.56217,-4.61622c18.171861,0 27.257681,25.865561 27.257681,77.596463zm-28.136961,-133.870386c0,15.534021 -5.4955,28.796421 -16.486501,39.787422s-24.253401,16.486501 -39.787422,16.486501s-28.796421,-5.4955 -39.787422,-16.486501s-16.486501,-24.253401 -16.486501,-39.787422s5.4955,-28.796421 16.486501,-39.787422s24.253401,-16.486501 39.787422,-16.486501s28.796421,5.4955 39.787422,16.486501s16.486501,24.253401 16.486501,39.787422z" fill="#ffffff"/>
 </svg>'''
+
+_logger = logging.getLogger(__name__)
 
 
 class DiscussChannel(models.Model):
@@ -452,9 +455,11 @@ class DiscussChannel(models.Model):
             self.env['discuss.channel.member'].sudo().create(to_create)
         for channel in self:
             channel.group_ids._bus_send_store(
-                Store(channel, channel._to_store_defaults(for_current_user=False)).add(
-                    channel, {"is_pinned": True}
-                )
+                Store(
+                    channel,
+                    channel._get_store_default_fields(for_current_user=False)
+                    + [{"is_pinned": True}],
+                ),
             )
 
     def _subscribe_users_automatically_get_members(self):
@@ -554,7 +559,7 @@ class DiscussChannel(models.Model):
                     "channel_id": member.channel_id.id,
                     "data": Store(
                         member.channel_id,
-                        member.channel_id._to_store_defaults(for_current_user=False),
+                        member.channel_id._get_store_default_fields(for_current_user=False),
                     )
                     .add(member.channel_id, {"is_pinned": True})
                     .get_result(),
@@ -622,7 +627,10 @@ class DiscussChannel(models.Model):
                         members,
                         [
                             Store.One("channel_id", [], as_thread=True),
-                            *self.env["discuss.channel.member"]._to_store_persona("avatar_card"),
+                            *self.env["discuss.channel.member"]._to_store_persona(
+                                "avatar_card",
+                                for_current_user=False,
+                            ),
                         ],
                         mode="DELETE",
                     ),
@@ -1006,7 +1014,7 @@ class DiscussChannel(models.Model):
         channels += self.env["discuss.channel"].search(pinned_member_domain)
         return channels
 
-    def _to_store_defaults(self, for_current_user=True):
+    def _get_store_default_fields(self, *, for_current_user):
         # As the method uses partial recordsets with filtered (that lose the prefetch ids) it is
         # best to prefetch these computed fields once to avoid doing partial queries multiple times,
         # especially because these 2 fields are used in ACL too.
@@ -1028,7 +1036,8 @@ class DiscussChannel(models.Model):
         # prefetch all fields for members with unknown channel_id. The following line force a
         # single fetch for all fields of all members.
         all_members.mapped("create_date")  # any field in table will do except channel_id
-        Store(all_members)  # prefetch in batch, including nested relations (member, guest, ...)
+        # prefetch in batch, including nested relations (member, guest, ...)
+        Store(all_members, all_members._get_store_default_fields(for_current_user=for_current_user))
         # sudo: bus.bus: reading non-sensitive last id
         bus_last_id = self.env["bus.bus"].sudo()._bus_last_id()
 
@@ -1045,6 +1054,7 @@ class DiscussChannel(models.Model):
             "create_uid",
             Store.Many(
                 "channel_member_ids",
+                all_members._get_store_default_fields(for_current_user=for_current_user),
                 only_data=True,
                 sort="id",
                 predicate=lambda channel: channel in channels_with_all_members,
@@ -1058,15 +1068,33 @@ class DiscussChannel(models.Model):
                 "invited_member_ids",
                 [
                     Store.One("channel_id", [], as_thread=True),
-                    *self.env["discuss.channel.member"]._to_store_persona("avatar_card"),
+                    *self.env["discuss.channel.member"]._to_store_persona(
+                        "avatar_card",
+                        for_current_user=for_current_user,
+                    ),
                 ],
                 mode="ADD",
             ),
             "last_interest_dt",
             "member_count",
             "name",
-            Store.One("parent_channel_id"),
-            Store.Many("rtc_session_ids", mode="ADD", extra=True, sudo=True),
+            Store.One(
+                "parent_channel_id",
+                self.parent_channel_id._get_store_default_fields(
+                    for_current_user=for_current_user,
+                )
+                if self.parent_channel_id
+                else [],  # prevents infinite recursion
+            ),
+            Store.Many(
+                "rtc_session_ids",
+                self.env["discuss.channel.rtc.session"]._get_store_default_fields(
+                    extra=True,
+                    for_current_user=for_current_user,
+                ),
+                mode="ADD",
+                sudo=True,
+            ),
             "uuid",
         ]
         if for_current_user:
@@ -1086,7 +1114,8 @@ class DiscussChannel(models.Model):
                 ),
                 Store.One(
                     "self_member_id",
-                    extra_fields=[
+                    self.self_member_id._get_store_default_fields(for_current_user=for_current_user)
+                    + [
                         "custom_channel_name",
                         "last_interest_dt",
                         "message_unread_counter",
@@ -1097,6 +1126,10 @@ class DiscussChannel(models.Model):
                 ),
             ]
         return res
+
+    def _to_store_defaults(self):
+        _logger.warning("_to_store_defaults of channel", stack_info=True)
+        return self._get_store_default_fields(for_current_user=False)
 
     def _to_store(self, store: Store, fields):
         store.add_records_fields(self, fields)

--- a/addons/mail/models/discuss/res_partner.py
+++ b/addons/mail/models/discuss/res_partner.py
@@ -91,7 +91,7 @@ class ResPartner(models.Model):
         members = self.env["discuss.channel.member"].search(members_domain)
         member_fields = [
             Store.One("channel_id", [], as_thread=True),
-            *self.env["discuss.channel.member"]._to_store_persona([]),
+            *self.env["discuss.channel.member"]._to_store_persona([], for_current_user=True),
         ]
         store = Store(members, member_fields).add(partners)
         store.add(channel, "group_public_id")

--- a/addons/mail/models/res_users.py
+++ b/addons/mail/models/res_users.py
@@ -330,7 +330,7 @@ class ResUsers(models.Model):
             internalUserGroupId=self.env.ref("base.group_user").id,
             mt_comment=xmlid_to_res_id("mail.mt_comment"),
             mt_note=xmlid_to_res_id("mail.mt_note"),
-            odoobot=Store.One(odoobot),
+            odoobot=Store.One(odoobot, odoobot._get_store_default_fields(for_current_user=True)),
         )
         if not self.env.user._is_public():
             settings = self.env["res.users.settings"]._find_or_create_for_user(self.env.user)

--- a/addons/mail/tools/discuss.py
+++ b/addons/mail/tools/discuss.py
@@ -105,13 +105,13 @@ class Store:
             if hasattr(records, "_thread_to_store"):
                 records._thread_to_store(self, fields, **kwargs)
             else:
-                assert not kwargs
+                assert not kwargs, kwargs
                 self.add_records_fields(records, fields, as_thread=True)
         else:
             if hasattr(records, "_to_store"):
                 records._to_store(self, fields, **kwargs)
             else:
-                assert not kwargs
+                assert not kwargs, kwargs
                 self.add_records_fields(records, fields)
         return self
 

--- a/addons/website_livechat/controllers/webclient.py
+++ b/addons/website_livechat/controllers/webclient.py
@@ -10,7 +10,11 @@ class WebClient(WebclientController):
         if name == "init_livechat" and (
             chat_request_channel := self._link_visitor_to_livechat(params)
         ):
-            store.add(chat_request_channel, extra_fields={"open_chat_window": True})
+            store.add(
+                chat_request_channel,
+                chat_request_channel._to_store_defaults(for_current_user=True)
+                + [{"open_chat_window": True}],
+            )
             chat_request_channel.is_pending_chat_request = False
         super()._process_request_for_all(store, name, params)
 

--- a/addons/website_livechat/models/discuss_channel.py
+++ b/addons/website_livechat/models/discuss_channel.py
@@ -36,8 +36,8 @@ class DiscussChannel(models.Model):
             ]
         return [field_name]
 
-    def _to_store_defaults(self, for_current_user=True):
-        return super()._to_store_defaults(for_current_user=for_current_user) + [
+    def _get_store_default_fields(self, *, for_current_user):
+        return super()._get_store_default_fields(for_current_user=for_current_user) + [
             Store.One(
                 "livechat_visitor_id",
                 [

--- a/addons/website_livechat/models/website_visitor.py
+++ b/addons/website_livechat/models/website_visitor.py
@@ -93,7 +93,11 @@ class WebsiteVisitor(models.Model):
                 )
                 channel._add_members(guests=guest, post_joined_message=False)
         # Open empty channel to allow the operator to start chatting with the visitor
-        operator._bus_send_store(discuss_channels, extra_fields={"open_chat_window": True})
+        operator._bus_send_store(
+            discuss_channels,
+            discuss_channels._to_store_defaults(for_current_user=True)
+            + [{"open_chat_window": True}],
+        )
 
     def _merge_visitor(self, target):
         """ Copy sessions of the secondary visitors to the main partner visitor. """


### PR DESCRIPTION
\* = hr_holidays, im_livechat

The email pop in _to_store of partner is especially problematic as it doesn't allow to set the email of a partner in a store for the portal user even in flows where it would be acceptable, which is necessary in some other tasks.

On top of that we want to remove this method as we have better ways to express the intent of storing a value in the store with the other existing methods.

The check was not even coded correctly, as it was checking if the current user was internal, but it wasn't checking if the value was broadcasted to non-internal users.

The only correct way to determine if the value can be accessed is if both the current user is internal and the value is only sent to the current user, which requires an extra parameter. The parameter must be cascaded from where the information is returned (rpc or bus send) to the lower level store methods through each layer. It's a bit verbose as all them have to be changed at the same time, but it will also allow fixing other unexpected data leaks in other cases.

Part of task-4775128
task-4676468
task-4676464