### PR TITLE
[IMP] l10n_fr_account: delivery date only set by users

### DIFF
--- a/addons/l10n_fr_account/models/account_move.py
+++ b/addons/l10n_fr_account/models/account_move.py
@@ -26,10 +26,3 @@ class AccountMove(models.Model):
         super()._compute_show_delivery_date()
         for move in self.filtered(lambda m: m.country_code == 'FR'):
             move.show_delivery_date = move.is_sale_document()
-
-    def _post(self, soft=True):
-        # EXTEND 'account'
-        res = super()._post(soft=soft)
-        for move in self.filtered(lambda m: m.show_delivery_date and not m.delivery_date):
-            move.delivery_date = move.invoice_date
-        return res


### PR DESCRIPTION
This commit prevents the delivery date from being set to invoice date by default in French localization.
We need the delivery date to be only set by the users.

task-4900043




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
