### PR TITLE
[FIX] mail: properly count activities for systray update

### DIFF
--- a/addons/mail/models/mail_activity.py
+++ b/addons/mail/models/mail_activity.py
@@ -292,47 +292,67 @@ class MailActivity(models.Model):
 
         # subscribe (batch by model and user to speedup)
         for model, activity_data in activities._classify_by_model().items():
-            per_user = defaultdict(list)
+            per_user = defaultdict(set)
             for activity in activity_data['activities'].filtered(lambda act: act.user_id):
-                if activity.res_id not in per_user[activity.user_id]:
-                    per_user[activity.user_id].append(activity.res_id)
+                per_user[activity.user_id].add(activity.res_id)
             for user, res_ids in per_user.items():
                 pids = user.partner_id.ids if user.partner_id in readable_user_partners else user.sudo().partner_id.ids
                 self.env[model].browse(res_ids).message_subscribe(partner_ids=pids)
 
         # send notifications about activity creation
-        todo_activities = activities.filtered(lambda act: act.date_deadline <= fields.Date.today())
+        todo_activities = activities.filtered(lambda act: act.active and act.date_deadline <= fields.Date.today())
         if todo_activities:
-            activity.user_id._bus_send("mail.activity/updated", {"activity_created": True})
+            for user, user_activities in todo_activities.grouped('user_id').items():
+                user._bus_send("mail.activity/updated", {"activity_created": True, "count_diff": len(user_activities)})
         return activities
 
     def write(self, values):
-        if values.get('user_id'):
-            user_changes = self.filtered(lambda activity: activity.user_id.id != values.get('user_id'))
-            pre_responsibles = user_changes.user_id
-        res = super(MailActivity, self).write(values)
+        today = fields.Date.today()
 
+        def get_user_todo_activity_count(activities):
+            return {
+                user: len(user_activities.filtered(lambda a: a.active and a.date_deadline <= today))
+                for user, user_activities in activities.grouped('user_id').items()
+            }
+
+        original_user_todo_activity_count = None
+        if 'date_deadline' in values or 'active' in values or 'user_id' in values:
+            original_user_todo_activity_count = get_user_todo_activity_count(self)
+
+        new_user_activities = self.env['mail.activity']
         if values.get('user_id'):
+            new_user_activities = self.filtered(lambda activity: activity.user_id.id != values.get('user_id'))
+
+        res = super().write(values)
+
+        # notify new responsibles
+        if 'user_id' in values:
             if values['user_id'] != self.env.uid:
                 if not self.env.context.get('mail_activity_quick_update', False):
-                    user_changes.action_notify()
-            for activity in user_changes:
-                self.env[activity.res_model].browse(activity.res_id).message_subscribe(partner_ids=[activity.user_id.partner_id.id])
+                    new_user_activities.action_notify()
+            new_user = self.env['res.users'].browse(values['user_id'])
+            for res_model, model_activities in new_user_activities.grouped('res_model').items():
+                res_ids = list(set(model_activities.mapped('res_id')))
+                self.env[res_model].browse(res_ids).message_subscribe(partner_ids=new_user.partner_id.ids)
 
-            # send bus notifications
-            todo_activities = user_changes.filtered(lambda act: act.date_deadline <= fields.Date.today())
-            if todo_activities:
-                todo_activities.user_id._bus_send(
-                    "mail.activity/updated", {"activity_created": True}
-                )
-                pre_responsibles._bus_send("mail.activity/updated", {"activity_deleted": True})
+        # update activity counter
+        if original_user_todo_activity_count is not None:
+            new_user_todo_activity_count = get_user_todo_activity_count(self)
+            for user in new_user_todo_activity_count.keys() | original_user_todo_activity_count.keys():
+                count_diff = new_user_todo_activity_count.get(user, 0) - original_user_todo_activity_count.get(user, 0)
+                if count_diff > 0:
+                    user._bus_send("mail.activity/updated", {"activity_created": True, "count_diff": count_diff})
+                elif count_diff < 0:
+                    user._bus_send("mail.activity/updated", {"activity_deleted": True, "count_diff": count_diff})
+
         return res
 
     def unlink(self):
-        todo_activities = self.filtered(lambda act: act.date_deadline <= fields.Date.today())
+        todo_activities = self.filtered(lambda act: act.active and act.date_deadline <= fields.Date.today())
         if todo_activities:
