### PR TITLE
[FIX] html_builder: allow dropdown labels to truncate

### DIFF
--- a/addons/html_builder/static/src/core/building_blocks/builder_select.scss
+++ b/addons/html_builder/static/src/core/building_blocks/builder_select.scss
@@ -12,7 +12,7 @@
 }
 
 .o-hb-select-wrapper {
-    flex: 1 0 auto;
+    flex: 1 0 0;
     min-width: 7ch; // Approx 4 characters + caret
     max-width: 100%;
     display: flex;


### PR DESCRIPTION
This PR allows dropdown labels to truncate within the `html_builder` environment. Prior to this PR, an `auto` value was assigned to the `flex-basis` property meaning it would take as much space as its content, meaning that if the label is very long, siblings wouldn't have enough space to grow.

With this PR, we remove this `flex-basis` value an rely on the other `flex` values already defined, as well as the `min-width`.

task-4910410

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
