### PR TITLE
[IMP] mrp: enable mass edits in workorders list view

### DIFF
--- a/addons/mrp/views/mrp_workorder_views.xml
+++ b/addons/mrp/views/mrp_workorder_views.xml
@@ -60,7 +60,7 @@
         <field name="model">mrp.workorder</field>
         <field name="priority" eval="100"/>
         <field name="arch" type="xml">
-            <list>
+            <list multi_edit="1">
                 <field name="consumption" column_invisible="True"/>
                 <field name="company_id" column_invisible="True"/>
                 <field name="is_produced" column_invisible="True"/>
@@ -126,7 +126,6 @@
             <xpath expr="//list" position="attributes">
                 <attribute name="create">0</attribute>
                 <attribute name="sample">1</attribute>
-                <attribute name="editable"/>
             </xpath>
             <field name="workcenter_id" position="after">
                 <field name="production_id" optional="hide"/>


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
- To save time in edits or updates for one workorder or more, mass edits are enabled.

Task: 4869056




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
