### PR TITLE
[FIX] hr_version: delete constraint update

### DIFF
--- a/addons/hr/models/hr_version.py
+++ b/addons/hr/models/hr_version.py
@@ -252,8 +252,11 @@ class HrVersion(models.Model):
 
     @api.ondelete(at_uninstall=False)
     def _unlink_except_last_version(self):
-        if self.employee_id.versions_count == len(self):
-            raise ValidationError(_('An employee must always have at least one version.'))
+        for employee_id, versions in self.filtered(lambda r: r.active).grouped('employee_id').items():
+            if employee_id.versions_count == len(versions):
+                raise ValidationError(
+                    self.env._('Employee %s must always have at least one active version.') % employee_id.name
+                )
 
     def write(self, values):
         # Employee Versions Validation


### PR DESCRIPTION
"An employee must always have at least one active version."

The constrain had two issues:
1. it took into account the number of archived versions selected for deletion, but it shouldn't.
2. It assumed a single employee for all versions getting deleted.

Task-4903960