### PR TITLE
[FIX] mrp: only use workorder_expected_duration of the current record

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -738,7 +738,7 @@ class MrpProduction(models.Model):
             days_delay = production.bom_id.produce_delay
             date_finished = production.date_start + relativedelta(days=days_delay)
             if production._should_postpone_date_finished(date_finished):
-                workorder_expected_duration = sum(self.workorder_ids.mapped('duration_expected'))
+                workorder_expected_duration = sum(production.workorder_ids.mapped('duration_expected'))
                 date_finished = date_finished + relativedelta(minutes=workorder_expected_duration or 60)
             production.date_finished = date_finished
 


### PR DESCRIPTION
If you create mrp.production in batch, date_finished is wrong.

Note: it probably works as is in standard flow because always used
on a single record (ex: form view) but it might break custom code.

opw-4629270


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
