### PR TITLE
[FIX] test_website, website: fix page properties tour

### DIFF
--- a/addons/test_website/static/tests/tours/website_page_properties.js
+++ b/addons/test_website/static/tests/tours/website_page_properties.js
@@ -19,21 +19,27 @@ const openPagePropertiesDialog = [
     },
 ];
 
-const clickOnSaveButtonStep = {
-    content: "Click on Save & Close",
-    trigger: ".o_form_button_save:enabled",
-    run: "click",
-};
+const clickOnSaveButtonStep = [
+    {
+        content: "Click on Save & Close",
+        trigger: ".o_form_button_save:enabled",
+        run: "click",
+    },
+    {
+        content: "Wait",
+        trigger: "body:not(.modal-open)",
+    }
+];
 
 const openCreatePageDialog = [
     {
         content: "Open create content menu",
-        trigger: ".o_new_content_container a",
+        trigger: ".o_new_content_container button",
         run: "click",
     },
     {
         content: "Create a new page",
-        trigger: 'a[title="New Page"]',
+        trigger: 'button[title="New Page"]',
         run: "click",
     },
 ];
@@ -80,6 +86,11 @@ function checkIsTemplate(isTemplate, pageTitle = undefined) {
             trigger: ".modal-header .btn-close",
             run: "click",
         },
+        {
+            content: "Exit new content backdrop",
+            trigger: "body",
+            run: "press escape",
+        }
     ];
 }
 
@@ -140,7 +151,6 @@ function testCommonProperties(url, canPublish, modifiedUrl = undefined) {
             {
                 content: "Verify is not in menu",
                 trigger: `:visible :iframe #top_menu:not(:has(a[href="${url}"]))`,
-                timeout: 30000,
             },
             stepUtils.goToUrl(getClientActionUrl("/")),
             ...assertPageCanonicalUrlIs("/"),
@@ -150,11 +160,11 @@ function testCommonProperties(url, canPublish, modifiedUrl = undefined) {
             return [
                 ...openPagePropertiesDialog,
                 ...this.setup,
-                clickOnSaveButtonStep,
+                ...clickOnSaveButtonStep,
                 ...this.check,
                 ...openPagePropertiesDialog,
                 ...this.teardown,
-                clickOnSaveButtonStep,
+                ...clickOnSaveButtonStep,
                 ...this.checkTorndown,
             ];
         },
@@ -211,7 +221,7 @@ function testWebsitePageProperties() {
             // TODO: this needs to be tested
             content: "Change date published",
             trigger: "#date_publish_0",
-            run: "edit 02/01/2005 01:00:00",
+            run: "edit 02/01/2005 01:00:00 && press enter",
         },
         {
             content: "Don't index",
@@ -259,15 +269,6 @@ function testWebsitePageProperties() {
             content: `Change url back to /new-page`,
             trigger: "#url_0",
             run: `edit new-page && press Enter`,
-        },
-        {
-            content: "Open dependencies link",
-            trigger: '[data-bs-html="true"][title="Dependencies"] a',
-            run: "click",
-        },
-        {
-            content: "Check that the dependencies popover exists",
-            trigger: ".o_page_dependencies",
         },
         {
             content: "Reset date published",
@@ -352,7 +353,7 @@ registerWebsitePreviewTour(
         },
         {
             content: "Wait for editor to open",
-            trigger: ".o_website_navbar_hide",
+            trigger: ":iframe body.editor_enable",
             timeout: 30000,
         },
         ...clickOnSave(),

--- a/addons/website/static/src/client_actions/website_preview/new_content_modal.js
+++ b/addons/website/static/src/client_actions/website_preview/new_content_modal.js
@@ -21,8 +21,10 @@ export class NewContentModal extends Component {
         this.orm = useService("orm");
         this.dialogs = useService("dialog");
         this.website = useService("website");
-        // preload the new page templates so they are ready as soon as possible
-        rpc("/website/get_new_page_templates", { context: { website_id: this.website.currentWebsiteId}}, { cached: true, silent: true });
+        // Preload the new page templates so they are ready as soon as possible.
+        // Do not cache here to avoid stale results when templates change
+        // (e.g., toggling "Is a Template" in page properties during a session).
+        rpc("/website/get_new_page_templates", { context: { website_id: this.website.currentWebsiteId}}, { silent: true });
         this.action = useService("action");
         this.isSystem = user.isSystem;
         useActiveElement("modalRef");

--- a/addons/website/static/src/components/dialog/add_page_dialog.js
+++ b/addons/website/static/src/components/dialog/add_page_dialog.js
@@ -319,7 +319,9 @@ class AddPageTemplates extends Component {
     }
 
     async preparePages() {
-        const loadTemplates = rpc("/website/get_new_page_templates", { context: { website_id: this.website.currentWebsiteId}}, { cached: true, silent: true });
+        // Fetch templates without client-side caching to reflect recent changes
+        // to custom templates within the same session.
+        const loadTemplates = rpc("/website/get_new_page_templates", { context: { website_id: this.website.currentWebsiteId}}, { silent: true });
 
         // Forces the correct website if needed before fetching the templates.
         // Displaying the correct images in the previews also relies on the


### PR DESCRIPTION
Since [1], the page dependencies algorithm was updated, requiring
adjustments to the tour logic. Additionally, following [2], the
"Add new content" button was changed from an `<a>` tag to a `<button>`,
which also needed to be reflected in the tour.

Furthermore (see [3]), removing a page from the menu could silently fail
when the page URL was changed in the same save because the wizard only
looked up menus by the current URL. Resolve menus by page_id (fallback
to URL) in both compute and inverse, and unlink accordingly, ensuring
"In Menu" toggles work reliably across URL changes.

Also, since [4], the "New Page" dialog cached the templates list, so
pages newly marked as "Is a Template" didn't appear until a reload.
Fetch templates without client-side caching so the Custom tab reflects
changes immediately. This fixes the tour steps for "Verify is not in
menu" and "Verify template Cool Page exists."

Steps to reproduce:

A. "In Menu" toggle fails when URL also changes (unlink by URL only)

- Website > Go to any page (e.g., /cool-page).
- Click Edit > Page (properties).
- Change URL from /cool-page to /cool-page-2.
- In the same dialog, disable "In Menu" (It should be automatic).
- Click Save & Close.
- Bug (before): The corresponding menu item is not removed because the
  unlink resolves only by the old/current URL.

  Now: Menus are resolved and unlinked by page_id (fallback to URL), so
  the menu entry is correctly removed.

B. "New Page" > Custom templates list becomes stale (client cache)

- Create a normal website page (not a template).
- Open Page (properties) and enable "Is a Template". Save.
- Without reloading the site, click New (Add new content) > New Page.
- Open the Custom tab.
- Bug (before): The page you just turned into a template doesn't appear
  because the dialog used a cached list.

  Now: The dialog fetches templates without client caching, so the new
  template appears immediately.

[1]: https://github.com/odoo/odoo/commit/cd4b0c91c1cf60ff72e91cf0544cb255ee5aff3f
[2]: https://github.com/odoo/odoo/commit/9fe45e2b7ddbbfd0445ffe25a859e67a316d02b2
[3]: https://github.com/odoo/odoo/commit/d6c8177824be3
[4]: https://github.com/odoo/odoo/commit/b7fe6e6704fad
runbot-224020

