### PR TITLE
[REF] html_builder, website: export action classes for external use

### DIFF
--- a/addons/html_builder/static/src/core/clone_plugin.js
+++ b/addons/html_builder/static/src/core/clone_plugin.js
@@ -111,7 +111,7 @@ export class ClonePlugin extends Plugin {
     }
 }
 
-class CloneItemAction extends BuilderAction {
+export class CloneItemAction extends BuilderAction {
     static id = "addItem";
     static dependencies = ["clone", "history"];
     apply({ editingElement, params: { mainParam: itemSelector }, value: position }) {

--- a/addons/html_builder/static/src/core/color_style_plugin.js
+++ b/addons/html_builder/static/src/core/color_style_plugin.js
@@ -19,7 +19,7 @@ class ColorStylePlugin extends Plugin {
     };
 }
 
-class BackgroundColorAction extends BuilderAction {
+export class BackgroundColorAction extends BuilderAction {
     static id = "background-color";
     static dependencies = ["color"];
     getValue(el) {
@@ -34,7 +34,7 @@ class BackgroundColorAction extends BuilderAction {
     }
 }
 
-class ColorAction extends BuilderAction {
+export class ColorAction extends BuilderAction {
     static id = "color";
     static dependencies = ["color"];
     getValue(el) {

--- a/addons/html_builder/static/src/core/composite_action_plugin.js
+++ b/addons/html_builder/static/src/core/composite_action_plugin.js
@@ -18,7 +18,7 @@ export class CompositeActionPlugin extends Plugin {
     };
 }
 
-class CompositeAction extends BuilderAction {
+export class CompositeAction extends BuilderAction {
     static id = "composite";
     static dependencies = ["builderActions"];
     loadOnClean = true;
@@ -189,7 +189,7 @@ class CompositeAction extends BuilderAction {
     }
 }
 
-class ReloadCompositeAction extends CompositeAction {
+export class ReloadCompositeAction extends CompositeAction {
     static id = "reloadComposite";
     setup() {
         this.reload = {};

--- a/addons/website/static/src/builder/plugins/alert_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/alert_option_plugin.js
@@ -22,7 +22,7 @@ class AlertOptionPlugin extends Plugin {
     };
 }
 
-class AlertIconAction extends BuilderAction {
+export class AlertIconAction extends BuilderAction {
     static id = "alertIcon";
     apply({ editingElement, params: { mainParam: className } }) {
         const icon = editingElement.querySelector(".s_alert_icon");

--- a/addons/website/static/src/builder/plugins/background_option/background_image_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/background_option/background_image_option_plugin.js
@@ -170,7 +170,7 @@ export class SelectFilterColorAction extends StyleAction {
     }
 }
 
-class ToggleBgImageAction extends BuilderAction {
+export class ToggleBgImageAction extends BuilderAction {
     static id = "toggleBgImage";
     static dependencies = ["backgroundImageOption"];
     load(context) {
@@ -193,7 +193,7 @@ class ToggleBgImageAction extends BuilderAction {
     }
 }
 
-class ReplaceBgImageAction extends BuilderAction {
+export class ReplaceBgImageAction extends BuilderAction {
     static id = "replaceBgImage";
     static dependencies = ["backgroundImageOption"];
     load(context) {
@@ -203,7 +203,7 @@ class ReplaceBgImageAction extends BuilderAction {
         return this.dependencies.backgroundImageOption.applyReplaceBackgroundImage(context);
     }
 }
-class DynamicColorAction extends BuilderAction {
+export class DynamicColorAction extends BuilderAction {
     static id = "dynamicColor";
     static dependencies = ["backgroundImageOption"];
     getValue({ editingElement, params: { mainParam: colorName } }) {

--- a/addons/website/static/src/builder/plugins/background_option/background_position_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/background_option/background_position_option_plugin.js
@@ -24,7 +24,7 @@ class BackgroundPositionOptionPlugin extends Plugin {
     };
 }
 
-class BackgroundTypeAction extends BuilderAction {
+export class BackgroundTypeAction extends BuilderAction {
     static id = "backgroundType";
     apply({ editingElement, value }) {
         editingElement.classList.toggle("o_bg_img_opt_repeat", value === "repeat-pattern");
@@ -40,7 +40,7 @@ class BackgroundTypeAction extends BuilderAction {
     }
 }
 
-class SetBackgroundSizeAction extends BuilderAction {
+export class SetBackgroundSizeAction extends BuilderAction {
     static id = "setBackgroundSize";
     getValue(context) {
         return getBgSizeValue(context);
@@ -64,7 +64,7 @@ class SetBackgroundSizeAction extends BuilderAction {
     }
 }
 
-class BackgroundPositionOverlayAction extends BuilderAction {
+export class BackgroundPositionOverlayAction extends BuilderAction {
     static id = "backgroundPositionOverlay";
     static dependencies = ["overlayButtons", "overlay"];
     async load({ editingElement }) {

--- a/addons/website/static/src/builder/plugins/carousel_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/carousel_option_plugin.js
@@ -300,7 +300,7 @@ export function updateCarouselIndicators(carouselEl, newPosition) {
         }
     });
 }
-class AddSlideAction extends BuilderAction {
+export class AddSlideAction extends BuilderAction {
     static id = "addSlide";
     static dependencies = ["carouselOption"];
     setup() {
@@ -310,7 +310,7 @@ class AddSlideAction extends BuilderAction {
         return this.dependencies.carouselOption.addSlide(editingElement);
     }
 }
-class SlideCarouselAction extends BuilderAction {
+export class SlideCarouselAction extends BuilderAction {
     static id = "slideCarousel";
     static dependencies = ["carouselOption"];
     setup() {
@@ -322,7 +322,7 @@ class SlideCarouselAction extends BuilderAction {
     }
 }
 
-class ToggleControllersAction extends BuilderAction {
+export class ToggleControllersAction extends BuilderAction {
     static id = "toggleControllers";
     apply({ editingElement }) {
         const carouselEl = editingElement.closest(".carousel");
@@ -333,7 +333,7 @@ class ToggleControllersAction extends BuilderAction {
         carouselEl.classList.toggle("s_carousel_controllers_hidden", areControllersHidden);
     }
 }
-class ToggleCardImgAction extends BuilderAction {
+export class ToggleCardImgAction extends BuilderAction {
     static id = "toggleCardImg";
     apply({ editingElement }) {
         const carouselEl = editingElement.closest(".carousel");

--- a/addons/website/static/src/builder/plugins/content_width_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/content_width_option_plugin.js
@@ -24,7 +24,7 @@ class ContentWidthOptionPlugin extends Plugin {
     };
 }
 
-class SetContainerWidthAction extends ClassAction {
+export class SetContainerWidthAction extends ClassAction {
     static id = "setContainerWidth";
     apply({ isPreviewing, editingElement }) {
         super.apply(...arguments);

--- a/addons/website/static/src/builder/plugins/customize_website_plugin.js
+++ b/addons/website/static/src/builder/plugins/customize_website_plugin.js
@@ -325,7 +325,7 @@ export class CustomizeWebsitePlugin extends Plugin {
     }
 }
 
-class SwitchThemeAction extends BuilderAction {
+export class SwitchThemeAction extends BuilderAction {
     static id = "switchTheme";
     static dependencies = ["savePlugin", "action"];
     setup() {
@@ -351,7 +351,7 @@ class SwitchThemeAction extends BuilderAction {
     }
 }
 
-class AddLanguageAction extends BuilderAction {
+export class AddLanguageAction extends BuilderAction {
     static id = "addLanguage";
     static dependencies = ["savePlugin"];
     setup() {
@@ -390,7 +390,7 @@ class AddLanguageAction extends BuilderAction {
     }
 }
 
-class CustomizeBodyBgTypeAction extends BuilderAction {
+export class CustomizeBodyBgTypeAction extends BuilderAction {
     static id = "customizeBodyBgType";
     static dependencies = ["builderActions", "history", "customizeWebsite"];
     isApplied({ value }) {
@@ -466,7 +466,7 @@ class CustomizeBodyBgTypeAction extends BuilderAction {
     }
 }
 
-class RemoveFontAction extends BuilderAction {
+export class RemoveFontAction extends BuilderAction {
     static id = "removeFont";
     static dependencies = ["builderActions"];
     setup() {
@@ -664,7 +664,7 @@ export class WebsiteConfigAction extends BuilderAction {
     }
 }
 
-class SelectTemplateAction extends BuilderAction {
+export class SelectTemplateAction extends BuilderAction {
     static id = "selectTemplate";
     static dependencies = ["customizeWebsite"];
     async prepare({ actionParam }) {
@@ -709,7 +709,7 @@ export class CustomizeWebsiteVariableAction extends BuilderAction {
     }
 }
 
-class CustomizeWebsiteColorAction extends BuilderAction {
+export class CustomizeWebsiteColorAction extends BuilderAction {
     static id = "customizeWebsiteColor";
     static dependencies = ["customizeWebsite"];
     setup() {
@@ -763,7 +763,7 @@ class CustomizeWebsiteColorAction extends BuilderAction {
     }
 }
 
-class CustomizeButtonStyleAction extends BuilderAction {
+export class CustomizeButtonStyleAction extends BuilderAction {
     static id = "customizeButtonStyle";
     static dependencies = ["customizeWebsite"];
     setup() {

--- a/addons/website/static/src/builder/plugins/dynamic_svg_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/dynamic_svg_option_plugin.js
@@ -23,7 +23,7 @@ class DynamicSvgOptionPlugin extends Plugin {
     };
 }
 
-class SvgColorAction extends BuilderAction {
+export class SvgColorAction extends BuilderAction {
     static id = "svgColor";
     getValue({ editingElement: imgEl, params: { mainParam: colorName } }) {
         const searchParams = new URL(imgEl.src, window.location.origin).searchParams;

--- a/addons/website/static/src/builder/plugins/font_awesome_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/font_awesome_option_plugin.js
@@ -20,7 +20,7 @@ class FontAwesomeOptionPlugin extends Plugin {
     };
 }
 
-class FaResizeAction extends ClassAction {
+export class FaResizeAction extends ClassAction {
     static id = "faResize";
     apply(context) {
         const { editingElement } = context;

--- a/addons/website/static/src/builder/plugins/form/form_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/form/form_option_plugin.js
@@ -719,7 +719,7 @@ export class FormOptionPlugin extends Plugin {
 
 // Form actions
 // Components that use this action MUST await fetchModels before they start.
-class SelectAction extends BuilderAction {
+export class SelectAction extends BuilderAction {
     static id = "selectAction";
     static dependencies = ["websiteFormOption"];
     async load({ editingElement: el, value: modelId }) {
@@ -757,7 +757,7 @@ class SelectAction extends BuilderAction {
 }
 // Select the value of a field (hidden) that will be used on the model as a preset.
 // ie: The Job you apply for if the form is on that job's page.
-class AddActionFieldAction extends BuilderAction {
+export class AddActionFieldAction extends BuilderAction {
     static id = "addActionField";
     static dependencies = ["websiteFormOption"];
     async load({ editingElement: el }) {
@@ -811,7 +811,7 @@ class AddActionFieldAction extends BuilderAction {
         return currentValue === value;
     }
 }
-class PromptSaveRedirectAction extends BuilderAction {
+export class PromptSaveRedirectAction extends BuilderAction {
     static id = "promptSaveRedirect";
     static dependencies = ["savePlugin"];
     apply({ params: { mainParam } }) {
@@ -834,7 +834,7 @@ class PromptSaveRedirectAction extends BuilderAction {
         });
     }
 }
-class UpdateLabelsMarkAction extends BuilderAction {
+export class UpdateLabelsMarkAction extends BuilderAction {
     static id = "updateLabelsMark";
     static dependencies = ["websiteFormOption"];
     apply({ editingElement: el }) {
@@ -845,7 +845,7 @@ class UpdateLabelsMarkAction extends BuilderAction {
     }
 }
 
-class SetMarkAction extends BuilderAction {
+export class SetMarkAction extends BuilderAction {
     static id = "setMark";
     static dependencies = ["websiteFormOption"];
     apply({ editingElement: el, value }) {
@@ -858,7 +858,7 @@ class SetMarkAction extends BuilderAction {
     }
 }
 
-class OnSuccessAction extends BuilderAction {
+export class OnSuccessAction extends BuilderAction {
     static id = "onSuccess";
     apply({ editingElement: el, value }) {
         el.dataset.successMode = value;
@@ -879,7 +879,7 @@ class OnSuccessAction extends BuilderAction {
         return currentValue === value;
     }
 }
-class ToggleEndMessageAction extends BuilderAction {
+export class ToggleEndMessageAction extends BuilderAction {
     static id = "toggleEndMessage";
     apply({ editingElement: el }) {
         const messageEl = el.parentElement.querySelector(".s_website_form_end_message");
@@ -897,7 +897,7 @@ class ToggleEndMessageAction extends BuilderAction {
         return el.classList.contains("o_builder_form_show_message");
     }
 }
-class FormToggleRecaptchaLegalAction extends BuilderAction {
+export class FormToggleRecaptchaLegalAction extends BuilderAction {
     static id = "formToggleRecaptchaLegal";
     apply({ editingElement: el }) {
         const labelWidth = el.querySelector(".s_website_form_label").style.width;
@@ -917,7 +917,7 @@ class FormToggleRecaptchaLegalAction extends BuilderAction {
     }
 }
 // Field actions
-class CustomFieldAction extends BuilderAction {
+export class CustomFieldAction extends BuilderAction {
     static id = "customField";
     static dependencies = ["websiteFormOption"];
     load(context) {
@@ -934,7 +934,7 @@ class CustomFieldAction extends BuilderAction {
         return currentValue === value;
     }
 }
-class ExistingFieldAction extends BuilderAction {
+export class ExistingFieldAction extends BuilderAction {
     static id = "existingField";
     static dependencies = ["websiteFormOption"];
     load(context) {
@@ -950,7 +950,7 @@ class ExistingFieldAction extends BuilderAction {
         return currentValue === value;
     }
 }
-class SelectTypeAction extends BuilderAction {
+export class SelectTypeAction extends BuilderAction {
     static id = "selectType";
     static dependencies = ["websiteFormOption"];
     load(context) {
@@ -966,7 +966,7 @@ class SelectTypeAction extends BuilderAction {
         return currentValue === value;
     }
 }
-class ExistingFieldSelectTypeAction extends BuilderAction {
+export class ExistingFieldSelectTypeAction extends BuilderAction {
     static id = "existingFieldSelectType";
     static dependencies = ["websiteFormOption"];
     load(context) {
@@ -982,7 +982,7 @@ class ExistingFieldSelectTypeAction extends BuilderAction {
         return currentValue === value;
     }
 }
-class MultiCheckboxDisplayAction extends BuilderAction {
+export class MultiCheckboxDisplayAction extends BuilderAction {
     static id = "multiCheckboxDisplay";
     apply({ editingElement: fieldEl, value }) {
         const targetEl = getMultipleInputs(fieldEl);
@@ -999,7 +999,7 @@ class MultiCheckboxDisplayAction extends BuilderAction {
         return currentValue === value;
     }
 }
-class SetLabelTextAction extends BuilderAction {
+export class SetLabelTextAction extends BuilderAction {
     static id = "setLabelText";
     apply({ editingElement: fieldEl, value }) {
         const labelEl = fieldEl.querySelector(".s_website_form_label_content");
@@ -1050,7 +1050,7 @@ class SetLabelTextAction extends BuilderAction {
         return labelEl.textContent;
     }
 }
-class SelectLabelPositionAction extends BuilderAction {
+export class SelectLabelPositionAction extends BuilderAction {
     static id = "selectLabelPosition";
     static dependencies = ["websiteFormOption"];
     load(context) {
@@ -1066,7 +1066,7 @@ class SelectLabelPositionAction extends BuilderAction {
         return currentValue === value;
     }
 }
-class ToggleDescriptionAction extends BuilderAction {
+export class ToggleDescriptionAction extends BuilderAction {
     static id = "toggleDescription";
     static dependencies = ["websiteFormOption"];
     load(context) {
@@ -1084,7 +1084,7 @@ class ToggleDescriptionAction extends BuilderAction {
         return !!description;
     }
 }
-class SelectTextareaValueAction extends BuilderAction {
+export class SelectTextareaValueAction extends BuilderAction {
     static id = "selectTextareaValue";
     apply({ editingElement: fieldEl, value }) {
         fieldEl.textContent = value;
@@ -1094,7 +1094,7 @@ class SelectTextareaValueAction extends BuilderAction {
         return fieldEl.textContent;
     }
 }
-class ToggleRequiredAction extends BuilderAction {
+export class ToggleRequiredAction extends BuilderAction {
     static id = "toggleRequired";
     static dependencies = ["websiteFormOption"];
     apply({ editingElement: fieldEl, params: { mainParam: activeValue } }) {
@@ -1115,7 +1115,7 @@ class ToggleRequiredAction extends BuilderAction {
         return fieldEl.classList.contains(activeValue);
     }
 }
-class SetVisibilityAction extends BuilderAction {
+export class SetVisibilityAction extends BuilderAction {
     static id = "setVisibility";
     static dependencies = ["websiteFormOption"];
     load(context) {
@@ -1140,7 +1140,7 @@ class SetVisibilityAction extends BuilderAction {
         return true;
     }
 }
-class SetVisibilityDependencyAction extends BuilderAction {
+export class SetVisibilityDependencyAction extends BuilderAction {
     static id = "setVisibilityDependency";
     apply({ editingElement: fieldEl, value }) {
         return setVisibilityDependency(fieldEl, value);
@@ -1150,7 +1150,7 @@ class SetVisibilityDependencyAction extends BuilderAction {
         return currentValue === value;
     }
 }
-class SetFormCustomFieldValueListAction extends BuilderAction {
+export class SetFormCustomFieldValueListAction extends BuilderAction {
     static id = "setFormCustomFieldValueList";
     static dependencies = ["websiteFormOption"];
     apply({ editingElement: fieldEl, value }) {

--- a/addons/website/static/src/builder/plugins/image/image_filter_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/image/image_filter_option_plugin.js
@@ -14,7 +14,7 @@ class ImageFilterOptionPlugin extends Plugin {
     };
 }
 
-class GlFilterAction extends BuilderAction {
+export class GlFilterAction extends BuilderAction {
     static id = "glFilter";
     static dependencies = ["imagePostProcess"];
     isApplied({ editingElement, params: { mainParam: glFilterName } }) {
@@ -36,7 +36,7 @@ class GlFilterAction extends BuilderAction {
         updateImageAttributes();
     }
 }
-class SetCustomFilterAction extends BuilderAction {
+export class SetCustomFilterAction extends BuilderAction {
     static id = "setCustomFilter";
     static dependencies = ["imagePostProcess"];
     getValue({ editingElement, params: { mainParam: filterProperty } }) {

--- a/addons/website/static/src/builder/plugins/image/image_format_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/image/image_format_option_plugin.js
@@ -59,7 +59,7 @@ class ImageFormatOptionPlugin extends Plugin {
     }
 }
 
-class SetImageFormatAction extends BuilderAction {
+export class SetImageFormatAction extends BuilderAction {
     static id = "setImageFormat";
     static dependencies = ["imagePostProcess"];
     isApplied({ editingElement, params: { width, mimetype, isOriginal } }) {
@@ -85,7 +85,7 @@ class SetImageFormatAction extends BuilderAction {
         updateImageAttributes();
     }
 }
-class SetImageQualityAction extends BuilderAction {
+export class SetImageQualityAction extends BuilderAction {
     static id = "setImageQuality";
     static dependencies = ["imagePostProcess"];
     getValue({ editingElement: img }) {

--- a/addons/website/static/src/builder/plugins/image/image_grid_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/image/image_grid_option_plugin.js
@@ -21,7 +21,7 @@ class ImageGridOptionPlugin extends Plugin {
     };
 }
 
-class SetGridImageModeAction extends BuilderAction {
+export class SetGridImageModeAction extends BuilderAction {
     static id = "setGridImageMode";
     isApplied({ editingElement, value: modeName }) {
         const imageGridItemEl = editingElement.closest(".o_grid_item_image");

--- a/addons/website/static/src/builder/plugins/image/image_shape_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/image/image_shape_option_plugin.js
@@ -365,7 +365,7 @@ export class ImageShapeOptionPlugin extends Plugin {
     }
 }
 
-class SetImageShapeAction extends BuilderAction {
+export class SetImageShapeAction extends BuilderAction {
     static id = "setImageShape";
     static dependencies = ["imageShapeOption"];
     async load({ editingElement: img, value: shapeId }) {
@@ -379,7 +379,7 @@ class SetImageShapeAction extends BuilderAction {
         img.dataset.fileName = `${imgFilename}.svg`;
     }
 }
-class SetImgShapeColorAction extends BuilderAction {
+export class SetImgShapeColorAction extends BuilderAction {
     static id = "setImgShapeColor";
     static dependencies = ["imageShapeOption"];
     getValue({ editingElement: img, params: { index: colorIndex } }) {
@@ -401,7 +401,7 @@ class SetImgShapeColorAction extends BuilderAction {
         updateImageAttributes();
     }
 }
-class FlipImageShapeAction extends BuilderAction {
+export class FlipImageShapeAction extends BuilderAction {
     static id = "flipImageShape";
     static dependencies = ["imageShapeOption"];
     async load({ editingElement: img, params: { axis } }) {
@@ -418,7 +418,7 @@ class FlipImageShapeAction extends BuilderAction {
     }
 }
 
-class RotateImageShapeAction extends BuilderAction {
+export class RotateImageShapeAction extends BuilderAction {
     static id = "rotateImageShape";
     static dependencies = ["imageShapeOption"];
     async load({ editingElement: img, params: { side } }) {
@@ -431,7 +431,7 @@ class RotateImageShapeAction extends BuilderAction {
         updateImageAttributes();
     }
 }
-class SetImageShapeSpeedAction extends BuilderAction {
+export class SetImageShapeSpeedAction extends BuilderAction {
     static id = "setImageShapeSpeed";
     static dependencies = ["imageShapeOption"];
     getValue({ editingElement: img }) {
@@ -446,7 +446,7 @@ class SetImageShapeSpeedAction extends BuilderAction {
         updateImageAttributes();
     }
 }
-class ToggleImageShapeRatioAction extends BuilderAction {
+export class ToggleImageShapeRatioAction extends BuilderAction {
     static id = "toggleImageShapeRatio";
     static dependencies = ["imageShapeOption"];
 

--- a/addons/website/static/src/builder/plugins/image/image_tool_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/image/image_tool_option_plugin.js
@@ -136,7 +136,7 @@ class ImageToolOptionPlugin extends Plugin {
     }
 }
 
-class CropImageAction extends BuilderAction {
+export class CropImageAction extends BuilderAction {
     static id = "cropImage";
     static dependencies = ["imageCrop", "imagePostProcess"];
     isApplied({ editingElement }) {
@@ -157,7 +157,7 @@ class CropImageAction extends BuilderAction {
     }
 }
 
-class ResetCropAction extends BuilderAction {
+export class ResetCropAction extends BuilderAction {
     static id = "resetCrop";
     static dependencies = ["imagePostProcess"];
     async load({ editingElement: img }) {
@@ -171,7 +171,7 @@ class ResetCropAction extends BuilderAction {
     }
 }
 
-class TransformImageAction extends BuilderAction {
+export class TransformImageAction extends BuilderAction {
     static id = "transformImage";
     static dependencies = ["userCommand"];
     isApplied({ editingElement }) {
@@ -181,7 +181,7 @@ class TransformImageAction extends BuilderAction {
         return this.dependencies.userCommand.getCommand("transformImage").run(editingElement);
     }
 }
-class ResetTransformImageAction extends BuilderAction {
+export class ResetTransformImageAction extends BuilderAction {
     static id = "resetTransformImage";
     apply({ editingElement }) {
         editingElement.setAttribute(
@@ -190,7 +190,7 @@ class ResetTransformImageAction extends BuilderAction {
         );
     }
 }
-class ReplaceMediaAction extends BuilderAction {
+export class ReplaceMediaAction extends BuilderAction {
     static id = "replaceMedia";
     static dependencies = ["media", "history", "builderOptions"];
     async load({ editingElement }) {
@@ -212,7 +212,7 @@ class ReplaceMediaAction extends BuilderAction {
         this.dependencies["builderOptions"].updateContainers(newImage);
     }
 }
-class SetLinkAction extends BuilderAction {
+export class SetLinkAction extends BuilderAction {
     static id = "setLink";
     setup() {
         this.preview = false;
@@ -235,7 +235,7 @@ class SetLinkAction extends BuilderAction {
     }
 }
 
-class SetUrlAction extends BuilderAction {
+export class SetUrlAction extends BuilderAction {
     static id = "setUrl";
     setup() {
         this.preview = false;
@@ -261,7 +261,7 @@ class SetUrlAction extends BuilderAction {
     }
 }
 
-class SetNewWindowAction extends BuilderAction {
+export class SetNewWindowAction extends BuilderAction {
     static id = "setNewWindow";
     setup() {
         this.preview = false;
@@ -280,7 +280,7 @@ class SetNewWindowAction extends BuilderAction {
     }
 }
 
-class AltAction extends BuilderAction {
+export class AltAction extends BuilderAction {
     static id = "alt";
     getValue({ editingElement: imgEl }) {
         return imgEl.alt;

--- a/addons/website/static/src/builder/plugins/layout_option/add_element_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/layout_option/add_element_option_plugin.js
@@ -70,7 +70,7 @@ export class AddElementOptionPlugin extends Plugin {
     }
 }
 
-class AddElTextAction extends BuilderAction {
+export class AddElTextAction extends BuilderAction {
     static id = "addElText";
     static dependencies = ["addElementOption"];
     apply({ editingElement }) {
@@ -89,7 +89,7 @@ class AddElTextAction extends BuilderAction {
         );
     }
 }
-class AddElImageAction extends BuilderAction {
+export class AddElImageAction extends BuilderAction {
     static id = "addElImage";
     static dependencies = ["media", "addElementOption"];
     async load({ editingElement }) {
@@ -131,7 +131,7 @@ class AddElImageAction extends BuilderAction {
         ]);
     }
 }
-class AddElButtonAction extends BuilderAction {
+export class AddElButtonAction extends BuilderAction {
     static id = "addElButton";
     static dependencies = ["addElementOption"];
     apply({ editingElement }) {

--- a/addons/website/static/src/builder/plugins/layout_option/grid_column_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/layout_option/grid_column_option_plugin.js
@@ -28,7 +28,7 @@ const removePaddingPreview = (event) => {
     editingElement.classList.remove("o_we_padding_highlight");
     editingElement.removeEventListener("animationend", removePaddingPreview);
 };
-class SetGridColumnsPaddingAction extends StyleAction {
+export class SetGridColumnsPaddingAction extends StyleAction {
     static id = "setGridColumnsPadding";
     apply(...args) {
         const { editingElement } = args[0];

--- a/addons/website/static/src/builder/plugins/layout_option/layout_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/layout_option/layout_option_plugin.js
@@ -55,7 +55,7 @@ const isGrid = (el) => {
     const rowEl = getRow(el);
     return !!(rowEl && rowEl.classList.contains("o_grid_mode"));
 };
-class SetGridLayoutAction extends BuilderAction {
+export class SetGridLayoutAction extends BuilderAction {
     static id = "setGridLayout";
     static dependencies = ["selection"];
     apply({ editingElement }) {
@@ -69,7 +69,7 @@ class SetGridLayoutAction extends BuilderAction {
         return isGrid(editingElement);
     }
 }
-class SetColumnLayoutAction extends BuilderAction {
+export class SetColumnLayoutAction extends BuilderAction {
     static id = "setColumnLayout";
     apply({ editingElement }) {
         const rowEl = getRow(editingElement);
@@ -99,7 +99,7 @@ class SetColumnLayoutAction extends BuilderAction {
         return !isGrid(editingElement);
     }
 }
-class ChangeColumnCountAction extends BuilderAction {
+export class ChangeColumnCountAction extends BuilderAction {
     static id = "changeColumnCount";
     static dependencies = ["selection", "clone"];
     apply({ editingElement, value: nbColumns }) {

--- a/addons/website/static/src/builder/plugins/layout_option/spacing_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/layout_option/spacing_option_plugin.js
@@ -48,7 +48,7 @@ class SpacingOptionPlugin extends Plugin {
 
 registry.category("website-plugins").add(SpacingOptionPlugin.id, SpacingOptionPlugin);
 
-class SetGridSpacingAction extends StyleAction {
+export class SetGridSpacingAction extends StyleAction {
     static id = "setGridSpacing";
     apply({ editingElement: rowEl }) {
         // Remove the grid preview if any.

--- a/addons/website/static/src/builder/plugins/options/accordion_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/accordion_option_plugin.js
@@ -25,7 +25,7 @@ class accordionOptionPlugin extends Plugin {
     };
 }
 
-class DefineCustomIconAction extends BuilderAction {
+export class DefineCustomIconAction extends BuilderAction {
     static id = "defineCustomIcon";
     static dependencies = ["media"];
     async load() {
@@ -68,7 +68,7 @@ class DefineCustomIconAction extends BuilderAction {
         }
     }
 }
-class CustomAccordionIconAction extends BuilderAction {
+export class CustomAccordionIconAction extends BuilderAction {
     static id = "customAccordionIcon";
     apply({ editingElement, params, value }) {
         const accordionButtonEls = editingElement.querySelectorAll(".accordion-button");

--- a/addons/website/static/src/builder/plugins/options/animate_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/animate_option_plugin.js
@@ -338,7 +338,7 @@ class AnimateOptionPlugin extends Plugin {
     }
 }
 
-class SetAnimationModeAction extends BuilderAction {
+export class SetAnimationModeAction extends BuilderAction {
     static id = "setAnimationMode";
     static dependencies = ["animateOption"];
     setup() {
@@ -440,7 +440,7 @@ class SetAnimationModeAction extends BuilderAction {
         }
     }
 }
-class SetAnimateIntensityAction extends BuilderAction {
+export class SetAnimateIntensityAction extends BuilderAction {
     static id = "setAnimateIntensity";
     static dependencies = ["animateOption"];
     getValue({ editingElement }) {
@@ -454,7 +454,7 @@ class SetAnimateIntensityAction extends BuilderAction {
         this.dependencies.animateOption.forceAnimation(editingElement);
     }
 }
-class ForceAnimationAction extends BuilderAction {
+export class ForceAnimationAction extends BuilderAction {
     static id = "forceAnimation";
     static dependencies = ["animateOption"];
     // todo: to remove after having the commit of louis
@@ -465,7 +465,7 @@ class ForceAnimationAction extends BuilderAction {
         this.dependencies.animateOption.forceAnimation(editingElement);
     }
 }
-class SetAnimationEffectAction extends BuilderAction {
+export class SetAnimationEffectAction extends BuilderAction {
     static id = "setAnimationEffect";
     static dependencies = ["animateOption"];
     isApplied({ editingElement, value: className }) {

--- a/addons/website/static/src/builder/plugins/options/background_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/background_option_plugin.js
@@ -83,7 +83,7 @@ class WebsiteBackgroundVideoPlugin extends Plugin {
     }
 }
 
-class ToggleBgVideoAction extends BuilderAction {
+export class ToggleBgVideoAction extends BuilderAction {
     static id = "toggleBgVideo";
     static dependencies = ["websiteBackgroundVideoPlugin"];
     load(context) {
@@ -110,7 +110,7 @@ class ToggleBgVideoAction extends BuilderAction {
     }
 }
 
-class ReplaceBgVideoAction extends BuilderAction {
+export class ReplaceBgVideoAction extends BuilderAction {
     static id = "replaceBgVideo";
     static dependencies = ["websiteBackgroundVideoPlugin"];
     load(context) {

--- a/addons/website/static/src/builder/plugins/options/card_image_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/card_image_option_plugin.js
@@ -64,7 +64,7 @@ class CardImageOptionPlugin extends Plugin {
     }
 }
 
-class SetCoverImagePositionAction extends BuilderAction {
+export class SetCoverImagePositionAction extends BuilderAction {
     static id = "setCoverImagePosition";
     static dependencies = ["cardImageOption"];
     apply({ editingElement, params: { mainParam: className } }) {
@@ -77,7 +77,7 @@ class SetCoverImagePositionAction extends BuilderAction {
         imageEl.classList.remove(className);
     }
 }
-class RemoveCoverImageAction extends BuilderAction {
+export class RemoveCoverImageAction extends BuilderAction {
     static id = "removeCoverImage";
     static dependencies = ["history", "builderOptions", "remove"];
     apply({ editingElement }) {
@@ -89,7 +89,7 @@ class RemoveCoverImageAction extends BuilderAction {
         this.dependencies["builderOptions"].updateContainers(elementToSelect);
     }
 }
-class AddCoverImageAction extends BuilderAction {
+export class AddCoverImageAction extends BuilderAction {
     static id = "addCoverImage";
     apply({ editingElement }) {
         const imageWrapper = renderToElement("website.s_card.imageWrapper");
@@ -97,7 +97,7 @@ class AddCoverImageAction extends BuilderAction {
         editingElement.classList.add("o_card_img_top");
     }
 }
-class AlignCoverImageAction extends BuilderAction {
+export class AlignCoverImageAction extends BuilderAction {
     static id = "alignCoverImage";
     apply({ editingElement, params: { mainParam: direction } }) {
         const imgWrapper = editingElement.querySelector(".o_card_img_wrapper");

--- a/addons/website/static/src/builder/plugins/options/card_width_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/card_width_option_plugin.js
@@ -14,7 +14,7 @@ class CardWidthOptionPlugin extends Plugin {
 
 registry.category("website-plugins").add(CardWidthOptionPlugin.id, CardWidthOptionPlugin);
 
-class SetCardAlignmentAction extends ClassAction {
+export class SetCardAlignmentAction extends ClassAction {
     static id = "setCardAlignment";
     isApplied({ editingElement: el, params: { mainParam: classNames } }) {
         if (classNames === "me-auto") {
@@ -24,7 +24,7 @@ class SetCardAlignmentAction extends ClassAction {
     }
 }
 
-class SetCardWidthAction extends StyleAction {
+export class SetCardWidthAction extends StyleAction {
     static id = "setCardWidth";
     getValue(...args) {
         const value = super.getValue(...args);

--- a/addons/website/static/src/builder/plugins/options/chart_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/chart_option_plugin.js
@@ -46,7 +46,7 @@ function getColor(color, win, doc) {
         ? color
         : getCSSVariableValue(color, win.getComputedStyle(doc.documentElement));
 }
-class BaseChartAction extends BuilderAction {
+export class BaseChartAction extends BuilderAction {
     static id = "baseChart";
     updateDOMData(editingElement, data) {
         editingElement.dataset.data = JSON.stringify(data);
@@ -85,7 +85,7 @@ class BaseChartAction extends BuilderAction {
     }
 }
 
-class SetChartTypeAction extends BaseChartAction {
+export class SetChartTypeAction extends BaseChartAction {
     static id = "setChartType";
     isApplied({ editingElement, value }) {
         return editingElement.dataset.type === value;
@@ -114,7 +114,7 @@ class SetChartTypeAction extends BaseChartAction {
         this.updateDOMData(editingElement, data);
     }
 }
-class AddColumnAction extends BaseChartAction {
+export class AddColumnAction extends BaseChartAction {
     static id = "addColumn";
     apply({ editingElement }) {
         const data = this.getData(editingElement);
@@ -133,7 +133,7 @@ class AddColumnAction extends BaseChartAction {
         this.updateDOMData(editingElement, data);
     }
 }
-class RemoveColumnAction extends BaseChartAction {
+export class RemoveColumnAction extends BaseChartAction {
     static id = "removeColumn";
     apply({ editingElement, params: { mainParam: key } }) {
         const data = this.getData(editingElement);
@@ -142,7 +142,7 @@ class RemoveColumnAction extends BaseChartAction {
         this.updateDOMData(editingElement, data);
     }
 }
-class AddRowAction extends BaseChartAction {
+export class AddRowAction extends BaseChartAction {
     static id = "addRow";
     apply({ editingElement }) {
         const data = this.getData(editingElement);
@@ -157,7 +157,7 @@ class AddRowAction extends BaseChartAction {
         this.updateDOMData(editingElement, data);
     }
 }
-class RemoveRowAction extends BaseChartAction {
+export class RemoveRowAction extends BaseChartAction {
     static id = "removeRow";
     apply({ editingElement, params: { mainParam: labelIndex } }) {
         const data = this.getData(editingElement);
@@ -172,7 +172,7 @@ class RemoveRowAction extends BaseChartAction {
         this.updateDOMData(editingElement, data);
     }
 }
-class UpdateDatasetValueAction extends BaseChartAction {
+export class UpdateDatasetValueAction extends BaseChartAction {
     static id = "updateDatasetValue";
     getValue({ editingElement, params: { datasetKey, valueIndex } }) {
         const data = this.getData(editingElement);
@@ -186,7 +186,7 @@ class UpdateDatasetValueAction extends BaseChartAction {
         this.updateDOMData(editingElement, data);
     }
 }
-class UpdateDatasetLabelAction extends BaseChartAction {
+export class UpdateDatasetLabelAction extends BaseChartAction {
     static id = "updateDatasetLabel";
     getValue({ editingElement, params: { mainParam: datasetKey } }) {
         const data = this.getData(editingElement);
@@ -201,7 +201,7 @@ class UpdateDatasetLabelAction extends BaseChartAction {
     }
 }
 
-class UpdateLabelNameAction extends BaseChartAction {
+export class UpdateLabelNameAction extends BaseChartAction {
     static id = "updateLabelName";
     getValue({ editingElement, params: { mainParam: labelIndex } }) {
         const data = this.getData(editingElement);
@@ -213,7 +213,7 @@ class UpdateLabelNameAction extends BaseChartAction {
         this.updateDOMData(editingElement, data);
     }
 }
-class setMinMaxAction extends BaseChartAction {
+export class setMinMaxAction extends BaseChartAction {
     static id = "setMinMax";
     getValue({ editingElement, params: { mainParam: type } }) {
         if (type === "min") {
@@ -271,7 +271,7 @@ class setMinMaxAction extends BaseChartAction {
         }
     }
 }
-class ColorChangeAction extends BaseChartAction {
+export class ColorChangeAction extends BaseChartAction {
     static id = "colorChange";
     getValue({ editingElement, params: { type, datasetIndex, dataIndex } }) {
         const data = this.getData(editingElement);

--- a/addons/website/static/src/builder/plugins/options/controller_page_listing_layout_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/controller_page_listing_layout_option_plugin.js
@@ -25,7 +25,7 @@ class ControllerPageListingLayoutOptionPlugin extends Plugin {
     };
 }
 
-class ListingLayoutAction extends BuilderAction {
+export class ListingLayoutAction extends BuilderAction {
     static id = "listingLayout";
     setup() {
         this.reload = {};

--- a/addons/website/static/src/builder/plugins/options/cookies_bar_option.js
+++ b/addons/website/static/src/builder/plugins/options/cookies_bar_option.js
@@ -19,7 +19,7 @@ class CookiesBarOptionPlugin extends Plugin {
     };
 }
 
-class SelectLayoutAction extends BuilderAction {
+export class SelectLayoutAction extends BuilderAction {
     static id = "selectLayout";
     apply({ editingElement, value: layout }) {
         const templateEl = renderToElement(`website.cookies_bar.${layout}`, {

--- a/addons/website/static/src/builder/plugins/options/countdown_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/countdown_option_plugin.js
@@ -30,7 +30,7 @@ class CountdownOptionPlugin extends Plugin {
 function cleanForSave(editingEl) {
     editingEl.classList.remove("s_countdown_enable_preview");
 }
-class BaseCountdownAction extends BuilderAction {
+export class BaseCountdownAction extends BuilderAction {
     static id = "baseCountdown";
     /**
      * Used to preserve modified end messages through end action changes. This
@@ -116,14 +116,14 @@ class BaseCountdownAction extends BuilderAction {
 
 // TODO AGAU: update after merging generalized restart interactions
 //  remove this and xml BuilderContext
-class ReloadCountdownAction extends BaseCountdownAction {
+export class ReloadCountdownAction extends BaseCountdownAction {
     static id = "reloadCountdown";
     apply({ editingElement }) {
         return this.dispatchTo("update_interactions", editingElement);
     }
 }
 
-class SetEndActionAction extends BaseCountdownAction {
+export class SetEndActionAction extends BaseCountdownAction {
     static id = "setEndAction";
     apply(context) {
         return this.setEndAction(context);
@@ -133,7 +133,7 @@ class SetEndActionAction extends BaseCountdownAction {
     }
 }
 
-class PreviewEndMessageAction extends BaseCountdownAction {
+export class PreviewEndMessageAction extends BaseCountdownAction {
     static id = "previewEndMessage";
     apply({ editingElement }) {
         return this.toggleEndMessagePreview(editingElement, true);
@@ -146,7 +146,7 @@ class PreviewEndMessageAction extends BaseCountdownAction {
     }
 }
 
-class SetLayoutAction extends BaseCountdownAction {
+export class SetLayoutAction extends BaseCountdownAction {
     static id = "setLayout";
     apply(context) {
         return this.setLayout(context);

--- a/addons/website/static/src/builder/plugins/options/cover_properties_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/cover_properties_option_plugin.js
@@ -119,14 +119,14 @@ class CoverPropertiesOptionPlugin extends Plugin {
     }
 }
 
-class BaseCoverPropertiesAction extends BuilderAction {
+export class BaseCoverPropertiesAction extends BuilderAction {
     static id = "baseCoverProperties";
     markCoverPropertiesToBeSaved({ editingElement }) {
         editingElement.closest(".o_record_cover_container").dataset.coverPropertiesToBeSaved = true;
     }
 }
 
-class SetCoverBackgroundAction extends BaseCoverPropertiesAction {
+export class SetCoverBackgroundAction extends BaseCoverPropertiesAction {
     static id = "setCoverBackground";
     static dependencies = ["builderActions", "media"];
     setup() {
@@ -180,7 +180,7 @@ class SetCoverBackgroundAction extends BaseCoverPropertiesAction {
         editingElement.closest(".o_record_cover_container").dataset.coverPropertiesToBeSaved = true;
     }
 }
-class MarkCoverPropertiesToBeSavedAction extends BaseCoverPropertiesAction {
+export class MarkCoverPropertiesToBeSavedAction extends BaseCoverPropertiesAction {
     static id = "markCoverPropertiesToBeSaved";
     apply({ editingElement }) {
         editingElement.closest(".o_record_cover_container").dataset.coverPropertiesToBeSaved = true;

--- a/addons/website/static/src/builder/plugins/options/dynamic_snippet_carousel_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/dynamic_snippet_carousel_option_plugin.js
@@ -59,7 +59,7 @@ class DynamicSnippetCarouselOptionPlugin extends Plugin {
     }
 }
 
-class SetCarouselSliderSpeedAction extends BuilderAction {
+export class SetCarouselSliderSpeedAction extends BuilderAction {
     static id = "setCarouselSliderSpeed";
     apply({ editingElement, value }) {
         editingElement.dataset.carouselInterval = value * 1000;

--- a/addons/website/static/src/builder/plugins/options/dynamic_snippet_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/dynamic_snippet_option_plugin.js
@@ -147,7 +147,7 @@ export function setDatasetIfUndefined(snippetEl, optionName, value) {
     }
 }
 
-class DynamicFilterAction extends BuilderAction {
+export class DynamicFilterAction extends BuilderAction {
     static id = "dynamicFilter";
     static dependencies = ["dynamicSnippetOption"];
     isApplied({ editingElement: el, params }) {
@@ -164,7 +164,7 @@ class DynamicFilterAction extends BuilderAction {
         }
     }
 }
-class DynamicFilterTemplateAction extends BuilderAction {
+export class DynamicFilterTemplateAction extends BuilderAction {
     static id = "dynamicFilterTemplate";
     static dependencies = ["dynamicSnippetOption"];
     isApplied({ editingElement: el, params }) {
@@ -174,7 +174,7 @@ class DynamicFilterTemplateAction extends BuilderAction {
         this.dependencies.dynamicSnippetOption.updateTemplate(el, params);
     }
 }
-class CustomizeTemplateAction extends BuilderAction {
+export class CustomizeTemplateAction extends BuilderAction {
     static id = "customizeTemplate";
     isApplied({ editingElement: el, params: { mainParam: customDataKey } }) {
         const customData = JSON.parse(el.dataset.customTemplateData);

--- a/addons/website/static/src/builder/plugins/options/embed_code_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/embed_code_option_plugin.js
@@ -38,7 +38,7 @@ class EmbedCodeOptionPlugin extends Plugin {
     }
 }
 
-class EditCodeAction extends BuilderAction {
+export class EditCodeAction extends BuilderAction {
     static id = "editCode";
     async load({ editingElement }) {
         let newContent;

--- a/addons/website/static/src/builder/plugins/options/facebook_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/facebook_option_plugin.js
@@ -84,7 +84,7 @@ class FacebookOptionPlugin extends Plugin {
     }
 }
 
-class DataAttributeListAction extends BuilderAction {
+export class DataAttributeListAction extends BuilderAction {
     static id = "dataAttributeList";
     isApplied({ editingElement, params: { mainParam } = {}, value }) {
         return (editingElement.dataset[mainParam]?.split(",") || []).includes(value);
@@ -101,7 +101,7 @@ class DataAttributeListAction extends BuilderAction {
             .join(",");
     }
 }
-class CheckFacebookLinkAction extends BuilderAction {
+export class CheckFacebookLinkAction extends BuilderAction {
     static id = "checkFacebookLink";
     setup() {
         this.closeNotif = () => {};

--- a/addons/website/static/src/builder/plugins/options/footer_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/footer_option_plugin.js
@@ -87,7 +87,7 @@ class FooterOptionPlugin extends Plugin {
     }
 }
 
-class WebsiteConfigFooterAction extends BuilderAction {
+export class WebsiteConfigFooterAction extends BuilderAction {
     static id = "websiteConfigFooter";
     static dependencies = ["builderActions", "customizeWebsite"];
     setup() {

--- a/addons/website/static/src/builder/plugins/options/gallery_element_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/gallery_element_option_plugin.js
@@ -21,7 +21,7 @@ export class GalleryElementOptionPlugin extends Plugin {
     };
 }
 
-class SetGalleryElementPositionAction extends BuilderAction {
+export class SetGalleryElementPositionAction extends BuilderAction {
     static id = "setGalleryElementPosition";
     apply({ editingElement: activeItemEl, value: position }) {
         const optionName = activeItemEl.classList.contains("carousel-item")

--- a/addons/website/static/src/builder/plugins/options/google_maps_option/google_maps_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/google_maps_option/google_maps_option_plugin.js
@@ -285,13 +285,13 @@ export class GoogleMapsOptionPlugin extends Plugin {
     }
 }
 
-class ResetMapColorAction extends BuilderAction {
+export class ResetMapColorAction extends BuilderAction {
     static id = "resetMapColor";
     apply({ editingElement }) {
         editingElement.dataset.mapColor = "";
     }
 }
-class ShowDescriptionAction extends BuilderAction {
+export class ShowDescriptionAction extends BuilderAction {
     static id = "showDescription";
     isApplied({ editingElement }) {
         return !!editingElement.querySelector(".description");

--- a/addons/website/static/src/builder/plugins/options/header_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/header_option_plugin.js
@@ -98,7 +98,7 @@ class HeaderOptionPlugin extends Plugin {
     };
 }
 
-class StyleActionHeaderAction extends StyleAction {
+export class StyleActionHeaderAction extends StyleAction {
     static id = "styleActionHeader";
     static dependencies = ["customizeWebsite", "color"];
     setup() {
@@ -127,7 +127,7 @@ class StyleActionHeaderAction extends StyleAction {
     }
 }
 
-class SetShadowModeHeaderAction extends SetShadowModeAction {
+export class SetShadowModeHeaderAction extends SetShadowModeAction {
     static id = "setShadowModeHeader";
     static dependencies = ["customizeWebsite"];
     setup() {
@@ -142,7 +142,7 @@ class SetShadowModeHeaderAction extends SetShadowModeAction {
     }
 }
 
-class SetShadowHeaderAction extends SetShadowAction {
+export class SetShadowHeaderAction extends SetShadowAction {
     static id = "setShadowHeader";
     static dependencies = ["customizeWebsite"];
     setup() {

--- a/addons/website/static/src/builder/plugins/options/image_gallery_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/image_gallery_option_plugin.js
@@ -391,7 +391,7 @@ class ImageGalleryOption extends Plugin {
     }
 }
 
-class AddImageAction extends BuilderAction {
+export class AddImageAction extends BuilderAction {
     static id = "addImage";
     static dependencies = ["media", "imageGalleryOption"];
     async load({ editingElement }) {
@@ -419,7 +419,7 @@ class AddImageAction extends BuilderAction {
         }
     }
 }
-class RemoveAllImagesAction extends BuilderAction {
+export class RemoveAllImagesAction extends BuilderAction {
     static id = "removeAllImages";
     apply({ editingElement: el }) {
         const containerEl = el.querySelector(".container, .container-fluid, .o_container_small");
@@ -430,7 +430,7 @@ class RemoveAllImagesAction extends BuilderAction {
         }
     }
 }
-class SetImageGalleryLayoutAction extends BuilderAction {
+export class SetImageGalleryLayoutAction extends BuilderAction {
     static id = "setImageGalleryLayout";
     static dependencies = ["imageGalleryOption"];
     load({ editingElement }) {
@@ -449,7 +449,7 @@ class SetImageGalleryLayoutAction extends BuilderAction {
         return mode === this.dependencies.imageGalleryOption.getMode(editingElement);
     }
 }
-class SetImageGalleryColumnsAction extends BuilderAction {
+export class SetImageGalleryColumnsAction extends BuilderAction {
     static id = "setImageGalleryColumns";
     static dependencies = ["imageGalleryOption"];
     load({ editingElement }) {
@@ -474,7 +474,7 @@ class SetImageGalleryColumnsAction extends BuilderAction {
     }
 }
 
-class SetCarouselSpeedAction extends BuilderAction {
+export class SetCarouselSpeedAction extends BuilderAction {
     static id = "setCarouselSpeed";
     apply({ editingElement, value }) {
         editingElement.dataset.bsInterval = value * 1000;

--- a/addons/website/static/src/builder/plugins/options/instagram_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/instagram_option_plugin.js
@@ -101,7 +101,7 @@ class InstagramOptionPlugin extends Plugin {
     }
 }
 
-class InstagramPageAction extends BuilderAction {
+export class InstagramPageAction extends BuilderAction {
     static id = "instagramPage";
     static dependencies = ["instagramOption"];
     getValue({ editingElement }) {

--- a/addons/website/static/src/builder/plugins/options/many2one_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/many2one_option_plugin.js
@@ -19,7 +19,7 @@ export class Many2OneOptionPlugin extends Plugin {
     };
 }
 
-class Many2OneAction extends BuilderAction {
+export class Many2OneAction extends BuilderAction {
     static id = "many2One";
     async load({ editingElement, value }) {
         const { id } = JSON.parse(value);

--- a/addons/website/static/src/builder/plugins/options/map_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/map_option_plugin.js
@@ -21,7 +21,7 @@ class MapOptionPlugin extends Plugin {
     };
 }
 
-class MapUpdateSrcAction extends BuilderAction {
+export class MapUpdateSrcAction extends BuilderAction {
     static id = "mapUpdateSrc";
     apply({ editingElement }) {
         const embedded = editingElement.querySelector(".s_map_embedded");
@@ -40,7 +40,7 @@ class MapUpdateSrcAction extends BuilderAction {
             .classList.toggle("d-none", !!editingElement.dataset.mapAddress);
     }
 }
-class MapDescriptionAction extends BuilderAction {
+export class MapDescriptionAction extends BuilderAction {
     static id = "mapDescription";
     isApplied({ editingElement }) {
         return editingElement.querySelector(".description") !== null;

--- a/addons/website/static/src/builder/plugins/options/media_list_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/media_list_option_plugin.js
@@ -28,7 +28,7 @@ class MediaListOptionPlugin extends Plugin {
     };
 }
 
-class SetMediaLayoutAction extends BuilderAction {
+export class SetMediaLayoutAction extends BuilderAction {
     static id = "setMediaLayout";
     isApplied({ editingElement, value }) {
         const image = editingElement.querySelector(".s_media_list_img_wrapper");

--- a/addons/website/static/src/builder/plugins/options/navtabs_style_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/navtabs_style_option_plugin.js
@@ -88,7 +88,7 @@ class NavTabsStyleOptionPlugin extends Plugin {
 
 const getTabsEl = (editingElement) => editingElement.querySelector(".s_tabs_nav");
 
-class BaseNavtabsStyleOption extends BuilderAction {
+export class BaseNavtabsStyleOption extends BuilderAction {
     static id = "baseNavtabsStyle";
     static dependencies = ["navTabsOptionStyle"];
     setup() {

--- a/addons/website/static/src/builder/plugins/options/parallax_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/parallax_option_plugin.js
@@ -86,7 +86,7 @@ class WebsiteParallaxPlugin extends Plugin {
         }
     }
 }
-class SetParallaxTypeAction extends BuilderAction {
+export class SetParallaxTypeAction extends BuilderAction {
     static id = "setParallaxType";
     static dependencies = ["websiteParallaxPlugin"];
     apply(context) {

--- a/addons/website/static/src/builder/plugins/options/popup_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/popup_option_plugin.js
@@ -88,7 +88,7 @@ class PopupOptionPlugin extends Plugin {
 // Moves the snippet in #o_shared_blocks to be common to all pages
 // or inside the first editable oe_structure in the main to be on
 // current page only.
-class MoveBlockAction extends BuilderAction {
+export class MoveBlockAction extends BuilderAction {
     static id = "moveBlock";
     isApplied({ editingElement, value }) {
         return editingElement.closest("#o_shared_blocks")
@@ -103,7 +103,7 @@ class MoveBlockAction extends BuilderAction {
         whereEl.insertAdjacentElement("afterbegin", popupEl);
     }
 }
-class SetBackdropAction extends BuilderAction {
+export class SetBackdropAction extends BuilderAction {
     static id = "setBackdrop";
     isApplied({ editingElement }) {
         const hasBackdropColor = !!editingElement.style.getPropertyValue("background-color").trim();
@@ -119,14 +119,14 @@ class SetBackdropAction extends BuilderAction {
         editingElement.style.removeProperty("background-color");
     }
 }
-class CopyAnchorAction extends BuilderAction {
+export class CopyAnchorAction extends BuilderAction {
     static id = "copyAnchor";
     static dependencies = ["anchor"];
     apply({ editingElement }) {
         this.dependencies.anchor.createOrEditAnchorLink(editingElement);
     }
 }
-class SetPopupDelayAction extends BuilderAction {
+export class SetPopupDelayAction extends BuilderAction {
     static id = "setPopupDelay";
     apply({ editingElement, value }) {
         editingElement.dataset.showAfter = value * 1000;

--- a/addons/website/static/src/builder/plugins/options/pricelist_option/pricelist_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/pricelist_option/pricelist_plugin.js
@@ -12,7 +12,7 @@ class PriceListPlugin extends Plugin {
     };
 }
 
-class TogglePriceListDescriptionAction extends BuilderAction {
+export class TogglePriceListDescriptionAction extends BuilderAction {
     static id = "togglePriceListDescription";
     isApplied({ editingElement, params }) {
         const description = editingElement.querySelector(`.${params.descriptionClass}`);

--- a/addons/website/static/src/builder/plugins/options/process_steps_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/process_steps_option_plugin.js
@@ -45,7 +45,7 @@ class ProcessStepsOptionPlugin extends Plugin {
     };
 }
 
-class ChangeConnectorAction extends ClassAction {
+export class ChangeConnectorAction extends ClassAction {
     static id = "changeConnector";
     apply({ editingElement, params: { mainParam: className } }) {
         super.apply(...arguments);
@@ -69,7 +69,7 @@ class ChangeConnectorAction extends ClassAction {
     }
 }
 
-class ChangeArrowColorAction extends BuilderAction {
+export class ChangeArrowColorAction extends BuilderAction {
     static id = "changeArrowColor";
     apply({ editingElement, value: colorValue }) {
         const arrowHeadEl = editingElement

--- a/addons/website/static/src/builder/plugins/options/progress_bar_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/progress_bar_option_plugin.js
@@ -33,7 +33,7 @@ class ProgressBarOptionPlugin extends Plugin {
     }
 }
 
-class DisplayAction extends BuilderAction {
+export class DisplayAction extends BuilderAction {
     static id = "display";
     apply({ editingElement, params: { mainParam: position } }) {
         // retro-compatibility
@@ -73,7 +73,7 @@ class DisplayAction extends BuilderAction {
     }
 }
 
-class ProgressBarValueAction extends BuilderAction {
+export class ProgressBarValueAction extends BuilderAction {
     static id = "progressBarValue";
     apply({ editingElement, value }) {
         value = parseInt(value);

--- a/addons/website/static/src/builder/plugins/options/scroll_button_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/scroll_button_option_plugin.js
@@ -82,7 +82,7 @@ class ScrollButtonManager {
 
 const scrollButtonManager = new ScrollButtonManager();
 
-class AddScrollButtonAction extends BuilderAction {
+export class AddScrollButtonAction extends BuilderAction {
     static id = "addScrollButton";
     setup() {
         this.manager = scrollButtonManager;
@@ -101,7 +101,7 @@ class AddScrollButtonAction extends BuilderAction {
     }
 }
 
-class ScrollButtonSectionHeightClassAction extends ClassAction {
+export class ScrollButtonSectionHeightClassAction extends ClassAction {
     static id = "scrollButtonSectionHeightClass";
     setup() {
         this.manager = scrollButtonManager;

--- a/addons/website/static/src/builder/plugins/options/searchbar_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/searchbar_option_plugin.js
@@ -65,7 +65,7 @@ class SearchbarOptionPlugin extends Plugin {
     };
 }
 
-class BaseSearchBarAction extends BuilderAction {
+export class BaseSearchBarAction extends BuilderAction {
     id = "baseSearchBar";
     defaultSearchType = "name asc";
 
@@ -80,7 +80,7 @@ class BaseSearchBarAction extends BuilderAction {
         return this.getFormEl(editingElement).querySelector(".o_search_order_by");
     }
 }
-class SetSearchTypeAction extends BaseSearchBarAction {
+export class SetSearchTypeAction extends BaseSearchBarAction {
     static id = "setSearchType";
     apply({ editingElement, value: formAction, dependencyManager }) {
         this.getFormEl(editingElement).action = formAction;
@@ -117,14 +117,14 @@ class SetSearchTypeAction extends BaseSearchBarAction {
         }
     }
 }
-class SetOrderByAction extends BaseSearchBarAction {
+export class SetOrderByAction extends BaseSearchBarAction {
     static id = "setOrderBy";
     apply({ editingElement, value: orderBy }) {
         this.getSearchOrderByInputEl(editingElement).value = orderBy;
     }
 }
 
-class SetSearchbarStyleAction extends BaseSearchBarAction {
+export class SetSearchbarStyleAction extends BaseSearchBarAction {
     static id = "setSearchbarStyle";
     isApplied({ editingElement, params: { mainParam: style } }) {
         const searchInputIsLight = editingElement.matches(".border-0.bg-light");
@@ -151,7 +151,7 @@ class SetSearchbarStyleAction extends BaseSearchBarAction {
 // `with_description = options['displayDescription']`) so we can use
 // the default `dataAttributeAction`. The python should not need a
 // value if it doesn't exist.
-class SetNonEmptyDataAttributeAction extends BuilderAction {
+export class SetNonEmptyDataAttributeAction extends BuilderAction {
     static id = "setNonEmptyDataAttribute";
     getValue({ editingElement, params: { mainParam: attributeName } = {} }) {
         return editingElement.dataset[attributeName];

--- a/addons/website/static/src/builder/plugins/options/social_media_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/social_media_option_plugin.js
@@ -359,13 +359,13 @@ class SocialMediaOptionPlugin extends Plugin {
     }
 }
 
-class DeleteSocialMediaLinkAction extends BuilderAction {
+export class DeleteSocialMediaLinkAction extends BuilderAction {
     static id = "deleteSocialMediaLink";
     apply({ editingElement }) {
         editingElement.remove();
     }
 }
-class ToggleRecordedSocialMediaLinkAction extends BuilderAction {
+export class ToggleRecordedSocialMediaLinkAction extends BuilderAction {
     static id = "toggleRecordedSocialMediaLink";
     static dependencies = ["socialMediaOptionPlugin"];
     isApplied({ editingElement, params: { domPosition } }) {
@@ -386,7 +386,7 @@ class ToggleRecordedSocialMediaLinkAction extends BuilderAction {
         editingElement.querySelector(`a:nth-of-type(${domPosition})`).remove();
     }
 }
-class EditRecordedSocialMediaLinkAction extends BuilderAction {
+export class EditRecordedSocialMediaLinkAction extends BuilderAction {
     static id = "editRecordedSocialMediaLink";
     static dependencies = ["socialMediaOptionPlugin", "history"];
     getValue({ params: { mainParam } }) {
@@ -407,7 +407,7 @@ class EditRecordedSocialMediaLinkAction extends BuilderAction {
         });
     }
 }
-class EditSocialMediaLinkAction extends BuilderAction {
+export class EditSocialMediaLinkAction extends BuilderAction {
     static id = "editSocialMediaLink";
     static dependencies = ["socialMediaOptionPlugin"];
     apply({ editingElement, params: { mainParam }, value }) {
@@ -436,7 +436,7 @@ class EditSocialMediaLinkAction extends BuilderAction {
         }
     }
 }
-class AddSocialMediaLinkAction extends BuilderAction {
+export class AddSocialMediaLinkAction extends BuilderAction {
     static id = "addSocialMediaLink";
     static dependencies = ["socialMediaOptionPlugin"];
     apply({ editingElement }) {

--- a/addons/website/static/src/builder/plugins/options/table_of_content_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/table_of_content_option_plugin.js
@@ -146,7 +146,7 @@ class TableOfContentOptionPlugin extends Plugin {
     }
 }
 
-class NavbarPositionAction extends BuilderAction {
+export class NavbarPositionAction extends BuilderAction {
     static id = "navbarPosition";
     isApplied({ editingElement: navbarWrapEl, params: { mainParam: position } }) {
         if (navbarWrapEl.classList.contains("s_table_of_content_horizontal_navbar")) {

--- a/addons/website/static/src/builder/plugins/options/visibility_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/visibility_option_plugin.js
@@ -212,7 +212,7 @@ class VisibilityOptionPlugin extends Plugin {
     }
 }
 
-class ForceVisibleAction extends BuilderAction {
+export class ForceVisibleAction extends BuilderAction {
     static id = "forceVisible";
     static dependencies = ["visibility"];
     apply({ editingElement }) {
@@ -222,7 +222,7 @@ class ForceVisibleAction extends BuilderAction {
         return true;
     }
 }
-class ToggleDeviceVisibilityAction extends BuilderAction {
+export class ToggleDeviceVisibilityAction extends BuilderAction {
     static id = "toggleDeviceVisibility";
     static dependencies = ["visibility", "visibilityOption"];
     apply({ editingElement, params: { mainParam: visibility } }) {

--- a/addons/website/static/src/builder/plugins/options/website_page_config_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/website_page_config_option_plugin.js
@@ -116,7 +116,7 @@ class WebsitePageConfigOptionPlugin extends Plugin {
         }
     }
 }
-class BaseWebsitePageConfigAction extends BuilderAction {
+export class BaseWebsitePageConfigAction extends BuilderAction {
     static id = "baseWebsitePageConfig";
     static dependencies = ["websitePageConfigOptionPlugin", "history", "visibility"];
     setup() {
@@ -174,7 +174,7 @@ class BaseWebsitePageConfigAction extends BuilderAction {
         });
     }
 }
-class SetWebsiteHeaderVisibilityAction extends BaseWebsitePageConfigAction {
+export class SetWebsiteHeaderVisibilityAction extends BaseWebsitePageConfigAction {
     static id = "setWebsiteHeaderVisibility";
     apply({ editingElement, value: headerPositionValue }) {
         const lastValue = this.websitePageConfig.getVisibilityItem();
@@ -189,7 +189,7 @@ class SetWebsiteHeaderVisibilityAction extends BaseWebsitePageConfigAction {
         return this.websitePageConfig.getVisibilityItem() === value;
     }
 }
-class SetWebsiteFooterVisibleAction extends BaseWebsitePageConfigAction {
+export class SetWebsiteFooterVisibleAction extends BaseWebsitePageConfigAction {
     static id = "setWebsiteFooterVisible";
     isApplied({ editingElement }) {
         return !this.websitePageConfig.getFooterVisibility();
@@ -204,7 +204,7 @@ class SetWebsiteFooterVisibleAction extends BaseWebsitePageConfigAction {
     }
 }
 
-class SetPageWebsiteDirtyAction extends BaseWebsitePageConfigAction {
+export class SetPageWebsiteDirtyAction extends BaseWebsitePageConfigAction {
     static id = "setPageWebsiteDirty";
     apply({ editingElement }) {
         this.websitePageConfig.setDirty();

--- a/addons/website/static/src/builder/plugins/rating_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/rating_option_plugin.js
@@ -21,7 +21,7 @@ class RatingOptionPlugin extends Plugin {
     };
 }
 
-class SetIconsAction extends BuilderAction {
+export class SetIconsAction extends BuilderAction {
     static id = "setIcons";
     apply({ editingElement, params: { mainParam: iconParam } }) {
         editingElement.dataset.icon = iconParam;
@@ -33,7 +33,7 @@ class SetIconsAction extends BuilderAction {
         return getIconType(editingElement) === iconParam;
     }
 }
-class CustomIconAction extends BuilderAction {
+export class CustomIconAction extends BuilderAction {
     static id = "customIcon";
     static dependencies = ["media"];
     async load({ editingElement, params: { mainParam: customParam } }) {
@@ -78,7 +78,7 @@ class CustomIconAction extends BuilderAction {
         editingElement.dataset.icon = "custom";
     }
 }
-class ActiveIconsNumberAction extends BuilderAction {
+export class ActiveIconsNumberAction extends BuilderAction {
     static id = "activeIconsNumber";
     apply({ editingElement, value }) {
         const nbActiveIcons = parseInt(value);
@@ -93,7 +93,7 @@ class ActiveIconsNumberAction extends BuilderAction {
         return getActiveIcons(editingElement).length;
     }
 }
-class TotalIconsNumberAction extends BuilderAction {
+export class TotalIconsNumberAction extends BuilderAction {
     static id = "totalIconsNumber";
     apply({ editingElement, value }) {
         const nbTotalIcons = Math.max(parseInt(value), 1);

--- a/addons/website/static/src/builder/plugins/theme/theme_tab_plugin.js
+++ b/addons/website/static/src/builder/plugins/theme/theme_tab_plugin.js
@@ -226,7 +226,7 @@ export class ThemeTabPlugin extends Plugin {
     }
 }
 
-class CustomizeGrayAction extends BuilderAction {
+export class CustomizeGrayAction extends BuilderAction {
     static id = "customizeGray";
     static dependencies = ["customizeWebsite", "themeTab"];
     setup() {
@@ -260,7 +260,7 @@ class CustomizeGrayAction extends BuilderAction {
         );
     }
 }
-class ChangeColorPaletteAction extends CustomizeWebsiteVariableAction {
+export class ChangeColorPaletteAction extends CustomizeWebsiteVariableAction {
     static id = "changeColorPalette";
     static dependencies = ["customizeWebsite"];
     setup() {}

--- a/addons/website/static/src/builder/plugins/vertical_alignment_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/vertical_alignment_option_plugin.js
@@ -34,7 +34,7 @@ class VerticalAlignmentOptionPlugin extends Plugin {
     };
 }
 
-class SetVerticalAlignmentAction extends ClassAction {
+export class SetVerticalAlignmentAction extends ClassAction {
     static id = "setVerticalAlignment";
     getPriority({ params: { mainParam: classNames } = { mainParam: "" } }) {
         return classNames === "align-items-stretch" ? 0 : 1;

--- a/addons/website_event/static/src/website_builder/event_page_option_plugin.js
+++ b/addons/website_event/static/src/website_builder/event_page_option_plugin.js
@@ -31,7 +31,7 @@ class EventPageOption extends Plugin {
     };
 }
 
-class DisplaySubMenuAction extends BuilderAction {
+export class DisplaySubMenuAction extends BuilderAction {
     static id = "displaySubMenu";
     setup() {
         this.orm = this.services.orm;

--- a/addons/website_mail_group/static/src/website_builder/mail_group_option_plugin.js
+++ b/addons/website_mail_group/static/src/website_builder/mail_group_option_plugin.js
@@ -63,7 +63,7 @@ class MailGroupOptionPlugin extends Plugin {
     }
 }
 
-class MailGroupAction extends BuilderAction {
+export class MailGroupAction extends BuilderAction {
     static id = "mailGroupAction"
     static dependencies = ["builderActions"];
     apply({ editingElement, value }) {
@@ -90,7 +90,7 @@ class MailGroupAction extends BuilderAction {
         return JSON.stringify(value);
     }
 }
-class CreateMailGroupAction extends BuilderAction {
+export class CreateMailGroupAction extends BuilderAction {
     static id = "createMailGroup";
     static dependencies = ["builderActions", "mailGroupOption"];
     load({ editingElement, value }) {

--- a/addons/website_mass_mailing/static/src/website_builder/mailing_list_subscribe_option_plugin.js
+++ b/addons/website_mass_mailing/static/src/website_builder/mailing_list_subscribe_option_plugin.js
@@ -105,7 +105,7 @@ class MailingListSubscribeOptionPlugin extends Plugin {
     }
 }
 
-class ToggleThanksMessageAction extends BuilderAction {
+export class ToggleThanksMessageAction extends BuilderAction {
     static id = "toggleThanksMessage";
     apply({ editingElement }) {
         this.setThanksMessageVisibility(editingElement, true);

--- a/addons/website_mass_mailing/static/src/website_builder/newsletter_layout_option_plugin.js
+++ b/addons/website_mass_mailing/static/src/website_builder/newsletter_layout_option_plugin.js
@@ -23,7 +23,7 @@ export class NewsletterLayoutOptionPlugin extends Plugin {
         },
     };
 }
-class SelectNewsletterTemplateAction extends BuilderAction {
+export class SelectNewsletterTemplateAction extends BuilderAction {
     static id = "selectNewsletterTemplate";
     static dependencies = ["builderActions"];
     setup() {

--- a/addons/website_mass_mailing/static/src/website_builder/recaptcha_subscribe_option_plugin.js
+++ b/addons/website_mass_mailing/static/src/website_builder/recaptcha_subscribe_option_plugin.js
@@ -18,7 +18,7 @@ class RecaptchaSubscribeOptionPlugin extends Plugin {
     }
 }
 
-class ToggleRecaptchaLegalAction extends BuilderAction {
+export class ToggleRecaptchaLegalAction extends BuilderAction {
     static id = "toggleRecaptchaLegal";
     apply({ editingElement }) {
         const template = document.createElement("template");

--- a/addons/website_payment/static/src/website_builder/donation_option_plugin.js
+++ b/addons/website_payment/static/src/website_builder/donation_option_plugin.js
@@ -230,7 +230,7 @@ class DonationOptionPlugin extends Plugin {
     }
 }
 
-class ToggleDataAttributeAction extends BuilderAction {
+export class ToggleDataAttributeAction extends BuilderAction {
     /**
      * @param {string} dataAttributeName - The data attribute to toggle (without "data-" prefix)
      * @param {Function} toggleFunction - Function to call when applying or cleaning
@@ -298,14 +298,14 @@ class ToggleDataAttributeAction extends BuilderAction {
     }
 }
 
-class ToggleDisplayOptionsAction extends ToggleDataAttributeAction {
+export class ToggleDisplayOptionsAction extends ToggleDataAttributeAction {
     static id = "toggleDisplayOptions";
     setup() {
         super.setup("displayOptions", this.toggleDisplayOptions)
     }
 }
 
-class TogglePrefilledOptionsAction extends ToggleDataAttributeAction {
+export class TogglePrefilledOptionsAction extends ToggleDataAttributeAction {
     static id = "togglePrefilledOptions";
     setup() {
         super.setup("prefilledOptions", this.togglePrefilledOptions)
@@ -313,13 +313,13 @@ class TogglePrefilledOptionsAction extends ToggleDataAttributeAction {
 }
 
 
-class ToggleDescriptionsAction extends ToggleDataAttributeAction {
+export class ToggleDescriptionsAction extends ToggleDataAttributeAction {
     static id = "toggleDescriptions";
     setup() {
         super.setup("descriptions", this.toggleDescriptions)
     }
 }
-class SetPrefilledOptionsAction extends BuilderAction {
+export class SetPrefilledOptionsAction extends BuilderAction {
     static id = "setPrefilledOptions";
     static dependencies = ["donationOption"];
     getValue(context) {
@@ -330,7 +330,7 @@ class SetPrefilledOptionsAction extends BuilderAction {
     }
 }
 
-class SelectAmountInputAction extends BuilderAction {
+export class SelectAmountInputAction extends BuilderAction {
     static id = "selectAmountInput";
     static dependencies = ["donationOption"];
     isApplied(context) {
@@ -341,7 +341,7 @@ class SelectAmountInputAction extends BuilderAction {
     }
 }
 
-class SetMinimumAmountAction extends BuilderAction {
+export class SetMinimumAmountAction extends BuilderAction {
     static id = "setMinimumAmount";
     static dependencies = ["donationOption"];
     getValue(context) {
@@ -351,7 +351,7 @@ class SetMinimumAmountAction extends BuilderAction {
         return this.dependencies.donationOption.setMinimumAmount(context);
     }
 }
-class SetMaximumAmountAction extends BuilderAction {
+export class SetMaximumAmountAction extends BuilderAction {
     static id = "setMaximumAmount";
     static dependencies = ["donationOption"];
     getValue(context) {
@@ -361,7 +361,7 @@ class SetMaximumAmountAction extends BuilderAction {
         return this.dependencies.donationOption.setMaximumAmount(context);
     }
 }
-class SetSliderStepAction extends BuilderAction {
+export class SetSliderStepAction extends BuilderAction {
     static id = "setSliderStep";
     static dependencies = ["donationOption"];
     getValue(context) {

--- a/addons/website_sale/static/src/website_builder/add_to_cart_option_plugin.js
+++ b/addons/website_sale/static/src/website_builder/add_to_cart_option_plugin.js
@@ -30,7 +30,7 @@ class AddToCartOptionPlugin extends Plugin {
     }
 }
 
-class ProductToCartAction extends BuilderAction {
+export class ProductToCartAction extends BuilderAction {
     static id = "productToCart";
     static dependencies = ["builderActions", "addToCartOption"];
     apply({ editingElement, value }) {
@@ -96,7 +96,7 @@ class ProductToCartAction extends BuilderAction {
         return JSON.stringify(value);
     }
 }
-class VariantToCartAction extends BuilderAction {
+export class VariantToCartAction extends BuilderAction {
     static id = "variantToCart";
     static dependencies = ["addToCartOption"];
     apply({ editingElement, value }) {
@@ -118,7 +118,7 @@ class VariantToCartAction extends BuilderAction {
         }
     }
 }
-class AddToCartAction extends BuilderAction {
+export class AddToCartAction extends BuilderAction {
     static id = "addToCart";
     static dependencies = ["builderActions"];
     apply({ editingElement, params: { action, icon, label } }) {

--- a/addons/website_sale/static/src/website_builder/checkout_page_option_plugin.js
+++ b/addons/website_sale/static/src/website_builder/checkout_page_option_plugin.js
@@ -23,7 +23,7 @@ class CheckoutPageOptionPlugin extends Plugin {
     };
 }
 
-class SetExtraStepAction extends WebsiteConfigAction {
+export class SetExtraStepAction extends WebsiteConfigAction {
     static id = "setExtraStep";
     async apply(context) {
         await Promise.all([

--- a/addons/website_sale/static/src/website_builder/mega_menu_option_plugin.js
+++ b/addons/website_sale/static/src/website_builder/mega_menu_option_plugin.js
@@ -35,7 +35,7 @@ class WebsiteSaleMegaMenuOptionPlugin extends Plugin {
     };
 }
 
-class ToggleFetchEcomCategoriesAction extends BuilderAction {
+export class ToggleFetchEcomCategoriesAction extends BuilderAction {
     static id = "toggleFetchEcomCategories";
     static dependencies = ["megaMenuOptionPlugin", "customizeWebsite"];
     async load({ editingElement }) {

--- a/addons/website_sale/static/src/website_builder/product_attribute_option_plugin.js
+++ b/addons/website_sale/static/src/website_builder/product_attribute_option_plugin.js
@@ -19,7 +19,7 @@ class ProductAttributeOptionPlugin extends Plugin {
 
 }
 
-class ProductAttributeDisplayAction extends BuilderAction {
+export class ProductAttributeDisplayAction extends BuilderAction {
     static id = "productAttributeDisplay";
 
     setup() {

--- a/addons/website_sale/static/src/website_builder/product_image_option_plugin.js
+++ b/addons/website_sale/static/src/website_builder/product_image_option_plugin.js
@@ -45,7 +45,7 @@ export class ProductImageOptionPlugin extends Plugin {
 /*
 * Change sequence of product page images
 */
-class SetPositionAction extends BuilderAction {
+export class SetPositionAction extends BuilderAction {
     static id = "setPosition";
     setup() {
         this.reload = {};
@@ -63,7 +63,7 @@ class SetPositionAction extends BuilderAction {
 /*
  * Removes the image in the back-end
  */
-class RemoveMediaAction extends BuilderAction {
+export class RemoveMediaAction extends BuilderAction {
     static id = "removeMedia";
     setup() {
         this.reload = {};

--- a/addons/website_sale/static/src/website_builder/product_page_option_plugin.js
+++ b/addons/website_sale/static/src/website_builder/product_page_option_plugin.js
@@ -118,7 +118,7 @@ class ProductPageOptionPlugin extends Plugin {
     }
 }
 
-class ProductPageImageWidthAction extends WebsiteConfigAction {
+export class ProductPageImageWidthAction extends WebsiteConfigAction {
     static id = "productPageImageWidth";
     static dependencies = ["customizeWebsite", "productPageOption"];
     isApplied({ editingElement: productDetailMainEl, value }) {
@@ -139,7 +139,7 @@ class ProductPageImageWidthAction extends WebsiteConfigAction {
         await rpc("/shop/config/website", { product_page_image_width: value });
     }
 }
-class ProductPageImageLayoutAction extends WebsiteConfigAction {
+export class ProductPageImageLayoutAction extends WebsiteConfigAction {
     static id = "productPageImageLayout";
     static dependencies = ["customizeWebsite", "productPageOption"];
     isApplied({ editingElement: productDetailMainEl, value }) {
@@ -169,7 +169,7 @@ class ProductPageImageLayoutAction extends WebsiteConfigAction {
     }
 }
 
-class BaseProductPageAction extends BuilderAction {
+export class BaseProductPageAction extends BuilderAction {
     static id = "baseProductPage";
     setup() {
         this.reload = {};
@@ -301,7 +301,7 @@ class BaseProductPageAction extends BuilderAction {
         }
     }
 }
-class ProductPageImageGridSpacingAction extends BaseProductPageAction {
+export class ProductPageImageGridSpacingAction extends BaseProductPageAction {
     static id = "productPageImageGridSpacing";
     getValue() {
         if (!this.productPageGrid) {
@@ -331,7 +331,7 @@ class ProductPageImageGridSpacingAction extends BaseProductPageAction {
         this.productPageGrid.dataset.image_spacing = spacing;
     }
 }
-class ProductPageImageGridColumnsAction extends BaseProductPageAction {
+export class ProductPageImageGridColumnsAction extends BaseProductPageAction {
     static id = "productPageImageGridColumns";
 
     isApplied({ value }) {
@@ -347,7 +347,7 @@ class ProductPageImageGridColumnsAction extends BaseProductPageAction {
         });
     }
 }
-class ProductReplaceMainImageAction extends BaseProductPageAction {
+export class ProductReplaceMainImageAction extends BaseProductPageAction {
     static id = "productReplaceMainImage";
     apply({ editingElement: productDetailMainEl }) {
         // Emulate click on the main image of the carousel.
@@ -358,7 +358,7 @@ class ProductReplaceMainImageAction extends BaseProductPageAction {
     }
 }
 
-class ProductAddExtraImageAction extends BaseProductPageAction {
+export class ProductAddExtraImageAction extends BaseProductPageAction {
     static id = "productAddExtraImage";
     static dependencies = ["media"];
     async apply({ editingElement: el }) {
@@ -389,7 +389,7 @@ class ProductAddExtraImageAction extends BaseProductPageAction {
         });
     }
 }
-class ProductRemoveAllExtraImagesAction extends BaseProductPageAction {
+export class ProductRemoveAllExtraImagesAction extends BaseProductPageAction {
     static id = "productRemoveAllExtraImages";
     async apply({ editingElement: el }) {
         // Removes all extra-images from the product.

--- a/addons/website_sale/static/src/website_builder/products_item_option_plugin.js
+++ b/addons/website_sale/static/src/website_builder/products_item_option_plugin.js
@@ -316,7 +316,7 @@ class ProductsItemOptionPlugin extends Plugin {
 
 }
 
-class SetItemSizeAction extends BuilderAction {
+export class SetItemSizeAction extends BuilderAction {
     static id = "setItemSize";
     static dependencies = ["productsItemOptionPlugin"];
     setup() {
@@ -348,7 +348,7 @@ class SetItemSizeAction extends BuilderAction {
         });
     }
 }
-class ChangeSequenceAction extends BuilderAction {
+export class ChangeSequenceAction extends BuilderAction {
     static id = "changeSequence";
     static dependencies = ["productsItemOptionPlugin"];
     setup() {
@@ -366,7 +366,7 @@ class ChangeSequenceAction extends BuilderAction {
         });
     }
 }
-class SetRibbonAction extends BuilderAction {
+export class SetRibbonAction extends BuilderAction {
     static id = "setRibbon";
     static dependencies = ["productsItemOptionPlugin"];
     isApplied({ editingElement, value }) {
@@ -395,7 +395,7 @@ class SetRibbonAction extends BuilderAction {
         return this.dependencies.productsItemOptionPlugin._setRibbon(editingElement, ribbon, !isPreviewing);
     }
 }
-class CreateRibbonAction extends BuilderAction {
+export class CreateRibbonAction extends BuilderAction {
     static id = "createRibbon";
     dependencies = ["productsItemOptionPlugin"]
     apply({ editingElement }) {
@@ -421,7 +421,7 @@ class CreateRibbonAction extends BuilderAction {
         return this.dependencies.productsItemOptionPlugin._setRibbon(editingElement, ribbon);
     }
 }
-class ModifyRibbonAction extends BuilderAction {
+export class ModifyRibbonAction extends BuilderAction {
     static id = "modifyRibbon";
     static dependencies = ["productsItemOptionPlugin"];
     setup() {
@@ -461,7 +461,7 @@ class ModifyRibbonAction extends BuilderAction {
         return this.plugin._setRibbon(editingElement, ribbon, !isPreviewing);
     }
 }
-class DeleteRibbonAction extends BuilderAction {
+export class DeleteRibbonAction extends BuilderAction {
     static id = "deleteRibbon";
     static dependencies = ["productsItemOptionPlugin"];
     async apply({ editingElement }) {

--- a/addons/website_sale/static/src/website_builder/products_list_page_option_plugin.js
+++ b/addons/website_sale/static/src/website_builder/products_list_page_option_plugin.js
@@ -29,7 +29,7 @@ class ProductsListPageOptionPlugin extends Plugin {
     };
 }
 
-class SetPpgAction extends BuilderAction {
+export class SetPpgAction extends BuilderAction {
     static id = "setPpg";
     setup() {
         this.reload = {};
@@ -47,7 +47,7 @@ class SetPpgAction extends BuilderAction {
         return rpc("/shop/config/website", { shop_ppg: ppg });
     }
 }
-class SetPprAction extends BuilderAction {
+export class SetPprAction extends BuilderAction {
     static id = "setPpr";
     setup() {
         this.reload = {};
@@ -60,7 +60,7 @@ class SetPprAction extends BuilderAction {
         return rpc("/shop/config/website", { shop_ppr: ppr });
     }
 }
-class SetGapAction extends BuilderAction {
+export class SetGapAction extends BuilderAction {
     static id = "setGap";
     setup() {
         this.reload = {};
@@ -70,7 +70,7 @@ class SetGapAction extends BuilderAction {
     }
 }
 
-class SetDefaultGapAction extends BuilderAction {
+export class SetDefaultGapAction extends BuilderAction {
     static id = "setDefaultGap";
     setup() {
         this.reload = {};
@@ -81,7 +81,7 @@ class SetDefaultGapAction extends BuilderAction {
     }
 }
 
-class SetDefaultSortAction extends BuilderAction {
+export class SetDefaultSortAction extends BuilderAction {
     static id = "setDefaultSort";
     setup() {
         this.reload = {};


### PR DESCRIPTION
This refactor adds `export` to all classes extending `BuilderAction`, allowing them to be reused or imported from other modules. It improves modularity.

