### PR TITLE
[FIX] point_of_sale: correct relation between pos_printer and pos_config

### DIFF
--- a/addons/point_of_sale/models/pos_printer.py
+++ b/addons/point_of_sale/models/pos_printer.py
@@ -16,7 +16,7 @@ class PosPrinter(models.Model):
     proxy_ip = fields.Char('Proxy IP Address', help="The IP Address or hostname of the Printer's hardware proxy")
     product_categories_ids = fields.Many2many('pos.category', 'printer_category_rel', 'printer_id', 'category_id', string='Printed Product Categories')
     company_id = fields.Many2one('res.company', string='Company', required=True, default=lambda self: self.env.company)
-    pos_config_ids = fields.Many2many('pos.printer', 'pos_config_printer_rel', 'printer_id', 'config_id')
+    pos_config_ids = fields.Many2many('pos.config', 'pos_config_printer_rel', 'printer_id', 'config_id')
 
     @api.model
     def _load_pos_data_domain(self, data):


### PR DESCRIPTION
Before this commit, the Many2many field used an incorrect model name 'pos.printer' instead of the correct 'pos.config' This commit fixes the relation to ensure proper association between printers and POS configurations


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
