### PR TITLE
[REM] web_tour: remove additionnal animationFrame

### DIFF
--- a/addons/web_tour/static/src/tour_service/tour_automatic.js
+++ b/addons/web_tour/static/src/tour_service/tour_automatic.js
@@ -49,9 +49,6 @@ export class TourAutomatic {
                         } else {
                             console.log(step.describeMe);
                         }
-                        // This delay is important for making the current set of tour tests pass.
-                        // IMPROVEMENT: Find a way to remove this delay.
-                        await new Promise((resolve) => requestAnimationFrame(resolve));
                     },
                 },
                 {


### PR DESCRIPTION
In tour_automatic, there is an await requestAnimationFrame() which
can finally be removed with the new tour engine (macro.js) which is
based on animationFrames rather than a MutationObserver.