### PR TITLE
[IMP] web, *: add bottom sheet on small screen

### DIFF
--- a/addons/html_editor/static/src/main/align/align_selector.xml
+++ b/addons/html_editor/static/src/main/align/align_selector.xml
@@ -1,6 +1,6 @@
 <templates xml:space="preserve">
     <t t-name="html_editor.AlignSelector">
-        <Dropdown menuClass="'o-we-toolbar-dropdown'">
+        <Dropdown menuClass="'o-we-toolbar-dropdown'" bottomSheet="false">
             <button class="btn btn-light" t-att-title="props.title" name="text_align">
                 <span class="px-1 d-flex align-items-center">
                     <i t-att-class="`fa fa-align-${state.displayName}`"/>

--- a/addons/html_editor/static/src/main/list/list_selector.xml
+++ b/addons/html_editor/static/src/main/list/list_selector.xml
@@ -1,6 +1,6 @@
 <templates xml:space="preserve">
     <t t-name="html_editor.ListSelector">
-        <Dropdown menuClass="'o-we-toolbar-dropdown'">
+        <Dropdown menuClass="'o-we-toolbar-dropdown'" bottomSheet="false">
             <button class="btn btn-light fa fa-list-ul" t-att-title="props.title" name="list_selector"/>
             <t t-set-slot="content" t-key="props.key.value">
                 <div data-prevent-closing-overlay="true">

--- a/addons/html_editor/static/src/main/table/table_align_selector.xml
+++ b/addons/html_editor/static/src/main/table/table_align_selector.xml
@@ -1,6 +1,6 @@
 <templates xml:space="preserve">
     <t t-name="html_editor.TableAlignSelector">
-        <Dropdown menuClass="'o-we-toolbar-dropdown'">
+        <Dropdown menuClass="'o-we-toolbar-dropdown'" bottomSheet="false">
             <button class="btn btn-light" t-att-title="props.title" name="vertical_align">
                 <t t-set="selectedItem" t-value="items.find(item => item.mode === state.displayName)" />
                 <t t-call="{{ selectedItem ? selectedItem.template : 'html_editor.VerticalAlignTop' }}" />

--- a/addons/html_editor/static/src/main/table/table_menu.xml
+++ b/addons/html_editor/static/src/main/table/table_menu.xml
@@ -1,6 +1,6 @@
 <templates xml:space="preserve">
     <t t-name="html_editor.TableMenu">
-        <Dropdown menuClass="'m-0'" position="props.type === 'column' ? 'bottom' : 'right'" state="props.dropdownState">
+        <Dropdown menuClass="'m-0'" position="props.type === 'column' ? 'bottom' : 'right'" state="props.dropdownState" bottomSheet="false">
             <button t-att-data-type="props.type" class="o-we-table-menu oi" t-attf-class="oi-ellipsis-{{props.type === 'column' ? 'h w-100' : 'v h-100 px-0'}}" />
             <t t-set-slot="content">
                 <div t-on-pointerdown.stop="() => {}">

--- a/addons/html_editor/static/tests/image.test.js
+++ b/addons/html_editor/static/tests/image.test.js
@@ -201,34 +201,34 @@ test("Can change the padding of an image", async () => {
 
     await click(".o-we-toolbar div[name='image_padding'] .dropdown-toggle");
     await animationFrame();
-    await click(".o_popover span:contains('Small')");
+    await click(".o-dropdown--menu span:contains('Small')");
     await animationFrame();
     expect("img").toHaveClass("p-1");
 
     await click(".o-we-toolbar div[name='image_padding'] .dropdown-toggle");
     await animationFrame();
-    await click(".o_popover span:contains('Medium')");
+    await click(".o-dropdown--menu span:contains('Medium')");
     await animationFrame();
     expect("img").not.toHaveClass("p-1");
     expect("img").toHaveClass("p-2");
 
     await click(".o-we-toolbar div[name='image_padding'] .dropdown-toggle");
     await animationFrame();
-    await click(".o_popover span:contains('Large')");
+    await click(".o-dropdown--menu span:contains('Large')");
     await animationFrame();
     expect("img").not.toHaveClass("p-2");
     expect("img").toHaveClass("p-3");
 
     await click(".o-we-toolbar div[name='image_padding'] .dropdown-toggle");
     await animationFrame();
-    await click(".o_popover span:contains('XL')");
+    await click(".o-dropdown--menu span:contains('XL')");
     await animationFrame();
     expect("img").not.toHaveClass("p-3");
     expect("img").toHaveClass("p-5");
 
     await click(".o-we-toolbar div[name='image_padding'] .dropdown-toggle");
     await animationFrame();
-    await click(".o_popover span:contains('None')");
+    await click(".o-dropdown--menu span:contains('None')");
     await animationFrame();
     expect("img").not.toHaveClass("p-5");
 });
