### PR TITLE
[FIX] website_sale: remove border around disabled quantity

### DIFF
--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -2832,14 +2832,14 @@
     </template>
 
     <template id="cart_lines_quantity" name="Shopping Cart Line quantity">
+        <t
+            t-set="should_show_quantity_selector"
+            t-value="is_view_active('website_sale.product_quantity')"
+        />
         <div
-            class="css_quantity input-group justify-content-end h-100 border"
+            t-attf-class="css_quantity input-group justify-content-end h-100 {{should_show_quantity_selector and line._is_sellable() and 'border' or ''}}"
             t-attf-name="{{'website_sale_cart_line_quantity' if not is_mobile else 'website_sale_cart_line_quantity_mobile'}}"
         >
-            <t
-                t-set="should_show_quantity_selector"
-                t-value="is_view_active('website_sale.product_quantity')"
-            />
             <t t-if="should_show_quantity_selector and line._is_sellable()">
                 <a
                     href="#"

--- a/addons/website_sale_stock/views/website_sale_stock_templates.xml
+++ b/addons/website_sale_stock/views/website_sale_stock_templates.xml
@@ -5,7 +5,7 @@
         <xpath expr="//input[@type='text'][hasclass('quantity')]" position="attributes">
             <attribute name="t-att-data-max">line._get_max_line_qty()</attribute>
         </xpath>
-        <xpath expr="//div[hasclass('css_quantity')]" position="after">
+        <xpath expr="//div[contains(@t-attf-class, 'css_quantity')]" position="after">
             <div class="availability_messages"/>
         </xpath>
     </template>


### PR DESCRIPTION
In commit[1] a the css has been cleaned up using utilities classes. It introduced a border on the quantity input, but the disabled input share the same parent having the border.

This PR restores the previous quantity design for unsellable lines.

task-4894371

[1]:
https://github.com/odoo/odoo/commit/d9eef371210feb28186dfe78ce75f4bed00e53e4


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
