### PR TITLE
[REF] iap_mail: clean up markup usage

### DIFF
--- a/addons/iap_mail/static/src/js/services/iap_notification_service.js
+++ b/addons/iap_mail/static/src/js/services/iap_notification_service.js
@@ -1,6 +1,5 @@
 import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
-import { escape } from "@web/core/utils/strings";
 
 import { markup } from "@odoo/owl";
 
@@ -25,17 +24,17 @@ export const iapNotificationService = {
         }
 
         function displayCreditErrorNotification(params) {
-            const message = markup(`
-            <a class='btn btn-link' href='${params.get_credits_url}' target='_blank'>
-                <i class='oi oi-arrow-right'></i>
-                ${escape(_t("Buy more credits"))}
-            </a>`);
+            const message = markup`
+                <a class='btn btn-link' href='${params.get_credits_url}' target='_blank'>
+                    <i class='oi oi-arrow-right'></i>
+                    ${_t("Buy more credits")}
+                </a>`;
             notification.add(message, {
                 title: params.title,
-                type: 'danger',
+                type: "danger",
             });
         }
-    }
+    },
 };
 
 registry.category("services").add("iapNotification", iapNotificationService);


### PR DESCRIPTION
Use markup template and html functions to make the code cleaner and safer while no longer triggering ci/security flag.