### PR TITLE
[FIX] survey: fix _get_stats_data_answers translation issue

### DIFF
--- a/addons/survey/models/survey_question.py
+++ b/addons/survey/models/survey_question.py
@@ -637,11 +637,11 @@ class SurveyQuestion(models.Model):
             'value': _('Other (see comments)') if not suggested_answer else suggested_answer.value_label,
             'suggested_answer': suggested_answer,
             'count': count_data[suggested_answer],
-            'count_text': _("%s Votes", count_data[suggested_answer]),
+            'count_text': self.env._("%s Votes", count_data[suggested_answer]),
             }
             for suggested_answer in suggested_answers]
         graph_data = [{
-            'text': _('Other (see comments)') if not suggested_answer else suggested_answer.value_label,
+            'text': self.env._('Other (see comments)') if not suggested_answer else suggested_answer.value_label,
             'count': count_data[suggested_answer]
             }
             for suggested_answer in suggested_answers]


### PR DESCRIPTION
Issue:
Prior to this commit, a translation issue occurred due to the use of a list comprehension. The _get_translation_source function attempts to scan the local variables, but in the context of a list comprehension, only variables defined within the comprehension are accessible. As a result, variables like uuid and cursor were not available to the _get_lang function, ultimately leading to an error.

Fix:
Replaced the list comprehension with a standard for loop to ensure proper access to local variables.

runbot-135198
