### PR TITLE
Saas 18.4 fix variant preview liew

### DIFF
--- a/addons/website_sale/models/product_template.py
+++ b/addons/website_sale/models/product_template.py
@@ -295,7 +295,7 @@ class ProductTemplate(models.Model):
                 if len(previewed_ptavs) > 1:
                     previewed_ptavs_data = []
                     for ptav in previewed_ptavs[:show_count]:
-                        matching_variant = ptav.ptav_product_variant_ids[0]
+                        matching_variant = ptav.ptav_product_variant_ids.sorted('id')[0]
                         previewed_ptavs_data.append({
                             'ptav': ptav,
                             'variant_image_url': self.env['website'].image_url(matching_variant, 'image_512'),

--- a/addons/website_sale/views/product_attribute_views.xml
+++ b/addons/website_sale/views/product_attribute_views.xml
@@ -19,12 +19,14 @@
                         widget="radio"
                         options="{'horizontal': True}"
                         readonly="create_variant != 'always' or display_type == 'multi'"
+                        force_save="1"
                     />
                     <field
                         name="is_thumbnail_visible"
                         widget="boolean_toggle"
                         readonly="create_variant != 'always' or display_type == 'multi'"
                         invisible="preview_variants == 'hidden'"
+                        force_save="1"
                     />
                 </group>
             </group>


### PR DESCRIPTION
Follow up of d930c3d424fb75149072774b847a6b13d277b771:
1. Make sure that displayed variants match the order of the first matching combination on /product page.
2. Disable the preview_variants and the is_thumbnail_visible fields when variant creation is 'no_variant' or 'dynamic'.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
