### PR TITLE
[FIX] account: reco model delete after apply

### DIFF
--- a/addons/account/demo/account_demo.py
+++ b/addons/account/demo/account_demo.py
@@ -106,16 +106,6 @@ class AccountChartTemplate(models.AbstractModel):
             ], limit=1)
             demo_bank_statement_1.line_ids[0].line_ids[1]['account_id'] = current_year_earnings_account.id
 
-        # We want the "Line with Bank Fees" reco model to be applied on the bank fees statement line
-        demo_bank_statement_line_5 = self.ref('demo_bank_statement_line_5', raise_if_not_found=False)
-        if demo_bank_statement_line_5:
-            demo_bank_statement_line_5.line_ids[0]['reconcile_model_id'] = self.ref('reconcile_from_label')
-
-        # The chart template creates a Bank Fees model, if possible, we want to apply it
-        bank_fees_statement_line = self.ref('demo_bank_statement_line_1', raise_if_not_found=False)
-        if bank_fees_statement_line:
-            bank_fees_statement_line.line_ids[0]['reconcile_model_id']: self.ref('bank_fees_reco', raise_if_not_found=False)
-
     @api.model
     def _get_demo_data_bank(self, company=False):
         if company.root_id.partner_id.bank_ids:


### PR DESCRIPTION
Correcting some demo data where they added the reconcile model on the liquidity but since the reco model will be added at the creation of the reco model, that's not needed. Also the reco model should be put on the suspense and not on the liquidity

task: 4908501




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
