### PR TITLE
[IMP] account_edi_ubl_cii: support additional nodes in DocumentReferences

### DIFF
--- a/addons/account_edi_ubl_cii/tools/ubl_21_common.py
+++ b/addons/account_edi_ubl_cii/tools/ubl_21_common.py
@@ -34,15 +34,23 @@ Attachment = {
     },
 }
 
+IssuerParty = {
+    'cac:PartyIdentification': {
+        'cbc:ID': {},
+    }
+}
+
 DocumentReference = {
     'cbc:ID': {},
     'cbc:UUID': {},
     'cbc:IssueDate': {},
     'cbc:IssueTime': {},
     'cbc:DocumentTypeCode': {},
+    'cbc:DocumentStatusCode': {},
     'cbc:DocumentType': {},
     'cbc:DocumentDescription': {},
     'cac:Attachment': Attachment,
+    'cac:IssuerParty': IssuerParty,
 }
 
 BillingReference = {


### PR DESCRIPTION
l10n_pe_edi requires more from the UBL 2.1 spec than currently supported post UBL refactor. As such we add the datatypes necessary to support it.

task-4605204