### PR TITLE
[FIX] pos_restaurant: prevent crash on table release

### DIFF
--- a/addons/pos_restaurant/static/src/app/product_screen/order_summary/order_summary.js
+++ b/addons/pos_restaurant/static/src/app/product_screen/order_summary/order_summary.js
@@ -22,8 +22,9 @@ patch(OrderSummary.prototype, {
     },
     async unbookTable() {
         const order = this.pos.get_order();
-        await this.pos.deleteOrders([order]);
         this.pos.showScreen(this.pos.firstScreen);
+        order.state = "cancel";
+        await this.pos.deleteOrders([order]);
     },
     showUnbookButton() {
         if (this.pos.selectedTable) {


### PR DESCRIPTION
### Steps to reproduce:
- Open the Restaurant POS.
- Select a table and add a product.
- Click order button.
- Reopen the same table and remove all order lines.
- Click "Release Table".

### Issue:
- A blank screen appears and an error is shown in the browser console.

### Reason:
- This happens because the order is deleted before switching screens, so the system tries to access order that no longer exists.

### Fix:
- The order is now deleted after switching back to the main screen.

Related PR: https://github.com/odoo/enterprise/pull/89715
Task: 4899160