### PR TITLE
[FIX] web: fix web_read_group for properties fields

### DIFF
--- a/addons/web/models/models.py
+++ b/addons/web/models/models.py
@@ -537,7 +537,7 @@ class Base(models.AbstractModel):
             for info_opening in parent_opening_info or ()
         }
         groupby_spec = groupby[0]
-        field = self._fields[groupby_spec.split(':')[0]]
+        field = self._fields[groupby_spec.split(':')[0].split('.')[0]]
         nb_opened_group = 0
 
         last_level = len(groupby) == 1


### PR DESCRIPTION
We get a KeyError in `self._fields[groupby_spec.split(':')[0]]` in the `_open_groups` when we group by a property field because groupby_spec contains a property path (properties.property_name).

Fix it and add a test for it.
