### PR TITLE
[IMP] website_sale(_stock): quick reorder

### DIFF
--- a/addons/website_sale/models/sale_order_line.py
+++ b/addons/website_sale/models/sale_order_line.py
@@ -57,6 +57,19 @@ class SaleOrderLine(models.Model):
             self.price_unit, self.currency_id, 1, self.product_id, self.order_partner_id,
         )[tax_display]
 
+    def _get_selected_combo_items(self):
+        if self.product_id.type == 'combo':
+            return [{
+                'id': linked_line.combo_item_id.id,
+                'no_variant_ptav_ids': linked_line.product_no_variant_attribute_value_ids.ids,
+                'custom_ptavs': [{
+                    'id': pcav.custom_product_template_attribute_value_id.id,
+                    'value': pcav.custom_value,
+                } for pcav in linked_line.product_custom_attribute_value_ids]
+            } for linked_line in self.linked_line_ids]
+
+        return None
+
     def _get_displayed_quantity(self):
         rounded_uom_qty = round(self.product_uom_qty,
                                 self.env['decimal.precision'].precision_get('Product Unit'))

--- a/addons/website_sale/static/src/interactions/cart_line.js
+++ b/addons/website_sale/static/src/interactions/cart_line.js
@@ -72,10 +72,12 @@ export class CartLine extends Interaction {
         );
 
         const cart = this.el.closest('#shop_cart');
-        // `updateCartNavBar` regenerates the cart lines, so we need to stop and start interactions
-        // to make sure the regenerated lines are properly handled.
+        // `updateCartNavBar` regenerates the cart lines and `updateQuickReorderSidebar`
+        // regenerates the quick reorder products, so we need to stop and start interactions
+        // to make sure the regenerated cart lines and reorder products are properly handled.
         this.services['public.interactions'].stopInteractions(cart);
         wSaleUtils.updateCartNavBar(data);
+        wSaleUtils.updateQuickReorderSidebar(data);
         this.services['public.interactions'].startInteractions(cart);
         wSaleUtils.showWarning(data.warning);
         // Propagate the change to the express checkout forms.

