### PR TITLE
[IMP] orm: remove flush parameter from fields

### DIFF
--- a/addons/account/models/account_account.py
+++ b/addons/account/models/account_account.py
@@ -137,11 +137,11 @@ class AccountAccount(models.Model):
     # Form view: show code mapping tab or not
     display_mapping_tab = fields.Boolean(default=lambda self: len(self.env.user.company_ids) > 1, store=False)
 
-    def _field_to_sql(self, alias: str, field_expr: str, query: (Query | None) = None, flush: bool = True) -> SQL:
+    def _field_to_sql(self, alias: str, field_expr: str, query: (Query | None) = None) -> SQL:
         if field_expr == 'internal_group':
-            return SQL("split_part(%s, '_', 1)", self._field_to_sql(alias, 'account_type', query, flush))
+            return SQL("split_part(%s, '_', 1)", self._field_to_sql(alias, 'account_type', query))
         if field_expr == 'code':
-            return self.with_company(self.env.company.root_id).sudo()._field_to_sql(alias, 'code_store', query, flush)
+            return self.with_company(self.env.company.root_id).sudo()._field_to_sql(alias, 'code_store', query)
         if field_expr == 'placeholder_code':
             if 'account_first_company' not in query._joins:
                 # When multiple accounts are selected, ``placeholder_code`` is used for all of them
@@ -189,10 +189,10 @@ class AccountAccount(models.Model):
         if field_expr == 'root_id':
             return SQL(
                 "SUBSTRING(%(placeholder_code)s, 1, 2)",
-                placeholder_code=self._field_to_sql(alias, 'placeholder_code', query, flush),
+                placeholder_code=self._field_to_sql(alias, 'placeholder_code', query),
             )
 
-        return super()._field_to_sql(alias, field_expr, query, flush)
+        return super()._field_to_sql(alias, field_expr, query)
 
     @api.constrains('reconcile', 'account_type', 'tax_ids')
     def _constrains_reconcile(self):

--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -1836,18 +1836,18 @@ class AccountMoveLine(models.Model):
                 line._copy_data_extend_business_fields(vals)
         return vals_list
 
-    def _field_to_sql(self, alias: str, field_expr: str, query: (Query | None) = None, flush: bool = True) -> SQL:
+    def _field_to_sql(self, alias: str, field_expr: str, query: (Query | None) = None) -> SQL:
         fname, property_name = fields.parse_field_expr(field_expr)
         if fname != 'payment_date':
-            return super()._field_to_sql(alias, field_expr, query, flush)
+            return super()._field_to_sql(alias, field_expr, query)
         sql = SQL("""
             CASE
                  WHEN %(discount_date)s >= %(today)s THEN %(discount_date)s
                  ELSE %(date_maturity)s
             END""",
             today=fields.Date.context_today(self),
-            discount_date=super()._field_to_sql(alias, "discount_date", query, flush),
-            date_maturity=super()._field_to_sql(alias, "date_maturity", query, flush),
+            discount_date=super()._field_to_sql(alias, "discount_date", query),
+            date_maturity=super()._field_to_sql(alias, "date_maturity", query),
         )
         if property_name:
             sql = self._field[fname].property_to_sql(sql, property_name, self, alias, query)

--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -362,11 +362,11 @@ class HrEmployee(models.Model):
         domain = Domain('id', operator, value)
         return Domain('id', 'in', self.env['hr.version']._search(domain).select('employee_id'))
 
-    def _field_to_sql(self, alias: str, field_expr: str, query: (Query | None) = None, flush: bool = True) -> SQL:
+    def _field_to_sql(self, alias: str, field_expr: str, query: (Query | None) = None) -> SQL:
         """This is required to search for the related fields of version_id as version_id is not stored"""
         if field_expr == 'version_id':
             field_expr = 'current_version_id'
