### PR TITLE
[FIX] crm: avoid crash when mass converting duplicated leads

### DIFF
--- a/addons/crm/tests/test_crm_lead_convert_mass.py
+++ b/addons/crm/tests/test_crm_lead_convert_mass.py
@@ -211,3 +211,20 @@ class TestLeadConvertMass(crm_common.TestLeadConvertMassCommon):
             self.assertEqual(lead.type, 'opportunity')
             assigned_user = self.assign_users[idx % len(self.assign_users)]
             self.assertEqual(lead.user_id, assigned_user)
+
+    @users('user_sales_manager')
+    def test_mass_convert_with_original_and_duplicate_selected(self):
+        _customer, lead_1_dups = self._create_duplicates(self.lead_1, create_opp=False)
+
+        mass_convert = self.env['crm.lead2opportunity.partner.mass'].with_context({
+            'active_model': 'crm.lead',
+            'active_ids': (self.lead_1 + lead_1_dups).ids,
+        }).create({
+            'deduplicate': True,
+        })
+
+        mass_convert.action_mass_convert()
+
+        remaining_leads = (self.lead_1 + lead_1_dups).exists()
+        self.assertEqual(len(remaining_leads), 1)
+        self.assertEqual(remaining_leads.type, 'opportunity')

--- a/addons/crm/wizard/crm_lead_to_opportunity_mass.py
+++ b/addons/crm/wizard/crm_lead_to_opportunity_mass.py
@@ -85,7 +85,7 @@ class Lead2OpportunityMassConvert(models.TransientModel):
             merged_lead_ids = set()
             remaining_lead_ids = set()
             for lead in self.lead_tomerge_ids:
-                if lead not in merged_lead_ids:
+                if lead.id not in merged_lead_ids:
                     duplicated_leads = self.env['crm.lead']._get_lead_duplicates(
                         partner=lead.partner_id,
                         email=lead.partner_id.email or lead.email_from,


### PR DESCRIPTION
Currently, when mass converting leads that contain duplicates, you are met with an error.

### Steps to reproduce

* Install `crm`
* Activate leads in CRM settings
* Pick a lead in the list of leads and duplicate it
* Select both the original and the duplicate leads → Action → Convert to Opportunity
* In the wizard, ensure that "Apply deduplication" is enabled

You will be met with the following error message:

```
Missing Record

Record does not exist or has been deleted.
(Record: crm.lead(...), User: ...)
```

### Cause

When mass converting leads with "Apply deduplication" enabled, the system processes each selected lead and attempts to deduplicate it by merging it with matching leads and deleting the duplicates.

However, if one of the selected leads is also identified as a duplicate and gets deleted earlier in the loop, the process fails when it later tries to access the already-deleted lead.

Although logic to skip already processed leads exists, there's a small mistake: it compares the lead record (`lead`) to a set of IDs (`merged_lead_ids`), which always fails.

opw-4893775
