### PR TITLE
[FIX] web,*: calendar view: correctly use given form_view_id

### DIFF
--- a/addons/hr_holidays/static/src/views/calendar/calendar_controller.js
+++ b/addons/hr_holidays/static/src/views/calendar/calendar_controller.js
@@ -29,10 +29,9 @@ export class TimeOffCalendarController extends CalendarController {
 
     newTimeOffRequest() {
         const context = {};
-        if (this.props.context.active_id && this.props.context.active_model === 'hr.employee') {
+        if (this.props.context.active_id && this.props.context.active_model === "hr.employee") {
             context["default_employee_id"] = this.props.context.active_id;
-        }
-        else if (this.employeeId) {
+        } else if (this.employeeId) {
             context["default_employee_id"] = this.employeeId;
         }
         if (this.model.meta.scale == "day") {
@@ -101,7 +100,8 @@ export class TimeOffCalendarController extends CalendarController {
                     title: _t("Time Off Request"),
                     viewId: this.model.formViewId,
                     onRecordSaved: onDialogClosed,
-                    onRecordDeleted: (record) => this._deleteRecord(record.resId, record.data.can_cancel),
+                    onRecordDeleted: (record) =>
+                        this._deleteRecord(record.resId, record.data.can_cancel),
                     onLeaveCancelled: onDialogClosed,
                     size: "md",
                 },
@@ -110,13 +110,13 @@ export class TimeOffCalendarController extends CalendarController {
         });
     }
 
-    async editRecord(record, context = {}, shouldFetchFormViewId = true) {
-        return this._editRecord(record, context)
+    async editRecord(record, context = {}) {
+        return this._editRecord(record, context);
     }
 }
 
 export class TimeOffReportCalendarController extends TimeOffCalendarController {
-    async editRecord(record, context = {}, shouldFetchFormViewId = true) {
-        return this._editRecord(record, context, {canExpand: false})
+    async editRecord(record, context = {}) {
+        return this._editRecord(record, context, { canExpand: false });
     }
 }

--- a/addons/hr_homeworking_calendar/static/src/calendar/common/hr_homeworking_calendar_controller.js
+++ b/addons/hr_homeworking_calendar/static/src/calendar/common/hr_homeworking_calendar_controller.js
@@ -11,7 +11,7 @@ patch(AttendeeCalendarController.prototype, {
         this.action = useService("action");
         this._baseRendererProps.openWorkLocationWizard = this.openWorkLocationWizard.bind(this);
     },
-    async editRecord(record, context = {}, shouldFetchFormViewId = true) {
+    async editRecord(record) {
         if (record.homeworking && 'start' in record) {
             return this.action.doAction('hr_homeworking_calendar.set_location_wizard_action', {
                 additionalContext: {

--- a/addons/project/static/tests/project_project_calendar.test.js
+++ b/addons/project/static/tests/project_project_calendar.test.js
@@ -12,12 +12,7 @@ defineProjectModels();
 test("check 'Edit' and 'View Tasks' buttons are in Project Calendar Popover", async () => {
     mockDate("2024-01-03 12:00:00", 0);
     onRpc(({ method, model, args }) => {
-        if (method === "get_formview_id") {
-            expect(model).toBe("project.project");
-            expect(args[0]).toEqual([1]);
-            expect.step("Edit");
-            return false;
-        } else if (model === "project.project" && method === "action_view_tasks") {
+        if (model === "project.project" && method === "action_view_tasks") {
             expect.step("view tasks");
             return false;
         } else if (method === "has_access") {
@@ -44,5 +39,5 @@ test("check 'Edit' and 'View Tasks' buttons are in Project Calendar Popover", as
 
     await click(".o_popover .card-footer a:contains(View Tasks)");
     await click(".o_popover .card-footer a:contains(Edit)");
-    expect.verifySteps(["view tasks", "Edit"]);
+    expect.verifySteps(["view tasks"]);
 });

--- a/addons/web/static/src/views/calendar/calendar_controller.js
+++ b/addons/web/static/src/views/calendar/calendar_controller.js
@@ -287,7 +287,7 @@ export class CalendarController extends Component {
             return this.editRecordInCreation(record);
         }
     }
-    async editRecord(record, context = {}, shouldFetchFormViewId = true) {
+    async editRecord(record, context = {}) {
         if (this.model.hasEditDialog) {
             return new Promise((resolve) => {
                 this.displayDialog(
@@ -306,19 +306,10 @@ export class CalendarController extends Component {
                 );
             });
         } else {
-            let formViewId = this.model.formViewId;
-            if (shouldFetchFormViewId) {
-                formViewId = await this.orm.call(
-                    this.model.resModel,
-                    "get_formview_id",
-                    [[record.id]],
-                    context
-                );
-            }
             const action = {
                 type: "ir.actions.act_window",
                 res_model: this.model.resModel,
-                views: [[formViewId || false, "form"]],
+                views: [[this.model.formViewId || false, "form"]],
                 target: "current",
                 context,
             };
@@ -331,7 +322,7 @@ export class CalendarController extends Component {
     editRecordInCreation(record) {
         const rawRecord = this.model.buildRawRecord(record);
         const context = this.model.makeContextDefaults(rawRecord);
-        return this.editRecord(record, context, false);
+        return this.editRecord(record, context);
     }
 
     deleteConfirmationDialogProps(record) {

--- a/addons/web/static/tests/views/calendar/calendar_view.test.js
+++ b/addons/web/static/tests/views/calendar/calendar_view.test.js
@@ -1618,7 +1618,6 @@ test(`render popover: inside fullcalendar popover`, async () => {
         },
     });
 
-    onRpc("get_formview_id", () => false);
     await mountView({
         resModel: "event",
         type: "calendar",
@@ -2136,7 +2135,7 @@ test(`open form view`, async () => {
         },
     });
 
-    onRpc("get_formview_id", () => "A view");
+    onRpc("get_formview_id", () => expect.step("get_formview_id")); // should not be called
     await mountView({
         resModel: "event",
         type: "calendar",
@@ -2147,7 +2146,7 @@ test(`open form view`, async () => {
         type: "ir.actions.act_window",
         res_id: 4,
         res_model: "event",
-        views: [["A view", "form"]],
+        views: [[false, "form"]],
         target: "current",
         context: {},
     };
@@ -2275,7 +2274,6 @@ test(`readonly date_start field`, async () => {
         },
     });
 
-    onRpc("get_formview_id", () => false);
     await mountView({
         resModel: "event",
         type: "calendar",
@@ -2327,7 +2325,6 @@ test(`readonly calendar view`, async () => {
         },
     });
 
-    onRpc("get_formview_id", () => false);
     await mountView({
         resModel: "event",
         type: "calendar",


### PR DESCRIPTION
*hr_holidays,hr_homeworking_calendar

Before this commit, when clicking on a calendar event to edit it, a `get_formview_id` rpc was done to retrieve the id of the form view to use to edit the event. However, the documentation [1] states that the attribute `form_view_id` can be set in the arch, for the same purpose. The given id was then overruled by the id returned by `get_formview_id`. This commit removes the rpc, so the id is always the one given in the arch, as written in the documentation.

[1] https://www.odoo.com/documentation/18.0/developer/reference/user_interface/view_architectures.html#calendar

Task-4910395

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
