### PR TITLE
[FIX] l10n_pe_reports_stock: ensure payment_reference is always a string

### DIFF
--- a/addons/purchase/tests/test_purchase_invoice.py
+++ b/addons/purchase/tests/test_purchase_invoice.py
@@ -1009,7 +1009,7 @@ class TestInvoicePurchaseMatch(TestPurchaseToInvoiceCommon):
                         move_form.ref = '111' if w_bill_ref == 'w_bill_ref' else ''
                         move_form.payment_reference = '222' if w_payment_reference == 'w_payment_reference' else ''
                         move_form.purchase_vendor_bill_id = self.env['purchase.bill.union'].browse(-purchase_order.id).exists()
-                        payment_reference = move_form._values['payment_reference']
+                        payment_reference = move_form._values['payment_reference'] or ''
                         self.assertEqual(payment_reference, expected_value, "The payment reference should be %s" % expected_value)
 
     def test_invoice_user_id_on_bill(self):


### PR DESCRIPTION
steps to reproduce:
1. install l10n_pe_reports_stock module
2. run the test `test_payment_reference_autocomplete_invoice`

This commit ensures that the payment_reference field is always a string, because it returs false when it is None, which causes an assertion error

build_error-75601


