### PR TITLE
[FIX] web: datetimepicker: show week numbers if range

### DIFF
--- a/addons/web/static/src/core/datetime/datetime_picker.js
+++ b/addons/web/static/src/core/datetime/datetime_picker.js
@@ -26,7 +26,7 @@ const { DateTime, Info } = luxon;
  *
  * @typedef DateTimePickerProps
  * @property {number} [focusedDateIndex=0]
- * @property {boolean} [showWeekNumbers]
+ * @property {boolean} [showWeekNumbers=true]
  * @property {DaysOfWeekFormat} [daysOfWeekFormat="narrow"]
  * @property {DateLimit} [maxDate]
  * @property {PrecisionLevel} [maxPrecision="decades"]
@@ -324,6 +324,7 @@ export class DateTimePicker extends Component {
         maxPrecision: "decades",
         minPrecision: "days",
         rounding: 5,
+        showWeekNumbers: true,
         type: "datetime",
     };
 

--- a/addons/web/static/src/core/datetime/datetime_picker.xml
+++ b/addons/web/static/src/core/datetime/datetime_picker.xml
@@ -16,7 +16,7 @@
                         </div>
                     </t>
                     <t t-foreach="month.weeks" t-as="week" t-key="week.number">
-                        <t t-if="props.showWeekNumbers ?? !props.range">
+                        <t t-if="props.showWeekNumbers">
                             <div
                                 class="o_week_number_cell d-flex align-items-center ps-2 text-muted fst-italic"
                                 t-esc="week.number"
@@ -95,7 +95,7 @@
     <t t-name="web.DateTimePicker">
         <div
             class="o_datetime_picker d-flex flex-column gap-2 user-select-none p-2"
-            t-attf-style="--DateTimePicker__Day-template-columns: {{ props.showWeekNumbers ?? !props.range ? 8 : 7 }}"
+            t-attf-style="--DateTimePicker__Day-template-columns: {{ props.showWeekNumbers ? 8 : 7 }}"
         >
             <nav class="o_datetime_picker_header">
                 <button

--- a/addons/web/static/tests/core/components/datetime/datetime_picker.test.js
+++ b/addons/web/static/tests/core/components/datetime/datetime_picker.test.js
@@ -671,7 +671,8 @@ test("range value", async () => {
                     [[23], [24], ["25"], [26], [27], [28], [29]],
                     [[30], [1], [2], [3], [4], [5], [6]],
                 ],
-                daysOfWeek: ["S", "M", "T", "W", "T", "F", "S"],
+                daysOfWeek: ["", "S", "M", "T", "W", "T", "F", "S"],
+                weekNumbers: [13, 14, 15, 16, 17, 18],
             },
         ],
         time: ["17:18", "5:25"],
@@ -686,7 +687,7 @@ test("range value", async () => {
     expect(queryAllTexts(".o_time_picker_option")).toEqual(TIME_OPTIONS);
 
     expect(".o_datetime_picker").toHaveStyle({
-        "--DateTimePicker__Day-template-columns": "7",
+        "--DateTimePicker__Day-template-columns": "8",
     });
 });
 
@@ -715,7 +716,8 @@ test("range value on small device", async () => {
                     [23, 24, ["25"], 26, 27, 28, 29],
                     [30, 1, 2, 3, 4, 5, 6],
                 ],
-                daysOfWeek: ["S", "M", "T", "W", "T", "F", "S"],
+                daysOfWeek: ["", "S", "M", "T", "W", "T", "F", "S"],
+                weekNumbers: [13, 14, 15, 16, 17, 18],
             },
         ],
         time: ["9:30", "21:05"],
@@ -730,7 +732,7 @@ test("range value on small device", async () => {
     expect(queryAllTexts(".o_time_picker_option")).toEqual(TIME_OPTIONS);
 
     expect(".o_datetime_picker").toHaveStyle({
-        "--DateTimePicker__Day-template-columns": "7",
+        "--DateTimePicker__Day-template-columns": "8",
     });
 });
 
@@ -755,7 +757,8 @@ test("range value, previous month", async () => {
                     [23, 24, "25", 26, 27, 28, 29],
                     [30, 1, 2, 3, 4, 5, 6],
                 ],
-                daysOfWeek: ["S", "M", "T", "W", "T", "F", "S"],
+                daysOfWeek: ["", "S", "M", "T", "W", "T", "F", "S"],
+                weekNumbers: [13, 14, 15, 16, 17, 18],
             },
         ],
         time: ["13:00", "14:00"],
@@ -776,7 +779,8 @@ test("range value, previous month", async () => {
                     [26, 27, 28, 29, 30, 31, 1],
                     [2, 3, 4, 5, 6, 7, 8],
                 ],
-                daysOfWeek: ["S", "M", "T", "W", "T", "F", "S"],
+                daysOfWeek: ["", "S", "M", "T", "W", "T", "F", "S"],
+                weekNumbers: [9, 10, 11, 12, 13, 14],
             },
         ],
         time: ["13:00", "14:00"],


### PR DESCRIPTION
Before this commit, if no value for ´showWeekNumbers´ was set,
week numbers were not shown in range mode, whereas in other
modes they were displayed.

This behavior was inconsistent, especially when a start or end date
could be added dynamically.
It was likely an aesthetic decision for cases where two calendars
were displayed side by side before [1].

´showWeekNumbers´ is now set to ´true´ by default no matter the case.

[1]: https://github.com/odoo/odoo/pull/214383
