### PR TITLE
[FIX] survey: print button redirection on survey

### DIFF
--- a/addons/survey/controllers/main.py
+++ b/addons/survey/controllers/main.py
@@ -67,9 +67,9 @@ class Survey(http.Controller):
         if answer_token and not answer_sudo:
             return 'token_wrong'
 
-        if not answer_sudo and ensure_token:
+        if not answer_sudo and ensure_token is True:
             return 'token_required'
-        if not answer_sudo and survey_sudo.access_mode == 'token':
+        if not answer_sudo and ensure_token != 'survey_only' and survey_sudo.access_mode == 'token':
             return 'token_required'
 
         if survey_sudo.users_login_required and request.env.user._is_public():
@@ -117,7 +117,8 @@ class Survey(http.Controller):
                 has_survey_access = True
             can_answer = bool(answer_sudo)
             if not can_answer:
-                can_answer = survey_sudo.access_mode == 'public'
+                can_answer = survey_sudo.access_mode == 'public' or (
+                    has_survey_access and ensure_token == 'survey_only')
 
         return {
             'survey_sudo': survey_sudo,
@@ -599,7 +600,7 @@ class Survey(http.Controller):
     def survey_print(self, survey_token, review=False, answer_token=None, **post):
         '''Display an survey in printable view; if <answer_token> is set, it will
         grab the answers of the user_input_id that has <answer_token>.'''
-        access_data = self._get_access_data(survey_token, answer_token, ensure_token=False, check_partner=False)
+        access_data = self._get_access_data(survey_token, answer_token, ensure_token='survey_only', check_partner=False)
         if access_data['validity_code'] is not True and (
                 access_data['has_survey_access'] or
                 access_data['validity_code'] not in ['token_required', 'survey_closed', 'survey_void', 'answer_deadline']):

--- a/addons/survey/tests/test_survey_security.py
+++ b/addons/survey/tests/test_survey_security.py
@@ -359,3 +359,53 @@ class TestSurveySecurityControllers(common.TestSurveyCommon, HttpCase):
         self.survey.write({'session_state': False, 'active': True})
         response = self.url_open('/s/123456')
         self.assertFalse(self.survey.title in response.text)
+
+    def test_print_survey_access_mode_token(self):
+        """Check that a survey with access_mode=token with questions defined can always be printed."""
+        # Case: No questions, no answers -> general print informs the user "your survey is empty"
+        survey = self.env['survey.survey'].with_user(self.survey_manager).create({
+            'title': 'Test Survey without answers',
+            'access_mode': 'token',
+            'users_login_required': False,
+            'users_can_go_back': False,
+        })
+        self.authenticate(self.survey_manager.login, self.survey_manager.login)
+        response = self.url_open(f'/survey/print/{survey.access_token}')
+        self.assertEqual(response.status_code, 200,
+            "Print request to shall succeed for a survey without questions nor answers")
+        self.assertIn("survey is empty", str(response.content),
+            "Survey print without questions nor answers should inform user that the survey is empty")
+
+        # Case: a question, no answers -> general print shows the question
+        question = self.env['survey.question'].with_user(self.survey_manager).create({
+            'title': 'Test Question',
+            'survey_id': survey.id,
+            'sequence': 1,
+            'is_page': False,
+            'question_type': 'char_box',
+        })
+        response = self.url_open(f'/survey/print/{survey.access_token}')
+        self.assertEqual(response.status_code, 200,
+            "Print request to shall succeed for a survey with questions but no answers")
+        self.assertIn(question.title, str(response.content),
+            "Should be possible to print a survey with a question and without answers")
+
+        # Case: a question, an answers -> general print shows the question
+        user_input = self._add_answer(survey, self.survey_manager.partner_id, state='done')
+        self._add_answer_line(question, user_input, "Test Answer")
+        response = self.url_open(f'/survey/print/{survey.access_token}')
+        self.assertEqual(response.status_code, 200,
+            "Print request without answer token, should be possible for a survey with questions and answers")
+        self.assertIn(question.title, str(response.content),
+            "Survey question should be visible in general print, even when answers exist and no answer_token is provided")
+        self.assertNotIn("Test Answer", str(response.content),
+            "Survey answer should not be in general print, when no answer_token is provided")
+
+        # Case: a question, an answers -> print with answer_token shows both
+        response = self.url_open(f'/survey/print/{survey.access_token}?answer_token={user_input.access_token}')
+        self.assertEqual(response.status_code, 200,
+            "Should be possible to print a sruvey with questions and answers")
+        self.assertIn(question.title, str(response.content),
+            "Question should appear when printing survey with using an answer_token")
+        self.assertIn("Test Answer", str(response.content),
+            "Answer should appear when printing survey with using an answer_token")


### PR DESCRIPTION
Issue
---
Previously, printing a survey with access mode set to "invited people only"
required an existing `survey.user_input` record.
Without it, the print route failed silently and redirected to the homepage.

FIX
---
This commit allows surveys to be printed without answers.
It introduces an option to bypass the "token_required" validity check
by allowing `ensure_token='survey_only'`. This skips token validation
specifically for the print route, while preserving it for the start route.

Reproduce
---
- -i survey
- create new Survey, with "Access Mode": "invited people only"
- click "Print" BUG -> taken to the odoo main page, instead of empty printed survey

backport commit : https://github.com/odoo/odoo/commit/f49a3445b2fb259333151ffa3c7b5197e0e9c309

opw:4878800