### PR TITLE
[FIX] mrp: enable batch edits in workorders list view

### DIFF
--- a/addons/mrp/views/mrp_workorder_views.xml
+++ b/addons/mrp/views/mrp_workorder_views.xml
@@ -60,7 +60,7 @@
         <field name="model">mrp.workorder</field>
         <field name="priority" eval="100"/>
         <field name="arch" type="xml">
-            <list>
+            <list multi_edit="1">
                 <field name="consumption" column_invisible="True"/>
                 <field name="company_id" column_invisible="True"/>
                 <field name="is_produced" column_invisible="True"/>


### PR DESCRIPTION
Multi-edit was disabled from the WO list view by mistake in commit:
https://github.com/odoo/odoo/commit/5767cf0c0cbf2a4130430cd92a3cba8891b84510
Therefore, it has been re-enabled.

Task: 4900236


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
