### PR TITLE
[IMP] fleet: Aligning fields order in Vehicle Request and Model Configuration forms

### DIFF
--- a/addons/fleet/views/fleet_vehicle_model_views.xml
+++ b/addons/fleet/views/fleet_vehicle_model_views.xml
@@ -42,18 +42,24 @@
                         <page string="Information" name="information">
                             <group>
                                 <group string="Model" invisible="vehicle_type != 'car'">
+                                    <field name="model_year"/>
                                     <field name="seats"/>
                                     <field name="doors"/>
-                                    <field name="model_year"/>
-                                    <field name="trailer_hook"/>
                                     <field name="color"/>
-                                    <field name="drive_type"/>
+                                    <field name="trailer_hook"/>
                                 </group>
                                 <group id="vehicle_information" string="Vehicle Information" invisible="vehicle_type != 'bike'">
                                     <field name="electric_assistance"/>
                                 </group>
                                 <group string="Engine" invisible="vehicle_type != 'car'" name="group_engine">
                                     <field name="default_fuel_type" required="1"/>
+                                    <field name="transmission"/>
+                                    <field name="drive_type"/>
+                                    <label for="power" invisible="power_unit != 'power'"/>
+                                    <div class="o_row" invisible="power_unit != 'power'">
+                                        <field name="power"/>
+                                        <field name="power_unit"/>
+                                    </div>
                                     <label for="vehicle_range"/>
                                     <div class="o_row">
                                         <field name="vehicle_range"/>
@@ -65,19 +71,12 @@
                                         <field name="co2_emission_unit"/>
                                     </div>
                                     <field name="co2_standard" placeholder="eg. WLTP, Euro 6, or EPA, ..."/>
-                                    <field name="transmission"/>
-                                    <label for="power" invisible="power_unit != 'power'"/>
-                                    <div class="o_row" invisible="power_unit != 'power'">
-                                        <field name="power"/>
-                                        <field name="power_unit"/>
-                                    </div>
                                     <label for="horsepower" invisible="power_unit != 'horsepower'"/>
                                     <div class="o_row" invisible="power_unit != 'horsepower'">
                                         <field name="horsepower"/>
                                         <field name="power_unit"/>
                                     </div>
                                     <field name="horsepower_tax" invisible="power_unit != 'horsepower'"/>
-
                                 </group>
                             </group>
                         </page>

--- a/addons/fleet/views/fleet_vehicle_views.xml
+++ b/addons/fleet/views/fleet_vehicle_views.xml
@@ -137,10 +137,9 @@
                             <group>
                                 <group string="Model" name="group_model">
                                     <field name="model_year"/>
-                                    <field name="transmission" invisible="vehicle_type != 'car'"/>
-                                    <field name="color"/>
                                     <field name="seats" invisible="vehicle_type != 'car'"/>
                                     <field name="doors" invisible="vehicle_type != 'car'"/>
+                                    <field name="color"/>
                                     <field name="trailer_hook" invisible="vehicle_type != 'car'"/>
                                     <field name="frame_type" invisible="vehicle_type != 'bike'"/>
                                     <label for="frame_size" invisible="vehicle_type != 'bike'"/>
@@ -150,6 +149,8 @@
                                     <field name="electric_assistance" invisible="vehicle_type != 'bike'"/>
                                 </group>
                                 <group string="Engine" invisible="vehicle_type != 'car'">
+                                    <field name="fuel_type"/>
+                                    <field name="transmission" invisible="vehicle_type != 'car'"/>
                                     <label for="power" invisible="power_unit != 'power'"/>
                                     <div class="o_row" invisible="power_unit != 'power'">
                                         <field name="power"/>
@@ -165,7 +166,6 @@
                                         <field name="vehicle_range"/>
                                         <field name="range_unit"/>
                                     </div>
-                                    <field name="fuel_type"/>
                                     <label for="co2"/>
                                     <div class="o_row">
                                         <field name="co2"/>


### PR DESCRIPTION
In this PR, we aligned the fields order in both vehicle request and model configuration forms.

Related task: 4899791.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