--- a/addons/website_sale/static/src/interactions/quick_reorder.js
+++ b/addons/website_sale/static/src/interactions/quick_reorder.js
@@ -1,0 +1,178 @@
+import { ProductCombo } from '@sale/js/models/product_combo';
+import { serializeComboItem } from '@sale/js/sale_utils';
+import { serializeDateTime } from '@web/core/l10n/dates';
+import { rpc } from '@web/core/network/rpc';
+import { registry } from '@web/core/registry';
+import { Interaction } from '@web/public/interaction';
+import wSaleUtils from '@website_sale/js/website_sale_utils';
+
+export class QuickReorder extends Interaction {
+
+    static selector = '#quick_reorder_sidebar';
+    dynamicContent = {
+        '.o_wsale_quick_reorder_qty_input': {
+            't-on-input': this.updateQuantityAndPrice,
+            't-on-keydown': this.triggerReorderOnEnter,
+        },
+        '.o_wsale_quick_reorder_product_button': { 't-on-click': this.reorderProduct },
+    };
+
+    /**
+     * Update the total price and enable/disable the add button based on the quantity input.
+     *
+     * @param {Event} ev
+     * @return {void}
+     */
+    async updateQuantityAndPrice(ev) {
+        const qtyInput = ev.currentTarget;
+        const priceUnit = parseFloat(qtyInput.dataset.priceUnit);
+        const digits = parseInt(qtyInput.dataset.currencyDigits, 10);
+        const qty = parseInt(qtyInput.value, 10) || 0;
+        this._updateAddButton(qtyInput, qty);
+        if (qty > 0) {
+            this._updateTotalPrice(qtyInput, qty, priceUnit, digits);
+        }
+    }
+
+    /**
+     * Update the add button state based on quantity.
+     *
+     * @private
+     * @param {Element} qtyInput - The quantity input element.
+     * @param {number} qty - The quantity value.
+     * @return {void}
+     */
+    _updateAddButton(qtyInput, qty) {
+        const addButton = qtyInput.closest('.o_wsale_quick_reorder_line').querySelector(
+            '.o_wsale_quick_reorder_product_button'
+        );
+        const isDisabled = qty <= 0;
+        addButton.classList.toggle('disabled', isDisabled);
+        if (qty > 0) {
+            addButton.dataset.quantity = String(qty);
+        }
+    }
+
+    /**
+     * Update the total price display for the related line.
+     *
+     * @private
+     * @param {Element} qtyInput - The quantity input element.
+     * @param {number} qty - The quantity.
+     * @param {number} priceUnit - The unit price.
+     * @param {number} digits - The number of decimal digits for the currency.
+     * @return {void}
+     */
+    _updateTotalPrice(qtyInput, qty, priceUnit, digits) {
+        const priceEl = qtyInput.closest('.o_wsale_quick_reorder_line').querySelector(
+            '.o_wsale_quick_reorder_product_price .oe_currency_value'
+        );
+        if (priceEl) {
+            const totalPrice = (qty * priceUnit).toFixed(digits);
+            priceEl.textContent = totalPrice;
+        }
+    }
+
+    /**
+     * Trigger the reorder action when Enter key is pressed on quantity input.
+     *
+     * @param {Event} ev
+     * @return {void}
+     */
+    async triggerReorderOnEnter(ev) {
+        if (ev.key !== 'Enter') return;
+
+        const addButton = ev.currentTarget.closest('.o_wsale_quick_reorder_line').querySelector(
+            '.o_wsale_quick_reorder_product_button'
+        );
+        if (addButton && !addButton.classList.contains('disabled')) {
+            addButton.click();
+        }
+    }
+
+    /**
+     * Reorder the product and update the page's content.
+     *
+     * @param {Event} ev
+     * @return {void}
+     */
+    async reorderProduct(ev) {
+        // Extract product data from the button dataset.
+        const addButtonDataset = ev.currentTarget.dataset;
+        const productTemplateId = parseInt(addButtonDataset.productTemplateId, 10);
+        const productId = parseInt(addButtonDataset.productId, 10);
+        let quantity = parseInt(addButtonDataset.quantity);
+        const isCombo = addButtonDataset.productType === 'combo';
+        const selectedComboItems = JSON.parse(addButtonDataset.selectedComboItems || '[]');
+
+        // Capture the button index before DOM updates.
+        const allButtons = document.querySelectorAll('.o_wsale_quick_reorder_product_button');
+        const currentButtonIndex = Array.from(allButtons).indexOf(ev.currentTarget);
+
+        // Process combo products if applicable.
+        let linkedProducts = [];
+        if (isCombo) {
+            const { quantity: updatedQty, combos } = await rpc(
+                '/website_sale/combo_configurator/get_data',
+                {
+                    product_tmpl_id: productTemplateId,
+                    quantity: quantity,
+                    date: serializeDateTime(luxon.DateTime.now()),
+                    selected_combo_items: selectedComboItems,
+                }
+            );
+            quantity = updatedQty;
+            linkedProducts = combos
+                .map(combo => new ProductCombo(combo).selectedComboItem)
+                .filter(Boolean)
+                .map(comboItem => ({
+                    product_template_id: comboItem.product.product_tmpl_id,
+                    parent_product_template_id: productTemplateId,
+                    quantity: quantity,
+                    ...serializeComboItem(comboItem),
+                }));
+        }
+
+        // Add the product to the cart and update the DOM.
+        const cart = document.getElementById('shop_cart');
+        // `updateCartNavBar` regenerates the cart lines and `updateQuickReorderSidebar`
+        // regenerates the quick reorder products, so we need to stop and start interactions to
+        // make sure the regenerated reorder products and cart lines are properly handled.
+        this.services['public.interactions'].stopInteractions();
+        this.services['public.interactions'].stopInteractions(cart);
+        const data = await rpc('/shop/cart/quick_add', {
+            product_template_id: productTemplateId,
+            product_id: productId,
+            quantity: quantity,
+            ...(isCombo && { linked_products: linkedProducts }),
+        })
+        wSaleUtils.updateQuickReorderSidebar(data);
+        wSaleUtils.updateCartNavBar(data);
+        this.services['public.interactions'].startInteractions();
+        this.services['public.interactions'].startInteractions(cart);
+
+        // Move the focus to the next quantity input.
+        this._focusNextQuantityInput(currentButtonIndex);
+    }
+
+    /**
+     * Moves the focus to the next quantity input.
+     *
+     * @param {HTMLElement} buttonIndex - The index of the reorder button that was clicked before
+     *                                    DOM updates.
+     * @return {void}
+     */
+    _focusNextQuantityInput(buttonIndex) {
+        const allQuantityInputs = document.querySelectorAll('.o_wsale_quick_reorder_qty_input');
+        const nextInput = allQuantityInputs[buttonIndex];
+        if (nextInput) {
+            nextInput.focus();
+            nextInput.select();
+        }
+    }
+
+}
+
+registry
+    .category('public.interactions')
+    .add('website_sale.quick_reorder', QuickReorder);

