### PR TITLE
[FIX] core: cron progress remaining=1 should be partially done

### DIFF
--- a/odoo/addons/base/models/ir_cron.py
+++ b/odoo/addons/base/models/ir_cron.py
@@ -465,13 +465,13 @@ class IrCron(models.Model):
                         status = CompletionStatus.FAILED
                 else:
                     if not progress.remaining:
-                        status = CompletionStatus.FULLY_DONE
-                    elif not progress.done:
                         # assume the server action doesn't use the progress API
                         # and that there is nothing left to process
                         status = CompletionStatus.FULLY_DONE
                     else:
                         status = CompletionStatus.PARTIALLY_DONE
+                        if not progress.done:
+                            break
 
                     if status == CompletionStatus.FULLY_DONE and progress.deactivate:
                         job['active'] = False


### PR DESCRIPTION
Have a cron action written like the following:

    def cron_complex(...):
        # prepare
        items_to_do = collections.deque(...)
        while self._commit_progress(remaining=len(items_to_do)):
            item_to_do = items_to_do.pop()
            try:
                process(item_to_do)
                self._commit_progress(1)
            except:
                pass

This case is similar to what ir.autovacuum is doing: it doesn't always
mark an item done, but instead decrease the remaining counter.

The problem with this code is the `while` conditional.

The first call to `_commit_progress` is gonna be `done=0`. In case the
function `return 0` (no remaining time) then the `while` is gonna break
and the function will return immediately. The ir.cron would then be in
the condition `not progress.done` which for this case should be
understood as PARTIALLY DONE (there are remaining items to process) but
instead is understood as FULLY DONE.

This scenario is the direct consequence of commit https://github.com/odoo-dev/odoo/commit/f135c06cfde62256348f5e0791a49fa019d1f15c: always run
at least 10 seconds AND at least 10 times. The action runs for 10
seconds the first time, but is called a second time in which it returns
immediately, with progress done=0, remaining>0.