### PR TITLE
[FIX] website_sale_comparison: product_comparison tour

### DIFF
--- a/addons/website_sale_comparison/static/tests/tours/website_sale_comparison.js
+++ b/addons/website_sale_comparison/static/tests/tours/website_sale_comparison.js
@@ -107,6 +107,12 @@
         run: "click",
     },
     {
+        content: "Ensure the comparator popover is visible. Click too fast can toggle it",
+        isActive: ["body:not(:has(.comparator-popover))"],
+        trigger: ".o_add_compare_dyn",
+        run: "click",
+    },
+    {
         content: "check limit is reached",
         trigger: '.o_comparelist_limit_warning',
     },


### PR DESCRIPTION
In this commit, we add a step to ensure that the popover comparator is visible in the DOM before moving on to the next check step.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
