### PR TITLE
[FIX] mail: prevent traceback when clicking on GIF preview

### DIFF
--- a/addons/mail/static/src/core/common/gif.xml
+++ b/addons/mail/static/src/core/common/gif.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="mail.Gif">
-       <img t-att-src="props.paused and state.snapshot ? state.snapshot : props.src" t-att-loading="props.loading" t-att-data-paused="props.paused" t-att-alt="props.alt" t-att-class="props.class" t-att-style="props.style" t-on-click="props.onClick" t-on-load="onLoad"/>
+       <img t-att-src="props.paused and state.snapshot ? state.snapshot : props.src" t-att-loading="props.loading" t-att-data-paused="props.paused" t-att-alt="props.alt" t-att-class="props.class" t-att-style="props.style" t-on-click="() => props.onClick?.()" t-on-load="onLoad"/>
     </t>
 </templates>

--- a/addons/mail/static/tests/gif_picker/gif_picker.test.js
+++ b/addons/mail/static/tests/gif_picker/gif_picker.test.js
@@ -312,3 +312,17 @@ test("Show help when no favorite GIF", async () => {
     await click(".o-discuss-GifPicker div[aria-label='list-item']", { text: "Favorites" });
     await contains("span", { text: "So uhh... maybe go favorite some GIFs?" });
 });
+
+test("Clicking GIF preview does not raise an error", async () => {
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({ name: "" });
+    onRpc("/discuss/gif/categories", () => rpc.categories);
+    onRpc("/discuss/gif/search", () => rpc.search);
+    await start();
+    await openDiscuss(channelId);
+    await click("button[title='Add GIFs']");
+    await click("img[data-src='https://media.tenor.com/6uIlQAHIkNoAAAAM/cry.gif']");
+    await click("img[data-src='https://media.tenor.com/np49Y1vrJO8AAAAM/crying-cry.gif']:eq(0)");
+    await click(".o-mail-LinkPreviewImage img");
+    await contains(".o-mail-Message");
+});


### PR DESCRIPTION
**Current behavior before PR:**

When a user posts a GIF link and clicks the preview, it opens in a new tab but throws an error
because `props.onClick` is called unconditionally, even if undefined.

**Desired behavior after PR is merged:**

The issue is fixed by ensuring `props.onClick` is only called if it is defined.

**Task**-4908537


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
