### PR TITLE
[FIX] web: x2many_field use specific js_class components when renderi…

### DIFF
--- a/addons/web/static/src/views/fields/x2many/x2many_field.js
+++ b/addons/web/static/src/views/fields/x2many/x2many_field.js
@@ -119,6 +119,9 @@ export class X2ManyField extends Component {
         };
         this.action = useService("action");
         this.notificationService = useService("notification");
+        const js_class = this.archInfo.xmlDoc.getAttribute('js_class');
+        if (js_class)
+            this.renderer = registry.category("views").get(js_class).Renderer;
     }
 
     get activeField() {

--- a/addons/web/static/src/views/fields/x2many/x2many_field.xml
+++ b/addons/web/static/src/views/fields/x2many/x2many_field.xml
@@ -32,8 +32,12 @@
                     <Pager t-props="pagerProps"/>
                 </div>
             </div>
-            <ListRenderer t-if="props.viewMode === 'list'" t-props="this.rendererProps" />
-            <KanbanRenderer t-elif="props.viewMode" t-props="this.rendererProps" />
+
+            <t t-if="this.renderer" t-component="this.renderer" t-props="this.rendererProps" />
+            <t t-else="">
+                <ListRenderer t-if="props.viewMode === 'list'" t-props="this.rendererProps" />
+                <KanbanRenderer t-elif="props.viewMode" t-props="this.rendererProps" />
+            </t>
         </div>
     </t>
 


### PR DESCRIPTION
…ng in specific mode

Before: When we spoecified a mode on a x2many field, it would only take the default KanbanRenderer if the view mode was Kanban or otherwise the ListRenderer.

The improvement is to use the Renderer from the js_class if there is one otherwise we still use the default one.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
