### PR TITLE
[FIX] pos_restaurant: fix empty fire course preparation ticket

### DIFF
--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -1750,6 +1750,45 @@ export class PosStore extends WithLazyGetterTrap {
         return { orderData, changes };
     }
 
+    async generateReceiptsDataToPrint(orderData, changes, orderChange) {
+        const receiptsData = [];
+        if (changes.new.length) {
+            const orderDataNew = { ...orderData };
+            orderDataNew.changes = {
+                title: _t("NEW"),
+                data: changes.new,
+            };
+            receiptsData.push(await this.prepareReceiptGroupedData(orderDataNew));
+        }
+
+        if (changes.cancelled.length) {
+            const orderDataCancelled = { ...orderData };
+            orderDataCancelled.changes = {
+                title: _t("CANCELLED"),
+                data: changes.cancelled,
+            };
+            receiptsData.push(await this.prepareReceiptGroupedData(orderDataCancelled));
+        }
+
+        if (changes.noteUpdate.length) {
+            const orderDataNoteUpdate = { ...orderData };
+            const { noteUpdateTitle, printNoteUpdateData = true } = orderChange;
+            orderDataNoteUpdate.changes = {
+                title: noteUpdateTitle || _t("NOTE UPDATE"),
+                data: printNoteUpdateData ? changes.noteUpdate : [],
+            };
+            receiptsData.push(await this.prepareReceiptGroupedData(orderDataNoteUpdate));
+            orderData.changes.noteUpdate = [];
+        }
+
+        if (orderChange.internal_note || orderChange.general_customer_note) {
+            const orderDataNote = { ...orderData };
+            orderDataNote.changes = { title: "", data: [] };
+            receiptsData.push(await this.prepareReceiptGroupedData(orderDataNote));
+        }
+        return receiptsData;
+    }
+
     async printChanges(order, orderChange, reprint = false) {
         const unsuccedPrints = [];
 
@@ -1760,45 +1799,13 @@ export class PosStore extends WithLazyGetterTrap {
                 printer.config.product_categories_ids,
                 reprint
             );
-
-            if (changes.new.length) {
-                orderData.changes = {
-                    title: _t("NEW"),
-                    data: changes.new,
-                };
-                const result = await this.printOrderChanges(orderData, printer);
-                if (!result.successful) {
-                    unsuccedPrints.push(printer.config.name);
-                }
-            }
-
-            if (changes.cancelled.length) {
-                orderData.changes = {
-                    title: _t("CANCELLED"),
-                    data: changes.cancelled,
-                };
-                const result = await this.printOrderChanges(orderData, printer);
-                if (!result.successful) {
-                    unsuccedPrints.push(printer.config.name);
-                }
-            }
-
-            if (changes.noteUpdate.length) {
-                const { noteUpdateTitle, printNoteUpdateData = true } = orderChange;
-                orderData.changes = {
-                    title: noteUpdateTitle || _t("NOTE UPDATE"),
-                    data: printNoteUpdateData ? changes.noteUpdate : [],
-                };
-                const result = await this.printOrderChanges(orderData, printer);
-                if (!result.successful) {
-                    unsuccedPrints.push(printer.config.name);
-                }
-                orderData.changes.noteUpdate = [];
-            }
-
-            if (orderChange.internal_note || orderChange.general_customer_note) {
-                orderData.changes = { title: "", data: [] };
-                const result = await this.printOrderChanges(orderData, printer);
+            const receiptsData = await this.generateReceiptsDataToPrint(
+                orderData,
+                changes,
+                orderChange
+            );
+            for (const data of receiptsData) {
+                const result = await this.printOrderChanges(data, printer);
                 if (!result.successful) {
                     unsuccedPrints.push(printer.config.name);
                 }
@@ -1815,7 +1822,7 @@ export class PosStore extends WithLazyGetterTrap {
         }
     }
 
-    async printOrderChanges(data, printer) {
+    async prepareReceiptGroupedData(data) {
         const dataChanges = data.changes?.data;
         if (dataChanges && dataChanges.some((c) => c.group)) {
             const groupedData = dataChanges.reduce((acc, c) => {
@@ -1828,6 +1835,10 @@ export class PosStore extends WithLazyGetterTrap {
             }, {});
             data.changes.groupedData = Object.values(groupedData).sort((a, b) => a.index - b.index);
         }
+        return data;
+    }
+
+    async printOrderChanges(data, printer) {
         const receipt = renderToElement("point_of_sale.OrderChangeReceipt", {
             data: data,
         });

--- a/addons/point_of_sale/static/src/app/store/order_change_receipt_template.xml
+++ b/addons/point_of_sale/static/src/app/store/order_change_receipt_template.xml
@@ -26,8 +26,8 @@
 
             <!-- Receipt Body -->
             <div class="pos-receipt-body pb-5">
-                <t t-set="hasDataChanges" t-value="data.changes.data or data.changes.groupedData" />
-                <div t-if="hasDataChanges?.length" class="new-changes w-100">
+                <t t-set="hasDataChanges" t-value="data.changes.data?.length or data.changes.groupedData or data.changes.title" />
+                <div t-if="hasDataChanges" class="new-changes w-100">
                     <div class="pos-receipt-title text-center w-100">
                         <strong t-esc="data.changes.title" />
                     </div>
@@ -45,13 +45,13 @@
                         </div>
                     </t>
                 </div>
-                <div t-if="data.internal_note and !hasDataChanges?.length" class="new-changes w-100" t-att-class="{'mb-3': data.general_customer_note}">
+                <div t-if="data.internal_note and !hasDataChanges" class="new-changes w-100" t-att-class="{'mb-3': data.general_customer_note}">
                     <div class="pos-receipt-title text-center w-100">
                         <strong>INTERNAL NOTE</strong>
                     </div>
                     <div class="text-center" style="font-size: 109%;" t-esc="data.internal_note" />
                 </div>
-                <div t-if="data.general_customer_note and !hasDataChanges?.length" class="new-changes w-100">
+                <div t-if="data.general_customer_note and !hasDataChanges" class="new-changes w-100">
                     <div class="pos-receipt-title text-center w-100">
                         <strong>CUSTOMER NOTE</strong>
                     </div>

--- a/addons/point_of_sale/static/tests/pos/tours/product_screen_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/product_screen_tour.js
@@ -14,7 +14,7 @@ import * as Numpad from "@point_of_sale/../tests/generic_helpers/numpad_util";
 import * as OfflineUtil from "@point_of_sale/../tests/generic_helpers/offline_util";
 import * as TicketScreen from "@point_of_sale/../tests/pos/tours/utils/ticket_screen_util";
 import * as combo from "@point_of_sale/../tests/pos/tours/utils/combo_popup_util";
-import { generatePreparationReceiptElement } from "@point_of_sale/../tests/pos/tours/utils/preparation_receipt_util";
+import { generatePreparationReceipts } from "@point_of_sale/../tests/pos/tours/utils/preparation_receipt_util";
 import * as Utils from "@point_of_sale/../tests/pos/tours/utils/common";
 import * as BackendUtils from "@point_of_sale/../tests/pos/tours/utils/backend_utils";
 
@@ -313,11 +313,11 @@ registry.category("web_tour.tours").add("test_restricted_categories_combo_produc
                 content: "Check if order preparation has product correctly ordered",
                 trigger: "body",
                 run: async () => {
-                    const rendered = generatePreparationReceiptElement();
-                    if (!rendered.innerHTML.includes("Office Combo")) {
+                    const rendered = await generatePreparationReceipts();
+                    if (!rendered[0].innerHTML.includes("Office Combo")) {
                         throw new Error("Office Combo not found in preparation receipt");
                     }
-                    if (!rendered.innerHTML.includes("Combo Product 5")) {
+                    if (!rendered[0].innerHTML.includes("Combo Product 5")) {
                         throw new Error("Combo Product 5 not found in preparation receipt");
                     }
                 },

--- a/addons/point_of_sale/static/tests/pos/tours/utils/preparation_receipt_util.js
+++ b/addons/point_of_sale/static/tests/pos/tours/utils/preparation_receipt_util.js
@@ -1,31 +1,49 @@
 /* global posmodel */
 
+import { _t } from "@web/core/l10n/translation";
 import { renderToElement } from "@web/core/utils/render";
 
-export function generatePreparationChanges() {
+export async function generateReceiptsToPrint(order, orderChange) {
+    const { orderData, changes } = posmodel.generateOrderChange(
+        order,
+        orderChange,
+        Array.from(posmodel.config.preparationCategories),
+        false
+    );
+    const receiptsData = await posmodel.generateReceiptsDataToPrint(
+        orderData,
+        changes,
+        orderChange
+    );
+    const groupedReceiptsData = await posmodel.prepareReceiptGroupedData(receiptsData);
+    return groupedReceiptsData.map((data) =>
+        renderToElement("point_of_sale.OrderChangeReceipt", {
+            data: data,
+        })
+    );
+}
+
+// Return rendered order change receipts that will be printed when clicking "Order" button
+export async function generatePreparationReceipts() {
     const order = posmodel.getOrder();
     const orderChange = posmodel.changesToOrder(
         order,
         posmodel.config.preparationCategories,
         false
     );
-
-    return posmodel.generateOrderChange(
-        order,
-        orderChange,
-        Array.from(posmodel.config.preparationCategories),
-        false
-    );
+    return await generateReceiptsToPrint(order, orderChange);
 }
 
-export function generatePreparationReceiptElement() {
-    const { orderData, changes } = generatePreparationChanges();
-    orderData.changes = {
-        title: "new",
-        data: changes.new,
+// Return rendered fire course receipts that will be printed when clicking "Fire course" button
+export async function generateFireCourseReceipts() {
+    const order = posmodel.getOrder();
+    const course = order.getSelectedCourse();
+    const orderChange = {
+        new: [],
+        cancelled: [],
+        noteUpdate: course.lines.map((line) => ({ product_id: line.getProduct().id })),
+        noteUpdateTitle: _t("Course %s fired", "" + course.index),
+        printNoteUpdateData: false,
     };
-
-    return renderToElement("point_of_sale.OrderChangeReceipt", {
-        data: orderData,
-    });
+    return await generateReceiptsToPrint(order, orderChange);
 }

--- a/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
@@ -15,11 +15,7 @@ import { registry } from "@web/core/registry";
 import * as Numpad from "@point_of_sale/../tests/generic_helpers/numpad_util";
 import { delay } from "@odoo/hoot-dom";
 import * as TextInputPopup from "@point_of_sale/../tests/generic_helpers/text_input_popup_util";
-import {
-    generatePreparationChanges,
-    generatePreparationReceiptElement,
-} from "@point_of_sale/../tests/pos/tours/utils/preparation_receipt_util";
-import { renderToElement } from "@web/core/utils/render";
+import * as PreparationReceipt from "@point_of_sale/../tests/pos/tours/utils/preparation_receipt_util";
 import { negate } from "@point_of_sale/../tests/generic_helpers/utils";
 
 const ProductScreen = { ...ProductScreenPos, ...ProductScreenResto };
@@ -442,15 +438,15 @@ registry.category("web_tour.tours").add("PreparationPrinterContent", {
                 content: "Check if order preparation contains always Variant",
                 trigger: "body",
                 run: async () => {
-                    const rendered = generatePreparationReceiptElement();
+                    const receipts = await PreparationReceipt.generatePreparationReceipts();
 
-                    if (!rendered.innerHTML.includes("Value 1")) {
+                    if (!receipts[0].innerHTML.includes("Value 1")) {
                         throw new Error("Value 1 not found in printed receipt");
                     }
-                    if (!rendered.innerHTML.includes("14:20")) {
+                    if (!receipts[0].innerHTML.includes("14:20")) {
                         throw new Error("14:20 not found in printed receipt");
                     }
-                    if (rendered.innerHTML.includes("DUPLICATA!")) {
+                    if (receipts[0].innerHTML.includes("DUPLICATA!")) {
                         throw new Error("DUPLICATA! should not be present in printed receipt");
                     }
                 },
@@ -464,22 +460,96 @@ registry.category("web_tour.tours").add("PreparationPrinterContent", {
                 content: "Check if order preparation contains 'To Serve' order level internal note",
                 trigger: "body",
                 run: async () => {
-                    const changes = generatePreparationChanges();
-                    const rendered = renderToElement("point_of_sale.OrderChangeReceipt", {
-                        data: changes.orderData,
-                    });
-
-                    if (!rendered.innerHTML.includes("INTERNAL NOTE")) {
+                    const receipts = await PreparationReceipt.generatePreparationReceipts();
+                    if (!receipts[0].innerHTML.includes("Water")) {
+                        throw new Error("'Water' not found in printed receipt");
+                    }
+                    if (!receipts[1].innerHTML.includes("INTERNAL NOTE")) {
                         throw new Error("'INTERNAL NOTE' not found in printed receipt");
                     }
-                    if (!rendered.innerHTML.includes("To Serve")) {
+                    if (!receipts[1].innerHTML.includes("To Serve")) {
                         throw new Error("To Serve not found in printed receipt");
                     }
-                    if (rendered.innerHTML.includes("colorIndex")) {
+                    if (receipts[1].innerHTML.includes("colorIndex")) {
                         throw new Error("colorIndex should not be displayed in printed receipt");
                     }
                 },
             },
+        ].flat(),
+});
+
+registry.category("web_tour.tours").add("test_course_restaurant_preparation_tour", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            FloorScreen.clickTable("5"),
+            ProductScreen.clickCourseButton(),
+            ProductScreen.clickDisplayedProduct("Coca-Cola"),
+            ProductScreen.clickCourseButton(),
+            ProductScreen.clickDisplayedProduct("Water"),
+            ProductScreen.clickCourseButton(),
+            ProductScreen.clickDisplayedProduct("Minute Maid"),
+            {
+                content: "Check if order preparation contains courses with products",
+                trigger: "body",
+                run: async () => {
+                    const receipts = await PreparationReceipt.generatePreparationReceipts();
+                    const coursesAndProducts = [
+                        { course: "Course 1", product: "Coca-Cola" },
+                        { course: "Course 2", product: "Water" },
+                        { course: "Course 3", product: "Minute Maid" },
+                    ];
+                    const courseEls = receipts[0].querySelectorAll("div.fw-bold");
+                    const productEls = receipts[0].querySelectorAll(".product-name");
+
+                    coursesAndProducts.forEach(({ course, product }) => {
+                        const courseFound = Array.from(courseEls).some((el) =>
+                            el.textContent.includes(course)
+                        );
+                        const productFound = Array.from(productEls).some((el) =>
+                            el.textContent.includes(product)
+                        );
+
+                        if (!courseFound || !productFound) {
+                            throw new Error(
+                                `"${course}" or "${product}" not found in printed receipt`
+                            );
+                        }
+                    });
+                },
+            },
+            ProductScreen.clickOrderButton(),
+            Dialog.bodyIs("Failed in printing Preparation Printer, Printer changes of the order"),
+            Dialog.confirm(),
+            FloorScreen.clickTable("5"),
+            ProductScreen.selectCourseLine("Course 2"),
+            {
+                content: "Check if 'Course 2' is printed on the receipt",
+                trigger: "body",
+                run: async () => {
+                    const receipts = await PreparationReceipt.generateFireCourseReceipts();
+                    if (!receipts[0].innerHTML.includes("Course 2 fired")) {
+                        throw new Error("'Course 2 fired' not found on printed receipt");
+                    }
+                },
+            },
+            ProductScreen.fireCourseButton(),
+            Dialog.bodyIs("Failed in printing Preparation Printer, Printer changes of the order"),
+            Dialog.confirm(),
+            FloorScreen.clickTable("5"),
+            ProductScreen.selectCourseLine("Course 3"),
+            {
+                content: "Check if 'Course 3' is printed on the receipt",
+                trigger: "body",
+                run: async () => {
+                    const receipts = await PreparationReceipt.generateFireCourseReceipts();
+                    if (!receipts[0].innerHTML.includes("Course 3 fired")) {
+                        throw new Error("'Course 3 fired' not found on printed receipt");
+                    }
+                },
+            },
+            ProductScreen.fireCourseButton(),
         ].flat(),
 });
 
@@ -503,8 +573,8 @@ registry.category("web_tour.tours").add("test_combo_preparation_receipt", {
                 content: "Check if order preparation has product correctly ordered",
                 trigger: "body",
                 run: async () => {
-                    const rendered = generatePreparationReceiptElement();
-                    const orderLines = [...rendered.querySelectorAll(".orderline")];
+                    const receipts = await PreparationReceipt.generatePreparationReceipts();
+                    const orderLines = [...receipts[0].querySelectorAll(".orderline")];
                     const orderLinesInnerText = orderLines.map((orderLine) => orderLine.innerText);
                     const expectedOrderLines = [
                         "Office Combo",
@@ -634,9 +704,9 @@ registry.category("web_tour.tours").add("test_combo_preparation_receipt_layout",
             {
                 trigger: "body",
                 run: async () => {
-                    const rendered = generatePreparationReceiptElement();
+                    const receipts = await PreparationReceipt.generatePreparationReceipts();
 
-                    const comboItemLines = [...rendered.querySelectorAll(".orderline.ms-5")].map(
+                    const comboItemLines = [...receipts[0].querySelectorAll(".orderline.ms-5")].map(
                         (el) => el.innerText
                     );
                     const expectedComboItemLines = [

--- a/addons/pos_restaurant/tests/test_frontend.py
+++ b/addons/pos_restaurant/tests/test_frontend.py
@@ -399,6 +399,21 @@ class TestFrontend(TestFrontendCommon):
             self.main_pos_config.with_user(self.pos_user).open_ui()
             self.start_tour(f"/pos/ui?config_id={self.main_pos_config.id}", 'PreparationPrinterContent', login="pos_user")
 
+    def test_course_restaurant_preparation_tour(self):
+        self.env['pos.printer'].create({
+            'name': 'Printer',
+            'printer_type': 'epson_epos',
+            'epson_printer_ip': '0.0.0.0',
+            'product_categories_ids': [Command.set(self.env['pos.category'].search([]).ids)],
+        })
+
+        self.main_pos_config.write({
+            'is_order_printer': True,
+            'printer_ids': [Command.set(self.env['pos.printer'].search([]).ids)],
+        })
+        self.pos_config.with_user(self.pos_user).open_ui()
+        self.start_pos_tour('test_course_restaurant_preparation_tour', login="pos_user")
+
     def test_create_floor_tour(self):
         self.pos_config.with_user(self.pos_user).open_ui()
         self.start_pos_tour('test_create_floor_tour', login="pos_admin")


### PR DESCRIPTION
- Since this PR (https://github.com/odoo/odoo/pull/212490), when clicking `Fire course` in restaurant generate empty preparation ticket. This commit fix this issue by ensuring the preparation ticket contains "Course x fired".
- Improve `preparation_receipt_util` to generate preparation receipt as close as the one we generate with a real printer.
- Add test to make sure the preparation ticket contains the course that is being fired.

Steps to reproduce:
    - Configure a preparation printer linked to your pos.config
    - Open POS
    - Open a table
    - Add items, organized by courses
    - Click on order btn
    - The whole order is sent to the kitchen  (good)
    - Go back on the table, click on 'fire course' btn 
    - The preparation printer prints a ticket to warn the kitchen that they need to prepare the next course but it does not contain the course number that is being fired

task-id: 4897844




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
