### PR TITLE
Saas 18.4 readonly version access from offer ammg

### DIFF
--- a/addons/hr/wizard/hr_contract_template_wizard.py
+++ b/addons/hr/wizard/hr_contract_template_wizard.py
@@ -26,4 +26,5 @@ class HrDepartureWizard(models.TransientModel):
                 if field in whitelist and not self.env['hr.version']._fields[field].related
         }
         employee.write(val_list)
+        employee.version_id.contract_template_id = self.contract_template_id
         return

--- a/addons/hr_recruitment/views/hr_applicant_views.xml
+++ b/addons/hr_recruitment/views/hr_applicant_views.xml
@@ -89,7 +89,7 @@
                         class="o_create_employee" invisible="employee_id or not active or not date_closed"/>
                 <button string="Refuse" name="archive_applicant" type="object" invisible="not active or is_pool_applicant" data-hotkey="d"/>
                 <button string="Restore" name="action_unarchive" type="object" invisible="active" data-hotkey="x"/>
-                <field name="stage_id" widget="statusbar_duration" options="{'clickable': '1', 'fold_field': 'fold'}" invisible="(not active and not employee_id) or is_pool_applicant"/>
+                <field name="stage_id" widget="statusbar_duration" options="{'clickable': '1'}" invisible="(not active and not employee_id) or is_pool_applicant"/>
                 <button string="Create Applications" name="action_job_add_applicants" type="object" invisible="not is_pool_applicant"/>
                 <button string="Add to Pool" name="action_talent_pool_add_applicants" type="object" invisible="is_pool_applicant or is_applicant_in_pool"/>
             </header>


### PR DESCRIPTION
By assigning the contract_template_id to version.contract_template_id when it's loaded and assigned to hr.employee.contract_template_id

This prevents the error:
"No signature template defined on this version.." when trying to submit the salary configurator form.

task-4873800