### PR TITLE
[FIX] hr_holidays: misuse + on array (python) in JS

### DIFF
--- a/addons/hr_holidays/static/src/store_service_patch.js
+++ b/addons/hr_holidays/static/src/store_service_patch.js
@@ -4,7 +4,7 @@ import { patch } from "@web/core/utils/patch";
 /** @type {import("models").Store} */
 const storeServicePatch = {
     get onlineMemberStatuses() {
-        return super.onlineMemberStatuses + ["leave_online", "leave_away", "leave_busy"];
+        return [...super.onlineMemberStatuses, "leave_online", "leave_away", "leave_busy"];
     },
 };
 


### PR DESCRIPTION
Follow-up of https://github.com/odoo/odoo/pull/198012

PR above made a typo in code in which list of "online" member IM status is a list of string, and it uses + to concatenate items like in python but this doesn't work in JS.

Thankfully it kinda "worked" because this casted the array into list (e.g. `["a", "b"]` becomes "a,b") and other items were appended to string. Since this list was used for `.includes()` by chance the ".includes()" method is on Array and String and functionally this results to about the same intention... Again by chance!