### PR TITLE
[REF] mail, mass_mailing: add getOuterHtml and getInnerHtml utils

### DIFF
--- a/addons/mail/__manifest__.py
+++ b/addons/mail/__manifest__.py
@@ -177,6 +177,7 @@ For more specific needs, you may also assign custom-defined actions
         ],
         "web.assets_frontend": [
             "mail/static/src/utils/common/format.js",
+            "mail/static/src/utils/common/html.js",
         ],
         'mail.assets_discuss_public_test_tours': [
             'web/static/lib/hoot-dom/**/*',

--- a/addons/mail/static/src/core/common/composer.js
+++ b/addons/mail/static/src/core/common/composer.js
@@ -6,8 +6,8 @@ import { NavigableList } from "@mail/core/common/navigable_list";
 import { MAIL_PLUGINS, MAIL_SMALL_UI_PLUGINS } from "@mail/core/common/plugin/plugin_sets";
 import { useSuggestion } from "@mail/core/common/suggestion_hook";
 import { useSelection } from "@mail/utils/common/hooks";
+import { getOuterHtml } from "@mail/utils/common/html";
 import { isDragSourceExternalFile } from "@mail/utils/common/misc";
-
 import { Wysiwyg } from "@html_editor/wysiwyg";
 
 import { rpc } from "@web/core/network/rpc";
@@ -612,7 +612,7 @@ export class Composer extends Component {
                 document.createElement("br"),
                 ...createElementWithContent("div", signature).childNodes
             );
-            signature = markup(divElement.outerHTML);
+            signature = getOuterHtml(divElement);
         }
         default_body = this.formatDefaultBodyForFullComposer(
             default_body,

--- a/addons/mail/static/src/core/common/message_search_hook.js
+++ b/addons/mail/static/src/core/common/message_search_hook.js
@@ -1,5 +1,6 @@
 import { useSequential } from "@mail/utils/common/hooks";
-import { useState, onWillUnmount, markup } from "@odoo/owl";
+import { getInnerHtml } from "@mail/utils/common/html";
+import { useState, onWillUnmount } from "@odoo/owl";
 import { useService } from "@web/core/utils/hooks";
 import { createDocumentFragmentFromContent } from "@web/core/utils/html";
 import { escapeRegExp } from "@web/core/utils/strings";
@@ -59,7 +60,7 @@ export function searchHighlight(searchTerm, target) {
             element.replaceChildren(...newNode);
         }
     }
-    return markup(htmlDoc.body.innerHTML);
+    return getInnerHtml(htmlDoc.body);
 }
 
 /** @param {import('models').Thread} thread */

--- a/addons/mail/static/src/core/web/composer_patch.js
+++ b/addons/mail/static/src/core/web/composer_patch.js
@@ -2,8 +2,7 @@ import { wrapInlinesInBlocks } from "@html_editor/utils/dom";
 import { childNodes } from "@html_editor/utils/dom_traversal";
 
 import { Composer } from "@mail/core/common/composer";
-
-import { markup } from "@odoo/owl";
+import { getInnerHtml } from "@mail/utils/common/html";
 
 import { createDocumentFragmentFromContent } from "@web/core/utils/html";
 import { patch } from "@web/core/utils/patch";
@@ -32,6 +31,6 @@ patch(Composer.prototype, {
         const container = document.createElement("DIV");
         container.append(...childNodes(fragment));
         wrapInlinesInBlocks(container, { baseContainerNodeName: "DIV" });
-        return markup(container.innerHTML);
+        return getInnerHtml(container);
     },
 });

--- a/addons/mail/static/src/utils/common/format.js
+++ b/addons/mail/static/src/utils/common/format.js
@@ -1,3 +1,13 @@
+/**
+ * @typedef DependencyInManifest
+ * ⚠️ Each dependency of this file in `mail` must be explicitly added in
+ * `web.assets_frontend` in the manifest. This error is not caught by the
+ * standard runbot, only during staging or nightly. The missing dependency might
+ * added by livechat so it only happens when frontend modules are installed and
+ * tested while livechat is not installed.
+ */
+import { getInnerHtml, getOuterHtml } from "@mail/utils/common/html";
+
 import { htmlEscape, markup } from "@odoo/owl";
 
 import { router } from "@web/core/browser/router";
@@ -141,8 +151,7 @@ function linkify(text) {
             });
             link.classList.add("o_message_redirect");
         }
-        // markup: outerHTML is safe when used as a node
-        result = htmlJoin([result, markup(link.outerHTML)]);
+        result = htmlJoin([result, getOuterHtml(link)]);
         curIndex = match.index + match[0].length;
     }
     return htmlJoin([result, text.slice(curIndex)]);
@@ -168,10 +177,10 @@ export function addLink(node, transformChildren) {
         return node.textContent;
     }
     if (node.tagName === "A") {
-        return markup(node.outerHTML);
+        return getOuterHtml(node);
     }
     transformChildren();
-    return markup(node.outerHTML);
+    return getOuterHtml(node);
 }
 
 function generateMentionElement({ className, id, model, text }) {
@@ -289,8 +298,7 @@ function generateMentionsLinks(
     }
     for (const mention of mentions) {
         const link = mention.link;
-        // markup: outerHTML is safe when used as a node
-        body = htmlReplace(body, mention.placeholder, markup(link.outerHTML));
+        body = htmlReplace(body, mention.placeholder, getOuterHtml(link));
     }
     return htmlEscape(body);
 }
@@ -336,7 +344,7 @@ export function getNonEditableMentions(body) {
     for (const mention of doc.body.querySelectorAll(".o-discuss-mention")) {
         mention.setAttribute("contenteditable", false);
     }
-    return markup(doc.body.innerHTML);
+    return getInnerHtml(doc.body);
 }
 
 /**
@@ -425,7 +433,7 @@ export function decorateEmojis(content) {
         );
         node.replaceWith(...span.childNodes);
     }
-    return markup(doc.body.innerHTML);
+    return getInnerHtml(doc.body);
 }
 
 /**

--- a/addons/mail/static/src/utils/common/html.js
+++ b/addons/mail/static/src/utils/common/html.js
@@ -1,0 +1,74 @@
+/**
+ * @import { DependencyInManifest } from "@mail/utils/common/format"
+ * ⚠️ {@link DependencyInManifest}
+ */
+
+import { markup } from "@odoo/owl";
+
+import { htmlJoin } from "@web/core/utils/html";
+
+/**
+ * Returns whether the given tag is a void HTML element.
+ *
+ * @param {string} tag
+ */
+function isVoidElement(tag) {
+    // outerHTML represents non-void elements with both opening and closing tags,
+    // so their length is strictly greater than the tag name length + 2 (for <>).
+    return document.createElement(tag).outerHTML.length === tag.length + 2;
+}
+
+/**
+ * @param {Node} node
+ * @param {Object} [options={}]
+ * @param {boolean} [options.innerOnly=false]
+ * @return {string|ReturnType<markup>}
+ */
+function escapeNode(node, { innerOnly = false } = {}) {
+    if (!node || node.nodeType === Node.COMMENT_NODE) {
+        return "";
+    }
+    if (node.nodeType === Node.TEXT_NODE) {
+        return innerOnly ? "" : node.textContent;
+    }
+    const children = htmlJoin(Array.from(node.childNodes).map((node) => escapeNode(node)));
+    if (innerOnly) {
+        return children;
+    }
+    const tag = node.tagName.toLowerCase();
+    const attributeList = Array.from(node.attributes);
+    if (attributeList.length === 0) {
+        if (isVoidElement(tag)) {
+            return markup`<${tag}>`;
+        }
+        return markup`<${tag}>${children}</${tag}>`;
+    }
+    const attributes = htmlJoin(
+        attributeList.map((attr) => markup`${attr.name}="${attr.value}"`),
+        " "
+    );
+    if (isVoidElement(tag)) {
+        return markup`<${tag} ${attributes}>`;
+    }
+    return markup`<${tag} ${attributes}>${children}</${tag}>`;
+}
+
+/**
+ * Safely gets innerHTML of the given Element.
+ *
+ * @param {Element} element
+ * @returns {string|ReturnType<markup>}
+ */
+export function getInnerHtml(element) {
+    return escapeNode(element, { innerOnly: true });
+}
+
+/**
+ * Safely gets outerHTML of the given Element.
+ *
+ * @param {Element} element
+ * @returns {string|ReturnType<markup>}
+ */
+export function getOuterHtml(element) {
+    return escapeNode(element);
+}

