### PR TITLE
[FIX] web: datetime_picker: week numbers in bold

### DIFF
--- a/addons/web/static/src/core/datetime/datetime_picker.xml
+++ b/addons/web/static/src/core/datetime/datetime_picker.xml
@@ -18,7 +18,7 @@
                     <t t-foreach="month.weeks" t-as="week" t-key="week.number">
                         <t t-if="props.showWeekNumbers ?? !props.range">
                             <div
-                                class="o_week_number_cell d-flex align-items-center ps-2 text-muted fst-italic"
+                                class="o_week_number_cell d-flex align-items-center ps-2 fw-bolder"
                                 t-esc="week.number"
                             />
                         </t>


### PR DESCRIPTION
Follow-up of https://github.com/odoo/odoo/pull/215343

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
