### PR TITLE
[IMP] core: hide warnings callstack above http.py

### DIFF
--- a/odoo/netsvc.py
+++ b/odoo/netsvc.py
@@ -345,6 +345,9 @@ def showwarning_with_traceback(message, category, filename, lineno, file=None, l
     # find the stack frame matching (filename, lineno)
     filtered = []
     for frame in traceback.extract_stack():
+        if frame.name == '__call__' and frame.filename.endswith('/odoo/http.py'):
+            # we don't care about the frames above our wsgi entrypoint
+            filtered.clear()
         if 'importlib' not in frame.filename:
             filtered.append(frame)
         if frame.filename == filename and frame.lineno == lineno:


### PR DESCRIPTION
When we have a error inside a controller, the traceback starts at http.py `__call__`. But when we have a warnings, the callstack goes beyond http.py `__call__` and up to `threading.py` (where the thread, in this case, started).

This changes makes the callstack logged for warnings stop at http.py `__call__` for consistency.

Please note that exceptions/warnings outside of controllers (e.g. during the server bootstrap) continue to be logged the same way: up to odoo-bin

```diff
 50:59.483 WARNING p.warnings: /home/julien/Odoo/community/addons/web/controllers/home.py:181: DeprecationWarning: coucou
-  File "/usr/lib/python3.10/threading.py", line 973, in _bootstrap
-    self._bootstrap_inner()
-  File "/usr/lib/python3.10/threading.py", line 1016, in _bootstrap_inner
-    self.run()
-  File "/usr/lib/python3.10/threading.py", line 953, in run
-    self._target(*self._args, **self._kwargs)
-  File "/usr/lib/python3.10/socketserver.py", line 683, in process_request_thread
-    self.finish_request(request, client_address)
-  File "/usr/lib/python3.10/socketserver.py", line 360, in finish_request
-    self.RequestHandlerClass(request, client_address, self)
-  File "/usr/lib/python3.10/socketserver.py", line 747, in __init__
-    self.handle()
-  File "/home/julien/Odoo/.venv19/lib/python3.10/site-packages/werkzeug/serving.py", line 342, in handle
-    BaseHTTPRequestHandler.handle(self)
-  File "/usr/lib/python3.10/http/server.py", line 433, in handle
-    self.handle_one_request()
-  File "/home/julien/Odoo/.venv19/lib/python3.10/site-packages/werkzeug/serving.py", line 374, in handle_one_request
-    self.run_wsgi()
-  File "/home/julien/Odoo/.venv19/lib/python3.10/site-packages/werkzeug/serving.py", line 319, in run_wsgi
-    execute(self.server.app)
-  File "/home/julien/Odoo/.venv19/lib/python3.10/site-packages/werkzeug/serving.py", line 308, in execute
-    application_iter = app(environ, start_response)
   File "/home/julien/Odoo/community/odoo/http.py", line 2621, in __call__
     response = request._serve_db()
   File "/home/julien/Odoo/community/odoo/http.py", line 2129, in _serve_db
     return self._transactioning(
   File "/home/julien/Odoo/community/odoo/http.py", line 2193, in _transactioning
     return service_model.retrying(func, env=self.env)
   File "/home/julien/Odoo/community/odoo/service/model.py", line 180, in retrying
     result = func()
   File "/home/julien/Odoo/community/odoo/http.py", line 2160, in _serve_ir_http
     response = self.dispatcher.dispatch(rule.endpoint, args)
   File "/home/julien/Odoo/community/odoo/http.py", line 2329, in dispatch
     return self.request.registry['ir.http']._dispatch(endpoint)
   File "/home/julien/Odoo/community/odoo/addons/base/models/ir_http.py", line 354, in _dispatch
     result = endpoint(**request.params)
   File "/home/julien/Odoo/community/odoo/http.py", line 762, in route_wrapper
     result = endpoint(self, *args, **params_ok)
   File "/home/julien/Odoo/community/addons/web/controllers/home.py", line 181, in health
     warnings.warn("coucou", DeprecationWarning, stacklevel=1)
```