### PR TITLE
[IMP] web, website : improve datetime picker frontend design

### DIFF
--- a/addons/web/static/src/core/datetime/datetime_picker.js
+++ b/addons/web/static/src/core/datetime/datetime_picker.js
@@ -41,6 +41,8 @@ const { DateTime, Info } = luxon;
  * @property {NullableDateTime | NullableDateRange} [value]
  * @property {(date: DateTime) => boolean} [isDateValid]
  * @property {(date: DateTime) => string} [dayCellClass]
+ * @property {string} [buttonClass]
+ * @property {string} [popoverButtonClass]
  *
  * @typedef {DateItem | MonthItem} Item
  *
@@ -316,6 +318,8 @@ export class DateTimePicker extends Component {
         isDateValid: { type: Function, optional: true },
         dayCellClass: { type: Function, optional: true },
         tz: { type: String, optional: true },
+        buttonClass: { type: String, optional: true },
+        popoverButtonClass: { type: String, optional: true },
     };
 
     static defaultProps = {

--- a/addons/web/static/src/core/datetime/datetime_picker.xml
+++ b/addons/web/static/src/core/datetime/datetime_picker.xml
@@ -97,25 +97,27 @@
             class="o_datetime_picker d-flex flex-column gap-2 user-select-none p-2"
             t-attf-style="--DateTimePicker__Day-template-columns: {{ props.showWeekNumbers ?? !props.range ? 8 : 7 }}"
         >
-            <nav class="o_datetime_picker_header">
+            <nav class="o_datetime_picker_header d-flex">
                 <button
-                    class="o_previous btn btn-light"
+                    class="o_previous btn"
+                    t-att-class="props.buttonClass || 'btn-light'"
                     t-on-click="previous"
                     tabindex="-1"
                 >
                     <i class="oi oi-chevron-left" t-att-title="activePrecisionLevel.prevTitle" />
                 </button>
                 <button
-                    class="o_next btn btn-light"
+                    class="o_next btn"
+                    t-att-class="props.buttonClass || 'btn-light'"
                     t-on-click="next"
                     tabindex="-1"
                 >
                     <i class="oi oi-chevron-right" t-att-title="activePrecisionLevel.nextTitle" />
                 </button>
                 <button
-                    class="o_zoom_out o_datetime_button btn text-truncate"
+                    class="o_zoom_out o_datetime_button btn ms-auto text-truncate"
                     tabindex="-1"
-                    t-att-class="{ 'btn-light': !isLastPrecisionLevel }"
+                    t-att-class="props.buttonClass || { 'btn-light': !isLastPrecisionLevel }"
                     t-att-title="!isLastPrecisionLevel and activePrecisionLevel.mainTitle"
                     t-on-click="zoomOut"
                 >

--- a/addons/web/static/src/core/datetime/datetime_picker_popover.xml
+++ b/addons/web/static/src/core/datetime/datetime_picker_popover.xml
@@ -4,7 +4,8 @@
         <DateTimePicker t-props="props.pickerProps">
             <t t-set-slot="buttons">
                 <button
-                    class="btn btn-sm btn-secondary"
+                    class="btn btn-sm"
+                    t-att-class="props.pickerProps.popoverButtonClass || 'btn-secondary'"
                     tabindex="-1"
                     t-on-click="() => props.pickerProps.range || props.pickerProps.focusedDateIndex ? props.pickerProps.onSelect([false, false]) : props.pickerProps.onSelect(false)"
                 >

--- a/addons/website/static/src/snippets/s_website_form/form.js
+++ b/addons/website/static/src/snippets/s_website_form/form.js
@@ -210,6 +210,8 @@ export class Form extends Interaction {
                 pickerProps: {
                     type: fieldEl.matches(".s_website_form_date, .o_website_form_date") ? "date" : "datetime",
                     value: defaultValue && DateTime.fromSeconds(parseInt(defaultValue)),
+                    buttonClass: "btn-sm",
+                    popoverButtonClass: "btn-light",
                 },
             }).enable());
         }


### PR DESCRIPTION
This PR fine-tunes the design of the datetime picker within the front-end after the merge of Commit[^1].

- Requires https://github.com/odoo/enterprise/pull/88480

| Master | This PR |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/7c63e2df-5075-4d5a-9a8c-c1f19a9ec1ca) | ![image](https://github.com/user-attachments/assets/b0287743-1922-4380-b613-e3ea5cefe570) | 
----------------

Prior Commit[^1], the previous, next, and month selection buttons were all placed in a flex at the top of the datetime picker. After Commit[^1], buttons are re-ordered in a different layout, with the right button class on each of them.

After this change, each button is separated and thus has its radius and background. In the backend, this `btn-light` is okay since it matches the background of our views, while in the front-end, this color is dynamic and does not match the page background. As each button is separated, it results in a weird visual result.

To fix this issue, we remove these `btn-light` classes and add a `btn-sm` one to handle the size of these buttons.

This change is meant to affect the datetime picker occurrences within the front-end but does not affect the `web_editor` one, as it inherits the backend design.

task-4893742



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr

[^1]: https://github.com/odoo/odoo/commit/e2b78fca435f268515f9593c2af821616aff7ebb