### PR TITLE
[FIX] base: res.country _name_search arbitrary capitalization

### DIFF
--- a/odoo/addons/base/models/res_country.py
+++ b/odoo/addons/base/models/res_country.py
@@ -89,6 +89,11 @@ class Country(models.Model):
         ids = []
         if len(name) == 2:
             ids = list(self._search([('code', 'ilike', name)] + domain, limit=limit, order=order))
+        elif operator in ('=', '!=', 'in', 'not in'):
+            if isinstance(name, str):
+                name = name.capitalize()
+            else:  # iterable
+                name = [n.capitalize() if n else n for n in name]
 
         search_domain = [('name', operator, name)]
         if ids:

--- a/odoo/addons/base/tests/test_res_country.py
+++ b/odoo/addons/base/tests/test_res_country.py
@@ -1,20 +1,56 @@
 from odoo.tests import TransactionCase, tagged
 
 
-@tagged('-at_install', 'post_install')
-class TestResCountryState(TransactionCase):
-    def test_find_by_name(self):
-        """It should be possible to find a state by its display name
-        """
-        glorious_arstotzka = self.env['res.country'].create({
+class TestResCountryCommon(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.glorious_arstotzka = cls.env['res.country'].create({
             'name': 'Arstotzka',
             'code': 'AA',
         })
-        altan = self.env['res.country.state'].create({
-            'country_id': glorious_arstotzka.id,
+        cls.altan = cls.env['res.country.state'].create({
+            'country_id': cls.glorious_arstotzka.id,
             'code': 'AL',
             'name': 'Altan',
         })
+
+
+@tagged('-at_install', 'post_install')
+class TestResCountry(TestResCountryCommon):
+    def test_name_search(self):
+        glorious_arstotzka_tuple = (self.glorious_arstotzka.id, self.glorious_arstotzka.display_name)
+        for (name, op) in [
+            ('ARSTOTZKA', '='),
+            ('arstotzka', '='),
+            ('ARSTOTZKA', '!='),
+            ('arstotzka', '!='),
+            (['ARSTOTZKA'], 'in'),
+            (['arstotzka'], 'in'),
+            (['ARSTOTZKA'], 'not in'),
+            (['arstotzka'], 'not in'),
+        ]:
+            with self.subTest((name, op)):
+                assertFunc = self.assertNotIn if op in ('!=', 'not in') else self.assertEqual
+                assertFunc(
+                    [glorious_arstotzka_tuple],
+                    self.env['res.country'].name_search(name, operator=op),
+                    f"Failed on operator: '{op}'"
+                )
+
+    def test_name_search_code(self):
+        glorious_arstotzka_tuple = (self.glorious_arstotzka.id, self.glorious_arstotzka.display_name)
+        res = self.env['res.country'].name_search('aA', operator='=')
+        self.assertEqual(res, [glorious_arstotzka_tuple])
+
+
+@tagged('-at_install', 'post_install')
+class TestResCountryState(TestResCountryCommon):
+    def test_find_by_name(self):
+        """It should be possible to find a state by its display name
+        """
+        glorious_arstotzka = self.glorious_arstotzka
+        altan = self.altan
 
         for name in [
             altan.name,


### PR DESCRIPTION
**Current behavior:**
When importing a res.country record, if specifying a `name` then the search performed expects it to exactly match a first-letter-only capitalized pattern.

**Expected behavior:**
Let arbitrary capitalization be used on the input name string.

**Steps to reproduce:**
1. Create a sheet to import to `Contacts` (res.partner)
* `name`: anything
* `country_id`: "ARMENIA"

2. Load the sheet for import -> test -> can't resolve country name

**Cause of the issue:**
The `res.country` records' names follow a
first-letter-capitalized pattern and we do an exact search on the strings.

**Fix:**
Use `capitalize()` on the input value when we do the search, which will transform the string into precisely the form we want.

opw-4780334