--- a/addons/website_sale/static/src/js/website_sale_utils.js
+++ b/addons/website_sale/static/src/js/website_sale_utils.js
@@ -1,4 +1,6 @@
+import { markup } from '@odoo/owl';
 import { browser } from '@web/core/browser/browser';
+import { setElementContent } from '@web/core/utils/html';
 
 function animateClone($cart, $elem, offsetTop, offsetLeft) {
     if (!$cart.length) {
@@ -47,8 +49,10 @@ function animateClone($cart, $elem, offsetTop, offsetLeft) {
 }
 
 /**
- * Updates both navbar cart
+ * Updates both navbar cart.
+ *
  * @param {Object} data
+ * @return {void}
  */
 function updateCartNavBar(data) {
     browser.sessionStorage.setItem('website_sale_cart_quantity', data.cart_quantity);
@@ -70,13 +74,51 @@ function updateCartNavBar(data) {
     }
 
     $(".js_cart_lines").first().before(data['website_sale.cart_lines']).end().remove();
-    document.querySelectorAll('div.o_cart_total').forEach(
-        div => div.innerHTML = data['website_sale.total']
-    );
+
+    updateCartSummary(data);
+
     if (data.cart_ready) {
         document.querySelector("a[name='website_sale_main_button']")?.classList.remove('disabled');
     } else {
         document.querySelector("a[name='website_sale_main_button']")?.classList.add('disabled');
+    }
+}
+
+/**
+ * Update the cart summary.
+ *
+ * @param {Object} data
+ * @return {void}
+ */
+function updateCartSummary(data) {
+    if (data['website_sale.shorter_cart_summary']) {
+        const shorterCartSummaryEl = document.querySelector('.o_wsale_shorter_cart_summary');
+        setElementContent(shorterCartSummaryEl, markup(data['website_sale.shorter_cart_summary']));
+    }
+    if (data['website_sale.total']) {
+        document.querySelectorAll('div.o_cart_total').forEach(
+            div => div.innerHTML = data['website_sale.total']
+        );
+    }
+}
+
+/**
+ * Update the quick reorder side panel.
+ *
+ * @param {Object} data
+ * @return {void}
+ */
+function updateQuickReorderSidebar(data) {
+    const quickReorderButton  = document.getElementById('quick_reorder_button');
+    document.querySelectorAll('.o_wsale_quick_reorder_line_group').forEach(el => el.remove());
+    if (data['website_sale.quick_reorder_history'].trim()) {
+        document.querySelector('#quick_reorder_sidebar .offcanvas-body').insertAdjacentHTML(
+            'afterbegin', data['website_sale.quick_reorder_history']
+        );
+        quickReorderButton.removeAttribute('disabled');
+    } else {
+        quickReorderButton.click();
+        quickReorderButton.setAttribute('disabled', 'true');
     }
 }
 
@@ -118,4 +160,5 @@ export default {
     updateCartNavBar: updateCartNavBar,
     showWarning: showWarning,
     getSelectedAttributeValues: getSelectedAttributeValues,
+    updateQuickReorderSidebar: updateQuickReorderSidebar,
 };

--- a/addons/website_sale/static/src/scss/website_sale.scss
+++ b/addons/website_sale/static/src/scss/website_sale.scss
@@ -1521,7 +1521,7 @@ a.no-decoration {
         }
     }
 
-    #cart_products {
+    #cart_products, .o_wsale_quick_reorder_line_group {
         --cart-product-img-size-lg: 6rem;
 
         .o_cart_product_image {
@@ -1612,6 +1612,41 @@ a.no-decoration {
 
     a.disabled {
         pointer-events: none;
+    }
+
+    #quick_reorder_sidebar {
+        &.offcanvas {
+            width: 760px;
+
+            .o_wsale_quick_reorder_qty_input {
+                width: 7ch;
+            }
+        }
+
+        .o_wsale_quick_reorder_line_group {
+            --cart-product-img-size-lg: 3rem;
+
+            .o_cart_product_image img {
+                @include media-breakpoint-down(md) {
+                    --cart-product-img-size-sm: 2.6rem;
+                }
+            }
+
+            .o_wsale_quick_reorder_group_content {
+                &:not(:last-child) {
+                    padding-bottom: map-get($spacers, 5);
+                }
+
+                .o_wsale_quick_reorder_line:not(:last-child) {
+                    margin-bottom: map-get($spacers, 3);
+
+                    @include media-breakpoint-down(sm) {
+                        padding-bottom: map-get($spacers, 3);
+                        border-bottom: $border-width solid $border-color;
+                    }
+                }
+            }
+        }
     }
 }
 

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -3006,7 +3006,10 @@
                         'o_img_ratio_2_3' if is_view_active('website_sale.products_thumb_2_3') else
                         '')
             ">
