### PR TITLE
[IMP] project: rename task_id and name labels in task analysis report

### DIFF
--- a/addons/project/report/project_report.py
+++ b/addons/project/report/project_report.py
@@ -12,7 +12,7 @@ class ReportProjectTaskUser(models.Model):
     _order = 'name desc, project_id'
     _auto = False
 
-    name = fields.Char(string='Task', readonly=True)
+    name = fields.Char(string='Task Title', readonly=True)
     user_ids = fields.Many2many('res.users', relation='project_task_user_rel', column1='task_id', column2='user_id',
                                 string='Assignees', readonly=True)
     create_date = fields.Datetime("Create Date", readonly=True)
@@ -51,7 +51,7 @@ class ReportProjectTaskUser(models.Model):
     company_id = fields.Many2one('res.company', string='Company', readonly=True)
     partner_id = fields.Many2one('res.partner', string='Customer', readonly=True)
     stage_id = fields.Many2one('project.task.type', string='Stage', readonly=True)
-    task_id = fields.Many2one('project.task', string='Tasks', readonly=True)
+    task_id = fields.Many2one('project.task', string='Task', readonly=True)
     tag_ids = fields.Many2many('project.tags', relation='project_tags_project_task_rel',
         column1='project_task_id', column2='project_tags_id',
         string='Tags', readonly=True)


### PR DESCRIPTION
Before this commit, when the user would like to group by task, he cannot know which one is task_id or name fields because the label of those fields is almost equivalent and so it is confusing for the users.

This commit renames the label of the both fields to avoid the confusion.

task-4781777
