### PR TITLE
[ADD] crm_sale_project: convert opportunity into a project

### DIFF
--- a/addons/crm_sale_project/__init__.py
+++ b/addons/crm_sale_project/__init__.py
@@ -1,0 +1,2 @@
+from . import models
+from . import wizard

--- a/addons/crm_sale_project/__manifest__.py
+++ b/addons/crm_sale_project/__manifest__.py
@@ -1,0 +1,18 @@
+{
+    'name': 'CRM - Project',
+    'summary': 'Project Generation from Opportunities',
+    'category': 'Sales/CRM',
+    'depends': [
+        'sale_project',
+        'crm',
+    ],
+    'data': [
+        'data/ir_actions_server_data.xml',
+        'views/crm_lead_views.xml',
+        'views/project_project_views.xml',
+        'wizard/project_template_create_wizard.xml',
+    ],
+    'auto_install': True,
+    'author': 'Odoo S.A.',
+    'license': 'LGPL-3',
+}

--- a/addons/crm_sale_project/data/ir_actions_server_data.xml
+++ b/addons/crm_sale_project/data/ir_actions_server_data.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <!-- Add action entry in the Action Menu for Leads -->
+    <record id="action_create_project_crm_lead" model="ir.actions.server">
+        <field name="name">Create Project</field>
+        <field name="model_id" ref="crm.model_crm_lead" />
+        <field name="binding_model_id" ref="crm.model_crm_lead" />
+        <field name="binding_view_types">form</field>
+        <field name="group_ids" eval="[(4, ref('project.group_project_manager'))]" />
+        <field name="state">code</field>
+        <field name="code">action = records.action_create_project()</field>
+    </record>
+
+</odoo>

--- a/addons/crm_sale_project/models/__init__.py
+++ b/addons/crm_sale_project/models/__init__.py
@@ -1,0 +1,2 @@
+from . import project_project
+from . import crm_lead

--- a/addons/crm_sale_project/models/crm_lead.py
+++ b/addons/crm_sale_project/models/crm_lead.py
@@ -1,0 +1,76 @@
+from odoo import api, fields, models
+
+
+class CrmLead(models.Model):
+    _inherit = 'crm.lead'
+
+    project_ids = fields.One2many('project.project', inverse_name='lead_id', groups="project.group_project_user", export_string_translation=False)
+    project_count = fields.Integer(compute='_compute_project_count', groups="project.group_project_user", export_string_translation=False)
+    task_count = fields.Integer(compute='_compute_task_count', groups="project.group_project_user", export_string_translation=False)
+
+    @api.depends('project_ids')
+    def _compute_project_count(self):
+        project_count_per_lead = dict(
+            self.env['project.project']._read_group(
+                domain=[('lead_id', 'in', self.ids)],
+                groupby=['lead_id'],
+                aggregates=['__count'],
+            ),
+        )
+
+        for lead in self:
+            lead.project_count = project_count_per_lead.get(lead, 0)
+
+    @api.depends('project_ids.task_ids')
+    def _compute_task_count(self):
+        task_count_per_lead = dict(
+            self.env['project.task']._read_group(
+                domain=[('project_id', 'in', self.project_ids.ids)],
+                groupby=['project_id.lead_id'],
+                aggregates=['__count'],
+            ),
+        )
+
+        for lead in self:
+            lead.task_count = task_count_per_lead.get(lead, 0)
+
+    def _get_project_create_from_lead_context(self):
+        """Return the context for creating a project from a lead."""
+        self.ensure_one()
+        return dict(
+            default_company_id=self.company_id.id,
+            default_lead_id=self.id,
+            default_partner_id=self.partner_id.id,
+            default_allow_billable=True,
+        )
+
+    def action_create_project(self):
+        self.ensure_one()
+        view_id = self.env.ref('crm_sale_project.crm_project_view_form_simplified_template', raise_if_not_found=False)
+        return {
+            **self.env['project.template.create.wizard'].action_open_template_view(),
+            'name': self.env._('Create a Project'),
+            'views': [(view_id.id, 'form')],
+            'context': {
+                **self._get_project_create_from_lead_context(),
+                'default_name': self.name,
+            },
+        }
+
+    def action_view_project_ids(self):
+        self.ensure_one()
+
+        if self.project_count == 1:
+            action = self.project_ids.action_view_tasks()
+            action['context'].update(self._get_project_create_from_lead_context())
+        else:
+            action = {
+                **self.env['ir.actions.actions']._for_xml_id('project.open_view_project_all'),
+                'domain': [
+                    '|',
+                    ('lead_id', '=', self.id),
+                    ('id', 'in', self.project_ids.ids),
+                ],
+                'context': self._get_project_create_from_lead_context(),
+            }
+        return action

