### PR TITLE
[FIX] html_builder: fix target of delete entry in builder list

### DIFF
--- a/addons/html_builder/static/src/core/building_blocks/builder_list.js
+++ b/addons/html_builder/static/src/core/building_blocks/builder_list.js
@@ -100,8 +100,7 @@ export class BuilderList extends Component {
         this.commit(items);
     }
 
-    deleteItem(e) {
-        const itemId = e.target.dataset.id;
+    deleteItem(itemId) {
         const items = this.formatRawValue(this.state.value);
         this.commit(items.filter((item) => item._id !== itemId));
     }

--- a/addons/html_builder/static/src/core/building_blocks/builder_list.xml
+++ b/addons/html_builder/static/src/core/building_blocks/builder_list.xml
@@ -41,8 +41,7 @@
                                 </t>
                                 <td>
                                     <button type="button" class="btn text-danger builder_list_remove_item"
-                                            t-on-click="deleteItem"
-                                            t-att-data-id="item._id">
+                                            t-on-click="() => this.deleteItem(item._id)">
                                         <i class="fa fa-fw fa-minus" aria-hidden="true"/>
                                         <span class="visually-hidden">Delete item</span>
                                     </button>


### PR DESCRIPTION
Steps to reproduce:
- In website builder
- In an option with a builder list (I got one in a form with a field of type "Guest")
- Add some entries
- Click exactly on the delete button (the red minus)
- Bug: It does not work (user must click outside of the icon to delete)

The bug was introduced during the initial refactor of website builder

Website refactor: 9fe45e2b7ddbbfd0445ffe25a859e67a316d02b2
task-4367641
