### PR TITLE
[FIX] spreadsheet_{dashboard}: Facet text is not correct for text and…

### DIFF
--- a/addons/spreadsheet/static/src/global_filters/helpers.js
+++ b/addons/spreadsheet/static/src/global_filters/helpers.js
@@ -572,3 +572,33 @@ export function getDateDomain(from, to, field, fieldType) {
     }
     return new Domain();
 }
+
+export async function getFacetInfo(filter, filterValues, nameService) {
+    let values;
+    const separator = _t("or");
+    switch (filter.type) {
+        case "boolean":
+            values = filterValues.map((value) => (value ? _t("Is set") : _t("Is not set")));
+            break;
+        case "text":
+            values = filterValues;
+            break;
+        case "date": {
+            if (!filterValues) {
+                throw new Error("Should be defined at this point");
+            }
+            values = [dateFilterValueToString(filterValues)];
+            break;
+        }
+        case "relation":
+            values = await nameService.loadDisplayNames(filter.modelName, filterValues);
+            values = Object.values(values);
+            break;
+    }
+    return {
+        title: filter.label,
+        values,
+        id: filter.id,
+        separator,
+    };
+}

--- a/addons/spreadsheet_dashboard/static/src/bundle/dashboard_action/dashboard_search_bar/dashboard_search_bar.js
+++ b/addons/spreadsheet_dashboard/static/src/bundle/dashboard_action/dashboard_search_bar/dashboard_search_bar.js
@@ -2,9 +2,8 @@ import { Component, onWillUpdateProps, onWillStart } from "@odoo/owl";
 import { DashboardFacet } from "../dashboard_facet/dashboard_facet";
 import { useService } from "@web/core/utils/hooks";
 import { useDropdownState } from "@web/core/dropdown/dropdown_hooks";
-import { _t } from "@web/core/l10n/translation";
 import { DashboardSearchDialog } from "../dashboard_search_dialog/dashboard_search_dialog";
-import { dateFilterValueToString } from "@spreadsheet/global_filters/helpers";
+import { getFacetInfo } from "@spreadsheet/global_filters/helpers";
 import { DashboardDateFilter } from "../dashboard_date_filter/dashboard_date_filter";
 
 export class DashboardSearchBar extends Component {
@@ -69,30 +68,6 @@ export class DashboardSearchBar extends Component {
 
     async getFacetFor(filter) {
         const filterValues = this.props.model.getters.getGlobalFilterValue(filter.id);
-        let values;
-        const separator = _t("or");
-        switch (filter.type) {
-            case "boolean":
-            case "text":
-                values = [filterValues];
-                break;
-            case "date": {
-                if (!filterValues) {
-                    throw new Error("Should be defined at this point");
-                }
-                values = [dateFilterValueToString(filterValues)];
-                break;
-            }
-            case "relation":
-                values = await this.nameService.loadDisplayNames(filter.modelName, filterValues);
-                values = Object.values(values);
-                break;
-        }
-        return {
-            title: filter.label,
-            values,
-            id: filter.id,
-            separator,
-        };
+        return getFacetInfo(filter, filterValues, this.nameService);
     }
 }


### PR DESCRIPTION
… boolean filters

Steps to reproduce:
1. Configure a spreadsheet dashboard with a text filter and a boolean filter.
2. Set these filters to at least two values. => Boolean filter is displayed as `true,false` instead of `Is set or Is not set`
=> Text filter is displayed as `text1,text2` instead of `text1 or text2`

To ease the testing, the function `getFacetFor` has been moved to a helper (it's already the case in master).
This commit also adds a test for the others filters (relation and date).

Task: 4900910

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
