### PR TITLE
[FIX] point_of_sale: fix combo and variant config

### DIFF
--- a/addons/point_of_sale/static/src/app/store/combo_configurator_popup/combo_configurator_popup.js
+++ b/addons/point_of_sale/static/src/app/store/combo_configurator_popup/combo_configurator_popup.js
@@ -79,8 +79,8 @@ export class ComboConfiguratorPopup extends Component {
     }
 
     async onClickProduct({ product, combo_item }, ev) {
-        if (product.isConfigurable() && product.product_template_variant_value_ids.length === 0) {
-            const payload = await this.pos.openConfigurator(product);
+        if (product.needToConfigure()) {
+            const payload = await this.pos.openConfigurator(product, { hideAlwaysVariants: true });
             if (payload) {
                 this.state.configuration[combo_item.id] = payload;
             } else {

--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -591,6 +591,7 @@ export class PosStore extends Reactive {
             }
             return await makeAwaitable(this.dialog, ProductConfiguratorPopup, {
                 product: product,
+                hideAlwaysVariants: opts.hideAlwaysVariants,
                 defaultValues: defaultValues,
             });
         }

--- a/addons/point_of_sale/static/src/app/store/product_configurator_popup/product_configurator_popup.js
+++ b/addons/point_of_sale/static/src/app/store/product_configurator_popup/product_configurator_popup.js
@@ -119,8 +119,16 @@ export class ProductConfiguratorPopup extends Component {
         MultiProductAttribute,
         Dialog,
     };
-    static props = ["product", "getPayload", "close", "defaultValues"];
-
+    static props = {
+        product: Object,
+        getPayload: Function,
+        close: Function,
+        defaultValues: { type: Object, optional: true },
+        hideAlwaysVariants: { type: Boolean, optional: true },
+    };
+    static defaultProps = {
+        hideAlwaysVariants: false,
+    };
     setup() {
         useSubEnv({
             attribute_components: [],
@@ -190,6 +198,15 @@ export class ProductConfiguratorPopup extends Component {
     }
     get unitPrice() {
         return this.env.utils.formatCurrency(this.props.product.lst_price);
+    }
+    get validAttributeLineIds() {
+        if (this.props.hideAlwaysVariants) {
+            return this.props.product.attribute_line_ids.filter(
+                (line) => line.attribute_id.create_variant !== "always"
+            );
+        } else {
+            return this.props.product.attribute_line_ids;
+        }
     }
     close() {
         this.props.close();

--- a/addons/point_of_sale/static/src/app/store/product_configurator_popup/product_configurator_popup.xml
+++ b/addons/point_of_sale/static/src/app/store/product_configurator_popup/product_configurator_popup.xml
@@ -130,7 +130,7 @@
                 <div t-if="isArchivedCombination()" class="alert alert-warning mt-3">
                     <span>This combination does not exist.</span>
                 </div>
-                <div t-foreach="this.props.product.attribute_line_ids" t-as="attributeLine" t-key="attributeLine.id" class="attribute mb-3">
+                <div t-foreach="this.validAttributeLineIds" t-as="attributeLine" t-key="attributeLine.id" class="attribute mb-3">
                     <div class="attribute_name mb-2 fw-bolder" t-esc="attributeLine.attribute_id.name"/>
                     <RadioProductAttribute t-if="attributeLine.attribute_id.display_type === 'radio'" attributeLine="attributeLine" defaultValues="this.props.defaultValues"/>
                     <PillsProductAttribute t-elif="attributeLine.attribute_id.display_type === 'pills'" attributeLine="attributeLine" defaultValues="this.props.defaultValues"/>

--- a/addons/point_of_sale/static/tests/tours/product_configurator_tour.js
+++ b/addons/point_of_sale/static/tests/tours/product_configurator_tour.js
@@ -2,6 +2,8 @@ import * as ProductScreen from "@point_of_sale/../tests/tours/utils/product_scre
 import * as Dialog from "@point_of_sale/../tests/tours/utils/dialog_util";
 import * as Chrome from "@point_of_sale/../tests/tours/utils/chrome_util";
 import * as ProductConfigurator from "@point_of_sale/../tests/tours/utils/product_configurator_util";
+import * as combo from "@point_of_sale/../tests/tours/utils/combo_popup_util";
+import { inLeftSide } from "@point_of_sale/../tests/tours/utils/common";
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("ProductConfiguratorTour", {
@@ -73,5 +75,22 @@ registry.category("web_tour.tours").add("ProductConfiguratorTour", {
             ProductConfigurator.numberRadioOptions(2),
             Dialog.confirm(),
             Chrome.endTour(),
+        ].flat(),
+});
+
+registry.category("web_tour.tours").add("test_combo_variant_mix", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+
+            // Click on Configurable Chair product
+            ProductScreen.clickDisplayedProduct("Test Product Combo"),
+            combo.select("Test Product (Large)"),
+            Dialog.is("Attribute selection"),
+            ProductConfigurator.pickRadio("Blue"),
+            Dialog.confirm("Add"),
+            Dialog.confirm(),
+            inLeftSide([...ProductScreen.orderLineHas("Test Product (Large) (Blue)", 1)]),
         ].flat(),
 });

--- a/addons/point_of_sale/static/tests/tours/utils/dialog_util.js
+++ b/addons/point_of_sale/static/tests/tours/utils/dialog_util.js
@@ -1,7 +1,7 @@
 import { negate } from "@point_of_sale/../tests/tours/utils/common";
 
 export function confirm(confirmationText, button = ".btn-primary") {
-    let trigger = `.modal .modal-footer ${button}`;
+    let trigger = `.modal:not(.o_inactive_modal) .modal-footer ${button}`;
     if (confirmationText) {
         trigger += `:contains("${confirmationText}")`;
     }

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -1776,7 +1776,7 @@ class TestUi(TestPointOfSaleHttpCommon):
 
         invoice = self.env['account.move'].search([('invoice_origin', '=', order.name)], limit=1)
         self.assertTrue(invoice)
-        self.assertFalse(invoice.invoice_payment_term_id) 
+        self.assertFalse(invoice.invoice_payment_term_id)
 
         self.assertAlmostEqual(order.amount_total, invoice.amount_total, places=2, msg="Order and Invoice amounts do not match.")
 
@@ -1896,6 +1896,64 @@ class TestUi(TestPointOfSaleHttpCommon):
         self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'test_draft_orders_not_syncing', login="pos_user")
         n_draft_order = self.env['pos.order'].search_count([('state', '=', 'draft')], limit=1)
         self.assertEqual(n_draft_order, 0, 'There should be no draft orders created')
+
+    def test_combo_variant_mix(self):
+        color_attribute = self.env['product.attribute'].create({
+            'name': 'Color',
+            'value_ids': [
+                Command.create({'name': 'Red'}),
+                Command.create({'name': 'Blue'})
+            ],
+            'create_variant': 'no_variant',
+        })
+        size_attribute = self.env['product.attribute'].create({
+            'name': 'Size',
+            'value_ids': [
+                Command.create({'name': 'Small'}),
+                Command.create({'name': 'Large'})
+            ],
+            'create_variant': 'always',
+        })
+
+        product_template = self.env['product.template'].create({
+            'name': 'Test Product',
+            'available_in_pos': True,
+            'list_price': 10,
+            'taxes_id': False,
+            'attribute_line_ids': [
+                Command.create({
+                    'attribute_id': color_attribute.id,
+                    'value_ids': [Command.link(id) for id in color_attribute.value_ids.ids]
+                }),
+                Command.create({
+                    'attribute_id': size_attribute.id,
+                    'value_ids': [Command.link(id) for id in size_attribute.value_ids.ids]
+                })
+            ]
+        })
+
+        combo = self.env['product.combo'].create({
+            'name': 'Test Combo',
+            'combo_item_ids': [
+                Command.create({
+                    'product_id': product_template.product_variant_ids[0].id,
+                    'extra_price': 0,
+                }),
+                Command.create({
+                    'product_id': product_template.product_variant_ids[1].id,
+                    'extra_price': 0,
+                }),
+            ]
+        })
+        self.env['product.template'].create({
+            'name': 'Test Product Combo',
+            'available_in_pos': True,
+            'list_price': 20,
+            'taxes_id': False,
+            'type': 'combo',
+            'combo_ids': [Command.link(combo.id)],
+        })
+        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'test_combo_variant_mix', login="pos_user")
 
     def test_barcode_search_attributes_preset(self):
         product = self.env['product.template'].create({


### PR DESCRIPTION
When a combo contained a product that had variant with type 'no_variant' and 'always', if you added the product to the cart the product configuration popup would not open. Also, in the combo you can only select product_product and not product_template, so the product configuration popup should not propose the variant linked to the 'always' type, as you already selected a product template in the combo configuration popup.

Steps to reproduce:
-------------------
* Create a product attribute PA1 with type 'no_variant' and 2 values V1 and V2
* Create a product attribute PA2 with type 'always' and 2 values V3 and V4
* Create a product template PT1 with PA1 and PA2
* Create a combo choice PC1 with the 2 variants of PT1
* Create a combo product CP1 with PC1
* Open PoS and add CP1 to the cart
* The combo configurator popup opens, click on the version with V2
> Observation: The product configurator popup does not open
> Second fix: The product configurator allows you to select the
  variant linked to the 'always' type, which is not correct as you already selected it through the combo configurator popup

Why the fix:
------------
The first fix just make sure that the product configuration popup opens when it is necessary.
The second fix filters the variants proposed in the product configuration popup to only show the variants that are not linked to the 'always' type. But this only happens when we do it from the combo configuration popup.

opw-4719258