### PR TITLE
[FIX] html_builder: handle initial BuilderDateTimePicker state - [FIX] website: resolve potential undeterminism in DateTimePicker tests

### DIFF
--- a/addons/html_builder/static/src/core/building_blocks/builder_datetimepicker.js
+++ b/addons/html_builder/static/src/core/building_blocks/builder_datetimepicker.js
@@ -38,9 +38,6 @@ export class BuilderDateTimePicker extends Component {
             parseDisplayValue: this.parseDisplayValue.bind(this),
         });
         this.state = state;
-        if (!this.state.value) {
-            this.state.value = this.getDefaultValue();
-        }
         this.oldValue = this.state.value;
 
         this.commit = (userInputValue) => {

--- a/addons/html_builder/static/src/core/building_blocks/builder_list.js
+++ b/addons/html_builder/static/src/core/building_blocks/builder_list.js
@@ -46,7 +46,7 @@ export class BuilderList extends Component {
         useBuilderComponent();
         const { state, commit, preview } = useInputBuilderComponent({
             id: this.props.id,
-            defaultValue: this.parseDisplayValue([this.makeDefaultItem()]),
+            defaultValue: this.parseDisplayValue([]),
             parseDisplayValue: this.parseDisplayValue,
             formatRawValue: this.formatRawValue,
         });

--- a/addons/html_builder/static/src/core/utils.js
+++ b/addons/html_builder/static/src/core/utils.js
@@ -651,7 +651,8 @@ export function useInputBuilderComponent({
             ({ actionId }) => getAction(actionId).getValue
         );
         const { actionId, actionParam } = actionWithGetValue;
-        const actionValue = getAction(actionId).getValue({ editingElement, params: actionParam });
+        const actionValue =
+            getAction(actionId).getValue({ editingElement, params: actionParam }) || defaultValue;
         return {
             value: actionValue,
         };

--- a/addons/website/static/tests/builder/custom_tab/builder_components/builder_datetimepicker.test.js
+++ b/addons/website/static/tests/builder/custom_tab/builder_components/builder_datetimepicker.test.js
@@ -26,11 +26,21 @@ test("defaults to now if undefined", async () => {
         selector: ".test-options-target",
         template: xml`<BuilderDateTimePicker dataAttributeAction="'date'"/>`,
     });
+    addOption({
+        selector: ".test-options-target",
+        template: xml`<BuilderCheckbox classAction="'checkbox-action'"/>`,
+    });
     await setupWebsiteBuilder(`<div class="test-options-target">b</div>`);
     await contains(":iframe .test-options-target").click();
 
     const expectedDateTime = DateTime.now();
-    expect(".we-bg-options-container input").toHaveValue(formatDateTime(expectedDateTime));
+    expect(".we-bg-options-container input.o-hb-input-base").toHaveValue(
+        formatDateTime(expectedDateTime)
+    );
+    await contains(".we-bg-options-container input.form-check-input").click();
+    expect(".we-bg-options-container input.o-hb-input-base").toHaveValue(
+        formatDateTime(expectedDateTime)
+    );
 });
 
 test("defaults to last one when invalid date provided", async () => {


### PR DESCRIPTION
A previous fix [1] for `BuilderDateTimePicker` addressed cases where it
was not initialized. However, that fix was not robust enough for the
scenario where modifying another option on the element would then
incorrectly clear the input field of an uninitialized DateTimePicker.

While this specific case is not currently reproducible in standard Odoo
snippets, as they always initialize a value upon being dropped,
this fix ensures the `BuilderDateTimePicker` maintains its proper state
regardless of its initial condition or subsequent modifications to other
element options.

This commit adds a tolerance in `BuilderDateTimePicker` tests to avoid
potential undeterminism. This addresses an issue introduced in [1].
Previously, checks were performed by directly comparing Unix integers,
which could differ if the comparison occurred within the final
milliseconds of a second.

[1]: https://github.com/odoo/odoo/commit/2d1a39f7224495ea04aa8765ae5ac11145a84398