### PR TITLE
[REF] project,web: use Dropdown comp. instead of Bootstrap

### DIFF
--- a/addons/project/static/src/views/components/project_task_template_dropdown.js
+++ b/addons/project/static/src/views/components/project_task_template_dropdown.js
@@ -1,8 +1,14 @@
 import { Component, onWillStart } from "@odoo/owl";
 import { useService } from "@web/core/utils/hooks";
+import { Dropdown } from "@web/core/dropdown/dropdown";
+import { DropdownItem } from "@web/core/dropdown/dropdown_item";
 
 export class ProjectTaskTemplateDropdown extends Component {
     static template = "project.TemplateDropdown";
+    static components = {
+        Dropdown,
+        DropdownItem,
+    };
 
     static props = {
         hotkey: {

--- a/addons/project/static/src/views/components/project_task_template_dropdown.xml
+++ b/addons/project/static/src/views/components/project_task_template_dropdown.xml
@@ -2,20 +2,22 @@
 <templates>
     <t t-name="project.TemplateDropdown">
         <button t-if="!taskTemplates.length" type="button" t-att-class="props.newButtonClasses" t-att-data-hotkey="props.hotkey" t-on-click.stop="props.onCreate" data-bounce-button="">New</button>
-        <t t-else="">
-            <a t-attf-class="{{ props.newButtonClasses }} dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false" t-att-data-hotkey="props.hotkey" data-bounce-button="">
+        <Dropdown t-else="">
+            <button t-attf-class="{{ props.newButtonClasses }} o-dropdown-caret" t-att-data-hotkey="props.hotkey" data-bounce-button="">
                 New
-            </a>
-            <ul class="dropdown-menu o-project-form-dropdown-menu">
-                <button type="button" class="btn btn-link dropdown-item o-dropdown-item" t-on-click="props.onCreate">
+            </button>
+            <t t-set-slot="content">
+                <DropdownItem tag="'button'" class="'btn btn-link'" onSelected="props.onCreate">
                     New Task
-                </button>
-                <div class="dropdown-divider"/>
-                <div class="dropdown-header" style="padding-left: 20px;">Task Templates</div>
+                </DropdownItem>
+                <div role="separator" class="dropdown-divider"/>
+                <div class="dropdown-header">Task Templates</div>
                 <t t-foreach="taskTemplates" t-as="template" t-key="template.id">
-                    <button type="button" class="btn btn-link o-dropdown-item dropdown-item" style="padding-left: 32px;" t-on-click="() =&gt; this.createTaskFromTemplate(template.id)" t-out="template.name"/>
+                    <DropdownItem tag="'button'" class="'btn btn-link o-dropdopwn-item-indent'" onSelected="() => this.createTaskFromTemplate(template.id)">
+                        <t t-out="template.name"/>
+                    </DropdownItem>
                 </t>
-            </ul>
-        </t>
+            </t>
+        </Dropdown>
     </t>
 </templates>

--- a/addons/project/static/src/views/components/project_template_dropdown.js
+++ b/addons/project/static/src/views/components/project_template_dropdown.js
@@ -1,8 +1,14 @@
 import { Component, onWillStart } from "@odoo/owl";
 import { useService } from "@web/core/utils/hooks";
+import { Dropdown } from "@web/core/dropdown/dropdown";
+import { DropdownItem } from "@web/core/dropdown/dropdown_item";
 
 export class ProjectTemplateDropdown extends Component {
     static template = "project.ProjectTemplateDropdown";
+    static components = {
+        Dropdown,
+        DropdownItem,
+    };
 
     static props = {
         hotkey: {

--- a/addons/project/static/src/views/components/project_template_dropdown.xml
+++ b/addons/project/static/src/views/components/project_template_dropdown.xml
@@ -2,20 +2,22 @@
 <templates>
     <t t-name="project.ProjectTemplateDropdown">
         <button t-if="!projectTemplates.length" type="button" t-att-class="props.newButtonClasses" t-att-disabled="props.isDisabled" t-att-data-hotkey="props.hotkey" t-on-click.stop="props.onCreate" data-bounce-button="">New</button>
-        <t t-else="">
-            <a t-attf-class="{{ props.newButtonClasses }} dropdown-toggle" data-bs-toggle="dropdown" t-att-disabled="props.isDisabled" aria-expanded="false" t-att-data-hotkey="props.hotkey" data-bounce-button="">
+        <Dropdown t-else="">
+            <button t-attf-class="{{ props.newButtonClasses }} o-dropdown-caret" t-att-disabled="props.isDisabled" t-att-data-hotkey="props.hotkey" data-bounce-button="">
                 New
-            </a>
-            <ul class="dropdown-menu o-project-form-dropdown-menu">
-                <button type="button" class="btn btn-link dropdown-item o-dropdown-item" t-on-click="props.onCreate">
+            </button>
+            <t t-set-slot="content">
+                <DropdownItem tag="'button'" class="'btn btn-link'" onSelected="props.onCreate">
                     New Project
-                </button>
-                <div class="dropdown-divider"/>
-                <div class="dropdown-header" style="padding-left: 20px;">Project Templates</div>
+                </DropdownItem>
+                <div role="separator" class="dropdown-divider"/>
+                <div class="dropdown-header">Project Templates</div>
                 <t t-foreach="projectTemplates" t-as="template" t-key="template.id">
-                    <button type="button" class="btn btn-link o-dropdown-item dropdown-item" style="padding-left: 32px;" t-on-click="() => this.createProjectFromTemplate(template)" t-out="template.name"/>
+                    <DropdownItem tag="'button'" class="'btn btn-link o-dropdopwn-item-indent'" onSelected="() => this.createProjectFromTemplate(template)">
+                        <t t-out="template.name"/>
+                    </DropdownItem>
                 </t>
-            </ul>
-        </t>
+            </t>
+        </Dropdown>
     </t>
 </templates>

--- a/addons/project/static/src/views/project_task_form/project_task_form_view.scss
+++ b/addons/project/static/src/views/project_task_form/project_task_form_view.scss
@@ -21,7 +21,3 @@
         margin-bottom: 0;
     }
 }
-
-.o-project-form-dropdown-menu {
-    z-index: 1030 !important;
-}

--- a/addons/project/static/tests/tours/project_task_templates_tour.js
+++ b/addons/project/static/tests/tours/project_task_templates_tour.js
@@ -19,11 +19,11 @@ registry.category("web_tour.tours").add("project_task_templates_tour", {
             content: "Wait for the kanban view to load",
         },
         {
-            trigger: "a.o-kanban-button-new",
+            trigger: ".o-kanban-button-new",
             run: "click",
         },
         {
-            trigger: 'ul.dropdown-menu button.dropdown-item:contains("Template")',
+            trigger: '.dropdown-menu button.dropdown-item:contains("Template")',
             run: "click",
             content: "Create a task with the template",
         },

--- a/addons/project/static/tests/tours/project_templates_tour.js
+++ b/addons/project/static/tests/tours/project_templates_tour.js
@@ -11,11 +11,11 @@ registry.category("web_tour.tours").add("project_templates_tour", {
         },
         {
             content: "Click on New Button of Kanban view",
-            trigger: "a.o-kanban-button-new",
+            trigger: ".o-kanban-button-new",
             run: "click",
         },
         {
-            trigger: 'ul.dropdown-menu button.dropdown-item:contains("Project Template")',
+            trigger: '.dropdown-menu button.dropdown-item:contains("Project Template")',
             run: "click",
             content: "Create a project from the template",
         },
@@ -43,12 +43,12 @@ registry.category("web_tour.tours").add("project_templates_tour", {
         },
         {
             content: "Click on New Button of List view",
-            trigger: "a.o_list_button_add",
+            trigger: ".o_list_button_add",
             run: "click",
         },
         {
             content: "Lets Create a second project from the template",
-            trigger: 'ul.dropdown-menu button.dropdown-item:contains("Project Template")',
+            trigger: '.dropdown-menu button.dropdown-item:contains("Project Template")',
             run: "click",
         },
         {

--- a/addons/web/static/src/core/dropdown/dropdown.scss
+++ b/addons/web/static/src/core/dropdown/dropdown.scss
@@ -103,6 +103,10 @@
             cursor: pointer;
         }
     }
+
+    .dropdown-item.o-dropdopwn-item-indent {
+        --#{$prefix}dropdown-item-padding-x: #{$dropdown-item-padding-x * 1.5};
+    }
 }
 
 // Unstyle buttons so they behave like regular dropdown-item


### PR DESCRIPTION
As we try to remove as much as possible our dependency on Bootstrap components for the backend, this commit rewrites the Project's templates dropdown by using our own implementation instead of the Bootstrap's one.

task-4277543




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
