### PR TITLE
[REF] iot_drivers: IoT platform system as a constant

### DIFF
--- a/addons/iot_drivers/connection_manager.py
+++ b/addons/iot_drivers/connection_manager.py
@@ -1,13 +1,13 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import logging
-import platform
 import requests
 from threading import Thread
 import time
 
 from odoo.addons.iot_drivers.main import iot_devices
 from odoo.addons.iot_drivers.tools import helpers, upgrade, wifi
+from odoo.addons.iot_drivers.tools.system import IS_RPI
 
 _logger = logging.getLogger(__name__)
 
@@ -33,7 +33,7 @@ class ConnectionManager(Thread):
         if all(key in req for key in ['pairing_code', 'pairing_uuid']):
             self.pairing_code = req['pairing_code']
             self.pairing_uuid = req['pairing_uuid']
-            if platform.system() == 'Linux':
+            if IS_RPI:
                 self._try_print_pairing_code()
             self.iot_box_registered = True
 
@@ -59,7 +59,7 @@ class ConnectionManager(Thread):
         return (
             not helpers.get_odoo_server_url() and
             helpers.get_ip() and
-            not (platform.system() == 'Linux' and wifi.is_access_point()) and
+            not (IS_RPI and wifi.is_access_point()) and
             not self.pairing_code_expired
         )
 

--- a/addons/iot_drivers/iot_handlers/drivers/l10n_eg_drivers.py
+++ b/addons/iot_drivers/iot_handlers/drivers/l10n_eg_drivers.py
@@ -2,7 +2,6 @@
 import base64
 import json
 import logging
-import platform
 import PyKCS11
 
 from passlib.context import CryptContext
@@ -10,6 +9,7 @@ from passlib.context import CryptContext
 from odoo import http
 from odoo.tools.config import config
 from odoo.addons.iot_drivers.tools import route
+from odoo.addons.iot_drivers.tools.system import IOT_SYSTEM, IS_RPI, IS_WINDOWS
 
 _logger = logging.getLogger(__name__)
 
@@ -118,13 +118,12 @@ class EtaUsbController(http.Controller):
 
     def get_crypto_lib(self):
         error = lib = False
-        system = platform.system()
-        if system == 'Linux':
-            lib = '/usr/lib/x86_64-linux-gnu/opensc-pkcs11.so'
-        elif system == 'Windows':
-            lib = 'C:/Windows/System32/eps2003csp11.dll'
-        elif system == 'Darwin':
+        if IOT_SYSTEM == 'Darwin':
             lib = '/Library/OpenSC/lib/onepin-opensc-pkcs11.so'
+        elif IS_RPI:
+            lib = '/usr/lib/x86_64-linux-gnu/opensc-pkcs11.so'
+        elif IS_WINDOWS:
+            lib = 'C:/Windows/System32/eps2003csp11.dll'
         else:
             error = self._get_error_template('unsupported_system')
         return lib, error

--- a/addons/iot_drivers/iot_handlers/interfaces/serial_interface.py
+++ b/addons/iot_drivers/iot_handlers/interfaces/serial_interface.py
@@ -1,8 +1,8 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-import platform
 from serial.tools.list_ports import comports
 
+from odoo.addons.iot_drivers.tools.system import IS_WINDOWS
 from odoo.addons.iot_drivers.interface import Interface
 
 
@@ -14,7 +14,7 @@ class SerialInterface(Interface):
         serial_devices = {
             port.device: {'identifier': port.device}
             for port in comports()
-            if platform.system() == 'Windows' or port.subsystem != 'amba'
+            if IS_WINDOWS or port.subsystem != 'amba'
             # RPI 5 uses ttyAMA10 as a console serial port for system messages: odoo interprets it as scale -> avoid it
         }
         return serial_devices

