### PR TITLE
[FIX] html_editor, website: move nav_bar related link code to website

### DIFF
--- a/addons/html_editor/static/src/main/link/link_plugin.js
+++ b/addons/html_editor/static/src/main/link/link_plugin.js
@@ -768,16 +768,14 @@ export class LinkPlugin extends Plugin {
             }
         } else {
             const closestLinkElement = closestElement(selection.anchorNode, "A");
+            const isLinkEditable = this.delegateTo(
+                "is_link_editable_predicates",
+                closestLinkElement) || false;
             if (closestLinkElement && closestLinkElement.isContentEditable) {
                 if (closestLinkElement !== this.linkInDocument || !this.currentOverlay.isOpen) {
                     this.openLinkTools(closestLinkElement);
                 }
-            } else if (
-                closestLinkElement &&
-                (closestLinkElement.getAttribute("role") === "menuitem" ||
-                    closestLinkElement.classList.contains("nav-link")) &&
-                !closestLinkElement.dataset.bsToggle
-            ) {
+            } else if (isLinkEditable) {
                 this.openLinkTools(closestLinkElement);
             } else {
                 this.linkInDocument = null;

--- a/addons/html_editor/static/src/main/link/link_popover.js
+++ b/addons/html_editor/static/src/main/link/link_popover.js
@@ -282,20 +282,6 @@ export class LinkPopover extends Component {
         this.onClickApply();
     }
 
-    onClickForceEditMode(ev) {
-        if (this.props.linkElement.href) {
-            const currentUrl = new URL(this.props.linkElement.href);
-            if (
-                browser.location.hostname === currentUrl.hostname &&
-                !currentUrl.pathname.startsWith("/@/")
-            ) {
-                ev.preventDefault();
-                currentUrl.pathname = `/@${currentUrl.pathname}`;
-                browser.open(currentUrl);
-            }
-        }
-    }
-
     onClickDirectDownload(checked) {
         this.state.directDownload = checked;
         this.state.url = this.state.url.replace("&download=true", "");

--- a/addons/html_editor/static/src/main/link/link_popover.xml
+++ b/addons/html_editor/static/src/main/link/link_popover.xml
@@ -131,7 +131,7 @@
                         </span>
                         <div class="ms-1 w-100">
                             <div class="d-flex">
-                                <a href="#" target="_blank" t-on-click="onClickForceEditMode" t-attf-href="{{state.url}}" class="o_we_url_link fw-bold flex-grow-1 text-truncate" style="max-width: 160px;" t-attf-title="{{state.urlTitle}}">
+                                <a href="#" target="_blank" t-attf-href="{{state.url}}" class="o_we_url_link fw-bold flex-grow-1 text-truncate" style="max-width: 160px;" t-attf-title="{{state.urlTitle}}">
                                     <t t-esc="state.urlTitle"/>
                                 </a>
                                 <div class="flex-grow-1 d-flex justify-content-end">

--- a/addons/website/static/src/builder/plugins/menu_data_plugin.js
+++ b/addons/website/static/src/builder/plugins/menu_data_plugin.js
@@ -1,6 +1,6 @@
 import { Plugin } from "@html_editor/plugin";
 import { registry } from "@web/core/registry";
-import { NavbarLinkPopover } from "@html_editor/main/link/navbar_link_popover";
+import { NavbarLinkPopover } from "./navbar_link_popover/navbar_link_popover";
 import { MenuDialog, EditMenuDialog } from "@website/components/dialog/edit_menu";
 import { withSequence } from "@html_editor/utils/resource";
 
@@ -54,7 +54,23 @@ export class MenuDataPlugin extends Plugin {
                 }),
             }),
         ],
+        is_link_editable_predicates: this.isMenuLink.bind(this),
     };
+
+    /**
+     * This predicate is used to determine if the link element is editable.
+     * It checks if the link element is a menu item or a nav link
+     * @param {HTMLElement} linkElement - The link element to check.
+     * @returns {boolean} - True if the link element is editable, false otherwise.
+     */
+    isMenuLink(linkElement) {
+        return (
+            linkElement &&
+            (linkElement.getAttribute("role") === "menuitem" ||
+            linkElement.classList.contains("nav-link")) &&
+            !linkElement.dataset.bsToggle
+        );
+    }
 }
 
 registry.category("website-plugins").add(MenuDataPlugin.id, MenuDataPlugin);

