### PR TITLE
[FIX] website: unknown action id for builderaction

### DIFF
--- a/addons/website/static/src/builder/plugins/options/facebook_option.xml
+++ b/addons/website/static/src/builder/plugins/options/facebook_option.xml
@@ -3,19 +3,19 @@
 
 <t t-name="website.FacebookOption">
     <BuilderRow label.translate="URL">
-        <BuilderTextInput dataAttributeAction="'href'" action="'checkFacebookLinkAction'"/>
+        <BuilderTextInput dataAttributeAction="'href'" action="'checkFacebookLink'"/>
     </BuilderRow>
     <BuilderRow label.translate="Cover Photo">
         <BuilderCheckbox dataAttributeAction="'hide_cover'" dataAttributeActionValue="'true'" inverseAction="true"/>
     </BuilderRow>
     <BuilderRow label.translate="Timeline">
-        <BuilderCheckbox action="'dataAttributeListAction'" actionParam="'tabs'" actionValue="'timeline'"/>
+        <BuilderCheckbox action="'dataAttributeList'" actionParam="'tabs'" actionValue="'timeline'"/>
     </BuilderRow>
     <BuilderRow label.translate="Events">
-        <BuilderCheckbox action="'dataAttributeListAction'" actionParam="'tabs'" actionValue="'events'"/>
+        <BuilderCheckbox action="'dataAttributeList'" actionParam="'tabs'" actionValue="'events'"/>
     </BuilderRow>
     <BuilderRow label.translate="Messages">
-        <BuilderCheckbox action="'dataAttributeListAction'" actionParam="'tabs'" actionValue="'messages'"/>
+        <BuilderCheckbox action="'dataAttributeList'" actionParam="'tabs'" actionValue="'messages'"/>
     </BuilderRow>
     <BuilderRow label.translate="Small Header">
         <BuilderCheckbox dataAttributeAction="'small_header'" dataAttributeActionValue="'true'"/>


### PR DESCRIPTION
steps to reproduce:

1. Drop facebook snippet.
2. Click on it.
3. Traceback

The DataAttributeListAction and CheckFacebookLinkAction were not registered correctly in the plugin, due to a mismatch in the action IDs.

Changes made:

"checkFacebookLink" ----> "checkFacebookLinkAction";

"dataAttributeList" ----> "dataAttributeListAction";

resolves issue:
Error: Unknown builder action id: dataAttributeListAction
    at BuilderActionsPlugin.getAction
    at usePrepareAction
    at useClickableBuilderComponent
    at BuilderCheckbox.setup
    at new ComponentNode
