### PR TITLE
[PERF] mail: ignore Documents route in legacy steps

### DIFF
--- a/addons/mail/static/tests/legacy/helpers/webclient_setup.js
+++ b/addons/mail/static/tests/legacy/helpers/webclient_setup.js
@@ -13,6 +13,7 @@ import { createWebClient } from "@web/../tests/webclient/helpers";
 const ROUTES_TO_IGNORE = [
     "/web/webclient/load_menus",
     "/web/dataset/call_kw/res.users/load_views",
+    "/web/dataset/call_kw/documents.document/user_has_groups",
     "/hr_attendance/attendance_user_data",
 ];
 const WEBCLIENT_PARAMETER_NAMES = new Set(["mockRPC", "serverData", "target", "webClientClass"]);


### PR DESCRIPTION
We're adding a route to allow fetching multiple groups at once for the Documents service.

This will be useful to compare with alternative solutions.

Task-4836624

