### PR TITLE
[FIX] hr_attendance: remove default groupby in reporting action to fix spreadsheet integration

### DIFF
--- a/addons/hr_attendance/views/hr_attendance_view.xml
+++ b/addons/hr_attendance/views/hr_attendance_view.xml
@@ -295,7 +295,6 @@
         <field name="search_view_id" ref="hr_attendance_view_filter"/>
         <field name="context">
             {
-                "search_default_groupby_name" : 1,
                 "search_default_employee": 2,
                 "search_default_activeemployees": 1,
                 "search_default_last_three_months": 1


### PR DESCRIPTION
The attendance reporting action had search_default_groupby_name in its context, causing duplicated group_by entries in pivot views used in spreadsheets. This breaks spreadsheet insertion. We removed the default groupby to restore compatibility.

Related Task: 4897934.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
