### PR TITLE
Saas 18.4 builder better UI role

### DIFF
--- a/addons/html_builder/static/src/builder.scss
+++ b/addons/html_builder/static/src/builder.scss
@@ -65,14 +65,22 @@
         --btn-active-bg: transparent;
         --btn-active-color: #{$o-we-fg-lighter};
 
-        &[data-name="blocks"] i {
-            color: $o-we-color-success;
+        &[data-name="blocks"] {
+            --o-snippets-tabs-accent-color: #{$o-we-color-success};
         }
-        &[data-name="customize"] i {
-            color: $o-we-color-accent;
+        &[data-name="customize"] {
+            --o-snippets-tabs-accent-color: #{$o-we-color-accent};
         }
-        &[data-name="theme"] i {
-            color: $o-we-color-global;
+        &[data-name="theme"] {
+            --o-snippets-tabs-accent-color: #{$o-we-color-global};
+        }
+
+        & i {
+            color: var(--o-snippets-tabs-accent-color);
+        }
+
+        &:focus-visible, &:active {
+            box-shadow: 0 0 0 #{$o-we-border-width} var(--o-snippets-tabs-accent-color);
         }
     }
 }

--- a/addons/html_builder/static/src/builder.variables.scss
+++ b/addons/html_builder/static/src/builder.variables.scss
@@ -806,3 +806,16 @@ $o-bg-shapes: (
         -moz-appearance: textfield;
     }
 };
