### PR TITLE
[REM] account: remove fiscal position filter from tax field search

### DIFF
--- a/addons/account/static/src/components/many2x_tax_tags/many2x_tax_tags.js
+++ b/addons/account/static/src/components/many2x_tax_tags/many2x_tax_tags.js
@@ -38,14 +38,6 @@ export class Many2XTaxTagsAutocomplete extends Many2XAutocomplete {
             ];
         }
 
-        const filterFP = context.dynamic_fiscal_position_id;
-        if (filterFP) {
-            dynamicFilters.push({
-                description: _t("Document Fiscal Position"),
-                domain: [["fiscal_position_ids", "in", [parseInt(filterFP)]]]
-            })
-        }
-
         const title = _t("Search: %s", fieldString);
         this.selectCreate({
             domain,

--- a/addons/account/views/account_tax_views.xml
+++ b/addons/account/views/account_tax_views.xml
@@ -61,7 +61,6 @@
             <field name="arch" type="xml">
                 <list string="Account Tax">
                     <field name="display_name" string="Name"/>
-                    <field name="original_tax_ids" widget="many2many_tax_tags"/>
                     <field name="tax_scope"/>
                     <field name="description"/>
                 </list>


### PR DESCRIPTION
In this PR:
- Removed the **Document Fiscal Position** default filter and **original_tax_ids** column from the tax field search view to improve user experience when searching for taxes outside the default scope.

Task-4899979