### PR TITLE
[REF] web: clean up markup usage

### DIFF
--- a/addons/web/static/src/core/l10n/translation.js
+++ b/addons/web/static/src/core/l10n/translation.js
@@ -1,8 +1,9 @@
-import { htmlEscape, markup } from "@odoo/owl";
+import { markup } from "@odoo/owl";
 
 import { formatList } from "@web/core/l10n/utils";
 import { isIterable } from "@web/core/utils/arrays";
 import { Deferred } from "@web/core/utils/concurrency";
+import { htmlSprintf } from "@web/core/utils/html";
 import { isObject } from "@web/core/utils/objects";
 import { sprintf } from "@web/core/utils/strings";
 
@@ -35,7 +36,7 @@ const Markup = markup().constructor;
  * _t("Good morning"); // "Bonjour"
  * _t("Good morning %s", user.name); // "Bonjour Marc"
  * _t("Good morning %(newcomer)s, goodbye %(departer)s", { newcomer: Marc, departer: Mitchel }); // Bonjour Marc, au revoir Mitchel
- * _t("I love %s", markup("<blink>Minecraft</blink>")); // Markup {"J'adore <blink>Minecraft</blink>"}
+ * _t("I love %s", markup`<blink>Minecraft</blink>`); // Markup {"J'adore <blink>Minecraft</blink>"}
  * _t("Good morning %s!", ["Mitchell", "Marc", "Louis"]); // Bonjour Mitchell, Marc et Louis !
  *
  * @param {string} term
@@ -136,25 +137,7 @@ function _safeFormatAndSprintf(str, ...values) {
         hasMarkup ||= value instanceof Markup;
     }
     if (hasMarkup) {
-        return markup(sprintf(htmlEscape(str), ..._escapeNonMarkup(values)));
+        return htmlSprintf(str, ...values);
     }
     return sprintf(str, ...values);
-}
-
-/**
- * Go through each value to be passed to sprintf and escape anything that isn't
- * a markup.
- *
- * @param {any[]|[Object]} values Values for use with sprintf.
- * @returns {any[]|[Object]}
- */
-function _escapeNonMarkup(values) {
-    if (isObject(values[0])) {
-        const sanitized = {};
-        for (const [key, value] of Object.entries(values[0])) {
-            sanitized[key] = htmlEscape(value);
-        }
-        return [sanitized];
-    }
-    return values.map((x) => htmlEscape(x));
 }

--- a/addons/web/static/src/core/utils/strings.js
+++ b/addons/web/static/src/core/utils/strings.js
@@ -1,5 +1,4 @@
 import { isObject } from "./objects";
-import { htmlEscape, markup } from "@odoo/owl";
 
 export const nbsp = "\u00a0";
 
