### PR TITLE
[FIX] sale_{project}: set project company to match the project's partner company

### DIFF
--- a/addons/project/models/project_project.py
+++ b/addons/project/models/project_project.py
@@ -254,7 +254,12 @@ class ProjectProject(models.Model):
         """
         for project in self:
             account = project.account_id
-            if project.partner_id and project.partner_id.company_id and project.company_id != project.partner_id.company_id:
+            if (
+                project.partner_id
+                and project.partner_id.company_id
+                and project.company_id
+                and project.company_id != project.partner_id.company_id
+            ):
                 raise UserError(_('The project and the associated partner must be linked to the same company.'))
             if not account or not account.company_id:
                 continue
@@ -262,7 +267,7 @@ class ProjectProject(models.Model):
             if (account.project_count > 1 or account.line_ids) and project.company_id != account.company_id:
                 raise UserError(
                     _("The project's company cannot be changed if its analytic account has analytic lines or if more than one project is linked to it."))
-            account.company_id = project.company_id
+            account.company_id = project.company_id or project.partner_id.company_id
 
     @api.depends('rating_status', 'rating_status_period')
     def _compute_rating_request_deadline(self):

--- a/addons/project/tests/test_project_base.py
+++ b/addons/project/tests/test_project_base.py
@@ -244,9 +244,6 @@ class TestProjectBase(TestProjectCommon):
             # Cannot change the company of a project if both the project and its partner have a company
             self.project_pigs.company_id = company_2
         with self.assertRaises(UserError):
-            # Cannot unset the project's company if its associated partner has a company
-            self.project_pigs.company_id = False
-        with self.assertRaises(UserError):
             # Cannot change the company of a partner if both the project and its partner have a company
             partner.company_id = company_2
         partner.company_id = False

--- a/addons/sale_project/tests/test_sale_project.py
+++ b/addons/sale_project/tests/test_sale_project.py
@@ -1426,3 +1426,23 @@ class TestSaleProject(HttpCase, TestSaleProjectCommon):
         self.assertEqual(self.project_global.sale_line_id, sale_order.order_line)
 
         sale_order.action_confirm()  # no error should be raised even if the SO is already confirmed
+
+    def test_so_with_project_template(self):
+        """ Test that a SO with a product using a project template creates the project
+            and the task on SO confirmation, and set project's company to the product's template company.
+        """
+        product_with_project_template = self.env['product.product'].create({
+            'name': 'product with template',
+            'list_price': 1,
+            'type': 'service',
+            'service_tracking': 'project_only',
+            'project_template_id': self.project_template.id,
+        })
+        partner = self.env['res.partner'].create({'name': 'Test Partner', 'company_id': self.env.company.id})
+        sale_order = self.env['sale.order'].create({
+            'partner_id': partner.id,
+            'order_line': [Command.create({'product_id': product_with_project_template.id})],
+        })
+        sale_order.action_confirm()
+        self.assertEqual(sale_order.project_ids[0].company_id, self.project_template.company_id)
+        self.assertEqual(sale_order.project_ids[0].account_id.company_id, partner.company_id)


### PR DESCRIPTION
Currently, a user error occurs when confirming a Sales Order (SO).

**Steps to reproduce:**

1) Install sale_project
2) Create a service product that generates a project and a task. 
3) Add a project template by creating one from the product form view. 
4) Create an SO by creating a customer with a company 
5) Add the above-created service product and confirm the SO.

**Error:**
A user exception will be triggered
```
The project and the associated partner must be linked to the same company.
```

**Cause:**

- When a project template is created from the product view, 
both the customer and the company_id default to empty.

- Later, when confirming a SO with a customer that belongs to a company, 
the new project's company_id is taken from the project template, which is empty.

https://github.com/odoo/odoo/blob/876e9d5e9ba87fa69188b2da098eec78f77040f5/addons/sale_project/models/sale_order.py#L140-L141

- However, the project’s partner_id (the customer) does have a company_id,
(since the customer value for the project will be set through SO's customer).

- This leads to a mismatch between the project’s company_id(which is empty) 
and its partner’s company_id. So a user exception will be triggered from the below lines

https://github.com/odoo/odoo/blob/876e9d5e9ba87fa69188b2da098eec78f77040f5/addons/project/models/project_project.py#L257-L258

**Solution:**

- If the project template has no company_id, and the customer of the project has one, 
set the project’s company_id to match that of the customer.

opw-4900741,4880495
