### PR TITLE
[FIX] l10n_tr_nilvera_einvoice: move InvoicePeriod element in XML

### DIFF
--- a/addons/l10n_tr_nilvera_einvoice/i18n/l10n_tr_nilvera_einvoice.pot
+++ b/addons/l10n_tr_nilvera_einvoice/i18n/l10n_tr_nilvera_einvoice.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 17.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-06-20 15:07+0000\n"
-"PO-Revision-Date: 2025-06-20 15:07+0000\n"
+"POT-Creation-Date: 2025-07-14 05:22+0000\n"
+"PO-Revision-Date: 2025-07-14 05:22+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -18,6 +18,13 @@ msgstr ""
 #. module: l10n_tr_nilvera_einvoice
 #: model:ir.model,name:l10n_tr_nilvera_einvoice.model_account_move_send
 msgid "Account Move Send"
+msgstr ""
+
+#. module: l10n_tr_nilvera_einvoice
+#. odoo-python
+#: code:addons/l10n_tr_nilvera_einvoice/wizard/account_move_send.py:0
+#, python-format
+msgid "Check data on Invoice(s)"
 msgstr ""
 
 #. module: l10n_tr_nilvera_einvoice
@@ -159,6 +166,15 @@ msgstr ""
 #: code:addons/l10n_tr_nilvera_einvoice/wizard/account_move_send.py:0
 #, python-format
 msgid ""
+"The following invoice(s) need to have the same Start Date and End Date on "
+"all their respective Invoice Lines."
+msgstr ""
+
+#. module: l10n_tr_nilvera_einvoice
+#. odoo-python
+#: code:addons/l10n_tr_nilvera_einvoice/wizard/account_move_send.py:0
+#, python-format
+msgid ""
 "The following partner(s) are either not Turkish or are missing one of the "
 "following fields: city, state, or street."
 msgstr ""
@@ -192,6 +208,15 @@ msgid "The invoice status couldn't be retrieved from Nilvera."
 msgstr ""
 
 #. module: l10n_tr_nilvera_einvoice
+#. odoo-python
+#: code:addons/l10n_tr_nilvera_einvoice/models/account_edi_xml_ubl_tr.py:0
+#, python-format
+msgid ""
+"The invoice(s) need to have the same Start Date and End Date on all their "
+"respective Invoice Lines."
+msgstr ""
+
+#. module: l10n_tr_nilvera_einvoice
 #: model:ir.model,name:l10n_tr_nilvera_einvoice.model_account_edi_xml_ubl_tr
 msgid "UBL-TR 1.2"
 msgstr ""
@@ -210,6 +235,14 @@ msgstr ""
 
 #. module: l10n_tr_nilvera_einvoice
 #. odoo-python
+#: code:addons/l10n_tr_nilvera_einvoice/wizard/account_move_send.py:0
+#, python-format
+msgid "View Invoice(s)"
+msgstr ""
+
+#. module: l10n_tr_nilvera_einvoice
+#. odoo-python
+#: code:addons/l10n_tr_nilvera_einvoice/wizard/account_move_send.py:0
 #: code:addons/l10n_tr_nilvera_einvoice/wizard/account_move_send.py:0
 #, python-format
 msgid "View Partner(s)"

--- a/addons/l10n_tr_nilvera_einvoice/i18n/tr.po
+++ b/addons/l10n_tr_nilvera_einvoice/i18n/tr.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 17.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-06-20 15:03+0000\n"
-"PO-Revision-Date: 2025-06-20 15:03+0000\n"
+"POT-Creation-Date: 2025-07-14 05:25+0000\n"
+"PO-Revision-Date: 2025-07-14 05:25+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -19,6 +19,13 @@ msgstr ""
 #: model:ir.model,name:l10n_tr_nilvera_einvoice.model_account_move_send
 msgid "Account Move Send"
 msgstr "Hesap Hareketi Yollandı"
+
+#. module: l10n_tr_nilvera_einvoice
+#. odoo-python
+#: code:addons/l10n_tr_nilvera_einvoice/wizard/account_move_send.py:0
+#, python-format
+msgid "Check data on Invoice(s)"
+msgstr "Fatura(lar)daki Verileri Kontrol Edin"
 
 #. module: l10n_tr_nilvera_einvoice
 #. odoo-python
@@ -165,6 +172,17 @@ msgstr ""
 #: code:addons/l10n_tr_nilvera_einvoice/wizard/account_move_send.py:0
 #, python-format
 msgid ""
+"The following invoice(s) need to have the same Start Date and End Date on "
+"all their respective Invoice Lines."
+msgstr ""
+"Aşağıdaki fatura(lar)ın tüm Fatura Satırlarında aynı Başlangıç Tarihi ve "
+"Bitiş Tarihi bulunmalıdır."
+
+#. module: l10n_tr_nilvera_einvoice
+#. odoo-python
+#: code:addons/l10n_tr_nilvera_einvoice/wizard/account_move_send.py:0
+#, python-format
+msgid ""
 "The following partner(s) are either not Turkish or are missing one of the "
 "following fields: city, state, or street."
 msgstr ""
