### PR TITLE
[FIX] html_builder: inside_editor_style inherit web.assets_frontend scss

### DIFF
--- a/addons/html_builder/__manifest__.py
+++ b/addons/html_builder/__manifest__.py
@@ -43,9 +43,8 @@
             'html_builder/static/src/**/*.dark.scss',
         ],
         'html_builder.inside_builder_style': [
-            ('include', 'web._assets_helpers'),
+            ('include', 'web.assets_frontend'),
 
-            'web/static/src/scss/bootstrap_overridden.scss',
             'html_builder/static/src/**/*.inside.scss',
             'html_editor/static/src/main/chatgpt/chatgpt_plugin.scss',
             'html_editor/static/src/main/link/link.scss',

--- a/addons/html_builder/static/src/builder.js
+++ b/addons/html_builder/static/src/builder.js
@@ -160,6 +160,13 @@ export class Builder extends Component {
             };
             this.editor.attachTo(this.editableEl);
             this.editableEl.addEventListener("dragstart", this.onDragStart);
+
+            // Remove the web.assets_frontend link from the iframe document,
+            // as its content is already included in website.inside_builder_style
+            const assetsFrontendLink = iframeEl.contentDocument.querySelector(
+                `link[type="text/css"][href*="assets_frontend"]`
+            );
+            assetsFrontendLink.remove();
         });
 
         useSubEnv({

--- a/addons/html_builder/static/src/core/composite_action_plugin.js
+++ b/addons/html_builder/static/src/core/composite_action_plugin.js
@@ -116,6 +116,7 @@ export class CompositeAction extends BuilderAction {
         loadResult,
         dependencyManager,
         selectableContext,
+        isPreviewing,
     }) {
         for (const actionDef of actions) {
             const action = this.dependencies.builderActions.getAction(actionDef.action);
@@ -127,6 +128,7 @@ export class CompositeAction extends BuilderAction {
                     loadResult,
                     dependencyManager,
                     selectableContext,
+                    isPreviewing,
                 });
                 await action.apply(actionDescr);
             }
@@ -140,6 +142,7 @@ export class CompositeAction extends BuilderAction {
         dependencyManager,
         selectableContext,
         nextAction,
+        isPreviewing,
     }) {
         for (const actionDef of actions) {
             const action = this.dependencies.builderActions.getAction(actionDef.action);
@@ -151,6 +154,7 @@ export class CompositeAction extends BuilderAction {
                 dependencyManager,
                 selectableContext,
                 nextAction,
+                isPreviewing,
             });
             if (action.has("clean")) {
                 action.clean(actionDescr);
@@ -170,6 +174,7 @@ export class CompositeAction extends BuilderAction {
             "dependencyManager",
             "selectableContext",
             "nextAction",
+            "isPreviewing",
         ];
         for (const spec of forwardedSpecs) {
             if (action[spec]) {

--- a/addons/html_builder/static/src/snippets/add_snippet_dialog.js
+++ b/addons/html_builder/static/src/snippets/add_snippet_dialog.js
@@ -75,14 +75,15 @@ export class AddSnippetDialog extends Component {
     }
 
     /**
-     * Loads and injects the required styles into the iframe's <head>.
-     * The URL for web.assets_frontend CSS bundle is retrieved from the editor
+     * Loads and injects the required styles into the iframe's <head>. The URL
+     * for website.inside_builder_style CSS bundle is retrieved from the editor
      * document to ensure consistency, especially when using the RTL version.
      */
     async insertStyle() {
         const loadCSSBundleFromEditor = (bundleName, loadOptions) => {
-            const cssLinkEl = this.props.editor.document.head
-                .querySelector(`link[type="text/css"][href*="/${bundleName}."]`);
+            const cssLinkEl = this.props.editor.document.head.querySelector(
+                `link[type="text/css"][href*="/${bundleName}."]`
+            );
             if (cssLinkEl) {
                 return loadCSS(cssLinkEl.getAttribute("href"), loadOptions);
             }
@@ -91,7 +92,7 @@ export class AddSnippetDialog extends Component {
 
         const loadOptions = { targetDoc: this.iframeRef.el.contentDocument, js: false };
         await Promise.all([
-            loadCSSBundleFromEditor("web.assets_frontend", loadOptions),
+            loadCSSBundleFromEditor("website.inside_builder_style", loadOptions),
             loadBundle("html_builder.iframe_add_dialog", loadOptions),
         ]);
     }

--- a/addons/website/controllers/main.py
+++ b/addons/website/controllers/main.py
@@ -1025,7 +1025,7 @@ class Website(Home):
         Reloads asset bundles and returns their unique URLs.
         """
         return {
-            'web.assets_frontend': request.env['ir.qweb']._get_asset_link_urls('web.assets_frontend', request.session.debug),
+            'website.inside_builder_style': request.env['ir.qweb']._get_asset_link_urls('website.inside_builder_style', request.session.debug),
         }
 
     @http.route(['/website/update_footer_template'], type='jsonrpc', auth='user', website=True)

--- a/addons/website/static/src/client_actions/website_preview/website_builder_action.js
+++ b/addons/website/static/src/client_actions/website_preview/website_builder_action.js
@@ -291,6 +291,7 @@ export class WebsiteBuilderClientAction extends Component {
             }),
             loadBundle("website.inside_builder_style", {
                 targetDoc: this.websiteContent.el.contentDocument,
+                js: false,
             }),
         ]);
     }

--- a/addons/website/static/tests/builder/website_helpers.js
+++ b/addons/website/static/tests/builder/website_helpers.js
@@ -158,6 +158,7 @@ export async function setupWebsiteBuilder(
             if (loadIframeBundles) {
                 await loadBundle("website.inside_builder_style", {
                     targetDoc: queryOne("iframe[data-src^='/website/force/1']").contentDocument,
+                    js: false,
                 });
             }
             await resolveEditAssetsLoaded();

--- a/addons/website_sale/__manifest__.py
+++ b/addons/website_sale/__manifest__.py
@@ -174,6 +174,9 @@
         'website.backend_assets_all_wysiwyg': [
             'website_sale/static/src/js/components/wysiwyg_adapter/wysiwyg_adapter.js',
         ],
+        'website.inside_builder_style': [
+            'website_sale/static/src/website_builder/**/*.inside.scss',
+        ],
         'web.assets_tests': [
             'website_sale/static/tests/tours/**/*',
             'website_sale/static/src/js/tours/product_configurator_tour_utils.js',

--- a/addons/website_sale/static/src/website_builder/products_list_page_option.inside.scss
+++ b/addons/website_sale/static/src/website_builder/products_list_page_option.inside.scss
@@ -1,0 +1,163 @@
+// ==================
+// Edit-Mode Previews
+// ==================
+
+body.editor_enable {
+  // Outline the category description box
+  #category_header {
+    &:has(br:first-child:last-child), &:empty {
+      outline: $border-width dashed fade-currentColor(25%);
+
+      &:hover {
+        outline: $border-width * 2 solid $o-we-handles-accent-color;
+      }
+    }
+  }
+
+  // Outline product description boxes
+  .oe_subdescription {
+    div:has(br:first-child:last-child):not(:hover), div:empty:not(:hover) {
+      outline: $border-width dashed fade-currentColor(25%);
+    }
+  }
+}
+
+// ==========================
+// Preview Components (/shop)
+// ==========================
+body.editor_enable:has(.o_wsale_edit_preview_enabled) {
+  // Hide default handles when other elements are highlighted
+  &:has(.o_wsale_previewing_sidebar),
+  &:has(.o_wsale_previewing_filmstrip),
+  &:has(.o_wsale_previewing_offcanvas),
+  &:has(.o_wsale_previewing_description),
+  &:has(.o_wsale_previewing_floating_bar) {
+    .o_handles {
+      visibility: hidden;
+    }
+  }
+
+  @mixin _showcase {
+    z-index: $zindex-tooltip;
+    outline: $border-width * 2 solid $o-we-handles-accent-color;
+  }
+
+  // Sidebar
+  .o_wsale_sidebar_preview {
+    padding: 0;
+    flex: 0 0 25%;
+    min-width: 0;
+    max-width: 0;
+    transform: translateX(-50%);
+    transition: all .2s;
+    opacity: 0;
+  }
+
+  .o_wsale_previewing_sidebar {
+    #products_grid_before {
+      @include _showcase();
+    }
+
+    .o_wsale_sidebar_preview:first-child {
+      @include media-breakpoint-up(lg) {
+        min-width: o-to-rem(240px);
+        max-width: var(--o-wsale-sidebar-maxwidth, 15rem);
+        opacity: 1;
+        transform: translateX(0);
+        @include _showcase();
+      }
+    }
+  }
+
+  // Categories Filmstrip (top)
+  .o_wsale_filmstrip_preview {
+    max-height: 0;
+    padding: 0;
+    transform: translateY(-50%);
+    opacity: 0;
+    transition: all .2s;
+  }
+
+  .o_wsale_previewing_filmstrip {
+    .o_wsale_filmstip_container {
+      @include _showcase();
+    }
+
+    .o_wsale_filmstrip_preview {
+      transform: translateY(0);
+      opacity: 1;
+      max-height: 100px;
+      @include _showcase();
+      outline-offset: 2px;
+    }
+  }
+
+  // Offcanvas
+  .o_wsale_previewing_offcanvas {
+    #o_wsale_offcanvas {
+      visibility: visible;
+      transform: none;
+      box-shadow: $box-shadow-lg;
+      @include _showcase();
+    }
+  }
+
+  // Descriptions
+  .o_wsale_description_preview {
+    opacity: 0;
+    transition: all .2s;
+
+    .placeholder {
+      transform: translateY(-50%);
+      min-height: 0em;
+      transition: all .2s;
+      opacity: .15;
+    }
+  }
+
+  .o_wsale_previewing_description {
+    .oe_product_cart .oe_subdescription {
+      @include _showcase();
+    }
+
+    .o_wsale_description_preview {
+      opacity: 1;
+      outline: $border-width solid $o-we-handles-accent-color;
+      outline-offset: 2px;
+
+      .placeholder {
+        transform: translateY(0);
+        min-height: .4em;
+      }
+    }
+  }
+
+  // Floating Bar
+  .o_wsale_floating_bar_preview {
+    transform: translateY(100%);
+    opacity: 0;
+    transition: all .2s;
+  }
+
+  .products_header {
+    max-height: 100px;
+    overflow: hidden;
+    transition: all .2s;
+  }
+
+  .o_wsale_previewing_floating_bar {
+    #o_wsale_floating_bar {
+      @include _showcase();
+    }
+
+    .products_header {
+      max-height: 0px;
+    }
+
+    .o_wsale_floating_bar_preview {
+      @include _showcase();
+      transform: translateY(0);
+      opacity: 1;
+    }
+  }
+}

--- a/addons/website_sale/static/src/website_builder/products_list_page_option.inside.scss
+++ b/addons/website_sale/static/src/website_builder/products_list_page_option.inside.scss
@@ -58,7 +58,7 @@ body.editor_enable:has(.o_wsale_edit_preview_enabled) {
       @include _showcase();
     }
 
-    .o_wsale_sidebar_preview:first-child {
+    .o_wsale_sidebar_preview {
       @include media-breakpoint-up(lg) {
         min-width: o-to-rem(240px);
         max-width: var(--o-wsale-sidebar-maxwidth, 15rem);

--- a/addons/website_sale/static/src/website_builder/products_list_page_option.xml
+++ b/addons/website_sale/static/src/website_builder/products_list_page_option.xml
@@ -140,7 +140,17 @@
     </BuilderRow>
 
     <BuilderRow label.translate="Description" level="1">
-        <BuilderCheckbox action="'websiteConfig'" actionParam="{views: ['website_sale.products_description']}"/>
+        <BuilderCheckbox
+                action="'reloadComposite'"
+                actionParam="[
+                    {action: 'websiteConfig', actionParam: {views: ['website_sale.products_description']}},
+                    {action: 'previewTemplate', actionParam: {
+                        templateId: 'website_sale.editor_preview.description',
+                        placeAfter: '.oe_product_cart:not(.oe_product_cart_has_description) .o_wsale_products_item_title',
+                        previewClass: 'o_wsale_previewing_description',
+                    }},
+                ]"
+        />
     </BuilderRow>
 
     <BuilderRow label.translate="Actions" level="1">
@@ -154,17 +164,35 @@
         <div class="flex-basis-100"/>
     </BuilderRow>
 
-    <BuilderRow label.translate="Categories" action="'websiteConfig'">
+    <BuilderRow label.translate="Categories">
         <BuilderButton
                 title.translate="Show into Sidebar"
                 id="'categories_opt'"
-                actionParam="{views: ['website_sale.products_categories']}"
+                action="'reloadComposite'"
+                actionParam="[
+                    {action: 'websiteConfig', actionParam: {views: ['website_sale.products_categories']}},
+                    {action: 'previewTemplate', actionParam: {
+                        templateId: 'website_sale.editor_preview.sidebar',
+                        placeBefore: '#products_grid',
+                        placeExcludeRootClosest: '#o_wsale_container.o_wsale_has_sidebar',
+                        previewClass: 'o_wsale_previewing_sidebar o_wsale_has_sidebar',
+                    }},
+                ]"
         >Sidebar</BuilderButton>
 
         <BuilderButton
                 title.translate="Show a filmstrip navigation at the Top"
                 id="'categories_opt_top'"
-                actionParam="{views: ['website_sale.products_categories_top']}"
+                action="'reloadComposite'"
+                actionParam="[
+                    {action: 'websiteConfig', actionParam: {views: ['website_sale.products_categories_top']}},
+                    {action: 'previewTemplate', actionParam: {
+                        templateId: 'website_sale.editor_preview.filmstrip',
+                        placeBefore: '.products_header',
+                        placeExcludeRootClosest: '#o_wsale_container.o_wsale_has_filmstrip',
+                        previewClass: 'o_wsale_previewing_filmstrip',
+                    }},
+                ]"
         >Top</BuilderButton>
     </BuilderRow>
 
@@ -251,12 +279,27 @@
             <BuilderSelectItem
                     title.translate="Show filters into Sidebar"
                     id="'attributes_opt'"
-                    actionParam="{views: ['website_sale.products_attributes']}"
+                    action="'reloadComposite'"
+                    actionParam="[
+                        {action: 'websiteConfig', actionParam: {views: ['website_sale.products_attributes']}},
+                        {action: 'previewTemplate', actionParam: {
+                            templateId: 'website_sale.editor_preview.sidebar',
+                            placeBefore: '#products_grid',
+                            placeExcludeRootClosest: '#o_wsale_container.o_wsale_has_sidebar',
+                            previewClass: 'o_wsale_previewing_sidebar o_wsale_has_sidebar',
+                        }},
+                    ]"
             >Sidebar</BuilderSelectItem>
             <BuilderSelectItem
                     title.translate="Render a button to show the Off-screen Menu"
                     id="'attributes_opt_top'"
-                    actionParam="{views: ['website_sale.products_attributes_top']}"
+                    action="'reloadComposite'"
+                    actionParam="[
+                        {action: 'websiteConfig', actionParam: {views: ['website_sale.products_attributes_top']}},
+                        {action: 'previewTemplate', actionParam: {
+                            previewClass: 'o_wsale_previewing_offcanvas',
+                        }},
+                    ]"
             >Off-screen Menu</BuilderSelectItem>
         </BuilderSelect>
     </BuilderRow>
@@ -296,9 +339,19 @@
             label.translate="Floating"
             tooltip.translate="Floating sticky Toolbar"
             level="1"
-            action="'websiteConfig'"
     >
-        <BuilderCheckbox actionParam="{views: ['website_sale.floating_bar']}"/>
+        <BuilderCheckbox
+                action="'reloadComposite'"
+                actionParam="[
+                    {action: 'websiteConfig', actionParam: {views: ['website_sale.floating_bar']}},
+                    {action: 'previewTemplate', actionParam: {
+                        templateId: 'website_sale.editor_preview.floating_bar',
+                        placeAfter: '.o_wsale_products_main_row',
+                        placeExcludeRootClosest: '#o_wsale_container.o_wsale_has_floating_bar',
+                        previewClass: 'o_wsale_previewing_floating_bar',
+                    }},
+                ]"
+        />
     </BuilderRow>
 
     <BuilderRow label.translate="Default Sort" level="1">

--- a/addons/website_sale/static/src/website_builder/products_list_page_option.xml
+++ b/addons/website_sale/static/src/website_builder/products_list_page_option.xml
@@ -141,9 +141,9 @@
 
     <BuilderRow label.translate="Description" level="1">
         <BuilderCheckbox
-                action="'reloadComposite'"
+                action="'composite'"
                 actionParam="[
-                    {action: 'websiteConfig', actionParam: {views: ['website_sale.products_description']}},
+                    {action: 'previewableWebsiteConfig', actionParam: {views: ['website_sale.products_description'], previewClass: 'o_wsale_previewing_description'}},
                     {action: 'previewTemplate', actionParam: {
                         templateId: 'website_sale.editor_preview.description',
                         placeAfter: '.oe_product_cart:not(.oe_product_cart_has_description) .o_wsale_products_item_title',
@@ -168,13 +168,12 @@
         <BuilderButton
                 title.translate="Show into Sidebar"
                 id="'categories_opt'"
-                action="'reloadComposite'"
+                action="'composite'"
                 actionParam="[
-                    {action: 'websiteConfig', actionParam: {views: ['website_sale.products_categories']}},
+                    {action: 'previewableWebsiteConfig', actionParam: {views: ['website_sale.products_categories'], previewClass: 'o_wsale_previewing_sidebar o_wsale_has_sidebar'}},
                     {action: 'previewTemplate', actionParam: {
                         templateId: 'website_sale.editor_preview.sidebar',
-                        placeBefore: '#products_grid',
-                        placeExcludeRootClosest: '#o_wsale_container.o_wsale_has_sidebar',
+                        placeFirstChild: '.o_wsale_products_grid_before_rail',
                         previewClass: 'o_wsale_previewing_sidebar o_wsale_has_sidebar',
                     }},
                 ]"
@@ -183,13 +182,12 @@
         <BuilderButton
                 title.translate="Show a filmstrip navigation at the Top"
                 id="'categories_opt_top'"
-                action="'reloadComposite'"
+                action="'composite'"
                 actionParam="[
-                    {action: 'websiteConfig', actionParam: {views: ['website_sale.products_categories_top']}},
+                    {action: 'previewableWebsiteConfig', actionParam: {views: ['website_sale.products_categories_top'], previewClass: 'o_wsale_previewing_filmstrip'}},
                     {action: 'previewTemplate', actionParam: {
                         templateId: 'website_sale.editor_preview.filmstrip',
                         placeBefore: '.products_header',
-                        placeExcludeRootClosest: '#o_wsale_container.o_wsale_has_filmstrip',
                         previewClass: 'o_wsale_previewing_filmstrip',
                     }},
                 ]"
@@ -270,22 +268,22 @@
     </BuilderRow>
 
     <BuilderRow label.translate="Filters">
-        <BuilderSelect action="'websiteConfig'">
+        <BuilderSelect>
             <BuilderSelectItem
                     title.translate="Hide all filters"
                     id="'attributes_hide_opt'"
-                    actionParam="{views: []}"
+                    action="'previewableWebsiteConfig'"
+                    actionParam="{views: [], previewClass: ''}"
             >Hide</BuilderSelectItem>
             <BuilderSelectItem
                     title.translate="Show filters into Sidebar"
                     id="'attributes_opt'"
-                    action="'reloadComposite'"
+                    action="'composite'"
                     actionParam="[
-                        {action: 'websiteConfig', actionParam: {views: ['website_sale.products_attributes']}},
+                        {action: 'previewableWebsiteConfig', actionParam: {views: ['website_sale.products_attributes'], previewClass: 'o_wsale_previewing_sidebar o_wsale_has_sidebar'}},
                         {action: 'previewTemplate', actionParam: {
                             templateId: 'website_sale.editor_preview.sidebar',
-                            placeBefore: '#products_grid',
-                            placeExcludeRootClosest: '#o_wsale_container.o_wsale_has_sidebar',
+                            placeLastChild: '.o_wsale_products_grid_before_rail',
                             previewClass: 'o_wsale_previewing_sidebar o_wsale_has_sidebar',
                         }},
                     ]"
@@ -293,9 +291,9 @@
             <BuilderSelectItem
                     title.translate="Render a button to show the Off-screen Menu"
                     id="'attributes_opt_top'"
-                    action="'reloadComposite'"
+                    action="'composite'"
                     actionParam="[
-                        {action: 'websiteConfig', actionParam: {views: ['website_sale.products_attributes_top']}},
+                        {action: 'previewableWebsiteConfig', actionParam: {views: ['website_sale.products_attributes_top'], previewClass: 'o_wsale_previewing_offcanvas'}},
                         {action: 'previewTemplate', actionParam: {
                             previewClass: 'o_wsale_previewing_offcanvas',
                         }},
@@ -341,13 +339,15 @@
             level="1"
     >
         <BuilderCheckbox
-                action="'reloadComposite'"
+                action="'composite'"
                 actionParam="[
-                    {action: 'websiteConfig', actionParam: {views: ['website_sale.floating_bar']}},
+                    {action: 'previewableWebsiteConfig', actionParam: {
+                        views: ['website_sale.floating_bar'],
+                        previewClass: 'o_wsale_previewing_floating_bar',
+                }},
                     {action: 'previewTemplate', actionParam: {
                         templateId: 'website_sale.editor_preview.floating_bar',
                         placeAfter: '.o_wsale_products_main_row',
-                        placeExcludeRootClosest: '#o_wsale_container.o_wsale_has_floating_bar',
                         previewClass: 'o_wsale_previewing_floating_bar',
                     }},
                 ]"

--- a/addons/website_sale/static/src/website_builder/products_list_page_option_plugin.js
+++ b/addons/website_sale/static/src/website_builder/products_list_page_option_plugin.js
@@ -1,9 +1,10 @@
-import { ProductsListPageOption } from "@website_sale/website_builder/products_list_page_option";
+import { BuilderAction } from "@html_builder/core/builder_action";
 import { Plugin } from "@html_editor/plugin";
 import { _t } from "@web/core/l10n/translation";
 import { rpc } from "@web/core/network/rpc";
 import { registry } from "@web/core/registry";
-import { BuilderAction } from "@html_builder/core/builder_action";
+import { renderToElement } from "@web/core/utils/render";
+import { ProductsListPageOption } from "@website_sale/website_builder/products_list_page_option";
 
 class ProductsListPageOptionPlugin extends Plugin {
     static id = "productsListPageOptionPlugin";
@@ -20,6 +21,7 @@ class ProductsListPageOptionPlugin extends Plugin {
             },
         ],
         builder_actions: {
+            PreviewTemplateAction,
             SetPpgAction,
             SetPprAction,
             SetGapAction,
@@ -39,6 +41,48 @@ class ProductsListPageOptionPlugin extends Plugin {
     }
 }
 
+class PreviewTemplateAction extends BuilderAction {
+    static id = "previewTemplate";
+
+    apply(...args) {
+        this._previewTemplate(true, ...args);
+    }
+
+    clean(...args) {
+        this._previewTemplate(false, ...args);
+    }
+
+    _previewTemplate(
+        apply,
+        {
+            editingElement,
+            params: { templateId, previewClass, placeBefore, placeAfter, placeExcludeRootClosest },
+            selectableContext,
+        }
+    ) {
+        if (!apply && selectableContext) {
+            return;
+        }
+
+        if (templateId && !editingElement.closest(placeExcludeRootClosest)) {
+            const renderedEl = renderToElement(templateId);
+            if (placeBefore) {
+                for (const el of editingElement.querySelectorAll(placeBefore)) {
+                    el.insertAdjacentElement("beforebegin", renderedEl.cloneNode(true));
+                }
+            }
+            if (placeAfter) {
+                for (const el of editingElement.querySelectorAll(placeAfter)) {
+                    el.insertAdjacentElement("afterend", renderedEl.cloneNode(true));
+                }
+            }
+        }
+
+        if (previewClass) {
+            editingElement.classList.add(...previewClass.split(" "));
+        }
+    }
+}
 export class SetPpgAction extends BuilderAction {
     static id = "setPpg";
     setup() {

--- a/addons/website_sale/static/src/xml/website_sale_editor_previews.xml
+++ b/addons/website_sale/static/src/xml/website_sale_editor_previews.xml
@@ -52,7 +52,7 @@
 
 <t t-name="website_sale.editor_preview.description">
     <div
-        class="o_wsale_description_preview position-relative d-flex flex-column gap-1 mb-2"
+        class="oe_subdescription o_wsale_description_preview position-relative d-flex flex-column gap-1 mb-2"
         data-wsale-injected-preview="website_sale.editor_preview.description"
     >
         <div class="d-block placeholder col-12"/>

--- a/addons/website_sale/static/src/xml/website_sale_editor_previews.xml
+++ b/addons/website_sale/static/src/xml/website_sale_editor_previews.xml
@@ -24,9 +24,6 @@
         class="o_wsale_sidebar_preview position-relative overflow-hidden"
         data-wsale-injected-preview="website_sale.editor_preview.sidebar"
     >
-        <div
-            class="position-absolute top-0 start-0 end-0 bottom-0 pt-4 px-3 opacity-50"
-        >
             <div class="d-flex flex-column gap-2">
                 <div class="d-block placeholder placeholder-lg col-7 mb-2"/>
                 <div
@@ -46,7 +43,6 @@
                     t-attf-class="d-block placeholder placeholder-xs opacity-25 col-{{(p % 3) + 6}}"
                 />
             </div>
-        </div>
     </div>
 </t>
 


### PR DESCRIPTION
The `html_builder.inside_editor_style` bundle provides style assets that are loaded exclusively inside the editor's iframe during edition. We want to use scss variables that are sometimes overriden in various ways such as the theme tab of the website builder, website settings or website themes.

The inheritance currently does not work and some variables are straight up not available. To resolve this, this commit inherits the `web.assets_frontend` which provides all those variables and is overriden by all said mechanisms.
