### PR TITLE
[IMP] web, website: make checkboxes' `border-radius` dynamic

### DIFF
--- a/addons/web/static/src/scss/bootstrap_overridden_frontend.scss
+++ b/addons/web/static/src/scss/bootstrap_overridden_frontend.scss
@@ -84,7 +84,6 @@ $input-disabled-bg: $gray-200 !default;
 $input-disabled-border-color: rgba($input-color, 0.15) !default;
 
 $form-check-input-border: $border-width solid $gray-400 !default;
-$form-check-input-border-radius: 0 !default;
 $form-check-input-checked-color: color-contrast($component-active-bg, $body-color, $white) !default;
 
 $form-switch-color: $input-color !default;

--- a/addons/website/static/src/scss/bootstrap_overridden.scss
+++ b/addons/website/static/src/scss/bootstrap_overridden.scss
@@ -261,6 +261,10 @@ $input-placeholder-color: mix($input-bg, $input-color) !default;
 $input-disabled-bg: mix($input-color, $input-bg, 10%) !default;
 
 $form-check-input-border: ($input-border-width or 1px) solid $input-border-color !default;
+// We limit the border radius for checkboxes to a maximum of 0.25rem
+// (BS5 default), to prevent checkboxes from appearing too rounded and
+// resembling radio buttons.
+$form-check-input-border-radius: if($input-border-radius != null, min($input-border-radius, .25rem), null) !default;
 // Note that using "input-disabled-bg" here might seems strange at first but it
 // is actually the most consistent found way at the moment:
 // - It does not depend on the "border-color", which is important as the


### PR DESCRIPTION
This PR makes the border-radius of checkboxes dynamic, so it automatically matches the border-radius of other input elements. This ensures that if a user changes the input roundness in the theme settings (e.g., sets it to 0), checkboxes will follow the same style for a consistent look.

It also resets the checkboxes’ border-radius to the Bootstrap default for front-end modules (that are not using website), ensuring consistency with regular inputs that already use it.

Design-themes: https://github.com/odoo/design-themes/pull/1113
task-4643128

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
