### PR TITLE
[FIX] hr_holidays: prevent error when validity period is removed

### DIFF
--- a/addons/hr_holidays/models/hr_leave_allocation.py
+++ b/addons/hr_holidays/models/hr_leave_allocation.py
@@ -172,18 +172,19 @@ class HrLeaveAllocation(models.Model):
     @api.depends('name', 'date_from', 'date_to')
     def _compute_description_validity(self):
         for allocation in self:
+            date_from = allocation.date_from or fields.Date.context_today(allocation)
             if allocation.date_to:
                 name_validity = _(
                     "%(allocation_name)s (from %(date_from)s to %(date_to)s)",
                     allocation_name=allocation.name,
-                    date_from=allocation.date_from.strftime("%b %d %Y"),
+                    date_from=date_from.strftime("%b %d %Y"),
                     date_to=allocation.date_to.strftime("%b %d %Y"),
                 )
             else:
                 name_validity = _(
                     "%(allocation_name)s (from %(date_from)s to No Limit)",
                     allocation_name=allocation.name,
-                    date_from=allocation.date_from.strftime("%b %d %Y"),
+                    date_from=date_from.strftime("%b %d %Y"),
                 )
             allocation.name_validity = name_validity
 


### PR DESCRIPTION
An error occurs if the Validity Period is removed while creating a new allocation.

Steps to reproduce:
---
- Install the `hr_holidays` module
- Time Off > My Time > My Allocation
- Open New and remove the `Validity Period`

Traceback:
---
`AttributeError: 'bool' object has no attribute 'strftime'`

This commit ensures that changing the date won't cause an error, but instead will display a warning upon saving the form, as it is a required field.

sentry-6709097746

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
