### PR TITLE
[FIX] website: editing and saving menus does not discard editor changes

### DIFF
--- a/addons/website/static/src/builder/plugins/menu_data_plugin.js
+++ b/addons/website/static/src/builder/plugins/menu_data_plugin.js
@@ -6,6 +6,7 @@ import { withSequence } from "@html_editor/utils/resource";
 
 export class MenuDataPlugin extends Plugin {
     static id = "menuDataPlugin";
+    static dependencies = ["savePlugin"];
     resources = {
         link_popovers: [
             withSequence(10, {
@@ -45,6 +46,7 @@ export class MenuDataPlugin extends Plugin {
                     onClickEditMenu: () => {
                         this.services.dialog.add(EditMenuDialog, {
                             save: async () => {
+                                await this.dependencies.savePlugin.save();
                                 await this.config.reloadEditor();
                             },
                         });


### PR DESCRIPTION
This plugin fixes a bug where making changes on the editor, opening the menu editor and clicking save would cause the changes to be discarded.

Steps to reproduce:
- Open editor
- Make any change
- Click on any navbar element (like Home) to open the navbar popover
- Click on the edit menu button in the popover
- A modal will open, click save
- All changes have been discarded

After the fix the changes will be saved when clicking save in the menu editor modal
