### PR TITLE
[FIX] mail: mirror message action placement for self-authored log note

### DIFF
--- a/addons/mail/static/src/core/common/message.xml
+++ b/addons/mail/static/src/core/common/message.xml
@@ -36,6 +36,7 @@
                                 <strong class="me-1" t-esc="authorName"/>
                             </span>
                             <t t-if="!isAlignedRight" t-call="mail.Message.notification"/>
+                            <t t-if="isAlignedRight and message.is_note" t-call="mail.Message.actions"/>
                             <small t-if="!message.is_transient" class="o-mail-Message-date o-xsmaller" t-att-title="message.datetimeShort">
                                 <t t-if="message.isPending" t-call="mail.Message.pendingStatus"/>
                                 <t t-else="" t-out="message.dateSimpleWithDay"/>
@@ -54,7 +55,7 @@
                                 </span>
                             </div>
                             <t t-if="isAlignedRight" t-call="mail.Message.notification"/>
-                            <t t-if="message.is_note" t-call="mail.Message.actions"/>
+                            <t t-if="!isAlignedRight and message.is_note" t-call="mail.Message.actions"/>
                         </div>
                         <div
                             class="o-mail-Message-contentContainer position-relative d-flex"


### PR DESCRIPTION
**Purpose of this PR:**
Fix the position of message actions on log notes authored by the current user.

Messages authored by self appear on the right side of the thread. 
This PR mirrors the action placement logic so that, 
like messages from others (which show actions to the right of the date), 
self-authored messages show actions to the left of the date.

Before:
<img width="392" height="638" alt="image" src="https://github.com/user-attachments/assets/8b66c98f-3e00-47c8-abf3-ee62169ed499" />

After:
<img width="392" height="638" alt="image" src="https://github.com/user-attachments/assets/d1a425da-fb0c-4793-a080-735286bc2bb9" />


task-[4689357](https://www.odoo.com/odoo/project/1519/tasks/4689357)