### PR TITLE
[FIX] base: fetch selection for reference field description

### DIFF
--- a/odoo/addons/base/models/ir_model.py
+++ b/odoo/addons/base/models/ir_model.py
@@ -1365,7 +1365,7 @@ class IrModelFields(models.Model):
             }
             for field in fields
         }
-        for field in fields.filtered(lambda field: field.ttype == 'selection'):
+        for field in fields.filtered(lambda field: field.ttype in ('selection', 'reference')):
             result[field.name]['selection'] = [
                 (sel.value, sel.name) for sel in field.selection_ids
             ]


### PR DESCRIPTION
[1] adds some optimizations around fetching selection for field descriptions but omits to consider "reference" is also a field type that uses selections.

This leads to selection not being provided when fetching views containing reference fields.

[1]: afe72a751ec073e76cd51e5c300468cd16d194d6

task-4894262