--- a/addons/mail/static/tests/core/search_highlight.test.js
+++ b/addons/mail/static/tests/core/search_highlight.test.js
@@ -35,7 +35,7 @@ test("Search highlight", async () => {
         },
         {
             input: '<a href="https://www.odoo.com">https://www.odoo.com</a>',
-            output: `&lt;a href="https://www.<span class="${HIGHLIGHT_CLASS}">odoo</span>.com"&gt;https://www.<span class="${HIGHLIGHT_CLASS}">odoo</span>.com&lt;/a&gt;`,
+            output: `&lt;a href=&quot;https://www.<span class="${HIGHLIGHT_CLASS}">odoo</span>.com&quot;&gt;https://www.<span class="${HIGHLIGHT_CLASS}">odoo</span>.com&lt;/a&gt;`,
             searchTerm: "odoo",
         },
         {

--- a/addons/mail/static/tests/mail_utils.test.js
+++ b/addons/mail/static/tests/mail_utils.test.js
@@ -64,7 +64,7 @@ test("addLink: utility function and special entities", () => {
         ],
         [
             markup`<p>https://example.com/"hello"&gt;</p>`,
-            '<p><a target="_blank" rel="noreferrer noopener" href="https://example.com/">https://example.com/</a>"hello"&gt;</p>',
+            '<p><a target="_blank" rel="noreferrer noopener" href="https://example.com/">https://example.com/</a>&quot;hello&quot;&gt;</p>',
         ],
         // & and ' linkified since they are in URL regex
         [
@@ -73,9 +73,9 @@ test("addLink: utility function and special entities", () => {
         ],
         [
             markup`<p>https://example.com/'yeah'</p>`,
-            '<p><a target="_blank" rel="noreferrer noopener" href="https://example.com/\'yeah\'">https://example.com/\'yeah\'</a></p>',
+            '<p><a target="_blank" rel="noreferrer noopener" href="https://example.com/&#x27;yeah&#x27;">https://example.com/&#x27;yeah&#x27;</a></p>',
         ],
-        [markup`<p>:'(</p>`, "<p>:'(</p>"],
+        [markup`<p>:'(</p>`, "<p>:&#x27;(</p>"],
         [markup`:'(`, ":&#x27;("],
         ["<p>:'(</p>", "&lt;p&gt;:&#x27;(&lt;/p&gt;"],
         [":'(", ":&#x27;("],

--- a/addons/mail/static/tests/utils/decorate_emojis.test.js
+++ b/addons/mail/static/tests/utils/decorate_emojis.test.js
@@ -33,6 +33,6 @@ test("unsafe content is escaped when wrapping emojis with title", async () => {
     await loadEmoji();
     const result = decorateEmojis("<img src='javascript:alert(\"xss\")'/>😇");
     expect(result.toString()).toEqual(
-        '&lt;img src=\'javascript:alert("xss")\'/&gt;<span class="o-mail-emoji" title=":innocent: :halo:">😇</span>'
+        '&lt;img src=&#x27;javascript:alert(&quot;xss&quot;)&#x27;/&gt;<span class="o-mail-emoji" title=":innocent: :halo:">😇</span>'
     );
 });

--- a/addons/mail/static/tests/utils/html.test.js
+++ b/addons/mail/static/tests/utils/html.test.js
@@ -1,0 +1,56 @@
+import { getInnerHtml, getOuterHtml } from "@mail/utils/common/html";
+
+import { describe, expect, test } from "@odoo/hoot";
+import { markup } from "@odoo/owl";
+
+import { createElementWithContent } from "@web/core/utils/html";
+
+const Markup = markup().constructor;
+
+describe.current.tags("headless");
+
+test("getInnerHtml escapes text and attributes", () => {
+    const div = document.createElement("div");
+    div.textContent = 'class="test" <i>abc</i>';
+    const span = document.createElement("span");
+    span.setAttribute("title", "<b>test</b>");
+    span.setAttribute("data-test", '" hack="failed');
+    div.appendChild(span);
+    const res = getInnerHtml(div);
+    expect(res.toString()).toBe(
+        'class=&quot;test&quot; &lt;i&gt;abc&lt;/i&gt;<span title="&lt;b&gt;test&lt;/b&gt;" data-test="&quot; hack=&quot;failed"></span>'
+    );
+    // ensure nothing is lost during conversion, the original node can be re-created
+    expect(createElementWithContent("dummy", res).innerHTML).toBe(div.innerHTML);
+});
+
+test("getOuterHtml escapes text and attributes", () => {
+    const div = document.createElement("div");
+    div.textContent = 'class="test" <i>abc</i>';
+    const span = document.createElement("span");
+    span.setAttribute("title", "<b>test</b>");
+    span.setAttribute("data-test", '" hack="failed');
+    div.appendChild(span);
+    const res = getOuterHtml(div);
+    expect(res.toString()).toBe(
+        '<div>class=&quot;test&quot; &lt;i&gt;abc&lt;/i&gt;<span title="&lt;b&gt;test&lt;/b&gt;" data-test="&quot; hack=&quot;failed"></span></div>'
+    );
+    // ensure nothing is lost during conversion, the original node can be re-created
+    expect(createElementWithContent("dummy", res).innerHTML).toBe(div.outerHTML);
+});
+
+test("getInnerHtml ignores text nodes", () => {
+    const res = getInnerHtml(document.createTextNode("<span>test</span>"));
+    expect(res.toString()).toBe("");
+});
+
+test("getOuterHtml escapes text nodes", () => {
+    const res = getOuterHtml(document.createTextNode("<span>test</span>"));
+    expect(res.toString()).toBe("<span>test</span>");
+    expect(res).not.toBeInstanceOf(Markup);
+});
+
+test("getOuterHtml ignores comment nodes", () => {
+    const res = getOuterHtml(document.createComment("<span>test</span>"));
+    expect(res.toString()).toBe("");
+});

--- a/addons/mass_mailing/static/src/themes/theme_service.js
+++ b/addons/mass_mailing/static/src/themes/theme_service.js
@@ -1,8 +1,9 @@
 import { children } from "@html_editor/utils/dom_traversal";
 import { parseHTML } from "@html_editor/utils/html";
-import { markup } from "@odoo/owl";
+import { getInnerHtml } from "@mail/utils/common/html";
 import { registry } from "@web/core/registry";
 import { Deferred } from "@web/core/utils/concurrency";
+import { htmlTrim } from "@web/core/utils/html";
 import { Reactive } from "@web/core/utils/reactive";
 import { renderToMarkup } from "@web/core/utils/render";
 
@@ -38,7 +39,7 @@ export class ThemeModel extends Reactive {
             const themeOptions = {
                 className: getClassName(theme.dataset.name),
                 hideFromMobile: hasDataOption(theme, "hide-from-mobile"),
-                html: markup(theme.innerHTML.trim()),
+                html: htmlTrim(getInnerHtml(theme)),
                 imgPath: theme.dataset.img || "",
                 layoutStyles: theme.dataset.layoutStyles || "",
                 name: theme.dataset.name,


### PR DESCRIPTION
Main issue, in summary: extracting `outerHTML` of a text node and injecting this value into an attribute will not escape the quotes, leading to XSS.

The goal is to remove as much as possible the need to manually use `markup()` as a function by providing safe utils instead.

Getting inner or outer HTML is a common operation which should be carefully done as textContent is natively not escaped in terms of quotes, which makes it unsafe for injection into attributes.

Markup string should always be built safely, thefore this PR introduces helpers to safefy get HTML from an element, no matter how it is going to be used.

https://github.com/odoo/enterprise/pull/88677