### PR TITLE
[FIX] web: do not clearUncommittedChanges for middle click

### DIFF
--- a/addons/web/static/src/webclient/actions/action_service.js
+++ b/addons/web/static/src/webclient/actions/action_service.js
@@ -1256,7 +1256,7 @@ export function makeActionManager(env, router = _router) {
         const clientAction = actionRegistry.get(action.tag);
         action.path ||= clientAction.path;
         if (clientAction.prototype instanceof Component) {
-            if (action.target !== "new") {
+            if (action.target !== "new" && !options.newWindow) {
                 const canProceed = await clearUncommittedChanges(env);
                 if (!canProceed) {
                     return;
@@ -1412,7 +1412,7 @@ export function makeActionManager(env, router = _router) {
             case "ir.actions.act_url":
                 return _executeActURLAction(action, options);
             case "ir.actions.act_window":
-                if (action.target !== "new") {
+                if (action.target !== "new" && !options.newWindow) {
                     const canProceed = await clearUncommittedChanges(env);
                     if (!canProceed) {
                         return new Promise(() => {});
@@ -1628,9 +1628,11 @@ export function makeActionManager(env, router = _router) {
                 view,
             });
 
-        const canProceed = await clearUncommittedChanges(env);
-        if (!canProceed) {
-            return;
+        if (!newWindow) {
+            const canProceed = await clearUncommittedChanges(env);
+            if (!canProceed) {
+                return;
+            }
         }
 
         Object.assign(


### PR DESCRIPTION
Before this commit, when middle clicking the clearUncommittedChanges (and subsequently the beforeLeave) were executed on the current controller. This is an issue, as we are not leaving the current controller.

Now, the clearUncommittedChanges is not called when middle clicking. Note that, this is already the behaviour if the target is "new".