-                <h4 class="mb-3">Order summary</h4>
+                <div class="d-flex align-items-center mb-3">
+                    <h4 class="mb-0">Order summary</h4>
+                    <div t-call="website_sale.quick_reorder_button" class="ms-3 border-start ps-2"/>
+                </div>
                 <div t-if="abandoned_proceed or access_token" class="alert alert-info mt8 mb8" role="alert"> <!-- abandoned cart choices -->
                     <t t-if="abandoned_proceed">
                         <p>Your previous cart has already been completed.</p>
@@ -3031,6 +3034,151 @@
                 <div class="oe_structure" id="oe_structure_website_sale_cart_1"/>
             </div>
         </t>
+    </template>
+
+    <template id="quick_reorder_button">
+        <!-- TODO SHRM: Make title translatable -->
+        <t
+            t-set="quick_reorder_button_title"
+            t-value="'Login to reorder' if request.website.is_public_user()
+                     else 'No previous products available for reorder.' if not order_history
+                     else ''"
+        />
+        <span t-att-title="quick_reorder_button_title">
+            <button
+                id="quick_reorder_button"
+                type="button"
+                class="btn btn-sm btn-link"
+                data-bs-toggle="offcanvas"
+                data-bs-target="#quick_reorder_sidebar"
+                aria-controls="quick_reorder_sidebar"
+                t-att-disabled="not order_history"
+            >
+                <i class="fa fa-rotate-left me-2"/>Quick reorder
+            </button>
+        </span>
+        <t t-call="website_sale.quick_reorder_sidebar"/>
+    </template>
+
+    <template id="quick_reorder_sidebar">
+        <div
+            id="quick_reorder_sidebar"
+            class="offcanvas offcanvas-end"
+            aria-labelledby="quick_reorder_sidebar"
+        >
+            <div class="offcanvas-header">
+                <h5 class="offcanvas-title">Quick reorder</h5>
+                <button
+                    type="button"
+                    class="btn-close text-reset"
+                    data-bs-dismiss="offcanvas"
+                    aria-label="Close"
+                />
+            </div>
+            <div class="offcanvas-body">
+                <!-- Parent element needed for proper JS side rendering -->
+                <t t-if="order_history" t-call="website_sale.quick_reorder_history"/>
+            </div>
+        </div>
+    </template>
+
+    <template id="quick_reorder_history">
+        <div
+            class="o_wsale_quick_reorder_line_group ps-sm-3"
+            t-foreach="order_history"
+            t-as="order_line_group"
+        >
+            <div class="o_wsale_quick_reorder_group_content d-flex gap-3 w-100 position-relative">
+                <div
+                    class="o_dot_line d-none d-sm-block position-absolute top-0 bottom-0 mb-1 border-start"
+                />
+                <span
+                    class="o_dot d-none d-sm-block position-absolute translate-middle-x text-o-color-1"
+                />
+                <div class="w-100 ps-sm-4">
+                    <h6 t-out="order_line_group['label']" class="mt-1 mb-3 text-muted"/>
+                    <div
+                        t-foreach="order_line_group['lines']"
+                        t-as="order_line"
+                        t-att-class="'o_wsale_quick_reorder_line d-flex flex-column flex-sm-row justify-content-between gap-3 '
+                                      + ('align-items-start' if order_line.product_type == 'combo' else '')"
+                    >
+                        <div
+                            t-att-class="'d-flex gap-2 ' + ('align-items-start' if order_line.product_type == 'combo' else 'align-items-center')"
+                        >
+                            <div class="o_cart_product_image">
+                                <div
+                                    t-field="order_line.product_id.image_128"
+                                    t-options="{
+                                        'widget': 'image',
+                                        'qweb_img_responsive': False,
+                                        'class': 'border rounded',
+                                    }"
+                                />
+                            </div>
+                            <div
+                                class="d-flex flex-column align-items-start justify-content-center flex-grow-1 h-100"
+                            >
+                                <div>
+                                    <h6
+                                        t-out="order_line.name_short"
+                                        t-att-class="'small ' + ('mb-2' if order_line.product_type == 'combo' else 'mb-0')"
+                                    />
+                                    <ul
+                                        t-if="order_line.product_type == 'combo'" class="list-group"
+                                    >
+                                        <t
+                                            t-foreach="order_line.linked_line_ids"
+                                            t-as="combo_item_line"
+                                            t-call="website_sale.cart_combo_item_line"
+                                        />
+                                    </ul>
+                                </div>
+                                <small
+                                    t-if="order_line.product_template_id._has_multiple_uoms()"
+                                    t-out="order_line.product_uom_id.name"
+                                    class="badge mt-1 bg-light"
+                                />
+                            </div>
+                        </div>
+                        <div class="d-flex align-items-center ms-auto gap-2">
+                            <t
+                                t-set="combination_info"
+                                t-value="order_line.product_id._get_combination_info_variant()"
+                            />
+                            <small
+                                t-out="combination_info['price'] * order_line.product_uom_qty"
+                                t-options="{
+                                    'widget': 'monetary',
+                                    'display_currency': website.currency_id,
+                                }"
+                                class="o_wsale_quick_reorder_product_price"
+                                style="white-space: nowrap;"
+                            />
+                            <input
+                                type="text"
+                                t-att-value="int(order_line.product_uom_qty)"
+                                class="o_wsale_quick_reorder_qty_input form-control text-center"
+                                t-att-data-price-unit="combination_info['price']"
+                                t-att-data-currency-digits="combination_info['currency'].decimal_places"
+                            />
+                            <button
+                                type="button"
+                                title="Press 'Enter' to add to cart"
+                                class="o_wsale_quick_reorder_product_button btn btn-outline-primary"
+                                t-att-data-quantity="order_line.product_uom_qty"
+                                t-att-data-product-id="order_line.product_id.id"
+                                t-att-data-product-template-id="order_line.product_id.product_tmpl_id.id"
+                                t-att-data-product-type="order_line.product_id.type"
+                                t-att-data-selected-combo-items="json.dumps(order_line._get_selected_combo_items())"
+                            >
+                                <i class="fa fa-cart-plus"/>
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
     </template>
 
     <!-- Deactivatable through the website editor. -->
