### PR TITLE
[FIX] hr_org_chart: fix employee org chart bug

### DIFF
--- a/addons/hr_org_chart/controllers/hr_org_chart.py
+++ b/addons/hr_org_chart/controllers/hr_org_chart.py
@@ -10,9 +10,7 @@ class HrOrgChartController(http.Controller):
     _managers_level = 5  # FP request
 
     def _check_employee(self, employee_id, **kw):
-        if not employee_id:  # to check
-            return None
-        employee_id = int(employee_id)
+        employee_id = int(employee_id) if employee_id else False
 
         if 'allowed_company_ids' in request.env.context:
             cids = request.env.context['allowed_company_ids']
@@ -22,11 +20,11 @@ class HrOrgChartController(http.Controller):
         Employee = request.env['hr.employee.public'].with_context(allowed_company_ids=cids)
         # check and raise
         if not Employee.check_access_rights('read', raise_exception=False):
-            return None
+            return request.env['hr.employee.public']
         try:
             Employee.browse(employee_id).check_access_rule('read')
         except AccessError:
-            return None
+            return request.env['hr.employee.public']
         else:
             return Employee.browse(employee_id)
 
@@ -51,8 +49,9 @@ class HrOrgChartController(http.Controller):
 
     @http.route('/hr/get_org_chart', type='json', auth='user')
     def get_org_chart(self, employee_id, **kw):
-
         employee = self._check_employee(employee_id, **kw)
