### PR TITLE
[FIX] web : datetime picker frontend header buttons design

### DIFF
--- a/addons/web/static/src/core/datetime/datetime_picker.scss
+++ b/addons/web/static/src/core/datetime/datetime_picker.scss
@@ -5,11 +5,6 @@
 
     width: $o-datetime-picker-width;
 
-    // Header
-    .o_datetime_picker_header .o_header_part {
-        text-transform: none;
-    }
-
     // Day
     .o_selected {
         color: $o-component-active-color;

--- a/addons/web/static/src/core/datetime/datetime_picker.xml
+++ b/addons/web/static/src/core/datetime/datetime_picker.xml
@@ -99,29 +99,29 @@
         >
             <nav class="o_datetime_picker_header">
                 <button
-                    class="o_previous btn btn-light"
+                    class="o_previous btn opacity-75 opacity-100-hover"
                     t-on-click="previous"
                     tabindex="-1"
                 >
                     <i class="oi oi-chevron-left" t-att-title="activePrecisionLevel.prevTitle" />
                 </button>
                 <button
-                    class="o_next btn btn-light"
+                    class="o_next btn opacity-75 opacity-100-hover"
                     t-on-click="next"
                     tabindex="-1"
                 >
                     <i class="oi oi-chevron-right" t-att-title="activePrecisionLevel.nextTitle" />
                 </button>
                 <button
-                    class="o_zoom_out o_datetime_button btn text-truncate"
+                    class="o_zoom_out o_datetime_button btn opacity-75 opacity-100-hover text-truncate"
                     tabindex="-1"
-                    t-att-class="{ 'btn-light': !isLastPrecisionLevel }"
+                    t-att-class="{ 'disabled': isLastPrecisionLevel }"
                     t-att-title="!isLastPrecisionLevel and activePrecisionLevel.mainTitle"
                     t-on-click="zoomOut"
                 >
                     <t t-foreach="titles" t-as="title" t-key="title">
                         <strong
-                            class="o_header_part fs-5"
+                            class="o_header_part"
                             t-esc="title"
                         />
                     </t>

--- a/addons/web/static/src/core/dialog/dialog.scss
+++ b/addons/web/static/src/core/dialog/dialog.scss
@@ -5,15 +5,8 @@
             white-space: nowrap;
             text-overflow: ellipsis;
         }
-
-        .modal-header .o_expand_button {
-            opacity: 75%;
-            &:hover {
-                opacity: 100%;
-            }
-        }
     }
-    
+
     .modal-footer {
         text-align: left;
 

--- a/addons/web/static/src/core/dialog/dialog.xml
+++ b/addons/web/static/src/core/dialog/dialog.xml
@@ -42,7 +42,7 @@
             <t t-esc="props.title"/>
         </h4>
         <t t-if="onExpand">
-            <button type="button" class="fa fa-expand btn o_expand_button" aria-label="Expand" tabindex="-1" t-on-click="onExpand"/>
+            <button type="button" class="fa fa-expand btn opacity-75 opacity-100-hover o_expand_button" aria-label="Expand" tabindex="-1" t-on-click="onExpand"/>
         </t>
         <t t-if="!fullscreen">
             <button type="button" class="btn-close" aria-label="Close" tabindex="-1" t-on-click="dismiss"></button>


### PR DESCRIPTION
After [1], each button is separated and therefore has its own
border radius and background color. On the backend side, using
the ´.btn-light´ class works well since it matches the background
of our views. However, on the frontend, the background color is
dynamic and does not match the page background, leading to a
visually awkward result.

One possible solution is to reintroduce the ´.btn-group´ class,
but only wrap the "Previous" and "Next" buttons, which makes sense.

However, we preferred to simply remove ´.btn-light´, which eliminates
background and border issues. We only want a hover effect, similar
to the one already implemented for the modal "expand" button.

The result is consistent across Community, Enterprise, Backend,
Frontend, and Dark mode.

Additionally, the font size has been removed to ensure consistent
button height, and ´text-transform´ no longer seems necessary.

[1]: https://github.com/odoo/odoo/commit/e2b78fca435f268515f9593c2af821616aff7ebb

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
