### PR TITLE
[IMP] stock*: use Domain

### DIFF
--- a/addons/mrp/models/mrp_bom.py
+++ b/addons/mrp/models/mrp_bom.py
@@ -1,11 +1,9 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import api, fields, models, _, Command
+from odoo import api, fields, models, _
 from odoo.exceptions import UserError, ValidationError
-from odoo.osv.expression import AND, OR
-from odoo.tools import float_round
-from odoo.tools.misc import clean_context
+from odoo.fields import Command, Domain
+from odoo.tools.misc import clean_context, OrderedSet
 
 from collections import defaultdict
 
@@ -157,10 +155,10 @@ class MrpBom(models.Model):
 
         boms_to_check = self
         if self.bom_line_ids.product_id:
-            boms_to_check |= self.search(OR([
+            boms_to_check |= self.search(Domain.OR(
                 self._bom_find_domain(product)
                 for product in self.bom_line_ids.product_id
-            ]))
+            ))
 
         for bom in boms_to_check:
             if not bom.active:
@@ -344,13 +342,17 @@ class MrpBom(models.Model):
 
     @api.model
     def _bom_find_domain(self, products, picking_type=None, company_id=False, bom_type=False):
-        domain = ['&', '|', ('product_id', 'in', products.ids), '&', ('product_id', '=', False), ('product_tmpl_id', 'in', products.product_tmpl_id.ids), ('active', '=', True)]
+        domain = (
+            Domain('product_id', 'in', products.ids) | (
+                Domain('product_id', '=', False) & Domain('product_tmpl_id', 'in', products.product_tmpl_id.ids)
+            )
+        ) & Domain('active', '=', True)
         if company_id or self.env.context.get('company_id'):
-            domain = AND([domain, ['|', ('company_id', '=', False), ('company_id', '=', company_id or self.env.context.get('company_id'))]])
+            domain &= Domain('company_id', 'in', [False, company_id or self.env.context.get('company_id')])
         if picking_type:
-            domain = AND([domain, ['|', ('picking_type_id', '=', picking_type.id), ('picking_type_id', '=', False)]])
+            domain &= Domain('picking_type_id', 'in', [picking_type.id, False])
         if bom_type:
-            domain = AND([domain, [('type', '=', bom_type)]])
+            domain &= Domain('type', '=', bom_type)
         return domain
 
     @api.model
@@ -446,21 +448,22 @@ class MrpBom(models.Model):
         }]
 
     def _set_outdated_bom_in_productions(self):
+        if not self:
+            return
         # Searches for MOs using these BoMs to notify them that their BoM has been updated.
         list_of_domain_by_bom = []
         for bom in self:
-            domain_by_products = [('product_id', 'in', bom.product_tmpl_id.product_variant_ids.ids)]
             if bom.product_id:
-                domain_by_products = [('product_id', '=', bom.product_id.id)]
-            domain_for_confirmed_mo = AND([[('state', '=', 'confirmed')], domain_by_products])
+                domain_by_products = Domain('product_id', '=', bom.product_id.id)
+            else:
+                domain_by_products = Domain('product_id', 'in', bom.product_tmpl_id.product_variant_ids.ids)
+            domain_for_confirmed_mo = Domain('state', '=', 'confirmed') & domain_by_products
             # Avoid confirmed MOs if the BoM's product was changed.
-            domain_by_states = OR([[('state', '=', 'draft')], domain_for_confirmed_mo])
-            list_of_domain_by_bom.append(AND([[('bom_id', '=', bom.id)], domain_by_states]))
-        if list_of_domain_by_bom:
-            domain = OR(list_of_domain_by_bom)
-            productions = self.env['mrp.production'].search(domain)
-            if productions:
-                productions.is_outdated_bom = True
+            domain_by_states = Domain('state', '=', 'draft') | domain_for_confirmed_mo
+            list_of_domain_by_bom.append(Domain('bom_id', '=', bom.id) & domain_by_states)
+        productions = self.env['mrp.production'].search(Domain.OR(list_of_domain_by_bom))
+        if productions:
+            productions.is_outdated_bom = True
 
     # -------------------------------------------------------------------------
     # CATALOG
@@ -521,24 +524,20 @@ class MrpBom(models.Model):
         return res | self._get_extra_attachments()
 
     def _get_extra_attachments(self):
-        final_domain = []
-        bom_domain = [('attached_on_mrp', '=', 'bom')]
         is_byproduct = self.env.user.has_group('mrp.group_mrp_byproducts')
+        product_ids, template_ids = OrderedSet(), OrderedSet()
         for bom in self:
