### PR TITLE
[FIX] stock: clean tour test_add_new_line_in_detailled_op

### DIFF
--- a/addons/stock/static/tests/tours/stock_picking_tour.js
+++ b/addons/stock/static/tests/tours/stock_picking_tour.js
@@ -530,13 +530,9 @@ registry.category("web_tour.tours").add("test_add_new_line_in_detailled_op", {
                 ".modal-content:has(.modal-header .modal-title:contains(Open: Stock move)) .o_data_row:nth-child(3)",
         },
         {
-            trigger: ".modal-header .modal-title:contains(Open: Stock move)",
-            run: "click",
-        },
-        {
             content: "Check that the first line is associated with LOT001 for a quantity of 0.00",
             trigger:
-                ".modal-content .o_data_row:nth-child(1):has(.o_data_cell[name=quant_id]:contains(WH/Stock - LOT001)):has(.o_data_cell[name=quantity]:contains(0.00))",
+                ".modal-content .o_data_row:has(.o_field_pick_from input:value(WH/Stock - LOT001)):has(.o_field_float[name=quantity] input:value(0.00))",
         },
         {
             trigger: ".modal-content .o_field_x2many_list_row_add > a",
@@ -568,7 +564,7 @@ registry.category("web_tour.tours").add("test_add_new_line_in_detailled_op", {
         {
             content: "Remove the newly created line",
             trigger:
-                ".modal-content .o_data_row:nth-child(1):has(.o_data_cell[name=quant_id]:contains(WH/Stock - LOT001)):has(.o_data_cell[name=quantity]:contains(0.00)) .o_list_record_remove",
+                ".modal-content .o_data_row:has(.o_field_pick_from input:value(WH/Stock - LOT001)):has(.o_field_float[name=quantity] input:value(0.00)) .o_list_record_remove",
             run: "click",
         },
         {
@@ -579,20 +575,20 @@ registry.category("web_tour.tours").add("test_add_new_line_in_detailled_op", {
         {
             content: "Check that the first line is associated with LOT001",
             trigger:
-                ".modal-content .o_data_row:nth-child(1) .o_data_cell[name=quant_id]:contains(WH/Stock - LOT001)",
+                ".modal-content .o_data_row:nth-child(1):has(.o_field_pick_from:contains(WH/Stock - LOT001))",
         },
         {
             content: "Check that the second line is associated with LOT002",
             trigger:
-                ".modal-content .o_data_row:nth-child(2) .o_data_cell[name=quant_id]:contains(WH/Stock - LOT002)",
+                ".modal-content .o_data_row:nth-child(2):has(.o_field_pick_from:contains(WH/Stock - LOT002))",
         },
         {
             content: "Modify the quant associated to the second line to fully use LOT003",
-            trigger: ".modal-content .o_data_row:nth-child(2) .o_data_cell[name=quant_id]",
+            trigger: ".modal-content .o_data_row:nth-child(2) .o_field_pick_from",
             run: "click",
         },
         {
-            trigger: ".modal-content .o_data_row:nth-child(2) .o_field_widget[name=quant_id] input",
+            trigger: ".modal-content .o_data_row:nth-child(2) .o_field_pick_from input",
             run: "edit LOT003",
         },
         {
@@ -605,10 +601,11 @@ registry.category("web_tour.tours").add("test_add_new_line_in_detailled_op", {
             run: "click",
         },
         {
-            trigger: ".modal-content .o_data_row:nth-child(1) .o_data_cell[name=quantity] .o_input",
+            trigger: ".modal-content .o_data_row:nth-child(1) .o_field_widget[name=quantity] input",
             run: "edit 8",
         },
         {
+            content: "Click on the header to update the total amount",
             trigger: ".modal-header .modal-title:contains(Open: Stock move)",
             run: "click",
         },
@@ -646,26 +643,22 @@ registry.category("web_tour.tours").add("test_add_new_line_in_detailled_op", {
             trigger: ".modal-content .o_list_number:contains(20.00)",
         },
         {
-            trigger: ".modal-header .modal-title:contains(Open: Stock move)",
-            run: "click",
-        },
-        {
             content: "Check that 2 units of LOT001 were added",
             trigger:
-                ".o_data_row:has(.o_data_cell[name=quant_id]:contains(WH/Stock - LOT001)) .o_data_cell[name=quantity]:contains(2.00)",
+                ".o_data_row:has(.o_field_pick_from input:value(WH/Stock - LOT001)) .o_field_widget[name=quantity] input:value(2.00)",
         },
         {
             content: "Check that the third line is associated with LOT003",
             trigger:
-                ".modal-content .o_data_row:nth-child(3) .o_data_cell[name=quant_id]:contains(WH/Stock - LOT003)",
+                ".modal-content .o_data_row:nth-child(3) .o_field_pick_from:contains(WH/Stock - LOT003)",
         },
         {
             content: "Modify the quant associated to the third line to use LOT002",
-            trigger: ".modal-content .o_data_row:nth-child(3) .o_data_cell[name=quant_id]",
+            trigger: ".modal-content .o_data_row:nth-child(3) .o_field_pick_from",
             run: "click",
         },
         {
-            trigger: ".modal-content .o_data_row:nth-child(3) .o_field_widget[name=quant_id] input",
+            trigger: ".modal-content .o_data_row:nth-child(3) .o_field_pick_from input",
             run: "edit LOT002",
         },
         {
@@ -677,8 +670,7 @@ registry.category("web_tour.tours").add("test_add_new_line_in_detailled_op", {
             run: "click",
         },
         {
-            trigger:
-                ".modal-content .o_data_row:nth-child(3) .o_data_cell[name=quant_id]:contains(LOT002)",
+            trigger: ".modal-content .o_data_row:nth-child(3) .o_field_pick_from:contains(LOT002)",
         },
         {
             content: "Modify the quantity of the first line from 10 to 15 to change the demand",
@@ -686,12 +678,8 @@ registry.category("web_tour.tours").add("test_add_new_line_in_detailled_op", {
             run: "click",
         },
         {
-            trigger: ".modal-content .o_data_row:nth-child(3) .o_data_cell[name=quantity] .o_input",
+            trigger: ".modal-content .o_data_row:nth-child(3) .o_field_widget[name=quantity] input",
             run: "edit 15",
-        },
-        {
-            trigger: ".modal-header .modal-title:contains(Open: Stock move)",
-            run: "click",
         },
         {
             content: "Remove the LOT001 line with a quantity of 8.00",
@@ -733,13 +721,9 @@ registry.category("web_tour.tours").add("test_add_new_line_in_detailled_op", {
             trigger: ".modal-content .o_list_number:contains(20.00)",
         },
         {
-            trigger: ".modal-header .modal-title:contains(Open: Stock move)",
-            run: "click",
-        },
-        {
             content: "Check that 3 units of LOT001 were added",
             trigger:
-                ".o_data_row:has(.o_data_cell[name=quant_id]:contains(WH/Stock - LOT001)) .o_data_cell[name=quantity]:contains(3.00)",
+                ".modal-content .o_data_row:has(.o_field_pick_from input:value(WH/Stock - LOT001)):has(.o_field_float[name=quantity] input:value(3.00))",
         },
         {
             trigger: ".modal-content .o_form_button_save",


### PR DESCRIPTION
The `test_add_new_line_in_detailled_op` fails in 18.0+ since clicking on the head of the modal content will trigger a web_read before the records has been updated in db. So that the last applied change disappear.

This commit attempt to clean the tour to be more reliable.

runbot-113534
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
