### PR TITLE
[FIX] payment: enable manual capture for payment method brands

### DIFF
--- a/addons/payment/models/payment_method.py
+++ b/addons/payment/models/payment_method.py
@@ -182,9 +182,10 @@ class PaymentMethod(models.Model):
     @api.constrains('active', 'support_manual_capture')
     def _check_manual_capture_supported_by_providers(self):
         incompatible_pms = self.filtered(
-            lambda method: method.active and method.support_manual_capture == 'none' and any(
-                provider.capture_manually for provider in method.provider_ids
-            )
+            lambda pm:
+                pm.active
+                and (pm.primary_payment_method_id or pm).support_manual_capture == 'none'
+                and any(provider.capture_manually for provider in pm.provider_ids),
         )
         if incompatible_pms:
             raise ValidationError(_(

--- a/addons/payment/wizards/payment_capture_wizard.py
+++ b/addons/payment/wizards/payment_capture_wizard.py
@@ -88,7 +88,9 @@ class PaymentCaptureWizard(models.TransientModel):
         for wizard in self:
             wizard.support_partial_capture = all(
                 tx.provider_id.support_manual_capture == 'partial'
-                and tx.payment_method_id.support_manual_capture == 'partial'
+                and (
+                    tx.payment_method_id.primary_payment_method_id or tx.payment_method_id
+                ).support_manual_capture == 'partial'
                 for tx in wizard.transaction_ids
             )
 


### PR DESCRIPTION
Versions
--------
- saas-18.2+

Steps
-----
1. Set up Adyen as a payment provider;
2. enable manual capture;
3. set up a sales order;
4. pay for sales order with Adyen using VISA;
5. do a partial manual capture.

Issue
-----
Payment method doesn't support partial capture.

Additionally, you're not allowed to enable the Hipercard & Elo payment method brands for the Card payment method.

Cause
-----
Commit 25feb5b11c2df added the `support_manual_capture` field to `payment.method`. This field is only set to a non-default value for primary payment methods, e.g. Card. For branded payment method, e.g. VISA, it defaults to 'none'.

Solution
--------
Add a `_get_primary_method` method to `payment.method` and `payment.transaction`, retrieving the relevant primary payment method to check support on.

opw-4817961