### PR TITLE
[FIX] web: Fix grouping on view with expand

### DIFF
--- a/addons/web/models/models.py
+++ b/addons/web/models/models.py
@@ -490,7 +490,7 @@ class Base(models.AbstractModel):
             current_groups = [
                 subgroup
                 for group in current_groups
-                for subgroup in group.get('__groups', ())
+                for subgroup in group.get('__groups', {}).get('groups', ())
             ]
 
     def _get_read_group_order(self, dict_order: dict[str, str], groupby: list[str], aggregates: Sequence[str]) -> str:


### PR DESCRIPTION
Since 26c37c9c070107f8bd753cb8a6d8343384fdd7bf, when performing nested Group
By on a view with expand = True, a traceback was raised when applying 2 or more groups.

  ```
File "/home/odoo/Documents/odoo_projects/odoo/addons/web/models/models.py", line 447, in web_read_group
    self._add_groupby_values(groupby_read_specification, groupby, groups)
  File "/home/odoo/Documents/odoo_projects/odoo/addons/web/models/models.py", line 480, in _add_groupby_values
    id_label[0] for group in current_groups if (id_label := group[groupby_spec])
                                                            ~~~~~^^^^^^^^^^^^^^
TypeError: string indices must be integers, not 'str'
```
This was because we expected 'group' to be a dict, but it was a string.
This commit change the 'group' creation, by adding the right dict in it.

no-task