### PR TITLE
[IMP] hr: Setting default email for administrator in fresh DB.

### DIFF
--- a/addons/hr/__init__.py
+++ b/addons/hr/__init__.py
@@ -14,3 +14,19 @@ def _install_hr_localization(env):
         ])
         if l10n_mx:
             l10n_mx.button_install()
+
+
+def _set_administrator_email_for_empty_db(env):
+    admin_user = env.ref('base.user_admin', raise_if_not_found=False)
+    if not admin_user:
+        return
+
+    if env['res.users'].search_count([]) == 1:
+        employee = env['hr.employee'].search([('user_id', '=', admin_user.id)], limit=1)
+        if employee and not employee.work_email:
+            employee.work_email = 'admin@example.com'
+
+
+def _post_init_hook(env):
+    _install_hr_localization(env)
+    _set_administrator_email_for_empty_db(env)

--- a/addons/hr/__manifest__.py
+++ b/addons/hr/__manifest__.py
@@ -52,7 +52,7 @@
     ],
     'installable': True,
     'application': True,
-    'post_init_hook': '_install_hr_localization',
+    'post_init_hook': '_post_init_hook',
     'assets': {
         'web.assets_backend': [
             'hr/static/src/**/*',


### PR DESCRIPTION
In this PR, we added a condition in the hr module's post init hook to check if the db contains a single employee (fresh DB case) to set a default work_email for it. 
Task: 4898175.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
