### PR TITLE
[FIX] mail: prevent error when creating a mail blacklist entry from the website

### DIFF
--- a/addons/mail/models/mail_blacklist.py
+++ b/addons/mail/models/mail_blacklist.py
@@ -28,7 +28,7 @@ class MailBlackList(models.Model):
         for value in values:
             email = tools.email_normalize(value.get('email'))
             if not email:
-                raise UserError(_('Invalid email address “%s”', value['email']))
+                raise UserError(_('Invalid email address “%s”', value.get('email')))
             if email in all_emails:
                 continue
             all_emails.append(email)


### PR DESCRIPTION
Currently, an error occurs when creating a blacklist entry from the website.

Steps to Reproduce:

 - Install the `website_crm_iap_reveal`, `website_mass_mailing` and `web studio`.
 - Go to `Website` > any page, click `Edit`, and drag and drop a `Form` onto the page.
 - Select the form, in `Action` dropdown, choose `More models` and select `Mail Blacklist`. Save the changes.
 - Click the Submit button.

`KeyError: 'email'`

This error occurs when creating a blacklist entry from the website and the email field is missing. When it tries to access the email key in value[1] while creating the record, it raises a KeyError.

[1] https://github.com/odoo/odoo/blob/d83801027c9a88b6e4db8166b6e2aad41ed760b9/addons/mail/models/mail_blacklist.py#L31

This commit ensures that if the email is not present in the value, a UserError is raised.

sentry-6708162583


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
