### PR TITLE
[FIX] html_editor, project: prevent error when saving after applying history

### DIFF
--- a/addons/html_editor/static/src/fields/html_field.js
+++ b/addons/html_editor/static/src/fields/html_field.js
@@ -26,6 +26,8 @@ import { HtmlViewer } from "./html_viewer";
 import { withSequence } from "@html_editor/utils/resource";
 import { fixInvalidHTML, instanceofMarkup } from "@html_editor/utils/sanitize";
 
+const HTML_FIELD_METADATA_ATTRIBUTES = ["data-last-history-steps"];
+
 /**
  * Check whether the current value contains nodes that would break
  * on insertion inside an existing body.
@@ -351,3 +353,23 @@ export const htmlField = {
 };
 
 registry.category("fields").add("html", htmlField, { force: true });
+
+export function getHtmlFieldMetadata(content) {
+    const metadata = {};
+    for (const attribute of HTML_FIELD_METADATA_ATTRIBUTES) {
+        const regex = new RegExp(`${attribute}\\s*=\\s*"([^"]+)"`);
+        metadata[attribute] = content.match(regex)?.[1];
+    }
+    return metadata;
+}
+export function setHtmlFieldMetadata(content, metadata) {
+    const htmlContent = content.toString() || "<div></div>";
+    const parser = new DOMParser();
+    const contentDocument = parser.parseFromString(htmlContent, "text/html");
+    for (const [attribute, value] of Object.entries(metadata)) {
+        if (value) {
+            contentDocument.body.firstChild.setAttribute(attribute, value);
+        }
+    }
+    return contentDocument.body.innerHTML;
+}

--- a/addons/project/static/src/views/project_task_form/project_task_form_controller.js
+++ b/addons/project/static/src/views/project_task_form/project_task_form_controller.js
@@ -7,6 +7,7 @@ import { useService } from '@web/core/utils/hooks';
 import { markup } from '@odoo/owl';
 import { escape } from '@web/core/utils/strings';
 import { FormControllerWithHTMLExpander } from '@resource/views/form_with_html_expander/form_controller_with_html_expander';
+import { getHtmlFieldMetadata, setHtmlFieldMetadata } from "@html_editor/fields/html_field";
 
 export const subTaskDeleteConfirmationMessage = _t(
     `Deleting a task will also delete its associated sub-tasks. \
@@ -81,7 +82,8 @@ export class ProjectTaskFormController extends FormControllerWithHTMLExpander {
                         body: _t("Restoring will replace the current content with the selected version. Any unsaved changes will be lost."),
                         confirm: () => {
                             const restoredData = {};
-                            restoredData[versionedFieldName] = html;
+                            const contentMetadata = getHtmlFieldMetadata(record.data[versionedFieldName]);
+                            restoredData[versionedFieldName] = setHtmlFieldMetadata(html, contentMetadata);
                             record.update(restoredData);
                             close();
                         },

--- a/addons/project/static/tests/tours/project_task_history.js
+++ b/addons/project/static/tests/tours/project_task_history.js
@@ -27,6 +27,28 @@ function changeDescriptionContentAndSave(newContent) {
     ];
 }
 
+function insertEditorContentAndSave(newContent) {
+    return [
+        {
+            // force focus on editable so editor will create initial p (if not yet done)
+            trigger: "div.note-editable.odoo-editor-editable",
+            run: "click",
+        },
+        {
+            trigger: `div.note-editable[spellcheck='true'].odoo-editor-editable`,
+            run: async function () {
+                // Insert content as html and make the field dirty
+                const div = document.createElement("div");
+                div.appendChild(document.createTextNode(newContent));
+                this.anchor.removeChild(this.anchor.firstChild);
+                this.anchor.appendChild(div);
+                this.anchor.dispatchEvent(new Event("input", { bubbles: true }));
+            },
+        },
+        ...stepUtils.saveForm(),
+    ];
+}
+
 registry.category("web_tour.tours").add("project_task_history_tour", {
     url: "/odoo",
     steps: () => [stepUtils.showAppsMenuItem(), {
@@ -181,3 +203,48 @@ registry.category("web_tour.tours").add("project_task_history_tour", {
         trigger: 'button.o_switch_view.o_kanban.active',
     }
 ]});
+
+registry.category("web_tour.tours").add("project_task_last_history_steps_tour", {
+    url: "/odoo",
+    steps: () => [stepUtils.showAppsMenuItem(), {
+        content: "Open the project app",
+        trigger: ".o_app[data-menu-xmlid='project.menu_main_pm']",
+        run: "click",
+    },
+    {
+        content: "Open Test History Project",
+        trigger: ".o_kanban_view .o_kanban_record:contains(Test History Project)",
+        run: "click",
+    },
+    {
+        content: "Open Test History Task",
+        trigger: ".o_kanban_view .o_kanban_record:contains(Test History Task)",
+        run: "click",
+    },
+    ...insertEditorContentAndSave("0"),
+    {
+        content: "Open History Dialog",
+        trigger: ".o_cp_action_menus i.fa-cog",
+        run: "click",
+    }, {
+        trigger: ".dropdown-menu",
+    }, {
+        content: "Open History Dialog",
+        trigger: ".o_menu_item i.fa-history",
+        run: "click",
+    },
+    {
+        content: "Open History Dialog",
+        trigger: ".revision-list a:first-child",
+        run: "click",
+    },
+    {
+        trigger: 'button:contains("/^Restore history$/")',
+        run: "click",
+    }, {
+        trigger: '.modal button.btn-primary:contains(/^Restore$/)',
+        run: "click",
+    },
+    ...insertEditorContentAndSave("2")
+    ],
+});

--- a/addons/project/tests/test_project_ui.py
+++ b/addons/project/tests/test_project_ui.py
@@ -32,3 +32,19 @@ class TestUi(odoo.tests.HttpCase):
         })
 
         self.start_tour('/odoo', 'project_task_history_tour', login='admin')
+
+    def test_project_task_last_history_steps(self):
+        """This tour will check that the history works properly."""
+        stage = self.env['project.task.type'].create({'name': 'To Do'})
+        project = self.env['project.project'].create([{
+            'name': 'Test History Project',
+            'type_ids': stage.ids,
+        }])
+
+        self.env['project.task'].create({
+            'name': 'Test History Task',
+            'stage_id': stage.id,
+            'project_id': project.id,
+        })
+
+        self.start_tour('/odoo', 'project_task_last_history_steps_tour', login='admin')


### PR DESCRIPTION
Problem:
When applying a specific version from history in `task.description`, then updating and saving it, an error appears stating the content was saved from a different history model.

Cause:
When inserting versioned content, the required
`data-last-history-steps` attribute is not included.

Solution:
Ensure the latest `data-last-history-steps` is added when restoring a version.

Steps to reproduce:
- Open Project > any task
- Change the description
- Save
- Open version history and apply any version
- Update the description
- Save
- Error appears

opw-4829553

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
