### PR TITLE
[IMP] partner_autocomplete: category tags autofill using CRM partner enrich

### DIFF
--- a/addons/partner_autocomplete/models/res_partner.py
+++ b/addons/partner_autocomplete/models/res_partner.py
@@ -182,8 +182,6 @@ class ResPartner(models.Model):
 
     def iap_partner_autocomplete_add_tags(self, unspsc_codes):
         """Called by JS to create the activity tags from the UNSPSC codes"""
-        self.ensure_one()
-
         # If the UNSPSC module is installed, we might have a translation, so let's use it
         if self.env['ir.module.module']._get('product_unspsc').state == 'installed':
             tag_names = self.env['product.unspsc.code']\
@@ -200,7 +198,7 @@ class ResPartner(models.Model):
                 tag_ids |= existing_tag
             else:
                 tag_ids |= self.env['res.partner.category'].create({'name': tag_name})
-        self.category_id = tag_ids
+        return tag_ids.ids
 
     @api.model
     def _get_view(self, view_id=None, view_type='form', **options):

--- a/addons/partner_autocomplete/static/src/js/partner_autocomplete_fieldchar.js
+++ b/addons/partner_autocomplete/static/src/js/partner_autocomplete_fieldchar.js
@@ -83,18 +83,15 @@ export class PartnerAutoCompleteCharField extends CharField {
         if (data.company.name) {
             await this.props.record.update({name: data.company.name});  // Needed otherwise name it is not saved
         }
-        await this.props.record.update(data.company);
 
         // Add UNSPSC codes (tags)
         if (this.props.record.resModel === 'res.partner' && unspsc_codes && unspsc_codes.length !== 0) {
-            // We must first save the record so that we can then create the tags (many2many)
-            const saved = await this.props.record.save();
-            if (saved){
-                await this.props.record.load();
-                await this.orm.call("res.partner", "iap_partner_autocomplete_add_tags", [this.props.record.resId, unspsc_codes]);
-                await this.props.record.load();
-            }
+            // category id is fetched and then tags are created (many2many)
+            const category_id = await this.orm.call("res.partner", "iap_partner_autocomplete_add_tags", [this.props.record.resId, unspsc_codes]);
+            data.company['category_id'] = [[6, 0, category_id]];
         }
+        await this.props.record.update(data.company);
+        
         if (this.props.setDirty) {
             this.props.setDirty(false);
         }

--- a/addons/partner_autocomplete/static/src/js/partner_autocomplete_many2one.js
+++ b/addons/partner_autocomplete/static/src/js/partner_autocomplete_many2one.js
@@ -4,6 +4,7 @@ import { Many2XAutocomplete } from '@web/views/fields/relational_utils';
 import { Many2OneField, many2OneField } from '@web/views/fields/many2one/many2one_field';
 import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
+import { useService } from "@web/core/utils/hooks";
 
 import { usePartnerAutocomplete } from "@partner_autocomplete/js/partner_autocomplete_core";
 import { PartnerAutoComplete } from "@partner_autocomplete/js/partner_autocomplete_component";
@@ -17,6 +18,7 @@ export class PartnerMany2XAutocomplete extends Many2XAutocomplete {
 
     setup() {
         super.setup();
+        this.orm = useService("orm");
         this.partnerAutocomplete = usePartnerAutocomplete();
     }
 
@@ -70,6 +72,11 @@ export class PartnerMany2XAutocomplete extends Many2XAutocomplete {
 
             if (data.logo) {
                 context.default_image_1920 = data.logo;
+            }
+
+            const unspsc_codes = data.company.unspsc_codes;
+            if(unspsc_codes){
+                context.default_category_id = await this.orm.call("res.partner", "iap_partner_autocomplete_add_tags", [[], unspsc_codes]);
             }
             return this.openMany2X({ context });
         }


### PR DESCRIPTION
when using partner enrich from CRM category tags were not fetched 
now category tags are autofilled when using partner enrich from CRM 
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
