### PR TITLE
[IMP] tools: improve idref

### DIFF
--- a/addons/mrp/views/mrp_workcenter_views.xml
+++ b/addons/mrp/views/mrp_workcenter_views.xml
@@ -71,7 +71,7 @@
         <record model="ir.actions.act_window" id="mrp_workcenter_productivity_report_oee">
             <field name="name">Overall Equipment Effectiveness</field>
             <field name="res_model">mrp.workcenter.productivity</field>
-            <field name="view_id" eval="oee_pie_view"/>
+            <field name="view_id" ref="oee_pie_view"/>
             <field name="view_mode">graph,pivot,list,form</field>
             <field name="domain">[('workcenter_id','=',active_id)]</field>
             <field name="context">{'search_default_thismonth':True}</field>

--- a/addons/mrp/wizard/mrp_workcenter_block_view.xml
+++ b/addons/mrp/wizard/mrp_workcenter_block_view.xml
@@ -25,7 +25,7 @@
         <field name="res_model">mrp.workcenter.productivity</field>
         <field name="view_mode">form</field>
         <field name="context">{'default_workcenter_id': active_id}</field>
-        <field name="view_id" eval="mrp_workcenter_block_wizard_form"/>
+        <field name="view_id" ref="mrp_workcenter_block_wizard_form"/>
         <field name="target">new</field>
     </record>
 
@@ -33,7 +33,7 @@
         <field name="name">Block Workcenter</field>
         <field name="res_model">mrp.workcenter.productivity</field>
         <field name="view_mode">form</field>
-        <field name="view_id" eval="mrp_workcenter_block_wizard_form"/>
+        <field name="view_id" ref="mrp_workcenter_block_wizard_form"/>
         <field name="target">new</field>
     </record>
 </odoo>


### PR DESCRIPTION
1. The key of ``idref: dict[str, int | Literal[False]]`` was either ``module_name.imd_name`` or ``imd_name`` depending on how ``id`` was defined in the imported xml. This commit enforces the key to ``module_name.imd_name`` to simplify the code and improve the readability.

2. When import xml data, if there is already ``id="imd_name"`` declared before, ``eval`` and ``search`` can directly use the ``imd_name: int | Literal[False]`` as a variable. This feature is
a. tricky since the reference is a str but also used as a variable name
b. not perfect when ``id="module_name.imd_name"``
c. not useful and can be simply replaced with ``ref="imd_name"`` or ``search="[... ref('imd_name').id ..."`` This commit removes the feature.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
