### PR TITLE
[FIX] web: restrict group quick create to default groupby

### DIFF
--- a/addons/project/static/tests/project_task_kanban_view.test.js
+++ b/addons/project/static/tests/project_task_kanban_view.test.js
@@ -12,7 +12,7 @@ const viewParams = {
     resModel: "project.task",
     type: "kanban",
     arch: `
-        <kanban js_class="project_task_kanban">
+        <kanban default_group_by="stage_id" js_class="project_task_kanban">
             <templates>
                 <t t-name="card">
                     <field name="name"/>
@@ -23,7 +23,6 @@ const viewParams = {
         active_model: "project.project",
         default_project_id: 1,
     },
-    groupBy: ["stage_id"],
 };
 
 test("stages nocontent helper should be displayed in the project Kanban", async () => {

--- a/addons/web/static/src/views/kanban/kanban_arch_parser.js
+++ b/addons/web/static/src/views/kanban/kanban_arch_parser.js
@@ -25,6 +25,9 @@ export class KanbanArchParser {
         activeActions.editGroup = exprToBoolean(xmlDoc.getAttribute("group_edit"), true);
         activeActions.quickCreate =
             activeActions.create && exprToBoolean(xmlDoc.getAttribute("quick_create"), true);
+        const defaultGroupBy = xmlDoc.hasAttribute("default_group_by")
+            ? xmlDoc.getAttribute("default_group_by").split(",")
+            : null;
         const onCreate = xmlDoc.getAttribute("on_create");
         const quickCreateView = xmlDoc.getAttribute("quick_create_view");
         const tooltipInfo = {};
@@ -151,6 +154,7 @@ export class KanbanArchParser {
             cardColorField: xmlDoc.getAttribute("highlight_color"),
             className,
             controls,
+            defaultGroupBy,
             fieldNodes,
             widgetNodes,
             handleField,

--- a/addons/web/static/src/views/kanban/kanban_renderer.js
+++ b/addons/web/static/src/views/kanban/kanban_renderer.js
@@ -429,8 +429,12 @@ export class KanbanRenderer extends Component {
     // ------------------------------------------------------------------------
 
     canCreateGroup() {
-        const { activeActions } = this.props.archInfo;
-        return activeActions.createGroup && this.props.list.groupByField.type === "many2one";
+        const { activeActions, defaultGroupBy } = this.props.archInfo;
+        return (
+            activeActions.createGroup &&
+            this.props.list.groupByField.type === "many2one" &&
+            this.props.list.groupByField.name === defaultGroupBy?.[0]
+        );
     }
 
     canQuickCreate() {

--- a/addons/web/static/src/views/list/list_arch_parser.js
+++ b/addons/web/static/src/views/list/list_arch_parser.js
@@ -204,6 +204,9 @@ export class ListArchParser {
                 treeAttr.openFormView = treeAttr.editable
                     ? exprToBoolean(xmlDoc.getAttribute("open_form_view") || "")
                     : false;
+                treeAttr.defaultGroupBy = xmlDoc.hasAttribute("default_group_by")
+                    ? xmlDoc.getAttribute("default_group_by").split(",")
+                    : null;
 
                 const limitAttr = node.getAttribute("limit");
                 treeAttr.limit = limitAttr && parseInt(limitAttr, 10);

--- a/addons/web/static/src/views/list/list_renderer.js
+++ b/addons/web/static/src/views/list/list_renderer.js
@@ -414,8 +414,13 @@ export class ListRenderer extends Component {
 
     get canCreateGroup() {
         const { archInfo, list, readonly } = this.props;
-        const { activeActions } = archInfo;
-        return !readonly && activeActions.createGroup && list.groupByField.type === "many2one";
+        const { activeActions, defaultGroupBy } = archInfo;
+        return (
+            !readonly &&
+            activeActions.createGroup &&
+            list.groupByField.type === "many2one" &&
+            list.groupByField.name === defaultGroupBy?.[0]
+        );
     }
 
     get canResequenceRows() {

--- a/addons/web/static/tests/views/kanban/kanban_view.test.js
+++ b/addons/web/static/tests/views/kanban/kanban_view.test.js
@@ -1608,7 +1608,9 @@ test("create in grouped on m2o", async () => {
 
     expect(".o_kanban_group.o_group_draggable").toHaveCount(2);
     expect(".o_control_panel_main_buttons button.o-kanban-button-new").toHaveCount(1);
-    expect(".o_column_quick_create").toHaveCount(1);
+    expect(".o_column_quick_create").toHaveCount(0, {
+        message: "no quick create since no default groupby",
+    });
 
     await createKanbanRecord();
 
@@ -4065,14 +4067,13 @@ test("quick create record while adding a new column", async () => {
         type: "kanban",
         resModel: "partner",
         arch: `
-            <kanban on_create="quick_create">
+            <kanban default_group_by="product_id" on_create="quick_create">
                 <templates>
                     <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
-        groupBy: ["product_id"],
     });
 
     expect(".o_kanban_group").toHaveCount(2);
