### PR TITLE
[FIX] l10n_ro_efactura: prevent EDI to be sent mulitple times

### DIFF
--- a/addons/l10n_ro_efactura/wizard/account_move_send.py
+++ b/addons/l10n_ro_efactura/wizard/account_move_send.py
@@ -88,6 +88,9 @@ class AccountMoveSend(models.TransientModel):
                     }
                     continue
 
+                if self._can_commit():
+                    self.env.cr.commit()
+
                 invoice._l10n_ro_edi_send_invoice(xml_data)
 
                 if self._can_commit():


### PR DESCRIPTION
**Steps to reproduce:**
From a Romanian company with the RO localization configured, when processing a payment transaction from the e-commerce, it can happen that the creation of the invoice fails due to a SerializationFailure but the EDI is correctly sent to the government service. As the creation of the invoice has failed, the system will retry to create it and trigger the sending of the EDI again.

**Solution:**
Trigger a commit before sending the EDI.

opw-4844913




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
