### PR TITLE
[IMP] testing: patch test cursor _now

### DIFF
--- a/addons/calendar/models/calendar_alarm_manager.py
+++ b/addons/calendar/models/calendar_alarm_manager.py
@@ -160,6 +160,7 @@ class AlarmManager(models.AbstractModel):
         already.
         """
         lastcall = self.env.context.get('lastcall', False) or fields.date.today() - relativedelta(weeks=1)
+        now = self.env.cr.now()
         self.env.cr.execute('''
             SELECT "alarm"."id", "event"."id"
               FROM "calendar_event" AS "event"
@@ -171,9 +172,9 @@ class AlarmManager(models.AbstractModel):
                    "alarm"."alarm_type" = %s
                AND "event"."active"
                AND "event"."start" - CAST("alarm"."duration" || ' ' || "alarm"."interval" AS Interval) >= %s
-               AND "event"."start" - CAST("alarm"."duration" || ' ' || "alarm"."interval" AS Interval) < now() at time zone 'utc'
-               AND "event"."stop" > now() at time zone 'utc'
-              ''' + self._get_notify_alert_extra_conditions(), [alarm_type, lastcall])
+               AND "event"."start" - CAST("alarm"."duration" || ' ' || "alarm"."interval" AS Interval) < %s at time zone 'utc'
+               AND "event"."stop" > %s at time zone 'utc'
+              ''' + self._get_notify_alert_extra_conditions(), [alarm_type, lastcall, now, now])
 
         events_by_alarm = {}
         for alarm_id, event_id in self.env.cr.fetchall():

--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -1533,6 +1533,7 @@ class Lead(models.Model):
 
         # Get the active followers (followers whose partner post a message on the
         # leads in the last 30 days) which should be moved on the destination lead
+        now = self.env.cr.now()
         self.env.cr.execute(
             '''
             SELECT MAX(mf.id) AS id
@@ -1541,7 +1542,7 @@ class Lead(models.Model):
                 ON mm.author_id = mf.partner_id
                AND mm.res_id = mf.res_id
                AND mm.model = 'crm.lead'
-               AND mm.date > NOW() - INTERVAL '30 DAY'
+               AND mm.date > %(now)s - INTERVAL '30 DAY'
                    /* Check if the partner is already
                       following the destination lead */
          LEFT JOIN mail_followers AS destf
@@ -1555,7 +1556,7 @@ class Lead(models.Model):
                AND destf IS NULL
           GROUP BY mf.partner_id
             ''',
-            {'lead_ids': tuple(opportunities.ids), 'lead_id': self.id},
+            {'lead_ids': tuple(opportunities.ids), 'lead_id': self.id, 'now': now},
         )
         followers_to_update = [r[0] for r in self.env.cr.fetchall()]
         followers_to_update = self.env['mail.followers'].browse(followers_to_update).sudo()

--- a/odoo/addons/base/models/ir_cron.py
+++ b/odoo/addons/base/models/ir_cron.py
@@ -198,20 +198,21 @@ class ir_cron(models.Model):
     @classmethod
     def _get_all_ready_jobs(cls, cr):
         """ Return a list of all jobs that are ready to be executed """
+        now = cr.now()
         cr.execute("""
             SELECT *, cron_name->>'en_US' as cron_name
             FROM ir_cron
             WHERE active = true
               AND numbercall != 0
-              AND (nextcall <= (now() at time zone 'UTC')
+              AND (nextcall <= (%s) at time zone 'utc'
                 OR id in (
                     SELECT cron_id
                     FROM ir_cron_trigger
-                    WHERE call_at <= (now() at time zone 'UTC')
+                    WHERE call_at <= (%s) at time zone 'utc'
                 )
               )
             ORDER BY priority
-        """)
+        """, (now, now))
         return cr.dictfetchall()
 
     @classmethod

--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -51,6 +51,7 @@ from urllib3.util import Url, parse_url
 
 import odoo
 from odoo import api
+from odoo import fields
 from odoo.models import BaseModel
 from odoo.exceptions import AccessError
 from odoo.http import BadRequest
@@ -764,6 +765,7 @@ class TransactionCase(BaseCase):
         cls.addClassCleanup(cls.registry.clear_caches)
 
         cls.cr = cls.registry.cursor()
+        cls.cr._now = fields.Datetime.now()
         cls.addClassCleanup(cls.cr.close)
 
         def check_cursor_stack():


### PR DESCRIPTION
When using faketime to modify the test time, the cursor `_now` is not affected by faketime because it uses the postresql `now`.

In order to fix that, this commit replaces the test cursor `_now` by a simple pythonic now in TransactionCase.


