### PR TITLE
[FIX] website: prevent dragging table of content main parts outside

### DIFF
--- a/addons/website/static/src/builder/plugins/options/table_of_content_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/table_of_content_option_plugin.js
@@ -39,9 +39,21 @@ class TableOfContentOptionPlugin extends Plugin {
             NavbarPositionAction,
         },
         normalize_handlers: this.normalize.bind(this),
+        // Prevent dropping a table of content inside another table of content.
         dropzone_selector: {
             selector: ".s_table_of_content",
             excludeAncestor: ".s_table_of_content",
+        },
+        // Only allow moving main parts of the table of content by using arrows.
+        is_draggable_handlers: (el) => {
+            if (
+                el.matches(
+                    ".s_table_of_content .s_table_of_content_navbar_wrap, .s_table_of_content .s_table_of_content_main"
+                )
+            ) {
+                return false;
+            }
+            return true;
         },
     };
 


### PR DESCRIPTION
When the table of content options were converted to `html_builder`, the drag'n'drop of the content part and the navbar part was not restricted to remain within the table of content section.
Because of this it was possible to e.g. drop the navbar inside the grid layout of another block.

This commit prevents this.

task-4367641
