### PR TITLE
[FIX] website: editing and saving menus does not discard editor changes

### DIFF
--- a/addons/website/static/src/builder/plugins/menu_data_plugin.js
+++ b/addons/website/static/src/builder/plugins/menu_data_plugin.js
@@ -6,6 +6,7 @@ import { withSequence } from "@html_editor/utils/resource";
 
 export class MenuDataPlugin extends Plugin {
     static id = "menuDataPlugin";
+    static dependencies = ["savePlugin"];
     resources = {
         link_popovers: [
             withSequence(10, {
@@ -45,6 +46,7 @@ export class MenuDataPlugin extends Plugin {
                     onClickEditMenu: () => {
                         this.services.dialog.add(EditMenuDialog, {
                             save: async () => {
+                                await this.dependencies.savePlugin.save();
                                 await this.config.reloadEditor();
                             },
                         });

--- a/addons/website/static/tests/builder/website_builder/menu_data.test.js
+++ b/addons/website/static/tests/builder/website_builder/menu_data.test.js
@@ -8,6 +8,7 @@ import { patchWithCleanup, mockService, onRpc } from "@web/../tests/web_test_hel
 import { MAIN_PLUGINS } from "@html_editor/plugin_sets";
 import { MenuDataPlugin } from "@website/builder/plugins/menu_data_plugin";
 import { MenuDialog } from "@website/components/dialog/edit_menu";
+import { SavePlugin } from "@html_builder/core/save_plugin";
 
 defineWebsiteModels();
 
@@ -23,7 +24,7 @@ describe("NavbarLinkPopover", () => {
             </ul>
             <p>Outside</p>`,
             {
-                config: { Plugins: [...MAIN_PLUGINS, MenuDataPlugin] },
+                config: { Plugins: [...MAIN_PLUGINS, MenuDataPlugin, SavePlugin] },
             }
         );
         await expectElementCount(".o-we-linkpopover", 0);
@@ -48,7 +49,7 @@ describe("NavbarLinkPopover", () => {
                 </li>
             </ul>`,
             {
-                config: { Plugins: [...MAIN_PLUGINS, MenuDataPlugin] },
+                config: { Plugins: [...MAIN_PLUGINS, MenuDataPlugin, SavePlugin] },
             }
         );
         expect(".o-we-linkpopover:has(i.fa-sitemap)").toHaveCount(0);
@@ -82,7 +83,7 @@ describe("NavbarLinkPopover", () => {
                 </div>
             </ul>`,
             {
-                config: { Plugins: [...MAIN_PLUGINS, MenuDataPlugin] },
+                config: { Plugins: [...MAIN_PLUGINS, MenuDataPlugin, SavePlugin] },
             }
         );
         expect(".o-we-linkpopover:has(i.fa-sitemap)").toHaveCount(0);
@@ -104,7 +105,7 @@ describe("MenuDialog", () => {
                 </li>
             </ul>`,
             {
-                config: { Plugins: [...MAIN_PLUGINS, MenuDataPlugin] },
+                config: { Plugins: [...MAIN_PLUGINS, MenuDataPlugin, SavePlugin] },
             }
         );
         patchWithCleanup(MenuDialog.prototype, {
@@ -170,7 +171,7 @@ describe("EditMenuDialog", () => {
                 </li>
             </ul>`,
             {
-                config: { Plugins: [...MAIN_PLUGINS, MenuDataPlugin] },
+                config: { Plugins: [...MAIN_PLUGINS, MenuDataPlugin, SavePlugin] },
             }
         );
         mockService("website", {


### PR DESCRIPTION
This plugin fixes a bug where making changes on the editor, opening the menu editor and clicking save would cause the changes to be discarded.

Steps to reproduce:
- Open editor
- Make any change
- Click on any navbar element (like Home) to open the navbar popover
- Click on the edit menu button in the popover
- A modal will open, click save
- All changes have been discarded

After the fix the changes will be saved when clicking save in the menu editor modal
