### PR TITLE
[FIX] core: imported modules warning during startup

### DIFF
--- a/odoo/modules/module_graph.py
+++ b/odoo/modules/module_graph.py
@@ -143,7 +143,7 @@ class ModuleNode:
         self.name: str = name
         # for performance reasons, use the cached value to avoid deepcopy; it is
         # acceptable in this context since we don't modify it
-        manifest = Manifest.for_addon(name)
+        manifest = Manifest.for_addon(name, display_warning=False)
         if manifest is not None:
             manifest.manifest_cached  # parse the manifest now
         self.manifest: Mapping = manifest or {}


### PR DESCRIPTION
Imported modules have no files on disk after they have been loaded. So when starting a server, we should not display warnings if these are not available.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
