### PR TITLE
[FIX] discuss: prevent race condition traceback in p2p

### DIFF
--- a/addons/mail/static/src/discuss/call/common/peer_to_peer.js
+++ b/addons/mail/static/src/discuss/call/common/peer_to_peer.js
@@ -556,6 +556,14 @@ export class PeerToPeer extends EventTarget {
                     this._recover(id, "failed at setting remoteDescription");
                     return;
                 }
+                if (!peer.connection) {
+                    this._emitLog(
+                        id,
+                        "the peer connection was closed during offer negotiation",
+                        LOG_LEVEL.WARN
+                    );
+                    return;
+                }
                 if (this._isStreamingEnabled) {
                     if (peer.connection.getTransceivers().length === 0) {
                         for (const streamType of ORDERED_TRANSCEIVER_TYPES) {

--- a/addons/mail/static/src/discuss/call/common/rtc_service.js
+++ b/addons/mail/static/src/discuss/call/common/rtc_service.js
@@ -853,7 +853,6 @@ export class Rtc extends Record {
             if (session.eq(this.selfSession)) {
                 continue;
             }
-            this.log(session, "init call", { step: "init call" });
             this.p2pService.addPeer(session.id, { sequence });
         }
     }


### PR DESCRIPTION
Before this commit, there could be a race condition where the peer connection gets closed while an offer is being negotiated.

This could happen for example when offers are being sent to establish a p2p connection and the fallback to the SFU kicks in and clears the connection.

This would lead to a traceback but no functional issue.

