### PR TITLE
[FIX] web: do not update if another load has been done

### DIFF
--- a/addons/web/static/src/model/relational_model/relational_model.js
+++ b/addons/web/static/src/model/relational_model/relational_model.js
@@ -21,6 +21,7 @@ import {
     getBasicEvalContext,
     getFieldsSpec,
     getGroupServerValue,
+    getId,
     makeActiveField,
 } from "./utils";
 import { FetchRecordError } from "./errors";
@@ -49,6 +50,7 @@ import { FetchRecordError } from "./errors";
  *  isRoot: boolean;
  *  resIds?: number[];
  *  mode?: "edit" | "readonly";
+ *  loadId?: string;
  *  limit?: number;
  *  offset?: number;
  *  countLimit?: number;
@@ -197,7 +199,7 @@ export class RelationalModel extends Model {
         const cached = this._getCacheParams(config, rootLoadDef);
         const data = await this.keepLast.add(this._loadData(config, cached));
         this.root = this._createRoot(config, data);
-        rootLoadDef.resolve(this.root);
+        rootLoadDef.resolve({ root: this.root, loadId: config.loadId });
         this.config = config;
         await this.hooks.onRootLoaded(this.root);
     }
@@ -281,7 +283,7 @@ export class RelationalModel extends Model {
         ) {
             return {
                 onUpdate: async (result) => {
-                    const root = await rootLoadDef;
+                    const { root, loadId } = await rootLoadDef;
                     if (root.id !== this.root.id) {
                         // The root that we want to update is not the current one. It may happen
                         // we displayed sample data from the cache, but the rpc returned records. In
@@ -291,6 +293,11 @@ export class RelationalModel extends Model {
                             this.useSampleModel = false;
                             this.root._setData(result);
                         }
+                        return;
+                    }
+                    if (loadId !== this.root.config.loadId) {
+                        // Avoid updating if another load was already done.
+                        // For instance a sort in a list.
                         return;
                     }
                     if (root.config.isMonoRecord) {
@@ -395,6 +402,7 @@ export class RelationalModel extends Model {
      * @param {Object} [cached]
      */
     async _loadData(config, cached) {
+        config.loadId = getId("load");
         if (config.isMonoRecord) {
             const evalContext = getBasicEvalContext(config);
             if (!config.resId) {


### PR DESCRIPTION
- Open a view list;
- The cached data are shown;
- The RPC (web_search_read) to recover the latests data is very slow.
- The user sort the list and this RPC will return immediatly;
- The list will be updated with the latests sorted data.
- The first RPC, which was very slow, returns (with a non sorted data).

Before this commit, the list will be updated with the retuned RPC. This is an issue because the user has already performed another action (like asking to sort the list). The last returned RPC should be ignored and not appllied.

Now, the relational model will only update the data if no other load is performed.

task-id 4896533