### PR TITLE
[FIX] base,website: wrong is_view_active value for website_sale template

### DIFF
--- a/addons/website/models/ir_ui_view.py
+++ b/addons/website/models/ir_ui_view.py
@@ -367,7 +367,7 @@ class IrUiView(models.Model):
 
     @api.model
     def _get_template_minimal_cache_keys(self):
-        return super()._get_template_minimal_cache_keys() + ['website_id']
+        return super()._get_template_minimal_cache_keys() + (self.env.context.get('website_id'),)
 
     @api.model
     def _get_template_domain(self, xmlids):

--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -1491,7 +1491,7 @@ class Website(models.Model):
         """
             Return True if active, False if not active, None if not found
         """
-        return self.env['ir.ui.view']._get_cached_template_info(key).get('active')
+        return self.env['ir.ui.view'].with_context(active_test=False)._get_cached_template_info(key).get('active')
 
     @api.model
     def get_template(self, template):

--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -1049,10 +1049,10 @@ actual arch.
         return ['id', 'key', 'active']
 
     def _get_template_minimal_cache_keys(self):
-        return ['active_test']
+        return (bool(self.env.context.get('active_test', True)),)
 
     @api.model
-    @tools.ormcache('id_or_xmlid', 'isinstance(id_or_xmlid, str) and tuple(self.env.context.get(k) or False for k in self._get_template_minimal_cache_keys())', cache='templates')
+    @tools.ormcache('id_or_xmlid', 'isinstance(id_or_xmlid, str) and self._get_template_minimal_cache_keys()', cache='templates')
     def _get_cached_template_info(self, id_or_xmlid, _view=None):
         """ Return the ir.ui.view id from the xml id, use `_preload_views`.
         """


### PR DESCRIPTION
Fixed cache pollution of _get_cached_template_info and added tests
regarding the website editor, more specifically on enabling or disabling
options related to views.

Context:
- Base:
  - the xmlid and key of ir.ui.view are unique;
  - the ir.ui.view are inherited if they are active, otherwise inheritance
    is not applied;
  - _get_cached_template_info(key) returns the cached record values.

- Website:
  - the key of ir.ui.view are not unique; they can exist for different
    websites and without a website;
  - the ir.ui.view are inherited if they are active, otherwise inheritance
    is not applied. If a specific inherited view exists (for the current
    website), the default view (with same key) is not applied;
  - for t-call, the specific view are used only if the view is active,
    otherwise the default view is displayed;
  - is_view_active(key) should return False if the view of the website in
    question is inactive. If the default view is False, but the website
    view is True, then the response should be True;

Issue:
`is_view_active` returns True if a view with this key is active, ignoring
the website-specific inactive view.

The issue was seen because the editor changes the display (active) of the
views by copying them with the website reference. So when we want to
change the menu, and hide it, the view is copied and set active=False.
Part of the menu was still visible because it uses a
`t-if="is_view_active(...)"`.

Issue introduced by: 97c2dd2ec569d34b044da6aa6f473277b48ada12