@@ -4660,14 +4661,13 @@ test("drag and drop outside of a column", async () => {
         type: "kanban",
         resModel: "partner",
         arch: `
-            <kanban on_create="quick_create">
+            <kanban default_group_by="product_id" on_create="quick_create">
                 <templates>
                     <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
-        groupBy: ["product_id"],
     });
     expect(".o_kanban_group:first-child .o_kanban_record").toHaveCount(2);
     expect(".o_kanban_group:nth-child(2) .o_kanban_record").toHaveCount(2);
@@ -5392,7 +5392,7 @@ test("environment is updated when (un)folding groups", async () => {
 });
 
 test.tags("desktop");
-test("create a column in grouped on m2o", async () => {
+test("create a column in default grouped on m2o", async () => {
     onRpc("web_resequence", ({ args, method }) => {
         expect.step([method, args[0]]);
     });
@@ -5404,14 +5404,13 @@ test("create a column in grouped on m2o", async () => {
         type: "kanban",
         resModel: "partner",
         arch: `
-            <kanban on_create="quick_create">
+            <kanban default_group_by="product_id" on_create="quick_create">
                 <templates>
                     <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
-        groupBy: ["product_id"],
     });
 
     expect(".o_kanban_group").toHaveCount(2);
@@ -5493,14 +5492,13 @@ test("create a column in grouped on m2o without sequence field on view model", a
         type: "kanban",
         resModel: "partner",
         arch: `
-            <kanban on_create="quick_create">
+            <kanban default_group_by="product_id" on_create="quick_create">
                 <templates>
                     <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
-        groupBy: ["product_id"],
     });
 
     expect(".o_kanban_group").toHaveCount(2);
@@ -5533,14 +5531,13 @@ test("delete a column in grouped on m2o", async () => {
         type: "kanban",
         resModel: "partner",
         arch: `
-            <kanban class="o_kanban_test" on_create="quick_create">
+            <kanban default_group_by="product_id" class="o_kanban_test" on_create="quick_create">
                 <templates>
                     <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
-        groupBy: ["product_id"],
     });
 
     // check the initial rendering
@@ -5672,14 +5669,13 @@ test("create a column, delete it and create another one", async () => {
         type: "kanban",
         resModel: "partner",
         arch: `
-            <kanban on_create="quick_create">
+            <kanban default_group_by="product_id" on_create="quick_create">
                 <templates>
                     <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
-        groupBy: ["product_id"],
     });
 
     expect(".o_kanban_group").toHaveCount(2);
@@ -5880,14 +5876,13 @@ test("quick create column should be opened if there is no column", async () => {
         type: "kanban",
         resModel: "partner",
         arch: `
-            <kanban>
+            <kanban default_group_by="product_id">
                 <templates>
                     <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
-        groupBy: ["product_id"],
         domain: [["foo", "=", "norecord"]],
     });
 
@@ -5903,14 +5898,13 @@ test("quick create column should close on window click if there is no column", a
         type: "kanban",
         resModel: "partner",
         arch: `
-            <kanban>
+            <kanban default_group_by="product_id">
                 <templates>
                     <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
-        groupBy: ["product_id"],
         domain: [["foo", "=", "norecord"]],
     });
 
@@ -5931,14 +5925,13 @@ test("quick create several columns in a row", async () => {
         type: "kanban",
         resModel: "partner",
         arch: `
-            <kanban>
+            <kanban default_group_by="product_id">
                 <templates>
                     <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
-        groupBy: ["product_id"],
     });
 
     expect(".o_kanban_group").toHaveCount(2, { message: "should have two columns" });
