### PR TITLE
[FIX] purchase: avoid traceback when merging POs with note or section

### DIFF
--- a/addons/purchase/models/purchase_order.py
+++ b/addons/purchase/models/purchase_order.py
@@ -744,7 +744,8 @@ class PurchaseOrder(models.Model):
                 # Merge RFQs into the oldest purchase order
                 rfqs -= oldest_rfq
                 for rfq_line in rfqs.order_line:
-                    existing_line = oldest_rfq.order_line.filtered(lambda l: l.product_id == rfq_line.product_id and
+                    existing_line = oldest_rfq.order_line.filtered(lambda l: l.display_type not in ['line_note', 'line_section'] and
+                                                                                l.product_id == rfq_line.product_id and
                                                                                 l.product_uom == rfq_line.product_uom and
                                                                                 l.product_packaging_id == rfq_line.product_packaging_id and
                                                                                 l.product_packaging_qty == rfq_line.product_packaging_qty and

--- a/addons/purchase/tests/test_purchase.py
+++ b/addons/purchase/tests/test_purchase.py
@@ -872,6 +872,9 @@ class TestPurchase(AccountTestInvoicingCommon):
             po_line.product_id = self.product_a
             po_line.product_qty = 1
             po_line.price_unit = 100
+        with po_1.order_line.new() as po_line:
+            po_line.display_type = 'line_note'
+            po_line.name = 'Test Note'
         po_1 = po_1.save()
         po_1.incoterm_id = incoterm_id_1
 
@@ -890,6 +893,9 @@ class TestPurchase(AccountTestInvoicingCommon):
             po_line_2.product_id = self.product_b
             po_line_2.product_qty = 5
             po_line_2.price_unit = 500
+        with po_2.order_line.new() as po_line:
+            po_line.display_type = 'line_section'
+            po_line.name = 'Test section'
         po_2 = po_2.save()
         po_2.incoterm_id = incoterm_id_2
 


### PR DESCRIPTION
Steps to reproduce the bug:
- Create two purchase orders and add a note
- Try to merge them

Problem:
A traceback is triggered:
```
ValueError: AttributeError("'int' object has no attribute
'total_seconds'") while evaluating 'if records:\n
action = records.action_merge()'
```

opw-4890120