@@ -200,6 +218,17 @@ msgid "The invoice status couldn't be retrieved from Nilvera."
 msgstr "Fatura durumu Nilvera'dan alınamadı."
 
 #. module: l10n_tr_nilvera_einvoice
+#. odoo-python
+#: code:addons/l10n_tr_nilvera_einvoice/models/account_edi_xml_ubl_tr.py:0
+#, python-format
+msgid ""
+"The invoice(s) need to have the same Start Date and End Date on all their "
+"respective Invoice Lines."
+msgstr ""
+"Fatura(lar)ın tüm Fatura Satırlarında aynı Başlangıç Tarihi ve "
+"Bitiş Tarihi bulunmalıdır."
+
+#. module: l10n_tr_nilvera_einvoice
 #: model:ir.model,name:l10n_tr_nilvera_einvoice.model_account_edi_xml_ubl_tr
 msgid "UBL-TR 1.2"
 msgstr ""
@@ -218,6 +247,14 @@ msgstr "Bilinmiyor"
 
 #. module: l10n_tr_nilvera_einvoice
 #. odoo-python
+#: code:addons/l10n_tr_nilvera_einvoice/wizard/account_move_send.py:0
+#, python-format
+msgid "View Invoice(s)"
+msgstr "Fatura(ları) Görüntüle"
+
+#. module: l10n_tr_nilvera_einvoice
+#. odoo-python
+#: code:addons/l10n_tr_nilvera_einvoice/wizard/account_move_send.py:0
 #: code:addons/l10n_tr_nilvera_einvoice/wizard/account_move_send.py:0
 #, python-format
 msgid "View Partner(s)"

--- a/addons/l10n_tr_nilvera_einvoice/models/account_move.py
+++ b/addons/l10n_tr_nilvera_einvoice/models/account_move.py
@@ -256,6 +256,19 @@ class AccountMove(models.Model):
 
         return msg, error_codes
 
+    def _l10n_tr_nilvera_einvoice_check_invalid_subscription_dates(self):
+        if 'deferred_start_date' not in self.invoice_line_ids._fields:
+            return False
+
+        # Ensure that either no lines have the start and end dates or all lines have the same start and end dates.
+        lines_to_check = self.invoice_line_ids.filtered(lambda line: line.display_type == 'product')
+        if not (subscription_lines := lines_to_check.filtered('deferred_start_date')):
+            return False
+
+        return len(subscription_lines) != len(lines_to_check) or len(set(subscription_lines.mapped(
+            lambda aml: (aml.deferred_start_date, aml.deferred_end_date))
+        )) > 1
+
     # -------------------------------------------------------------------------
     # CRONS
     # -------------------------------------------------------------------------

--- a/addons/l10n_tr_nilvera_einvoice/wizard/account_move_send.py
+++ b/addons/l10n_tr_nilvera_einvoice/wizard/account_move_send.py
@@ -1,9 +1,6 @@
 from io import BytesIO
-import logging
 
 from odoo import _, api, fields, models
-
-_logger = logging.getLogger(__name__)
 
 
 class AccountMoveSend(models.TransientModel):
@@ -68,6 +65,18 @@ class AccountMoveSend(models.TransientModel):
                 "action_text": _("View Partner(s)"),
                 "action": critical_invalid_records._get_records_action(
                     name=_("Check reference on Partner(s)")
+                ),
+                "critical": True,
+            }
+
+        if invalid_subscription_dates := moves_to_check.filtered(
+            lambda move: move._l10n_tr_nilvera_einvoice_check_invalid_subscription_dates()
+        ):
+            warnings["critical_invalid_subscription_dates"] = {
+                "message": _("The following invoice(s) need to have the same Start Date and End Date on all their respective Invoice Lines."),
+                "action_text": _("View Invoice(s)"),
+                "action": invalid_subscription_dates._get_records_action(
+                    name=_("Check data on Invoice(s)"),
                 ),
                 "critical": True,
             }

--- a/addons/l10n_tr_nilvera_einvoice/wizard/account_move_send_views.xml
+++ b/addons/l10n_tr_nilvera_einvoice/wizard/account_move_send_views.xml
@@ -6,9 +6,9 @@
             <field name="model">account.move.send</field>
             <field name="inherit_id" ref="account.account_move_send_form"/>
             <field name="arch" type="xml">
-            <xpath expr="//div[@name='warnings']" position="inside">
-                <field name="l10n_tr_nilvera_warnings" class="o_field_html" widget="actionable_errors"/>
-            </xpath>
+                <xpath expr="//div[@name='warnings']" position="inside">
+                    <field name="l10n_tr_nilvera_warnings" class="o_field_html" widget="actionable_errors"/>
+                </xpath>
                 <xpath expr="//div[@name='advanced_options']" position='after'>
                     <field name="l10n_tr_nilvera_einvoice_enable_xml" invisible="1"/>
                     <div name="option_send_nilvera"


### PR DESCRIPTION
The UBL TR 1.2.1 format does not support \<InvoicePeriod\> element in invoice lines in the XML
generated for e-invoice.
This commit moves the \<InvoicePeriod\> element from invoice lines to document level.
It also validates that the start and end dates of all subscription invoice lines in one invoice should
be same, or else it shows warning and disables the `Send & Print` wizard button

TaskId:4885865


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
