### PR TITLE
[FIX] website: prevent crash when remove slide twice

### DIFF
--- a/addons/website/static/src/builder/plugins/carousel_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/carousel_option_plugin.js
@@ -41,8 +41,13 @@ export class CarouselOptionPlugin extends Plugin {
                 ".s_carousel .carousel-item, .s_quotes_carousel .carousel-item, .s_carousel_intro .carousel-item, .s_carousel_cards .carousel-item",
             props: {
                 addSlide: (editingElement) => this.addSlide(editingElement.closest(".carousel")),
-                removeSlide: (editingElement) =>
-                    this.removeSlide(editingElement.closest(".carousel")),
+                removeSlide: async (editingElement) => {
+                    // Check if the slide is still in the DOM
+                    // TODO: find a more general way to handle target element already removed by an option
+                    if (editingElement.parentElement) {
+                        await this.removeSlide(editingElement.closest(".carousel"));
+                    }
+                },
                 applyAction: this.dependencies.builderActions.applyAction,
             },
         },

--- a/addons/website/static/tests/builder/website_builder/carousel_item.test.js
+++ b/addons/website/static/tests/builder/website_builder/carousel_item.test.js
@@ -30,3 +30,25 @@ test("Reordering a carousel item should update the container title", async () =>
     expectOptionContainerToInclude(firstItemEl);
     expect("[data-container-title='Slide (3/3)']").toHaveCount(1);
 });
+
+test("Remove slide", async () => {
+    await setupWebsiteBuilderWithSnippet("s_carousel");
+
+    expect(":iframe .carousel-item").toHaveCount(3);
+    await contains(":iframe .carousel-item").click();
+
+    const removeSlideButton = await waitFor("button[title='Remove Slide']");
+    removeSlideButton.click();
+    removeSlideButton.click();
+    await waitFor("[data-container-title='Slide (2/2)']", {
+        message:
+            "Clicking on Remove slide twice without waiting should not crash " +
+            "and remove only one slide. Then it should focus on the previous slide.",
+    });
+
+    expect(":iframe .carousel-item").toHaveCount(2);
+    expect(":iframe .carousel-item.active").toHaveCount(1);
+
+    expect(":iframe .carousel-indicators > *").toHaveCount(2);
+    expect(":iframe .carousel-indicators > .active").toHaveCount(1);
+});


### PR DESCRIPTION
__Current behavior before commit:__
When pressing on Remove slide button twice rapidly the page crashes because it tries to access the closest `.carousel` element on a slide that has already been removed from the DOM.

__Description of the fix:__
- Prevent calling `removeSlide` if the slide has already been removed from the DOM.
- Add a test to check the remove slide behaviour.
