### PR TITLE
[FIX] mrp_subcontracting: subcontracting BoM with operations backorder status

### DIFF
--- a/addons/mrp_subcontracting/models/stock_picking.py
+++ b/addons/mrp_subcontracting/models/stock_picking.py
@@ -90,7 +90,7 @@ class StockPicking(models.Model):
             productions_to_done = productions_to_done.sudo()
             production_ids_backorder = []
             if not self.env.context.get('cancel_backorder'):
-                production_ids_backorder = productions_to_done.filtered(lambda mo: mo.state == "progress").ids
+                production_ids_backorder = productions_to_done._subcontracting_filter_to_backorder().ids
             productions_to_done.with_context(mo_ids_to_backorder=production_ids_backorder).button_mark_done()
             # For concistency, set the date on production move before the date
             # on picking. (Traceability report + Product Moves menu item)

--- a/doc/cla/individual/giarve.md
+++ b/doc/cla/individual/giarve.md
@@ -1,0 +1,11 @@
+Spain, 2025-06-29
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Gil gav@wvbs.eu https://github.com/giarve


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

The program allows to create a normal BoM with operations and later switch it to a subcontracting BoM without deleting its list of operations. These operations are also instantiated as workorders in subcontractor MOs as if they were not different to internal MOs.

Current behavior before PR:

This effect marks as "in progress" instead of "to close" all subcontractor MOs states that have workorders on them when marking as done with full MO quantity. 
All of this is transparent to the user.

Therefore, the program tries to backorder and split an MO that is being fully manufactured (nonsensical).

The error the user gets is:
![image](https://github.com/user-attachments/assets/3a800116-c402-450e-a740-dd5a16f0a594)

because the new MO (backorder) has to produce 0 units, as all the others were produced in the one about to be closed.

Desired behavior after PR is merged:

do not backorder "in progress" subcontractor MO that will have not quantity remaining to produce

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
