### PR TITLE
[FIX] pos_{,restaurant}: dynamic dialog for missing slot address or customer

### DIFF
--- a/addons/point_of_sale/static/src/app/models/pos_order.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order.js
@@ -69,6 +69,7 @@ export class PosOrder extends Base {
                 TipScreen: {
                     inputTipAmount: "",
                 },
+                requiredPartnerDetails: {},
             };
         }
     }
@@ -129,12 +130,27 @@ export class PosOrder extends Base {
     }
 
     get presetRequirementsFilled() {
-        return (
-            (!this.preset_id?.needsPartner ||
-                (this.partner_id?.name && (this.partner_id?.street || this.partner_id?.street2))) &&
-            (!this.preset_id?.needsName || this.partner_id?.name || this.floating_order_name) &&
-            (!this.preset_id?.needsSlot || this.preset_time)
-        );
+        const invalidCustomer =
+            (this.preset_id?.needsName && !(this.floating_order_name || this.partner_id)) ||
+            (this.preset_id?.needsPartner && !this.partner_id);
+        const isAddressMissing =
+            this.preset_id?.needsPartner && !(this.partner_id?.street || this.partner_id?.street2);
+        const invalidSlot = this.preset_id?.needsSlot && !this.preset_time;
+
+        if (invalidCustomer || isAddressMissing || invalidSlot) {
+            this.uiState.requiredPartnerDetails = {
+                field: _t(
+                    invalidCustomer ? _t("Customer") : isAddressMissing ? _t("Address") : _t("Slot")
+                ),
+                message: invalidCustomer
+                    ? _t("Please add a valid customer to the order.")
+                    : isAddressMissing
+                    ? _t("The selected customer needs an address.")
+                    : _t("Please select a time slot before proceeding."),
+            };
+            return false;
+        }
+        return true;
     }
 
     getEmailItems() {

--- a/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.js
@@ -510,9 +510,10 @@ export class PaymentScreen extends Component {
         }
 
         if (!this.currentOrder.presetRequirementsFilled) {
+            const { field, message } = this.currentOrder.uiState.requiredPartnerDetails || {};
             this.dialog.add(AlertDialog, {
-                title: _t("Customer required"),
-                body: _t("Please add a valid customer to the order."),
+                title: field ? _t("%s required", field) : _t("Missing required"),
+                body: message || _t("Some required information is missing."),
             });
             return false;
         }

--- a/addons/point_of_sale/static/tests/pos/tours/utils/payment_screen_util.js
+++ b/addons/point_of_sale/static/tests/pos/tours/utils/payment_screen_util.js
@@ -358,7 +358,7 @@ export function clickPartnerButton() {
         },
         {
             content: "partner screen is shown",
-            trigger: `.modal ${PartnerList.clickPartner().trigger}`,
+            trigger: `${PartnerList.clickPartner().trigger}`,
         },
     ];
 }

--- a/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
@@ -895,3 +895,23 @@ registry.category("web_tour.tours").add("test_delete_line_release_table", {
             negateStep(...Order.hasLine({ productName: "Coca-Cola" })),
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("test_preset_timing_restaurant_dialog", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            FloorScreen.clickTable("5"),
+            ProductScreen.clickDisplayedProduct("Coca-Cola"),
+            ProductScreen.selectPreset("Eat in", "Takeaway"),
+            ProductScreen.clickPayButton(),
+            PaymentScreen.clickPaymentMethod("Bank"),
+            PaymentScreen.clickValidate(),
+            Dialog.bodyIs("Please add a valid customer to the order."),
+            Dialog.confirm(),
+            PaymentScreen.clickPartnerButton(),
+            PaymentScreen.clickCustomer("A simple PoS man!"),
+            PaymentScreen.clickValidate(),
+            Dialog.bodyIs("Please select a time slot before proceeding."),
+            Dialog.confirm(),
+        ].flat(),
+});

--- a/addons/pos_restaurant/tests/test_frontend.py
+++ b/addons/pos_restaurant/tests/test_frontend.py
@@ -575,6 +575,9 @@ class TestFrontend(TestFrontendCommon):
             'resource_calendar_id': resource_calendar
         })
         self.start_pos_tour('test_preset_timing_restaurant')
+        # remove time slot for this preset
+        self.preset_takeaway.resource_calendar_id = False
+        self.start_pos_tour('test_preset_timing_restaurant_dialog')
 
     def test_restaurant_preset_takeout_tour(self):
         self.pos_config.write({


### PR DESCRIPTION
STEPS TO REPRODUCE:
----------------
- Install `pos_restaurant`.
- Set up a "Takeaway" preset with "identification = not required".
- Remove all slots for today.
- Try to place an order using "Takeaway" or "Delivery" without selecting a slot
  or address.

ISSUE:
-----------
- Only the "customer required" popup appeared, even if slot or address was
  missing.
- For Delivery, missing address was not checked.

CAUSE:
-----------
- One single dialog was used for all checks, so it didn't check each thing
  separately.

FIX:
---------------
- Show specific popup depending on what is missing (customer, address, or slot).

Task-4892105