### PR TITLE
[IMP] hr_recruitment: correct in progress applications count on jobs dashboard

### DIFF
--- a/addons/hr_recruitment/views/hr_job_views.xml
+++ b/addons/hr_recruitment/views/hr_job_views.xml
@@ -123,7 +123,7 @@
                                     </div>
                                     <div class="col align-content-center">
                                         <div class="d-flex justify-content-center">
-                                            <field name="old_application_count" class="number"/>
+                                            <field name="open_application_count" class="number"/>
                                             <div class=" number_description text-body-secondary fs-4 lh-1">
                                                 in<br/>progress
                                             </div>
@@ -388,7 +388,7 @@
         <field name="arch" type="xml">
             <field name="name" position="after">
                 <field name="department_id"/>
-                <field name="application_count" string="Applications" groups="hr_recruitment.group_hr_recruitment_interviewer"/>
+                <field name="open_application_count" string="Open Applications" groups="hr_recruitment.group_hr_recruitment_interviewer"/>
                 <field name="no_of_recruitment"/>
             </field>
             <field name="no_of_employee" position="after">


### PR DESCRIPTION
Currently, the Jobs dashboard in Recruitment app includes hired applications in the "Open applications" count. Open applications should only include current applications in the pipe that are not hired or refused.

task-4903763



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
