### PR TITLE
[FIX] pos_hr: initialize employeeBuffer before super call to avoid error

### DIFF
--- a/addons/pos_hr/static/src/overrides/models/pos_store.js
+++ b/addons/pos_hr/static/src/overrides/models/pos_store.js
@@ -4,6 +4,7 @@ import { browser } from "@web/core/browser/browser";
 
 patch(PosStore.prototype, {
     async setup() {
+        this.employeeBuffer = [];
         await super.setup(...arguments);
         if (this.config.module_pos_hr) {
             this.login = Boolean(odoo.from_backend) && !this.config.module_pos_hr;
@@ -11,7 +12,6 @@ patch(PosStore.prototype, {
                 this.showScreen("LoginScreen");
             }
         }
-        this.employeeBuffer = [];
         browser.addEventListener("online", () => {
             this.employeeBuffer.forEach((employee) =>
                 this.data.write("pos.session", [this.config.current_session_id.id], {


### PR DESCRIPTION
Steps to reproduce:
===================
- Enable Login with Employee in POS settings
- Open POS and log in with employee
- Turn off the internet connection
- Reload the POS page

Issue:
======
- POS crashes with the following error:
`TypeError: Cannot read properties of undefined (reading 'push')`
- At that point, employeeBuffer is still undefined

Cause:
======
- The method `set_cashier()` is triggered during the parent `setup()`
- `employeeBuffer` was only initialized after `super.setup()`
- In offline mode, this sequence still executes, leading to an exception 
when trying to .push() into an undefined buffer

Fix:
====
- Moved the initialization of `employeeBuffer` to the beginning of the 
setup() method

Task: 4850543
Runbot Error: 227777