### PR TITLE
[FIX] web: Remove `rpcId` from `ErrorDialog`

### DIFF
--- a/addons/web/static/src/core/errors/error_dialogs.js
+++ b/addons/web/static/src/core/errors/error_dialogs.js
@@ -61,8 +61,8 @@ export class ErrorDialog extends Component {
         if (this.props.serverHost) {
             this.contextDetails += `on ${this.props.serverHost} `;
         }
-        if (this.props.model && this.props.id) {
-            this.contextDetails += `on model ${this.props.model} and id ${this.props.id} `;
+        if (this.props.model) {
+            this.contextDetails += `on model ${this.props.model} `;
         }
         this.contextDetails += `on ${DateTime.now()
             .setZone("UTC")


### PR DESCRIPTION
Steps:
- Enable debug mode
- Go to server actions
- Create a server action that crashes with `Execute code`
- Example -> "a" (will crash because `a` is undefined)
- Traceback will contains an invalid ID

`Occured on odoo180 on model ir.actions.server and id 19 on 2025-06-30 09:20:48 GMT`

This was an error and this ID is not linked with the model, it is the rpc id, so it should not be on the traceback.

This commit remove this id to have something like this 

`Occured on odoo180 on model ir.actions.server on 2025-06-30 09:20:48 GMT`

opw-4816514