### PR TITLE
[FIX] web: show nested allowed child companies in company selector

### DIFF
--- a/addons/web/models/ir_http.py
+++ b/addons/web/models/ir_http.py
@@ -145,7 +145,7 @@ class Http(models.AbstractModel):
                             'id': comp.id,
                             'name': comp.name,
                             'sequence': comp.sequence,
-                            'child_ids': (comp.child_ids & user.company_ids).ids,
+                            'child_ids': (comp.child_ids & all_companies_in_hierarchy_sudo).ids,
                             'parent_id': comp.parent_id.id,
                         } for comp in user.company_ids
                     },

--- a/addons/web/static/src/webclient/switch_company_menu/switch_company_menu.js
+++ b/addons/web/static/src/webclient/switch_company_menu/switch_company_menu.js
@@ -38,17 +38,20 @@ export class CompanySelector {
     }
 
     _selectCompany(companyId, unshift = false) {
-        if (!this.selectedCompaniesIds.includes(companyId)) {
-            if (unshift) {
+        if (!(companyId in this.companyService.disallowedAncestorCompanies)) {
+            if (!this.selectedCompaniesIds.includes(companyId)) {
+                if (unshift) {
+                    this.selectedCompaniesIds.unshift(companyId);
+                } else {
+                    this.selectedCompaniesIds.push(companyId);
+                }
+            } else if (unshift) {
+                const index = this.selectedCompaniesIds.findIndex((c) => c === companyId);
+                this.selectedCompaniesIds.splice(index, 1);
                 this.selectedCompaniesIds.unshift(companyId);
-            } else {
-                this.selectedCompaniesIds.push(companyId);
             }
-        } else if (unshift) {
-            const index = this.selectedCompaniesIds.findIndex((c) => c === companyId);
-            this.selectedCompaniesIds.splice(index, 1);
-            this.selectedCompaniesIds.unshift(companyId);
         }
+
         this._getBranches(companyId).forEach((companyId) => this._selectCompany(companyId));
     }
 

--- a/addons/web/static/tests/webclient/mobile/mobile_switch_company_menu_tests.js
+++ b/addons/web/static/tests/webclient/mobile/mobile_switch_company_menu_tests.js
@@ -54,6 +54,7 @@ QUnit.module("MobileSwitchCompanyMenu", (hooks) => {
                 3: { id: 3, name: "Heroes TM", parent_id: false, child_ids: [] },
             },
             current_company: 1,
+            disallowed_ancestor_companies: {},
         });
         serviceRegistry.add("ui", uiService);
         serviceRegistry.add("company", companyService);

--- a/addons/web/tests/test_session_info.py
+++ b/addons/web/tests/test_session_info.py
@@ -15,8 +15,10 @@ class TestSessionInfo(common.HttpCase):
         cls.company_b = cls.env['res.company'].create({'name': "B"})
         cls.company_c = cls.env['res.company'].create({'name': "C"})
         cls.company_b_branch = cls.env['res.company'].create({'name': "B Branch", 'parent_id': cls.company_b.id})
-        cls.allowed_companies = cls.company_a + cls.company_b_branch + cls.company_c
-        cls.disallowed_ancestor_companies = cls.company_b
+        cls.company_c_branch = cls.env['res.company'].create({'name': "C Branch", 'parent_id': cls.company_c.id})
+        cls.company_c_branch_branch = cls.env['res.company'].create({'name': "C Branch Branch", 'parent_id': cls.company_c_branch.id})
+        cls.allowed_companies = cls.company_a + cls.company_b_branch + cls.company_c + cls.company_c_branch_branch
+        cls.disallowed_ancestor_companies = cls.company_b + cls.company_c_branch
 
         cls.user_password = "info"
         cls.user = common.new_test_user(


### PR DESCRIPTION
### Issue:
Given a specific configuration, the `SwitchCompanyMenu` will not display all the companies a user can access. Suppose we have a company hierarchy with the following: `Company 1 > Company 2 > Company 3` (where 2 is a branch of 1, and 3 is a branch of 2). If a user has access to C1 and C3, but not C2, the menu selector will only display C1, rather than a hierarchy of all 3 companies with C2 disabled.

This menu has been improved between versions, but the logic behind how we determine which companies to display remains consistent. We loop over each root company from `companyService.allowedCompaniesWithAncestors`, add it, and then add its children. Depending on whether the child company is accessible, it will be disabled (but still displayed) in the hierarchy list.

`companyService` pulls its company information from the `session['user_companies']` dict that is created from `session_info`. For each of the `allowed_companies`, we build the `child_ids` from the intersection of each `user.company_id.child_ids` and `user.company_ids`. So we only add the child if it itself is an allowed company, which C2 would not be. C1 is now considered a root company with no children in our loop, so C2 is skipped. C2 isn't a root company either, so it will never be seen, and therefore neither will C3.

### Solution:
A similar case was addressed in #138942, where given the same company hierarchy as above, the user instead has access to C2 and C3, but not C1. This PR adjusted how we build the `child_ids` for `disallowed_ancestor_companies` (C1 in this case), properly setting the children for us to loop through. We can use this same logic for the `child_ids` of `allowed_companies`, ensuring we can properly loop through the disallowed children of allowed companies.  Additionally, we need to adapt the `CompanySelector` component, which previously grabbed all children even if they were disallowed.

opw-4880477