### PR TITLE
[IMP] tools: use `DotDict` only in tests

### DIFF
--- a/addons/http_routing/tests/common.py
+++ b/addons/http_routing/tests/common.py
@@ -7,7 +7,8 @@ from werkzeug.test import EnvironBuilder
 
 import odoo.http
 from odoo.tests import HOST, HttpCase
-from odoo.tools import DotDict, config, frozendict
+from odoo.tests.common import DotDict
+from odoo.tools import config, frozendict
 
 
 @contextlib.contextmanager

--- a/addons/rpc/tests/test_xmlrpc.py
+++ b/addons/rpc/tests/test_xmlrpc.py
@@ -11,7 +11,7 @@ from odoo.http import _request_stack
 from odoo.service import common as auth
 from odoo.service import model
 from odoo.tests import common
-from odoo.tools import DotDict
+from odoo.tests.common import DotDict
 
 
 class TestExternalAPI(SavepointCaseWithUserDemo):

--- a/odoo/addons/test_http/tests/test_misc.py
+++ b/odoo/addons/test_http/tests/test_misc.py
@@ -8,7 +8,7 @@ from unittest.mock import patch
 import odoo
 from odoo.http import content_disposition, root
 from odoo.tests import tagged
-from odoo.tests.common import HOST, BaseCase, get_db_name, new_test_user
+from odoo.tests.common import DotDict, HOST, BaseCase, get_db_name, new_test_user
 from odoo.tools import config, file_path, parse_version
 
 from .test_common import TestHttpBase
@@ -64,7 +64,7 @@ class TestHttpMisc(TestHttpBase):
 
     def test_misc2_local_redirect(self):
         def local_redirect(path):
-            fake_req = odoo.tools.misc.DotDict(db=False)
+            fake_req = DotDict(db=False)
             return odoo.http.Request.redirect(fake_req, path, local=True).headers['Location']
         self.assertEqual(local_redirect('https://www.example.com/hello?a=b'), '/hello?a=b')
         self.assertEqual(local_redirect('/hello?a=b'), '/hello?a=b')

--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -62,7 +62,7 @@ from odoo.fields import Command
 from odoo.modules.registry import Registry, DummyRLock
 from odoo.service import security
 from odoo.sql_db import Cursor, Savepoint
-from odoo.tools import config, float_compare, mute_logger, profiler, SQL, DotDict
+from odoo.tools import config, float_compare, mute_logger, profiler, SQL
 from odoo.tools.mail import single_email_re
 from odoo.tools.misc import find_in_path, lower_logging
 from odoo.tools.xml_utils import _validate_xml
@@ -245,6 +245,19 @@ def new_test_user(env, login='', groups='base.group_user', context=None, **kwarg
 
 def loaded_demo_data(env):
     return bool(env.ref('base.user_demo', raise_if_not_found=False))
+
+
+class DotDict(dict):
+    """Helper for dot.notation access to dictionary attributes
+
+        E.g.
+          foo = DotDict({'bar': False})
+          return foo.bar
+    """
+    def __getattr__(self, attrib):
+        val = self.get(attrib)
+        return DotDict(val) if isinstance(val, dict) else val
+
 
 class RecordCapturer:
     def __init__(self, model, domain):

--- a/odoo/tools/image.py
+++ b/odoo/tools/image.py
@@ -16,7 +16,6 @@ except ImportError:
 from random import randrange
 
 from odoo.exceptions import UserError
-from odoo.tools.misc import DotDict
 from odoo.tools.translate import LazyTranslate
 
 
@@ -517,16 +516,15 @@ def is_image_size_above(base64_source_1, base64_source_2):
         if (source[0:4] == b'RIFF' and source[8:15] == b'WEBPVP8'):
             size = get_webp_size(source)
             if size:
-                return DotDict({'width': size[0], 'height': size[0]})
-            else:
-                # False for unknown WEBP format
-                return False
-        else:
-            return image_fix_orientation(binary_to_image(source))
+                return size[0], size[0]  # width, height
+            # False for unknown WEBP format
+            return False
+        fixed_image = image_fix_orientation(binary_to_image(source))
+        return fixed_image.width, fixed_image.height
 
-    image_source = get_image_size(base64_source_1)
-    image_target = get_image_size(base64_source_2)
-    return image_source.width > image_target.width or image_source.height > image_target.height
+    source_width, source_height = get_image_size(base64_source_1)
+    target_width, target_height = get_image_size(base64_source_2)
+    return source_width > target_width or source_height > target_height
 
 
 def image_guess_size_from_field_name(field_name: str) -> Tuple[int, int]:

--- a/odoo/tools/misc.py
+++ b/odoo/tools/misc.py
@@ -62,7 +62,6 @@ __all__ = [
     'DEFAULT_SERVER_TIME_FORMAT',
     'NON_BREAKING_SPACE',
     'SKIPPED_ELEMENT_TYPES',
-    'DotDict',
     'LastOrderedSet',
     'OrderedSet',
     'Reverse',
@@ -1683,18 +1682,6 @@ class ReadonlyDict(Mapping[K, T], typing.Generic[K, T]):
 
     def __iter__(self):
         return iter(self._data__)
-
-
-class DotDict(dict):
-    """Helper for dot.notation access to dictionary attributes
-
-        E.g.
-          foo = DotDict({'bar': False})
-          return foo.bar
-    """
-    def __getattr__(self, attrib):
-        val = self.get(attrib)
-        return DotDict(val) if isinstance(val, dict) else val
 
 
 def get_diff(data_from, data_to, custom_style=False, dark_color_scheme=False):


### PR DESCRIPTION
The `DotDict` class can produce unexpected behaviour if used incorrectly.
This commit moves this class so that it is only used in tests.

task-4822364