### PR TITLE
[FIX] event: fix event_registration_calender_view traceback

### DIFF
--- a/addons/event/models/event_registration.py
+++ b/addons/event/models/event_registration.py
@@ -60,7 +60,7 @@ class EventRegistration(models.Model):
         string='Attended Date', compute='_compute_date_closed',
         readonly=False, store=True)
     event_begin_date = fields.Datetime("Event Start Date", compute="_compute_event_begin_date", search="_search_event_begin_date")
-    event_end_date = fields.Datetime("Event End Date", compute="_compute_event_end_date")
+    event_end_date = fields.Datetime("Event End Date", compute="_compute_event_end_date", search="_search_event_end_date")
     event_date_range = fields.Char("Date Range", compute="_compute_date_range")
     event_organizer_id = fields.Many2one(string='Event Organizer', related='event_id.organizer_id', readonly=True)
     event_user_id = fields.Many2one(string='Event Responsible', related='event_id.user_id', readonly=True)
@@ -189,6 +189,13 @@ class EventRegistration(models.Model):
     def _compute_event_end_date(self):
         for registration in self:
             registration.event_end_date = registration.event_slot_id.end_datetime or registration.event_id.date_end
+
+    @api.model
+    def _search_event_end_date(self, operator, value):
+        return expression.OR([
+            ["&", ("event_slot_id", "!=", False), ("event_slot_id.end_datetime", operator, value)],
+            ["&", ("event_slot_id", "=", False), ("event_id.date_end", operator, value)],
+        ])
 
     @api.constrains('event_id', 'event_slot_id')
     def _check_event_slot(self):

--- a/addons/event/tests/test_event_slot.py
+++ b/addons/event/tests/test_event_slot.py
@@ -99,6 +99,24 @@ class TestEventSlotRegistration(TestEventSlotsCommon):
                 expected,
             )
 
+    def test_search_event_end_date(self):
+        """ Searching on the registration 'event_end_date' field should correctly search
+        on the slot end datetime if the registration is linked to a slot,
+        else on the event end date.
+        """
+        for search_to_date, expected in [
+            (self.reference_end, self.test_reg_no_slot + self.test_reg_slot_1 + self.test_reg_slot_2),
+            (self.reference_beg + timedelta(hours=12), self.test_reg_slot_1 + self.test_reg_slot_2),
+            (self.reference_beg + timedelta(hours=6), self.test_reg_slot_1),
+        ]:
+            self.assertEqual(
+                self.env["event.registration"].search([
+                    ('event_id', 'in', [self.test_event_no_slot.id, self.test_event.id]),
+                    ('event_end_date', '<=', search_to_date),
+                ]),
+                expected,
+            )
+
 
 @tagged('event_slot', 'event_seats')
 class TestEventSlotSeats(TestEventSlotsCommon):


### PR DESCRIPTION
**Steps to Reproduce:**
- Install the website and website_event module.
- Navigate to Events -> Attendees -> Calendar View.

Issue:
- While accessing the calendar view, we are getting an error because that view needs the event_end_date field to be searchable. We have added search method for field [event_begin_date](https://github.com/odoo/odoo/pull/210532/files#diff-b8b0a21217ded7346150f1dd8353fbe2932e83f5e3d3755fd6e1c8281bb50c64R62) but missed it for event_end_date.
opw-4892275
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
