### PR TITLE
[FIX] hr: prevent traceback showing invisible elements

### DIFF
--- a/addons/hr/static/src/views/open_chat_hook.js
+++ b/addons/hr/static/src/views/open_chat_hook.js
@@ -8,11 +8,14 @@ patch(helpers, {
         ...helpers.SUPPORTED_M2X_AVATAR_MODELS,
         "hr.employee",
         "hr.employee.public",
+        "hr.candidate",
     ],
     buildOpenChatParams(resModel, id) {
-        if (["hr.employee", "hr.employee.public"].includes(resModel)) {
+        if (resModel === "hr.candidate") {
+            return;
+        } else if (["hr.employee", "hr.employee.public"].includes(resModel)) {
             return { employeeId: id };
         }
         return super.buildOpenChatParams(...arguments);
-    }
+    },
 });

--- a/addons/hr/static/tests/tours/hr_employee_flow.js
+++ b/addons/hr/static/tests/tours/hr_employee_flow.js
@@ -27,3 +27,46 @@ registry.category("web_tour.tours").add('hr_employee_tour', {
         run: 'click',
     },
 ]});
+
+registry.category("web_tour.tours").add("hr_candidate_tour", {
+    url: "/odoo",
+    steps: () => [
+        {
+            content: "Open Recruitment App",
+            trigger: '.o_app[data-menu-xmlid="hr_recruitment.menu_hr_recruitment_root"]',
+            run: "click",
+        },
+        {
+            content: "Open Applications menu",
+            trigger: 'button.dropdown-toggle:contains("Applications")',
+            run: "click",
+        },
+        {
+            content: "Go to Candidates list",
+            trigger: 'a.dropdown-item:contains("Candidates")',
+            run: "click",
+        },
+        {
+            content: "Click on candidate",
+            trigger: '.o_kanban_record:contains("Extended Test Candidate")',
+            run: "click",
+        },
+        {
+            content: "Candidate form should open",
+            trigger: ".o_form_view", // Wait for form view container
+        },
+        {
+            trigger: 'button[title="Toggle Studio"]',
+            run: "click",
+        },
+        {
+            trigger: ".nav-link.o_web_studio_view",
+            run: "click",
+        },
+        {
+            content: "Show invisible elements",
+            trigger: 'label[for="show_invisible"]',
+            run: "click",
+        },
+    ],
+});

--- a/addons/hr/tests/test_hr_employee.py
+++ b/addons/hr/tests/test_hr_employee.py
@@ -504,3 +504,13 @@ class TestHrEmployeeWebJson(HttpCase):
         }
         res = self.url_open(url, headers=CSRF_USER_HEADERS)
         self.assertEqual(res.status_code, 200)
+
+    def test_candidate_view_error(self):
+        """Run the hr_candidate_tour UI tour."""
+
+        self.env['hr.candidate'].create({
+            'partner_name': "Extended Test Candidate",
+        })
+
+        # Start the tour
+        self.start_tour("/odoo", 'hr_candidate_tour', login="admin")

--- a/addons/hr_recruitment/views/hr_candidate_views.xml
+++ b/addons/hr_recruitment/views/hr_candidate_views.xml
@@ -52,7 +52,7 @@
                     <div class="row justify-content-between position-relative w-100 m-0 mb-2">
                         <div class="oe_title mw-75 ps-0 pe-2">
                             <h1 class="d-flex flex-row align-items-center">
-                                <div invisible="not user_id" class="me-2">
+                                <div invisible="1" class="me-2">
                                     <widget name="hr_employee_chat" invisible="not context.get('chat_icon')"/>
                                 </div>
                                 <field name="partner_name" placeholder="Candidate's Name"


### PR DESCRIPTION
To reproduce:
==============
1/ Go to the Candidate form view
2/ Pick any candidate
3/ Open Studio
4/ Click on "Show Invisible Elements"

Problem:
=========
A traceback occurs because the `hr.candidate` model was not included in the supported models list for showing invisible elements.

Solution:
==========
Add `hr.candidate` to the supported models to avoid the traceback and properly show invisible elements in Studio.

opw-4886130
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
