### PR TITLE
[FIX] base: don't block export if no translatable terms found

### DIFF
--- a/odoo/addons/base/wizard/base_export_language_views.xml
+++ b/odoo/addons/base/wizard/base_export_language_views.xml
@@ -18,23 +18,42 @@
                     </group>
                     <div invisible="state != 'get'">
                         <h2>Export Complete</h2>
-                        <p>Here is the exported translation file: <field name="data" readonly="1" filename="name"/></p>
-                        <p>This file was generated using the universal <strong>Unicode/UTF-8</strong> file encoding, please be sure to view and edit
-                           using the same encoding.</p>
-                        <p>The next step depends on the file format:
-                            <ul>
-                            <li>CSV format: you may edit it directly with your favorite spreadsheet software,
-                                the rightmost column (value) contains the translations</li>
-                            <li>PO(T) format: you should edit it with a PO editor such as
-                                <a href="http://www.poedit.net/" target="_blank">POEdit</a>, or your preferred text editor</li>
-                            <li>TGZ format: bundles multiple PO(T) files as a single archive</li>
-                            </ul>
-                        </p>
-                        <p>For more details about translating Odoo in your language, please refer to the
-                           <a href="https://github.com/odoo/odoo/wiki/Translations" target="_blank">documentation</a>.</p>
+                        <div invisible="data">
+                            <div class="mb-2 rounded-2 overflow-hidden d-grid gap-2" >
+                                <div class="alert alert-warning m-0 p-1 ps-3" role="alert">
+                                    <div name="error" style="white-space: pre-wrap;" invisible="export_type == 'module'">
+                                        Model
+                                        <field name="model_id" readonly="1"/>
+                                        does not contain translatable terms.<br/>
+                                    </div>
+                                    <div name="error" style="white-space: pre-wrap;" invisible="export_type == 'model'">
+                                        Modules
+                                        <field name="modules" widget="many2many_tags" readonly="1"/>
+                                        do not contain translatable terms.<br/>
+                                    </div>
+                                </div>
+                            </div>
+                            No file could be exported.
+                        </div>
+                        <div invisible="not data">
+                            <p>Here is the exported translation file: <field name="data" readonly="1" filename="name"/></p>
+                            <p>This file was generated using the universal <strong>Unicode/UTF-8</strong> file encoding, please be sure to view and edit
+                               using the same encoding.</p>
+                            <p>The next step depends on the file format:
+                                <ul>
+                                <li>CSV format: you may edit it directly with your favorite spreadsheet software,
+                                    the rightmost column (value) contains the translations</li>
+                                <li>PO(T) format: you should edit it with a PO editor such as
+                                    <a href="http://www.poedit.net/" target="_blank">POEdit</a>, or your preferred text editor</li>
+                                <li>TGZ format: bundles multiple PO(T) files as a single archive</li>
+                                </ul>
+                            </p>
+                            <p>For more details about translating Odoo in your language, please refer to the
+                                <a href="https://github.com/odoo/odoo/wiki/Translations" target="_blank">documentation</a>.</p>
+                        </div>
                     </div>
                     <footer invisible="state != 'choose'">
-                        <button name="act_getfile" string="Export" type="object" class="btn-primary" data-hotkey="q"/>
+                        <button name="act_getfile" data-hotkey="q" string="Export" type="object" class="btn-primary"/>
                         <button special="cancel" data-hotkey="x" string="Cancel" type="object" class="btn-secondary"/>
                     </footer>
                     <footer invisible="state != 'get'">

--- a/odoo/cli/i18n.py
+++ b/odoo/cli/i18n.py
@@ -221,7 +221,8 @@ class I18n(Command):
         _logger.info("Exporting %s (%s) to %s", source, lang_code or 'pot', destination)
 
         if destination == 'stdout':
-            trans_export(lang_code, module_names, sys.stdout.buffer, 'po', env)
+            if not trans_export(lang_code, module_names, sys.stdout.buffer, 'po', env):
+                _logger.warning("No translatable terms were found in %s.", module_names)
             return
 
         path.parent.mkdir(exist_ok=True)
@@ -229,7 +230,8 @@ class I18n(Command):
         if export_format == 'pot':
             export_format = 'po'
         with path.open('wb') as outfile:
-            trans_export(lang_code, module_names, outfile, export_format, env)
+            if not trans_export(lang_code, module_names, outfile, export_format, env):
+                _logger.warning("No translatable terms were found in %s.", module_names)
 
     def _loadlang(self, parsed_args):
         with Registry(parsed_args.db_name).cursor() as cr:

--- a/odoo/tools/translate.py
+++ b/odoo/tools/translate.py
@@ -1020,17 +1020,19 @@ class TarFileWriter:
 def trans_export(lang, modules, buffer, format, env):
     reader = TranslationModuleReader(env.cr, modules=modules, lang=lang)
     if not reader:
-        raise UserError(env._("No translatable terms were found in %s.", modules))
+        return False
     writer = TranslationFileWriter(buffer, fileformat=format, lang=lang)
     writer.write_rows(reader)
+    return True
 
 
 def trans_export_records(lang, model_name, ids, buffer, format, env):
     reader = TranslationRecordReader(env.cr, model_name, ids, lang=lang)
     if not reader:
-        raise UserError(env._("No translatable terms were found in %s.", model_name))
+        return False
     writer = TranslationFileWriter(buffer, fileformat=format, lang=lang)
     writer.write_rows(reader)
+    return True
 
 
 def _push(callback, term, source_line):


### PR DESCRIPTION
A blocking error is too much, because it impedes the automatic sync flow.
Warnings have been added to the `i18n` command and the `base_language_export` wizard.

A retry / more button has been added, in case the user wants
to export something else.

The title was changing to the default `Odoo` after switching state.
Now it stays `Export Translation`

<details><summary>Screenshots (click me)</summary>

Model:

![image](https://github.com/user-attachments/assets/325d7302-30e3-4314-9010-f38ca2f826dc)

![image](https://github.com/user-attachments/assets/b02d7305-b898-41a2-8b8a-01f31b2a2cb2)

![image](https://github.com/user-attachments/assets/a3d27699-e839-4d13-b387-ed8a8c50657d)

Module:

![image](https://github.com/user-attachments/assets/f015e53c-ba0a-4368-bbc9-b0ddbce6fda3)

![image](https://github.com/user-attachments/assets/df3f6008-13c0-4251-be61-b65fcec4d7ff)

![image](https://github.com/user-attachments/assets/73e36443-c305-43a6-8c30-b447de987359)

CLI:
![image](https://github.com/user-attachments/assets/c5e3144e-09ef-4755-b7c9-7abecc343b78)

</details> 

*(note: retargeted to saas-18.4)*
ref: https://github.com/odoo/odoo/pull/194933#discussion_r2176924160