### PR TITLE
[IMP] html_editor: toolbar enhancements

### DIFF
--- a/addons/html_builder/static/src/builder.js
+++ b/addons/html_builder/static/src/builder.js
@@ -136,6 +136,7 @@ export class Builder extends Component {
                 allowTargetBlank: true,
                 dropImageAsAttachment: true,
                 getAnimateTextConfig: () => ({ editor: this.editor, editorBus: this.editorBus }),
+                baseContainers: ["P"],
             },
             this.env.services
         );

--- a/addons/html_editor/static/src/core/base_container_plugin.js
+++ b/addons/html_editor/static/src/core/base_container_plugin.js
@@ -18,6 +18,9 @@ import { selectElements } from "@html_editor/utils/dom_traversal";
 export class BaseContainerPlugin extends Plugin {
     static id = "baseContainer";
     static shared = ["createBaseContainer", "getDefaultNodeName", "isCandidateForBaseContainer"];
+    static defaultConfig = {
+        baseContainers: ["P", "DIV"],
+    };
     /**
      * Register one of the predicates for `invalid_for_base_container_predicates`
      * as a property for optimization, see variants of `isCandidateForBaseContainer`.
@@ -62,7 +65,7 @@ export class BaseContainerPlugin extends Plugin {
     }
 
     getDefaultNodeName() {
-        return this.config.baseContainer || "P";
+        return this.config.baseContainers[0];
     }
 
     /**

--- a/addons/html_editor/static/src/core/format_plugin.js
+++ b/addons/html_editor/static/src/core/format_plugin.js
@@ -145,7 +145,6 @@ export class FormatPlugin extends Plugin {
             {
                 id: "strikethrough",
                 groupId: "decoration",
-                namespaces: ["compact", "expanded"],
                 commandId: "formatStrikethrough",
                 isActive: isFormatted(this, "strikeThrough"),
             },

--- a/addons/html_editor/static/src/editor.js
+++ b/addons/html_editor/static/src/editor.js
@@ -1,5 +1,5 @@
 import { MAIN_PLUGINS } from "./plugin_sets";
-import { createBaseContainer } from "./utils/base_container";
+import { createBaseContainer, SUPPORTED_BASE_CONTAINER_NAMES } from "./utils/base_container";
 import { fillShrunkPhrasingParent, removeClass } from "./utils/dom";
 import { isEmpty } from "./utils/dom_info";
 import { resourceSequenceSymbol, withSequence } from "./utils/resource";
@@ -24,7 +24,7 @@ import { setElementContent } from "@web/core/utils/html";
  * @typedef { Object } EditorConfig
  * @property { string } [content]
  * @property { boolean } [allowInlineAtRoot]
- * @property { string } [baseContainer]
+ * @property { string[] } [baseContainers]
  * @property { PluginConstructor[] } [Plugins]
  * @property { string[] } [classList]
  * @property { Object } [localOverlayContainers]
@@ -99,7 +99,10 @@ export class Editor {
         if (this.config.content) {
             setElementContent(editable, fixInvalidHTML(this.config.content));
             if (isEmpty(editable)) {
-                const baseContainer = createBaseContainer(this.config.baseContainer, this.document);
+                const baseContainer = createBaseContainer(
+                    this.config.baseContainers[0],
+                    this.document
+                );
                 fillShrunkPhrasingParent(baseContainer);
                 editable.replaceChildren(baseContainer);
             }
@@ -113,6 +116,17 @@ export class Editor {
         }
         if (this.config.height) {
             editable.style.height = this.config.height;
+        }
+        if (
+            !this.config.baseContainers.every((name) =>
+                SUPPORTED_BASE_CONTAINER_NAMES.includes(name)
+            )
+        ) {
+            throw new Error(
+                `Invalid baseContainers: ${this.config.baseContainers.join(
+                    ", "
+                )}. Supported: ${SUPPORTED_BASE_CONTAINER_NAMES.join(", ")}`
+            );
         }
         this.startPlugins();
         this.isReady = true;

--- a/addons/html_editor/static/src/fields/html_field.js
+++ b/addons/html_editor/static/src/fields/html_field.js
@@ -256,8 +256,8 @@ export class HtmlField extends Component {
             ...this.props.editorConfig,
         };
 
-        if (!("baseContainer" in config)) {
-            config.baseContainer = "DIV";
+        if (!("baseContainers" in config)) {
+            config.baseContainers = ["DIV", "P"];
         }
 
         if (this.props.embeddedComponents) {
@@ -348,8 +348,8 @@ export const htmlField = {
             editorConfig.allowImage = Boolean(options.allowAttachmentCreation);
             editorConfig.allowFile = Boolean(options.allowAttachmentCreation);
         }
-        if ("baseContainer" in options) {
-            editorConfig.baseContainer = options.baseContainer;
+        if ("baseContainers" in options) {
+            editorConfig.baseContainers = options.baseContainers;
         }
         return {
             editorConfig,

--- a/addons/html_editor/static/src/main/font/color_plugin.js
+++ b/addons/html_editor/static/src/main/font/color_plugin.js
@@ -55,6 +55,7 @@ export class ColorPlugin extends Plugin {
             {
                 id: "forecolor",
                 groupId: "decoration",
+                namespaces: ["compact", "expanded"],
                 description: _t("Apply Font Color"),
                 Component: ColorSelector,
                 props: this.getPropsForColorSelector("foreground"),

--- a/addons/html_editor/static/src/main/font/font_plugin.js
+++ b/addons/html_editor/static/src/main/font/font_plugin.js
@@ -27,7 +27,10 @@ import {
 import { DIRECTIONS } from "@html_editor/utils/position";
 import { _t } from "@web/core/l10n/translation";
 import { FontSelector } from "./font_selector";
-import { getBaseContainerSelector } from "@html_editor/utils/base_container";
+import {
+    getBaseContainerSelector,
+    SUPPORTED_BASE_CONTAINER_NAMES,
+} from "@html_editor/utils/base_container";
 import { withSequence } from "@html_editor/utils/resource";
 import { reactive } from "@odoo/owl";
 import { FontSizeSelector } from "./font_size_selector";
@@ -186,7 +189,7 @@ export class FontPlugin extends Plugin {
                 description: _t("Select font style"),
                 Component: FontSelector,
                 props: {
-                    getItems: () => fontItems,
+                    getItems: () => this.availableFontItems,
                     getDisplay: () => this.font,
                     onSelected: (item) => {
                         this.dependencies.dom.setTag({
@@ -313,6 +316,14 @@ export class FontPlugin extends Plugin {
         }
     }
 
+    get availableFontItems() {
+        return fontItems.filter(
+            ({ tagName }) =>
+                !SUPPORTED_BASE_CONTAINER_NAMES.includes(tagName.toUpperCase()) ||
+                this.config.baseContainers.includes(tagName.toUpperCase())
+        );
+    }
+
     get fontName() {
         const sel = this.dependencies.selection.getSelectionData().deepEditableSelection;
         // if (!sel) {
@@ -322,7 +333,7 @@ export class FontPlugin extends Plugin {
         const block = closestBlock(anchorNode);
         const tagName = block.tagName.toLowerCase();
 
-        const matchingItems = fontItems.filter((item) =>
+        const matchingItems = this.availableFontItems.filter((item) =>
             item.selector ? block.matches(item.selector) : item.tagName === tagName
         );
 

--- a/addons/html_editor/static/src/main/media/image_description.js
+++ b/addons/html_editor/static/src/main/media/image_description.js
@@ -1,34 +1,17 @@
 import { Component } from "@odoo/owl";
 import { Dialog } from "@web/core/dialog/dialog";
-import { useService } from "@web/core/utils/hooks";
 import { toolbarButtonProps } from "@html_editor/main/toolbar/toolbar";
 
 export class ImageDescription extends Component {
     static components = { Dialog };
     static props = {
         ...toolbarButtonProps,
-        getDescription: Function,
-        getTooltip: Function,
-        updateImageDescription: Function,
+        openImageDescriptionPopover: Function,
     };
     static template = "html_editor.ImageDescription";
-
-    setup() {
-        this.dialog = useService("dialog");
-    }
-
-    openDescriptionDialog() {
-        this.dialog.add(ImageDescriptionDialog, {
-            description: this.props.getDescription(),
-            onConfirm: (description, tooltip) =>
-                this.props.updateImageDescription({ description, tooltip }),
-            tooltip: this.props.getTooltip(),
-        });
-    }
 }
 
-class ImageDescriptionDialog extends Component {
-    static components = { Dialog };
+export class ImageDescriptionPopover extends Component {
     static props = {
         close: Function,
         description: {
@@ -41,7 +24,7 @@ class ImageDescriptionDialog extends Component {
             optional: true,
         },
     };
-    static template = "html_editor.ImageDescriptionDialog";
+    static template = "html_editor.ImageDescriptionPopover";
 
     setup() {
         this.state = {
@@ -51,7 +34,7 @@ class ImageDescriptionDialog extends Component {
     }
 
     onSave() {
-        this.props.onConfirm(this.state.description, this.state.tooltip);
+        this.props.onConfirm(this.state.description || "", this.state.tooltip || "");
         this.props.close();
     }
 }

--- a/addons/html_editor/static/src/main/media/image_description.xml
+++ b/addons/html_editor/static/src/main/media/image_description.xml
@@ -1,34 +1,32 @@
 <templates xml:space="preserve">
     <t t-name="html_editor.ImageDescription">
-        <button class="btn btn-light" t-att-title="props.title" t-on-click="openDescriptionDialog">
+        <button class="btn btn-light" t-att-title="props.title" t-on-click="this.props.openImageDescriptionPopover">
             Description
         </button>
     </t>
 
-    <t t-name="html_editor.ImageDescriptionDialog">
-        <Dialog size="'md'" title.translate="Image description">
-            <div class="mb-3 row">
-                <label class="col-md-3 col-form-label" for="alt">
-                    Description
-                    <sup class="text-info" title="'Alt tag' specifies an alternate text for an image, if the image cannot be displayed (slow connection, missing image, screen reader ...).">?</sup>
-                </label>
-                <div class="col-md-8">
-                    <input t-model="this.state.description" name="description" class="form-control" required="required" type="text"/>
-                </div>
+    <t t-name="html_editor.ImageDescriptionPopover">
+        <div class="o-we-image-description-popover p-3">
+            <input
+                type="text"
+                t-model="this.state.description"
+                placeholder="Description"
+                title="'Alt tag' specifies an alternate text for an image, if the image cannot be displayed (slow connection, missing image, screen reader ...)."
+                name="description"
+                class="border-dark-subtle form-control mb-2"
+            />
+            <input
+                type="text"
+                t-model="this.state.tooltip"
+                placeholder="Tooltip"
+                title="'Title tag' is shown as a tooltip when you hover the picture."
+                name="tooltip"
+                class="border-dark-subtle form-control mb-2"
+            />
+            <div class="mt-3">
+                <button class="o_we_apply_link btn btn-sm btn-primary" t-on-click="this.onSave">Apply</button>
+                <button class="o_we_discard_link btn btn-sm btn-dark ms-1" t-on-click="this.props.close">Discard</button>
             </div>
-            <div class="mb-3 row">
-                <label class="col-md-3 col-form-label" for="title">
-                    Tooltip
-                    <sup class="text-info" title="'Title tag' is shown as a tooltip when you hover the picture.">?</sup>
-                </label>
-                <div class="col-md-8">
-                    <input t-model="this.state.tooltip" name="tooltip" class="form-control" required="required" type="text"/>
-                </div>
-            </div>
-            <t t-set-slot="footer">
-                <button class="btn btn-primary" t-on-click="this.onSave">Save</button>
-                <button class="btn btn-secondary" t-on-click="this.props.close">Discard</button>
-            </t>
-        </Dialog>
+        </div>
     </t>
 </templates>

--- a/addons/html_editor/static/tests/image.test.js
+++ b/addons/html_editor/static/tests/image.test.js
@@ -114,10 +114,10 @@ test("can add an image description & tooltip", async () => {
     await click(".o-we-toolbar .btn-group[name='image_description'] button");
     await animationFrame();
 
-    expect(".modal-body").toHaveCount(1);
+    expect(".o-we-image-description-popover").toHaveCount(1);
     await contains("input[name='description']").edit("description modified");
     await contains("input[name='tooltip']").edit("tooltip modified");
-    await click(".modal-footer button");
+    await click(".o-we-image-description-popover button");
     await animationFrame();
     expect("img").toHaveAttribute("alt", "description modified");
     expect("img").toHaveAttribute("title", "tooltip modified");
@@ -133,12 +133,12 @@ test("can edit an image description & tooltip", async () => {
     await click(".o-we-toolbar .btn-group[name='image_description'] button");
     await animationFrame();
 
-    expect(".modal-body").toHaveCount(1);
+    expect(".o-we-image-description-popover").toHaveCount(1);
     expect("input[name='description']").toHaveValue("description");
     expect("input[name='tooltip']").toHaveValue("tooltip");
     await contains("input[name='description']").edit("description modified");
     await contains("input[name='tooltip']").edit("tooltip modified");
-    await click(".modal-footer button");
+    await click(".o-we-image-description-popover button");
     await animationFrame();
     expect("img").toHaveAttribute("alt", "description modified");
     expect("img").toHaveAttribute("title", "tooltip modified");
@@ -327,7 +327,9 @@ test("Image transformation disappears on backspace/delete", async () => {
     `);
     click("img.test-image");
     await expectElementCount(".o-we-toolbar", 1);
-    await contains(".o-we-toolbar div[name='image_modifiers'] button[name='image_transform']").click();
+    await contains(
+        ".o-we-toolbar div[name='image_modifiers'] button[name='image_transform']"
+    ).click();
     await expectElementCount(".transfo-container", 1);
     press("backspace");
     await expectElementCount(".transfo-container", 0);
@@ -336,12 +338,13 @@ test("Image transformation disappears on backspace/delete", async () => {
     click("img.test-image");
     await waitFor(".o-we-toolbar");
     await expectElementCount(".o-we-toolbar", 1);
-    await contains(".o-we-toolbar div[name='image_modifiers'] button[name='image_transform']").click();
+    await contains(
+        ".o-we-toolbar div[name='image_modifiers'] button[name='image_transform']"
+    ).click();
     await expectElementCount(".transfo-container", 1);
     press("delete");
     await expectElementCount(".transfo-container", 0);
 });
-
 
 test("Image transformation disappears on character key press", async () => {
     const { editor } = await setupEditor(`
@@ -349,7 +352,9 @@ test("Image transformation disappears on character key press", async () => {
     `);
     click("img.test-image");
     await expectElementCount(".o-we-toolbar", 1);
-    await contains(".o-we-toolbar div[name='image_modifiers'] button[name='image_transform']").click();
+    await contains(
+        ".o-we-toolbar div[name='image_modifiers'] button[name='image_transform']"
+    ).click();
     await expectElementCount(".transfo-container", 1);
     insertText(editor, "a");
     await expectElementCount(".transfo-container", 0);

--- a/addons/html_editor/static/tests/paste.test.js
+++ b/addons/html_editor/static/tests/paste.test.js
@@ -42,7 +42,7 @@ describe("Html Paste cleaning - whitelist", () => {
                         pasteHtml(editor, `a<${tagDescription}>b</${tagName}>c`);
                     },
                     contentAfter: "<p>123" + html + "[]4</p>",
-                    config: { baseContainer: "DIV" },
+                    config: { baseContainers: ["DIV", "P"] },
                 });
             }
         }
@@ -776,7 +776,7 @@ describe("Simple html elements containing <br>", () => {
                     pasteHtml(editor, "<div>abc<br>def</div>");
                 },
                 contentAfter: `<div>abc</div><div>def[]</div>`,
-                config: { baseContainer: "DIV" },
+                config: { baseContainers: ["DIV", "P"] },
             });
         });
 
@@ -1928,7 +1928,7 @@ describe("Complex html div", () => {
                 pasteHtml(editor, complexHtmlData);
             },
             contentAfter: `<div>abcdef</div><div dir="rtl">ghijkl</div><div>jklmno[]</div>`,
-            config: { baseContainer: "DIV" },
+            config: { baseContainers: ["DIV", "P"] },
         });
     });
 
@@ -1950,7 +1950,7 @@ describe("Complex html div", () => {
                 pasteHtml(editor, copiedHtmlData);
             },
             contentAfter: `<p>12</p><ol><li><div>abc</div></li><li><div>def</div><div>ghi</div><div>jkl[]</div></li></ol><p>3</p>`,
-            config: { baseContainer: "DIV" },
+            config: { baseContainers: ["DIV", "P"] },
         });
     });
 

--- a/addons/website/static/tests/builder/editor.test.js
+++ b/addons/website/static/tests/builder/editor.test.js
@@ -209,4 +209,11 @@ describe("toolbar dropdowns", () => {
         await animationFrame();
         expect(p.firstChild).toHaveClass("test-font-size");
     });
+
+    test("font selector dropdown should not have normal as an option", async () => {
+        await setup();
+        click(".o-we-toolbar .btn[name='font']");
+        await animationFrame();
+        expect(".o_font_selector_menu .o-dropdown-item[name='div']").toHaveCount(0);
+    });
 });


### PR DESCRIPTION
Description of the feature this PR addresses:

I. Replaces strike through with font color in compact toolbar.
II. Ensures that the Normal option is removed from the font selector dropdown of toolbar in website.
It does this by replacing the baseContainer config with baseContainers, a list that defines the allowed base containers. The first element of the list now serves as the default, equivalent to the previous baseContainer.
This change enables conditional display of "Normal" and "Paragraph" options in the toolbar. For example, if baseContainers only includes "DIV", only the "Normal" option will be shown. Similarly, if it only includes "P", only the "Paragraph" option will be shown.
III. Replaces the image description dialog with a popover. Just like the dialog, the popover allows users to edit the alt and title attributes of an image.

enterprise-https://github.com/odoo/enterprise/pull/91029

task-4770922

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
