### PR TITLE
[FIX] web: keep list_datetime_field clickable when empty

### DIFF
--- a/addons/web/static/src/core/utils/autoresize.js
+++ b/addons/web/static/src/core/utils/autoresize.js
@@ -19,6 +19,9 @@ export function useAutoresize(ref, options = {}) {
             if (el) {
                 resize = (programmaticResize = false) => {
                     wasProgrammaticallyResized = programmaticResize;
+                    if (options.ignoreIfEmpty && !el.value) {
+                        return;
+                    }
                     if (el instanceof HTMLInputElement) {
                         resizeInput(el, options);
                     } else {

--- a/addons/web/static/src/views/fields/datetime/list_datetime_field.js
+++ b/addons/web/static/src/views/fields/datetime/list_datetime_field.js
@@ -7,7 +7,7 @@ export class ListDateTimeField extends DateTimeField {
     setup() {
         super.setup();
         const startDateRef = useRef("start-date");
-        useAutoresize(startDateRef, { offset: -5 });
+        useAutoresize(startDateRef, { offset: -5, ignoreIfEmpty: true });
     }
 }
 

--- a/addons/web/static/tests/views/fields/datetime_field.test.js
+++ b/addons/web/static/tests/views/fields/datetime_field.test.js
@@ -1,8 +1,22 @@
 import { after, expect, test } from "@odoo/hoot";
-import { click, edit, queryAll, queryAllProperties, queryAllTexts, resize } from "@odoo/hoot-dom";
+import {
+    click,
+    edit,
+    queryAll,
+    queryAllProperties,
+    queryAllTexts,
+    queryRect,
+    resize,
+} from "@odoo/hoot-dom";
 import { animationFrame, mockTimeZone } from "@odoo/hoot-mock";
 import {
+    editTime,
+    getPickerCell,
+    zoomOut,
+} from "@web/../tests/core/datetime/datetime_test_helpers";
+import {
     clickSave,
+    contains,
     defineModels,
     defineParams,
     fields,
@@ -10,11 +24,6 @@ import {
     mountView,
     onRpc,
 } from "@web/../tests/web_test_helpers";
-import {
-    editTime,
-    getPickerCell,
-    zoomOut,
-} from "@web/../tests/core/datetime/datetime_test_helpers";
 
 import { resetDateFieldWidths } from "@web/views/list/column_width_hook";
 class Partner extends models.Model {
@@ -274,6 +283,20 @@ test("DatetimeField in editable list view", async () => {
         { message: "the selected datetime should be displayed after saving" }
     );
 });
+
+test("DatetimeField input in editable list view keeps its parent's width when empty", async () => {
+    await mountView({
+        type: "list",
+        resModel: "partner",
+        arch: /* xml */ `<list editable="bottom"><field name="datetime"/></list>`,
+    });
+    await contains(".o_data_row:eq(1) .o_data_cell").click();
+    expect(".o_data_row:eq(1) .o_data_cell input").toHaveRect(
+        queryRect(".o_data_row:eq(1) .o_data_cell .o_field_datetime"),
+        { message: "input should have the same size as its parent when empty" }
+    );
+});
+
 test.tags("desktop");
 test("multi edition of DatetimeField in list view: edit date in input", async () => {
     onRpc("has_group", () => true);


### PR DESCRIPTION
This commit fixes an issue where an empty list_datetime_field becomes too small to click reliably, due to the autoresize hook assigning it a minimum width of only 10px.

To resolve this, an option is added to the autoresize hook to skip resizing when the input is empty, ensuring the field remains accessible.

task-4908209
