### PR TITLE
[FIX] base: remove street 2 empty line

### DIFF
--- a/odoo/addons/base/models/res_partner.py
+++ b/odoo/addons/base/models/res_partner.py
@@ -1007,6 +1007,7 @@ class ResPartner(models.Model):
                     name = f"{name} <{partner.email}>"
                 if partner._context.get('show_address'):
                     name = name + "\n" + partner._display_address(without_company=True)
+                name = re.sub(r'\s+\n', '\n', name)
 
                 if partner._context.get('show_vat') and partner.vat:
                     if partner._context.get('show_address'):


### PR DESCRIPTION
When the address is shown, if the street 2 is empty, there is a empty line.

Now, this line is removed.

TASK-ID: 4900293


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
