### PR TITLE
[FIX] html_editor: properly trim whitespaces with unformat test helper

### DIFF
--- a/addons/html_editor/static/tests/_helpers/format.js
+++ b/addons/html_editor/static/tests/_helpers/format.js
@@ -1,10 +1,23 @@
+const OPENING_TAG_REGEX = /<\s*([^\s/>]+)([^>]*?)(\/?)>/g;
+const ATTRIBUTES_REGEX = /([^\s=]+)(=(?:"[^"]*"|'[^']*'))?/g;
+
 /**
  * Unformat the given html in order to use it with `innerHTML`.
  */
 export function unformat(html) {
-    return html
-        .replace(/(^|[^ ])[^\S\ufeff]+([^<>]*?)</g, "$1$2<")
-        .replace(/>([^<>]*?)[^\S\ufeff]+([^ ]|$)/g, ">$1$2");
+    return (
+        html
+            // Trim whitespaces between attributes.
+            .replace(OPENING_TAG_REGEX, (match, tag, attrs, selfClosing) => {
+                // Isolate each attribute key/value pair.
+                const attributes = attrs.match(ATTRIBUTES_REGEX);
+                return `<${tag}${attributes ? " " + attributes.join(" ") : ""}${selfClosing}>`;
+            })
+            // Trim whitespace (except \ufeff) between > and <.
+            .replace(/>[^\S\uFEFF]+/g, ">")
+            .replace(/[^\S\uFEFF]+</g, "<")
+            .trim()
+    );
 }
 
 /**

--- a/addons/html_editor/static/tests/color.test.js
+++ b/addons/html_editor/static/tests/color.test.js
@@ -197,12 +197,12 @@ test("should not apply font tag to t nodes (protects if else nodes separation)",
             <p>
                 <t t-if="object.partner_id.parent_id">
                     <t t-out="object.partner_id.parent_id.name or ''" style="color: red;">
-                        <font style="color: red;">AzureInterior</font>
+                        <font style="color: red;">Azure Interior</font>
                     </t>
                 </t>
                 <t t-else="">
                     <t t-out="object.partner_id.name or ''" style="color: red;">
-                        <font style="color: red;">BrandonFreeman</font>
+                        <font style="color: red;">Brandon Freeman</font>
                     </t>
                 </t>
             </p>

--- a/addons/html_editor/static/tests/embedded_components_plugins/toggle_block.test.js
+++ b/addons/html_editor/static/tests/embedded_components_plugins/toggle_block.test.js
@@ -529,7 +529,7 @@ describe("Enter applied to toggle title", () => {
                     </button>
                     <div class="flex-fill ms-1">
                         <div data-embedded-editable="title" data-oe-protected="false" contenteditable="true">
-                            <p>Hello</p>
+                            <p>Hello&nbsp;</p>
                         </div>
                     </div>
                 </div>
@@ -588,7 +588,7 @@ describe("Enter applied to toggle title", () => {
                     </button>
                     <div class="flex-fill ms-1">
                         <div data-embedded-editable="title" data-oe-protected="false" contenteditable="true">
-                            <p>Hello </p>
+                            <p>Hello&nbsp;</p>
                         </div>
                     </div>
                 </div>

--- a/addons/html_editor/static/tests/utils/format_helpers.test.js
+++ b/addons/html_editor/static/tests/utils/format_helpers.test.js
@@ -1,0 +1,105 @@
+import { describe, expect, test } from "@odoo/hoot";
+import { unformat } from "../_helpers/format";
+import { base64Img } from "../_helpers/editor";
+
+describe("unformat", () => {
+    test("should trim space between a tag name and an attribute", () => {
+        expect(
+            unformat(`<div
+        class="something">`)
+        ).toBe(`<div class="something">`);
+    });
+    test("should trim space at the beginning and end of the string", () => {
+        expect(
+            unformat(`
+                <div>abc</div>
+            `)
+        ).toBe(`<div>abc</div>`);
+    });
+    test("should trim space between a node and its text content", () => {
+        expect(
+            unformat(
+                `<div>
+                    abc
+                </div>`
+            )
+        ).toBe(`<div>abc</div>`);
+    });
+    test("should trim space between nodes", () => {
+        expect(
+            unformat(
+                `<div>abc</div>
+                <p>def</p>`
+            )
+        ).toBe(`<div>abc</div><p>def</p>`);
+    });
+    test("should not trim space between words in text content", () => {
+        expect(unformat(`<div>some content</div>`)).toBe(`<div>some content</div>`);
+    });
+    test("should not remove feff characters", () => {
+        expect(
+            unformat(
+                `<div>
+                    text     \ufeff     
+                </div>`
+            )
+        ).toBe(`<div>text     \ufeff</div>`);
+    });
+    test("should not remove spaces within an attribute", () => {
+        const html = `<img src="${base64Img}" class="a  b"/>`;
+        expect(unformat(html)).toBe(html);
+    });
+    test("should unformat a complex structure", () => {
+        expect(
+            unformat(`
+                <div>
+                    abc
+                    \ufeff
+                    <span
+                        class="something"
+                        contenteditable
+                        style='font-size: 5px; font-family:"Helvetica Neue";'
+                        data-attr="console.log('it works')"
+                    />
+                    def ghi
+                    <br><br>
+                </div>
+                <p>jkl</p>
+                <div class="hello"/>
+                <fake-node fake="true"
+                    style='font-size: 5px; font-family:"Helvetica Neue";'>
+                    <div>mno</div>
+                    <p><span>pqr</span>
+                        stu<b>
+                            vwx
+                        </b>
+                    </p>
+                </fake-node>
+            `)
+        ).toBe(
+            `<div>` +
+                `abc
+                    \ufeff` +
+                `<span ` +
+                `class="something" ` +
+                `contenteditable ` +
+                `style='font-size: 5px; font-family:"Helvetica Neue";' ` +
+                `data-attr="console.log('it works')"` +
+                `/>` +
+                `def ghi` +
+                `<br><br>` +
+                `</div>` +
+                `<p>jkl</p>` +
+                `<div class="hello"/>` +
+                `<fake-node fake="true" ` +
+                `style='font-size: 5px; font-family:"Helvetica Neue";'>` +
+                `<div>mno</div>` +
+                `<p><span>pqr</span>` +
+                `stu<b>` +
+                `vwx` +
+                `</b>` +
+                `</p>` +
+                `</fake-node>`
+        );
+    });
+});


### PR DESCRIPTION
The `unformat` test helper was inadequate in a number of situations. For example: `unformat("<p>a b</p>")` returned `"<p>ab</p>"`, and `unformat('<div\n class="a"/>')` returned the html unchanged instead of removing the `"\n"`.

This rewrites the function to properly trim the whitespaces, and introduces test to ensure its adequacy.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
