### PR TITLE
[FIX] website: fix field visibility based on dynamic select value

### DIFF
--- a/addons/website/static/src/snippets/s_website_form/form.js
+++ b/addons/website/static/src/snippets/s_website_form/form.js
@@ -764,11 +764,17 @@ export class Form extends Interaction {
      * @returns {FormData} a FormData object containing also disabled fields
      */
     getFormDataIncludingDisabledFields(formEl) {
-        const formCopy = formEl.cloneNode(true);
-        formCopy.querySelectorAll("input, select, textarea").forEach((element) => {
+        const disabledFields = formEl.querySelectorAll(
+            "input:disabled, select:disabled, textarea:disabled"
+        );
+        disabledFields.forEach((element) => {
             element.removeAttribute("disabled");
         });
-        return new FormData(formCopy);
+        const formData = new FormData(formEl);
+        disabledFields.forEach((element) => {
+            element.setAttribute("disabled", true);
+        });
+        return formData;
     }
 
     isFieldVisible(fieldEl) {


### PR DESCRIPTION
Problem:
After (https://github.com/odoo/odoo/commit/82fac504803fd17520a1289eb1e38bc7662c54a2), in a form, if a field is set to be visible only when another select field has a specific value (e.g., "x"), that field remains always visible regardless of the selected value.

Cause:
`isFieldVisible` evaluates visibility using the form's default values. This happens because `getFormDataIncludingDisabledFields` returns a cloned form, and cloning a form does not preserve field values.

Solution:
Remove disabled attribute from the `formEl` fields and create
`FormData` then revert the changes.

Steps to reproduce:
- Add a form
- Change a field ("A") type to selection
- Set another field ("B") to be visible only when "A" has a specific value
- Save
- Change the selection to a value that should hide "B"
> "B" remains visible

opw-4874379

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
