### PR TITLE
[FIX] l10n_it: 25,82 threshold moved to 100

### DIFF
--- a/addons/l10n_it/data/account_tax_report_data.xml
+++ b/addons/l10n_it/data/account_tax_report_data.xml
@@ -107,7 +107,7 @@
                         </field>
                     </record>
                     <record id="tax_report_line_vp7" model="account.report.line">
-                        <field name="name">VP7 - Previous period debt not to exceed 25,82</field>
+                        <field name="name">VP7 - Previous period debt not to exceed 100,00</field>
                         <field name="code">VP7</field>
                         <field name="expression_ids">
                             <record id="tax_report_line_vp7_tag" model="account.report.expression">
@@ -252,7 +252,7 @@
                                         <field name="label">_carryover_balance</field>
                                         <field name="engine">aggregation</field>
                                         <field name="formula">VP14a.balance</field>
-                                        <field name="subformula">if_between(EUR(0), EUR(25.82))</field>
+                                        <field name="subformula">if_between(EUR(0), EUR(100.00))</field>
                                         <field name="carryover_target">VP7._applied_carryover_balance</field>
                                     </record>
                                 </field>

--- a/addons/l10n_it/data/tax_report/account_monthly_tax_report_data.xml
+++ b/addons/l10n_it/data/tax_report/account_monthly_tax_report_data.xml
@@ -82,7 +82,7 @@
                         </field>
                     </record>
                     <record id="tax_monthly_report_line_vp7" model="account.report.line">
-                        <field name="name">VP7 - Previous period debt not to exceed 25,82</field>
+                        <field name="name">VP7 - Previous period debt not to exceed 100,00</field>
                         <field name="code">VP7</field>
                         <field name="expression_ids">
                             <record id="tax_monthly_report_line_vp7_tag" model="account.report.expression">
@@ -203,7 +203,7 @@
                                         <field name="label">_carryover_balance</field>
                                         <field name="engine">aggregation</field>
                                         <field name="formula">VP14a.balance</field>
-                                        <field name="subformula">if_between(EUR(0), EUR(25.82))</field>
+                                        <field name="subformula">if_between(EUR(0), EUR(100.00))</field>
                                         <field name="carryover_target">VP7._applied_carryover_balance</field>
                                     </record>
                                 </field>

--- a/addons/l10n_it/i18n/it.po
+++ b/addons/l10n_it/i18n/it.po
@@ -1730,8 +1730,8 @@ msgstr "VP6b - IVA dovuta (credito)"
 #. module: l10n_it
 #: model:account.report.line,name:l10n_it.tax_monthly_report_line_vp7
 #: model:account.report.line,name:l10n_it.tax_report_line_vp7
-msgid "VP7 - Previous period debt not to exceed 25,82"
-msgstr "VP7 - Debito periodo precedente non superiore 25,82"
+msgid "VP7 - Previous period debt not to exceed 100,00"
+msgstr "VP7 - Debito periodo precedente non superiore 100,00"
 
 #. module: l10n_it
 #: model:account.report.line,name:l10n_it.tax_monthly_report_line_vp8

--- a/addons/l10n_it/i18n/l10n_it.pot
+++ b/addons/l10n_it/i18n/l10n_it.pot
@@ -1600,7 +1600,7 @@ msgstr ""
 #. module: l10n_it
 #: model:account.report.line,name:l10n_it.tax_monthly_report_line_vp7
 #: model:account.report.line,name:l10n_it.tax_report_line_vp7
-msgid "VP7 - Previous period debt not to exceed 25,82"
+msgid "VP7 - Previous period debt not to exceed 100,00"
 msgstr ""
 
 #. module: l10n_it


### PR DESCRIPTION
While implementing the modulo tag of the tax report xml export, it came to light that the vp7 line of that report which previously used a 25,82€ threshold has been changed for one at 100,00€.

This commit adapts the amount across the module.

---

Enterprise PR: https://github.com/odoo/enterprise/pull/86642
task-4826511

---

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr