### PR TITLE
[FIX] website: fix card image hover to prevent white borders

### DIFF
--- a/addons/website/static/src/snippets/s_card/000.scss
+++ b/addons/website/static/src/snippets/s_card/000.scss
@@ -16,7 +16,10 @@
         width: 100%;
         object-fit: cover;
 
-        &[data-shape] {
+        // When an image is cropped, we use `object-fit: contain` so the visible crop area
+        // is displayed correctly inside containers. However, when the image is stretched
+        // to fill its container, it should use `object-fit: cover` instead.
+        &[data-shape].o_we_image_cropped {
             object-fit: contain;
         }
 


### PR DESCRIPTION
Step to reproduce:
1. Open website
2. Click edit button and drop s_three_columns snippet
3. Click image and change animation option into hover
4. Some extra white space shown.

Before this commit:
Applying a hover animation on card images caused the `object-fit`
property to unintentionally switch from `cover` to `contain`, resulting
in visible white borders around the image.This happened because of the
`geo_square` shape, which is automatically injected when a hover effect
is applied and no user shape is chosen. This behavior was intentionally
introduced in PR [1].

After this commit:
Now cropped images use object-fit: contain to preserve the visible
properly. and after stretch option apply it can take cover of this
container. so his ensures the image fully covers its container without
leaving any white gaps.

[1]:https://github.com/odoo/odoo/pull/119197

task:4875770
