### PR TITLE
[REV] spreadsheet: numeric fields not diplayed in list formula

### DIFF
--- a/addons/spreadsheet/static/src/list/list_data_source.js
+++ b/addons/spreadsheet/static/src/list/list_data_source.js
@@ -168,7 +168,7 @@ export default class ListDataSource extends OdooViewsDataSource {
             case "json":
                 throw new Error(sprintf(_t('Fields of type "%s" are not supported'), "json"));
             default:
-                return fieldName in record ? record[fieldName] : "";
+                return record[fieldName] || "";
         }
     }
 

--- a/addons/spreadsheet/static/tests/lists/list_plugin_test.js
+++ b/addons/spreadsheet/static/tests/lists/list_plugin_test.js
@@ -6,14 +6,7 @@ import { nextTick, patchWithCleanup } from "@web/../tests/helpers/utils";
 import CommandResult from "@spreadsheet/o_spreadsheet/cancelled_reason";
 import { createModelWithDataSource, waitForDataSourcesLoaded } from "../utils/model";
 import { addGlobalFilter, selectCell, setCellContent } from "../utils/commands";
-import {
-    getCell,
-    getCellContent,
-    getCellFormula,
-    getCells,
-    getCellValue,
-    getCellFormattedValue,
-} from "../utils/getters";
+import { getCell, getCellContent, getCellFormula, getCells, getCellValue } from "../utils/getters";
 import { createSpreadsheetWithList } from "../utils/list";
 import { registry } from "@web/core/registry";
 import { RPCError } from "@web/core/network/rpc_service";
@@ -54,39 +47,6 @@ QUnit.module("spreadsheet > list plugin", {}, () => {
         const { model } = await createSpreadsheetWithList({ columns: ["bar"] });
         assert.strictEqual(getCellValue(model, "A2"), "TRUE");
         assert.strictEqual(getCellValue(model, "A5"), "FALSE");
-    });
-
-    QUnit.test("Numeric/monetary fields are correctly loaded and displayed", async (assert) => {
-        const serverData = getBasicServerData();
-        serverData.models.partner.records = [
-            ...serverData.models.partner.records,
-            {
-                id: 5,
-                probability: 0,
-                field_with_array_agg: 0,
-                currency_id: 2,
-                pognon: 0,
-            },
-        ];
-        const { model } = await createSpreadsheetWithList({
-            serverData,
-            columns: ["pognon", "probability", "field_with_array_agg"],
-        });
-        assert.strictEqual(getCellFormattedValue(model, "A2"), "74.40€");
-        assert.strictEqual(getCellFormattedValue(model, "A3"), "$74.80");
-        assert.strictEqual(getCellFormattedValue(model, "A4"), "4.00€");
-        assert.strictEqual(getCellFormattedValue(model, "A5"), "$1,000.00");
-        assert.strictEqual(getCellFormattedValue(model, "A6"), "$0.00");
-        assert.strictEqual(getCellFormattedValue(model, "B2"), "10.00");
-        assert.strictEqual(getCellFormattedValue(model, "B3"), "11.00");
-        assert.strictEqual(getCellFormattedValue(model, "B4"), "95.00");
-        assert.strictEqual(getCellFormattedValue(model, "B5"), "15.00");
-        assert.strictEqual(getCellFormattedValue(model, "B6"), "0.00");
-        assert.strictEqual(getCellFormattedValue(model, "C2"), "1");
-        assert.strictEqual(getCellFormattedValue(model, "C3"), "2");
-        assert.strictEqual(getCellFormattedValue(model, "C4"), "3");
-        assert.strictEqual(getCellFormattedValue(model, "C5"), "4");
-        assert.strictEqual(getCellFormattedValue(model, "C6"), "0");
     });
 
     QUnit.test("properties field displays property display names", async (assert) => {

--- a/addons/spreadsheet/static/tests/utils/getters.js
+++ b/addons/spreadsheet/static/tests/utils/getters.js
@@ -54,7 +54,6 @@ export function getMerges(model, sheetId = model.getters.getActiveSheetId()) {
     return model.exportData().sheets.find((sheet) => sheet.id === sheetId).merges;
 }
 
-
 /**
  * Get the formatted value of the given xc
  */


### PR DESCRIPTION
The fix 64a7b630, while fixing the behaviour of the numeric fields, ended up also breaking the behaviour of text fields. Namely, the empty text fields were represented by empty strings and the fix forced their value to 'False' which is the result returned by the server.

Since the original idea was to fix an issue that occured in version 18.0 and later, we will revert the change in 16.0 and address it properly in 18.0.

task-4897690

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
