### PR TITLE
[IMP] account:  add most usefull column in CoA view

### DIFF
--- a/addons/account/views/account_account_views.xml
+++ b/addons/account/views/account_account_views.xml
@@ -104,6 +104,7 @@
                     <field name="group_id" optional="hide"/>
                     <field name="internal_group" column_invisible="True"/>
                     <field name="reconcile" widget="boolean_toggle" invisible="account_type in ('asset_cash', 'liability_credit_card', 'off_balance')"/>
+                    <field name="active" optional="hide" widget="boolean_toggle"/>
                     <field name="non_trade" widget="boolean_toggle" invisible="account_type not in ('liability_payable', 'asset_receivable')" optional="hide"/>
                     <field name="tax_ids" optional="hide" widget="many2many_tax_tags"/>
                     <field name="tag_ids" domain="[('applicability', '=', 'accounts')]" optional="hide" widget="many2many_tags"/>

--- a/addons/account/wizard/setup_wizards_view.xml
+++ b/addons/account/wizard/setup_wizards_view.xml
@@ -91,7 +91,8 @@
                     <field name="name"/>
                     <field name="company_ids" column_invisible="True"/>
                     <field name="account_type" widget="account_type_selection"/>
-                    <field name="reconcile" widget="boolean_toggle"/>
+                    <field name="reconcile" optional="hide" widget="boolean_toggle"/>
+                    <field name="active" optional="show" widget="boolean_toggle"/>
                     <field name="opening_debit" options="{'no_symbol': True}"/>
                     <field name="opening_credit" options="{'no_symbol': True}"/>
                     <field name="opening_balance" optional="hide" options="{'no_symbol': True}"/>


### PR DESCRIPTION
In this commit:
- Moved the 'Allow Reconciliation' column to the optional 'Hide' section.
- Added the 'Active' column to the optional 'Show' section.
- Added the 'Active' column to the optional 'Hide' section in
  'Chart Of Accounts' menu.

task-4907725

