### PR TITLE
[IMP] spreadsheet: consistent values for ODOO.FILTER.VALUE

### DIFF
--- a/addons/spreadsheet/static/src/@types/commands.d.ts
+++ b/addons/spreadsheet/static/src/@types/commands.d.ts
@@ -125,7 +125,6 @@ declare module "@spreadsheet" {
         type: "SET_GLOBAL_FILTER_VALUE";
         id: string;
         value: any;
-        displayNames?: string[];
     }
 
     export interface SetManyGlobalFilterValueCommand {

--- a/addons/spreadsheet/static/src/global_filters/components/filter_value/filter_value.js
+++ b/addons/spreadsheet/static/src/global_filters/components/filter_value/filter_value.js
@@ -37,7 +37,6 @@ export class FilterValue extends Component {
 
     setup() {
         this.getters = this.props.model.getters;
-        this.nameService = useService("name");
         this.fieldService = useService("field");
         this.isValid = false;
         onWillStart(async () => {
@@ -121,11 +120,7 @@ export class FilterValue extends Component {
             // force clear, even automatic default values
             this.clear(id);
         } else {
-            const displayNames = await this.nameService.loadDisplayNames(
-                this.filter.modelName,
-                resIds
-            );
-            this.props.setGlobalFilterValue(id, resIds, Object.values(displayNames));
+            this.props.setGlobalFilterValue(id, resIds);
         }
     }
 

--- a/addons/spreadsheet/static/src/global_filters/components/filters_search_dialog/filters_search_dialog.js
+++ b/addons/spreadsheet/static/src/global_filters/components/filters_search_dialog/filters_search_dialog.js
@@ -61,9 +61,8 @@ export class FiltersSearchDialog extends Component {
         return _t(node.globalFilter.label); // Label is extracted from the spreadsheet json file
     }
 
-    setGlobalFilterValue(node, value, displayNames) {
+    setGlobalFilterValue(node, value) {
         node.value = value;
-        node.displayNames = displayNames;
     }
 
     getTranslatedFilterLabel(filter) {
@@ -88,7 +87,6 @@ export class FiltersSearchDialog extends Component {
                 this.props.model.dispatch("SET_GLOBAL_FILTER_VALUE", {
                     id: filter.id,
                     value: node.value,
-                    displayNames: node.displayNames,
                 });
             } else {
                 this.props.model.dispatch("SET_GLOBAL_FILTER_VALUE", { id: filter.id });

--- a/addons/spreadsheet/static/src/global_filters/components/filters_search_dialog/filters_search_dialog.xml
+++ b/addons/spreadsheet/static/src/global_filters/components/filters_search_dialog/filters_search_dialog.xml
@@ -10,7 +10,7 @@
                     </div>
                     <FilterValue filter="item.globalFilter"
                                  model="props.model"
-                                 setGlobalFilterValue="(id, value, displayNames) => this.setGlobalFilterValue(item, value, displayNames)"
+                                 setGlobalFilterValue="(id, value) => this.setGlobalFilterValue(item, value)"
                                  globalFilterValue="item.value"/>
                     <button class="btn btn-link px-2 text-danger fs-4" t-on-click="() => this.removeFilter(item.globalFilter.id)">
                         <i class="fa fa-trash"></i>

--- a/addons/spreadsheet/static/tests/global_filters/global_filters_model.test.js
+++ b/addons/spreadsheet/static/tests/global_filters/global_filters_model.test.js
@@ -1122,19 +1122,7 @@ test("ODOO.FILTER.VALUE date from/to with from and to defined", async function (
 });
 
 test("ODOO.FILTER.VALUE relation filter", async function () {
-    const { model } = await createModelWithDataSource({
-        mockRPC: function (route, { method, kwargs }) {
-            if (method === "web_search_read") {
-                const resId = kwargs.domain[0][2][0];
-                const names = {
-                    1: "Jean-Jacques",
-                    2: "Raoul Grosbedon",
-                };
-                expect.step(`read_${resId}`);
-                return { records: [{ id: resId, display_name: names[resId] }] };
-            }
-        },
-    });
+    const { model } = await createModelWithDataSource();
     setCellContent(model, "A10", `=ODOO.FILTER.VALUE("Relation Filter")`);
     await animationFrame();
     await addGlobalFilter(model, {
@@ -1145,32 +1133,26 @@ test("ODOO.FILTER.VALUE relation filter", async function () {
     });
     await animationFrame();
     const [filter] = model.getters.getGlobalFilters();
-    expect.verifySteps([]);
-    // One record; displayNames not defined => rpc
     await setGlobalFilterValue(model, {
         id: filter.id,
         value: [1],
     });
     await animationFrame();
-    expect(getCellValue(model, "A10")).toBe("Jean-Jacques");
+    expect(getCellValue(model, "A10")).toBe("1");
 
-    // Two records; displayNames defined => no rpc
     await setGlobalFilterValue(model, {
         id: filter.id,
         value: [1, 2],
-        displayNames: ["Jean-Jacques", "Raoul Grosbedon"],
     });
     await animationFrame();
-    expect(getCellValue(model, "A10")).toBe("Jean-Jacques, Raoul Grosbedon");
+    expect(getCellValue(model, "A10")).toBe("1, 2");
 
-    // another record; displayNames not defined => rpc
     await setGlobalFilterValue(model, {
         id: filter.id,
         value: [2],
     });
     await animationFrame();
-    expect(getCellValue(model, "A10")).toBe("Raoul Grosbedon");
-    expect.verifySteps(["read_1", "read_2"]);
+    expect(getCellValue(model, "A10")).toBe("2");
 });
 
 test("ODOO.FILTER.VALUE with escaped quotes in the filter label", async function () {


### PR DESCRIPTION
Before this commit, the `ODOO.FILTER.VALUE` was not consistent across different global filters. The value was the technical value for `text`, `date`, and `boolean` filters (and the upcomming `selection` filter), while it was the display value for `relation` filters.

As the main use case of the `ODOO.FILTER.VALUE` is to be used in others functions like `PIVOT`, it is better to consistently use the technical value for all filters.

Task: 4910291

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
