### PR TITLE
[FIX] point_of_sale: prevent order duplication

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -337,6 +337,8 @@ class PosOrder(models.Model):
     order_edit_tracking = fields.Boolean(related="config_id.order_edit_tracking", readonly=True)
     available_payment_method_ids = fields.Many2many('pos.payment.method', related='config_id.payment_method_ids', string='Available Payment Methods', readonly=True, store=False)
 
+    _sql_constraints = [('uuid_unique', 'unique (uuid)', "An order with this uuid already exists")]
+
     def get_preparation_change(self):
         self.ensure_one()
         return {
@@ -1379,6 +1381,8 @@ class PosOrderLine(models.Model):
 
     combo_item_id = fields.Many2one('product.combo.item', string='Combo Item')
     is_edited = fields.Boolean('Edited', default=False)
+
+    _sql_constraints = [('uuid_unique', 'unique (uuid)', "An order line with this uuid already exists")]
 
     @api.model
     def _load_pos_data_domain(self, data):

--- a/addons/point_of_sale/models/pos_payment.py
+++ b/addons/point_of_sale/models/pos_payment.py
@@ -42,6 +42,8 @@ class PosPayment(models.Model):
     account_move_id = fields.Many2one('account.move', index='btree_not_null')
     uuid = fields.Char(string='Uuid', readonly=True, copy=False)
 
+    _sql_constraints = [('uuid_unique', 'unique (uuid)', "A payment with this uuid already exists")]
+
     @api.model
     def _load_pos_data_domain(self, data):
         return [('pos_order_id', 'in', [order['id'] for order in data['pos.order']['data']])]


### PR DESCRIPTION
Before this commit, it was possible for concurrent requests to create duplicate PoS orders, order lines, and payments. This was due to the absence of unique identifiers at the database level for these records during their creation.

This commit addresses the issue by adding SQL unique constraints on the UUID fields for the `pos.order`, `pos.order.line`, and `pos.payment`.

These database-level constraints ensure that any attempt to insert a duplicate record (based on its unique UUID) will be rejected, thereby preventing data duplication and maintaining transactional integrity.

opw-4899804

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
