### PR TITLE
[IMP] account_peppol: Branch Company Peppol Connection

### DIFF
--- a/addons/account_edi_proxy_client/models/account_edi_proxy_user.py
+++ b/addons/account_edi_proxy_client/models/account_edi_proxy_user.py
@@ -55,10 +55,6 @@ class Account_Edi_Proxy_ClientUser(models.Model):
     )
 
     _unique_id_client = models.Constraint('unique(id_client)', "This id_client is already used on another user.")
-    _unique_active_edi_identification = models.UniqueIndex(
-        '(edi_identification, proxy_type, edi_mode) WHERE (active IS TRUE)',
-        "This edi identification is already assigned to an active user",
-    )
     _unique_active_company_proxy = models.UniqueIndex(
         '(company_id, proxy_type, edi_mode) WHERE (active IS TRUE)',
         "This company has an active user already created for this EDI type",

--- a/addons/account_peppol/models/__init__.py
+++ b/addons/account_peppol/models/__init__.py
@@ -1,6 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import account_edi_proxy_user
+from . import account_edi_ubl_xml
 from . import account_journal
 from . import account_move
 from . import account_move_send

--- a/addons/account_peppol/models/account_edi_proxy_user.py
+++ b/addons/account_peppol/models/account_edi_proxy_user.py
@@ -410,9 +410,7 @@ class Account_Edi_Proxy_ClientUser(models.Model):
         if self.company_id.account_peppol_proxy_state != 'not_registered':
             self._call_peppol_proxy(endpoint='/api/peppol/1/cancel_peppol_registration')
 
-        self.company_id.account_peppol_proxy_state = 'not_registered'
-        self.company_id.account_peppol_migration_key = False
-        self.company_id.peppol_external_provider = None
+        self.company_id._reset_peppol_configuration()
         self.unlink()
 
     @api.model

--- a/addons/account_peppol/models/account_edi_ubl_xml.py
+++ b/addons/account_peppol/models/account_edi_ubl_xml.py
@@ -1,0 +1,17 @@
+from odoo import models
+
+
+class AccountEdiXmlUbl_20(models.AbstractModel):
+    _inherit = 'account.edi.xml.ubl_20'
+
+    def _add_invoice_config_vals(self, vals):
+        """
+        When generating the XML on behalf of the parent peppol company,
+        use the parent company details on the XML.
+        """
+        super()._add_invoice_config_vals(vals)
+        invoice = vals['invoice']
+        company = invoice.company_id
+
+        if parent_peppol_company := company.peppol_parent_company_id:
+            vals['supplier'] = parent_peppol_company.partner_id.commercial_partner_id

--- a/addons/account_peppol/models/account_move_send.py
+++ b/addons/account_peppol/models/account_move_send.py
@@ -65,22 +65,28 @@ class AccountMoveSend(models.AbstractModel):
         always_on_companies = moves.company_id.filtered(
             lambda c: c.country_code in info_always_on_countries and not c.peppol_can_send
         )
-        if always_on_companies and any_moves_not_sent_peppol and not filter_peppol_state(moves, ['not_valid', 'not_verified']):
+        if all((
+            always_on_companies,
+            any_moves_not_sent_peppol,
+            not filter_peppol_state(moves, ['not_valid', 'not_verified']),
+        )):
             alerts.pop('account_edi_ubl_cii_configure_company', False)
             alerts['account_peppol_what_is_peppol'] = {
                 'message': _("You can send this invoice electronically via Peppol."),
                 **what_is_peppol_alert,
             }
-        elif (peppol_not_selected_partners := filter_peppol_state(not_peppol_moves, ['valid'])) and any_moves_not_sent_peppol:
-            # Check for not peppol partners that are on the network.
-            if len(peppol_not_selected_partners) == 1:
-                alerts['account_peppol_partner_want_peppol'] = {
-                    'message': _(
-                        "%s has requested electronic invoices reception on Peppol.",
-                        peppol_not_selected_partners.display_name
-                    ),
-                    **what_is_peppol_alert,
-                }
+        elif all((
+            (peppol_not_selected_partners := filter_peppol_state(not_peppol_moves, ['valid'])),
+            any_moves_not_sent_peppol,
+            len(peppol_not_selected_partners) == 1,  # Check for not peppol partners that are on the network
+        )):
+            alerts['account_peppol_partner_want_peppol'] = {
+                'message': _(
+                    "%s has requested electronic invoices reception on Peppol.",
+                    peppol_not_selected_partners.display_name
+                ),
+                **what_is_peppol_alert,
+            }
         return alerts
 
     # -------------------------------------------------------------------------
@@ -190,8 +196,7 @@ class AccountMoveSend(models.AbstractModel):
         if not params['documents']:
             return
 
-        edi_user = next(iter(invoices_data)).company_id.account_edi_proxy_client_ids.filtered(
-            lambda u: u.proxy_type == 'peppol')
+        edi_user = next(iter(invoices_data)).company_id.account_peppol_edi_user
 
         try:
             response = edi_user._call_peppol_proxy(

--- a/addons/account_peppol/models/res_config_settings.py
+++ b/addons/account_peppol/models/res_config_settings.py
@@ -1,19 +1,10 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
-from odoo import _, api, fields, models, modules, tools
-from odoo.exceptions import UserError, ValidationError
-
-from odoo.addons.account_peppol.tools.demo_utils import handle_demo
+from odoo import _, api, fields, models
 
 
 class ResConfigSettings(models.TransientModel):
     _inherit = 'res.config.settings'
 
-    account_peppol_edi_user = fields.Many2one(
-        comodel_name='account_edi_proxy_client.user',
-        string='EDI user',
-        compute='_compute_account_peppol_edi_user',
-    )
+    account_peppol_edi_user = fields.Many2one(related='company_id.account_peppol_edi_user')
     account_peppol_edi_mode = fields.Selection(related='account_peppol_edi_user.edi_mode')
     account_peppol_contact_email = fields.Char(related='company_id.account_peppol_contact_email', readonly=False)
     account_peppol_eas = fields.Selection(related='company_id.peppol_eas', readonly=False)
@@ -24,16 +15,17 @@ class ResConfigSettings(models.TransientModel):
     account_peppol_proxy_state = fields.Selection(related='company_id.account_peppol_proxy_state', readonly=False)
     account_peppol_purchase_journal_id = fields.Many2one(related='company_id.peppol_purchase_journal_id', readonly=False)
     peppol_external_provider = fields.Char(related='company_id.peppol_external_provider', readonly=False)
+    peppol_use_parent_company = fields.Boolean(compute='_compute_peppol_use_parent_company')
+    peppol_parent_company_name = fields.Char(related='company_id.peppol_parent_company_id.name', string="Peppol Parent Company Name")
 
     # -------------------------------------------------------------------------
     # COMPUTE METHODS
     # -------------------------------------------------------------------------
 
-    @api.depends("company_id.account_edi_proxy_client_ids")
-    def _compute_account_peppol_edi_user(self):
-        for config in self:
-            config.account_peppol_edi_user = config.company_id.account_edi_proxy_client_ids.filtered(
-                lambda u: u.proxy_type == 'peppol')
+    @api.depends('company_id.peppol_parent_company_id')
+    def _compute_peppol_use_parent_company(self):
+        for setting in self:
+            setting.peppol_use_parent_company = bool(setting.company_id.peppol_parent_company_id)
 
     # -------------------------------------------------------------------------
     # BUSINESS ACTIONS
@@ -51,6 +43,21 @@ class ResConfigSettings(models.TransientModel):
             'res_model': 'peppol.config.wizard',
             'view_mode': 'form',
             'target': 'new',
+        }
+
+    def button_peppol_disconnect_branch_from_parent(self):
+        self.ensure_one()
+        previous_parent_company_name = self.company_id.peppol_parent_company_id.name
+        self.account_peppol_edi_user._peppol_deregister_participant()
+        return {
+            'type': 'ir.actions.client',
+            'tag': 'display_notification',
+            'params': {
+                'title': None,
+                'type': 'success',
+                'message': _("Disconnected this branch company peppol configuration from %s.", previous_parent_company_name),
+                'next': {'type': 'ir.actions.act_window_close'},
+            }
         }
 
     def button_peppol_register_sender_as_receiver(self):

--- a/addons/account_peppol/views/res_config_settings_views.xml
+++ b/addons/account_peppol/views/res_config_settings_views.xml
@@ -9,12 +9,12 @@
                 <div id="account_peppol" class="col-12 o_setting_box">
                     <div class="o_setting_right_pane border-0">
                         <!-- Info in case of sender. -->
-                        <div invisible="account_peppol_proxy_state != 'sender'">
+                        <div invisible="peppol_use_parent_company or account_peppol_proxy_state != 'sender'">
                             You are sending your e-invoices via Odoo with this Peppol ID <field name="account_peppol_edi_identification" class="oe_inline o_form_label" readonly="1"/>.<br/>
                             But you are receiving your e-invoices via this Access Point: <field name="peppol_external_provider" class="oe_inline o_form_label" readonly="1"/>.
                         </div>
                         <!-- Info in case of receiver/smp_registration. -->
-                        <div invisible="account_peppol_proxy_state not in ('receiver', 'smp_registration')">
+                        <div invisible="peppol_use_parent_company or account_peppol_proxy_state not in ('receiver', 'smp_registration')">
                             You are sending and receiving your e-invoices via Odoo with this Peppol ID <field name="account_peppol_edi_identification" class="oe_inline o_form_label" readonly="1"/>.
                             <div invisible="account_peppol_proxy_state != 'smp_registration'">
                                 Your registration should be activated within a day.
@@ -28,16 +28,19 @@
                                            required="account_peppol_proxy_state in ('smp_registration', 'receiver')"/>
                                 </div>
                             </div>
-
                         </div>
                         <!-- Info in case of rejected. -->
-                        <div invisible="account_peppol_proxy_state != 'rejected'">
+                        <div invisible="peppol_use_parent_company or account_peppol_proxy_state != 'rejected'">
                             You registration has been rejected, the reason has been sent to you via email.
                             Please contact our support if you need further assistance.
                         </div>
+                        <!-- Info in case of a branch company using the active peppol connection from their parent. -->
+                        <div invisible="not peppol_use_parent_company">
+                            You are sending from <field name="peppol_parent_company_name" class="oe_inline o_form_label" readonly="1"/>.
+                        </div>
 
                         <div class="d-flex gap-1 action_buttons mt-2"
-                             invisible="account_peppol_proxy_state not in ('sender', 'smp_registration', 'receiver')">
+                             invisible="peppol_use_parent_company or account_peppol_proxy_state not in ('sender', 'smp_registration', 'receiver')">
                             <button string="Advanced Configuration"
                                 icon="oi-arrow-right"
                                 name="button_open_peppol_config_wizard"
@@ -46,7 +49,7 @@
                         </div>
                         <div class="d-flex gap-1 action_buttons" colspan="3">
                             <!-- Not yet registered on Peppol -->
-                            <div invisible="account_peppol_proxy_state not in ('not_registered', 'in_verification')">
+                            <div invisible="peppol_use_parent_company or account_peppol_proxy_state != 'not_registered'">
                                 <div class="text-muted">
                                     Allow sending and receiving invoices through the Peppol network
                                 </div>
@@ -56,12 +59,19 @@
                                         class="oe_highlight mt-2"/>
                             </div>
                             <!-- Registered on Peppol -->
-                            <div invisible="account_peppol_proxy_state not in ('sender', 'smp_registration', 'receiver')" class="mt-3">
+                            <div invisible="peppol_use_parent_company or account_peppol_proxy_state not in ('sender', 'smp_registration', 'receiver')" class="mt-3">
                                 <button string="Register with Odoo"
                                         name="button_peppol_register_sender_as_receiver"
                                         type="object"
                                         class="btn-primary me-1"
                                         invisible="account_peppol_proxy_state != 'sender'"/>
+                            </div>
+                            <!--Branch company connected to parent's active peppol connection.-->
+                            <div invisible="not peppol_use_parent_company" class="mt-2">
+                                <button string="Disconnect"
+                                        name="button_peppol_disconnect_branch_from_parent"
+                                        type="object"
+                                        class="btn-secondary me-1"/>
                             </div>
                         </div>
                     </div>

--- a/addons/account_peppol/wizard/account_move_send_wizard.py
+++ b/addons/account_peppol/wizard/account_move_send_wizard.py
@@ -1,6 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 from odoo import models, _
-from odoo.exceptions import UserError
+from odoo.exceptions import AccessError, UserError
+
 
 class AccountMoveSendWizard(models.TransientModel):
     _inherit = 'account.move.send.wizard'
@@ -22,6 +23,8 @@ class AccountMoveSendWizard(models.TransientModel):
                     addendum_disable_reason = _(' (Customer not on Peppol)')
                 elif peppol_partner.peppol_verification_state == 'not_verified':
                     addendum_disable_reason = _(' (no VAT)')
+                elif wizard.company_id._have_unauthorized_peppol_parent_company():
+                    addendum_disable_reason = _(' (no access)')
                 else:
                     addendum_disable_reason = ''
                 vals_not_valid = {'readonly': True, 'checked': False} if addendum_disable_reason else {}
@@ -51,6 +54,9 @@ class AccountMoveSendWizard(models.TransientModel):
         if self.sending_methods and 'peppol' in self.sending_methods:
             if self.move_id.partner_id.commercial_partner_id.peppol_verification_state != 'valid':
                 raise UserError(_("Partner doesn't have a valid Peppol configuration."))
+            if self.move_id.company_id._have_unauthorized_peppol_parent_company():
+                raise AccessError(_("You are not allowed to send invoice on behalf of %s.",
+                                    self.move_id.company_id.peppol_parent_company_id.sudo().name))  # sudo needed because the current user does not have access
             if registration_action := self._do_peppol_pre_send(self.move_id):
                 return registration_action
         return super().action_send_and_print(allow_fallback_pdf=allow_fallback_pdf)

--- a/addons/account_peppol/wizard/peppol_config_wizard.py
+++ b/addons/account_peppol/wizard/peppol_config_wizard.py
@@ -23,10 +23,7 @@ class PeppolConfigWizard(models.TransientModel):
         required=True,
         default=lambda self: self.env.company,
     )
