### PR TITLE
[FIX] survey: use correct time zone for display_name

### DIFF
--- a/addons/survey/models/survey_user_input.py
+++ b/addons/survey/models/survey_user_input.py
@@ -651,7 +651,7 @@ class SurveyUserInputLine(models.Model):
             elif line.answer_type == 'date':
                 line.display_name = fields.Date.to_string(line.value_date)
             elif line.answer_type == 'datetime':
-                line.display_name = fields.Datetime.to_string(line.value_datetime)
+                line.display_name = fields.Datetime.to_string(fields.Datetime.context_timestamp(self.env.user, line.value_datetime))
             elif line.answer_type == 'suggestion':
                 if line.matrix_row_id:
                     line.display_name = '%s: %s' % (

--- a/addons/survey/tests/common.py
+++ b/addons/survey/tests/common.py
@@ -261,7 +261,7 @@ class TestSurveyCommon(SurveyCase):
         """ Create test data: a survey with some pre-defined questions and various test users for ACL """
         self.survey_manager = mail_new_test_user(
             self.env, name='Gustave Doré', login='survey_manager', email='survey.manager@example.com',
-            groups='survey.group_survey_manager,base.group_user'
+            groups='survey.group_survey_manager,base.group_user', tz='Europe/Brussels',
         )
 
         self.survey_user = mail_new_test_user(

--- a/addons/survey/tests/test_survey.py
+++ b/addons/survey/tests/test_survey.py
@@ -44,6 +44,7 @@ class TestSurveyInternals(common.TestSurveyCommon):
         self.assertEqual(fourth_attempt['attempts_count'], 4)
 
     @freeze_time("2020-02-15 18:00")
+    @users('survey_manager')
     def test_answer_display_name(self):
         """ The "display_name" field in a survey.user_input.line is a computed field that will
         display the answer label for any type of question.
@@ -67,7 +68,7 @@ class TestSurveyInternals(common.TestSurveyCommon):
                 self.assertEqual(question_answer.display_name, '2020-02-15')
             elif question.question_type == 'datetime':
                 question_answer = self._add_answer_line(question, user_input, fields.Datetime.now())
-                self.assertEqual(question_answer.display_name, '2020-02-15 18:00:00')
+                self.assertEqual(question_answer.display_name, '2020-02-15 19:00:00')
             elif question.question_type == 'simple_choice':
                 question_answer = self._add_answer_line(question, user_input, question.suggested_answer_ids[0].id)
                 self.assertEqual(question_answer.display_name, 'SChoice0')


### PR DESCRIPTION
Steps to reproduce
====================
1. Create survey with some datetime questions.
2. Receive some response on it.
3. Check answer of datetime questions in answer tab.
4. Click on that answer to open form. ->The time shown in answer tab differs from actual value in form.

The display_name of survey.user_input.line is computed based on the answers submitted by users. For questions of type datetime, the display_name was generated by converting the datetime value to a string without accounting for the user's timezone, leading to a mismatch between the actual value and the displayed time.

After this commit
==================
This commit updates the computation of display_name for datetime answers to consider the current user's timezone.

Task-4890423