### PR TITLE
[IMP] *: get rid of useless calls to sprintf

### DIFF
--- a/addons/hr_expense/static/src/components/qrcode_action.js
+++ b/addons/hr_expense/static/src/components/qrcode_action.js
@@ -1,7 +1,7 @@
 import { Component } from "@odoo/owl";
 
 import { registry } from "@web/core/registry";
-import { sprintf } from "@web/core/utils/strings";
+import { url } from "@web/core/utils/urls";
 
 const actionRegistry = registry.category("actions");
 
@@ -14,9 +14,14 @@ class QRModalComponent extends Component {
     static template = "hr_expense.QRModalComponent";
 
     setup() {
-        this.url = sprintf(
-            "/report/barcode/?barcode_type=QR&value=%s&width=256&height=256&humanreadable=1&quiet=0",
-            this.props.action.params.url);
+        this.url = url("/report/barcode", {
+            barcode_type: "QR",
+            value: this.props.action.params.url,
+            width: 256,
+            height: 256,
+            humanreadable: 1,
+            quiet: 0,
+        });
     }
 }
 

--- a/addons/html_editor/static/src/main/media/media_dialog/upload_progress_toast/upload_service.js
+++ b/addons/html_editor/static/src/main/media/media_dialog/upload_progress_toast/upload_service.js
@@ -5,7 +5,6 @@ import { _t } from "@web/core/l10n/translation";
 import { checkFileSize } from "@web/core/utils/files";
 import { humanNumber } from "@web/core/utils/numbers";
 import { getDataURLFromFile } from "@web/core/utils/urls";
-import { sprintf } from "@web/core/utils/strings";
 import { reactive } from "@odoo/owl";
 
 export const AUTOCLOSE_DELAY = 3000;
@@ -102,7 +101,7 @@ export const uploadService = {
                     } catch {
                         deleteFile(file.id);
                         env.services.notification.add(
-                            sprintf(_t('Could not load the file "%s".'), sortedFile.name),
+                            _t('Could not load the file "%s".', sortedFile.name),
                             { type: "danger" }
                         );
                         continue;

--- a/addons/im_livechat/static/src/core/web/livechat_channel_model_patch.js
+++ b/addons/im_livechat/static/src/core/web/livechat_channel_model_patch.js
@@ -4,7 +4,6 @@ import { useSequential } from "@mail/utils/common/hooks";
 
 import { _t } from "@web/core/l10n/translation";
 import { patch } from "@web/core/utils/patch";
-import { sprintf } from "@web/core/utils/strings";
 
 const sequential = useSequential();
 
@@ -21,7 +20,7 @@ const livechatChannelPatch = {
         );
     },
     get joinTitle() {
-        return sprintf(_t("Join %s"), this.name);
+        return _t("Join %s", this.name);
     },
     async leave({ notify = true } = {}) {
         this.are_you_inside = false;
@@ -35,7 +34,7 @@ const livechatChannelPatch = {
         );
     },
     get leaveTitle() {
-        return sprintf(_t("Leave %s"), this.name);
+        return _t("Leave %s", this.name);
     },
 };
 patch(LivechatChannel.prototype, livechatChannelPatch);

--- a/addons/mail/static/src/core/common/settings_model.js
+++ b/addons/mail/static/src/core/common/settings_model.js
@@ -1,5 +1,4 @@
 import { _t } from "@web/core/l10n/translation";
-import { sprintf } from "@web/core/utils/strings";
 import { browser } from "@web/core/browser/browser";
 import { fields, Record } from "./record";
 import { debounce } from "@web/core/utils/timing";