--- a/addons/crm_sale_project/models/project_project.py
+++ b/addons/crm_sale_project/models/project_project.py
@@ -1,0 +1,31 @@
+from odoo import api, fields, models
+
+
+class ProjectProject(models.Model):
+    _inherit = 'project.project'
+
+    lead_id = fields.Many2one('crm.lead', index=True, export_string_translation=False)
+
+    @api.model
+    def default_get(self, fields):
+        defaults = super().default_get(fields)
+        if self.env.context.get('default_lead_id'):
+            defaults['allow_billable'] = True
+        return defaults
+
+    @api.model
+    def _get_template_default_context_whitelist(self):
+        return [
+            *super()._get_template_default_context_whitelist(),
+            'lead_id',
+        ]
+
+    def action_view_lead(self):
+        self.ensure_one()
+        return {
+            'type': 'ir.actions.act_window',
+            'res_model': 'crm.lead',
+            'view_mode': 'form',
+            'res_id': self.lead_id.id,
+            'context': {'create': False},
+        }

--- a/addons/crm_sale_project/views/crm_lead_views.xml
+++ b/addons/crm_sale_project/views/crm_lead_views.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0"?>
+<odoo>
+
+    <!-- Add stat button for linked projects -->
+    <record id="crm_lead_view_form" model="ir.ui.view">
+        <field name="name">crm.lead.form.inherit.crm.project</field>
+        <field name="model">crm.lead</field>
+        <field name="inherit_id" ref="crm.crm_lead_view_form" />
+        <field name="arch" type="xml">
+            <button name="action_schedule_meeting" position="after">
+                <button
+                    name="action_view_project_ids"
+                    type="object"
+                    class="oe_stat_button"
+                    icon="fa-check"
+                    groups="project.group_project_user"
+                    invisible="not project_count"
+                >
+                    <div class="o_stat_info">
+                        <div class="o_row">
+                            <span class="o_stat_value order-first">
+                                <field name="project_count"/>
+                            </span>
+                            <span class="o_stat_text"> Projects</span>
+                        </div>
+                        <div class="o_row">
+                            <span class="o_stat_value order-first">
+                                <field name="task_count"/>
+                            </span>
+                            <span class="o_stat_text"> Tasks</span>
+                        </div>
+                    </div>
+                </button>
+            </button>
+        </field>
+    </record>
+
+</odoo>

--- a/addons/crm_sale_project/views/project_project_views.xml
+++ b/addons/crm_sale_project/views/project_project_views.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="view_edit_project_inherit_form_crm_project" model="ir.ui.view">
+        <field name="name">project.project.view.inherit.crm.project</field>
+        <field name="model">project.project</field>
+        <field name="inherit_id" ref="project.edit_project"/>
+        <field name="arch" type="xml">
+            <xpath expr="//button[@name='action_customer_preview']" position="after">
+                <button name="action_view_lead" icon="fa-star" type="object" class="oe_stat_button"
+                    invisible="not lead_id or not allow_billable" groups="sales_team.group_sale_salesman_all_leads">
+                    <div class="o_stat_info">
+                        <span class="o_stat_text">Opportunity</span>
+                    </div>
+                </button>
+            </xpath>
+        </field>
+    </record>
+
+</odoo>

--- a/addons/crm_sale_project/wizard/__init__.py
+++ b/addons/crm_sale_project/wizard/__init__.py
@@ -1,0 +1,1 @@
+from . import project_template_create_wizard

