### PR TITLE
[FIX] html_editor: prevent error when invalid URL format is provided

### DIFF
--- a/addons/html_editor/controllers/main.py
+++ b/addons/html_editor/controllers/main.py
@@ -252,7 +252,10 @@ class HTML_Editor(http.Controller):
             # This approach is beneficial when the URL doesn't conclude with an
             # image extension. By verifying the MIME type, the code ensures that
             # only supported image types are incorporated into the data.
-            response = requests.head(url, timeout=10)
+            try:
+                response = requests.head(url, timeout=10)
+            except requests.exceptions.MissingSchema:
+                raise UserError(_("Invalid URL format. \nPlease provide a valid URL (including http:// or https://)."))
             if response.status_code == 200:
                 mime_type = response.headers.get('content-type')
                 if mime_type in SUPPORTED_IMAGE_MIMETYPES:


### PR DESCRIPTION
Currently, an error occurs when the user adds an invalid URL without a 
scheme (e.g., http:// or https://).

**Steps to produce:**
- Install the `website` module.
- Open the Website app and click `Edit`.
- From the `Categories` section, drag and drop the `Images snippet` onto
  the page. 
- Double-click on the image.
- In the `Documents` tab, enter `'www.kalkiranonlinestore.com'` in the 
 `Add URL` field and click `Add URL`.

**Error:**
**MissingSchema: Invalid URL 'www.kalkiranonlinestore.com': No scheme 
supplied. Perhaps you meant https://www.kalkiranonlinestore.com?**

**Root Cause:**
At [1], the URL is missing a valid scheme (`http:// or https://`), 
causing an error.

[1]
https://github.com/odoo/odoo/blob/9f45d0de54f8349c18cabeb08be95c9b841b98b4/addons/html_editor/controllers/main.py#L255

This commit ensures an error message is raised when the user provides an
invalid URL format.

Sentry – 5967688614