### PR TITLE
[FIX] hr_skills: fix hr_skills_tours

### DIFF
--- a/addons/hr_skills/static/tests/tours/skills_tour.js
+++ b/addons/hr_skills/static/tests/tours/skills_tour.js
@@ -123,7 +123,7 @@ registry.category("web_tour.tours").add("hr_skills_tour", {
         },
         {
             content: "Select Certification",
-            trigger: ".o_field_widget[name='skill_type_id'] span:contains('Certification')",
+            trigger: ".o_field_widget[name='skill_type_id'] span:contains('Music Certification')",
             run: "click",
         },
         {

--- a/addons/hr_skills/tests/test_ui.py
+++ b/addons/hr_skills/tests/test_ui.py
@@ -19,7 +19,7 @@ class SkillsTestUI(HttpCase):
         skill_type.save()
 
         with Form(self.env['hr.skill.type']) as skill_type:
-            skill_type.name = 'Certification'
+            skill_type.name = 'Music Certification'
             skill_type.is_certification = True
             with skill_type.skill_ids.new() as skill:
                 skill.name = 'Piano'


### PR DESCRIPTION
Steps to reproduce:
-------------------
- Install a database with demo data
- launch the test test_ui in hr_skills
- This test will failed because two hr_skill_type have the same name and the wrong one is chosen.

Solution:
---------
The skill type "Certification" is renamed to "Music certification" to avoid mis-selection.

task-4908637

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
