### PR TITLE
[FIX] iot_drivers: random printer chosen during deduplication

### DIFF
--- a/addons/iot_drivers/iot_handlers/interfaces/printer_interface_L.py
+++ b/addons/iot_drivers/iot_handlers/interfaces/printer_interface_L.py
@@ -127,7 +127,7 @@ class PrinterInterface(Interface):
         sorted_printers = sorted(discovered_printers.values(), key=lambda printer: str(printer.get('ip')))
 
         for ip, printers_with_same_ip in groupby(sorted_printers, lambda printer: printer.get('ip')):
-            printers_with_same_ip = list(printers_with_same_ip)
+            printers_with_same_ip = sorted(printers_with_same_ip, key=lambda printer: printer['identifier'])
             if ip is None or len(printers_with_same_ip) == 1:
                 result += printers_with_same_ip
                 continue


### PR DESCRIPTION
There was a flaw in the printer deduplication logic that meant that in the case where we have two printers with the same IP and the same device-id, the printer that was returned could change randomly with each `get_devices` call. The result was the printers appearing and disappearing randomly in the device list.

We fix this by sorting the list of printers first. If multiple printers could be chosen, we take the first one based on identifier.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
