### PR TITLE
[FIX] hr: add get_avatar_card_data method to fetch avatar card popover data

### DIFF
--- a/addons/hr/models/hr_employee_public.py
+++ b/addons/hr/models/hr_employee_public.py
@@ -204,3 +204,6 @@ class HrEmployeePublic(models.Model):
                 ORDER BY employee_id, date_version DESC
             ) v ON v.employee_id = e.id
         )""" % (self._table, self._get_fields()))
+
+    def get_avatar_card_data(self, fields):
+        return self.read(fields)


### PR DESCRIPTION
Steps to reproduce:
- Open Time Off
- Click on the employee avatar

Before this commit:
- A traceback occurred due to a missing method that was previously
  in `hr.employee.base`.

After this commit:
- The missing method is now restored in `hr.employee.public`, resolving the error.

related task-4210513