@@ -5982,14 +5975,13 @@ test("quick create column with enter", async () => {
         type: "kanban",
         resModel: "partner",
         arch: `
-            <kanban>
+            <kanban default_group_by="product_id">
                 <templates>
                     <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
-        groupBy: ["product_id"],
     });
 
     await quickCreateKanbanColumn();
@@ -6026,14 +6018,13 @@ test("empty stages kanban examples", async () => {
         type: "kanban",
         resModel: "partner",
         arch: `
-            <kanban examples="test">
+            <kanban default_group_by="product_id" examples="test">
                 <templates>
                     <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
-        groupBy: ["product_id"],
     });
 
     expect(".o_kanban_stages_nocontent").toHaveCount(1, {
@@ -6094,14 +6085,13 @@ test("quick create column with x_name as _rec_name", async () => {
         type: "kanban",
         resModel: "partner",
         arch: `
-            <kanban>
+            <kanban default_group_by="product_id">
                 <templates>
                     <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
-        groupBy: ["product_id"],
     });
     await quickCreateKanbanColumn();
     await editKanbanColumnName("New Column 1");
@@ -6215,14 +6205,13 @@ test("empty stages kanban examples: with folded columns", async () => {
         type: "kanban",
         resModel: "partner",
         arch: `
-            <kanban examples="test">
+            <kanban default_group_by="product_id" examples="test">
                 <templates>
                     <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
-        groupBy: ["product_id"],
     });
 
     // click to see the examples
@@ -6268,14 +6257,13 @@ test("empty stages kanban examples: apply button's display text", async () => {
         type: "kanban",
         resModel: "partner",
         arch: `
-            <kanban examples="test">
+            <kanban default_group_by="product_id" examples="test">
                 <templates>
                     <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
-        groupBy: ["product_id"],
     });
 
     // click to see the examples
@@ -6451,14 +6439,13 @@ test("stages nocontent helper for grouped kanban with no records", async () => {
         type: "kanban",
         resModel: "partner",
         arch: `
-            <kanban>
+            <kanban default_group_by="product_id">
                 <templates>
                     <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
-        groupBy: ["product_id"],
         noContentHelp: "No content helper",
     });
 
@@ -6475,14 +6462,13 @@ test("basic nocontent helper is shown when no longer creating column", async () 
         type: "kanban",
         resModel: "partner",
         arch: `
-            <kanban>
+            <kanban default_group_by="product_id">
                 <templates>
                     <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
-        groupBy: ["product_id"],
         noContentHelp: "No content helper",
     });
 
@@ -6523,14 +6509,13 @@ test("no nocontent helper is hidden when quick creating a column", async () => {
         type: "kanban",
         resModel: "partner",
         arch: `
-            <kanban>
+            <kanban default_group_by="product_id">
                 <templates>
                     <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
-        groupBy: ["product_id"],
         noContentHelp: "No content helper",
     });
 
@@ -6670,14 +6655,13 @@ test("nocontent helper for grouped kanban (on m2o field) with no records with no
         type: "kanban",
         resModel: "partner",
         arch: `
-            <kanban group_create="false">
+            <kanban default_group_by="product_id" group_create="false">
                 <templates>
                     <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
-        groupBy: ["product_id"],
         noContentHelp: "No content helper",
     });
 
@@ -6698,14 +6682,13 @@ test("nocontent helper for grouped kanban (on date field) with no records with n
         type: "kanban",
         resModel: "partner",
         arch: `
-            <kanban group_create="false">
+            <kanban default_group_by="date" group_create="false">
                 <templates>
                     <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
-        groupBy: ["date"],
         noContentHelp: "No content helper",
     });
 
