### PR TITLE
[FIX] web: fix overlapping and cut-off issue of address block in report layout

### DIFF
--- a/addons/web/views/report_templates.xml
+++ b/addons/web/views/report_templates.xml
@@ -309,7 +309,7 @@
                     <img t-if="company.logo" class="o_company_logo_big" t-att-src="image_data_uri(company.logo)" alt="Logo"/>
                     <div t-if="company.report_header" t-field="company.report_header" class="o_company_tagline fw-bold mt-2">Company tagline</div>
                 </div>
-                <div class="ms-3" name="company_address">
+                <div class=" w-50 ms-3" name="company_address">
                     <ul class="list-unstyled" name="company_address_list">
                         <li t-if="company.is_company_details_empty">
                             <span t-field="company.partner_id" t-options='{"widget": "contact", "fields": ["address", "name"], "no_marker": true}'>
@@ -320,7 +320,7 @@
                             </span>
                         </li>
                         <li t-else="">
-                            <span t-field="company.company_details" class="text-nowrap">
+                            <span t-field="company.company_details">
                                 <div class="bg-light border-1 rounded h-100 d-flex flex-column align-items-center justify-content-center p-4 w-100 opacity-75 text-muted text-center">
                                     <strong>Company details block</strong>
                                     <div>Contains the company details.</div>
@@ -366,7 +366,7 @@
                     <img t-if="company.logo" class="o_company_logo_big" t-att-src="image_data_uri(company.logo)" alt="Logo"/>
                 </div>
                 <div class="col-8 text-end mb4">
-                    <div name="company_address" class="float-end mb4">
+                    <div name="company_address" class="mb4">
                         <ul class="list-unstyled" name="company_address_list">
                             <li t-if="company.is_company_details_empty"><span t-field="company.partner_id" t-options='{"widget": "contact", "fields": ["address", "name"], "no_marker": true}'>
                                 <div class="bg-light border-1 rounded h-100 d-flex flex-column align-items-center justify-content-center p-4 w-100 opacity-75 text-muted text-center">
@@ -375,7 +375,7 @@
                                 </div>
                             </span></li>
                             <li t-else="">
-                                <span t-field="company.company_details" class="text-nowrap">
+                                <span t-field="company.company_details">
                                     <div class="bg-light border-1 rounded h-100 d-flex flex-column align-items-center justify-content-center p-4 w-100 opacity-75 text-muted text-center">
                                         <strong>Company details block</strong>
                                         <div>Contains the company details.</div>
@@ -434,7 +434,7 @@
                             </div>
                         </span></li>
                         <li t-else="">
-                            <span t-field="company.company_details" class="text-nowrap">
+                            <span t-field="company.company_details">
                                 <div class="bg-light border-1 rounded h-100 d-flex flex-column align-items-center justify-content-center p-4 w-100 opacity-75 text-muted text-center">
                                     <strong>Company details block</strong>
                                     <div>Contains the company details.</div>
@@ -494,7 +494,7 @@
                             </div>
                         </span></li>
                         <li t-else="">
-                            <span t-field="company.company_details" class="text-nowrap">
+                            <span t-field="company.company_details">
                                 <div class="bg-light border-1 rounded h-100 d-flex flex-column align-items-center justify-content-center p-4 w-100 opacity-75 text-muted text-center">
                                     <strong>Company details block</strong>
                                     <div>Contains the company details.</div>
@@ -559,7 +559,7 @@
                     <img t-if="company.logo" class="o_company_logo_big mb-2" t-att-src="image_data_uri(company.logo)" alt="Logo"/>
                     <div t-if="company.report_header" t-field="company.report_header" class="o_company_tagline fw-bold">Company tagline</div>
                 </div>
-                <div name="company_address" class="text-end">
+                <div name="company_address" class="w-50 text-end">
                     <ul class="list-unstyled" name="company_address_list">
                         <li t-if="company.is_company_details_empty"><span t-field="company.partner_id" t-options='{"widget": "contact", "fields": ["address", "name"], "no_marker": true}'>
                             <div class="d-flex flex-column align-items-center justify-content-center border-1 rounded p-4 h-100 w-100 bg-light opacity-75 text-muted text-center">
@@ -568,7 +568,7 @@
                             </div>
                         </span></li>
                         <li t-else="">
-                            <span t-field="company.company_details" class="text-nowrap">
+                            <span t-field="company.company_details">
                                 <div class="d-flex flex-column align-items-center justify-content-center border-1 rounded p-4 h-100 w-100 bg-light opacity-75 text-muted text-center">
                                     <strong>Company details block</strong>
                                     <div>Contains the company details.</div>
