### PR TITLE
[FIX] base: prevent error when adding invalid asset path

### DIFF
--- a/odoo/addons/base/models/ir_asset.py
+++ b/odoo/addons/base/models/ir_asset.py
@@ -210,6 +210,8 @@ class IrAsset(models.Model):
             return
         if can_aggregate(path_def):
             paths = self._get_paths(path_def, installed)
+            if paths is None:
+                return
         else:
             paths = [(path_def, EXTERNAL_ASSET, -1)]  # external urls
 


### PR DESCRIPTION
Currently, an error occurs when the user adds an invalid `path` to `assets`.

**Steps to produce:**
- Install the `point_of_sale` module and activate developer mode.
- Navigate to `Settings > Technical > Database Structure > Assets`.
- Create a new asset with: 
     >**Path**: Invalid characters like `*`,  `[`,  `]`,  `?`,  etc. 
     >**Bundle**: `point_of_sale._assets_pos`.
- Open a POS session.

**Error:**
`TypeError: 'NoneType' object is not iterable`

**Root Cause:**
At [1], when an invalid asset path is provided, the `_get_paths` method returns `None`. This value is then passed to `_process_path`, which attempts to iterate over it, causing an `error`.

[1]
https://github.com/odoo/odoo/blob/b6b6bf74428e8cbd0b23362ce4ae05a742a6264f/odoo/addons/base/models/ir_asset.py#L212

This commit ensures and prevents an error when an invalid asset path is defined in the assets.

Sentry – 6499122709