### PR TITLE
[IMP] html_editor: optionally remove document tab from media dialog

### DIFF
--- a/addons/html_editor/static/src/fields/html_field.js
+++ b/addons/html_editor/static/src/fields/html_field.js
@@ -338,6 +338,9 @@ export const htmlField = {
         if ("allowMediaDialogVideo" in options) {
             editorConfig.allowMediaDialogVideo = Boolean(options.allowMediaDialogVideo);
         }
+        if ("allowMediaDocuments" in options) {
+            editorConfig.allowMediaDocuments = Boolean(options.allowMediaDocuments);
+        }
         if ("allowFile" in options) {
             editorConfig.allowFile = Boolean(options.allowFile);
         }

--- a/addons/html_editor/static/src/main/media/file_plugin.js
+++ b/addons/html_editor/static/src/main/media/file_plugin.js
@@ -33,14 +33,15 @@ export class FilePlugin extends Plugin {
             description: _t("Upload a file"),
         }),
         unsplittable_node_predicates: (node) => node.classList?.contains("o_file_box"),
-        ...(this.config.allowFile && {
-            media_dialog_extra_tabs: {
-                id: "DOCUMENTS",
-                title: _t("Documents"),
-                Component: this.componentForMediaDialog,
-                sequence: 15,
-            },
-        }),
+        ...(this.config.allowFile &&
+            this.config.allowMediaDocuments && {
+                media_dialog_extra_tabs: {
+                    id: "DOCUMENTS",
+                    title: _t("Documents"),
+                    Component: this.componentForMediaDialog,
+                    sequence: 15,
+                },
+            }),
         selectors_for_feff_providers: () => ".o_file_box",
     };
 

--- a/addons/html_editor/static/src/main/media/media_plugin.js
+++ b/addons/html_editor/static/src/main/media/media_plugin.js
@@ -33,6 +33,7 @@ export class MediaPlugin extends Plugin {
     static defaultConfig = {
         allowImage: true,
         allowMediaDialogVideo: true,
+        allowMediaDocuments: true,
     };
     resources = {
         user_commands: [

--- a/addons/html_editor/static/tests/html_field.test.js
+++ b/addons/html_editor/static/tests/html_field.test.js
@@ -1194,6 +1194,31 @@ test("'Media' command is not available when 'allowImage' = false", async () => {
     expect(queryAllTexts(".o-we-command-name")).not.toInclude("Media");
 });
 
+test("MediaDialog does not contain 'Documents' tab in html field when 'allowMediaDocuments' = false", async () => {
+    await mountView({
+        type: "form",
+        resId: 1,
+        resModel: "partner",
+        arch: `
+            <form>
+            <field name="txt" widget="html" options="{'allowMediaDocuments': False}"/>
+            </form>`,
+    });
+
+    setSelectionInHtmlField();
+    await insertText(htmlEditor, "/media");
+    await expectElementCount(".o-we-powerbox", 1);
+    expect(queryAllTexts(".o-we-command-name")[0]).toBe("Media");
+
+    await press("Enter");
+    await expectElementCount(".o_select_media_dialog", 1);
+    expect(queryAllTexts(".o_select_media_dialog .nav-tabs .nav-item")).toEqual([
+        "Images",
+        "Icons",
+        "Videos",
+    ]);
+});
+
 test("'Upload a file' command is not available when 'allowFile' = false", async () => {
     await mountView({
         type: "form",


### PR DESCRIPTION
- This commit introduces a new config prop `allowMediaDocuments` to add or remove `Documents` tab in media dialog.
- By default `allowMediaDocuments` is true so that media dialog contains `Documents` tab by default.

task-4900846



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
