### PR TITLE
[FIX] sale_mrp: fix test_sale_mrp_anglo_saxon_valuation

### DIFF
--- a/addons/sale_mrp/tests/test_sale_mrp_anglo_saxon_valuation.py
+++ b/addons/sale_mrp/tests/test_sale_mrp_anglo_saxon_valuation.py
@@ -53,6 +53,7 @@ class TestSaleMRPAngloSaxonValuation(ValuationReconciliationTestCommon):
             'property_account_expense_id': self.company_data['default_account_expense'].id,
             'property_account_income_id': self.company_data['default_account_revenue'].id,
         })
+        self.env.user.groups_id += self.env.ref('product.group_product_variant')
 
         # Create BoM for Kit A
         bom_product_form = Form(self.env['mrp.bom'])


### PR DESCRIPTION
The `test_sale_mrp_kit_bom_cogs` test failed due to an AssertionError when writing to the `product_id` field using the Form API. This field is conditionally invisible unless the user has the `product.group_product_variant` group. The test user was missing this group, causing the field to be invisible.

The fix adds the required group to the test user to ensure the field is visible and the test passes as expected.

build_error-100736
