### PR TITLE
[FIX] website: block chatter inside builder

### DIFF
--- a/addons/portal/__manifest__.py
+++ b/addons/portal/__manifest__.py
@@ -111,6 +111,9 @@ a dependency towards website editing and customization capabilities.""",
             ("remove", "mail/static/src/**/*.dark.scss"),
             "portal/static/src/chatter/scss/shadow.scss",
         ],
+        'website.inside_builder_style': [
+            'portal/static/src/scss/portal.inside.scss'
+        ],
     },
     'author': 'Odoo S.A.',
     'license': 'LGPL-3',

--- a/addons/portal/static/src/scss/portal.inside.scss
+++ b/addons/portal/static/src/scss/portal.inside.scss
@@ -1,0 +1,3 @@
+#discussion {
+    pointer-events: none;
+}


### PR DESCRIPTION
> [MOU, chrome]: Enable comments on a blog post page > You can send comments from the "Edit" mode (already spotted on master, but with the new code, a user can also upload documents...) 

Steps to reproduce:
- Go to `/blog`
- Open website builder
- Enable "Comments" at the "Bottom"
- Bug: you can write messages, send them, ... while still in editor mode

This commit blocks with `pointer-event: none` on `#discussion` because this is the id of the top div of `portal.message_thread`

task-4367641