-            product_subdomain = ['|',
-                '&', ('res_model', '=', 'product.product'), ('res_id', '=', bom.product_id.id),
-                '&', ('res_model', '=', 'product.template'), ('res_id', '=', bom.product_tmpl_id.id)]
+            product_ids.add(bom.product_id.id)
+            template_ids.add(bom.product_tmpl_id.id)
             if is_byproduct:
-                product_domain = OR([product_subdomain, [
-                    '|',
-                    '&', ('res_model', '=', 'product.product'), ('res_id', 'in', bom.byproduct_ids.product_id.ids),
-                    '&', ('res_model', '=', 'product.template'), ('res_id', 'in', bom.byproduct_ids.product_id.product_tmpl_id.ids)]])
-            else:
-                product_domain = product_subdomain
-            prod_final_domain = AND([bom_domain, product_domain])
-            final_domain = OR([final_domain, prod_final_domain]) if final_domain else prod_final_domain
+                product_ids.update(bom.byproduct_ids.product_id.ids)
+                template_ids.update(bom.byproduct_ids.product_id.product_tmpl_id.ids)
 
-        attachements = self.env['product.document'].search(final_domain).ir_attachment_id
+        domain = Domain('attached_on_mrp', '=', 'bom') & (
+            (Domain('res_model', '=', 'product.product') & Domain('res_id', 'in', product_ids))
+            | (Domain('res_model', '=', 'product.template') & Domain('res_id', 'in', template_ids))
+        )
+        attachements = self.env['product.document'].search(domain).ir_attachment_id
         return attachements
 
     @api.model

--- a/addons/mrp/models/stock_orderpoint.py
+++ b/addons/mrp/models/stock_orderpoint.py
@@ -1,11 +1,9 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import _, api, fields, models
-from odoo.tools.float_utils import float_is_zero
-from odoo.osv.expression import AND
-from dateutil.relativedelta import relativedelta
 from datetime import datetime, time
+
+from odoo import _, api, fields, models
+from odoo.fields import Domain
 
 
 class StockWarehouseOrderpoint(models.Model):
@@ -19,9 +17,9 @@ class StockWarehouseOrderpoint(models.Model):
 
     def _get_replenishment_order_notification(self):
         self.ensure_one()
-        domain = [('orderpoint_id', 'in', self.ids)]
+        domain = Domain('orderpoint_id', 'in', self.ids)
         if self.env.context.get('written_after'):
