### PR TITLE
[IMP] web, *: support arrows for colorpicker custom sliders

### DIFF
--- a/addons/html_builder/static/src/core/building_blocks/builder_colorpicker.scss
+++ b/addons/html_builder/static/src/core/building_blocks/builder_colorpicker.scss
@@ -4,7 +4,7 @@
 }
 
 .o-hb-colorpicker {
-    --o-hb-colorpicker-focus-border-color: var(--o-hb-select-item-active-color, #{$o-we-sidebar-content-field-toggle-active-bg});
+    --o-color-picker-active-color: var(--o-hb-select-item-active-color, #{$o-we-sidebar-content-field-toggle-active-bg});
 
     --bg: #{$o-we-item-clickable-bg};
 
@@ -34,7 +34,7 @@
             );
 
             &:hover {
-                border: $o-we-border-width solid var(--o-hb-colorpicker-focus-border-color);
+                border: $o-we-border-width solid var(--o-color-picker-active-color);
             }
         }
     }
@@ -73,13 +73,14 @@
     }
 
     .btn:focus-visible {
-        border: $o-we-border-width solid var(--o-hb-colorpicker-focus-border-color);
+        border: $o-we-border-width solid var(--o-color-picker-active-color);
+        z-index: 1;
     }
 
     .color-combination-button:focus-visible {
         box-shadow:
             0 0 0 1px $o-we-bg-darker,
-            0 0 0 3px var(--o-hb-colorpicker-focus-border-color);
+            0 0 0 3px var(--o-color-picker-active-color);
         outline: none;
     }
 
@@ -91,7 +92,9 @@
     .gradient-angle-thumb {
         background-color: $white;
     }
