### PR TITLE
[FIX] mrp: reassign by product lines with new operation on bom copy

### DIFF
--- a/addons/mrp/models/mrp_bom.py
+++ b/addons/mrp/models/mrp_bom.py
@@ -236,6 +236,9 @@ class MrpBom(models.Model):
             for bom_line in res.bom_line_ids:
                 if bom_line.operation_id:
                     bom_line.operation_id = operations_mapping[bom_line.operation_id]
+            for byproduct in res.byproduct_ids:
+                if byproduct.operation_id:
+                    byproduct.operation_id = operations_mapping[byproduct.operation_id]
             for operation in self.operation_ids:
                 if operation.blocked_by_operation_ids:
                     copied_operation = operations_mapping[operation]

--- a/addons/mrp/tests/test_bom.py
+++ b/addons/mrp/tests/test_bom.py
@@ -1751,3 +1751,26 @@ class TestBoM(TestMrpCommon):
         self.env['stock.quant']._update_available_quantity(comp, location, 3.0)
         # With 3 components on hand, 1.5 products could be created, rounded down to 1.0 due to the integer uom
         self.assertEqual(prod.qty_available, 1.0)
+
+    def test_copy_bom_with_operations(self):
+        """
+        Check that copying a bom with operations reassign the component and by
+        product lines to the appropirate operations.
+        """
+        bom = self.bom_2
+        bom.bom_line_ids.operation_id = bom.operation_ids
+        bom.byproduct_ids = [Command.create({
+            'product_id': self.product_2.id,
+            'product_qty': 1,
+            'operation_id': bom.operation_ids.id,
+        })]
+        copied_bom = bom.copy()
+        # check that a new operation was created and linked to th copied lines
+        copied_operation = copied_bom.operation_ids
+        self.assertEqual(len(copied_operation), 1)
+        self.assertNotEqual(bom.operation_ids, copied_operation)
+        self.assertEqual(copied_bom.bom_line_ids.operation_id, copied_operation)
+        self.assertEqual(copied_bom.byproduct_ids.operation_id, copied_operation)
+        # Archive the operation of the copied bom and check that the operation linked are removed
+        copied_operation.action_archive()
+        self.assertFalse(copied_bom.bom_line_ids.operation_id | copied_bom.byproduct_ids.operation_id)


### PR DESCRIPTION
### Issue:

Copying a bom with an operation will not reassign the copied operation to the by product lines.

### Steps to reproduce:
- In the settings enable operations and by-products
- Create a bom with an operation op1 and a by product produced in op1
- Copy the bom
#### > The copied by product line refer to the operation of the original bom this can be checked by archiving the copied operation which should erase its link with the copied by product line but will not

### Cause of the issue:

When a bom is copied, the new operation is reassigned to the new bom lines by these lines:
https://github.com/odoo/odoo/blob/9cb4230a6b2252243a8e0546a1a8f5bc52e74009/addons/mrp/models/mrp_bom.py#L230-L247 However, nothing is made for the by product lines.

opw-4788252
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
