### PR TITLE
[IMP] website_sale: Add short descriptions to product demos

### DIFF
--- a/addons/product/data/product_demo.xml
+++ b/addons/product/data/product_demo.xml
@@ -58,6 +58,7 @@
             <field name="weight">0.01</field>
             <field name="uom_id" ref="uom.product_uom_unit"/>
             <field name="default_code">FURN_7777</field>
+            <field name="description_sale">Comfortable yellow chair for daily work</field>
             <field name="image_1920" type="base64" file="product/static/img/product_chair.jpg"/>
         </record>
 
@@ -81,6 +82,7 @@
             <field name="type">consu</field>
             <field name="weight">0.01</field>
             <field name="uom_id" ref="uom.product_uom_unit"/>
+            <field name="description_sale">Design and plan smart offices with ease</field>
             <field name="default_code">FURN_9999</field>
             <field name="image_1920" type="base64" file="product/static/img/product_product_43-image.jpg"/>
         </record>
@@ -93,7 +95,7 @@
             <field name="type">consu</field>
             <field name="weight">0.01</field>
             <field name="uom_id" ref="uom.product_uom_unit"/>
-            <field name="description_sale">Desk combination, black-brown: chair + desk + drawer.</field>
+            <field name="description_sale">Desk combination, black-brown: chair + desk + drawer</field>
             <field name="default_code">FURN_7800</field>
             <field name="image_1920" type="base64" file="product/static/img/product_product_3-image.jpg"/>
         </record>
@@ -108,7 +110,7 @@
             <field name="type">consu</field>
             <field name="weight">0.01</field>
             <field name="uom_id" ref="uom.product_uom_unit"/>
-            <field name="description_sale">160x80cm, with large legs.</field>
+            <field name="description_sale">160x80cm, with large legs</field>
         </record>
 
         <!-- the product template attribute lines have to be defined before creating the variants -->
@@ -192,6 +194,7 @@
             <field name="type">consu</field>
             <field name="weight">0.01</field>
             <field name="uom_id" ref="uom.product_uom_unit"/>
+            <field name="description_sale">Right-aligned desk with storage</field>
             <field name="default_code">E-COM06</field>
             <field name="image_1920" type="base64" file="product/static/img/product_product_5-image.jpg"/>
         </record>
@@ -218,6 +221,7 @@
             <field name="weight">0.01</field>
             <field name="uom_id" ref="uom.product_uom_unit"/>
             <field name="default_code">E-COM08</field>
+            <field name="description_sale">Blue plastic bin for flexible office storage</field>
             <field name="image_1920" type="base64" file="product/static/img/product_product_7-image.png"/>
         </record>
 
@@ -230,6 +234,7 @@
             <field name="weight">0.01</field>
             <field name="uom_id" ref="uom.product_uom_unit"/>
             <field name="default_code">E-COM09</field>
+            <field name="description_sale">Minimalist wooden desk for executive use</field>
             <field name='weight'>9.54</field>
             <field name="image_1920" type="base64" file="product/static/img/product_product_8-image.jpg"/>
         </record>
@@ -243,6 +248,7 @@
             <field name="weight">0.01</field>
             <field name="uom_id" ref="uom.product_uom_unit"/>
             <field name="default_code">E-COM10</field>
+            <field name="description_sale">Soft-close pedal bin for office use</field>
             <field name="image_1920" type="base64" file="product/static/img/product_product_9-image.jpg"/>
         </record>
 
@@ -357,6 +363,7 @@
             <field name="weight">0.01</field>
             <field name="uom_id" ref="uom.product_uom_unit"/>
             <field name="default_code">FURN_0269</field>
+            <field name="description_sale">High-back office chair with great support</field>
             <field name="image_1920" type="base64" file="product/static/img/product_product_12-image.jpg"/>
         </record>
 
@@ -369,6 +376,7 @@
             <field name="weight">0.01</field>
             <field name="uom_id" ref="uom.product_uom_unit"/>
             <field name="default_code">FURN_1118</field>
+            <field name="description_sale">Left-sided workspace with storage</field>
             <field name="image_1920" type="base64" file="product/static/img/product_product_13-image.jpg"/>
         </record>
 
@@ -416,6 +424,7 @@
             <field name="weight">0.01</field>
             <field name="uom_id" ref="uom.product_uom_unit"/>
             <field name="default_code">FURN_0789</field>
+            <field name="description_sale">Private pod with desk and chair</field>
             <field name="image_1920" type="base64" file="product/static/img/product_product_24-image.jpg"/>
         </record>
 
@@ -427,6 +436,7 @@
             <field name="type">consu</field>
             <field name="weight">0.01</field>
             <field name="uom_id" ref="uom.product_uom_unit"/>
+            <field name="description_sale">Noise-reducing panels for open spaces</field>
             <field name="image_1920" type="base64" file="product/static/img/product_product_25-image.png"/>
             <field name="attribute_line_ids" eval="[
                 Command.create({
@@ -449,7 +459,7 @@
             <field name="type">consu</field>
             <field name="weight">0.01</field>
             <field name="uom_id" ref="uom.product_uom_unit"/>
-            <field name="description">Drawer with two routing possiblities.</field>
+            <field name="description">Drawer with two routing possiblities</field>
             <field name="default_code">FURN_8855</field>
             <field name="image_1920" type="base64" file="product/static/img/product_product_27-image.jpg"/>
         </record>
@@ -462,7 +472,6 @@
             <field name="type">consu</field>
             <field name="weight">0.01</field>
             <field name="uom_id" ref="uom.product_uom_unit"/>
-            <field name="description_sale">Four person modern office workstation</field>
             <field name="default_code">FURN_8220</field>
             <field name="image_1920" type="base64" file="product/static/img/product_product_d03-image.png"/>
         </record>
@@ -475,7 +484,7 @@
             <field name="type">consu</field>
             <field name="weight">0.01</field>
             <field name="uom_id" ref="uom.product_uom_unit"/>
-            <field name="description_sale">Conference room table</field>
+            <field name="description_sale">Big table seats 10–12 for team discussions</field>
             <field name="default_code">FURN_6741</field>
             <field name="image_1920" type="base64" file="product/static/img/product_product_46-image.jpg"/>
         </record>

--- a/addons/sale/data/product_demo.xml
+++ b/addons/sale/data/product_demo.xml
@@ -204,7 +204,7 @@
         <field name="list_price">12.0</field>
         <field name="weight">0.01</field>
         <field name="uom_id" ref="uom.product_uom_unit"/>
-        <field name="description_sale">Office chairs can harm your floor: protect it.</field>
+        <field name="description_sale">Office chairs can harm your floor: protect it</field>
         <field name="image_1920" type="base64" file="sale/static/img/floor_protection-image.jpg"/>
     </record>
 


### PR DESCRIPTION
Before this commit, only the first four demo products had descriptions, showcasing a variety of none/short/long formats.

This commit adds short descriptions (max 50 characters) to several other demo products to better demonstrate the "Enable/Disable Description" feature.

The initial four products remain unchanged to preserve their existing diversity. Other products were selectively updated to maintain visual variation while keeping descriptions short enough to avoid layout issues on narrow or tricky UIs.

requires: https://github.com/odoo/enterprise/pull/88615
task-4893752

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
