### PR TITLE
[REF] project, project_todo: clean up markup usage

### DIFF
--- a/addons/project/static/src/components/subtask_kanban_list/subtask_kanban_list.js
+++ b/addons/project/static/src/components/subtask_kanban_list/subtask_kanban_list.js
@@ -2,7 +2,6 @@ import { Component, useState, markup } from "@odoo/owl";
 
 import { useService } from "@web/core/utils/hooks";
 import { registry } from "@web/core/registry";
-import { escape } from "@web/core/utils/strings";
 import { _t } from "@web/core/l10n/translation";
 
 import { Field, getPropertyFieldInfo } from "@web/views/fields/field";
@@ -90,13 +89,10 @@ export class SubtaskKanbanList extends Component {
 
     async _onSubtaskCreateNameChanged(name) {
         if (name.trim() === "") {
-            this.notification.add(
-                markup(`<ul><li>${escape(_t("Display Name"))}</li></ul>`),
-                {
-                    title: _t("Invalid fields: "),
-                    type: "danger",
-                }
-            );
+            this.notification.add(markup`<ul><li>${_t("Display Name")}</li></ul>`, {
+                title: _t("Invalid fields: "),
+                type: "danger",
+            });
         } else {
             await this.orm.create("project.task", [{
                 display_name: name,

--- a/addons/project/static/src/views/project_task_form/project_task_form_controller.js
+++ b/addons/project/static/src/views/project_task_form/project_task_form_controller.js
@@ -3,7 +3,6 @@ import { ConfirmationDialog } from "@web/core/confirmation_dialog/confirmation_d
 import { HistoryDialog } from "@html_editor/components/history_dialog/history_dialog";
 import { useService } from '@web/core/utils/hooks';
 import { markup, useEffect } from "@odoo/owl";
-import { escape } from '@web/core/utils/strings';
 import { FormControllerWithHTMLExpander } from '@resource/views/form_with_html_expander/form_controller_with_html_expander';
 
 import { ProjectTaskTemplateDropdown } from "../components/project_task_template_dropdown";
@@ -85,9 +84,9 @@ export class ProjectTaskFormController extends FormControllerWithHTMLExpander {
         const historyMetadata = record.data["html_field_history_metadata"]?.[versionedFieldName];
         if (!historyMetadata) {
             this.notifications.add(
-                escape(_t(
+                _t(
                     "The task description lacks any past content that could be restored at the moment."
-                ))
+                )
             );
             return;
         }
@@ -96,13 +95,10 @@ export class ProjectTaskFormController extends FormControllerWithHTMLExpander {
             HistoryDialog,
             {
                 title: _t("Task Description History"),
-                noContentHelper: markup(
-                    `<span class='text-muted fst-italic'>${escape(
-                        _t(
-                            "The task description was empty at the time."
-                        )
-                    )}</span>`
-                ),
+                noContentHelper: markup`
+                    <span class='text-muted fst-italic'>${_t(
+                        "The task description was empty at the time."
+                    )}</span>`,
                 recordId: record.resId,
                 recordModel: this.props.resModel,
                 versionedFieldName,

--- a/addons/project/static/src/views/project_task_kanban/project_task_kanban_examples.js
+++ b/addons/project/static/src/views/project_task_kanban/project_task_kanban_examples.js
@@ -3,10 +3,10 @@ import { registry } from "@web/core/registry";
 import { renderToMarkup } from '@web/core/utils/render';
 import { markup } from "@odoo/owl";
 
-const greenBullet = markup(`<span class="o_status d-inline-block o_status_green"></span>`);
-const orangeBullet = markup(`<span class="o_status d-inline-block text-warning"></span>`);
-const star = markup(`<a style="color: gold;" class="fa fa-star"></a>`);
-const clock = markup(`<a class="fa fa-clock-o"></a>`);
+const greenBullet = markup`<span class="o_status d-inline-block o_status_green"></span>`;
+const orangeBullet = markup`<span class="o_status d-inline-block text-warning"></span>`;
+const star = markup`<a style="color: gold;" class="fa fa-star"></a>`;
+const clock = markup`<a class="fa fa-clock-o"></a>`;
 
 const exampleData = {
     applyExamplesText: _t("Use This For My Project"),

--- a/addons/project_todo/static/src/views/todo_form/todo_form_controller.js
+++ b/addons/project_todo/static/src/views/todo_form/todo_form_controller.js
@@ -5,7 +5,6 @@ import { ConfirmationDialog } from "@web/core/confirmation_dialog/confirmation_d
 import { _t } from "@web/core/l10n/translation";
 import { user } from "@web/core/user";
 import { useService } from "@web/core/utils/hooks";
-import { escape } from "@web/core/utils/strings";
 import { FormControllerWithHTMLExpander } from "@resource/views/form_with_html_expander/form_controller_with_html_expander";
 import { TodoFormCogMenu } from "./todo_form_cog_menu";
 
@@ -75,9 +74,9 @@ export class TodoFormController extends FormControllerWithHTMLExpander {
         const historyMetadata = record.data["html_field_history_metadata"]?.[versionedFieldName];
         if (!historyMetadata) {
             this.notifications.add(
-                escape(_t(
+                _t(
                     "The To-do description lacks any past content that could be restored at the moment."
-                ))
+                )
             );
             return;
         }
@@ -86,13 +85,10 @@ export class TodoFormController extends FormControllerWithHTMLExpander {
             HistoryDialog,
             {
                 title: _t("To-do History"),
-                noContentHelper: markup(
-                    `<span class='text-muted fst-italic'>${escape(
-                        _t(
-                            "The To-do description was empty at the time."
-                        )
-                    )}</span>`
-                ),
+                noContentHelper: markup`
+                    <span class='text-muted fst-italic'>${_t(
+                        "The To-do description was empty at the time."
+                    )}</span>`,
                 recordId: record.resId,
                 recordModel: this.props.resModel,
                 versionedFieldName,

--- a/addons/project_todo/static/tests/tours/project_todo_main_functions.js
+++ b/addons/project_todo/static/tests/tours/project_todo_main_functions.js
@@ -166,7 +166,7 @@ registry.category("web_tour.tours").add('project_todo_main_functions', {
     expectUnloadPage: true,
 }, {
     trigger: ".o_form_view .breadcrumb-item:last-child",
-    content: markup("Let's go back to the <b>kanban view</b> to have an overview of tasks linked to project chosen."),
+    content: markup`Let's go back to the <b>kanban view</b> to have an overview of tasks linked to project chosen.`,
     run: "click",
 }, {
     trigger: ".o_kanban_view",


### PR DESCRIPTION
Use markup template and html functions to make the code cleaner and safer while no longer triggering ci/security flag.