### PR TITLE
[FIX] website: resolve builder action id issue

### DIFF
--- a/addons/website/static/src/builder/plugins/options/facebook_option.xml
+++ b/addons/website/static/src/builder/plugins/options/facebook_option.xml
@@ -3,19 +3,19 @@
 
 <t t-name="website.FacebookOption">
     <BuilderRow label.translate="URL">
-        <BuilderTextInput dataAttributeAction="'href'" action="'checkFacebookLinkAction'"/>
+        <BuilderTextInput dataAttributeAction="'href'" action="'checkFacebookLink'"/>
     </BuilderRow>
     <BuilderRow label.translate="Cover Photo">
         <BuilderCheckbox dataAttributeAction="'hide_cover'" dataAttributeActionValue="'true'" inverseAction="true"/>
     </BuilderRow>
     <BuilderRow label.translate="Timeline">
-        <BuilderCheckbox action="'dataAttributeListAction'" actionParam="'tabs'" actionValue="'timeline'"/>
+        <BuilderCheckbox action="'dataAttributeList'" actionParam="'tabs'" actionValue="'timeline'"/>
     </BuilderRow>
     <BuilderRow label.translate="Events">
-        <BuilderCheckbox action="'dataAttributeListAction'" actionParam="'tabs'" actionValue="'events'"/>
+        <BuilderCheckbox action="'dataAttributeList'" actionParam="'tabs'" actionValue="'events'"/>
     </BuilderRow>
     <BuilderRow label.translate="Messages">
-        <BuilderCheckbox action="'dataAttributeListAction'" actionParam="'tabs'" actionValue="'messages'"/>
+        <BuilderCheckbox action="'dataAttributeList'" actionParam="'tabs'" actionValue="'messages'"/>
     </BuilderRow>
     <BuilderRow label.translate="Small Header">
         <BuilderCheckbox dataAttributeAction="'small_header'" dataAttributeActionValue="'true'"/>


### PR DESCRIPTION
Problem:

Dropping the Facebook snippet and interacting with its options caused a traceback due to unregistered or incorrect builder action IDs.

Steps to Reproduce:

1. Drop the Facebook snippet in website builder.
2. Click on the snippet to open its configuration panel.
3. Observe the traceback due to unrecognized builder actions.

Root Cause:

The action IDs used in the XML template (`website.FacebookOption`) did not match the registered plugin action IDs.

Fix:

Updated the mismatched action IDs in the builder components:

* Replaced `checkFacebookLinkAction` → `checkFacebookLink`
* Replaced `dataAttributeListAction` → `dataAttributeList`