### PR TITLE
[IMP] core: support -u continue

### DIFF
--- a/odoo/modules/loading.py
+++ b/odoo/modules/loading.py
@@ -401,6 +401,8 @@ def load_modules(
             cr.execute("SELECT model || '.' || name FROM ir_model_fields WHERE translate IS TRUE")
             registry._database_translated_fields = {row[0] for row in cr.fetchall()}
 
+        upgrade_modules = [m for m in upgrade_modules if m != 'continue']
+
         report = registry._assertion_report
         env = api.Environment(cr, api.SUPERUSER_ID, {})
         load_module_graph(
@@ -488,7 +490,10 @@ def load_modules(
         modules = Module.search_fetch(Module._get_modules_to_load_domain(), ['name'], order='name')
         missing = [name for name in modules.mapped('name') if name not in graph]
         if missing:
-            _logger.error("Some modules are not loaded, some dependencies or manifest may be missing: %s", missing)
+            if update_module:
+                _logger.error("Some modules are not loaded, some dependencies or manifest may be missing: %s", missing)
+            else:
+                _logger.error("Some modules are updated, call -u continue to update them %s", missing)
 
         # STEP 3.5: execute migration end-scripts
         if update_module:


### PR DESCRIPTION
Technically, using `odoo-bin` without `-i` and `-u` for database with `to upgrade` module was wrong before 18.2, which will skip some upgrade processes/checks in `loading.py`.
A quick workaround is using `odoo-bin -u any_to_upgrade_customized_module` for customers.

From 18.2
ask user to call `odoo-bin -u continue` (new parameter similar as `odoo-bin -u all`) explicitly

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
