### PR TITLE
[IMP] orm: dynamic dates in domains

### DIFF
--- a/addons/web/static/tests/core/l10n/dates.test.js
+++ b/addons/web/static/tests/core/l10n/dates.test.js
@@ -276,6 +276,26 @@ test("parse smart date input", async () => {
     expect(parseDateTime("-3m").toFormat(format)).toBe("2019-10-01 00:00");
     expect(parseDateTime("-2w").toFormat(format)).toBe("2019-12-18 00:00");
     expect(parseDateTime("-1d").toFormat(format)).toBe("2019-12-31 00:00");
+
+    // continue with only parseDateTime (which uses the same underlaying function)
+    mockDate("2020-01-01 00:01:00", 0);
+
+    expect(parseDateTime("=3d").toFormat(format)).toBe("2020-01-03 00:00");
+    expect(parseDateTime("+3d +1m").toFormat(format)).toBe("2020-02-04 00:01");
+    expect(parseDateTime("=11d +2H +15M").toFormat(format)).toBe("2020-01-11 02:15");
+    expect(parseDateTime("=11d =3H +2H +15M").toFormat(format)).toBe("2020-01-11 05:15");
+
+    expect(parseDateTime("now").toFormat(format)).toBe("2020-01-01 00:01");
+    expect(parseDateTime("today").toFormat(format)).toBe("2020-01-01 00:00");
+    expect(parseDateTime("today +1w").toFormat(format)).toBe("2020-01-08 00:00");
+
+    expect(parseDateTime("=monday").toFormat(format)).toBe("2019-12-29 00:00");
+    expect(parseDateTime("=sunday").toFormat(format)).toBe("2020-01-04 00:00");
+    expect(parseDateTime("+monday").toFormat(format)).toBe("2020-01-05 00:01");
+
+    // reset after setting the day
+    expect(parseDateTime("=3H =11d").toFormat(format)).toBe("2020-01-11 00:00");
+    expect(parseDateTime("=3H =sunday").toFormat(format)).toBe("2020-01-04 00:00");
 });
 
 test("parseDateTime ISO8601 Format", async () => {

--- a/odoo/addons/base/tests/test_date_utils.py
+++ b/odoo/addons/base/tests/test_date_utils.py
@@ -1,8 +1,9 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
-from datetime import date, datetime, time
+from datetime import date, datetime, time, timedelta, timezone
 
 import pytz
 from dateutil.relativedelta import relativedelta
+from freezegun import freeze_time
 
 from odoo.tests import BaseCase
 from odoo.tools.date_utils import (
@@ -10,12 +11,27 @@ from odoo.tools.date_utils import (
     date_range,
     end_of,
     get_fiscal_year,
+    localized,
     start_of,
     subtract,
+    to_timezone,
 )
 
 
 class TestDateUtils(BaseCase):
+
+    @freeze_time('2024-05-01 14:00:00')
+    def test_localized_timezone(self):
+        dt = datetime.now()
+        self.assertIsNotNone(localized(dt).tzinfo)
+        tz = timezone(timedelta(hours=5))
+        self.assertIs(localized(dt.astimezone(tz)).tzinfo, tz)
+
+        dtz = dt.astimezone(tz)
+        self.assertEqual(dtz.hour, 19)
+        self.assertIs(dtz.tzinfo, tz)
+        self.assertEqual(to_timezone(None)(dtz), dt)
+        self.assertEqual(to_timezone(tz)(dt), dtz)
 
     def test_fiscal_year(self):
         self.assertEqual(get_fiscal_year(date(2024, 12, 31)), (date(2024, 1, 1), date(2024, 12, 31)))

--- a/odoo/addons/test_orm/tests/test_fields.py
+++ b/odoo/addons/test_orm/tests/test_fields.py
@@ -1171,6 +1171,12 @@ class TestFields(TransactionCaseWithUserDemo, TransactionExpressionCase):
         self.assertFalse(record.filtered_domain([('moment', '!=', False)]))
         self.assertTrue(record.filtered_domain([('moment', '=', False)]))
 
+    def test_21_date_dynamic(self):
+        record = self.env['test_orm.mixed'].create({'moment': fields.Datetime.now()})
+        self.assertEqual(record, self._search(record, [('moment', '<', 'now +1d')], [('id', 'in', record.ids)]))
+        self.assertFalse(self._search(record, [('moment', '<', 'today')], [('id', 'in', record.ids)]))
+        self.assertEqual(record, self._search(record, [('moment', '>', '-1H')], [('id', 'in', record.ids)]))
+
     def test_22_selection(self):
         """ test selection fields """
         record_list = self.env['test_orm.selection'].create({})

--- a/odoo/tools/date_utils.py
+++ b/odoo/tools/date_utils.py
@@ -135,6 +135,8 @@ def parse_date(value: str, env: Environment) -> date | datetime:
     weekday := [=+-] ('monday' | ... | 'sunday')
     ```
 
+    An equivalent function is JavaScript is `parseSmartDateInput`.
+
     :param value: The string to parse
     :param env: The environment to get the current date (in user's tz)
     :param naive: Whether to cast the result to a naive datetime.


### PR DESCRIPTION
Implement relative dates to now for domains. Usually, the value is
computed by the user using evalution and using `relativedelta` which can
become complex inside the domains. We introduce a simpler language to
specify such dates for date and datetime fields.

```py
recent = Domain('moment', '>',
    datetime.now() - relativedelta(minutes=5))
recent = Domain('moment', '>', 'now -5M')

last_week = Domain('moment', '>=',
    context_today() + relativedelta(weeks=-2, days=1, weekday=0, hour=0, minute=0, second=0)) \
  & Domain('moment', '<',
    context_today() + relativedelta(weeks=-1, days=1, weekday=0, hour=0, minute=0, second=0))
last_week = Domain('moment', '>=', '=monday -1w') \
  & Domain('moment', '<', '=monday')
```

Moreover, this allows to stop depending on environment variables such as
`context_today`. We will be able to remove these in the future.

For the implementation, we add a new optimization level after BASE which
will evaluate all context-dependent values.


This covers the introduction of the feature. Migration of domains is for another PR.
task-4868324




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
