### PR TITLE
[FIX] purchase_requisition : Error when creating an RFQ alternative without the stock module 

### DIFF
--- a/addons/purchase_requisition/wizard/purchase_requisition_create_alternative.py
+++ b/addons/purchase_requisition/wizard/purchase_requisition_create_alternative.py
@@ -96,6 +96,5 @@ class PurchaseRequisitionCreateAlternative(models.TransientModel):
             'product_uom_id': order_line.product_uom_id.id,
             'display_type': order_line.display_type,
             'analytic_distribution': order_line.analytic_distribution,
-            'group_id': order_line.group_id.id,
             **({'name': order_line.name} if order_line.display_type in ('line_section', 'line_note') or not has_product_description else {}),
         }

--- a/addons/purchase_requisition_stock/wizard/purchase_requisition_create_alternative.py
+++ b/addons/purchase_requisition_stock/wizard/purchase_requisition_create_alternative.py
@@ -19,6 +19,7 @@ class PurchaseRequisitionCreateAlternative(models.TransientModel):
     @api.model
     def _get_alternative_line_value(self, order_line, product_tmpl_ids_with_description):
         res_line = super()._get_alternative_line_value(order_line, product_tmpl_ids_with_description)
+        res_line['group_id'] = order_line.group_id.id
         if order_line.move_dest_ids:
             res_line['move_dest_ids'] = [Command.set(order_line.move_dest_ids.ids)]
 


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

When Creating an RFQ alternative and ticking **copy products** there is a traceback if the stock module is not installed.
This PR moves a previous one line PR from the module purchase_requisiton to the modules purchase_requistion_stock to prevent the traceback

Current behavior before PR:

Traceback when Creating an RFQ alternative and ticking **copy products**

Desired behavior after PR is merged:

No Traceback when Creating an RFQ alternative and ticking **copy products**

Privous PR: https://github.com/odoo/odoo/pull/210812
Recording: https://drive.google.com/file/d/13jU1sD3KxjF9qqi4wtdX9nAjd0DhX0jb/view?usp=sharing
Task: [4898505](https://www.odoo.com/odoo/project/966/tasks/4898505)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
