### PR TITLE
[FIX] hr_expense: Broken access rights

### DIFF
--- a/addons/hr_expense/models/hr_expense.py
+++ b/addons/hr_expense/models/hr_expense.py
@@ -611,6 +611,13 @@ class HrExpense(models.Model):
                 raise UserError(_('You cannot delete a posted or approved expense.'))
 
     def write(self, vals):
+        if (
+                'state' in vals
+                and vals['state'] != 'submitted'
+                and not (self.env.user.has_group('hr_expense.group_hr_expense_manager') or self.env.su)
+                and any(state == 'draft' for state in self.mapped('state'))
+        ):
+            raise UserError(_("You don't have the rights to bypass the validation process of this expense."))
         expense_to_previous_sheet = {}
         if 'sheet_id' in vals:
             # Check access rights on the sheet

--- a/addons/hr_expense/models/hr_expense_sheet.py
+++ b/addons/hr_expense/models/hr_expense_sheet.py
@@ -342,9 +342,9 @@ class HrExpenseSheet(models.Model):
     @api.depends_context('uid')
     @api.depends('employee_id')
     def _compute_can_approve(self):
-        is_team_approver = self.env.user.has_group('hr_expense.group_hr_expense_team_approver')
-        is_approver = self.env.user.has_group('hr_expense.group_hr_expense_user')
-        is_hr_admin = self.env.user.has_group('hr_expense.group_hr_expense_manager')
+        is_team_approver = self.env.user.has_group('hr_expense.group_hr_expense_team_approver') or self.env.su
+        is_approver = self.env.user.has_group('hr_expense.group_hr_expense_user') or self.env.su
+        is_hr_admin = self.env.user.has_group('hr_expense.group_hr_expense_manager') or self.env.su
 
         for sheet in self:
             reason = False
@@ -489,6 +489,20 @@ class HrExpenseSheet(models.Model):
         return sheets
 
     def write(self, values):
+        # Avoid user with write access on expense sheet in draft state to bypass the validation process
+        is_editing_states = 'state' in values or 'approval_state' in values
+        if is_editing_states:
+            valid_states = {'submit', None}
+            if (
+                    not (self.env.user.has_group('hr_expense.group_hr_expense_manager') or self.env.su)
+                    and any(state == 'draft' for state in self.mapped('state'))
+                    and (values.get('state') not in valid_states or values.get('approval_state') not in valid_states)
+            ):
+                raise UserError(_("You don't have the rights to bypass the validation process of this expense report."))
+            elif values.get('state') == 'approve' or values.get('approval_state') == 'approve':
+                self._check_can_approve()
+            elif values.get('state') == 'cancel' or values.get('approval_state') == 'cancel':
+                self._check_can_refuse()
         res = super().write(values)
 
         user_is_accountant = self.env.user.has_group('account.group_account_user')
@@ -786,14 +800,15 @@ class HrExpenseSheet(models.Model):
 
     def _do_reverse_moves(self):
         self = self.with_context(clean_context(self.env.context))
