### PR TITLE
[IMP] im_livechat: more performant duration computation

### DIFF
--- a/addons/im_livechat/models/discuss_channel.py
+++ b/addons/im_livechat/models/discuss_channel.py
@@ -158,13 +158,10 @@ class DiscussChannel(models.Model):
         "(channel_type, create_date) WHERE channel_type = 'livechat'"
     )
 
-    @api.depends('message_ids')
+    @api.depends("livechat_end_dt")
     def _compute_duration(self):
-        last_msg_by_channel_id = {
-            message.res_id: message for message in self._get_last_messages()
-        }
         for record in self:
-            end = last.date if (last := last_msg_by_channel_id.get(record.id)) else fields.Datetime.now()
+            end = record.livechat_end_dt or fields.Datetime.now()
             record.duration = (end - record.create_date).total_seconds() / 3600
 
     @api.depends("livechat_end_dt")

--- a/addons/im_livechat/tests/test_im_livechat_report.py
+++ b/addons/im_livechat/tests/test_im_livechat_report.py
@@ -41,6 +41,12 @@ class TestImLivechatReport(TestImLivechatCommon):
         partner_message = self._create_message(channel, self.operator, '2023-03-17 05:05:54')
         partner_message |= self._create_message(channel, self.operator, '2023-03-17 09:15:54')
         partner_message.model = 'res.partner'
+
+        with freeze_time("2023-03-17 09:20:54"):
+            self.make_jsonrpc_request(
+                "/im_livechat/visitor_leave_session",
+                {"channel_id": channel_id}
+            )
         self.env['mail.message'].flush_model()
 
     def test_im_livechat_report_channel(self):
@@ -53,16 +59,16 @@ class TestImLivechatReport(TestImLivechatCommon):
         # 08:15:54: operator first answer
         # 08:45:54: operator second answer
         # 09:15:54: wrong model
-        # So the duration of the session is: (08:45:54 - 06:05:54) = 2h40 = 160 minutes
+        # So the duration of the session is: (09:20:54 - 06:05:54) = 3h15 = 195 minutes
         # The time to answer of this session is: (08:15:54 - 06:05:54) = 2h10 = 7800 seconds
         self.assertEqual(report.time_to_answer, 7800 / 3600)
-        self.assertEqual(int(report.duration), 160)
+        self.assertEqual(int(report.duration), 195)
 
     def test_im_livechat_report_operator(self):
         result = self.env["im_livechat.report.channel"].formatted_read_group([], aggregates=["time_to_answer:avg", "duration:avg"])
         self.assertEqual(len(result), 1)
         self.assertEqual(result[0]["time_to_answer:avg"], 7800 / 3600)
-        self.assertEqual(int(result[0]['duration:avg']), 160)
+        self.assertEqual(int(result[0]['duration:avg']), 195)
 
     @classmethod
     def _create_message(cls, channel, author, date):


### PR DESCRIPTION
This PR introduces an optimized approach for computing the duration of livechat sessions by replacing the previous logic based on the last message timestamp with a more efficient and reliable method using the `livechat_end_dt` field by avoiding costly lateral joins.

task-4882318

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
