### PR TITLE
[FIX] account_edi_ubl_cii: fix error when printing multiple invoices

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_move.py
+++ b/addons/account_edi_ubl_cii/models/account_move.py
@@ -68,16 +68,17 @@ class AccountMove(models.Model):
 
     def get_extra_print_items(self):
         print_items = super().get_extra_print_items()
+        posted_moves = self.filtered(lambda move: move.state == 'posted')
         suggested_edi_formats = {
             suggested_format
-            for partner in self.commercial_partner_id
+            for partner in posted_moves.commercial_partner_id
             if (suggested_format := partner ._get_suggested_ubl_cii_edi_format())
         }
-        if self.state == 'posted' and (self.ubl_cii_xml_id or suggested_edi_formats):
+        if posted_moves.ubl_cii_xml_id or suggested_edi_formats:
             print_items.append({
                 'key': 'download_ubl',
                 'description': _('Export XML'),
-                **self.action_invoice_download_ubl(),
+                **posted_moves.action_invoice_download_ubl(),
             })
         return print_items
 


### PR DESCRIPTION
When User tries to print multiple invoices,
A traceback will appear.

Steps to reproduce the error:
- Install ``account`` module with demo data
- Go to Invoices > Select multiple invoices > Print

Traceback:
```
ValueError: Expected singleton: account.move(2, 1)
```

After this commit: https://github.com/odoo/odoo/commit/1a8123177dbcb01435f3608508302f40532477c1

https://github.com/odoo/odoo/blob/871c7d23336cf06619998795c073bd2001b20af1/addons/account_edi_ubl_cii/models/account_move.py#L76
When user prints multiple invoices,
self will have multiple records.
So, checking ``self.state`` will lead to the above traceback.

opw-4912628
sentry-6717623103

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
