### PR TITLE
[FIX] mail: show only 1 chat hub at once in website builder

### DIFF
--- a/addons/im_livechat/static/src/embed/frontend/livechat_root.js
+++ b/addons/im_livechat/static/src/embed/frontend/livechat_root.js
@@ -19,5 +19,7 @@ export class LivechatRoot extends Component {
     setup() {
         useSubEnv({ embedLivechat: true });
         this.overlayService = useService("overlay");
+        this.store = useService("mail.store");
+        this.store.embedLivechat = true;
     }
 }

--- a/addons/mail/static/src/core/common/chat_hub.xml
+++ b/addons/mail/static/src/core/common/chat_hub.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
 <t t-name="mail.ChatHub">
-    <div class="o-mail-ChatHub d-print-none">
+    <div t-if="chatHub.show" class="o-mail-ChatHub d-print-none">
 
         <t t-set="visibleChatWindows" t-value="chatHub.compact ? chatHub.opened.filter(({ bypassCompact }) => bypassCompact) : chatHub.opened "/>
         <t t-foreach="visibleChatWindows" t-as="cw" t-key="cw.localId">

--- a/addons/mail/static/src/core/common/chat_hub_model.js
+++ b/addons/mail/static/src/core/common/chat_hub_model.js
@@ -146,6 +146,10 @@ export class ChatHub extends Record {
         );
     }
 
