### PR TITLE
[FIX] base_import_module: force the icon from the zip

### DIFF
--- a/addons/base_import_module/models/ir_module.py
+++ b/addons/base_import_module/models/ir_module.py
@@ -18,7 +18,7 @@ from odoo.http import request
 from odoo.modules.module import MANIFEST_NAMES, Manifest
 from odoo.release import major_version
 from odoo.tools import convert_file, exception_to_unicode
-from odoo.tools import file_open, file_open_temporary_directory, ormcache
+from odoo.tools import file_open, file_path, file_open_temporary_directory, ormcache
 from odoo.tools.misc import topological_sort
 
 _logger = logging.getLogger(__name__)
@@ -77,6 +77,12 @@ class IrModuleModule(models.Model):
         if not terp:
             return False
         values = self.get_values_from_terp(terp)
+        try:
+            icon_path = terp.manifest_cached.get('icon') or opj(terp.name, 'static/description/icon.png')
+            file_path(icon_path, env=self.env, check_exists=True)
+            values['icon'] = '/' + icon_path
+        except OSError:
+            pass  # keep the default icon
         values['latest_version'] = terp.version
         if self.env.context.get('data_module'):
             values['module_type'] = 'industries'


### PR DESCRIPTION
The icon is not found by `get_module_icon` which checks whether the file exists on the system. However, that function has no access to temporary storage. We need to explicitly find the path for the imported module.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
