### PR TITLE
[IMP] mail: create chat with no participant

### DIFF
--- a/addons/mail/static/src/discuss/core/public_web/discuss_command_palette.js
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_command_palette.js
@@ -31,16 +31,20 @@ class CreateChatDialog extends Component {
     }
 
     get createText() {
-        if (this.invitePeopleState.selectedPartners.length > 1) {
-            return _t("Create Group Chat");
+        if (this.invitePeopleState.selectedPartners.length === 1) {
+            return _t("Open Chat");
         }
-        return _t("Open Chat");
+        return _t("Create Group Chat");
     }
 
     onClickConfirm() {
         const selectedPartnersId = this.invitePeopleState.selectedPartners.map((p) => p.id);
         const partners_to = [...new Set([this.store.self.id, ...selectedPartnersId])];
-        this.store.startChat(partners_to);
+        if (partners_to.length === 1) {
+            this.store.createGroupChat({ partners_to });
+        } else {
+            this.store.startChat(partners_to);
+        }
         this.props.close();
     }
 }

--- a/addons/mail/static/src/discuss/core/public_web/discuss_command_palette.xml
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_command_palette.xml
@@ -47,7 +47,7 @@
             <ChannelInvitation state="invitePeopleState"/>
         </div>
         <t t-set-slot="footer">
-            <button class="btn btn-primary me-2" t-att-disabled="invitePeopleState.selectedPartners.length === 0" t-on-click="onClickConfirm" t-esc="createText"/>
+            <button class="btn btn-primary me-2" t-on-click="onClickConfirm" t-esc="createText"/>
             <button class="btn btn-secondary me-2" t-on-click="props.close">Cancel</button>
         </t>
     </Dialog>

--- a/addons/mail/static/tests/discuss/core/web/command_palette.test.js
+++ b/addons/mail/static/tests/discuss/core/web/command_palette.test.js
@@ -164,3 +164,12 @@ test("Ctrl-K opens @ command palette in discuss app", async () => {
     triggerHotkey("control+k");
     await contains(".o_command_palette_search", { text: "@" });
 });
+
+test("Can create group chat from ctrl-k without any user selected", async () => {
+    await start();
+    await openDiscuss();
+    triggerHotkey("control+k");
+    await click(".o_command_name:contains(Create Chat)");
+    await click(".modal-footer > .btn:contains(Create Group Chat)");
+    await contains(".o-mail-DiscussSidebarChannel-itemName", { text: "Mitchell Admin" });
+});


### PR DESCRIPTION
The purpose of this commit is to allow the creation of chats without any user (when on the command palette ctrl+k "create chat").

This gives the possibility to quickly create a conversation and later on invite people either with the link or directly to add users.

It was already to achieve the same result with "start a meeting" but it had the side-effect of starting a call. This commit is only creating the channel without starting the call.

task-4860930

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
