### PR TITLE
[FIX] web, website: remove params key from context

### DIFF
--- a/addons/web/static/src/model/relational_model/relational_model.js
+++ b/addons/web/static/src/model/relational_model/relational_model.js
@@ -324,7 +324,6 @@ export class RelationalModel extends Model {
 
         config.context = "context" in params ? params.context : config.context;
         config.context = { ...config.context };
-        delete config.context.params;
         if (currentConfig.isMonoRecord) {
             config.resId = "resId" in params ? params.resId : config.resId;
             config.resIds = "resIds" in params ? params.resIds : config.resIds;

--- a/addons/web/static/src/webclient/actions/action_service.js
+++ b/addons/web/static/src/webclient/actions/action_service.js
@@ -509,7 +509,6 @@ export function makeActionManager(env, router = _router) {
                 }
             } else {
                 // The action to load isn't the current one => executes it
-                context.params = state;
                 Object.assign(options, {
                     additionalContext: context,
                     viewType: state.resId ? "form" : state.view_type,
@@ -1265,10 +1264,11 @@ export function makeActionManager(env, router = _router) {
                     action.target = clientAction.target;
                 }
             }
+            const props = clientAction.extractProps?.(action) || {};
             const controller = _makeController({
                 Component: clientAction,
                 action,
-                ..._getActionInfo(action, options.props),
+                ..._getActionInfo(action, { ...props, ...options.props }),
             });
             controller.displayName ||= clientAction.displayName?.toString() || "";
             return _updateUI(controller, options);

--- a/addons/web/static/tests/webclient/actions/client_action.test.js
+++ b/addons/web/static/tests/webclient/actions/client_action.test.js
@@ -278,6 +278,31 @@ test("ClientAction receives arbitrary props from doAction", async () => {
     });
 });
 
+test("ClientAction with extractProps", async () => {
+    defineActions([
+        {
+            id: 128,
+            name: "My Client Action",
+            tag: "SomeClientAction",
+            type: "ir.actions.client",
+            params: {
+                my_prop: "coucou",
+            },
+        },
+    ]);
+    class ClientAction extends Component {
+        static template = xml`<div class="my_client_action" t-esc="props.myProp"/>`;
+        static props = ["*"];
+        static extractProps(action) {
+            return { myProp: action.params.my_prop };
+        }
+    }
+    actionRegistry.add("SomeClientAction", ClientAction);
+    await mountWithCleanup(WebClient);
+    await getService("action").doAction(128);
+    expect(".my_client_action").toHaveText("coucou");
+});
+
 test("test display_notification client action", async () => {
     await mountWithCleanup(WebClient);
     await getService("action").doAction(1);

--- a/addons/web/static/tests/webclient/actions/misc.test.js
+++ b/addons/web/static/tests/webclient/actions/misc.test.js
@@ -663,15 +663,6 @@ test("retrieving a stored action should remove 'allowed_company_ids' from its co
     // Check the current action context
     expect(getService("action").currentController.action.context).toEqual({
         // action context
-        params: {
-            action: 1,
-            actionStack: [
-                {
-                    action: 1,
-                },
-            ],
-            view_type: "kanban",
-        },
         someKey: 44,
         lang: "not_en",
         tz: "not_taht",

--- a/addons/website/models/ir_module_module.py
+++ b/addons/website/models/ir_module_module.py
@@ -416,7 +416,7 @@ class IrModuleModule(models.Model):
         self._theme_upgrade_upstream()
 
         result = website.button_go_website()
-        result['context']['params']['with_loader'] = True
+        result['params']['with_loader'] = True
         return result
 
     def button_remove_theme(self):

--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -1717,12 +1717,10 @@ class Website(models.Model):
 
     def get_client_action(self, url, mode_edit=False, website_id=False):
         action = self.env["ir.actions.actions"]._for_xml_id("website.website_preview")
-        action['context'] = {
-            'params': {
-                'path': url,
-                'enable_editor': mode_edit,
-                'website_id': website_id,
-            }
+        action['params'] = {
+            'path': url,
+            'enable_editor': mode_edit,
+            'website_id': website_id,
         }
         return action
 

--- a/addons/website/static/src/services/website_service.js
+++ b/addons/website/static/src/services/website_service.js
@@ -253,13 +253,11 @@ export const websiteService = {
                 }
                 action.doAction("website.website_preview", {
                     clearBreadcrumbs: true,
-                    additionalContext: {
-                        params: {
-                            website_id: websiteId || currentWebsiteId,
-                            path: path || (contentWindow && contentWindow.location.href) || '/',
-                            enable_editor: edition,
-                            edit_translations: translation,
-                        },
+                    props: {
+                        websiteId: websiteId || currentWebsiteId,
+                        path: path || (contentWindow && contentWindow.location.href) || '/',
+                        enableEditor: edition,
+                        editTranslations: translation,
                     },
                 });
             },

--- a/addons/website/static/tests/builder/translation.test.js
+++ b/addons/website/static/tests/builder/translation.test.js
@@ -258,12 +258,16 @@ async function setupSidebarBuilderForTranslation(options) {
             this.websiteContext = this.websiteService.context;
         },
     });
-    const { getEditor, getEditableContent, getIframeEl, openBuilderSidebar } =
-        await setupWebsiteBuilder(websiteContent, {
+    const { getEditor, getEditableContent, openBuilderSidebar } = await setupWebsiteBuilder(
+        websiteContent,
+        {
             openEditor: false,
             translateMode: true,
-        });
-    websiteServiceInTranslateMode.pageDocument = getIframeEl().contentDocument;
+            onIframeLoaded: (iframe) => {
+                websiteServiceInTranslateMode.pageDocument = iframe.contentDocument;
+            },
+        }
+    );
     await openBuilderSidebar();
     return { getEditor, getEditableContent };
 }

--- a/addons/website/static/tests/builder/website_helpers.js
+++ b/addons/website/static/tests/builder/website_helpers.js
@@ -86,6 +86,7 @@ export async function setupWebsiteBuilder(
         headerContent = "",
         beforeWrapwrapContent = "",
         translateMode = false,
+        onIframeLoaded = () => {},
     } = {}
 ) {
     // TODO: fix when the iframe is reloaded and become empty (e.g. discard button)
@@ -115,6 +116,7 @@ export async function setupWebsiteBuilder(
             iframe.contentDocument.body.innerHTML = `
                 ${beforeWrapwrapContent}
                 <div id="wrapwrap">${headerContent} <div id="wrap" class="oe_structure oe_empty" data-oe-model="ir.ui.view" data-oe-id="539" data-oe-field="arch">${websiteContent}</div></div>`;
+            onIframeLoaded(iframe);
             resolve(el);
         };
     });
@@ -232,7 +234,6 @@ export async function setupWebsiteBuilder(
         getEditor: () => editor,
         getEditableContent: () => editableContent,
         openBuilderSidebar: async () => await openBuilderSidebar(editAssetsLoaded),
-        getIframeEl: () => iframe,
     };
 }
 


### PR DESCRIPTION
Before this commit, the action service added a `params` key into
the context, typically when doing a `loadState`, i.e. loading the
state from the url. The value of that key was the state of url (an
object with, amongs other things, a `actionStack` key,
representing the current breadcrumbs, a typical JS thing).

Adding this key was a mistake from day 1, as it was then sent to
the python at each rpc. It means that the context sent to load a
form view was different before and after a page reload, which
doesn't make sense. Worse, it caused an issue with the newly
introduced cache system [1], as we did a cache miss on reload, due
to that altered context. To circumvent that, we manually removed
that key in RelationalModel, before loading data.

However, this caused an issue in website, as the code was actually
using that `params` key mecanism: they relied on the fact that it
was automatically added by the framework in some cases (F5), and
built it themselves in other case (calls to doAction).

This commit properly fixes the issue we tried to fix in [1]: we no
longer add the `params` key when loading the state from the url.
So we don't need to remove it later anymore. We obviously had to
adapt a bit the code in website. We added some props to parameterize
the WebsideBuilder action, and that component now also reads
directly into the state of the router. We also introduced an
`extractProps` mecanism (like we have for fields), to convert an
action (especially its `params`) into props to provide to the
client action itself.

[1] https://www.odoo.com/odoo/project/133/tasks/4479845

task-4901018