### PR TITLE
[IMP] hw_drivers: add usb to printer name

### DIFF
--- a/addons/hw_drivers/iot_handlers/drivers/PrinterDriver_L.py
+++ b/addons/hw_drivers/iot_handlers/drivers/PrinterDriver_L.py
@@ -71,7 +71,9 @@ class PrinterDriver(Driver):
         super(PrinterDriver, self).__init__(identifier, device)
         self.device_type = 'printer'
         self.device_connection = device['device-class'].lower()
-        self.device_name = device['device-make-and-model']
+        self.connected_by_usb = self.device_connection == 'direct'
+        connection_prefix = "[USB] " if self.connected_by_usb else ""
+        self.device_name = connection_prefix + device['device-make-and-model']
         self.state = {
             'status': 'connecting',
             'message': 'Connecting to printer',
@@ -86,7 +88,6 @@ class PrinterDriver(Driver):
         })
 
         self.receipt_protocol = 'star' if 'STR_T' in device['device-id'] else 'escpos'
-        self.connected_by_usb = self.device_connection == 'direct'
 
         if any(cmd in device['device-id'] for cmd in ['CMD:STAR;', 'CMD:ESC/POS;']):
             self.device_subtype = "receipt_printer"

--- a/addons/hw_drivers/iot_handlers/drivers/PrinterDriver_W.py
+++ b/addons/hw_drivers/iot_handlers/drivers/PrinterDriver_W.py
@@ -40,7 +40,8 @@ class PrinterDriver(Driver):
         super().__init__(identifier, device)
         self.device_type = 'printer'
         self.device_connection = self._compute_device_connection(device)
-        self.device_name = device.get('identifier')
+        connection_prefix = "[USB] " if self.device_connection == 'direct' else ""
+        self.device_name = connection_prefix + device.get('identifier')
         self.printer_handle = device.get('printer_handle')
         self.state = {
             'status': 'connecting',


### PR DESCRIPTION
This PR adds "[USB]" to the printer name to help the user who configures his PoS easily choose the usb printer if needed

Backport of #211238

