### PR TITLE
[FIX] html_editor: retain font-size when applying button style

### DIFF
--- a/addons/html_editor/static/src/core/split_plugin.js
+++ b/addons/html_editor/static/src/core/split_plugin.js
@@ -240,8 +240,20 @@ export class SplitPlugin extends Plugin {
         let before = firstNode.previousSibling;
         let after = lastNode.nextSibling;
         let beforeSplit, afterSplit;
-        if (!before && !after && elements[0] !== limitAncestor) {
-            return this.splitAroundUntil(elements[0].parentElement, limitAncestor);
+        if (
+            !before &&
+            !after &&
+            firstNode.parentElement !== limitAncestor &&
+            lastNode.parentElement !== limitAncestor
+        ) {
+            return this.splitAroundUntil(
+                [firstNode.parentElement, lastNode.parentElement],
+                limitAncestor
+            );
+        } else if (!after && lastNode.parentElement !== limitAncestor) {
+            return this.splitAroundUntil([firstNode, lastNode.parentElement], limitAncestor);
+        } else if (!before && firstNode.parentElement !== limitAncestor) {
+            return this.splitAroundUntil([firstNode.parentElement, lastNode], limitAncestor);
         }
         // Split up ancestors up to font
         while (after && after.parentElement !== limitAncestor) {

--- a/addons/html_editor/static/tests/link/popover.test.js
+++ b/addons/html_editor/static/tests/link/popover.test.js
@@ -15,7 +15,7 @@ import { animationFrame, tick } from "@odoo/hoot-mock";
 import { markup } from "@odoo/owl";
 import { contains, onRpc, patchWithCleanup } from "@web/../tests/web_test_helpers";
 import { setupEditor } from "../_helpers/editor";
-import { cleanLinkArtifacts } from "../_helpers/format";
+import { cleanLinkArtifacts, unformat } from "../_helpers/format";
 import { getContent, setContent, setSelection } from "../_helpers/selection";
 import { insertLineBreak, insertText, splitBlock, undo } from "../_helpers/user_actions";
 import { execCommand } from "../_helpers/userCommands";
@@ -512,6 +512,63 @@ describe("Link creation", () => {
             undo(editor);
             expect(cleanLinkArtifacts(getContent(el))).toBe(
                 `<p>[<a href="https://www.test.com">Hello</a> my friend]</p>`
+            );
+        });
+        test("should wrap selected text with link and preserve styles", async () => {
+            const { el } = await setupEditor(
+                `<p><span style="font-size: 48px;"><strong>s[trong</strong><u>underlin]e</u></span></p>`
+            );
+            await waitFor(".o-we-toolbar");
+            await click(".o-we-toolbar .fa-link");
+            await expectElementCount(".o-we-linkpopover", 1);
+            expect(".o_we_href_input_link").toBeFocused();
+            await fill("http://test.com");
+            await click('select[name="link_type"');
+            await select("primary");
+            await click(".o_we_apply_link");
+            await animationFrame();
+            expect(cleanLinkArtifacts(getContent(el))).toBe(
+                unformat(`
+                    <p>
+                        <span style="font-size: 48px;"><strong>s</strong></span>
+                        <a class="btn btn-fill-primary" href="http://test.com">
+                            <span style="font-size: 48px;"><strong>trong</strong><u>underlin[]</u></span>
+                        </a>
+                        <span style="font-size: 48px;"><u>e</u></span>
+                    </p>
+                `)
+            );
+        });
+        test("should apply link over split text nodes while preserving styles", async () => {
+            const { el } = await setupEditor(`<p><span class="display-1-fs"></span></p>`);
+
+            const fontSizeSpan = queryOne("span.display-1-fs");
+            fontSizeSpan.appendChild(document.createTextNode("te"));
+            fontSizeSpan.appendChild(document.createTextNode("st"));
+            setSelection({
+                anchorNode: fontSizeSpan.firstChild,
+                anchorOffset: 1,
+                focusNode: fontSizeSpan.lastChild,
+                focusOffset: 1,
+            });
+
+            await waitFor(".o-we-toolbar");
+            await click(".o-we-toolbar .fa-link");
+            await expectElementCount(".o-we-linkpopover", 1);
+            expect(".o_we_href_input_link").toBeFocused();
+            await fill("http://test.com");
+            await click(".o_we_apply_link");
+            await animationFrame();
+            expect(cleanLinkArtifacts(getContent(el))).toBe(
+                unformat(`
+                    <p>
+                        <span class="display-1-fs">t</span>
+                        <a href="http://test.com">
+                            <span class="display-1-fs">es[]</span>
+                        </a>
+                        <span class="display-1-fs">t</span>
+                    </p>
+                `)
             );
         });
     });

--- a/addons/html_editor/static/tests/utils/dom.test.js
+++ b/addons/html_editor/static/tests/utils/dom.test.js
@@ -9,6 +9,7 @@ import {
 import { getContent } from "../_helpers/selection";
 import { parseHTML } from "@html_editor/utils/html";
 import { unformat } from "../_helpers/format";
+import { queryOne } from "@odoo/hoot-dom";
 
 describe("splitAroundUntil", () => {
     test("should split a slice of text from its inline ancestry (1)", async () => {
@@ -70,6 +71,95 @@ describe("splitAroundUntil", () => {
         const result = editor.shared.split.splitAroundUntil(bcd, p.childNodes[1]);
         expect(result).toBe(p.childNodes[1]);
         expect(p.outerHTML).toBe("<p>a<font><span>bcd</span></font>e</p>");
+    });
+
+    test("should split when node is first child of inline ancestry (1)", async () => {
+        const { editor, el } = await setupEditor("<p>a<font>b<span>cde</span>f</font>g</p>");
+        const [p] = el.childNodes;
+        const cde = p.childNodes[1].childNodes[1].firstChild;
+        splitTextNode(cde, 2);
+        const cd = cde.previousSibling;
+        const result = editor.shared.split.splitAroundUntil(cd, p.childNodes[1]);
+        expect(result.tagName).toBe("FONT");
+        expect(p.outerHTML).toBe(
+            "<p>a<font>b</font><font><span>cd</span></font><font><span>e</span>f</font>g</p>"
+        );
+    });
+
+    test("should split when node is first child of inline ancestry (2)", async () => {
+        const { editor, el } = await setupEditor("<p>a<font><span>bcd</span></font>e</p>");
+        const [p] = el.childNodes;
+        const bcd = p.childNodes[1].childNodes[0].firstChild;
+        splitTextNode(bcd, 2);
+        const bc = bcd.previousSibling;
+        const result = editor.shared.split.splitAroundUntil(bc, p.childNodes[1]);
+        expect(result.tagName).toBe("FONT");
+        expect(p.outerHTML).toBe(
+            "<p>a<font><span>bc</span></font><font><span>d</span></font>e</p>"
+        );
+    });
+
+    test("should split when node is first child of inline ancestry (3)", async () => {
+        const { editor, el } = await setupEditor("<p>a<font>b<span>cde</span></font>f</p>");
+        const [p] = el.childNodes;
+        const cde = p.childNodes[1].childNodes[1].firstChild;
+        splitTextNode(cde, 2);
+        const cd = cde.previousSibling;
+        const result = editor.shared.split.splitAroundUntil(cd, p.childNodes[1]);
+        expect(result.tagName).toBe("FONT");
+        expect(p.outerHTML).toBe(
+            "<p>a<font>b</font><font><span>cd</span></font><font><span>e</span></font>f</p>"
+        );
+    });
+
+    test("should split when node is last child of inline ancestry (1)", async () => {
+        const { editor, el } = await setupEditor("<p>a<font>b<span>cde</span>f</font>g</p>");
+        const [p] = el.childNodes;
+        const cde = p.childNodes[1].childNodes[1].firstChild;
+        splitTextNode(cde, 2);
+        const result = editor.shared.split.splitAroundUntil(cde, p.childNodes[1]);
+        expect(result.tagName).toBe("FONT");
+        expect(p.outerHTML).toBe(
+            "<p>a<font>b<span>cd</span></font><font><span>e</span></font><font>f</font>g</p>"
+        );
+    });
+
+    test("should split when node is last child of inline ancestry (2)", async () => {
+        const { editor, el } = await setupEditor("<p>a<font><span>bcd</span></font>e</p>");
+        const [p] = el.childNodes;
+        const bcd = p.childNodes[1].childNodes[0].firstChild;
+        splitTextNode(bcd, 2);
+        const result = editor.shared.split.splitAroundUntil(bcd, p.childNodes[1]);
+        expect(result.tagName).toBe("FONT");
+        expect(p.outerHTML).toBe(
+            "<p>a<font><span>bc</span></font><font><span>d</span></font>e</p>"
+        );
+    });
+
+    test("should split when node is last child of inline ancestry (3)", async () => {
+        const { editor, el } = await setupEditor("<p>a<font><span>bcd</span>e</font>f</p>");
+        const [p] = el.childNodes;
+        const bcd = p.childNodes[1].childNodes[0].firstChild;
+        splitTextNode(bcd, 2);
+        const result = editor.shared.split.splitAroundUntil(bcd, p.childNodes[1]);
+        expect(result.tagName).toBe("FONT");
+        expect(p.outerHTML).toBe(
+            "<p>a<font><span>bc</span></font><font><span>d</span></font><font>e</font>f</p>"
+        );
+    });
+
+    test("should split a multi-node inline range near end of ancestry", async () => {
+        const { editor, el } = await setupEditor(
+            "<p>a<font>b<strong>cde</strong>fgh<u>ijk</u>l</font>m</p>"
+        );
+        const [p] = el.childNodes;
+        const cde = queryOne("strong").firstChild;
+        const ijk = queryOne("u").firstChild;
+        const result = editor.shared.split.splitAroundUntil([cde, ijk], p.childNodes[1]);
+        expect(result.tagName).toBe("FONT");
+        expect(p.outerHTML).toBe(
+            "<p>a<font>b</font><font><strong>cde</strong>fgh<u>ijk</u></font><font>l</font>m</p>"
+        );
     });
 });
 


### PR DESCRIPTION
### Steps to reproduce:

- Type some text and apply a large font-size.
- Select the text and apply the button style.
- Notice that the font-size is not reflected on the button.

### Description of the issue/feature this PR addresses:

- The `<a class=btn>` element was placed inside a font-size `<span>`.
- However, the `.btn` class defined its own font-size, causing the original styling to be overridden.

### Desired behavior after PR is merged:

- Improved the splitAroundUntil utility to correctly handle cases where the target node has no previous or next sibling. In such edge cases, the function now recursively splits up the inline ancestry until the specified limitAncestor, ensuring that the target node is fully isolated.
- The font-size `<span>` is moved inside `<a>` tag when applying a button style.
- This ensures the original font-size is preserved and correctly displayed.

task-4731416

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
