### PR TITLE
[FIX] stock: return serial for exchange

### DIFF
--- a/addons/stock/wizard/stock_picking_return.py
+++ b/addons/stock/wizard/stock_picking_return.py
@@ -94,6 +94,7 @@ class ReturnPicking(models.TransientModel):
         return res
 
     picking_id = fields.Many2one('stock.picking')
+    picking_type_code = fields.Selection(related='picking_id.picking_type_code', readonly=True)
     product_return_moves = fields.One2many('stock.return.picking.line', 'wizard_id', 'Moves', compute='_compute_moves_locations', precompute=True, readonly=False, store=True)
     company_id = fields.Many2one(related='picking_id.company_id')
 
@@ -187,6 +188,11 @@ class ReturnPicking(models.TransientModel):
         for return_line in self.product_return_moves:
             return_line._process_line(exchange_picking)
 
+        # The exchange moves should be independent of their origin moves
+        exchange_picking.move_ids.write({
+            'origin_returned_move_id': False,
+            'move_orig_ids': False,
+        })
         exchange_picking.action_confirm()
         exchange_picking.action_assign()
         return exchange_picking

--- a/addons/stock/wizard/stock_picking_return_views.xml
+++ b/addons/stock/wizard/stock_picking_return_views.xml
@@ -26,7 +26,7 @@
                 <footer>
                     <button name="action_create_returns" string="Return" type="object" class="btn-primary" data-hotkey="q"/>
                     <button name="action_create_returns_all" string="Return All" type="object" class="btn-primary"/>
-                    <button name="action_create_exchanges" string="Return for Exchange" type="object" class="btn-primary"/>
+                    <button name="action_create_exchanges" string="Return for Exchange" invisible="picking_type_code not in ('incoming', 'outgoing')" type="object" class="btn-primary"/>
                     <button string="Cancel" class="btn-secondary" special="cancel" data-hotkey="x" />
                 </footer>
             </form>


### PR DESCRIPTION
When returning tracked-by-serial products from an incoming picking for
an exchange, the exchange move will have selected existing serial numbers
for the new incoming picking.

This happens because `move_orig_ids` is set on the exchange move(s),
then `_action_assign()` happens. If there's a `move_orig_ids`, it will
use the available move lines from the move_orig_ids and so assign the
corresponding serial number.

Additionally, the buttons to generate/import serials/lots are invisible
because `origin_returned_move_id` is set on the same exchange move(s).
Again, the exchange move(s) should be considered 'new' move thus having
no origin.

task 4893860:
Additionally (again), it fixes an issue where on-hand quantities and
forecasted quantities of the exchanged product were incorrect after
validating the exchange.

task 4778066:
Finally, this PR also hides the 'Return for Exchange' button for
pickings that are neither `incoming` nor `outgoing`.

tasks 4748294 (& 4778066 & 4893860)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
