### PR TITLE
[REF] account: clean up markup usage

### DIFF
--- a/addons/account/static/src/services/account_move_service.js
+++ b/addons/account/static/src/services/account_move_service.js
@@ -1,5 +1,4 @@
 import { _t } from "@web/core/l10n/translation";
-import { escape } from "@web/core/utils/strings";
 import { markup } from "@odoo/owl";
 import { registry } from "@web/core/registry";
 
@@ -19,7 +18,7 @@ export class AccountMoveService {
         const isMoveEndOfChain = await this.orm.call("account.move", "check_move_sequence_chain", [moveIds]);
         if (!isMoveEndOfChain) {
             const message = _t("This operation will create a gap in the sequence.");
-            return markup(`<div class="text-danger">${escape(message)}</div>${escape(body)}`);
+            return markup`<div class="text-danger">${message}</div>${body}`;
         }
         return body;
     }


### PR DESCRIPTION
Use markup template and html functions to make the code cleaner and safer while no longer triggering ci/security flag.