### PR TITLE
[FIX] web_tour: allowUnload is true at tour init

### DIFF
--- a/addons/web_tour/static/src/tour_service/tour_automatic.js
+++ b/addons/web_tour/static/src/tour_service/tour_automatic.js
@@ -8,6 +8,7 @@ import * as hootDom from "@odoo/hoot-dom";
 
 export class TourAutomatic {
     mode = "auto";
+    allowUnload = true;
     constructor(data) {
         Object.assign(this, data);
         this.steps = this.steps.map((step, index) => new TourStepAutomatic(step, this, index));
@@ -64,6 +65,7 @@ export class TourAutomatic {
                         if (delayToCheckUndeterminisms > 0) {
                             await step.checkForUndeterminisms(trigger, delayToCheckUndeterminisms);
                         }
+                        this.allowUnload = false;
                         if (!step.skipped && step.expectUnloadPage) {
                             this.allowUnload = true;
                             setTimeout(() => {


### PR DESCRIPTION
When a tour starts (or resumes), the first step of the macro may not be executed even though the page is already
reloaded (e.g. client_actions.js => reload).
In this case, the value of allowUnload was false and triggered an error. This was fixed by setting allowUnload to true, and then recalculating the value of allowUnload at each step.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
