### PR TITLE
[FIX] point_of_sale: use correct lst_price witch dynamic variants

### DIFF
--- a/addons/point_of_sale/models/product.py
+++ b/addons/point_of_sale/models/product.py
@@ -70,7 +70,7 @@ class ProductProduct(models.Model):
     @api.model
     def _load_pos_data_fields(self, config_id):
         return [
-            'id', 'display_name', 'lst_price', 'standard_price', 'categ_id', 'pos_categ_ids', 'taxes_id', 'barcode', 'name',
+            'id', 'display_name', 'lst_price', 'list_price', 'standard_price', 'categ_id', 'pos_categ_ids', 'taxes_id', 'barcode', 'name',
             'default_code', 'to_weight', 'uom_id', 'description_sale', 'description', 'product_tmpl_id', 'tracking', 'type', 'service_tracking', 'is_storable',
             'write_date', 'color', 'available_in_pos', 'attribute_line_ids', 'active', 'image_128', 'combo_ids', 'product_template_variant_value_ids', 'product_tag_ids',
         ]

--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -853,11 +853,13 @@ export class PosStore extends Reactive {
             values.price_unit = values.product_id.get_price(order.pricelist_id, values.qty);
         }
         const isScannedProduct = opts.code && opts.code.type === "product";
-        if (values.price_extra && !isScannedProduct) {
+        if ((values.price_extra || values.product_id.isConfigurable()) && !isScannedProduct) {
             const price = values.product_id.get_price(
                 order.pricelist_id,
                 values.qty,
-                values.price_extra
+                values.price_extra,
+                false,
+                product.list_price
             );
 
             values.price_unit = price;

--- a/addons/point_of_sale/static/src/app/store/product_configurator_popup/product_configurator_popup.js
+++ b/addons/point_of_sale/static/src/app/store/product_configurator_popup/product_configurator_popup.js
@@ -143,10 +143,7 @@ export class ProductConfiguratorPopup extends Component {
                 // for custom values, it will never be a multiple attribute
                 attribute_custom_values[valueIds[0]] = custom_value;
             }
-            const attr = this.pos.data.models["product.template.attribute.value"].get(valueIds[0]);
-            if (attr && attr.attribute_id.create_variant !== "always") {
-                price_extra += extra;
-            }
+            price_extra += extra;
         });
 
         attribute_value_ids = attribute_value_ids.flat();

