### PR TITLE
[FIX] hr: set correct company environment on employee creation

### DIFF
--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -968,13 +968,25 @@ class HrEmployee(models.Model):
 
     @api.model_create_multi
     def create(self, vals_list):
-        for vals in vals_list:
+        vals_per_company = defaultdict(list)
+        for idx, vals in enumerate(vals_list):
             if vals.get('user_id'):
                 user = self.env['res.users'].browse(vals['user_id'])
                 vals.update(self._sync_user(user, bool(vals.get('image_1920'))))
                 vals['name'] = vals.get('name', user.name)
                 self._remove_work_contact_id(user, vals.get('company_id'))
-        employees = super().create(vals_list)
+            # Having one create per company is necessary to pass the company in the context to correctly set it in
+            # the underlying version created by the framework
+            vals_per_company[vals.get('company_id', self.env.company)].append((idx, vals))
+        index_per_employee = {}
+        employees = self.env['hr.employee']
+        for company, vals_list in vals_per_company.items():
+            idxs, vals_list = zip(*vals_list)
+            new_employees = super(HrEmployee, self.with_company(company)).create(vals_list)
+            index_per_employee.update(dict(zip(new_employees, idxs)))
+            employees |= new_employees
+        # As we do a custom batch by company, we must reorder the records to respect the original order.
+        employees = employees.sorted(key=lambda employee: index_per_employee[employee])
         # Sudo in case HR officer doesn't have the Contact Creation group
         employees.filtered(lambda e: not e.work_contact_id).sudo()._create_work_contacts()
         for employee_sudo in employees.sudo():


### PR DESCRIPTION
=== Problem ===
Both hr_employee and hr_version have a stored field 'company_id'. The hr_version company_id field is a computed field that depends on the company_id field of the employee, if there is an employee (i.e. it is not a contract template).
The problem is: when we create a new employee, the company_id field of the version will first be the current company, not the one of the created employee.
This causes some problems, for example the constraints related to the company's country being wrongly executed on the hr_version.

=== Solution ===
To solve this problem, we explicitely set the correct company in the context when creating new employees, so that the version created by the ORM will have directly the correct country.
These are batched by company to avoid loss in performance.

task-4897733