### PR TITLE
[IMP] base: avoid exists when calling ref if not raise_if_not_found

### DIFF
--- a/odoo/orm/environments.py
+++ b/odoo/orm/environments.py
@@ -165,10 +165,11 @@ class Environment(Mapping[str, "BaseModel"]):
 
         if res_model and res_id:
             record = self[res_model].browse(res_id)
+            if not raise_if_not_found:
+                return record
             if record.exists():
                 return record
-            if raise_if_not_found:
-                raise ValueError('No record found for unique ID %s. It may have been deleted.' % (xml_id))
+            raise ValueError('No record found for unique ID %s. It may have been deleted.' % (xml_id))
         return None
 
     def is_superuser(self) -> bool:


### PR DESCRIPTION
Let's be honest: in the code, either we suppose that the thing exists and it would raise anyways (maybe a bit less gracefully) when someone deleted it.  Or we actively check if it is there or not.

So, if you want to be fast and you suppose the record is there, no problem to fail ungracefully when raise_if_not_found is False.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
