### PR TITLE
[FIX] mail: prevent deletion of mail template attachments

### DIFF
--- a/addons/mail/static/src/core/common/attachment_upload_service.js
+++ b/addons/mail/static/src/core/common/attachment_upload_service.js
@@ -121,7 +121,7 @@ export class AttachmentUploadService {
             abort();
             return;
         }
-        await attachment.remove();
+        await attachment.delete();
     }
 
     async upload(thread, composer, file, options) {


### PR DESCRIPTION
### Issue:
In recent 18.0 PRs (https://github.com/odoo/odoo/pull/186617 and https://github.com/odoo/odoo/pull/199922), new functionality was
added to the `MailComposer`. As a result, we now hit the
`mail/attachment/delete` controller when we delete an attachment
in the wizard due to the `unlink` in the `AttachmentUploadService`
using `remove` instead of `delete`. This causes us to remove the
original `attachment_id` from the `mail.template` itself, since
a copy of the attachment is only created once the mail has been sent.
This behavior doesn't match other 2many widgets, which shouldn't
remove records, only links to them.

### Steps to Reproduce:
1) Add an attachment to any `mail.template`.
2) Select that template via a `MailComposer`.
3) Delete the attachment that appears in the composer.
4) Notice the attachment is also removed from the db and template.

### Solution:
Use `delete` instead of `remove` as defined in 
[#0c22b8cbd51ae31485ba2e85e5fc6ec9e13856fe
](https://github.com/odoo/odoo/commit/0c22b8cbd51ae31485ba2e85e5fc6ec9e13856fe)
opw-4715466