### PR TITLE
[IMP] pos_{ ,self_order}: show session cash, sold & ongoing stats

### DIFF
--- a/addons/point_of_sale/static/tests/pos/tours/chrome_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/chrome_tour.js
@@ -227,3 +227,33 @@ registry.category("web_tour.tours").add("test_zero_decimal_places_currency", {
             ReceiptScreen.totalAmountContains("100"),
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("SessionStatisticsDisplay", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            ProductScreen.enterOpeningAmount("100.00"),
+            Dialog.confirm("Open Register"),
+            ProductScreen.addOrderline("Desk Pad", "5", "5"),
+            ProductScreen.clickPayButton(),
+            PaymentScreen.clickPaymentMethod("Cash"),
+            PaymentScreen.validateButtonIsHighlighted(true),
+            PaymentScreen.clickValidate(),
+            ReceiptScreen.clickNextOrder(),
+            ProductScreen.isShown(),
+            ProductScreen.addOrderline("Monitor Stand", "2", "10"),
+            ProductScreen.clickPayButton(),
+            PaymentScreen.clickPaymentMethod("Cash"),
+            PaymentScreen.validateButtonIsHighlighted(true),
+            PaymentScreen.clickValidate(),
+            ReceiptScreen.clickNextOrder(),
+            ProductScreen.isShown(),
+            Chrome.clickMenuOption("Backend", { expectUnloadPage: true }),
+            {
+                trigger: `[name=opening_cash]:contains(100.00)`,
+            },
+            {
+                trigger: `[name=paid_orders]:contains(45.00 (2 orders))`,
+            },
+        ].flat(),
+});

--- a/addons/point_of_sale/views/point_of_sale_dashboard.xml
+++ b/addons/point_of_sale/views/point_of_sale_dashboard.xml
@@ -63,6 +63,7 @@
                 <field name="pos_session_state"/>
                 <field name="pos_session_duration"/>
                 <field name="currency_id"/>
+                <field name="statistics_for_current_session" />
                 <templates>
                     <t t-name="menu">
                         <div class="container dropdown-pos-config">
@@ -107,28 +108,57 @@
                             </div>
                         </div>
                         <div class="row g-0 pb-4 ms-2 mt-auto">
-                            <div name="card_left" class="col-6 d-flex flex-wrap align-items-center gap-2">
+                            <div name="card_left" class="col-12 col-md-6 d-flex flex-wrap align-items-center gap-2 mb-2 mb-md-0">
                                 <button t-if="record.current_session_state.raw_value != 'closing_control'" class="btn btn-primary" name="open_ui" type="object">
                                     <t t-if="record.current_session_state.raw_value === 'opened'">Continue Selling</t>
                                     <t t-else="">Open Register</t>
                                 </button>
                                 <button t-else="" class="btn btn-secondary" name="open_existing_session_cb" type="object">Close</button>
                             </div>
-                            <div class="col-6">
-                                <div t-if="record.last_session_closing_date.value" class="row">
-                                    <div class="col-6">
-                                        <span>Closing</span>
+                            <div class="col-12 col-md-6">
+                                <t t-set="statistics" t-value="record.statistics_for_current_session.raw_value" />
+                                <t t-if="statistics">
+                                    <div t-if="statistics.date.is_started" class="row">
+                                        <div class="col-5">
+                                            <span>Date</span>
+                                        </div>
+                                        <span t-esc="statistics.date.start_date" class="col-7"/>
                                     </div>
-                                    <field name="last_session_closing_date" class="col-6"/>
-                                </div>
-
-                                <div t-if="record.last_session_closing_date.value" invisible="not cash_control" class="row">
-                                    <div class="col-6">
-                                        <span>Balance</span>
+                                    <div class="row">
+                                        <div class="col-5">
+                                            <span>Opening</span>
+                                        </div>
+                                        <span name="opening_cash" t-esc="statistics.cash.opening_cash" class="col-7"/>
                                     </div>
-                                    <field name="last_session_closing_cash" widget="monetary" class="col-6"/>
-                                </div>
+                                    <div t-if="statistics.orders.paid.display" class="row">
+                                        <div class="col-5">
+                                            <span>Sold</span>
+                                        </div>
+                                        <span name="paid_orders" t-esc="statistics.orders.paid.display" class="col-7"/>
+                                    </div>
+                                    <div t-if="statistics.orders.draft.display" class="row">
+                                        <div class="col-5">
+                                            <span>Ongoing</span>
+                                        </div>
+                                        <span name="draft_orders" t-esc="statistics.orders.draft.display" class="col-7"/>
+                                    </div>
+                                </t>
 
+                                <t t-elif="record.last_session_closing_date.value">
+                                    <div class="row">
+                                        <div class="col-6">
+                                            <span>Closing</span>
+                                        </div>
+                                        <field name="last_session_closing_date" class="col-6"/>
+                                    </div>
+                                    <div class="row" invisible="not cash_control">
+                                        <div class="col-6">
+                                            <span>Balance</span>
+                                        </div>
+                                        <field name="last_session_closing_cash" widget="monetary" class="col-6"/>
+                                    </div>
+                                </t>
+                                
                                 <a t-if="record.number_of_rescue_session.value &gt; 0" class="col-12" name="open_opened_rescue_session_form" type="object">
                                     <field name="number_of_rescue_session" /> outstanding rescue session
                                 </a>

--- a/addons/pos_restaurant/data/scenarios/restaurant_demo_session.xml
+++ b/addons/pos_restaurant/data/scenarios/restaurant_demo_session.xml
@@ -173,6 +173,7 @@
             <field name="name">OpenSession/0003</field>
             <field name="config_id" ref="pos_config_main_restaurant" />
             <field name="user_id" ref="base.user_admin" />
+            <field name="start_at" eval="(DateTime.today() + relativedelta(days=-1)).strftime('%Y-%m-%d %H:%M:%S')" />
         </record>
 
         <record id="pos_open_order_2" model="pos.order" forcecreate="False">

--- a/addons/pos_self_order/views/point_of_sale_dashboard.xml
+++ b/addons/pos_self_order/views/point_of_sale_dashboard.xml
@@ -31,13 +31,6 @@
                         Mobile Menu
                  </button>
             </xpath>
-            <xpath expr="//field[@name='name']" position="after">
-                <field name="self_ordering_mode" invisible="1" />
-                <div class="badge text-bg-info o_kanban_inline_block me-2"
-                    invisible="not self_ordering_mode == 'mobile'">
-                    Self Ordering Enabled
-                </div>
-            </xpath>
             <xpath expr="//div[@name='card_left']" position="after">
                 <field name="self_ordering_mode" invisible="1" />
                 <field name="current_session_id" invisible="1" />


### PR DESCRIPTION
Before this commit:
=======================
- The POS dashboard does not show data such as opening cash,
paid orders, and active restaurant orders.
- The self_ordering_mode badge was displayed in the
POS config kanban, despite the mobile menu already indicating this mode.

After this commit:
=======================
- POS dashboard Kanban view now shows: 
     - Opening cash from the current POS session
     - Paid (sold) order amount and count
     - Active restaurant order amount and count
- Removed the self_ordering_mode badge from the POS config
kanban view, as the mobile menu already conveys this status.

Task - 4896778