### PR TITLE
[FIX] website: test_17_website_edit_menus failing on runbot

### DIFF
--- a/addons/website/static/src/client_actions/website_preview/website_builder_action.js
+++ b/addons/website/static/src/client_actions/website_preview/website_builder_action.js
@@ -351,6 +351,7 @@ export class WebsiteBuilderClientAction extends Component {
         // If we detect that behavior, we reload the iframe with a new query
         // parameter, so that it's not cached for Chrome.
         const iframe = this.websiteContent.el;
+        iframe.contentDocument.body.setAttribute("is-ready", "false");
         if (isBrowserChrome() && !iframe.src.includes("iframe_reload")) {
             try {
                 /* eslint-disable no-unused-expressions */
@@ -492,7 +493,7 @@ export class WebsiteBuilderClientAction extends Component {
                 resolve();
             } else {
                 const observer = new MutationObserver(() => {
-                    if (doc.body.hasAttribute("is-ready")) {
+                    if (doc.body.getAttribute("is-ready") === "true") {
                         observer.disconnect();
                         resolve();
                     }

--- a/addons/website/static/tests/tours/edit_menus.js
+++ b/addons/website/static/tests/tours/edit_menus.js
@@ -156,6 +156,22 @@ registerWebsitePreviewTour('edit_menus', {
     // Edit the menu item from the "edit menu" popover button
     ...clickOnEditAndWaitEditMode(),
     clickOnExtraMenuItem({}, true),
+    {
+        content: "Wait for the builder sidebar to fully open",
+        trigger: ":iframe .editor_enable",
+        run: async function() {
+            // Entering the edit mode opens the builder sidebar, which triggers
+            // multiple iframe resize events, which in turn rebuilds the extra
+            // menu items dropdown (see `auto_hide_menu.js` resize handler).
+            //
+            // We wait briefly to ensure all recalculations complete,
+            // avoiding race conditions when opening the link popover.
+            //
+            // NOTE: the delay below (200ms) matches the CSS `transition-delay`
+            // defined for `o-website-builder_sidebar`.
+            await delay(200);
+        },
+    },
     ...openLinkPopup(":iframe .top_menu .nav-item a:contains('Modnar')", "Modnar"),
     {
         content: "Click on the popover Edit Menu button",
@@ -187,6 +203,9 @@ registerWebsitePreviewTour('edit_menus', {
         content: "Save the website menu with the new menu label",
         trigger: ".modal:not(.o_inactive_modal) .modal-footer button:contains(save)",
         run: "click",
+    },
+    {
+        trigger: "body:not(:has(.oe_menu_editor))",
     },
     // Drag a block to be able to scroll later.
     goBackToBlocks(),


### PR DESCRIPTION
The `edit_menus` tour was occasionally failing on runbot due to race
conditions affecting certain steps.

Issue:
1. Following the [PR [1]](https://github.com/odoo/odoo/pull/198596), the tour system has a safeguard where steps
   wait for iframe readiness, determined by the `is-ready="true"`
   attribute on the iframe body.
   However, the `parentFrameIsReady` function had a bug: when called
   before the `is-ready` attribute was set, it defaulted to `true`
   instead of waiting.
   This caused tour steps to execute prematurely while the iframe was
   still loading, creating race conditions.
2. Entering edit mode causes the builder sidebar to open, triggering
   multiple iframe resize events.
   Each resize rebuilds (i.e., removes and recreates) the extra menu
   items dropdown (see auto_hide_menu.js [2]).
   The tour tried to open a link popover inside this dropdown
   immediately after entering edit mode.
   This caused a race condition where, if the step ran before all
   resize events had completed, the dropdown could be rebuilt
   mid-process, and our target element could be lost, causing the step
   to fail to open the popover.

Fix:
1. Set `is-ready="false"` as the initial value on iframe body load.
   This ensures the readiness check waits for the attribute to be
   explicitly set to "true" when publicRoot is ready, eliminating false
   positives.
2. After the builder sidebar fully opens, we now wait briefly before
   interacting with the link in the extra menu items dropdown.
   This delay ensures all recalculations (triggered by iframe resizes)
   are complete before proceeding, avoiding race conditions.

[1] - https://github.com/odoo/odoo/pull/198596
[2] - [website/static/src/js/content/auto_hide_menu.js#L92](https://github.com/odoo/odoo/blob/saas-18.4/addons/website/static/src/js/content/auto_hide_menu.js#L92)

[runbot-226308](https://runbot.odoo.com/odoo/error/226308)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr