### PR TITLE
[FIX] *livechat: use livechat_member_type in livechat mock server

### DIFF
--- a/addons/crm_livechat/static/tests/create_lead.test.js
+++ b/addons/crm_livechat/static/tests/create_lead.test.js
@@ -27,8 +27,8 @@ test("can create a lead from the thread action after the conversation ends", asy
     const channel_id = pyEnv["discuss.channel"].create({
         channel_type: "livechat",
         channel_member_ids: [
-            Command.create({ partner_id: serverState.partnerId }),
-            Command.create({ guest_id: guestId }),
+            Command.create({ partner_id: serverState.partnerId, livechat_member_type: "agent" }),
+            Command.create({ guest_id: guestId, livechat_member_type: "visitor" }),
         ],
         livechat_operator_id: serverState.partnerId,
     });

--- a/addons/crm_livechat/static/tests/message.test.js
+++ b/addons/crm_livechat/static/tests/message.test.js
@@ -8,11 +8,11 @@ import {
     startServer,
 } from "@mail/../tests/mail_test_helpers";
 import { Command, serverState } from "@web/../tests/web_test_helpers";
-import { defineCrmModels } from "@crm/../tests/crm_test_helpers";
 import { press } from "@odoo/hoot-dom";
+import { defineCrmLivechatModels } from "./crm_livechat_test_helpers";
 
 describe.current.tags("desktop");
-defineCrmModels();
+defineCrmLivechatModels();
 
 test("Can open lead from internal link", async () => {
     const pyEnv = await startServer();
@@ -20,8 +20,8 @@ test("Can open lead from internal link", async () => {
     const channelId = pyEnv["discuss.channel"].create({
         anonymous_name: "Visitor",
         channel_member_ids: [
-            Command.create({ partner_id: serverState.partnerId }),
-            Command.create({ guest_id: guestId }),
+            Command.create({ partner_id: serverState.partnerId, livechat_member_type: "agent" }),
+            Command.create({ guest_id: guestId, livechat_member_type: "visitor" }),
         ],
         channel_type: "livechat",
         livechat_operator_id: serverState.partnerId,

--- a/addons/im_livechat/static/tests/call.test.js
+++ b/addons/im_livechat/static/tests/call.test.js
@@ -28,8 +28,8 @@ test("should display started a call message with operator livechat username", as
     const channelId = pyEnv["discuss.channel"].create({
         anonymous_name: "Visitor",
         channel_member_ids: [
-            Command.create({ partner_id: serverState.partnerId }),
-            Command.create({ guest_id: guestId }),
+            Command.create({ partner_id: serverState.partnerId, livechat_member_type: "agent" }),
+            Command.create({ guest_id: guestId, livechat_member_type: "visitor" }),
         ],
         channel_type: "livechat",
         livechat_operator_id: serverState.partnerId,

--- a/addons/im_livechat/static/tests/channel_invite.test.js
+++ b/addons/im_livechat/static/tests/channel_invite.test.js
@@ -38,8 +38,13 @@ test("Can invite a partner to a livechat channel", async () => {
             Command.create({
                 partner_id: serverState.partnerId,
                 last_interest_dt: "2021-01-03 12:00:00",
+                livechat_member_type: "agent",
             }),
-            Command.create({ guest_id: guestId, last_interest_dt: "2021-01-03 12:00:00" }),
+            Command.create({
+                guest_id: guestId,
+                last_interest_dt: "2021-01-03 12:00:00",
+                livechat_member_type: "visitor",
+            }),
         ],
         channel_type: "livechat",
         livechat_operator_id: serverState.partnerId,
@@ -81,8 +86,8 @@ test("Available operators come first", async () => {
     const channelId = pyEnv["discuss.channel"].create({
         anonymous_name: "Visitor #1",
         channel_member_ids: [
-            Command.create({ partner_id: serverState.partnerId }),
-            Command.create({ guest_id: guestId }),
+            Command.create({ partner_id: serverState.partnerId, livechat_member_type: "agent" }),
+            Command.create({ guest_id: guestId, livechat_member_type: "visitor" }),
         ],
         channel_type: "livechat",
     });
@@ -115,8 +120,13 @@ test("Partners invited most frequently by the current user come first", async ()
             Command.create({
                 partner_id: serverState.partnerId,
                 last_interest_dt: "2021-01-03 12:00:00",
+                livechat_member_type: "agent",
             }),
-            Command.create({ guest_id: guestId_1, last_interest_dt: "2021-01-03 12:00:00" }),
+            Command.create({
+                guest_id: guestId_1,
+                last_interest_dt: "2021-01-03 12:00:00",
+                livechat_member_type: "visitor",
+            }),
         ],
         livechat_operator_id: serverState.partnerId,
     });
@@ -128,8 +138,13 @@ test("Partners invited most frequently by the current user come first", async ()
             Command.create({
                 partner_id: serverState.partnerId,
                 last_interest_dt: "2021-01-03 11:00:00",
+                livechat_member_type: "agent",
             }),
-            Command.create({ guest_id: guestId_2, last_interest_dt: "2021-01-03 11:00:00" }),
+            Command.create({
+                guest_id: guestId_2,
+                last_interest_dt: "2021-01-03 11:00:00",
+                livechat_member_type: "visitor",
+            }),
         ],
         livechat_operator_id: serverState.partnerId,
     });
@@ -155,7 +170,10 @@ test("shows operators are in call", async () => {
     ]);
     const bobChannelId = pyEnv["discuss.channel"].create({
         channel_type: "livechat",
-        channel_member_ids: [Command.create({ partner_id: bobPartnerId })],
+        channel_member_ids: [
+            Command.create({ partner_id: bobPartnerId, livechat_member_type: "agent" }),
+            Command.create({ guest_id: guestId, livechat_member_type: "visitor" }),
+        ],
     });
     const [bobMemberId] = pyEnv["discuss.channel.member"].search([
         ["partner_id", "=", bobPartnerId],
@@ -169,8 +187,8 @@ test("shows operators are in call", async () => {
     const channelId = pyEnv["discuss.channel"].create({
         channel_type: "livechat",
         channel_member_ids: [
-            Command.create({ partner_id: serverState.partnerId }),
-            Command.create({ guest_id: guestId }),
+            Command.create({ partner_id: serverState.partnerId, livechat_member_type: "agent" }),
+            Command.create({ guest_id: guestId, livechat_member_type: "visitor" }),
         ],
     });
     await start();
@@ -199,8 +217,13 @@ test("Operator invite shows livechat_username", async () => {
             Command.create({
                 partner_id: serverState.partnerId,
                 last_interest_dt: "2021-01-03 12:00:00",
+                livechat_member_type: "agent",
             }),
-            Command.create({ guest_id: guestId_1, last_interest_dt: "2021-01-03 12:00:00" }),
+            Command.create({
+                guest_id: guestId_1,
+                last_interest_dt: "2021-01-03 12:00:00",
+                livechat_member_type: "visitor",
+            }),
         ],
         livechat_operator_id: serverState.partnerId,
     });

--- a/addons/im_livechat/static/tests/channel_join_leave.test.js
+++ b/addons/im_livechat/static/tests/channel_join_leave.test.js
@@ -31,8 +31,8 @@ test("from the discuss app", async () => {
     pyEnv["discuss.channel"].create({
         channel_type: "livechat",
         channel_member_ids: [
-            Command.create({ partner_id: serverState.partnerId }),
-            Command.create({ guest_id: guestId }),
+            Command.create({ partner_id: serverState.partnerId, livechat_member_type: "agent" }),
+            Command.create({ guest_id: guestId, livechat_member_type: "visitor" }),
         ],
         livechat_channel_id: livechatChannelId,
         livechat_operator_id: serverState.partnerId,
@@ -90,8 +90,8 @@ test("from chat window", async () => {
     const channelId = pyEnv["discuss.channel"].create({
         channel_type: "livechat",
         channel_member_ids: [
-            Command.create({ partner_id: serverState.partnerId }),
-            Command.create({ guest_id: guestId }),
+            Command.create({ partner_id: serverState.partnerId, livechat_member_type: "agent" }),
+            Command.create({ guest_id: guestId, livechat_member_type: "visitor" }),
         ],
         livechat_channel_id: livechatChannelId,
         livechat_operator_id: serverState.partnerId,
@@ -120,8 +120,8 @@ test("visitor leaving ends the livechat conversation", async () => {
     const channel_id = pyEnv["discuss.channel"].create({
         channel_type: "livechat",
         channel_member_ids: [
-            Command.create({ partner_id: serverState.partnerId }),
-            Command.create({ guest_id: guestId }),
+            Command.create({ partner_id: serverState.partnerId, livechat_member_type: "agent" }),
+            Command.create({ guest_id: guestId, livechat_member_type: "visitor" }),
         ],
         livechat_channel_id: livechatChannelId,
         livechat_operator_id: serverState.partnerId,

--- a/addons/im_livechat/static/tests/channel_member_list.test.js
+++ b/addons/im_livechat/static/tests/channel_member_list.test.js
@@ -20,8 +20,8 @@ test("display country in channel member list", async () => {
     const channelId = pyEnv["discuss.channel"].create({
         anonymous_name: "Visitor #20",
         channel_member_ids: [
-            Command.create({ partner_id: serverState.partnerId }),
-            Command.create({ guest_id: guestId }),
+            Command.create({ partner_id: serverState.partnerId, livechat_member_type: "agent" }),
+            Command.create({ guest_id: guestId, livechat_member_type: "visitor" }),
         ],
         country_id: countryId,
         channel_type: "livechat",

--- a/addons/im_livechat/static/tests/chat_hub_compact.test.js
+++ b/addons/im_livechat/static/tests/chat_hub_compact.test.js
@@ -15,8 +15,8 @@ test("Do not open chat windows automatically when chat hub is compact", async ()
     const guestId = pyEnv["mail.guest"].create({ name: "Visitor" });
     const channelId = pyEnv["discuss.channel"].create({
         channel_member_ids: [
-            Command.create({ partner_id: serverState.partnerId }),
-            Command.create({ guest_id: guestId }),
+            Command.create({ partner_id: serverState.partnerId, livechat_member_type: "agent" }),
+            Command.create({ guest_id: guestId, livechat_member_type: "visitor" }),
         ],
         channel_type: "livechat",
         livechat_operator_id: serverState.partnerId,

--- a/addons/im_livechat/static/tests/chat_window_patch.test.js
+++ b/addons/im_livechat/static/tests/chat_window_patch.test.js
@@ -26,10 +26,12 @@ test("can fold livechat chat windows in mobile", async () => {
             Command.create({
                 unpin_dt: false,
                 partner_id: serverState.partnerId,
+                livechat_member_type: "agent",
             }),
-            Command.create({ partner_id: partnerId }),
+            Command.create({ partner_id: partnerId, livechat_member_type: "visitor" }),
         ],
         channel_type: "livechat",
+        livechat_operator_id: serverState.partnerId,
     });
     await start();
     await click(".o_menu_systray i[aria-label='Messages']");
@@ -53,18 +55,21 @@ test("closing a chat window with no message from admin side unpins it", async ()
             Command.create({
                 unpin_dt: false,
                 partner_id: serverState.partnerId,
+                livechat_member_type: "agent",
             }),
-            Command.create({ partner_id: partnerId_1 }),
+            Command.create({ partner_id: partnerId_1, livechat_member_type: "visitor" }),
         ],
         channel_type: "livechat",
+        livechat_operator_id: serverState.partnerId,
     });
     pyEnv["discuss.channel"].create({
         channel_member_ids: [
             Command.create({
                 unpin_dt: false,
                 partner_id: serverState.partnerId,
+                livechat_member_type: "agent",
             }),
-            Command.create({ partner_id: partnerId_2 }),
+            Command.create({ partner_id: partnerId_2, livechat_member_type: "visitor" }),
         ],
         channel_type: "livechat",
         livechat_end_dt: serializeDate(today()),
@@ -92,8 +97,9 @@ test("Focus should not be stolen when a new livechat open", async () => {
             channel_member_ids: [
                 Command.create({
                     partner_id: serverState.partnerId,
+                    livechat_member_type: "agent",
                 }),
-                Command.create({ guest_id: guestId }),
+                Command.create({ guest_id: guestId, livechat_member_type: "visitor" }),
             ],
             channel_type: "livechat",
         },
@@ -125,9 +131,9 @@ test("do not ask confirmation if other operators are present", async () => {
     const otherOperatorId = pyEnv["res.partner"].create({ name: "John" });
     const channelId = pyEnv["discuss.channel"].create({
         channel_member_ids: [
-            Command.create({ partner_id: serverState.partnerId }),
-            Command.create({ guest_id: guestId }),
-            Command.create({ partner_id: otherOperatorId }),
+            Command.create({ partner_id: serverState.partnerId, livechat_member_type: "agent" }),
+            Command.create({ guest_id: guestId, livechat_member_type: "visitor" }),
+            Command.create({ partner_id: otherOperatorId, livechat_member_type: "agent" }),
         ],
         livechat_operator_id: serverState.partnerId,
         channel_type: "livechat",

--- a/addons/im_livechat/static/tests/composer_patch.test.js
+++ b/addons/im_livechat/static/tests/composer_patch.test.js
@@ -28,8 +28,8 @@ test("Can execute help command on livechat channels", async () => {
     const channelId = pyEnv["discuss.channel"].create({
         anonymous_name: "Visitor 11",
         channel_member_ids: [
-            Command.create({ partner_id: serverState.partnerId }),
-            Command.create({ guest_id: guestId }),
+            Command.create({ partner_id: serverState.partnerId, livechat_member_type: "agent" }),
+            Command.create({ guest_id: guestId, livechat_member_type: "visitor" }),
         ],
         channel_type: "livechat",
         livechat_operator_id: serverState.partnerId,
@@ -51,8 +51,8 @@ test('Receives visitor typing status "is typing"', async () => {
     const channelId = pyEnv["discuss.channel"].create({
         anonymous_name: "Visitor 20",
         channel_member_ids: [
-            Command.create({ partner_id: serverState.partnerId }),
-            Command.create({ guest_id: guestId }),
+            Command.create({ partner_id: serverState.partnerId, livechat_member_type: "agent" }),
+            Command.create({ guest_id: guestId, livechat_member_type: "visitor" }),
         ],
         channel_type: "livechat",
         livechat_operator_id: serverState.partnerId,

--- a/addons/im_livechat/static/tests/discuss_patch.test.js
+++ b/addons/im_livechat/static/tests/discuss_patch.test.js
@@ -33,9 +33,10 @@ test("add livechat in the sidebar on visitor sending first message", async () =>
             Command.create({
                 unpin_dt: "2021-01-01 12:00:00",
                 last_interest_dt: "2021-01-01 10:00:00",
+                livechat_member_type: "agent",
                 partner_id: serverState.partnerId,
             }),
-            Command.create({ guest_id: guestId }),
+            Command.create({ guest_id: guestId, livechat_member_type: "visitor" }),
         ],
         channel_type: "livechat",
         country_id: countryId,
@@ -71,8 +72,8 @@ test("invite button should be present on livechat", async () => {
     const channelId = pyEnv["discuss.channel"].create({
         anonymous_name: "Visitor 11",
         channel_member_ids: [
-            Command.create({ partner_id: serverState.partnerId }),
-            Command.create({ guest_id: guestId }),
+            Command.create({ partner_id: serverState.partnerId, livechat_member_type: "agent" }),
+            Command.create({ guest_id: guestId, livechat_member_type: "visitor" }),
         ],
         channel_type: "livechat",
         livechat_operator_id: serverState.partnerId,
@@ -93,9 +94,10 @@ test("livechats are sorted by last activity time in the sidebar: most recent at 
             channel_member_ids: [
                 Command.create({
                     last_interest_dt: "2021-01-01 10:00:00",
+                    livechat_member_type: "agent",
                     partner_id: serverState.partnerId,
                 }),
-                Command.create({ guest_id: guestId_1 }),
+                Command.create({ guest_id: guestId_1, livechat_member_type: "visitor" }),
             ],
             channel_type: "livechat",
             livechat_operator_id: serverState.partnerId,
@@ -105,9 +107,10 @@ test("livechats are sorted by last activity time in the sidebar: most recent at 
             channel_member_ids: [
                 Command.create({
                     last_interest_dt: "2021-02-01 10:00:00",
+                    livechat_member_type: "agent",
                     partner_id: serverState.partnerId,
                 }),
-                Command.create({ guest_id: guestId_2 }),
+                Command.create({ guest_id: guestId_2, livechat_member_type: "visitor" }),
             ],
             channel_type: "livechat",
             livechat_operator_id: serverState.partnerId,
@@ -136,8 +139,8 @@ test("sidebar search finds livechats", async () => {
     pyEnv["discuss.channel"].create({
         anonymous_name: "Visitor 11",
         channel_member_ids: [
-            Command.create({ partner_id: serverState.partnerId }),
-            Command.create({ guest_id: guestId }),
+            Command.create({ partner_id: serverState.partnerId, livechat_member_type: "agent" }),
+            Command.create({ guest_id: guestId, livechat_member_type: "visitor" }),
         ],
         channel_type: "livechat",
         livechat_operator_id: serverState.partnerId,

--- a/addons/im_livechat/static/tests/go_to_oldest_unread_thread.test.js
+++ b/addons/im_livechat/static/tests/go_to_oldest_unread_thread.test.js
@@ -30,8 +30,11 @@ test("tab on discuss composer goes to oldest unread livechat", async () => {
         {
             anonymous_name: "Visitor 11",
             channel_member_ids: [
-                Command.create({ partner_id: serverState.partnerId }),
-                Command.create({ guest_id: guestId_1 }),
+                Command.create({
+                    partner_id: serverState.partnerId,
+                    livechat_member_type: "agent",
+                }),
+                Command.create({ guest_id: guestId_1, livechat_member_type: "visitor" }),
             ],
             channel_type: "livechat",
             livechat_operator_id: serverState.partnerId,
@@ -44,8 +47,9 @@ test("tab on discuss composer goes to oldest unread livechat", async () => {
                     partner_id: serverState.partnerId,
                     message_unread_counter: 1,
                     last_interest_dt: "2021-01-02 10:00:00",
+                    livechat_member_type: "agent",
                 }),
-                Command.create({ guest_id: guestId_2 }),
+                Command.create({ guest_id: guestId_2, livechat_member_type: "visitor" }),
             ],
             channel_type: "livechat",
             livechat_operator_id: serverState.partnerId,
@@ -58,8 +62,9 @@ test("tab on discuss composer goes to oldest unread livechat", async () => {
                     partner_id: serverState.partnerId,
                     message_unread_counter: 1,
                     last_interest_dt: "2021-01-01 10:00:00",
+                    livechat_member_type: "agent",
                 }),
-                Command.create({ guest_id: guestId_3 }),
+                Command.create({ guest_id: guestId_3, livechat_member_type: "visitor" }),
             ],
             channel_type: "livechat",
             livechat_operator_id: serverState.partnerId,
@@ -116,8 +121,9 @@ test("Tab livechat picks ended livechats last", async () => {
                 Command.create({
                     partner_id: serverState.partnerId,
                     last_interest_dt: `2021-01-02 10:00:0${idx}`,
+                    livechat_member_type: "agent",
                 }),
-                Command.create({ guest_id: guestId }),
+                Command.create({ guest_id: guestId, livechat_member_type: "visitor" }),
             ],
             livechat_channel_id: livechatChannelId,
             livechat_operator_id: serverState.partnerId,
@@ -242,8 +248,11 @@ test("switching to folded chat window unfolds it", async () => {
         {
             anonymous_name: "Visitor 11",
             channel_member_ids: [
-                Command.create({ partner_id: serverState.partnerId }),
-                Command.create({ guest_id: guestId_1 }),
+                Command.create({
+                    partner_id: serverState.partnerId,
+                    livechat_member_type: "agent",
+                }),
+                Command.create({ guest_id: guestId_1, livechat_member_type: "visitor" }),
             ],
             channel_type: "livechat",
             livechat_operator_id: serverState.partnerId,
@@ -255,8 +264,9 @@ test("switching to folded chat window unfolds it", async () => {
                 Command.create({
                     partner_id: serverState.partnerId,
                     last_interest_dt: "2021-01-02 10:00:00",
+                    livechat_member_type: "agent",
                 }),
-                Command.create({ guest_id: guestId_2 }),
+                Command.create({ guest_id: guestId_2, livechat_member_type: "visitor" }),
             ],
             channel_type: "livechat",
             livechat_operator_id: serverState.partnerId,
@@ -293,8 +303,11 @@ test("switching to hidden chat window unhides it", async () => {
         {
             anonymous_name: "Visitor 11",
             channel_member_ids: [
-                Command.create({ partner_id: serverState.partnerId }),
-                Command.create({ guest_id: guestId_1 }),
+                Command.create({
+                    partner_id: serverState.partnerId,
+                    livechat_member_type: "agent",
+                }),
+                Command.create({ guest_id: guestId_1, livechat_member_type: "visitor" }),
             ],
             channel_type: "livechat",
             livechat_operator_id: serverState.partnerId,
@@ -306,8 +319,9 @@ test("switching to hidden chat window unhides it", async () => {
                 Command.create({
                     partner_id: serverState.partnerId,
                     last_interest_dt: "2021-01-02 10:00:00",
+                    livechat_member_type: "agent",
                 }),
-                Command.create({ guest_id: guestId_2 }),
+                Command.create({ guest_id: guestId_2, livechat_member_type: "visitor" }),
             ],
             channel_type: "livechat",
             livechat_operator_id: serverState.partnerId,
@@ -346,8 +360,11 @@ test("tab on composer doesn't switch thread if user is typing", async () => {
         {
             anonymous_name: "Visitor 11",
             channel_member_ids: [
-                Command.create({ partner_id: serverState.partnerId }),
-                Command.create({ guest_id: guestId_1 }),
+                Command.create({
+                    partner_id: serverState.partnerId,
+                    livechat_member_type: "agent",
+                }),
+                Command.create({ guest_id: guestId_1, livechat_member_type: "visitor" }),
             ],
             channel_type: "livechat",
             livechat_operator_id: serverState.partnerId,
@@ -360,8 +377,9 @@ test("tab on composer doesn't switch thread if user is typing", async () => {
                     partner_id: serverState.partnerId,
                     message_unread_counter: 1,
                     last_interest_dt: "2021-01-02 10:00:00",
+                    livechat_member_type: "agent",
                 }),
-                Command.create({ guest_id: guestId_2 }),
+                Command.create({ guest_id: guestId_2, livechat_member_type: "visitor" }),
             ],
             channel_type: "livechat",
             livechat_operator_id: serverState.partnerId,
@@ -383,8 +401,11 @@ test("tab on composer doesn't switch thread if no unread thread", async () => {
         {
             anonymous_name: "Visitor 11",
             channel_member_ids: [
-                Command.create({ partner_id: serverState.partnerId }),
-                Command.create({ guest_id: guestId_1 }),
+                Command.create({
+                    partner_id: serverState.partnerId,
+                    livechat_member_type: "agent",
+                }),
+                Command.create({ guest_id: guestId_1, livechat_member_type: "visitor" }),
             ],
             channel_type: "livechat",
             livechat_operator_id: serverState.partnerId,
@@ -393,8 +414,11 @@ test("tab on composer doesn't switch thread if no unread thread", async () => {
         {
             anonymous_name: "Visitor 12",
             channel_member_ids: [
-                Command.create({ partner_id: serverState.partnerId }),
-                Command.create({ guest_id: guestId_2 }),
+                Command.create({
+                    partner_id: serverState.partnerId,
+                    livechat_member_type: "agent",
+                }),
+                Command.create({ guest_id: guestId_2, livechat_member_type: "visitor" }),
             ],
             channel_type: "livechat",
             livechat_operator_id: serverState.partnerId,

--- a/addons/im_livechat/static/tests/livechat_channel_info_list.test.js
+++ b/addons/im_livechat/static/tests/livechat_channel_info_list.test.js
@@ -27,8 +27,8 @@ test("livechat note is loaded when opening the channel info list", async () => {
     const channelId = pyEnv["discuss.channel"].create({
         anonymous_name: "Visitor #20",
         channel_member_ids: [
-            Command.create({ partner_id: serverState.partnerId }),
-            Command.create({ guest_id: guestId }),
+            Command.create({ partner_id: serverState.partnerId, livechat_member_type: "agent" }),
+            Command.create({ guest_id: guestId, livechat_member_type: "visitor" }),
         ],
         country_id: countryId,
         channel_type: "livechat",
@@ -54,8 +54,8 @@ test("editing livechat note is synced between tabs", async () => {
     const channelId = pyEnv["discuss.channel"].create({
         anonymous_name: "Visitor #20",
         channel_member_ids: [
-            Command.create({ partner_id: serverState.partnerId }),
-            Command.create({ guest_id: guestId }),
+            Command.create({ partner_id: serverState.partnerId, livechat_member_type: "agent" }),
+            Command.create({ guest_id: guestId, livechat_member_type: "visitor" }),
         ],
         country_id: countryId,
         channel_type: "livechat",

--- a/addons/im_livechat/static/tests/messaging_menu_patch.test.js
+++ b/addons/im_livechat/static/tests/messaging_menu_patch.test.js
@@ -12,8 +12,8 @@ test('livechats should be in "chat" filter', async () => {
     pyEnv["discuss.channel"].create({
         anonymous_name: "Visitor 11",
         channel_member_ids: [
-            Command.create({ partner_id: serverState.partnerId }),
-            Command.create({ guest_id: guestId }),
+            Command.create({ partner_id: serverState.partnerId, livechat_member_type: "agent" }),
+            Command.create({ guest_id: guestId, livechat_member_type: "visitor" }),
         ],
         channel_type: "livechat",
         livechat_operator_id: serverState.partnerId,
@@ -34,8 +34,8 @@ test('livechats should be in "livechat" tab in mobile', async () => {
     pyEnv["discuss.channel"].create({
         anonymous_name: "Visitor 11",
         channel_member_ids: [
-            Command.create({ partner_id: serverState.partnerId }),
-            Command.create({ guest_id: guestId }),
+            Command.create({ partner_id: serverState.partnerId, livechat_member_type: "agent" }),
+            Command.create({ guest_id: guestId, livechat_member_type: "visitor" }),
         ],
         channel_type: "livechat",
         livechat_operator_id: serverState.partnerId,

--- a/addons/im_livechat/static/tests/messaging_service_patch.test.js
+++ b/addons/im_livechat/static/tests/messaging_service_patch.test.js
@@ -35,8 +35,8 @@ test("push notifications are Odoo toaster on Android", async () => {
         name: "Livechat 1",
         channel_type: "livechat",
         channel_member_ids: [
-            Command.create({ partner_id: serverState.partnerId }),
-            Command.create({ guest_id: guestId }),
+            Command.create({ partner_id: serverState.partnerId, livechat_member_type: "agent" }),
+            Command.create({ guest_id: guestId, livechat_member_type: "visitor" }),
         ],
     });
     listenStoreFetch("init_messaging");

--- a/addons/im_livechat/static/tests/mobile_messaging_menu_patch.test.js
+++ b/addons/im_livechat/static/tests/mobile_messaging_menu_patch.test.js
@@ -27,8 +27,11 @@ test("Livechat button is present when there is at least one livechat thread", as
     pyEnv["discuss.channel"].create({
         anonymous_name: "Visitor 11",
         channel_member_ids: [
-            Command.create({ partner_id: serverState.partnerId }),
-            Command.create({ partner_id: serverState.publicPartnerId }),
+            Command.create({ partner_id: serverState.partnerId, livechat_member_type: "agent" }),
+            Command.create({
+                partner_id: serverState.publicPartnerId,
+                livechat_member_type: "visitor",
+            }),
         ],
         channel_type: "livechat",
         livechat_operator_id: serverState.partnerId,

--- a/addons/im_livechat/static/tests/mock_server/mock_models/discuss_channel_member.js
+++ b/addons/im_livechat/static/tests/mock_server/mock_models/discuss_channel_member.js
@@ -1,6 +1,15 @@
 import { mailModels } from "@mail/../tests/mail_test_helpers";
+import { fields } from "@web/../tests/web_test_helpers";
 
 export class DiscussChannelMember extends mailModels.DiscussChannelMember {
+    livechat_member_type = fields.Selection({
+        selection: [
+            ["agent", "Agent"],
+            ["visitor", "Visitor"],
+            ["bot", "Chatbot"],
+        ],
+        compute: false,
+    });
     /**
      * @override
      * @type {typeof mailModels.DiscussChannelMember["prototype"]["_get_store_partner_fields"]}
@@ -15,5 +24,18 @@ export class DiscussChannelMember extends mailModels.DiscussChannelMember {
             return ["active", "avatar_128", "country_id", "is_public", "user_livechat_username"];
         }
         return super._get_store_partner_fields(...arguments);
+    }
+    /**
+     * @override
+     * @type {typeof mailModels.DiscussChannelMember["prototype"]["_to_store"]}
+     */
+    _to_store(ids, store, fields, extra_fields) {
+        super._to_store(...arguments);
+        const members = this.browse(ids);
+        for (const member of members) {
+            store.add(this.browse(member.id), {
+                livechat_member_type: member.livechat_member_type,
+            });
+        }
     }
 }

--- a/addons/im_livechat/static/tests/sidebar_patch.test.js
+++ b/addons/im_livechat/static/tests/sidebar_patch.test.js
@@ -28,8 +28,8 @@ test("Unknown visitor", async () => {
     pyEnv["discuss.channel"].create({
         anonymous_name: "Visitor 11",
         channel_member_ids: [
-            Command.create({ partner_id: serverState.partnerId }),
-            Command.create({ guest_id: guestId }),
+            Command.create({ partner_id: serverState.partnerId, livechat_member_type: "agent" }),
+            Command.create({ guest_id: guestId, livechat_member_type: "visitor" }),
         ],
         channel_type: "livechat",
         livechat_operator_id: serverState.partnerId,
@@ -52,8 +52,8 @@ test("Known user with country", async () => {
     });
     pyEnv["discuss.channel"].create({
         channel_member_ids: [
-            Command.create({ partner_id: serverState.partnerId }),
-            Command.create({ partner_id: partnerId }),
+            Command.create({ partner_id: serverState.partnerId, livechat_member_type: "agent" }),
+            Command.create({ partner_id: partnerId, livechat_member_type: "visitor" }),
         ],
         channel_type: "livechat",
         country_id: countryId,
@@ -82,9 +82,10 @@ test("Do not show channel when visitor is typing", async () => {
             Command.create({
                 unpin_dt: "2021-01-01 12:00:00",
                 last_interest_dt: "2021-01-01 10:00:00",
+                livechat_member_type: "agent",
                 partner_id: serverState.partnerId,
             }),
-            Command.create({ guest_id: guestId }),
+            Command.create({ guest_id: guestId, livechat_member_type: "visitor" }),
         ],
         channel_type: "livechat",
         livechat_channel_id: livechatChannelId,
@@ -123,8 +124,8 @@ test("Smiley face avatar for livechat item linked to a guest", async () => {
     pyEnv["discuss.channel"].create({
         anonymous_name: "Visitor 11",
         channel_member_ids: [
-            Command.create({ partner_id: serverState.partnerId }),
-            Command.create({ guest_id: guestId }),
+            Command.create({ partner_id: serverState.partnerId, livechat_member_type: "agent" }),
+            Command.create({ guest_id: guestId, livechat_member_type: "visitor" }),
         ],
         channel_type: "livechat",
         livechat_operator_id: serverState.partnerId,
@@ -146,8 +147,8 @@ test("Partner profile picture for livechat item linked to a partner", async () =
     const partnerId = pyEnv["res.partner"].create({ name: "Jean" });
     const channelId = pyEnv["discuss.channel"].create({
         channel_member_ids: [
-            Command.create({ partner_id: serverState.partnerId }),
-            Command.create({ partner_id: partnerId }),
+            Command.create({ partner_id: serverState.partnerId, livechat_member_type: "agent" }),
+            Command.create({ partner_id: partnerId, livechat_member_type: "visitor" }),
         ],
         channel_type: "livechat",
         livechat_operator_id: serverState.partnerId,
@@ -172,9 +173,10 @@ test("No counter if the category is unfolded and with unread messages", async ()
         channel_member_ids: [
             Command.create({
                 message_unread_counter: 10,
+                livechat_member_type: "agent",
                 partner_id: serverState.partnerId,
             }),
-            Command.create({ guest_id: guestId }),
+            Command.create({ guest_id: guestId, livechat_member_type: "visitor" }),
         ],
         channel_type: "livechat",
         livechat_operator_id: serverState.partnerId,
@@ -193,8 +195,8 @@ test("No counter if category is folded and without unread messages", async () =>
     pyEnv["discuss.channel"].create({
         anonymous_name: "Visitor 11",
         channel_member_ids: [
-            Command.create({ partner_id: serverState.partnerId }),
-            Command.create({ guest_id: guestId }),
+            Command.create({ partner_id: serverState.partnerId, livechat_member_type: "agent" }),
+            Command.create({ guest_id: guestId, livechat_member_type: "visitor" }),
         ],
         channel_type: "livechat",
         livechat_operator_id: serverState.partnerId,
@@ -213,9 +215,10 @@ test("Counter should have correct value of unread threads if category is folded 
         anonymous_name: "Visitor 11",
         channel_member_ids: [
             Command.create({
+                livechat_member_type: "agent",
                 partner_id: serverState.partnerId,
             }),
-            Command.create({ guest_id: guestId }),
+            Command.create({ guest_id: guestId, livechat_member_type: "visitor" }),
         ],
         channel_type: "livechat",
         livechat_operator_id: serverState.partnerId,
@@ -239,8 +242,8 @@ test("Close manually by clicking the title", async () => {
     pyEnv["discuss.channel"].create({
         anonymous_name: "Visitor 11",
         channel_member_ids: [
-            Command.create({ partner_id: serverState.partnerId }),
-            Command.create({ guest_id: guestId }),
+            Command.create({ partner_id: serverState.partnerId, livechat_member_type: "agent" }),
+            Command.create({ guest_id: guestId, livechat_member_type: "visitor" }),
         ],
         channel_type: "livechat",
         livechat_operator_id: serverState.partnerId,
@@ -265,8 +268,13 @@ test("Open manually by clicking the title", async () => {
             Command.create({
                 partner_id: serverState.partnerId,
                 last_interest_dt: "2021-01-01 10:00:00",
+                livechat_member_type: "agent",
             }),
-            Command.create({ guest_id: guestId, last_interest_dt: "2021-01-01 10:00:00" }),
+            Command.create({
+                guest_id: guestId,
+                last_interest_dt: "2021-01-01 10:00:00",
+                livechat_member_type: "visitor",
+            }),
         ],
         channel_type: "livechat",
         livechat_operator_id: serverState.partnerId,
@@ -295,8 +303,8 @@ test("Category item should be invisible if the category is closed", async () => 
     pyEnv["discuss.channel"].create({
         anonymous_name: "Visitor 11",
         channel_member_ids: [
-            Command.create({ partner_id: serverState.partnerId }),
-            Command.create({ guest_id: guestId }),
+            Command.create({ partner_id: serverState.partnerId, livechat_member_type: "agent" }),
+            Command.create({ guest_id: guestId, livechat_member_type: "visitor" }),
         ],
         channel_type: "livechat",
         livechat_operator_id: serverState.partnerId,
@@ -325,8 +333,13 @@ test("Active category item should be visible even if the category is closed", as
             Command.create({
                 partner_id: serverState.partnerId,
                 last_interest_dt: "2021-01-01 10:00:00",
+                livechat_member_type: "agent",
             }),
-            Command.create({ guest_id: guestId, last_interest_dt: "2021-01-01 10:00:00" }),
+            Command.create({
+                guest_id: guestId,
+                last_interest_dt: "2021-01-01 10:00:00",
+                livechat_member_type: "visitor",
+            }),
         ],
         channel_type: "livechat",
         livechat_operator_id: serverState.partnerId,
@@ -344,8 +357,11 @@ test("Clicking on leave button leaves the channel", async () => {
     pyEnv["discuss.channel"].create({
         anonymous_name: "Visitor 11",
         channel_member_ids: [
-            Command.create({ partner_id: serverState.partnerId }),
-            Command.create({ guest_id: pyEnv["mail.guest"].create({ name: "Visitor 11" }) }),
+            Command.create({ partner_id: serverState.partnerId, livechat_member_type: "agent" }),
+            Command.create({
+                guest_id: pyEnv["mail.guest"].create({ name: "Visitor 11" }),
+                livechat_member_type: "visitor",
+            }),
         ],
         channel_type: "livechat",
         livechat_operator_id: serverState.partnerId,
@@ -370,8 +386,13 @@ test("Message unread counter", async () => {
             Command.create({
                 partner_id: serverState.partnerId,
                 last_interest_dt: "2021-01-03 10:00:00",
+                livechat_member_type: "agent",
             }),
-            Command.create({ guest_id: guestId, last_interest_dt: "2021-01-03 10:00:00" }),
+            Command.create({
+                guest_id: guestId,
+                last_interest_dt: "2021-01-03 10:00:00",
+                livechat_member_type: "visitor",
+            }),
         ],
         channel_type: "livechat",
         livechat_operator_id: serverState.partnerId,
@@ -398,7 +419,15 @@ test("unknown livechat can be displayed and interacted with", async () => {
     const partnerId = pyEnv["res.partner"].create({ name: "Jane" });
     const channelId = pyEnv["discuss.channel"].create({
         channel_member_ids: [
-            Command.create({ partner_id: partnerId, last_interest_dt: "2021-01-01 10:00:00" }),
+            Command.create({
+                partner_id: partnerId,
+                last_interest_dt: "2021-01-01 10:00:00",
+                livechat_member_type: "agent",
+            }),
+            Command.create({
+                guest_id: pyEnv["mail.guest"].create({ name: "Jane" }),
+                livechat_member_type: "visitor",
+            }),
         ],
         channel_type: "livechat",
         livechat_operator_id: partnerId,
@@ -432,6 +461,13 @@ test("Local sidebar category state is shared between tabs", async () => {
     const pyEnv = await startServer();
     pyEnv["discuss.channel"].create({
         channel_type: "livechat",
+        channel_member_ids: [
+            Command.create({ partner_id: serverState.partnerId, livechat_member_type: "agent" }),
+            Command.create({
+                guest_id: pyEnv["mail.guest"].create({ name: "Visitor #12" }),
+                livechat_member_type: "visitor",
+            }),
+        ],
         livechat_operator_id: serverState.user,
     });
     const env1 = await start({ asTab: true });
@@ -456,9 +492,13 @@ test("live chat is displayed below its category", async () => {
         channel_type: "livechat",
         livechat_channel_id: livechatChannelId,
         channel_member_ids: [
-            Command.create({ partner_id: serverState.partnerId }),
-            Command.create({ guest_id: pyEnv["mail.guest"].create({ name: "Visitor #12" }) }),
+            Command.create({ partner_id: serverState.partnerId, livechat_member_type: "agent" }),
+            Command.create({
+                guest_id: pyEnv["mail.guest"].create({ name: "Visitor #12" }),
+                livechat_member_type: "visitor",
+            }),
         ],
+        livechat_operator_id: serverState.partnerId,
     });
     await start();
     await openDiscuss();

--- a/addons/im_livechat/static/tests/suggestions.test.js
+++ b/addons/im_livechat/static/tests/suggestions.test.js
@@ -22,8 +22,11 @@ test("Suggestions are shown after delimiter was used in text (::)", async () => 
         anonymous_name: "Visitor",
         channel_type: "livechat",
         channel_member_ids: [
-            Command.create({ partner_id: serverState.partnerId }),
-            Command.create({ partner_id: serverState.publicPartnerId }),
+            Command.create({ partner_id: serverState.partnerId, livechat_member_type: "agent" }),
+            Command.create({
+                partner_id: serverState.publicPartnerId,
+                livechat_member_type: "visitor",
+            }),
         ],
     });
     await start();
@@ -43,8 +46,14 @@ test("Cannot mention other channels in a livechat", async () => {
             anonymous_name: "Visitor",
             channel_type: "livechat",
             channel_member_ids: [
-                Command.create({ partner_id: serverState.partnerId }),
-                Command.create({ partner_id: serverState.publicPartnerId }),
+                Command.create({
+                    partner_id: serverState.partnerId,
+                    livechat_member_type: "agent",
+                }),
+                Command.create({
+                    partner_id: serverState.publicPartnerId,
+                    livechat_member_type: "visitor",
+                }),
             ],
         },
         {

--- a/addons/im_livechat/static/tests/thread_icon_patch.test.js
+++ b/addons/im_livechat/static/tests/thread_icon_patch.test.js
@@ -15,8 +15,8 @@ test("Public website visitor is typing", async () => {
     const channelId = pyEnv["discuss.channel"].create({
         anonymous_name: "Visitor 20",
         channel_member_ids: [
-            Command.create({ partner_id: serverState.partnerId }),
-            Command.create({ guest_id: guestId }),
+            Command.create({ partner_id: serverState.partnerId, livechat_member_type: "agent" }),
+            Command.create({ guest_id: guestId, livechat_member_type: "visitor" }),
         ],
         channel_type: "livechat",
         livechat_operator_id: serverState.partnerId,

--- a/addons/im_livechat/static/tests/thread_model_patch.test.js
+++ b/addons/im_livechat/static/tests/thread_model_patch.test.js
@@ -28,8 +28,8 @@ test("Thread name unchanged when inviting new users", async () => {
     const channelId = pyEnv["discuss.channel"].create({
         anonymous_name: "Visitor #20",
         channel_member_ids: [
-            Command.create({ partner_id: serverState.partnerId }),
-            Command.create({ guest_id: guestId }),
+            Command.create({ partner_id: serverState.partnerId, livechat_member_type: "agent" }),
+            Command.create({ guest_id: guestId, livechat_member_type: "visitor" }),
         ],
         channel_type: "livechat",
         livechat_operator_id: serverState.partnerId,
@@ -54,8 +54,8 @@ test("Can set a custom name to livechat conversation", async () => {
     const channelId = pyEnv["discuss.channel"].create({
         anonymous_name: "Visitor #20",
         channel_member_ids: [
-            Command.create({ partner_id: serverState.partnerId }),
-            Command.create({ guest_id: guestId }),
+            Command.create({ partner_id: serverState.partnerId, livechat_member_type: "agent" }),
+            Command.create({ guest_id: guestId, livechat_member_type: "visitor" }),
         ],
         channel_type: "livechat",
         livechat_operator_id: serverState.partnerId,
@@ -79,8 +79,8 @@ test("Display livechat custom username if defined", async () => {
     const channelId = pyEnv["discuss.channel"].create({
         anonymous_name: "Visitor #20",
         channel_member_ids: [
-            Command.create({ partner_id: serverState.partnerId }),
-            Command.create({ guest_id: guestId }),
+            Command.create({ partner_id: serverState.partnerId, livechat_member_type: "agent" }),
+            Command.create({ guest_id: guestId, livechat_member_type: "visitor" }),
         ],
         channel_type: "livechat",
         livechat_operator_id: serverState.partnerId,
@@ -103,8 +103,8 @@ test("Display livechat custom name in typing status", async () => {
     const channelId = pyEnv["discuss.channel"].create({
         anonymous_name: "Visitor #20",
         channel_member_ids: [
-            Command.create({ partner_id: partnerId }),
-            Command.create({ partner_id: serverState.partnerId }),
+            Command.create({ partner_id: partnerId, livechat_member_type: "agent" }),
+            Command.create({ partner_id: serverState.partnerId, livechat_member_type: "visitor" }),
         ],
         channel_type: "livechat",
         livechat_operator_id: partnerId,

--- a/addons/im_livechat/static/tests/translation.test.js
+++ b/addons/im_livechat/static/tests/translation.test.js
@@ -12,8 +12,11 @@ test("message translation in livechat", async () => {
         anonymous_name: "Visitor",
         channel_type: "livechat",
         channel_member_ids: [
-            Command.create({ partner_id: serverState.partnerId }),
-            Command.create({ partner_id: serverState.publicPartnerId }),
+            Command.create({ partner_id: serverState.partnerId, livechat_member_type: "agent" }),
+            Command.create({
+                partner_id: serverState.publicPartnerId,
+                livechat_member_type: "visitor",
+            }),
         ],
     });
     pyEnv["mail.message"].create({

--- a/addons/im_livechat/static/tests/visitor_disconnection.test.js
+++ b/addons/im_livechat/static/tests/visitor_disconnection.test.js
@@ -37,8 +37,8 @@ test("Visitor going offline shows disconnection banner to operator", async () =>
     const channel_id = pyEnv["discuss.channel"].create({
         channel_type: "livechat",
         channel_member_ids: [
-            Command.create({ partner_id: serverState.partnerId }),
-            Command.create({ guest_id: guestId }),
+            Command.create({ partner_id: serverState.partnerId, livechat_member_type: "agent" }),
+            Command.create({ guest_id: guestId, livechat_member_type: "visitor" }),
         ],
         livechat_channel_id: livechatChannelId,
         livechat_operator_id: serverState.partnerId,


### PR DESCRIPTION
Mock server was missing `livechat_member_type`, which can lead to issues when JS features are `livechat_member_type` aware.