### PR TITLE
[FIX] l10n_lu_tax_report: fix translation for tax report line in french lang.

### DIFF
--- a/addons/l10n_lu/i18n_extra/fr.po
+++ b/addons/l10n_lu/i18n_extra/fr.po
@@ -1490,7 +1490,7 @@ msgid ""
 "481 - Supplies carried out within the scope of the domestic SME scheme of "
 "article 57bis (7)"
 msgstr ""
-"Opérations réalisées dans le cadre du régime de franchise national de "
+"481 - Opérations réalisées dans le cadre du régime de franchise national de "
 "l'article 57bis (17)"
 
 #. module: l10n_lu


### PR DESCRIPTION

Behavior before commit:

In the Luxembourg tax report, certain SME-related field (481) was missing from the electronic declaration when the user language was set to French. This caused a crash (KeyError: '481') during report export, as the system failed to locate the required lines.

Root cause:

The report logic parsed the line code by splitting the translated name field of the report line (e.g., 481 - SME Revenue Threshold). However, the French translation did not preserve the numeric code prefix (481 - ...) — it was simply 'Seuil de revenus PME'. As a result, the code failed to detect the line, skipping it entirely.

Fix:

Updated the fr.po translation file to ensure the translated name for the SME report lines starts with the corresponding numeric code ('481 -' ). This allows the report logic to correctly identify and process these lines in all languages.

Steps to reproduce:

1. Set your user language to French.

2. Go to Accounting > Reporting > Luxembourg VAT Report.

3. Generate a report for any period.

4. Try to export the report in XML format.

5. Observe a crash (KeyError: '481') due to missing SME fields.

opw-4860455



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
