### PR TITLE
[FIX] l10n_ar_website_sale: fix test failure when running module standalone

### DIFF
--- a/addons/l10n_ar_website_sale/tests/test_l10n_ar_website_sale.py
+++ b/addons/l10n_ar_website_sale/tests/test_l10n_ar_website_sale.py
@@ -1,12 +1,12 @@
 from datetime import datetime
 
 from odoo.addons.l10n_ar.tests.common import TestAr
-from odoo.addons.website_sale.tests.common import MockRequest, WebsiteSaleCommon
+from odoo.addons.website_sale.tests.common import MockRequest
 from odoo.tests import tagged
 
 
 @tagged('post_install_l10n', 'post_install', '-at_install')
-class TestL10nArWebsiteSale(WebsiteSaleCommon, TestAr):
+class TestL10nArWebsiteSale(TestAr):
 
     @classmethod
     def setUpClass(cls):


### PR DESCRIPTION
## Before this commit:
Running `l10n_ar_website_sale` tests in isolation (e.g., single module install with `--test-enable`) failed due to `access rights`. The test class relied on inherited setup from `website_sale's` test common, which implicitly granted sales-related access to the test user. This caused `AccessError` when attempting to create `sales orders`.

## After this commit:
The test class no longer inherits from `WebsiteSaleCommon`, avoiding unintended dependencies and access rights assumptions. The tests now run successfully when the module is installed and tested on its own.

> Error Log - https://runbot.odoo.com/odoo/runbot.build.error/227642
> Commit Causing Issue - https://github.com/odoo/odoo/commit/e331bcf1cb62d4610fb8d9bbca90e925a676fa38




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
