### PR TITLE
[REV] web: revert dollar sign aliases

### DIFF
--- a/addons/web/static/lib/hoot-dom/hoot-dom.js
+++ b/addons/web/static/lib/hoot-dom/hoot-dom.js
@@ -70,9 +70,6 @@ export {
 //-----------------------------------------------------------------------------
 
 // DOM
-export const $ = dom.queryFirst;
-export const $$ = dom.queryAll;
-export const $1 = dom.queryOne;
 export const observe = interactor("query", dom.observe);
 export const waitFor = interactor("query", dom.waitFor);
 export const waitForNone = interactor("query", dom.waitForNone);

--- a/addons/web/static/lib/hoot/tests/hoot-dom/dom.test.js
+++ b/addons/web/static/lib/hoot/tests/hoot-dom/dom.test.js
@@ -2,9 +2,6 @@
 
 import { describe, expect, getFixture, test } from "@odoo/hoot";
 import {
-    $,
-    $$,
-    $1,
     animationFrame,
     click,
     formatXml,
@@ -17,8 +14,11 @@ import {
     isFocusable,
     isInDOM,
     isVisible,
+    queryAll,
     queryAllRects,
     queryAllTexts,
+    queryFirst,
+    queryOne,
     queryRect,
     waitFor,
     waitForNone,
@@ -26,6 +26,10 @@ import {
 import { mockTouch } from "@odoo/hoot-mock";
 import { getParentFrame } from "@web/../lib/hoot-dom/helpers/dom";
 import { mountForTest, parseUrl } from "../local_helpers";
+
+const $ = queryFirst;
+const $1 = queryOne;
+const $$ = queryAll;
 
 /**
  * @param {...string} queryAllSelectors


### PR DESCRIPTION
**What's the issue?**

On multiple database instances, there is a blank screen appearing with a console error: unknown token 'export'

**Why is it happening?**

While the exact reason is still unknown, here are the main cuplrits: [this first commit](<https://github.com/odoo/odoo/pull/213223/commits/d4c7e7abbde31806a49d4cdba340cd238eb9130b>) and [this second commit](<https://github.com/odoo/odoo/pull/213223/commits/f7426b366431ebc6266113700eeb3821e9e6a884>).

The first commit adds support for '$' characters in JS variable names, while the second takes advantage of that feature to declare short-hand aliases for the Hoot-DOM library. 

The issue is caused because the aliases from the second commit seem to have been applied to the static assets (and it also seems that they have been correctly transpiled by the server), but for some reason the transpiler still doesn't support '$' characters and ignores the added export statements. Database server code has been verified as having the correct version of the transpiler code, but the resulting static assets still present this issue.

**What can be done?**

This PR should fix the issue, as it effectively reverts changes on the second commit. The first commit has not been reverted (yet), as the cause of the issue is still unknown, and the damage need to be mitigated as quickly as possible.

A temporary fix while the revert arrives in stable is to head to the crashing DB in `debug=assets` mode, to head to the debug menu (Bug icon) and to `"Regenerate Assets"`. 

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
