### PR TITLE
[FIX] website_sale: prevent error when category comes as str instead of int

### DIFF
--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -547,6 +547,7 @@ class WebsiteSale(payment_portal.PaymentPortal):
         # Compatibility pre-v14
         # Redirect to the "correct" product URL, which doesn't include `/product`, and where the
         # category has been removed from the query parameters and added to the path.
+        category = int(category) if str(category).isdigit() else False
         category = self._validate_and_get_category(category)
         query = self._get_filtered_query_string(
             request.httprequest.query_string.decode(), keys_to_remove=['category']

--- a/addons/website_sale/tests/test_website_sale_shop_redirects.py
+++ b/addons/website_sale/tests/test_website_sale_shop_redirects.py
@@ -40,6 +40,16 @@ class TestWebsiteSaleShopRedirects(HttpCase, WebsiteSaleCommon):
         )
 
         response = self.url_open(
+            f'/shop/product/{slug(test_product)}?category=test&some-key=some-value',
+            allow_redirects=False,
+        )
+        self.assertEqual(response.status_code, 301)
+        self.assertURLEqual(
+            response.headers.get('Location'),
+            f'/shop/{slug(test_product)}?some-key=some-value'
+        )
+
+        response = self.url_open(
             f'/shop/{slug(category_b)}/{slug(test_product)}?some-key=some-value',
             allow_redirects=False,
         )


### PR DESCRIPTION
The system will crash when we get the `category` as `str` and we try to evaluate `int(category)` in `_validate_and_get_category` method.

**Root Cause:-**
- At [1] and [2], we are passing an object in the arguments for the category. If we manually provide a category, it may result in a `not found` error instead of a regular error.
- However, at point [3], Since the `category` is received from a `query parameter`, it can be easily tampered with, so it should be properly validated before use.
- This controller makes the `older controller` (used before V14) `compatible` with the new one.


[1]
https://github.com/odoo/odoo/blob/1df0feb3dc1b0ac34227683337eca4d95fa986b5/addons/website_sale/controllers/main.py#L470

[2]
https://github.com/odoo/odoo/blob/1df0feb3dc1b0ac34227683337eca4d95fa986b5/addons/website_sale/controllers/main.py#L247

[3]
https://github.com/odoo/odoo/blob/1df0feb3dc1b0ac34227683337eca4d95fa986b5/addons/website_sale/controllers/main.py#L546

**Error:-**
`ValueError: invalid literal for int() with base 10: 'duffle-bags'`

**Solution:-**
- We added a `validation` to ensure the category parameter is a `valid integer` before using it.
- This prevents crashes when users manually input 'invalid` or `tampered category` values in the URL.

**Sentry - 6658317828**

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
