### PR TITLE
[FIX] purchase_stock, mrp: fix RR for unconfigured products

### DIFF
--- a/addons/mrp/models/stock_rule.py
+++ b/addons/mrp/models/stock_rule.py
@@ -207,12 +207,17 @@ class StockRule(models.Model):
             return delays, delay_description
         manufacture_rule.ensure_one()
         bom = values.get('bom') or self.env['mrp.bom']._bom_find(product, picking_type=manufacture_rule.picking_type_id, company_id=manufacture_rule.company_id.id)[product]
+        if not bom:
+            delays['total_delay'] += 365
+            delays['no_bom_found_delay'] += 365
+            if not bypass_delay_description:
+                delay_description.append((_('No BoM Found'), _('+ %s day(s)', 365)))
         manufacture_delay = bom.produce_delay
         delays['total_delay'] += manufacture_delay
         delays['manufacture_delay'] += manufacture_delay
         if not bypass_delay_description:
             delay_description.append((_('Manufacturing Lead Time'), _('+ %d day(s)', manufacture_delay)))
-        if not bom or bom.type == 'normal':
+        if bom.type == 'normal':
             # pre-production rules
             warehouse = self.location_dest_id.warehouse_id
             for wh in warehouse:

--- a/addons/mrp/tests/test_replenish.py
+++ b/addons/mrp/tests/test_replenish.py
@@ -271,12 +271,10 @@ class TestMrpReplenish(TestMrpCommon):
         self.assertEqual(form.qty_to_order, 8)
         self.assertEqual(orderpoint.qty_to_order, 8)
 
-    def test_manuf_lead_time_without_bom(self):
+    def test_lead_time_with_no_bom(self):
+        """Test that lead time is incremented by 365 days (1 year) when there
+        is no BoM defined.
         """
-        Test that the manufacturing lead time is correctly applied to a product
-        without a Bill of Materials (BoM).
-        """
-        self.env.company.write({'manufacturing_lead': 3.0})
         route_manufacture = self.warehouse_1.manufacture_pull_id.route_id
         product = self.env['product.product'].create({
             'name': 'test',
@@ -290,4 +288,4 @@ class TestMrpReplenish(TestMrpCommon):
             'product_min_qty': 0,
             'product_max_qty': 5,
         })
-        self.assertEqual(orderpoint.lead_days_date, fields.Date.today() + timedelta(days=3))
+        self.assertEqual(orderpoint.lead_days_date, fields.Date.today() + timedelta(days=365))

--- a/addons/purchase_stock/models/stock_rule.py
+++ b/addons/purchase_stock/models/stock_rule.py
@@ -164,7 +164,13 @@ class StockRule(models.Model):
         bypass_delay_description = self.env.context.get('bypass_delay_description')
         buy_rule = self.filtered(lambda r: r.action == 'buy')
         seller = 'supplierinfo' in values and values['supplierinfo'] or product.with_company(buy_rule.company_id)._select_seller(quantity=None)
-        if not buy_rule or not seller:
+        if not buy_rule:
+            return delays, delay_description
+        if not seller:
+            delays['total_delay'] += 365
+            delays['no_vendor_found_delay'] += 365
+            if not bypass_delay_description:
+                delay_description.append((_('No Vendor Found'), _('+ %s day(s)', 365)))
             return delays, delay_description
         buy_rule.ensure_one()
         if not self.env.context.get('ignore_vendor_lead_time'):

--- a/addons/purchase_stock/tests/test_purchase_lead_time.py
+++ b/addons/purchase_stock/tests/test_purchase_lead_time.py
@@ -319,3 +319,23 @@ class TestPurchaseLeadTime(PurchaseTestCommon):
         today = datetime.combine(fields.Datetime.now(), time(12))
         self.assertEqual(purchase_order.date_order, today)
         self.assertEqual(purchase_order.date_planned, today + timedelta(days=7))
+
+    def test_lead_time_with_no_supplier(self):
+        """Test that lead time is incremented by 365 days (1 year) when there
+        is no supplier defined on a product with buy route.
+        """
+        buy_route = self.warehouse_1.buy_pull_id.route_id
+        product = self.env['product.product'].create({
+            'name': 'test',
+            'is_storable': True,
+            'route_ids': buy_route.ids,
+        })
+        orderpoint = self.env['stock.warehouse.orderpoint'].create({
+            'name': 'test',
+            'location_id': self.warehouse_1.lot_stock_id.id,
+            'product_id': product.id,
+            'product_min_qty': 0,
+            'product_max_qty': 5,
+        })
+
+        self.assertEqual(orderpoint.lead_days_date, fields.Date.today() + timedelta(days=365))

--- a/addons/sale_mrp/tests/test_sale_mrp_lead_time.py
+++ b/addons/sale_mrp/tests/test_sale_mrp_lead_time.py
@@ -206,6 +206,10 @@ class TestSaleMrpLeadTime(TestStockCommon):
             'is_storable': True,
             'route_ids': routes,
         })
+        self.env['mrp.bom'].create({
+            'product_tmpl_id': product.product_tmpl_id.id,
+            'product_qty': 1,
+        })
         order = self.env['sale.order'].create({
             'partner_id': self.partner_1.id,
             'warehouse_id': wh_supply_sale_order.id,


### PR DESCRIPTION
Before this commit, RR for unconfigured products (no BoM/ no vendor),
was not created until the same day of the delivery date (lead_time=0).
Now, RR for unconfigured products is created considering
the lead_time is incremented by 365 days.

Note that this commit reverts the effect of the commit: https://github.com/odoo/odoo/commit/40d0bc0df0dc09f5138aa747cbbc715ae77f104c

It's functionally decided to make the total lead_days for products
with no bom to be 365 days without adding the security_lead_days.
It's meant just to warn the user on the RR dashboard that the product
needing replenishment is not configured,
no matter to the security_lead_days in this case.

Task-4779057