### PR TITLE
[FIX] *: fix untranslated content

### DIFF
--- a/addons/pos_online_payment/views/payment_portal_templates.xml
+++ b/addons/pos_online_payment/views/payment_portal_templates.xml
@@ -4,7 +4,7 @@
     <!-- Display of /pos/pay (the order of the if conditions matters)-->
     <template id="pay">
         <t t-call="portal.frontend_layout">
-            <t t-set="page_title" t-value="'Payment'" />
+            <t t-set="page_title">Payment</t>
             <t t-set="additional_title">
                 <t t-esc="page_title" />
             </t>
@@ -54,7 +54,7 @@
     <!-- Display of /pos/pay/confirmation -->
     <template id="pay_confirmation">
         <t t-call="portal.frontend_layout">
-            <t t-set="page_title" t-value="'Payment Confirmation'" />
+            <t t-set="page_title">Payment Confirmation</t>
             <t t-set="additional_title">
                 <t t-esc="page_title" />
             </t>

--- a/addons/sale_timesheet/report/report_timesheet_templates.xml
+++ b/addons/sale_timesheet/report/report_timesheet_templates.xml
@@ -9,7 +9,7 @@
                     <t t-foreach="docs" t-as="doc">
                         <t t-set="doc_name" t-value="doc.name"/>
                         <t t-if="with_order_id" t-set="doc_name" t-value="str(doc.order_id.name) +' - '+ str(doc_name)"/>
-                        <t t-elif="doc_name == '/'" t-set="doc_name" t-value="'Draft'"/>
+                        <t t-elif="doc_name == '/'" t-set="doc_name">Draft</t>
                         <div class="oe_structure"/>
                         <div class="row mt8">
                             <div class="col-12">

--- a/addons/web/static/src/webclient/settings_form_view/settings_form_view.xml
+++ b/addons/web/static/src/webclient/settings_form_view/settings_form_view.xml
@@ -24,8 +24,8 @@
         <xpath expr="//Layout/t[@t-component='props.Renderer']" position="inside">
             <t t-set-slot="NoContentHelper" isVisible="state.displayNoContent">
                 <t t-call="web.NoContentHelper">
-                    <t t-set="title" t-value="'No setting found'"/>
-                    <t t-set="description" t-value="'Try searching for another keyword'"/>
+                    <t t-set="title">No settings found</t>
+                    <t t-set="description">Try searching for another keyword</t>
                 </t>
             </t>
         </xpath>

--- a/addons/website_hr_recruitment/views/website_hr_recruitment_templates.xml
+++ b/addons/website_hr_recruitment/views/website_hr_recruitment_templates.xml
@@ -943,7 +943,7 @@
             <t t-set="non_filter_params" t-valuef="#{current_department_param}#{current_employment_type_param}#{current_industry_param}"/>
             <t t-set="count_per_filter" t-value="count_per_office"/>
             <t t-set="dropdown_id" t-value="'officesDropdown'"/>
-            <t t-set="untype_label" t-value="'Remote'"/>
+            <t t-set="untype_label">Remote</t>
         </t>
     </xpath>
     <xpath expr="//div[hasclass('accordion-flush')]" position="inside">
@@ -957,7 +957,7 @@
             <t t-set="non_filter_params" t-valuef="#{current_department_param}#{current_employment_type_param}#{current_industry_param}"/>
             <t t-set="count_per_filter" t-value="count_per_office"/>
             <t t-set="dropdown_id" t-value="'officesDropdown'"/>
-            <t t-set="untype_label" t-value="'Remote'"/>
+            <t t-set="untype_label">Remote</t>
         </t>
     </xpath>
 </template>
@@ -974,7 +974,7 @@
             <t t-set="non_filter_params" t-valuef="#{current_country_param}#{current_office_param}#{current_employment_type_param}#{current_industry_param}"/>
             <t t-set="count_per_filter" t-value="count_per_department"/>
             <t t-set="dropdown_id" t-value="'departmentsDropdown'"/>
-            <t t-set="untype_label" t-value="'Others'"/>
+            <t t-set="untype_label">Others</t>
         </t>
     </xpath>
     <xpath expr="//div[hasclass('accordion-flush')]" position="inside">
@@ -988,7 +988,7 @@
             <t t-set="non_filter_params" t-valuef="#{current_country_param}#{current_office_param}#{current_employment_type_param}#{current_industry_param}"/>
             <t t-set="count_per_filter" t-value="count_per_department"/>
             <t t-set="dropdown_id" t-value="'departmentsDropdown'"/>
-            <t t-set="untype_label" t-value="'Others'"/>
+            <t t-set="untype_label">Others</t>
         </t>
     </xpath>
 </template>

--- a/addons/website_payment/views/payment_form_templates.xml
+++ b/addons/website_payment/views/payment_form_templates.xml
@@ -13,7 +13,7 @@
     <!-- Display of /donation/pay -->
     <template id="website_payment.donation_pay" name="Donation payment">
         <t t-call="portal.frontend_layout">
-            <t t-set="page_title" t-value="'Donation'"/>
+            <t t-set="page_title">Donation</t>
             <t t-set="additional_title"><t t-out="page_title"/></t>
             <div class="wrap">
                 <div class="oe_structure" id="oe_structure_website_payment_donation_1"/>

--- a/addons/website_sale_loyalty/views/website_sale_templates.xml
+++ b/addons/website_sale_loyalty/views/website_sale_templates.xml
@@ -194,7 +194,7 @@
 
     <template id="reduction_coupon_code" inherit_id="website_sale.reduction_code">
         <xpath expr="//t[@t-set='force_coupon']" position="after">
-            <t t-set="_placeholder" t-value="'Discount code or gift card'"/>
+            <t t-set="_placeholder">Discount code or gift card</t>
         </xpath>
     </template>
 


### PR DESCRIPTION
Content passed to a t-value directive is not translated. This commit redefines as text nodes human-readable content that was incorrectly placed in a t-value, so that it is now translated.

*: pos_online_payment, sale_timesheet, web, website_hr_recruitment, website_payment, website_sale_loyalty

Enterprise: https://github.com/odoo/enterprise/pull/88666