### PR TITLE
[FIX] base: cron done=0 remaining=1 should be partially done

### DIFF
--- a/odoo/addons/base/tests/test_ir_cron.py
+++ b/odoo/addons/base/tests/test_ir_cron.py
@@ -253,20 +253,12 @@ class TestIrCron(TransactionCase, CronMixinCase):
             state = {'call_count': 0}
             CALL_TARGET = 5
             def f(self):
+                frozen_datetime.tick(delta=timedelta(seconds=1))
                 state['call_count'] += 1
                 self.env['ir.cron']._notify_progress(
                     done=1,
                     remaining=CALL_TARGET - state['call_count']
                 )
-                self.env.cr.commit()
-                raise ValueError
-            return f, state
-
-        def failure_fully(cron):
-            state = {'call_count': 0}
-            def f(self):
-                state['call_count'] += 1
-                self.env['ir.cron']._notify_progress(done=1, remaining=0)
                 self.env.cr.commit()
                 raise ValueError
             return f, state
@@ -282,10 +274,8 @@ class TestIrCron(TransactionCase, CronMixinCase):
             (   five_success, almost_failed,   False,          5,          5,          0,  True),
             (        failure,             0,   False,          1,          0,          1,  True),
             (        failure, almost_failed,   False,          1,          0,          0, False),
-            (failure_partial,             0,   False,          5,          5,          1,  True),
-            (failure_partial, almost_failed,   False,          5,          5,          0, False),
-            (  failure_fully,             0,   False,          1,          1,          1,  True),
-            (  failure_fully, almost_failed,   False,          1,          1,          0, False),
+            (failure_partial,             0,    True,          1,          1,          0,  True),
+            (failure_partial, almost_failed,    True,          1,          1,          0,  True),
         ]
 
         for cb, curr_failures, trigger, call_count, done_count, fail_count, active in CASES:


### PR DESCRIPTION
Have a ir cron action with the following code:

	self.env['ir.cron']._commit_progress(remaining=1)

The code looks stupid, but we tracked down a bug we had in the autovacuum cron, and the minimum code to reproduce the problem is that above line of code.

Since there are remaining stuff to do, the cron worker should report a `PARTIALLY_DONE` status, and schedule to call the cron action asap. But the system currently determine a `FULLY_DONE` status. We believe it is a bug.

We used the opportunity to rework the `status` computation to one big match-case, for extra readability.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