@@ -242,7 +242,7 @@ test("Can undo the image padding", async () => {
 
     await click(".o-we-toolbar div[name='image_padding'] .dropdown-toggle");
     await animationFrame();
-    await click(".o_popover span:contains('Small')");
+    await click(".o-dropdown--menu span:contains('Small')");
     await animationFrame();
     expect("img").toHaveClass("p-1");
 

--- a/addons/mail/static/src/core/web/activity_menu.xml
+++ b/addons/mail/static/src/core/web/activity_menu.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
 <t t-name="mail.ActivityMenu">
-    <Dropdown position="'bottom-end'" state="dropdown" beforeOpen.bind="onBeforeOpen" menuClass="discussSystray.menuClass">
+    <Dropdown position="'bottom-end'" state="dropdown" beforeOpen.bind="onBeforeOpen" menuClass="discussSystray.menuClass" bottomSheet="false">
         <button>
             <i class="fa fa-lg fa-clock-o" role="img" aria-label="Activities"></i>
             <span t-if="store.activityCounter" class="o-mail-ActivityMenu-counter badge rounded-pill"><t t-esc="store.activityCounter"/></span>

--- a/addons/mail/static/src/core/web/messaging_menu_patch.xml
+++ b/addons/mail/static/src/core/web/messaging_menu_patch.xml
@@ -3,7 +3,7 @@
     <t t-inherit="mail.MessagingMenu" t-inherit-mode="extension">
         <xpath expr="//*[@t-name='mail.MessagingMenu']" position="inside">
             <div t-if="!env.inDiscussApp" t-att-class="discussSystray.class">
-                <Dropdown state="dropdown" beforeOpen.bind="beforeOpen" position="'bottom-end'" menuClass="discussSystray.menuClass">
+                <Dropdown state="dropdown" beforeOpen.bind="beforeOpen" position="'bottom-end'" menuClass="discussSystray.menuClass" bottomSheet="false">
                     <button class="bg-transparent">
                         <i class="fa fa-lg fa-comments" role="img" aria-label="Messages" t-on-click="() => store.discuss.activeTab = ui.isSmall and store.discuss.activeTab === 'main' ? 'main' : store.discuss.activeTab"></i>
                         <span t-if="counter" class="o-mail-MessagingMenu-counter badge rounded-pill"><t t-esc="counter"/></span>

--- a/addons/web/static/src/core/bottom_sheet/bottom_sheet.js
+++ b/addons/web/static/src/core/bottom_sheet/bottom_sheet.js
@@ -1,0 +1,318 @@
+/**
+ * BottomSheet
+ *
+ * @class
+ */
+import { Component, useState, useRef, onMounted, useExternalListener } from "@odoo/owl";
+import { useHotkey } from "@web/core/hotkeys/hotkey_hook";
+import { useForwardRefToParent } from "@web/core/utils/hooks";
+import { useThrottleForAnimation } from "@web/core/utils/timing";
+import { compensateScrollbar } from "@web/core/utils/scrolling";
+import { getViewportDimensions, useViewportChange } from "@web/core/utils/dvu";
+import { clamp } from "@web/core/utils/numbers";
+import { browser } from "@web/core/browser/browser";
+
+export class BottomSheet extends Component {
+    static template = "web.BottomSheet";
+
+    static defaultProps = {
+        class: "",
+    };
+
+    static props = {
+        // Main props
+        component: { type: Function },
+        componentProps: { optional: true, type: Object },
+        close: { type: Function },
+
+        class: { optional: true },
+        role: { optional: true, type: String },
+
+        // Technical props
+        ref: { optional: true, type: Function },
+        slots: { optional: true, type: Object },
+    };
+
+    setup() {
+        this.maxHeightPercent = 90;
+
+        this.state = useState({
+            isPositionedReady: false, // Sheet is ready for display
+            isSnappingEnabled: false,
+            isDismissing: false, // Sheet is being dismissed
+            progress: 0, // Visual progress (0-1)
+        });
+
+        // Measurements and configuration
+        this.measurements = {
+            viewportHeight: 0,
+            naturalHeight: 0,
+            maxHeight: 0,
+            dismissThreshold: 0,
+        };
+
+        // Popover Ref Requirement
+        useForwardRefToParent("ref");
+
+        // References
+        this.containerRef = useRef("container");
+        this.scrollRailRef = useRef("scrollRail");
+        this.sheetRef = useRef("sheet");
+        this.sheetBodyRef = useRef("ref");
+
+        // Create throttled version for onScroll
+        this.throttledOnScroll = useThrottleForAnimation(this.onScroll.bind(this));
+
+        // Adapt dimensions when mobile virtual-keyboards or browsers bars toggle
+        useViewportChange(() => {
+            if (this.state.isPositionedReady && !this.state.isDismissing) {
+                this.updateDimensions();
+            }
+        });
+
+        // Handle "ESC" key press.
+        useHotkey("escape", () => this.slideOut());
+
+        // Handle mobile "back" gesture and "back" navigation button.
+        // Push a history state when the BottomSheet opens, intercept the browser's
+        // history events, prevents navigation by pushing another state and closes the sheet.
+        window.history.pushState({ bottomSheet: true }, "");
+        this.handlePopState = () => {
+            if (this.state.isPositionedReady && !this.state.isDismissing) {
+                window.history.pushState({ bottomSheet: true }, "");
+                this.slideOut();
+            }
+        };
+        useExternalListener(window, "popstate", this.handlePopState);
+
+        onMounted(() => {
+            const isReduced =
+                browser.matchMedia(`(prefers-reduced-motion: reduce)`) === true ||
+                browser.matchMedia(`(prefers-reduced-motion: reduce)`).matches === true;
+
+            this.prefersReducedMotion =
+                isReduced || getComputedStyle(this.containerRef.el).animationName === "none";
+
+            this.initializeSheet();
+            compensateScrollbar(this.scrollRailRef.el, true, true, "padding-right");
+        });
+    }
+
+    /**
+     * Main initialization method for the sheet
+     * Sets up measurements, snap points, and event handlers
+     */
+    initializeSheet() {
+        if (!this.containerRef.el || !this.scrollRailRef.el || !this.sheetRef.el) {
+            return;
+        }
+
+        // Step 1: Take measurements
+        this.measureDimensions();
+
+        // Step 2: Apply Dimensions
+        this.applyDimensions();
+
+        // Step 3: Set initial position
+        this.positionSheet();
+
+        // Step 4: Setup event handlers after everything has been properly resized and positioned
+        this.setupEventHandlers();
+
+        // Step 5: Mark as ready
+        this.state.isPositionedReady = true;
+
+        if (this.prefersReducedMotion) {
+            this.state.isSnappingEnabled = true;
+        } else {
+            this.sheetRef.el?.addEventListener(
+                "animationend",
+                () => (this.state.isSnappingEnabled = true),
+                {
+                    once: true,
+                }
+            );
+            this.sheetRef.el?.addEventListener(
+                "animationcancel",
+                () => (this.state.isSnappingEnabled = true),
+                {
+                    once: true,
+                }
+            );
+        }
+    }
+
+    /**
+     * Updates dimensions when viewport changes
+     * Recalculates measurements and snap points while preserving extended state
+     */
+    updateDimensions() {
+        // Temporarily disable snapping during update
+        this.state.isSnappingEnabled = false;
+
+        // Update measurements with new viewport dimensions
+        this.measureDimensions();
+        this.applyDimensions();
+
+        // // Update scroll position
+        const scrollTop = this.scrollRailRef.el.scrollTop;
+
+        // Update progress value
+        this.updateProgressValue(scrollTop);
+    }
+
+    /**
+     * Takes measurements of viewport and sheet dimensions
+     * Calculates natural height and other key measurements
+     */
+    measureDimensions() {
+        const viewportHeight = getViewportDimensions().height;
+
+        // Calculate heights based on percentages
+        const maxHeightPx = (this.maxHeightPercent / 100) * viewportHeight;
+
+        // Reset any previously set constraints to measure natural height
+        const sheet = this.sheetRef.el;
+        sheet.style.removeProperty("min-height");
+        sheet.style.removeProperty("height");
+        sheet.style.maxHeight = "none";
+
+        const naturalHeight = sheet.offsetHeight;
+        const initialHeightPx = Math.min(naturalHeight, maxHeightPx);
+
+        // Store all measurements
+        this.measurements = {
+            viewportHeight,
+            naturalHeight,
+            initialHeight: initialHeightPx,
+            maxHeight: maxHeightPx,
+            dismissThreshold: Math.min(initialHeightPx * 0.3, 100),
+        };
+    }
+
+    /**
+     * Applies calculated dimensions to the DOM elements
+     * Sets CSS variables and styles based on measurements and snap points
+     */
+    applyDimensions() {
+        const rail = this.scrollRailRef.el;
+
+        // Convert heights to dvh percentages for CSS variables
+        const heightPercent = Math.min(
+            (this.measurements.initialHeight / this.measurements.viewportHeight) * 100,
+            this.maxHeightPercent
+        );
+
+        // Set CSS variables for heights
+        rail.style.setProperty("--sheet-height", `${heightPercent}dvh`);
+        rail.style.setProperty("--sheet-max-height", `${this.maxHeightPercent}dvh`);
+        rail.style.setProperty("--dismiss-height", `${this.measurements.initialHeight || 0}px`);
+    }
+
+    /**
+     * Sets the initial position of the sheet
+     * Configures initial scroll position and overflow behavior
+     */
+    positionSheet() {
+        const scrollRail = this.scrollRailRef.el;
+        const bodyContent = this.sheetBodyRef.el;
+
+        const scrollValue = this.measurements.maxHeight;
+
+        // Configure body content overflow
+        if (bodyContent) {
+            bodyContent.style.overflowY = "auto";
+        }
+
+        // Set scroll position
+        scrollRail.scrollTop = scrollValue || 0;
+        scrollRail.style.containerType = "scroll-state size";
+    }
+
+    /**
+     * Sets up event handlers for scroll and touch events
+     */
+    setupEventHandlers() {
+        const scrollRail = this.scrollRailRef.el;
+
+        // Add scroll event listener
+        scrollRail.addEventListener("scroll", this.throttledOnScroll);
+    }
+
+    /**
+     * Handles scroll events on the rail element
+     * Updates progress, handles position snapping, and triggers dismissal
+     */
+    onScroll() {
+        if (!this.scrollRailRef.el) {
+            return;
+        }
+
+        const scrollTop = this.scrollRailRef.el.scrollTop;
+
+        // Update progress value for visual effects
+        this.updateProgressValue(scrollTop);
+
+        // Check for dismissal condition
+        if (scrollTop < this.measurements.dismissThreshold) {
+            this.slideOut();
+        }
+    }
+
+    /**
+     * Calculates and updates the progress value based on scroll position
+     *
+     * @param {number} scrollTop - Current scroll position
+     */
+    updateProgressValue(scrollTop) {
+        const initialPosition = this.measurements.naturalHeight;
+        const progress = clamp(scrollTop / initialPosition, 0, 1);
+
+        if (Math.abs(this.state.progress - progress) > 0.01) {
+            this.state.progress = progress;
+        }
+    }
+
+    /**
+     * Initiates the slide out animation and dismissal
+     */
+    slideOut() {
+        // Prevent duplicate calls
+        if (this.state.isDismissing) {
+            return;
+        }
+
+        if (this.prefersReducedMotion) {
+            this.props.close?.();
+        } else {
+            this.sheetRef.el?.addEventListener("animationend", () => this.props.close?.(), {
+                once: true,
+            });
+            this.sheetRef.el?.addEventListener("animationcancel", () => this.props.close?.(), {
+                once: true,
+            });
+        }
+
+        // Update state to trigger animation
+        this.state.isDismissing = true;
+        this.state.isSnappingEnabled = false;
+    }
+
+    /**
+     * Closes the sheet (public API)
+     */
+    close() {
+        this.slideOut();
+    }
+
+    /**
+     * Handles back button press (public API)
+     */
+    back() {
+        if (this.props.onBack) {
+            this.props.onBack();
+        } else {
+            this.slideOut();
+        }
+    }
+}

--- a/addons/web/static/src/core/bottom_sheet/bottom_sheet.scss
+++ b/addons/web/static/src/core/bottom_sheet/bottom_sheet.scss
@@ -1,0 +1,308 @@
+.o_bottom_sheet {
+    // =============================================
+    // Layout and inner elements
+    // =============================================
+    --BottomSheet-slideIn-duration: #{$o_BottomSheet_slideIn_duration};
+    --BottomSheet-slideIn-easing: #{$o_BottomSheet_slideIn_easing};
+    --BottomSheet-slideOut-duration: #{$o_BottomSheet_slideOut_duration};
+    --BottomSheet-slideOut-easing: #{$o_BottomSheet_slideOut_easing};
+
+    --BottomSheet-Sheet-borderColor: #{$o_BottomSheet_Sheet_borderColor};
+
+    @mixin has-more-content-visual {
+        content: "";
+        position: fixed;
+        inset: auto 0 0;
+        height: map-get($spacers, 4);
+        background: linear-gradient(transparent, #00000050);
+        z-index: $zindex-offcanvas;
+        pointer-events: none;
+    }
+
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 100dvh;
+    z-index: $zindex-offcanvas;
+    opacity: 0;
+    transform-style: preserve-3d;
+    contain: layout paint size;
+
+    // Workaround
+    animation-name: has-animation;
+    @media (prefers-reduced-motion: reduce) {
+        animation-name: none;
+    }
+
+    // Main scroll container for gesture handling
+    .o_bottom_sheet_rail {
+        @include o-position-absolute(0, 0, 0, 0);
+        overflow-y: auto;
+        scrollbar-width: none;
+        -ms-overflow-style: none;
+        touch-action: pan-y;
+        pointer-events: auto;
+
+        &::-webkit-scrollbar {
+            display: none;
+        }
+
+        &.o_bottom_sheet_rail_prevent_overscroll,
+        &.o_bottom_sheet_rail_prevent_overscroll * {
+            overscroll-behavior: contain;
+        }
+
+        &::after {
+            @include has-more-content-visual;
+            opacity: 0;
+            transition: opacity var(--BottomSheet-slideIn-duration, 500ms);
+        }
+    }
+
+    // Set snapping behaviors
+    .o_bottom_sheet_dismiss, .o_bottom_sheet_spacer, .o_bottom_sheet_sheet {
+        scroll-snap-align: start;
+        scroll-snap-stop: always;
+    }
+
+    // Backdrop overlay
+    .o_bottom_sheet_backdrop {
+        position: fixed;
+        inset: 0;
+        background-color: rgba($modal-backdrop-bg, $modal-backdrop-opacity);
+        opacity: 0;
+        transition: all 0.2s ease;
+        pointer-events: auto;
+        touch-action: none;
+        z-index: $zindex-offcanvas - 1;
+        backdrop-filter: blur(0px) grayscale(0%);
+        @media (prefers-reduced-motion: reduce) {
+            transition: none;
+        }
+    }
+
+    // Dismiss area
+    .o_bottom_sheet_dismiss {
+        height: var(--dismiss-height, 50dvh);
+    }
+
+    // Spacer area
+    .o_bottom_sheet_spacer {
+        height: calc(100dvh - var(--sheet-height, 50dvh));
+        pointer-events: none;
+    }
+
+    // The actual sheet
+    .o_bottom_sheet_sheet {
+        --offcanvas-box-shadow: #{$box-shadow};
+
+        margin: 0 auto;
+        min-height: var(--sheet-height);
+        max-height: var(--sheet-max-height, 90dvh);
+        border-radius: $border-radius-xl $border-radius-xl 0 0;
+        border-bottom-width: 0;
+        visibility: visible;
+        transition: none;
+        contain: content;
+        backface-visibility: hidden;
+        perspective: 1000px;
+        user-select: none;
+        background-color: $dropdown-bg;
+
+        .o_bottom_sheet_body {
+            overflow-y: hidden; // Initially hidden, will be 'auto' when extended
+            scrollbar-width: none;
+            -ms-overflow-style: none;
+            flex: 1;
+        }
+    }
+
+    // =============================================
+    // States
+    // =============================================
+    @keyframes bottom-sheet-in {
+        from { transform: translateY(100%) translateZ(0); }
+        to { transform: translateY(0) translateZ(0); }
+    }
+
+    @keyframes bottom-sheet-out {
+        from { transform: translateY(0) translateZ(0); }
+        to { transform: translateY(100%) translateZ(0); }
+    }
+
+    // BottomSheet is ready to be rendered on screen
+    &.o_bottom_sheet_ready {
+        opacity: 1;
+
+        .o_bottom_sheet_sheet {
+            animation: var(--BottomSheet-slideIn-duration, 500ms) bottom-sheet-in var(--BottomSheet-slideIn-easing, ease-out) forwards;
+            @media (prefers-reduced-motion: reduce) {
+                animation: none;
+            }
+        }
+
+        .o_bottom_sheet_backdrop {
+            opacity: MAX(var(--BottomSheet-progress, 0), 0.2);
+            backdrop-filter: blur(.5px) grayscale(50%);
+        }
+    }
+
+    // User interactions are now allowed
+    &.o_bottom_sheet_snapping .o_bottom_sheet_rail {
+        // Enable snap behavior
+        scroll-snap-type: y mandatory;
+
+        .o_bottom_sheet_backdrop {
+            transition: none;
+        }
+
+        // Provide a visual safenet in case of elastic
+        // overscroll (mostly iOS).
+        &:before {
+            position: fixed;
+            inset: auto auto 0 50%;
+            height: calc(var(--sheet-height) - #{$border-radius-xl * 2});
+            width: calc(100% - #{$border-width * 2});
+            max-width: map-get($grid-breakpoints, sm) - ($border-width * 2);
+            background: $offcanvas-bg-color;
+            z-index: $zindex-offcanvas;
+            transform: translateY(calc((1 - var(--BottomSheet-progress)) * 150%)) translateX(-50%);
+            content: "";
+        }
+
+        &::after {
+            @container scroll-state(scrollable: bottom) {
+                opacity: 1;
+            }
+        }
+    }
+
+    // Dismissing the sheet
+    &.o_bottom_sheet_dismissing {
+        .o_bottom_sheet_sheet {
+            animation: var(--BottomSheet-slideOut-duration, 300ms) bottom-sheet-out var(--BottomSheet-slideOut-easing, ease-in) forwards;
+            @media (prefers-reduced-motion: reduce) {
+                animation: none;
+            }
+        }
+
+        .o_bottom_sheet_backdrop {
+            opacity: 0;
+            backdrop-filter: blur(0) grayscale(0%);
+            transition: all var(--BottomSheet-slideOut-duration, 300ms) var(--BottomSheet-slideOut-easing, ease-in);
+            @media (prefers-reduced-motion: reduce) {
+                transition: none;
+            }
+        }
+    }
+
+    // When bottom sheet is open, apply styles to the body
+    @at-root .bottom-sheet-open {
+        overflow: hidden;
+
+        // Scale down the main content
+        .o_navbar, .o_action_manager {
+            transition: transform $o_BottomSheet_slideIn_duration ease;
+            transform: scale(.95) translateZ(0);
+            transform-origin: center top;
+            @media (prefers-reduced-motion: reduce) {
+                transition: none;
+            }
+        }
+
+        // Avoid blank on the side
+        &:not(.o_home_menu_background) .o_main_navbar {
+            box-shadow: 20px 0 0 $o-navbar-background, -20px 0 0 $o-navbar-background;
+        }
+
+        &:not(.bottom-sheet-open-multiple):has(.o_bottom_sheet_dismissing) {
+            .o_navbar, .o_action_manager {
+                transition: transform $o_BottomSheet_slideOut_duration ease;
+                transform: scale(1) translateZ(0);
+                @media (prefers-reduced-motion: reduce) {
+                    transition: none;
+                }
+            }
+        }
+    }
+}
+
+// =============================================
+// Inner components design
+// =============================================
+.o_bottom_sheet .o_bottom_sheet_sheet {
+    --BottomSheet-Entry-paddingX: #{$list-group-item-padding-x};
+
+    %BottomSheet-Entry-active {
+        position: relative;
+        border: $border-width solid $list-group-active-border-color;
+        border-radius: $border-radius-lg;
+        color: color-contrast($component-active-bg);
+
+        &:not(.focus) {
+            background: rgba($component-active-bg, .5);
+        }
+
+        &::before {
+            content: none !important;
+        }
+
+        &::after {
+            @include o-position-absolute(50%, $list-group-item-padding-x);
+            transform: translateY(-50%);
+            color: $o-action;
+            // .fa
+            text-rendering: auto;
+            font: normal normal normal 14px/1 FontAwesome;
+            // .fa-check
+            content: "";
+        }
+    }
+
+    // TreeEntry
+    --treeEntry-padding-v: 1.4rem;
+
+    // Dropdown
+    .dropdown-divider {
+        --dropdown-divider-bg: #{$border-color};
+        margin: map-get($spacers, 2) ($offcanvas-padding-x * .5);
+    }
+
+    .dropdown-item, .dropdown-header {
+        --dropdown-item-padding-y: #{map-get($spacers, 3)};
+        --dropdown-item-padding-x: var(--BottomSheet-Entry-paddingX);
+
+        font-size: $h5-font-size;
+        font-weight: $o-font-weight-medium;
+    }
+
+    .o_bottom_sheet_body:not(.o_custom_bottom_sheet) {
+        // Dropdown
+        .dropdown-item {
+            &.active, &.selected {
+                @extend %BottomSheet-Entry-active;
+            }
+        }
+    }
+
+    .o_accordion_toggle {
+        &::after {
+            // Reset original style
+            border: unset;
+            transform: unset;
+
+            @include o-position-absolute(var(--dropdown-item-padding-y), $list-group-item-padding-x);
+            padding-block: map-get($spacers, 2);
+            // .fa
+            text-rendering: auto;
+            font: normal normal normal 14px/1 FontAwesome;
+            // .fa-caret-down
+            content: "\f0d7";
+        }
+        &.open::after {
+            // .fa-caret-up
+            content: "\f0d8";
+        }
+    }
+}

--- a/addons/web/static/src/core/bottom_sheet/bottom_sheet.variables.scss
+++ b/addons/web/static/src/core/bottom_sheet/bottom_sheet.variables.scss
@@ -1,0 +1,8 @@
+
+$o_BottomSheet_Sheet_borderColor: transparent !default;
+
+$o_BottomSheet_slideIn_duration: 400ms !default;
+$o_BottomSheet_slideIn_easing: $o-easing-enter !default;
+
+$o_BottomSheet_slideOut_duration: 200ms !default;
+$o_BottomSheet_slideOut_easing: $o-easing-exit !default;

--- a/addons/web/static/src/core/bottom_sheet/bottom_sheet.xml
+++ b/addons/web/static/src/core/bottom_sheet/bottom_sheet.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+    <t t-name="web.BottomSheet">
+        <div
+            class="o_bottom_sheet"
+            t-att-class="{
+                'o_bottom_sheet_ready': state.isPositionedReady,
+                'o_bottom_sheet_dismissing': state.isDismissing,
+                'o_bottom_sheet_snapping': state.isSnappingEnabled,
+            }"
+            t-attf-style="--BottomSheet-progress: {{state.progress}}"
+            t-ref="container"
+            >
+            <!-- Scroll container that handles drag gestures -->
+            <div
+                class="o_bottom_sheet_rail"
+                t-att-class="{
+                        o_bottom_sheet_rail_prevent_overscroll : props.preventDismissOnContentScroll
+                    }"
+                t-ref="scrollRail"
+                >
+                <!-- Backdrop overlay -->
+                <div class="o_bottom_sheet_backdrop" t-on-click="slideOut"/>
+
+                <!-- Dismiss area - used for scroll snap -->
+                <div class="o_bottom_sheet_dismiss"/>
+
+                <!-- Spacer area - used for scroll snap -->
+                <div class="o_bottom_sheet_spacer"/>
+
+                <!-- Sheet container -->
+                <div
+                    class="o_bottom_sheet_sheet offcanvas position-relative overflow-hidden"
+                    role="dialog"
+                    t-ref="sheet"
+                    >
+
+                    <!-- Handle bar -->
+                    <div
+                        tabindex="-1"
+                        role="button"
+                        class="o_bottom_sheet_handle text-center d-flex align-items-center justify-content-center opacity-50 pt-2 pb-1"
+                        t-on-click.stop="slideOut"
+                        >
+                        <div class="o_bottom_sheet_handle_bar pt-1 mx-auto rounded-pill d-inline-block px-5 bg-dark"/>
+                    </div>
+
+                    <!-- Body content -->
+                    <div
+                        class="o_bottom_sheet_body offcanvas-body"
+                        role="menu"
+                        t-att-class="props.class"
+                        t-ref="ref"
+                        >
+
+                        <!-- Render dynamic component if provided -->
+                        <t t-if="props.component">
+                            <t t-component="props.component" t-props="props.componentProps || {}"/>
+                        </t>
+
+                        <!-- Render slot content if provided -->
+                        <t t-else="">
+                            <t t-slot="default" close="close" back="back"/>
+                        </t>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </t>
+</templates>

--- a/addons/web/static/src/core/bottom_sheet/bottom_sheet_service.js
+++ b/addons/web/static/src/core/bottom_sheet/bottom_sheet_service.js
@@ -1,0 +1,71 @@
+import { markRaw } from "@odoo/owl";
+import { BottomSheet } from "@web/core/bottom_sheet/bottom_sheet";
+import { registry } from "@web/core/registry";
+
+/**
+ * @typedef {{
+ *   env?: object;
+ *   onClose?: () => void;
+ *   class?: string;
+ *   role?: string;
+ *   ref?: Function;
+ *   useBottomSheet?: Boolean;
+ * }} PopoverServiceAddOptions
+ *
+ * @typedef {ReturnType<popoverService["start"]>["add"]} PopoverServiceAddFunction
+ */
+
+export const popoverService = {
+    dependencies: ["overlay"],
+    start(_, { overlay }) {
+        let bottomSheetCount = 0;
+        /**
+         * Signals the manager to add a popover.
+         *
+         * @param {HTMLElement} target
+         * @param {typeof import("@odoo/owl").Component} component
+         * @param {object} [props]
+         * @param {PopoverServiceAddOptions} [options]
+         * @returns {() => void}
+         */
+        const add = (target, component, props = {}, options = {}) => {
+            function removeAndUpdateCount() {
+                _remove();
+                bottomSheetCount--;
+                if (bottomSheetCount === 0) {
+                    document.body.classList.remove("bottom-sheet-open");
+                } else if (bottomSheetCount === 1) {
+                    document.body.classList.remove("bottom-sheet-open-multiple");
+                }
+            }
+            const _remove = overlay.add(
+                BottomSheet,
+                {
+                    close: removeAndUpdateCount,
+                    component,
+                    componentProps: markRaw(props),
+                    ref: options.ref,
+                    class: options.class,
+                    role: options.role,
+                },
+                {
+                    env: options.env,
+                    onRemove: options.onClose,
+                    rootId: target.getRootNode()?.host?.id,
+                }
+            );
+            bottomSheetCount++;
+            if (bottomSheetCount === 1) {
+                document.body.classList.add("bottom-sheet-open");
+            } else if (bottomSheetCount > 1) {
+                document.body.classList.add("bottom-sheet-open-multiple");
+            }
+
+            return removeAndUpdateCount;
+        };
+
+        return { add };
+    },
+};
+
+registry.category("services").add("bottom_sheet", popoverService);

--- a/addons/web/static/src/core/browser/browser.js
+++ b/addons/web/static/src/core/browser/browser.js
@@ -55,6 +55,7 @@ export const browser = {
     innerWidth: window.innerWidth,
     ontouchstart: window.ontouchstart,
     BroadcastChannel: window.BroadcastChannel,
+    visualViewport: window.visualViewport,
 };
 
 Object.defineProperty(browser, "location", {

--- a/addons/web/static/src/core/browser/feature_detection.js
+++ b/addons/web/static/src/core/browser/feature_detection.js
@@ -73,3 +73,7 @@ export function hasTouch() {
 export function maxTouchPoints() {
     return browser.navigator.maxTouchPoints || 1;
 }
+
+export function isVirtualKeyboardSupported() {
+    return "virtualKeyboard" in browser.navigator;
+}

--- a/addons/web/static/src/core/dropdown/dropdown.scss
+++ b/addons/web/static/src/core/dropdown/dropdown.scss
@@ -119,3 +119,11 @@
         }
     }
 }
+
+.o_bottom_sheet .o_bottom_sheet_body.dropdown-menu {
+    --dropdown-border-width: 0;
+    --dropdown-box-shadow: none;
+
+    position: static;
+    max-height: unset;
+}

--- a/addons/web/static/src/core/popover/popover_hook.js
+++ b/addons/web/static/src/core/popover/popover_hook.js
@@ -53,7 +53,12 @@ export function makePopover(addFn, component, options) {
  * @returns {PopoverHookReturnType}
  */
 export function usePopover(component, options = {}) {
-    const popoverService = useService("popover");
+    let service;
+    if (options.useBottomSheet) {
+        service = useService("bottom_sheet");
+    } else {
+        service = useService("popover");
+    }
     const owner = useComponent();
     const newOptions = Object.create(options);
     newOptions.onClose = () => {
@@ -61,7 +66,7 @@ export function usePopover(component, options = {}) {
             options.onClose?.();
         }
     };
-    const popover = makePopover(popoverService.add, component, newOptions);
+    const popover = makePopover(service.add, component, newOptions);
     onWillUnmount(popover.close);
     return popover;
 }

--- a/addons/web/static/src/core/popover/popover_service.js
+++ b/addons/web/static/src/core/popover/popover_service.js
@@ -13,7 +13,7 @@ import { registry } from "@web/core/registry";
  *   onClose?: () => void;
  *   onPositioned?: import("@web/core/position/position_hook").UsePositionOptions["onPositioned"];
  *   popoverClass?: string;
- *   popoverRole?: string;
+ *   role?: string;
  *   position?: import("@web/core/position/position_hook").UsePositionOptions["position"];
  *   ref?: Function;
  * }} PopoverServiceAddOptions
@@ -51,7 +51,7 @@ export const popoverService = {
                     class: options.popoverClass,
                     animation: options.animation,
                     arrow: options.arrow,
-                    role: options.popoverRole,
+                    role: options.role,
                     position: options.position,
                     onPositioned: options.onPositioned,
                     fixedPosition: options.fixedPosition,

--- a/addons/web/static/src/core/utils/dvu.js
+++ b/addons/web/static/src/core/utils/dvu.js
@@ -1,0 +1,110 @@
+/**
+ * Dynamic Viewport Units (DVU)
+ *
+ * Provides viewport measurement tools focusing on:
+ * - Viewport change tracking for responsive components
+ * - Viewport dimensions that respond to virtual keyboard
+ *
+ * Key differences between visualViewport and standard window dimensions:
+ * - On mobile, when virtual keyboards appear, visualViewport.height decreases while
+ *   innerHeight often doesn't
+ * - During pinch-zoom on mobile, visualViewport dimensions change, while innerWidth/innerHeight
+ *   remain static
+ * - When mobile browser UI elements (address bars, toolbars) appear/disappear, visualViewport
+ *   reflects these changes
+ *
+ * Enhanced with VirtualKeyboard API support:
+ * - Reacts to the keyboard's appearance/disappearance via the geometrychange event
+ * - Automatically updates viewport dimensions when keyboard visibility changes
+ * - Triggers viewport change listeners when keyboard visibility changes
+ *
+ * The module will fall back to standard window dimensions when visualViewport API is not
+ * available (primarily older browsers or some embedded webviews).
+ *
+ * References:
+ * - https://www.w3.org/blog/CSS/2021/07/15/css-values-4-viewport-units/
+ * - https://developer.mozilla.org/en-US/docs/Web/API/VirtualKeyboard_API
+ */
+
+import { throttleForAnimation } from "@web/core/utils/timing";
+import { onWillUnmount } from "@odoo/owl";
+import { browser } from "@web/core/browser/browser";
+import { isVirtualKeyboardSupported } from "@web/core/browser/feature_detection";
+
+const viewport = {
+    listeners: [],
+
+    /**
+     * Register a callback for viewport changes
+     *
+     * @param {Function} listener - Function to call when viewport changes
+     * @returns {Function} - Function to remove the listener
+     */
+    addListener(listener) {
+        this.listeners.push(listener);
+        return () => {
+            const index = this.listeners.indexOf(listener);
+            if (index !== -1) {
+                this.listeners.splice(index, 1);
+            }
+        };
+    },
+
+    /**
+     * Notify all listeners of viewport changes
+     */
+    notifyListeners() {
+        this.listeners.forEach((listener) => listener());
+    },
+};
+
+// Initialize viewport tracking
+if (typeof window !== "undefined") {
+    const throttledUpdate = throttleForAnimation(() => viewport.notifyListeners());
+
+    if (browser.visualViewport) {
+        browser.visualViewport.addEventListener("resize", throttledUpdate);
+    }
+
+    if (isVirtualKeyboardSupported()) {
+        browser.navigator.virtualKeyboard.addEventListener("geometrychange", throttledUpdate);
+    }
+
+    // Fallback to window resize for browsers without VisualViewport or VirtualKeyboard
+    browser.addEventListener("resize", throttledUpdate);
+}
+
+/**
+ * Get current viewport dimensions
+ * Takes into account VirtualKeyboard API if available
+ *
+ * @returns {Object} - Object with width and height properties in pixels
+ */
+export function getViewportDimensions() {
+    return {
+        width: browser.visualViewport?.width || browser.innerWidth,
+        height: browser.visualViewport?.height || browser.innerHeight,
+    };
+}
+
+/**
+ * Register a callback for viewport dimension changes
+ * This will trigger for regular viewport changes and virtual keyboard visibility changes
+ *
+ * @param {Function} callback - Function to call on viewport change
+ * @returns {Function} - Function to remove the listener
+ */
+export function onViewportChange(callback) {
+    return viewport.addListener(callback);
+}
+
+/**
+ * OWL hook to use viewport change tracking in components
+ * Automatically cleans up listener when component is unmounted
+ *
+ * @param {Function} callback - Function to call when viewport changes
+ */
+export function useViewportChange(callback) {
+    const removeListener = onViewportChange(callback);
+    onWillUnmount(() => removeListener());
+}

--- a/addons/web/static/src/scss/primary_variables.scss
+++ b/addons/web/static/src/scss/primary_variables.scss
@@ -287,3 +287,11 @@ $o-btns-bs-outline-override: map-merge((
         active-color: $o-component-active-color,
     ),
 ), $o-btns-bs-outline-override);
+
+
+// == Easings
+
+// Entering easing
+$o-easing-enter: cubic-bezier(0.05, 0.7, 0.1, 1.0) !default;
+// Exit easing
+$o-easing-exit: cubic-bezier(0.3, 0.0, 0.8, 0.15) !default;

--- a/addons/web/static/src/search/control_panel/control_panel.scss
+++ b/addons/web/static/src/search/control_panel/control_panel.scss
@@ -161,3 +161,51 @@
         transform: rotate(180deg);
     }
 }
