### PR TITLE
[IMP] l10n_in_ewaybill_stock: add constraint on creating ewaybill

### DIFF
--- a/addons/l10n_in_ewaybill_stock/i18n/l10n_in_ewaybill_stock.pot
+++ b/addons/l10n_in_ewaybill_stock/i18n/l10n_in_ewaybill_stock.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 17.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-05-23 09:39+0000\n"
-"PO-Revision-Date: 2025-05-23 09:39+0000\n"
+"POT-Creation-Date: 2025-06-26 08:51+0000\n"
+"PO-Revision-Date: 2025-06-26 08:51+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -61,6 +61,7 @@ msgstr ""
 #. module: l10n_in_ewaybill_stock
 #. odoo-python
 #: code:addons/l10n_in_ewaybill_stock/models/l10n_in_ewaybill.py:0
+#: code:addons/l10n_in_ewaybill_stock/tests/test_ewaybill_stock.py:0
 #, python-format
 msgid "- Transporter %s does not have a GST Number"
 msgstr ""
@@ -711,6 +712,13 @@ msgstr ""
 #: code:addons/l10n_in_ewaybill_stock/models/l10n_in_ewaybill.py:0
 #, python-format
 msgid "Only Delivery Challan and Cancelled E-waybill can be reset to pending."
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#. odoo-python
+#: code:addons/l10n_in_ewaybill_stock/models/l10n_in_ewaybill.py:0
+#, python-format
+msgid "Only one e-Waybill can be generated per document."
 msgstr ""
 
 #. module: l10n_in_ewaybill_stock

--- a/addons/l10n_in_ewaybill_stock/models/l10n_in_ewaybill.py
+++ b/addons/l10n_in_ewaybill_stock/models/l10n_in_ewaybill.py
@@ -218,6 +218,14 @@ class Ewaybill(models.Model):
         for ewaybill in self.filtered(lambda ewb: ewb.state == 'pending' and ewb.mode == "4"):
             ewaybill.vehicle_type = 'O'
 
+    @api.constrains('picking_id')
+    def _check_one_ewaybill_per_document(self):
+        if self.search_count([
+            ('picking_id', '=', self.picking_id.id),
+            ('id', '!=', self.id)
+        ], limit=1):
+            raise UserError(_("Only one e-Waybill can be generated per document."))
+
     def action_export_json(self):
         self.ensure_one()
         return {


### PR DESCRIPTION
Before this commit-
In case of unintended user actions, user is able to create 2 Ewaybill for 1 document. Which is not supposed to be happening

After this commit-
We add a python constraint to restrict creation of Ewaybill if any record of it exist with the related document

discord channel post-https://discord.com/channels/678381219515465750/1387046861445009469/1387046861445009469

opw-4885994

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
