### PR TITLE
[PERF] point_of_sale: speed up exclusion lookup

### DIFF
--- a/addons/point_of_sale/models/product_attribute.py
+++ b/addons/point_of_sale/models/product_attribute.py
@@ -69,4 +69,4 @@ class ProductTemplateAttributeExclusion(models.Model):
 
     @api.model
     def _load_pos_data_fields(self, config_id):
-        return ['value_ids']
+        return ['product_template_attribute_value_id', 'value_ids']

--- a/addons/point_of_sale/static/src/app/models/data_service_options.js
+++ b/addons/point_of_sale/static/src/app/models/data_service_options.js
@@ -43,6 +43,7 @@ export class DataServiceOptions {
             "calendar.event": ["appointment_resource_ids"],
             "res.partner": ["barcode"],
             "product.uom": ["barcode"],
+            "product.template.attribute.exclusion": ["product_template_attribute_value_id"],
         };
 
         for (const model in databaseTable) {

--- a/addons/point_of_sale/static/src/app/models/product_template_attribute_value.js
+++ b/addons/point_of_sale/static/src/app/models/product_template_attribute_value.js
@@ -4,17 +4,24 @@ import { Base } from "./related_models";
 export class ProductTemplateAttributeValue extends Base {
     static pythonModel = "product.template.attribute.value";
 
-    get exclusions() {
-        const values = this.models["product.template.attribute.value"].filter((value) =>
-            value.exclude_for.some(({ value_ids }) => value_ids.some(({ id }) => id === this.id))
-        );
-
-        return [...this.exclude_for.flatMap(({ value_ids }) => value_ids), ...values];
-    }
-
     doHaveConflictWith(values) {
-        const excludedIds = values.map(({ id }) => id);
-        return this.exclusions.some(({ id }) => excludedIds.includes(id));
+        if (
+            this.exclude_for.some(({ value_ids }) =>
+                value_ids.some((v) => values.some((value) => value.id === v.id))
+            )
+        ) {
+            return true;
+        }
+        for (const value of values) {
+            const exclusion = this.models["product.template.attribute.exclusion"].getBy(
+                "product_template_attribute_value_id",
+                value.id
+            );
+            if (exclusion?.value_ids.some((v) => v.id === this.id)) {
+                return true;
+            }
+        }
+        return false;
     }
 }
 


### PR DESCRIPTION
Before this commit, when opening a product with variants, the exclusion lookup was performed by iterating over all product template attribute values (PTAVs). In databases with a large number of products and variants, this could lead to significant performance degradation.

This commit refactors the lookup logic to achieve O(1) (constant time) complexity for exclusion searches. Instead of iterating over a potentially vast number of PTAVs, the system now directly accesses exclusions. This significantly improves the performance.

As a result, in a database with 100,000 PTAVs, the speed of opening the product configuration popup has improved dramatically, changing from approximately 5 seconds to just 50 milliseconds.

opw-4888069

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
