### PR TITLE
[FIX] mass_mailing: restore Dynamic Placeholder command in powerbox

### DIFF
--- a/addons/mass_mailing/static/src/js/mass_mailing_wysiwyg.js
+++ b/addons/mass_mailing/static/src/js/mass_mailing_wysiwyg.js
@@ -206,7 +206,7 @@ export class MassMailingWysiwyg extends Wysiwyg {
             ...options,
             autoActivateContentEditable: false,
             allowCommandVideo: false,
-            powerboxItems,
+            powerboxItems: [...(options.powerboxItems || []), ...powerboxItems],
             powerboxCategories,
         };
         return finalOptions;

--- a/addons/mass_mailing/static/tests/tours/mass_mailing_dynamic_placeholder_tour.js
+++ b/addons/mass_mailing/static/tests/tours/mass_mailing_dynamic_placeholder_tour.js
@@ -1,0 +1,90 @@
+import { registry } from "@web/core/registry";
+import { stepUtils } from "@web_tour/tour_service/tour_utils";
+
+registry.category("web_tour.tours").add('mass_mailing_dynamic_placeholder_tour', {
+    url: '/odoo',
+    steps: () => [
+        stepUtils.showAppsMenuItem(),
+        {
+            content: "Select the 'Email Marketing' app.",
+            trigger: '.o_app[data-menu-xmlid="mass_mailing.mass_mailing_menu_root"]',
+            run: "click",
+        },
+        {
+            content: "Click on the create button to create a new mailing.",
+            trigger: 'button.o_list_button_add',
+            run: "click",
+        },
+        {
+            content: "Fill in Subject",
+            trigger: '#subject_0',
+            run: "edit Test Dynamic Placeholder",
+        },
+        {
+            trigger: ":iframe .o_mail_theme_selector_new",
+        },
+        {
+            content: "Pick the basic theme",
+            trigger: ':iframe #basic',
+            run: "click",
+        },
+         {
+            content: "Insert text inside editable",
+            trigger: ':iframe .odoo-editor-editable',
+            async run(actions) {
+                await actions.editor(`/`);
+                const iframe = document.querySelector("iframe");
+                iframe?.contentDocument?.querySelector(".note-editable").dispatchEvent(
+                    new InputEvent("input", {
+                        inputType: "insertText",
+                        data: "/",
+                    })
+                );
+            },
+        },
+        {
+            content: "Click on the the dynamic placeholder powerBox options",
+            trigger: '.oe-powerbox-commandName:contains("Dynamic Placeholder")',
+            run: "click",
+        },
+        {
+            content: "Check if the dynamic placeholder popover is opened",
+            trigger: "div.o_model_field_selector_popover",
+            run: "click",
+        },
+        {
+            content: "filter the dph result",
+            trigger: "div.o_model_field_selector_popover_search input[type='text']",
+            run: "edit name",
+        },
+        {
+            content: "Click on the first entry of the dynamic placeholder",
+            trigger: 'div.o_model_field_selector_popover button:contains("Company Name")',
+            run: "click",
+        },
+        {
+            content: "Enter a default value",
+            trigger:
+                'div.o_model_field_selector_popover .o_model_field_selector_default_value_input input[type="text"]',
+            run: "edit defValue",
+        },
+        {
+            content: "Click on the insert button",
+            trigger: "div.o_model_field_selector_popover button:first-child",
+            run: "click",
+        },
+        {
+            content: "Ensure the editable contain the dynamic placeholder t tag",
+            trigger: `:iframe .note-editable.odoo-editor-editable t[t-out="object.company_name"]:contains("defValue")`,
+        },
+        {
+            content: "Discard form changes",
+            trigger: "button.o_form_button_cancel",
+            run: "click",
+        },
+        {
+            content: "Wait for the form view to disappear",
+            trigger: "body:not(:has(.o_form_sheet))",
+        },
+    ],
+});

--- a/addons/mass_mailing/tests/test_mailing_ui.py
+++ b/addons/mass_mailing/tests/test_mailing_ui.py
@@ -79,3 +79,6 @@ class TestMailingUi(MassMailCommon, HttpCaseWithUserDemo):
 
     def test_mass_mailing_code_view_tour(self):
         self.start_tour("/odoo?debug=tests", 'mass_mailing_code_view_tour', login="demo")
+
+    def test_mass_mailing_dynamic_placeholder_tour(self):
+        self.start_tour("/odoo", 'mass_mailing_dynamic_placeholder_tour', login="demo")


### PR DESCRIPTION
Description of the issue this PR addresses:

- In saas-18.4, the "Dynamic Placeholder" command stopped appearing when typing `/field` in the email editor's powerbox.
- This issue appears after the changes made in this Commit https://github.com/odoo/odoo/commit/3a02143e4d91c6f46110f22f1be84b77e7fb0bb6.

Current behavior before PR:

- The `_getEditorOptions` method in the `mass_mailing editor` replaced the default powerboxItems with its own (e.g., for Rating), which unintentionally removed built-in commands like "Dynamic Placeholder".

Desired behavior after PR is merged:

- The overridden powerboxItems now extend the default ones instead of replacing them. This ensures that both built-in commands (e.g., "Dynamic Placeholder") and custom ones (e.g., "Rating") are available in the powerbox.

task-4901178

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
