### PR TITLE
[IMP] point_of_sale: reposition duplicata label on preparation receipt

### DIFF
--- a/addons/point_of_sale/static/src/app/store/order_change_receipt_template.xml
+++ b/addons/point_of_sale/static/src/app/store/order_change_receipt_template.xml
@@ -5,9 +5,6 @@
         <div class="pos-receipt m-0 p-0 pt-5">
             <!-- Receipt Header -->
             <div class="receipt-header text-center">
-                <div class="pos-receipt-title" t-if="data.reprint">
-                    DUPLICATA !
-                </div>
                 <div class="pos-receipt-title preset-name" t-if="data.preset_name">
                     <t t-esc="data.preset_name"/> <t t-if="data.preset_time">(<t t-esc="data.preset_time"/>)</t>
                 </div>
@@ -30,6 +27,9 @@
                 <div t-if="hasDataChanges" class="new-changes w-100">
                     <div class="pos-receipt-title text-center w-100">
                         <strong t-esc="data.changes.title" />
+                        <t t-if="data.reprint">
+                            (DUPLICATE !)
+                        </t>
                     </div>
                     <t t-if="data.changes.groupedData">
                         <div t-foreach="data.changes.groupedData" t-as="group" t-key="group_index">


### PR DESCRIPTION
In this commit:
===============
- Replaced `DUPLICATA` with `DUPLICATE`.
- Repositioned the `DUPLICATE` label on the preparation ticket.
- This change was made because most restaurants use ticket holders that obscure
the top portion of the ticket, making the original placement of the label
difficult to see.

Task: 4893867

![before](https://github.com/user-attachments/assets/200c6a39-0677-4722-9b61-557b34fb22ca)
![after](https://github.com/user-attachments/assets/daac5e85-8d7d-4a99-8e23-6b057c0fdf3e)
