### PR TITLE
[IMP] website_sale: de-emphasize firefox filmstrip scrollbar

### DIFF
--- a/addons/website_sale/static/src/scss/website_sale.scss
+++ b/addons/website_sale/static/src/scss/website_sale.scss
@@ -390,12 +390,7 @@ $input-border-color: $gray-400;
             }
         }
 
-        $-o-scrollbar-subdle-bg: rgba($dark, 0.05);
         transform: translateZ(0);
-
-        &.o_wsale_filmstrip_fancy_disabled {
-            scrollbar-color: currentColor $-o-scrollbar-subdle-bg;
-        }
 
         .o_wsale_filmstrip_wrapper {
             margin-bottom: map-get($spacers, 2);
@@ -405,6 +400,12 @@ $input-border-color: $gray-400;
             padding-bottom: var(--o-wsale-filmstrip-wrapper-padding-bottom, #{map-get($spacers, 1)});
             cursor: grab;
             scroll-snap-type: x mandatory;
+
+            // Firefox only scrollbar style
+            @supports (-moz-appearance:none) {
+                scrollbar-width: thin;
+                scrollbar-color: currentColor transparent;
+            }
 
             .o_wsale_filmstrip {
                 gap: var(--o-wsale-filmstrip-gap, #{map-get($spacers, 2)});
@@ -477,23 +478,25 @@ $input-border-color: $gray-400;
                     box-shadow: var(--o-wsale-filmstrip-item-box-shadow-hover, none);
                 }
             }
-
-            &::-webkit-scrollbar {
-                height: 2px;
-            }
-
-            &::-webkit-scrollbar-thumb {
-                border-radius: $btn-border-radius-sm;
-                background: currentColor;
-            }
-
-            &::-webkit-scrollbar-track {
-                background: $-o-scrollbar-subdle-bg;
-            }
         }
 
-        &:not(.o_wsale_filmstrip_fancy_disabled):hover {
+        &:where(:not(.o_wsale_filmstrip_fancy_disabled)) {
             .o_wsale_filmstrip_wrapper {
+                &::-webkit-scrollbar {
+                    height: 2px;
+                }
+
+                &::-webkit-scrollbar-thumb {
+                    border-radius: $btn-border-radius-sm;
+                    background: currentColor;
+                }
+
+                &::-webkit-scrollbar-track {
+                    background: rgba($dark, 0.05);
+                }
+            }
+
+            &:hover .o_wsale_filmstrip_wrapper {
                 margin-bottom: map-get($spacers, 1);
 
                 &::-webkit-scrollbar {

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -1342,7 +1342,7 @@
             class="o_wsale_filmstrip_container o_wsale_filmstrip_default d-flex align-items-stretch w-100 overflow-hidden"
             role="navigation"
         >
-            <div class="o_wsale_filmstrip_wrapper w-100 overflow-auto">
+            <div class="o_wsale_filmstrip_wrapper position-relative w-100 overflow-auto z-1">
                 <ul
                     class="o_wsale_filmstrip d-flex align-items-stretch mb-0 w-100 list-unstyled overflow-visible"
                     role="menu"


### PR DESCRIPTION
The filmstrip scrollbar on non webkit browser was very thick. This
commit improves it by making the track transparent and reducing the size
of the thumb for non webkit browser.

Switch to @support to avoid a loading time before the style applies on
firefox.

Note added: position-relative z-1 on the wrapper to ensure the scrollbar
appears on top on Ios.

[task-4895342](https://www.odoo.com/web#id=4895342&cids=1&menu_id=4720&action=333&active_id=1695&model=project.task&view_type=form)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
