### PR TITLE
[FIX] stock_account,stock_dropshipping: create svl correct value back…

### DIFF
--- a/addons/purchase_stock/models/stock_valuation_layer.py
+++ b/addons/purchase_stock/models/stock_valuation_layer.py
@@ -14,3 +14,16 @@ class StockValuationLayer(models.Model):
     def _get_related_product(self):
         res = super()._get_related_product()
         return self.stock_move_id.purchase_line_id.product_id if self.stock_move_id.purchase_line_id else res
+
+    def _should_impact_price_unit_receipt_value(self):
+        # In case of dropshipping, we only want the positive layers. When returned,
+        # only the negative one matters
+        res = super()._should_impact_price_unit_receipt_value()
+        if not self.stock_move_id:
+            return res
+
+        return (
+            res
+            and (not self.stock_move_id._is_dropshipped() or self.value > 0)
+            and (not self.stock_move_id._is_dropshipped_returned() or self.value < 0)
+        )


### PR DESCRIPTION
…order dropship

**Problem:**
when the backorder of the delivery (with a bill) of a dropshipped fifo/avco product is validated, the svl created don't have the right values

**Steps to reproduce:**
- create a new product, with dropship and buy routes
- in the purchase tab select "on ordered quantities"
- add a vendor with a price of 10
- create a new quotation for a quantity of 10
- confirm and confirm the purchase order
- click on "create bill" and confirm it
- go back to the PO and click on the "dropship" smart button
- change the quantity to 5, validate and create backorder
- go back to the PO, click on the "dropship" smart button and select the picking of the backorder (with status ready)
- validate
- click on the "valuation smart" button

**Current behavior:**
the svl created for the backorder have a value of 100 and -100

**Expected behavior:**
it should be 50 and -50

**Cause of the issue:**
inside _get_dropshipped_svl_vals
_get_price_unit is called
https://github.com/odoo/odoo/blob/f7c8cc76f15bc6e974969fb4ab4a93654443b973/addons/stock_account/models/stock_move.py#L219 because we created a bill and it's a backorder
line.qty_invoiced is higher than received_qty and this condition is true
https://github.com/odoo/odoo/blob/f7c8cc76f15bc6e974969fb4ab4a93654443b973/addons/purchase_stock/models/stock_move.py#L51 but because it's a dropship there is as much positive svl as negative svl linked to the move so receipt value is null https://github.com/odoo/odoo/blob/f7c8cc76f15bc6e974969fb4ab4a93654443b973/addons/purchase_stock/models/stock_move.py#L56-L63 and remaining value will be 100 instead of 50 (receipt value should have been 50)
https://github.com/odoo/odoo/blob/f7c8cc76f15bc6e974969fb4ab4a93654443b973/addons/purchase_stock/models/stock_move.py#L80

**fix**
the negative svl from the dropshipped move should not
impact receipt value


opw-4888827
