### PR TITLE
[FIX] hr: fix avatar popup for employee public

### DIFF
--- a/addons/hr/models/hr_employee_public.py
+++ b/addons/hr/models/hr_employee_public.py
@@ -204,3 +204,6 @@ class HrEmployeePublic(models.Model):
                 ORDER BY employee_id, date_version DESC
             ) v ON v.employee_id = e.id
         )""" % (self._table, self._get_fields()))
+
+    def get_avatar_card_data(self, fields):
+        return self.read(fields)


### PR DESCRIPTION
A traceback error occurs when clicking on the avatar in the work entry gantt view. 
The function has been added to open the avatar popup