-        moves = self.account_move_ids
-        draft_moves = moves.filtered(lambda m: m.state == 'draft')
-        non_draft_moves = moves - draft_moves
-        non_draft_moves._reverse_moves(
-            default_values_list=[{'invoice_date': fields.Date.context_today(move), 'ref': False} for move in non_draft_moves],
-            cancel=True
-        )
-        draft_moves.unlink()
+        moves_sudo = self.sudo().account_move_ids
+        if moves_sudo:
+            draft_moves_sudo = moves_sudo.filtered(lambda m: m.state == 'draft')
+            non_draft_moves_sudo = moves_sudo - draft_moves_sudo
+            non_draft_moves_sudo._reverse_moves(
+                default_values_list=[{'invoice_date': fields.Date.context_today(move), 'ref': False} for move in non_draft_moves_sudo],
+                cancel=True
+            )
+            draft_moves_sudo.unlink()
 
     def _calculate_default_accounting_date(self):
         """

--- a/addons/hr_expense/security/ir_rule.xml
+++ b/addons/hr_expense/security/ir_rule.xml
@@ -23,8 +23,17 @@
         <record id="ir_rule_hr_expense_employee" model="ir.rule">
             <field name="name">Employee Expense</field>
             <field name="model_id" ref="model_hr_expense"/>
-            <field name="domain_force">[('employee_id.user_id', '=', user.id)]</field>
+            <field name="domain_force">[('employee_id.user_id', '=', user.id), ('state', 'in', ('draft', 'reported'))]</field>
             <field name="groups" eval="[(4, ref('base.group_user'))]"/>
+        </record>
+        <record id="ir_rule_hr_expense_employee_not_draft" model="ir.rule">
+            <field name="name">Employee can't modify expense that is not in draft state</field>
+            <field name="model_id" ref="model_hr_expense"/>
+            <field name="domain_force">[('employee_id.user_id', '=', user.id), ('state', 'not in', ('draft', 'reported'))]</field>
+            <field name="groups" eval="[(4, ref('base.group_user'))]"/>
+            <field name="perm_create" eval="False"/>
+            <field name="perm_write" eval="False"/>
+            <field name="perm_unlink" eval="False"/>
         </record>
 
         <record id="ir_rule_hr_expense_sheet_manager" model="ir.rule">

--- a/addons/hr_expense/tests/test_expenses_access_rights.py
+++ b/addons/hr_expense/tests/test_expenses_access_rights.py
@@ -26,8 +26,32 @@ class TestExpensesAccessRights(TestExpenseCommon, HttpCase):
                 'employee_id': expense_employee_2.id,
                 'product_id': self.product_a.id,
                 'quantity': 1,
-                'price_unit': 1,
             })
+
+        expense = self.env['hr.expense'].with_user(self.expense_user_employee).create({
+            'name': 'expense_1',
+            'date': '2016-01-01',
+            'product_id': self.product_a.id,
+            'quantity': 10.0,
+            'employee_id': self.expense_employee.id,
+        })
+
+        # The expense employee shouldn't be able to bypass the submit state.
+        with self.assertRaises(UserError):
+            expense.with_user(self.expense_user_employee).state = 'approved'
+
+        # Employee can report & submit their expense
+        expense_sheet = self.env['hr.expense.sheet'].with_user(self.expense_user_employee).create({
+            'name': 'expense sheet for employee',
+            'expense_line_ids': expense,
+            'payment_mode': expense.payment_mode,
+        })
+        expense_sheet.with_user(self.expense_user_employee).action_submit_sheet()
+        self.assertEqual(expense.state, 'submitted')
+
+        # Employee can also revert from the submitted state to a draft state
+        expense_sheet.with_user(self.expense_user_employee).action_reset_expense_sheets()
+        self.assertEqual(expense.state, 'reported')
 
     def test_expense_sheet_access_rights(self):
         # The expense employee is able to a create an expense sheet.
@@ -42,7 +66,7 @@ class TestExpensesAccessRights(TestExpenseCommon, HttpCase):
                 'name': 'expense_1',
                 'date': '2016-01-01',
                 'product_id': self.product_a.id,
-                'price_unit': 1000.0,
+                'quantity': 1000.0,
                 'employee_id': self.expense_employee.id,
             })],
         })
@@ -57,13 +81,17 @@ class TestExpensesAccessRights(TestExpenseCommon, HttpCase):
                 'name': 'expense_1',
                 'date': '2016-01-01',
                 'product_id': self.product_a.id,
-                'price_unit': 1000.0,
+                'quantity': 1000.0,
                 'employee_id': self.expense_employee.id,
             })],
         })
         sheets = expense_sheet_approve | expense_sheet_refuse
 
         self.assertRecordValues(sheets, [{'state': 'draft'}, {'state': 'draft'}])
+
+        # The expense employee shouldn't be able to bypass the submit state.
+        with self.assertRaises(UserError):
+            expense_sheet_approve.with_user(self.expense_user_employee).state = 'approve'
 
         # The expense employee is able to submit the expense sheet.
         sheets.with_user(self.expense_user_employee).action_submit_sheet()
@@ -83,7 +111,11 @@ class TestExpensesAccessRights(TestExpenseCommon, HttpCase):
         expense_sheet_refuse.with_user(self.expense_user_manager)._do_refuse('failed')
         self.assertRecordValues(sheets, [{'state': 'approve'}, {'state': 'cancel'}])
 
-        # An expense manager is not able to post the journal entry.
+        # The expense employee shouldn't be able to modify an approved expense.
+        with self.assertRaises(UserError):
+            expense_sheet_approve.expense_line_ids[0].with_user(self.expense_user_employee).total_amount = 1000.0
+
+        # An expense manager is not able to create the journal entry.
         with self.assertRaises(AccessError):
             expense_sheet_approve.with_user(self.expense_user_manager).action_sheet_move_post()
         self.assertRecordValues(expense_sheet_approve, [{'state': 'approve'}])
@@ -140,7 +172,7 @@ class TestExpensesAccessRights(TestExpenseCommon, HttpCase):
                     'name': 'expense_1',
                     'date': '2016-01-01',
                     'product_id': self.product_a.id,
-                    'price_unit': 1000.0,
+                    'quantity': 1000.0,
                     'employee_id': expense_employee.id,
                 }),
             ],


### PR DESCRIPTION
The state changes right check was only done on specific method but it wasn't check at write level. Which allowed to bypass it.

The record rule on hr_expense_user without a check on the state is in draft allow to change data on approved expense sheets.


forward port : #189360