### PR TITLE
[FIX] account: cancel deferred entries protected by audit trail when reversed

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -4801,8 +4801,7 @@ class AccountMove(models.Model):
     def _can_be_unlinked(self):
         self.ensure_one()
         lock_date = self.company_id._get_user_fiscal_lock_date(self.journal_id)
-        is_part_of_audit_trail = self.posted_before and self.company_id.check_account_audit_trail
-        return not self.inalterable_hash and self.date > lock_date and not is_part_of_audit_trail
+        return not self.inalterable_hash and self.date > lock_date
 
     def _is_protected_by_audit_trail(self):
         return any(move.posted_before and move.company_id.check_account_audit_trail for move in self)


### PR DESCRIPTION
**Steps to reproduce:**
- Install accountant
- In Accounting settings, activate "Audit Trail"

- Create an invoice:
  * Customer: [any]
  * Invoice Lines:
    - Product: [any]
    - Start Date: [2 months ago]
    - End Date: [2 months later]
- Confirm the invoice
=> Deferred Entries are created. Posted for the previous months and in draft for the future ones.

- Reset the invoice to draft

**Issue:**
The draft entires are correctly unlinked, but the posted ones are reversed instead of being cancelled.

**Cause:**
This fix https://github.com/odoo/odoo/commit/cc448bf77aa3d11e634e6bab6da1690a1b67a723 is supposed to cancel the deferred entries when the move is protected by the audi trail.
However we never get into the `elif move._is_protected_by_audit_trail():` branch because its condition is also included in the previous `if not move._can_be_unlinked():` branch.

Linked enterprise PR (test): https://github.com/odoo/enterprise/pull/88992

opw-4891975



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
