### PR TITLE
[FIX] test_lint, *: Avoid false-positive when running indexing CI test

### DIFF
--- a/addons/event/models/event_mail_slot.py
+++ b/addons/event/models/event_mail_slot.py
@@ -10,7 +10,7 @@ class EventMailRegistration(models.Model):
 
     event_slot_id = fields.Many2one('event.slot', 'Slot', ondelete='cascade', required=True)
     scheduled_date = fields.Datetime('Schedule Date', compute='_compute_scheduled_date', store=True)
-    scheduler_id = fields.Many2one('event.mail', 'Mail Scheduler', ondelete='cascade', required=True)
+    scheduler_id = fields.Many2one('event.mail', 'Mail Scheduler', ondelete='cascade', required=True, index=True)
     # contact and status
     last_registration_id = fields.Many2one('event.registration', 'Last Attendee')
     mail_count_done = fields.Integer('# Sent', copy=False, readonly=True)

--- a/addons/event/models/event_slot.py
+++ b/addons/event/models/event_slot.py
@@ -17,7 +17,7 @@ class EventSlot(models.Model):
     _description = "Event Slot"
     _order = "event_id, date, start_hour, end_hour, id"
 
-    event_id = fields.Many2one("event.event", "Event", required=True, ondelete="cascade")
+    event_id = fields.Many2one("event.event", "Event", required=True, ondelete="cascade", index=True)
     color = fields.Integer("Color", default=0)
     date = fields.Date("Date", required=True)
     date_tz = fields.Selection(related="event_id.date_tz")

--- a/addons/mail/models/discuss/discuss_call_history.py
+++ b/addons/mail/models/discuss/discuss_call_history.py
@@ -12,7 +12,7 @@ class DiscussCallHistory(models.Model):
     duration_hour = fields.Float(compute="_compute_duration_hour")
     start_dt = fields.Datetime(index=True, required=True)
     end_dt = fields.Datetime()
-    start_call_message_id = fields.Many2one("mail.message")
+    start_call_message_id = fields.Many2one("mail.message", index=True)
 
     _channel_id_not_null_constraint = models.Constraint(
         "CHECK (channel_id IS NOT NULL)", "Call history must have a channel"

--- a/addons/mail/models/mail_message_link_preview.py
+++ b/addons/mail/models/mail_message_link_preview.py
@@ -10,7 +10,7 @@ class MessageMailLinkPreview(models.Model):
     _description = "Link between link previews and messages"
     _order = "sequence, id"
 
-    message_id = fields.Many2one("mail.message", required=True, ondelete="cascade")
+    message_id = fields.Many2one("mail.message", required=True, index=True, ondelete="cascade")
     link_preview_id = fields.Many2one(
         "mail.link.preview", index=True, required=True, ondelete="cascade"
     )

--- a/odoo/addons/test_lint/tests/test_index.py
+++ b/odoo/addons/test_lint/tests/test_index.py
@@ -8,6 +8,14 @@ BTREE_INDEX_PY_DEFS = (True, '1', 'btree', 'btree_not_null')
 BTREE_INDEX_IGNORE_MODELS = {  # model._name
     'res.company',
     'stock.warehouse',
+    'event.type',
+    'event.type.mail',
+    'event.type.ticket',
+    'ir.sequence',
+    'ir.sequence.date_range',
+    'ir.module.module',
+    'ir.module.module.dependency',
+    'ir.module.module.exclusion',
 }
 BTREE_INDEX_IGNORE_FIELDS = {  # str(field)  (fully-qualified field name)
     'mail.message.res_id',                              # covered by _model_res_id_idx, should always be accessed via a domain adding the model
@@ -25,10 +33,11 @@ BTREE_INDEX_IGNORE_FIELDS = {  # str(field)  (fully-qualified field name)
     'mail.presence.user_id',                            # covered by _user_unique
     'mail.presence.guest_id',                           # covered by _guest_unique
     'res.users.settings.user_id',                       # covered by _unique_user_id
+    'res.users.log.create_uid',                         # TODO(master): move the field definition in the base module instead of hr_presence, and remove this line
 }
 
 @common.tagged('post_install', '-at_install')
-class TestOne2manyInverseIndexing(common.TransactionCase):
+class TestIndex(common.TransactionCase):
 
     def test_enforce_index_on_one2many_inverse(self):
         """Ensure btree indexes are enforced on the stored inverse fields of One2many relations."""
@@ -45,9 +54,13 @@ class TestOne2manyInverseIndexing(common.TransactionCase):
                 return True  # the m2o field is in the field ignore list
             if m2o_field.index in BTREE_INDEX_PY_DEFS:
                 return True  # the field is already indexed in the definition
-            if all('test' in model_data.module
-                   for model_data in self.env['ir.model.data'].search([('model', '=', comodel._name)])):
-                return True  # skip model if it's exclusively used in testing modules
+            ir_model_id = self.env['ir.model']._get_id(comodel._name)
+            modules = self.env['ir.model.data'].search_fetch([
+                ('model', '=', 'ir.model'), ('res_id', '=', ir_model_id)
+            ], ['module']).mapped('module')
+            # ruff: noqa: SIM103
+            if modules and all('test' in module for module in modules):
+                return True  # skip model if it's in a test module
             return False
 
         fields_to_index = set()


### PR DESCRIPTION
Description
-----------
The test `.test_enforce_index_on_one2many_inverse` was added to fail upon a missing index, so developers could add them during development, before merging.

One of the criteria used to ignore the field for indexing was if it belongs to a `test` model in some test module. The best-effort heuristic used for this is to see if there is some `ir.model. data` associated with the model in question and if all module's names associated with these data entries have `test`, then we can ignore the field for indexing.

But due to the semantics of `all` for empty collections:
```py
assert all([]) is True
```
models that had *no* `ir.model.data` associated at all, e.g. install `--without-demo` and no master data, the field would be ignored for indexing, leading to a passing test.

But on nightly, where the CI is run with demo data also, the field isn't ignored anymore and is caught by the test's assertion for indexing suggestion as expected.

This leads to errors that are never addressed by the developer that added the fields in question.

This commits corrects the test and add the missing indexes that were raised from the CI's false-positive that were missed.

Reference
---------
runbot-227546

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
