### PR TITLE
[FIX] spreadsheet: correctly handle text filter value

### DIFF
--- a/addons/spreadsheet/static/src/pivot/plugins/pivot_core_view_global_filter_plugin.js
+++ b/addons/spreadsheet/static/src/pivot/plugins/pivot_core_view_global_filter_plugin.js
@@ -194,7 +194,7 @@ export class PivotCoreViewGlobalFilterPlugin extends OdooCoreViewPlugin {
                         break;
                     case "text":
                         if (currentValue !== value) {
-                            transformedValue = value;
+                            transformedValue = [value];
                         }
                         break;
                 }

--- a/addons/spreadsheet/static/tests/pivots/pivot_core_view_global_filter_plugin.test.js
+++ b/addons/spreadsheet/static/tests/pivots/pivot_core_view_global_filter_plugin.test.js
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "@odoo/hoot";
+import { defineSpreadsheetModels } from "@spreadsheet/../tests/helpers/data";
+
+import { addGlobalFilterWithoutReload } from "@spreadsheet/../tests/helpers/commands";
+import { createSpreadsheetWithPivot } from "@spreadsheet/../tests/helpers/pivot";
+
+describe.current.tags("headless");
+defineSpreadsheetModels();
+
+test("getFiltersMatchingPivotArgs should returns correct value for each filter", async function () {
+    const { model, pivotId } = await createSpreadsheetWithPivot({
+        arch: /* xml */ `
+                <pivot>
+                    <field name="product_id" type="col"/>
+                    <field name="foo" type="row"/>
+                    <field name="probability" type="measure"/>
+                </pivot>`,
+    });
+    addGlobalFilterWithoutReload(
+        model,
+        {
+            type: "text",
+            label: "Text",
+            id: "1",
+        },
+        {
+            pivot: {
+                [pivotId]: { chain: "foo", type: "char" },
+            },
+        }
+    );
+    const filters = model.getters.getFiltersMatchingPivotArgs(pivotId, [
+        { field: "foo", type: "char", value: "hello" },
+    ]);
+    expect(filters).toEqual([{ filterId: "1", value: ["hello"] }]);
+});


### PR DESCRIPTION
Since 31a443fc06b38d129e7da0fd0c11304d08ac8480, the text filter value is now an array of strings instead of a single string. This commit updates the getters used to retrieve the filter value from the pivot formula to handle this change correctly.

Steps to reproduce:
1. Open the dashboard "Pipeline"
2. Click on a cell in the "Top cities" column
3. Boom

Task: 4894663

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
