### PR TITLE
[FIX] html_editor: font size input color in dark mode

### DIFF
--- a/addons/html_editor/static/src/main/font/font_plugin.js
+++ b/addons/html_editor/static/src/main/font/font_plugin.js
@@ -207,6 +207,7 @@ export class FontPlugin extends Plugin {
                         });
                         this.updateFontSizeSelectorParams();
                     },
+                    document: this.document,
                 },
             },
         ],

--- a/addons/html_editor/static/src/main/font/font_size_selector.js
+++ b/addons/html_editor/static/src/main/font/font_size_selector.js
@@ -4,6 +4,8 @@ import { DropdownItem } from "@web/core/dropdown/dropdown_item";
 import { toolbarButtonProps } from "@html_editor/main/toolbar/toolbar";
 import { useDropdownState } from "@web/core/dropdown/dropdown_hooks";
 import { useDebounced } from "@web/core/utils/timing";
+import { cookie } from "@web/core/browser/cookie";
+import { getCSSVariableValue, getHtmlStyle } from "@html_editor/utils/formatting";
 
 const MAX_FONT_SIZE = 144;
 
@@ -14,6 +16,7 @@ export class FontSizeSelector extends Component {
         getDisplay: Function,
         onFontSizeInput: Function,
         onSelected: Function,
+        document: { validate: (p) => p.nodeType === Node.DOCUMENT_NODE },
         ...toolbarButtonProps,
     };
     static components = { Dropdown, DropdownItem };
@@ -37,6 +40,13 @@ export class FontSizeSelector extends Component {
                 }
 
                 this.fontSizeInput = iframeDoc.createElement("input");
+                const isDarkMode = cookie.get("color_scheme") === "dark";
+                const htmlStyle = getHtmlStyle(this.props.document);
+                const backgroundColor = getCSSVariableValue(
+                    isDarkMode ? "gray-200" : "white",
+                    htmlStyle
+                );
+                const color = getCSSVariableValue("black", htmlStyle);
                 Object.assign(iframeDoc.body.style, {
                     padding: "0",
                     margin: "0",
@@ -47,6 +57,8 @@ export class FontSizeSelector extends Component {
                     border: "none",
                     outline: "none",
                     textAlign: "center",
+                    backgroundColor: backgroundColor,
+                    color: color,
                 });
                 this.fontSizeInput.type = "text";
                 this.fontSizeInput.name = "font-size-input";


### PR DESCRIPTION
Purpose of this PR:

- Backport a [PR #206008](https://github.com/odoo/odoo/pull/206008), which ensures that the font-size input now changes its color appropriately in dark mode.

task-4897771

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
