### PR TITLE
[FIX] l10n_es_pos_tbai: make sure to await refund

### DIFF
--- a/addons/l10n_es_pos_tbai/static/src/overrides/components/ticket_screen/ticket_screen.js
+++ b/addons/l10n_es_pos_tbai/static/src/overrides/components/ticket_screen/ticket_screen.js
@@ -22,6 +22,6 @@ patch(TicketScreen.prototype, {
                 destinationOrder.to_invoice = true;
             }
         }
-        super.addAdditionalRefundInfo(...arguments);
+        await super.addAdditionalRefundInfo(...arguments);
     },
 });


### PR DESCRIPTION
When both l10n_es_pos_tbai and l10n_pe_edi_pos are installed, the refund reason popup was not showing up because we were not awaiting the super method call in the l10n_pe_edi_pos override.

runbot-227630