### PR TITLE
[FIX] html_editor: prevent extra character deletion with o_file_box

### DIFF
--- a/addons/html_editor/static/src/core/delete_plugin.js
+++ b/addons/html_editor/static/src/core/delete_plugin.js
@@ -4,12 +4,9 @@ import {
     isAllowedContent,
     isButton,
     isContentEditable,
-    isEditorTab,
     isEmpty,
     isInPre,
-    isMediaElement,
     isProtected,
-    isSelfClosingElement,
     isShrunkBlock,
     isTangible,
     isTextNode,
@@ -630,7 +627,11 @@ export class DeletePlugin extends Plugin {
             // The joinable in this case is its sibling (previous for the start
             // side, next for the end side), but only if inline.
             const sibling = childNodes(commonAncestor)[side === "start" ? offset - 1 : offset];
-            if (sibling && !isBlock(sibling) && !(sibling.nodeType === Node.TEXT_NODE && !isVisibleTextNode(sibling))) {
+            if (
+                sibling &&
+                !isBlock(sibling) &&
+                !(sibling.nodeType === Node.TEXT_NODE && !isVisibleTextNode(sibling))
+            ) {
                 return { node: sibling, type: "inline" };
             }
             // No fragment to join.
@@ -1126,9 +1127,10 @@ export class DeletePlugin extends Plugin {
         if (leaf.nodeName === "BR" && isFakeLineBreak(leaf)) {
             return true;
         }
-        // @todo: register these as resources by other plugins?
         if (
-            [isSelfClosingElement, isMediaElement, isEditorTab].some((predicate) => predicate(leaf))
+            this.getResource("functional_empty_node_predicates").some((predicate) =>
+                predicate(leaf)
+            )
         ) {
             return false;
         }

--- a/addons/html_editor/static/src/core/dom_plugin.js
+++ b/addons/html_editor/static/src/core/dom_plugin.js
@@ -28,6 +28,7 @@ import {
     isUnprotecting,
     listElementSelector,
     paragraphRelatedElementsSelector,
+    isEditorTab,
 } from "../utils/dom_info";
 import {
     childNodes,
@@ -93,6 +94,7 @@ export class DomPlugin extends Plugin {
             }
         },
         normalize_handlers: this.normalize.bind(this),
+        functional_empty_node_predicates: [isSelfClosingElement, isEditorTab],
     };
     contentEditableToRemove = new Set();
 

--- a/addons/html_editor/static/src/main/media/file_plugin.js
+++ b/addons/html_editor/static/src/main/media/file_plugin.js
@@ -34,6 +34,8 @@ export class FilePlugin extends Plugin {
             },
         }),
         selectors_for_feff_providers: () => ".o_file_box",
+        functional_empty_node_predicates: (node) =>
+            node?.nodeName === "SPAN" && node.classList.contains("o_file_box"),
     };
 
     get recordInfo() {

--- a/addons/html_editor/static/src/main/media/media_dialog/document_selector.js
+++ b/addons/html_editor/static/src/main/media/media_dialog/document_selector.js
@@ -92,7 +92,7 @@ export class DocumentSelector extends FileSelector {
 
 export function renderStaticFileBox(filename, mimetype, downloadUrl, id) {
     const rootSpan = document.createElement("span");
-    rootSpan.classList.add("o_file_box");
+    rootSpan.classList.add("o_file_box", "o-contenteditable-false");
     rootSpan.contentEditable = false;
     rootSpan.dataset.attachmentId = id;
     const bannerElement = renderToElement("html_editor.StaticFileBox", {

--- a/addons/html_editor/static/src/main/media/media_plugin.js
+++ b/addons/html_editor/static/src/main/media/media_plugin.js
@@ -2,6 +2,7 @@ import { Plugin } from "@html_editor/plugin";
 import {
     ICON_SELECTOR,
     isIconElement,
+    isMediaElement,
     isProtected,
     isProtecting,
 } from "@html_editor/utils/dom_info";
@@ -65,6 +66,7 @@ export class MediaPlugin extends Plugin {
         normalize_handlers: this.normalizeMedia.bind(this),
 
         unsplittable_node_predicates: isIconElement, // avoid merge
+        functional_empty_node_predicates: isMediaElement,
 
         selectors_for_feff_providers: () => ICON_SELECTOR,
     };

--- a/addons/html_editor/static/tests/delete/find_adjacent_position.test.js
+++ b/addons/html_editor/static/tests/delete/find_adjacent_position.test.js
@@ -92,6 +92,15 @@ describe("findAdjacentPosition method", () => {
                 const { editor } = await setupEditor(previous);
                 assertAdjacentPositions(editor, previous, next);
             });
+            test("Should find position before filebox", async () => {
+                const content = `<div>\ufeff<span contenteditable="false" class="o_file_box"></span>\ufeff[]</div>`;
+                const { editor, el } = await setupEditor(content);
+                const [node, offset] = findAdjacentPosition(editor, "backward");
+                setSelection({ anchorNode: node, anchorOffset: offset });
+                expect(getContent(el)).toBe(
+                    `<div class="o-paragraph o-we-hint" placeholder='Type "/" for commands'>\ufeff[]<span contenteditable="false" class="o_file_box"></span>\ufeff<br></div>`
+                );
+            });
         });
         describe("Blocks", () => {
             test("Should find position after the div", async () => {


### PR DESCRIPTION
Problem:
When pressing backspace after text followed by an `o_file_box`, both the last character and the file box are deleted at once.

Cause:
An empty `o_file_box` is skipped in `findPosition` because it's treated like a zero-width space (`.textContent === "\ufeef"`), causing incorrect position resolution.

Solution:
`o_file_box` elements should not be skipped during position checks, even when empty.

Steps to reproduce:
- Go to Quality ---> Quality Control --> Control Points
- Create New.
- Add text
- Add a file just after the text
- Delete all content of the file box
- Place the cursor after the file box and press backspace
-> The character before the file box is also deleted

opw-4903841

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
