### PR TITLE
[IMP] im_livechat: add expertise in info list

### DIFF
--- a/addons/im_livechat/models/discuss_channel.py
+++ b/addons/im_livechat/models/discuss_channel.py
@@ -315,6 +315,7 @@ class DiscussChannel(models.Model):
         field_names["internal_users"].extend([
             Store.Attr("livechat_note", predicate=lambda c: c.channel_type == "livechat"),
             Store.Attr("livechat_status", predicate=lambda c: c.channel_type == "livechat"),
+            Store.Many("livechat_expertise_ids", ["name"], predicate=lambda c: c.channel_type == "livechat"),
         ])
         return field_names
 
@@ -340,6 +341,7 @@ class DiscussChannel(models.Model):
             fields.extend([
                 Store.Attr("livechat_note", predicate=lambda c: c.channel_type == "livechat"),
                 Store.Attr("livechat_status", predicate=lambda c: c.channel_type == "livechat"),
+                Store.Many("livechat_expertise_ids", ["name"], predicate=lambda c: c.channel_type == "livechat"),
             ])
         return super()._to_store_defaults(for_current_user=for_current_user) + fields
 

--- a/addons/im_livechat/static/src/core/common/livechat_expertise_model.js
+++ b/addons/im_livechat/static/src/core/common/livechat_expertise_model.js
@@ -1,0 +1,12 @@
+import { Record } from "@mail/core/common/record";
+
+export class LivechatExpertise extends Record {
+    static id = "id";
+    static _name = "im_livechat.expertise";
+
+    /** @type {number} */
+    id;
+    /** @type {string} */
+    name;
+}
+LivechatExpertise.register();

--- a/addons/im_livechat/static/src/core/web/livechat_channel_info_list.js
+++ b/addons/im_livechat/static/src/core/web/livechat_channel_info_list.js
@@ -7,15 +7,27 @@ import { Component } from "@odoo/owl";
 
 import { rpc } from "@web/core/network/rpc";
 import { useService } from "@web/core/utils/hooks";
+import { TagsList } from "@web/core/tags_list/tags_list";
 
 export class LivechatChannelInfoList extends Component {
-    static components = { ActionPanel, TranscriptSender };
+    static components = { ActionPanel, TranscriptSender, TagsList };
     static template = "im_livechat.LivechatChannelInfoList";
     static props = ["thread"];
 
     setup() {
         super.setup();
         this.store = useService("mail.store");
+    }
+
+    get expertiseTags() {
+        return this.props.thread.livechat_expertise_ids.map((expertise) => {
+            return {
+                id: expertise.id,
+                text: expertise.name,
+                colorIndex: 0,
+                className: "me-1 mb-1",
+            };
+        });
     }
 
     onBlurNote() {

--- a/addons/im_livechat/static/src/core/web/livechat_channel_info_list.xml
+++ b/addons/im_livechat/static/src/core/web/livechat_channel_info_list.xml
@@ -8,6 +8,12 @@
                     <t t-set="livechatThread" t-value="props.thread"/>
                 </t>
             </div>
+            <div t-if="expertiseTags.length" class="d-flex flex-column bg-inherit gap-1">
+                <h3 class="pt-3">Expertise</h3>
+                <div class="d-flex flex-wrap gap-1">
+                    <TagsList displayText="true" tags="expertiseTags"/>
+                </div>
+            </div>
             <t t-name="extra_infos"/>
             <div class="d-flex flex-column bg-inherit gap-1">
                 <h3 class="pt-3">Notes</h3>

--- a/addons/im_livechat/static/src/core/web/thread_model_patch.js
+++ b/addons/im_livechat/static/src/core/web/thread_model_patch.js
@@ -19,6 +19,7 @@ patch(Thread.prototype, {
                 return this.livechatNoteText;
             },
         });
+        this.livechat_expertise_ids = fields.Many("im_livechat.expertise");
     },
     get livechatStatusLabel() {
         const status = this.livechat_status;

--- a/addons/im_livechat/static/tests/livechat_channel_info_list.test.js
+++ b/addons/im_livechat/static/tests/livechat_channel_info_list.test.js
@@ -166,3 +166,35 @@ test("editing livechat status is synced between tabs", async () => {
         target: tab2,
     }); // Status should be synced with bus
 });
+
+test("Shows expertise", async () => {
+    const pyEnv = await startServer();
+    const userId = pyEnv["res.users"].create({ name: "James" });
+    pyEnv["res.partner"].create({
+        name: "James",
+        user_ids: [userId],
+    });
+    const countryId = pyEnv["res.country"].create({ code: "be", name: "Belgium" });
+    const guestId = pyEnv["mail.guest"].create({
+        name: "Visitor #20",
+    });
+    const expertiseIds = pyEnv["im_livechat.expertise"].create([
+        { name: "pricing" },
+        { name: "events" },
+    ]);
+    const channelId = pyEnv["discuss.channel"].create({
+        anonymous_name: "Visitor #20",
+        channel_member_ids: [
+            Command.create({ partner_id: serverState.partnerId, livechat_member_type: "agent" }),
+            Command.create({ guest_id: guestId, livechat_member_type: "visitor" }),
+        ],
+        country_id: countryId,
+        channel_type: "livechat",
+        livechat_operator_id: serverState.partnerId,
+        livechat_expertise_ids: expertiseIds,
+    });
+    await start();
+    await openDiscuss(channelId);
+    await contains(".o-livechat-ChannelInfoList .o_tag", { text: "pricing" });
+    await contains(".o-livechat-ChannelInfoList .o_tag", { text: "events" });
+});