+
+/* Simple button place-holder */
+%-custom-button {
+    $-value: map-get($o-btns-bs-override, 'secondary');
+    @include button-variant(
+            o-safe-get($-value, background),
+            o-safe-get($-value, border),
+            o-safe-get($-value, color),
+            o-safe-get($-value, hover-background),
+            o-safe-get($-value, hover-border),
+            o-safe-get($-value, hover-color),
+            o-safe-get($-value, active-background),
+            o-safe-get($-value, active-border),
+            o-safe-get($-value, active-color),
+    );
+    --#{$prefix}btn-border-width: var(--border-width);
+    --#{$prefix}btn-border-radius: #{$btn-border-radius};
+
+    background-color: var(--#{$prefix}btn-bg);
+    border: var(--#{$prefix}btn-border-width) solid var(--#{$prefix}btn-border-color);
+    @include border-radius(var(--#{$prefix}btn-border-radius));
+
+    &.selected {
+        color: var(--#{$prefix}btn-active-color);
+        background-color: var(--#{$prefix}btn-active-bg);
+        border-color: var(--#{$prefix}btn-active-border-color);
+        box-shadow: var(--#{$prefix}btn-active-shadow);
+    }
+}
+
+.o_bottom_sheet .o_cp_switch_buttons {
+    display: grid;
+    gap: map-get($spacers, 2);
+    grid-template-columns: repeat(3, 1fr);
+
+    .o-dropdown-item {
+        @extend %-custom-button;
+
+        display: grid;
+        justify-items: center;
+        gap: map-get($spacers, 2);
+        padding: map-get($spacers, 3);
+
+        &.selected::before {
+            content: none !important;
+        }
+    }
+}

--- a/addons/web/static/src/search/control_panel/control_panel.xml
+++ b/addons/web/static/src/search/control_panel/control_panel.xml
@@ -94,7 +94,7 @@
                     </button>
                     <t t-if="env.config.viewSwitcherEntries?.length > 1">
                         <div t-if="env.isSmall" class="o_cp_switch_buttons btn-group d-print-none">
-                            <Dropdown>
+                            <Dropdown menuClass="{o_cp_switch_buttons: true, o_custom_bottom_sheet: true }">
                                 <button class="btn btn-secondary">
                                     <t t-set="activeView" t-value="env.config.viewSwitcherEntries.find((view) => view.active)"/>
                                     <i class="oi-fw" t-att-class="activeView.icon"/>

--- a/addons/web/static/src/search/search_bar/search_bar.xml
+++ b/addons/web/static/src/search/search_bar/search_bar.xml
@@ -96,6 +96,7 @@
                 navigationOptions="inputDropdownNavOptions"
                 onStateChanged.bind="onInputDropdownChanged"
                 menuRef="menuRef"
+                bottomSheet="false"
             >
                 <div class="o_searchview form-control d-print-contents d-flex align-items-center py-1 border-end-0"
                     role="search" aria-autocomplete="list">

--- a/addons/web/static/src/search/search_bar_menu/search_bar_menu.xml
+++ b/addons/web/static/src/search/search_bar_menu/search_bar_menu.xml
@@ -5,7 +5,8 @@
         <Dropdown menuClass="'o_search_bar_menu d-flex flex-wrap flex-lg-nowrap w-100 w-md-auto mx-md-auto mt-2 py-3'"
                   position="'bottom-end'"
                   state="this.props.dropdownState"
-                  t-if="this.env.searchModel.searchMenuTypes.size">
+                  t-if="this.env.searchModel.searchMenuTypes.size"
+                  bottomSheet="false">
             <button
                 class="o_searchview_dropdown_toggler d-print-none btn btn-outline-secondary o-dropdown-caret rounded-start-0"
                 data-hotkey="shift+q"

--- a/addons/web/static/src/views/fields/kanban_color_picker/kanban_color_picker_field.scss
+++ b/addons/web/static/src/views/fields/kanban_color_picker/kanban_color_picker_field.scss
@@ -1,41 +1,29 @@
-@mixin o-kanban-colorpicker {
-    max-width: 150px;
-    padding: 3px ($o-dropdown-hpadding - $o-kanban-inner-hmargin) 3px $o-dropdown-hpadding;
+.o_kanban_colorpicker {
+    .o_field_kanban_color_picker:has(> &) {
+        width: 100%;
+    }
 
-    > li {
-        display: inline-block;
-        margin: $o-kanban-inner-hmargin $o-kanban-inner-hmargin 0 0;
+    gap: map-get($spacers, 2);
+    grid-template-columns: repeat(auto-fit, minmax(28px, 1fr));
+    padding: var(--dropdown-item-padding-y) var(--dropdown-item-padding-x);
+
+
+    > button {
         border: 1px solid white;
         box-shadow: 0 0 0 1px map-get($grays, '300');
 
-        > a {
-            display: block;
+        aspect-ratio: 4 / 3;
 
-            &::after {
-                content: "";
-                display: block;
-                width: 20px;
-                height: 15px;
+        @for $size from 2 through length($o-colors) {
+            // Note: the first color is not defined as it is the 'no color' for kanban
+            &.o_kanban_color_#{$size - 1} {
+                background-color: nth($o-colors, $size);
             }
         }
 
         // No Color
-        &:first-child > a:after {
+        &:first-child {
             background: linear-gradient(45deg, rgba($dropdown-bg, 0) 0%, rgba($dropdown-bg, 0) 48%, $danger 48%, $danger 52%, rgba($dropdown-bg, 0) 52%, rgba($dropdown-bg, 0) 100%);
         }
     }
-}
-
-@mixin o-kanban-colorpicker-colors {
-    @for $size from 2 through length($o-colors) {
-        // Note: the first color is not defined as it is the 'no color' for kanban
-        .o_kanban_color_#{$size - 1}:after {
-            background-color: nth($o-colors, $size);
-        }
-    }
-}
-
-.o_kanban_colorpicker {
-    @include o-kanban-colorpicker-colors();
-    @include o-kanban-colorpicker();
 }

--- a/addons/web/static/src/views/fields/kanban_color_picker/kanban_color_picker_field.xml
+++ b/addons/web/static/src/views/fields/kanban_color_picker/kanban_color_picker_field.xml
@@ -2,13 +2,11 @@
 <templates xml:space="preserve">
 
     <t t-name="web.KanbanColorPickerField">
-        <ul t-if="!props.readonly" class="o_kanban_colorpicker mb-0 ms-2">
+        <div t-if="!props.readonly" class="o_kanban_colorpicker d-grid">
             <t t-foreach="colors" t-as="color" t-key="color_index">
-                <li role="menuitem" t-on-click="() => this.selectColor(color_index)" t-att-title="color" t-att-aria-label="color">
-                    <a href="#" t-attf-class="o_kanban_color_{{ color_index }}" />
-                </li>
+                <button role="menuitem" t-on-click="() => this.selectColor(color_index)" t-attf-class="o_kanban_color_{{ color_index }}" t-att-title="color" t-att-aria-label="color"/>
             </t>
-        </ul>
+        </div>
     </t>
 
 </templates>

--- a/addons/web/static/src/views/form/button_box/button_box.scss
+++ b/addons/web/static/src/views/form/button_box/button_box.scss
@@ -211,3 +211,43 @@
         padding-bottom: map-get($spacers, 2);
     }
 }
+
+.o_bottom_sheet .o-form-buttonbox {
+    --button-box-per-row: 1;
+    --o-stat-text-color: black;
+    --o-stat-button-color: black;
+
+    display: grid;
+    gap: map-get($spacers, 2);
+    padding: map-get($spacers, 3) !important;
+
+    &.o-form-buttonbox-small:not(:has(.o-dropdown-item:only-child)) {
+        width: revert !important;
+    }
+
+    .o-dropdown-item {
+        --oi-font-size: 1.5rem;
+
+        border: solid 1px lightgray;
+        border-radius: 5px;
+        outline: none;
+
+        .oe_stat_button {
+            gap: map-get($spacers, 3);
+            height: unset;
+
+            &, * {
+                font-size: 1rem;
+            }
+
+            .o_button_icon {
+                &::before {
+                    margin-right: unset;
+
+                    width: unset;
+                    text-align: center;
+                }
+            }
+        }
+    }
+}

--- a/addons/web/static/src/views/kanban/kanban_controller.scss
+++ b/addons/web/static/src/views/kanban/kanban_controller.scss
@@ -4,9 +4,6 @@
     margin-bottom: 0px;
     min-width: 9rem;
 
-    // Records colours
-    @include o-kanban-record-color;
-
     $o-kanban-manage-toggle-height: 35px;
 
     // Arbitrary value to place the dropdown-menu exactly below the
@@ -55,9 +52,7 @@
             }
 
             .o_kanban_colorpicker {
-                max-width: none;
                 padding: 0;
-                margin-left: 2px !important;
             }
 
             div[class*="col-"] + div[class*="col-"] {

--- a/addons/web/static/tests/_framework/component_test_helpers.js
+++ b/addons/web/static/tests/_framework/component_test_helpers.js
@@ -78,6 +78,9 @@ export function findComponent(parent, predicate) {
  * @returns {HTMLElement | undefined}
  */
 export function getDropdownMenu(togglerSelector) {
+    if (getMockEnv().isSmall) {
+        return queryFirst(".o-dropdown--menu", { eq: -1 });
+    }
     let el = queryFirst(togglerSelector);
     if (el && !el.classList.contains("o-dropdown")) {
         el = el.querySelector(".o-dropdown");

--- a/addons/web/static/tests/core/select_menu.test.js
+++ b/addons/web/static/tests/core/select_menu.test.js
@@ -2,7 +2,7 @@ import { expect, test } from "@odoo/hoot";
 import { click, edit, press, queryAllTexts, queryOne } from "@odoo/hoot-dom";
 import { animationFrame, runAllTimers } from "@odoo/hoot-mock";
 import { Component, useState, xml } from "@odoo/owl";
-import { mountWithCleanup, patchWithCleanup } from "@web/../tests/web_test_helpers";
+import { getMockEnv, mountWithCleanup, patchWithCleanup } from "@web/../tests/web_test_helpers";
 
 import { MainComponentsContainer } from "@web/core/main_components_container";
 import { SelectMenu } from "@web/core/select_menu/select_menu";
@@ -138,7 +138,11 @@ test("Close dropdown on click outside", async () => {
     await open();
     expect(".o_select_menu_menu").toHaveCount(1);
 
-    await click(document.body);
+    if (getMockEnv().isSmall) {
+        await click(".o_bottom_sheet_backdrop");
+    } else {
+        await click(document.body);
+    }
     await animationFrame();
 
     expect(".o_select_menu_menu").toHaveCount(0);

--- a/addons/web/static/tests/views/fields/state_selection_field.test.js
+++ b/addons/web/static/tests/views/fields/state_selection_field.test.js
@@ -303,29 +303,6 @@ test("StateSelectionField in editable list view", async () => {
     ).toHaveCount(1, { message: "should still have one green status" });
     expect(".o-dropdown--menu").toHaveCount(0, { message: "there should not be a dropdown" });
 
-    // Click on the status button to make the dropdown appear
-    await click(".o_state_selection_cell .o_field_state_selection span.o_status");
-    await animationFrame();
-    expect(".o-dropdown--menu").toHaveCount(1, { message: "there should be a dropdown" });
-    expect(".o-dropdown--menu .dropdown-item").toHaveCount(3, {
-        message: "there should be three options in the dropdown",
-    });
-
-    // Click on another row
-    const lastCell = queryAll("tbody td.o_state_selection_cell")[4];
-    await click(lastCell);
-    await animationFrame();
-    expect(".o-dropdown--menu").toHaveCount(0, {
-        message: "there should not be a dropdown anymore",
-    });
-    const firstCell = queryFirst("tbody td.o_state_selection_cell");
-    expect(firstCell.parentElement).not.toHaveClass("o_selected_row", {
-        message: "first row should not be in edit mode anymore",
-    });
-    expect(lastCell.parentElement).toHaveClass("o_selected_row", {
-        message: "last row should be in edit mode",
-    });
-
     // Click on the third status button to make the dropdown appear
     await click(".o_state_selection_cell .o_field_state_selection span.o_status:eq(2)");
     await animationFrame();
@@ -364,6 +341,43 @@ test("StateSelectionField in editable list view", async () => {
         ".o_state_selection_cell .o_field_state_selection span.o_status.o_status_green"
     ).toHaveCount(2, { message: "should have two green status" });
     expect(".o-dropdown--menu").toHaveCount(0, { message: "there should not be a dropdown" });
+});
+
+test.tags("desktop");
+test("StateSelectionField line stay in edit mode when StateSelectionField is opened", async () => {
+    await mountView({
+        type: "list",
+        resModel: "partner",
+        arch: /* xml */ `
+            <list editable="bottom">
+                <field name="foo"/>
+                <field name="selection" widget="state_selection"/>
+            </list>
+        `,
+    });
+
+    // Click on the status button to make the dropdown appear
+    await click(".o_state_selection_cell .o_field_state_selection span.o_status");
+    await animationFrame();
+    expect(".o-dropdown--menu").toHaveCount(1, { message: "there should be a dropdown" });
+    expect(".o-dropdown--menu .dropdown-item").toHaveCount(3, {
+        message: "there should be three options in the dropdown",
+    });
+
+    // Click on another row
+    const lastCell = queryAll("tbody td.o_state_selection_cell")[4];
+    await click(lastCell);
+    await animationFrame();
+    expect(".o-dropdown--menu").toHaveCount(0, {
+        message: "there should not be a dropdown anymore",
+    });
+    const firstCell = queryFirst("tbody td.o_state_selection_cell");
+    expect(firstCell.parentElement).not.toHaveClass("o_selected_row", {
+        message: "first row should not be in edit mode anymore",
+    });
+    expect(lastCell.parentElement).toHaveClass("o_selected_row", {
+        message: "last row should be in edit mode",
+    });
 });
 
 test('StateSelectionField edited by the smart actions "Set kanban state as <state name>"', async () => {

--- a/addons/web/static/tests/views/form/form_view.test.js
+++ b/addons/web/static/tests/views/form/form_view.test.js
@@ -2007,6 +2007,7 @@ test(`readonly stat buttons stays disabled on mobile`, async () => {
     expect(`button.oe_stat_button[disabled]`).toHaveCount(1);
 
     await contains(`button[name=action_to_perform]`).click();
+    await contains(".o_bottom_sheet_backdrop").click();
     await contains(".o-form-buttonbox .o_button_more").click();
     expect(`button.oe_stat_button[disabled]`).toHaveCount(1, {
         message: "After performing the action, only one button should be disabled.",
@@ -12460,6 +12461,7 @@ test(`statusbar buttons are correctly rendered in mobile`, async () => {
     expect(".o_statusbar_buttons button:eq(0)").toHaveText("Confirm");
     // open the dropdown
     await contains(".o_statusbar_buttons button:has(.oi-ellipsis-v)").click();
+    await animationFrame();
     expect(".o-dropdown--menu:visible").toHaveCount(1, { message: "dropdown should be visible" });
     expect(".o-dropdown--menu button").toHaveCount(1, {
         message: "should have 1 button in the dropdown",
@@ -12503,50 +12505,6 @@ test(`statusbar widgets should appear in the CogMenu dropdown`, async () => {
     expect(".o_statusbar_buttons button:eq(0)").toHaveText("Attach document");
     expect(".o_statusbar_buttons button:has(.oi-ellipsis-v)").toHaveCount(0, {
         message: "shouldn't have 'More' dropdown",
-    });
-});
-
-test.tags("mobile");
-test(`CogMenu dropdown should keep its open/close state`, async () => {
-    await mountView({
-        type: "form",
-        resModel: "partner",
-        arch: `
-                <form>
-                    <header>
-                        <button string="Just more than one" />
-                        <button string="Confirm" invisible="name == ''" />
-                        <button string="Do it" invisible="name != ''" />
-                    </header>
-                    <sheet>
-                        <field name="name" />
-                    </sheet>
-                </form>
-            `,
-    });
-    expect(".o_cp_action_menus button:has(.fa-cog)").toHaveCount(1, {
-        message: "should have a 'CogMenu' dropdown",
-    });
-
-    expect(".o_cp_action_menus button:has(.fa-cog)").not.toHaveClass("show", {
-        message: "dropdown should be closed",
-    });
-
-    // open the dropdown
-    await contains(".o_cp_action_menus button:has(.fa-cog)").click();
-    expect(".o_cp_action_menus button:has(.fa-cog)").toHaveClass("show", {
-        message: "dropdown should be opened",
-    });
-
-    // change name to update buttons' modifiers
-    await contains(".o_field_widget[name=name] input").edit("test");
-
-    expect(".o_cp_action_menus button:has(.fa-cog)").toHaveCount(1, {
-        message: "should have a 'CogMenu' dropdown",
-    });
-
-    expect(".o_cp_action_menus button:has(.fa-cog)").not.toHaveClass("show", {
-        message: "dropdown should be opened",
     });
 });
 

--- a/addons/web/static/tests/views/kanban/kanban_view.test.js
+++ b/addons/web/static/tests/views/kanban/kanban_view.test.js
@@ -7883,7 +7883,7 @@ test("edit the kanban color with the colorpicker", async () => {
         })
     ).toHaveCount(12, { message: "the color picker should have 12 children (the colors)" });
 
-    await contains(".o_kanban_colorpicker a.o_kanban_color_9").click();
+    await contains(".o_kanban_colorpicker .o_kanban_color_9").click();
 
     // should write on the color field
     expect.verifySteps(["write-color-9"]);
@@ -7915,7 +7915,7 @@ test("kanban with colorpicker and node with color attribute", async () => {
     });
     expect(getKanbanRecord({ index: 0 })).toHaveClass("o_kanban_color_3");
     await toggleKanbanRecordDropdown(0);
-    await contains(`.o_kanban_colorpicker li[title="Raspberry"] a.o_kanban_color_9`).click();
+    await contains(`.o_kanban_colorpicker .o_kanban_color_9[title="Raspberry"]`).click();
     // should write on the color field
     expect.verifySteps(["write-color-9"]);
     expect(getKanbanRecord({ index: 0 })).toHaveClass("o_kanban_color_9");
@@ -7947,7 +7947,7 @@ test("edit the kanban color with translated colors resulting in the same terms",
     });
 
     await toggleKanbanRecordDropdown(0);
-    await contains(".o_kanban_colorpicker a.o_kanban_color_9").click();
+    await contains(".o_kanban_colorpicker .o_kanban_color_9").click();
     expect(getKanbanRecord({ index: 0 })).toHaveClass("o_kanban_color_9");
 });
 

--- a/addons/web/static/tests/views/list/list_view.test.js
+++ b/addons/web/static/tests/views/list/list_view.test.js
@@ -1030,10 +1030,10 @@ test(`list view: action button in controlPanel basic rendering on mobile`, async
     });
     expect(`.o_control_panel_actions > *`).toHaveCount(0);
     await contains(".o_control_panel_breadcrumbs .o_cp_action_menus .fa-cog").click();
-    expect(queryAllTexts(`.o_popover .o-dropdown-item`)).toEqual(["Export All"]);
+    expect(queryAllTexts(`.o-dropdown--menu .o-dropdown-item`)).toEqual(["Export All"]);
     await clickRecordSelector();
     await contains(".o_control_panel_breadcrumbs .o_cp_action_menus .fa-cog").click();
-    expect(queryAllTexts(`.o_popover .o-dropdown-item`)).toEqual([
+    expect(queryAllTexts(`.o-dropdown--menu .o-dropdown-item`)).toEqual([
         "plaf",
         "Export",
         "Duplicate",
@@ -1041,7 +1041,7 @@ test(`list view: action button in controlPanel basic rendering on mobile`, async
     ]);
     await clickRecordSelector();
     await contains(".o_control_panel_breadcrumbs .o_cp_action_menus .fa-cog").click();
-    expect(queryAllTexts(`.o_popover .o-dropdown-item`)).toEqual(["Export All"]);
+    expect(queryAllTexts(`.o-dropdown--menu .o-dropdown-item`)).toEqual(["Export All"]);
 });
 
 test.tags("desktop");
@@ -1122,7 +1122,7 @@ test(`list view: action button in controlPanel with display='always' on mobile`,
 
     await clickRecordSelector();
     await contains(".o_control_panel_breadcrumbs .o_cp_action_menus .fa-cog").click();
-    expect(queryAllTexts(`.o_popover .o-dropdown-item`)).toEqual([
+    expect(queryAllTexts(`.o-dropdown--menu .o-dropdown-item`)).toEqual([
         "",
         "default-selection",
         "Export",
@@ -2427,8 +2427,8 @@ test(`grouped list rendering with groupby m2o field: edit group`, async () => {
     expect(queryAllTexts(`.o_group_name`)).toEqual(["Value 1 (3)", "Value 2 (1)"]);
     expect(`.o_group_header:first .o_group_config`).toHaveCount(1);
     await contains(`.o_group_header:first .o_group_config button`, { visible: false }).click();
-    expect(`.o_popover.o-dropdown--group-config-menu`).toHaveCount(1);
-    await contains(`.o_popover.o-dropdown--group-config-menu .o_group_edit`).click();
+    expect(`.o-dropdown--group-config-menu`).toHaveCount(1);
+    await contains(`.o-dropdown--group-config-menu .o_group_edit`).click();
     expect(`.o_dialog`).toHaveCount(1);
     expect(`.o_dialog .o_form_renderer .o_field_char[name="name"]`).toHaveCount(1);
     await contains(`.o_dialog .o_form_renderer .o_field_char[name="name"] input`).edit(
@@ -2439,9 +2439,12 @@ test(`grouped list rendering with groupby m2o field: edit group`, async () => {
     expect.verifySteps(["web_save"]);
     expect(queryAllTexts(`.o_group_name`)).toEqual(["Value edit (3)", "Value 2 (1)"]);
     await contains(`.o_group_header:first .o_group_config button`, { visible: false }).click();
-    expect(`.o_popover.o-dropdown--group-config-menu`).toHaveCount(1);
-    await contains(getFixture()).click();
-    expect(`.o_popover.o-dropdown--group-config-menu`).toHaveCount(0, {
+    if (getMockEnv().isSmall) {
+        await contains(".o_bottom_sheet_backdrop").click();
+    } else {
+        await contains(getFixture()).click();
+    }
+    expect(`.o-dropdown--group-config-menu`).toHaveCount(0, {
         message: "Close on click away should occur properly",
     });
 });
@@ -2461,8 +2464,8 @@ test(`grouped list rendering with groupby m2o field: delete group`, async () => 
     expect(queryAllTexts(`.o_group_name`)).toEqual(["Value 1 (3)", "Value 2 (1)"]);
     expect(`.o_group_header:first .o_group_config`).toHaveCount(1);
     await contains(`.o_group_header:first .o_group_config button`, { visible: false }).click();
-    expect(`.o_popover.o-dropdown--group-config-menu`).toHaveCount(1);
-    await contains(`.o_popover.o-dropdown--group-config-menu .o_group_delete`).click();
+    expect(`.o-dropdown--group-config-menu`).toHaveCount(1);
+    await contains(`.o-dropdown--group-config-menu .o_group_delete`).click();
     expect(`.o_dialog`).toHaveCount(1);
     expect(`.o_dialog .modal-body`).toHaveText("Are you sure you want to delete this column?");
     await contains(`.o_dialog footer button:contains(Delete)`).click();

--- a/addons/web/static/tests/views/pivot_view.test.js
+++ b/addons/web/static/tests/views/pivot_view.test.js
@@ -262,7 +262,7 @@ test("all measures should be displayed with a pivot_measures context", async () 
     });
 
     await contains("button:contains(Measures)").click();
-    expect(".o_popover.popover.o-dropdown--menu.dropdown-menu").toHaveCount(1);
+    expect(".o-dropdown--menu.o-dropdown--menu.dropdown-menu").toHaveCount(1);
     const measures = queryAllTexts(".o-dropdown-item");
     expect(measures).toEqual(["bouh", "Computed and not stored", "Foo", "Count"]);
 });
@@ -2633,6 +2633,7 @@ test("group bys added via control panel and expand Header do not stack", async (
     ]);
 });
 
+test.tags("desktop");
 test("display only one dropdown menu", async () => {
     await mountView({
         type: "pivot",


### PR DESCRIPTION
* = html_editor, mail

A BottomSheet is a UI component in mobile apps that slides up from the
bottom of the screen to display additional content or options. It can be
partially or fully expanded and is commonly used for actions, menus, or
forms. BottomSheets provide a non-intrusive way to show relevant
information without leaving the current screen.

This commit adds:
* BottomSheet Component
* Dynamic Viewport Units (DVU) hook
* Feature Detection (virtualKeyboard)
* Adapt Popover service to use BottomSheet Component
* All Dropdown are show in bottom sheet
* Adapt code to support `prefers-reduced-motion`
* IMP kanban color picker in menu
* CSS tweak: stats button, "switch view"
* CSS adapt home menu navbar (box-shadow)
* CSS scroll-state when more content in sheet (content not visible)
* Disable bottom sheet for search bar
* Disable bottom sheet for some dropdown of HTML Editor
* Disable bottom sheet for activity menu and messaging menu

task-4551522

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
