### PR TITLE
[FIX] mail: fixed messaging menu systray background

### DIFF
--- a/addons/mail/static/src/core/web/messaging_menu_patch.xml
+++ b/addons/mail/static/src/core/web/messaging_menu_patch.xml
@@ -4,7 +4,7 @@
         <xpath expr="//*[@t-name='mail.MessagingMenu']" position="inside">
             <div t-if="!env.inDiscussApp" t-att-class="discussSystray.class">
                 <Dropdown state="dropdown" beforeOpen.bind="beforeOpen" position="'bottom-end'" menuClass="discussSystray.menuClass">
-                    <button>
+                    <button class="bg-transparent">
                         <i class="fa fa-lg fa-comments" role="img" aria-label="Messages" t-on-click="() => store.discuss.activeTab = ui.isSmall and store.discuss.activeTab === 'main' ? 'main' : store.discuss.activeTab"></i>
                         <span t-if="!store.settings.mute_until_dt and counter" class="o-mail-MessagingMenu-counter badge rounded-pill"><t t-esc="counter"/></span>
                     </button>


### PR DESCRIPTION
This commit fixes a background issue on the
messaging menu button in the systray.

issue introduced by: https://github.com/odoo/odoo/pull/198012

before: 
![image](https://github.com/user-attachments/assets/df1fe80f-184b-4539-a39c-0448850f61e5)
after:
![image](https://github.com/user-attachments/assets/3494a880-70a3-471a-a826-c4786b520283)

