### PR TITLE
[FIX] highlight_utils: correct SVG positioning by adjusting span offsets

### DIFF
--- a/addons/website/static/src/js/highlight_utils.js
+++ b/addons/website/static/src/js/highlight_utils.js
@@ -266,9 +266,10 @@ export function makeHighlightSvgs(highlightEl, highlightID) {
             numberOfCharPerWidth,
         });
         svgs.push(svg);
-        const spanOffset = firstRect.x - containerRect.x;
-        svg.style.left = `${(rects.x - containerRect.x - spanOffset) * scale}px`;
-        svg.style.top = `${(rects.y - containerRect.y) * scale}px`;
+        const spanOffsetX = firstRect.x - containerRect.x;
+        const spanOffsetY = firstRect.y - containerRect.y;
+        svg.style.left = `${(rects.x - containerRect.x - spanOffsetX) * scale}px`;
+        svg.style.top = `${(rects.y - containerRect.y - spanOffsetY) * scale}px`;
         svg.style.bottom = `0px`;
         svg.style.right = `0px`;
     }


### PR DESCRIPTION
Steps to reproduce:
- Go to the website builder in edit mode
- Select "We build great products ... to optimize their performance", the goal here is to have a `<br>` in the selection
- Highlight the selection

| Expected behaviour | Current behaviour |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/614d0542-7025-42b0-8d8e-e049f8fd5699) | ![image](https://github.com/user-attachments/assets/4934f580-8e44-4945-b3f8-312fff095f2f) |
| Highlights are well positioned | The highlights SVGs are not well positioned, the br shift everything | 

