### PR TITLE
[FIX] fields: Fix selection export

### DIFF
--- a/addons/test_import_export/tests/test_export_impex.py
+++ b/addons/test_import_export/tests/test_export_impex.py
@@ -237,9 +237,10 @@ class test_selection_function(CreatorCase):
 
     def test_value(self):
         # selection functions export the *value* itself
-        self.assertEqual(self.export('1'), [['1']])
-        self.assertEqual(self.export('3'), [['3']])
-        self.assertEqual(self.export('0'), [['0']])
+
+        self.assertEqual(self.export('1'), [['Grault']])
+        self.assertEqual(self.export('3'), [['Moog']])
+        self.assertEqual(self.export('0'), [['Corge']])
 
 
 class test_m2o(CreatorCase):

--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -2992,7 +2992,8 @@ class Selection(Field[str | typing.Literal[False]]):
         raise ValueError("Wrong value for %s: %r" % (self, value))
 
     def convert_to_export(self, value, record):
-        if not isinstance(self.selection, list):
+        selection = self.selection
+        if not isinstance(selection, (list, str)) and not callable(selection):
             # FIXME: this reproduces an existing buggy behavior!
             return value if value else ''
         for item in self._description_selection(record.env):


### PR DESCRIPTION
Whenever selection field have the any function in selection value at that time while export it not export associated language ``value``.  For Fixing this, according to [this](https://github.com/odoo/odoo/blob/a7a5470596b1d08311d87931c0ef24217087f729/odoo/fields.py#L2960) adding this condition to get the correct values.

opw-4882812
upg-2985436

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
