### PR TITLE
[FIX] discuss: prevent traceback when downloading call logs

### DIFF
--- a/addons/mail/static/src/discuss/call/common/rtc_service.js
+++ b/addons/mail/static/src/discuss/call/common/rtc_service.js
@@ -726,7 +726,7 @@ export class Rtc extends Record {
         if (this.serverInfo) {
             this.log(this.localSession, "loading sfu server", {
                 step: "loading sfu server",
-                serverInfo: this.serverInfo,
+                serverInfo: toRaw(this.serverInfo),
             });
             this.localSession.connectionState = "loading SFU assets";
             try {


### PR DESCRIPTION
Before this commit, there could be a traceback when downloading call logs that contains `serverInfo`, that was because it is a proxy and cannot be cloned (to be passed to the service worker).

This commit fixes it by using the raw value instead of the proxy when logging.

