### PR TITLE
[FIX] l10n_es: prevent error on installing module

### DIFF
--- a/addons/l10n_es/data/product_data.xml
+++ b/addons/l10n_es/data/product_data.xml
@@ -3,7 +3,7 @@
     <record id="product_dua_valuation_21" model="product.product">
         <field name="name">DUA VAT Valuation 21%</field>
         <field name="default_code">DUA21</field>
-        <field name="categ_id" ref="product.product_category_services"/>
+        <field name="categ_id" eval="ref('product.product_category_services', raise_if_not_found=False)"/>
         <field name="type">service</field>
         <field name="sale_ok" eval="False"/>
         <field name="purchase_ok" eval="True"/>
@@ -11,7 +11,7 @@
     <record id="product_dua_valuation_10" model="product.product">
         <field name="name">DUA VAT Valuation 10%</field>
         <field name="default_code">DUA10</field>
-        <field name="categ_id" ref="product.product_category_services"/>
+        <field name="categ_id" eval="ref('product.product_category_services', raise_if_not_found=False)"/>
         <field name="type">service</field>
         <field name="sale_ok" eval="False"/>
         <field name="purchase_ok" eval="True"/>
@@ -19,7 +19,7 @@
     <record id="product_dua_valuation_4" model="product.product">
         <field name="name">DUA VAT Valuation 4%</field>
         <field name="default_code">DUA4</field>
-        <field name="categ_id" ref="product.product_category_services"/>
+        <field name="categ_id" eval="ref('product.product_category_services', raise_if_not_found=False)"/>
         <field name="type">service</field>
         <field name="sale_ok" eval="False"/>
         <field name="purchase_ok" eval="True"/>


### PR DESCRIPTION
Currently, an error occurs when the user installs the modules after deleting the 'Service' product category.

**Steps to reproduce:**
- Install the Inventory app.
- Inventory > Configuration  > Categories > Delete 'Service'.
- Install the `l10n_es` module.

**Traceback:**
```
ValueError: External ID not found in the system: product.product_category_services

ParseError
while parsing /home/odoo/src/odoo/saas-18.3/addons/l10n_es/data/product_data.xml:3, somewhere inside <record id="product_dua_valuation_21" model="product. Product">
        <field name="name">DUA VAT Valuation 21%</field>
        <field name="default_code">DUA21</field>
        <field name="categ_id" ref="product.product_category_services"/>
        <field name="type">service</field>
        <field name="sale_ok" eval="False"/>
        <field name="purchase_ok" eval="True"/>
    </record>
```

The error occurs because the user deleted the category and then installed the modules that reference the missing product category.

This commit resolves the error by providing a False value for the field if the product category is missing.

Sentry - 6710886848