@@ -6721,14 +6704,13 @@ test("empty grouped kanban with sample data and no columns", async () => {
 
     await mountView({
         arch: `
-            <kanban sample="1">
+            <kanban default_group_by="product_id" sample="1">
                 <templates>
                     <div t-name="card">
                         <field name="foo"/>
                     </div>
                 </templates>
             </kanban>`,
-        groupBy: ["product_id"],
         resModel: "partner",
         type: "kanban",
         noContentHelp: "No content helper",
@@ -7135,14 +7117,13 @@ test("empty grouped kanban with sample data: add a column", async () => {
 
     await mountView({
         arch: `
-            <kanban sample="1">
+            <kanban default_group_by="product_id" sample="1">
                 <templates>
                     <div t-name="card">
                         <field name="foo"/>
                     </div>
                 </templates>
             </kanban>`,
-        groupBy: ["product_id"],
         resModel: "partner",
         type: "kanban",
     });
@@ -7227,14 +7208,13 @@ test("empty grouped kanban with sample data: delete a column", async () => {
         resModel: "partner",
         type: "kanban",
         arch: `
-            <kanban sample="1">
+            <kanban default_group_by="product_id" sample="1">
                 <templates>
                     <div t-name="card">
                         <field name="foo"/>
                     </div>
                 </templates>
             </kanban>`,
-        groupBy: ["product_id"],
     });
 
     expect(".o_content").toHaveClass("o_view_sample_data");
@@ -7270,14 +7250,13 @@ test("empty grouped kanban with sample data: add a column and delete it right aw
         resModel: "partner",
         type: "kanban",
         arch: `
-            <kanban sample="1">
+            <kanban default_group_by="product_id" sample="1">
                 <templates>
                     <div t-name="card">
                         <field name="foo"/>
                     </div>
                 </templates>
             </kanban>`,
-        groupBy: ["product_id"],
     });
 
     expect(".o_content").toHaveClass("o_view_sample_data");
@@ -7766,14 +7745,13 @@ test("resequence all when creating new record + partial resequencing", async () 
         type: "kanban",
         resModel: "partner",
         arch: `
-            <kanban>
+            <kanban default_group_by="product_id">
                 <templates>
                     <t t-name="card">
                         <field name="id"/>
                     </t>
                 </templates>
             </kanban>`,
-        groupBy: ["product_id"],
     });
 
     await quickCreateKanbanColumn();
@@ -8124,7 +8102,7 @@ test("update buttons after column creation", async () => {
         type: "kanban",
         resModel: "partner",
         arch: `
-            <kanban>
+            <kanban default_group_by="product_id">
                 <templates>
                     <t t-name="card">
                         <field name="foo"/>
@@ -8301,14 +8279,13 @@ test("move a record then put it again in the same column", async () => {
         type: "kanban",
         resModel: "partner",
         arch: `
-            <kanban>
+            <kanban default_group_by="product_id">
                 <templates>
                     <t t-name="card">
                         <field name="display_name"/>
                     </t>
                 </templates>
             </kanban>`,
-        groupBy: ["product_id"],
     });
 
     await editKanbanColumnName("column1");
@@ -8352,14 +8329,13 @@ test("resequence a record twice", async () => {
         type: "kanban",
         resModel: "partner",
         arch: `
-            <kanban>
+            <kanban default_group_by="product_id">
                 <templates>
                     <t t-name="card">
                         <field name="display_name"/>
                     </t>
                 </templates>
             </kanban>`,
-        groupBy: ["product_id"],
     });
 
     await editKanbanColumnName("column1");
@@ -8508,7 +8484,7 @@ test("filter on progressbar in new groups", async () => {
         type: "kanban",
         resModel: "partner",
         arch: `
-            <kanban on_create="quick_create" quick_create_view="some_view_ref">
+            <kanban default_group_by="product_id" on_create="quick_create" quick_create_view="some_view_ref">
                 <progressbar field="foo" colors='{"yop": "success", "gnap": "warning", "blip": "danger"}'/>
                 <templates>
                     <t t-name="card">
@@ -8516,7 +8492,6 @@ test("filter on progressbar in new groups", async () => {
                     </t>
                 </templates>
             </kanban>`,
-        groupBy: ["product_id"],
     });
 
     expect(".o_kanban_group").toHaveCount(2);
@@ -8685,7 +8660,7 @@ test("column progressbars: creating a new column should create a new progressbar
         type: "kanban",
         resModel: "partner",
         arch: `
-            <kanban>
+            <kanban default_group_by="product_id">
                 <progressbar field="foo" colors='{"yop": "success", "gnap": "warning", "blip": "danger"}'/>
                 <templates>
                     <t t-name="card">
@@ -8693,7 +8668,6 @@ test("column progressbars: creating a new column should create a new progressbar
                     </t>
                 </templates>
             </kanban>`,
-        groupBy: ["product_id"],
     });
 
     expect(".o_kanban_counter").toHaveCount(2);
@@ -11742,7 +11716,7 @@ test("click on the progressBar of a new column", async () => {
         type: "kanban",
         resModel: "partner",
         arch: `
-            <kanban on_create="quick_create">
+            <kanban default_group_by="product_id" on_create="quick_create">
                 <progressbar field="state" colors='{"abc": "success", "def": "warning", "ghi": "danger"}' />
                 <templates>
                     <div t-name="card">
@@ -11751,7 +11725,6 @@ test("click on the progressBar of a new column", async () => {
                     </div>
                 </templates>
             </kanban>`,
-        groupBy: ["product_id"],
         domain: [["id", ">", 0]],
     });
 
@@ -11780,9 +11753,8 @@ test("keep focus in cp when pressing arrowdown and no kanban card", async () => 
     await mountView({
         type: "kanban",
         resModel: "partner",
-        groupBy: ["product_id"],
         arch: `
-            <kanban on_create="quick_create">
+            <kanban default_group_by="product_id" on_create="quick_create">
                 <templates>
                     <t t-name="card">
                         <field name="display_name"/>
@@ -12030,14 +12002,13 @@ test("column quick create - title and placeholder", async function (assert) {
         type: "kanban",
         resModel: "partner",
         arch: `
-            <kanban>
+            <kanban default_group_by="product_id">
                 <templates>
                     <t t-name="card">
                         <field name="int_field"/>
                     </t>
                 </templates>
             </kanban>`,
-        groupBy: ["product_id"],
     });
 
     expect(".o_column_quick_create.o_quick_create_folded").toHaveProperty(
@@ -13181,7 +13152,7 @@ test("quick create a column by pressing enter when input is focused", async () =
         type: "kanban",
         resModel: "partner",
         arch: `
-            <kanban>
+            <kanban default_group_by="product_id">
                 <templates>
                     <t t-name="card">
                         <field name="foo"/>
@@ -13687,14 +13658,13 @@ test("groups will be scrolled to on unfold if outside of viewport", async () => 
         type: "kanban",
         resModel: "partner",
         arch: `
-            <kanban>
+            <kanban default_group_by="product_id">
                 <templates>
                     <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
-        groupBy: ["product_id"],
     });
     disableAnimations();
     expect(".o_content").toHaveProperty("scrollLeft", 0);

--- a/addons/web/static/tests/views/list/list_view.test.js
+++ b/addons/web/static/tests/views/list/list_view.test.js
@@ -2340,6 +2340,9 @@ test(`grouped list rendering with groupby m2o and m2m field`, async () => {
         `,
         groupBy: ["m2o", "m2m"],
     });
+    expect(`.o_list_footer td > button`).toHaveCount(0, {
+        message: "no quick create since no default groupby",
+    });
     expect(queryAllTexts(`tbody > tr`)).toEqual(["Value 1 (3)", "Value 2 (1)"]);
 
     await contains(`th.o_group_name`).click();
@@ -2364,7 +2367,7 @@ test(`grouped list rendering with groupby m2o and m2m field`, async () => {
     ]);
 });
 
-test(`grouped list rendering with groupby m2o field: add group`, async () => {
+test(`grouped list rendering with default_group_by m2o field: add group`, async () => {
     onRpc("name_create", ({ args }) => {
         expect(args[0]).toBe("New group");
         expect.step("name_create");
@@ -2372,8 +2375,7 @@ test(`grouped list rendering with groupby m2o field: add group`, async () => {
     await mountView({
         resModel: "foo",
         type: "list",
-        arch: `<list><field name="foo"/></list>`,
-        groupBy: ["m2o"],
+        arch: `<list default_group_by="m2o"><field name="foo"/></list>`,
     });
     expect(`.o_group_header:eq(0) th`).toHaveCount(1);
     expect(queryAllTexts(".o_group_name")).toEqual(["Value 1 (3)", "Value 2 (1)"]);


### PR DESCRIPTION
This commit updates the conditions for enabling group quick create in list and kanban views. In addition to existing checks, the view must now be grouped using its default groupby (if defined) for quick create to be available.

This ensures that group quick create is only shown in contexts where it is properly supported and avoids undesired behavior when grouping by arbitrary fields.

task-4897809
