### PR TITLE
[FIX] models, {sale_,}stock, *: allow branch warehouses

### DIFF
--- a/addons/stock/models/stock_location.py
+++ b/addons/stock/models/stock_location.py
@@ -21,6 +21,7 @@ class Location(models.Model):
     _rec_name = 'complete_name'
     _rec_names_search = ['complete_name', 'barcode']
     _check_company_auto = True
+    _check_company_domain = models.check_company_domain_child_of
 
     @api.model
     def default_get(self, fields):

--- a/addons/stock/models/stock_warehouse.py
+++ b/addons/stock/models/stock_warehouse.py
@@ -27,6 +27,7 @@ class Warehouse(models.Model):
     _description = "Warehouse"
     _order = 'sequence,id'
     _check_company_auto = True
+    _check_company_domain = models.check_company_domain_child_of
     # namedtuple used in helper methods generating values for routes
     Routing = namedtuple('Routing', ['from_loc', 'dest_loc', 'picking_type', 'action'])
 

--- a/addons/stock_dropshipping/models/stock.py
+++ b/addons/stock_dropshipping/models/stock.py
@@ -29,7 +29,7 @@ class ProcurementGroup(models.Model):
     def _get_rule_domain(self, location, values):
         domain = super()._get_rule_domain(location, values)
         if 'sale_line_id' in values and values.get('company_id'):
-            domain = expression.AND([domain, [('company_id', '=', values['company_id'].id)]])
+            domain = expression.AND([domain, [('company_id', 'child_of', values['company_id'].id)]])
         return domain
 
 class StockPicking(models.Model):

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -222,6 +222,20 @@ def check_companies_domain_parent_of(self, companies):
     ])]
 
 
+def check_company_domain_child_of(self, companies):
+    """ A `_check_company_domain` function that lets a record be used if either:
+        - record.company_id = False (which implies that it is shared between all companies), or
+        - record.company_id is a child of any of the given companies.
+    """
+    if isinstance(companies, str):
+        company_ids = companies
+    else:
+        company_ids = [id for id in to_company_ids(companies) if id]
+    if not company_ids:
+        return [('company_id', '=', False)]
+    return ['|', ('company_id', '=', False), ('company_id', 'child_of', company_ids)]
+
+
 class MetaModel(api.Meta):
     """ The metaclass of all model classes.
         Its main purpose is to register the models per module.


### PR DESCRIPTION
*: stock_dropshipping, website_sale_collect

Versions
--------
- 18.0+

Steps
-----
1. Create a branch company;
2. switch to branch company;
3. create a new warehouse;
4. create a new delivery method;
5. select "Pick up in store" as provider;
6. add warehouse as pick-up location;
7. replenish stock of a published product in the warehouse;
8. go to product's eCommerce page;
9. select store as a pick-up location.

Issue
-----
> Invalid Operation: Incompatible companies on records

Cause
-----
The `warehouse_id` field of `sale.order` has `check_company` set to `True`. When `_check_company` gets called, it will throw an error if the `warehouse_id` belongs to a different company than the order.

Solution
--------
Add `check_company_domain_child_of` to `models`, and use it for `stock.warehouse` and `stock.location` to allow for companies to use warehouses & locations of their branch companies.

opw-4777937