### PR TITLE
[IMP] iot_box_image: add arp-scan and mtr to image

### DIFF
--- a/addons/iot_box_image/overwrite_before_init/etc/init_image.sh
+++ b/addons/iot_box_image/overwrite_before_init/etc/init_image.sh
@@ -155,6 +155,7 @@ echo "pi:${password}" | chpasswd
 echo TrustedUserCAKeys /etc/ssh/ca.pub >> /etc/ssh/sshd_config
 
 PKGS_TO_INSTALL="
+    arp-scan \
     chromium-browser \
     console-data \
     cups \
@@ -171,6 +172,7 @@ PKGS_TO_INSTALL="
     libpq-dev \
     libffi-dev \
     localepurge \
+    mtr \
     nginx-full \
     printer-driver-all \
     python3 \


### PR DESCRIPTION
Network scan/analysis tools can be useful when debugging configurations., so we added `arp-scan` and `mtr`.
