### PR TITLE
[FIX][IMP] mrp: stock.move table update in init

### DIFF
--- a/addons/mrp/__init__.py
+++ b/addons/mrp/__init__.py
@@ -9,13 +9,9 @@ from . import controller
 
 def _pre_init_mrp(env):
     """ Allow installing MRP in databases with large stock.move table (>1M records)
-        - Creating the computed+stored field stock_move.is_done and
-          stock_move.unit_factor is terribly slow with the ORM and leads to "Out of
-          Memory" crashes
+        - Creating the computed+stored field stock_move.unit_factor is terribly
+        slow with the ORM and leads to "Out of Memory" crashes
     """
-    env.cr.execute("""ALTER TABLE "stock_move" ADD COLUMN "is_done" bool;""")
-    env.cr.execute("""UPDATE stock_move
-                     SET is_done=COALESCE(state in ('done', 'cancel'), FALSE);""")
     env.cr.execute("""ALTER TABLE "stock_move" ADD COLUMN "unit_factor" double precision;""")
     env.cr.execute("""UPDATE stock_move
                      SET unit_factor=1;""")

--- a/addons/mrp/__init__.py
+++ b/addons/mrp/__init__.py
@@ -12,9 +12,7 @@ def _pre_init_mrp(env):
         - Creating the computed+stored field stock_move.unit_factor is terribly
         slow with the ORM and leads to "Out of Memory" crashes
     """
-    env.cr.execute("""ALTER TABLE "stock_move" ADD COLUMN "unit_factor" double precision;""")
-    env.cr.execute("""UPDATE stock_move
-                     SET unit_factor=1;""")
+    env.cr.execute("""ALTER TABLE "stock_move" ADD COLUMN "unit_factor" double precision NOT NULL DEFAULT 1;""")
 
 def _create_warehouse_data(env):
     """ This hook is used to add a default manufacture_pull_id, manufacture

--- a/addons/mrp/__init__.py
+++ b/addons/mrp/__init__.py
@@ -9,10 +9,11 @@ from . import controller
 
 def _pre_init_mrp(env):
     """ Allow installing MRP in databases with large stock.move table (>1M records)
-        - Creating the computed+stored field stock_move.unit_factor is terribly
-        slow with the ORM and leads to "Out of Memory" crashes
+        - Creating the computed stored fields `stock_move` `unit_factor` and `manual_consumption`
+        is terribly slow with the ORM and leads to "Out of Memory" crashes.
     """
     env.cr.execute("""ALTER TABLE "stock_move" ADD COLUMN "unit_factor" double precision NOT NULL DEFAULT 1;""")
+    env.cr.execute("""ALTER TABLE "stock_move" ADD COLUMN "manual_consumption" boolean NOT NULL DEFAULT FALSE;""")
 
 def _create_warehouse_data(env):
     """ This hook is used to add a default manufacture_pull_id, manufacture


### PR DESCRIPTION
## [FIX] mrp: don't create `is_done` column
> ### Issue
> In the PR odoo/odoo#186483, we removed the `stock.move` `is_done` field but we forgot to remove the creation of the column and the computation of the field in the MRP init function.
> 
>  ### How to reproduce
> - Install MRP;
> - Uninstall MRP;
> - Re-install MRP -> Error because the added column already exists.

## [IMP] mrp: unit_factor not null
> In the MRP init method, replace the write in the `stock.move` `unit_factor` field by a NOT NULL constraint and a DEFAULT value, that way, a single query is enough.

## [IMP] mrp: create manual_consumption in init
> This commit creates the `stock.move` `manual_consumption` column in the MRP init, that way the field won't be computed during the installation which can be very slow and causes a crash.