### PR TITLE
[FIX] web: fix progressbar field's input on firefox

### DIFF
--- a/addons/web/static/src/views/fields/input_field_hook.js
+++ b/addons/web/static/src/views/fields/input_field_hook.js
@@ -11,14 +11,21 @@ import { useComponent, useEffect, useRef } from "@odoo/owl";
  * erased by an update of the model (typically coming from an onchange) when the
  * user is currently editing it.
  *
- * @param {() => string} getValue a function that returns the value to write in
+ * @param {Object} params
+ * @param {() => string} params.getValue a function that returns the value to write in
  *   the input, if the user isn't currently editing it
- * @param {string} [refName="input"] the ref of the input/textarea
- * @param {boolean} preventLineBreaks Prevent line breaks in input when set
+ * @param {(value: string) => any} [params.parse] a function that parses the value of the input.
+ * @param {Ref<HTMLInputElement | HTMLTextAreaElement>} [params.ref] a ref containing the input/textarea
+ * @param {string} [params.refName="input"] the ref name of the input/textarea
+ * @param {boolean} [params.preventLineBreaks] Prevent line breaks in input when set
+ * @param {string} [params.fieldName]
+ * @param {() => boolean} [params.shouldSave] if true, save the record with the new value
  */
 export function useInputField(params) {
     const inputRef = params.ref || useRef(params.refName || "input");
     const component = useComponent();
+    const fieldName = params.fieldName || component.props.name;
+    const shouldSave = params.shouldSave ?? (() => false);
 
     /*
      * A field is dirty if it is no longer sync with the model
@@ -51,7 +58,7 @@ export function useInputField(params) {
         }
         component.props.record.model.bus.trigger("FIELD_IS_DIRTY", isDirty);
         if (!component.props.record.isValid) {
-            component.props.record.resetFieldValidity(component.props.name);
+            component.props.record.resetFieldValidity(fieldName);
         }
     }
 
@@ -68,16 +75,16 @@ export function useInputField(params) {
                 try {
                     val = params.parse(val);
                 } catch {
-                    component.props.record.setInvalidField(component.props.name);
+                    component.props.record.setInvalidField(fieldName);
                     isInvalid = true;
                 }
             }
 
             if (!isInvalid) {
-                if (val !== component.props.record.data[component.props.name]) {
+                if (val !== component.props.record.data[fieldName]) {
                     lastSetValue = inputRef.el.value;
                     pendingUpdate = true;
-                    await component.props.record.update({ [component.props.name]: val });
+                    await component.props.record.update({ [fieldName]: val }, { save: shouldSave() });
                     pendingUpdate = false;
                     component.props.record.model.bus.trigger("FIELD_IS_DIRTY", isDirty);
                 } else {
@@ -126,7 +133,7 @@ export function useInputField(params) {
         if (
             inputRef.el &&
             !isDirty &&
-            !component.props.record.isFieldInvalid(component.props.name)
+            !component.props.record.isFieldInvalid(fieldName)
         ) {
             inputRef.el.value = value;
             lastSetValue = inputRef.el.value;
@@ -158,7 +165,7 @@ export function useInputField(params) {
                     if (urgent) {
                         return;
                     } else {
-                        component.props.record.setInvalidField(component.props.name);
+                        component.props.record.setInvalidField(fieldName);
                     }
                 }
             }
@@ -167,9 +174,9 @@ export function useInputField(params) {
                 return;
             }
 
-            if ((val || false) !== (component.props.record.data[component.props.name] || false)) {
+            if ((val || false) !== (component.props.record.data[fieldName] || false)) {
                 lastSetValue = inputRef.el.value;
-                await component.props.record.update({ [component.props.name]: val });
+                await component.props.record.update({ [fieldName]: val }, { save: shouldSave() });
                 component.props.record.model.bus.trigger("FIELD_IS_DIRTY", false);
             } else {
                 inputRef.el.value = params.getValue();

--- a/addons/web/static/src/views/fields/progress_bar/progress_bar_field.xml
+++ b/addons/web/static/src/views/fields/progress_bar/progress_bar_field.xml
@@ -16,9 +16,7 @@
                         type="text"
                         inputmode="decimal"
                         autocomplete="off"
-                        t-att-value="formatCurrentValue() or ''"
                         t-att-required="props.required"
-                        t-on-change="onCurrentValueChange"
                         t-on-focus="onInputFocus"
                         t-on-blur="onInputBlur"
                     />
@@ -33,8 +31,6 @@
                         type="text"
                         inputmode="decimal"
                         autocomplete="off"
-                        t-att-value="formatCurrentValue()"
-                        t-on-change="onCurrentValueChange"
                         t-on-focus="onInputFocus"
                         t-on-blur="onInputBlur"
                     />
@@ -47,8 +43,6 @@
                         type="text"
                         inputmode="decimal"
                         autocomplete="off"
-                        t-att-value="formatMaxValue()"
-                        t-on-change="onMaxValueChange"
                         t-on-focus="onInputFocus"
                         t-on-blur="onInputBlur"
                     />

--- a/addons/web/static/tests/views/fields/progress_bar_field_tests.js
+++ b/addons/web/static/tests/views/fields/progress_bar_field_tests.js
@@ -253,6 +253,7 @@ QUnit.module("Fields", (hooks) => {
             );
 
             await editInput(target, ".o_progressbar_value .o_input", "69");
+            target.querySelector(".o_progressbar_value .o_input").blur(); // because clickSave does not trigger blur
             await clickSave(target);
             assert.strictEqual(
                 target.querySelector(".o_progressbar").textContent +
@@ -490,6 +491,7 @@ QUnit.module("Fields", (hooks) => {
             assert.ok(target.querySelector(".o_form_view .o_form_editable"), "Form in edit mode");
 
             await editInput(target, ".o_field_widget input", "1#037:9");
+            target.querySelector(".o_progressbar_value .o_input").blur(); // because clickSave does not trigger blur
             await clickSave(target);
 
             assert.strictEqual(


### PR DESCRIPTION
Before this commit, the input of the progressbar field couldn't be
updated on firefox. It works on the other browsers by chance.
In the list renderer, we call `preventDefault` on enter keydown.
The event is first catch by the list renderer. This call is enough
to prevent "change" event to trigger but on chromium browsers it is
actually triggered (but should not). The progressbar field catches
it and saves the new value. On firefox, the "change" event is never
triggered.

The commit fixes the input by using the input field hook to make it
behave correctly.

task-4881210