@@ -116,55 +115,6 @@ export function sprintf(s, ...values) {
  */
 export function capitalize(s) {
     return s ? s[0].toUpperCase() + s.slice(1) : "";
-}
-
-/**
- * Format the text as follow:
- *      \*\*text\*\* => Put the text in bold.
- *      --text-- => Put the text in muted.
- *      \`text\` => Put the text in a rounded badge (bg-primary).
- *      \n => Insert a breakline.
- *      \t => Insert 4 spaces.
- *
- * @param {string} text **will be escaped**
- * @returns {ReturnType<markup>} the formatted text
- */
-export function odoomark(text) {
-    const boldEx = /\*\*(.+?)\*\*/g;
-    const textMutedEx = /--(.+?)--/g;
-    const tagEx = /&#x60;(.+?)&#x60;/g;
-    const brEx = /\n/g;
-    const tabEx = /\t/g;
-
-    return markup(
-        escape(text)
-            .replaceAll(boldEx, `<b>$1</b>`)
-            .replaceAll(textMutedEx, `<span class='text-muted'>$1</span>`)
-            .replaceAll(
-                tagEx,
-                `<span class="o_tag position-relative d-inline-flex align-items-center mw-100 o_badge badge rounded-pill lh-1 o_tag_color_0">$1</span>`
-            )
-            .replaceAll(brEx, `<br/>`)
-            .replaceAll(tabEx, `<span style="margin-left: 2em"></span>`)
-    );
-}
-
-/**
- * Returns a markuped version of the input text where
- * the query is highlighted using the input classes
- * if it is part of the text.
- *
- * @param {string} query
- * @param {string | ReturnType<markup>} text
- * @param {string} classes
- * @returns {string | ReturnType<markup>}
- */
-export function highlightText(query, text, classes) {
-    if (!query) {
-        return text;
-    }
-    const regex = new RegExp(`(${escapeRegExp(escape(query))})+(?=(?:[^>]*<[^<]*>)*[^<>]*$)`, "ig");
-    return markup(htmlEscape(text).replaceAll(regex, markup`<span class="${classes}">$1</span>`));
 }
 
 /**

--- a/addons/web/static/src/model/relational_model/record.js
+++ b/addons/web/static/src/model/relational_model/record.js
@@ -4,7 +4,7 @@ import { serializeDate, serializeDateTime } from "@web/core/l10n/dates";
 import { _t } from "@web/core/l10n/translation";
 import { x2ManyCommands } from "@web/core/orm_service";
 import { evaluateBooleanExpr } from "@web/core/py_js/py";
-import { escape } from "@web/core/utils/strings";
+import { htmlJoin } from "@web/core/utils/html";
 import { DataPoint } from "./datapoint";
 import { FetchRecordError } from "./errors";
 import {
@@ -33,7 +33,6 @@ import {
  *
  * @typedef {"edit" | "readonly"} Mode
  */
-
 export class Record extends DataPoint {
     static type = "Record";
 
@@ -495,11 +494,11 @@ export class Record extends DataPoint {
         const isValid = !this._invalidFields.size;
         if (!isValid && displayNotification) {
             const items = [...this._invalidFields].map(
-                (fieldName) => `<li>${escape(this.fields[fieldName].string || fieldName)}</li>`,
+                (fieldName) => markup`<li>${this.fields[fieldName].string || fieldName}</li>`,
                 this
             );
             this._closeInvalidFieldsNotification = this.model.notification.add(
-                markup(`<ul>${items.join("")}</ul>`),
+                markup`<ul>${htmlJoin(items)}</ul>`,
                 {
                     title: _t("Invalid fields: "),
                     type: "danger",
@@ -1126,10 +1125,9 @@ export class Record extends DataPoint {
                 this.dirty = false;
             } else {
                 this.model._closeUrgentSaveNotification = this.model.notification.add(
-                    markup(
-                        _t(
-                            `Heads up! Your recent changes are too large to save automatically. Please click the <i class="fa fa-cloud-upload fa-fw"></i> button now to ensure your work is saved before you exit this tab.`
-                        )
+                    _t(
+                        `Heads up! Your recent changes are too large to save automatically. Please click the %(upload_icon)s button now to ensure your work is saved before you exit this tab.`,
+                        { upload_icon: markup`<i class="fa fa-cloud-upload fa-fw"></i>` }
                     ),
                     { sticky: true }
                 );

--- a/addons/web/static/src/views/fields/formatters.js
+++ b/addons/web/static/src/views/fields/formatters.js
@@ -8,7 +8,7 @@ import {
     humanNumber,
     insertThousandsSep,
 } from "@web/core/utils/numbers";
-import { escape, exprToBoolean } from "@web/core/utils/strings";
+import { exprToBoolean } from "@web/core/utils/strings";
 
 import { markup } from "@odoo/owl";
 import { formatCurrency } from "@web/core/currency";
@@ -52,19 +52,18 @@ export function formatBinary(value) {
  * @returns {string}
  */
 export function formatBoolean(value) {
-    return markup(`
+    return markup`
         <div class="o-checkbox d-inline-block me-2">
             <input id="boolean_checkbox" type="checkbox" class="form-check-input" disabled ${
                 value ? "checked" : ""
             }/>
             <label for="boolean_checkbox" class="form-check-label"/>
-        </div>`);
+        </div>`;
 }
 
 /**
  * @param {string} value
  * @param {Object} [options] additional options
- * @param {boolean} [options.escape=false] if true, escapes the formatted value
  * @param {boolean} [options.isPassword=false] if true, returns '********'
  *   instead of the formatted value
  * @returns {string}
@@ -72,9 +71,6 @@ export function formatBoolean(value) {
 export function formatChar(value, options) {
     if (options && options.isPassword) {
         return "*".repeat(value ? value.length : 0);
-    }
-    if (options && options.escape) {
-        value = escape(value);
     }
     return value || "";
 }

--- a/addons/web/static/src/views/fields/relational_utils.js
+++ b/addons/web/static/src/views/fields/relational_utils.js
@@ -47,7 +47,7 @@ import {
     useState,
     useSubEnv,
 } from "@odoo/owl";
-import { highlightText, odoomark } from "@web/core/utils/strings";
+import { highlightText, odoomark } from "@web/core/utils/html";
 
 //
 // Commons

--- a/addons/web/static/src/views/fields/statusbar/statusbar_field.js
+++ b/addons/web/static/src/views/fields/statusbar/statusbar_field.js
@@ -7,7 +7,6 @@ import { DropdownItem } from "@web/core/dropdown/dropdown_item";
 import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 import { groupBy } from "@web/core/utils/arrays";
-import { escape } from "@web/core/utils/strings";
 import { throttleForAnimation } from "@web/core/utils/timing";
 import { getFieldDomain } from "@web/model/relational_model/utils";
 import { useSpecialData } from "@web/views/fields/relational_utils";
@@ -100,7 +99,7 @@ export class StatusBarField extends Component {
                     fieldNames.push(foldField);
                 }
                 const value = record.data[fieldName];
-                let domain = getFieldDomain(record, fieldName, props.domain)
+                let domain = getFieldDomain(record, fieldName, props.domain);
                 domain = Domain.and([this.getDomain(), domain]).toList();
                 if (domain.length && value) {
                     domain = Domain.or([[["id", "=", value.id]], domain]).toList(
@@ -113,7 +112,7 @@ export class StatusBarField extends Component {
 
         // Command palette
         if (this.props.withCommand) {
-            const moveToCommandName = _t("Move to %s...", escape(this.field.string));
+            const moveToCommandName = _t("Move to %s...", this.field.string);
             useCommand(
                 moveToCommandName,
                 () => ({
@@ -313,7 +312,10 @@ export class StatusBarField extends Component {
      */
     async selectItem(item) {
         const { name, record } = this.props;
-        const value = this.field.type === "many2one" ? { id: item.value, display_name: item.label } : item.value;
+        const value =
+            this.field.type === "many2one"
+                ? { id: item.value, display_name: item.label }
+                : item.value;
         await record.update({ [name]: value });
         await record.save();
     }

--- a/addons/web/static/src/webclient/actions/client_actions.js
+++ b/addons/web/static/src/webclient/actions/client_actions.js
@@ -2,7 +2,7 @@ import { browser } from "@web/core/browser/browser";
 import { router } from "@web/core/browser/router";
 import { rpc } from "@web/core/network/rpc";
 import { registry } from "@web/core/registry";
-import { escape, sprintf } from "@web/core/utils/strings";
+import { htmlSprintf } from "@web/core/utils/html";
 
 import { markup } from "@odoo/owl";
 
@@ -14,10 +14,10 @@ export function displayNotificationAction(env, action) {
         title: params.title,
         type: params.type || "info",
     };
-    const links = (params.links || []).map((link) => {
-        return `<a href="${escape(link.url)}" target="_blank">${escape(link.label)}</a>`;
-    });
-    const message = markup(sprintf(escape(params.message), ...links));
+    const links = (params.links || []).map(
+        (link) => markup`<a href="${link.url}" target="_blank">${link.label}</a>`
+    );
+    const message = htmlSprintf(params.message, ...links);
     env.services.notification.add(message, options);
     return params.next;
 }

--- a/addons/web/static/src/webclient/settings_form_view/highlight_text/highlight_text.js
+++ b/addons/web/static/src/webclient/settings_form_view/highlight_text/highlight_text.js
@@ -1,5 +1,5 @@
 import { Component, useState, onWillRender } from "@odoo/owl";
-import { highlightText } from "@web/core/utils/strings";
+import { highlightText } from "@web/core/utils/html";
 
 export class HighlightText extends Component {
     static template = "web.HighlightText";

--- a/addons/web/static/src/webclient/user_menu/user_menu_items.js
+++ b/addons/web/static/src/webclient/user_menu/user_menu_items.js
@@ -3,7 +3,6 @@ import { isMacOS } from "@web/core/browser/feature_detection";
 import { _t } from "@web/core/l10n/translation";
 import { rpc } from "@web/core/network/rpc";
 import { user } from "@web/core/user";
-import { escape } from "@web/core/utils/strings";
 import { session } from "@web/session";
 import { browser } from "../../core/browser/browser";
 import { registry } from "../../core/registry";
@@ -37,12 +36,11 @@ function shortCutsItem(env) {
         type: "item",
         id: "shortcuts",
         hide: env.isSmall,
-        description: markup(
-            `<div class="d-flex align-items-center justify-content-between p-0 w-100">
-                <span>${escape(_t("Shortcuts"))}</span>
+        description: markup`
+            <div class="d-flex align-items-center justify-content-between p-0 w-100">
+                <span>${_t("Shortcuts")}</span>
                 <span class="fw-bold">${isMacOS() ? "CMD" : "CTRL"}+K</span>
-            </div>`
-        ),
+            </div>`,
         callback: () => {
             env.services.command.openMainPalette({ FooterComponent: ShortcutsFooterComponent });
         },

--- a/addons/web/static/tests/core/code_editor.test.js
+++ b/addons/web/static/tests/core/code_editor.test.js
@@ -102,7 +102,7 @@ test("CodeEditor shouldn't accepts markup values", async () => {
     }
 
     const codeEditor = await mountWithCleanup(GrandParent);
-    const textMarkup = markup("<div>Some Text</div>");
+    const textMarkup = markup`<div>Some Text</div>`;
 
     codeEditor.state.value = textMarkup;
     await animationFrame();

--- a/addons/web/static/tests/core/effects/effect_service.test.js
+++ b/addons/web/static/tests/core/effects/effect_service.test.js
@@ -11,7 +11,7 @@ let effectParams;
 beforeEach(async () => {
     await mountWithCleanup(MainComponentsContainer);
     effectParams = {
-        message: markup("<div>Congrats!</div>"),
+        message: markup`<div>Congrats!</div>`,
     };
 });
 

--- a/addons/web/static/tests/core/l10n/translation.test.js
+++ b/addons/web/static/tests/core/l10n/translation.test.js
@@ -428,8 +428,8 @@ describe("_t with markups", () => {
         const translatedStr = _t(
             "FREE %(blink_start)sROBUX%(blink_end)s, please contact %(email)s",
             {
-                blink_start: markup("<blink>"),
-                blink_end: markup("</blink>"),
+                blink_start: markup`<blink>`,
+                blink_end: markup`</blink>`,
                 email: maliciousUserInput,
             }
         );
@@ -442,7 +442,7 @@ describe("_t with markups", () => {
         translatedTerms[translationLoaded] = true;
         const maliciousTranslation = "<script>document.write('pizza hawai')</script> %s";
         patchTranslations({ "I love %s": maliciousTranslation });
-        const translatedStr = _t("I love %s", markup("<blink>Mario Kart</blink>"));
+        const translatedStr = _t("I love %s", markup`<blink>Mario Kart</blink>`);
         expect(translatedStr.valueOf()).toBe(
             "&lt;script&gt;document.write(&#x27;pizza hawai&#x27;)&lt;/script&gt; <blink>Mario Kart</blink>"
         );

--- a/addons/web/static/tests/core/notifications/notifications.test.js
+++ b/addons/web/static/tests/core/notifications/notifications.test.js
@@ -49,7 +49,7 @@ test("can display a notification with markup content", async () => {
         .category("main_components")
         .get("NotificationContainer");
     await mountWithCleanup(NotificationContainer, { props, noMainContainer: true });
-    getService("notification").add(markup("<b>I'm a <i>markup</i> notification</b>"));
+    getService("notification").add(markup`<b>I'm a <i>markup</i> notification</b>`);
     await animationFrame();
     expect(".o_notification").toHaveCount(1);
     expect(".o_notification_content").toHaveInnerHTML("<b>I'm a <i>markup</i> notification</b>");

--- a/addons/web/static/tests/core/utils/html.test.js
+++ b/addons/web/static/tests/core/utils/html.test.js
@@ -6,12 +6,15 @@ import { describe, expect, test } from "@odoo/hoot";
 import {
     createDocumentFragmentFromContent,
     createElementWithContent,
+    highlightText,
     htmlFormatList,
     htmlJoin,
     htmlReplace,
     htmlReplaceAll,
+    htmlSprintf,
     htmlTrim,
     isHtmlEmpty,
+    odoomark,
     setElementContent,
 } from "@web/core/utils/html";
 
@@ -23,7 +26,7 @@ test("createDocumentFragmentFromContent escapes text", () => {
 });
 
 test("createDocumentFragmentFromContent keeps html markup", () => {
-    const doc = createDocumentFragmentFromContent(markup("<p>test</p>"));
+    const doc = createDocumentFragmentFromContent(markup`<p>test</p>`);
     expect(doc.body.innerHTML).toEqual("<p>test</p>");
 });
 
@@ -33,8 +36,31 @@ test("createElementWithContent escapes text", () => {
 });
 
 test("createElementWithContent keeps html markup", () => {
-    const res = createElementWithContent("div", markup("<p>test</p>"));
+    const res = createElementWithContent("div", markup`<p>test</p>`);
     expect(res.outerHTML).toBe("<div><p>test</p></div>");
+});
+
+test("highlightText", () => {
+    expect(highlightText("b", "", "hl").toString()).toBe("");
+    expect(highlightText("", "b", "hl").toString()).toBe("b");
+    expect(highlightText("b", "abc", "hl").toString()).toBe('a<span class="hl">b</span>c');
+    expect(highlightText("b", "abcb", "hl").toString()).toBe(
+        'a<span class="hl">b</span>c<span class="hl">b</span>'
+    );
+    expect(highlightText("b", "<p>ab</p>", "hl").toString()).toBe(
+        '&lt;p&gt;a<span class="hl">b</span>&lt;/p&gt;'
+    );
+    expect(highlightText("b", markup`<p>ab</p>`, "hl").toString()).toBe(
+        '<p>a<span class="hl">b</span></p>'
+    );
+    expect(highlightText("<", "<p>ab</p>", "hl").toString()).toBe(
+        '<span class="hl">&lt;</span>p&gt;ab<span class="hl">&lt;</span>/p&gt;'
+    );
+    expect(highlightText("<", markup`<p>ab</p>`, "hl").toString()).toBe("<p>ab</p>");
+    expect(highlightText(markup`<`, "<p>ab</p>", "hl").toString()).toBe("&lt;p&gt;ab&lt;/p&gt;");
+    expect(highlightText(markup`<p>ab</p>`, markup`<p>ab</p>`, "hl").toString()).toBe(
+        '<span class="hl"><p>ab</p></span>'
+    );
 });
 
 test("htmlEscape escapes text", () => {
@@ -44,7 +70,7 @@ test("htmlEscape escapes text", () => {
 });
 
 test("htmlEscape keeps html markup", () => {
-    const res = htmlEscape(markup("<p>test</p>"));
+    const res = htmlEscape(markup`<p>test</p>`);
     expect(res.toString()).toBe("<p>test</p>");
     expect(res).toBeInstanceOf(Markup);
 });
@@ -67,12 +93,45 @@ test("htmlJoin keeps html separator", () => {
     expect(res).toBeInstanceOf(Markup);
 });
 
+test("htmlSprintf escapes str with list params", () => {
+    const res = htmlSprintf("<p>%s</p>", "Hi");
+    expect(res.toString()).toBe("&lt;p&gt;Hi&lt;/p&gt;");
+    expect(res).toBeInstanceOf(Markup);
+});
+
+test("htmlSprintf escapes list params", () => {
+    const res = htmlSprintf(
+        markup`<p>%s</p>%s`,
+        markup`<span>test 1</span>`,
+        `<span>test 2</span>`
+    );
+    expect(res.toString()).toBe(
+        "<p><span>test 1</span>,&lt;span&gt;test 2&lt;/span&gt;</p>undefined"
+    );
+    expect(res).toBeInstanceOf(Markup);
+});
+
+test("htmlSprintf escapes str with object params", () => {
+    const res = htmlSprintf("<p>%(t1)s</p>", { t1: "Hi" });
+    expect(res.toString()).toBe("&lt;p&gt;Hi&lt;/p&gt;");
+    expect(res).toBeInstanceOf(Markup);
+});
+
+test("htmlSprintf escapes object param", () => {
+    const res = htmlSprintf(markup`<p>%(t1)s</p>%(t2)s`, {
+        t1: `<span>test 1</span>`,
+        t2: markup`<span>test 2</span>`,
+    });
+    expect(res.toString()).toBe("<p>&lt;span&gt;test 1&lt;/span&gt;</p><span>test 2</span>");
+    expect(res).toBeInstanceOf(Markup);
+});
+
 test("isHtmlEmpty does not consider text as empty", () => {
     expect(isHtmlEmpty("<p></p>")).toBe(false);
 });
 
 test("isHtmlEmpty considers empty html markup as empty", () => {
-    expect(isHtmlEmpty(markup("<p></p>"))).toBe(true);
+    expect(isHtmlEmpty(markup`<p></p>`)).toBe(true);
 });
 
 test("setElementContent escapes text", () => {
@@ -83,12 +142,12 @@ test("setElementContent escapes text", () => {
 
 test("setElementContent keeps html markup", () => {
     const div = document.createElement("div");
-    setElementContent(div, markup("<p>test</p>"));
+    setElementContent(div, markup`<p>test</p>`);
     expect(div.innerHTML).toBe("<p>test</p>");
 });
 
 test("htmlFormatList", () => {
-    const list = ["<p>test 1</p>", markup("<p>test 2</p>"), "&lt;p&gt;test 3&lt;/p&gt;"];
+    const list = ["<p>test 1</p>", markup`<p>test 2</p>`, "&lt;p&gt;test 3&lt;/p&gt;"];
     const res = htmlFormatList(list, { localeCode: "fr-FR" });
     expect(res.toString()).toBe(
         "&lt;p&gt;test 1&lt;/p&gt;, <p>test 2</p> et &amp;lt;p&amp;gt;test 3&amp;lt;/p&amp;gt;"
@@ -107,57 +166,51 @@ test("htmlReplace with text/text/text replaces with escaped text", () => {
 });
 
 test("htmlReplace with text/text/html replaces with html markup", () => {
-    let res = htmlReplace("<p>test</p>", "<p>test</p>", markup("<span>test</span>"));
+    let res = htmlReplace("<p>test</p>", "<p>test</p>", markup`<span>test</span>`);
     expect(res.toString()).toBe("<span>test</span>");
     expect(res).toBeInstanceOf(Markup);
 
-    res = htmlReplace("<p>test</p>", "<p>test</p>", () => markup("<span>test</span>"));
+    res = htmlReplace("<p>test</p>", "<p>test</p>", () => markup`<span>test</span>`);
     expect(res.toString()).toBe("<span>test</span>");
     expect(res).toBeInstanceOf(Markup);
 });
 
 test("htmlReplace with text/html does not find", () => {
-    let res = htmlReplace("<p>test</p>", markup("<p>test</p>"), "never found");
+    let res = htmlReplace("<p>test</p>", markup`<p>test</p>`, "never found");
     expect(res.toString()).toBe("&lt;p&gt;test&lt;/p&gt;");
     expect(res).toBeInstanceOf(Markup);
 
-    res = htmlReplace("<p>test</p>", () => markup("<p>test</p>"), "never found");
+    res = htmlReplace("<p>test</p>", () => markup`<p>test</p>`, "never found");
     expect(res.toString()).toBe("&lt;p&gt;test&lt;/p&gt;");
     expect(res).toBeInstanceOf(Markup);
 });
 
 test("htmlReplace with html/html/html replaces with html markup", () => {
-    let res = htmlReplace(
-        markup("<p>test</p>"),
-        markup("<p>test</p>"),
-        markup("<span>test</span>")
-    );
+    let res = htmlReplace(markup`<p>test</p>`, markup`<p>test</p>`, markup`<span>test</span>`);
     expect(res.toString()).toBe("<span>test</span>");
     expect(res).toBeInstanceOf(Markup);
 
-    res = htmlReplace(markup("<p>test</p>"), markup("<p>test</p>"), () =>
-        markup("<span>test</span>")
-    );
+    res = htmlReplace(markup`<p>test</p>`, markup`<p>test</p>`, () => markup`<span>test</span>`);
     expect(res.toString()).toBe("<span>test</span>");
     expect(res).toBeInstanceOf(Markup);
 });
 
 test("htmlReplace with html/html/text replaces with escaped text", () => {
-    let res = htmlReplace(markup("<p>test</p>"), markup("<p>test</p>"), "<span>test</span>");
+    let res = htmlReplace(markup`<p>test</p>`, markup`<p>test</p>`, "<span>test</span>");
     expect(res.toString()).toBe("&lt;span&gt;test&lt;/span&gt;");
     expect(res).toBeInstanceOf(Markup);
 
-    res = htmlReplace(markup("<p>test</p>"), markup("<p>test</p>"), () => "<span>test</span>");
+    res = htmlReplace(markup`<p>test</p>`, markup`<p>test</p>`, () => "<span>test</span>");
     expect(res.toString()).toBe("&lt;span&gt;test&lt;/span&gt;");
     expect(res).toBeInstanceOf(Markup);
 });
 
 test("htmlReplace with html/text does not find", () => {
-    let res = htmlReplace(markup("<p>test</p>"), "<p>test</p>", "never found");
+    let res = htmlReplace(markup`<p>test</p>`, "<p>test</p>", "never found");
     expect(res.toString()).toBe("<p>test</p>");
     expect(res).toBeInstanceOf(Markup);
 
-    res = htmlReplace(markup("<p>test</p>"), () => "<p>test</p>", "never found");
+    res = htmlReplace(markup`<p>test</p>`, () => "<p>test</p>", "never found");
     expect(res.toString()).toBe("<p>test</p>");
     expect(res).toBeInstanceOf(Markup);
 });
@@ -173,13 +226,11 @@ test("htmlReplaceAll with text/text/text replaces all with escaped text", () => 
 });
 
 test("htmlReplaceAll with text/text/html replaces all with html markup", () => {
-    let res = htmlReplaceAll("<p>test</p> <p>test</p>", "<p>test</p>", markup("<span>test</span>"));
+    let res = htmlReplaceAll("<p>test</p> <p>test</p>", "<p>test</p>", markup`<span>test</span>`);
     expect(res.toString()).toBe("<span>test</span> <span>test</span>");
     expect(res).toBeInstanceOf(Markup);
 
-    res = htmlReplaceAll("<p>test</p> <p>test</p>", "<p>test</p>", () =>
-        markup("<span>test</span>")
-    );
+    res = htmlReplaceAll("<p>test</p> <p>test</p>", "<p>test</p>", () => markup`<span>test</span>`);
     expect(res.toString()).toBe("<span>test</span> <span>test</span>");
     expect(res).toBeInstanceOf(Markup);
 });
@@ -196,15 +247,17 @@ test("htmlReplaceAll with text/html does not find, escapes all", () => {
 
 test("htmlReplaceAll with html/html/html replaces all with html markup", () => {
     let res = htmlReplaceAll(
-        markup("<p>test</p> <p>test</p>"),
-        markup("<p>test</p>"),
-        markup("<span>test</span>")
+        markup`<p>test</p> <p>test</p>`,
+        markup`<p>test</p>`,
+        markup`<span>test</span>`
     );
     expect(res.toString()).toBe("<span>test</span> <span>test</span>");
     expect(res).toBeInstanceOf(Markup);
 
-    res = htmlReplaceAll(markup("<p>test</p> <p>test</p>"), markup("<p>test</p>"), () =>
-        markup("<span>test</span>")
+    res = htmlReplaceAll(
+        markup`<p>test</p> <p>test</p>`,
+        markup`<p>test</p>`,
+        () => markup`<span>test</span>`
     );
     expect(res.toString()).toBe("<span>test</span> <span>test</span>");
     expect(res).toBeInstanceOf(Markup);
@@ -212,16 +265,16 @@ test("htmlReplaceAll with html/html/html replaces all with html markup", () => {
 
 test("htmlReplaceAll with html/html/text replaces all with escaped text", () => {
     let res = htmlReplaceAll(
-        markup("<p>test</p> <p>test</p>"),
-        markup("<p>test</p>"),
+        markup`<p>test</p> <p>test</p>`,
+        markup`<p>test</p>`,
         "<span>test</span>"
     );
     expect(res.toString()).toBe("&lt;span&gt;test&lt;/span&gt; &lt;span&gt;test&lt;/span&gt;");
     expect(res).toBeInstanceOf(Markup);
 
     res = htmlReplaceAll(
-        markup("<p>test</p> <p>test</p>"),
-        markup("<p>test</p>"),
+        markup`<p>test</p> <p>test</p>`,
+        markup`<p>test</p>`,
         () => "<span>test</span>"
     );
     expect(res.toString()).toBe("&lt;span&gt;test&lt;/span&gt; &lt;span&gt;test&lt;/span&gt;");
@@ -229,11 +282,11 @@ test("htmlReplaceAll with html/html/text replaces all with escaped text", () => 
 });
 
 test("htmlReplaceAll with html/text does not find, keeps all", () => {
-    let res = htmlReplaceAll(markup("<p>test</p> <p>test</p>"), "<p>test</p>", "never found");
+    let res = htmlReplaceAll(markup`<p>test</p> <p>test</p>`, "<p>test</p>", "never found");
     expect(res.toString()).toBe("<p>test</p> <p>test</p>");
     expect(res).toBeInstanceOf(Markup);
 
-    res = htmlReplaceAll(markup("<p>test</p> <p>test</p>"), "<p>test</p>", () => "never found");
+    res = htmlReplaceAll(markup`<p>test</p> <p>test</p>`, "<p>test</p>", () => "never found");
     expect(res.toString()).toBe("<p>test</p> <p>test</p>");
     expect(res).toBeInstanceOf(Markup);
 });
@@ -254,7 +307,31 @@ test("htmlTrim escapes text", () => {
 });
 
 test("htmlTrim keeps html markup", () => {
-    const res = htmlTrim(markup(" <p>test</p> "));
+    const res = htmlTrim(markup` <p>test</p> `);
     expect(res.toString()).toBe("<p>test</p>");
     expect(res).toBeInstanceOf(Markup);
+});
+
+test("odoomark", () => {
+    expect(odoomark("").toString()).toBe("");
+    expect(odoomark("**test**").toString()).toBe("<b>test</b>");
+    expect(odoomark("**test** something else **test**").toString()).toBe(
+        "<b>test</b> something else <b>test</b>"
+    );
+    expect(odoomark("--test--").toString()).toBe("<span class='text-muted'>test</span>");
+    expect(odoomark("--test-- something else --test--").toString()).toBe(
+        "<span class='text-muted'>test</span> something else <span class='text-muted'>test</span>"
+    );
+    expect(odoomark("`test`").toString()).toBe(
+        `<span class="o_tag position-relative d-inline-flex align-items-center mw-100 o_badge badge rounded-pill lh-1 o_tag_color_0">test</span>`
+    );
+    expect(odoomark("`test` something else `test`").toString()).toBe(
+        `<span class="o_tag position-relative d-inline-flex align-items-center mw-100 o_badge badge rounded-pill lh-1 o_tag_color_0">test</span> something else <span class="o_tag position-relative d-inline-flex align-items-center mw-100 o_badge badge rounded-pill lh-1 o_tag_color_0">test</span>`
+    );
+    expect(odoomark("test\ttest2").toString()).toBe(
+        `test<span style="margin-left: 2em"></span>test2`
+    );
+    expect(odoomark("test\ntest2").toString()).toBe("test<br/>test2");
+    expect(odoomark("<p>**test**</p>").toString()).toBe("&lt;p&gt;<b>test</b>&lt;/p&gt;");
+    expect(odoomark(markup`<p>**test**</p>`).toString()).toBe("<p><b>test</b></p>");
 });

--- a/addons/web/static/tests/core/utils/strings.test.js
+++ b/addons/web/static/tests/core/utils/strings.test.js
@@ -9,7 +9,6 @@ import {
     isEmail,
     isNumeric,
     sprintf,
-    odoomark,
 } from "@web/core/utils/strings";
 import { _t } from "@web/core/l10n/translation";
 
@@ -129,26 +128,4 @@ test("isNumeric", () => {
     expect(isNumeric("12.34")).toBe(false);
 
     expect(isNumeric("1234")).toBe(true);
-});
-
-test("odoomark", () => {
-    expect(odoomark("").toString()).toBe("");
-    expect(odoomark("**test**").toString()).toBe("<b>test</b>");
-    expect(odoomark("**test** something else **test**").toString()).toBe(
-        "<b>test</b> something else <b>test</b>"
-    );
-    expect(odoomark("--test--").toString()).toBe("<span class='text-muted'>test</span>");
-    expect(odoomark("--test-- something else --test--").toString()).toBe(
-        "<span class='text-muted'>test</span> something else <span class='text-muted'>test</span>"
-    );
-    expect(odoomark("`test`").toString()).toBe(
-        `<span class="o_tag position-relative d-inline-flex align-items-center mw-100 o_badge badge rounded-pill lh-1 o_tag_color_0">test</span>`
-    );
-    expect(odoomark("`test` something else `test`").toString()).toBe(
-        `<span class="o_tag position-relative d-inline-flex align-items-center mw-100 o_badge badge rounded-pill lh-1 o_tag_color_0">test</span> something else <span class="o_tag position-relative d-inline-flex align-items-center mw-100 o_badge badge rounded-pill lh-1 o_tag_color_0">test</span>`
-    );
-    expect(odoomark("test\ttest2").toString()).toBe(
-        `test<span style="margin-left: 2em"></span>test2`
-    );
-    expect(odoomark("test\ntest2").toString()).toBe("test<br/>test2");
 });

--- a/addons/web/static/tests/public/interaction.test.js
+++ b/addons/web/static/tests/public/interaction.test.js
@@ -1807,7 +1807,7 @@ describe("t-att and t-out", () => {
                     _root: {
                         "t-out": () => {
                             expect.step("t-out");
-                            return markup(this.tOut);
+                            return this.tOut;
                         },
                     },
                     span: {
@@ -1817,11 +1817,11 @@ describe("t-att and t-out", () => {
                     },
                 };
                 setup() {
-                    this.tOut = `<span class="old-inner">Hi</span>`;
+                    this.tOut = markup`<span class="old-inner">Hi</span>`;
                 }
                 start() {
                     this.waitForTimeout(() => {
-                        this.tOut = "<span class='inner'>Hello</span>";
+                        this.tOut = markup`<span class='inner'>Hello</span>`;
                     }, 1000);
                 }
             }

--- a/addons/web/static/tests/views/calendar/calendar_multi_create.test.js
+++ b/addons/web/static/tests/views/calendar/calendar_multi_create.test.js
@@ -770,7 +770,7 @@ test("multi_create: test required attribute in form", async () => {
     expect(".o_calendar_sidebar_container .o_form_view [name='name']").toHaveClass(
         "o_required_modifier"
     );
-    expect.verifySteps([markup("<ul><li>Name</li></ul>")]);
+    expect.verifySteps([markup`<ul><li>Name</li></ul>`]);
 
     await click(".o_calendar_sidebar_container .o_form_view [name='name'] input");
     await edit("Test required");

--- a/addons/web/static/tests/views/fields/formatters.test.js
+++ b/addons/web/static/tests/views/fields/formatters.test.js
@@ -111,7 +111,7 @@ test("formatText", () => {
     expect(formatText("value")).toBe("value");
     expect(formatText(1)).toBe("1");
     expect(formatText(1.5)).toBe("1.5");
-    expect(formatText(markup("<p>This is a Test</p>"))).toBe("<p>This is a Test</p>");
+    expect(formatText(markup`<p>This is a Test</p>`)).toBe("<p>This is a Test</p>");
     expect(formatText([1, 2, 3, 4, 5])).toBe("1,2,3,4,5");
     expect(formatText({ a: 1, b: 2 })).toBe("[object Object]");
 });

--- a/addons/web/static/tests/views/list/list_view.test.js
+++ b/addons/web/static/tests/views/list/list_view.test.js
@@ -5382,7 +5382,7 @@ test(`custom delete confirmation dialog`, async () => {
     class CautiousController extends listView.Controller {
         get deleteConfirmationDialogProps() {
             const props = super.deleteConfirmationDialogProps;
-            props.body = markup(`<span class="text-danger">These are the consequences</span>`);
+            props.body = markup`<span class="text-danger">These are the consequences</span>`;
             return props;
         }
     }

--- a/addons/web/static/tests/views/pivot_view.test.js
+++ b/addons/web/static/tests/views/pivot_view.test.js
@@ -2733,7 +2733,7 @@ test("empty pivot view with action helper", async () => {
         type: "pivot",
         resModel: "partner",
         context: { search_default_small_than_0: true },
-        noContentHelp: markup(`<p class="abc">click to add a foo</p>`),
+        noContentHelp: markup`<p class="abc">click to add a foo</p>`,
         config: {
             views: [[false, "search"]],
         },
@@ -2760,7 +2760,7 @@ test("empty pivot view with sample data", async () => {
         type: "pivot",
         resModel: "partner",
         context: { search_default_small_than_0: true },
-        noContentHelp: markup('<p class="abc">click to add a foo</p>'),
+        noContentHelp: markup`<p class="abc">click to add a foo</p>`,
         config: {
             views: [[false, "search"]],
         },
@@ -2789,7 +2789,7 @@ test("non empty pivot view with sample data", async () => {
     await mountView({
         type: "pivot",
         resModel: "partner",
-        noContentHelp: markup('<p class="abc">click to add a foo</p>'),
+        noContentHelp: markup`<p class="abc">click to add a foo</p>`,
         config: {
             views: [[false, "search"]],
         },

--- a/addons/web/static/tests/webclient/mobile/burger_user_menu.test.js
+++ b/addons/web/static/tests/webclient/mobile/burger_user_menu.test.js
@@ -70,7 +70,7 @@ test("can be rendered", async () => {
     userMenuRegistry.add("html_item", () => ({
         type: "item",
         id: "html",
-        description: markup(`<div>HTML<i class="fa fa-check px-2"></i></div>`),
+        description: markup`<div>HTML<i class="fa fa-check px-2"></i></div>`,
         callback: () => {
             expect.step("callback html_item");
         },


### PR DESCRIPTION
Use markup template and html functions to make the code cleaner and safer while no longer triggering ci/security flag.