### PR TITLE
[FIX] point_of_sale: include orderline customer notes in preparation tickets

### DIFF
--- a/addons/point_of_sale/static/src/app/models/pos_order.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order.js
@@ -328,10 +328,12 @@ export class PosOrder extends Base {
             orderlineIdx.push(line.preparationKey);
 
             if (this.last_order_preparation_change.lines[line.preparationKey]) {
-                this.last_order_preparation_change.lines[line.preparationKey]["quantity"] =
-                    line.getQuantity();
-                this.last_order_preparation_change.lines[line.preparationKey]["note"] =
-                    line.getNote();
+                this.last_order_preparation_change.lines[line.preparationKey] = {
+                    ...this.last_order_preparation_change.lines[line.preparationKey],
+                    quantity: line.getQuantity(),
+                    note: line.getNote(),
+                    customer_note: line.getCustomerNote(),
+                };
             } else {
                 this.last_order_preparation_change.lines[line.preparationKey] = {
                     attribute_value_names: line.attribute_value_ids.map((a) => a.name),
@@ -343,6 +345,7 @@ export class PosOrder extends Base {
                     display_name: line.getProduct().display_name,
                     note: line.getNote(),
                     quantity: line.getQuantity(),
+                    customer_note: line.getCustomerNote(),
                 };
             }
             line.setHasChange(false);

--- a/addons/point_of_sale/static/src/app/models/pos_order_line.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order_line.js
@@ -594,7 +594,7 @@ export class PosOrderline extends Base {
     }
 
     getCustomerNote() {
-        return this.customer_note;
+        return this.customer_note || "";
     }
 
     getTotalCost() {

--- a/addons/point_of_sale/static/src/app/store/order_change_receipt_template.xml
+++ b/addons/point_of_sale/static/src/app/store/order_change_receipt_template.xml
@@ -76,6 +76,9 @@
             <div t-if="line.note" class="fst-italic" style="font-size: 91%;">
                 <t t-esc="line.note.split('\n').join(', ')"/><br/>
             </div>
+            <div t-if="line.customer_note" class="fst-italic" style="font-size: 91%;">
+                <t t-esc="line.customer_note"/><br/>
+            </div>
         </div>
     </t>
 </templates>

--- a/addons/point_of_sale/static/tests/pos/tours/utils/preparation_receipt_util.js
+++ b/addons/point_of_sale/static/tests/pos/tours/utils/preparation_receipt_util.js
@@ -2,7 +2,7 @@
 
 import { renderToElement } from "@web/core/utils/render";
 
-export function generatePreparationReceiptElement() {
+export function generatePreparationReceiptElement(ticketType) {
     const order = posmodel.getOrder();
     const orderChange = posmodel.changesToOrder(
         order,
@@ -17,10 +17,26 @@ export function generatePreparationReceiptElement() {
         false
     );
 
-    orderData.changes = {
-        title: "new",
-        data: changes.new,
-    };
+    if (ticketType === "new") {
+        orderData.changes = {
+            title: "NEW",
+            data: changes.new,
+        };
+    }
+    if (ticketType === "cancelled") {
+        orderData.changes = {
+            title: "CANCELLED",
+            data: changes.cancelled,
+        };
+    }
+    if (ticketType === "noteUpdate") {
+        const { noteUpdateTitle, printNoteUpdateData = true } = orderChange;
+
+        orderData.changes = {
+            title: noteUpdateTitle || "NOTE UPDATE",
+            data: printNoteUpdateData ? changes.noteUpdate : [],
+        };
+    }
 
     return renderToElement("point_of_sale.OrderChangeReceipt", {
         data: orderData,
@@ -33,10 +49,11 @@ export function checkPreparationTicketData(
         visibleInDom: [],
         invisibleInDom: [],
         lineOrder: [],
+        type: "new", // can be "new", "cancelled" or "noteUpdate"
     }
 ) {
     const check = () => {
-        const ticket = generatePreparationReceiptElement();
+        const ticket = generatePreparationReceiptElement(opts.type || "new");
         const lines = ticket.querySelectorAll(".orderline");
         const lineNames = [];
 

--- a/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
@@ -382,10 +382,31 @@ registry.category("web_tour.tours").add("PreparationPrinterContent", {
             ProductScreen.clickDisplayedProduct("Product Test"),
             Chrome.freezeDateTime(1739370000000),
             Dialog.confirm("Add"),
+            // Cutomer Note on orderline
+            ProductScreen.addCustomerNote("Test customer note - orderline"),
             ProductScreen.totalAmountIs("10"),
             checkPreparationTicketData([{ name: "Product Test", qty: 1, attribute: ["Value 1"] }], {
-                visibleInDom: ["14:20"],
+                visibleInDom: ["14:20", "Test customer note - orderline"],
                 invisibleInDom: ["DUPLICATA!"],
+            }),
+            ProductScreen.clickOrderButton(),
+            Chrome.closePrintingWarning(),
+            FloorScreen.clickTable("5"),
+            ProductScreen.clickLine("Product Test"),
+            ProductScreen.addCustomerNote("Updated customer note - orderline"),
+            checkPreparationTicketData([{ name: "Product Test", qty: 1, attribute: ["Value 1"] }], {
+                visibleInDom: ["NOTE UPDATE", "Updated customer note - orderline"],
+                type: "noteUpdate",
+            }),
+            ProductScreen.clickOrderButton(),
+            Chrome.closePrintingWarning(),
+            FloorScreen.clickTable("5"),
+            ProductScreen.clickLine("Product Test"),
+            ProductScreen.clickNumpad("⌫"),
+            ProductScreen.clickNumpad("⌫"),
+            checkPreparationTicketData([{ name: "Product Test", qty: 1, attribute: ["Value 1"] }], {
+                visibleInDom: ["CANCELLED"],
+                type: "cancelled",
             }),
         ].flat(),
 });


### PR DESCRIPTION
In this commit:
-----------
Orderline-level customer notes are now printed on preparation tickets.

Task-4879140


Related: https://github.com/odoo/enterprise/pull/90229