@@ -3522,22 +3670,10 @@
                         <!-- Short Checkout Summary displayed on /cart | Right Column -->
                         <div
                             t-if="show_shorter_cart_summary"
-                            class="offset-xxl-1 col-lg-5 col-xxl-4"
+                            class="o_wsale_shorter_cart_summary offset-xxl-1 col-lg-5 col-xxl-4"
                         >
-                            <div
-                                t-if="website_sale_order and website_sale_order.website_order_line"
-                                class="o_total_card card sticky-lg-top"
-                            >
-                                <div class="card-body p-0 p-lg-4" name="o_cart_total_card_body">
-                                    <t t-call="website_sale.total">
-                                        <t
-                                            t-set="_cart_total_classes"
-                                            t-valuef="o_checkout_cart_total pt-2 pt-lg-0"
-                                        />
-                                    </t>
-                                    <t t-call="website_sale.navigation_buttons"/>
-                                </div>
-                            </div>
+                            <!-- Parent element needed for proper JS side rendering -->
+                            <t t-call="website_sale.shorter_cart_summary"/>
                         </div>
                         <!-- Full Checkout Summary displayed on all checkout pages | Right Column -->
                         <div
@@ -3632,6 +3768,23 @@
                 <t t-out="oe_structure"/>
             </div>
         </t>
