### PR TITLE
[FIX] point_of_sale: prevent children categories from being displayed

### DIFF
--- a/addons/point_of_sale/models/pos_category.py
+++ b/addons/point_of_sale/models/pos_category.py
@@ -41,8 +41,7 @@ class PosCategory(models.Model):
         limited_categories = data['pos.config'][0]['limit_categories']
         if limited_categories:
             available_category_ids = data['pos.config'][0]['iface_available_categ_ids']
-            category_ids = self.env['pos.category'].browse(available_category_ids)._get_descendants().ids
-            domain += [('id', 'in', category_ids)]
+            domain += [('id', 'in', available_category_ids)]
         return domain
 
     @api.model


### PR DESCRIPTION
## Short functional explanation of the error
When a category is the child of another category, it is always displayed, despite specifying in the settings that we don't want to display the child.

## Reproduction Steps
1. Go to settings. In "Product & PoS categories", check "Restrict categories", click on PoS Product Categories and create 2 new categories: a
 parent category and a child
category.
2. Close the settings and go to Products and create 2 different products: one to which you'll assign the parent category and one to which you'll assign the child category.
3. Go back to settings. In "Product & PoS categories", under "Restrict categories", only select the parent category.
4. Go to Point of Sales and click on the parent category.

### Expected behavior
Only the parent categories and the parent product should show.

### Unexpected behavior
The child category shows, with no products inside.

## Origin of the issue
This behavior was previously expected. Therefore, there was a line in pos_category.py that would add to the available categories the children of each available category.

opw-4877405

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
