### PR TITLE
[FIX] base: prevent child partner remaining location on map using import

### DIFF
--- a/odoo/addons/base/tests/test_res_partner.py
+++ b/odoo/addons/base/tests/test_res_partner.py
@@ -509,6 +509,53 @@ class TestPartnerAddressCompany(TransactionCase):
         p1.write({'street': p1street})
         self.assertEqual(ghoststep.street, ghoststreet, 'Touching contact should never alter parent')
 
+    def test_address_change_latitude_longitude_reset(self):
+        res_partner = self.env['res.partner']
+        parent = res_partner.create({
+            'name': 'Parent',
+            'is_company': True,
+            'street': 'test',
+            'type': 'contact',
+        })
+        child = res_partner.browse(res_partner.name_create('Child <child@ghoststep.com>')[0])
+        self.assertEqual(child.type, 'contact', 'Default type must be "contact"')
+        child.write({'parent_id': parent.id})
+        self.assertEqual(child.street, parent.street, 'Address fields must be synced')
+
+        def set_latitude_longitude():
+            parent.write({
+                'partner_latitude': 10.0,
+                'partner_longitude': 10.0,
+            })
+
+            child.write({
+                'partner_latitude': 10.0,
+                'partner_longitude': 10.0,
+            })
+
+        set_latitude_longitude()
+
+        self.assertEqual(parent.partner_latitude, 10.0)
+        self.assertEqual(parent.partner_longitude, 10.0)
+        self.assertEqual(child.partner_latitude, 10.0)
+        self.assertEqual(child.partner_longitude, 10.0)
+
+        parent.write({'street': 'street'})
+        self.assertEqual(child.street, parent.street, 'Address fields must be synced')
+
+        self.assertEqual(parent.partner_latitude, 0.0)
+        self.assertEqual(parent.partner_longitude, 0.0)
+        self.assertEqual(child.partner_latitude, 0.0)
+        self.assertEqual(child.partner_longitude, 0.0)
+
+        set_latitude_longitude()
+
+        child.write({'street': 'other street'})
+        self.assertEqual(parent.partner_latitude, 10.0)
+        self.assertEqual(parent.partner_longitude, 10.0)
+        self.assertEqual(child.partner_latitude, 0.0)
+        self.assertEqual(child.partner_longitude, 0.0)
+
     def test_address_first_contact_sync(self):
         """ Test initial creation of company/contact pair where contact address gets copied to
         company """


### PR DESCRIPTION
**Issue:**
When importing contacts with incorrect address data, the Map View could display outdated or incorrect markers

**Cause:**
The `partner_latitude` and `partner_longitude` fields were not reset for child contacts when the parent’s address changed
Although an `onchange` exists in `web_map`, the `_delete_coordinates()` method is not triggered for children during parent updates

**Fix:**
We added a `partner_latitude` and `partner_longitude` reset when changing address
We also call `update_address()` on parent `write` to ensure all address-related fields are synchronized

**Limitations:**
One issue remains during import: the parent-child address synchronization is disabled on contact creation
This means children may be created with addresses different from the parent’s and have mismatch positions on Map
This can be corrected by updating or re-importing the parent to trigger synchronization

**Steps to reproduce:**
Create an import file (an example is in on the ticket)
- Add a sheet for the Parent contact with an error on Street
- Add a sheet to add the Child contact with a parent_Id
- Add a sheet to fix the address error on the parent
- Open the contacts app
- Import the Parent and Child sheets (you need to select Related Company / External ID)
- Add a filter to get your created contacts
- Check the Map View (No address is displayed)
- Import the Fix sheet
- Check the Map View (You should see both parent and child)
- Reimport the Parent sheet
- Check the Map View (The children is still there before the fix)

A video can be found on the ticket for clearer importation details

opw-4842910