### PR TITLE
[FIX] spreadsheet_dashboard: show full dashboard name on hover in search panel

### DIFF
--- a/addons/spreadsheet_dashboard/static/src/bundle/dashboard_action/dashboard_action.xml
+++ b/addons/spreadsheet_dashboard/static/src/bundle/dashboard_action/dashboard_action.xml
@@ -37,6 +37,7 @@
                                 t-on-click="() => this.openDashboard(dashboard.id)"
                                 t-esc="dashboard.displayName"
                                 t-att-data-name="dashboard.displayName"
+                                t-att-title="dashboard.displayName"
                                 class="o_search_panel_category_value list-group-item cursor-pointer border-0"
                                 t-att-class="{'active': dashboard.id === state.activeDashboard.id}"/>
                         </ul>


### PR DESCRIPTION
Before this pr:
- Long dashboard names were truncated in the search panel.
- There was no way for the user to see the full name.

After this pr:
- A tooltip has been added to display the full dashboard name on hover.

Task: [4903713](https://www.odoo.com/odoo/2328/tasks/4903713)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
