### PR TITLE
[FIX] website: consider "false" social media as empty, not missing

### DIFF
--- a/addons/website/static/src/builder/plugins/options/social_media_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/social_media_option_plugin.js
@@ -185,8 +185,8 @@ class SocialMediaOptionPlugin extends Plugin {
         );
         for (const name of socialMediaInfo.keys()) {
             const key = `social_${name}`;
-            if (key in res[0] && res[0][key]) {
-                this.recordedSocialMedia.set(name, res[0][key]);
+            if (key in res[0]) {
+                this.recordedSocialMedia.set(name, res[0][key] || "");
             }
         }
         this.config.onChange({ isPreviewing: false });

--- a/addons/website/static/tests/builder/website_builder/social_media.test.js
+++ b/addons/website/static/tests/builder/website_builder/social_media.test.js
@@ -9,7 +9,8 @@ test("add social medias", async () => {
     onRpc("website", "read", ({ args }) => {
         expect(args[0]).toEqual([1]);
         expect(args[1]).toInclude("social_facebook");
-        return [{ id: 1, social_facebook: "https://fb.com/odoo" }];
+        expect(args[1]).toInclude("social_twitter");
+        return [{ id: 1, social_facebook: "https://fb.com/odoo", social_twitter: false }];
     });
 
     await setupWebsiteBuilder(`<div class="s_social_media"><h4>Social Media</h4></div>`);
@@ -31,6 +32,8 @@ test("add social medias", async () => {
     expect(exampleLinkSelector).toHaveCount(1);
     await contains("button[data-action-id='deleteSocialMediaLink']").click();
     expect(exampleLinkSelector).toHaveCount(0);
+
+    expect("td:has([data-action-param='twitter'])").toHaveCount(1);
 });
 
 test("reorder social medias", async () => {


### PR DESCRIPTION
Steps to reproduce:
- On a database without demo data (and no social links set)
- Open website builder
- Click on a social media snippet (by default there is one in footer)
- Bug: social media not in the snippet are not present in the option

The bug was introduced when changing the handling of empty social media records to fix a crash: d4621f81698cdbf3e6a1d72349b3e5f135e0ee53