+    get show() {
+        return true;
+    }
+
     showConversations = fields.Attr(false, {
         compute() {
             return this.canShowOpened.length + this.canShowFolded.length > 0;

--- a/addons/website/static/src/client_actions/website_preview/website_builder_action.js
+++ b/addons/website/static/src/client_actions/website_preview/website_builder_action.js
@@ -57,6 +57,9 @@ export class WebsiteBuilderClientAction extends Component {
         this.component = useComponent();
 
         this.onKeydownRefresh = this._onKeydownRefresh.bind(this);
+        this.env.services["mail.store"].isReady.then(() => {
+            this.env.services["mail.store"].websiteBuilder.on = true;
+        });
 
         onMounted(() => {
             // You can't wait for rendering because the Builder depends on the
@@ -125,6 +128,9 @@ export class WebsiteBuilderClientAction extends Component {
             websiteSystrayRegistry.remove("website.WebsiteSystrayItem");
             this.websiteService.currentWebsiteId = null;
             websiteSystrayRegistry.trigger("EDIT-WEBSITE");
+            this.env.services["mail.store"].isReady.then(() => {
+                this.env.services["mail.store"].websiteBuilder.on = false;
+            });
         });
 
         effect(
@@ -145,8 +151,14 @@ export class WebsiteBuilderClientAction extends Component {
                         websiteSystrayRegistry.trigger("EDIT-WEBSITE");
                         document.querySelector(".o_builder_open .o_main_navbar").classList.add("d-none");
                     }, 200);
+                    this.env.services["mail.store"].isReady.then(() => {
+                        this.env.services["mail.store"].websiteBuilder.editing = true;
+                    });
                 } else {
                     document.querySelector(".o_main_navbar")?.classList.remove("d-none");
+                    this.env.services["mail.store"].isReady.then(() => {
+                        this.env.services["mail.store"].websiteBuilder.editing = false;
+                    });
                 }
             },
             () => [this.state.isEditing]
@@ -264,6 +276,10 @@ export class WebsiteBuilderClientAction extends Component {
     }
 
     onIframeLoad(ev) {
+        this.env.services["mail.store"].isReady.then(() => {
+            this.env.services["mail.store"].websiteBuilder.iframeWindow =
+                this.websiteContent.el.contentWindow;
+        });
         this.websiteService.pageDocument = this.websiteContent.el.contentDocument;
         if (this.translation) {
             deleteQueryParam("edit_translations", this.websiteService.contentWindow, true);

--- a/addons/website/static/src/common/chat_hub_model_patch.js
+++ b/addons/website/static/src/common/chat_hub_model_patch.js
@@ -1,0 +1,57 @@
+import { ChatHub } from "@mail/core/common/chat_hub_model";
+import { toRaw } from "@odoo/owl";
+import { patch } from "@web/core/utils/patch";
+
+patch(ChatHub, {
+    new(...args) {
+        const record = super.new(...args);
+        record.onWindowMessage = (...args) => record._onWindowMessage(...args);
+        window.addEventListener("message", toRaw(record.onWindowMessage));
+        return record;
+    },
+});
+
+patch(ChatHub.prototype, {
+    delete(...args) {
+        window.removeEventListener("message", toRaw(this.onWindowMessage));
+        super.delete(...args);
+    },
+    _onWindowMessage({ data }) {
+        switch (data) {
+            case "WEBSITE_BUILDER:ON": {
+                this.store.websiteBuilder.on = true;
+                break;
+            }
+            case "WEBSITE_BUILDER:OFF": {
+                this.store.websiteBuilder.on = false;
+                break;
+            }
+            case "WEBSITE_BUILDER:EDITING:ON": {
+                this.store.websiteBuilder.editing = true;
+                break;
+            }
+            case "WEBSITE_BUILDER:EDITING:OFF": {
+                this.store.websiteBuilder.editing = false;
+                break;
+            }
+            case "WEBSITE_BUILDER:ASK_ON?": {
+                this.store.websiteBuilder?.iframeWindow.postMessage("WEBSITE_BUILDER:ON");
+                this.store.websiteBuilder?.iframeWindow.postMessage(
+                    this.store.websiteBuilder.isEditing
+                        ? "WEBSITE_BUILDER:EDITING:ON"
+                        : "WEBSITE_BUILDER:EDITING:OFF"
+                );
+                break;
+            }
+        }
+    },
+    get show() {
+        if (!this.store.websiteBuilder?.on) {
+            return super.show;
+        }
+        if (Boolean(this.store.embedLivechat) === Boolean(this.store.websiteBuilder?.editing)) {
+            return false;
+        }
+        return super.show;
+    },
+});

--- a/addons/website/static/src/common/store_service_patch.js
+++ b/addons/website/static/src/common/store_service_patch.js
@@ -1,0 +1,15 @@
+import { Store } from "@mail/core/common/store_service";
+import { fields } from "@mail/model/misc";
+import { patch } from "@web/core/utils/patch";
+
+/** @type {import("models").Store} */
+const storeServicePatch = {
+    setup() {
+        super.setup();
+        this.websiteBuilder = fields.One("WebsiteBuilder", {
+            compute: () => ({}),
+        });
+    },
+};
+
+patch(Store.prototype, storeServicePatch);

--- a/addons/website/static/src/common/website_builder_model.js
+++ b/addons/website/static/src/common/website_builder_model.js
@@ -1,0 +1,33 @@
+import { fields } from "@mail/model/misc";
+import { Record } from "@mail/model/record";
+
+export class WebsiteBuilder extends Record {
+    on = fields.Attr(false, {
+        /** @this {import("models").WebsiteBuilder} */
+        onUpdate() {
+            this.onUpdate();
+        },
+    });
+    editing = fields.Attr(false, {
+        /** @this {import("models").WebsiteBuilder} */
+        onUpdate() {
+            this.onUpdate();
+        },
+    });
+    iframeWindow = fields.Attr(undefined, {
+        /** @this {import("models").WebsiteBuilder} */
+        onUpdate() {
+            this.onUpdate();
+        },
+    });
+    onUpdate() {
+        this.iframeWindow?.postMessage(this.on ? "WEBSITE_BUILDER:ON" : "WEBSITE_BUILDER:OFF");
+        if (this.on) {
+            this.iframeWindow?.postMessage(
+                this.editing ? "WEBSITE_BUILDER:EDITING:ON" : "WEBSITE_BUILDER:EDITING:OFF"
+            );
+        }
+    }
+}
+
+WebsiteBuilder.register();

--- a/addons/website_livechat/__manifest__.py
+++ b/addons/website_livechat/__manifest__.py
@@ -24,6 +24,7 @@
     'assets': {
         "im_livechat.assets_embed_core": [
             "website/static/src/**/common/**/*",
+            "website_livechat/static/src/**/common/**/*",
         ],
         "mail.assets_public": [
             "website_livechat/static/src/**/common/**/*",


### PR DESCRIPTION
Before this commit, website builder page was showing 2 chat hubs at once:
- chat hub from the web client
- chat hub from the website (live chat)

The website builder is in web client so makes sense to enable chat windows from web client. Some feature are specific to backend and need to be shown while editing the website.
The website builder also previews how the website look. Therefore it makes sense to show website chat hub because it's part of the actual website page being previewed.

The problem with showing the 2 chat hubs is that chats are duplicated due to being shown in both hubs. The chats are intended to be seen from the website so the underlying problem is showing both chat hubs at once.

This commit fixes the issue as follow in website builder:
- when not editing the website, show the website chat hub and hide the web client chat hub
- when editing the website, show the web client chat hub and hide the website chat hub.

This works because web client chat features at desired when actually editing the website. Viewing the website hub when not editing the website works because this is the actual showing of website with the website chat hub. There's also no feature on website editor that affects the website chat hub.