### PR TITLE
[REV] web: domain selector: in operator for everyone

### DIFF
--- a/addons/web/static/src/core/domain_selector/domain_selector_operator_editor.js
+++ b/addons/web/static/src/core/domain_selector/domain_selector_operator_editor.js
@@ -1,51 +1,113 @@
-function getSpecificOperators(fieldDef, params) {
+export function getDomainDisplayedOperators(fieldDef, params = {}) {
+    if (!fieldDef) {
+        fieldDef = {};
+    }
     const { type, is_property } = fieldDef;
 
     if (is_property) {
         switch (type) {
             case "many2many":
             case "tags":
+                return ["in", "not in", "set", "not_set"];
             case "many2one":
-                return [];
+            case "selection":
+                return ["=", "!=", "set", "not_set"];
         }
     }
-    const allowExpressions = "allowExpressions" in params ? params.allowExpressions : true;
     switch (type) {
+        case "boolean":
+            return ["set", "not_set"];
+        case "selection":
+            return ["=", "!=", "in", "not in", "set", "not_set"];
         case "char":
         case "text":
         case "html":
-        case "many2one":
-        case "many2many":
-        case "one2many":
-            return ["ilike", "not ilike", "starts_with", "ends_with"];
+            return [
+                "=",
+                "!=",
+                "ilike",
+                "not ilike",
+                "in",
+                "not in",
+                "set",
+                "not_set",
+                "starts_with",
+                "ends_with",
+            ];
         case "date":
         case "datetime":
             return [
-                ...(allowExpressions ? ["today", "not_today"] : []),
+                ...("allowExpressions" in params && !params.allowExpressions
+                    ? []
+                    : ["today", "not_today"]),
+                "=",
+                "!=",
                 ">",
                 "<",
                 "between",
                 "not_between",
-                ...(allowExpressions ? ["next", "not_next", "last", "not_last"] : []),
+                ...("allowExpressions" in params && !params.allowExpressions
+                    ? []
+                    : ["next", "not_next", "last", "not_last"]),
+                "set",
+                "not_set",
             ];
         case "integer":
         case "float":
         case "monetary":
-            return [">", "<", "between", "not_between", "ilike", "not ilike"];
+            return [
+                "=",
+                "!=",
+                ">",
+                "<",
+                "between",
+                "not_between",
+                "ilike",
+                "not ilike",
+                "set",
+                "not_set",
+            ];
+        case "many2one":
+        case "many2many":
+        case "one2many":
+            return [
+                "in",
+                "not in",
+                "=",
+                "!=",
+                "ilike",
+                "not ilike",
+                "set",
+                "not_set",
+                "starts_with",
+                "ends_with",
+            ];
         case "json":
-            return ["ilike", "not ilike"];
+            return ["=", "!=", "ilike", "not ilike", "set", "not_set"];
+        case "properties":
+            return ["set", "not_set"];
+        case "date_option":
+        case "datetime_option":
+        case "time_option":
+            return ["=", "!=", ">", "<", "between", "not_between", "set", "not_set"];
+        case undefined:
+            return ["="];
         default:
-            return [];
+            return [
+                "=",
+                "!=",
+                ">",
+                "<",
+                "ilike",
+                "not ilike",
+                "like",
+                "not like",
+                "=like",
+                "=ilike",
+                "in",
+                "not in",
+                "set",
+                "not_set",
+            ];
     }
-}
-
-export function getDomainDisplayedOperators(fieldDef, params = {}) {
-    fieldDef ||= {};
-    if (!fieldDef.type) {
-        return ["="];
-    }
-    if (fieldDef.type === "boolean") {
-        return ["set", "not_set"];
-    }
-    return ["in", "not in", ...getSpecificOperators(fieldDef, params), "set", "not_set"];
 }

--- a/addons/web/static/src/core/tree_editor/tree_editor_operator_editor.js
+++ b/addons/web/static/src/core/tree_editor/tree_editor_operator_editor.js
@@ -5,8 +5,8 @@ import { Select } from "@web/core/tree_editor/tree_editor_components";
 
 const OPERATOR_DESCRIPTIONS = {
     // valid operators (see TERM_OPERATORS in expression.py)
-    "=": _t("="),
-    "!=": _t("!="),
+    "=": _t("equals"),
+    "!=": _t("not equals"),
     "<=": _t("lower or equal"),
     "<": _t("lower"),
     ">": _t("greater"),
@@ -18,8 +18,8 @@ const OPERATOR_DESCRIPTIONS = {
     "not like": _t("not like"),
     ilike: _t("contains"),
     "not ilike": _t("not contains"),
-    in: _t("equals"),
-    "not in": _t("not equals"),
+    in: _t("is in"),
+    "not in": _t("is not in"),
     child_of: _t("child of"),
     parent_of: _t("parent of"),
 

--- a/addons/web/static/src/core/tree_editor/tree_editor_value_editors.js
+++ b/addons/web/static/src/core/tree_editor/tree_editor_value_editors.js
@@ -207,6 +207,8 @@ function getPartialValueEditorInfo(fieldDef, operator, params = {}) {
         case "in":
         case "not in": {
             switch (fieldDef.type) {
+                case "tags":
+                    return STRING_EDITOR;
                 case "many2one":
                 case "many2many":
                 case "one2many":

--- a/addons/web/static/tests/core/domain_field.test.js
+++ b/addons/web/static/tests/core/domain_field.test.js
@@ -904,7 +904,7 @@ test("domain field with 'inDialog' options", async function () {
     await contains(`.modal ${SELECTORS.addNewRule}`).click();
     await contains(".modal-footer .btn-primary").click();
     expect(SELECTORS.condition).toHaveCount(1);
-    expect(getConditionText()).toBe("Id = ( )");
+    expect(getConditionText()).toBe("Id = 1");
 });
 
 test("invalid value in domain field with 'inDialog' options", async function () {
@@ -1121,7 +1121,7 @@ test("add condition in empty foldable domain", async function () {
     await contains(".o_domain_add_first_node_button").click();
     // Domain is now unfolded with the default condition
     expect(".o_model_field_selector").toHaveCount(1);
-    expect(SELECTORS.debugArea).toHaveValue('[("id", "in", [])]');
+    expect(SELECTORS.debugArea).toHaveValue('[("id", "=", 1)]');
 });
 
 test("foldable domain field unfolds and hides caret when domain is invalid", async function () {
@@ -1316,7 +1316,6 @@ test("hide today, last, next operators when allow_expressions = False", async fu
         "not between",
         "set",
         "not set",
-        "=",
     ]);
 
     await contains(SELECTORS.debugArea).edit(

--- a/addons/web/static/tests/core/expression_editor/expression_editor.test.js
+++ b/addons/web/static/tests/core/expression_editor/expression_editor.test.js
@@ -107,7 +107,7 @@ test("rendering of falsy values", async () => {
         await parent.set(expr);
         expect(getTreeEditorContent()).toEqual([
             { value: "all", level: 0 },
-            { value: ["0", "=", "1"], level: 1 },
+            { value: ["0", "equals", "1"], level: 1 },
         ]);
     }
 });
@@ -184,7 +184,7 @@ test("change path, operator and value", async () => {
     await makeExpressionEditor({ expression: `bar != "blabla"` });
     expect(getTreeEditorContent()).toEqual([
         { level: 0, value: "all" },
-        { level: 1, value: ["Bar", "!=", "blabla"] },
+        { level: 1, value: ["Bar", "not equals", "blabla"] },
     ]);
     const tree = getTreeEditorContent({ node: true });
     await openModelFieldSelectorPopover();
@@ -193,7 +193,7 @@ test("change path, operator and value", async () => {
     await editValue(["Doku", "Lukaku", "KDB"]);
     expect(getTreeEditorContent()).toEqual([
         { level: 0, value: "all" },
-        { level: 1, value: ["Foo", "not equals", "Doku,Lukaku,KDB"] },
+        { level: 1, value: ["Foo", "is not in", "Doku,Lukaku,KDB"] },
     ]);
 });
 
@@ -217,8 +217,8 @@ test("rendering of a valid fieldName in fields", async () => {
 
     const toTests = [
         { expr: `foo`, condition: ["Foo", "set"] },
-        { expr: `foo == "a"`, condition: ["Foo", "=", "a"] },
-        { expr: `foo != "a"`, condition: ["Foo", "!=", "a"] },
+        { expr: `foo == "a"`, condition: ["Foo", "equals", "a"] },
+        { expr: `foo != "a"`, condition: ["Foo", "not equals", "a"] },
         // { expr: `foo is "a"`, complexCondition: `foo is "a"` },
         // { expr: `foo is not "a"`, complexCondition: `foo is not "a"` },
         { expr: `not foo`, condition: ["Foo", "not set"] },
@@ -248,10 +248,10 @@ test("rendering of simple conditions", async () => {
     const parent = await makeExpressionEditor({ fieldFilters: ["foo", "bar"] });
 
     const toTests = [
-        { expr: `bar == "a"`, condition: ["Bar", "=", "a"] },
-        { expr: `foo == expr`, condition: ["Foo", "=", "expr"] },
-        { expr: `"a" == foo`, condition: ["Foo", "=", "a"] },
-        { expr: `expr == foo`, condition: ["Foo", "=", "expr"] },
+        { expr: `bar == "a"`, condition: ["Bar", "equals", "a"] },
+        { expr: `foo == expr`, condition: ["Foo", "equals", "expr"] },
+        { expr: `"a" == foo`, condition: ["Foo", "equals", "a"] },
+        { expr: `expr == foo`, condition: ["Foo", "equals", "expr"] },
         { expr: `foo == bar`, complexCondition: `foo == bar` },
         { expr: `"a" == "b"`, complexCondition: `"a" == "b"` },
         { expr: `expr1 == expr2`, complexCondition: `expr1 == expr2` },
@@ -264,8 +264,8 @@ test("rendering of simple conditions", async () => {
         { expr: `"a" < "b"`, complexCondition: `"a" < "b"` },
         { expr: `expr1 < expr2`, complexCondition: `expr1 < expr2` },
 
-        { expr: `foo in ["a"]`, condition: ["Foo", "equals", "a"] },
-        { expr: `foo in [expr]`, condition: ["Foo", "equals", "expr"] },
+        { expr: `foo in ["a"]`, condition: ["Foo", "is in", "a"] },
+        { expr: `foo in [expr]`, condition: ["Foo", "is in", "expr"] },
         { expr: `"a" in foo`, complexCondition: `"a" in foo` },
         { expr: `expr in foo`, complexCondition: `expr in foo` },
         { expr: `foo in bar`, complexCondition: `foo in bar` },
@@ -298,7 +298,7 @@ test("rendering of connectors", async () => {
         { level: 0, value: "any" },
         { level: 1, value: "all" },
         { level: 2, value: "expr" },
-        { level: 2, value: ["Foo", "=", "abc"] },
+        { level: 2, value: ["Foo", "equals", "abc"] },
         { level: 1, value: ["Bar", "not set"] },
     ]);
 });
@@ -314,7 +314,7 @@ test("rendering of connectors (2)", async () => {
     expect(getTreeEditorContent()).toEqual([
         { level: 0, value: "none" },
         { level: 1, value: "expr" },
-        { level: 1, value: ["Foo", "=", "abc"] },
+        { level: 1, value: ["Foo", "equals", "abc"] },
     ]);
     expect.verifySteps([]);
     expect(queryOne(SELECTORS.debugArea)).toHaveValue(`not (expr or foo == "abc")`);
@@ -323,7 +323,7 @@ test("rendering of connectors (2)", async () => {
     expect(getTreeEditorContent()).toEqual([
         { level: 0, value: "all" },
         { level: 1, value: "expr" },
-        { level: 1, value: ["Foo", "=", "abc"] },
+        { level: 1, value: ["Foo", "equals", "abc"] },
     ]);
     expect.verifySteps([`expr and foo == "abc"`]);
     expect(queryOne(SELECTORS.debugArea)).toHaveValue(`expr and foo == "abc"`);
@@ -334,11 +334,11 @@ test("rendering of if else", async () => {
     expect(getTreeEditorContent()).toEqual([
         { level: 0, value: "any" },
         { level: 1, value: "all" },
-        { level: 2, value: ["0", "=", "1"] },
-        { level: 2, value: ["1", "=", "1"] },
+        { level: 2, value: ["0", "equals", "1"] },
+        { level: 2, value: ["1", "equals", "1"] },
         { level: 1, value: "all" },
-        { level: 2, value: ["1", "=", "1"] },
-        { level: 2, value: ["0", "=", "1"] },
+        { level: 2, value: ["1", "equals", "1"] },
+        { level: 2, value: ["0", "equals", "1"] },
     ]);
 });
 
@@ -370,9 +370,9 @@ test("allow selection of boolean field", async () => {
 
 test("render false and true leaves", async () => {
     await makeExpressionEditor({ expression: `False and True` });
-    expect(getOperatorOptions()).toEqual(["="]);
+    expect(getOperatorOptions()).toEqual(["equals"]);
     expect(getValueOptions()).toEqual(["1"]);
-    expect(getOperatorOptions(-1)).toEqual(["="]);
+    expect(getOperatorOptions(-1)).toEqual(["equals"]);
     expect(getValueOptions(-1)).toEqual(["1"]);
 });
 
@@ -397,7 +397,7 @@ test("no field of type properties in model field selector", async () => {
     ]);
     expect(isNotSupportedPath()).toBe(true);
     await clearNotSupported();
-    expect.verifySteps([`foo in []`]);
+    expect.verifySteps([`foo == ""`]);
 
     await openModelFieldSelectorPopover();
     expect(queryAllTexts(".o_model_field_selector_popover_item_name")).toEqual(["Bar", "Foo"]);
@@ -418,7 +418,7 @@ test("no special fields in fields", async () => {
         { level: 0, value: "all" },
         { level: 1, value: ["Foo", "equals", ""] },
     ]);
-    expect.verifySteps([`foo in []`]);
+    expect.verifySteps([`foo == ""`]);
 });
 
 test("between operator", async () => {
@@ -437,7 +437,6 @@ test("between operator", async () => {
         "not between",
         "set",
         "not set",
-        "=",
     ]);
     expect.verifySteps([]);
     await selectOperator("between");
@@ -452,10 +451,10 @@ test("next operator", async () => {
         },
     });
     expect(getOperatorOptions()).toEqual([
-        "equals",
-        "not equals",
         "today",
         "not today",
+        "equals",
+        "not equals",
         "greater",
         "lower",
         "between",
@@ -466,7 +465,6 @@ test("next operator", async () => {
         "not last",
         "set",
         "not set",
-        "!=",
     ]);
     expect.verifySteps([]);
     await selectOperator("next");
@@ -483,10 +481,10 @@ test("not_next operator", async () => {
         },
     });
     expect(getOperatorOptions()).toEqual([
-        "equals",
-        "not equals",
         "today",
         "not today",
+        "equals",
+        "not equals",
         "greater",
         "lower",
         "between",
@@ -497,7 +495,6 @@ test("not_next operator", async () => {
         "not last",
         "set",
         "not set",
-        "!=",
     ]);
     expect.verifySteps([]);
     await selectOperator("not_next");
@@ -514,10 +511,10 @@ test("last operator", async () => {
         },
     });
     expect(getOperatorOptions()).toEqual([
-        "equals",
-        "not equals",
         "today",
         "not today",
+        "equals",
+        "not equals",
         "greater",
         "lower",
         "between",
@@ -528,7 +525,6 @@ test("last operator", async () => {
         "not last",
         "set",
         "not set",
-        "!=",
     ]);
     expect.verifySteps([]);
     await selectOperator("last");
@@ -545,10 +541,10 @@ test("not_last operator", async () => {
         },
     });
     expect(getOperatorOptions()).toEqual([
-        "equals",
-        "not equals",
         "today",
         "not today",
+        "equals",
+        "not equals",
         "greater",
         "lower",
         "between",
@@ -559,7 +555,6 @@ test("not_last operator", async () => {
         "not last",
         "set",
         "not set",
-        "!=",
     ]);
     expect.verifySteps([]);
     await selectOperator("not_last");

--- a/addons/web/static/tests/search/search_bar.test.js
+++ b/addons/web/static/tests/search/search_bar.test.js
@@ -1341,7 +1341,7 @@ test("search a property: definition record id in the context", async () => {
 
 test("edit a filter", async () => {
     onRpc("/web/domain/validate", () => true);
-    const searchBar = await mountWithSearch(SearchBar, {
+    await mountWithSearch(SearchBar, {
         resModel: "partner",
         searchMenuTypes: ["groupBy"], // we need it to have facet (see facets getter in search_model)
         searchViewId: false,
@@ -1380,12 +1380,11 @@ test("edit a filter", async () => {
     expect(SELECTORS.condition).toHaveCount(1);
     expect(getCurrentPath()).toBe("Id");
     expect(getCurrentOperator()).toBe("equals");
-    expect(getCurrentValue()).toBe("");
+    expect(getCurrentValue()).toBe("1");
 
     await contains(".modal footer button").click();
     expect(`.modal`).toHaveCount(0);
-    expect(getFacetTexts()).toEqual(["Id = ( )", "Bool"]);
-    expect(searchBar.env.searchModel.domain).toEqual([["id", "in", []]]);
+    expect(getFacetTexts()).toEqual(["Id = 1", "Bool"]);
 });
 
 test("edit a filter with context: context is kept after edition", async () => {

--- a/addons/web/static/tests/search/search_bar_menu/filter_menu.test.js
+++ b/addons/web/static/tests/search/search_bar_menu/filter_menu.test.js
@@ -700,17 +700,17 @@ test("Add a custom filter", async () => {
     await clickOnButtonAddBranch(-1);
     await clickOnButtonAddRule(-1);
     await contains(".modal footer button").click();
-    expect(getFacetTexts()).toEqual(["Filter", "Id = ( )", "Id = ( )", "Id = ( )"]);
+    expect(getFacetTexts()).toEqual(["Filter", "Id = 1", "Id = 1", "Id = 1"]);
     expect(searchBar.env.searchModel.domain).toEqual([
         "&",
         ["foo", "=", "abc"],
         "&",
-        ["id", "in", []],
+        ["id", "=", 1],
         "&",
-        ["id", "in", []],
+        ["id", "=", 1],
         "|",
-        ["id", "in", []],
-        ["id", "in", []],
+        ["id", "=", 1],
+        ["id", "=", 1],
     ]);
 
     // open again the search menu -> the custom filter should not be displayed

--- a/addons/web/static/tests/tours/favorite_management_tour.js
+++ b/addons/web/static/tests/tours/favorite_management_tour.js
@@ -65,10 +65,6 @@ registry.category("web_tour.tours").add("test_favorite_management", {
             run: "click",
         },
         {
-            trigger: ".o_tree_editor_row .o_tree_editor_editor input",
-            run: "edit 1",
-        },
-        {
             trigger: ".o_form_button_save",
             run: "click",
         },

--- a/addons/web/static/tests/views/kanban/kanban_view.test.js
+++ b/addons/web/static/tests/views/kanban/kanban_view.test.js
@@ -3435,7 +3435,7 @@ test("kanban grouped by stage_id: move record from to the None column", async ()
     // Set up a record with no stage initially
     Partner._records = [
         { id: 1, foo: "Task A", stage_id: false },
-        { id: 2, foo: "Task B", stage_id: 10},
+        { id: 2, foo: "Task B", stage_id: 10 },
     ];
     Partner._fields.stage_id = fields.Many2one({ relation: "partner.stage" });
 
@@ -3456,9 +3456,9 @@ test("kanban grouped by stage_id: move record from to the None column", async ()
     expect(queryAll(".o_kanban_group")).toHaveCount(2); // None and New
 
     await click(".o_kanban_group:first .o_kanban_header");
-    
+
     // Drag a record to the "None" column
-    let dragActions = await contains(".o_kanban_record:contains(Task B)").drag();
+    const dragActions = await contains(".o_kanban_record:contains(Task B)").drag();
     await dragActions.moveTo(".o_kanban_group:nth-child(1) .o_kanban_header");
     await dragActions.drop();
 
@@ -5220,7 +5220,7 @@ test("edit a favorite: group by = default_group_by", async () => {
     await contains(".o_searchview_facet_label").click();
     await addNewRule();
     await contains("button:contains('Search')").click();
-    expect(getFacetTexts()).toEqual(["Id = ( )"]);
+    expect(getFacetTexts()).toEqual(["Id = 1"]);
 });
 
 test.tags("desktop");
@@ -5263,7 +5263,7 @@ test("edit a favorite: group by != default_group_by", async () => {
     await contains(".o_searchview_facet_label").click();
     await addNewRule();
     await contains("button:contains('Search')").click();
-    expect(getFacetTexts()).toEqual(["Id = ( )", "Product"]);
+    expect(getFacetTexts()).toEqual(["Id = 1", "Product"]);
 });
 
 test.tags("desktop");


### PR DESCRIPTION
This commit partially reverts the commit https://github.com/odoo/odoo/commit/cf944e460cdb7ff371a56479e2fed89930680061.
The tree editor will be developed in another direction where less operators are available (see task 4894524).