### PR TITLE
[REF] html_builder, *: remove method bindings from BuilderAction

### DIFF
--- a/addons/html_builder/static/src/core/builder_action.js
+++ b/addons/html_builder/static/src/core/builder_action.js
@@ -9,16 +9,12 @@ export class BuilderAction {
         this.config = plugin.config;
         this.getResource = plugin.getResource.bind(plugin);
         this.dispatchTo = plugin.dispatchTo.bind(plugin);
-        this.preview = true;
+        this.delegateTo = plugin.delegateTo.bind(this);
 
-        this.apply = this.apply.bind(this);
-        this.isApplied = this.isApplied.bind(this);
-        this.getPriority = this.getPriority.bind(this);
-        this.setup = this.setup.bind(this);
-        this.getValue = this.getValue.bind(this);
-        this.clean = this.clean.bind(this);
-        this.load = this.load.bind(this);
-        this.prepare = this.prepare.bind(this);
+        this.preview = true;
+        this.withLoadingEffect = true;
+        this.loadOnClean = false;
+
         this.setup();
     }
     /**

--- a/addons/html_builder/static/src/core/builder_actions_plugin.js
+++ b/addons/html_builder/static/src/core/builder_actions_plugin.js
@@ -15,19 +15,15 @@ export class BuilderActionsPlugin extends Plugin {
     setup() {
         this.actions = {};
         for (const actions of this.getResource("builder_actions")) {
-            for (const [actionKey, Action] of Object.entries(actions)) {
-                if (actionKey in this.actions) {
-                    throw new Error(`Duplicate builder action id: ${actionKey}`);
+            for (const Action of Object.values(actions)) {
+                if (Action.id in this.actions) {
+                    throw new Error(`Duplicate builder action id: ${Action.id}`);
                 }
-                if (Action.constructor.name === "Function") {
-                    const deps = {};
-                    for (const depName of Action.dependencies) {
-                        deps[depName] = this.config.getShared()[depName];
-                    }
-                    this.actions[Action.id] = new Action(this, deps);
-                } else {
-                    this.actions[actionKey] = { id: actionKey, ...Action };
+                const deps = {};
+                for (const depName of Action.dependencies) {
+                    deps[depName] = this.config.getShared()[depName];
                 }
+                this.actions[Action.id] = new Action(this, deps);
             }
         }
         Object.freeze(this.actions);

--- a/addons/html_builder/static/src/core/building_blocks/builder_colorpicker.js
+++ b/addons/html_builder/static/src/core/building_blocks/builder_colorpicker.js
@@ -22,7 +22,7 @@ export function useColorPickerBuilderComponent() {
             const proms = [];
             for (const applySpec of applySpecs) {
                 proms.push(
-                    applySpec.apply({
+                    applySpec.action.apply({
                         editingElement: applySpec.editingElement,
                         params: applySpec.actionParam,
                         value: applySpec.actionValue,

--- a/addons/html_builder/static/src/core/building_blocks/builder_many2many.js
+++ b/addons/html_builder/static/src/core/building_blocks/builder_many2many.js
@@ -71,7 +71,7 @@ export class BuilderMany2Many extends Component {
         const proms = [];
         for (const applySpec of applySpecs) {
             proms.push(
-                applySpec.apply({
+                applySpec.action.apply({
                     editingElement: applySpec.editingElement,
                     params: applySpec.actionParam,
                     value: applySpec.actionValue,

--- a/addons/html_builder/static/src/core/building_blocks/builder_many2one.js
+++ b/addons/html_builder/static/src/core/building_blocks/builder_many2one.js
@@ -65,15 +65,15 @@ export class BuilderMany2One extends Component {
     callApply(applySpecs) {
         const proms = [];
         for (const applySpec of applySpecs) {
-            if (applySpec.clean && applySpec.actionValue === undefined) {
-                applySpec.clean({
+            if (applySpec.actionValue === undefined) {
+                applySpec.action.clean({
                     editingElement: applySpec.editingElement,
                     params: applySpec.actionParam,
                     dependencyManager: this.env.dependencyManager,
                 });
             } else {
                 proms.push(
-                    applySpec.apply({
+                    applySpec.action.apply({
                         editingElement: applySpec.editingElement,
                         params: applySpec.actionParam,
                         value: applySpec.actionValue,

--- a/addons/html_builder/static/src/core/utils.js
+++ b/addons/html_builder/static/src/core/utils.js
@@ -548,7 +548,7 @@ export function useClickableBuilderComponent() {
             const shouldClean = _shouldClean(comp, hasClean, isAlreadyApplied);
             if (shouldClean) {
                 proms.push(
-                    applySpec.clean({
+                    applySpec.action.clean({
                         isPreviewing,
                         editingElement: applySpec.editingElement,
                         params: applySpec.actionParam,
@@ -560,7 +560,7 @@ export function useClickableBuilderComponent() {
                 );
             } else {
                 proms.push(
-                    applySpec.apply({
+                    applySpec.action.apply({
                         isPreviewing,
                         editingElement: applySpec.editingElement,
                         params: applySpec.actionParam,
@@ -627,7 +627,7 @@ export function useInputBuilderComponent({
         const proms = [];
         for (const applySpec of applySpecs) {
             proms.push(
-                applySpec.apply({
+                applySpec.action.apply({
                     isPreviewing,
                     editingElement: applySpec.editingElement,
                     params: applySpec.actionParam,
@@ -805,7 +805,10 @@ export function getAllActionsAndOperations(comp) {
                     actionId,
                     actionParam,
                     actionValue,
+                    action,
                 };
+                // TODO Since the action is now in the spec, this shouldn't be
+                // necessary anymore.
                 for (const method of overridableMethods) {
                     if (!action.has || action.has(method)) {
                         spec[method] = action[method];
@@ -874,15 +877,15 @@ export function getAllActionsAndOperations(comp) {
             load: async () =>
                 Promise.all(
                     actionsSpecs.map(async (applySpec) => {
-                        if (!applySpec.load) {
+                        if (!applySpec.action.has("load")) {
                             return;
                         }
-                        const hasClean = !!applySpec.clean;
+                        const hasClean = !!applySpec.action.has("clean");
                         if (!applySpec.loadOnClean && _shouldClean(comp, hasClean, isApplied())) {
                             // The element will be cleaned, do not load
                             return;
                         }
-                        const result = await applySpec.load({
+                        const result = await applySpec.action.load({
                             editingElement: applySpec.editingElement,
                             params: applySpec.actionParam,
                             value: applySpec.actionValue,

--- a/addons/website/static/src/builder/plugins/floating_blocks/floating_blocks_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/floating_blocks/floating_blocks_option_plugin.js
@@ -4,8 +4,9 @@ import { withSequence } from "@html_editor/utils/resource";
 import { after } from "@html_builder/utils/option_sequence";
 import { DEVICE_VISIBILITY } from "@website/builder/option_sequence";
 import { renderToElement } from "@web/core/utils/render";
+import { BuilderAction } from "@html_builder/core/builder_action";
 
-class FloatingBlocksOptionPlugin extends Plugin {
+export class FloatingBlocksOptionPlugin extends Plugin {
     static id = "floatingBlocksOptionPlugin";
     resources = {
         builder_options: [
@@ -15,32 +16,36 @@ class FloatingBlocksOptionPlugin extends Plugin {
             }),
         ],
         builder_actions: {
-            floatingBlocksRoundness: {
-                getValue: ({ editingElement }) => {
-                    for (let x = 0; x <= 5; x++) {
-                        if (editingElement.classList.contains(`rounded-${x}`)) {
-                            return x;
-                        }
-                    }
-                    return 0;
-                },
-                apply: ({ editingElement, value }) => {
-                    for (let x = 0; x <= 5; x++) {
-                        editingElement.classList.remove(`rounded-${x}`);
-                    }
-                    editingElement.classList.add(`rounded-${value}`);
-                },
-            },
-            addCard: {
-                apply: ({ editingElement: el }) => {
-                    const newCardEl = renderToElement("website.s_floating_blocks.new_card");
-                    const wrapperEl = el.querySelector(".s_floating_blocks_wrapper");
-                    wrapperEl.appendChild(newCardEl);
-                    newCardEl.scrollIntoView({ behavior: "smooth", block: "center" });
-                },
-            },
+            FloatingBlocksRoundnessAction,
+            AddCardAction,
         },
     };
+}
+
+export class FloatingBlocksRoundnessAction extends BuilderAction {
+    static id = "floatingBlocksRoundness";
+    getValue({ editingElement }) {
+        for (let x = 0; x <= 5; x++) {
+            if (editingElement.classList.contains(`rounded-${x}`)) {
+                return x;
+            }
+        }
+        return 0;
+    }
+    apply({ editingElement, value }) {
+        for (let x = 0; x <= 5; x++) {
+            editingElement.classList.remove(`rounded-${x}`);
+        }
+        editingElement.classList.add(`rounded-${value}`);
+    }
+}
+export class AddCardAction extends BuilderAction {
+    apply({ editingElement: el }) {
+        const newCardEl = renderToElement("website.s_floating_blocks.new_card");
+        const wrapperEl = el.querySelector(".s_floating_blocks_wrapper");
+        wrapperEl.appendChild(newCardEl);
+        newCardEl.scrollIntoView({ behavior: "smooth", block: "center" });
+    }
 }
 
 registry.category("website-plugins").add(FloatingBlocksOptionPlugin.id, FloatingBlocksOptionPlugin);

--- a/addons/website/static/tests/builder/custom_tab/builder_components/builder_button.test.js
+++ b/addons/website/static/tests/builder/custom_tab/builder_components/builder_button.test.js
@@ -401,7 +401,9 @@ describe("inherited actions", () => {
     function makeAction(n, { async, isApplied } = {}) {
         const action = class extends BuilderAction {
             static id = `customAction${n}`;
-            isApplied = isApplied;
+            isApplied() {
+                return isApplied?.();
+            }
             clean({ params: { mainParam: testParam }, value }) {
                 expect.step(`customAction${n} clean ${testParam} ${value}`);
             }


### PR DESCRIPTION
*: website

This refactor centralizes the responsibility of binding BuilderAction methods (`apply`, `prepare`, `isApplied`, etc.) into the builder plugin registration logic, instead of having them bound within the BuilderAction constructor.

It simplifies the BuilderAction class and gives the plugin more control over instance behavior, improving flexibility and future extensibility.

Minor fix in builder button test included.
