### PR TITLE
[FIX] web: increase js unit tests timeout

### DIFF
--- a/addons/web/tests/test_js.py
+++ b/addons/web/tests/test_js.py
@@ -145,7 +145,7 @@ class WebSuite(QunitCommon, HOOTCommon):
     @odoo.tests.no_retry
     def test_unit_desktop(self):
         # Unit tests suite (desktop)
-        self.browser_js(f'/web/tests?headless&loglevel=2&preset=desktop&timeout=15000{self.hoot_filters}', "", "", login='admin', timeout=2400, success_signal="[HOOT] test suite succeeded", error_checker=unit_test_error_checker)
+        self.browser_js(f'/web/tests?headless&loglevel=2&preset=desktop&timeout=15000{self.hoot_filters}', "", "", login='admin', timeout=3000, success_signal="[HOOT] test suite succeeded", error_checker=unit_test_error_checker)
 
     @odoo.tests.no_retry
     def test_hoot(self):


### PR DESCRIPTION
The suite usualy lasts around ~~33~~ 38 minutes. The timeout of ~~35~~ 40 minutes seems too close and thus fails too often.


