### PR TITLE
[FIX] stock_rule: avoid creating duplicate MO name

### DIFF
--- a/addons/mrp/models/stock_rule.py
+++ b/addons/mrp/models/stock_rule.py
@@ -184,7 +184,7 @@ class StockRule(models.Model):
         }
         # Use the procurement group created in _run_pull mrp override
         # Preserve the origin from the original stock move, if available
-        if location_dest_id.warehouse_id.manufacture_steps == 'pbm_sam' and values.get('move_dest_ids') and values.get('group_id') and not values['move_dest_ids'][0].origin.startswith(values['group_id'].name):
+        if location_dest_id.warehouse_id.manufacture_steps == 'pbm_sam' and values.get('move_dest_ids') and values.get('group_id') and values['group_id'].name not in values['move_dest_ids'][0].origin:
             origin = values['move_dest_ids'][0].origin
             mo_values.update({
                 'name': values['group_id'].name,


### PR DESCRIPTION
__Issue:__

Condition used for MOs triggered under the `pbm_sam` manufacturing flow only checks the start of the group name, not the whole name, which could fail in case triggered by reordering rules where the origin might be a compound string such as: "OP/00001,WH/MO/00001"

__Steps to reproduce:__

1.) Install sales; inventory; manufacturing
2.) Enable multi-step routes
3.) Unarchive MTO
4.) Set warehouse manufacture steps to:
Pick components, manufacture, then store products (3 steps) (manufacture_steps == 'pbm_sam')
5.) Create product A-bom (enable manufacture and mto routes) 6.) Create product B (enable manufacture)
7.) Add Product A as bom for product B
8.) Add a reordering rule (manufacture) for product B 9.) run SA Procurement: run scheduler
Error: duplicate key value violates unique constraint

opw-4866263
bug found: [#c50cb9d][1]

[1] : https://github.com/odoo/odoo/commit/c50cb9d552f352bde4e3b8d92e8509476f194830
