### PR TITLE
[FIX] html_builder, website: display image weight tag

### DIFF
--- a/addons/html_builder/static/src/builder.scss
+++ b/addons/html_builder/static/src/builder.scss
@@ -153,3 +153,16 @@
         appearance: auto !important;
     }
 }
+
+// TODO tags (e.g. image weight)
+.o_hb_tag {
+    background-color: $o-we-bg-darkest;
+    white-space: nowrap;
+    padding: ($o-we-sidebar-content-field-label-spacing / 4) ($o-we-sidebar-content-field-label-spacing / 2);
+    border-radius: 3px;
+    font-size: 0.85em;
+}
+
+we-title .o_hb_tag {
+    margin-left: $o-we-sidebar-content-field-label-spacing * 2;
+}

--- a/addons/website/static/src/builder/plugins/image/image_tool_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/image/image_tool_option_plugin.js
@@ -15,6 +15,7 @@ import {
 } from "@html_builder/utils/option_sequence";
 import { ReplaceMediaOption, searchSupportedParentLinkEl } from "./replace_media_option";
 import { computeMaxDisplayWidth } from "./image_format_option";
+import { ImageWeightHeaderInfo } from "./image_weight_header_info";
 import { BuilderAction } from "@html_builder/core/builder_action";
 
 export const REPLACE_MEDIA_SELECTOR = "img, .media_iframe_video, span.fa, i.fa";
@@ -61,6 +62,13 @@ class ImageToolOptionPlugin extends Plugin {
             SetUrlAction,
             SetNewWindowAction,
             AltAction,
+        },
+        builder_header_middle_buttons: {
+            Component: ImageWeightHeaderInfo,
+            selector: "img",
+            props: {
+                isImageSupportedForProcessing,
+            },
         },
         on_media_dialog_saved_handlers: async (elements, { node }) => {
             for (const image of elements) {

--- a/addons/website/static/src/builder/plugins/image/image_weight_header_info.js
+++ b/addons/website/static/src/builder/plugins/image/image_weight_header_info.js
@@ -1,0 +1,30 @@
+import { Component, useState } from "@odoo/owl";
+import { useDomState } from "@html_builder/core/utils";
+import { loadImageDataURL, getImageSizeFromCache } from "@html_editor/utils/image_processing";
+
+export class ImageWeightHeaderInfo extends Component {
+    static template = "website.ImageWeightHeaderInfo";
+    static props = {
+        isImageSupportedForProcessing: Function,
+    };
+
+    setup() {
+        this.state = useState({
+            weight: "",
+        });
+        useDomState(async (imgEl) => {
+            try {
+                await loadImageDataURL(imgEl.src);
+                const size = getImageSizeFromCache(imgEl.src);
+                this.state.weight = size ? `${(size / 1024).toFixed(1)} kb` : "";
+            } catch (error) {
+                if (error) {
+                    this.state.weight = "";
+                }
+            }
+            return {
+                // Not actually used because of async.
+            };
+        });
+    }
+}

--- a/addons/website/static/src/builder/plugins/image/image_weight_header_info.xml
+++ b/addons/website/static/src/builder/plugins/image/image_weight_header_info.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+
+<t t-name="website.ImageWeightHeaderInfo">
+    <span t-if="state.weight" class="o_hb_image_weight o_hb_tag" title="Size" t-out="state.weight"/>
+</t>
+
+</templates>


### PR DESCRIPTION
When converting the website builder to `html_builder`, the tag that displayed the selected image's size was forgotten.

This commit re-introduces it.

task-4367641
