### PR TITLE
[REF] web_tour: uncomment beforeUnload listener

### DIFF
--- a/addons/point_of_sale/static/tests/pos/tours/product_screen_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/product_screen_tour.js
@@ -792,7 +792,11 @@ registry.category("web_tour.tours").add("test_remove_archived_product_from_cache
             PaymentScreen.clickValidate(),
             ReceiptScreen.isShown(),
             Chrome.clickMenuOption("Close Register"),
-            Dialog.confirm("Close Register"),
+            {
+                trigger: ".modal .modal-footer .btn:contains(close register)",
+                run: "click",
+                expectUnloadPage: true,
+            },
             {
                 content: `Select button backend`,
                 trigger: `button:contains(backend)`,

--- a/addons/point_of_sale/static/tests/pos/tours/receipt_screen_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/receipt_screen_tour.js
@@ -175,7 +175,11 @@ registry.category("web_tour.tours").add("OrderPaidInCash", {
             Chrome.clickMenuOption("Close Register"),
             ProductScreen.closeWithCashAmount("25"),
             ProductScreen.cashDifferenceIs("0.00"),
-            Dialog.confirm("Close Register"),
+            {
+                trigger: ".modal .modal-footer .btn:contains(close register)",
+                run: "click",
+                expectUnloadPage: true,
+            },
             {
                 trigger: "button:contains(backend)",
                 run: "click",

--- a/addons/test_website_modules/static/tests/tours/configurator_flow.js
+++ b/addons/test_website_modules/static/tests/tours/configurator_flow.js
@@ -104,6 +104,7 @@ registry.category("web_tour.tours").add("configurator_flow", {
         {
             content: "Loader should be shown",
             trigger: ".o_website_loader_container",
+            expectUnloadPage: true,
         },
         {
             content: "Wait until the configurator is finished",

--- a/addons/website_event_sale/static/tests/tours/website_event_sale_last_ticket.js
+++ b/addons/website_event_sale/static/tests/tours/website_event_sale_last_ticket.js
@@ -56,6 +56,10 @@ registry.category("web_tour.tours").add('event_buy_last_ticket', {
         run: "click",
         expectUnloadPage: true,
     },
-    ...wsTourUtils.payWithTransfer({ redirect: true }),
+        ...wsTourUtils.payWithTransfer({
+            redirect: true,
+            expectUnloadPage: true,
+            waitFinalizeYourPayment: true,
+        }),
     ],
 });

--- a/addons/website_sale/static/tests/tours/website_sale_buy.js
+++ b/addons/website_sale/static/tests/tours/website_sale_buy.js
@@ -13,6 +13,10 @@ registry.category("web_tour.tours").add('shop_buy_product', {
         tourUtils.goToCart(),
         tourUtils.goToCheckout(),
         tourUtils.confirmOrder(),
-        ...tourUtils.payWithTransfer({ redirect: true }),
+        ...tourUtils.payWithTransfer({
+            redirect: true,
+            expectUnloadPage: true,
+            waitFinalizeYourPayment: true,
+        }),
     ]
 });

--- a/addons/website_sale/static/tests/tours/website_sale_complete_flow.js
+++ b/addons/website_sale/static/tests/tours/website_sale_complete_flow.js
@@ -171,21 +171,11 @@ import { pay } from "@website_sale/js/tours/tour_utils";
         content: "Check selected billing address is same as typed in previous step",
         trigger: '#delivery_and_billing :contains(Billing):contains(SO1 Billing Street Edited, 33):contains(SO1BillingCityEdited):contains(Afghanistan)',
     },
-    {
-        content: "Select `Wire Transfer` payment method",
-        trigger: 'input[name="o_payment_radio"][data-payment-method-code="wire_transfer"]',
-        run: "click",
-    },
-    {
-        trigger:
-            'input[name="o_payment_radio"][data-payment-method-code="wire_transfer"]:checked',
-    },
-    {
-        content: "Pay Now",
-        trigger: 'button[name="o_payment_submit_button"]:not(:disabled)',
-        run: "click",
+    ...tourUtils.payWithTransfer({
+        redirect: false,
         expectUnloadPage: true,
-    },
+        waitFinalizeYourPayment: true,
+    }),
     {
         content: "Sign up",
         trigger: '.oe_cart a:contains("Sign Up")',
@@ -380,6 +370,7 @@ import { pay } from "@website_sale/js/tours/tour_utils";
         content: "Click on Confirm button to save the address",
         trigger: 'a[name="website_sale_main_button"]',
         run: "click",
+        expectUnloadPage: true,
     },
         tourUtils.confirmOrder(),
     {

--- a/addons/website_sale/static/tests/tours/website_sale_reorder_from_portal.js
+++ b/addons/website_sale/static/tests/tours/website_sale_reorder_from_portal.js
@@ -96,15 +96,36 @@ registry.category("web_tour.tours").add('website_sale_reorder_from_portal', {
         // Fourth reorder making sure confirmation dialog doesn't pop up unnecessary
         {
             content: "Deleting All products from cart",
-            trigger: 'div.js_cart_lines',
-            run: async () => {
-
-                // Keep clicking delete buttons until none are left
-                while ($('a.js_delete_product').length > 0) {
-                    $('a.js_delete_product:first').click();
-                    await new Promise(resolve => setTimeout(resolve, 1200)); 
-                }
-            }
+            trigger: "div.js_cart_lines",
+        },
+        {
+            trigger: "#cart_products:has(.o_cart_product:eq(3)):not(:has(.o_cart_product:eq(4)))",
+        },
+        {
+            trigger: `a.js_delete_product:first`,
+            run: "click",
+        },
+        {
+            trigger: "#cart_products:has(.o_cart_product:eq(2)):not(:has(.o_cart_product:eq(3)))",
+        },
+        {
+            trigger: `a.js_delete_product:first`,
+            run: "click",
+        },
+        {
+            trigger: "#cart_products:has(.o_cart_product:eq(1)):not(:has(.o_cart_product:eq(2)))",
+        },
+        {
+            trigger: `a.js_delete_product:first`,
+            run: "click",
+        },
+        {
+            trigger: "#cart_products:has(.o_cart_product:eq(0)):not(:has(.o_cart_product:eq(1)))",
+        },
+        {
+            trigger: `a.js_delete_product:first`,
+            run: "click",
+            expectUnloadPage: true,
         },
         {
             content: "Go to my orders",


### PR DESCRIPTION
In this commit, we uncomment the listener on beforeUnload to ensure that expectUnloadPage is correctly used in tours.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
