### PR TITLE
[FIX] base: remove trailing nul byte in datamatrix barcode before generation

### DIFF
--- a/odoo/_monkeypatches/__init__.py
+++ b/odoo/_monkeypatches/__init__.py
@@ -37,3 +37,5 @@ def patch_all():
     patch_werkzeug()
     from .zeep import patch_zeep
     patch_zeep()
+    from .reportlab import patch_reportlab
+    patch_reportlab()

--- a/odoo/_monkeypatches/reportlab.py
+++ b/odoo/_monkeypatches/reportlab.py
@@ -1,0 +1,81 @@
+import logging
+
+_logger = logging.getLogger(__name__)
+
+try:
+    from reportlab.graphics.barcode.ecc200datamatrix import ECC200DataMatrix
+except ImportError:
+    ECC200DataMatrix = None
+    _logger.warning("reportlab.graphics.barcode.ecc200datamatrix not found. DataMatrix barcode generation might not work.")
+
+
+def datamatrix_encode_ascii(value):
+    """Encode ASCII data in a list of integer of ASCII value + 1,
+    supporting Extended ASCII (ISO-8859-1) characters.
+    """
+
+    i = 0
+
+    while i < len(value):
+        c = value[i]
+        char_ord = ord(c)
+
+        if char_ord >= 128:
+            yield 235
+            yield char_ord - 127
+            i += 1
+        elif char_ord >= 48 and char_ord <= 57 and i + 1 < len(value) and value[i + 1].isdigit():
+            yield 130 + int(value[i : i + 2])
+            i += 2
+        else:
+            yield char_ord + 1
+            i += 1
+
+
+def patch_encode_c40(self, value):
+    """
+    Patched version of ECC200DataMatrix._encode_c40 to prevent trailing nul bytes.
+    Also ensures compatibility with the updated datamatrix_encode_ascii for Extended ASCII.
+    """
+
+    if isinstance(value, str):
+        value = value.replace('\x00', '')
+    elif isinstance(value, bytes):
+        value = value.replace(b'\x00', b'')
+
+    encoded = []
+    for c in value:
+        c40_char = self._encode_c40_char(c)
+        encoded.extend(c40_char)
+
+    codewords = [230]
+
+    length, remaining = divmod(len(encoded), 3)
+    for i in range(length):
+        total = encoded[i * 3] * 1600 + encoded[i * 3 + 1] * 40 + encoded[i * 3 + 2] + 1
+        codewords.extend(divmod(total, 256))
+
+    codewords.append(254)
+    if remaining:
+        index = 1 if (remaining == len(value) == 2 or len(value) == 0) else remaining
+        if value[-index:]:
+            codewords.extend(datamatrix_encode_ascii(value[-index:]))
+
+    if len(codewords) > self.cw_data:
+        raise Exception("Too much data to fit into a data matrix of this size")
+
+    if len(codewords) < self.cw_data:
+        codewords.append(129)  # End of data
+        while len(codewords) < self.cw_data:
+            r = ((149 * (len(codewords) + 1)) % 253) + 1
+            codewords.append((129 + r) % 254)
+
+    return codewords
+
+
+def patch_reportlab():
+    """
+    Applies the patch to ECC200DataMatrix._encode_c40 if ECC200DataMatrix is available.
+    """
+    if ECC200DataMatrix is not None:
+        ECC200DataMatrix._encode_c40 = patch_encode_c40

--- a/odoo/addons/base/tests/test_barcode.py
+++ b/odoo/addons/base/tests/test_barcode.py
@@ -1,10 +1,16 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo.tests.common import TransactionCase
+import logging
+
+from odoo.tests.common import TransactionCase, tagged
 from odoo.tools.barcode import check_barcode_encoding, get_barcode_check_digit
+from odoo._monkeypatches.reportlab import datamatrix_encode_ascii
+
+_logger = logging.getLogger(__name__)
 
 
+@tagged('post_install', '-at_install')
 class TestBarcode(TransactionCase):
     def test_barcode_check_digit(self):
         ean8 = "87111125"
@@ -25,3 +31,97 @@ class TestBarcode(TransactionCase):
         self.assertFalse(check_barcode_encoding('9745213796148', 'ean13'), 'incorrect check digit')
         self.assertFalse(check_barcode_encoding('2022!71416014', 'ean13'), 'should contains digits only')
         self.assertFalse(check_barcode_encoding('0022071416014', 'ean13'), 'when starting with one zero, it indicates that a 12-digit UPC-A code follows')
