### PR TITLE
[FIX] website_payment: fix a possible concurrency issue

### DIFF
--- a/addons/website_payment/static/src/snippets/s_donation/donation_snippet.js
+++ b/addons/website_payment/static/src/snippets/s_donation/donation_snippet.js
@@ -7,7 +7,6 @@ import { _t } from "@web/core/l10n/translation";
 import { rpc } from "@web/core/network/rpc";
 
 const CUSTOM_BUTTON_EXTRA_WIDTH = 10;
-let cachedCurrency;
 
 export class DonationSnippet extends Interaction {
     static selector = ".s_donation";
@@ -37,8 +36,7 @@ export class DonationSnippet extends Interaction {
     }
 
     async willStart() {
-        cachedCurrency ||= await this.waitFor(rpc("/website/get_current_currency"));
-        this.currency = cachedCurrency;
+        this.currency = await rpc("/website/get_current_currency", { cached: true });
     }
 
     start() {


### PR DESCRIPTION
The previous code had a small potential issue: if two instances of the s_donation snippets were present on a page (not sure it happens in practice), then the two interactions would be created, then willStarted. The first one would initiate the rpc, then the second one would do the same, since the cached value was not assigned yet, and only when the first of these 2 rpcs would resolve, then the cached value will be assigned.

A possible solution would be to cache the promise instead, but we need to be careful, the waitFor operator will leave a promise pending if the interaction has been destroyed in the time it takes for it to resolve. So, putting in cache a pending forever promise can cause issues.

A simple way to solve the issue is to simply remove the waitFor call in willStart, it does not do anything anyway. Another solution is to use the new cached feature from the rpc system.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