@@ -628,7 +628,7 @@
                     <img t-if="company.logo" class="o_company_logo mb-2" t-att-src="image_data_uri(company.logo)" alt="Logo"/>
                     <div t-if="company.report_header" t-field="company.report_header" class="o_company_tagline fw-bold">Company tagline</div>
                 </div>
-                <div name="company_address" class="text-end">
+                <div name="company_address" class="w-50 text-end">
                     <ul class="list-unstyled" name="company_address_list">
                         <li t-if="company.is_company_details_empty"><span t-field="company.partner_id" t-options='{"widget": "contact", "fields": ["address", "name"], "no_marker": true}'>
                             <div class="d-flex flex-column align-items-center justify-content-center border-1 rounded p-4 h-100 w-100 bg-light opacity-75 text-muted text-center">
@@ -637,7 +637,7 @@
                             </div>
                         </span></li>
                         <li t-else="">
-                            <span t-field="company.company_details" class="text-nowrap">
+                            <span t-field="company.company_details">
                                 <div class="d-flex flex-column align-items-center justify-content-center border-1 rounded p-4 h-100 w-100 bg-light opacity-75 text-muted text-center">
                                     <strong>Company details block</strong>
                                     <div>Contains the company details.</div>
@@ -694,7 +694,7 @@
                     <img t-if="company.logo" class="o_company_logo mb-2" t-att-src="image_data_uri(company.logo)" alt="Logo"/>
                     <div t-if="company.report_header" t-field="company.report_header" class="o_company_tagline fw-bold">Company tagline</div>
                 </div>
-                <div name="company_address" class="text-end">
+                <div name="company_address" class="w-50 text-end">
                     <ul class="list-unstyled" name="company_address_list">
                         <li t-if="company.is_company_details_empty"><span t-field="company.partner_id" t-options='{"widget": "contact", "fields": ["address", "name"], "no_marker": true}'>
                             <div class="d-flex flex-column align-items-center justify-content-center border-1 rounded p-4 h-100 w-100 bg-light opacity-75 text-muted text-center">
@@ -703,7 +703,7 @@
                             </div>
                         </span></li>
                         <li t-else="">
-                            <span t-field="company.company_details" class="text-nowrap">
+                            <span t-field="company.company_details">
                                 <div class="d-flex flex-column align-items-center justify-content-center border-1 rounded p-4 h-100 w-100 bg-light opacity-75 text-muted text-center">
                                     <strong>Company details block</strong>
                                     <div>Contains the company details.</div>


### PR DESCRIPTION
<b>Steps to Reproduce:</b>
1. Go to Settings > Companies > Configure Document Layout.
2. Choose layout Boxed or any layout that horizontally places the company logo and address.
3. Edit the address block choose long string.
4. Save the layout and click Preview Document or print SO or invoice.

<b>Issue:</b>
- Observe in PDF output the long text overlaps into logo or extend outside the layout bound(differ in layouts) — even though enough space is visually available

<b>Cause:</b>
- A previous change in [PR #201198](https://github.com/odoo/odoo/pull/201198) added the text-nowrap class to address blocks to fix a minor wrapping issue. However, this unintentionally caused layout overflow issues with long lines.

<b>Solution:</b>
- Added width to the address block to ensure balanced layout structure.
- Removed text-nowrap from all layouts, as the original issue is now resolved by applying proper width sizing.
- Removed float-end from Boxed layout, as it was contributing to misalignment.

<b>Additional Notes:</b>
All behaviors addressed by  [PR #201198](https://github.com/odoo/odoo/pull/201198) were re-tested to ensure this fix does not reintroduce previous issues.

<b>opw-4764975</b>
<br>
<b>[PR #201198](https://github.com/odoo/odoo/pull/201198) ISSUE : </b>

![image](https://github.com/user-attachments/assets/789e8c9e-0e24-4e2b-8ba6-9421ab02eaf8)
<br>
<b>ISSUE after [PR #201198](https://github.com/odoo/odoo/pull/201198) FIX:</b>

Folder - ![image](https://github.com/user-attachments/assets/176bfe25-ddbc-4774-bed3-b21eddacbb2c)
Boxed - ![image](https://github.com/user-attachments/assets/e45c37f5-8040-47c6-988c-bf2e7a175400)
<br>
<b>After this PR FIX : </b>

![image](https://github.com/user-attachments/assets/f1eb0d39-3e3b-469e-a978-2637107ba606)
![image](https://github.com/user-attachments/assets/df254c8d-8f0c-486f-ac4e-ec04f3b9e8a1)
![image](https://github.com/user-attachments/assets/315d5854-6ea2-4f0d-8a34-e86ea9e020db)
![image](https://github.com/user-attachments/assets/e582845e-2704-413f-af2b-0bf8bd8977a8)

