### PR TITLE
[FIX] core: cloc path argument not working

### DIFF
--- a/odoo/cli/cloc.py
+++ b/odoo/cli/cloc.py
@@ -31,11 +31,11 @@ class Cloc(Command):
         if not opt.database and not opt.path:
             self.parser.print_help()
             sys.exit()
-        if ',' in opt.database:
-            sys.exit("-d/--database has multiple database, please provide a single one")
 
         c = cloc.Cloc()
         if opt.database:
+            if ',' in opt.database:
+                sys.exit("-d/--database has multiple databases, please provide a single one")
             config.parse_config(['-d', opt.database] + unknown)
             c.count_database(config['db_name'][0])
         if opt.path:


### PR DESCRIPTION
`odoo-bin cloc -p /mypath` should work on the given path, but results in an error when trying to split the database because `',' in opt.database` fails as it is `None`.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
