### PR TITLE
[FIX] sale: factor in parent company taxes when computing unit price

### DIFF
--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -471,12 +471,11 @@ class SaleOrderLine(models.Model):
             else:
                 line = line.with_company(line.company_id)
                 price = line._get_display_price()
+                product_taxes = line.product_id.taxes_id._filter_taxes_by_company(line.company_id)
                 line.price_unit = line.product_id._get_tax_included_unit_price_from_price(
                     price,
                     line.currency_id or line.order_id.currency_id,
-                    product_taxes=line.product_id.taxes_id.filtered(
-                        lambda tax: tax.company_id == line.env.company
-                    ),
+                    product_taxes=product_taxes,
                     fiscal_position=line.order_id.fiscal_position_id,
                 )
 

--- a/addons/sale/tests/test_sale_prices.py
+++ b/addons/sale/tests/test_sale_prices.py
@@ -832,6 +832,50 @@ class TestSalePrices(SaleCommon):
             100, order.order_line[0].price_unit,
             "The included tax must be subtracted to the price")
 
+    def test_so_tax_mapping_multicompany(self):
+        tax_group = self.env['account.tax.group'].create({'name': "10%"})
+        tax_include, tax_exclude = self.env['account.tax'].create([{
+            'name': "10% Tax Inc.",
+            'amount': 10.0,
+            'price_include': True,
+            'type_tax_use': 'sale',
+            'tax_group_id': tax_group.id,
+        }, {
+            'name': "10% Tax Exc.",
+            'amount': 0.0,
+            'type_tax_use': 'sale',
+            'tax_group_id': tax_group.id,
+        }])
+        fpos = self.env['account.fiscal.position'].create({
+            'name': "B2B",
+            'tax_ids': [Command.create({
+                'tax_src_id': tax_include.id,
+                'tax_dest_id': tax_exclude.id,
+            })],
+        })
+        self.product.write({
+            'list_price': 110.0,
+            'taxes_id': tax_include.ids,
+        })
+        branch_company = self.env['res.company'].create({
+            'name': "Branch Co.",
+            'parent_id': self.env.company.id,
+            'country_id': self.env.company.country_id.id,
+        })
+        order = self.empty_order.with_company(branch_company)
+        order.sudo().write({
+            'company_id': branch_company.id,
+            'fiscal_position_id': fpos.id,
+            'user_id': False,
+            'team_id': False,
+            'order_line': [Command.create({'product_id': self.product.id})],
+        })
+        self.assertEqual(order.order_line.tax_id, tax_exclude, "Line tax should be mapped")
+        self.assertAlmostEqual(
+            order.order_line.price_unit, 100.0,
+            msg="Tax should not be included in unit price",
+        )
+
     def test_free_product_and_price_include_fixed_tax(self):
         """ Check that fixed tax include are correctly computed while the price_unit is 0 """
         taxes = self.env['account.tax'].create([{


### PR DESCRIPTION
Versions
--------
- 17.0+

Steps
-----
1. Set up 10% price-included tax;
2. copy the tax to a B2B version that's price-excluded;
3. create a B2B fiscal position mapping the first tax to the second;
4. create a $10 product using the first tax;
5. create a branch for the current company;
6. switch to the branch company;
7. set up a sale order with the fiscal position;
8. add the product to the order.

Issue
-----
While the line displays the correct B2B tax, the unit price displays $10, as if it was computed without any taxes, instead of a price-excluded tax.

Cause
-----
In the `_compute_price_unit` method, it filters out all tax records linked to the product that don't have the same company as the order line, so the parent company's tax does not get factored in.

Solution
--------
Rather than requiring strict equality between companies, also allow taxes that belong to a parent company of the line's company.

opw-4853042