-    account_peppol_edi_user = fields.Many2one(
-        comodel_name='account_edi_proxy_client.user',
-        compute='_compute_account_peppol_edi_user',
-    )
+    account_peppol_edi_user = fields.Many2one(related='company_id.account_peppol_edi_user')
     account_peppol_edi_identification = fields.Char(related='account_peppol_edi_user.edi_identification')
     account_peppol_proxy_state = fields.Selection(related='company_id.account_peppol_proxy_state', readonly=False)
     account_peppol_contact_email = fields.Char(related='company_id.account_peppol_contact_email', readonly=False, required=True)
@@ -50,12 +47,6 @@ class PeppolConfigWizard(models.TransientModel):
     # -------------------------------------------------------------------------
     # COMPUTES
     # -------------------------------------------------------------------------
-
-    @api.depends('company_id')
-    def _compute_account_peppol_edi_user(self):
-        for wizard in self:
-            wizard.account_peppol_edi_user = wizard.company_id.account_edi_proxy_client_ids.filtered(
-                lambda u: u.proxy_type == 'peppol')
 
     @api.depends('account_peppol_edi_user', 'account_peppol_proxy_state')
     def _compute_service_json(self):

--- a/addons/account_peppol/wizard/peppol_registration.py
+++ b/addons/account_peppol/wizard/peppol_registration.py
@@ -7,7 +7,6 @@ except ImportError:
 
 from odoo import _, api, fields, models, modules
 from odoo.exceptions import UserError, ValidationError
