### PR TITLE
[FIX] quality_control: switch to MTS when move line to failure_location

### DIFF
--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -2368,3 +2368,8 @@ Please change the quantity done or the rounding precision of your unit of measur
                 self.env['stock.warehouse.orderpoint']._fields['qty_to_order'],
                 self.env['stock.warehouse.orderpoint'].sudo().search(orderpoint_domain, order='id')
             )
+
+    def _break_mto_link(self, parent_move):
+        self.move_orig_ids = [Command.unlink(parent_move.id)]
+        self.procure_method = 'make_to_stock'
+        self._recompute_state()


### PR DESCRIPTION
Steps to reproduce the bug:
- Unarchive the MTO route
- Create a product P1:
    - Type: Storable
    - Route: MTO + Buy
    - Supplier: Vendor A
- Create a quality point:
    - Product: P1
    - Control per: Quantity
    - Failure location: WH/input/order Processing

- Create a sales order for 1 unit of P1
- Confirm the SO → A purchase order is created for Vendor A with 1 unit of P1
- Confirm the PO
- Go to the related PO picking
- Fail the quality check

Problem:
picking related to the SO remains in the "Waiting Availability" state and the stock move is not switched to the Make to stock procure method

opw-4874199
