### PR TITLE
[16.0] [FIX] core: fix record missing when install or update module on upgraded db when call model _flush 

### DIFF
--- a/odoo/models.py
+++ b/odoo/models.py
@@ -5756,7 +5756,7 @@ class BaseModel(metaclass=MetaModel):
                         vals = {
                             f.name: convert(record, f, dirty_field_cache[f][id_])
                             for f, ids in dirty_field_ids.items()
-                            if id_ in ids
+                            if id_ in ids and f in dirty_field_cache and id_ in dirty_field_cache[f]
                         }
                         vals_ids[frozendict(vals)].append(id_)
                 except KeyError:


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
On module install / upgrade on migrated db some records are marked as dirty but the value is not present in cache and this give an Assertion error about missing data for that record 

Current behavior before PR:
Odoo crash with assertion error because the data is not present
 
Desired behavior after PR is merged:
Odoo not crash and allow to install / upgrade module in migrated db

Solve the isssue #215882 

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
