### PR TITLE
[IMP] web: remove escape function

### DIFF
--- a/addons/mail/static/src/core/common/notification_message.js
+++ b/addons/mail/static/src/core/common/notification_message.js
@@ -1,8 +1,7 @@
 import { useForwardRefsToParent } from "@mail/utils/common/hooks";
-import { Component, useRef } from "@odoo/owl";
+import { Component, htmlEscape, useRef } from "@odoo/owl";
 import { _t } from "@web/core/l10n/translation";
 import { useService } from "@web/core/utils/hooks";
-import { escape } from "@web/core/utils/strings";
 
 export class NotificationMessage extends Component {
     static template = "mail.NotificationMessage";
@@ -12,7 +11,7 @@ export class NotificationMessage extends Component {
         super.setup();
         this.root = useRef("root");
         useForwardRefsToParent("messageRefs", (props) => props.message.id, this.root);
-        this.escape = escape;
+        this.htmlEscape = htmlEscape;
         this.store = useService("mail.store");
     }
 

--- a/addons/mail/static/src/core/common/notification_message.xml
+++ b/addons/mail/static/src/core/common/notification_message.xml
@@ -11,7 +11,7 @@
                 <span class="text-muted" t-out="message.inlineBody"/>
             </t>
             <t t-else="">
-                <span class="o-mail-NotificationMessage-author d-inline text-muted" t-if="message.authorName and !message.richBody.includes(escape(message.authorName))" t-esc="message.authorName"/> <span class="text-muted" t-out="message.richBody"/>
+                <span class="o-mail-NotificationMessage-author d-inline text-muted" t-if="message.authorName and !message.richBody.includes(htmlEscape(message.authorName))" t-esc="message.authorName"/> <span class="text-muted" t-out="message.richBody"/>
             </t>
             <span class="o-mail-Message-date o-xsmaller ms-1" t-esc="message.dateSimpleWithDay"/>
         </div>

--- a/addons/web/static/src/core/utils/strings.js
+++ b/addons/web/static/src/core/utils/strings.js
@@ -3,32 +3,6 @@ import { isObject } from "./objects";
 export const nbsp = "\u00a0";
 
 /**
- * Escapes a string for HTML.
- *
- * @param {string | number} [str] the string to escape
- * @returns {string} an escaped string
- */
-export function escape(str) {
-    if (str === undefined) {
-        return "";
-    }
-    if (typeof str === "number") {
-        return String(str);
-    }
-    [
-        ["&", "&amp;"],
-        ["<", "&lt;"],
-        [">", "&gt;"],
-        ["'", "&#x27;"],
-        ['"', "&quot;"],
-        ["`", "&#x60;"],
-    ].forEach((pairs) => {
-        str = String(str).replaceAll(pairs[0], pairs[1]);
-    });
-    return str;
-}
-
-/**
  * Escapes a string to use as a RegExp.
  * @url https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions#Escaping
  *

--- a/addons/web/static/tests/core/utils/strings.test.js
+++ b/addons/web/static/tests/core/utils/strings.test.js
@@ -3,7 +3,6 @@ import { patchTranslations } from "@web/../tests/web_test_helpers";
 
 import {
     capitalize,
-    escape,
     escapeRegExp,
     intersperse,
     isEmail,
@@ -20,19 +19,6 @@ function _t() {
 }
 
 describe.current.tags("headless");
-
-test("escape", () => {
-    expect(escape("<a>this is a link</a>")).toBe("&lt;a&gt;this is a link&lt;/a&gt;");
-    expect(escape(`<a href="https://www.odoo.com">odoo<a>`)).toBe(
-        `&lt;a href=&quot;https://www.odoo.com&quot;&gt;odoo&lt;a&gt;`
-    );
-    expect(escape(`<a href='https://www.odoo.com'>odoo<a>`)).toBe(
-        `&lt;a href=&#x27;https://www.odoo.com&#x27;&gt;odoo&lt;a&gt;`
-    );
-    expect(escape("<a href='https://www.odoo.com'>Odoo`s website<a>")).toBe(
-        `&lt;a href=&#x27;https://www.odoo.com&#x27;&gt;Odoo&#x60;s website&lt;a&gt;`
-    );
-});
 
 test("escapeRegExp", () => {
     expect(escapeRegExp("")).toBe("");

--- a/addons/website/static/src/builder/plugins/form/utils.js
+++ b/addons/website/static/src/builder/plugins/form/utils.js
@@ -1,5 +1,4 @@
 import { _t } from "@web/core/l10n/translation";
-import { escape } from "@web/core/utils/strings";
 import { renderToElement } from "@web/core/utils/render";
 import { generateHTMLId } from "@html_builder/utils/utils_css";
 import { isSmallInteger } from "@html_builder/utils/utils";
@@ -108,7 +107,7 @@ export function renderField(field, resetId = false) {
             });
         }
     }
-    const params = { field: { ...field }, defaultName: escape(field.string || _t("Field")) };
+    const params = { field: { ...field }, defaultName: field.string || _t("Field") };
     if (["url", "email", "tel"].includes(field.type)) {
         params.field.inputType = field.type;
     }


### PR DESCRIPTION
All occurrences have been removed.

markup template automatically escapes its params, so there should be no need to manually escape strings before passing them to a template.

If escaping manually is necessary, `htmlEscape` should be used instead, as it wraps its result into markup which prevents double escaping when used in templates and other HTML utility functions.