--- a/addons/crm_sale_project/wizard/project_template_create_wizard.py
+++ b/addons/crm_sale_project/wizard/project_template_create_wizard.py
@@ -1,0 +1,45 @@
+from odoo import api, fields, models
+
+
+class ProjectTemplateCreateWizard(models.TransientModel):
+    _inherit = 'project.template.create.wizard'
+
+    customer_action = fields.Selection([
+        ('create', 'Create a new customer'),
+        ('exist', 'Link to an existing customer'),
+        ('nothing', 'Do not link to a customer'),
+    ], string='Project Customer', default='create')
+    is_customer_action_visible = fields.Boolean(compute='_compute_customer_action_visibility', export_string_translation=False)
+
+    def _compute_customer_action_visibility(self):
+        for wizard in self:
+            wizard.is_customer_action_visible = not bool(self.env.context.get("default_partner_id"))
+
+    @api.model
+    def action_open_template_view(self):
+        action = super().action_open_template_view()
+        if self.env.context.get("default_lead_id"):
+            action['context']['default_lead_id'] = self.env.context.get("default_lead_id")
+            action['context']['default_partner_id'] = self.env.context.get("default_partner_id")
+        return action
+
+    def action_create_project_from_lead(self):
+        """Create a project either from template or directly if no template is set."""
+        self.ensure_one()
+        lead = self.env['crm.lead'].browse(self.env.context.get("default_lead_id"))
+
+        if self.customer_action == 'create':
+            lead._handle_partner_assignment(create_missing=True)
+            self.partner_id = lead.partner_id
+        elif self.customer_action == 'exist':
+            lead._handle_partner_assignment(force_partner_id=self.partner_id.id, create_missing=False)
+
+        if self.template_id:
+            project = self._create_project_from_template()
+        else:
+            values = {
+                'partner_id': self.partner_id.id,
+                'company_id': lead.company_id.id,
+            }
+            project = self.env['project.project'].create(values)
+        return project.action_view_tasks()

--- a/addons/crm_sale_project/wizard/project_template_create_wizard.xml
+++ b/addons/crm_sale_project/wizard/project_template_create_wizard.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+
+    <record id="crm_project_view_form_simplified_template" model="ir.ui.view">
+        <field name="name">crm.project.create.wizard.form</field>
+        <field name="model">project.template.create.wizard</field>
+        <field name="inherit_id" ref="sale_project.sale_project_view_form_simplified_template"/>
+        <field name="mode">primary</field>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='template_id']" position="before">
+                <field name="customer_action" widget="radio" invisible="not is_customer_action_visible" required="True"/>
+            </xpath>
+            <xpath expr="//field[@name='customer_action']" position="after">
+                <field
+                    name="partner_id"
+                    string="Customer"
+                    invisible="customer_action != 'exist'"
+                    required="customer_action == 'exist'"
+                    widget="res_partner_many2one"
+                    options="{'no_create_edit': True, 'no_open': True}"
+                />
+            </xpath>
+            <xpath expr="//field[@name='template_id']" position="attributes">
+                <attribute name="domain">[('is_template', '=', True), ('allow_billable', '=', True)]</attribute>
+                <attribute name="context">{'default_is_template': True, 'default_allow_billable': True}</attribute>
+            </xpath>
+            <xpath expr="//form/footer/button[@name='action_create_project_from_so']" position="attributes">
+                <attribute name="name">action_create_project_from_lead</attribute>
+            </xpath>
+        </field>
+    </record>
+
+</odoo>

--- a/addons/sale_project/views/sale_order_views.xml
+++ b/addons/sale_project/views/sale_order_views.xml
@@ -12,7 +12,7 @@
                     name="action_view_project_ids"
                     type="object"
                     class="oe_stat_button"
-                    icon="fa-puzzle-piece"
+                    icon="fa-check"
                     invisible="not show_project_button"
                     groups="project.group_project_user"
                 >


### PR DESCRIPTION
Desired behavior after PR is merged:
- menu button to create a project out of an opportunity
- allow billable is true by default
- Partner is the same as the lead by default
- restrict access to the `Create Project` option only to the admin access level
- add stat button when a project is created
- show the stat button only with project access level
- newly created project from the stat button linked to the opportunity
- added opportunity stat button in project form view

---

task-4847853