### PR TITLE
[FIX] sale_pdf_quote_builder: prevent errors when handling non-PDF files

### DIFF
--- a/addons/sale_pdf_quote_builder/models/product_document.py
+++ b/addons/sale_pdf_quote_builder/models/product_document.py
@@ -52,7 +52,7 @@ class ProductDocument(models.Model):
         # Empty the linked form fields as we want all and only those from the current datas
         self.form_field_ids = [Command.clear()]
         document_to_parse = self.filtered(
-            lambda doc: doc.attached_on_sale == 'inside' and doc.datas
+            lambda doc: doc.attached_on_sale == 'inside' and doc.datas and doc.mimetype and doc.mimetype.endswith('pdf')
         )
         if document_to_parse:
             doc_type = 'product_document'

--- a/addons/sale_pdf_quote_builder/tests/test_pdf_quote_builder.py
+++ b/addons/sale_pdf_quote_builder/tests/test_pdf_quote_builder.py
@@ -8,6 +8,7 @@ from unittest.mock import patch
 from werkzeug.datastructures import FileStorage
 
 from odoo import Command
+from odoo.exceptions import ValidationError
 from odoo.tests import Form, tagged
 from odoo.tools.misc import file_open
 
@@ -184,6 +185,22 @@ class TestPDFQuoteBuilder(BaseUsersCommon, SaleManagementCommon):
         so_form.save()
 
         self.assertNotEqual(self.sale_order.quotation_document_ids, self.header)
+
+    def test_non_pdf_attachment_inside_quote_form_save(self):
+        non_pdf_att = self.env['ir.attachment'].create({
+            'name': 'Not a PDF',
+            'datas': b64encode(b"hello"),
+            'mimetype': 'text/plain',
+        })
+
+        product_document = self.product_document
+
+        product_document.write({
+            'ir_attachment_id': non_pdf_att.id,
+        })
+        with self.assertRaises(ValidationError):
+            with Form(product_document) as doc_form:
+                doc_form.attached_on_sale = 'inside'
 
     def test_onchange_product_removes_previously_selected_documents(self):
         """ Check that changing a line that has a selected document unselect said document. """


### PR DESCRIPTION
Currently an error occurs when user uploads a non-pdf file on product documents.

Steps to replicate:
- Install `sale_management` and go to products.
- Open any product's form view and click on the `Documents` smart button.
- Click new and upload any non-pdf file.
- On the field `Sale : Visible at`, select the value `inside quote pdf` and you will get the error.

Error:
`PdfReadError: EOF marker not found`

The error occurs because at the line [1] the code requires a pdf file, and as we have passed a non-pdf file the error occurs.

[1] - https://github.com/odoo/odoo/blob/e750244c3125a48e2ca030160b977bb0344609db/addons/sale_pdf_quote_builder/models/sale_pdf_form_field.py#L206

There is already a constraint made for this particular thing [2], but the problem is that the error is due the compute [3] (Because constraints are checked at the time of form saving, and compute runs when a field is changed so even before the constraint is checked the error will be triggered).

[2] - https://github.com/odoo/odoo/blob/e750244c3125a48e2ca030160b977bb0344609db/addons/sale_pdf_quote_builder/models/product_document.py#L44-L45

[3] - https://github.com/odoo/odoo/blob/e750244c3125a48e2ca030160b977bb0344609db/addons/sale_pdf_quote_builder/models/product_document.py#L59-L61

This commit resolves this issue by  skipping the pdf extraction if the file is not a pdf type, because we already have a constraint [2] that will trigger at save.


sentry-6161120972
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
