### PR TITLE
[FIX] mail: properly center discuss sidebar items in compact mode

### DIFF
--- a/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.xml
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.xml
@@ -161,8 +161,7 @@
             t-ref="root"
         >
             <div class="o-mail-DiscussSidebarChannel-itemMain border-0 rounded-start-2 text-reset d-flex align-items-center p-0" t-att-class="{ 'overflow-hidden': !store.discuss.isSidebarCompact }" t-att-title="store.discuss.isSidebarCompact ? undefined : thread.displayName">
-                <span t-if="!store.discuss.isSidebarCompact" class="ms-1"/>
-                <div class="bg-inherit position-relative d-flex flex-shrink-0 ms-1 o-my-0_5 rounded-3" style="width:32px;height:32px;" name="threadAvatar">
+                <div class="bg-inherit position-relative d-flex flex-shrink-0 o-my-0_5 rounded-3" style="width:32px;height:32px;" name="threadAvatar" t-att-class="{ 'ms-2': !store.discuss.isSidebarCompact }">
                     <img class="w-100 h-100 rounded-3 o_object_fit_cover shadow-sm" t-att-src="thread.avatarUrl" alt="Thread Image"/>
                     <ThreadIcon t-if="thread.channel_type?.includes('chat') or (thread.channel_type === 'channel' and !thread.group_public_id)" thread="thread" size="'small'" className="'o-mail-DiscussSidebarChannel-threadIcon position-absolute top-100 start-100 translate-middle mt-n1 ms-n1 d-flex align-items-center justify-content-center rounded-circle bg-inherit'"/>
                     <CountryFlag t-if="thread.showCorrespondentCountry" country="thread.correspondentCountry" class="'position-absolute o-mail-DiscussSidebarChannel-country border shadow-sm'"/>


### PR DESCRIPTION
Follow-up of https://github.com/odoo/odoo/pull/215447

PR above makes improvements to new livechat status feature, one of the improvement is to show the livechat status as floating icon on livechat conversation avatar in discuss sidebar when it's not in "in progress", i.e. "waiting customer" or "need help".

At some point in dev, the icon was before the avatar when discuss sidebar was not compact. This was changed in last minute to floating icon too. However template kept lefovers of old design and mistakenly put a left margin in compact mode, leading to not centered discuss sidebar items in compact mode.

This commit fixes the issue by reverting to original margin rules that was before the improvements made in PR above.