-
 from odoo.addons.account_edi_proxy_client.models.account_edi_proxy_user import AccountEdiProxyError
 
 
@@ -15,10 +14,39 @@ class PeppolRegistration(models.TransientModel):
     _name = 'peppol.registration'
     _description = "Peppol Registration"
 
+    def _get_default_use_parent_connection_selection(self):
+        if all((
+            (parent_company := self.env.company._get_active_peppol_parent_company()),  # potential parent peppol company exist
+            parent_company in self.env.user.company_ids,  # current user has access to the potential parent peppol company
+            self.env.company.vat in (False, parent_company.vat),  # current company doesn't have VAT or have same VAT as parent
+        )):
+            return 'use_parent'
+        else:
+            return 'use_self'
+
     company_id = fields.Many2one(
         comodel_name='res.company',
         required=True,
         default=lambda self: self.env.company,
+    )
+    is_branch_company = fields.Boolean(compute='_compute_from_company_id')
+    active_parent_company = fields.Many2one(
+        comodel_name='res.company',
+        compute='_compute_from_company_id',
+    )
+    active_parent_company_name = fields.Char(related='active_parent_company.name')
+    use_parent_connection_selection = fields.Selection(
+        selection=[
+            ('use_parent', "Send from parent company"),
+            ('use_self', "Register this company on peppol"),
+        ],
+        default=_get_default_use_parent_connection_selection,
+    )
+    can_use_parent_connection = fields.Boolean(compute='_compute_from_company_id')
+    use_parent_connection = fields.Boolean(compute='_compute_use_parent_connection')
+    selected_company_id = fields.Many2one(
+        comodel_name='res.company',
+        compute='_compute_selected_company_id',
     )
     edi_mode = fields.Selection(
         string='EDI mode',
@@ -30,19 +58,19 @@ class PeppolRegistration(models.TransientModel):
         string='EDI user',
         compute='_compute_edi_user_id',
     )
