### PR TITLE
[FIX] account: preserve journal entry name on edit

### DIFF
--- a/addons/account/models/account_payment.py
+++ b/addons/account/models/account_payment.py
@@ -989,17 +989,19 @@ class AccountPayment(models.Model):
                 line_ids_commands.append((0, 0, extra_line_vals))
             # Update the existing journal items.
             # If dealing with multiple write-off lines, they are dropped and a new one is generated.
-            pay.move_id \
-                .with_context(skip_invoice_sync=True) \
-                .write({
-                'name': pay.name if pay.name else '/',  # Set the name to '/' to allow it to be changed
+            to_write = {
                 'date': pay.date,
                 'partner_id': pay.partner_id.id,
                 'currency_id': pay.currency_id.id,
                 'partner_bank_id': pay.partner_bank_id.id,
                 'line_ids': line_ids_commands,
-                'journal_id': pay.journal_id.id,
-            })
+            }
+            if 'journal_id' in changed_fields:
+                to_write.update({
+                    'name': '/',  # Set the name to '/' to allow it to be changed
+                    'journal_id': pay.journal_id.id
+                })
+            pay.move_id.with_context(skip_invoice_sync=True).write(to_write)
 
     @api.model
     def _get_trigger_fields_to_synchronize(self):


### PR DESCRIPTION
Since PR #204507, the move name is reset whenever a payment with a `move_id` is modified, which was intended to allow changing the journal. However, this also resets the journal entry name unnecessarily when unrelated fields (e.g. amount) are updated.

This causes confusion for users, especially when the payment is re-posted and a new sequence is generated, leading to gaps in the journal entry numbering without any apparent reason.

This fix ensures the journal entry name is only reset when the `journal_id` field is updated.

Steps to reproduce:
1. Create a payment and post it
2. Reset it to draft
3. Change the amount
4. Check the journal entry name → it is reset to '/'
4. Repost the payment, and a new sequence is generated

Ticket [link](https://www.odoo.com/odoo/project/967/tasks/4886466)
opw-4886466