-            todo_activities.user_id._bus_send("mail.activity/updated", {"activity_deleted": True})
-        return super(MailActivity, self).unlink()
+            for user, user_activities in todo_activities.grouped('user_id').items():
+                user._bus_send("mail.activity/updated", {"activity_deleted": True, "count_diff": -len(user_activities)})
+        return super().unlink()
 
     @api.model
     def _search(self, domain, offset=0, limit=None, order=None):

--- a/addons/mail/static/src/core/web/mail_core_web_service.js
+++ b/addons/mail/static/src/core/web/mail_core_web_service.js
@@ -15,12 +15,18 @@ export class MailCoreWeb {
 
     setup() {
         this.busService.subscribe("mail.activity/updated", (payload, { id: notifId }) => {
-            if (payload.activity_created && notifId > this.store.activity_counter_bus_id) {
-                this.store.activityCounter++;
+            if (notifId <= this.store.activity_counter_bus_id) {
+                return;
             }
-            if (payload.activity_deleted && notifId > this.store.activity_counter_bus_id) {
-                this.store.activityCounter--;
+            let countDiff = 0;
+            if ("count_diff" in payload) {
+                countDiff = payload.count_diff;
+            } else if (payload.activity_created) {
+                countDiff = 1;
+            } else if (payload.activity_deleted) {
+                countDiff = -1;
             }
+            this.store.activityCounter += countDiff;
         });
         this.env.bus.addEventListener("mail.message/delete", ({ detail: { message, notifId } }) => {
             if (message.needaction && notifId > this.store.inbox.counter_bus_id) {

--- a/addons/mail/tests/common.py
+++ b/addons/mail/tests/common.py
@@ -1417,7 +1417,7 @@ class MailCase(MockEmail):
         notif_messages = [n.message for n in bus_notifs]
         for expected in message_items or []:
             for notification in notif_messages:
-                if json_dump(expected) == notification:
+                if json.loads(json_dump(expected)) == json.loads(notification):
                     break
             else:
                 matching_notifs = [m for m in notif_messages if json.loads(m).get("type") == expected.get("type")]

--- a/addons/test_mail/tests/test_mail_activity.py
+++ b/addons/test_mail/tests/test_mail_activity.py
@@ -3,7 +3,6 @@
 
 from datetime import date, datetime, timedelta
 from dateutil.relativedelta import relativedelta
-from freezegun import freeze_time
 from psycopg2 import IntegrityError
 from unittest.mock import patch
 from unittest.mock import DEFAULT
@@ -16,6 +15,7 @@ from odoo.addons.mail.models.mail_activity import MailActivity
 from odoo.addons.mail.tests.common import mail_new_test_user, MailCommon
 from odoo.addons.test_mail.models.test_mail_models import MailTestActivity
 from odoo.tests import Form, HttpCase, users
+from odoo.tests.common import freeze_time
 from odoo.tools import mute_logger
 
 
@@ -822,6 +822,129 @@ class TestActivitySystray(TestActivityCommon, HttpCase):
             if record.get("model") == self.test_record._name
         )
         self.assertEqual(total_count, 1)
+
+
+@tests.tagged('mail_activity')
+@freeze_time("2024-01-01 09:00:00")
+class TestActivitySystrayBusNotify(TestActivityCommon):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.user_employee_2 = cls.user_employee.copy(default={'login': "employee_2"})
+
+        cls.activity_vals = [
+            {
+                'res_model_id': cls.env['ir.model']._get_id(cls.test_record._name),
+                'res_id': cls.test_record.id,
+                'date_deadline': dt,
+                'user_id': cls.user_employee.id,
+            } | extra
+            for dt, extra in zip(
+                (datetime(2023, 12, 31, 15, 0, 0), datetime(2023, 12, 31, 15, 0, 0), datetime(2024, 1, 1, 15, 0, 0), datetime(2024, 1, 2, 15, 0, 0)),
+                ({'active': False}, {}, {}, {}),
+            )
+        ]
+
+    @users('employee')
+    def test_notify_create_unlink_activities(self):
+        """Check creating and unlinking activities notifies of the change in 'to be done' activity count per user."""
+        users = self.env.user + self.user_employee_2
+
+        expected_create_notifs = [
+            ([(self.env.cr.dbname, user.partner_id._name, user.partner_id.id)], [{
+                "type": "mail.activity/updated",
+                "payload": {
+                    "activity_created": True,
+                    "count_diff": 2,
+                },
+            }])
+            for user in users
+        ]
+        expected_unlink_notifs = [
+            ([(self.env.cr.dbname, user.partner_id._name, user.partner_id.id)], [{
+                "type": "mail.activity/updated",
+                "payload": {
+                    "activity_deleted": True,
+                    "count_diff": -2,
+                },
+            }])
+            for user in users
+        ]
+        for (
+            user,
+            (expected_create_notif_channels, expected_create_notif_message_items),
+            (expected_unlink_notif_channels, expected_unlink_notif_message_items),
+        ) in zip(users, expected_create_notifs, expected_unlink_notifs):
+            user_activity_vals = [vals | {'user_id': user.id} for vals in self.activity_vals]
+            with self.assertBus(expected_create_notif_channels, expected_create_notif_message_items):
+                activities = self.env['mail.activity'].create(user_activity_vals)
+            self._reset_bus()
+            with self.assertBus(expected_unlink_notif_channels, expected_unlink_notif_message_items):
+                activities.unlink()
+
+    @users('employee')
+    def test_notify_update_activities(self):
+        write_vals_all = [
+            # added to counter for employee 2, removed from counter for current employee
+            {'user_id': self.user_employee_2.id},
+            {'user_id': self.user_employee_2.id, 'date_deadline': datetime(2023, 12, 31, 15, 0, 0), 'active': True},
+            # just notify
+            {'date_deadline': datetime(2024, 1, 2, 15, 0, 0)},  # everything is in the future -> all removed from counter
+            {'date_deadline': datetime(2023, 12, 31, 15, 0, 0)},  # everything is in the past -> the one from the future is added
+            {'active': False},  # everything is archived -> all removed from counter
+            {'active': True},  # the archived one is unarchived -> added to counter
+            {},  # no "to be done" count change -> no notif
+            [{'date_deadline': datetime(2024, 1, 2, 15, 0, 0), 'active': True}, {}, {}, {}],
+        ]
+
+        expected_notifs = [
+            # transfer 4 activities to the second employee, 2 todos taken and 2 given
+            [
+                ([(self.env.cr.dbname, user.partner_id._name, user.partner_id.id)], [{
+                    "type": "mail.activity/updated",
+                    "payload": {
+                        "count_diff": count_diff,
+                    } | ({"activity_created": True} if count_diff > 0 else {"activity_deleted": True}),
+                }])
+                for user, count_diff
+                in zip(self.user_employee + self.user_employee_2, [-2, 2])
+            ],
+            # transfer 4 activities to the second employee, 2 todos are taken and 4 are given
+            [
+                ([(self.env.cr.dbname, user.partner_id._name, user.partner_id.id)], [{
+                    "type": "mail.activity/updated",
+                    "payload": {
+                        "count_diff": count_diff,
+                    } | ({"activity_created": True} if count_diff > 0 else {"activity_deleted": True}),
+                }])
+                for user, count_diff
+                in zip(self.user_employee + self.user_employee_2, [-2, 4])
+            ],
+        ] + [[
+                ([(self.env.cr.dbname, self.user_employee.partner_id._name, self.user_employee.partner_id.id)], [{
+                    "type": "mail.activity/updated",
+                    "payload": {
+                        "count_diff": count_diff,
+                    } | ({"activity_created": True} if count_diff > 0 else {"activity_deleted": True}),
+                }])
+            ] for count_diff in (-2, 1, -2, 1)
+        ] + [
+            [([], [])],  # no change -> no notif
+            [([], [])],  # no change in "todo" count -> no notif
+        ]
+        for write_vals, expected_notif_vals in zip(write_vals_all, expected_notifs):
+            with self.subTest(vals=write_vals):
+                _past_archived, _past_active, _today, _tomorrow = activities = self.env['mail.activity'].create(self.activity_vals)
+                self._reset_bus()
+                if isinstance(write_vals, list):
+                    for activity, vals in zip(activities, write_vals):
+                        activity.write(vals)
+                else:
+                    activities.write(write_vals)
+                for (notif_channels, notif_messages) in expected_notif_vals:
+                    self.assertBusNotifications(notif_channels, notif_messages)
+                activities.unlink()
 
 
 @tests.tagged('mail_activity')


### PR DESCRIPTION
Currently the systray counter is only updated at:
- create
- unlink
- write, but only if the user changes

We want to detect changes such as activities being archived or due dates being updated to properly reflect the changes as the user applies them.

We now do a separate check for activity count per user before and after a write call that modifies these fields.

Additionally since we now have a count we provide that as part of the bus notification so that it can be updated accurately when modifying/creation/deleting activities in batch.

Common activity test utils are updated to avoid false negatives.

task-4862215
