### PR TITLE
[IMP] hr_holidays: allow admin to edit the leaves even in approve stage

### DIFF
--- a/addons/hr_holidays/views/hr_leave_views.xml
+++ b/addons/hr_holidays/views/hr_leave_views.xml
@@ -290,6 +290,7 @@
             <header>
                 <button string="Approve" name="action_approve" type="object" class="oe_highlight" invisible="not can_approve or not id"/>
                 <button string="Validate" name="action_approve" invisible="not can_validate or can_approve or not id" type="object" class="oe_highlight"/>
+                <button string="Back to Approval" name="action_back_to_approval" type="object" invisible="not can_back_to_approve or not id"/>
                 <button string="Refuse" name="action_refuse" type="object" invisible="not can_refuse or not id"/>
                 <button string="Cancel" name="action_cancel" type="object" invisible="not can_cancel or not id" />
                 <field name="state" widget="statusbar" statusbar_visible="confirm,validate,validate1" invisible="validation_type != 'both'"/>

--- a/addons/hr_work_entry_holidays/models/hr_leave.py
+++ b/addons/hr_work_entry_holidays/models/hr_leave.py
@@ -135,6 +135,11 @@ class HrLeave(models.Model):
         self._regen_work_entries()
         return res
 
+    def _move_validate_leave_to_confirm(self):
+        res = super()._move_validate_leave_to_confirm()
+        self._regen_work_entries()
+        return res
+
     def _action_user_cancel(self, reason=None):
         res = super()._action_user_cancel(reason)
         self.sudo()._regen_work_entries()


### PR DESCRIPTION
- Allowing HR people to always edit the leave, as long as it's not included in a payslip.

task-4866887

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
