### PR TITLE
[FIX] purchase, purchase_product_matrix: make product description editable in po

### DIFF
--- a/addons/purchase/views/purchase_views.xml
+++ b/addons/purchase/views/purchase_views.xml
@@ -238,11 +238,13 @@
                                     <field name="product_uom_category_id" column_invisible="True"/>
                                     <field name="invoice_lines" column_invisible="True"/>
                                     <field name="sequence" widget="handle"/>
+                                    <!-- optional="show" allows name (description) to be editable -->
                                     <field
                                         name="product_id"
                                         widget="product_label_section_and_note_field"
                                         readonly="state in ('purchase', 'to approve', 'done', 'cancel') or is_downpayment"
                                         required="not display_type and not is_downpayment"
+                                        optional="show"
                                         context="{'partner_id':parent.partner_id, 'quantity':product_qty, 'company_id': parent.company_id}"
                                         force_save="1" domain="[('purchase_ok', '=', True), '|', ('company_id', '=', False), ('company_id', 'parent_of', parent.company_id)]"/>
                                     <field name="name" widget="section_and_note_text" optional="show"/>

--- a/addons/purchase_product_matrix/views/purchase_views.xml
+++ b/addons/purchase_product_matrix/views/purchase_views.xml
@@ -10,10 +10,12 @@
                 <attribute name="column_invisible">1</attribute>
             </xpath>
             <xpath expr="//list/field[@name='product_id']" position="after">
+                <!-- optional="show" allows name (description) to be editable -->
                 <field name="product_template_id"
                     string="Product"
                     readonly="state in ('purchase', 'to approve', 'done', 'cancel')"
                     required="not display_type"
+                    optional="show"
                     context="{'partner_id': parent.partner_id}"
                     widget="pol_product_many2one"/>
                 <field name="product_template_attribute_value_ids" column_invisible="1"/>


### PR DESCRIPTION
<b>Steps to Reproduce:</b>
- Navigate to Purchase → Create a new Purchase Order.
- Add a Vendor → Add a Product with description or enter one using the ☰ widget.
- Save and Confirm the order, Try to edit the description.

<b>Issue:</b>
- The product description becomes non-editable after confirming the PO.
- Previously, the description was separated in view.

<b>Cause:</b>
- Since `product_id` is readonly, the `name` (description) field also does not allow to edit.
- e.g. In SO, the description is editable if the product_id is hidden and only name (description) field is visible.

<b>Since the product_id field is read-only in the states ('purchase', 'to approve', 'done', 'cancel'), the description field 
also becomes read-only, as they are combined. By hiding the product_id, we can edit the description, as it is not.</b>

<b>Solution:</b>
- Added `optional="show"` to `product_id` in the XML view to  allow toggling discription editability.
- When `product_id` is hidden, the `name` field becomes editable.

<b>Steps to Verify:</b>
- Open same confirmed PO and hide the `product_id` column.
- Make sure `name` (description) field is visible and now it is editable.

<b>opw-4892063</b>