### PR TITLE
[FIX] website: keep navbar dropdowns open when clicked  during editing

### DIFF
--- a/addons/website/static/src/interactions/dropdown.edit.js
+++ b/addons/website/static/src/interactions/dropdown.edit.js
@@ -1,0 +1,17 @@
+import { Interaction } from "@web/public/interaction";
+import { registry } from "@web/core/registry";
+
+export class DropdownEdit extends Interaction {
+    static selector = "[data-bs-toggle=dropdown]";
+    dynamicContent = {
+        _root: {
+            // We want dropdown menus not to close when clicking inside them in
+            // edit mode.
+            "t-att-data-bs-auto-close": () => "outside",
+        },
+    };
+}
+
+registry.category("public.interactions.edit").add("website.dropdown_edit", {
+    Interaction: DropdownEdit,
+});

--- a/addons/website/static/src/js/content/auto_hide_menu.js
+++ b/addons/website/static/src/js/content/auto_hide_menu.js
@@ -1,3 +1,10 @@
+// TODO: this code should probably be converted into an interaction. At the
+// moment, the `data-bs-auto-close` attribute of the dropdown is set both by
+// the code in this file and by the `website.dropdown_edit` interaction. Because
+// of a timing issue (`editor_enable` being set too late), at the moment both
+// this code and the interaction are needed to ensure the correct behaviour in
+// any possible case. See commit message for more details.
+
 const BREAKPOINT_SIZES = {sm: '575', md: '767', lg: '991', xl: '1199', xxl: '1399'};
 
 let ignoreDOMMutations;


### PR DESCRIPTION
**Problem**
This commit addresses two problems related to navbar dropdown menus closing on click during editing. The first problem concerns the "more" dropdown menu that appears when there are too many links. The second problem concerns the dropdown containing the links "my account" and "logout".

How to reproduce problem 1:
1. Start editing a page that doesn't have a "more" dropdown in its navbar
2. Click on a navbar link, then click on the "edit menu" icon
3. From the "Edit Menu", add enough menu items to make the "more" dropdown appear (adding mega menu items works too)
4. Click on the "more" button to open the dropdown
5. Click on an item of the dropdown
6. PROBLEM: the dropdown closes
7. Reload the editor, now it works properly

How to reproduce problem 2:
1. Start editing a page
2. Click on the username dropdown in the navbar
3. Click on "My Account" or "Logout"
4. PROBLEM: the dropdown closes

**Solution**
This commit introduces an edit interaction that adds the attribute `data-bs-auto-close: outside` to dropdown elements in the editor.

**Note**
Some code  defining the behaviour of the "more" dropdown is already present in [1] and it is still necessary for the functioning of the dropdown. The newly introduced interaction only fixes a specific case: when new elements are added to the navbar and the "more" dropdown has just been  created. In this specific case, the code in [1] does not work properly because the code is executed too soon and the class `editor_enable` is still missing from the body. At the same time, when the editor is opened and the "more" button is already present on the navbar, the interaction fails to set the proper behaviour because the code in [1] replaces the dropdown menu. In this case, anyway, the code in [1] works properly and the dropdown takes the correct behaviour. Probably [1] needs a refactoring, maybe it should be written as an interaction.

[1] odoo/addons/website/static/src/js/content/auto_hide_menu.js

task-4367641