### PR TITLE
[FIX] stock: fix IoT reception report printing

### DIFF
--- a/addons/stock/static/src/components/reception_report_line/stock_reception_report_line.js
+++ b/addons/stock/static/src/components/reception_report_line/stock_reception_report_line.js
@@ -26,15 +26,13 @@ export class ReceptionReportLine extends Component {
         if (!this.data.move_out_id) {
             return;
         }
-        const reportFile = 'stock.report_reception_report_label';
         const modelIds = [this.data.move_out_id];
         const productQtys = [Math.ceil(this.data.quantity) || '1'];
 
         return this.actionService.doAction({
-            type: "ir.actions.report",
-            report_type: "qweb-pdf",
-            report_name: `${reportFile}?docids=${modelIds}&quantity=${productQtys}`,
-            report_file: reportFile,
+            ...this.props.labelReport,
+            context: { active_ids: modelIds },
+            data: { docids: modelIds, quantity: productQtys.join(",") },
         });
     }
 
@@ -68,6 +66,7 @@ export class ReceptionReportLine extends Component {
 ReceptionReportLine.template = "stock.ReceptionReportLine";
 ReceptionReportLine.props = {
     data: Object,
+    labelReport: Object,
     parentIndex: String,
     showUom: Boolean,
     precision: Number,

--- a/addons/stock/static/src/components/reception_report_main/stock_reception_report_main.xml
+++ b/addons/stock/static/src/components/reception_report_main/stock_reception_report_main.xml
@@ -35,6 +35,7 @@
                         scheduledDate="data.sources_to_formatted_scheduled_date[source]"
                         lines="state.sourcesToLines[source]"
                         source="data.sources_info[source]"
+                        labelReport="receptionReportLabelAction"
                         showUom="data.show_uom"
                         precision="data.precision"/>
                 </table>

--- a/addons/stock/static/src/components/reception_report_table/stock_reception_report_table.js
+++ b/addons/stock/static/src/components/reception_report_table/stock_reception_report_table.js
@@ -42,7 +42,6 @@ export class ReceptionReportTable extends Component {
     }
 
     async onClickPrintLabels() {
-        const reportFile = 'stock.report_reception_report_label';
         const modelIds = [];
         const quantities = [];
         for (const line of this.props.lines) {
@@ -55,10 +54,9 @@ export class ReceptionReportTable extends Component {
         }
 
         return this.actionService.doAction({
-            type: "ir.actions.report",
-            report_type: "qweb-pdf",
-            report_name: `${reportFile}?docids=${modelIds}&quantity=${quantities}`,
-            report_file: reportFile,
+            ...this.props.labelReport,
+            context: { active_ids: modelIds },
+            data: { docids: modelIds, quantity: quantities.join(",") },
         });
     }
 
@@ -90,6 +88,7 @@ ReceptionReportTable.props = {
     scheduledDate: { type: String, optional: true },
     lines: Array,
     source: Array,
+    labelReport: Object,
     showUom: Boolean,
     precision: Number,
 };

--- a/addons/stock/static/src/components/reception_report_table/stock_reception_report_table.xml
+++ b/addons/stock/static/src/components/reception_report_table/stock_reception_report_table.xml
@@ -32,6 +32,7 @@
             <t t-foreach="props.lines" t-as="line" t-key="line.index">
                 <ReceptionReportLine
                     data="line"
+                    labelReport="props.labelReport"
                     parentIndex="props.index"
                     showUom="props.showUom"
                     precision="props.precision"/>


### PR DESCRIPTION
Steps to reproduce:
1. Connect IoT Box and any printer that accepts PDF
2. Turn on Reception Report option on Inventory Settings
3. Set configuration of Receipts to print out Reception Report and Label
4. Assign Reception Report and label to the printer
5. Create a PO and run through the Reception process (PO > Reception of Delivery)
6. Print the Reception Report under "Allocations"

-> Result: Reception Report and label is downloaded as a PDF instead of
   being sent to the printer.

The reason for this bug is that the report models were being constructed directly in the frontend, rather than being fetched from the backend. This didn't work with IoT printing because its override used to assign devices to reports is on the backend `ir.actions.report` model.

The fix is to fetch the report from the backend when the component is loaded. This report is then passed down to the child components as well.

opw-4790299

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
