### PR TITLE
[FIX] l10n_es_edi_sii: Fixed _has_oss_taxes to work for refunds

### DIFF
--- a/addons/l10n_es_edi_sii/models/account_edi_format.py
+++ b/addons/l10n_es_edi_sii/models/account_edi_format.py
@@ -623,7 +623,8 @@ class AccountEdiFormat(models.Model):
     def _has_oss_taxes(self, invoice):
         oss_tag = self.env.ref('l10n_eu_oss.tag_oss', raise_if_not_found=False)
         lines = invoice.invoice_line_ids.filtered(lambda line: line.display_type not in ('line_section', 'line_note'))
-        return bool(oss_tag and oss_tag in lines.tax_ids.invoice_repartition_line_ids.tag_ids)
+        tags = (lines.tax_ids.invoice_repartition_line_ids | lines.tax_ids.refund_repartition_line_ids).tag_ids
+        return bool(oss_tag and oss_tag in tags)
 
     # -------------------------------------------------------------------------
     # EDI OVERRIDDEN METHODS


### PR DESCRIPTION
Before this commit, the method _has_oss_taxes was determining whether a tax is OSS based on the tax_ids.invoice_repartition_line_ids.tag_ids This works fine for invoices, but for credit notes it should be based on tax_ids.refund_repartition_line_ids.tag_ids
This commit solves this issue

followup of: https://github.com/odoo/odoo/pull/215614

task-4548095





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
