### PR TITLE
[IMP] website, website_*: replace `o-line-clamp` mixin with a class

### DIFF
--- a/addons/website/static/src/scss/primary_variables.scss
+++ b/addons/website/static/src/scss/primary_variables.scss
@@ -2351,12 +2351,6 @@ $o-offcanvas-horizontal-width: var(--Offcanvas-horizontal-width, #{$o-offcanvas-
     }
 };
 
-@mixin o-line-clamp($lines) {
-    display: -webkit-box;
-    -webkit-line-clamp: $lines;
-    -webkit-box-orient: vertical;
-}
-
 // Replaces 'NULL' string values in a map by the sass null value (this is useful
 // as a "hack" to allow users to define null values in their custom palette as
 // normal null values are immediately removed to act as "removing the user custo

--- a/addons/website/static/src/scss/website.scss
+++ b/addons/website/static/src/scss/website.scss
@@ -594,6 +594,13 @@ p {
     margin-top: $paragraph-margin-top;
 }
 
+.o_line_clamp {
+    display: -webkit-box;
+    -webkit-line-clamp: var(--lines-clamp, 2);
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+}
+
 font[style*='background']:not(.text-gradient),
 font[class*='bg-'] {
     // Not adding any horizontal padding is important as it ensures that several

--- a/addons/website_blog/static/src/snippets/s_blog_posts/000.scss
+++ b/addons/website_blog/static/src/snippets/s_blog_posts/000.scss
@@ -4,15 +4,10 @@
     }
 
     .s_blog_posts_post_teaser {
-        @include o-line-clamp(2);
 
         @include media-breakpoint-up(md) {
-            @include o-line-clamp(4);
+            --lines-clamp: 4;
         }
-    }
-
-    .s_blog_posts_post_subtitle {
-        @include o-line-clamp(2);
     }
 
     &.s_blog_post_list:not(:has(.s_dynamic_snippet_title_aside)){

--- a/addons/website_blog/views/snippets/s_blog_posts.xml
+++ b/addons/website_blog/views/snippets/s_blog_posts.xml
@@ -106,7 +106,7 @@
                     </div>
                     <div class="s_blog_posts_post_cover_hidden h-auto py-2 px-4">
                         <t t-call="website_blog.s_dynamic_snippet_template_author"/>
-                        <p class="s_blog_posts_post_subtitle w-100 mt-2 m-0 lead overflow-hidden" t-field="record.subtitle"/>
+                        <p class="s_blog_posts_post_subtitle o_line_clamp w-100 mt-2 m-0 lead" t-field="record.subtitle"/>
                     </div>
                 </div>
             </t>
@@ -136,7 +136,7 @@
                         <t t-call="website_blog.s_dynamic_snippet_template_date">
                             <t t-set="date_custom_class" t-value="'small'"/>
                         </t>
-                        <p class="s_blog_posts_post_subtitle mt-1 mb-0 lead overflow-hidden" t-field="record.subtitle"/>
+                        <p class="s_blog_posts_post_subtitle o_line_clamp mt-1 mb-0 lead" t-field="record.subtitle"/>
                     </a>
                     <div class="d-flex justify-content-between small">
                         <t t-call="website_blog.s_dynamic_snippet_template_author"/>
@@ -303,7 +303,7 @@
 
 <!-- Blog Post Teaser (optional for Card and List layouts) -->
 <template id="website_blog.s_dynamic_snippet_template_teaser" name="Blog Post Teaser">
-    <p t-if="blog_posts_post_teaser_active" t-attf-class="s_blog_posts_post_teaser overflow-hidden {{ teaser_custom_class }}" t-field="record.teaser"/>
+    <p t-if="blog_posts_post_teaser_active" t-attf-class="s_blog_posts_post_teaser o_line_clamp {{ teaser_custom_class }}" t-field="record.teaser"/>
 </template>
 
 <!-- Blog Post Date (optional for Card, Horizontal and List layouts) -->

--- a/addons/website_sale/static/src/scss/website_sale.scss
+++ b/addons/website_sale/static/src/scss/website_sale.scss
@@ -1279,10 +1279,6 @@ a.no-decoration {
                 width: var(--cart-product-img-size-sm, var(--cart-product-img-size-lg));
             }
         }
-
-        .o_description_line {
-            @include o-line-clamp(2);
-        }
     }
 
     .o_cart_item_count {

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -2695,7 +2695,7 @@
             <t t-foreach="description_lines" t-as="name_line">
                 <span
                     t-if="name_line"
-                    t-attf-class="o_description_line overflow-hidden #{not name_line_last and 'mb-1'}"
+                    t-attf-class="o_description_line o_line_clamp #{not name_line_last and 'mb-1'}"
                     t-out="name_line"
                 />
             </t>
@@ -2946,7 +2946,7 @@
                 <t t-foreach="description_lines" t-as="description_line">
                     <span
                         t-if="description_line"
-                        class="o_description_line overflow-hidden"
+                        class="o_description_line o_line_clamp"
                         t-out="description_line"
                     />
                 </t>
@@ -3189,7 +3189,7 @@
                                     />
                                 </a>
                                 <div
-                                    class="o_description_line overflow-hidden mb-2 small text-muted"
+                                    class="o_description_line o_line_clamp mb-2 small text-muted"
                                     t-field="product.description_sale"
                                 />
                             </div>


### PR DESCRIPTION
*: sale, blog

This PR removes the existing `o-line-clamp` mixin in favor of a class.

This change allows to avoid using multiple `@include` statements across multiple files, which will decrease the size of these files.

We also improve the properties that were contained within the mixin by setting the `overflow: hidden` rule at a class level rather than on each element we were applying the class to.

Prior to this PR, each time you were including the `o-line-clamp` mixin within an element, you needed to set either `.overflow-hidden` or `overflow: hidden;` manually.

Since 2019[^1], Firefox supports the vendor prefixed `-webkit-line-clamp` property but ONLY in combination with the `display` property being set to `-webkit-box` or `-webkit-inline-box` and `-webkit-box-orient` set to `vertical`.

As all those properties are included within the class, we can safely set the `overflow: hidden` on it.

[1]: https://hg-edge.mozilla.org/mozilla-central/rev/c2250a23fd66
See also https://developer.mozilla.org/en-US/docs/Web/CSS/line-clamp

task-4905930

[^1]: https://hg-edge.mozilla.org/mozilla-central/rev/c2250a23fd66

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