--- a/addons/point_of_sale/static/tests/tours/product_variants_tour.js
+++ b/addons/point_of_sale/static/tests/tours/product_variants_tour.js
@@ -1,0 +1,115 @@
+import * as Dialog from "@point_of_sale/../tests/tours/utils/dialog_util";
+import * as ProductScreen from "@point_of_sale/../tests/tours/utils/product_screen_util";
+import * as Chrome from "@point_of_sale/../tests/tours/utils/chrome_util";
+import { registry } from "@web/core/registry";
+import * as ProductConfiguratorPopup from "@point_of_sale/../tests/tours/utils/product_configurator_util";
+
+function check_variant_price(product, choices, price) {
+    const steps = [...ProductScreen.clickDisplayedProduct(product)];
+    for (const choice of choices) {
+        steps.push(...ProductConfiguratorPopup.pickRadio(choice));
+    }
+    steps.push(
+        Dialog.confirm(),
+        ...ProductScreen.totalAmountIs(price),
+        ...ProductScreen.clickNumpad("⌫"),
+        ...ProductScreen.clickNumpad("⌫")
+    );
+    return steps.flat();
+}
+
+registry.category("web_tour.tours").add("test_integration_dynamic_variant_price", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            check_variant_price("A dynamic product", ["dyn1"], "1.00"),
+            check_variant_price("A dynamic product", ["dyn2"], "6.00"),
+            check_variant_price("A dynamic product", ["dyn3"], "11.00"),
+            Chrome.endTour(),
+        ].flat(),
+});
+
+registry.category("web_tour.tours").add("test_integration_always_variant_price", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            check_variant_price("A always product", ["S"], "1.00"),
+            check_variant_price("A always product", ["M"], "6.00"),
+            Chrome.endTour(),
+        ].flat(),
+});
+
+registry.category("web_tour.tours").add("test_integration_never_variant_price", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            check_variant_price("A never product", ["extra"], "1.00"),
+            check_variant_price("A never product", ["second"], "6.00"),
+            Chrome.endTour(),
+        ].flat(),
+});
+
+registry.category("web_tour.tours").add("test_integration_dynamic_always_variant_price", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            check_variant_price("A dyn/alw product", ["dyn1", "S"], "1.00"),
+            check_variant_price("A dyn/alw product", ["dyn1", "M"], "6.00"),
+            check_variant_price("A dyn/alw product", ["dyn2", "S"], "11.00"),
+            check_variant_price("A dyn/alw product", ["dyn2", "M"], "16.00"),
+            check_variant_price("A dyn/alw product", ["dyn3", "S"], "21.00"),
+            check_variant_price("A dyn/alw product", ["dyn3", "M"], "26.00"),
+            Chrome.endTour(),
+        ].flat(),
+});
+
+registry.category("web_tour.tours").add("test_integration_dynamic_never_variant_price", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            check_variant_price("A dyn/nev product", ["dyn1", "extra"], "1.00"),
+            check_variant_price("A dyn/nev product", ["dyn1", "second"], "6.00"),
+            check_variant_price("A dyn/nev product", ["dyn2", "extra"], "11.00"),
+            check_variant_price("A dyn/nev product", ["dyn2", "second"], "16.00"),
+            check_variant_price("A dyn/nev product", ["dyn3", "extra"], "21.00"),
+            check_variant_price("A dyn/nev product", ["dyn3", "second"], "26.00"),
+            Chrome.endTour(),
+        ].flat(),
+});
+
+registry.category("web_tour.tours").add("test_integration_always_never_variant_price", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            check_variant_price("A alw/nev product", ["S", "extra"], "1.00"),
+            check_variant_price("A alw/nev product", ["S", "second"], "6.00"),
+            check_variant_price("A alw/nev product", ["M", "extra"], "11.00"),
+            check_variant_price("A alw/nev product", ["M", "second"], "16.00"),
+            Chrome.endTour(),
+        ].flat(),
+});
+
+registry.category("web_tour.tours").add("test_integration_dynamic_always_never_variant_price", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+
+            check_variant_price("A dyn/alw/nev product", ["dyn1", "S", "extra"], "1.00"),
+            check_variant_price("A dyn/alw/nev product", ["dyn1", "S", "second"], "1.50"),
+            check_variant_price("A dyn/alw/nev product", ["dyn1", "M", "extra"], "6.00"),
+            check_variant_price("A dyn/alw/nev product", ["dyn1", "M", "second"], "6.50"),
+
+            check_variant_price("A dyn/alw/nev product", ["dyn2", "S", "extra"], "11.00"),
+            check_variant_price("A dyn/alw/nev product", ["dyn2", "S", "second"], "11.50"),
+            check_variant_price("A dyn/alw/nev product", ["dyn2", "M", "extra"], "16.00"),
+            check_variant_price("A dyn/alw/nev product", ["dyn2", "M", "second"], "16.50"),
+            Chrome.endTour(),
+        ].flat(),
+});

--- a/addons/point_of_sale/tests/test_pos_product_variants.py
+++ b/addons/point_of_sale/tests/test_pos_product_variants.py
@@ -4,10 +4,11 @@ from odoo import Command
 from odoo.tests import tagged
 
 from odoo.addons.product.tests.common import ProductVariantsCommon
+from odoo.addons.point_of_sale.tests.test_frontend import TestPointOfSaleHttpCommon
 
 
 @tagged('post_install', '-at_install')
-class TestPoSProductVariants(ProductVariantsCommon):
+class TestPoSProductVariants(ProductVariantsCommon, TestPointOfSaleHttpCommon):
 
     def get_ptav(self, template, pav):
         return template.valid_product_template_attribute_line_ids.filtered(
@@ -55,3 +56,250 @@ class TestPoSProductVariants(ProductVariantsCommon):
             unavailable_sofas,
             "Blue, small sofas should be unavailable for sale due to being archived",
         )
