### PR TITLE
[FIX] sale_stock: prevent error on validating stock picking

### DIFF
--- a/addons/sale_stock/models/stock.py
+++ b/addons/sale_stock/models/stock.py
@@ -64,7 +64,7 @@ class StockMove(models.Model):
                 # No unit price if the product is invoiced on the ordered qty.
                 so_line_vals['price_unit'] = 0
             # New lines should be added at the bottom of the SO (higher sequence number)
-            if not so_line:
+            if not so_line and sale_order.order_line:
                 so_line_vals['sequence'] = max(sale_order.order_line.mapped('sequence')) + len(sale_order_lines_vals) + 1
             sale_order_lines_vals.append(so_line_vals)
 


### PR DESCRIPTION
The error occurs when a SO line is deleted, and a return is processed for the associated delivery using a different product, after which the return is validated.

Steps to reproduce:
---
- Install the `sale_management` and `stock` modules
- Create & Confirm an SO for one product
- Now cancel that SO and remove that product
- In Stock > Deliveries > Open that delivery(Cancelled)
- Click on the `Return` button and add any product > Return > Validate

Traceback:
---
`ValueError: max() iterable argument is empty`

At [1], a ValueError is raised because there are no SO lines, resulting in an empty sequence is being passed to the max() function.

[1]- https://github.com/odoo/odoo/blob/deab3cafc8b3cd79dcc52fddd9511a38a7e77afa/addons/sale_stock/models/stock.py#L68

sentry-6709665025

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
