### PR TITLE
[FIX] account_edi_ubl_cii: Fix Bis3 tests in community

### DIFF
--- a/addons/account_edi_ubl_cii/tests/test_ubl_bis3.py
+++ b/addons/account_edi_ubl_cii/tests/test_ubl_bis3.py
@@ -35,6 +35,7 @@ class TestUblBis3(AccountTestInvoicingCommon):
             'zip': "1367",
             'city': "Ramillies",
             'vat': 'BE0202239951',
+            'company_registry': '0202239951',
             'country_id': self.env.ref('base.be').id,
             'bank_ids': [Command.create({'acc_number': 'BE15001559627230'})],
         })
@@ -45,6 +46,7 @@ class TestUblBis3(AccountTestInvoicingCommon):
             'zip': "1367",
             'city': "Ramillies",
             'vat': 'BE0477472701',
+            'company_registry': '0477472701',
             'country_id': self.env.ref('base.be').id,
             'bank_ids': [Command.create({'acc_number': 'BE90735788866632'})],
         })


### PR DESCRIPTION
The TestUblBis3 tests are failing in the nightly community runbot because the company_registry is not set on the company, causing the peppol_eas and peppol_endpoint to use the company's VAT number rather than its company_registry number.

runbot-227638