### PR TITLE
[FIX] account : prevent invoice layout issue

### DIFF
--- a/addons/account/views/report_invoice.xml
+++ b/addons/account/views/report_invoice.xml
@@ -106,7 +106,7 @@
 
                         <t t-set="display_discount" t-value="any(l.discount for l in o.invoice_line_ids)"/>
                         <div class="oe_structure"></div>
-                        <table class="o_has_total_table table o_main_table table-borderless" name="invoice_line_table">
+                        <table class="o_has_total_table table o_main_table table-borderless mb-0" name="invoice_line_table">
                             <thead>
                                 <tr>
                                     <th name="th_description" class="text-start"><span>Description</span></th>
@@ -181,9 +181,9 @@
                                 </t>
                             </tbody>
                         </table>
-                        <div>
+                        <div class="overflow-hidden">
                             <div id="right-elements" t-attf-class="#{'col-5 mt-5' if report_type == 'pdf' else 'col-12 col-md-5'} ms-5 d-inline-block float-end">
-                                <div id="total" class="clearfix row mt-n3">
+                                <div id="total" class="clearfix row">
                                     <div class="ms-auto">
                                         <table class="o_total_table table table-borderless avoid-page-break-inside">
 
@@ -236,7 +236,7 @@
                                     <div class="oe_structure"/>
                                 </t>
                             </div>
-                            <div id="payment_term" class="clearfix">
+                            <div id="payment_term" class="clearfix mt-3">
                                 <div class="justify-text">
                                     <p t-if="not is_html_empty(o.fiscal_position_id.note)" name="note" class="mb-2">
                                         <span t-field="o.fiscal_position_id.note"/>


### PR DESCRIPTION
Before this commit, a print invoice that's on 2 pages with a boxed template left 2 vertical lines on the page bottom
A negative margin top in applied that push the table top to the first page


I change the layout of `report_invoice_document` to avoid a negative margin.
The negative margin-top to `total` was there to move the float div higher to compensate the ´table` margin-bottom.

I remove the `table` margin-bottom and replace that by a `payment term` margin-top.
The margin were collapsed for `total` and `payment term` so I had to add an overflow-hidden on the parent div.


## Before :
![image](https://github.com/user-attachments/assets/382f9a8e-37db-41c3-a81e-e9adf8ceab82)

## After :
![image](https://github.com/user-attachments/assets/8e9fedec-3207-4c47-adbf-a98bc4f291ad)


## Steps to reproduce :
- Change the document layout to a boxed one in the Settings
- Create products with long descriptions (example can be found in the linked ticket)
- Create an invoice with the products
- Print the invoice (the total should be on the second page top)
- The vertical lines should be there

opw-4841652