### PR TITLE
[FIX] mail: add more information when failling to validate template

### DIFF
--- a/addons/mail/models/mail_template.py
+++ b/addons/mail/models/mail_template.py
@@ -199,6 +199,7 @@ class MailTemplate(models.Model):
                 try:
                     template._render_field(fname, record.ids, options=render_options)
                 except Exception as e:
+                    _logger.exception("Error while checking if template can be rendered for field %s", fname)
                     raise ValidationError(
                         _("Oops! We couldn't save your template due to an issue with this value: %(template_txt)s. Correct it and try again.",
                         template_txt=template[fname])

--- a/addons/mail/tests/test_mail_template.py
+++ b/addons/mail/tests/test_mail_template.py
@@ -34,6 +34,7 @@ class TestMailTemplate(MailCommon):
         })
 
     @users('admin')
+    @mute_logger('odoo.addons.mail.models.mail_template')
     @mute_logger('odoo.addons.mail.models.mail_render_mixin')
     def test_invalid_template_on_save(self):
         mail_template = self.env['mail.template'].create({


### PR DESCRIPTION
The installation of auth_signup can fail when creating mail templates. This issue is hard to reproduce and only occurs when a worker enters some broken state.

Adding some log to help to solve the issue.