--- a/addons/im_livechat/static/tests/mock_server/mock_models/discuss_channel.js
+++ b/addons/im_livechat/static/tests/mock_server/mock_models/discuss_channel.js
@@ -15,6 +15,9 @@ export class DiscussChannel extends mailModels.DiscussChannel {
             ("need_help", "Looking for help"),
         ],
     });
+    livechat_expertise_ids = fields.Many2many({
+        relation: "im_livechat.expertise",
+    });
 
     action_unfollow(idOrIds) {
         /** @type {import("mock_models").BusBus} */
@@ -38,7 +41,12 @@ export class DiscussChannel extends mailModels.DiscussChannel {
     }
 
     _channel_basic_info_fields() {
-        return super._channel_basic_info_fields().concat(["livechat_note", "livechat_status"]);
+        return [
+            ...super._channel_basic_info_fields(),
+            "livechat_note",
+            "livechat_status",
+            "livechat_expertise_ids",
+        ];
     }
 
     /**
@@ -79,6 +87,10 @@ export class DiscussChannel extends mailModels.DiscussChannel {
                 channelInfo["livechat_end_dt"] = channel.livechat_end_dt;
                 channelInfo["livechat_note"] = ["markup", channel.livechat_note];
                 channelInfo["livechat_status"] = channel.livechat_status;
+                channelInfo["livechat_expertise_ids"] = mailDataHelpers.Store.many(
+                    this.env["im_livechat.expertise"].browse(channel.livechat_expertise_ids),
+                    makeKwArgs({ fields: ["name"] })
+                );
                 channelInfo.livechat_channel_id = mailDataHelpers.Store.one(
                     this.env["im_livechat.channel"].browse(channel.livechat_channel_id),
                     makeKwArgs({ fields: ["name"] })

--- a/addons/im_livechat/static/tests/mock_server/mock_models/im_livechat_expertise.js
+++ b/addons/im_livechat/static/tests/mock_server/mock_models/im_livechat_expertise.js
@@ -1,5 +1,17 @@
-import { models } from "@web/../tests/web_test_helpers";
+import { getKwArgs, models } from "@web/../tests/web_test_helpers";
 
 export class Im_LivechatExpertise extends models.ServerModel {
     _name = "im_livechat.expertise";
+
+    _to_store(ids, store, fields) {
+        const kwargs = getKwArgs(arguments, "ids", "store", "fields");
+        fields = kwargs.fields;
+        if (!fields) {
+            fields = [];
+        }
+        for (const LivechatExpertise of this.browse(ids)) {
+            const [res] = this._read_format(LivechatExpertise.id, fields, false);
+            store.add(this.browse(LivechatExpertise.id), res);
+        }
+    }
 }

--- a/addons/test_discuss_full/tests/test_performance.py
+++ b/addons/test_discuss_full/tests/test_performance.py
@@ -95,7 +95,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
     #       - fetch discuss_channel_rtc_session
     #       - search member (channel_member_ids)
     #       - fetch discuss_channel_member (manual prefetch)
-    #       17: member _to_store:
+    #       19: member _to_store:
     #           - search im_livechat_channel_member_history (livechat member type)
     #           - fetch im_livechat_channel_member_history (livechat member type)
     #           12: partner _to_store:
@@ -123,6 +123,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
     #       - fetch res_groups (group_ids)
     #       - _compute_message_unread
     #       - fetch im_livechat_channel
+    #       2: fetch livechat_expertise_ids
     #   - _get_last_messages
     #   20: message _to_store:
     #       - search mail_message_schedule
@@ -145,7 +146,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
     #       - fetch discuss_call_history
     #       - search mail_tracking_value
     #       - _compute_rating_stats
-    _query_count_discuss_channels = 58
+    _query_count_discuss_channels = 60
 
     def setUp(self):
         super().setUp()
@@ -944,6 +945,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
                 "livechat_channel_id": self.im_livechat_channel.id,
                 "livechat_note": False,
                 "livechat_status": "in_progress",
+                "livechat_expertise_ids": [],
                 "livechat_operator_id": {"id": self.users[0].partner_id.id, "type": "partner"},
                 "member_count": 2,
                 "message_needaction_counter_bus_id": bus_last_id,
@@ -977,6 +979,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
                 "livechat_channel_id": self.im_livechat_channel.id,
                 "livechat_note": False,
                 "livechat_status": "in_progress",
+                "livechat_expertise_ids": [],
                 "livechat_operator_id": {"id": self.users[0].partner_id.id, "type": "partner"},
                 "member_count": 2,
                 "message_needaction_counter_bus_id": bus_last_id,

--- a/addons/website_livechat/tests/test_livechat_basic_flow.py
+++ b/addons/website_livechat/tests/test_livechat_basic_flow.py
@@ -213,6 +213,7 @@ class TestLivechatBasicFlowHttpCase(HttpCaseWithUserDemo, TestLivechatCommon):
                         "livechat_end_dt": False,
                         "livechat_note": False,
                         "livechat_status": "in_progress",
+                        "livechat_expertise_ids": [],
                         "livechat_operator_id": {
                             "id": self.operator.partner_id.id,
                             "type": "partner",


### PR DESCRIPTION
provide a way for the agent to understand why the conversation was forwarded to them based on their qualifications;
also useful for the reporting

task-4889092



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
