### PR TITLE
[FIX] spreadsheet: text field not correct in list formula

### DIFF
--- a/addons/spreadsheet/static/src/list/list_data_source.js
+++ b/addons/spreadsheet/static/src/list/list_data_source.js
@@ -234,8 +234,12 @@ export class ListDataSource extends OdooViewsDataSource {
             }
             case "json":
                 return new EvaluationError(_t('Fields of type "%s" are not supported', "json"));
-            default:
+            case "monetary":
+            case "float":
+            case "integer":
                 return fieldName in record ? record[fieldName] : "";
+            default:
+                return record[fieldName] || "";
         }
     }
 

--- a/addons/spreadsheet/static/tests/lists/list_plugin.test.js
+++ b/addons/spreadsheet/static/tests/lists/list_plugin.test.js
@@ -18,6 +18,7 @@ import {
     getCellValue,
     getEvaluatedCell,
     getEvaluatedGrid,
+    getFormattedValueGrid,
 } from "@spreadsheet/../tests/helpers/getters";
 import { THIS_YEAR_GLOBAL_FILTER } from "@spreadsheet/../tests/helpers/global_filter";
 import { createSpreadsheetWithList } from "@spreadsheet/../tests/helpers/list";
@@ -86,25 +87,28 @@ test("Numeric/monetary fields are correctly loaded and displayed", async () => {
         field_with_array_agg: 0,
         currency_id: 2,
         pognon: 0,
-    })
+    });
     const { model } = await createSpreadsheetWithList({
         columns: ["pognon", "probability", "field_with_array_agg"],
     });
-    expect(getCellFormattedValue(model, "A2")).toBe("74.40€");
-    expect(getCellFormattedValue(model, "A3")).toBe("$74.80");
-    expect(getCellFormattedValue(model, "A4")).toBe("4.00€");
-    expect(getCellFormattedValue(model, "A5")).toBe("$1,000.00");
-    expect(getCellFormattedValue(model, "A6")).toBe("$0.00");
-    expect(getCellFormattedValue(model, "B2")).toBe("10.00");
-    expect(getCellFormattedValue(model, "B3")).toBe("11.00");
-    expect(getCellFormattedValue(model, "B4")).toBe("95.00");
-    expect(getCellFormattedValue(model, "B5")).toBe("15.00");
-    expect(getCellFormattedValue(model, "B6")).toBe("0.00");
-    expect(getCellFormattedValue(model, "C2")).toBe("1");
-    expect(getCellFormattedValue(model, "C3")).toBe("2");
-    expect(getCellFormattedValue(model, "C4")).toBe("3");
-    expect(getCellFormattedValue(model, "C5")).toBe("4");
-    expect(getCellFormattedValue(model, "C6")).toBe("0");
+
+    // prettier-ignore
+    expect(getFormattedValueGrid(model, "A2:C6")).toEqual({
+        A2: "74.40€",    B2: "10.00",  C2: "1",
+        A3: "$74.80",    B3: "11.00",  C3: "2",
+        A4: "4.00€",     B4: "95.00",  C4: "3",      
+        A5: "$1,000.00", B5: "15.00",  C5: "4",
+        A6: "$0.00",     B6: "0.00",   C6: "0",
+    });
+});
+
+test("Text fields are correctly loaded and displayed", async () => {
+    Partner._records = [{ name: "Record 1" }, { name: false }];
+    const { model } = await createSpreadsheetWithList({
+        columns: ["name"],
+    });
+    expect(getCellFormattedValue(model, "A2")).toBe("Record 1");
+    expect(getCellFormattedValue(model, "A3")).toBe("");
 });
 
 test("properties field displays property display names", async () => {


### PR DESCRIPTION
Following the fix in d927a7b6, we broke the default behaviour of empty text/chart fields. While the server returns the value `false` when they're empty, we want to display an empty string in the `ODOO.LIST` formulas.

Task-4897690

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
