### PR TITLE
[FIX] analytic: fix traceback when selecting options in analytic reports

### DIFF
--- a/addons/analytic/static/src/views/pivot/pivot_renderer.js
+++ b/addons/analytic/static/src/views/pivot/pivot_renderer.js
@@ -6,16 +6,16 @@ export class AnalyticPivotRenderer extends PivotRenderer {
     /*
      * Override to avoid using incomplete groupByItems
      */
-    onGroupBySelected(type, payload) {
-        if (typeof(payload.optionId) === "number") {
-            let searchItems = this.env.searchModel.getSearchItems(
-                (searchItem) =>
-                    ["groupBy", "dateGroupBy"].includes(searchItem.type) && !searchItem.custom
-            )
-            searchItems = [...searchItems, ...searchItems.flatMap((f) => f.options).filter((f) => typeof(f?.id) === "number")]
-            const { fieldName } = searchItems.find(({ id }) => id === payload.optionId);
-            payload.fieldName = fieldName;
+    onGroupBySelected({ itemId, optionId }) {
+        if (typeof(optionId) === "number") {
+            itemId = optionId;
         }
-        super.onGroupBySelected(type, payload);
+        let searchItems = this.env.searchModel.getSearchItems(
+            (searchItem) =>
+                ["groupBy", "dateGroupBy"].includes(searchItem.type) && !searchItem.custom
+        )
+        searchItems = [...searchItems, ...searchItems.flatMap((f) => f.options).filter((f) => typeof(f?.id) === "number")]
+        const { fieldName } = searchItems.find(({ id }) => id === itemId);
+        this.model.addGroupBy({ ...this.dropdown.cellInfo, fieldName, interval: optionId });
     }
 }

--- a/addons/analytic/static/tests/analytic_views.test.js
+++ b/addons/analytic/static/tests/analytic_views.test.js
@@ -102,6 +102,8 @@ test("Analytic hierachy in pivot view", async () => {
     await contains(".o_pivot tbody .o_pivot_header_cell_closed").click()
     await contains(".o_popover .o-dropdown-caret").hover()
     expect(".o_popover.o-dropdown--menu-submenu span.o-dropdown-item").toHaveCount(3);
+    await contains(".o_popover.o-dropdown--menu-submenu span.o-dropdown-item").click();
+    expect(".o_pivot tbody .o_value").toHaveCount(6); // 3 groups + 2 subgroups of group 1 + 1 total
 });
 
 test.tags("desktop");


### PR DESCRIPTION
A JavaScript traceback occurs when a user selects an option in Analytic Reports.

**To reproduce this issue:**

1) Install the Accounting module and enable Analytic Accounting in the settings.
2) Create a confirmed invoice with an analytic value in the AML 
3) Navigate to Reporting > Analytic Reports (Pivot view).
4) Click on Total > Project.

A JavaScript traceback is triggered

```
TypeError: Cannot read properties of undefined (reading 'optionId')
```

**Cause:-**

Starting from saas-18.3, a major refactoring was done to the Pivot view, 
which removed the payload argument from the `onGroupBySelected` method, 
as shown in the following commit:

https://github.com/odoo/odoo/pull/200207/commits/aa3a6a1fc13c2c3dce81eff149a06be59a3e72e4#diff-96f34307ba1a5e0256c5f484bde94cefa42aa97de2f64137cbe12510e1362981L100-R179

https://github.com/odoo/odoo/blob/8fb3776b54a17307979733e7f155939d7d87d9d2/addons/web/static/src/views/pivot/pivot_renderer.js#L185-L187

Due to this change, any attempt to access optionId from the payload results in a TypeError

Note: 
This issue has already been fixed in saas-18.4 as part of the following commit:

https://github.com/odoo/odoo/commit/4cdd32db4a090acf01457cd5466f7bb2d5575a3d#diff-55e1559a925afd33d6ab73c27e38fe6ac484e2dfb31004add6ac4058eda3f820R1-R21

**Solution:**

Backport and adapt the fix introduced in saas-18.4.

opw-4892766