### PR TITLE
[REF] web, *: use textContent instead of innerHTML when empty

### DIFF
--- a/addons/point_of_sale/static/src/app/services/render_service.js
+++ b/addons/point_of_sale/static/src/app/services/render_service.js
@@ -62,7 +62,7 @@ export const renderService = {
         };
         const whenMounted = async ({ el, container, callback }) => {
             container ||= document.querySelector(".render-container");
-            container.innerHTML = "";
+            container.textContent = "";
             return await applyWhenMounted({ el, container, callback });
         };
         return { toHtml, toCanvas, toJpeg, whenMounted };

--- a/addons/web_editor/static/src/js/editor/add_snippet_dialog.js
+++ b/addons/web_editor/static/src/js/editor/add_snippet_dialog.js
@@ -274,7 +274,7 @@ export class AddSnippetDialog extends Component {
                     const previewImgEl = document.createElement("img");
                     previewImgEl.src = imagePreview;
                     previewImgDivEl.appendChild(previewImgEl);
-                    clonedSnippetEl.innerHTML = "";
+                    clonedSnippetEl.textContent = "";
                     clonedSnippetEl.appendChild(previewImgDivEl);
                 }
 

--- a/addons/website/static/src/builder/plugins/options/table_of_content_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/table_of_content_option_plugin.js
@@ -116,7 +116,7 @@ class TableOfContentOptionPlugin extends Plugin {
         const headingIds = currentHeadingItems.map(({ el }) => getTocAndHeadingId(el).headingId);
         let maxHeadingIds = Math.max(0, ...headingIds);
 
-        tableOfContentNavbar.innerHTML = "";
+        tableOfContentNavbar.textContent = "";
         const uniqueHeadingIds = new Set();
         for (const { title, el } of currentHeadingItems) {
             let { headingId } = getTocAndHeadingId(el);

--- a/addons/website/static/src/interactions/video/media_video.js
+++ b/addons/website/static/src/interactions/video/media_video.js
@@ -56,7 +56,7 @@ export class MediaVideo extends Interaction {
     generateIframe() {
         // Bug fix / compatibility: empty the <div/> element as all information
         // to rebuild the iframe should have been saved on the <div/> element
-        this.el.innerHTML = "";
+        this.el.textContent = "";
 
         // Add extra content for size / edition
         const div1 = document.createElement("div");

--- a/addons/website_payment/static/src/website_builder/donation_option_plugin.js
+++ b/addons/website_payment/static/src/website_builder/donation_option_plugin.js
@@ -195,7 +195,7 @@ class DonationOptionPlugin extends Plugin {
         const descriptionInputContainerEl = editingElement.querySelector(
             "#s_donation_description_inputs"
         );
-        descriptionInputContainerEl.innerHTML = "";
+        descriptionInputContainerEl.textContent = "";
         if (showDescriptions) {
             descriptionInputContainerEl.insertBefore(
                 renderToFragment("website_payment.donation.descriptionTranslationInputs", {

--- a/addons/website_slides_survey/static/src/js/slides_course_fullscreen_player.js
+++ b/addons/website_slides_survey/static/src/js/slides_course_fullscreen_player.js
@@ -13,7 +13,7 @@ Fullscreen.include({
         var def = this._super.apply(this, arguments);
         const contentEl = this.el.querySelector(".o_wslides_fs_content");
         if (this._slideValue.category === "certification") {
-            contentEl.innerHTML = "";
+            contentEl.textContent = "";
             contentEl.append(
                 renderToElement("website.slides.fullscreen.certification", { widget: this })
             );


### PR DESCRIPTION
Writing on innerHTML is generally not recommended as it can lead to security issues. This is highlighted by triggering the ci/security.

`setElementContent` utils is now available to safely write it on `innerHTML` by checking the content type (markup in particular).

However, when writing an empty value, using `textContent` has the same effect of clearing all children. It is therefore preferable to use it instead, in order to remove direct usage of `innerHTML` in code and to avoid triggering unncessary security checks.

https://developer.mozilla.org/en-US/docs/Web/API/Node/textContent

https://github.com/odoo/enterprise/pull/88628