### PR TITLE
[FIX] hr_attendance: debounce check in/out calls

### DIFF
--- a/addons/hr_attendance/models/hr_attendance.py
+++ b/addons/hr_attendance/models/hr_attendance.py
@@ -178,7 +178,7 @@ class HrAttendance(models.Model):
         """ verifies if check_in is earlier than check_out. """
         for attendance in self:
             if attendance.check_in and attendance.check_out:
-                if attendance.check_out < attendance.check_in:
+                if attendance.check_out <= attendance.check_in:
                     raise exceptions.ValidationError(_('"Check Out" time cannot be earlier than "Check In" time.'))
 
     @api.constrains('check_in', 'check_out', 'employee_id')

--- a/addons/hr_attendance/static/src/components/attendance_menu/attendance_menu.js
+++ b/addons/hr_attendance/static/src/components/attendance_menu/attendance_menu.js
@@ -7,6 +7,7 @@ import { DropdownItem } from "@web/core/dropdown/dropdown_item";
 import { deserializeDateTime } from "@web/core/l10n/dates";
 import { registry } from "@web/core/registry";
 import { useService } from "@web/core/utils/hooks";
+import { debounce } from "@web/core/utils/timing";
 import { isIosApp } from "@web/core/browser/feature_detection";
 const { DateTime } = luxon;
 
@@ -24,6 +25,7 @@ export class ActivityMenu extends Component {
             checkedIn: false,
             isDisplayed: false
         });
+        this.signInOut = debounce(this.signInOut, 1000, true);
         this.date_formatter = registry.category("formatters").get("float_time")
         // load data but do not wait for it to render to prevent from delaying
         // the whole webclient

--- a/addons/hr_attendance/static/src/public_kiosk/public_kiosk_app.js
+++ b/addons/hr_attendance/static/src/public_kiosk/public_kiosk_app.js
@@ -9,6 +9,7 @@ import { isIosApp } from "@web/core/browser/feature_detection";
 import { _t } from "@web/core/l10n/translation";
 import { MainComponentsContainer } from "@web/core/main_components_container";
 import { useService, useBus } from "@web/core/utils/hooks";
+import { debounce } from "@web/core/utils/timing";
 import { url } from "@web/core/utils/urls";
 import {KioskGreetings} from "@hr_attendance/components/greetings/greetings";
 import {KioskPinCode} from "@hr_attendance/components/pin_code/pin_code";
@@ -50,6 +51,7 @@ class kioskAttendanceApp extends Component{
             this.manualKioskMode = true
             this.state = useState({active_display: "manual"});
         }
+        this.onManualSelection = debounce(this.onManualSelection, 1000, true);
     }
 
     switchDisplay(screen) {


### PR DESCRIPTION
**Issue**
If multiple clicks are registered in quick succession on an employee card
in the attendance's kiosk mode, it could lead to a blocking situation
where the message
`Cannot create new attendance record for XXX, the employee hasn't checked out
since XXX`.
was shown for that employee.

Can be reproduced either by clicking 3 times in quick succession on an employee
card and having all check in/check out in the same second.
Can be simulated by creating:
- a first attendance with check in and check out on same second
- a second attendance with check in on same second than the first and no check out

**Cause**
In `_attendance_action_change` of `hr.employee`, we rely on the `attendance_state`
of the employee to decide between checking in or out. This is done by using the
`last_attendance_id` of the employee. If multiple attendances have a `check_in`
in the same second, the `attendance_state` of the employee is incorrectly computed.

**Change**
This commit adds a delay to prevent too many check in/check out actions to be sent
by the frontend in a short amount of time, which is most likely not wanted.

opw-4861498
opw-4822038
opw-4446239