### PR TITLE
[FIX] website, web: support negative main-object IDs

### DIFF
--- a/addons/web/static/src/legacy/js/public/public_root.js
+++ b/addons/web/static/src/legacy/js/public/public_root.js
@@ -292,7 +292,7 @@ export const PublicRoot = publicWidget.RootWidget.extend({
      */
     _onMainObjectRequest: function (ev) {
         var repr = $('html').data('main-object');
-        var m = repr.match(/(.+)\((\d+),(.*)\)/);
+        var m = repr.match(/(.+)\((-?\d+),(.*)\)/);
         ev.data.callback({
             model: m[1],
             id: m[2] | 0,

--- a/addons/website/static/src/js/content/website_root.js
+++ b/addons/website/static/src/js/content/website_root.js
@@ -231,7 +231,7 @@ export const WebsiteRoot = publicRootData.PublicRoot.extend(KeyboardNavigationMi
      */
     _unslugHtmlDataObject: function (dataAttr) {
         var repr = $('html').data(dataAttr);
-        var match = repr && repr.match(/(.+)\((\d+),(.*)\)/);
+        var match = repr && repr.match(/(.+)\((-?\d+),(.*)\)/);
         if (!match) {
             return null;
         }

--- a/addons/website/static/src/services/website_service.js
+++ b/addons/website/static/src/services/website_service.js
@@ -11,8 +11,9 @@ const { reactive, EventBus } = owl;
 
 const websiteSystrayRegistry = registry.category('website_systray');
 
+// TODO this is duplicated in website_root at least, it should be a shared util
 export const unslugHtmlDataObject = (repr) => {
-    const match = repr && repr.match(/(.+)\((\d+),(.*)\)/);
+    const match = repr && repr.match(/(.+)\((-?\d+),(.*)\)/);
     if (!match) {
         return null;
     }


### PR DESCRIPTION
Steps to reproduce:
1. Install website_blog
2. Create a blog post with a negative ID (you'll need to change it via SQL) -> such kind of record is something we have on Odoo.com
3. Go to that blog post in the backend website view => Crash

We have several places where the main-object data is parsed from the HTML, it did not consider the negative ID possibility. In master, an unified way to parse the main-object will be made.

task-jke
