### PR TITLE
[FIX] html_builder, website: batch Img load

### DIFF
--- a/addons/html_builder/static/src/core/img_group.js
+++ b/addons/html_builder/static/src/core/img_group.js
@@ -1,0 +1,32 @@
+import { Component, useSubEnv, xml } from "@odoo/owl";
+import { batched } from "@web/core/utils/timing";
+
+export class ImgGroup extends Component {
+    static template = xml`<t><t t-slot="default"/></t>`;
+    static props = {
+        slots: Object,
+    };
+
+    setup() {
+        this.load = () => {};
+        this.imgProms = [];
+        this.loadImgs = batched(this._loadImgs.bind(this));
+
+        useSubEnv({
+            imgGroup: {
+                loaded: new Promise((resolve) => {
+                    this.load = resolve;
+                }),
+                addImgProm: (promise) => {
+                    this.imgProms.push(promise);
+                    this.loadImgs();
+                },
+            },
+        });
+    }
+
+    async _loadImgs() {
+        await Promise.all(this.imgProms);
+        this.load();
+    }
+}

--- a/addons/html_builder/static/src/plugins/shape/shape_selector.js
+++ b/addons/html_builder/static/src/plugins/shape/shape_selector.js
@@ -1,4 +1,5 @@
 import { useRef, useState } from "@odoo/owl";
+import { ImgGroup } from "@html_builder/core/img_group";
 import { BaseOptionComponent } from "@html_builder/core/utils";
 import { useThrottleForAnimation } from "@web/core/utils/timing";
 import { getShapeURL } from "../image/image_helpers";
@@ -14,6 +15,7 @@ export class ShapeSelector extends BaseOptionComponent {
         imgThroughDiv: { type: Boolean, optional: true },
         getShapeUrl: { type: Function, optional: true },
     };
+    static components = { ImgGroup };
 
     setup() {
         super.setup();

--- a/addons/html_builder/static/src/plugins/shape/shape_selector.xml
+++ b/addons/html_builder/static/src/plugins/shape/shape_selector.xml
@@ -25,25 +25,27 @@
                 <t t-foreach="Object.entries(group[1].subgroups)" t-as="subgroup" t-key="subgroup_index">
                     <div class="ms-3 py-2" t-out="subgroup[1].label"/>
                     <div class="builder_select_page my-2">
-                        <t t-foreach="Object.entries(subgroup[1].shapes)" t-as="shape" t-key="shape_index">
-                            <div t-att-class="this.props.buttonWrapperClassName" t-on-click="this.props.onClose">
-                                <BuilderButton type="''" action="this.props.shapeActionId" actionValue="shape[0]">
-                                    <div t-att-class="props.imgThroughDiv ? 'o_we_shape_btn_content' : ''">
-                                        <t t-if="props.imgThroughDiv">
-                                            <div class="o_we_shape" t-att-class="this.getShapeClass(shape[0])"/>
-                                        </t>
-                                        <t t-else="" >
-                                            <Img src="this.getShapeUrl(shape[0])" svgCheck="false"/>
-                                        </t>
-                                        <span t-if="shape[1].imgSize" class="o_we_shape_animated_label">
-                                            <i class="fa fa-expand"></i>
-                                            <span t-out="shape[1].imgSize"/>
-                                        </span>
-                                        <span t-elif="shape[1].animated" class="o_we_shape_animated_label">A<span>nimated</span></span>
-                                    </div>
-                                </BuilderButton>
-                            </div>
-                        </t>
+                        <ImgGroup>
+                            <t t-foreach="Object.entries(subgroup[1].shapes)" t-as="shape" t-key="shape_index">
+                                <div t-att-class="this.props.buttonWrapperClassName" t-on-click="this.props.onClose">
+                                    <BuilderButton type="''" action="this.props.shapeActionId" actionValue="shape[0]">
+                                        <div t-att-class="props.imgThroughDiv ? 'o_we_shape_btn_content' : ''">
+                                            <t t-if="props.imgThroughDiv">
+                                                <div class="o_we_shape" t-att-class="this.getShapeClass(shape[0])"/>
+                                            </t>
+                                            <t t-else="" >
+                                                <Img src="this.getShapeUrl(shape[0])" svgCheck="false"/>
+                                            </t>
+                                            <span t-if="shape[1].imgSize" class="o_we_shape_animated_label">
+                                                <i class="fa fa-expand"></i>
+                                                <span t-out="shape[1].imgSize"/>
+                                            </span>
+                                            <span t-elif="shape[1].animated" class="o_we_shape_animated_label">A<span>nimated</span></span>
+                                        </div>
+                                    </BuilderButton>
+                                </div>
+                            </t>
+                        </ImgGroup>
                     </div>
                 </t>
             </div>

--- a/addons/html_builder/static/tests/img.test.js
+++ b/addons/html_builder/static/tests/img.test.js
@@ -1,0 +1,44 @@
+import { Img } from "@html_builder/core/img";
+import { ImgGroup } from "@html_builder/core/img_group";
+import { defineMailModels } from "@mail/../tests/mail_test_helpers";
+import { expect, test } from "@odoo/hoot";
+import { animationFrame, Deferred } from "@odoo/hoot-dom";
+import { Component, xml } from "@odoo/owl";
+import { mountWithCleanup, patchWithCleanup } from "@web/../tests/web_test_helpers";
+
+defineMailModels(); // meh
+test("ImgGroup's inner Img components should not be blocked before src load", async () => {
+    const defs = {
+        img1: new Deferred(),
+        img2: new Deferred(),
+        img3: new Deferred(),
+    };
+    patchWithCleanup(Img.prototype, {
+        loadImage() {
+            const def = defs[this.props.class];
+            return Promise.all([super.loadImage(), def]);
+        },
+    });
+    class Container extends Component {
+        static components = { ImgGroup, Img };
+        static template = xml`
+            <ImgGroup>
+                <t t-foreach="Object.keys(defs)" t-as="key" t-key="key">
+                    <Img src="''" class="key"/>
+                </t>
+            </ImgGroup>`;
+        static props = {};
+
+        setup() {
+            this.defs = defs;
+        }
+    }
+    await mountWithCleanup(Container);
+
+    for (const key in defs) {
+        expect("img").toHaveCount(0);
+        defs[key].resolve();
+        await animationFrame();
+    }
+    expect("img").toHaveCount(3);
+});


### PR DESCRIPTION
Steps to reproduce:
- In the website builder, select an image
- Click on "Shape"
=> It takes several seconds to open, without any feedback to the user.

In [commit 1], the `Img` component's `onWillStart` was wrongly rewritten
to await the image load.
In this commit, we don't await the `Img` load to avoid a laggy
interface.

When each `<Img>` in a group appears one at a time, the visual effect is
not optimal. In such a case, we can wait for all the images in the group
to display them all at once.
This commit adds an `ImgGroup` wrapper component to be used in those
situations. After the 1st load, images are cached by the browser and
should appear immediately.

Note that the intent of the `ImgGroup` was initially to also display a
placeholder until the images are shown. This was finally scrapped, as
the builder images should load fast enough that we don't need to
actually show a placeholder. As a matter of fact, if present, those
placeholders give a worse impression because they trigger several visual
changes on the page in a small time frame.

[commit 1]: https://github.com/odoo/odoo/commit/3cc5ff6e96493f2b068090f880987def3787895e#diff-b4107c5542b3089f488c9a60dd38df72710d0702d5c1ee2de36eb80bc884697c

task-4367641