### PR TITLE
[FIX] web_editor: allow deletion of empty nested div elements

### DIFF
--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
@@ -2421,6 +2421,30 @@ export class OdooEditor extends EventTarget {
         const restoreCursor = preserveCursor(this.document);
         restoreUpdate();
         restoreCursor();
+        const selection = document.getSelection();
+        this.deleteEmptyDivSelection(selection)
+    }
+
+    deleteEmptyDivSelection(selection) {
+        if (
+            selection.anchorNode.nodeName === "DIV" &&
+            selection.anchorNode !== this.editable &&
+            isEmptyBlock(selection.anchorNode) &&
+            !selection.anchorNode.classList.contains("o_text_columns")
+        ) {
+            const paragraph = document.createElement("P");
+            fillEmpty(paragraph);
+            if (isUnremovable(selection.anchorNode)) {
+                if (selection.anchorNode.firstChild) {
+                    selection.anchorNode.firstChild.remove();
+                }
+                selection.anchorNode.appendChild(paragraph);
+            } else {
+                selection.anchorNode.parentElement.replaceChild(paragraph, selection.anchorNode);
+            }
+            setSelection(paragraph, 0, paragraph, 0);
+            return true;
+        }
     }
 
     /**
@@ -2609,6 +2633,10 @@ export class OdooEditor extends EventTarget {
             if (BACKSPACE_ONLY_COMMANDS.includes(method)) {
                 return true;
             }
+        }
+
+        if (this.deleteEmptyDivSelection(sel)) {
+            return;
         }
 
         this.options.beforeAnyCommand();

--- a/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/editor.test.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/editor.test.js
@@ -1919,7 +1919,7 @@ X[]
                             `</div>`,
                         stepFunction: deleteBackward,
                         contentAfter: `<div class="oe_unbreakable">` +
-                            `<div class="oe_unbreakable">[]<br></div>` +
+                            `<p>[]<br></p>` +
                             `<div class="oe_unbreakable">f1</div>` +
                             `</div>`,
                     });
@@ -1954,7 +1954,7 @@ X[]
                             `</div>`,
                         stepFunction: deleteBackward,
                         contentAfter: `<div class="oe_unbreakable">` +
-                            `<div class="oe_unbreakable">[]<br></div>` +
+                            `<p>[]<br></p>` +
                             `</div>`,
                     });
                     await testEditor(BasicEditor, {
@@ -1970,7 +1970,7 @@ X[]
                             `</div>`,
                         stepFunction: deleteBackward,
                         contentAfter: `<div class="oe_unbreakable">` +
-                            `<div class="oe_unbreakable">[]<br></div>` +
+                            `<p>[]<br></p>` +
                             `</div>` +
                             `<div class="oe_unbreakable">` +
                             `<div class="oe_unbreakable">l5</div>` +
@@ -2118,6 +2118,23 @@ X[]
                         contentBefore: `<p>a<a class="btn">[]</a></p>`,
                         stepFunction: deleteBackward,
                         contentAfter: `<p>a[]</p>`,
+                    });
+                });
+                it('should replace div with p', async () => {
+                    await testEditor(BasicEditor, {
+                        contentBefore: `<div>a[]</div>`,
+                        stepFunction: async (...args) => {
+                            await deleteBackward(...args);
+                            await deleteBackward(...args);
+                        },
+                        contentAfter: `<p>[]<br></p>`,
+                    });
+                });
+                it('should add p inside unremovable', async () => {
+                    await testEditor(BasicEditor, {
+                        contentBefore: `<div class="oe_unremovable">[]</div>`,
+                        stepFunction: deleteBackward,
+                        contentAfter: `<div class="oe_unremovable"><p>[]<br></p></div>`,
                     });
                 });
             });
@@ -3545,6 +3562,20 @@ X[]
                         stepFunction: deleteBackward,
                         contentAfter: `<ul><li>ab</li></ul><ol><li>[]f</li><li>gh</li></ol>`,
                     });
+                });
+            });
+            it('should replace div with p', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: `<div>[abc]</div>`,
+                    stepFunction: deleteBackward,
+                    contentAfter: `<p>[]<br></p>`,
+                });
+            });
+            it('should add p inside unremovable', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: `<div class="oe_unremovable">[abc]</div>`,
+                    stepFunction: deleteBackward,
+                    contentAfter: `<div class="oe_unremovable"><p>[]<br></p></div>`,
                 });
             });
         });


### PR DESCRIPTION
Problem:
In some cases, content with nested `div` elements is added to the editor. These `div`s can break certain editor features and cannot be deleted through the UI.

Solution:
Add support to remove empty `div` elements when clearing content.

Steps to reproduce:
- Add `<div><div>abc</div></div>` to the editor
- Focus inside and remove all content
- The `div` elements remain and are not removed

opw-4805901

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
