### PR TITLE
[FIX] html_builder: restore custom style action handling in builder

### DIFF
--- a/addons/html_builder/static/src/core/builder_action.js
+++ b/addons/html_builder/static/src/core/builder_action.js
@@ -9,7 +9,7 @@ export class BuilderAction {
         this.config = plugin.config;
         this.getResource = plugin.getResource.bind(plugin);
         this.dispatchTo = plugin.dispatchTo.bind(plugin);
-        this.delegateTo = plugin.delegateTo.bind(this);
+        this.delegateTo = plugin.delegateTo.bind(plugin);
 
         this.preview = true;
         this.withLoadingEffect = true;

--- a/addons/html_builder/static/src/core/color_style_plugin.js
+++ b/addons/html_builder/static/src/core/color_style_plugin.js
@@ -2,51 +2,34 @@ import { Plugin } from "@html_editor/plugin";
 import { registry } from "@web/core/registry";
 import { applyNeededCss } from "@html_builder/utils/utils_css";
 import { withSequence } from "@html_editor/utils/resource";
-import { BuilderAction } from "@html_builder/core/builder_action";
 
 class ColorStylePlugin extends Plugin {
     static id = "colorStyle";
     static dependencies = ["color"];
     resources = {
-        builder_style_actions: {
-            BackgroundColorAction,
-            ColorAction,
-        },
         apply_style: withSequence(5, (element, cssProp, color) => {
             applyNeededCss(element, cssProp, color);
             return true;
         }),
+        apply_custom_css_style: withSequence(20, this.applyColorStyle.bind(this)),
     };
-}
-
-export class BackgroundColorAction extends BuilderAction {
-    static id = "background-color";
-    static dependencies = ["color"];
-    getValue(el) {
-        return this.dependencies.color.getElementColors(el)["backgroundColor"];
-    }
-    apply(el, value) {
-        const match = value.match(/var\(--([a-zA-Z0-9-_]+)\)/);
-        if (match) {
-            value = `bg-${match[1]}`;
+    applyColorStyle({ editingElement, params: { mainParam: styleName = "" }, value }) {
+        if (styleName === "background-color") {
+            const match = value.match(/var\(--([a-zA-Z0-9-_]+)\)/);
+            if (match) {
+                value = `bg-${match[1]}`;
+            }
+            this.dependencies.color.colorElement(editingElement, value, "backgroundColor");
+            return true;
+        } else if (styleName === "color") {
+            const match = value.match(/var\(--([a-zA-Z0-9-_]+)\)/);
+            if (match) {
+                value = `text-${match[1]}`;
+            }
+            this.dependencies.color.colorElement(editingElement, value, "color");
+            return true;
         }
-        this.dependencies.color.colorElement(el, value, "backgroundColor");
-    }
-}
-
-export class ColorAction extends BuilderAction {
-    static id = "color";
-    static dependencies = ["color"];
-    getValue(el) {
-        console.log(el);
-        return this.dependencies.color.getElementColors(el)["color"];
-    }
-    apply(el, value) {
-        const match = value.match(/var\(--([a-zA-Z0-9-_]+)\)/);
-        if (match) {
-            value = `text-${match[1]}`;
-        }
-        this.dependencies.color.colorElement(el, value, "color");
+        return false;
     }
 }
 

--- a/addons/html_builder/static/src/core/core_builder_action_plugin.js
+++ b/addons/html_builder/static/src/core/core_builder_action_plugin.js
@@ -22,7 +22,6 @@ export function withoutTransition(editingElement, callback) {
 
 export class CoreBuilderActionPlugin extends Plugin {
     static id = "coreBuilderAction";
-    static dependencies = ["color"];
     resources = {
         builder_actions: {
             ClassAction,
@@ -258,36 +257,24 @@ export class StyleAction extends BuilderAction {
         return currentValue === value;
     }
     apply({ editingElement, params = {}, value }) {
+        if (!this.delegateTo("apply_custom_css_style", { editingElement, params, value })) {
+            this.applyCssStyle({ editingElement, params, value });
+        }
+    }
+    applyCssStyle({ editingElement, params = {}, value }) {
         params = { ...params };
         const styleName = params.mainParam;
         delete params.mainParam;
-        if (styleName === "background-color") {
-            const match = value.match(/var\(--([a-zA-Z0-9-_]+)\)/);
-            if (match) {
-                value = `bg-${match[1]}`;
-            }
-            this.dependencies.color.colorElement(editingElement, value, "backgroundColor");
-        } else if (styleName === "color") {
-            const match = value.match(/var\(--([a-zA-Z0-9-_]+)\)/);
-            if (match) {
-                value = `text-${match[1]}`;
-            }
-            this.dependencies.color.colorElement(editingElement, value, "color");
-        } else {
-            this._setStyle(editingElement, styleName, value, params);
-        }
-    }
-    _getValueWithoutTransition(el, styleName) {
-        return withoutTransition(el, () => getStyleValue(el, styleName));
-    }
-    _setStyle(element, styleName, styleValue, params) {
         // Disable all transitions for the duration of the method as many
         // comparisons will be done on the element to know if applying a
         // property has an effect or not. Also, changing a css property via the
         // editor should not show any transition as previews would not be done
         // immediately, which is not good for the user experience.
-        withoutTransition(element, () => {
-            setStyle(element, styleName, styleValue, params);
+        withoutTransition(editingElement, () => {
+            setStyle(editingElement, styleName, value, params);
         });
+    }
+    _getValueWithoutTransition(el, styleName) {
+        return withoutTransition(el, () => getStyleValue(el, styleName));
     }
 }


### PR DESCRIPTION
Following the refactoring introduced in [1], the
`builder_style_actions` which defines custom behavior for specific CSS
styles such as `background-color` and `color` was
unintentionally omitted.

This commit restores its implementation.

The `border-radius` style implementation, that still remains untouched
will be restored in another PR: [2]

[1]: https://github.com/odoo/odoo/commit/b4b2153
[2]: https://github.com/odoo/odoo/pull/215371

