### PR TITLE
[FIX] bus: non deterministic bus monitoring test

### DIFF
--- a/addons/bus/static/src/services/bus_monitoring_service.js
+++ b/addons/bus/static/src/services/bus_monitoring_service.js
@@ -33,9 +33,6 @@ export class BusMonitoringService {
      * @param {WORKER_STATE[keyof WORKER_STATE]} state
      */
     workerStateOnChange(state) {
-        if (!navigator.onLine) {
-            return;
-        }
         switch (state) {
             case WORKER_STATE.CONNECTING: {
                 this.isReconnecting = true;


### PR DESCRIPTION
This commit fixes the non-deterministic `connection considered as lost after failed reconnect attempt` test. The monitoring service does not show the connection as lost when the navigator online property is false which makes this test fail when network is not available. This check makes no sense, it doesn't matter if we lost the connection because of a server/client error or because the network is down. This commit removes this check on the "online" navigator property and fixes this test.

fixes runbot-226892

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
