### PR TITLE
[IMP] html_editor, website: use EmbeddedFilePlugin for /file command in powerbox

### DIFF
--- a/addons/html_editor/static/src/fields/html_field.js
+++ b/addons/html_editor/static/src/fields/html_field.js
@@ -5,6 +5,7 @@ import {
     COLLABORATION_PLUGINS,
     EMBEDDED_COMPONENT_PLUGINS,
     MAIN_PLUGINS,
+    NO_EMBEDDED_COMPONENTS_FALLBACK_PLUGINS,
 } from "@html_editor/plugin_sets";
 import { DYNAMIC_PLACEHOLDER_PLUGINS } from "@html_editor/backend/plugin_sets";
 import {
@@ -225,7 +226,9 @@ export class HtmlField extends Component {
                 ...MAIN_PLUGINS,
                 ...(this.props.isCollaborative ? COLLABORATION_PLUGINS : []),
                 ...(this.props.dynamicPlaceholder ? DYNAMIC_PLACEHOLDER_PLUGINS : []),
-                ...(this.props.embeddedComponents ? EMBEDDED_COMPONENT_PLUGINS : []),
+                ...(this.props.embeddedComponents
+                    ? EMBEDDED_COMPONENT_PLUGINS
+                    : NO_EMBEDDED_COMPONENTS_FALLBACK_PLUGINS),
             ],
             classList: this.classList,
             onChange: this.onChange.bind(this),

--- a/addons/html_editor/static/src/plugin_sets.js
+++ b/addons/html_editor/static/src/plugin_sets.js
@@ -64,6 +64,7 @@ import { TableOfContentPlugin } from "@html_editor/others/embedded_components/pl
 import { ToggleBlockPlugin } from "@html_editor/others/embedded_components/plugins/toggle_block_plugin/toggle_block_plugin";
 import { VideoPlugin } from "@html_editor/others/embedded_components/plugins/video_plugin/video_plugin";
 import { CaptionPlugin } from "@html_editor/others/embedded_components/plugins/caption_plugin/caption_plugin";
+import { EmbeddedFilePlugin } from "@html_editor/others/embedded_components/plugins/embedded_file_plugin/embedded_file_plugin";
 import { QWebPlugin } from "./others/qweb_plugin";
 import { EditorVersionPlugin } from "./core/editor_version_plugin";
 import { ImagePostProcessPlugin } from "./main/media/image_post_process_plugin";
@@ -170,7 +171,6 @@ export const MAIN_PLUGINS = [
     TextDirectionPlugin,
     InlineCodePlugin,
     TableResizePlugin,
-    FilePlugin,
     PlaceholderPlugin,
 ];
 
@@ -187,7 +187,10 @@ export const EMBEDDED_COMPONENT_PLUGINS = [
     ToggleBlockPlugin,
     VideoPlugin,
     CaptionPlugin,
+    EmbeddedFilePlugin,
 ];
+
+export const NO_EMBEDDED_COMPONENTS_FALLBACK_PLUGINS = [FilePlugin];
 
 export const EXTRA_PLUGINS = [
     ...COLLABORATION_PLUGINS,

--- a/addons/html_editor/static/tests/file.test.js
+++ b/addons/html_editor/static/tests/file.test.js
@@ -1,6 +1,9 @@
 import { MAIN_EMBEDDINGS } from "@html_editor/others/embedded_components/embedding_sets";
-import { EmbeddedFilePlugin } from "@html_editor/others/embedded_components/plugins/embedded_file_plugin/embedded_file_plugin";
-import { EMBEDDED_COMPONENT_PLUGINS, MAIN_PLUGINS } from "@html_editor/plugin_sets";
+import {
+    EMBEDDED_COMPONENT_PLUGINS,
+    MAIN_PLUGINS,
+    NO_EMBEDDED_COMPONENTS_FALLBACK_PLUGINS,
+} from "@html_editor/plugin_sets";
 import { isZwnbsp } from "@html_editor/utils/dom_info";
 import { describe, expect, test } from "@odoo/hoot";
 import { animationFrame, click, press, queryOne, waitFor } from "@odoo/hoot-dom";
@@ -11,12 +14,12 @@ import { insertText } from "./_helpers/user_actions";
 import { execCommand } from "./_helpers/userCommands";
 
 const configWithEmbeddedFile = {
-    Plugins: [
-        ...MAIN_PLUGINS.filter((P) => P.id !== "file"),
-        EmbeddedFilePlugin,
-        ...EMBEDDED_COMPONENT_PLUGINS,
-    ],
+    Plugins: [...MAIN_PLUGINS, ...EMBEDDED_COMPONENT_PLUGINS],
     resources: { embedded_components: MAIN_EMBEDDINGS },
+};
+
+const configWithoutEmbeddedFile = {
+    Plugins: [...MAIN_PLUGINS, ...NO_EMBEDDED_COMPONENTS_FALLBACK_PLUGINS],
 };
 
 const patchUpload = (editor) => {
@@ -33,7 +36,9 @@ const patchUpload = (editor) => {
 
 describe("file command", () => {
     test("/file uploads a file via the system's selector, skipping the media dialog", async () => {
-        const { editor } = await setupEditor("<p>[]<br></p>");
+        const { editor } = await setupEditor("<p>[]<br></p>", {
+            config: configWithoutEmbeddedFile,
+        });
         const mockedUpload = patchUpload(editor);
         // Open powerbox.
         await insertText(editor, "/file");
@@ -49,7 +54,9 @@ describe("file command", () => {
     });
 
     test("file card should have inline display, BS alert-info style and no download button", async () => {
-        const { editor } = await setupEditor("<p>[]<br></p>");
+        const { editor } = await setupEditor("<p>[]<br></p>", {
+            config: configWithoutEmbeddedFile,
+        });
         patchUpload(editor);
         execCommand(editor, "uploadFile");
         // wait for the embedded component to be mounted
@@ -77,7 +84,7 @@ describe("document tab in media dialog", () => {
     describe("without File nor EmbeddedFile plugin", () => {
         test("Document tab is not available by default", async () => {
             const { editor } = await setupEditor("<p>[]<br></p>", {
-                config: { Plugins: MAIN_PLUGINS.filter((p) => p.id !== "file") },
+                config: { Plugins: MAIN_PLUGINS },
             });
             execCommand(editor, "insertMedia");
             await animationFrame();
@@ -103,7 +110,9 @@ describe("document tab in media dialog", () => {
 
     describe("with File plugin (no embedded component)", () => {
         test("file upload via media dialog inserts a link in the editable", async () => {
-            const { editor } = await setupEditor("<p>[]<br></p>");
+            const { editor } = await setupEditor("<p>[]<br></p>", {
+                config: configWithoutEmbeddedFile,
+            });
             execCommand(editor, "insertMedia");
             await animationFrame();
             await click(".nav-link:contains('Documents')");
@@ -116,7 +125,9 @@ describe("document tab in media dialog", () => {
 
 describe("powerbutton", () => {
     test("file powerbutton uploads a file directly via the system's selector", async () => {
-        const { editor } = await setupEditor("<p>[]<br></p>");
+        const { editor } = await setupEditor("<p>[]<br></p>", {
+            config: configWithoutEmbeddedFile,
+        });
         const mockedUpload = patchUpload(editor);
         // Click on the upload powerbutton.
         await click(".power_button.fa-upload");
@@ -144,7 +155,9 @@ describe("powerbutton", () => {
 
 describe("zero width no-break space", () => {
     test("file card should be padded with zero-width no-break spaces", async () => {
-        const { editor } = await setupEditor("<p>[]<br></p>");
+        const { editor } = await setupEditor("<p>[]<br></p>", {
+            config: configWithoutEmbeddedFile,
+        });
         patchUpload(editor);
         execCommand(editor, "uploadFile");
         // wait for the the file to be uploaded and the card rendered

--- a/addons/html_editor/static/tests/link/popover.test.js
+++ b/addons/html_editor/static/tests/link/popover.test.js
@@ -20,6 +20,7 @@ import { getContent, setContent, setSelection } from "../_helpers/selection";
 import { expectElementCount } from "../_helpers/ui_expectations";
 import { insertLineBreak, insertText, splitBlock, undo } from "../_helpers/user_actions";
 import { execCommand } from "../_helpers/userCommands";
+import { MAIN_PLUGINS, NO_EMBEDDED_COMPONENTS_FALLBACK_PLUGINS } from "@html_editor/plugin_sets";
 
 const base64Img =
     "data:image/png;base64, iVBORw0KGgoAAAANSUhEUgAAAAUA\n        AAAFCAYAAACNbyblAAAAHElEQVQI12P4//8/w38GIAXDIBKE0DHxgljNBAAO\n            9TXL0Y4OHwAAAABJRU5ErkJggg==";
@@ -1306,7 +1307,9 @@ describe("readonly mode", () => {
 
 describe("upload file via link popover", () => {
     test("should display upload button when url input is empty", async () => {
-        const { editor } = await setupEditor("<p>[]<br></p>");
+        const { editor } = await setupEditor("<p>[]<br></p>", {
+            config: { Plugins: [...MAIN_PLUGINS, ...NO_EMBEDDED_COMPONENTS_FALLBACK_PLUGINS] },
+        });
         execCommand(editor, "openLinkTools");
         await waitFor(".o-we-linkpopover");
         // Upload button should be visible
@@ -1333,7 +1336,9 @@ describe("upload file via link popover", () => {
         return mockedUploadPromise;
     };
     test("can create a link to an uploaded file", async () => {
-        const { editor, el } = await setupEditor("<p>[]<br></p>");
+        const { editor, el } = await setupEditor("<p>[]<br></p>", {
+            config: { Plugins: [...MAIN_PLUGINS, ...NO_EMBEDDED_COMPONENTS_FALLBACK_PLUGINS] },
+        });
         const mockedUpload = patchUpload(editor);
         execCommand(editor, "openLinkTools");
         await waitFor(".o-we-linkpopover");
@@ -1377,7 +1382,9 @@ describe("upload file via link popover", () => {
     });
 
     test("label input does not get filled on file upload if it is already filled", async () => {
-        const { editor } = await setupEditor("<p>[]<br></p>");
+        const { editor } = await setupEditor("<p>[]<br></p>", {
+            config: { Plugins: [...MAIN_PLUGINS, ...NO_EMBEDDED_COMPONENTS_FALLBACK_PLUGINS] },
+        });
         const mockedUpload = patchUpload(editor);
         execCommand(editor, "openLinkTools");
         await waitFor(".o-we-linkpopover");

--- a/addons/html_editor/static/tests/media.test.js
+++ b/addons/html_editor/static/tests/media.test.js
@@ -8,6 +8,7 @@ import { base64Img, setupEditor, testEditor } from "./_helpers/editor";
 import { getContent } from "./_helpers/selection";
 import { expectElementCount } from "./_helpers/ui_expectations";
 import { deleteBackward, deleteForward, insertText } from "./_helpers/user_actions";
+import { MAIN_PLUGINS, NO_EMBEDDED_COMPONENTS_FALLBACK_PLUGINS } from "@html_editor/plugin_sets";
 
 test("Can replace an image", async () => {
     onRpc("ir.attachment", "search_read", () => [
@@ -48,7 +49,7 @@ test("Replace an image with link by a document should remove the link", async ()
     const env = await makeMockEnv();
     await setupEditor(
         `<p><a href="http://test.com"><img class="img-fluid" src="/web/static/img/logo.png"></a></p>`,
-        { env }
+        { env, config: { Plugins: [...MAIN_PLUGINS, ...NO_EMBEDDED_COMPONENTS_FALLBACK_PLUGINS] } }
     );
     expect("img[src='/web/static/img/logo.png']").toHaveCount(1);
     await click("img");

--- a/addons/html_editor/static/tests/powerbox.test.js
+++ b/addons/html_editor/static/tests/powerbox.test.js
@@ -87,7 +87,7 @@ describe("search", () => {
         const { el, editor } = await setupEditor("<p>ab[]</p>");
         await insertText(editor, "/");
         await animationFrame();
-        expect(commandNames(el).length).toBe(27);
+        expect(commandNames(el).length).toBe(26);
         await insertText(editor, "head");
         await animationFrame();
         expect(commandNames(el)).toEqual(["Heading 1", "Heading 2", "Heading 3"]);
@@ -97,7 +97,7 @@ describe("search", () => {
         const { el, editor } = await setupEditor("<p>ab[]</p>");
         await insertText(editor, "/");
         await animationFrame();
-        expect(commandNames(el).length).toBe(27);
+        expect(commandNames(el).length).toBe(26);
         expect(".o-we-category").toHaveCount(7);
         expect(queryAllTexts(".o-we-category")).toEqual([
             "FORMAT",
@@ -120,7 +120,7 @@ describe("search", () => {
         const { el, editor } = await setupEditor("<p>ab[]</p>", { props: { iframe: true } });
         await insertText(editor, "/");
         await animationFrame();
-        expect(commandNames(el).length).toBe(27);
+        expect(commandNames(el).length).toBe(26);
         await insertText(editor, "head");
         await animationFrame();
         expect(commandNames(el)).toEqual(["Heading 1", "Heading 2", "Heading 3"]);
@@ -172,7 +172,7 @@ describe("search", () => {
         await insertText(editor, "/");
         await animationFrame();
         await expectElementCount(".o-we-powerbox", 1);
-        expect(commandNames(el).length).toBe(27);
+        expect(commandNames(el).length).toBe(26);
 
         await insertText(editor, "headx");
         await animationFrame();

--- a/addons/website/static/src/builder/website_builder.js
+++ b/addons/website/static/src/builder/website_builder.js
@@ -7,7 +7,10 @@ import { SavePlugin } from "@html_builder/core/save_plugin";
 import { SetupEditorPlugin } from "@html_builder/core/setup_editor_plugin";
 import { VisibilityPlugin } from "@html_builder/core/visibility_plugin";
 import { removePlugins } from "@html_builder/utils/utils";
-import { MAIN_PLUGINS as MAIN_EDITOR_PLUGINS } from "@html_editor/plugin_sets";
+import {
+    MAIN_PLUGINS as MAIN_EDITOR_PLUGINS,
+    NO_EMBEDDED_COMPONENTS_FALLBACK_PLUGINS,
+} from "@html_editor/plugin_sets";
 import { closestElement } from "@html_editor/utils/dom_traversal";
 import { Component } from "@odoo/owl";
 import { registry } from "@web/core/registry";
@@ -63,7 +66,10 @@ export class WebsiteBuilder extends Component {
         const pluginsToRemove = this.props.translation
             ? [...mainEditorPluginsToRemove, ...pluginsBlockedInTranslationMode]
             : mainEditorPluginsToRemove;
-        const mainEditorPlugins = removePlugins([...MAIN_EDITOR_PLUGINS], pluginsToRemove);
+        const mainEditorPlugins = removePlugins(
+            [...MAIN_EDITOR_PLUGINS, ...NO_EMBEDDED_COMPONENTS_FALLBACK_PLUGINS],
+            pluginsToRemove
+        );
         const coreBuilderPlugins = this.props.translation ? [] : CORE_BUILDER_PLUGINS;
         const Plugins = [...mainEditorPlugins, ...coreBuilderPlugins, ...(websitePlugins || [])];
         builderProps.Plugins = Plugins;


### PR DESCRIPTION
### Current behavior before PR:

- The /file command in powerbox used a static file box (FilePlugin)
across all editor usages.
- EmbeddedFilePlugin was only used in the Knowledge app.

### Desired behavior after PR is merged:

- The editor uses EmbeddedFilePlugin when embedded components are enabled.
- Other fallback to the standard FilePlugin.

**enterprise-https://github.com/odoo/enterprise/pull/88929**

task-4671755

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