-            domain = AND([domain, [('write_date', '>=', self.env.context.get('written_after'))]])
+            domain &= Domain('write_date', '>=', self.env.context.get('written_after'))
         production = self.env['mrp.production'].search(domain, limit=1)
         if production:
             return {

--- a/addons/mrp/models/stock_picking.py
+++ b/addons/mrp/models/stock_picking.py
@@ -1,11 +1,10 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from ast import literal_eval
 
 from odoo import _, api, fields, models
 from odoo.exceptions import ValidationError
-from odoo.osv import expression
+from odoo.fields import Domain
 
 
 class StockPickingType(models.Model):
@@ -191,7 +190,7 @@ class StockPicking(models.Model):
 
         if picking_type_code == "mrp_operation":
             action = self._get_action("mrp.action_picking_tree_mrp_operation_graph")
-            action["domain"] = expression.AND([
+            action["domain"] = Domain.AND([
                 literal_eval(action["domain"] or '[]'), [('picking_type_id', '=', picking_type_id)]
             ])
             allowed_company_ids = self.env.context.get("allowed_company_ids", [])

--- a/addons/mrp/models/stock_rule.py
+++ b/addons/mrp/models/stock_rule.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from collections import defaultdict
@@ -6,8 +5,8 @@ from datetime import datetime
 from dateutil.relativedelta import relativedelta
 
 from odoo import api, fields, models, SUPERUSER_ID, _
-from odoo.osv import expression
-from odoo.tools import float_compare, OrderedSet
+from odoo.fields import Domain
+from odoo.tools import OrderedSet
 
 
 class StockRule(models.Model):
@@ -279,9 +278,9 @@ class ProcurementGroup(models.Model):
                         procurement.origin, procurement.company_id, values))
             else:
                 procurements_without_kit.append(procurement)
-        return super(ProcurementGroup, self).run(procurements_without_kit, raise_user_error=raise_user_error)
+        return super().run(procurements_without_kit, raise_user_error=raise_user_error)
 
     def _get_moves_to_assign_domain(self, company_id):
-        domain = super(ProcurementGroup, self)._get_moves_to_assign_domain(company_id)
-        domain = expression.AND([domain, [('production_id', '=', False)]])
+        domain = super()._get_moves_to_assign_domain(company_id)
+        domain = Domain.AND([domain, Domain('production_id', '=', False)])
         return domain

--- a/addons/mrp_subcontracting/models/mrp_bom.py
+++ b/addons/mrp_subcontracting/models/mrp_bom.py
@@ -1,9 +1,8 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import api, fields, models, _
 from odoo.exceptions import ValidationError
-from odoo.osv.expression import AND
+from odoo.fields import Domain
 
 
 class MrpBom(models.Model):
@@ -17,7 +16,7 @@ class MrpBom(models.Model):
     def _bom_subcontract_find(self, product, picking_type=None, company_id=False, bom_type='subcontract', subcontractor=False):
         domain = self._bom_find_domain(product, picking_type=picking_type, company_id=company_id, bom_type=bom_type)
         if subcontractor:
-            domain = AND([domain, [('subcontractor_ids', 'parent_of', subcontractor.ids)]])
+            domain &= Domain('subcontractor_ids', 'parent_of', subcontractor.ids)
             return self.search(domain, order='sequence, product_id, id', limit=1)
         else:
             return self.env['mrp.bom']

--- a/addons/mrp_subcontracting/models/stock_replenish_mixin.py
+++ b/addons/mrp_subcontracting/models/stock_replenish_mixin.py
@@ -1,7 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import models, _
-from odoo.osv import expression
+from odoo.fields import Domain
 
 
 class StockReplenishMixin(models.AbstractModel):
@@ -10,4 +10,4 @@ class StockReplenishMixin(models.AbstractModel):
     def _get_allowed_route_domain(self):
         domains = super()._get_allowed_route_domain()
         route_id = self.env['stock.warehouse']._find_or_create_global_route('mrp_subcontracting.route_resupply_subcontractor_mto', _('Resupply Subcontractor on Order')).id
-        return expression.AND([domains, [('id', '!=', route_id)]])
+        return Domain.AND([domains, [('id', '!=', route_id)]])

--- a/addons/mrp_subcontracting_account/models/stock_picking.py
+++ b/addons/mrp_subcontracting_account/models/stock_picking.py
@@ -1,8 +1,7 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import models
-from odoo.osv.expression import OR
+from odoo.fields import Domain
 
 
 class StockPicking(models.Model):
@@ -15,5 +14,5 @@ class StockPicking(models.Model):
             return action
         domain = action['domain']
         domain_subcontracting = [('id', 'in', (subcontracted_productions.move_raw_ids | subcontracted_productions.move_finished_ids).stock_valuation_layer_ids.ids)]
-        domain = OR([domain, domain_subcontracting])
+        domain = Domain.OR([domain, domain_subcontracting])
         return dict(action, domain=domain)

--- a/addons/mrp_subcontracting_dropshipping/models/stock_replenish_mixin.py
+++ b/addons/mrp_subcontracting_dropshipping/models/stock_replenish_mixin.py
@@ -1,7 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import models
-from odoo.osv import expression
+from odoo.fields import Domain
 
 
 class StockReplenishMixin(models.AbstractModel):
@@ -9,4 +9,4 @@ class StockReplenishMixin(models.AbstractModel):
 
     def _get_allowed_route_domain(self):
         domains = super()._get_allowed_route_domain()
-        return expression.AND([domains, [('id', '!=', self.env.ref('mrp_subcontracting_dropshipping.route_subcontracting_dropshipping', raise_if_not_found=False).id)]])
+        return Domain.AND([domains, [('id', '!=', self.env.ref('mrp_subcontracting_dropshipping.route_subcontracting_dropshipping', raise_if_not_found=False).id)]])

--- a/addons/project_mrp_account/models/project_project.py
+++ b/addons/project_mrp_account/models/project_project.py
@@ -1,7 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import models
-from odoo.osv import expression
+from odoo.fields import Domain
 
 
 class ProjectProject(models.Model):
@@ -22,9 +22,9 @@ class ProjectProject(models.Model):
         return sequence_per_invoice_type
 
     def _get_profitability_aal_domain(self):
-        return expression.AND([
+        return Domain.AND([
             super()._get_profitability_aal_domain(),
-            [('category', '!=', 'manufacturing_order')],
+            Domain('category', '!=', 'manufacturing_order'),
         ])
 
     def _get_profitability_items(self, with_action=True):

--- a/addons/project_stock_account/models/stock_move.py
+++ b/addons/project_stock_account/models/stock_move.py
@@ -2,7 +2,7 @@
 
 from odoo import _, models
 from odoo.exceptions import ValidationError
-from odoo.osv.expression import OR
+from odoo.fields import Domain
 
 
 class StockMove(models.Model):
@@ -25,8 +25,8 @@ class StockMove(models.Model):
         return ['&', ('picking_id.project_id', '!=', False), ('picking_type_id.analytic_costs', '!=', False)]
 
     def _account_analytic_entry_move(self):
-        domain = self._get_valid_moves_domain()
-        domain = OR([[('picking_id', '=', False)], domain])
+        domain = Domain(self._get_valid_moves_domain())
+        domain = Domain('picking_id', '=', False) | domain
         valid_moves = self.filtered_domain(domain)
         super(StockMove, valid_moves)._account_analytic_entry_move()
 

--- a/addons/purchase_stock/models/stock.py
+++ b/addons/purchase_stock/models/stock.py
@@ -3,7 +3,7 @@
 from collections import defaultdict
 
 from odoo import api, fields, models, _
-from odoo.osv.expression import AND
+from odoo.fields import Domain
 
 
 class StockPicking(models.Model):
@@ -193,9 +193,9 @@ class StockWarehouseOrderpoint(models.Model):
 
     def _get_replenishment_order_notification(self):
         self.ensure_one()
-        domain = [('orderpoint_id', 'in', self.ids)]
+        domain = Domain('orderpoint_id', 'in', self.ids)
         if self.env.context.get('written_after'):
-            domain = AND([domain, [('write_date', '>=', self.env.context.get('written_after'))]])
+            domain &= Domain('write_date', '>=', self.env.context.get('written_after'))
         order = self.env['purchase.order.line'].search(domain, limit=1).order_id
         if order:
             return {

--- a/addons/stock/models/product_strategy.py
+++ b/addons/stock/models/product_strategy.py
@@ -1,10 +1,8 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import _, api, fields, models
-from odoo.osv import expression
+from odoo.fields import Domain
 from odoo.exceptions import UserError
-from odoo.tools.float_utils import float_compare
 
 
 class ProductRemoval(models.Model):
@@ -111,20 +109,17 @@ class StockPutawayRule(models.Model):
             for rule in self:
                 if rule.company_id.id != vals['company_id']:
                     raise UserError(_("Changing the company of this record is forbidden at this point, you should rather archive it and create a new one."))
-        return super(StockPutawayRule, self).write(vals)
+        return super().write(vals)
 
     def _get_last_used_search_domain(self, product):
         self.ensure_one()
-        domain = expression.AND([
-            [('state', '=', 'done')],
-            [('location_dest_id', 'child_of', self.location_out_id.id)],
-            [('product_id', '=', product.id)],
+        domain = Domain([
+            ('state', '=', 'done'),
+            ('location_dest_id', 'child_of', self.location_out_id.id),
+            ('product_id', '=', product.id),
         ])
         if self.package_type_ids:
-            domain = expression.AND([
-                domain,
-                [('result_package_id.package_type_id', 'in', self.package_type_ids.ids)],
-            ])
+            domain &= Domain('result_package_id.package_type_id', 'in', self.package_type_ids.ids)
         return domain
 
     def _get_last_used_location(self, product):

--- a/addons/stock/models/stock_location.py
+++ b/addons/stock/models/stock_location.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import calendar
@@ -8,8 +7,7 @@ from datetime import timedelta
 
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError, ValidationError
-from odoo.osv import expression
-from odoo.tools.float_utils import float_compare
+from odoo.fields import Domain
 
 
 class StockLocation(models.Model):
@@ -479,13 +477,13 @@ class StockLocation(models.Model):
             [('location_id', 'in', self.ids)],
             groupby=['location_id', 'product_id'], aggregates=['quantity:sum'],
         )
-        base_domain = [('state', 'not in', ['draft', 'done', 'cancel']), ('id', 'not in', tuple(excluded_sml_ids))]
+        base_domain = Domain('state', 'not in', ['draft', 'done', 'cancel']) & Domain('id', 'not in', tuple(excluded_sml_ids))
         outgoing_move_lines = StockMoveLine._read_group(
-            expression.AND([[('location_id', 'in', self.ids)], base_domain]),
+            Domain('location_id', 'in', self.ids) & base_domain,
             groupby=['location_id', 'product_id'], aggregates=['quantity_product_uom:sum'],
         )
         incoming_move_lines = StockMoveLine._read_group(
-            expression.AND([[('location_dest_id', 'in', self.ids)], base_domain]),
+            Domain('location_dest_id', 'in', self.ids) & base_domain,
             groupby=['location_dest_id', 'product_id'], aggregates=['quantity_product_uom:sum']
         )
 

--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 import itertools
 from ast import literal_eval
@@ -9,7 +8,7 @@ from re import findall as regex_findall
 
 from odoo import _, api, Command, fields, models, SUPERUSER_ID
 from odoo.exceptions import UserError, ValidationError
-from odoo.osv import expression
+from odoo.fields import Domain
 from odoo.tools.float_utils import float_compare, float_is_zero, float_round
 from odoo.tools.misc import clean_context, OrderedSet, groupby
 
@@ -806,20 +805,18 @@ Please change the quantity done or the rounding precision in your settings.""",
         """ Manually mark the relevant orderpoints for re-computation.
         This allows us to only recompute the qty_to_order for the orderpoints in the relevant warehouse(s),
         instead of all the orderpoints linked to the product."""
-        orderpoint_domain = []
+        if not self:
+            return
+        domains = []
         for move in self:
-            domain_for_move = [('product_id', '=', move.product_id.id)]
+            domain_for_move = Domain('product_id', '=', move.product_id.id)
             wh_ids = move.location_id.warehouse_id.ids + move.location_dest_id.warehouse_id.ids
             if wh_ids:
-                domain_for_move = expression.AND([domain_for_move, [('warehouse_id', 'in', wh_ids)]])
-            if not orderpoint_domain:
-                orderpoint_domain = domain_for_move
-                continue
-            orderpoint_domain = expression.OR([orderpoint_domain, domain_for_move])
-        if orderpoint_domain:
-            orderpoints = self.env['stock.warehouse.orderpoint'].sudo().search(orderpoint_domain, order='id')
-            orderpoints.invalidate_recordset(['qty_to_order', 'qty_forecast'])
-            self.env.add_to_compute(self.env['stock.warehouse.orderpoint']._fields['qty_to_order_computed'], orderpoints)
+                domain_for_move &= Domain('warehouse_id', 'in', wh_ids)
+            domains.append(domain_for_move)
+        orderpoints = self.env['stock.warehouse.orderpoint'].sudo().search(Domain.OR(domains), order='id')
+        orderpoints.invalidate_recordset(['qty_to_order', 'qty_forecast'])
+        self.env.add_to_compute(self.env['stock.warehouse.orderpoint']._fields['qty_to_order_computed'], orderpoints)
 
     def _delay_alert_get_documents(self):
         """Returns a list of recordset of the documents linked to the stock.move in `self` in order
@@ -2345,18 +2342,19 @@ Please change the quantity done or the rounding precision in your settings.""",
         if not self or self.env['ir.config_parameter'].sudo().get_param('stock.picking_no_auto_reserve'):
             return
 
-        domains = [
+        product_domains = Domain.OR(
             [('product_id', '=', move.product_id.id), ('location_id', '=', move.location_dest_id.id)]
             for move in self
-        ]
+        )
         static_domain = [('state', 'in', ['confirmed', 'partially_available']),
                          ('procure_method', '=', 'make_to_stock'),
                          '|',
                             ('reservation_date', '<=', fields.Date.today()),
                             ('picking_type_id.reservation_method', '=', 'at_confirm')
                         ]
-        moves_to_reserve = self.env['stock.move'].search(expression.AND([static_domain, expression.OR(domains)]),
-                                                         order='priority desc, date asc, id asc')
+        moves_to_reserve = self.env['stock.move'].search(
+            Domain(static_domain) & product_domains,
+            order='priority desc, date asc, id asc')
         moves_to_reserve = moves_to_reserve.sorted(key=lambda m: m.group_id.id in self.group_id.ids, reverse=True)
         moves_to_reserve._action_assign()
 

--- a/addons/stock/models/stock_orderpoint.py
+++ b/addons/stock/models/stock_orderpoint.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import logging
@@ -12,7 +11,7 @@ from odoo import SUPERUSER_ID, _, api, fields, models
 from odoo.addons.stock.models.stock_rule import ProcurementException
 from odoo.exceptions import RedirectWarning, UserError, ValidationError
 from odoo.modules.registry import Registry
-from odoo.osv import expression
+from odoo.fields import Domain
 from odoo.sql_db import BaseCursor
 from odoo.tools import float_compare, float_is_zero, frozendict, split_every, format_date
 
@@ -105,11 +104,11 @@ class StockWarehouseOrderpoint(models.Model):
         #  - strictly belonging to our warehouse
         #  - not belonging to any warehouses
         for orderpoint in self:
-            loc_domain = [('usage', 'in', ('internal', 'view'))]
+            loc_domain = Domain('usage', 'in', ('internal', 'view'))
             other_warehouses = self.env['stock.warehouse'].search([('id', '!=', orderpoint.warehouse_id.id)])
             for view_location_id in other_warehouses.mapped('view_location_id'):
-                loc_domain = expression.AND([loc_domain, ['!', ('id', 'child_of', view_location_id.id)]])
-                loc_domain = expression.AND([loc_domain, ['|', ('company_id', '=', False), ('company_id', '=', orderpoint.company_id.id)]])
+                loc_domain &= ~Domain('id', 'child_of', view_location_id.id)
+                loc_domain &= Domain('company_id', 'in', [False, orderpoint.company_id.id])
             orderpoint.allowed_location_ids = self.env['stock.location'].search(loc_domain)
 
     @api.depends('rule_ids', 'product_id.seller_ids', 'product_id.seller_ids.delay')
@@ -429,16 +428,15 @@ class StockWarehouseOrderpoint(models.Model):
         ploc_per_day = defaultdict(set)
         # For each replenish location get products with negative virtual_available aka forecast
 
-
         Move = self.env['stock.move'].with_context(active_test=False)
         Quant = self.env['stock.quant'].with_context(active_test=False)
         domain_quant, domain_move_in_loc, domain_move_out_loc = all_product_ids._get_domain_locations_new(all_replenish_location_ids.ids)
-        domain_state = [('state', 'in', ('waiting', 'confirmed', 'assigned', 'partially_available'))]
-        domain_product = [['product_id', 'in', all_product_ids.ids]]
+        domain_state = Domain('state', 'in', ('waiting', 'confirmed', 'assigned', 'partially_available'))
+        domain_product = Domain('product_id', 'in', all_product_ids.ids)
 
-        domain_quant = expression.AND([domain_product, domain_quant])
-        domain_move_in = expression.AND([domain_product, domain_state, domain_move_in_loc])
-        domain_move_out = expression.AND([domain_product, domain_state, domain_move_out_loc])
+        domain_quant = Domain.AND((domain_product, domain_quant))
+        domain_move_in = Domain.AND((domain_product, domain_state, domain_move_in_loc))
+        domain_move_out = Domain.AND((domain_product, domain_state, domain_move_out_loc))
 
         moves_in = defaultdict(list)
         for item in Move._read_group(domain_move_in, ['product_id', 'location_dest_id', 'location_final_id'], ['product_qty:sum']):
@@ -553,9 +551,9 @@ class StockWarehouseOrderpoint(models.Model):
 
     def _get_replenishment_order_notification(self):
         self.ensure_one()
-        domain = [('orderpoint_id', 'in', self.ids)]
+        domain = Domain('orderpoint_id', 'in', self.ids)
         if self.env.context.get('written_after'):
-            domain = expression.AND([domain, [('write_date', '>=', self.env.context.get('written_after'))]])
+            domain &= Domain('write_date', '>=', self.env.context.get('written_after'))
         move = self.env['stock.move'].search(domain, limit=1)
         if ((move.location_id.warehouse_id and move.location_id.warehouse_id != self.warehouse_id)
             or move.location_id.usage == 'transit') and move.picking_id:
@@ -583,12 +581,12 @@ class StockWarehouseOrderpoint(models.Model):
 
     @api.autovacuum
     def _unlink_processed_orderpoints(self):
-        domain = [
+        domain = Domain([
             ('create_uid', '=', SUPERUSER_ID),
             ('trigger', '=', 'manual'),
-        ]
+        ])
         if self.ids:
-            expression.AND([domain, [('ids', 'in', self.ids)]])
+            domain &= Domain('id', 'in', self.ids)
         manual_orderpoints = self.env['stock.warehouse.orderpoint'].with_context(active_test=False).search(domain)
         orderpoints_to_remove = manual_orderpoints.filtered(lambda o: o.qty_to_order <= 0.0)
         # Remove previous automatically created orderpoint that has been refilled.

--- a/addons/stock/report/stock_forecasted.py
+++ b/addons/stock/report/stock_forecasted.py
@@ -1,12 +1,11 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from collections import defaultdict
 from datetime import date
 
 from odoo import api, models
-from odoo.osv.expression import AND
-from odoo.tools import float_is_zero, format_date, float_round, float_compare
+from odoo.fields import Domain
+from odoo.tools import float_is_zero, format_date
 
 
 class StockForecasted_Product_Product(models.AbstractModel):
@@ -287,8 +286,8 @@ class StockForecasted_Product_Product(models.AbstractModel):
         past_domain = [('reservation_date', '<=', date.today())]
         future_domain = ['|', ('reservation_date', '>', date.today()), ('reservation_date', '=', False)]
 
-        past_outs = self.env['stock.move'].search(AND([out_domain, past_domain]), order='priority desc, date, id')
-        future_outs = self.env['stock.move'].search(AND([out_domain, future_domain]), order='reservation_date, priority desc, date, id')
+        past_outs = self.env['stock.move'].search(Domain.AND([out_domain, past_domain]), order='priority desc, date, id')
+        future_outs = self.env['stock.move'].search(Domain.AND([out_domain, future_domain]), order='reservation_date, priority desc, date, id')
 
         outs = past_outs | future_outs
 

--- a/addons/stock/wizard/product_replenish.py
+++ b/addons/stock/wizard/product_replenish.py
@@ -1,11 +1,8 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
-
-import datetime
 
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError
-from odoo.osv import expression
+from odoo.fields import Domain
 from odoo.tools.misc import clean_context
 
 
@@ -170,7 +167,7 @@ class ProductReplenish(models.TransientModel):
 
     def _get_route_domain(self, product_tmpl_id):
         company = product_tmpl_id.company_id or self.env.company
-        domain = expression.AND([self._get_allowed_route_domain(), self.env['stock.route']._check_company_domain(company)])
+        domain = Domain.AND([self._get_allowed_route_domain(), self.env['stock.route']._check_company_domain(company)])
         if product_tmpl_id.route_ids:
-            domain = expression.AND([domain, [('product_ids', '=', product_tmpl_id.id)]])
+            domain &= Domain('product_ids', '=', product_tmpl_id.id)
         return domain

--- a/addons/stock/wizard/stock_quantity_history.py
+++ b/addons/stock/wizard/stock_quantity_history.py
@@ -1,8 +1,7 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import _, fields, models
-from odoo.osv import expression
+from odoo.fields import Domain
 from odoo.tools.misc import format_datetime
 
 
@@ -17,13 +16,13 @@ class StockQuantityHistory(models.TransientModel):
     def open_at_date(self):
         tree_view_id = self.env.ref('stock.view_stock_product_tree').id
         form_view_id = self.env.ref('stock.product_form_view_procurement_button').id
-        domain = [('is_storable', '=', True)]
+        domain = Domain('is_storable', '=', True)
         product_id = self.env.context.get('product_id', False)
         product_tmpl_id = self.env.context.get('product_tmpl_id', False)
         if product_id:
-            domain = expression.AND([domain, [('id', '=', product_id)]])
+            domain &= Domain('id', '=', product_id)
         elif product_tmpl_id:
-            domain = expression.AND([domain, [('product_tmpl_id', '=', product_tmpl_id)]])
+            domain = Domain('product_tmpl_id', '=', product_tmpl_id)
         # We pass `to_date` in the context so that `qty_available` will be computed across
         # moves until date.
         action = {

--- a/addons/stock/wizard/stock_replenishment_info.py
+++ b/addons/stock/wizard/stock_replenishment_info.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import babel.dates
@@ -8,9 +7,8 @@ from dateutil.relativedelta import relativedelta
 
 
 from odoo import api, fields, models, SUPERUSER_ID, _
-from odoo.osv.expression import AND
+from odoo.fields import Domain
 from odoo.tools.date_utils import get_month, subtract
-from odoo.tools.float_utils import float_compare
 from odoo.tools.misc import get_lang, format_date
 
 
@@ -69,18 +67,18 @@ class StockReplenishmentInfo(models.TransientModel):
             first_month = subtract(today, months=2)
             date_from, dummy = get_month(first_month)
             dummy, date_to = get_month(today)
-            domain = [
+            domain = Domain([
                 ('product_id', '=', replenishment_report.product_id.id),
                 ('date', '>=', date_from),
                 ('date', '<=', datetime.combine(date_to, time.max)),
                 ('state', '=', 'done'),
                 ('company_id', '=', replenishment_report.orderpoint_id.company_id.id)
-            ]
+            ])
             quantity_by_month_out = self.env['stock.move']._read_group(
-                AND([domain, [('location_dest_id.usage', '=', 'customer')]]),
+                domain & Domain('location_dest_id.usage', '=', 'customer'),
                 ['date:month'], ['product_qty:sum'])
             quantity_by_month_returned = dict(self.env['stock.move']._read_group(
-                AND([domain, [('location_id.usage', '=', 'customer')]]),
+                domain & Domain('location_id.usage', '=', 'customer'),
                 ['date:month'], ['product_qty:sum']))
             locale = get_lang(self.env).code
             fmt = models.READ_GROUP_DISPLAY_FORMAT['month']

--- a/addons/stock/wizard/stock_request_count.py
+++ b/addons/stock/wizard/stock_request_count.py
@@ -1,8 +1,7 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import fields, models
-from odoo.osv import expression
+from odoo.fields import Domain
 
 
 class StockRequestCount(models.TransientModel):
@@ -33,9 +32,11 @@ class StockRequestCount(models.TransientModel):
             return quants_to_count
         # Searches sibling quants for tracked product.
         if tracked_quants:
-            domain = {('&', ('product_id', '=', quant.product_id.id), ('location_id', '=', quant.location_id.id))
-                    for quant in tracked_quants}
-            domain = expression.OR(domain)
+            domain = {
+                Domain('product_id', '=', quant.product_id.id) & Domain('location_id', '=', quant.location_id.id)
+                for quant in tracked_quants
+            }
+            domain = Domain.OR(domain)
             sibling_quants = self.env['stock.quant'].search(domain)
             quants_to_count |= sibling_quants
         return quants_to_count

--- a/addons/stock_dropshipping/models/stock.py
+++ b/addons/stock_dropshipping/models/stock.py
@@ -1,8 +1,7 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import api, models, fields
-from odoo.osv import expression
+from odoo.fields import Domain
 
 
 class StockRule(models.Model):
@@ -29,7 +28,7 @@ class ProcurementGroup(models.Model):
     def _get_rule_domain(self, location, values):
         domain = super()._get_rule_domain(location, values)
         if 'sale_line_id' in values and values.get('company_id'):
-            domain = expression.AND([domain, [('company_id', '=', values['company_id'].id)]])
+            domain = Domain.AND([domain, [('company_id', '=', values['company_id'].id)]])
         return domain
 
 
@@ -97,7 +96,7 @@ class StockLot(models.Model):
 
     def _get_outgoing_domain(self):
         res = super()._get_outgoing_domain()
-        return expression.OR([res, [
+        return Domain.OR([res, [
             ('location_dest_id.usage', '=', 'customer'),
             ('location_id.usage', '=', 'supplier'),
         ]])

--- a/addons/stock_dropshipping/models/stock_replenish_mixin.py
+++ b/addons/stock_dropshipping/models/stock_replenish_mixin.py
@@ -1,7 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import models
-from odoo.osv import expression
+from odoo.fields import Domain
 
 
 class StockReplenishMixin(models.AbstractModel):
@@ -9,4 +9,4 @@ class StockReplenishMixin(models.AbstractModel):
 
     def _get_allowed_route_domain(self):
         domains = super()._get_allowed_route_domain()
-        return expression.AND([domains, [('id', '!=', self.env.ref('stock_dropshipping.route_drop_shipping', raise_if_not_found=False).id)]])
+        return Domain.AND([domains, [('id', '!=', self.env.ref('stock_dropshipping.route_drop_shipping', raise_if_not_found=False).id)]])

--- a/addons/stock_picking_batch/models/stock_move.py
+++ b/addons/stock_picking_batch/models/stock_move.py
@@ -1,8 +1,7 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import models
-from odoo.osv import expression
+from odoo.fields import Domain
 
 
 class StockMove(models.Model):
@@ -10,7 +9,7 @@ class StockMove(models.Model):
 
     def _search_picking_for_assignation_domain(self):
         domain = super()._search_picking_for_assignation_domain()
-        domain = expression.AND([domain, ['|', ('batch_id', '=', False), ('batch_id.is_wave', '=', False)]])
+        domain = Domain.AND([domain, ['|', ('batch_id', '=', False), ('batch_id.is_wave', '=', False)]])
         return domain
 
     def _action_cancel(self):

--- a/addons/stock_picking_batch/models/stock_picking_batch.py
+++ b/addons/stock_picking_batch/models/stock_picking_batch.py
@@ -1,12 +1,9 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from markupsafe import Markup
 
 from odoo import api, fields, models, _
 from odoo.exceptions import UserError
-from odoo.osv.expression import AND
-from odoo.tools import float_is_zero
 
 
 class StockPickingBatch(models.Model):


### PR DESCRIPTION
In order to deprecate odoo.osv, we must first stop using it and replace it with Domain. This covers most of usages in stock.

task-4280707
odoo/enterprise#88894



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
