### PR TITLE
[REF] html_builder: clean up markup usage

### DIFF
--- a/addons/html_builder/static/src/core/save_snippet_plugin.js
+++ b/addons/html_builder/static/src/core/save_snippet_plugin.js
@@ -2,7 +2,6 @@ import { Plugin } from "@html_editor/plugin";
 import { withSequence } from "@html_editor/utils/resource";
 import { markup } from "@odoo/owl";
 import { _t } from "@web/core/l10n/translation";
-import { escape } from "@web/core/utils/strings";
 
 const savableSelector = "[data-snippet], a.btn";
 // TODO `so_submit_button_selector` ?
@@ -40,11 +39,9 @@ export class SaveSnippetPlugin extends Plugin {
         const cleanForSaveHandlers = this.getResource("clean_for_save_handlers");
         const savedName = await this.config.saveSnippet(el, cleanForSaveHandlers);
         if (savedName) {
-            const message = markup(
-                _t(
-                    "Your custom snippet was successfully saved as <strong>%s</strong>. Find it in your snippets collection.",
-                    escape(savedName)
-                )
+            const message = _t(
+                "Your custom snippet was successfully saved as %s. Find it in your snippets collection.",
+                markup`<strong>${savedName}</strong>`
             );
             this.services.notification.add(message, {
                 type: "success",

--- a/addons/html_builder/static/src/snippets/snippet_service.js
+++ b/addons/html_builder/static/src/snippets/snippet_service.js
@@ -2,7 +2,6 @@ import { ConfirmationDialog } from "@web/core/confirmation_dialog/confirmation_d
 import { _t } from "@web/core/l10n/translation";
 import { uniqueId } from "@web/core/utils/functions";
 import { Reactive } from "@web/core/utils/reactive";
-import { escape } from "@web/core/utils/strings";
 import { AddSnippetDialog } from "./add_snippet_dialog";
 import { registry } from "@web/core/registry";
 import { user } from "@web/core/user";
@@ -200,7 +199,7 @@ export class SnippetModel extends Reactive {
                     content: snippetEl.children[0],
                     viewId: parseInt(snippetEl.dataset.oeSnippetId),
                     key: snippetEl.dataset.oeSnippetKey,
-                    thumbnailSrc: escape(snippetEl.dataset.oeThumbnail),
+                    thumbnailSrc: snippetEl.dataset.oeThumbnail,
                     imagePreviewSrc: snippetEl.dataset.oImagePreview,
                     isCustom: false,
                     label: snippetEl.dataset.oLabel,


### PR DESCRIPTION
Use markup template and html functions to make the code cleaner and safer while no longer triggering ci/security flag.