### PR TITLE
[FIX] base: send webhook calls after cursor commit

### DIFF
--- a/addons/test_base_automation/tests/test_flow.py
+++ b/addons/test_base_automation/tests/test_flow.py
@@ -1779,9 +1779,11 @@ class TestHttp(common.HttpCase):
             "webhook_url": automation_receiver.url,
         })
 
-        with self.allow_requests(all_requests=True):  # Changing the name will make an http request.
-            obj.name = "new_name"
+        # Changing the name will make an http request, post-commitedly
+        obj.name = "new_name"
         self.cr.flush()
+        with self.allow_requests(all_requests=True):
+            self.cr.postcommit.run()  # webhooks run in postcommit
         self.cr.clear()
         self._wait_remaining_requests()  # just in case the request timeouts
         self.assertEqual(json.loads(obj.another_field), {

--- a/odoo/addons/base/models/ir_actions.py
+++ b/odoo/addons/base/models/ir_actions.py
@@ -1057,21 +1057,28 @@ class IrActionsServer(models.Model):
         json_values = json.dumps(vals, sort_keys=True, default=str)
         _logger.info("Webhook call to %s", url)
         _logger.debug("POST JSON data for webhook call: %s", json_values)
-        import requests  # noqa: PLC0415
-        try:
-            # 'send and forget' strategy, and avoid locking the user if the webhook
-            # is slow or non-functional (we still allow for a 1s timeout so that
-            # if we get a proper error response code like 400, 404 or 500 we can log)
-            response = requests.post(url, data=json_values, headers={'Content-Type': 'application/json'}, timeout=1)
-            response.raise_for_status()
-        except requests.exceptions.ReadTimeout:
-            _logger.warning("Webhook call timed out after 1s - it may or may not have failed. "
-                            "If this happens often, it may be a sign that the system you're "
-                            "trying to reach is slow or non-functional.")
-        except requests.exceptions.RequestException as e:
-            _logger.warning("Webhook call failed: %s", e)
-        except Exception as e:  # noqa: BLE001
-            raise UserError(_("Wow, your webhook call failed with a really unusual error: %s", e)) from e
+
+        @self.env.cr.postrollback.add
+        def _add_post_rollback():
+            _logger.warning("Webhook call to %s - cancelled due to a rollback", url)
+
+        @self.env.cr.postcommit.add
+        def _add_post_commit():
+            _logger.debug("Webhook call to %s - start", url)
+            import requests  # noqa: PLC0415
+            try:
+                # 'send and forget' strategy, and avoid locking the user if the webhook
+                # is slow or non-functional (we still allow for a 1s timeout so that
+                # if we get a proper error response code like 400, 404 or 500 we can log)
+                response = requests.post(url, data=json_values, headers={'Content-Type': 'application/json'}, timeout=1)
+                response.raise_for_status()
+                _logger.info("Webhook call to %s - succeeded", url)
+            except requests.exceptions.ReadTimeout:
+                _logger.warning("Webhook call timed out after 1s - it may or may not have failed. "
+                                "If this happens often, it may be a sign that the system you're "
+                                "trying to reach is slow or non-functional.")
+            except requests.exceptions.RequestException as e:
+                _logger.warning("Webhook call failed: %s", e)
 
     def _run_action_object_copy(self, eval_context=None):
         """ Duplicate specified model object.

--- a/odoo/addons/base/tests/test_ir_actions.py
+++ b/odoo/addons/base/tests/test_ir_actions.py
@@ -592,9 +592,11 @@ ZeroDivisionError: division by zero""" % self.test_server_action.id
         with patch.object(requests, 'post', _patched_post), mute_logger('odoo.addons.base.models.ir_actions'):
             # first run: 200
             self.action.with_context(self.context).run()
+            self.env.cr.postcommit.run()  # webhooks run in postcommit
             # second run: 400, should *not* raise but
             # should warn in logs (hence mute_logger)
             self.action.with_context(self.context).run()
+            self.env.cr.postcommit.run()  # webhooks run in postcommit
         self.assertEqual(num_requests, 2)
 
     def test_90_convert_to_float(self):


### PR DESCRIPTION
Before this commit if an action calls a external webhook, the call was made immediately, without waiting for the current transaction to be committed.

We should never call an external resource while we are not sure our work is not rolled back.

We already have a similar safeguard for "Send an Email/Whatsapp/SMS" (queued jobs), but we did not have one for external webhooks.

We considered adding a new type of queued job for external webhooks, but decided it was simple enough to just hook into the transaction post-commit hook.

For history:
- we found about this issue on the feedback opw-4657626 that raised to our attention that dryrun imports were calling external webhooks even though in a dryrun import the transaction is rolled back at the end of the import.