### PR TITLE
[FIX] account: compute product description textarea's height on mounted

### DIFF
--- a/addons/account/static/src/core/utils/product_and_label_autoresize.js
+++ b/addons/account/static/src/core/utils/product_and_label_autoresize.js
@@ -10,7 +10,11 @@ import { useAutoresize } from "@web/core/utils/autoresize";
  * @param {Ref} ref
  */
 export function useProductAndLabelAutoresize(ref, options = {}) {
-    useAutoresize(ref, { onResize: productAndLabelResizeTextArea, ...options });
+    useAutoresize(ref, { 
+        onMounted: productAndLabelResizeTextArea, 
+        onResize: productAndLabelResizeTextArea,
+        ...options,
+    });
 }
 
 export function productAndLabelResizeTextArea(textarea, options = {}) {


### PR DESCRIPTION
## Versions
18.0+

## Issue
Blank spaces appear at the bottom of each Sale Order line when a long product description is set.

## Steps to reproduce
- Create a new quotation:
  - Add a product;
  - Change the description for a long one (3+ lines) or add one;
- Go back to the quote list view;
- Come back to the quote.

## Cause
The component's height computation is done before the columns' widths' computation which then resizes based on font styles, making the text take less space and blank spaces appear.

## Fix
Force the computation of the SO line's height once the component is mounted.

opw-4766800