### PR TITLE
[FIX] stock_rule: avoid creating duplicate MO name

### DIFF
--- a/addons/mrp/models/stock_rule.py
+++ b/addons/mrp/models/stock_rule.py
@@ -176,7 +176,7 @@ class StockRule(models.Model):
         }
         # Use the procurement group created in _run_pull mrp override
         # Preserve the origin from the original stock move, if available
-        if location_dest_id.warehouse_id.manufacture_steps == 'pbm_sam' and values.get('move_dest_ids') and values.get('group_id') and not values['move_dest_ids'][0].origin.startswith(values['group_id'].name):
+        if location_dest_id.warehouse_id.manufacture_steps == 'pbm_sam' and values.get('move_dest_ids') and values.get('group_id') and values['group_id'].name not in values['move_dest_ids'][0].origin:
             origin = values['move_dest_ids'][0].origin
             mo_values.update({
                 'name': values['group_id'].name,

--- a/addons/mrp/tests/test_replenish.py
+++ b/addons/mrp/tests/test_replenish.py
@@ -194,3 +194,46 @@ class TestMrpReplenish(TestMrpCommon):
         lead_days_date = datetime.strptime(
             loads(repl_info.json_lead_days)['lead_days_date'], '%m/%d/%Y').date()
         self.assertEqual(lead_days_date, fields.Date.today() + timedelta(days=365))
+
+    def test_replenish_multi_level_bom_with_pbm_sam(self):
+        """
+        Ensure that in a 3-step manufacturing flow ('pbm_sam') with MTO + reordering rule,
+        a multi-level BOM triggers separate MOs for each level without constraint errors.
+        1.) Set warehouse manufacture to (manufacture_steps == 'pbm_sam')
+        2.) Product_1 (enable manufacture and mto routes)
+        3.) Product_4 (enable manufacture)
+        4.) Add Product_1 as bom for product_4
+        5.) Add a reordering rule (manufacture) for product_4
+        6.) trigger replenishment for product_4
+        """
+        self.warehouse = self.env.ref('stock.warehouse0')
+        self.warehouse.write({'manufacture_steps': 'pbm_sam'})
+        self.warehouse.mto_pull_id.route_id.active = True
+
+        route_manufacture = self.warehouse.manufacture_pull_id.route_id.id
+        route_mto = self.warehouse.mto_pull_id.route_id.id
+
+        self.product_1.write({
+            'route_ids': [(6, 0, [route_mto, route_manufacture])]
+        })  # Component
+        self.product_4.write({
+            'route_ids': [(6, 0, [route_manufacture])],
+            'bom_ids': [(6, 0, [self.bom_1.id])]
+        })  # Finished Product
+
+        # Create reordering rule
+        self.env['stock.warehouse.orderpoint'].create({
+            'location_id': self.warehouse.lot_stock_id.id,
+            'product_id': self.product_4.id,
+            'route_id': route_manufacture,
+            'product_min_qty': 1,
+            'product_max_qty': 1,
+        })
+        self.product_4.orderpoint_ids.action_replenish()
+
+        # Check both MOs were created
+        mo_final = self.env['mrp.production'].search([('product_id', '=', self.product_4.id)])
+        mo_component = self.env['mrp.production'].search([('product_id', '=', self.product_1.id)])
+
+        self.assertEqual(len(mo_final), 1, "Expected one MO for the final product.")
+        self.assertEqual(len(mo_component), 1, "Expected one MO for the manufactured BOM component.")


### PR DESCRIPTION
__Issue:__

Condition used for MOs triggered under the `pbm_sam` manufacturing flow only checks the start of the group name, not the whole name, which could fail in case triggered by reordering rules where the origin might be a compound string such as: "OP/00001,WH/MO/00001"

__Steps to reproduce:__

1.) Install sales; inventory; manufacturing
2.) Enable multi-step routes
3.) Unarchive MTO
4.) Set warehouse manufacture steps to:
Pick components, manufacture, then store products (3 steps) (manufacture_steps == 'pbm_sam')
5.) Create product A-bom (enable manufacture and mto routes) 
6.) Create product B (enable manufacture)
7.) Add Product A as bom for product B
8.) Add a reordering rule (manufacture) for product B
9.) run SA Procurement: run scheduler
Error: duplicate key value violates unique constraint

opw-4866263
bug found: [[#c50cb9d]](https://github.com/odoo/odoo/commit/c50cb9d552f352bde4e3b8d92e8509476f194830)