### PR TITLE
[FIX] hr_expense: double "New" button in Expenses Kanban on small screen

### DIFF
--- a/addons/hr_expense/static/src/views/kanban.xml
+++ b/addons/hr_expense/static/src/views/kanban.xml
@@ -23,19 +23,11 @@
             <attribute name="class" remove="d-flex" separator=" "/>
             <attribute name="class" add="d-block d-xl-flex" separator=" "/>
         </xpath>
-        <xpath expr="//div[hasclass('o_cp_buttons')]" position="inside">
-            <input type="file" name="ufile" class="d-none" t-ref="fileInput" multiple="1" accept="*" t-on-change="onChangeFileInput" />
-            <t t-if="canCreate and props.showButtons and env.isSmall">
-                <button type="button" class="btn btn-primary o-kanban-button-new" data-hotkey="c" t-on-click="() => this.createRecord()" data-bounce-button="">
-                    New
-                </button>
-            </t>
-        </xpath>
-
     </t>
 
     <t t-name="hr_expense.KanbanView" t-inherit="web.KanbanView" t-inherit-mode="primary">
         <xpath expr="//button[hasclass('o-kanban-button-new')]" position="before">
+            <input type="file" name="ufile" class="d-none" t-ref="fileInput" multiple="1" accept="*" t-on-change="onChangeFileInput" />
             <button t-if="!env.isSmall" type="button" class="o_button_upload_expense btn btn-primary" t-on-click.prevent="uploadDocument">
                 Upload
             </button>

--- a/addons/hr_expense/static/src/views/list.xml
+++ b/addons/hr_expense/static/src/views/list.xml
@@ -9,7 +9,6 @@
             <attribute name="class" add="d-block d-xl-flex" separator=" "/>
         </xpath>
         <xpath expr="//div[hasclass('o_list_buttons')]" position="inside">
-            <input type="file" name="ufile" class="d-none" t-ref="fileInput" multiple="1" accept="*" t-on-change="onChangeFileInput"/>
             <button t-if="displaySubmit()" class="d-none d-md-block btn btn-secondary" t-on-click="() => this.onClick('action_submit')">
                 Submit
             </button>
@@ -24,6 +23,7 @@
 
     <t t-name="hr_expense.ListView" t-inherit="web.ListView" t-inherit-mode="primary">
         <xpath expr="//button[hasclass('o_list_button_add')]" position="before">
+            <input type="file" name="ufile" class="d-none" t-ref="fileInput" multiple="1" accept="*" t-on-change="onChangeFileInput"/>
             <button t-if="!env.isSmall" type="button" class="o_button_upload_expense btn btn-primary" t-on-click.prevent="uploadDocument">
                 Upload
             </button>


### PR DESCRIPTION
This commit avoids a duplicated "New" button definition and being displayed in the Expenses Kanban view on small screen.

It also moves the hidden input used for upload next to the button calling it in both List and Kanban views (for coherence).

Steps to reproduce (in small screen):
- Open Expenses app => double "New" button : one displayed, one in the dropdown



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
