### PR TITLE
[FIX] point_of_sale: fix test failure due to unordered set

### DIFF
--- a/addons/point_of_sale/tests/test_point_of_sale.py
+++ b/addons/point_of_sale/tests/test_point_of_sale.py
@@ -125,7 +125,7 @@ class TestPointOfSale(TransactionCase):
         products_to_display = [product3.id, product4.id]
         models_to_filter = {'product.template': products_to_display}
         products_to_display = list(set(products_to_display) - set(session.filter_local_data(models_to_filter)['product.template']))
-        self.assertEqual(products_to_display, [product3.id, product4.id])
+        self.assertEqual(sorted(products_to_display), sorted([product3.id, product4.id]))
 
         # Delete all products
         products_to_display = [product3.id, product4.id]


### PR DESCRIPTION
This PR https://github.com/odoo/odoo/pull/214829 caused a Runbot error.
The test introduced in the PR is failing because it compared a list
converted from a set to a hardcoded list, leading to inconsistent order.

Using a sorted list when converting the set fixes the issue.
