### PR TITLE
[FIX] web: remove erroneously-added robots.txt

### DIFF
--- a/addons/web/controllers/home.py
+++ b/addons/web/controllers/home.py
@@ -165,16 +165,11 @@ class Home(http.Controller):
                    ('Cache-Control', 'no-store')]
         return request.make_response(data, headers, status=status)
 
-    @http.route(['/robots.txt'], type='http', auth="none")
-    def robots(self, **kwargs):
-        allowed_routes = self._get_allowed_robots_routes()
-        robots_content = ["User-agent: *", "Disallow: /"]
-        robots_content.extend(f"Allow: {route}" for route in allowed_routes)
-
-        return request.make_response("\n".join(robots_content), [('Content-Type', 'text/plain')])
-
     def _get_allowed_robots_routes(self):
         """Override this method to return a list of allowed routes.
+        By default this controller does not serve robots.txt so all routes
+        are implicitly open but we want any module to be able to append
+        to this list, in case the website module is installed.
 
         :return: A list of URL paths that should be allowed by robots.txt
               Examples: ['/social_instagram/', '/sitemap.xml', '/web/']


### PR DESCRIPTION
[1] was backported from 17.0 to 16.0 and erroneously introduced the robots route that is present in that version in the web module.

As this changes the behavior considerably we don't actually want robots.txt to be added in stable.

Remove the route but keep the overridable list getter for website.

[1]: @44f9d161234e6f99477f4dc946318c36360ae009
