### PR TITLE
[FIX] website: limit height of svg of highlighted text

### DIFF
--- a/addons/website/static/src/scss/website_common.scss
+++ b/addons/website/static/src/scss/website_common.scss
@@ -12,5 +12,6 @@
     }
     svg {
         z-index: -1;
+        height: 1px;
     }
 }


### PR DESCRIPTION
Steps to reproduce:
- Open website builder
- Select text at the bottom of the footer
- Set some highlight
- Bug:
  - Can scroll down below the bottom of the footer
  - There is some blank space below the list of highlights

task-4367641
