### PR TITLE
[FIX] l10n_latam_base: provide hidden identification type in form

### DIFF
--- a/addons/l10n_latam_base/views/portal_address_templates.xml
+++ b/addons/l10n_latam_base/views/portal_address_templates.xml
@@ -29,6 +29,13 @@
                     title="Changing Identification type is not allowed once document(s) have been
                         issued for your account. Please contact us directly for this operation."
                 />
+                <input
+                    t-if="not (is_commercial_address and can_edit_vat)"
+                    type="hidden"
+                    readonly="1"
+                    name="l10n_latam_identification_type_id"
+                    t-att-value="identification_type.id"
+                />
             </div>
         </div>
     </template>


### PR DESCRIPTION
Versions
--------
- saas-18.2+

Steps
-----
1. Set up a company & website with Peruvian l10n;
2. add an identification type of "DNI" to your partner data;
3. set the identification number to "09123456";
5. go to /shop;
6. add product to cart and go to checkout;
7. try to add a new billing address.

Issue
-----
Cannot save the address, as it thinks you selected the RUC identification type, which is not allowed.

Cause
-----
When a partner already has an identification type & number, they're not allowed to add new ones to alternate addresses. Issue is that the read-only field added via 5a93da8 is not an actual form field, and doesn't provide its value on submit.

Solution
--------
Add a hidden `input` element with `l10n_latam_identification_type_id`, after the read-only `t-else` element with a seperate `t-if` to prevent breaking xpaths in stable.

opw-4817712