### PR TITLE
[FIX] hr_holidays: time off warning displayed on own user chats

### DIFF
--- a/addons/hr_holidays/static/src/thread_patch.xml
+++ b/addons/hr_holidays/static/src/thread_patch.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
     <t t-inherit="mail.Thread" t-inherit-mode="extension">
         <xpath expr="//*[hasclass('o-mail-Thread')]" position="before">
-            <div t-if="props.thread.model === 'discuss.channel' and props.thread.correspondent?.persona.outOfOfficeDateEndText" class="alert alert-primary mb-0 smaller fw-bolder o-rounded-bubble mx-1 o-mt-0_5 py-1 shadow-sm" t-esc="props.thread.correspondent.persona.outOfOfficeDateEndText" role="alert"/>
+            <div t-if="this.props.thread.model === 'discuss.channel' and this.props.thread.correspondent?.persona.outOfOfficeDateEndText" class="alert alert-primary mb-0 smaller fw-bolder o-rounded-bubble mx-1 o-mt-0_5 py-1 shadow-sm" t-esc="props.thread.correspondent.persona.outOfOfficeDateEndText" role="alert"/>
         </xpath>
     </t>
 </templates>


### PR DESCRIPTION
This commit removes the holiday warning label from chats, when the correspondent is the user themselves.

Basically when the user is sending a message to themselves, or with an AI chat, the holiday label (for their own holiday) will not be present in the chat.

Task-4895064

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
