### PR TITLE
[FIX] *: fix linkage between so and alternative rfqs in mtso

### DIFF
--- a/addons/purchase_requisition/wizard/purchase_requisition_create_alternative.py
+++ b/addons/purchase_requisition/wizard/purchase_requisition_create_alternative.py
@@ -96,6 +96,5 @@ class PurchaseRequisitionCreateAlternative(models.TransientModel):
             'product_uom_id': order_line.product_uom_id.id,
             'display_type': order_line.display_type,
             'analytic_distribution': order_line.analytic_distribution,
-            'group_id': order_line.group_id.id,
             **({'name': order_line.name} if order_line.display_type in ('line_section', 'line_note') or not has_product_description else {}),
         }

--- a/addons/purchase_requisition_stock/wizard/purchase_requisition_create_alternative.py
+++ b/addons/purchase_requisition_stock/wizard/purchase_requisition_create_alternative.py
@@ -21,5 +21,7 @@ class PurchaseRequisitionCreateAlternative(models.TransientModel):
         res_line = super()._get_alternative_line_value(order_line, product_tmpl_ids_with_description)
         if order_line.move_dest_ids:
             res_line['move_dest_ids'] = [Command.set(order_line.move_dest_ids.ids)]
+        if order_line.group_id:
+            res_line['group_id'] = order_line.group_id.id
 
         return res_line


### PR DESCRIPTION
*: purchase_requisition, purchase_requisition_stock

This commit fixes a single app test error because of this PR: https://github.com/odoo/odoo/pull/210812

The PR keeps the linkage between the alternative RFQs and SO when the product is in MTSO route.
