### PR TITLE
[FIX] website_sale: fix ribbon alignment on product image in website view

### DIFF
--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -3165,7 +3165,7 @@
         </div>
         <div
             t-elif="len(product_images) == 1 and website.product_page_image_layout != 'grid'"
-            class="position-relative d-inline-flex overflow-hidden m-auto w-100"
+            class="position-relative d-inline-flex overflow-hidden m-auto h-100"
         >
             <span t-attf-class="o_ribbon #{ribbon._get_position_class()} z-1"
                   t-attf-style="#{text_color and ('color: %s; ' % text_color)}#{bg_color and 'background-color:' + bg_color}"
@@ -3174,11 +3174,11 @@
             <div
                 t-field="product_image.image_1920"
                 name="o_img_with_max_suggested_width"
-                class="d-flex align-items-start justify-content-center w-100 oe_unmovable"
+                class="d-flex align-items-start justify-content-center h-100 oe_unmovable"
                 t-options="{
                     'widget': 'image',
                     'preview_image': 'image_1024',
-                    'class': 'oe_unmovable product_detail_img w-100',
+                    'class': 'oe_unmovable product_detail_img mh-100',
                     'alt-field': 'name',
                     'zoom': product_image.can_image_1024_be_zoomed and 'image_1920',
                 }"


### PR DESCRIPTION
<b>Steps to Reproduce:</b>
1. Install Sales and eCommerce modules.
2. Go to Sales → Products, open any product, go to Sales tab, and set a Ribbon.
3. Navigate to Website → Shop, search for the product and open its page.
4. Zoom in or out.

<b>Issue:</b>
- The ribbon on the product image becomes misaligned (shifts away from the image) when zooming in or out 
on the product detail page. This results in a broken visual layout.

<b>Cause:</b>
- A previous change in [PR #175473](https://github.com/odoo/odoo/pull/175473) unintentionally replaced 
the height class (h-100) with width (w-100) on ribbon container, causing layout instability during zoom operations.

<b>Solution:</b>
- Restore the proper layout by reintroducing h-100 to both the ribbon container and inner image div. 
This ensures the ribbon stays correctly positioned relative to the image regardless of zoom level.

<b>opw-4854217</b>

<b>Before FIX :</b>
![image](https://github.com/user-attachments/assets/caace073-9605-4d30-afcc-a470acd54e3c)
<b>After FIX:</b>
![image](https://github.com/user-attachments/assets/9206699b-9c39-4748-8398-d8cf9ae6ab9a)
