### PR TITLE
[FIX] mail: use alias local parts when detecting new partners

### DIFF
--- a/addons/mail/models/mail_alias_domain.py
+++ b/addons/mail/models/mail_alias_domain.py
@@ -180,17 +180,43 @@ class MailAliasDomain(models.Model):
     @api.model
     def _find_aliases(self, email_list):
         """ Utility method to find both alias domains aliases (bounce, catchall
-        or default from) and mail aliases from an email list. """
+        or default from) and mail aliases from an email list.
+
+        :param email_list: list of normalized emails; normalization / removing
+            wrong emails is considered as being caller's job
+        """
         if not email_list:
             return email_list
         all_domains = self.search([])
         aliases = all_domains.mapped('bounce_email') + all_domains.mapped('catchall_email') + all_domains.mapped('default_from_email')
+
+        catchall_domains_allowed = list(filter(None, (self.env["ir.config_parameter"].sudo().get_param(
+            "mail.catchall.domain.allowed") or '').split(',')))
+        if catchall_domains_allowed:
+            catchall_domains_allowed += all_domains.mapped('name')
+            email_localparts_tocheck = [
+                email.partition('@')[0] for email in email_list if (
+                    email and email.partition('@')[2] in catchall_domains_allowed
+                )]
+        else:
+            email_localparts_tocheck = [email.partition('@')[0] for email in email_list if email]
+
         # search on aliases using the proposed list, as we could have a lot of aliases
         # better than returning 'all alias emails'
-        aliases += self.env['mail.alias'].search(
-            [('alias_full_name', 'in', email_list)]
-        ).mapped('alias_full_name')
-        return [email for email in email_list if email in aliases]
+        potential_aliases = self.env['mail.alias'].search([
+            '|',
+            ('alias_full_name', 'in', email_list),
+            '&', ('alias_name', 'in', email_localparts_tocheck), ('alias_incoming_local', '=', True),
+        ])
+        # global alias: email match
+        aliases += potential_aliases.filtered(lambda x: not x.alias_incoming_local).mapped('alias_full_name')
+        # compat-mode alias: left-part only (filter on allowed domains already done)
+        local_alias_names = potential_aliases.filtered(lambda x: x.alias_incoming_local).mapped('alias_name')
+        return [
+            email for email in email_list if (
+                email in aliases or
+                email.partition('@')[0] in local_alias_names
+            )]
 
     @api.model
     def _migrate_icp_to_domain(self):

--- a/addons/website_slides/tests/test_gamification_karma.py
+++ b/addons/website_slides/tests/test_gamification_karma.py
@@ -128,7 +128,7 @@ class TestKarmaGain(common.SlidesCase):
         self.assertEqual(len(channel_partners), 4)
 
         # Set courses as completed and update karma
-        with self.assertQueryCount(65):  # com 55
+        with self.assertQueryCount(66):  # com 55
             channel_partners._post_completion_update_hook()
 
         computed_karma = self.channel.karma_gen_channel_finish + self.channel_2.karma_gen_channel_finish


### PR DESCRIPTION
Sending an email that was auto-forwarded would lead to the recipient line having two different emails which would cause any emails that were not set up as aliases to be added as followers even if local part detection was enabled in the alias settings. This was due to the fact that partner detection was changed in 18.2 and now looked for exact email to alias matches. Ban emails were passed to the _find_or_create_from_emails and then directly matched to the emails in the list of recipient emails. When a match was not found for emails that did not have an exact matching alias_full_name, we would then look for or create a partner for that email. This caused erroneous followers to be added.

Changing the functionality to also look for matching local parts in order to skip partner finding and creation reverts this functionality to how it previously worked where extra recipients with matching local parts when local part detection was enabled would not add those partners as followers.

opw-4896074