### PR TITLE
[FIX] point_of_sale: avoid 500 internal error pos

### DIFF
--- a/addons/point_of_sale/controllers/main.py
+++ b/addons/point_of_sale/controllers/main.py
@@ -245,7 +245,7 @@ class PosController(PortalAccount):
 
     def _validate_extra_form_details(self, addtional_form_values, additional_required_fields):
         """ Ensure that all additional required fields have a value in the data. """
-        missing_fields = {}
+        missing_fields = set()
         error_messages = []
         for field in additional_required_fields:
             if field.name not in addtional_form_values or not addtional_form_values[field.name]:


### PR DESCRIPTION
[FIX] point_of_sale: avoid 500 internal error pos

When requesting an invoice from the portal, if an additional required field is left empty, the user gets a 500 Internal server error. (e.g. fields l10n_mx_edi_fiscal_regime, l10n_mx_edi_usage)

Steps to reproduce:
- Install POS & l10n_mx_reports
- Open a POS session and sell a product without invoicing (and print the ticket)
- Close the session
- Open a new private window and go to \<url\>/pos/ticket
- Enter ticket number, date and unique code and press "Request invoice"
- Fill the form in but leave l10n_mx_edi_fiscal_regime & l10n_mx_edi_usage empty
- Press "Get my invoice"


Runbot: https://runbot.odoo.com/runbot/bundle/saas-18-2-dump-pos-extra-fields-roto-380043
