### PR TITLE
[FIX] point_of_sale: load product during session

### DIFF
--- a/addons/point_of_sale/static/tests/pos/tours/pricelist_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/pricelist_tour.js
@@ -1,3 +1,5 @@
+/* global posmodel */
+
 import { registry } from "@web/core/registry";
 import * as ProductScreen from "@point_of_sale/../tests/pos/tours/utils/product_screen_util";
 import * as Numpad from "@point_of_sale/../tests/generic_helpers/numpad_util";
@@ -6,6 +8,7 @@ import * as Dialog from "@point_of_sale/../tests/generic_helpers/dialog_util";
 import * as Pricelist from "@point_of_sale/../tests/pos/tours/utils/pricelist_util";
 import * as Chrome from "@point_of_sale/../tests/pos/tours/utils/chrome_util";
 import * as OfflineUtil from "@point_of_sale/../tests/generic_helpers/offline_util";
+import * as ProductConfigurator from "@point_of_sale/../tests/pos/tours/utils/product_configurator_util";
 import { scan_barcode } from "@point_of_sale/../tests/generic_helpers/utils";
 
 registry.category("web_tour.tours").add("pos_pricelist", {
@@ -120,5 +123,22 @@ registry.category("web_tour.tours").add("test_pricelists_in_pos", {
             ProductScreen.selectedOrderlineHas("Kiwi", "1", "5.0", "MEDIUM"),
             scan_barcode("kiwi_2"),
             ProductScreen.selectedOrderlineHas("Kiwi", "1", "5.0", "SMALL"),
+
+            // Test if post-loaded product with attribute open the configrator
+            {
+                content: "Click hided product with attribute",
+                trigger: "body",
+                run: () => {
+                    const productTemplate = posmodel.models["product.template"].find(
+                        (p) => p.name === "Banana"
+                    );
+
+                    posmodel.addLineToCurrentOrder({
+                        product_tmpl_id: productTemplate,
+                    });
+                },
+            },
+            ProductConfigurator.pickRadio("SMALL"),
+            Dialog.confirm(),
         ].flat(),
 });


### PR DESCRIPTION
When loading new configurable products in the pos, we do not load the good product attribute lines and product attribute values. This commit changes a bit the way of loading the different records to ensure that we follow what is done with each model in the classic way. This ensures that we load all the related records properly.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
