### PR TITLE
[FIX] mail: fix runbot error 227568 (portal start message)

### DIFF
--- a/addons/mail/static/src/core/common/message.xml
+++ b/addons/mail/static/src/core/common/message.xml
@@ -8,6 +8,7 @@
         </div>
         <ActionSwiper t-else="" onRightSwipe="hasTouch() and props.thread?.eq(store.inbox) ? { action: () => this.message.setDone(), bgColor: 'bg-success', icon: 'fa-check-circle' } : undefined">
             <div class="o-mail-Message position-relative rounded-0"
+                t-att-data-starred="message.starred"
                 t-att-class="attClass"
                 role="group"
                 t-att-aria-label="messageTypeText"

--- a/addons/test_mail_full/static/tests/tours/message_actions_tour.js
+++ b/addons/test_mail_full/static/tests/tours/message_actions_tour.js
@@ -3,12 +3,12 @@ import { registry } from "@web/core/registry";
 registry.category("web_tour.tours").add("star_message_tour", {
     steps: () => [
         {
-            trigger: "#chatterRoot:shadow .o-mail-Message:contains(Test Message)",
-            run: "hover && click #chatterRoot:shadow .o-mail-Message [title='Mark as Todo'] i.fa-star-o",
+            trigger:
+                "#chatterRoot:shadow .o-mail-Message:not([data-starred]):contains(Test Message)",
+            run: "hover && click #chatterRoot:shadow .o-mail-Message [title='Mark as Todo']",
         },
         {
-            trigger: "#chatterRoot:shadow .o-mail-Message:contains(Test Message)",
-            run: "hover #chatterRoot:shadow .o-mail-Message [title='Mark as Todo'] i.fa-star.o-mail-Message-starred",
+            trigger: "#chatterRoot:shadow .o-mail-Message[data-starred]",
         },
     ],
 });


### PR DESCRIPTION
Before this commit, test "test_star_message" was failing frequently on runbot at step to check message was starred have click on "Mark as Todo".

This happens because when click on mark as todo, the message is asynchronously starred. However, there's no visual indication other than the message action have yellow filled star icon. This requires hovering the message to see it, but we don't know when we should exactly hover the message to see it.

This commit fixes the issue by adding a `data-starred` on the `o-mail-Message` root node of message template that tells whether the message is starred or not. This removes necessity to hover to check whether message is starred.

Fixes runbot-227568