### PR TITLE
[IMP] website_payment: new supported payment methods snippet (static)

### DIFF
--- a/addons/website/views/snippets/snippets.xml
+++ b/addons/website/views/snippets/snippets.xml
@@ -489,6 +489,7 @@
                 <t id="snippet_donation_button_hook"/>
                 <t id="snippet_add_to_cart_hook"/>
                 <t id="snippet_rental_search_hook"/>
+                <t id="snippet_supported_payment_methods"/>
             </snippets>
         </t>
     </xpath>

--- a/addons/website_payment/__manifest__.py
+++ b/addons/website_payment/__manifest__.py
@@ -20,6 +20,7 @@ This is a bridge module that adds multi-website support for payment providers.
         'views/res_config_settings_views.xml',
         'views/snippets/snippets.xml',
         'views/snippets/s_donation.xml',
+        'views/snippets/s_supported_payment_methods.xml',
     ],
     'auto_install': True,
     'assets': {

--- a/addons/website_payment/static/src/snippets/s_supported_payment_methods/000.edit.xml
+++ b/addons/website_payment/static/src/snippets/s_supported_payment_methods/000.edit.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+    <t t-name="website_payment.s_supported_payment_methods.view_providers">
+        <div class="alert alert-warning container my-0 px-3 border-2 border-warning">
+            <div class="row gx-1 text-warning">
+                <span class="col-auto me-auto">No published payment methods</span>
+                <a href="/odoo/action-payment.action_payment_provider" class="btn-view_providers col-auto link-warning">
+                    <strong><i class="oi oi-arrow-right"/> View providers</strong>
+                </a>
+            </div>
+        </div>
+    </t>
+</templates>

--- a/addons/website_payment/static/src/snippets/s_supported_payment_methods/000.xml
+++ b/addons/website_payment/static/src/snippets/s_supported_payment_methods/000.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+    <t t-name="website_payment.s_supported_payment_methods.icons">
+        <!-- The `image` field on the payment method has a max height of 64px -->
+        <t t-set="height" t-value="Math.min(height, 64)"/>
+        <!-- The `min-height` ensures that in the event that no payment methods are given, then the
+        element stays selectable. -->
+        <div class="d-flex flex-wrap gap-1" t-attf-style="min-height: #{height}px">
+            <t t-foreach="payment_methods" t-as="pm" t-key="pm.id">
+                <t t-set="img_src" t-valuef="/web/image/payment.method/#{pm.id}/image"/>
+                <img class="o_editable_media img img-fluid rounded"
+                     t-att-alt="pm.name"
+                     t-att-title="pm.name"
+                     t-att-src="img_src"
+                     t-attf-style="height: #{height}px;"
+                     t-att-data-original-src="img_src"
+                     loading="lazy"
+                />
+            </t>
+        </div>
+    </t>
+</templates>

--- a/addons/website_payment/static/src/snippets/s_supported_payment_methods/supported_payment_methods.edit.js
+++ b/addons/website_payment/static/src/snippets/s_supported_payment_methods/supported_payment_methods.edit.js
@@ -1,0 +1,39 @@
+import { browser } from "@web/core/browser/browser";
+import { registry } from "@web/core/registry";
+import { Interaction } from "@web/public/interaction";
+
+
+class SupportedPaymentMethodsEdit extends Interaction {
+    static selector = ".s_supported_payment_methods[data-empty=true]";
+    dynamicContent = {
+        // Bypass the ctrl-click required to open a link in edit mode
+        ".btn-view_providers": { "t-on-click": this.onClickViewPorviders.bind(this) },
+    };
+
+    start() {
+        this.render();
+    }
+
+    /**
+     * Displays a message when no payment methods could be found (will not be saved by the editor).
+     */
+    render() {
+        this.el.replaceChildren();
+        this.renderAt(
+            "website_payment.s_supported_payment_methods.view_providers",
+            {},
+            this.el,
+            // removeOnClean = true,  // by default
+        );
+    }
+
+    async onClickViewPorviders(ev) {
+        // Opens the view in a seperate tab such that any edit are kept
+        browser.open("/odoo/action-payment.action_payment_provider");
+    }
+};
+
+
+registry
+    .category("public.interactions.edit")
+    .add("website.supported_payment_methods", { Interaction: SupportedPaymentMethodsEdit });

--- a/addons/website_payment/static/src/website_builder/supported_payment_methods_option.js
+++ b/addons/website_payment/static/src/website_builder/supported_payment_methods_option.js
@@ -1,0 +1,20 @@
+import { BaseOptionComponent } from "@html_builder/core/utils";
+import { useState } from "@odoo/owl";
+import { useBus } from "@web/core/utils/hooks";
+
+export class SupportedPaymentMethodsOption extends BaseOptionComponent {
+    static template = "website_payment.SupportedPaymentMethodsOption";
+    static props = {
+        getMaxLimit: Function,
+    };
+
+    setup() {
+        super.setup();
+        this.state = useState({ maxLimit: Infinity });
+        useBus(this.env.editorBus, "DOM_UPDATED", this.updateState.bind(this));
+    }
+
+    async updateState() {
+        this.state.maxLimit = await this.props.getMaxLimit();
+    }
+}

--- a/addons/website_payment/static/src/website_builder/supported_payment_methods_option.xml
+++ b/addons/website_payment/static/src/website_builder/supported_payment_methods_option.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+    <t t-name="website_payment.SupportedPaymentMethodsOption">
+        <BuilderRow label.translate="Limit">
+            <BuilderNumberInput min="1" max="state.maxLimit" step="1"
+                                unit="'icons'" applyWithUnit="false"
+                                action="'supportedPaymentMethodsLimit'"
+            />
+        </BuilderRow>
+        <BuilderRow label.translate="Height">
+            <!-- The `image` field on payment methods is max 64px tall. -->
+            <BuilderRange min="16" max="64" step="1"
+                          displayRangeValue="true" unit="'px'"
+                          action="'supportedPaymentMethodsHeight'"
+            />
+        </BuilderRow>
+    </t>
+</templates>

--- a/addons/website_payment/static/src/website_builder/supported_payment_methods_option_plugin.js
+++ b/addons/website_payment/static/src/website_builder/supported_payment_methods_option_plugin.js
@@ -1,0 +1,154 @@
+import { SupportedPaymentMethodsOption } from "./supported_payment_methods_option";
+import { BuilderAction } from "@html_builder/core/builder_action";
+import { SNIPPET_SPECIFIC } from "@html_builder/utils/option_sequence";
+import { Plugin } from "@html_editor/plugin";
+import { withSequence } from "@html_editor/utils/resource";
+import { _t } from "@web/core/l10n/translation";
+import { rpc } from "@web/core/network/rpc";
+import { registry } from "@web/core/registry";
+import { renderToElement } from "@web/core/utils/render";
+
+
+class SupportedPaymentMethodsOptionPlugin extends Plugin {
+    static id = "supportedPaymentMethodsOption";
+    static shared = ["renderSnippetOn"];
+
+    resources = {
+        so_content_addition_selector: [".s_supported_payment_methods"],
+        builder_options: [
+            withSequence(SNIPPET_SPECIFIC, {
+                OptionComponent: SupportedPaymentMethodsOption,
+                props: { getMaxLimit: this.getMaxLimit.bind(this) },
+                selector: ".s_supported_payment_methods",
+            }),
+        ],
+        builder_actions: {
+            SupportedPaymentMethodsLimit,
+            SupportedPaymentMethodsHeight,
+        },
+        on_snippet_dragged_handlers: ({ snippetEl }) => this.renderSnippetOn(snippetEl),
+        get_options_container_top_buttons: withSequence(
+            0,
+            editingElement => this.getOptionButtons(editingElement),
+        ),
+        get_overlay_buttons: withSequence(0, {
+            getButtons: editingElement => this.getOptionButtons(editingElement),
+        }),
+    };
+
+    setup() {
+        this.getOptionButtons = this.selectSnippetEl(this.getOptionButtons.bind(this), []);
+        this.renderSnippetOn = this.selectSnippetEl(this.renderSnippetOn.bind(this));
+    }
+
+    /**
+     * Applies `fn` only to `s_supported_payment_methods` elements.
+     */
+    selectSnippetEl(fn, defaultVal) {
+        return (editingElement, ...args) => {
+            if (editingElement?.dataset?.snippet !== "s_supported_payment_methods") {
+                return defaultVal;
+            }
+            return fn(editingElement, ...args);
+        }
+    }
+
+    /**
+     * Add a reload button at the top in case the user made some changes to the supported payment
+     * methods list.
+     */
+    getOptionButtons(editingElement) {
+        return [{
+            class: "fa fa-fw fa-rotate-right btn btn-outline-info",
+            title: _t("Refresh the payment methods."),
+            handler: this.renderSnippetOn.bind(this, editingElement, true),
+        }];
+    }
+
+    async getPaymentMethods(limit, force = false) {
+        if (force) {
+            this.payment_methods = undefined;
+        }
+
+        if (this.payment_methods === undefined) {
+            this.payment_methods = await rpc(
+                "/website_payment/snippet/supported_payment_methods",
+            ).catch(() => []);
+        }
+        return this.payment_methods.slice(0, limit);
+    }
+
+    async renderSnippetOn(editingElement, force = false) {
+        const limit = getLimit(editingElement);
+        const payment_methods = await this.getPaymentMethods(limit, force);
+        if (payment_methods.length) {
+            delete editingElement.dataset.empty;
+            editingElement.dataset.limit = Math.min(limit, await this.getMaxLimit());
+            editingElement.replaceChildren(renderToElement(
+                "website_payment.s_supported_payment_methods.icons",
+                { payment_methods, height: getHeight(editingElement) },
+            ));
+        } else {
+            // Triggers an interaction that renders a warning message instead in the snippet (the
+            // warning message will be clean by the interaction and is thus not saved by the editor)
+            editingElement.dataset.empty = true;
+        }
+    }
+
+    async getMaxLimit() {
+        return await this.getPaymentMethods().then(pms => pms.length)
+    }
+}
+
+
+class SupportedPaymentMethodsLimit extends BuilderAction {
+    static id = "supportedPaymentMethodsLimit";
+    static dependencies = ["supportedPaymentMethodsOption"];
+
+    getValue({ editingElement }) {
+        if (editingElement.dataset.empty) {
+            return 0; // This is only visual, the actual limit should always be positive
+        }
+        return getLimit(editingElement);
+    }
+
+    async apply({ editingElement, value: limit }) {
+        // Should always be positive otherwise the snippet element could end up empty which would
+        // make it impossbile to select it anymore.
+        if (limit <= 0) {
+            return;
+        }
+        editingElement.dataset.limit = limit;
+        await this.dependencies.supportedPaymentMethodsOption.renderSnippetOn(editingElement);
+    }
+}
+
+
+class SupportedPaymentMethodsHeight extends BuilderAction {
+    static id = "supportedPaymentMethodsHeight";
+    static dependencies = ["supportedPaymentMethodsOption"];
+
+    getValue({ editingElement }) {
+        return editingElement.dataset.height; // The `BuilderRange` component expects a raw string
+    }
+
+    async apply({ editingElement, value: height }) {
+        editingElement.dataset.height = height;
+        await this.dependencies.supportedPaymentMethodsOption.renderSnippetOn(editingElement);
+    }
+}
+
+
+function getLimit(editingElement) {
+    return parseInt(editingElement.dataset.limit) || 6;
+}
+
+
+function getHeight(editingElement) {
+    return parseInt(editingElement.dataset.height) || 30;
+}
+
+
+registry
+    .category("website-plugins")
+    .add(SupportedPaymentMethodsOptionPlugin.id, SupportedPaymentMethodsOptionPlugin);

--- a/addons/website_payment/views/snippets/s_supported_payment_methods.xml
+++ b/addons/website_payment/views/snippets/s_supported_payment_methods.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <template id="s_supported_payment_methods" name="Supported Payment Methods">
+        <div class="s_supported_payment_methods o_not_editable" data-limit="6" data-height="30px"/>
+    </template>
+
+    <record id="website_payment.s_supported_payment_methods_OOO_xml" model="ir.asset">
+        <field name="name">Supported Payment Methods 000 XML</field>
+        <field name="bundle">web.assets_web</field>
+        <field name="path">/website_payment/static/src/snippets/s_supported_payment_methods/000.xml</field>
+    </record>
+
+    <record id="website_payment.s_supported_payment_methods_OOO_edit_xml" model="ir.asset">
+        <field name="name">Supported Payment Methods 000 XML (edit)</field>
+        <field name="bundle">website.assets_edit_frontend</field>
+        <field name="path">/website_payment/static/src/snippets/s_supported_payment_methods/000.edit.xml</field>
+    </record>
+</odoo>

--- a/addons/website_payment/views/snippets/snippets.xml
+++ b/addons/website_payment/views/snippets/snippets.xml
@@ -12,6 +12,9 @@
     <xpath expr="//t[@id='snippet_donation_button_hook']" position="replace">
         <t t-snippet="website_payment.s_donation_button" string="Donation Button" t-thumbnail="/website/static/src/img/snippets_thumbs/s_donation_button.svg" t-forbid-sanitize="form"/>
     </xpath>
+    <xpath expr="//t[@id='snippet_supported_payment_methods']" position="replace">
+        <t t-snippet="website_payment.s_supported_payment_methods" string="Supported Payment Methods" t-thumbnail="/payment/static/img/payment-methods.svg"/>
+     </xpath>
 </template>
 
 </odoo>


### PR DESCRIPTION
Many eCommerce websites display the available payment methods at checkout. This practice enhances conversion rates and informs customers promptly that their preferred payment method is supported.

This commit introduces a new “Supported Payment Methods” snippet to the Odoo building blocks. This snippet dynamically displays the supported payment methods published on the website to potential customers.

To customize the snippet, two parameters are available:
- Limit: This parameter limits the number of brands displayed in the snippet.
- Height: This parameter controls the height of each image.

When no payment method is published, a subtle warning message is displayed (only in editor mode) with a link to quickly configure the payment providers.

task-2889752





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