+        new_parent_id = request.env.context.get('new_parent_id', None)
+        new_parent = self._check_employee(new_parent_id, **kw)
         if not employee:  # to check
             return {
                 'managers': [],
@@ -61,16 +60,22 @@ class HrOrgChartController(http.Controller):
 
         # compute employee data for org chart
         ancestors, current = request.env['hr.employee.public'].sudo(), employee.sudo()
-        while current.parent_id and len(ancestors) < self._managers_level+1 and current != current.parent_id:
-            ancestors += current.parent_id
-            current = current.parent_id
+        current_parent = new_parent if new_parent_id is not None else current.parent_id
+        max_level = (request.env.context.get('max_level', None) or self._managers_level) + 1
+        while current_parent and current != current_parent and employee.sudo() != current_parent and len(ancestors) < max_level:
+            current = current_parent
+            current_parent = current.parent_id if current != employee or not new_parent else new_parent
+            if current_parent in ancestors:
+                break
+            else:
+                ancestors += current
 
         values = dict(
             self=self._prepare_employee_data(employee),
             managers=[
                 self._prepare_employee_data(ancestor)
                 for idx, ancestor in enumerate(ancestors)
-                if idx < self._managers_level
+                if idx < max_level - 1
             ],
             managers_more=len(ancestors) > self._managers_level,
             children=[self._prepare_employee_data(child) for child in employee.child_ids if child != employee],

--- a/addons/hr_org_chart/static/src/fields/hr_org_chart.js
+++ b/addons/hr_org_chart/static/src/fields/hr_org_chart.js
@@ -6,7 +6,7 @@ import { useService } from "@web/core/utils/hooks";
 import { usePopover } from "@web/core/popover/popover_hook";
 import { onEmployeeSubRedirect } from './hooks';
 
-const { Component, onWillStart, onWillRender, useState } = owl;
+const { Component, onWillStart, onWillUpdateProps, useState } = owl;
 
 function useUniquePopover() {
     const popover = usePopover();
@@ -62,24 +62,40 @@ export class HrOrgChart extends Field {
 
         this.state = useState({'employee_id': null});
         this.lastParent = null;
+        this.max_level = null;
         this._onEmployeeSubRedirect = onEmployeeSubRedirect();
 
-        onWillStart(this.handleComponentUpdate.bind(this));
-        onWillRender(this.handleComponentUpdate.bind(this));
-    }
+        onWillStart(async () => {
+            this.employee = this.props.record.data;
+            // the widget is either dispayed in the context of a hr.employee form or a res.users form
+            this.state.employee_id =
+                this.employee.employee_ids !== undefined
+                    ? this.employee.employee_ids.resIds[0]
+                    : this.employee.id;
+            const parentId =
+                this.employee.parent_id && this.employee.parent_id[0]
+                    ? this.employee.parent_id[0]
+                    : false;
+            const forceReload =
+                this.lastRecord !== this.props.record || this.lastParent != parentId;
+            this.lastParent = parentId;
+            this.lastRecord = this.props.record;
+            await this.fetchEmployeeData(this.state.employee_id, forceReload);
+        });
 
-    /**
-     * Called on start and on render
-     */
-    async handleComponentUpdate() {
-        this.employee = this.props.record.data;
-        // the widget is either dispayed in the context of a hr.employee form or a res.users form
-        this.state.employee_id = this.employee.employee_ids !== undefined ? this.employee.employee_ids.resIds[0] : this.employee.id;
-        const manager = this.employee.parent_id || this.employee.employee_parent_id;
-        const forceReload = this.lastRecord !== this.props.record || this.lastParent != manager;
-        this.lastParent = manager;
-        this.lastRecord = this.props.record;
-        await this.fetchEmployeeData(this.state.employee_id, forceReload);
+        onWillUpdateProps(async (nextProps) => {
+            const newParentId =
+                nextProps.record.data.parent_id && nextProps.record.data.parent_id[0]
+                    ? nextProps.record.data.parent_id[0]
+                    : false;
+            const newEmployeeId = nextProps.record.data.id || false;
+            if (this.lastParent !== newParentId || this.state.employee_id !== newEmployeeId) {
+                this.lastParent = newParentId;
+                this.max_level = null; // Reset max_level to default
+                await this.fetchEmployeeData(newEmployeeId, true);
+            }
+            this.state.employee_id = newEmployeeId;
+        });
     }
 
     async fetchEmployeeData(employeeId, force = false) {
@@ -96,9 +112,12 @@ export class HrOrgChart extends Field {
                 '/hr/get_org_chart',
                 {
                     employee_id: employeeId,
-                    context: Component.env.session.user_context,
-                }
-            );
+                    context: {
+                        ...Component.env.session.user_context,
+                    max_level: this.max_level,
+                    new_parent_id: this.lastParent,
+                },
+            });
             if (Object.keys(orgData).length === 0) {
                 orgData = {
                     managers: [],
@@ -135,8 +154,8 @@ export class HrOrgChart extends Field {
     }
 
     async _onEmployeeMoreManager(managerId) {
-        await this.fetchEmployeeData(managerId);
-        this.state.employee_id = managerId;
+        this.max_level = 100; // Set a high level to fetch all managers
+        await this.fetchEmployeeData(this.state.employee_id, true);
     }
 }
 

--- a/addons/hr_org_chart/static/src/fields/hr_org_chart.xml
+++ b/addons/hr_org_chart/static/src/fields/hr_org_chart.xml
@@ -72,7 +72,7 @@
         -->
     <t t-set="emp_count" t-value="0"/>
     <div t-if='managers.length &gt; 0' class="o_org_chart_group_up position-relative">
-        <div t-if='managers_more' class="o_org_chart_more pe-3">
+        <div t-if='managers_more' class="o_org_chart_more pe-3" t-attf-class="{{max_level !== null ? 'invisible' : ''}}">
             <a href="#" t-att-data-employee-id="managers[0].id" class="o_employee_more_managers d-block bg-100 px-3" t-on-click.prevent="() => this._onEmployeeMoreManager(managers[0].id)">
                 <i class="fa fa-angle-double-up" role="img" aria-label="More managers" title="More managers"/>
             </a>


### PR DESCRIPTION
A buggy behavior when there are more than 5 managers was fixed. The org chart now updates before the employee record is saved.

task-4609465

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
