### PR TITLE
[FIX] web: don't show `False` in the list view for HTML properties

### DIFF
--- a/addons/html_editor/static/src/fields/html_field.js
+++ b/addons/html_editor/static/src/fields/html_field.js
@@ -112,7 +112,7 @@ export class HtmlField extends Component {
     }
 
     get value() {
-        const value = this.props.record.data[this.props.name];
+        const value = this.props.record.data[this.props.name] || "";
         let newVal = fixInvalidHTML(value);
         if (this.props.migrateHTML) {
             newVal = this.htmlUpgradeManager.processForUpgrade(newVal, {

--- a/addons/web/static/src/views/fields/formatters.js
+++ b/addons/web/static/src/views/fields/formatters.js
@@ -429,7 +429,7 @@ export function formatText(value) {
  * @returns {html}
  */
 export function formatHtml(value) {
-    return value;
+    return value || "";
 }
 
 export function formatJson(value) {


### PR DESCRIPTION
Bug
===
Create an HTML properties, and don't set a value. It is displayed as "False" in the list view, while it should be an empty string.

Change the HTML formatter, so it's consistent with the text formatter.

Task-4896271