### PR TITLE
[FIX] html_editor: use correct Bootstrap z-index utility

### DIFF
--- a/addons/html_editor/static/src/main/media/media_dialog/file_selector.js
+++ b/addons/html_editor/static/src/main/media/media_dialog/file_selector.js
@@ -21,7 +21,7 @@ export const IMAGE_MIMETYPES = [
 export const IMAGE_EXTENSIONS = [".jpg", ".jpeg", ".jpe", ".png", ".svg", ".gif", ".webp"];
 
 class RemoveButton extends Component {
-    static template = xml`<i class="fa fa-trash o_existing_attachment_remove position-absolute top-0 end-0 p-2 bg-white-25 cursor-pointer opacity-0 opacity-100-hover z-index-1 transition-base" t-att-title="removeTitle" role="img" t-att-aria-label="removeTitle" t-on-click="this.remove"/>`;
+    static template = xml`<i class="fa fa-trash o_existing_attachment_remove position-absolute top-0 end-0 p-2 bg-white-25 cursor-pointer opacity-0 opacity-100-hover z-1 transition-base" t-att-title="removeTitle" role="img" t-att-aria-label="removeTitle" t-on-click="this.remove"/>`;
     static props = ["model?", "remove"];
     setup() {
         this.removeTitle = _t("This file is attached to the current record.");


### PR DESCRIPTION
Description of the issue this PR addresses:

- The remove icon in the media dialog attachment was not visible due to the use of an invalid `z-index-1` class.

This commit c5a98c76ea1cce4acb55faf4768388b94255508f removed custom `z-index` utilities. Replaces `z-index-1` with Bootstrap's default `z-1` class.

Before this commit:

- The icon used `z-index-1`, which is not a valid Bootstrap class.

After this commit:

-  Replaced with `z-1`, the correct Bootstrap 5 utility class for `z-index: 1`.

task-4903381

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
