### PR TITLE
[FIX] web: colorpicker: correctly align colors

### DIFF
--- a/addons/web/static/src/core/color_picker/color_picker.js
+++ b/addons/web/static/src/core/color_picker/color_picker.js
@@ -219,12 +219,21 @@ export class ColorPicker extends Component {
             targetBtn = target.previousElementSibling;
         } else if (key === "ArrowUp" || key === "ArrowDown") {
             const buttonIndex = [...target.parentElement.children].indexOf(target);
-            const row =
-                key === "ArrowUp"
-                    ? target.parentElement.previousElementSibling
-                    : target.parentElement.nextElementSibling;
-            if (row?.matches(".o_color_section, .o_colorpicker_section")) {
-                targetBtn = row.children[buttonIndex];
+            const nbColumns = getComputedStyle(target).getPropertyValue(
+                "--o-color-picker-grid-columns"
+            );
+            targetBtn =
+                target.parentElement.children[
+                    buttonIndex + (key === "ArrowUp" ? -1 : 1) * nbColumns
+                ];
+            if (!targetBtn) {
+                const row =
+                    key === "ArrowUp"
+                        ? target.parentElement.previousElementSibling
+                        : target.parentElement.nextElementSibling;
+                if (row?.matches(".o_color_section, .o_colorpicker_section")) {
+                    targetBtn = row.children[buttonIndex];
+                }
             }
         }
         if (targetBtn && targetBtn.classList.contains("o_color_button")) {

--- a/addons/web/static/src/core/color_picker/color_picker.scss
+++ b/addons/web/static/src/core/color_picker/color_picker.scss
@@ -22,7 +22,6 @@
 .o_color_button {
     width: 23px;
     height: 22px;
-    padding: 0px;
     box-shadow: inset 0 0 0 1px rgba(var(--border-rgb), .5);
     margin: 0.5px;
 
@@ -57,8 +56,14 @@
 
 .o_font_color_selector .o_colorpicker_section {
     margin-bottom: 3px;
-    width: fit-content;
-    margin-left: 2px;
+}
+
+.o_font_color_selector {
+    --o-color-picker-grid-columns: 8;
+    .o_colorpicker_section, .o_color_section {
+        display: grid;
+        grid-template-columns: repeat(var(--o-color-picker-grid-columns), 1fr);
+    }
 }
 
 .o_font_color_selector {
@@ -142,6 +147,7 @@
     }
 }
 .o_font_color_selector .o_colorpicker_widget {
+    width: 100%;
     .o_hex_input {
         border: 1px solid !important;
         padding: 0 2px !important;

--- a/addons/web/static/src/core/color_picker/color_picker.xml
+++ b/addons/web/static/src/core/color_picker/color_picker.xml
@@ -62,7 +62,7 @@
             </div>
         </t>
         <t t-if="state.activeTab==='solid'">
-            <div class="p-1"
+            <div class="d-flex flex-column align-items-center p-1"
                 t-on-click="onColorApply"
                 t-on-mouseover="onColorHover"
                 t-on-mouseout="onColorHoverOut"
@@ -71,39 +71,39 @@
                 t-on-focusin="onColorFocusin"
                 t-on-focusout="onColorFocusout">
                 <div class="o_colorpicker_section">
-                    <button data-color="o-color-1" t-attf-style="background-color: var(--o-color-1)" class="btn o_color_button"/>
-                    <button data-color="o-color-3" t-attf-style="background-color: var(--o-color-3)" class="btn o_color_button"/>
-                    <button data-color="o-color-2" t-attf-style="background-color: var(--o-color-2)" class="btn o_color_button"/>
-                    <button data-color="o-color-4" t-attf-style="background-color: var(--o-color-4)" class="ms-2 btn o_color_button"/>
-                    <button data-color="o-color-5" t-attf-style="background-color: var(--o-color-5)" class="btn o_color_button"/>
+                    <button data-color="o-color-1" t-attf-style="background-color: var(--o-color-1)" class="btn p-0 o_color_button"/>
+                    <button data-color="o-color-3" t-attf-style="background-color: var(--o-color-3)" class="btn p-0 o_color_button"/>
+                    <button data-color="o-color-2" t-attf-style="background-color: var(--o-color-2)" class="btn p-0 o_color_button"/>
+                    <button data-color="o-color-4" t-attf-style="grid-column: 5; background-color: var(--o-color-4)" class="btn p-0 o_color_button"/>
+                    <button data-color="o-color-5" t-attf-style="background-color: var(--o-color-5)" class="btn p-0 o_color_button"/>
                 </div>
 
-                <t t-foreach="DEFAULT_COLORS" t-as="line" t-key="line_index">
-                    <div class="o_color_section justify-content-center d-flex">
+                <div class="o_color_section">
+                    <t t-foreach="DEFAULT_COLORS" t-as="line" t-key="line_index">
                         <t t-foreach="line" t-as="color" t-key="color_index">
-                            <button class="o_color_button btn" t-att-class="{'selected': color === this.state.currentCustomColor.toUpperCase()}" t-att-data-color="color" t-attf-style="background-color: {{color}}"/>
+                            <button class="o_color_button btn p-0" t-att-class="{'selected': color === this.state.currentCustomColor.toUpperCase()}" t-att-data-color="color" t-attf-style="background-color: {{color}}"/>
                         </t>
-                    </div>
-                </t>
+                    </t>
+                </div>
             </div>
         </t>
         <t t-if="state.activeTab==='custom'">
-            <div class="p-1" t-on-keydown="colorPickerNavigation">
+            <div class="d-flex flex-column align-items-start p-1" t-on-keydown="colorPickerNavigation">
                 <div class="o_colorpicker_section" t-on-click="onColorApply" t-on-mouseover="onColorHover" t-on-mouseout="onColorHoverOut" t-on-focusin="onColorFocusin" t-on-focusout="onColorHoverOut">
                     <t t-foreach="this.usedCustomColors" t-as="color" t-key="color_index">
-                        <button t-if="color !== this.state.currentCustomColor?.toLowerCase()" class="o_color_button btn" t-att-data-color="color" t-attf-style="background-color: {{color}}"/>
+                        <button t-if="color !== this.state.currentCustomColor?.toLowerCase()" class="o_color_button btn p-0" t-att-data-color="color" t-attf-style="background-color: {{color}}"/>
                     </t>
-                    <button class="o_color_button btn selected" t-att-data-color="this.state.currentCustomColor" t-attf-style="background-color: {{this.state.currentCustomColor}}"/>
+                    <button class="o_color_button btn p-0 selected" t-att-data-color="this.state.currentCustomColor" t-attf-style="background-color: {{this.state.currentCustomColor}}"/>
                 </div>
                 <div class="o_colorpicker_section" t-on-click="onColorApply" t-on-mouseover="onColorHover" t-on-mouseout="onColorHoverOut" t-on-focusin="onColorFocusin" t-on-focusout="onColorHoverOut">
-                    <button data-color="black" class="btn o_color_button bg-black"></button>
-                    <button data-color="900" class="o_color_button btn" style="background-color: var(--900)"></button>
-                    <button data-color="800" class="o_color_button btn" style="background-color: var(--800)"></button>
-                    <button data-color="600" class="o_color_button btn" style="background-color: var(--600)"></button>
-                    <button data-color="400" class="o_color_button btn" style="background-color: var(--400)"></button>
-                    <button data-color="200" class="o_color_button btn" style="background-color: var(--200)"></button>
-                    <button data-color="100" class="o_color_button btn" style="background-color: var(--100)"></button>
-                    <button data-color="white" class="o_color_button btn bg-white"></button>
+                    <button data-color="black" class="btn p-0 o_color_button bg-black"></button>
+                    <button data-color="900" class="o_color_button btn p-0" style="background-color: var(--900)"></button>
+                    <button data-color="800" class="o_color_button btn p-0" style="background-color: var(--800)"></button>
+                    <button data-color="600" class="o_color_button btn p-0" style="background-color: var(--600)"></button>
+                    <button data-color="400" class="o_color_button btn p-0" style="background-color: var(--400)"></button>
+                    <button data-color="200" class="o_color_button btn p-0" style="background-color: var(--200)"></button>
+                    <button data-color="100" class="o_color_button btn p-0" style="background-color: var(--100)"></button>
+                    <button data-color="white" class="o_color_button btn p-0 bg-white"></button>
                 </div>
                 <CustomColorPicker
                     defaultColor="this.state.currentCustomColor"
@@ -117,7 +117,7 @@
             <t t-set="currentGradient" t-value="getCurrentGradientColor()" />
             <div class="o_colorpicker_sections p-2" t-on-click="onColorApply" t-on-mouseover="onColorHover" t-on-mouseout="onColorHoverOut" t-on-focusin="onColorFocusin" t-on-focusout="onColorHoverOut">
                 <t t-foreach="this.DEFAULT_GRADIENT_COLORS" t-as="gradient" t-key="gradient">
-                    <button class="w-50 m-0 o_color_button o_gradient_color_button btn" t-att-class="{'selected': currentGradient?.includes(gradient)}" t-attf-style="background-image: #{gradient};" t-att-data-color="gradient"/>
+                    <button class="w-50 m-0 o_color_button o_gradient_color_button btn p-0" t-att-class="{'selected': currentGradient?.includes(gradient)}" t-attf-style="background-image: #{gradient};" t-att-data-color="gradient"/>
                 </t>
             </div>
             <div class="px-2">

--- a/addons/web/static/tests/core/color_picker.test.js
+++ b/addons/web/static/tests/core/color_picker.test.js
@@ -1,0 +1,143 @@
+import { test, expect } from "@odoo/hoot";
+import { press, click, animationFrame } from "@odoo/hoot-dom";
+import { mountWithCleanup } from "@web/../tests/web_test_helpers";
+import { ColorPicker, DEFAULT_COLORS } from "@web/core/color_picker/color_picker";
+
+test("basic rendering", async () => {
+    await mountWithCleanup(ColorPicker, {
+        props: {
+            state: {
+                selectedColor: "",
+                defaultTab: "",
+            },
+            getUsedCustomColors: () => [],
+            applyColor() {},
+            applyColorPreview() {},
+            applyColorResetPreview() {},
+            colorPrefix: "",
+        },
+    });
+    expect(".o_font_color_selector").toHaveCount(1);
+    expect(".o_font_color_selector .btn-tab").toHaveCount(3);
+    expect(".o_font_color_selector .btn.fa-trash").toHaveCount(1);
+    expect(".o_font_color_selector .o_colorpicker_section").toHaveCount(1);
+    expect(".o_font_color_selector .o_colorpicker_section .o_color_button").toHaveCount(5);
+    expect(".o_font_color_selector .o_color_section .o_color_button[data-color]").toHaveCount(
+        DEFAULT_COLORS.flat().length
+    );
+});
+
+test("basic rendering with selected color", async () => {
+    await mountWithCleanup(ColorPicker, {
+        props: {
+            state: {
+                selectedColor: "#B5D6A5",
+                defaultTab: "",
+            },
+            getUsedCustomColors: () => [],
+            applyColor() {},
+            applyColorPreview() {},
+            applyColorResetPreview() {},
+            colorPrefix: "",
+        },
+    });
+    expect(".o_font_color_selector").toHaveCount(1);
+    expect(".o_font_color_selector .o_color_section .o_color_button[data-color]").toHaveCount(
+        DEFAULT_COLORS.flat().length
+    );
+    expect(
+        ".o_font_color_selector .o_color_section .o_color_button[data-color='#B5D6A5'].selected"
+    ).toHaveCount(1);
+});
+
+test("keyboard navigation", async () => {
+    await mountWithCleanup(ColorPicker, {
+        props: {
+            state: {
+                selectedColor: "",
+                defaultTab: "",
+            },
+            getUsedCustomColors: () => [],
+            applyColor() {},
+            applyColorPreview() {},
+            applyColorResetPreview() {},
+            colorPrefix: "",
+        },
+    });
+    // select the first color
+    await click(
+        ".o_font_color_selector .o_color_section .o_color_button[data-color]:first-of-type"
+    );
+    await animationFrame();
+    expect(
+        ".o_font_color_selector .o_color_section .o_color_button[data-color]:first-of-type"
+    ).toBeFocused();
+
+    // move to the second color
+    await press("arrowright");
+    expect(
+        ".o_font_color_selector .o_color_section .o_color_button[data-color]:nth-of-type(2)"
+    ).toBeFocused();
+
+    // select the second color using Enter key
+    await press("enter");
+    await animationFrame();
+    expect(
+        ".o_font_color_selector .o_color_section .o_color_button[data-color]:nth-of-type(2)"
+    ).toHaveClass("selected");
+
+    // move back to the first color
+    await press("arrowleft");
+    expect(
+        ".o_font_color_selector .o_color_section .o_color_button[data-color]:first-of-type"
+    ).toBeFocused();
+
+    // cannot move if no previous color
+    await press("arrowleft");
+    expect(
+        ".o_font_color_selector .o_color_section .o_color_button[data-color]:first-of-type"
+    ).toBeFocused();
+
+    // move the color below
+    await press("arrowdown");
+    expect(
+        ".o_font_color_selector .o_color_section .o_color_button[data-color]:nth-of-type(9)"
+    ).toBeFocused();
+
+    // move back to the first color
+    await press("arrowup");
+    expect(
+        ".o_font_color_selector .o_color_section .o_color_button[data-color]:first-of-type"
+    ).toBeFocused();
+
+    // select the last color of the first row
+    await click(
+        ".o_font_color_selector .o_color_section .o_color_button[data-color]:nth-of-type(8)"
+    );
+    await animationFrame();
+
+    // move to the first color of the second row
+    await press("arrowright");
+    expect(
+        ".o_font_color_selector .o_color_section .o_color_button[data-color]:nth-of-type(9)"
+    ).toBeFocused();
+
+    // move back to the last color of the first row
+    await press("arrowleft");
+    expect(
+        ".o_font_color_selector .o_color_section .o_color_button[data-color]:nth-of-type(8)"
+    ).toBeFocused();
+
+    // select the last color
+    await click(".o_font_color_selector .o_color_section .o_color_button[data-color]:last-of-type");
+    await animationFrame();
+    expect(
+        ".o_font_color_selector .o_color_section .o_color_button[data-color]:last-of-type"
+    ).toBeFocused();
+
+    // cannot move if no next color
+    await press("arrowright");
+    expect(
+        ".o_font_color_selector .o_color_section .o_color_button[data-color]:last-of-type"
+    ).toBeFocused();
+});


### PR DESCRIPTION
Steps to reproduce:
- Go to the html_editor (via Project for example)
- Select a text and open the colorpicker

| Current | Expected |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/6d1745ea-a8e9-4b3b-ad87-1108ccff3d3e) | ![image](https://github.com/user-attachments/assets/6a11eec2-a914-4ed3-aa88-6aecbd703ebb) | 

