### PR TITLE
[FIX] web_editor: prevent error when document is empty

### DIFF
--- a/addons/web_editor/models/ir_ui_view.py
+++ b/addons/web_editor/models/ir_ui_view.py
@@ -123,7 +123,11 @@ class IrUiView(models.Model):
         if not lang_value:
             return
 
-        tree = html.fromstring(lang_value)
+        try:
+            tree = html.fromstring(lang_value)
+        except etree.ParserError as e:
+            raise ValidationError(str(e))
+
         for custom_snippet_el in tree.xpath('//*[hasclass("s_custom_snippet")]'):
             custom_snippet_name = custom_snippet_el.get('data-name')
             custom_snippet_view = self.search([('name', '=', custom_snippet_name)], limit=1)


### PR DESCRIPTION
Currently an error occurs when we try to save a blog post with no content.

Steps to replicate:
- Install the `website_blog` module.
- Navigate to the website, go to the Blogs section, and create a new blog.
- Click to open the newly created blog.
- Remove any existing content (e.g., placeholder text like 'Start Typing...').
- Type `/column` and click on the 2-column option.
- Click on the columns that appear — you’ll see a delete icon.
- Delete all the columns, click Save and check the terminal.

Error:
`ParserError: Document is empty`

The error occurs when all content in the blog is deleted, resulting in empty HTML content. During saving, `html.fromstring(lang_value)` [1] is called with `lang_value` being effectively empty, which leads to a `ParserError`.

[1] - https://github.com/odoo/odoo/blob/28c3b9cf10488536dce5a4927fdbe8fcd6e5a839/addons/web_editor/models/ir_ui_view.py#L126

This commit fixes the problem by catching the `ParserError` and raising a `ValidationError` when the HTML content is empty.

sentry-5081806749
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
