### PR TITLE
[FIX] ZATCA: Handle missing confirmation_date in prepayment invoices

### DIFF
--- a/addons/l10n_sa_edi/models/account_edi_xml_ubl_21_zatca.py
+++ b/addons/l10n_sa_edi/models/account_edi_xml_ubl_21_zatca.py
@@ -5,6 +5,7 @@ from lxml import etree
 from odoo import models, fields
 from odoo.tools.misc import file_path
 import re
+from odoo.exceptions import ValidationError
 
 TAX_EXEMPTION_CODES = ['VATEX-SA-29', 'VATEX-SA-29-7', 'VATEX-SA-30']
 TAX_ZERO_RATE_CODES = ['VATEX-SA-32', 'VATEX-SA-33', 'VATEX-SA-34-1', 'VATEX-SA-34-2', 'VATEX-SA-34-3', 'VATEX-SA-34-4',
@@ -360,6 +361,9 @@ class AccountEdiXmlUBL21Zatca(models.AbstractModel):
         """
         if not line.move_id._is_downpayment() and line.sale_line_ids and all(sale_line.is_downpayment for sale_line in line.sale_line_ids):
             prepayment_move_id = line.sale_line_ids.invoice_lines.move_id.filtered(lambda m: m._is_downpayment())
+            if not prepayment_move_id.l10n_sa_confirmation_datetime:
+                raise ValidationError(f"Please Insure that the Prepayment Move [{prepayment_move_id.name}] has been posted to zatca successfully in order to be able to post the current invoice.")
+
             return {
                 'prepayment_id': prepayment_move_id.name,
                 'issue_date': fields.Datetime.context_timestamp(self.with_context(tz='Asia/Riyadh'),

--- a/doc/cla/individual/shawkialaddin.md
+++ b/doc/cla/individual/shawkialaddin.md
@@ -1,0 +1,11 @@
+Saudi Arabia, 2025-07-01
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Shawki Aladdin bolshuq@gmail.com https://github.com/shawkialaddin


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Invoices linked to prepayments (down payments) crash during ZATCA UBL generation when the related prepayment invoice lacks a l10n_sa_confirmation_datetime. This happens when the prepayment has not yet been successfully submitted to ZATCA.

Current behavior before PR:

If a prepayment is missing the confirmation datetime, posting the final invoice results in an error or invalid QR/UBL structure, with no clear user guidance.

Desired behavior after PR is merged:

The system raises a clear ValidationError instructing the user to first post the related prepayment to ZATCA. This prevents crashes and ensures proper invoice sequencing and compliance.

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr