### PR TITLE
[FIX] website: fix builder buttons in `ThemeAdvancedOption`

### DIFF
--- a/addons/website/static/src/builder/plugins/theme/theme_advanced_option.js
+++ b/addons/website/static/src/builder/plugins/theme/theme_advanced_option.js
@@ -1,23 +1,8 @@
 import { BaseOptionComponent } from "@html_builder/core/utils";
-import { EditHeadBodyDialog } from "@website/components/edit_head_body_dialog/edit_head_body_dialog";
-import { useService } from "@web/core/utils/hooks";
 
 export class ThemeAdvancedOption extends BaseOptionComponent {
     static template = "website.ThemeAdvancedOption";
     static props = {
         grays: Object,
-        configureGMapsAPI: Function,
     };
-
-    setup() {
-        super.setup();
-        this.dialog = useService("dialog");
-    }
-
-    openCustomCodeDialog() {
-        this.dialog.add(EditHeadBodyDialog);
-    }
-    configureApiKey() {
-        this.props.configureGMapsAPI("", true);
-    }
 }

--- a/addons/website/static/src/builder/plugins/theme/theme_advanced_option.xml
+++ b/addons/website/static/src/builder/plugins/theme/theme_advanced_option.xml
@@ -11,10 +11,10 @@
             />
         </BuilderRow>
         <BuilderRow label.translate="Code Injection" tooltip.translate="Enter code that will be added into every page of your site">
-            <button role="button" class="btn" t-on-click="() => this.openCustomCodeDialog()">&lt;head&gt; and &lt;/body&gt;</button>
+            <BuilderButton title.translate="&lt;Head&gt; and &lt;body&gt;" action="'editCustomCode'">&lt;head&gt; and &lt;/body&gt;</BuilderButton>
         </BuilderRow>
         <BuilderRow label.translate="Google Map">
-            <button role="button" class="btn" t-on-click="() => this.configureApiKey()">Custom Key</button>
+            <BuilderButton title.translate="Custom Key" action="'configureApiKey'">Custom Key</BuilderButton>
         </BuilderRow>
         <BuilderRow label.translate="Status Colors">
             <BuilderColorPicker title.translate="Success"

--- a/addons/website/static/src/builder/plugins/theme/theme_tab_plugin.js
+++ b/addons/website/static/src/builder/plugins/theme/theme_tab_plugin.js
@@ -16,6 +16,7 @@ import {
 import { reactive } from "@odoo/owl";
 import { BuilderAction } from "@html_builder/core/builder_action";
 import { CustomizeWebsiteVariableAction } from "../customize_website_plugin";
+import { EditHeadBodyDialog } from "@website/components/edit_head_body_dialog/edit_head_body_dialog";
 
 export const GRAY_PARAMS = {
     EXTRA_SATURATION: "gray-extra-saturation",
@@ -35,7 +36,6 @@ export const OPTION_POSITIONS = {
 
 export class ThemeTabPlugin extends Plugin {
     static id = "themeTab";
-    static dependencies = ["builderActions", "customizeWebsite", "googleMapsOption"];
     static shared = ["getGrayParams", "getGrays", "setGrays", "setGrayParams", "buildGray"];
     grayParams = {};
     grays = reactive({});
@@ -45,6 +45,8 @@ export class ThemeTabPlugin extends Plugin {
         builder_actions: {
             CustomizeGrayAction,
             ChangeColorPaletteAction,
+            EditCustomCodeAction,
+            ConfigureApiKeyAction,
         },
         theme_options: [
             withSequence(
@@ -95,7 +97,6 @@ export class ThemeTabPlugin extends Plugin {
                     OptionComponent: ThemeAdvancedOption,
                     props: {
                         grays: this.grays,
-                        configureGMapsAPI: this.dependencies.googleMapsOption.configureGMapsAPI,
                     },
                 })
             ),
@@ -284,6 +285,21 @@ export class ChangeColorPaletteAction extends CustomizeWebsiteVariableAction {
         }
         await super.apply(context);
         setBuilderCSSVariables();
+    }
+}
+
+export class EditCustomCodeAction extends BuilderAction {
+    static id = "editCustomCode";
+    apply() {
+        this.services.dialog.add(EditHeadBodyDialog);
+    }
+}
+
+export class ConfigureApiKeyAction extends BuilderAction {
+    static id = "configureApiKey";
+    static dependencies = ["googleMapsOption"];
+    apply() {
+        this.dependencies.googleMapsOption.configureGMapsAPI("", true);
     }
 }
 


### PR DESCRIPTION
Before this commit, the buttons "Code Injection" and "Google Map Custom Key" in `ThemeAdvancedOption` were defined with the tag `button` instead of `BuilderButton` and were acting via `t-on-click` instead of using a `BuilderAction`.

This commit converts the two elements to `BuilderButton` using `BuilderAction`. In addition, unused references are removed from `ThemeTabPlugin`.

**How to reproduce**
1. In the website builder
2. In the "Theme" tab
3. In the "Advanced" section
4. Problem: the two objects on the rows "Code Injection" and "Custom Key" do not look like buttons.

task-4367641
