### PR TITLE
[IMP] sale: hide payment successful message when invoice is posted

### DIFF
--- a/addons/sale/views/sale_portal_templates.xml
+++ b/addons/sale/views/sale_portal_templates.xml
@@ -346,9 +346,11 @@
                         Your order is not in a state to be rejected.
                     </div>
 
-                    <t t-if="sale_order.get_portal_last_transaction()">
+                    <t t-set="current_tx" t-value="sale_order.get_portal_last_transaction()"/>
+                    <!-- hide state header when invoice is posted for current transaction. -->
+                    <t t-if="current_tx and not (current_tx.state == 'done' and len(current_tx.invoice_ids) == 1 and current_tx.invoice_ids.state == 'posted')">
                         <t t-call="payment.state_header">
-                            <t t-set="tx" t-value="sale_order.get_portal_last_transaction()"/>
+                            <t t-set="tx" t-value="current_tx"/>
                         </t>
                     </t>
 


### PR DESCRIPTION
Before this commit,
the payment success message was always shown on the portal, even when the related invoice had already been posted. This could cause confusion in cases like subscriptions, where the message appeared while a new payment request was also shown for the next billing period.

In this commit,
This improvement ensures that the "Payment Successful" message is no longer shown on the portal page once the related invoice has been posted.

task-4420352






---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
