### PR TITLE
[FIX] uom: Validate uom references when computing quants

### DIFF
--- a/addons/stock/tests/test_move2.py
+++ b/addons/stock/tests/test_move2.py
@@ -2754,7 +2754,7 @@ class TestStockUOM(TestStockCommon):
         T_TEST = self.env['product.product'].create({
             'name': 'T_TEST',
             'is_storable': True,
-            'uom_ids': [(4, T_LBS.id)],
+            'uom_id': T_LBS.id,
             'tracking': 'lot',
         })
 

--- a/addons/stock/tests/test_proc_rule.py
+++ b/addons/stock/tests/test_proc_rule.py
@@ -383,10 +383,7 @@ class TestProcRule(TransactionCase):
         ])
         self.assertTrue(rr)
         orderpoint.write({
-            'replenishment_uom_id': self.env['uom.uom'].create({
-                'name': 'Test UoM',
-                'relative_factor': 1,
-            })
+            'replenishment_uom_id': self.env.ref('uom.product_uom_unit').id,
         })
         self.assertEqual(orderpoint.qty_to_order, 15.0)  # 15.0 < 14.5 + 15 <= 30.0
         orderpoint.write({

--- a/addons/uom/models/uom_uom.py
+++ b/addons/uom/models/uom_uom.py
@@ -81,6 +81,14 @@ class UomUom(models.Model):
             return qty
         self.ensure_one()
 
+        if self != to_unit and not self._has_common_reference(to_unit):
+            if raise_if_failure:
+                raise UserError(_(
+                    'The unit of measure %(unit)s cannot be converted to %(to_unit)s. Please correct one of these units to ensure compatibility. The units must share a common reference unit.',
+                    unit=self.name, to_unit=to_unit.name))
+            else:
+                return qty
+
         if self == to_unit:
             amount = qty
         else:


### PR DESCRIPTION
With the removal of uom categories, the uom factor can only be valid if the uoms have a common reference somewhere but the [validation](https://github.com/odoo/odoo/blob/794c0cfd6fee2e674d244951bc0576f639eed392/addons/uom/models/uom_uom.py#L225-L227) was not replaced.
This fix adds back the validation when a quantity needs to be computed in a different uom.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
