### PR TITLE
[FIX] sms: do not fall back on partner phone if field is selected

### DIFF
--- a/addons/sms/wizard/sms_composer.py
+++ b/addons/sms/wizard/sms_composer.py
@@ -120,7 +120,8 @@ class SmsComposer(models.TransientModel):
                 composer.recipient_single_number_itf = ''
                 continue
             records.ensure_one()
-            res = records._sms_get_recipients_info(force_field=composer.number_field_name, partner_fallback=True)
+            # If the composer was opened with a specific field use that, otherwise get the partner's
+            res = records._sms_get_recipients_info(force_field=composer.number_field_name, partner_fallback=not composer.number_field_name)
             if not composer.recipient_single_number_itf:
                 composer.recipient_single_number_itf = res[records.id]['sanitized'] or res[records.id]['number'] or ''
             if not composer.number_field_name:

--- a/addons/test_mail_sms/tests/test_sms_mixin.py
+++ b/addons/test_mail_sms/tests/test_sms_mixin.py
@@ -92,14 +92,16 @@ class TestSMSNoThread(SMSCommon, TestSMSRecipients):
                     self.assertTrue(composer.comment_single_recipient)
                     self.assertEqual(composer.composition_mode, 'comment')
                     if ctx.get('default_number_field_name') == 'mobile':
+                        stored_number = ''  # invalid field + single recipient -> no number
                         self.assertEqual(composer.recipient_valid_count, 0)
                         self.assertEqual(composer.recipient_invalid_count, 1)
                     else:
+                        stored_number = '+32455135790'
                         self.assertEqual(composer.recipient_valid_count, 1)
                         self.assertEqual(composer.recipient_invalid_count, 0)
                     self.assertEqual(composer.recipient_single_description, self.user_admin.name)
                     self.assertEqual(composer.recipient_single_number, '+32455135790')
-                    self.assertEqual(composer.recipient_single_number_itf, '+32455135790')
+                    self.assertEqual(composer.recipient_single_number_itf, stored_number)
                     self.assertTrue(composer.recipient_single_valid)
                     self.assertEqual(composer.number_field_name, ctx.get('default_number_field_name', 'phone'))
                     self.assertFalse(composer.numbers)
@@ -107,3 +109,6 @@ class TestSMSNoThread(SMSCommon, TestSMSRecipients):
 
                     with self.mockSMSGateway():
                         composer._action_send_sms()
+
+                    # even if the stored number is correct, fall back on the computed number
+                    self.assertSMS(self.env['res.partner'], '+32455135790', 'pending')


### PR DESCRIPTION
If a user picks a specific field to open the composer with and that field is invalid we currently attempt to pick the number from the partner of the record as a fall back.

Instead if the user picked a specific field and it happens to be invalid for some reason, they will want to correct it in-situ rather than have it be something completely different.

Some similar tests are regrouped.

task-4900210
