### PR TITLE
[FIX] mail: no traceback from ptt extension no present


### DIFF
--- a/addons/mail/static/src/discuss/call/common/ptt_extension_service.js
+++ b/addons/mail/static/src/discuss/call/common/ptt_extension_service.js
@@ -11,8 +11,9 @@ export const pttExtensionHookService = {
         // https://chromewebstore.google.com/detail/discuss-push-to-talk/mdiacebcbkmjjlpclnbcgiepgifcnpmg
         const EXT_ID = "mdiacebcbkmjjlpclnbcgiepgifcnpmg";
         const versionPromise =
-            window.chrome?.runtime?.sendMessage(EXT_ID, { type: "ask-version" }) ??
-            Promise.resolve("1.0.0.0");
+            window.chrome?.runtime
+                ?.sendMessage(EXT_ID, { type: "ask-version" })
+                .catch(() => "1.0.0.0") ?? Promise.resolve("1.0.0.0");
         let isEnabled = false;
         let voiceActivated = false;
 


### PR DESCRIPTION

Scenario:

- install website, im_livechat, Metamask external extension
- go to any page on the website with chrome

Result: a traceback is shown on all pages with no stacktrace and the
message "Could not establish connection. Receiving end does not exist.".

Issue: the error happen if the push to talk extension is not installed
in the pttExtensionHookService. Because of metamask extension,
"window.chrome.runtime" is not undefined (if metamask is uninstalled,
"the window.chrome.runtime" is undefined). So when metamask (or another
extension that cause window.chrome.runtime to be defined) is installed,
we get an error shown because the promise rejection is not handled.

Fix: handle the unhandled promise error.

opw-4874027
