### PR TITLE
[FIX] point_of_sale: prevent error on create invoices for orders with different users

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -814,7 +814,7 @@ class PosOrder(models.Model):
             'partner_bank_id': self._get_partner_bank_id(),
             'currency_id': self.currency_id.id,
             'invoice_date': invoice_date.astimezone(timezone).date(),
-            'invoice_user_id': self.user_id.id,
+            'invoice_user_id': self.env.user.id,
             'fiscal_position_id': fiscal_position.id,
             'invoice_line_ids': self._prepare_invoice_lines(move_type),
             'invoice_payment_term_id': False,


### PR DESCRIPTION
Currently, an error occurs when trying to create invoices for POS orders with the `same customer` but `different users(employees)`.

**Steps to produce:**
- Install the `point_of_sale` module.
- Create two POS order for same customer (ensure `Invoice` is disabled on the `Payment screen`).
- Switch to another tab, open a POS order, and change the `user` on one of the orders.
- In the list view, select both orders and click `Create Invoices`.

(Refer [this](https://drive.google.com/file/d/1MsFR6c6nOkYFGTXF8w-wLAybqhPRmlc6/view?usp=sharing) for step to produce.)

**Error:**
ValueError: Expected singleton: res.users(5, 2)

**Root Cause:**

At [1], when generating the invoice, `self.user_id` is assuming a single record, but the action is performed on multiple orders created by different users, causing the error.

[1]
https://github.com/odoo/odoo/blob/c9b9376cc68350cb341913ecf9862a7bcc7da339/addons/point_of_sale/models/pos_order.py#L817

This commit prevents the error by ensuring that the currently logged-in user is set as the `invoice_user_id`.

Sentry – 6708281910