### PR TITLE
[FIX] point_of_sale: correctly use attribute line model

### DIFF
--- a/addons/point_of_sale/models/product_template.py
+++ b/addons/point_of_sale/models/product_template.py
@@ -83,12 +83,20 @@ class ProductTemplate(models.Model):
         )
 
         # product.template.attribute.value & product.template.attribute.line loading
-        product_tmpl_attr_value = products.product_template_attribute_value_ids
-        product_tmpl_attr_line = products.product_template_variant_value_ids
+        product_tmpl_attr_line = product_tmpls.attribute_line_ids
+        product_tmpl_attr_value = product_tmpls.attribute_line_ids.product_template_value_ids
         product_tmpl_attr_value_fields = product_tmpl_attr_value._load_pos_data_fields(config.id)
         product_tmpl_attr_line_fields = product_tmpl_attr_line._load_pos_data_fields(config.id)
         product_tmpl_attr_value_read = product_tmpl_attr_value.read(product_tmpl_attr_value_fields, load=False)
         product_tmpl_attr_line_read = product_tmpl_attr_line.read(product_tmpl_attr_line_fields, load=False)
+
+        # product.template.attribute.exclusion loading
+        product_tmpl_excl = self.env['product.template.attribute.exclusion']
+        product_tmpl_exclusion = product_tmpl_attr_value.exclude_for + product_tmpl_excl.search([
+            ('product_tmpl_id', 'in', product_tmpls.ids),
+        ])
+        product_tmpl_exclusion_fields = product_tmpl_exclusion._load_pos_data_fields(config.id)
+        product_tmpl_exclusion_read = product_tmpl_exclusion.read(product_tmpl_exclusion_fields, load=False)
 
         # product.product loading
         product_fields = products._load_pos_data_fields(config.id)
@@ -128,6 +136,7 @@ class ProductTemplate(models.Model):
             'product.combo.item': combo_item_read,
             'product.template.attribute.value': product_tmpl_attr_value_read,
             'product.template.attribute.line': product_tmpl_attr_line_read,
+            'product.template.attribute.exclusion': product_tmpl_exclusion_read,
         }
 
     @api.model

--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -563,7 +563,7 @@ export class PosStore extends WithLazyGetterTrap {
             offset,
             limit,
         ]);
-        this.computeProductAttributesExclusion();
+        this.productAttributesExclusion = this.computeProductAttributesExclusion();
         return result;
     }
 

--- a/addons/point_of_sale/static/tests/pos/tours/pricelist_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/pricelist_tour.js
@@ -1,3 +1,5 @@
+/* global posmodel */
+
 import { registry } from "@web/core/registry";
 import * as ProductScreen from "@point_of_sale/../tests/pos/tours/utils/product_screen_util";
 import * as Numpad from "@point_of_sale/../tests/generic_helpers/numpad_util";
@@ -6,6 +8,7 @@ import * as Dialog from "@point_of_sale/../tests/generic_helpers/dialog_util";
 import * as Pricelist from "@point_of_sale/../tests/pos/tours/utils/pricelist_util";
 import * as Chrome from "@point_of_sale/../tests/pos/tours/utils/chrome_util";
 import * as OfflineUtil from "@point_of_sale/../tests/generic_helpers/offline_util";
+import * as ProductConfigurator from "@point_of_sale/../tests/pos/tours/utils/product_configurator_util";
 import { scan_barcode } from "@point_of_sale/../tests/generic_helpers/utils";
 
 registry.category("web_tour.tours").add("pos_pricelist", {
@@ -120,5 +123,25 @@ registry.category("web_tour.tours").add("test_pricelists_in_pos", {
             ProductScreen.selectedOrderlineHas("Kiwi", "1", "5.0", "MEDIUM"),
             scan_barcode("kiwi_2"),
             ProductScreen.selectedOrderlineHas("Kiwi", "1", "5.0", "SMALL"),
+
+            // Test if post-loaded product with attribute open the configrator
+            scan_barcode("cherry_3"),
+            Chrome.waitRequest(),
+            {
+                content: "Click hided product with attribute",
+                trigger: "body",
+                run: () => {
+                    const productTemplate = posmodel.models["product.template"].find(
+                        (p) => p.name === "Cherry"
+                    );
+
+                    posmodel.addLineToCurrentOrder({
+                        product_tmpl_id: productTemplate,
+                    });
+                },
+            },
+            ProductConfigurator.pickRadio("BIG"),
+            ProductConfigurator.isUnavailable("RED"),
+            Dialog.confirm(),
         ].flat(),
 });

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -2295,6 +2295,37 @@ class TestUi(TestPointOfSaleHttpCommon):
         load_product_from_pos_stats = {'count': 0, 'items': {}}
         product_template = self.env.registry.models['product.template']
 
+        # Test product exclusion
+        cherry = generate_product_template_with_attributes('cherry', 2.00)
+        color_attribute = self.env['product.attribute'].create({
+            'name': 'Color',
+            'sequence': 5,
+            'value_ids': [(0, 0, {
+                'name': 'RED',
+                'sequence': 1,
+            }), (0, 0, {
+                'name': 'GREEN',
+                'sequence': 2,
+            }), (0, 0, {
+                'name': 'BLUE',
+                'sequence': 3,
+            })],
+        })
+        cherry.attribute_line_ids = [(0, 0, {
+            'attribute_id': color_attribute.id,
+            'value_ids': [(6, 0, color_attribute.value_ids.ids)]
+        })]
+        color_attribute = cherry.attribute_line_ids.filtered(lambda l: l.attribute_id.name == 'Color')
+        first_color_value = color_attribute.product_template_value_ids.filtered(lambda v: v.attribute_id.name == 'Color' and v.name == 'RED')
+        first_size_value = cherry.product_variant_ids.product_template_attribute_value_ids.filtered(lambda v: v.attribute_id.name == 'Size' and v.name == 'BIG')
+        first_color_value.exclude_for = [(0, 0, {
+            'product_tmpl_id': cherry.id,
+            'value_ids': first_size_value.ids,
+            'product_template_attribute_value_id': first_size_value.id
+        })]
+        for index, variant in enumerate(cherry.product_variant_ids):
+            variant.write({'barcode': f'cherry_{index}'})
+
         @api.model
         def load_product_from_pos_patch(self, config_id, domain, offset=0, limit=0):
             load_product_from_pos_stats['count'] += 1
@@ -2307,7 +2338,7 @@ class TestUi(TestPointOfSaleHttpCommon):
             self.start_pos_tour('test_pricelists_in_pos')
 
         # Should load 6 different products, since 6 products were created
-        self.assertEqual(load_product_from_pos_stats['count'], 6)
+        self.assertEqual(load_product_from_pos_stats['count'], 7)
 
         # Length of loaded pricelist items should correspond to the number of items linked
         # to the product template or product variant


### PR DESCRIPTION
Prior to this commit, we were loading the wrong relationships for
`product.template.attribute.line`, which caused bad behavior when
clicking on a product with variants.

Without this relationship, PoS is no longer able to check whether the
product is configurable or not.

This commit solves this problem by replacing the erroneous data with
`attribute_line_ids` from the product template.