### PR TITLE
[FIX] account: Create reversal reference using partner's language

### DIFF
--- a/addons/account/wizard/account_move_reversal.py
+++ b/addons/account/wizard/account_move_reversal.py
@@ -87,13 +87,16 @@ class AccountMoveReversal(models.TransientModel):
             record.currency_id = len(move_ids.currency_id) == 1 and move_ids.currency_id or False
             record.move_type = move_ids.move_type if len(move_ids) == 1 else (any(move.move_type in ('in_invoice', 'out_invoice') for move in move_ids) and 'some_invoice' or False)
 
+    def _get_ref_string(self, move):
+        return (_('Reversal of: %(move_name)s, %(reason)s', move_name=move.name, reason=self.reason)
+            if self.reason
+            else _('Reversal of: %s', move.name))
+
     def _prepare_default_reversal(self, move):
         reverse_date = self.date
         mixed_payment_term = move.invoice_payment_term_id.id if move.invoice_payment_term_id.early_pay_discount_computation == 'mixed' else None
         return {
-            'ref': _('Reversal of: %(move_name)s, %(reason)s', move_name=move.name, reason=self.reason)
-                   if self.reason
-                   else _('Reversal of: %s', move.name),
+            'ref': self.with_context(lang=move.partner_id.lang or self.env.lang)._get_ref_string(move),
             'date': reverse_date,
             'invoice_date_due': reverse_date,
             'invoice_date': move.is_invoice(include_receipts=True) and (self.date or move.date) or False,


### PR DESCRIPTION
Steps to reproduce:
====================
- Create an invoice
- Add a customer whose language differs from the user's language
- Create a reversal
- Print the PDF

Problem:
=========
The reversal reference is generated using the user's language, making it impossible to translate properly because the string value is changed and concatenated with the invoice name.

Solution:
==========
Generate the reversal reference using the partner's language to enable proper translation.

opw-4743430
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
