### PR TITLE
[FIX] payment{,_stripe}: log payment values

### DIFF
--- a/addons/payment/models/payment_transaction.py
+++ b/addons/payment/models/payment_transaction.py
@@ -465,10 +465,11 @@ class PaymentTransaction(models.Model):
         # Complete generic processing values with provider-specific values.
         processing_values.update(self._get_specific_processing_values(processing_values))
         secret_keys = self._get_specific_secret_keys()
+        logged_values = {k: v for k, v in processing_values.items() if k not in secret_keys}
         _logger.info(
             "generic and provider-specific processing values for transaction with reference "
             "%(ref)s:\n%(values)s",
-            {'ref': self.reference, 'values': pprint.pformat(processing_values - secret_keys)},
+            {'ref': self.reference, 'values': pprint.pformat(logged_values)},
         )
 
         # Render the html form for the redirect flow if available.

--- a/addons/payment_stripe/controllers/main.py
+++ b/addons/payment_stripe/controllers/main.py
@@ -48,7 +48,8 @@ class StripeController(http.Controller):
                 payload={'expand[]': 'payment_method'},  # Expand all required objects.
                 method='GET',
             )
-            logged_intent = payment_intent - tx_sudo._get_specific_secret_keys()
+            secret_keys = tx_sudo._get_specific_secret_keys()
+            logged_intent = {k: v for k, v in payment_intent.items() if k not in secret_keys}
             _logger.info("Received payment_intents response:\n%s", pprint.pformat(logged_intent))
             self._include_payment_intent_in_notification_data(payment_intent, data)
         else:


### PR DESCRIPTION
Versions
--------
- 17.0+

Steps
-----
1. Log Stripe payment values.

Issue
-----
Only the keys get logged.

Cause
-----
Commit 1a2573881281 fixed the logging of secret keys, but in doing so, only logs keys and no values.

Solution
--------
Use a dict comprehension to create a full dict to log.

opw-4818301