### PR TITLE
[IMP] web: remove reset filter button

### DIFF
--- a/addons/web/static/src/views/action_helper.js
+++ b/addons/web/static/src/views/action_helper.js
@@ -10,19 +10,11 @@ export class ActionHelper extends Component {
         noContentHelp: { type: String, optional: true },
     };
 
-    get hasFacets() {
-        return this.env.searchModel.facets.length > 0;
-    }
-
     get showDefaultHelper() {
         return !this.props.noContentHelp;
     }
 
     showWidgetSampleData() {
         return this.props.showRibbon;
-    }
-
-    clearFilters() {
-        this.env.searchModel.clearFilters();
     }
 }

--- a/addons/web/static/src/views/action_helper.xml
+++ b/addons/web/static/src/views/action_helper.xml
@@ -24,11 +24,6 @@
                 <t t-else="">
                     <t t-out="props.noContentHelp"/>
                 </t>
-                <t t-if="hasFacets">
-                    <button 
-                        class="btn text-nowrap me-1 btn-primary my-2 o_reset_filter_button"
-                        t-on-click="this.clearFilters">Reset Filters</button>
-                </t>
             </div>    
         </div>
     </t>

--- a/addons/web/static/tests/views/graph/graph_view.test.js
+++ b/addons/web/static/tests/views/graph/graph_view.test.js
@@ -7,7 +7,6 @@ import {
     defineModels,
     editFavoriteName,
     fields,
-    getFacetTexts,
     getService,
     makeMockServer,
     mockService,
@@ -2263,42 +2262,6 @@ test("graph view sort by measure for multiple grouped data", async () => {
         { data: [0, 1, 0, 0] },
         { data: [2, 3, 1, 2] },
     ]);
-});
-
-test("reset filter button should appear when no data corresponding to facets", async () => {
-    await mountView({
-        type: "graph",
-        resModel: "foo",
-        arch: /* xml */ `
-            <graph sample="1">
-                <field name="product_id" />
-                <field name="date" />
-            </graph>
-        `,
-        context: {
-            search_default_false_domain: 1,
-        },
-        searchViewArch: /* xml */ `
-            <search>
-                <filter name="no_match" string="Match nothing" domain="[['id', '=', 0]]"/>
-            </search>
-        `,
-        noContentHelp: /* xml */ `<p class="abc">click to add a foo</p>`,
-    });
-
-    await contains(".o_graph_view").click();
-    await toggleSearchBarMenu();
-    await toggleMenuItem("Match nothing");
-
-    expect(".o_view_nocontent").toHaveCount(1);
-    expect(getFacetTexts()).not.toEqual([]);
-    expect(".o_reset_filter_button").toHaveCount(1);
-    expect(".o_reset_filter_button").toHaveText("Reset Filters");
-    expect(".o_facet_value").toHaveText("Match nothing");
-
-    await contains(".o_reset_filter_button").click();
-    expect(getFacetTexts()).toEqual([]);
-    expect(".o_reset_filter_button").not.toHaveCount(1);
 });
 
 test("empty graph view with sample data", async () => {

--- a/addons/web/static/tests/views/kanban/kanban_view.test.js
+++ b/addons/web/static/tests/views/kanban/kanban_view.test.js
@@ -6110,41 +6110,6 @@ test("quick create column with x_name as _rec_name", async () => {
 });
 
 test.tags("desktop");
-test("reset filter button should appear when no data corresponding to facets", async () => {
-    await mountView({
-        type: "kanban",
-        resModel: "partner",
-        arch: `
-            <kanban>
-                <templates>
-                    <t t-name="card">
-                        <field name="foo"/>
-                    </t>
-                </templates>
-            </kanban>`,
-        searchViewArch: `
-            <search>
-                <filter name="no_match" string="Match nothing" domain="[['id', '=', 0]]"/>
-            </search>`,
-        noContentHelp: "click to add a partnerReset Filters",
-    });
-
-    await contains(".o_kanban_view").click();
-    await toggleSearchBarMenu();
-    await toggleMenuItem("Match nothing");
-
-    expect(".o_view_nocontent").toHaveCount(1);
-    expect(getFacetTexts()).not.toEqual([]);
-    expect(".o_reset_filter_button").toHaveCount(1);
-    expect(".o_reset_filter_button").toHaveText("Reset Filters");
-    expect(".o_facet_value").toHaveText("Match nothing");
-
-    await contains(".o_reset_filter_button").click();
-    expect(getFacetTexts()).toEqual([]);
-    expect(".o_reset_filter_button").not.toHaveCount(1);
-});
-
-test.tags("desktop");
 test("count of folded groups in empty kanban with sample data", async () => {
     onRpc("web_read_group", () => ({
         groups: [

--- a/addons/web/static/tests/views/list/list_view.test.js
+++ b/addons/web/static/tests/views/list/list_view.test.js
@@ -7109,34 +7109,6 @@ test(`no nocontent helper when no data and no help`, async () => {
     expect(`.o_list_view table`).toHaveCount(1, { message: "should have a table in the dom" });
 });
 
-test.tags("desktop");
-test("reset filter button should appear when no data corresponding to facets", async () => {
-    await mountView({
-        type: "list",
-        resModel: "foo",
-        arch: `<list><field name="foo"/></list>`,
-        searchViewArch: `
-            <search>
-                <filter name="no_match" string="Match nothing" domain="[['id', '=', 0]]"/>
-            </search>`,
-        noContentHelp: "click to add a partnerReset Filters",
-    });
-
-    await contains(".o_list_view").click();
-    await toggleSearchBarMenu();
-    await toggleMenuItem("Match nothing");
-
-    expect(".o_view_nocontent").toHaveCount(1);
-    expect(getFacetTexts()).not.toEqual([]);
-    expect(".o_reset_filter_button").toHaveCount(1);
-    expect(".o_reset_filter_button").toHaveText("Reset Filters");
-    expect(".o_facet_value").toHaveText("Match nothing");
-
-    await contains(".o_reset_filter_button").click();
-    expect(getFacetTexts()).toEqual([]);
-    expect(".o_reset_filter_button").not.toHaveCount(1);
-});
-
 test(`empty list with sample data`, async () => {
     await mountView({
         resModel: "foo",

--- a/addons/web/static/tests/views/pivot_view.test.js
+++ b/addons/web/static/tests/views/pivot_view.test.js
@@ -2729,41 +2729,6 @@ test("empty pivot view with action helper", async () => {
 });
 
 test.tags("desktop");
-test("reset filter button should appear when no data corresponding to facets", async () => {
-    Partner._views["pivot,false"] = `<pivot>
-		<field name="product_id" type="measure"/>
-		<field name="date" interval="month" type="col"/>
-	</pivot>`;
-    Partner._views["search,false"] = `<search>
-		<filter name="no_match" string="Match nothing" domain="[['id', '=', 0]]"/>
-	</search>`;
-
-    await mountView({
-        type: "pivot",
-        resModel: "partner",
-        context: { search_default_small_than_0: true },
-        noContentHelp: markup(`<p class="abc">click to add a foo</p>`),
-        config: {
-            views: [[false, "search"]],
-        },
-    });
-
-    await contains(".o_pivot_view").click();
-    await toggleSearchBarMenu();
-    await toggleMenuItem("Match nothing");
-
-    expect(".o_view_nocontent").toHaveCount(1);
-    expect(getFacetTexts()).not.toEqual([]);
-    expect(".o_reset_filter_button").toHaveCount(1);
-    expect(".o_reset_filter_button").toHaveText("Reset Filters");
-    expect(".o_facet_value").toHaveText("Match nothing");
-
-    await contains(".o_reset_filter_button").click();
-    expect(getFacetTexts()).toEqual([]);
-    expect(".o_reset_filter_button").not.toHaveCount(1);
-});
-
-test.tags("desktop");
 test("empty pivot view with sample data", async () => {
     Partner._views["pivot"] = `<pivot sample="1">
 		<field name="product_id" type="measure"/>


### PR DESCRIPTION
This commit removes the button used to reset filters in the action helper.

task-4891535

