### PR TITLE
Prevent clicks in document

### DIFF
--- a/addons/website/static/src/client_actions/website_preview/website_builder_action.js
+++ b/addons/website/static/src/client_actions/website_preview/website_builder_action.js
@@ -305,16 +305,12 @@ export class WebsiteBuilderClientAction extends Component {
                 // Forward clicks to close backend client action's navbar
                 // dropdowns.
                 this.websiteContent.el.dispatchEvent(new MouseEvent("click", ev));
-                /* TODO ?
             } else {
                 // When in edit mode, prevent the default behaviours of clicks
                 // as to avoid DOM changes not handled by the editor.
                 // (Such as clicking on a link that triggers navigating to
                 // another page.)
-                if (!ev.target.closest("#oe_manipulators")) {
-                    ev.preventDefault();
-                }
-                */
+                ev.preventDefault();
             }
             const linkEl = ev.target.closest("[href]");
             if (!linkEl) {

--- a/addons/website/static/src/client_actions/website_preview/website_builder_action.js
+++ b/addons/website/static/src/client_actions/website_preview/website_builder_action.js
@@ -317,36 +317,7 @@ export class WebsiteBuilderClientAction extends Component {
                 return;
             }
 
-            const { href, target /*, classList*/ } = linkEl;
-            /* TODO ? If to be done, most likely in a plugin
-            if (classList.contains('o_add_language')) {
-                ev.preventDefault();
-                const searchParams = new URLSearchParams(href);
-                this.action.doAction('base.action_view_base_language_install', {
-                    target: 'new',
-                    additionalContext: {
-                        params: {
-                            website_id: this.websiteId,
-                            url_return: searchParams.get("url_return"),
-                        },
-                    },
-                });
-            } else if (classList.contains('js_change_lang') && isEditing) {
-                ev.preventDefault();
-                const lang = linkEl.dataset['url_code'];
-                // The "edit_translations" search param coming from keep_query
-                // is removed, and the hash is added.
-                const destinationUrl = new URL(href, window.location);
-                destinationUrl.searchParams.delete('edit_translations');
-                destinationUrl.hash = this.websiteService.contentWindow.location.hash;
-                this.websiteService.bus.trigger('LEAVE-EDIT-MODE', {
-                    onLeave: () => {
-                        this.websiteService.goToWebsite({ path: destinationUrl.toString(), lang });
-                    },
-                    reloadIframe: false,
-                });
-            } else
-            */
+            const { href, target } = linkEl;
             if (href && target !== "_blank" && !this.state.isEditing) {
                 if (isTopWindowURL(linkEl)) {
                     ev.preventDefault();


### PR DESCRIPTION
> [ROLE] Go to '/@/web/login' > Edit >
> - Click on "Login" => instead of allowing to edit the label, it opens the warning that every field must be completed. 
> - Enter a login/password and clock on "Login" > you're logged in, redirected, and now out of the editor iframe (every link is clickable).
> - (Another way to reproduce the same bug: go to Forum > Help > New Post, then edit)