+    </template>
+
+    <template id="website_sale.shorter_cart_summary">
+        <div
+            t-if="website_sale_order and website_sale_order.website_order_line"
+            class="o_total_card card sticky-lg-top"
+        >
+            <div class="card-body p-0 p-lg-4" name="o_cart_total_card_body">
+                <t t-call="website_sale.total">
+                    <t
+                        t-set="_cart_total_classes"
+                        t-valuef="o_checkout_cart_total pt-2 pt-lg-0"
+                    />
+                </t>
+                <t t-call="website_sale.navigation_buttons"/>
+            </div>
+        </div>
     </template>
 
     <!-- Called in `website_sale.checkout_layout` and `website_sale.confirmation`. -->

--- a/addons/website_sale_stock/models/sale_order.py
+++ b/addons/website_sale_stock/models/sale_order.py
@@ -54,9 +54,10 @@ class SaleOrder(models.Model):
                     )
                     returned_warning = self.shop_warning
                 else:
-                    returned_warning = self.env._(
+                    self.shop_warning = self.env._(
                         "The item has not been added to your cart since it is not available."
                     )
+                    returned_warning = self.shop_warning
                 return allowed_line_qty, returned_warning
         return super()._verify_updated_quantity(order_line, product_id, new_qty, uom_id, **kwargs)
 


### PR DESCRIPTION
Prior this commit:
Users could only reorder by duplicating an entire previous sales order, with no option to reorder individual products directly. The cart page, especially in its empty state, did not offer any product suggestions based on past purchases.

Post this commit:
A Quick Reorder sidebar has been added to the cart page, visible to logged-in users with previous orders. It displays individual products from their past confirmed orders, allowing them to quickly add these items back to the cart. The empty cart view now also includes this sidebar, improving the experience for repeat customers.

task-4761121