### PR TITLE
[IMP] website: allow resizing of animated text option popover

### DIFF
--- a/addons/website/static/src/builder/plugins/options/animate_text.js
+++ b/addons/website/static/src/builder/plugins/options/animate_text.js
@@ -1,9 +1,10 @@
-import { Component, useRef, useState } from "@odoo/owl";
+import { Component, onMounted, onWillDestroy, useRef, useState } from "@odoo/owl";
 import { toolbarButtonProps } from "@html_editor/main/toolbar/toolbar";
 import { AnimateOption } from "./animate_option";
 import { usePopover } from "@web/core/popover/popover_hook";
 import { DependencyManager } from "@html_builder/core/dependency_manager";
 import { BaseOptionComponent } from "@html_builder/core/utils";
+import { POSITION_BUS } from "@web/core/position/position_hook";
 
 class AnimateTextPopover extends BaseOptionComponent {
     static template = "website_builder.AnimateTextPopover";
@@ -15,6 +16,20 @@ class AnimateTextPopover extends BaseOptionComponent {
         close: { type: Function, optional: true },
     };
     static components = { AnimateOption };
+
+    setup() {
+        super.setup();
+        this.contentRef = useRef("content");
+        this.resizeObserver = new ResizeObserver(() => {
+            this.env[POSITION_BUS]?.trigger("update");
+        });
+        onMounted(() => {
+            this.resizeObserver.observe(this.contentRef.el);
+        });
+        onWillDestroy(() => {
+            this.resizeObserver.disconnect();
+        });
+    }
 }
 
 export class AnimateText extends Component {

--- a/addons/website/static/src/builder/plugins/options/animate_text.scss
+++ b/addons/website/static/src/builder/plugins/options/animate_text.scss
@@ -1,6 +1,5 @@
 .o_animate_text_popover {
     min-width: unset;
     width: 300px;
-    height: 200px;
     overflow-y: auto;
 }

--- a/addons/website/static/src/builder/plugins/options/animate_text.xml
+++ b/addons/website/static/src/builder/plugins/options/animate_text.xml
@@ -6,7 +6,7 @@
     </t>
 
     <t t-name="website_builder.AnimateTextPopover">
-        <div class="o_animate_text_popover" data-prevent-closing-overlay="true">
+        <div class="o_animate_text_popover" data-prevent-closing-overlay="true" t-ref="content">
             <div class="my-1 d-flex">
                 <div class="flex-grow-1"/>
                 <button class="btn btn-sm btn-light fa fa-trash me-1" title="Reset" t-on-click="props.onReset"/>


### PR DESCRIPTION
When animated text option was added to the toolbar, the size of the popover was fixed, to avoid annoying moves of the popover when the content changed size. But moving vertically the popover when the content changes is not too annoying, and having the height adapted to the content is nicer.

Animated text option: e80a2a20d4ba49b51f31f8ed06a5a0d3d1fa2e6d
task-4367641
