### PR TITLE
[FIX] im_livechat: hardcode buffer time

### DIFF
--- a/addons/im_livechat/tests/test_get_operator.py
+++ b/addons/im_livechat/tests/test_get_operator.py
@@ -449,16 +449,15 @@ class TestGetOperator(MailCommon, TestGetOperatorCommon):
             {
                 "name": "Livechat Channel",
                 "user_ids": [first_operator.id, second_operator.id],
-                "buffer_time": 10,
             }
         )
         now = fields.Datetime.now()
-        with freeze_all_time(now + timedelta(minutes=-1)):
+        with freeze_all_time(now + timedelta(minutes=-3)):
             self._create_chat(livechat_channel, second_operator)
         with freeze_all_time(now):
             self._create_chat(livechat_channel, first_operator)
             self.assertEqual(second_operator, livechat_channel._get_operator())
-        with freeze_all_time(now + timedelta(seconds=11)):
+        with freeze_all_time(now + timedelta(seconds=121)):
             self.assertEqual(first_operator, livechat_channel._get_operator())
 
     def test_bypass_buffer_time_when_impossible_selection(self):
@@ -468,7 +467,6 @@ class TestGetOperator(MailCommon, TestGetOperatorCommon):
             {
                 "name": "Livechat Channel",
                 "user_ids": [first_operator.id, second_operator.id],
-                "buffer_time": 10,
             }
         )
         now = fields.Datetime.now()

--- a/addons/im_livechat/views/im_livechat_channel_views.xml
+++ b/addons/im_livechat/views/im_livechat_channel_views.xml
@@ -143,7 +143,6 @@
                                 </group>
                                 <group string="Session Limits">
                                     <group>
-                                        <field name="buffer_time"/>
                                         <field name="max_sessions_mode" widget="radio" options="{'horizontal': true}"/>
                                         <field name="max_sessions" invisible="max_sessions_mode != 'limited'"/>
                                         <field name="block_assignment_during_call"/>


### PR DESCRIPTION
This PR removes the `buffer time` field from live chat channels and
hardcodes the buffer time to 120 seconds for all channels.

Task-4892243

upgrade: https://github.com/odoo/upgrade/pull/7939

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
