### PR TITLE
[FIX] base: cron done=0 remaining=1 should be partially done

### DIFF
--- a/odoo/addons/base/models/ir_cron.py
+++ b/odoo/addons/base/models/ir_cron.py
@@ -445,39 +445,65 @@ class IrCron(models.Model):
 
             # stop after MIN_RUNS_PER_JOB runs and MIN_TIME_PER_JOB seconds, or
             # upon full completion or failure
-            while (
+            while status is None and (
                 loop_count < MIN_RUNS_PER_JOB
                 or time.monotonic() < env.context['cron_end_time']
             ):
                 cron, progress = cron._add_progress(timed_out_counter=timed_out_counter)
                 job_cr.commit()
 
+                success = False
                 try:
                     # signaling check and commit is done inside `_callback`
                     cron._callback(job['cron_name'], job['ir_actions_server_id'])
+                    success = True
                 except Exception:  # noqa: BLE001
                     _logger.exception('Job %r (%s) server action #%s failed',
                         job['cron_name'], job['id'], job['ir_actions_server_id'])
-                    if progress.done and progress.remaining:
-                        # we do not consider it a failure if some progress has
-                        # been committed
-                        status = CompletionStatus.PARTIALLY_DONE
-                    else:
-                        status = CompletionStatus.FAILED
-                else:
-                    if not progress.remaining:
-                        # assume the server action doesn't use the progress API
-                        # and that there is nothing left to process
-                        status = CompletionStatus.FULLY_DONE
-                    else:
-                        status = CompletionStatus.PARTIALLY_DONE
-                        if not progress.done:
-                            break
-
-                    if status == CompletionStatus.FULLY_DONE and progress.deactivate:
-                        job['active'] = False
                 finally:
                     done, remaining = progress.done, progress.remaining
+                    match (success, done, remaining):
+                        case (False, d, r) if d and r:
+                            # The cron action failed but was nonetheless able
+                            # to commit some progress.
+                            # Hopefully this failure is temporary.
+                            pass
+
+                        case (False, _, _):
+                            # The cron action failed, and was unable to commit
+                            # any progress this time. Consider it failed even
+                            # if it progressed in a previous loop iteration.
+                            status = CompletionStatus.FAILED
+
+                        case (True, _, 0):
+                            # The cron action completed. Either it doesn't use
+                            # the progress API, either it reported no remaining
+                            # stuff to process.
+                            status = CompletionStatus.FULLY_DONE
+                            if progress.deactivate:
+                                job['active'] = False
+
+                        case (True, 0, _) if loop_count == 0:
+                            # The cron action was able to determine there are
+                            # remaining records to process, but couldn't
+                            # process any of them.
+                            # Hopefully this condition is temporary.
+                            status = CompletionStatus.PARTIALLY_DONE
+                            _logger.warning("Job %r (%s) processed no record",
+                                job['cron_name'], job['id'])
+
+                        case (True, 0, _):
+                            # The cron action was able to determine there are
+                            # remaining records to process, did process some
+                            # records in a previous loop iteration, but
+                            # processed none this time.
+                            status = CompletionStatus.PARTIALLY_DONE
+
+                        case (True, _, _):
+                            # The cron action was able to process some but not
+                            # all records. Loop.
+                            pass
+
                     loop_count += 1
                     progress.timed_out_counter = 0
                     timed_out_counter = 0
@@ -486,9 +512,7 @@ class IrCron(models.Model):
                     _logger.debug('Job %r (%s) processed %s records, %s records remaining',
                         job['cron_name'], job['id'], done, remaining)
 
-                if status in (CompletionStatus.FULLY_DONE, CompletionStatus.FAILED):
-                    break
-
+            status = status or CompletionStatus.PARTIALLY_DONE
             _logger.info(
                 'Job %r (%s) %s (#loop %s; done %s; remaining %s; duration %.2fs)',
                 job['cron_name'], job['id'], status,


### PR DESCRIPTION
**NOTE** the problem regarding the auto-vacuum was fixed in 18.3 and above (including master) at https://github.com/odoo/odoo/pull/216483, this PR now solely exists for branlette intellectuelle. 

Have a ir cron action with the following code:

	time.sleep(MIN_TIME_PER_JOB)
	self.env['ir.cron']._commit_progress(remaining=1)
	return

The code looks stupid, but we tracked down a bug we had in the autovacuum cron in 18.3, and the minimum code to reproduce the problem is that above line of code.

Since there are remaining stuff to do, the cron worker should report a `PARTIALLY_DONE` status, and reschedule to call the cron action asap. But the system currently determine a `FULLY_DONE` status and reschedule the cron action *later* (next day for a cron with an interval of 1 day).

It is pretty bad for the autovacuum cron in 18.3

We used the opportunity to rework the `status` computation to one big match-case, for extra readability.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
