### PR TITLE
[FIX] pos_loyalty: skip test without pos_settle_due

### DIFF
--- a/addons/pos_loyalty/tests/test_frontend.py
+++ b/addons/pos_loyalty/tests/test_frontend.py
@@ -2813,6 +2813,8 @@ class TestUi(TestPointOfSaleHttpCommon):
         Tests that when settling an order that has been partially paid, it does not give the loyalty
         points again. All of them should be given during the first transaction.
         """
+        if not self.env["ir.module.module"].search([("name", "=", "pos_settle_due"), ("state", "=", "installed")]):
+            self.skipTest("pos_settle_due module is required for this test")
         if self.main_pos_config.current_session_id:
             self.main_pos_config.current_session_id.action_pos_session_closing_control()
         LoyaltyProgram = self.env['loyalty.program']


### PR DESCRIPTION
**Problem:**
The test was run even when pos_settle_due was not installed, which resulted in an error during the tour, as it looked for a component that did not exist. We now skip the test if pos_settle_due is not installed.

runbot-227672