+
+    def test_integration_dynamic_variant_price(self):
+        """Tests the price of products with dynamic variant when added to cart"""
+        self.env['product.attribute.value'].create({
+            'name': 'dyn3',
+            'attribute_id': self.dynamic_attribute.id,
+            'default_extra_price': 10,
+        })
+        (dyn1, dyn2, dyn3) = self.dynamic_attribute.value_ids
+        dyn2.default_extra_price = 5
+
+        product_template = self.env['product.template'].create({
+            'name': 'A dynamic product',
+            'taxes_id': False,
+            'available_in_pos': True,
+            'pos_categ_ids': [Command.set(self.pos_desk_misc_test.ids)],
+        })
+        self.env['product.template.attribute.line'].create({
+            'product_tmpl_id': product_template.id,
+            'attribute_id': self.dynamic_attribute.id,
+            'value_ids': [Command.set([dyn1.id, dyn2.id, dyn3.id])],
+        })
+
+        # Create a variant (because of dynamic attribute)
+        ptav_dyn2 = self.env['product.template.attribute.value'].search([
+            ('attribute_line_id', '=', product_template.attribute_line_ids.id),
+            ('product_attribute_value_id', '=', dyn2.id)
+        ])
+
+        self.env['product.product'].create({
+            'available_in_pos': True,
+            'product_tmpl_id': product_template.id,
+            'product_template_attribute_value_ids': [(6, 0, [ptav_dyn2.id])],
+            'pos_categ_ids': [Command.set(self.pos_desk_misc_test.ids)],
+        })
+        self.main_pos_config.with_user(self.pos_user).open_ui()
+        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'test_integration_dynamic_variant_price', login="pos_user")
+
+    def test_integration_always_variant_price(self):
+        """Tests the price of products with always variant when added to cart"""
+        self.size_attribute_m.default_extra_price = 5
+
+        product_template = self.env['product.template'].create({
+            'name': 'A always product',
+            'uom_id': self.env.ref('uom.product_uom_unit').id,
+            'is_storable': True,
+            'taxes_id': False,
+            'available_in_pos': True,
+            'pos_categ_ids': [Command.set(self.pos_desk_misc_test.ids)],
+        })
+        self.env['product.template.attribute.line'].create({
+            'product_tmpl_id': product_template.id,
+            'attribute_id': self.size_attribute.id,
+            'value_ids': [Command.set([self.size_attribute_s.id, self.size_attribute_m.id])],
+        })
+
+        self.main_pos_config.with_user(self.pos_user).open_ui()
+        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'test_integration_always_variant_price', login="pos_user")
+
+    def test_integration_never_variant_price(self):
+        """Tests the price of products with no variant(never) variant when added to cart"""
+        self.no_variant_attribute_second.default_extra_price = 5
+
+        product_template = self.env['product.template'].create({
+            'name': 'A never product',
+            'uom_id': self.env.ref('uom.product_uom_unit').id,
+            'is_storable': True,
+            'taxes_id': False,
+            'available_in_pos': True,
+            'pos_categ_ids': [Command.set(self.pos_desk_misc_test.ids)],
+        })
+        self.env['product.template.attribute.line'].create({
+            'product_tmpl_id': product_template.id,
+            'attribute_id': self.no_variant_attribute.id,
+            'value_ids': [Command.set([self.no_variant_attribute_extra.id, self.no_variant_attribute_second.id])],
+        })
+
+        self.main_pos_config.with_user(self.pos_user).open_ui()
+        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'test_integration_never_variant_price', login="pos_user")
+
+    def test_integration_dynamic_always_variant_price(self):
+        """Tests the price of products with dynamic and always variants when added to cart"""
+        self.env['product.attribute.value'].create({
+            'name': 'dyn3',
+            'attribute_id': self.dynamic_attribute.id,
+            'default_extra_price': 20,
+        })
+        (dyn1, dyn2, dyn3) = self.dynamic_attribute.value_ids
+        dyn2.default_extra_price = 10
+        self.size_attribute_m.default_extra_price = 5
+
+        product_template = self.env['product.template'].create({
+            'name': 'A dyn/alw product',
+            'taxes_id': False,
+            'available_in_pos': True,
+            'pos_categ_ids': [Command.set(self.pos_desk_misc_test.ids)],
+        })
+        self.env['product.template.attribute.line'].create([{
+            'product_tmpl_id': product_template.id,
+            'attribute_id': self.dynamic_attribute.id,
+            'value_ids': [Command.set([dyn1.id, dyn2.id, dyn3.id])],
+        }, {
+            'product_tmpl_id': product_template.id,
+            'attribute_id': self.size_attribute.id,
+            'value_ids': [Command.set([self.size_attribute_s.id, self.size_attribute_m.id])],
+        }])
+
+        # Create a variant (because of dynamic attribute)
+        ptav_dyn2 = self.env['product.template.attribute.value'].search([
+            ('attribute_line_id', '=', product_template.attribute_line_ids[0].id),
+            ('product_attribute_value_id', '=', dyn2.id)
+        ])
+        ptav_always1 = self.env['product.template.attribute.value'].search([
+            ('attribute_line_id', '=', product_template.attribute_line_ids[1].id),
+            ('product_attribute_value_id', '=', self.size_attribute_s.id)
+        ])
+
+        self.env['product.product'].create({
+            'available_in_pos': True,
+            'product_tmpl_id': product_template.id,
+            'product_template_attribute_value_ids': [(6, 0, (ptav_dyn2 + ptav_always1).ids)],
+            'pos_categ_ids': [Command.set(self.pos_desk_misc_test.ids)],
+        })
+        self.main_pos_config.with_user(self.pos_user).open_ui()
+        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'test_integration_dynamic_always_variant_price', login="pos_user")
+
+    def test_integration_dynamic_never_variant_price(self):
+        """Tests the price of products with dynamic and never variants when added to cart"""
+        self.env['product.attribute.value'].create({
+            'name': 'dyn3',
+            'attribute_id': self.dynamic_attribute.id,
+            'default_extra_price': 20,
+        })
+        (dyn1, dyn2, dyn3) = self.dynamic_attribute.value_ids
+        dyn2.default_extra_price = 10
+        self.no_variant_attribute_second.default_extra_price = 5
+
+        product_template = self.env['product.template'].create({
+            'name': 'A dyn/nev product',
+            'taxes_id': False,
+            'available_in_pos': True,
+            'pos_categ_ids': [Command.set(self.pos_desk_misc_test.ids)],
+        })
+        self.env['product.template.attribute.line'].create([{
+            'product_tmpl_id': product_template.id,
+            'attribute_id': self.dynamic_attribute.id,
+            'value_ids': [Command.set([dyn1.id, dyn2.id, dyn3.id])],
+        }, {
+            'product_tmpl_id': product_template.id,
+            'attribute_id': self.no_variant_attribute.id,
+            'value_ids': [Command.set([self.no_variant_attribute_extra.id, self.no_variant_attribute_second.id])],
+        }])
+
+        # Create a variant (because of dynamic attribute)
+        ptav_dyn2 = self.env['product.template.attribute.value'].search([
+            ('attribute_line_id', '=', product_template.attribute_line_ids[0].id),
+            ('product_attribute_value_id', '=', dyn2.id)
+        ])
+        ptav_never1 = self.env['product.template.attribute.value'].search([
+            ('attribute_line_id', '=', product_template.attribute_line_ids[1].id),
+            ('product_attribute_value_id', '=', self.no_variant_attribute_extra.id)
+        ])
+
+        self.env['product.product'].create({
+            'available_in_pos': True,
+            'product_tmpl_id': product_template.id,
+            'product_template_attribute_value_ids': [(6, 0, (ptav_dyn2 + ptav_never1).ids)],
+            'pos_categ_ids': [Command.set(self.pos_desk_misc_test.ids)],
+        })
+        self.main_pos_config.with_user(self.pos_user).open_ui()
+        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'test_integration_dynamic_never_variant_price', login="pos_user")
+
+    def test_integration_always_never_variant_price(self):
+        """Tests the price of products with always and never variants when added to cart"""
+        self.no_variant_attribute_second.default_extra_price = 5
+        self.size_attribute_m.default_extra_price = 10
+
+        product_template = self.env['product.template'].create({
+            'name': 'A alw/nev product',
+            'uom_id': self.env.ref('uom.product_uom_unit').id,
+            'is_storable': True,
+            'taxes_id': False,
+            'available_in_pos': True,
+            'pos_categ_ids': [Command.set(self.pos_desk_misc_test.ids)],
+        })
+        self.env['product.template.attribute.line'].create([{
+            'product_tmpl_id': product_template.id,
+            'attribute_id': self.no_variant_attribute.id,
+            'value_ids': [Command.set([self.no_variant_attribute_extra.id, self.no_variant_attribute_second.id])],
+        }, {
+            'product_tmpl_id': product_template.id,
+            'attribute_id': self.size_attribute.id,
+            'value_ids': [Command.set([self.size_attribute_s.id, self.size_attribute_m.id])],
+        }])
+
+        self.main_pos_config.with_user(self.pos_user).open_ui()
+        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'test_integration_always_never_variant_price', login="pos_user")
+
+    def test_integration_dynamic_always_never_variant_price(self):
+        """Tests the price of products with all types of variants when added to cart"""
+        (dyn1, dyn2) = self.dynamic_attribute.value_ids
+        dyn2.default_extra_price = 10
+        self.size_attribute_m.default_extra_price = 5
+        self.no_variant_attribute_second.default_extra_price = 0.5
+
+        product_template = self.env['product.template'].create({
+            'name': 'A dyn/alw/nev product',
+            'taxes_id': False,
+            'available_in_pos': True,
+            'pos_categ_ids': [Command.set(self.pos_desk_misc_test.ids)],
+        })
+        self.env['product.template.attribute.line'].create([{
+            'product_tmpl_id': product_template.id,
+            'attribute_id': self.dynamic_attribute.id,
+            'value_ids': [Command.set([dyn1.id, dyn2.id])],
+        }, {
+            'product_tmpl_id': product_template.id,
+            'attribute_id': self.no_variant_attribute.id,
+            'value_ids': [Command.set([self.no_variant_attribute_extra.id, self.no_variant_attribute_second.id])],
+        }, {
+            'product_tmpl_id': product_template.id,
+            'attribute_id': self.size_attribute.id,
+            'value_ids': [Command.set([self.size_attribute_s.id, self.size_attribute_m.id])],
+        }])
+
+        # Create a variant (because of dynamic attribute)
+        ptav_dyn2 = self.env['product.template.attribute.value'].search([
+            ('attribute_line_id', '=', product_template.attribute_line_ids[0].id),
+            ('product_attribute_value_id', '=', dyn2.id)
+        ])
+        ptav_never1 = self.env['product.template.attribute.value'].search([
+            ('attribute_line_id', '=', product_template.attribute_line_ids[1].id),
+            ('product_attribute_value_id', '=', self.no_variant_attribute_extra.id)
+        ])
+        ptav_always1 = self.env['product.template.attribute.value'].search([
+            ('attribute_line_id', '=', product_template.attribute_line_ids[1].id),
+            ('product_attribute_value_id', '=', self.size_attribute_s.id)
+        ])
+
+        self.env['product.product'].create({
+            'available_in_pos': True,
+            'product_tmpl_id': product_template.id,
+            'product_template_attribute_value_ids': [(6, 0, (ptav_dyn2 + ptav_always1 + ptav_never1).ids)],
+            'pos_categ_ids': [Command.set(self.pos_desk_misc_test.ids)],
+        })
+        self.main_pos_config.with_user(self.pos_user).open_ui()
+        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'test_integration_dynamic_always_never_variant_price', login="pos_user")


