### PR TITLE
[IMP/REM] Remove some indexes of base

### DIFF
--- a/addons/account_test/models/accounting_assert_test.py
+++ b/addons/account_test/models/accounting_assert_test.py
@@ -17,8 +17,8 @@ class AccountingAssertTest(models.Model):
     _description = 'Accounting Assert Test'
     _order = "sequence"
 
-    name = fields.Char(string='Test Name', required=True, index=True, translate=True)
-    desc = fields.Text(string='Test Description', index=True, translate=True)
+    name = fields.Char(string='Test Name', required=True, translate=True)
+    desc = fields.Text(string='Test Description', translate=True)
     code_exec = fields.Text(string='Python code', required=True, default=CODE_EXEC_DEFAULT)
     active = fields.Boolean(default=True)
     sequence = fields.Integer(default=10)

--- a/odoo/addons/base/models/ir_model.py
+++ b/odoo/addons/base/models/ir_model.py
@@ -1792,7 +1792,7 @@ class IrModelConstraint(models.Model):
     model = fields.Many2one('ir.model', required=True, ondelete="cascade", index=True, readonly=True)
     module = fields.Many2one('ir.module.module', required=True, index=True, ondelete='cascade', readonly=True)
     type = fields.Char(
-        string='Constraint Type', required=True, size=1, index=True, readonly=True,
+        string='Constraint Type', required=True, size=1, readonly=True,
         help="Type of the constraint: `f` for a foreign key, `u` for other constraints.")
 
     _module_name_uniq = models.Constraint('UNIQUE (name, module)',

--- a/odoo/addons/base/models/ir_model.py
+++ b/odoo/addons/base/models/ir_model.py
@@ -508,7 +508,6 @@ class IrModelFields(models.Model):
     _allow_sudo_commands = False
 
     name = fields.Char(string='Field Name', default='x_', required=True, index=True)
-    complete_name = fields.Char(index=True)
     model = fields.Char(string='Model Name', required=True, index=True,
                         help="The technical name of the model this field belongs to")
     relation = fields.Char(string='Related Model',

--- a/odoo/addons/base/models/ir_module.py
+++ b/odoo/addons/base/models/ir_module.py
@@ -75,7 +75,7 @@ class IrModuleCategory(models.Model):
     _order = 'sequence, name, id'
     _allow_sudo_commands = False
 
-    name = fields.Char(string='Name', required=True, translate=True, index=True)
+    name = fields.Char(string='Name', required=True, translate=True)
     parent_id = fields.Many2one('ir.module.category', string='Parent Application', index=True)
     child_ids = fields.One2many('ir.module.category', 'parent_id', string='Child Applications')
     module_ids = fields.One2many('ir.module.module', 'category_id', string='Modules')


### PR DESCRIPTION
#### [IMP] core: warning if index attribute is ignored
    
Only trigram index is possible on translated fields.
Add a warning if the field is translated and try to be indexed with a btree from the field definition.
Then remove ignored index attribute of accounting.assert.test.name/description.

#### [REM] base: remove complete_name from ir.model.fields

This field is unused and always empty. Also it is indexed for no reason.

#### [IMP] base: remove index of ir.model.constraint.type

This index is unlikely to be used, only 3 values are possible and the table is small in the worst case.

https://github.com/odoo/upgrade/pull/7966
https://github.com/odoo/enterprise/pull/88911