### PR TITLE
[FIX] l10n_es_edi_sii: Search for OSS taxes

### DIFF
--- a/addons/l10n_es_edi_sii/models/account_edi_format.py
+++ b/addons/l10n_es_edi_sii/models/account_edi_format.py
@@ -621,12 +621,9 @@ class AccountEdiFormat(models.Model):
         return results
 
     def _has_oss_taxes(self, invoice):
-        oss_tax_groups = self.env['ir.model.data'].sudo().search([
-            ('module', '=', 'l10n_eu_oss'),
-            ('model', '=', 'account.tax.group')])
+        oss_tag = self.env.ref('l10n_eu_oss.tag_oss', raise_if_not_found=False)
         lines = invoice.invoice_line_ids.filtered(lambda line: line.display_type not in ('line_section', 'line_note'))
-        tax_groups = lines.mapped('tax_ids.tax_group_id')
-        return bool(set(tax_groups.ids) & set(oss_tax_groups.mapped('res_id')))
+        return bool(oss_tag and oss_tag in lines.tax_ids.invoice_repartition_line_ids.tag_ids)
 
     # -------------------------------------------------------------------------
     # EDI OVERRIDDEN METHODS


### PR DESCRIPTION
This commit fixes the search for OSS taxes in `_has_oss_taxes` function. The current search approach (with tax tags) is better in the following points:
1. No need to use `sudo` for ir.model.data access
2. Currently, user-created OSS taxes are considered in the search

task-4548095




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
