### PR TITLE
[FIX] html_editor: fix non-deterministic font size

### DIFF
--- a/addons/html_editor/static/tests/list/list_font_size.test.js
+++ b/addons/html_editor/static/tests/list/list_font_size.test.js
@@ -36,16 +36,16 @@ test("should apply font-size to completely selected list item", async () => {
                 <li>ghi]</li>
             </ol>
         `),
-        stepFunction: setFontSize("64px"),
+        stepFunction: setFontSize("72px"),
         contentAfter: unformat(`
-            <ol style="padding-inline-start: 68px;">
-                <li style="font-size: 64px;">[abc</li>
+            <ol style="padding-inline-start: 77px;">
+                <li style="font-size: 72px;">[abc</li>
                 <li class="oe-nested">
-                    <ol style="padding-inline-start: 67px;">
-                        <li style="font-size: 64px;">def</li>
+                    <ol style="padding-inline-start: 75px;">
+                        <li style="font-size: 72px;">def</li>
                     </ol>
                 </li>
-                <li style="font-size: 64px;">ghi]</li>
+                <li style="font-size: 72px;">ghi]</li>
             </ol>
         `),
     });


### PR DESCRIPTION
It looks like, on runbot specifically, the previously chosen size unfortunately resulted in a size near the 0.5px mark. Because of that, sometimes it would be rounded down and sometimes up. Hopefully changing to another font size won't have the same issue. If it does then we'll need to manually choose either to always round down or up.