-        return super()._field_to_sql(alias, field_expr, query, flush)
+        return super()._field_to_sql(alias, field_expr, query)
 
     def _get_version(self, date=fields.Date.today()):
         """

--- a/odoo/addons/base/models/properties_base_definition_mixin.py
+++ b/odoo/addons/base/models/properties_base_definition_mixin.py
@@ -46,11 +46,11 @@ class PropertiesBaseDefinitionMixin(models.AbstractModel):
             vals["properties_base_definition_id"] = parent
         return super().create(vals_list)
 
-    def _field_to_sql(self, alias, fname, query=None, flush: bool = True):
+    def _field_to_sql(self, alias, fname, query=None):
         if fname == 'properties_base_definition_id':
             # Allow the export to work
             parent = self.env["properties.base.definition"] \
                 ._get_definition_id_for_property_field(self._name, "properties")
             return SQL("%s", parent)
 
-        return super()._field_to_sql(alias, fname, query, flush)
+        return super()._field_to_sql(alias, fname, query)

--- a/odoo/orm/fields.py
+++ b/odoo/orm/fields.py
@@ -1195,20 +1195,15 @@ class Field(typing.Generic[T]):
     # SQL generation methods
     #
 
-    def to_sql(self, model: BaseModel, alias: str, flush: bool = True) -> SQL:
+    def to_sql(self, model: BaseModel, alias: str) -> SQL:
         """ Return an :class:`SQL` object that represents the value of the given
         field from the given table alias.
 
         The query object is necessary for fields that need to add tables to the query.
-
-        When parameter ``flush`` is true, the method adds some metadata in the
-        result to make method :meth:`~odoo.api.Environment.execute_query` flush
-        the field before executing the query.
         """
         if not self.store or not self.column_type:
             raise ValueError(f"Cannot convert {self} to SQL because it is not stored")
-        field_to_flush = self if flush else None
-        sql_field = SQL.identifier(alias, self.name, to_flush=field_to_flush)
+        sql_field = SQL.identifier(alias, self.name, to_flush=self)
         if self.company_dependent:
             fallback = self.get_company_dependent_fallback(model)
             fallback = self.convert_to_column(self.convert_to_write(fallback, model), model)

--- a/odoo/orm/fields_misc.py
+++ b/odoo/orm/fields_misc.py
@@ -117,9 +117,10 @@ class Id(Field[IdType | typing.Literal[False]]):
     def convert_to_column(self, value, record, values=None, validate=True):
         return value
 
-    def to_sql(self, model: BaseModel, alias: str, flush: bool = True) -> SQL:
+    def to_sql(self, model: BaseModel, alias: str) -> SQL:
         # do not flush, just return the identifier
         assert self.store, 'id field must be stored'
+        # id is never flushed
         return SQL.identifier(alias, self.name)
 
     def expression_getter(self, field_expr):

--- a/odoo/orm/fields_relational.py
+++ b/odoo/orm/fields_relational.py
@@ -440,8 +440,8 @@ class Many2one(_Relational):
                 ids1 = tuple(unique((ids0 or ()) + valid_records._ids))
                 invf._update_cache(corecord, ids1)
 
-    def to_sql(self, model: BaseModel, alias: str, flush: bool = True) -> SQL:
-        sql_field = super().to_sql(model, alias, flush)
+    def to_sql(self, model: BaseModel, alias: str) -> SQL:
+        sql_field = super().to_sql(model, alias)
         if self.company_dependent:
             comodel = model.env[self.comodel_name]
             sql_field = SQL(

--- a/odoo/orm/fields_textual.py
+++ b/odoo/orm/fields_textual.py
@@ -383,8 +383,8 @@ class BaseString(Field[str | typing.Literal[False]]):
         for record, new_translation in zip(records.with_context(prefetch_langs=True), new_translations_list, strict=True):
             self._update_cache(record, new_translation, dirty=True)
 
-    def to_sql(self, model: BaseModel, alias: str, flush: bool = True) -> SQL:
-        sql_field = super().to_sql(model, alias, flush)
+    def to_sql(self, model: BaseModel, alias: str) -> SQL:
+        sql_field = super().to_sql(model, alias)
         if self.translate and not model.env.context.get('prefetch_langs'):
             langs = self.get_translation_fallback_langs(model.env)
             sql_field_langs = [SQL("%s->>%s", sql_field, lang) for lang in langs]


### PR DESCRIPTION
When generating the SQL for fields, we remove the `to_flush` parameter to simplify the API and implementation.

In most cases, we want to flush properly the data. There is only one case, when fetching fields from a query, where we may want to avoid flushing: in that case, we can just rebuild the SQL for that field without the flush data.


Note: (some code always adds a field to flush even if it is not requested)


odoo/enterprise#88664

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
