### PR TITLE
[REM] *: step_delay only used in debug mode

### DIFF
--- a/addons/account/tests/common.py
+++ b/addons/account/tests/common.py
@@ -856,9 +856,9 @@ class AccountTestInvoicingCommon(ProductCommon):
 
 
 class AccountTestMockOnlineSyncCommon(HttpCase):
-    def start_tour(self, url_path, tour_name, step_delay=None, **kwargs):
+    def start_tour(self, url_path, tour_name, **kwargs):
         with self.mock_online_sync_favorite_institutions():
-            super().start_tour(url_path, tour_name, step_delay, **kwargs)
+            super().start_tour(url_path, tour_name, **kwargs)
 
     @classmethod
     @contextmanager

--- a/addons/hr_holidays/tests/test_hr_leave_type_tour.py
+++ b/addons/hr_holidays/tests/test_hr_leave_type_tour.py
@@ -71,4 +71,4 @@ class TestHrLeaveTypeTour(HttpCase):
             'requires_allocation': False,
             'leave_validation_type': 'hr'
         })
-        self.start_tour('/web', 'hr_leave_type_tour', login="admin", step_delay=500)
+        self.start_tour('/web', 'hr_leave_type_tour', login="admin")

--- a/addons/im_livechat/tests/test_chatbot_form_ui.py
+++ b/addons/im_livechat/tests/test_chatbot_form_ui.py
@@ -15,7 +15,6 @@ class TestLivechatChatbotFormUI(HttpCaseWithUserDemo):
             '/odoo',
             'im_livechat_chatbot_steps_sequence_tour',
             login='admin',
-            step_delay=1000
         )
 
         chatbot_script = self.env['chatbot.script'].search([('title', '=', 'Test Chatbot Sequence')])
@@ -39,7 +38,6 @@ class TestLivechatChatbotFormUI(HttpCaseWithUserDemo):
             '/odoo',
             'im_livechat_chatbot_steps_sequence_with_move_tour',
             login='admin',
-            step_delay=1000
         )
 
         chatbot_script = self.env['chatbot.script'].search([('title', '=', 'Test Chatbot Sequence')])

--- a/addons/im_livechat/tests/test_session_history_open.py
+++ b/addons/im_livechat/tests/test_session_history_open.py
@@ -28,4 +28,4 @@ class TestImLivechatSessionHistoryOpen(TestImLivechatCommon):
         )
         channel1.message_post(body="Test Channel 1 Msg", message_type="comment", subtype_xmlid="mail.mt_comment")
         channel2.message_post(body="Test Channel 2 Msg", message_type="comment", subtype_xmlid="mail.mt_comment")
-        self.start_tour("/web", "im_livechat_session_history_open", login="operator", step_delay=25)
+        self.start_tour("/web", "im_livechat_session_history_open", login="operator")

--- a/addons/point_of_sale/static/src/app/hooks/use_tours.js
+++ b/addons/point_of_sale/static/src/app/hooks/use_tours.js
@@ -48,7 +48,6 @@ export default function useTours() {
                 states.index = 0;
             }
             await tour.startTour(states.selectedTours[states.index], {
-                stepDelay: 150,
                 throw: false,
             });
 

--- a/addons/pos_restaurant/tests/test_frontend.py
+++ b/addons/pos_restaurant/tests/test_frontend.py
@@ -217,12 +217,12 @@ class TestFrontend(TestFrontendCommon):
         })
 
         self.pos_config.with_user(self.pos_user).open_ui()
-        self.start_pos_tour('pos_restaurant_sync', step_delay=300)
+        self.start_pos_tour('pos_restaurant_sync')
 
         self.assertEqual(1, self.env['pos.order'].search_count([('amount_total', '=', 4.4), ('state', '=', 'draft')]))
         self.assertEqual(1, self.env['pos.order'].search_count([('amount_total', '=', 4.4), ('state', '=', 'paid')]))
 
-        self.start_pos_tour('pos_restaurant_sync_second_login', step_delay=300)
+        self.start_pos_tour('pos_restaurant_sync_second_login')
 
         self.assertEqual(0, self.env['pos.order'].search_count([('amount_total', '=', 4.4), ('state', '=', 'draft')]))
         self.assertEqual(1, self.env['pos.order'].search_count([('amount_total', '=', 2.2), ('state', '=', 'draft')]))
@@ -238,7 +238,7 @@ class TestFrontend(TestFrontendCommon):
         # disable kitchen printer to avoid printing errors
         self.pos_config.is_order_printer = False
         self.pos_config.with_user(self.pos_admin).open_ui()
-        self.start_pos_tour('ControlButtonsTour', login="pos_admin", step_delay=100)
+        self.start_pos_tour('ControlButtonsTour', login="pos_admin")
 
     def test_04_ticket_screen(self):
         self.pos_config.is_order_printer = False

--- a/addons/web_tour/static/src/widgets/tour_start.js
+++ b/addons/web_tour/static/src/widgets/tour_start.js
@@ -31,7 +31,6 @@ export class TourStartWidget extends CharField {
             mode: "auto",
             url: this.tourData.url,
             fromDB: this.tourData.custom,
-            stepDelay: 500,
             showPointerDuration: 250,
             rainbowManMessage: this.tourData.rainbow_man_message,
         });

--- a/addons/website/tests/test_ui.py
+++ b/addons/website/tests/test_ui.py
@@ -424,14 +424,14 @@ class TestUi(HttpCaseWithWebsiteUser):
     # TODO master-mysterious-egg fix error
     @unittest.skip("prepare mysterious-egg for merging")
     def test_09_website_edit_link_popover(self):
-        self.start_tour('/@/', 'edit_link_popover', login='admin', step_delay=500, timeout=180)
+        self.start_tour('/@/', 'edit_link_popover', login='admin', timeout=180)
 
     # TODO master-mysterious-egg fix error
     @unittest.skip("prepare mysterious-egg for merging")
     def test_10_website_conditional_visibility(self):
         self.start_tour(self.env['website'].get_client_action_url('/'), 'conditional_visibility_1', login='admin')
         self.start_tour('/odoo', 'conditional_visibility_2', login='website_user')
-        self.start_tour(self.env['website'].get_client_action_url('/'), 'conditional_visibility_3', login='admin', step_delay=500, timeout=180)
+        self.start_tour(self.env['website'].get_client_action_url('/'), 'conditional_visibility_3', login='admin', timeout=180)
         self.start_tour(self.env['website'].get_client_action_url('/'), 'conditional_visibility_4', login='admin')
         self.start_tour(self.env['website'].get_client_action_url('/'), 'conditional_visibility_5', login='admin')
 

--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -2430,6 +2430,8 @@ class HttpCase(TransactionCase):
         ready = kwargs.pop('ready', f"odoo.isTourReady({tour_name!r})")
         timeout = kwargs.pop('timeout', 60)
 
+        if step_delay is not None:
+            self._logger.warning('step_delay is only suitable for local testing')
         if options["delayToCheckUndeterminisms"] > 0:
             timeout = timeout + 1000 * options["delayToCheckUndeterminisms"]
             _logger.runbot("Tour %s is launched with mode: check for undeterminisms.", tour_name)


### PR DESCRIPTION
In this commit, we remove the step_delay from the start_tour because since commit 968703b8f6e189aa1, step_delay is only used in debug mode. To avoid adding it to the codebase, we also add a warning.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
