### PR TITLE
[FIX] website: hide "Header Position" when header is a sidebar

### DIFF
--- a/addons/website/static/src/builder/plugins/options/website_page_config_option.xml
+++ b/addons/website/static/src/builder/plugins/options/website_page_config_option.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
 <t t-name="website.TopMenuVisibilityOption">
-    <BuilderRow label.translate="Header Position">
+    <BuilderRow label.translate="Header Position" t-if="!this.isActiveItem('header_sidebar_opt')">
         <BuilderSelect preview="false" action="'setWebsiteHeaderVisibility'">
             <BuilderSelectItem actionValue="'overTheContent'" id="'overTheContent'" t-if="props.doesPageOptionExist('header_overlay')">Over The Content</BuilderSelectItem>
             <BuilderSelectItem actionValue="'regular'">Regular</BuilderSelectItem>


### PR DESCRIPTION
> [BVR] select the "sidebar" header. Select "over the content" => no effect .. I think the option should be hidden for "sidebar" (check before mysterious egg).


Steps to reproduce:
- Open website builder
- Click on the header
- Change the "Template" to the last one: "Sidebar"
- Bug: "Header Position" is still visible

This bug was introduced during the initial website builder refactor.

Website refactor: 9fe45e2b7ddbbfd0445ffe25a859e67a316d02b2
task-4367641