--- a/addons/iot_drivers/tools/__init__.py
+++ b/addons/iot_drivers/tools/__init__.py
@@ -1,3 +1,4 @@
+from . import system
 from . import helpers
 from . import wifi
 from . import route

--- a/addons/iot_drivers/tools/certificate.py
+++ b/addons/iot_drivers/tools/certificate.py
@@ -1,6 +1,5 @@
 import datetime
 import logging
-import platform
 import requests
 from cryptography import x509
 from cryptography.x509.oid import NameOID
@@ -16,6 +15,7 @@ from odoo.addons.iot_drivers.tools.helpers import (
     update_conf,
     writable,
 )
+from odoo.addons.iot_drivers.tools.system import IS_RPI, IS_WINDOWS
 
 _logger = logging.getLogger(__name__)
 
@@ -36,7 +36,7 @@ def get_certificate_end_date():
     :return: End date of the certificate if it is valid, None otherwise
     :rtype: str
     """
-    base_path = [get_path_nginx(), 'conf'] if platform.system() == 'Windows' else ['/etc/ssl/certs']
+    base_path = [get_path_nginx(), 'conf'] if IS_WINDOWS else ['/etc/ssl/certs']
     path = Path(*base_path, 'nginx-cert.crt')
     if not path.exists():
         return None
@@ -99,7 +99,7 @@ def download_odoo_certificate():
 
     certificate = result['x509_pem']
     private_key = result['private_key_pem']
-    if platform.system() == 'Linux':
+    if IS_RPI:
         with writable():
             Path('/etc/ssl/certs/nginx-cert.crt').write_text(certificate, encoding='utf-8')
             Path('/root_bypass_ramdisks/etc/ssl/certs/nginx-cert.crt').write_text(certificate, encoding='utf-8')

--- a/addons/iot_drivers/tools/route.py
+++ b/addons/iot_drivers/tools/route.py
@@ -1,9 +1,9 @@
 import functools
 import logging
-import platform
 
 from odoo.addons.iot_base.tools.payload_signature import verify_hmac_signature
 from odoo.addons.iot_drivers.tools import helpers
+from odoo.addons.iot_drivers.tools.system import IS_RPI
 from odoo.http import request
 from odoo import http
 from werkzeug.exceptions import Forbidden
@@ -53,7 +53,7 @@ def iot_route(route=None, sign=False, linux_only=False, **kwargs):
     http_decorator = http.route(route, **kwargs)
 
     def decorator(endpoint):
-        if linux_only and platform.system() != 'Linux':
+        if linux_only and not IS_RPI:
             return None  # Remove the route if not Linux (will return 404)
         return protect(http_decorator(endpoint)) if sign else http_decorator(endpoint)
 

--- a/addons/iot_drivers/tools/system.py
+++ b/addons/iot_drivers/tools/system.py
@@ -1,0 +1,19 @@
+"""Operating system-related utilities for the IoT"""
+
+from platform import system
+
+IOT_SYSTEM = system()
+
+IOT_RPI_CHAR, IOT_WINDOWS_CHAR = "L", "W"
+
+IS_RPI = IOT_SYSTEM[0] == IOT_RPI_CHAR
+IS_WINDOWS = IOT_SYSTEM[0] == IOT_WINDOWS_CHAR
+
+if IS_RPI:
+    def rpi_only(function):
+        """Decorator to check if the system is raspberry pi before running the function."""
+        return function
+else:
+    def rpi_only(_):
+        """No-op decorator for non raspberry pi systems."""
+        return lambda *args, **kwargs: None


### PR DESCRIPTION
Introduce the "type" of IoT as a constant, it ca be either:
 - Linux OS -> raspberry pi -> Physical IoT box
 - Windows OS -> windows virtual IoT

This aim to replace the numerous `if platform.system() == ...` which make the code less easy to read. It also make it easier to maintain in the case on which we would like to introduce a new IoT system in the future.

Extra enterprise PR: https://github.com/odoo/enterprise/pull/88619
