### PR TITLE
[FIX] point_of_sale, *: prevent duplicate receipt printing on online payment

### DIFF
--- a/addons/point_of_sale/static/src/app/services/printer_service.js
+++ b/addons/point_of_sale/static/src/app/services/printer_service.js
@@ -53,6 +53,9 @@ export class PrinterService extends Reactive {
         }
         this.state.isPrinting = true;
         const el = await this.renderer.toHtml(component, props);
+        if (!el) {
+            return;
+        }
         try {
             await waitImages(el);
         } catch (e) {

--- a/addons/pos_online_payment_self_order/static/src/overrides/services/pos_store.js
+++ b/addons/pos_online_payment_self_order/static/src/overrides/services/pos_store.js
@@ -14,6 +14,10 @@ patch(PosStore.prototype, {
 
                 const orderId = notification.data["pos.order"][0].id;
                 if (document.visibilityState === "visible") {
+                    // If auto printing is enabled, no need to print again
+                    if (this.config.iface_print_auto) {
+                        return;
+                    }
                     this.printSelfOrderReceipt(orderId);
                 } else {
                     this.printingQueue.push(() => this.printSelfOrderReceipt(orderId));


### PR DESCRIPTION
`* = pos_online_payment_self_order`

**Installation:** `pos_online_payment_self_order` and `payment_demo`

**POS Shop Configuration:**
- **Restaurant** mode.
- Self-order mode: **"QR menu + Ordering"**.
- Enable **online payment** method for self-order.
- Activate **Automatic Receipt Printing**.

**Steps to Reproduce:**
- Open the register.
- Place an order and choose **Online Payment**, and validate it (**QR** code appears).
- **Deactivate** the register tab (e.g., by opening another browser tab).
- **Pay** the amount by scanning the code (can use phone).
- Wait for the payment to **succeed**.
- Switch to the original register tab.

**Error:**
Frontend: `TypeError: Cannot read properties of null (reading 'cloneNode')` 
Backend: `ValueError - This order has already been printed automatically.`

**Case 1: Register tab is active**
No crash occurs, the receipt printing pop-up is triggered twice:
1. When the order is auto-validated and printed [(Ref 1)](https://github.com/odoo/odoo/blob/52badedb4edb4018bbf400af4f48f81aa597654a/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.js#L391-L401)
2. When the `ONLINE_PAYMENT_STATUS` notification with status success is received [(Ref 2)](https://github.com/odoo/odoo/blob/52badedb4edb4018bbf400af4f48f81aa597654a/addons/pos_online_payment_self_order/static/src/overrides/services/pos_store.js#L16-L17)

**Case 2: Register tab is inactive (hidden)**
- The auto-print logic fails due to the DOM element (`el`) being `null`, skipping the first print and leading to a `TypeError` at [1].
- When the tab becomes visible again (`visibilitychange` event), a backend call is triggered to `get_order_to_print` at [2], which fails with a `ValueError` because the order was already flagged as printed.

[1] - https://github.com/odoo/odoo/blob/52badedb4edb4018bbf400af4f48f81aa597654a/addons/point_of_sale/static/src/app/services/printer_service.js#L55-L57
[2] - https://github.com/odoo/odoo/blob/8fb3776b54a17307979733e7f155939d7d87d9d2/addons/pos_online_payment_self_order/models/pos_order.py#L19-L20

**Fix:**
This commit ensures each order is printed only once:
- If the tab is active and auto-print works, skip printing on visible status.
- If the tab is inactive and auto-print fails, fallback printing is allowed via the visibility change event.

Sentry - 6707550067