+
+    def _get_patched_datamatrix_components(self):
+        # Helper method to get ECC200DataMatrix and skip test if not available/patched.
+        try:
+            from reportlab.graphics.barcode.ecc200datamatrix import ECC200DataMatrix  # noqa: PLC0415
+
+            if not hasattr(ECC200DataMatrix,
+                           '_encode_c40') or ECC200DataMatrix._encode_c40.__name__ != 'patch_encode_c40':
+                _logger.warning(
+                    "DataMatrix ECC200DataMatrix._encode_c40 monkeypatch was not applied correctly or found. Skipping related tests.")
+                self.skipTest("DataMatrix ECC200DataMatrix._encode_c40 monkeypatch not found or not applied.")
+
+            return ECC200DataMatrix
+
+        except ImportError:
+            _logger.warning("Reportlab ECC200DataMatrix not available, skipping DataMatrix barcode tests.")
+            self.skipTest("Reportlab ECC200DataMatrix not available, skipping datamatrix barcode tests.")
+
+    def test_datamatrix_ascii_encoding(self):
+        # Call helper to ensure environment is set up and patched components are available.
+        _ = self._get_patched_datamatrix_components()
+
+        self.assertEqual(list(datamatrix_encode_ascii("2022071416014")), [150, 152, 137, 144, 146, 131, 53])
+        self.assertEqual(list(datamatrix_encode_ascii("9745213796142")), [227, 175, 151, 167, 226, 144, 51])
+        self.assertEqual(list(datamatrix_encode_ascii("abc123")), [98, 99, 100, 142, 52])
+
+    def test_datamatrix_c40_encoding(self):
+        patched_ecc200datamatrix = self._get_patched_datamatrix_components()
+
+        def get_datamatrix(data):
+            codewords = patched_ecc200datamatrix()._encode_c40(data)
+            try:
+                end_of_data_idx = codewords.index(254)
+                padding_start_idx = codewords.index(129, end_of_data_idx)
+                return codewords[:padding_start_idx]
+            except ValueError:
+                return codewords
+
+        self.assertEqual(get_datamatrix("123a"), [230, 32, 56, 254, 52, 98])
+        self.assertEqual(get_datamatrix("1234"), [230, 32, 56, 254, 53])
+        self.assertEqual(get_datamatrix("1234a"), [230, 32, 56, 50, 82, 254])
+        self.assertEqual(get_datamatrix("abc123"), [230, 12, 171, 12, 212, 32, 56, 254])
+
+        self.assertEqual(get_datamatrix("2022071416014"), [230, 38, 39, 38, 44, 32, 134, 63, 38, 254, 53])
+        self.assertEqual(get_datamatrix("9745213796142"), [230, 83, 1, 57, 54, 45, 134, 63, 81, 254, 51])
+        self.assertEqual(
+            get_datamatrix("011234567890510abcde"),
+            [230, 25, 206, 38, 161, 57, 220, 77, 13, 57, 13, 12, 171, 12, 212, 13, 35, 254, 102],
+        )
+
+    def test_datamatrix_no_nul_byte_in_generated_barcode(self):
+        """
+        Test that Data Matrix barcode generation (via patch_encode_c40) correctly
+        removes trailing (or embedded) nul bytes from input data *before* encoding.
+        """
+        patched_ecc200datamatrix = self._get_patched_datamatrix_components()
+
+        data_with_nul = "Test\x00String\x00With\x00Nul"
+
+        try:
+            codewords = patched_ecc200datamatrix()._encode_c40(data_with_nul)
+            self.assertGreater(len(codewords), 0, "Codewords not generated after stripping NUL bytes.")
+        except Exception as e:  # noqa: BLE001
+            self.fail(f"Barcode generation failed for NUL-containing input after stripping: {e}")
+
+        data_with_trailing_nul = "TestString\x00"
+
+        try:
+            codewords_trailing = patched_ecc200datamatrix()._encode_c40(data_with_trailing_nul)
+            self.assertGreater(len(codewords_trailing), 0, "Codewords not generated after stripping trailing NUL bytes.")
+        except Exception as e:  # noqa: BLE001
+            self.fail(f"Barcode generation failed for trailing NUL input after stripping: {e}")
+
+    def test_datamatrix_extended_ascii_encoding(self):
+        """
+        Test that datamatrix_encode_ascii correctly handles Extended ASCII (ISO-8859-1) characters.
+        """
+        _ = self._get_patched_datamatrix_components()
+
+        value_extended_ascii = "Héllö Wörldñ"
+        self.assertEqual(list(datamatrix_encode_ascii(value_extended_ascii)),
+                         [73, 235, 106, 109, 109, 235, 119, 33, 88, 235, 119, 115, 109, 101, 235, 114])
+
+        mixed_value = "123_Á_é_789"
+        self.assertEqual(list(datamatrix_encode_ascii(mixed_value)),
+                         [142, 52, 96, 235, 66, 96, 235, 106, 96, 208, 58])
+
+        value_with_nul_in_ascii = "Test\x00Extended\x00"
+
+        try:
+            result_codewords_ascii = list(datamatrix_encode_ascii(value_with_nul_in_ascii))
+            self.assertGreater(len(result_codewords_ascii), 0, "Codewords not generated for NUL-containing ASCII input.")
+        except Exception as e:  # noqa: BLE001
+            self.fail(f"Extended ASCII encoding failed for NUL-containing input: {e}")


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

When we try to scan a datamatrix, it can crash due to a trailing NUL byte:
- Enable datamatrix when printing GS1 barcodes in the settings
- Create a product tracked by lot with the barcode 12345678905
- Create a lot for the product: abcde
- Print the Lot number into PDF
- Scan the datamatrix

Current behavior before PR:

- Traceback when scanning due to an additional NUL byte

Desired behavior after PR is merged:

- To prevent the trailing NUL byte when printing the lot. These NUL bytes could be coming from too many sources, such as data imports, weird edge cases, or custom modifications. Therefore, cleaning the data at the generation stage is chosen to avoid all those cases at once.

opw-4814641

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
