### PR TITLE
[FIX] l10n_in, l10n_in_sale: fixed wrong state assignment for foreign customers without states

### DIFF
--- a/addons/l10n_in/models/account_invoice.py
+++ b/addons/l10n_in/models/account_invoice.py
@@ -53,20 +53,20 @@ class AccountMove(models.Model):
 
     @api.depends('partner_id', 'partner_shipping_id', 'company_id')
     def _compute_l10n_in_state_id(self):
+        foreign_state = self.env.ref('l10n_in.state_in_oc', raise_if_not_found=False)
         for move in self:
             if move.country_code == 'IN' and move.is_sale_document(include_receipts=True):
-                partner_state = (
+                partner = (
                     move.partner_id.commercial_partner_id == move.partner_shipping_id.commercial_partner_id
-                    and move.partner_shipping_id.state_id
-                    or move.partner_id.state_id
+                    and move.partner_shipping_id
+                    or move.partner_id
                 )
-                if not partner_state:
-                    partner_state = move.partner_id.commercial_partner_id.state_id or move.company_id.state_id
+                if partner.country_id and partner.country_id.code != 'IN':
+                    move.l10n_in_state_id = foreign_state
+                    continue
+                partner_state = partner.state_id or move.partner_id.commercial_partner_id.state_id or move.company_id.state_id
                 country_code = partner_state.country_id.code or move.country_code
-                if country_code == 'IN':
-                    move.l10n_in_state_id = partner_state
-                else:
-                    move.l10n_in_state_id = self.env.ref('l10n_in.state_in_oc', raise_if_not_found=False)
+                move.l10n_in_state_id = partner_state if country_code == 'IN' else foreign_state
             elif move.country_code == 'IN' and move.journal_id.type == 'purchase':
                 move.l10n_in_state_id = move.company_id.state_id
             else:

--- a/addons/l10n_in/tests/test_partner_details_on_invoice.py
+++ b/addons/l10n_in/tests/test_partner_details_on_invoice.py
@@ -39,6 +39,12 @@ class TestReports(AccountTestInvoicingCommon):
             'country_id': cls.env.ref("base.us").id,
             'zip': "123456",
         })
+        cls.partner_d = cls.env['res.partner'].create({
+            'name': "Overseas partner without State",
+            'l10n_in_gst_treatment': 'overseas',
+            'country_id': cls.env.ref("base.us").id,
+            # No state_id defined
+        })
         cls.igst_sale_18 = cls.env['account.chart.template'].ref('igst_sale_18')
 
     def test_partner_details_change_with_invoice(self):
@@ -167,5 +173,23 @@ class TestReports(AccountTestInvoicingCommon):
             invoice,
             [{
                 'l10n_in_state_id': self.partner_b.state_id.id,
+            }]
+        )
+
+    def test_foreign_customer_without_state(self):
+        """Verify foreign customer without state_id gets foreign state reference"""
+        invoice = self.init_invoice(
+            move_type='out_invoice',
+            partner=self.partner_d,
+            amounts=[100, 200],
+            taxes=[self.igst_sale_18]
+        )
+
+        # Should assign foreign state reference even without partner state
+        self.assertRecordValues(
+            invoice,
+            [{
+                'l10n_in_gst_treatment': 'overseas',
+                'l10n_in_state_id': self.env.ref("l10n_in.state_in_oc").id,
             }]
         )

--- a/addons/l10n_in_sale/models/sale_order.py
+++ b/addons/l10n_in_sale/models/sale_order.py
@@ -39,18 +39,18 @@ class SaleOrder(models.Model):
             elif order.l10n_in_gst_treatment == 'special_economic_zone':
                 # Special Economic Zone
                 return foreign_state
-            
+
             # Computing Place of Supply for particular order
-            partner_state = (
+            partner = (
                 order.partner_id.commercial_partner_id == order.partner_shipping_id.commercial_partner_id
-                and order.partner_shipping_id.state_id
-                or order.partner_id.state_id
+                and order.partner_shipping_id
+                or order.partner_id
             )
-            if not partner_state:
-                partner_state = order.partner_id.commercial_partner_id.state_id or order.company_id.state_id
-            if partner_state.country_id.code != 'IN':
-                partner_state = foreign_state
-            return partner_state
+            if partner.country_id and partner.country_id.code != 'IN':
+                return foreign_state
+            partner_state = partner.state_id or order.partner_id.commercial_partner_id.state_id or order.company_id.state_id
+            country_code = partner_state.country_id.code or order.country_code
+            return partner_state if country_code == 'IN' else foreign_state
 
         FiscalPosition = self.env['account.fiscal.position']
         foreign_state = self.env['res.country.state'].search([('code', '!=', 'IN')], limit=1)

--- a/addons/l10n_in_sale/tests/test_l10n_in_sale_fiscal_position.py
+++ b/addons/l10n_in_sale/tests/test_l10n_in_sale_fiscal_position.py
@@ -31,6 +31,11 @@ class TestSaleFiscal(AccountTestInvoicingCommon):
             'state_id': cls.env.ref('base.state_us_1').id,
             'country_id': cls.env.ref('base.us').id,
         })
+        cls.partner_foreign_no_state = cls.env['res.partner'].create({
+            'name': 'Partner Outside India without State',
+            'country_id': cls.env.ref('base.us').id,
+            # No state_id defined
+        })
 
     def _assert_order_fiscal_position(self, fpos_ref, partner, post=True):
         test_order = self.env['sale.order'].create({
@@ -101,3 +106,13 @@ class TestSaleFiscal(AccountTestInvoicingCommon):
                 sale_order.fiscal_position_id,
                 template.ref('fiscal_position_in_export_sez_in')
             )
+
+    def test_foreign_partner_without_state_fiscal_position(self):
+        """Verify foreign partner without state gets export fiscal position"""
+        self.env.company = self.default_company
+
+        # Foreign partner without state should get export fiscal position
+        self._assert_order_fiscal_position(
+            fpos_ref='fiscal_position_in_export_sez_in',
+            partner=self.partner_foreign_no_state.id,
+        )


### PR DESCRIPTION
Before this PR:
When creating invoices/orders for foreign customers that don't have states defined in their country, both **account.move** and **sale.order** models would incorrectly assign the company's Indian state as the place of supply. This happened because the fallback logic would always use **move.company_id.state_id** without checking if the partner was actually Indian. As a result, foreign customers would be treated as Indian customers in GST calculations, leading to incorrect tax treatment and compliance issues.

After this PR:
Both models now correctly identify foreign customers by checking the partner's country first, before falling back to state-based logic. Foreign customers without states are now properly assigned the foreign state reference (**l10n_in.state_in_oc**) instead of the Indian company's state. This ensures accurate GST treatment where foreign customers are correctly identified as overseas transactions.

Task-4900697