+
+%o-hb-input-base {
+    border: $o-we-sidebar-content-field-border-width solid $o-we-sidebar-content-field-border-color;
+    border-radius: $o-we-sidebar-content-field-border-radius;
+    background-color: var(--o-hb-field-input-bg, #{$o-we-sidebar-content-field-input-bg});
+    padding: 0.15rem $o-we-sidebar-content-field-clickable-spacing;
+    color: inherit;
+
+    &:focus, &:focus-within {
+        border-color: var(--o-hb-input-active-border, #{$o-we-sidebar-content-field-input-border-color});
+        color: var(--o-hb-row-color-active, #{$o-we-fg-lighter});
+    }
+}

--- a/addons/html_builder/static/src/core/building_blocks/builder_colorpicker.js
+++ b/addons/html_builder/static/src/core/building_blocks/builder_colorpicker.js
@@ -137,9 +137,11 @@ export class BuilderColorPicker extends Component {
                 showRgbaField: true,
                 noTransparency: this.props.noTransparency,
                 enabledTabs: this.props.enabledTabs,
+                className: "o-hb-colorpicker",
             },
             {
                 onClose: onPreviewRevert,
+                popoverClass: "o-hb-colorpicker-popover",
             }
         );
     }

--- a/addons/html_builder/static/src/core/building_blocks/builder_colorpicker.scss
+++ b/addons/html_builder/static/src/core/building_blocks/builder_colorpicker.scss
@@ -1,0 +1,111 @@
+.o-hb-colorpicker-popover {
+    --popover-bg: #{$o-we-bg-darker};
+    --popover-border-color: #{$o-we-bg-darker};
+}
+
+.o-hb-colorpicker {
+    --o-hb-colorpicker-focus-border-color: var(--o-hb-select-item-active-color, #{$o-we-sidebar-content-field-toggle-active-bg});
+
+    --bg: #{$o-we-item-clickable-bg};
+
+    background-color: $o-we-item-clickable-bg;
+    color: $white;
+
+    & > div:first-child {
+        background-color: $o-we-bg-darker;
+        padding-block: 0.5em;
+    }
+
+    & > div:not(:first-child) {
+        .btn {
+            @include button-variant(
+                $background: $o-we-item-clickable-bg,
+                $border: transparent,
+                $color: $o-we-item-clickable-color,
+                $hover-background: $o-we-item-clickable-hover-bg,
+                $hover-border: transparent,
+                $hover-color: $o-we-item-clickable-color,
+                $active-background: rgba($o-we-color-accent, .15),
+                $active-border: var(--o-hb-select-item-active-color, $o-we-sidebar-content-field-toggle-active-bg),
+                $active-color: $o-we-fg-lighter,
+                $disabled-background: rgba($o-we-item-clickable-hover-bg, 0.5),
+                $disabled-border: transparent,
+                $disabled-color: $o-we-item-clickable-color,
+            );
+
+            &:hover {
+                border: $o-we-border-width solid var(--o-hb-colorpicker-focus-border-color);
+            }
+        }
+    }
+
+    .btn[title=Reset] {
+        @include button-variant(
+            $background: $o-we-bg-light,
+            $border: transparent,
+            $color: $o-we-item-clickable-color,
+            $hover-background: $o-we-bg-lighter,
+            $hover-border: transparent,
+            $hover-color: $o-we-item-clickable-color,
+            $active-background: $o-we-bg-lighter,
+            $active-border: transparent,
+            $active-color: $o-we-fg-lighter,
+            $disabled-background: rgba($o-we-item-clickable-hover-bg, 0.5),
+            $disabled-border: transparent,
+            $disabled-color: $o-we-item-clickable-color,
+        );
+    }
+    .btn-tab {
+        @include button-variant(
+            $background: $o-we-bg-darker,
+            $border: transparent,
+            $color: $o-we-item-clickable-color,
+            $hover-background: $o-we-bg-light,
+            $hover-border: transparent,
+            $hover-color: $o-we-item-clickable-color,
+            $active-background: rgba($o-we-color-accent, .15),
+            $active-border: var(--o-hb-select-item-active-color, $o-we-sidebar-content-field-toggle-active-bg),
+            $active-color: $o-we-fg-lighter,
+            $disabled-background: rgba($o-we-item-clickable-hover-bg, 0.5),
+            $disabled-border: transparent,
+            $disabled-color: $o-we-item-clickable-color,
+        );
+    }
+
+    .btn:focus-visible {
+        border: $o-we-border-width solid var(--o-hb-colorpicker-focus-border-color);
+    }
+
+    .color-combination-button:focus-visible {
+        box-shadow:
+            0 0 0 1px $o-we-bg-darker,
+            0 0 0 3px var(--o-hb-colorpicker-focus-border-color);
+        outline: none;
+    }
+
+    // Gradients
+    .o_custom_gradient_button {
+        color: $o-we-item-clickable-color;
+    }
+
+    .gradient-angle-thumb {
+        background-color: $white;
+    }
+    .gradient-angle-knob + input[name=angle] {
+        @extend %o-hb-input-base;
+
+        & + .input-group-text {
+            background-color: revert;
+            border: revert;
+            color: inherit;
+        }
+    }
+
+    .o_color_picker_inputs {
+        color: $o-we-item-clickable-color;
+
+        & input {
+            color: currentColor;
+        }
+    }
+}

--- a/addons/html_builder/static/src/core/building_blocks/builder_select.js
+++ b/addons/html_builder/static/src/core/building_blocks/builder_select.js
@@ -28,6 +28,7 @@ export class BuilderSelect extends Component {
     static props = {
         ...basicContainerBuilderComponentProps,
         className: { type: String, optional: true },
+        dropdownContainerClass: { type: String, optional: true },
         slots: {
             type: Object,
             shape: {

--- a/addons/html_builder/static/src/core/building_blocks/builder_select.xml
+++ b/addons/html_builder/static/src/core/building_blocks/builder_select.xml
@@ -12,7 +12,7 @@
                     <t t-slot="fixedButton"/>
                 </button>
                 <t t-set-slot="content">
-                    <div data-prevent-closing-overlay="true">
+                    <div t-att-class="props.dropdownContainerClass" data-prevent-closing-overlay="true">
                         <t t-slot="default" />
                     </div>
                 </t>

--- a/addons/html_builder/static/src/core/building_blocks/builder_text_input_base.scss
+++ b/addons/html_builder/static/src/core/building_blocks/builder_text_input_base.scss
@@ -2,14 +2,5 @@
     .popover & {
         --o-hb-field-input-bg: var(--o-hb-field-input-bg-popover, #{$o-we-fg-lighter});
     }
-    border: $o-we-sidebar-content-field-border-width solid $o-we-sidebar-content-field-border-color;
-    border-radius: $o-we-sidebar-content-field-border-radius;
-    background-color: var(--o-hb-field-input-bg, #{$o-we-sidebar-content-field-input-bg});
-    padding: 0.15rem $o-we-sidebar-content-field-clickable-spacing;
-    color: inherit;
-
-    &:focus, &:focus-within {
-        border-color: var(--o-hb-input-active-border, #{$o-we-sidebar-content-field-input-border-color});
-        color: var(--o-hb-row-color-active, #{$o-we-fg-lighter});
-    }
+    @extend %o-hb-input-base;
 }

--- a/addons/html_builder/static/src/core/overlay_buttons/overlay_buttons_plugin.js
+++ b/addons/html_builder/static/src/core/overlay_buttons/overlay_buttons_plugin.js
@@ -24,24 +24,30 @@ export class OverlayButtonsPlugin extends Plugin {
     setup() {
         // TODO find how to not overflow the mobile preview.
         this.iframe = this.editable.ownerDocument.defaultView.frameElement;
-        this.overlay = this.dependencies.overlay.createOverlay(OverlayButtons, {
-            positionOptions: {
-                position: "top-middle",
-                onPositioned: (overlayEl, position) => {
-                    const iframeRect = this.iframe.getBoundingClientRect();
-                    if (this.target && position.top < iframeRect.top) {
-                        const targetRect = this.target.getBoundingClientRect();
-                        const newTop = iframeRect.top + targetRect.bottom + 15;
-                        position.top = newTop;
-                        overlayEl.style.top = `${newTop}px`;
-                    }
-                    return;
+        this.overlay = this.dependencies.overlay.createOverlay(
+            OverlayButtons,
+            {
+                positionOptions: {
+                    position: "top-middle",
+                    onPositioned: (overlayEl, position) => {
+                        const iframeRect = this.iframe.getBoundingClientRect();
+                        if (this.target && position.top < iframeRect.top) {
+                            const targetRect = this.target.getBoundingClientRect();
+                            const newTop = iframeRect.top + targetRect.bottom + 15;
+                            position.top = newTop;
+                            overlayEl.style.top = `${newTop}px`;
+                        }
+                        return;
+                    },
+                    margin: 15,
+                    flip: false,
                 },
-                margin: 15,
-                flip: false,
+                closeOnPointerdown: false,
             },
-            closeOnPointerdown: false,
-        });
+            // The buttons should appear under other overlays, like the link
+            // popover. The default sequence is 50.
+            { sequence: 49 }
+        );
         this.target = null;
         this.state = reactive({
             isVisible: true,

--- a/addons/html_builder/static/src/utils/utils_css.js
+++ b/addons/html_builder/static/src/utils/utils_css.js
@@ -516,7 +516,6 @@ export function setBuilderCSSVariables() {
             // Gradient values are recovered within a string.
             value = value.substring(1, value.length - 1);
         }
-        const builderEl = editableWindow.top.document.querySelector(".o-snippets-menu");
-        builderEl.style.setProperty(`--hb-cp-${style}`, value);
+        editableWindow.top.document.documentElement.style.setProperty(`--hb-cp-${style}`, value);
     }
 }

--- a/addons/web/static/src/core/color_picker/color_picker.scss
+++ b/addons/web/static/src/core/color_picker/color_picker.scss
@@ -115,6 +115,20 @@
         border-radius: 4px;
         border: 1px solid #666;
     }
+
+    input[type=range]:focus-visible {
+        outline: none;
+
+        &::-webkit-slider-thumb {
+            box-shadow: 0 0 0 1px var(--bg, $white), 0 0 0 3px $o-enterprise-action-color;
+        }
+        &::-moz-range-thumb {
+            box-shadow: 0 0 0 1px var(--bg, $white), 0 0 0 3px $o-enterprise-action-color;
+        }
+        &::-ms-thumb {
+            box-shadow: 0 0 0 1px var(--bg, $white), 0 0 0 3px $o-enterprise-action-color;
+        }
+    }
 }
 .gradient-color-bin {
     position: relative;

--- a/addons/website/static/src/builder/plugins/options/dynamic_snippet_option.xml
+++ b/addons/website/static/src/builder/plugins/options/dynamic_snippet_option.xml
@@ -16,7 +16,7 @@
             <t t-foreach="filteredTemplates" t-as="template" t-key="template.key">
                 <t t-if="template.thumb">
                     <BuilderSelectItem actionParam="template">
-                        <Img src="template.thumb" alt="'template.name'"/>
+                        <Img src="template.thumb" alt="template.name" svgCheck="false"/>
                     </BuilderSelectItem>
                 </t>
                 <t t-else="">

--- a/addons/website/static/src/builder/plugins/theme/theme_colors_option.scss
+++ b/addons/website/static/src/builder/plugins/theme/theme_colors_option.scss
@@ -1,0 +1,26 @@
+.o-color-palette-dropdown {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    width: $o-we-sidebar-width - 30px;
+    padding-block: 0.3rem;
+
+    .o-hb-select-dropdown-item {
+        padding-block: 0.5em;
+        border-bottom: none;
+
+        &.focus {
+            background-color: inherit !important; // override
+        }
+
+        .o-color-palette-pill {
+            height: 30px;
+        }
+
+        &:is(.focus, .active) .o-color-palette-pill {
+            box-shadow:
+                0 0 0 #{$o-we-border-width} #{$o-we-bg-light},
+                0 0 0 #{$o-we-border-width * 2} var(--o-hb-select-item-active-color, #{$o-we-sidebar-content-field-toggle-active-bg});
+        }
+    }
+
+}

--- a/addons/website/static/src/builder/plugins/theme/theme_colors_option.xml
+++ b/addons/website/static/src/builder/plugins/theme/theme_colors_option.xml
@@ -50,15 +50,15 @@
                     </div>
                     <div class="d-flex flex-column h-100">
                         <div class="d-flex flex-column h-100 justify-content-center">
-                            <BuilderSelect action="'changeColorPalette'" actionParam="'color-palettes-name'">
+                            <BuilderSelect action="'changeColorPalette'" actionParam="'color-palettes-name'" dropdownContainerClass="'o-color-palette-dropdown'">
                                 <t t-set-slot="fixedButton">
                                     <Img class="'h-100'" src="'/website/static/src/img/snippets_options/palette.svg'"/>
                                 </t>
                                 <t t-foreach="palettes" t-as="palette" t-key="palette.name">
                                     <BuilderSelectItem actionValue="palette.name">
-                                        <div class="d-flex flex-row" style="min-width: 60px">
+                                        <div class="o-color-palette-pill d-flex flex-row border rounded-pill overflow-hidden">
                                             <t t-foreach="palette.colors" t-as="color" t-key="color">
-                                                <span class="w-100" t-attf-style="background-color: {{color}}; height: 25px"></span>
+                                                <span class="w-100" t-attf-style="background-color: {{color}};"></span>
                                             </t>
                                         </div>
                                     </BuilderSelectItem>


### PR DESCRIPTION
### [IMP] html_builder, website: improve color palette select UI

This brings back the color palette on two columns and styles closer to
what it looked like before [1].

[1]: https://github.com/odoo/odoo/commit/9fe45e2b7ddbbfd0445ffe25a859e67a316d02b2

task-4879833

### [FIX] html_builder: fix colors of theme tab colorpicker

Commit [1] was supposed to fix the theme tab in colorpickers, but the
variables were set on the wrong element. As the picker's popover is in
another part of the DOM, the variables need to be set either on the
`html` or the `body` element.

[1]: https://github.com/odoo/odoo/commit/4a48b7ce1257

task-4367641

### [FIX] html_builder: improve focus on builder tabs

The `:focus-visible` state on the builder tabs (Add, Edit, Theme)
clashed with the highlight styles as the outline did not have the same
width and height. Additionally, `:focus-visible` and `:hover` states
were incompatible.

task-4879833

### [FIX] html_builder: prioritize link popover over button overlays

In the website builder, the button overlays may sometimes appear over
the link popover. Adding a sequence makes sure that the buttons will
appear first in the DOM order, and therefore under most other overlays.

Steps to reproduce:
- Drop enough snippets to have a scrollbar.
- On the 1st snippet, have an inner column with a small width (just to
make sure that the buttons will appear at the "right" place) and a
button or a link at the bottom.
- Click on the button
=> The overlay buttons appear over the link popover.

task-4879833

### [IMP] html_builder, web: integrate BuilderColorPicker styles
Use dark styles for the BuilderColorPicker, like the rest of the builder
interface.

task-4879833

### [FIX] website: do not crop template option
We now insert actual images instead of svgs for the "Template" option on
dynamic snippets. The alt is also fixed.

task-4879833