### PR TITLE
[FIX] bus: non deterministic subscription test

### DIFF
--- a/addons/bus/static/tests/helpers/mock_websocket.js
+++ b/addons/bus/static/tests/helpers/mock_websocket.js
@@ -77,8 +77,8 @@ export function patchWebsocketWorkerWithCleanup(params = {}) {
             return new WebSocketMock();
         },
     });
-    patchWithCleanup(websocketWorker || WebsocketWorker.prototype, params);
     websocketWorker = websocketWorker || new WebsocketWorker();
+    patchWithCleanup(websocketWorker, params);
     websocketWorker.INITIAL_RECONNECT_DELAY = 0;
     websocketWorker.RECONNECT_JITTER = 0;
     patchWithCleanup(browser, {


### PR DESCRIPTION
This commit fixes the `subscribe to presence channels according
to store data` test. Some of the websocket worker functions are
debounced meaning some old worker functions can be called after
the test ends. Since `_patchWebsocketWorker` with cleanup patches
the prototype of the worker, patches can be executed from old
workers which is an issue. This commit ensures only the actual
instance is patched.

fixes runbot-226354