### PR TITLE
[IMP] hr_attendance: Update the employee status immediately on checkout or checkin in UI

### DIFF
--- a/addons/hr_attendance/models/__init__.py
+++ b/addons/hr_attendance/models/__init__.py
@@ -8,5 +8,6 @@ from . import hr_employee
 from . import hr_employee_public
 from . import hr_version
 from . import ir_http
+from . import ir_websocket
 from . import res_company
 from . import res_users

--- a/addons/hr_attendance/models/hr_employee.py
+++ b/addons/hr_attendance/models/hr_employee.py
@@ -162,6 +162,15 @@ class HrEmployee(models.Model):
             att = employee.last_attendance_id.sudo()
             employee.attendance_state = att and not att.check_out and 'checked_in' or 'checked_out'
 
+    def _notify_employee_presence_status(self):
+        self.ensure_one()
+        payload = {
+            "hr_presence_state": self.hr_presence_state,
+            "hr_icon_display": self.hr_icon_display,
+            "employee_id": self.id,
+        }
+        self._bus_send("hr.employee/presence", payload)
+
     def _attendance_action_change(self, geo_information=None):
         """ Check In/Check Out action
             Check In: create a new attendance record
@@ -182,7 +191,9 @@ class HrEmployee(models.Model):
                     'employee_id': self.id,
                     'check_in': action_date,
                 }
-            return self.env['hr.attendance'].create(vals)
+            res = self.env['hr.attendance'].create(vals)
+            self._notify_employee_presence_status()
+            return res
         attendance = self.env['hr.attendance'].search([('employee_id', '=', self.id), ('check_out', '=', False)], limit=1)
         if attendance:
             if geo_information:
@@ -194,6 +205,7 @@ class HrEmployee(models.Model):
                 attendance.write({
                     'check_out': action_date
                 })
+            self._notify_employee_presence_status()
         else:
             raise exceptions.UserError(_(
                 'Cannot perform check out on %(empl_name)s, could not find corresponding check in. '

--- a/addons/hr_attendance/models/ir_websocket.py
+++ b/addons/hr_attendance/models/ir_websocket.py
@@ -1,0 +1,26 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models
+
+
+class IrWebsocket(models.AbstractModel):
+    """Override to handle hr_employee specific features (presence in particular)."""
+
+    _inherit = "ir.websocket"
+
+    def _build_bus_channel_list(self, channels):
+        new_channels_list = []
+        employee_channel_ids = []
+        has_employee_public_access = self.env["hr.employee.public"].has_access("read")
+
+        for channel in list(channels):
+            if not isinstance(channel, str) or not channel.startswith("hr.employee_"):
+                new_channels_list.append(channel)
+                continue
+            emp_id = channel[len("hr.employee_"):]
+            if emp_id.isdigit() and has_employee_public_access:
+                employee_channel_ids.append(int(emp_id))
+
+        if employee_channel_ids and has_employee_public_access:
+            new_channels_list.extend(self.env["hr.employee.public"].browse(employee_channel_ids).exists().employee_id)
+        return super()._build_bus_channel_list(new_channels_list)

--- a/addons/hr_attendance/static/src/components/hr_presence_status/hr_attendance_presence_status.js
+++ b/addons/hr_attendance/static/src/components/hr_presence_status/hr_attendance_presence_status.js
@@ -1,8 +1,45 @@
+/** @odoo-module */
+
+import { onWillUnmount, onMounted } from "@odoo/owl";
 import { hrPresenceStatus, HrPresenceStatus } from "@hr/components/hr_presence_status/hr_presence_status";
 import { patch } from "@web/core/utils/patch";
 import { _t } from "@web/core/l10n/translation";
 
 patch(HrPresenceStatus.prototype, {
+    setup() {
+        super.setup();
+
+        this.busService = this.env.services.bus_service;
+        this._onPresenceStatus = this._onPresenceStatus.bind(this);
+
+        this.employeeAttendanceChannel = `hr.employee_${this.props.record.resId}`;
+        this.notificationType = "hr.employee/presence";
+
+        onMounted(() => this._mounted());
+        onWillUnmount(() => this._willUnmount());
+    },
+
+    _mounted() {
+        this.busService.addChannel(this.employeeAttendanceChannel);
+        this.busService.subscribe(this.notificationType, this._onPresenceStatus);
+    },
+
+    _willUnmount() {
+        this.busService.unsubscribe(this.notificationType, this._onPresenceStatus);
+        this.busService.deleteChannel(this.employeeAttendanceChannel);
+    },
+
+    /** Handle incoming hr.employee/presence notifications. */
+    _onPresenceStatus(payload) {
+        if (payload?.employee_id === this.props.record.resId) {
+            this.props.record.data = {
+                ...this.props.record.data,
+                hr_presence_state: payload.hr_presence_state,
+                hr_icon_display: payload.hr_icon_display,
+            };
+        }
+    },
+
     get label() {
         if (this.value === 'presence_present') {
             const hasUser = this.props.record.data.user_id;
@@ -12,9 +49,8 @@ patch(HrPresenceStatus.prototype, {
         } else if (this.value === 'presence_out_of_working_hour') {
             return _t("Off-Hours");
         }
-        
         return super.label;
-    }
+    },
 });
 
 Object.assign(hrPresenceStatus, {

--- a/addons/hr_attendance/static/tests/employee_presence_state.test.js
+++ b/addons/hr_attendance/static/tests/employee_presence_state.test.js
@@ -1,0 +1,68 @@
+/** @odoo-module */
+
+import { expect, test } from "@odoo/hoot";
+import { runAllTimers } from "@odoo/hoot-dom";
+import { waitForChannels, waitNotifications } from "@bus/../tests/bus_test_helpers";
+
+import {
+    MockServer,
+    defineModels,
+    mountView,
+    models,
+    makeMockEnv,
+} from "@web/../tests/web_test_helpers";
+
+import { hrModels } from "@hr/../tests/hr_test_helpers";
+import { serverState } from "@web/../tests/_framework/mock_server_state.hoot";
+
+
+class HrEmployee extends models.ServerModel {
+    _name = "hr.employee";
+    _records = [
+        {
+            id: 22,
+            name: "Test Employee",
+            hr_icon_display: "presence_absent",
+            hr_presence_state: "absent",
+            user_id: serverState.userId,
+        },
+    ];
+}
+
+defineModels({ ...hrModels, HrEmployee });
+
+test("Check presence status state", async function () {
+    const env = await makeMockEnv();
+    const channel = "hr.employee_22";
+
+    env.services.bus_service.addChannel(channel);
+    await waitForChannels([channel]);
+
+    await mountView({
+        type: "kanban",
+        resModel: "hr.employee",
+        arch: `
+            <kanban class="o_hr_employee_kanban" sample="1" duplicate="false">
+                <templates>
+                    <t t-name="card" class="flex-row">
+                        <field name="name"/>
+                        <field name="hr_icon_display" widget="hr_presence_status"/>
+                    </t>
+                </templates>
+            </kanban>
+        `,
+    });
+
+    expect(".o_employee_availability span").toHaveAttribute("title", "Absent");
+
+    await MockServer.env["bus.bus"]._sendone(channel, "hr.employee/presence", {
+        hr_icon_display: "presence_present",
+        hr_presence_state: "present",
+        employee_id: 22,
+    });
+
+    await waitNotifications([env, "hr.employee/presence"]);
+    await runAllTimers();
+
+    expect(".o_employee_availability span").toHaveAttribute("title", "Present");
+});


### PR DESCRIPTION
### Before:
- When a user is checked-in/checked-out, his presence indicator is only updated if you refresh your browser. 

### After:
- Status will update immediately if checkout/checkin in the ui.

Task-4855213

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
