### PR TITLE
[IMP] calendar: auto-create discuss videocall url when sync is not active

### DIFF
--- a/addons/calendar/models/calendar_event.py
+++ b/addons/calendar/models/calendar_event.py
@@ -636,6 +636,10 @@ class CalendarEvent(models.Model):
 
         events.filtered(lambda event: event.start > fields.Datetime.now()).attendee_ids._send_invitation_emails()
 
+        if not self.env.user._has_any_active_synchronization():
+            for event in events.filtered(lambda event: not (event.location or event.videocall_location)):
+                event._set_discuss_videocall_location()
+
         # update activities based on calendar event data, unless already prepared
         # above manually. Heuristic: a new command (0, 0, vals) is considered as
         # complete

--- a/addons/calendar/tests/test_calendar.py
+++ b/addons/calendar/tests/test_calendar.py
@@ -583,3 +583,16 @@ class TestCalendar(SavepointCaseWithUserDemo):
 
         duration = self.env['calendar.event'].with_company(second_company).get_default_duration()
         self.assertEqual(duration, 8, "Custom duration is 8 hours in the other company")
+
+    def test_videocall_location_set_when_sync_disabled_and_no_location(self):
+        """Testing that when the location is empty (online meeting) and sync is disabled, a new discuss videocall link is created"""
+
+        event = self.CalendarEvent.create({
+            'name': 'Test Meeting',
+            'start': '2025-07-08 10:00:00',
+            'stop': '2025-07-08 11:00:00',
+            'allday': False,
+        })
+
+        self.assertTrue(event.videocall_location, "Expected videocall_location to be set automatically.")
+        self.assertIn("/calendar/join_videocall/", event.videocall_location, "Expected discuss videocall link in videocall_location.")

--- a/addons/calendar/views/calendar_views.xml
+++ b/addons/calendar/views/calendar_views.xml
@@ -309,6 +309,7 @@
                             context="{'form_view_ref': 'base.view_partner_simple_form'}"
                             class="oe_inline"
                         />
+                        <field name="location" placeholder="Online Meeting" readonly="not user_can_edit"/>
                         <label for="videocall_location" class="opacity-100"/>
                         <div col="2">
                             <field name="videocall_location" string="Videocall URL" widget="CopyClipboardChar" force_save="1" readonly="videocall_source == 'discuss'"/>

--- a/addons/microsoft_calendar/tests/test_create_events.py
+++ b/addons/microsoft_calendar/tests/test_create_events.py
@@ -50,14 +50,16 @@ class TestCreateEvents(TestCommon):
         with self.assertRaises(ValidationError):
             record._sync_odoo2microsoft()
 
+    @patch.object(ResUsers, '_has_any_active_synchronization')
     @patch.object(MicrosoftCalendarService, 'get_events')
-    def test_create_simple_event_from_outlook_organizer_calendar(self, mock_get_events):
+    def test_create_simple_event_from_outlook_organizer_calendar(self, mock_get_events, mock_has_active_sync):
         """
         An event has been created in Outlook and synced in the Odoo organizer calendar.
         """
 
         # arrange
         mock_get_events.return_value = (MicrosoftEvent([self.simple_event_from_outlook_organizer]), None)
+        mock_has_active_sync.return_value = True
         existing_records = self.env["calendar.event"].search([])
 
         # act


### PR DESCRIPTION
**Purpose:**
When sync is active with google/outlook and location is not specified, meeting link is automatically generated.

**Specifications:**
Generate discuss link when sync is not active.
Add location field in calendar event quick create form view

Task-4893764