### PR TITLE
[IMP] html_editor: add attribute in links for seo

### DIFF
--- a/addons/html_editor/static/src/main/link/link_plugin.js
+++ b/addons/html_editor/static/src/main/link/link_plugin.js
@@ -464,12 +464,25 @@ export class LinkPlugin extends Plugin {
         const selectionTextContent = selection?.textContent();
         const isImage = !!findInSelection(selection, "img");
 
-        const applyCallback = (url, label, classes, customStyle, linkTarget, attachmentId) => {
+        const applyCallback = (
+            url,
+            label,
+            classes,
+            customStyle,
+            linkTarget,
+            attachmentId,
+            relValue
+        ) => {
             if (this.linkInDocument) {
                 if (url) {
                     this.linkInDocument.href = url;
                 } else {
                     this.linkInDocument.removeAttribute("href");
+                }
+                if (relValue) {
+                    this.linkInDocument.setAttribute("rel", relValue);
+                } else {
+                    this.linkInDocument.removeAttribute("rel");
                 }
                 if (linkTarget) {
                     this.linkInDocument.setAttribute("target", linkTarget);
@@ -509,6 +522,9 @@ export class LinkPlugin extends Plugin {
                             (FONT_SIZE_CLASSES.some((cls) => el.classList.contains(cls)) ||
                                 el.style?.fontSize)
                     );
+                    if (relValue) {
+                        link.setAttribute("rel", relValue);
+                    }
                     const image = isImage && findInSelection(selection, "img");
                     const figure =
                         image?.parentElement?.matches("figure[contenteditable=false]") &&

--- a/addons/html_editor/static/src/main/link/link_popover.js
+++ b/addons/html_editor/static/src/main/link/link_popover.js
@@ -97,6 +97,7 @@ export class LinkPopover extends Component {
             textContent + "/" === linkElement.getAttribute("href");
 
         const computedStyle = this.props.document.defaultView.getComputedStyle(linkElement);
+        const currentRelValues = linkElement.rel.split(" ");
         this.state = useState({
             editing: this.props.LinkPopoverState.editing,
             // `.getAttribute("href")` instead of `.href` to keep relative url
@@ -126,6 +127,29 @@ export class LinkPopover extends Component {
             showReplaceTitleBanner: this.props.showReplaceTitleBanner,
             showLabel: !linkElement.childElementCount,
             stripDomain: true,
+            showAdvancedOptions: false,
+            relAttributeOptions: {
+                nofollow: {
+                    label: "nofollow",
+                    description: _t("Tells search engines not to follow this link"),
+                    isChecked: currentRelValues.includes("nofollow"),
+                },
+                noreferrer: {
+                    label: "noreferrer",
+                    description: _t("Removes referrer information sent to the target site"),
+                    isChecked: currentRelValues.includes("noreferrer"),
+                },
+                sponsored: {
+                    label: "sponsored",
+                    description: _t("Indicates the link is sponsored or paid content"),
+                    isChecked: currentRelValues.includes("sponsored"),
+                },
+                noopener: {
+                    label: "noopener",
+                    description: _t("Prevents the new page from accessing the original window (security)"),
+                    isChecked: currentRelValues.includes("noopener"),
+                },
+            }
         });
 
         const getTargetedElements = () => [this.props.linkElement];
@@ -232,6 +256,15 @@ export class LinkPopover extends Component {
         }
     }
 
+    toggleAdvancedOptions() {
+        this.state.showAdvancedOptions = !this.state.showAdvancedOptions;
+    }
+
+    toggleRelAttr(attr) {
+        const option = this.state.relAttributeOptions[attr];
+        option.isChecked = !option.isChecked;
+    }
+
     onChange() {
         // Apply changes to update the link preview.
         this.props.onChange(
@@ -245,6 +278,10 @@ export class LinkPopover extends Component {
         this.updateDocumentState();
     }
     onClickApply() {
+        const relOptions = this.state.relAttributeOptions;
+        const relValue = Object.keys(relOptions)
+            .filter((key) => relOptions[key].isChecked)
+            .join(" ");
         this.state.editing = false;
         this.applyDeducedUrl();
         this.props.onApply(
@@ -253,7 +290,8 @@ export class LinkPopover extends Component {
             this.classes,
             this.customStyles,
             this.state.linkTarget,
-            this.state.attachmentId
+            this.state.attachmentId,
+            relValue,
         );
     }
     applyDeducedUrl() {
@@ -336,6 +374,9 @@ export class LinkPopover extends Component {
 
     onClickNewWindow(checked) {
         this.state.linkTarget = checked ? "_blank" : "";
+        if (!checked) {
+            this.state.relAttributeOptions.noopener.isChecked = false;
+        }
     }
 
     onClickStripDomain(checked) {

--- a/addons/html_editor/static/src/main/link/link_popover.scss
+++ b/addons/html_editor/static/src/main/link/link_popover.scss
@@ -20,6 +20,30 @@
     }
 }
 
+.o_seo_option_child {
+    padding-left: 20px;
+    position: relative;
+
+    &::before, &::after {
+        content: "";
+        position: absolute;
+        left: 6px;
+        background: #999;
+    }
+
+    &::before {
+        top: 0;
+        height: calc(100% - 14px);
+        width: 1px;
+    }
+
+    &::after {
+        top: 16px;
+        width: 10px;
+        height: 1px;
+    }
+}
+
 .custom-border {
     @include o-input-number-no-arrows();
 

--- a/addons/html_editor/static/src/main/link/link_popover.xml
+++ b/addons/html_editor/static/src/main/link/link_popover.xml
@@ -11,6 +11,39 @@
                     </div>
                 </div>
                 <div t-else="" class="d-flex">
+                    <t t-if="state.showAdvancedOptions">
+                        <div class="o_advance_option_panel">
+                            <div class="o_advance_options_grid" style="width: 200px;">
+                                <button t-if="state.showAdvancedOptions" class="fa fa-angle-left btn btn-secondary border-10" t-on-click="toggleAdvancedOptions"/>
+                                    <t t-foreach="Object.values(state.relAttributeOptions)" t-as="opt" t-key="opt.label">
+                                        <t t-if="opt.label !== 'noopener'">
+                                            <div class="o_seo_option_row d-flex justify-content-between align-items-center py-1 gap-2">
+                                                <span t-att-title="opt.description"><t t-out="opt.label"/></span>
+                                                <CheckBox
+                                                    value="opt.isChecked"
+                                                    onChange="toggleRelAttr.bind(this, opt.label)"/>
+                                            </div>
+                                        </t>
+                                    </t>
+                                <div class="o_seo_option_row d-flex justify-content-between align-items-center py-1 gap-2">
+                                    <span>Open in new tab</span>
+                                    <CheckBox
+                                        value="state.linkTarget === '_blank'"
+                                        onChange="onClickNewWindow.bind(this)"
+                                        className="'target-blank-option'"/>
+                                </div>
+                                <t t-if="state.linkTarget === '_blank'">
+                                    <div class="o_seo_option_row o_seo_option_child d-flex justify-content-between align-items-center py-1 gap-2 ps-4">
+                                        <span>noopener</span>
+                                        <CheckBox
+                                            value="state.relAttributeOptions.noopener.isChecked"
+                                            onChange="toggleRelAttr.bind(this, 'noopener')"/>
+                                    </div>
+                                </t>
+                            </div>
+                        </div>
+                    </t>
+                <t t-else="">
                     <div class="col p-2" style="max-width: 250px;">
                         <div class="input-group mb-1" t-att-class="{'d-none': !state.showLabel}">
                             <input t-ref="label"
@@ -105,14 +138,6 @@
                                     Direct download
                                 </CheckBox>
                             </t>
-                            <t t-if="!state.isDocument || (state.isDocument and !state.directDownload)">
-                                <CheckBox
-                                    value="state.linkTarget === '_blank'"
-                                    onChange="onClickNewWindow.bind(this)"
-                                    className="'target-blank-option'">
-                                    Open in new window
-                                </CheckBox>
-                            </t>
                         </t>
                         <t t-if="props.allowStripDomain and isAbsoluteURLInCurrentDomain()">
                             <CheckBox
@@ -122,13 +147,19 @@
                                 Autoconvert to relative link
                             </CheckBox>
                         </t>
-                        <div class="mt-3">
-                            <button class="o_we_apply_link btn btn-sm btn-primary" t-att-disabled="!state.url" t-on-click="onClickApply">Apply</button>
-                            <button class="o_we_discard_link btn btn-sm btn-dark ms-1" t-on-click="props.onDiscard">Discard</button>
+                        <div class="d-flex justify-content-between align-items-center mt-1">
+                            <div>
+                                <button class="o_we_apply_link btn btn-sm btn-primary" t-att-disabled="!state.url" t-on-click="onClickApply">Apply</button>
+                                <button class="o_we_discard_link btn btn-sm btn-secondary ms-1" t-on-click="props.onDiscard">Discard</button>
+                            </div>
+                            <button class="btn btn-sm btn-secondary" title="Advanced mode" t-att-disabled="!state.url" t-on-click="toggleAdvancedOptions">
+                                <i class="fa fa-gear"/>
+                            </button>
                         </div>
                     </div>
-                </div>
+                </t>
             </div>
+        </div>
             <div t-else="" style="width: 260px;" data-prevent-closing-overlay="true">
                 <div class="d-flex flex-column p-2">
                     <div class="d-flex">

--- a/addons/html_editor/static/tests/link/button.test.js
+++ b/addons/html_editor/static/tests/link/button.test.js
@@ -88,16 +88,6 @@ describe("Custom button style", () => {
         expect(optionsvalues).toInclude("Button Secondary");
         expect(optionsvalues).toInclude("Custom");
     });
-    test("Editor allow target blank style if config is active", async () => {
-        await setupEditor(
-            '<p><a href="https://test.com/">link[]Label</a></p>',
-            allowTargetBlankOpt
-        );
-        await waitFor(".o-we-linkpopover");
-        await click(".o_we_edit_link");
-        await animationFrame();
-        await waitFor(".target-blank-option");
-    });
     test("The link popover should load the current custom format correctly", async () => {
         await setupEditor(
             '<p><a href="https://test.com/" class="btn btn-custom" style="color: rgb(0, 255, 0); background-color: rgb(0, 0, 255); border-width: 4px; border-color: rgb(255, 0, 0); border-style: dotted;">link[]Label</a></p>',
@@ -172,8 +162,11 @@ describe("Custom button style", () => {
         await contains(".o-we-linkpopover input.o_we_href_input_link").edit("http://test.test/", {
             confirm: false,
         });
+        await click(".o-we-linkpopover .fa-gear");
+        await contains(".o_advance_option_panel .target-blank-option").click();
+        await click(".o_advance_option_panel .fa-angle-left");
+        await waitFor(".o-we-linkpopover");
 
-        await click(".target-blank-option input[type='checkbox']");
         await animationFrame();
         await click(".o_we_apply_link");
         await animationFrame();

--- a/addons/html_editor/static/tests/link/popover.test.js
+++ b/addons/html_editor/static/tests/link/popover.test.js
@@ -175,6 +175,78 @@ describe("popover should switch UI depending on editing state", () => {
             '<p>this is a <a href="http://test.com/">linkABCD[]</a></p>'
         );
     });
+    test("should open seo advanced popup when gear icon is clicked", async () => {
+        await setupEditor('<p>this is a <a href="http://test.com/">li[]nk</a></p>');
+        await waitFor(".o-we-linkpopover");
+        await click(".o_we_edit_link");
+        await waitFor(".o_we_href_input_link");
+        await click(".o_we_href_input_link");
+        await click(".o-we-linkpopover .fa-gear");
+        await expectElementCount(".o_advance_option_panel", 1);
+        expect(".o_advance_option_panel .o_seo_option_row").toHaveCount(4);
+    });
+    test("should add rel='nofollow' when checkbox is selected and applied", async () => {
+        const { el } = await setupEditor('<p>this is a <a href="http://test.com/">li[]nk</a></p>');
+        await waitFor(".o-we-linkpopover");
+        await click(".o_we_edit_link");
+        await waitFor(".o_we_href_input_link");
+        await click(".o_we_href_input_link");
+        await click(".o-we-linkpopover .fa-gear");
+        await expectElementCount(".o_advance_option_panel", 1);
+        await contains(".o_seo_option_row:nth-of-type(1) input[type='checkbox']").click();
+        await click(".o_advance_option_panel .fa-angle-left");
+        await waitFor(".o-we-linkpopover");
+        await contains(".o_we_apply_link").click();
+        expect(cleanLinkArtifacts(getContent(el))).toBe(
+            '<p>this is a <a href="http://test.com/" rel="nofollow">li[]nk</a></p>'
+        );
+    });
+    test("should add and remove relAttribute in anchor tag when checkbox is selected and applied", async () => {
+        const { el } = await setupEditor('<p>this is a <a href="http://test.com/">li[]nk</a></p>');
+        await waitFor(".o-we-linkpopover");
+        await click(".o_we_edit_link");
+        await waitFor(".o_we_href_input_link");
+        await click(".o_we_href_input_link");
+        await click(".o-we-linkpopover .fa-gear");
+        await expectElementCount(".o_advance_option_panel", 1);
+        await contains(".o_seo_option_row:nth-of-type(1) input[type='checkbox']").click();
+        await contains(".o_seo_option_row:nth-of-type(2) input[type='checkbox']").click();
+        await contains(".o_seo_option_row:nth-of-type(3) input[type='checkbox']").click();
+        await click(".o_advance_option_panel .fa-angle-left");
+        await waitFor(".o-we-linkpopover");
+        await contains(".o_we_apply_link").click();
+        expect(cleanLinkArtifacts(getContent(el))).toBe(
+            '<p>this is a <a href="http://test.com/" rel="nofollow noreferrer sponsored">li[]nk</a></p>'
+        );
+        await click(".o_we_edit_link");
+        await waitFor(".o_we_href_input_link");
+        await click(".o_we_href_input_link");
+        await click(".o-we-linkpopover .fa-gear");
+        await contains(".o_seo_option_row:nth-of-type(1) input[type='checkbox']").click();
+        await click(".o_advance_option_panel .fa-angle-left");
+        await waitFor(".o-we-linkpopover");
+        await contains(".o_we_apply_link").click();
+        expect(cleanLinkArtifacts(getContent(el))).toBe(
+            '<p>this is a <a href="http://test.com/" rel="noreferrer sponsored">li[]nk</a></p>'
+        );
+    });
+    test("should add _blank attribute on open in a new window is checked", async () => {
+        const { el } = await setupEditor('<p>this is a <a href="http://test.com/">li[]nk</a></p>');
+        await waitFor(".o-we-linkpopover");
+        await click(".o_we_edit_link");
+        await waitFor(".o_we_href_input_link");
+        await click(".o_we_href_input_link");
+        await click(".o-we-linkpopover .fa-gear");
+        await expectElementCount(".o_advance_option_panel", 1);
+        await contains(".o_advance_option_panel .target-blank-option").click();
+        await contains(".o_seo_option_row:nth-of-type(5) input[type='checkbox']").click();
+        await click(".o_advance_option_panel .fa-angle-left");
+        await waitFor(".o-we-linkpopover");
+        await contains(".o_we_apply_link").click();
+        expect (cleanLinkArtifacts(getContent(el))).toBe(
+            '<p>this is a <a href="http://test.com/" rel="noopener" target="_blank">li[]nk</a></p>'
+        );
+    });
 });
 
 describe("popover should edit,copy,remove the link", () => {


### PR DESCRIPTION
Before this commit:-
Users could not add any SEO-related attributes when creating a link in
the HTML editor.

After this commit:
Users can now add SEO-optimized attributes while creating or editing a
link. The available attributes meaning are:

nofollow: Instructs search engines not to follow the link.
noopener: Improves security and performance by preventing the new page
from accessing the original window.
noreferrer: Hides referrer information sent to the target site.
sponsored: Marks the link as sponsored or paid content.

This improvement makes link creation more SEO-friendly and secure.

task-4896906
