### PR TITLE
[FIX] website: adapt s_floating_blocks to class-based action system

### DIFF
--- a/addons/website/static/src/builder/plugins/floating_blocks/floating_blocks_option.xml
+++ b/addons/website/static/src/builder/plugins/floating_blocks/floating_blocks_option.xml
@@ -7,7 +7,7 @@
             title.translate="Add a new Card"
             action="'addCard'"
             preview="false"
-            className="'o_we_bg_success'">
+            type="'success'">
             Add New
         </BuilderButton>
     </BuilderRow>
@@ -21,7 +21,7 @@
         tooltip.translate="Applies to all cards">
         <BuilderRange
             applyTo="'.s_floating_blocks_wrapper'"
-            action="'floatingBlocksRoundness'"
+            action="'cardRoundness'"
             max="5"
             displayRangeValue="false"/>
     </BuilderRow>

--- a/addons/website/static/src/builder/plugins/floating_blocks/floating_blocks_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/floating_blocks/floating_blocks_option_plugin.js
@@ -1,4 +1,5 @@
 import { Plugin } from "@html_editor/plugin";
+import { BuilderAction } from "@html_builder/core/builder_action";
 import { registry } from "@web/core/registry";
 import { withSequence } from "@html_editor/utils/resource";
 import { after } from "@html_builder/utils/option_sequence";
@@ -15,32 +16,38 @@ class FloatingBlocksOptionPlugin extends Plugin {
             }),
         ],
         builder_actions: {
-            floatingBlocksRoundness: {
-                getValue: ({ editingElement }) => {
-                    for (let x = 0; x <= 5; x++) {
-                        if (editingElement.classList.contains(`rounded-${x}`)) {
-                            return x;
-                        }
-                    }
-                    return 0;
-                },
-                apply: ({ editingElement, value }) => {
-                    for (let x = 0; x <= 5; x++) {
-                        editingElement.classList.remove(`rounded-${x}`);
-                    }
-                    editingElement.classList.add(`rounded-${value}`);
-                },
-            },
-            addCard: {
-                apply: ({ editingElement: el }) => {
-                    const newCardEl = renderToElement("website.s_floating_blocks.new_card");
-                    const wrapperEl = el.querySelector(".s_floating_blocks_wrapper");
-                    wrapperEl.appendChild(newCardEl);
-                    newCardEl.scrollIntoView({ behavior: "smooth", block: "center" });
-                },
-            },
+            CardRoundnessAction,
+            AddCardAction,
         },
     };
+}
+
+class CardRoundnessAction extends BuilderAction {
+    static id = "cardRoundness";
+    getValue({ editingElement }) {
+        for (let x = 0; x <= 5; x++) {
+            if (editingElement.classList.contains(`rounded-${x}`)) {
+                return x;
+            }
+        }
+        return 0;
+    }
+    apply({ editingElement, value }) {
+        for (let x = 0; x <= 5; x++) {
+            editingElement.classList.remove(`rounded-${x}`);
+        }
+        editingElement.classList.add(`rounded-${value}`);
+    }
+}
+
+class AddCardAction extends BuilderAction {
+    static id = "addCard";
+    apply({ editingElement: el }) {
+        const newCardEl = renderToElement("website.s_floating_blocks.new_card");
+        const wrapperEl = el.querySelector(".s_floating_blocks_wrapper");
+        wrapperEl.appendChild(newCardEl);
+        newCardEl.scrollIntoView({ behavior: "smooth", block: "center" });
+    }
 }
 
 registry.category("website-plugins").add(FloatingBlocksOptionPlugin.id, FloatingBlocksOptionPlugin);


### PR DESCRIPTION
Commit [1] introduced a new class-based action system for the builder. Commit [2], merged just after [1], introduced the `s_floating_blocks` snippet, but was still using the old action system, which is now broken.

This commit updates `s_floating_blocks` to use the new class-based system. Additionally, the "Add Card" button appearance is fixed (now it correclty displays with the "success" style), and an action is renamed for clarity.

task-4367641

[1] odoo@b4b2153
[2] odoo@35f1846
