### PR TITLE
[FIX] im_livechat: prevent start chat button flicker

### DIFF
--- a/addons/im_livechat/static/src/embed/common/livechat_service.js
+++ b/addons/im_livechat/static/src/embed/common/livechat_service.js
@@ -147,7 +147,7 @@ export const livechatService = {
     dependencies: ["mail.store", "notification"],
     start(env, services) {
         const livechat = reactive(new LivechatService(env, services));
-        if (livechat.store.livechat_available) {
+        if (session.livechatData?.can_load_livechat) {
             livechat.initialize();
         }
         return livechat;

--- a/addons/im_livechat/static/src/embed/common/store_service_patch.js
+++ b/addons/im_livechat/static/src/embed/common/store_service_patch.js
@@ -3,7 +3,6 @@ import { Store } from "@mail/core/common/store_service";
 import { fields } from "@mail/model/export";
 
 import { patch } from "@web/core/utils/patch";
-import { session } from "@web/session";
 
 export const GUEST_TOKEN_STORAGE_KEY = "im_livechat_guest_token";
 /** @type {import("models").Store} */
@@ -30,8 +29,7 @@ const StorePatch = {
             eager: true,
         });
         this.livechat_rule = fields.One("im_livechat.channel.rule");
-        /** @type {boolean} */
-        this.livechat_available = session.livechatData?.isAvailable;
+        this.livechat_available = false;
     },
 };
 patch(Store.prototype, StorePatch);

--- a/addons/im_livechat/static/src/embed/external/boot.js
+++ b/addons/im_livechat/static/src/embed/external/boot.js
@@ -2,17 +2,17 @@ import { makeRoot, makeShadow } from "@im_livechat/embed/common/boot_helpers";
 
 import { mount, whenReady } from "@odoo/owl";
 
+import { loadBundle } from "@web/core/assets";
 import { _t } from "@web/core/l10n/translation";
 import { MainComponentsContainer } from "@web/core/main_components_container";
 import { getTemplate } from "@web/core/templates";
-import { Deferred } from "@web/core/utils/concurrency";
 import { makeEnv, startServices } from "@web/env";
 import { session } from "@web/session";
-import { loadBundle } from "@web/core/assets";
-
-odoo.livechatReady = new Deferred();
 
 (async function boot() {
+    if (!session.livechatData.can_load_livechat) {
+        return;
+    }
     session.origin = session.livechatData.serverUrl;
     await whenReady();
     if (session.test_mode) {
@@ -28,5 +28,4 @@ odoo.livechatReady = new Deferred();
         translateFn: _t,
         dev: env.debug,
     });
-    odoo.livechatReady.resolve();
 })();

--- a/addons/im_livechat/static/src/embed/frontend/boot_service.js
+++ b/addons/im_livechat/static/src/embed/frontend/boot_service.js
@@ -18,7 +18,7 @@ export const livechatBootService = {
     },
 
     start(env) {
-        if (!session.livechatData?.isAvailable) {
+        if (!session.livechatData?.can_load_livechat) {
             return;
         }
         const target = this.getTarget();

--- a/addons/im_livechat/static/tests/livechat_test_helpers.js
+++ b/addons/im_livechat/static/tests/livechat_test_helpers.js
@@ -49,7 +49,7 @@ export async function loadDefaultEmbedConfig() {
     });
     patchWithCleanup(session, {
         livechatData: {
-            isAvailable: true,
+            can_load_livechat: true,
             serverUrl: window.origin,
             options: {
                 header_background_color: "#875A7B",

--- a/addons/im_livechat/static/tests/mock_server/livechat_mock_server.js
+++ b/addons/im_livechat/static/tests/mock_server/livechat_mock_server.js
@@ -210,4 +210,8 @@ patch(mailDataHelpers, {
             );
         }
     },
+    _process_request_for_all(store) {
+        super._process_request_for_all(...arguments);
+        store.add({ livechat_available: true });
+    },
 });

--- a/addons/im_livechat/views/im_livechat_channel_templates.xml
+++ b/addons/im_livechat/views/im_livechat_channel_templates.xml
@@ -100,7 +100,7 @@
                 }
                 odoo.__session_info__ = Object.assign(odoo.__session_info__, {
                     livechatData: {
-                        isAvailable: <t t-out="'true' if info['available'] else 'false'"/>,
+                        can_load_livechat: <t t-out="'true' if info['available'] else 'false'"/>,
                         serverUrl: "<t t-out="info['server_url']"/>",
                         options: <t t-out="json.dumps(info.get('options', {}))"/>,
                     },


### PR DESCRIPTION
When the live chat is loaded on a page, it receives a value called `isAvailable` from the session. This name is misleading: it indicates availability if either an agent or a bot is present, but it doesn’t consider the live chat rules.

These rules depend on the URL. Since `get_livechat_info` is called from the website template, we can’t determine which rule applies at that point. The goal is mainly to avoid calling `init_livechat` ("/mail/data") if we already know the live chat won’t be available. However, this check alone isn’t enough to decide whether to show the chat button.

This commit renames `isAvailable` to `can_load_livechat` for clarity. If `can_load_livechat` is set, we can load the live chat and call `init_livechat`, which will then set the `livechat_available` value.

task-4908197

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
