### PR TITLE
[FIX] website_sale_delivery: fix carrier domain to avoid company mismatch

### DIFF
--- a/addons/website_sale_delivery/models/sale_order.py
+++ b/addons/website_sale_delivery/models/sale_order.py
@@ -68,6 +68,7 @@ class SaleOrder(models.Model):
         # computed field)
         return self.env['delivery.carrier'].sudo().search([
             ('website_published', '=', True),
+            '|', ('company_id', '=', False), ('company_id', '=', self.company_id.id)
         ]).filtered(lambda carrier: carrier._is_available_for_order(self))
 
     def _cart_update(self, *args, **kwargs):

--- a/addons/website_sale_delivery/tests/__init__.py
+++ b/addons/website_sale_delivery/tests/__init__.py
@@ -4,4 +4,5 @@
 from . import test_express_checkout_flows
 from . import test_ui
 from . import test_controller
+from . import test_sale_order
 from . import test_website_sale_controller

--- a/addons/website_sale_delivery/tests/test_sale_order.py
+++ b/addons/website_sale_delivery/tests/test_sale_order.py
@@ -1,0 +1,59 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import Command
+from odoo.tests import tagged
+
+from odoo.addons.sale.tests.common import SaleCommon
+
+
+@tagged('post_install', '-at_install')
+class TestSaleOrder(SaleCommon):
+
+    def test_delivery_methods_match_order_company(self):
+        company_1 = self.env['res.company'].create({'name': 'Test Company 1'})
+        company_2 = self.env['res.company'].create({'name': 'Test Company 2'})
+        product_delivery_1 = self.env['product.product'].create(
+            {
+                'name': 'Delivery Product 1',
+                'type': 'service',
+                'company_id': company_1.id,
+            }
+        )
+        product_delivery_2 = self.env['product.product'].create(
+            {
+                'name': 'Delivery Product 2',
+                'type': 'service',
+                'company_id': company_2.id,
+            }
+        )
+        delivery_1 = self.env['delivery.carrier'].create(
+            {
+                'name': 'Delivery 1',
+                'delivery_type': 'fixed',
+                'product_id': product_delivery_1.id,
+                'is_published': True,
+            }
+        )
+        delivery_2 = self.env['delivery.carrier'].create(
+            {
+                'name': 'Delivery 2',
+                'delivery_type': 'fixed',
+                'product_id': product_delivery_2.id,
+                'is_published': True,
+            }
+        )
+        sale_order = self.env['sale.order'].create(
+            {
+                'partner_id': self.partner.id,
+                'company_id': company_1.id,
+                'order_line': [
+                    Command.create(
+                        {
+                            'product_id': self.product.id,
+                        }
+                    )],
+            }
+        )
+        available_dms = sale_order._get_delivery_methods()
+        self.assertIn(delivery_1, available_dms)
+        self.assertNotIn(delivery_2, available_dms)

--- a/doc/cla/individual/elierwclik.md
+++ b/doc/cla/individual/elierwclik.md
@@ -1,0 +1,11 @@
+Canada, 2025-02-01
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Elier Ayala Bernal elier@wclik.com https://github.com/elierwclik


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Error during checkout when using delivery methods with mixed company assignments.

Current behavior before PR:
If you create a delivery method assigned to company X, and then create another without a company (i.e., assigned to the website company or left empty), the checkout process fails when trying to select a delivery method.

Steps to reproduce:

1. Create a delivery method and assign it to company X.
2. Create another delivery method with no company or assign it to the website's company.
3. Go to the website and try to place an order.
4. The checkout will fail when selecting the delivery method.

Desired behavior after PR is merged:
Checkout handles delivery methods consistently, even when companies are mixed or missing.




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
