### PR TITLE
[FIX] website: ignore empty social media record

### DIFF
--- a/addons/website/static/src/builder/plugins/options/social_media_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/social_media_option_plugin.js
@@ -185,7 +185,7 @@ class SocialMediaOptionPlugin extends Plugin {
         );
         for (const name of socialMediaInfo.keys()) {
             const key = `social_${name}`;
-            if (key in res[0]) {
+            if (key in res[0] && res[0][key]) {
                 this.recordedSocialMedia.set(name, res[0][key]);
             }
         }


### PR DESCRIPTION
Steps to reproduce:
- On a database without demo data (and no social links set)
- Open website builder in debug
- Click on a social media snippet (by default there is one in footer)
- Traceback: Validation of props failed because of a `false` value for input text

The implementation for the options of snippet `s_social_media` (made in the website builder refactor) did not correctly handle the case where there is no record and the server returns the `false` value instead of a string.

Website refactor: 9fe45e2b7ddbbfd0445ffe25a859e67a316d02b2
task-4367641
