### PR TITLE
[FIX] l10n_sa_pos: display correct time in QR code in SA

### DIFF
--- a/addons/l10n_sa_pos/__manifest__.py
+++ b/addons/l10n_sa_pos/__manifest__.py
@@ -16,6 +16,13 @@ Saudi Arabia POS Localization
         'point_of_sale._assets_pos': [
             'web/static/lib/zxing-library/zxing-library.js',
             'l10n_sa_pos/static/src/**/*',
+        ],
+        'web.assets_tests': [
+            'l10n_sa_pos/static/tests/tours/**/*',
+        ],
+        'web.assets_unit_tests': [
+            'l10n_sa_pos/static/src/app/utils/qr.js',
+            'l10n_sa_pos/static/tests/unit/**/*',
         ]
     },
     'auto_install': True,

--- a/addons/l10n_sa_pos/static/src/app/utils/qr.js
+++ b/addons/l10n_sa_pos/static/src/app/utils/qr.js
@@ -1,0 +1,38 @@
+import { deserializeDateTime, formatDateTime } from "@web/core/l10n/dates";
+
+export function computeSAQRCode(name, vat, date_isostring, amount_total, amount_tax) {
+    /* Generate the qr code for Saudi e-invoicing. Specs are available at the following link at page 23
+    https://zatca.gov.sa/ar/E-Invoicing/SystemsDevelopers/Documents/20210528_ZATCA_Electronic_Invoice_Security_Features_Implementation_Standards_vShared.pdf
+    */
+
+    const ksa_timestamp = formatDateTime(deserializeDateTime(date_isostring), {
+        tz: "Asia/Riyadh",
+        format: "MM/dd/yyyy, HH:mm:ss",
+    });
+
+    const seller_name_enc = _compute_qr_code_field(1, name);
+    const company_vat_enc = _compute_qr_code_field(2, vat);
+    const timestamp_enc = _compute_qr_code_field(3, ksa_timestamp);
+    const invoice_total_enc = _compute_qr_code_field(4, amount_total.toString());
+    const total_vat_enc = _compute_qr_code_field(5, amount_tax.toString());
+
+    const str_to_encode = seller_name_enc.concat(
+        company_vat_enc,
+        timestamp_enc,
+        invoice_total_enc,
+        total_vat_enc
+    );
+
+    let binary = "";
+    for (let i = 0; i < str_to_encode.length; i++) {
+        binary += String.fromCharCode(str_to_encode[i]);
+    }
+    return btoa(binary);
+}
+function _compute_qr_code_field(tag, field) {
+    const textEncoder = new TextEncoder();
+    const name_byte_array = Array.from(textEncoder.encode(field));
+    const name_tag_encoding = [tag];
+    const name_length_encoding = [name_byte_array.length];
+    return name_tag_encoding.concat(name_length_encoding, name_byte_array);
+}

--- a/addons/l10n_sa_pos/static/src/overrides/models/pos_order.js
+++ b/addons/l10n_sa_pos/static/src/overrides/models/pos_order.js
@@ -1,5 +1,6 @@
 import { PosOrder } from "@point_of_sale/app/models/pos_order";
 import { patch } from "@web/core/utils/patch";
+import { computeSAQRCode } from "@l10n_sa_pos/app/utils/qr";
 
 patch(PosOrder.prototype, {
     export_for_printing(baseUrl, headerData) {
@@ -41,34 +42,8 @@ patch(PosOrder.prototype, {
             ).length
         );
     },
+
     compute_sa_qr_code(name, vat, date_isostring, amount_total, amount_tax) {
-        /* Generate the qr code for Saudi e-invoicing. Specs are available at the following link at page 23
-https://zatca.gov.sa/ar/E-Invoicing/SystemsDevelopers/Documents/20210528_ZATCA_Electronic_Invoice_Security_Features_Implementation_Standards_vShared.pdf
-*/
-        const seller_name_enc = this._compute_qr_code_field(1, name);
-        const company_vat_enc = this._compute_qr_code_field(2, vat);
-        const timestamp_enc = this._compute_qr_code_field(3, date_isostring);
-        const invoice_total_enc = this._compute_qr_code_field(4, amount_total.toString());
-        const total_vat_enc = this._compute_qr_code_field(5, amount_tax.toString());
-
-        const str_to_encode = seller_name_enc.concat(
-            company_vat_enc,
-            timestamp_enc,
-            invoice_total_enc,
-            total_vat_enc
-        );
-
-        let binary = "";
-        for (let i = 0; i < str_to_encode.length; i++) {
-            binary += String.fromCharCode(str_to_encode[i]);
-        }
-        return btoa(binary);
-    },
-    _compute_qr_code_field(tag, field) {
-        const textEncoder = new TextEncoder();
-        const name_byte_array = Array.from(textEncoder.encode(field));
-        const name_tag_encoding = [tag];
-        const name_length_encoding = [name_byte_array.length];
-        return name_tag_encoding.concat(name_length_encoding, name_byte_array);
+        return computeSAQRCode(name, vat, date_isostring, amount_total, amount_tax);
     },
 });

--- a/addons/l10n_sa_pos/static/tests/tours/sa_pos_tour.js
+++ b/addons/l10n_sa_pos/static/tests/tours/sa_pos_tour.js
@@ -1,0 +1,21 @@
+import * as Dialog from "@point_of_sale/../tests/tours/utils/dialog_util";
+import * as Chrome from "@point_of_sale/../tests/tours/utils/chrome_util";
+import * as ProductScreen from "@point_of_sale/../tests/tours/utils/product_screen_util";
+import * as PaymentScreen from "@point_of_sale/../tests/tours/utils/payment_screen_util";
+import { registry } from "@web/core/registry";
+
+registry.category("web_tour.tours").add("test_sa_qr_is_shown", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            ProductScreen.addOrderline("Small Shelf", "1"),
+            ProductScreen.clickPayButton(),
+            PaymentScreen.clickPaymentMethod("Cash"),
+            PaymentScreen.clickValidate(),
+            {
+                trigger: "#qrcode.pos-receipt-qrcode",
+                content: "QR code should be visible on the receipt.",
+            },
+        ].flat(),
+});

--- a/addons/l10n_sa_pos/static/tests/unit/sa_pos_unit.test.js
+++ b/addons/l10n_sa_pos/static/tests/unit/sa_pos_unit.test.js
@@ -1,0 +1,20 @@
+import { describe, expect, test } from "@odoo/hoot";
+import { computeSAQRCode } from "@l10n_sa_pos/app/utils/qr";
+
+describe("SA QR Code", () => {
+    test("check QR format", () => {
+        const qrEncoded = computeSAQRCode(
+            "SA Company",
+            "123456789012345",
+            "2025-03-07 10:15:17",
+            100.0,
+            0
+        );
+        const expected =
+            "AQpTQSBDb21wYW55Ag8xMjM0NTY3ODkwMTIzNDUDFDAzLzA3LzIwMjUsIDEzOjE1OjE3BAMxMDAFATA=";
+
+        expect(qrEncoded).toBe(expected, {
+            message: `QR code mismatch: expected "${expected}", got "${qrEncoded}", make sure the timezone is respected`,
+        });
+    });
+});

--- a/addons/l10n_sa_pos/tests/__init__.py
+++ b/addons/l10n_sa_pos/tests/__init__.py
@@ -1,0 +1,3 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import test_sa_pos

--- a/addons/l10n_sa_pos/tests/test_sa_pos.py
+++ b/addons/l10n_sa_pos/tests/test_sa_pos.py
@@ -1,0 +1,41 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.addons.point_of_sale.tests.test_frontend import TestPointOfSaleHttpCommon
+from odoo.addons.account_edi.tests.common import AccountEdiTestCommon
+from odoo.tests.common import tagged
+
+
+@tagged('post_install_l10n', 'post_install', '-at_install')
+class TestUi(TestPointOfSaleHttpCommon):
+
+    @classmethod
+    @AccountEdiTestCommon.setup_edi_format('l10n_sa_edi.edi_sa_zatca')
+    @AccountEdiTestCommon.setup_country('sa')
+    def setUpClass(cls):
+        super().setUpClass()
+        # Setup company
+        cls.company.write({
+            'name': 'SA Company Test',
+            'email': 'info@company.saexample.com',
+            'phone': '+966 51 234 5678',
+            'street2': 'Testomania',
+            'vat': '311111111111113',
+            'state_id': cls.env['res.country.state'].create({
+                'name': 'Riyadh',
+                'code': 'RYA',
+                'country_id': cls.company.country_id.id
+            }),
+            'street': 'Al Amir Mohammed Bin Abdul Aziz Street',
+            'city': 'المدينة المنورة',
+            'zip': '42317',
+        })
+
+    def test_sa_qr_is_shown(self):
+        """
+        Tests that the Saudi Arabia's timezone is applied on the QR code generated at the
+        end of an order.
+        """
+        if self.env['ir.module.module']._get('l10n_sa_edi').state == 'installed':
+            self.skipTest("The needed configuration for e-invoices is not available")
+        self.main_pos_config.with_user(self.pos_admin).open_ui()
+        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'test_sa_qr_is_shown', login="pos_admin")


### PR DESCRIPTION
**Problem:**
If you have an SA company, and try to scan the QR code generated on the receipt, the time will be the UTC time instead of the KSA time, as we are in SA.

**Steps to reproduce:**
- Change your company to SA and install l10n_sa_pos
- Make a purchase with a customer from SA
- Scan the QR code from the receipt using an app such as E-invoice QR reader
- The invoice date will be the UTC time, or 3 hours less than it should

**Why the fix:**
Before this fix, the time was always displayed as UTC. It could have been correct if it also displayed a 'Z' in the end, to indicate that it is not local KSA time.
We now directly change it using the KSA time, to respect the ZATCA guidelines.
The time is now the same on the printed invoice and in the app when scanning the QR code.

opw-4769521