### PR TITLE
[FIX] mail: composer correct height when empty

### DIFF
--- a/addons/mail/static/src/core/common/composer.js
+++ b/addons/mail/static/src/core/common/composer.js
@@ -158,7 +158,15 @@ export class Composer extends Component {
         );
         useEffect(
             () => {
+                let wasEmpty = false;
+                if (!this.fakeTextarea.el.value) {
+                    wasEmpty = true;
+                    this.fakeTextarea.el.value = "0";
+                }
                 this.ref.el.style.height = this.fakeTextarea.el.scrollHeight + "px";
+                if (wasEmpty) {
+                    this.fakeTextarea.el.value = "";
+                }
             },
             () => [this.props.composer.textInputContent, this.ref.el]
         );


### PR DESCRIPTION
Before this commit, composer height was too small when it had no content. This lead to composer changing height when typing some characters which looks off.

This bug is specific to Chromium browsers and seems to be new since Chrome 138.0. The code expected that textarea had unchanged scrollheight when textarea has height 0 and fits its content in at most 1 line, but this seems to have changed with Chrome 138.0.

This commit fixes the issue by cheating when composer is empty: the fake textarea artificially adds a character so that the computation for height when empty works as if it has 1 character, thus the computed height is the same when there are few characters in composer.
