### PR TITLE
[FIX] mail: traceback on invite people from sidebar actions

### DIFF
--- a/addons/mail/static/src/discuss/core/common/channel_invitation.js
+++ b/addons/mail/static/src/discuss/core/common/channel_invitation.js
@@ -54,7 +54,7 @@ export class ChannelInvitation extends Component {
         useEffect(
             () => {
                 if (this.props.autofocus) {
-                    this.inputRef.el.focus();
+                    this.inputRef.el?.focus();
                 }
             },
             () => [this.props.autofocus]

--- a/addons/mail/static/tests/tours/discuss_sidebar_in_public_page_tour.js
+++ b/addons/mail/static/tests/tours/discuss_sidebar_in_public_page_tour.js
@@ -36,5 +36,14 @@ registry.category("web_tour.tours").add("sidebar_in_public_page_tour", {
         {
             trigger: ".o-mail-DiscussSidebarChannel:contains(Channel 2).o-active",
         },
+        {
+            content: "Open channel actions",
+            trigger: ".o-mail-DiscussSidebarChannel:contains(Channel 2).o-active",
+            run: "hover && click [title='Channel Actions']",
+        },
+        {
+            trigger: ".o-dropdown-item:contains('Invite People')",
+            run: "click",
+        },
     ],
 });


### PR DESCRIPTION
Before this commit, when opening the invite people action from the sidebar in discuss public page as a guest you would get a traceback.

This happens because the component has a useEffect that focuses the search input, but that element is not present as a non partner.
This commit fixes the issue by adding a guard in the useEffect.

task-4904119