### PR TITLE
[FIX] sale, sale_expense: forward analytic_distribution from account_move to sale_order

### DIFF
--- a/addons/sale/models/account_move_line.py
+++ b/addons/sale/models/account_move_line.py
@@ -175,6 +175,7 @@ class AccountMoveLine(models.Model):
             'product_uom': self.product_uom_id.id,
             'product_uom_qty': self.quantity,
             'is_expense': True,
+            'analytic_distribution': self.analytic_distribution,
         }
 
     def _sale_get_invoice_price(self, order):

--- a/addons/sale_expense/tests/test_sale_expense.py
+++ b/addons/sale_expense/tests/test_sale_expense.py
@@ -54,6 +54,7 @@ class TestSaleExpense(TestExpenseCommon, TestSaleCommon):
         sol = so.order_line.filtered(lambda sol: sol.product_id.id == self.company_data['product_delivery_cost'].id)
         self.assertEqual((sol.price_unit, sol.qty_delivered), (55.0, 11.3), 'Sale Expense: error when invoicing an expense at cost')
         self.assertEqual(so.amount_total, init_price + exp.total_amount, 'Sale Expense: price of so should be updated after adding expense')
+        self.assertEqual(sol.analytic_distribution, {str(analytic_account.id): 100})
 
         # create some expense and validate it (expense at sale price)
         init_price = so.amount_total


### PR DESCRIPTION
#### Step to reproduce:
  - Enable Analytic accounting in Accounting settings
  - Create a sale order
  - Show Analytic Distribution
  - Create an expense and put this sale order in the "Customer to Reinvoice" field.
  - Add an Analytic Distribution
  - Create Report
  - Submit to Manager
  - Approve
  - Post Journal Entries

#### Curent behavior:
  - No analytic_distribution on the sale_order

#### Expected behavior:
  - analytic_distribution form the expense should be copied to the sale_order

#### Cause:
  analytic_distribution was not set at the creation of the sale order from the account_move

`_sale_get_invoice_price()` is called only in `_sale_create_reinvoice_sale_line()` which is only called in `_prepare_analytic_lines()`. According to [this note](https://github.com/odoo/odoo/blob/18.0/addons/sale/models/account_move_line.py#L31-L32) `_prepare_analytic_lines()` is called only on `move.line` having an `analytic_distribution`. 

Ticket [link](https://www.odoo.com/odoo/project/967/tasks/4710137)
opw-4710137