### PR TITLE
[FIX] account: prevent error on reloading fiscal localization

### DIFF
--- a/addons/account/models/chart_template.py
+++ b/addons/account/models/chart_template.py
@@ -188,7 +188,7 @@ class AccountChartTemplate(models.AbstractModel):
         if module:
             module.button_immediate_install()
             self.env.transaction.reset()  # clear the transaction with an old registry
-
+            self = self.env()['account.chart.template']  # noqa: PLW0642 create a new env with the new registry
         # To be able to use code translation we load everything in 'en_US'
         # The demo data is still loaded "normally" since code translations cannot be used for them reliably.
         # (Since we rely on the "@template functions" to determine the module to take the code translations from.)


### PR DESCRIPTION
Currently, an error occurs when a user attempts to reload the fiscal localization after uninstalling the `l10n_syscohada` module.

**Steps to Reproduce:**
- Install l10n_cf module(with demo).
- Switch the company to `CF Company`.
- Navigate to Invoicing settings
- Login in different device with admin rights
- In other device, uninstall l10n_syscohada module.
- Now switch back to main device  and do not reload the tab.
- Click on Reload button under Fiscal Localization.

**Error:**
`TypeError: super(type, obj): obj must be an instance or subtype of type`

**Root Cause:**
since https://github.com/odoo/odoo/pull/186635/commits/58fb2db14ce3b7ddd70ffd617d2152c836151455, the line `self = self.env()['account.chart.template']` was removed from [1] when clicking the reload button, system tries create **data** at [2] but fails because the registry has been reset.

[1]- https://github.com/odoo/odoo/blob/1dfa4cc9d259b4918424a07394938e24da8c643d/addons/account/models/chart_template.py#L183-L184

[2]- https://github.com/odoo/odoo/blob/c363014fe77d2ea706dabf8af232745d4e723267/addons/account/models/chart_template.py#L222

**Solution:**
This commit prevents the error by providing new `env` with new `registry` to handle
loading during the reload process.


Sentry-**6272559266, 6750055374**