-    account_peppol_proxy_state = fields.Selection(related='company_id.account_peppol_proxy_state')
+    account_peppol_proxy_state = fields.Selection(related='selected_company_id.account_peppol_proxy_state')
     peppol_warnings = fields.Json(
         string="Peppol warnings",
         compute="_compute_peppol_warnings",
     )
     contact_email = fields.Char(
-        related='company_id.account_peppol_contact_email',
+        related='selected_company_id.account_peppol_contact_email',
         readonly=False,
         required=True,
     )
-    phone_number = fields.Char(related='company_id.account_peppol_phone_number', readonly=False)
-    peppol_eas = fields.Selection(related='company_id.peppol_eas', readonly=False, required=True)
-    peppol_endpoint = fields.Char(related='company_id.peppol_endpoint', readonly=False, required=True)
+    phone_number = fields.Char(related='selected_company_id.account_peppol_phone_number', readonly=False)
+    peppol_eas = fields.Selection(related='selected_company_id.peppol_eas', readonly=False, required=True)
+    peppol_endpoint = fields.Char(related='selected_company_id.peppol_endpoint', readonly=False, required=True)
     smp_registration = fields.Boolean(  # you're registering to SMP when you register as a sender+receiver
         string='Register as a receiver',
         compute='_compute_smp_registration_external_provider'
@@ -68,7 +96,7 @@ class PeppolRegistration(models.TransientModel):
                 with contextlib.suppress(phonenumbers.NumberParseException):
                     parsed_phone_number = phonenumbers.parse(
                         wizard.phone_number,
-                        region=wizard.company_id.country_code,
+                        region=wizard.selected_company_id.country_code,
                     )
                     wizard.phone_number = phonenumbers.format_number(
                         parsed_phone_number,
@@ -79,37 +107,63 @@ class PeppolRegistration(models.TransientModel):
     # COMPUTE METHODS
     # -------------------------------------------------------------------------
 
-    @api.depends('company_id.account_edi_proxy_client_ids')
+    @api.depends('company_id')
+    def _compute_from_company_id(self):
+        for wizard in self:
+            wizard.is_branch_company = bool(wizard.company_id.parent_id)
+            wizard.active_parent_company = wizard.company_id._get_active_peppol_parent_company()
+            wizard.can_use_parent_connection = wizard.active_parent_company in self.env.user.company_ids
+
+    @api.depends('use_parent_connection_selection')
+    def _compute_use_parent_connection(self):
+        for wizard in self:
+            wizard.use_parent_connection = wizard.use_parent_connection_selection == 'use_parent'
+
+    @api.depends('use_parent_connection', 'active_parent_company')
+    @api.depends_context('company')
+    def _compute_selected_company_id(self):
+        for wizard in self:
+            if wizard.use_parent_connection and wizard.active_parent_company:
+                wizard.selected_company_id = wizard.active_parent_company
+            else:
+                wizard.selected_company_id = wizard.company_id
+
+    @api.depends('selected_company_id.account_edi_proxy_client_ids')
     def _compute_edi_user_id(self):
         for wizard in self:
             wizard.edi_user_id = wizard.company_id.account_edi_proxy_client_ids.filtered(lambda u: u.proxy_type == 'peppol')[:1]
 
-    @api.depends('peppol_eas', 'peppol_endpoint', 'smp_registration', 'peppol_external_provider')
+    @api.depends('selected_company_id', 'peppol_eas', 'peppol_endpoint', 'smp_registration', 'peppol_external_provider', 'use_parent_connection')
     def _compute_peppol_warnings(self):
         for wizard in self:
             peppol_warnings = {}
-            if (
-                wizard.peppol_eas
-                and wizard.peppol_endpoint
-                and not wizard.company_id._check_peppol_endpoint_number(warning=True)
-            ):
+            if all((
+                wizard.peppol_eas,
+                wizard.peppol_endpoint,
+                not wizard.selected_company_id._check_peppol_endpoint_number(warning=True),
+            )):
                 peppol_warnings['company_peppol_endpoint_warning'] = {
                     'message': _("The endpoint number might not be correct. "
-                                "Please check if you entered the right identification number."),
+                                 "Please check if you entered the right identification number."),
                 }
-            if not wizard.smp_registration:
+            if all((
+                not wizard.use_parent_connection,
+                wizard.peppol_eas,
+                wizard.peppol_endpoint,
+                not wizard.smp_registration,
+            )):
                 peppol_warnings['company_already_on_smp'] = {
                     'message': _("Your company is already registered on an Access Point (%s) for receiving invoices. "
                                  "We will register you on Odoo as a sender only.", wizard.peppol_external_provider)
                 }
             wizard.peppol_warnings = peppol_warnings or False
 
-    @api.depends('company_id', 'edi_user_id', 'peppol_eas')
+    @api.depends('selected_company_id', 'edi_user_id', 'peppol_eas')
     def _compute_edi_mode(self):
         for wizard in self:
             wizard.edi_mode = wizard.company_id._get_peppol_edi_mode(temporary_eas=wizard.peppol_eas)
 
-    @api.depends('peppol_eas', 'peppol_endpoint')
+    @api.depends('selected_company_id', 'peppol_eas', 'peppol_endpoint')
     def _compute_smp_registration_external_provider(self):
         for wizard in self:
             is_company_on_peppol = True
@@ -126,11 +180,25 @@ class PeppolRegistration(models.TransientModel):
     # BUSINESS ACTIONS
     # -------------------------------------------------------------------------
 
+    def _branch_with_same_address(self):
+        self.ensure_one()
+        return all((
+            self.is_branch_company,
+            self.active_parent_company,
+            not self.use_parent_connection,
+            self.peppol_eas == self.active_parent_company.peppol_eas,
+            self.peppol_endpoint == self.active_parent_company.peppol_endpoint,
+        ))
+
     def _ensure_mandatory_fields(self):
+        if self.use_parent_connection:
+            return
         if not self.contact_email or not self.phone_number:
             raise ValidationError(_("Contact email and phone number are required."))
         if not self.peppol_eas or not self.peppol_endpoint:
             raise ValidationError(_("Peppol Address should be provided."))
+        if self._branch_with_same_address():
+            raise ValidationError(_("Peppol ID should be different from main company."))
 
     def _action_open_peppol_form(self, reopen=True):
         action_dict = {
@@ -174,7 +242,15 @@ class PeppolRegistration(models.TransientModel):
         self.ensure_one()
         self._ensure_mandatory_fields()
 
-        if self.account_peppol_proxy_state in ('smp_registration', 'receiver', 'rejected'):
+        if self.use_parent_connection:
+            self.company_id.write({
+                'peppol_eas': self.peppol_eas,
+                'peppol_endpoint': self.peppol_endpoint,
+                'account_peppol_contact_email': self.contact_email,
+                'account_peppol_phone_number': self.phone_number,
+            })
+
+        if not self.is_branch_company and self.account_peppol_proxy_state in ('smp_registration', 'receiver', 'rejected'):
             raise UserError(
                 _('Cannot register a user with a %s application', self.account_peppol_proxy_state))
 

--- a/addons/account_peppol/wizard/peppol_registration_views.xml
+++ b/addons/account_peppol/wizard/peppol_registration_views.xml
@@ -6,26 +6,46 @@
         <field name="group_ids" eval="[Command.link(ref('account.group_account_manager'))]"/>
         <field name="arch" type="xml">
             <form class="form_peppol_registration">
-                <field name="company_id" invisible="1"/>
                 <sheet>
-                    <div class="m-0" name="warnings" invisible="not peppol_warnings or account_peppol_proxy_state != 'not_registered'">
+                    <div class="m-0" name="warnings" invisible="not peppol_warnings">
                         <field name="peppol_warnings" class="o_field_html" widget="actionable_errors"/>
                     </div>
 
-                    <div name="peppol_registration" invisible="account_peppol_proxy_state not in ('not_registered', 'in_verification')">
-                        <p class="text-muted">Send electronic invoices, and receive bills automatically via Peppol</p>
+                    <div name="peppol_registration">
+                        <p class="text-muted" invisible="not use_parent_connection">
+                            This branch company will use the active Peppol connection found on
+                            <field name="active_parent_company_name" class="oe_inline o_form_label" readonly="1"/>
+                            and send invoices via Peppol on their behalf.
+                        </p>
+                        <p class="text-muted" invisible="use_parent_connection">
+                            Send electronic invoices, and receive bills automatically via Peppol.
+                        </p>
+
+                        <div class="mb-3" invisible="not is_branch_company">
+                            <field name="use_parent_connection_selection" widget="radio" readonly="not can_use_parent_connection"/>
+                        </div>
+
                         <group col="1">
                             <group>
                                 <field name="peppol_eas"
                                        placeholder="Peppol ID"
                                        nolabel="1"
+                                       readonly="use_parent_connection"
                                        class="o_field_peppol_eas_selection"/>
-                                <field name="peppol_endpoint" nolabel="1" placeholder="Your endpoint"/>
-                                <field name="contact_email" string="Email"/>
-                                <field name="phone_number" required="edi_mode not in ('demo', 'test')" string="Phone"/>
+                                <field name="peppol_endpoint"
+                                       nolabel="1"
+                                       readonly="use_parent_connection"
+                                       placeholder="Your endpoint"/>
+                                <field name="contact_email"
+                                       readonly="use_parent_connection"
+                                       string="Email"/>
+                                <field name="phone_number"
+                                       required="edi_mode not in ('demo', 'test')"
+                                       readonly="use_parent_connection"
+                                       string="Phone"/>
                             </group>
 
-                            <group invisible="account_peppol_proxy_state != 'not_registered'">
+                            <group>
                                 <div class="text-muted col" invisible="edi_mode != 'prod'">
                                     By clicking the button below I accept that Odoo may process my e-invoices.
                                 </div>

--- a/addons/l10n_it_edi/models/account_edi_proxy_user.py
+++ b/addons/l10n_it_edi/models/account_edi_proxy_user.py
@@ -13,6 +13,11 @@ class Account_Edi_Proxy_ClientUser(models.Model):
 
     proxy_type = fields.Selection(selection_add=[('l10n_it_edi', 'Italian EDI')], ondelete={'l10n_it_edi': 'cascade'})
 
+    _unique_identification_l10n_it_edi = models.UniqueIndex(
+        "(edi_identification, proxy_type, edi_mode) WHERE (active AND proxy_type = 'l10n_it_edi')",
+        "This edi identification is already assigned to an active user",
+    )
+
     def _get_proxy_urls(self):
         urls = super()._get_proxy_urls()
         urls['l10n_it_edi'] = {

--- a/addons/l10n_my_edi/models/account_edi_proxy_user.py
+++ b/addons/l10n_my_edi/models/account_edi_proxy_user.py
@@ -20,6 +20,11 @@ class AccountEdiProxyClientUser(models.Model):
 
     proxy_type = fields.Selection(selection_add=[('l10n_my_edi', 'Malaysian EDI')], ondelete={'l10n_my_edi': 'cascade'})
 
+    _unique_identification_l10n_my_edi = models.UniqueIndex(
+        "(edi_identification, proxy_type, edi_mode) WHERE (active AND proxy_type = 'l10n_my_edi')",
+        "This edi identification is already assigned to an active user",
+    )
+
     # -----------------------
     # CRUD, inherited methods
     # -----------------------


### PR DESCRIPTION
This commit implements the functionality to allow all branch company to use Peppol in 2 ways:

- if any of its parent has an active peppol connection, allow the branch register new connection with the same identification as the parent and allow them to send invoice on behalf of that parent company.
- allow the branch company to register their own new connection on Peppol, which has now been made possible from the IAP refactor task.

Some quality of life features added to support this change:

- If the branch is using the parent's connection, allow them to also disconnect from the peppol settings.
- Show the parent company name as an info in the branch's registration wizard and peppol setting once activated.

related upgrade-PR: https://github.com/odoo/upgrade/pull/8318
task-4852830
