### PR TITLE
[FIX] website_payment: fix donation_snippet_use tour

### DIFF
--- a/addons/website_payment/static/tests/tours/donation.js
+++ b/addons/website_payment/static/tests/tours/donation.js
@@ -92,11 +92,9 @@ registry.category('web_tour.tours').add('donation_snippet_use', {
             expectUnloadPage: true,
         },
         {
-            trigger: "body:contains(Your payment has been successfully processed.)",
-        },
-        {
             content: "Verify that the amount displayed is 67",
-            trigger: 'span.oe_currency_value:contains("67.00")',
+            trigger:
+                'body:contains(Your payment has been successfully processed.) span.oe_currency_value:contains("67.00")',
             expectUnloadPage: true,
         },
         {


### PR DESCRIPTION
In this commit, we fix the donation_snippet_use tour. At the end of the tour, when you click on submit donation, you are redirected to a page "Your payment has been processed." From this page, you are then redirected to a page with "Thank you". This intermediate redirection page can be a problem if there are several steps that concern it because we do not know when the redirection will be triggered (in the first or the second step?) Therefore, it is essential to have only one step for intermediate redirections.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
