### PR TITLE
[FIX] l10n_tr_nilvera_einvoice: add exchange rate, discount and fix xml layout

### DIFF
--- a/addons/l10n_tr_nilvera_einvoice/__manifest__.py
+++ b/addons/l10n_tr_nilvera_einvoice/__manifest__.py
@@ -8,6 +8,7 @@ For sending and receiving electronic invoices to Nilvera.
     'depends': ['l10n_tr_nilvera', 'account_edi_ubl_cii'],
     'data': [
         'data/cron.xml',
+        'data/ubl_tr_templates.xml',
         'views/account_journal_dashboard_views.xml',
         'views/account_move_views.xml',
         'wizard/account_move_send_views.xml',

--- a/addons/l10n_tr_nilvera_einvoice/data/ubl_tr_templates.xml
+++ b/addons/l10n_tr_nilvera_einvoice/data/ubl_tr_templates.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <template id="ubl_tr_InvoiceType" inherit_id="account_edi_ubl_cii.ubl_20_InvoiceType" primary="True">
+        <!-- the placement of <cac:AllowanceCharge> node is improper for Nilvera, so it is replaced. -->
+        <xpath expr="//*[local-name()='AllowanceCharge']" position="replace"/>
+        <xpath expr="//*[local-name()='PaymentTerms']" position="after">
+            <t xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2">
+                <cac:AllowanceCharge t-foreach="vals.get('allowance_charge_vals', [])" t-as="foreach_vals">
+                    <t t-call="{{AllowanceChargeType_template}}">
+                        <t t-set="vals" t-value="foreach_vals"/>
+                    </t>
+                </cac:AllowanceCharge>
+            </t>
+        </xpath>
+    </template>
+
+</odoo>

--- a/addons/l10n_tr_nilvera_einvoice/i18n/l10n_tr_nilvera_einvoice.pot
+++ b/addons/l10n_tr_nilvera_einvoice/i18n/l10n_tr_nilvera_einvoice.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 17.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-07-14 05:22+0000\n"
-"PO-Revision-Date: 2025-07-14 05:22+0000\n"
+"POT-Creation-Date: 2025-07-16 12:38+0000\n"
+"PO-Revision-Date: 2025-07-16 12:38+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -214,6 +214,15 @@ msgstr ""
 msgid ""
 "The invoice(s) need to have the same Start Date and End Date on all their "
 "respective Invoice Lines."
+msgstr ""
+
+#. module: l10n_tr_nilvera_einvoice
+#. odoo-python
+#: code:addons/l10n_tr_nilvera_einvoice/models/account_edi_xml_ubl_tr.py:0
+#, python-format
+msgid ""
+"To continue sending e-Invoices to Nilvera, please upgrade the 'Türkiye - "
+"Nilvera E-Invoice' module."
 msgstr ""
 
 #. module: l10n_tr_nilvera_einvoice

--- a/addons/l10n_tr_nilvera_einvoice/i18n/tr.po
+++ b/addons/l10n_tr_nilvera_einvoice/i18n/tr.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 17.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-07-14 05:25+0000\n"
-"PO-Revision-Date: 2025-07-14 05:25+0000\n"
+"POT-Creation-Date: 2025-07-16 12:39+0000\n"
+"PO-Revision-Date: 2025-07-16 12:39+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -227,6 +227,17 @@ msgid ""
 msgstr ""
 "Fatura(lar)ın tüm Fatura Satırlarında aynı Başlangıç Tarihi ve "
 "Bitiş Tarihi bulunmalıdır."
+
+#. module: l10n_tr_nilvera_einvoice
+#. odoo-python
+#: code:addons/l10n_tr_nilvera_einvoice/models/account_edi_xml_ubl_tr.py:0
+#, python-format
+msgid ""
+"To continue sending e-Invoices to Nilvera, please upgrade the 'Türkiye - "
+"Nilvera E-Invoice' module."
+msgstr ""
+"Nilvera’ya e-Fatura göndermeye devam etmek için için lütfen "
+"'Türkiye - Nilvera E-Invoice' modülünü güncelleyin."
 
 #. module: l10n_tr_nilvera_einvoice
 #: model:ir.model,name:l10n_tr_nilvera_einvoice.model_account_edi_xml_ubl_tr

--- a/addons/l10n_tr_nilvera_einvoice/models/account_edi_xml_ubl_tr.py
+++ b/addons/l10n_tr_nilvera_einvoice/models/account_edi_xml_ubl_tr.py
@@ -33,6 +33,14 @@ class AccountEdiXmlUblTr(models.AbstractModel):
         if invoice.partner_id.l10n_tr_nilvera_customer_status == 'not_checked':
             invoice.partner_id.check_nilvera_customer()
 
+        # Update the Invoice Template
+        if self.env.ref('l10n_tr_nilvera_einvoice.ubl_tr_InvoiceType', raise_if_not_found=False):
+            vals['InvoiceType_template'] = 'l10n_tr_nilvera_einvoice.ubl_tr_InvoiceType'
+        else:
+            raise UserError(_(
+                "To continue sending e-Invoices to Nilvera, please upgrade the 'Türkiye - Nilvera E-Invoice' module."
+            ))
+
         vals['vals'].update({
             'id': _get_formatted_id(invoice),
             'customization_id': 'TR1.2',
@@ -53,6 +61,7 @@ class AccountEdiXmlUblTr(models.AbstractModel):
         vals['vals']['note_vals'].append({'note': self._l10n_tr_get_amount_integer_partn_text_note(invoice.amount_residual_signed, self.env.ref('base.TRY')), 'note_attrs': {}})
         if vals['invoice'].currency_id.name != 'TRY':
             vals['vals']['note_vals'].append({'note': self._l10n_tr_get_amount_integer_partn_text_note(invoice.amount_residual, vals['invoice'].currency_id), 'note_attrs': {}})
+            vals['vals']['note_vals'].append({'note': self._get_invoice_currency_exchange_rate(invoice)})
         return vals
 
     @api.model
@@ -64,6 +73,16 @@ class AccountEdiXmlUblTr(models.AbstractModel):
         text_i = num2words(amount_integer_part * sign, lang="tr") or 'Sifir'
         text_d = num2words(amount_decimal_part * sign, lang="tr") or 'Sifir'
         return f'YALNIZ : {text_i} {currency.name} {text_d} {currency.currency_subunit_label}'.upper()
+
+    def _get_invoice_currency_exchange_rate(self, invoice):
+        conversion_rate = self.env['res.currency']._get_conversion_rate(
+            from_currency=invoice.currency_id,
+            to_currency=invoice.company_currency_id,
+            company=invoice.company_id,
+            date=invoice.invoice_date,
+        )
+        # Nilvera Portal accepts the exchange rate for 6 decimals places only.
+        return f'KUR : {conversion_rate:.6f} TL'
 
     def _get_country_vals(self, country):
         # EXTENDS account.edi.xml.ubl_21
@@ -177,8 +196,10 @@ class AccountEdiXmlUblTr(models.AbstractModel):
         vals = super()._get_invoice_monetary_total_vals(invoice, taxes_vals, line_extension_amount, allowance_total_amount, charge_total_amount)
         # allowance_total_amount needs to have a value even if 0.0 otherwise it's blank in the Nilvera PDF.
         vals['allowance_total_amount'] = allowance_total_amount
-        if invoice.currency_id.is_zero(vals.get('prepaid_amount', 1)):
-            del vals['prepaid_amount']
+
+        # <cac:PrepaidAmount> node is not supported by Nilvera, so it is removed and added to the payable_amount so that
+        # the total invoice amount (in invoice currency) is preserved.
+        vals['payable_amount'] += vals.pop('prepaid_amount', 0.0)
         vals['currency_dp'] = 2
         return vals
 
@@ -198,6 +219,29 @@ class AccountEdiXmlUblTr(models.AbstractModel):
                     },
                 ]
         return super()._get_invoice_period_vals_list(invoice)
+
+    def _get_document_allowance_charge_vals_list(self, invoice):
+        # EXTENDS account.edi.xml.ubl_21
+        vals = super()._get_document_allowance_charge_vals_list(invoice)
+        for val in vals:
+            # The allowance_charge_reason_code is not supported in UBL TR so we need to remove that.
+            val.pop('allowance_charge_reason_code', None)
+
+        invoice_lines = invoice.invoice_line_ids.filtered(lambda line: line.display_type not in {'line_note', 'line_section'})
+        total_discount_amount = sum(
+            line.currency_id.round(line.price_unit * line.quantity * (line.discount / 100))
+            for line in invoice_lines
+        )
+        if total_discount_amount:
+            vals.append({
+                # Must be false since this is a discount.
+                'charge_indicator': 'false',
+                'amount': total_discount_amount,
+                'currency_dp': 2,
+                'currency_name': invoice.currency_id.name,
+                'allowance_charge_reason': "Discount",
+            })
+        return vals
 
     def _get_invoice_line_item_vals(self, line, taxes_vals):
         # EXTENDS account.edi.xml.ubl_21


### PR DESCRIPTION
This commit does following fixes for e-invoice XML generated for Nilvera.
- adds currency exchange rate as note in XML if invoice currency is other than TRY.
- adds total discount amount at the Invoice document level.
- creates a new XML template for TR e-invoice inherited from the UBL Invoice Template.
- removes the `<cac:PrepaidAmount>` node as it is not a valid node in Nilvera and adds the node value to `<cac:PayableAmount>` so that actual invoice amount is preserved while sending e-invoice.


TaskID:4815875

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
