### PR TITLE
[FIX] l10n_ar: Default CoA installation

### DIFF
--- a/addons/l10n_ar/models/template_ar_base.py
+++ b/addons/l10n_ar/models/template_ar_base.py
@@ -15,6 +15,7 @@ class AccountChartTemplate(models.AbstractModel):
             'property_account_income_categ_id': 'base_venta_de_mercaderia',
             'name': _('Generic Chart of Accounts Argentina Single Taxpayer / Basis'),
             'code_digits': '12',
+            'sequence': 1,
         }
 
     @template('ar_base', 'res.company')

--- a/addons/l10n_ar/models/template_ar_ex.py
+++ b/addons/l10n_ar/models/template_ar_ex.py
@@ -12,6 +12,7 @@ class AccountChartTemplate(models.AbstractModel):
             'name': _('Argentine Generic Chart of Accounts for Exempt Individuals'),
             'parent': 'ar_base',
             'code_digits': '12',
+            'sequence': 2,
         }
 
     @template('ar_ex', 'res.company')

--- a/addons/l10n_ar/models/template_ar_ri.py
+++ b/addons/l10n_ar/models/template_ar_ri.py
@@ -12,6 +12,7 @@ class AccountChartTemplate(models.AbstractModel):
             'name': _('Argentine Generic Chart of Accounts for Registered Accountants'),
             'parent': 'ar_ex',
             'code_digits': '12',
+            'sequence': 0,
         }
 
     @template('ar_ri', 'res.company')


### PR DESCRIPTION
### Description of the issue/feature this PR addresses:

Odoo will try to auto install a Coa when creating a database or creating a new company where country is defined

The problem is that in Argentina we have different CoA depending on the AFIP Responsibility, and the one that is currently installed by default is the 'ar_base' (Responsable Monotributista): the less used one.

In this case we prefer to do not install any CoA and let the user to install it manually (as it was working in older versions, but it is not possible). For that reason we made this change force to install 'ar_ri' (Responsable Inscripto) CoA by default instead

### Current behavior before PR:

1. Create a new company with country AR
2. Will automatically install the "Responsable Monotributista" Coa

### Desired behavior after PR is merged:

Now will install the "Responsable Inscripto" Coa



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
