### PR TITLE
[IMP] fleet: manager selection to authorized users

### DIFF
--- a/addons/fleet/models/fleet_vehicle.py
+++ b/addons/fleet/models/fleet_vehicle.py
@@ -40,7 +40,7 @@ class FleetVehicle(models.Model):
     active = fields.Boolean('Active', default=True, tracking=True)
     manager_id = fields.Many2one(
         'res.users', 'Fleet Manager',
-        domain=lambda self: [('all_group_ids', 'in', self.env.ref('fleet.fleet_group_manager').id), ('company_id', 'in', self.env.companies.ids)],
+        domain=lambda self: f"[('share', '=', False), ('company_id', '=', company_id), ('all_group_ids', 'in', {self.env.ref('fleet.fleet_group_user').id})]",
     )
     company_id = fields.Many2one(
         'res.company', 'Company',

--- a/addons/fleet/views/fleet_vehicle_views.xml
+++ b/addons/fleet/views/fleet_vehicle_views.xml
@@ -106,7 +106,7 @@
                                 <field class="o_fleet_odometer_unit" name="odometer_unit"/>
                                 <button name="action_open_odometer_report" type="object" class="fa fa-line-chart me-1" title="Odometer Report"/>
                             </div>
-                            <field name="manager_id" domain="[('share', '=', False), ('company_id', '=', company_id)]" widget="many2one_avatar_user"/>
+                            <field name="manager_id" widget="many2one_avatar_user"/>
                             <field name="location"/>
                             <label string="Make Vehicle Available" for="plan_to_change_car" class="text-nowrap" invisible="vehicle_type != 'car'"/>
                             <field name="plan_to_change_car" groups="fleet.fleet_group_manager" invisible="vehicle_type != 'car'" nolabel="1"


### PR DESCRIPTION
On the Fleet Manager field, show only users who are authorized to manage the vehicle (have access rights to the Fleet app).

task-4903269

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
