### PR TITLE
[REF] web: hiding dialog's default button in pure CSS

### DIFF
--- a/addons/web/static/src/core/dialog/dialog.scss
+++ b/addons/web/static/src/core/dialog/dialog.scss
@@ -27,6 +27,10 @@
         button {
             margin: 0; // Reset boostrap.
         }
+
+        button.o-default-button:not(:only-child) {
+            display: none;
+        }
         
         @include media-breakpoint-down(md) {
             .btn {

--- a/addons/web/static/src/views/view_dialogs/form_view_dialog.js
+++ b/addons/web/static/src/views/view_dialogs/form_view_dialog.js
@@ -3,7 +3,7 @@ import { useChildRef, useService } from "@web/core/utils/hooks";
 import { CallbackRecorder } from "@web/search/action_hook";
 import { View } from "@web/views/view";
 
-import { Component, onMounted } from "@odoo/owl";
+import { Component } from "@odoo/owl";
 
 export class FormViewDialog extends Component {
     static template = "web.FormViewDialog";
@@ -97,17 +97,6 @@ export class FormViewDialog extends Component {
                 this.props.close();
             };
         }
-
-        onMounted(() => {
-            if (this.modalRef.el.querySelector(".modal-footer").childElementCount > 1) {
-                const defaultButton = this.modalRef.el.querySelector(
-                    ".modal-footer button.o-default-button"
-                );
-                if (defaultButton) {
-                    defaultButton.classList.add("d-none");
-                }
-            }
-        });
     }
 
     async discardRecord() {

--- a/addons/web/static/src/webclient/actions/action_dialog.js
+++ b/addons/web/static/src/webclient/actions/action_dialog.js
@@ -2,8 +2,6 @@ import { Dialog } from "@web/core/dialog/dialog";
 import { DebugMenu } from "@web/core/debug/debug_menu";
 import { useOwnDebugContext } from "@web/core/debug/debug_context";
 
-import { useEffect } from "@odoo/owl";
-
 export class ActionDialog extends Dialog {
     static components = { ...Dialog.components, DebugMenu };
     static template = "web.ActionDialog";
@@ -24,16 +22,5 @@ export class ActionDialog extends Dialog {
     setup() {
         super.setup();
         useOwnDebugContext();
-        useEffect(
-            () => {
-                if (this.modalRef.el.querySelector(".modal-footer")?.childElementCount > 1) {
-                    const defaultButton = this.modalRef.el.querySelector(
-                        ".modal-footer button.o-default-button"
-                    );
-                    defaultButton.classList.add("d-none");
-                }
-            },
-            () => []
-        );
     }
 }

--- a/addons/web/static/tests/views/form/form_view.test.js
+++ b/addons/web/static/tests/views/form/form_view.test.js
@@ -7613,10 +7613,10 @@ test(`modifiers are considered on multiple <footer/> tags`, async () => {
 
     await mountWithCleanup(WebClient);
     await getService("action").doAction(1);
-    expect(queryAllTexts`.modal-footer button:not(.d-none)`).toEqual(["Hello", "World"]);
+    expect(queryAllTexts`.modal-footer button:visible`).toEqual(["Hello", "World"]);
 
     await contains(`.o_field_boolean input`).click();
-    expect(queryAllTexts`.modal-footer button:not(.d-none)`).toEqual(["Foo"]);
+    expect(queryAllTexts`.modal-footer button:visible`).toEqual(["Foo"]);
 });
 
 test(`buttons in footer are moved to $buttons if necessary`, async () => {

--- a/addons/web/static/tests/views/view_dialogs/form_view_dialog.test.js
+++ b/addons/web/static/tests/views/view_dialogs/form_view_dialog.test.js
@@ -79,7 +79,7 @@ test("formviewdialog buttons in footer are positioned properly", async () => {
     await animationFrame();
 
     expect(".modal-body button").toHaveCount(0, { message: "should not have any button in body" });
-    expect(".modal-footer button:not(.d-none)").toHaveCount(1, {
+    expect(".modal-footer button:visible").toHaveCount(1, {
         message: "should have only one button in footer",
     });
 });
@@ -105,13 +105,13 @@ test("modifiers are considered on multiple <footer/> tags", async () => {
 
     await animationFrame();
 
-    expect(queryAllTexts(".modal-footer button:not(.d-none)")).toEqual(["Hello", "World"], {
+    expect(queryAllTexts(".modal-footer button:visible")).toEqual(["Hello", "World"], {
         message: "only the first button section should be visible",
     });
 
     await click(".o_field_boolean input");
     await animationFrame();
-    expect(queryAllTexts(".modal-footer button:not(.d-none)")).toEqual(["Foo"], {
+    expect(queryAllTexts(".modal-footer button:visible")).toEqual(["Foo"], {
         message: "only the second button section should be visible",
     });
 });

--- a/addons/web/static/tests/webclient/actions/target.test.js
+++ b/addons/web/static/tests/webclient/actions/target.test.js
@@ -152,7 +152,7 @@ describe("new", () => {
         expect(".o_technical_modal .modal-footer button.infooter").toHaveCount(1, {
             message: "the button should be in the footer",
         });
-        expect(".modal-footer button:not(.d-none)").toHaveCount(1, {
+        expect(".modal-footer button:visible").toHaveCount(1, {
             message: "the modal footer should only contain one visible button",
         });
     });
@@ -305,13 +305,13 @@ describe("new", () => {
         expect('.o_technical_modal .modal-body button[special="save"]').toHaveCount(0);
         expect(".o_technical_modal .modal-body button.infooter").toHaveCount(0);
         expect(".o_technical_modal .modal-footer button.infooter").toHaveCount(1);
-        expect(".o_technical_modal .modal-footer button:not(.d-none)").toHaveCount(1);
+        expect(".o_technical_modal .modal-footer button:visible").toHaveCount(1);
         await getService("action").doAction(25);
         expect(".o_technical_modal .modal-body button.infooter").toHaveCount(0);
         expect(".o_technical_modal .modal-footer button.infooter").toHaveCount(0);
         expect('.o_technical_modal .modal-body button[special="save"]').toHaveCount(0);
         expect('.o_technical_modal .modal-footer button[special="save"]').toHaveCount(1);
-        expect(".o_technical_modal .modal-footer button:not(.d-none)").toHaveCount(1);
+        expect(".o_technical_modal .modal-footer button:visible").toHaveCount(1);
     });
 
     test('button with confirm attribute in act_window action in target="new"', async () => {


### PR DESCRIPTION
Dialog's footer contains a default "Ok" button, which should be hidden once/if the displayed view in the dialog provides buttons.

Before this commit, this was performed through a useEffect/onMounted hook in JS, but actually we can do way simpler using only CSS. This commit reimplements it using a single CSS rule.

task-4277543



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
