### PR TITLE
[FIX] purchase: compute volumes in purchase reports

### DIFF
--- a/addons/purchase/report/purchase_report.py
+++ b/addons/purchase/report/purchase_report.py
@@ -79,18 +79,18 @@ class PurchaseReport(models.Model):
                     extract(epoch from age(l.date_planned,po.date_order))/(24*60*60)::decimal(16,2) as delay_pass,
                     count(*) as nbr_lines,
                     sum(l.price_total / COALESCE(po.currency_rate, 1.0))::decimal(16,2) * account_currency_table.rate as price_total,
-                    (sum(l.product_qty * l.price_unit / COALESCE(po.currency_rate, 1.0))/NULLIF(sum(l.product_qty/line_uom.factor*product_uom.factor),0.0))::decimal(16,2) * account_currency_table.rate as price_average,
+                    (sum(l.product_qty * l.price_unit / COALESCE(po.currency_rate, 1.0))/NULLIF(sum(l.product_qty * line_uom.factor / product_uom.factor),0.0))::decimal(16,2) * account_currency_table.rate as price_average,
                     partner.country_id as country_id,
                     partner.commercial_partner_id as commercial_partner_id,
-                    sum(p.weight * l.product_qty/line_uom.factor*product_uom.factor) as weight,
-                    sum(p.volume * l.product_qty/line_uom.factor*product_uom.factor) as volume,
+                    sum(p.weight * l.product_qty * line_uom.factor / product_uom.factor) as weight,
+                    sum(p.volume * l.product_qty * line_uom.factor / product_uom.factor) as volume,
                     sum(l.price_subtotal / COALESCE(po.currency_rate, 1.0))::decimal(16,2) * account_currency_table.rate as untaxed_total,
                     sum(l.product_qty * line_uom.factor / product_uom.factor) as qty_ordered,
                     sum(l.qty_received * line_uom.factor / product_uom.factor) as qty_received,
                     sum(l.qty_invoiced * line_uom.factor / product_uom.factor) as qty_billed,
                     case when t.purchase_method = 'purchase'
-                         then sum(l.product_qty / line_uom.factor * product_uom.factor) - sum(l.qty_invoiced / line_uom.factor * product_uom.factor)
-                         else sum(l.qty_received / line_uom.factor * product_uom.factor) - sum(l.qty_invoiced / line_uom.factor * product_uom.factor)
+                         then sum(l.product_qty * line_uom.factor / product_uom.factor) - sum(l.qty_invoiced * line_uom.factor / product_uom.factor)
+                         else sum(l.qty_received * line_uom.factor / product_uom.factor) - sum(l.qty_invoiced * line_uom.factor / product_uom.factor)
                     end as qty_to_be_billed
             """,
         )


### PR DESCRIPTION
_______________________________________
## Short functional explanation of the error
When setting the unit of measure as packs, the volume of products aren't computed correctly.

## Reproduction Steps
1. Go to settings. In the purchase section, click on Units of Measure & Packagings.
2. Click on new, set the unit name as "pack of 4", and set the quantity of the reference unit at 4. Set the reference unit as "units."
3. Go to products and create a test product.
4. In the inventory tab, set the volume greater than 0.
5. Go back to purchase and click on new. Add a line containing the test product, a set quantity, and set as unit "pack of 4."
6. Confirm the order, click on receive then validate.
7. Click on the reporting tab, then purchase. Set the measure as volume and click on the bar chart button. Then, click on the blue column and click on the row corresponding to the purchase operation.

### Expected behavior
Let's say we set the product volume as 4 m³, and we purchased one pack
 of 4. The total volume would be (product volume) * (number of
 products), which would correspond to 4*4 = 16.

### Unexpected behavior
Instead of 16, the total volume shows 1.

## Origin of the issue
In the code, the volume is obtained with the operation (product volume) / (number of products)


_________________________________________
opw-4871100

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
