### PR TITLE
[FIX] core: auto update modules

### DIFF
--- a/odoo/service/server.py
+++ b/odoo/service/server.py
@@ -1349,6 +1349,10 @@ def preload_registries(dbnames):
         try:
             threading.current_thread().dbname = dbname
             update_module = config['init'] or config['update']
+            if not update_module:
+                with sql_db.db_connect(dbname).cursor() as cr:
+                    cr.execute("SELECT 1 FROM ir_module_module WHERE state IN ('to remove', 'to upgrade', 'to install') FETCH FIRST 1 ROW ONLY")
+                    update_module = bool(cr.rowcount)
             registry = Registry.new(dbname, update_module=update_module, install_modules=config['init'], upgrade_modules=config['update'])
 
             # run post-install tests


### PR DESCRIPTION
Technically, using `odoo-bin` without `-i` and `-u` for database with
`to upgrade` module was wrong before 18.2, which will skip some upgrade
processes/checks in `loading.py`.

From 18.2
If there are `to upgrade`, `to install` or `to remove` modules in the database
`odoo-bin` without `-i` and `-u` will still automatically update these modules.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