### PR DESCRIPTION
When you have product with dynamic variants using extra price, the price
added to the cart is not correctly computed.

Steps to reproduce:
-------------------
* Create a product with a dynamic variant (2 values), price 1
* Add an extra price for each value, ex 10, 20, 100
* Make a sale order with the first two variant value
* Open shop
* Add the product to the order 3 times, 1 for each value
> Observation: Prices are respectively: 21, 41, 111

Why the fix:
------------
In the shop only `product.product` are shown. When selecting the product with variant, the product has a `lst_price` of 11 which corresponds to the price of the `product_template` plus the extra price. This value is normal but cannot be used in the computation of `get_price` as we also provide the value for `extra_price`.

We can use `list_price` instead of `lst_price` as it does not include the information related to variants.

Why do we see 2 different behaviors before this fix? When selecting a variant option, if the product with this variant already exist, the lst_price already contains the information about the selected variant. Which explains why, in the end, the price has twice the extra price of the variant selected.

When the product with the variant does not exist, the price has one time the price of the selected variant plus one time the price of the first product with variant the is created.

Configurable products were also having issues when mixing multiple variants, especially when one of them had creation mode set to "always". When exiting the configuration popup the payload does not include the extra price coming from "always" attributes. depending on what the other choices were we would have an extra price, meaning we would compute the price with `list_price` but the extra price did not include the information about the "always" variant if it had one.

Using `list_price` is enough for the initial problem but only when the selected DYNAMIC variant has an extra price otherwise the code does not pass through the condition asking for extra price. In such case there is no extra price from the payload and it's still computing the price with `lst_price`, which includes information about the extra price of the variant that was already sold previously. Thus we make sure that we compute with `list_price` whenever a configurable product is added.

opw-4815555
