### PR TITLE
[FIX][17.0] web: Adjust loading indicator position on mobile devices

### DIFF
--- a/addons/web/static/src/webclient/loading_indicator/loading_indicator.scss
+++ b/addons/web/static/src/webclient/loading_indicator/loading_indicator.scss
@@ -11,4 +11,13 @@
   &.o-fade-leave, &.o-fade-enter {
     opacity: 0;
   }
+  
+  @media (max-width: 767.98px) {
+    bottom: 10px;
+    left: 50%;
+    transform: translateX(-50%);
+    right: auto;
+    border-radius: 4px;
+    padding: 6px 12px;
+  }
 }


### PR DESCRIPTION
Issue: On mobile devices, the loading indicator positioned at the bottom right corner was partially obscured by other UI elements.

Solution: Repositioned the loading indicator on mobile screens (< 768px) to appear at the bottom center of the viewport:
- Used left: 50% and transform: translateX(-50%) to center it horizontally
- Set bottom: 10px to avoid overlap with navigation bars
- Added border-radius and padding to improve visibility

This technique ensures the loading indicator remains clearly visible on all mobile screen sizes.

Description of the issue/feature this PR addresses:

Current behavior before PR:


https://github.com/user-attachments/assets/55f419ac-9dae-485c-8110-ba5916d77e2c





Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
