### PR TITLE
[FIX] website: cleanup useless code in font family picker

### DIFF
--- a/addons/website/static/src/builder/builder_fontfamilypicker.js
+++ b/addons/website/static/src/builder/builder_fontfamilypicker.js
@@ -1,11 +1,10 @@
-import { Component, onMounted, onWillStart, useSubEnv } from "@odoo/owl";
+import { Component, onWillStart } from "@odoo/owl";
 import { _t } from "@web/core/l10n/translation";
 import { useService } from "@web/core/utils/hooks";
 import {
     basicContainerBuilderComponentProps,
     useVisibilityObserver,
     useApplyVisibility,
-    useSelectableComponent,
 } from "@html_builder/core/utils";
 import { ConfirmationDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
 import { BuilderSelect } from "@html_builder/core/building_blocks/builder_select";
@@ -26,30 +25,11 @@ export class BuilderFontFamilyPicker extends Component {
         this.dialog = useService("dialog");
         this.orm = useService("orm");
         useVisibilityObserver("content", useApplyVisibility("root"));
-        useSelectableComponent(this.props.id, {
-            /*
-            onItemChange(item) {
-                currentLabel = item.getLabel();
-                updateCurrentLabel();
-            },
-            */
-        });
-        onMounted(() => {});
-        useSubEnv({
-            /*
-            onSelectItem: () => {
-                this.dropdown.close();
-            },
-            */
-        });
         this.fonts = [];
         onWillStart(async () => {
             const fontsData = await this.env.editor.shared.websiteFont.getFontsData();
             this.fonts = fontsData._fonts;
         });
-    }
-    getAllClasses() {
-        return "TODO";
     }
     forwardProps(fontValue) {
         const result = Object.assign({}, this.props, {

--- a/addons/website/static/src/builder/builder_fontfamilypicker.xml
+++ b/addons/website/static/src/builder/builder_fontfamilypicker.xml
@@ -2,8 +2,7 @@
 <templates xml:space="preserve">
 
 <t t-name="website.BuilderFontFamilyPicker">
-    <BuilderSelect className="getAllClasses()">
-    <!-- TODO Can't t-att on component: t-att="getAllDataAttributes()" -->
+    <BuilderSelect>
         <t t-foreach="fonts" t-as="font" t-key="font_index">
             <BuilderSelectItem t-props="forwardProps(font)">
                 <div class="d-flex justify-content-between">


### PR DESCRIPTION
The font family picker introduced when creating the website builder based on `html_builder` contains some dead code and some useless code.

This commit cleans up this component.

task-4367641
