### PR TITLE
[FIX] mail: attempt fix runbot 227618 (181952 reincarnated)

### DIFF
--- a/addons/mail/static/src/core/common/composer.js
+++ b/addons/mail/static/src/core/common/composer.js
@@ -656,7 +656,6 @@ export class Composer extends Component {
     }
 
     async processMessage(cb) {
-        const el = this.ref.el;
         const attachments = this.props.composer.attachments;
         if (attachments.some(({ uploading }) => uploading)) {
             this.env.services.notification.add(_t("Please wait while the file is uploading."), {
@@ -677,7 +676,7 @@ export class Composer extends Component {
             }
             this.clear();
             this.state.active = true;
-            el.focus();
+            this.ref.el?.focus();
         }
     }
 

--- a/addons/mail/static/tests/message/message.test.js
+++ b/addons/mail/static/tests/message/message.test.js
@@ -19,6 +19,7 @@ import { animationFrame, leave, press, queryFirst } from "@odoo/hoot-dom";
 import { Deferred, mockDate, tick } from "@odoo/hoot-mock";
 import {
     asyncStep,
+    contains as webContains,
     Command,
     mockService,
     onRpc,
@@ -187,25 +188,28 @@ test("Can edit message comment in chatter", async () => {
     await openFormView("res.partner", partnerId);
     await click(".o-mail-Message [title='Expand']");
     await click(".o-mail-Message-moreMenu [title='Edit']");
-    await insertText(".o-mail-Message .o-mail-Composer-input", "edited message", { replace: true });
+    await contains(".o-mail-Message .o-mail-Composer.o-focused");
+    await webContains(".o-mail-Message .o-mail-Composer-input").edit("edited message");
     await click(".o-mail-Message a", { text: "save" });
     await contains(".o-mail-Message-content", { text: "edited message (edited)" });
     await click(".o-mail-Message [title='Expand']");
     await click(".o-mail-Message-moreMenu [title='Edit']");
     await contains(".o-mail-Message:contains('Escape to cancel, CTRL-Enter to save')");
-    await insertText(".o-mail-Message .o-mail-Composer-input", "edited again", { replace: true });
-    await press("Enter");
+    await contains(".o-mail-Message .o-mail-Composer.o-focused");
+    await webContains(".o-mail-Message .o-mail-Composer-input").edit("edited again");
+    await webContains(".o-mail-Message .o-mail-Composer-input").press("Enter");
     await animationFrame();
     await contains(".o-mail-Message .o-mail-Composer-input"); // still editing message
     await contains(".o-mail-Message .o-mail-Composer-input:value('edited again')"); // FIXME: even though value has trailing '\n', HOOT selector doesn't see it on the node
-    await triggerHotkey("control+Enter"); // somehow press doesn't work :(
+    await webContains(".o-mail-Message .o-mail-Composer-input").press(["Control", "Enter"]);
     await contains(".o-mail-Message-content", { text: "edited again (edited)" });
     // save without change should keep (edited)
     await click(".o-mail-Message [title='Expand']");
     await click(".o-mail-Message-moreMenu [title='Edit']");
+    await contains(".o-mail-Message .o-mail-Composer.o-focused");
     await contains(".o-mail-Message .o-mail-Composer-input:value('edited again')");
     await contains(".o-mail-Message:contains('Escape to cancel, CTRL-Enter to save')");
-    await triggerHotkey("control+Enter"); // somehow press doesn't work :(
+    await webContains(".o-mail-Message .o-mail-Composer-input").press(["Control", "Enter"]);
     await contains(".o-mail-Message-content", { text: "edited again (edited)" });
 });
 


### PR DESCRIPTION
Follow-up of https://github.com/odoo/odoo/pull/214626

Runbot error 181952 is hardly reproduce-able. Don't have a exact idea what causes the problem.

These are theories of the causes:
1. insertText, contains, triggerHotkey of mail helpers are not robust enough (lack simulation, not robust against CPU load / prone to race conditions).
2. focus in composer is lost non-deterministically

Previous attempts were thinking the root cause are mail test helpers and web test helpers would fix issue, but that's probably not the exact cause of issue. A more likely candidate is composer loosing focus and therefore pressing of keys do not make proper transition from message with composer to message without composer.

One likely cause of loosing focus is `processMessage` that reuses the old ref after asynchronous handling of message edition / post. This commit fixes by using the current ref of texarea.

Test helpers can still be prone to problems. That's why this commit this converts the most important LOCs to web test helpers. The user interactions are made with `contains().press()`, where the `contains()` enforces focus on the targeted element, giving more guarantee the composer is focused for proper press of key. `press("Control+Enter")` were not working because this passed "Control+Enter" instead of "Enter" as `ev.key`. This was fixed by using more primitive syntax `["Control", "Enter"]` which is better parsed for proper `ev` object of KeyboardEvent.

Runbot-error-227618
