### PR TITLE
[IMP] website: enhance s_tabs_images

### DIFF
--- a/addons/website/static/src/builder/plugins/options/navtabs_images_style_option.xml
+++ b/addons/website/static/src/builder/plugins/options/navtabs_images_style_option.xml
@@ -5,9 +5,23 @@
             <attribute name="classAction">'s_tabs_nav_vertical'</attribute>
             <attribute name="id">'vertical_opt'</attribute>
         </xpath>
+        <xpath expr="//BuilderRow[@label.translate=&quot;Style&quot;]" position="after">
+            <BuilderContext t-if="isActiveItem('pills_opt')" applyTo="'.s_tabs_pills_template .nav-pills'">
+                <BuilderRow label.translate="Background" level="1">
+                    <BuilderColorPicker enabledTabs="['solid', 'custom', 'gradient']" styleAction="'--nav-pills-link-active-bg'"/>
+                </BuilderRow>
+                <BuilderRow label.translate="Text" level="1">
+                    <BuilderColorPicker enabledTabs="['solid', 'custom']" styleAction="'--nav-pills-link-active-color'"/>
+                </BuilderRow>
+            </BuilderContext>
+        </xpath>
         <xpath expr="//BuilderRow[@label.translate=&quot;Direction&quot;]" position="after">
             <BuilderRow label.translate="Descriptions" t-if="isActiveItem('vertical_opt')">
-                <BuilderCheckbox classAction="'s_tabs_nav_with_descriptions'"/>
+                <BuilderSelect>
+                    <BuilderSelectItem classAction="'s_tabs_nav_with_descriptions'">All items</BuilderSelectItem>
+                    <BuilderSelectItem classAction="'s_tabs_nav_with_descriptions_active'">Active only</BuilderSelectItem>
+                    <BuilderSelectItem classAction="''">Hidden</BuilderSelectItem>
+                </BuilderSelect>
             </BuilderRow>
         </xpath>
     </t>

--- a/addons/website/static/src/builder/plugins/options/navtabs_style_option.xml
+++ b/addons/website/static/src/builder/plugins/options/navtabs_style_option.xml
@@ -6,7 +6,7 @@
             <BuilderSelectItem actionValue="'nav-underline'" id="'underline_opt'">Underline</BuilderSelectItem>
             <BuilderSelectItem actionValue="'nav-tabs'" id="'tabs_opt'">Tabs</BuilderSelectItem>
             <BuilderSelectItem actionValue="'nav-buttons'" id="'buttons_opt'">Buttons</BuilderSelectItem>
-            <BuilderSelectItem actionValue="'nav-pills'" id="'pills_opt'">Pills</BuilderSelectItem>
+            <BuilderSelectItem actionValue="'nav-pills'" classAction="'s_tabs_pills_template'" id="'pills_opt'">Pills</BuilderSelectItem>
         </BuilderSelect>
     </BuilderRow>
     <t t-if="isActiveItem('tabs_opt') or isActiveItem('buttons_opt')">

--- a/addons/website/static/src/snippets/s_tabs_images/000.scss
+++ b/addons/website/static/src/snippets/s_tabs_images/000.scss
@@ -3,9 +3,16 @@
         display: none;
     }
 
-    .s_tabs_nav_with_descriptions:where(.s_tabs_nav_vertical) :where(.o_nav_tabs_description) {
+    .s_tabs_nav_with_descriptions:where(.s_tabs_nav_vertical) :where(.o_nav_tabs_description),
+    .s_tabs_nav_with_descriptions_active:where(.s_tabs_nav_vertical) .active > :where(.o_nav_tabs_description) {
         @include media-breakpoint-up(lg) {
             display: block;
         }
+    }
+
+    // Forces custom colors to be maintained independently of the color preset.
+    .s_tabs_pills_template .nav-link.active {
+        background: var(--#{$prefix}nav-pills-link-active-bg) !important;
+        color: var(--#{$prefix}nav-pills-link-active-color) !important;
     }
 }

--- a/addons/website/views/snippets/s_tabs_images.xml
+++ b/addons/website/views/snippets/s_tabs_images.xml
@@ -6,7 +6,7 @@
         <div class="container">
             <div class="s_tabs_main s_tabs_nav_vertical s_tabs_nav_with_descriptions s_col_no_resize s_col_no_bgcolor row">
                 <div class="s_tabs_nav col-md-3 mb-3 overflow-y-hidden overflow-x-auto" data-name="Tab Header" role="navigation">
-                    <ul class="nav nav-underline flex-nowrap flex-md-column" role="tablist">
+                    <ul class="nav nav-underline flex-nowrap flex-md-column" role="tablist" style="--nav-pills-link-active-bg: var(--nav-link-color);">
                         <li class="nav-item" role="presentation">
                             <a class="nav-link active text-break" id="nav_tabs_images_link_1" data-bs-toggle="tab" href="#nav_tabs_images_content_1" role="tab" aria-controls="nav_tabs_images_content_1" aria-selected="true">
                                 First Slide


### PR DESCRIPTION
This commit adds two new options to improve the "pills" presentation of `s_tabs_images`:
- Display the nav element description for the active element only.
- Allows the user to change the background and text colors of the active navigation element.

task-4900052

<img width="1791" alt="Capture d’écran 2025-07-01 à 10 39 52" src="https://github.com/user-attachments/assets/58f3a8af-2c23-4aac-b2cc-564b4df2b31b" />



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
