### PR TITLE
[PERF] account: improve method `_existing_accounting`

### DIFF
--- a/addons/account/models/company.py
+++ b/addons/account/models/company.py
@@ -654,7 +654,7 @@ class ResCompany(models.Model):
     def _existing_accounting(self) -> bool:
         """Return True iff some accounting entries have already been made for the current company."""
         self.ensure_one()
-        return bool(self.env['account.move.line'].search([('company_id', 'child_of', self.id)], limit=1))
+        return bool(self.env['account.move.line'].search_count([('company_id', 'child_of', self.id)], limit=1))
 
     def _chart_template_selection(self):
         return self.env['account.chart.template']._select_chart_template(self.country_id)


### PR DESCRIPTION
Issue ->

For databases with large `account_move_line` tables, running the `_existing_accounting` (when opening Settings) method to check if a company has accounting entries by searching for any `account_move_line` records belonging to the current company is slow. The default search order for this model is `date desc, move_name desc, id`. This causes an index scan on the table using `account_move_line_date_name_id_idx`. The combination of using `date` to order by and the query planner using an unrelated index for the search leads to a long running SELECT query.

Solution -->

We replace the `search` with a `search_count` where the ordering doesn't matter and the order by clause is skipped.

Benchmark -->

On customers' database with about 30M move lines and 1 `res.company` record, speedup on the SELECT query is as follows -->

62743.883 ms ->  0.392 ms

Ticket [link](https://www.odoo.com/odoo/project/967/tasks/4811622)
opw-4811622