### PR TITLE
[FIX] html_builder, website: make form option list look like before

### DIFF
--- a/addons/html_builder/static/src/core/building_blocks/builder_list.scss
+++ b/addons/html_builder/static/src/core/building_blocks/builder_list.scss
@@ -1,0 +1,9 @@
+.bl-dropdown-toggle:disabled {
+    cursor: default;
+    border: 1px solid #00000088;
+
+    &:active {
+        background-color: unset;
+        color: unset;
+    }
+}

--- a/addons/html_builder/static/src/core/building_blocks/builder_list.xml
+++ b/addons/html_builder/static/src/core/building_blocks/builder_list.xml
@@ -3,7 +3,7 @@
 
 <t t-name="html_builder.BuilderList">
     <BuilderComponent>
-        <div class="w-100">
+        <div class="w-100 p-2 py-0">
             <t t-if="state.value?.length > 2">
                 <div class="o_we_table_wrapper">
                     <table t-ref="table">
@@ -51,10 +51,39 @@
                     </table>
                 </div>
             </t>
-            <button type="button" class="builder_list_add_item o-hb-btn btn btn-success d-block mt-2 ms-auto"
-                    t-on-click="addItem">
-                <t t-out="props.addItemTitle"/>
-            </button>
+            <div class="o-hb-select-wrapper" t-if="this.allRecords and this.allRecords.length" >
+                <Dropdown state="this.dropdown" menuClass="'o-hb-select-dropdown mt-1'">
+                    <button class="bl-dropdown-toggle o-hb-select-toggle o-hb-btn btn btn-secondary text-start o-dropdown-caret w-100 mx-auto"
+                        t-att-disabled="!this.availableRecords.length">
+                        <span class="w-100"
+                            t-att-title="!this.availableRecords.length ? `You don't have any record to add` : ''"
+                            t-att-style="!this.availableRecords.length ? 'pointer-events: auto; display: inline-block;' : ''">
+                            <t t-out="props.addItemTitle" />
+                        </span>
+                    </button>
+                    <t t-set-slot="content">
+                        <t t-foreach="this.availableRecords" t-as="item" t-key="item.id">
+                                <t t-foreach="Object.entries(props.itemShape).filter(([key, value]) => !value.endsWith('boolean'))" t-as="entry" t-key="entry[0]">
+                                    <div class="o-hb-select-dropdown-item d-flex flex-column cursor-pointer o-dropdown-item dropdown-item o-navigable w-100 mx-auto"
+                                        style="max-height: 50vh;"
+                                        t-att-type="entry[1]"
+                                        t-att-name="entry[0]"
+                                        t-att-data-id="item.id"
+                                        t-on-click="addItem"
+                                    >
+                                        <t t-out="item[entry[0]]" />
+                                    </div>
+                                </t>
+                            </t>
+                    </t>
+                </Dropdown>
+            </div>
+            <t t-else="">
+                <button type="button" class="builder_list_add_item o-hb-btn btn btn-success d-block mt-1 mx-auto w-100"
+                        t-on-click="addItem">
+                    <t t-out="props.addItemTitle"/>
+                </button>
+            </t>
         </div>
     </BuilderComponent>
 </t>

--- a/addons/website/static/src/builder/plugins/form/form_field_option.js
+++ b/addons/website/static/src/builder/plugins/form/form_field_option.js
@@ -117,7 +117,7 @@ export class FormFieldOption extends BaseOptionComponent {
             dependencyEl.nodeName === "TEXTAREA"
         );
     }