@@ -147,7 +146,7 @@ export class Settings extends Record {
     getMuteUntilText(dt) {
         if (dt) {
             return dt.year <= luxon.DateTime.now().year + 2
-                ? sprintf(_t(`Until %s`), dt.toLocaleString(luxon.DateTime.DATETIME_MED))
+                ? _t(`Until %s`, dt.toLocaleString(luxon.DateTime.DATETIME_MED))
                 : _t("Until I turn it back on");
         }
         return undefined;

--- a/addons/mail/static/src/discuss/core/public/welcome_page.js
+++ b/addons/mail/static/src/discuss/core/public/welcome_page.js
@@ -2,7 +2,6 @@ import { Component, useRef, useState, onMounted } from "@odoo/owl";
 
 import { browser } from "@web/core/browser/browser";
 import { useService } from "@web/core/utils/hooks";
-import { sprintf } from "@web/core/utils/strings";
 import { _t } from "@web/core/l10n/translation";
 
 export class WelcomePage extends Component {
@@ -126,6 +125,6 @@ export class WelcomePage extends Component {
         }
     }
     getLoggedInAsText() {
-        return sprintf(_t("Logged in as %s"), this.store.self.name);
+        return _t("Logged in as %s", this.store.self.name);
     }
 }

--- a/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.js
@@ -17,7 +17,6 @@ import { Component, onMounted } from "@odoo/owl";
 import { Numpad, enhancedButtons } from "@point_of_sale/app/components/numpad/numpad";
 import { ask, makeAwaitable } from "@point_of_sale/app/utils/make_awaitable_dialog";
 import { handleRPCError } from "@point_of_sale/app/utils/error_handlers";
-import { sprintf } from "@web/core/utils/strings";
 import { serializeDateTime } from "@web/core/l10n/dates";
 import { useRouterParamsChecker } from "@point_of_sale/app/hooks/pos_router_hook";
 
@@ -686,14 +685,16 @@ export class PaymentScreen extends Component {
 
             this.dialog.add(AlertDialog, {
                 title: _t("Rounding error in payment lines"),
-                body: sprintf(
-                    _t(
-                        "The amount of your payment lines must be rounded to validate the transaction.\n" +
-                            "The rounding precision is %s so you should set %s as payment amount instead of %s."
-                    ),
-                    cashRounding.rounding.toFixed(this.pos.currency.decimal_places),
-                    expectedAmountPaid.toFixed(this.pos.currency.decimal_places),
-                    amountPaid.toFixed(this.pos.currency.decimal_places)
+                body: _t(
+                    "The amount of your payment lines must be rounded to validate the transaction.\n" +
+                        "The rounding precision is %(rounding)s so you should set %(expectedAmount)s as payment amount instead of %(paidAmount)s.",
+                    {
+                        rounding: cashRounding.rounding.toFixed(this.pos.currency.decimal_places),
+                        expectedAmount: expectedAmountPaid.toFixed(
+                            this.pos.currency.decimal_places
+                        ),
+                        paidAmount: amountPaid.toFixed(this.pos.currency.decimal_places),
+                    }
                 ),
             });
             return false;

--- a/addons/pos_adyen/static/src/app/utils/payment/payment_adyen.js
+++ b/addons/pos_adyen/static/src/app/utils/payment/payment_adyen.js
@@ -2,7 +2,6 @@ import { _t } from "@web/core/l10n/translation";
 import { PaymentInterface } from "@point_of_sale/app/utils/payment/payment_interface";
 import { AlertDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
 import { register_payment_method } from "@point_of_sale/app/services/pos_store";
-import { sprintf } from "@web/core/utils/strings";
 const { DateTime } = luxon;
 
 export class PaymentAdyen extends PaymentInterface {
@@ -55,7 +54,7 @@ export class PaymentAdyen extends PaymentInterface {
 
     _adyenGetSaleId() {
         var config = this.pos.config;
-        return sprintf("%s (ID: %s)", config.display_name, config.id);
+        return `${config.display_name} (ID: ${config.id})`;
     }
 
     _adyenCommonMessageHeader() {
@@ -159,9 +158,9 @@ export class PaymentAdyen extends PaymentInterface {
         return output_text.reduce((acc, entry) => {
             var params = new URLSearchParams(entry.Text);
             if (params.get("name") && !params.get("value")) {
-                return acc + sprintf("\n%s", params.get("name"));
+                return acc + "\n" + params.get("name");
             } else if (params.get("name") && params.get("value")) {
-                return acc + sprintf("\n%s: %s", params.get("name"), params.get("value"));
+                return `${acc}\n${params.get("name")}: ${params.get("value")}`;
             }
 
             return acc;
@@ -230,9 +229,7 @@ export class PaymentAdyen extends PaymentInterface {
         if (isPaymentSuccessful) {
             this.handleSuccessResponse(line, notification, additional_response);
         } else {
-            this._show_error(
-                sprintf(_t("Message from Adyen: %s"), additional_response.get("message"))
-            );
+            this._show_error(_t("Message from Adyen: %s", additional_response.get("message")));
         }
         // when starting to wait for the payment response we create a promise
         // that will be resolved when the payment response is received.

--- a/addons/pos_restaurant/static/src/app/screens/floor_screen/floor_screen.js
+++ b/addons/pos_restaurant/static/src/app/screens/floor_screen/floor_screen.js
@@ -1,5 +1,4 @@
 import { _t } from "@web/core/l10n/translation";
-import { sprintf } from "@web/core/utils/strings";
 import { debounce } from "@web/core/utils/timing";
 import { registry } from "@web/core/registry";
 import { cookie } from "@web/core/browser/cookie";
@@ -938,8 +937,8 @@ export class FloorScreen extends Component {
     async deleteFloor() {
         const confirmed = await ask(this.dialog, {
             title: `Removing floor ${this.activeFloor.name}`,
-            body: sprintf(
-                _t("Removing a floor cannot be undone. Do you still want to remove %s?"),
+            body: _t(
+                "Removing a floor cannot be undone. Do you still want to remove %s?",
                 this.activeFloor.name
             ),
         });

--- a/addons/pos_sale/static/src/app/services/pos_store.js
+++ b/addons/pos_sale/static/src/app/services/pos_store.js
@@ -1,5 +1,4 @@
 import { _t } from "@web/core/l10n/translation";
-import { sprintf } from "@web/core/utils/strings";
 import { parseFloat } from "@web/views/fields/parsers";
 import { SelectionPopup } from "@point_of_sale/app/components/popups/selection_popup/selection_popup";
 import { AlertDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
@@ -208,10 +207,7 @@ patch(PosStore.prototype, {
         }
         const payload = await makeAwaitable(this.dialog, NumberPopup, {
             title: _t("Down Payment"),
-            subtitle: sprintf(
-                _t("Due balance: %s"),
-                this.env.utils.formatCurrency(saleOrder.amount_unpaid)
-            ),
+            subtitle: _t("Due balance: %s", this.env.utils.formatCurrency(saleOrder.amount_unpaid)),
             buttons: enhancedButtons(),
             formatDisplayedValue: (x) => (isPercentage ? `% ${x}` : x),
             feedback: (buffer) =>

--- a/addons/pos_viva_com/static/src/app/payment_viva_com.js
+++ b/addons/pos_viva_com/static/src/app/payment_viva_com.js
@@ -1,7 +1,6 @@
 import { _t } from "@web/core/l10n/translation";
 import { PaymentInterface } from "@point_of_sale/app/utils/payment/payment_interface";
 import { AlertDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
-import { sprintf } from "@web/core/utils/strings";
 import { roundPrecision } from "@web/core/utils/numbers";
 import { uuidv4 } from "@point_of_sale/utils";
 import { register_payment_method } from "@point_of_sale/app/services/pos_store";
@@ -139,7 +138,7 @@ export class PaymentVivaCom extends PaymentInterface {
         if (isPaymentSuccessful) {
             this.handleSuccessResponse(line, notification);
         } else {
-            this._show_error(sprintf(_t("Message from Viva.com: %s"), notification.error));
+            this._show_error(_t("Message from Viva.com: %s", notification.error));
         }
 
         // when starting to wait for the payment response we create a promise

--- a/addons/spreadsheet/static/src/ir_ui_menu/index.js
+++ b/addons/spreadsheet/static/src/ir_ui_menu/index.js
@@ -12,7 +12,6 @@ import {
     parseIrMenuIdLink,
 } from "./odoo_menu_link_cell";
 import { _t } from "@web/core/l10n/translation";
-import { sprintf } from "@web/core/utils/strings";
 import { navigateTo } from "../actions/helpers";
 
 const { urlRegistry, corePluginRegistry, errorTypes } = spreadsheet.registries;
@@ -26,7 +25,7 @@ errorTypes.add(LINK_ERROR);
 class BadOdooLinkError extends EvaluationError {
     constructor(menuId) {
         super(
-            sprintf(_t("Menu %s not found. You may not have the required access rights."), menuId),
+            _t("Menu %s not found. You may not have the required access rights.", menuId),
             LINK_ERROR
         );
     }

--- a/addons/spreadsheet/static/src/list/list_functions.js
+++ b/addons/spreadsheet/static/src/list/list_functions.js
@@ -1,6 +1,5 @@
 import { _t } from "@web/core/l10n/translation";
 import { helpers, registries, EvaluationError } from "@odoo/o-spreadsheet";
-import { sprintf } from "@web/core/utils/strings";
 
 const { arg, toString, toNumber } = helpers;
 const { functionRegistry } = registries;
@@ -11,7 +10,7 @@ const { functionRegistry } = registries;
 
 function assertListsExists(listId, getters) {
     if (!getters.isExistingList(listId)) {
-        throw new EvaluationError(sprintf(_t('There is no list with id "%s"'), listId));
+        throw new EvaluationError(_t('There is no list with id "%s"', listId));
     }
 }
 

--- a/addons/spreadsheet/static/src/pivot/pivot_helpers.js
+++ b/addons/spreadsheet/static/src/pivot/pivot_helpers.js
@@ -2,7 +2,6 @@
 
 import { _t } from "@web/core/l10n/translation";
 import { EvaluationError, helpers } from "@odoo/o-spreadsheet";
-import { sprintf } from "@web/core/utils/strings";
 
 const { isDateOrDatetimeField } = helpers;
 
@@ -75,7 +74,7 @@ export function parseGroupField(allFields, groupFieldString) {
     fieldName = isPositional ? fieldName.substring(1) : fieldName;
     const field = allFields[fieldName];
     if (field === undefined) {
-        throw new EvaluationError(sprintf(_t("Field %s does not exist"), fieldName));
+        throw new EvaluationError(_t("Field %s does not exist", fieldName));
     }
     if (isDateOrDatetimeField(field)) {
         granularity = granularity || "month";

--- a/addons/spreadsheet/static/src/pivot/pivot_model.js
+++ b/addons/spreadsheet/static/src/pivot/pivot_model.js
@@ -2,7 +2,6 @@
 
 import { _t } from "@web/core/l10n/translation";
 import { Domain } from "@web/core/domain";
-import { sprintf } from "@web/core/utils/strings";
 import { PivotModel } from "@web/views/pivot/pivot_model";
 
 import { helpers, constants, EvaluationError, SpreadsheetPivotTable } from "@odoo/o-spreadsheet";
@@ -484,7 +483,7 @@ export class OdooPivotModel extends PivotModel {
                 rows.push(value);
             } else {
                 throw new EvaluationError(
-                    sprintf(_t("Dimension %s is not a group by"), dimensionWithGranularity)
+                    _t("Dimension %s is not a group by", dimensionWithGranularity)
                 );
             }
         }

--- a/addons/spreadsheet_account/static/src/accounting_functions.js
+++ b/addons/spreadsheet_account/static/src/accounting_functions.js
@@ -1,5 +1,4 @@
 import { _t } from "@web/core/l10n/translation";
-import { sprintf } from "@web/core/utils/strings";
 
 import * as spreadsheet from "@odoo/o-spreadsheet";
 import { EvaluationError } from "@odoo/o-spreadsheet";
@@ -128,10 +127,8 @@ export function parseAccountingDate(dateRange, locale) {
         );
     } catch {
         throw new EvaluationError(
-            sprintf(
-                _t(
-                    `'%s' is not a valid period. Supported formats are "21/12/2022", "Q1/2022", "12/2022", and "2022".`
-                ),
+            _t(
+                `'%s' is not a valid period. Supported formats are "21/12/2022", "Q1/2022", "12/2022", and "2022".`,
                 dateRange?.value
             )
         );

--- a/addons/stock/static/src/client_actions/multi_print.js
+++ b/addons/stock/static/src/client_actions/multi_print.js
@@ -1,6 +1,5 @@
 import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
-import { sprintf } from "@web/core/utils/strings";
 
 async function doMultiPrint(env, action) {
     for (const report of action.params.reports) {
@@ -11,12 +10,9 @@ async function doMultiPrint(env, action) {
             continue
         } else if (report.report_type === "qweb-html") {
             env.services.notification.add(
-                sprintf(
-                    _t("HTML reports cannot be auto-printed, skipping report: %s"),
-                            report.name)
-                , {
-                title: _t("Report Printing Error"),
-            });
+                _t("HTML reports cannot be auto-printed, skipping report: %s", report.name),
+                { title: _t("Report Printing Error") }
+            );
             continue
         }
         // WARNING: potential issue if pdf generation fails, then action_service defaults

--- a/addons/web_editor/static/src/components/upload_progress_toast/upload_service.js
+++ b/addons/web_editor/static/src/components/upload_progress_toast/upload_service.js
@@ -5,7 +5,6 @@ import { _t } from "@web/core/l10n/translation";
 import { checkFileSize } from "@web/core/utils/files";
 import { humanNumber } from "@web/core/utils/numbers";
 import { getDataURLFromFile } from "@web/core/utils/urls";
-import { sprintf } from "@web/core/utils/strings";
 import { reactive } from "@odoo/owl";
 
 export const AUTOCLOSE_DELAY = 3000;
@@ -102,10 +101,7 @@ export const uploadService = {
                     } catch {
                         deleteFile(file.id);
                         env.services.notification.add(
-                            sprintf(
-                                _t('Could not load the file "%s".'),
-                                sortedFile.name
-                            ),
+                            _t('Could not load the file "%s".', sortedFile.name),
                             { type: 'danger' }
                         );
                         continue

--- a/addons/website_slides/static/src/js/slides_course_join.js
+++ b/addons/website_slides/static/src/js/slides_course_join.js
@@ -1,4 +1,3 @@
-import { sprintf } from '@web/core/utils/strings';
 import { renderToElement } from "@web/core/utils/render";
 import publicWidget from '@web/legacy/js/public/public_widget';
 import { _t } from "@web/core/l10n/translation";
@@ -94,7 +93,7 @@ var CourseJoinWidget = publicWidget.Widget.extend({
         } else {
             url = `/slides/${encodeURIComponent(this.channel.channelId)}`;
         }
-        document.location = sprintf('/web/login?redirect=%s', encodeURIComponent(url));
+        document.location = `/web/login?redirect=${encodeURIComponent(url)}`;
     },
 
     /**


### PR DESCRIPTION
On the JavaScript side, the main use case for sprintf used to be interpolating values inside translated strings. However, ever since version 17.0, this has been handled directly by _t.

This commit gets rid of occurrences of sprintf that can easily be simplified to either a call to _t or a template string.

Enterprise: https://github.com/odoo/enterprise/pull/88812
