### PR TITLE
[FIX] website: bring missing "help" on product filter option

### DIFF
--- a/addons/website/static/src/builder/plugins/options/dynamic_snippet_option.xml
+++ b/addons/website/static/src/builder/plugins/options/dynamic_snippet_option.xml
@@ -6,7 +6,7 @@
     <BuilderRow label.translate="Filter" t-if="dynamicOptionParams.showFilterOption()">
         <BuilderSelect action="'dynamicFilter'" preview="false" id="'filter_opt'">
             <t t-foreach="dynamicFilters" t-as="filter" t-key="filter.id">
-                <BuilderSelectItem actionParam="filter" t-out="filter.name"/>
+                <BuilderSelectItem actionParam="filter" t-out="filter.name" title="filter.help || ''"/>
             </t>
         </BuilderSelect>
     </BuilderRow>


### PR DESCRIPTION
> [LIPI] Missing dynamic filter help tooltip added in https://github.com/odoo/odoo/pull/196493 (quick fix: `title="fitler.help"` in dynamic_snippet_option.xml:9)

Steps to reproduce:
- Open website builder (with website_sale)
- Drop snippet `s_dynamic_snippet_products`
- Open the "Filter" dropdown and hover "Recently Viewed Products (...)"
- Bug: No tooltip appears with a help message

The tooltip with a help message on filter option was implemented on master in parallel of the initial refactor of the website builder. This commit adds the tooltip on the refactored builder

Help on filter option: 5e21f518d285d0e3ca619ba3505ded6da5fb2e67
Website refactor: 9fe45e2b7ddbbfd0445ffe25a859e67a316d02b2
task-4367641