-    get isExisingFieldSelectType() {
+    get isExistingFieldSelectType() {
         const el = this.env.getEditingElement();
         return !isFieldCustom(el) && ["selection", "many2one"].includes(el.dataset.type);
     }

--- a/addons/website/static/src/builder/plugins/form/form_option.xml
+++ b/addons/website/static/src/builder/plugins/form/form_option.xml
@@ -213,13 +213,18 @@
             unit="'MB'"
         />
     </BuilderRow>
-    <BuilderRow t-if="state.valueList" label="state.valueList.label">
-        <BuilderList
-            action="'setFormCustomFieldValueList'"
-            addItemTitle="state.valueList.addItemTitle"
-            itemShape="{ display_name: 'text', selected: state.valueList.checkType }"
-            default="{ display_name: state.valueList.defaultItemName, selected: false }"
-        />
+    <BuilderRow t-if="state.valueList">
+        <div class="d-flex flex-column w-100">
+            <p class="hb-row-label mb-0 flex-grow-0 flex-shrink-0 flex-basis-auto">
+                <t t-out="state.valueList.title" />
+            </p>
+            <BuilderList
+                action="'setFormCustomFieldValueList'"
+                addItemTitle="state.valueList.addItemTitle"
+                itemShape="{ display_name: 'text', selected: state.valueList.checkType }"
+                default="{ display_name: state.valueList.defaultItemName, selected: false }"
+                records="state.valueList.availableRecords" />
+        </div>
     </BuilderRow>
     <BuilderRow label.translate="Visibility">
         <BuilderSelect preview="false" action="'setVisibility'">

--- a/addons/website/static/src/builder/plugins/form/form_option.xml
+++ b/addons/website/static/src/builder/plugins/form/form_option.xml
@@ -128,7 +128,7 @@
         </BuilderSelect>
     </BuilderRow>
     <BuilderRow label.translate="Selection type">
-        <BuilderSelect t-if="isExisingFieldSelectType"
+        <BuilderSelect t-if="isExistingFieldSelectType"
             id="'existing_field_select_type_opt'" preview="false" action="'existingFieldSelectType'"
         >
             <BuilderSelectItem actionValue="'many2one'">Dropdown List</BuilderSelectItem>

--- a/addons/website/static/src/builder/plugins/form/form_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/form/form_option_plugin.js
@@ -228,7 +228,10 @@ export class FormOptionPlugin extends Plugin {
         return await this.services.orm.call("ir.model", "get_compatible_form_models");
     }
     async fetchFieldRecords(field) {
-        return this.fieldRecordsCache.preload(field);
+        if (field) {
+            field.records = await this.fieldRecordsCache.preload(field);
+            return field.records;
+        }
     }
     /**
      * Returns a promise which is resolved once the records of the field
@@ -1216,8 +1219,10 @@ export class SetVisibilityDependencyAction extends BuilderAction {
 export class SetFormCustomFieldValueListAction extends BuilderAction {
     static id = "setFormCustomFieldValueList";
     static dependencies = ["websiteFormOption"];
-    apply({ editingElement: fieldEl, value }) {
-        const fields = [];
+    load(context) {
+        return this.dependencies.websiteFormOption.prepareFields(context);
+    }
+    apply({ editingElement: fieldEl, value, loadResult: fields }) {
         let valueList = JSON.parse(value);
         if (getSelect(fieldEl)) {
             valueList = valueList.filter((value) => value.id !== "" || value.display_name !== "");

--- a/addons/website/static/tests/builder/website_builder/form_option.test.js
+++ b/addons/website/static/tests/builder/website_builder/form_option.test.js
@@ -85,6 +85,44 @@ test("change action of form changes available options", async () => {
     expect("div:has(>span:contains('URL')) + div input").toHaveValue("/contactus-thank-you");
 });
 
+test("'Author' field's type stays selected when you modify the option list", async () => {
+    onRpc("get_authorized_fields", () => ({
+        author_id: {
+            name: "author_id",
+            relation: "res.partner",
+            string: "Author",
+            type: "many2one",
+        },
+    }));
+    await setupWebsiteBuilder(
+        `<section class="s_website_form" data-snippet="s_website_form" data-name="Form">
+            <div class="container-fluid">
+            <form action="/website/form/" method="post" class="o_mark_required" data-model_name="mail.mail">
+                <div class="s_website_form_rows">
+                    <div data-name="Field" class="s_website_form_field s_website_form_required" data-type="many2one">
+                        <div class="row">
+                            <label class="s_website_form_label" for="oyeqnysxh10b">
+                                <span class="s_website_form_label_content">Author</span>
+                            </label>
+                        <select class="form-select s_website_form_input" required="" id="oyeqnysxh10b" name="author_id" />
+                        </div>
+                    </div>
+                </div>
+            </form>
+            </div>
+        </section>`
+    );
+
+    await contains(":iframe section span:contains(Author)").click();
+    await contains(".hb-row[data-label='Type'] button.o-dropdown-caret:contains('Author')").click();
+    expect(".o_popover [data-action-value='author_id']").toHaveClass("active");
+    await contains(".hb-row button.o-dropdown-caret:contains('Add New Option')").click();
+    await contains(".o_popover .o-hb-select-dropdown-item").click();
+    // check that the author is still marked as selected
+    await contains(".hb-row[data-label='Type'] button.o-dropdown-caret:contains('Author')").click();
+    expect(".o_popover [data-action-value='author_id']").toHaveClass("active");
+});
+
 test("undo redo add form field", async () => {
     onRpc("get_authorized_fields", () => ({}));
     const { getEditor } = await setupWebsiteBuilder(


### PR DESCRIPTION
Before the [html_builder refactoring], form option list had a dropdown, 
not a button, which was lost in the refactoring.
To see the issue:
- open website and start editing
- drop form and click on it
- click on a field and change its type to author/guest
=> 'Add new option' is a button instead of a dropdown

Related to task-4367641

[html_builder refactoring]: odoo/odoo@9fe45e2b7ddb
