### PR TITLE
[FIX] website: prevent traceback when order_by input is deleted

### DIFF
--- a/addons/website/static/src/snippets/s_searchbar/search_bar.js
+++ b/addons/website/static/src/snippets/s_searchbar/search_bar.js
@@ -31,8 +31,8 @@ export class SearchBar extends Interaction {
         this.menuEl = null;
         this.searchType = this.inputEl.dataset.searchType;
         const orderByEl = this.el.querySelector(".o_search_order_by");
-        const form = orderByEl.closest("form");
-        this.order = orderByEl.value;
+        const form = this.el.closest("form");
+        this.order = orderByEl?.value;
         this.limit = parseInt(this.inputEl.dataset.limit) || 5;
         this.wasEmpty = !this.inputEl.value;
         this.linkHasFocus = false;


### PR DESCRIPTION
Problem:
Removing the `order_by` hidden input from a form and then saving results in a traceback.

Cause:
When a search element is added inside a text block, it may get accidentally deleted while editing the text. In version 18.1 and earlier, this did not cause a traceback because jQuery was used to get the form from the `order_by` input, and missing elements in the DOM did not cause a failure.

Solution:
Retrieve the form from the search element itself, rather than relying on the presence of the `order_by` hidden input.

Steps to reproduce:
- Add a "Title" text block
- Insert a search element before the text
- Delete all the text
- Use backspace to delete the header block
- Save
-> Traceback occurs

opw-4863089

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
