### PR TITLE
[FIX] hr_timesheet: removed duplicate "Delete" action in employee kanban view

### DIFF
--- a/addons/hr_timesheet/static/src/views/kanban_view.js
+++ b/addons/hr_timesheet/static/src/views/kanban_view.js
@@ -1,0 +1,17 @@
+import { registry } from "@web/core/registry";
+import { KanbanController } from "@web/views/kanban/kanban_controller";
+import { kanbanView } from "@web/views/kanban/kanban_view";
+
+export class EmployeeKanbanController extends KanbanController {
+
+    getStaticActionMenuItems() {
+        const menuItems = super.getStaticActionMenuItems();
+        delete menuItems.delete;
+        return menuItems;
+    }
+}
+
+registry.category("views").add("hr_employee_kanban_action", {
+    ...kanbanView,
+    Controller: EmployeeKanbanController,
+});

--- a/addons/hr_timesheet/views/hr_employee_views.xml
+++ b/addons/hr_timesheet/views/hr_employee_views.xml
@@ -38,13 +38,13 @@
         </field>
     </record>
 
-    <record id="hr_employee_view_kanban_inherit_timesheet" model="ir.ui.view">
+    <record id="hr_employee_kanban_inherit_timesheet" model="ir.ui.view">
         <field name="name">hr.employee.kanban.timesheet</field>
         <field name="model">hr.employee</field>
         <field name="inherit_id" ref="hr.hr_kanban_view_employees"/>
         <field name="arch" type="xml">
             <xpath expr="/kanban" position="attributes">
-                <attribute name="delete">0</attribute>
+                <attribute name="js_class">hr_employee_kanban_action</attribute>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
Steps to Reproduce :
- Install hr_timesheet
- Navigate to Employees > Employees
- In Kanban View, use Alt + Click to multi-select any employee
- Open the "Actions" dropdown
- You will see two "Delete" options

Root Cause:
- Since the default controller already includes a delete action, and the inherited one adds another implicitly, this resulted in duplicate "Delete" entries.

Solution:
- Created a custom EmployeeKanbanController that extends KanbanController
- Overrode getStaticActionMenuItems() to remove the delete entry using delete menuItems.delete

task-4850063

