### PR TITLE
[FIX] point_of_sale: fix test for account_tax_periodicity_journal_id

### DIFF
--- a/addons/point_of_sale/tests/test_res_config_settings.py
+++ b/addons/point_of_sale/tests/test_res_config_settings.py
@@ -5,7 +5,6 @@ import odoo
 
 from odoo import Command
 from odoo.addons.point_of_sale.tests.common import TestPoSCommon
-from odoo.tests import Form
 
 
 @odoo.tests.tagged('post_install', '-at_install')
@@ -32,55 +31,6 @@ class TestConfigureShops(TestPoSCommon):
         self.env['account.tax'].search([
             ('company_id', '=', self.env.company.id), ('tax_exigibility', '=', 'on_payment')
         ]).unlink()
-
-    def test_should_not_affect_other_pos_config(self):
-        """ Change in one pos.config should not reflect to the other.
-        """
-        self._remove_on_payment_taxes()
-
-        pos_config1 = self.env['pos.config'].create({'name': 'Shop 1', 'module_pos_restaurant': False})
-        pos_config2 = self.env['pos.config'].create({'name': 'Shop 2', 'module_pos_restaurant': False})
-        self.assertEqual(pos_config1.receipt_header, False)
-        self.assertEqual(pos_config2.receipt_header, False)
-
-        # Modify Shop 1.
-        with Form(self.env['res.config.settings']) as form:
-            form.pos_config_id = pos_config1
-            form.pos_is_header_or_footer = True
-            form.pos_receipt_header = 'xxxxx'
-            form.account_tax_periodicity_journal_id = self.invoice_journal
-
-        self.assertEqual(pos_config1.receipt_header, 'xxxxx')
-        self.assertEqual(pos_config2.receipt_header, False)
-
-        # Modify Shop 2.
-        with Form(self.env['res.config.settings']) as form:
-            form.pos_config_id = pos_config2
-            form.pos_is_header_or_footer = True
-            form.pos_receipt_header = 'yyyyy'
-            form.account_tax_periodicity_journal_id = self.invoice_journal
-
-        self.assertEqual(pos_config1.receipt_header, 'xxxxx')
-        self.assertEqual(pos_config2.receipt_header, 'yyyyy')
-
-    def test_is_header_or_footer_to_false(self):
-        self._remove_on_payment_taxes()
-
-        pos_config = self.env['pos.config'].create({
-            'name': 'Shop',
-            'is_header_or_footer': True,
-            'module_pos_restaurant': False,
-            'receipt_header': 'header val',
-            'receipt_footer': 'footer val',
-        })
-
-        with Form(self.env['res.config.settings']) as form:
-            form.pos_config_id = pos_config
-            form.pos_is_header_or_footer = False
-            form.account_tax_periodicity_journal_id = self.invoice_journal
-
-        self.assertEqual(pos_config.receipt_header, False)
-        self.assertEqual(pos_config.receipt_footer, False)
 
     def test_properly_set_pos_config_x2many_fields(self):
         """Simulate what is done from the res.config.settings view when editing x2 many fields."""


### PR DESCRIPTION
this commit fixes the test for the account_tax_periodicity_journal_id field in the res.config.settings model, which was failing due to an assertion error cause it is not in the community version of Odoo 18.2.

but it is in the saas-18.2 version enterprise version of Odoo 18.2. refer to this [commit](https://github.com/odoo/odoo/commit/8d841025ecb0b62719fa92236696c0e3421ca270)

build_error-227602

