### PR TITLE
[IMP] website_sale: adapt add_to_cart_snippet_tour tour

### DIFF
--- a/addons/website/static/src/js/tours/tour_utils.js
+++ b/addons/website/static/src/js/tours/tour_utils.js
@@ -162,7 +162,7 @@ export function changeOptionInPopover(blockName, optionName, elementName, search
     steps.push(
         clickOnElement(
             `${elementName} in the ${optionName} option`,
-            `.o_popover div.o-dropdown-item:contains("${elementName}"), .o_popover ${elementName}`
+            `.o_popover div.o-dropdown-item:contains("${elementName}"), .o_popover span.o-dropdown-item:contains("${elementName}"), .o_popover ${elementName}`
         )
     );
     return steps;

--- a/addons/website_sale/static/tests/tours/website_sale_add_to_cart_snippet_tour.js
+++ b/addons/website_sale/static/tests/tours/website_sale_add_to_cart_snippet_tour.js
@@ -17,6 +17,13 @@ function editAddToCartSnippet() {
     ]
 }
 
+function checkQuanityInCart(quantity) {
+    return {
+        content: `Check if the cart quantity is ${quantity}`,
+        trigger: `:iframe .my_cart_quantity:contains(${quantity})`,
+    };
+}
+
 registerWebsitePreviewTour('add_to_cart_snippet_tour', {
         url: '/',
         edition: true,
@@ -29,6 +36,7 @@ registerWebsitePreviewTour('add_to_cart_snippet_tour', {
         ...changeOptionInPopover("Add to Cart Button", "Product", "Product No Variant", true),
         ...clickOnSave(),
         clickOnElement("add to cart button", ":iframe .s_add_to_cart_btn"),
+        checkQuanityInCart("1"),
 
         // Product with 2 variants with visitor choice (will open modal)
         ...editAddToCartSnippet(),
@@ -36,6 +44,7 @@ registerWebsitePreviewTour('add_to_cart_snippet_tour', {
         ...clickOnSave(),
         clickOnElement("add to cart button", ":iframe .s_add_to_cart_btn"),
         clickOnElement("continue shopping", ":iframe .modal button:contains(Continue Shopping)"),
+        checkQuanityInCart("2"),
 
         // Product with 2 variants with a variant selected
         ...editAddToCartSnippet(),
@@ -61,6 +70,7 @@ registerWebsitePreviewTour('add_to_cart_snippet_tour', {
             trigger: ":iframe .modal li:contains(Pink) input:checked",
         },
         clickOnElement('continue shopping', ':iframe .modal button:contains(Continue Shopping)',),
+        checkQuanityInCart("3"),
 
         // Basic product with no variants and action=buy now
         ...editAddToCartSnippet(),
@@ -69,6 +79,7 @@ registerWebsitePreviewTour('add_to_cart_snippet_tour', {
         // At this point the "Add to cart" button was changed to a "Buy Now" button
         ...clickOnSave(),
         clickOnElement('"Buy Now" button', ':iframe .s_add_to_cart_btn'),
+        checkQuanityInCart("4"),
         {
             // wait for the page to load, as the next check was sometimes too fast
             content: "Wait for the redirection to the cart page",


### PR DESCRIPTION
Before this commit: changeOptionInPopover was failed in some cases where dropdown-item element is not div, current selector in changeOptionInPopover was not able to select element.
resetDefaultAction in AddToCartOptionPlugin plugin was not shared and we were calling this method from other plugins.
addToCart builder actions was not fetched with right name, builder actions are using id of the action class to fetch that specific action.

This commit solves all above issues.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