-    .gradient-angle-knob + input[name=angle] {
+    .gradient-angle-knob + input[name=angle],
+    input[name=positionX],
+    input[name=positionY] {
         @extend %o-hb-input-base;
 
         & + .input-group-text {

--- a/addons/html_editor/static/tests/color_selector.test.js
+++ b/addons/html_editor/static/tests/color_selector.test.js
@@ -668,6 +668,175 @@ test("custom tab color navigation using keys", async () => {
 });
 
 describe.tags("desktop");
+describe("keyboard navigation", () => {
+    test("update saturation and brightness picker with keys", async () => {
+        await setupEditor(
+            `<p>
+                <font style="color: rgb(255, 0, 0);">[test]</font>
+            </p>`
+        );
+        await expandToolbar();
+        await click(".o-we-toolbar .o-select-color-foreground");
+        await animationFrame();
+        await press("Tab");
+        expect(getActiveElement()).toBe(
+            queryFirst('.o_font_color_selector button:contains("Custom")')
+        );
+        await press("Enter");
+        await animationFrame();
+        await press("Tab", { shiftKey: true });
+        await press("Tab", { shiftKey: true });
+        await press("Tab", { shiftKey: true });
+        await press("Tab", { shiftKey: true });
+        await press("Tab", { shiftKey: true });
+        expect(getActiveElement()).toBe(queryFirst(".o_font_color_selector .o_picker_pointer"));
+        expect(".o_hex_input").toHaveValue("#FF0000");
+        await press("ArrowUp");
+        expect(".o_hex_input").toHaveValue("#FF3333");
+        await press("ArrowLeft");
+        expect(".o_hex_input").toHaveValue("#F53D3D");
+        await press("ArrowDown");
+        expect(".o_hex_input").toHaveValue("#F20D0D");
+        await press("ArrowRight");
+        expect(".o_hex_input").toHaveValue("#FF0000");
+    });
+
+    test("update hue slider with keys", async () => {
+        await setupEditor(
+            `<p>
+                <font style="color: rgb(0, 255, 0);">[test]</font>
+            </p>`
+        );
+        await expandToolbar();
+        await click(".o-we-toolbar .o-select-color-foreground");
+        await animationFrame();
+        await press("Tab");
+        expect(getActiveElement()).toBe(
+            queryFirst('.o_font_color_selector button:contains("Custom")')
+        );
+        await press("Enter");
+        await animationFrame();
+        await press("Tab", { shiftKey: true });
+        await press("Tab", { shiftKey: true });
+        await press("Tab", { shiftKey: true });
+        await press("Tab", { shiftKey: true });
+        expect(getActiveElement()).toBe(queryFirst(".o_font_color_selector .o_slider_pointer"));
+        expect(".o_hex_input").toHaveValue("#00FF00");
+        await press("ArrowUp");
+        expect(".o_hex_input").toHaveValue("#00FF2A");
+        await press("ArrowDown");
+        expect(".o_hex_input").toHaveValue("#00FF00");
+        await press("ArrowRight");
+        expect(".o_hex_input").toHaveValue("#00FF2A");
+        await press("ArrowLeft");
+        expect(".o_hex_input").toHaveValue("#00FF00");
+        await press("PageUp");
+        expect(".o_hex_input").toHaveValue("#00FF80");
+        await press("PageDown");
+        expect(".o_hex_input").toHaveValue("#00FF00");
+        await press("Home");
+        expect(".o_hex_input").toHaveValue("#FF0000");
+        await press("ArrowUp");
+        expect(".o_hex_input").not.toHaveValue("#FF0000");
+        await press("End");
+        expect(".o_hex_input").toHaveValue("#FF0000");
+    });
+
+    test("update opacity slider with keys", async () => {
+        await setupEditor(
+            `<p>
+                <font style="color: rgb(255, 0, 0);">[test]</font>
+            </p>`
+        );
+        await expandToolbar();
+        await click(".o-we-toolbar .o-select-color-foreground");
+        await animationFrame();
+        await press("Tab");
+        expect(getActiveElement()).toBe(
+            queryFirst('.o_font_color_selector button:contains("Custom")')
+        );
+        await press("Enter");
+        await animationFrame();
+        await press("Tab", { shiftKey: true });
+        await press("Tab", { shiftKey: true });
+        await press("Tab", { shiftKey: true });
+        expect(getActiveElement()).toBe(queryFirst(".o_font_color_selector .o_opacity_pointer"));
+        expect(".o_hex_input").toHaveValue("#FF0000");
+        await press("ArrowDown");
+        expect(".o_hex_input").toHaveValue("#FF0000E6");
+        await press("ArrowLeft");
+        expect(".o_hex_input").toHaveValue("#FF0000CC");
+        await press("Home");
+        expect(".o_hex_input").toHaveValue("#FF000000");
+        await press("ArrowUp");
+        expect(".o_hex_input").toHaveValue("#FF00001A");
+        await press("ArrowRight");
+        expect(".o_hex_input").toHaveValue("#FF000033");
+        await press("End");
+        expect(".o_hex_input").toHaveValue("#FF0000");
+    });
+
+    test("click on saturation and brightness picker sets implicit focus on it", async () => {
+        await setupEditor("<p>[test]</p>");
+        await expandToolbar();
+        await click(".o-we-toolbar .o-select-color-foreground");
+        await animationFrame();
+        await contains('.o_font_color_selector button:contains("Custom")').click();
+        await contains(".o_font_color_selector .o_color_pick_area").click();
+        await press("Tab");
+        expect(getActiveElement()).toBe(queryFirst(".o_font_color_selector .o_slider_pointer"));
+        await contains(".o_font_color_selector .o_color_pick_area").click({
+            position: { top: 0, left: 0 }, // other positions don't guarantee a fixed color
+            relative: true,
+        });
+        expect(".o_hex_input").toHaveValue("#FFFFFF");
+        await press("ArrowDown");
+        expect(".o_hex_input").toHaveValue("#E6E6E6");
+    });
+
+    test("click on hue slider sets implicit focus on it", async () => {
+        await setupEditor(
+            `<p>
+                <font style="color: rgb(0, 255, 0);">[test]</font>
+            </p>`
+        );
+        await expandToolbar();
+        await click(".o-we-toolbar .o-select-color-foreground");
+        await animationFrame();
+        await contains('.o_font_color_selector button:contains("Custom")').click();
+        await contains(".o_font_color_selector .o_color_slider").click();
+        await press("Tab");
+        expect(getActiveElement()).toBe(queryFirst(".o_font_color_selector .o_opacity_pointer"));
+        await contains(".o_font_color_selector .o_color_slider").click();
+        expect(".o_hex_input").not.toHaveValue("#00FF00");
+        await press("Home");
+        expect(".o_hex_input").toHaveValue("#FF0000");
+    });
+
+    test("click on opacity slider sets implicit focus on it", async () => {
+        await setupEditor(
+            `<p>
+                <font style="color: rgb(255, 0, 0);">[test]</font>
+            </p>`
+        );
+        await expandToolbar();
+        await click(".o-we-toolbar .o-select-color-foreground");
+        await animationFrame();
+        await contains('.o_font_color_selector button:contains("Custom")').click();
+        const opacityPointer = queryOne(".o_opacity_pointer");
+        expect(opacityPointer.ariaValueNow).toBe("100.00");
+        await contains(".o_font_color_selector .o_opacity_slider").click();
+        await press("Tab");
+        expect(getActiveElement()).toBe(queryFirst(".o_font_color_selector .o_hex_input"));
+        await contains(".o_font_color_selector .o_opacity_slider").click();
+        expect(opacityPointer.ariaValueNow).not.toBe("100.00");
+        const opacityValue = opacityPointer.ariaValueNow;
+        await press("ArrowDown");
+        expect(opacityPointer.ariaValueNow).not.toBe(opacityValue);
+    });
+});
+
+describe.tags("desktop");
 describe("color preview", () => {
     test("preview color should work and be reverted", async () => {
         await setupEditor("<p>[test]</p>");

--- a/addons/web/static/src/core/color_picker/color_picker.scss
+++ b/addons/web/static/src/core/color_picker/color_picker.scss
@@ -125,13 +125,13 @@
         outline: none;
 
         &::-webkit-slider-thumb {
-            box-shadow: 0 0 0 1px var(--bg, $white), 0 0 0 3px $o-enterprise-action-color;
+            box-shadow: 0 0 0 1px var(--bg, $white), 0 0 0 3px var(--o-color-picker-active-color, $o-enterprise-action-color);
         }
         &::-moz-range-thumb {
-            box-shadow: 0 0 0 1px var(--bg, $white), 0 0 0 3px $o-enterprise-action-color;
+            box-shadow: 0 0 0 1px var(--bg, $white), 0 0 0 3px var(--o-color-picker-active-color, $o-enterprise-action-color);
         }
         &::-ms-thumb {
-            box-shadow: 0 0 0 1px var(--bg, $white), 0 0 0 3px $o-enterprise-action-color;
+            box-shadow: 0 0 0 1px var(--bg, $white), 0 0 0 3px var(--o-color-picker-active-color, $o-enterprise-action-color);
         }
     }
 }

--- a/addons/web/static/src/core/color_picker/custom_color_picker/custom_color_picker.scss
+++ b/addons/web/static/src/core/color_picker/custom_color_picker/custom_color_picker.scss
@@ -7,7 +7,7 @@
         cursor: crosshair;
     }
     .o_color_slider {
-        background: linear-gradient(#F00 0%, #FF0 16.66%, #0F0 33.33%, #0FF 50%, #00F 66.66%, #F0F 83.33%, #F00 100%);
+        background: linear-gradient(#F00 0%, #F0F 16.66%, #00F 33.33%, #0FF 50%, #0F0 66.66%, #FF0 83.33%, #F00 100%);
     }
     .o_opacity_slider, .o_color_preview {
         @extend %o-preview-alpha-background;
@@ -22,6 +22,15 @@
         width: 200%;
         height: 8px;
         margin-top: -2px;
+    }
+    .o_slider_pointer, .o_opacity_pointer, .o_picker_pointer {
+        &:focus-visible {
+            outline: none;
+            box-shadow:
+                inset 0 0 0 1px rgba(white, 0.9),
+                0 0 0 1px var(--bg, $white),
+                0 0 0 3px var(--o-color-picker-active-color, $o-enterprise-action-color);
+        }
     }
     .o_slider_pointer, .o_opacity_pointer, .o_picker_pointer, .o_color_preview {
         box-shadow: inset 0 0 0 1px rgba(white, 0.9);

--- a/addons/web/static/src/core/color_picker/custom_color_picker/custom_color_picker.xml
+++ b/addons/web/static/src/core/color_picker/custom_color_picker/custom_color_picker.xml
@@ -4,14 +4,21 @@
 <t t-name="web.CustomColorPicker">
     <div class="o_colorpicker_widget" t-ref="el" t-on-click="onClick" t-on-keydown="onKeydown" >
         <div class="d-flex justify-content-between align-items-stretch mb-2">
-            <div t-ref="colorPickerArea" class="o_color_pick_area position-relative w-75" t-att-style="props.noTransparency ? 'width: 89%;' : None" t-on-pointerdown="onPointerDownPicker">
-                <div t-ref="colorPickerPointer" class="o_picker_pointer rounded-circle p-1 position-absolute" tabindex="-1"/>
+            <div t-ref="colorPickerArea"
+                    role="application"
+                    aria-label="Saturation and brightness color picker."
+                    aria-roledescription="Use up and down arrow keys to adapt the brightness. Use left and right arrow keys to adapt the saturation. Press the Control or Command key at the same time to have finer control."
+                    aria-activedescendant="picker_pointer"
+                    class="o_color_pick_area position-relative w-75"
+                    t-att-style="props.noTransparency ? 'width: 89%;' : None"
+                    t-on-pointerdown="onPointerDownPicker">
+                <div t-ref="colorPickerPointer" id="picker_pointer" class="o_picker_pointer rounded-circle p-1 position-absolute" tabindex="0" t-on-keydown="onPickerKeydown"/>
             </div>
             <div t-ref="colorSlider" class="o_color_slider position-relative" t-on-pointerdown="onPointerDownSlider">
-                <div t-ref="colorSliderPointer" class="o_slider_pointer" tabindex="-1"/>
+                <div t-ref="colorSliderPointer" class="o_slider_pointer" tabindex="0" t-on-keydown="onSliderKeydown" role="slider" aria-label="Hue" aria-orientation="vertical" aria-valuemin="0" aria-valuemax="360"/>
             </div>
             <div t-ref="opacitySlider" class="o_opacity_slider position-relative" t-if="!props.noTransparency" t-on-pointerdown="onPointerDownOpacitySlider">
-                <div t-ref="opacitySliderPointer" class="o_opacity_pointer" tabindex="-1"/>
+                <div t-ref="opacitySliderPointer" class="o_opacity_pointer" tabindex="0" t-on-keydown="onOpacitySliderKeydown" role="slider" aria-label="Opacity" aria-orientation="vertical" aria-valuemin="0" aria-valuemax="100"/>
             </div>
         </div>
         <div class="o_color_picker_inputs d-flex justify-content-between mb-2" t-on-change="debouncedOnChangeInputs">


### PR DESCRIPTION
*: html_builder, html_editor

To add keyboard support on colorpicker sliders as well as on the saturation / brightness area, this commit not only sets proper roles, focus, aria attributes, but also has to invert the order of the hue slider, so that pressing ArrowUp actually increases the value of the hue, and ArrowDown decreases it. Otherwise, the `aria-valuenow` is inconsistent with the key pressed.

Note that there is no official aria role for multi-dimensional sliders such as the colorpicker area. I fell back on `role="application"` and explicit `aria-label`s and `aria-roledescription`.

Finally, just like any other button would do, when you click on a slider pointer, it is not visually focused, but the next navigation key should be listened to by the pointer.
i.e.:
- click on the opacity slider, then press an arrow => it should update the opacity.
- click on the hue slider, then press Tab => it should focus the opacity slider.

task-4879833