### PR TITLE
[FIX] web: don't show separator in field selection

### DIFF
--- a/addons/mail/models/mail_render_mixin.py
+++ b/addons/mail/models/mail_render_mixin.py
@@ -271,6 +271,7 @@ class MailRenderMixin(models.AbstractModel):
             'is_html_empty': is_html_empty,
             'slug': self.env['ir.http']._slug,
             'user': self.env.user,
+            'env': self.env,
         }
         render_context.update(copy.copy(template_env_globals))
         return render_context

--- a/addons/mail/tests/test_mail_template.py
+++ b/addons/mail/tests/test_mail_template.py
@@ -314,6 +314,11 @@ class TestMailTemplate(MailCommon):
             self.assertEqual(rendered, "&lt;b&gt; test &lt;/b&gt;")
             self.assertTrue(render.called)
 
+        # Check that the environment is the evaluation context
+        mail_template.with_user(self.user_admin).email_to = '{{ env.user.name }}'
+        rendered = mail_template._render_field('email_to', record.ids)[record.id]
+        self.assertIn(self.user_admin.name, rendered)
+
     def test_mail_template_acl_translation(self):
         ''' Test that a user that doesn't have the group_mail_template_editor cannot create / edit
         translation with dynamic code if he cannot write dynamic code on the related record itself.

--- a/addons/web/static/src/core/model_field_selector/model_field_selector_popover.js
+++ b/addons/web/static/src/core/model_field_selector/model_field_selector_popover.js
@@ -118,7 +118,7 @@ export class ModelFieldSelectorPopover extends Component {
         update: Function,
     };
     static defaultProps = {
-        filter: (value) => value.searchable && value.type != "json",
+        filter: (value) => value.searchable && value.type != "json" && value.type !== "separator",
         isDebugMode: false,
         followRelations: true,
     };

--- a/addons/web/static/src/search/search_model.js
+++ b/addons/web/static/src/search/search_model.js
@@ -1027,7 +1027,7 @@ export class SearchModel extends EventBus {
                         relatedPropertyField: field,
                     };
 
-                    if (!searchItemsNames.includes(fullName)) {
+                    if (!searchItemsNames.includes(fullName) && definition.type !== "separator") {
                         const groupByItem = {
                             description: definition.string,
                             definitionRecordId,

--- a/addons/web/static/src/search/search_model.js
+++ b/addons/web/static/src/search/search_model.js
@@ -1022,7 +1022,7 @@ export class SearchModel extends EventBus {
                         selection: definition.selection,
                         sortable: true,
                         store: true,
-                        string: `${definition.string} (${definitionRecordName})`,
+                        string: definition.string,
                         type: definition.type,
                         relatedPropertyField: field,
                     };

--- a/addons/web/static/src/views/fields/field_selector/field_selector_field.js
+++ b/addons/web/static/src/views/fields/field_selector/field_selector_field.js
@@ -17,6 +17,10 @@ export class FieldSelectorField extends Component {
     };
 
     filter(fieldDef) {
+        if (fieldDef.type === "separator") {
+            // Don't show properties separator
+            return false;
+        }
         return !this.props.onlySearchable || fieldDef.searchable;
     }
 

--- a/addons/web/static/src/views/fields/field_selector/field_selector_field.js
+++ b/addons/web/static/src/views/fields/field_selector/field_selector_field.js
@@ -13,12 +13,16 @@ export class FieldSelectorField extends Component {
         ...standardFieldProps,
         resModel: { type: String, optional: true },
         onlySearchable: { type: Boolean, optional: true },
+        allowProperties: { type: Boolean, optional: true },
         followRelations: { type: Boolean, optional: true },
     };
 
     filter(fieldDef) {
         if (fieldDef.type === "separator") {
             // Don't show properties separator
+            return false;
+        }
+        if (!this.props.allowProperties && fieldDef.type === "properties") {
             return false;
         }
         return !this.props.onlySearchable || fieldDef.searchable;
@@ -74,6 +78,7 @@ export const fieldSelectorField = {
     ],
     extractProps({ options }, dynamicInfo) {
         return {
+            allowProperties: options.allow_properties ?? true,
             followRelations: options.follow_relations ?? true,
             onlySearchable: exprToBoolean(options.only_searchable),
             resModel: options.model,

--- a/addons/web/static/src/views/fields/properties/properties_field.scss
+++ b/addons/web/static/src/views/fields/properties/properties_field.scss
@@ -62,6 +62,7 @@
     .o_field_property_open_popover,
     .oi-draggable {
         cursor: pointer;
+        font-size: 15px;
     }
     .o_field_property_open_popover:hover,
     .oi-draggable:hover {

--- a/addons/web/static/src/views/fields/properties/properties_field.xml
+++ b/addons/web/static/src/views/fields/properties/properties_field.xml
@@ -36,7 +36,7 @@
                         t-att-property-name="propertyConfiguration.name">
                         <t t-set="domId" t-value="generateUniqueDomID()"/>
                         <label
-                            class="o_field_property_label o_form_label text-break d-flex align-items-baseline mb-0"
+                            class="o_field_property_label o_form_label text-break d-flex align-items-baseline mb-0 pe-2"
                             t-att-class="{'w-auto': env.isSmall}"
                             t-att-for="domId">
                             <span
@@ -44,7 +44,7 @@
                                 t-out="propertyConfiguration.string"
                                 t-att-class="{'o_property_field_highlight': state.movedPropertyName === propertyConfiguration.name}"/>
                             <i
-                                t-else="" class="o_field_property_empty_label">
+                                t-else="" class="o_field_property_empty_label mt-1">
                                 New Property
                             </i>
                             <i
@@ -52,7 +52,7 @@
                                 class="o_field_property_open_popover fa fa-pencil ms-2"
                                 t-on-click="(event) => this.onPropertyEdit(event, propertyConfiguration.name)"/>
                             <i t-if="state.isInEditMode"
-                                class="oi oi-draggable ms-1 d-none d-sm-block"/>
+                                class="oi oi-draggable ms-1 d-none d-sm-block mt-1"/>
                         </label>
                         <div class="o_property_field_value w-100">
                             <PropertyValue

--- a/odoo/addons/base/views/ir_actions_views.xml
+++ b/odoo/addons/base/views/ir_actions_views.xml
@@ -376,7 +376,7 @@
                             </div>
                             <div class="d-flex flex-row flex-wrap gap-2" invisible="state != 'object_write'">
                                 <field name="evaluation_type" class="oe_inline"/>
-                                <field name="update_path" widget="field_selector" class="oe_inline" options="{'model': 'model_name'}"/>
+                                <field name="update_path" widget="field_selector" class="oe_inline" options="{'model': 'model_name', 'allow_properties': False}"/>
                                 <field name="update_field_id" invisible="True"/>  <!-- The field is store=True and readonly=False, in this view we want to save the value from compute/onchange -->
                                 <field name="update_related_model_id" invisible="True"/> <!-- This field is required for 'resource_ref' to compute possible m2m and m2o values -->
                                 <span invisible="evaluation_type != 'value' or update_field_type not in ['one2many', 'many2many']">by</span>


### PR DESCRIPTION
Bug
===
When inserting properties in a domain, or in the server action form view, the property separator should not be visible.

Improve the alignment of the pencil / drag property icon.

Task-4896271