### PR TITLE
[FIX] api_doc: use docstring of introducing class

### DIFF
--- a/addons/api_doc/controllers/api_doc.py
+++ b/addons/api_doc/controllers/api_doc.py
@@ -272,8 +272,9 @@ class DocController(http.Controller):
             for parent_class in reversed(type(model).mro())
             if hasattr(parent_class, method_name)
         )
+        introducing_method = getattr(introducing_class, method_name)
 
-        signature = parse_signature(method)
+        signature = parse_signature(introducing_method)
         return signature.as_dict() | {
             'model': introducing_class._name or 'core',
             'module': introducing_class._module or 'core',


### PR DESCRIPTION
Have the following:

    class BaseModel:
        def unlink(...):
            """docstring of unlink"""

    class ResPartner:
        def unlink(...):
            """some comment explaining the override"""

Developers often add a docstring to the function they override, but use
it to explain what the override does, and fail to keep the original
docstring. Even if they do, it is possible a same method be overridden
in two totally independent modules, so it is not possible to "aggregate"
all the docstrings pieces.

Solve this by always using the docstring of the method in the
introducing class. This way we ignore all the override.