### PR TITLE
[FIX] website_sale: Ensure checkout steps are published

### DIFF
--- a/addons/website_sale/models/website.py
+++ b/addons/website_sale/models/website.py
@@ -767,8 +767,17 @@ class Website(models.Model):
         generic_steps = self.env['website.checkout.step'].sudo().search([
             ('website_id', '=', False),
         ])
+        is_extra_info_feature_enabled = self.env['ir.ui.view'].sudo().search([
+            ('key', '=', 'website_sale.extra_info'),
+            ('active', '=', True),
+            ('website_id', '=', self.id)
+        ], limit=1)
+        
         for step in generic_steps:
-            is_published = bool(step.step_href != '/shop/extra_info')
+            if is_extra_info_feature_enabled:
+                is_published = True
+            else:
+                is_published = bool(step.step_href != '/shop/extra_info')
             step.copy({'website_id': self.id, 'is_published': is_published})
 
     def _get_checkout_step(self, href):


### PR DESCRIPTION
Traceback:
---------
```
Error while render the template
KeyError: 'current_step'
Template: website.step_wizard
Path: /t/div/div[1]/div/div/a/span
```
Ensure `is_published` is set to True for '/shop/extra_info' if the `extra step` feature is enabled during migration.

Cause of the issue:
-----------------------
The issue occurs because the is_published field is set to False, resulting in an empty value for [`current_step`](https://github.com/odoo/odoo/blob/saas-18.3/addons/website_sale/models/website.py#L799). This happens because the [`allowed_steps_domain`](https://github.com/odoo/odoo/blob/saas-18.3/addons/website_sale/models/website.py#L780-L783) fails to include the step when the condition is_published=True is not satisfied.

During migration while creation of `website.checkout.step` records, the standard logic `is_published = bool(step.step_href != '/shop/extra_info')` sets `is_published=False` for the [/shop/extra_info](https://github.com/odoo/odoo/blob/saas-18.3/addons/website_sale/models/website.py#L771) step, even if the extra step feature was enabled in v18.2. This leads to a KeyError when accessing `/shop/extra_info` after migration. This fix ensures `is_published` is correctly
 set based on whether the extra info feature is enabled.

Steps to reproduce:
------------------------
1) In Odoo v18.2, go to Website > Configuration > Settings,
   and enable Extra Step During Checkout
2) Migrate the database to v18.3.
3) Navigate to /shop/extra_info on the website.

Before Fix
------------
```
v_18.3=# select id,name,key,website_id,active from ir_ui_view where key = 'website_sale.extra_info';
  id  |        name         |           key           | website_id | active 
------+---------------------+-------------------------+------------+--------
 2100 | Checkout Extra Info | website_sale.extra_info |            | f
 2218 | Checkout Extra Info | website_sale.extra_info |          1 | t
(2 rows)

v_18.3=# select id,website_id,is_published,step_href from website_checkout_step where step_href = '/shop/extra_info' and website_id is not null;
 id | website_id | is_published |    step_href     
----+------------+--------------+------------------
  7 |          1 | f            | /shop/extra_info
 11 |          2 | f            | /shop/extra_info
(2 rows)
```

After Fx
------------
```
v_18.3=# select id,website_id,is_published,step_href from website_checkout_step where step_href = '/shop/extra_info' and website_id is not null;
 id | website_id | is_published |    step_href     
----+------------+--------------+------------------
  7 |          1 | t            | /shop/extra_info
 11 |          2 | f            | /shop/extra_info
(2 rows)

v_18.3=# select id,name,key,website_id,active from ir_ui_view where key = 'website_sale.extra_info';
  id  |        name         |           key           | website_id | active 
------+---------------------+-------------------------+------------+--------
 2100 | Checkout Extra Info | website_sale.extra_info |            | f
 2218 | Checkout Extra Info | website_sale.extra_info |          1 | t
(2 rows)
```

upg-2992540
opw-4867915

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