--- a/addons/website/static/src/builder/plugins/navbar_link_popover/navbar_link_popover.js
+++ b/addons/website/static/src/builder/plugins/navbar_link_popover/navbar_link_popover.js
@@ -1,7 +1,7 @@
-import { LinkPopover } from "./link_popover";
+import { LinkPopover } from "@html_editor/main/link/link_popover";
 
 export class NavbarLinkPopover extends LinkPopover {
-    static template = "html_editor.navbarLinkPopover";
+    static template = "website.navbarLinkPopover";
     static props = {
         ...LinkPopover.props,
         onClickEditLink: Function,

--- a/addons/website/static/src/builder/plugins/navbar_link_popover/navbar_link_popover.xml
+++ b/addons/website/static/src/builder/plugins/navbar_link_popover/navbar_link_popover.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
 
-    <t t-name="html_editor.navbarLinkPopover" t-inherit="html_editor.linkPopover">
+    <t t-name="website.navbarLinkPopover" t-inherit="html_editor.linkPopover">
         <xpath expr="//a[@title='Remove Link']" position="replace">
             <a href="#" class="ms-2 js_edit_menu text-dark" t-on-click="onClickEditMenu" title="Edit Menu">
                 <i class="fa fa-sitemap"></i>

--- a/addons/website/static/src/js/editor/html_editor.js
+++ b/addons/website/static/src/js/editor/html_editor.js
@@ -6,6 +6,7 @@ import { patch } from "@web/core/utils/patch";
 import { useChildRef } from "@web/core/utils/hooks";
 import wUtils from "@website/js/utils";
 import { useEffect } from "@odoo/owl";
+import { browser } from "@web/core/browser/browser";
 
 /**
  * The goal of this patch is to handle the URL autocomplete in the LinkPopover
@@ -134,5 +135,20 @@ patch(LinkPopover.prototype, {
     updateValue(val) {
         this.state.url = val;
         this.onChange();
+    },
+    onClickForcePreviewMode(ev) {
+        if (this.props.linkElement.href) {
+            const currentUrl = new URL(this.props.linkElement.href);
+            if (
+                browser.location.hostname === currentUrl.hostname &&
+                !currentUrl.pathname.startsWith("/odoo") &&
+                !currentUrl.pathname.startsWith("/web") &&
+                !currentUrl.pathname.startsWith("/@/")
+            ) {
+                ev.preventDefault();
+                currentUrl.pathname = `/@${currentUrl.pathname}`;
+                browser.open(currentUrl);
+            }
+        }
     },
 });

--- a/addons/website/static/src/xml/html_editor.xml
+++ b/addons/website/static/src/xml/html_editor.xml
@@ -46,6 +46,9 @@
     <xpath expr="//input[@name='o_linkpopover_url_img']" position="replace">
         <t t-call="website.InputURLAutoComplete"/>
     </xpath>
+    <xpath expr="//a[hasclass('o_we_url_link')]" position="attributes">
+        <attribute name="t-on-click">onClickForcePreviewMode</attribute>
+    </xpath>
 </t>
 
 </templates>


### PR DESCRIPTION
reproduction 1:
1. create a db without website installed
2. In todo, create a link with internal link
3. click on the link, the redirection is 404 not found

reproduction 2:
1. create a db installed website and project
2. In todo, create a link with internal link pointing to a project task
3. click the link, it always redirects to the website homepage

ref pr: https://github.com/odoo-dev/odoo/pull/4465

Before this commit: With the reference PR, we introduced `navbar_link_popover` for the website menu. When the website is in editing mode, if the URL points to a page created by the website, the URL is opened in edit mode (e.g., the website edit button is unfolded). However, this functionality should only be available when the website module is installed. Additionally, the redirection condition need to be refined to apply only to website pages.

After this commit: The navbar-related link code has been moved to the website module, and the link popover is patched with the `onClickForceEditMode` method. This ensures that the functionality is only applicable when the website module is installed.  Note that, in link_plugin, only the added code related to menu item and nav_bar is moved, the more generalized code is kept as it extends the link plugin to support other use cases outside of html_editor.

task-4879511


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
