### PR TITLE
[FIX] sale_project: unset analytic dist in SOL on project delete

### DIFF
--- a/addons/sale_project/models/project_project.py
+++ b/addons/sale_project/models/project_project.py
@@ -176,6 +176,13 @@ class ProjectProject(models.Model):
             self._ensure_sale_order_linked([sol_id])
         return project
 
+    def unlink(self):
+        sale_order = self.reinvoiced_sale_order_id | self.sale_order_id
+        res = super().unlink()
+        # Updated the analytic_distribution of the order line
+        sale_order.order_line._compute_analytic_distribution()
+        return res
+
     def action_view_sols(self):
         self.ensure_one()
         all_sale_order_lines = self._fetch_sale_order_items({'project.task': [('is_closed', '=', False)]})

--- a/addons/sale_project/models/sale_order_line.py
+++ b/addons/sale_project/models/sale_order_line.py
@@ -139,6 +139,8 @@ class SaleOrderLine(models.Model):
         for line in self:
             project = line.product_id.project_id or line.order_id.project_id
             if line.display_type or not line.product_id or not project:
+                # fallback when linked project is deleted.
+                line.analytic_distribution = False
                 continue
 
             if line.analytic_distribution:

--- a/addons/sale_project/tests/test_sale_project.py
+++ b/addons/sale_project/tests/test_sale_project.py
@@ -1320,3 +1320,19 @@ class TestSaleProject(HttpCase, TestSaleProjectCommon):
         so.action_confirm()
         self.assertFalse(self.product_order_service2.project_id.task_ids)
         self.assertFalse(sol.task_id)
+
+    def test_so_project_unlink_changes_analytic_distribution(self):
+        sale_order = self.env['sale.order'].create({
+            'partner_id': self.partner.id,
+            'order_line': [
+                Command.create({
+                    'product_id': self.product_order_service3.id,
+                    'product_uom_qty': 1,
+                }),
+            ],
+        })
+
+        sale_order.action_confirm()
+        self.assertTrue(sale_order.order_line.analytic_distribution)
+        sale_order.project_id.unlink()
+        self.assertFalse(sale_order.order_line.analytic_distribution)


### PR DESCRIPTION
Issue:
------
  When a project linked to a sale order is deleted, the analytic distribution in the corresponding sale order line is not removed.
    This causes a missing record error when creating an invoice.

Cause:
--------
   The analytic distribution on the sale order line still references the deleted project, leading to an error during invoice creation.

Fix:
-----
   This commit ensures that _compute_analytic_distribution is triggered when the linked project is deleted, so the analytic
   distribution is reset to False.

Steps to reproduce:
   - Install the sale_project module
   - Enable analytic accounting
   - Create a service-type product
   - Create and confirm a sale order
   - Delete the linked project
   - Create an invoice — an error will occur if the fix is not applied
