### PR TITLE
[FIX] account: creating document on mail send

### DIFF
--- a/addons/account/wizard/account_move_send.py
+++ b/addons/account/wizard/account_move_send.py
@@ -460,7 +460,7 @@ class AccountMoveSend(models.TransientModel):
             if allow_raising:
                 raise UserError(self._format_error_text(error))
 
-            move.with_context(no_new_invoice=True).message_post(body=self._format_error_html(error))
+            move.with_context(no_document=True, no_new_invoice=True).message_post(body=self._format_error_html(error))
 
     @api.model
     def _hook_if_success(self, moves_data, from_cron=False, allow_fallback_pdf=False):
@@ -481,6 +481,7 @@ class AccountMoveSend(models.TransientModel):
 
         new_message = move\
             .with_context(
+                no_document=True,
                 no_new_invoice=True,
                 mail_notify_author=author_id in partner_ids,
             ).message_post(


### PR DESCRIPTION
Event with the document integration correctly setup, e-invoice xml generated in the send&print wizard will not create an associated document unless the attachment is actually sent via mail

Steps to reproduce:
- Have a EU Company setup
- Enable and configure Peppol Electronic Invoicing
- Enable documents integration with accounting
- Create an invoice to a Peppol enabled customer, confirm
- Open send&print wizard, enable only 'Download' and 'BIS Billing 3.0'

Issue: Document related to the xml attachment is not created. This will work as expected when the message is sent to the customer

opw-4720588
Enterprise PR https://github.com/odoo/enterprise/pull/88746
