### PR TITLE
[FIX] website: prevent autoclosing of Linkpopover

### DIFF
--- a/addons/website/static/src/js/editor/html_editor.js
+++ b/addons/website/static/src/js/editor/html_editor.js
@@ -3,8 +3,9 @@ import { rpc } from "@web/core/network/rpc";
 import { _t } from "@web/core/l10n/translation";
 import { AutoComplete } from "@web/core/autocomplete/autocomplete";
 import { patch } from "@web/core/utils/patch";
-import { useAutofocus, useChildRef } from "@web/core/utils/hooks";
+import { useChildRef } from "@web/core/utils/hooks";
 import wUtils from "@website/js/utils";
+import { useEffect } from "@odoo/owl";
 
 /**
  * The goal of this patch is to handle the URL autocomplete in the LinkPopover
@@ -111,10 +112,14 @@ patch(LinkPopover.prototype, {
     setup() {
         super.setup();
         this.urlRef = useChildRef();
-        useAutofocus({
-            refName: this.state.isImage || this.state.label !== "" ? this.urlRef.name : "label",
-            mobile: true,
-        });
+        useEffect(
+            (el) => {
+                if (el) {
+                    el.focus();
+                }
+            },
+            () => [this.urlRef.el]
+        );
     },
 
     get sources() {

--- a/addons/website/static/tests/website_html_editor.test.js
+++ b/addons/website/static/tests/website_html_editor.test.js
@@ -1,11 +1,13 @@
 import { expect, test } from "@odoo/hoot";
-import { click, press, waitFor } from "@odoo/hoot-dom";
+import { click, press, waitFor, queryOne } from "@odoo/hoot-dom";
 import { animationFrame } from "@odoo/hoot-mock";
 import { cleanLinkArtifacts } from "@html_editor/../tests/_helpers/format";
-import { getContent } from "@html_editor/../tests/_helpers/selection";
+import { getContent, setSelection } from "@html_editor/../tests/_helpers/selection";
 import { setupEditor } from "@html_editor/../tests/_helpers/editor";
-import { contains, defineModels, onRpc } from "@web/../tests/web_test_helpers";
-import { mailModels } from "@mail/../tests/mail_test_helpers";
+import { contains, defineModels, onRpc, serverState, patchWithCleanup } from "@web/../tests/web_test_helpers";
+import { click as mailClick, mailModels, openFormView, start } from "@mail/../tests/mail_test_helpers";
+import { insertText } from "@html_editor/../tests/_helpers/user_actions";
+import { HtmlField } from "@html_editor/fields/html_field";
 
 defineModels(mailModels);
 
@@ -69,4 +71,33 @@ test("autocomplete should shown and able to edit the link", async () => {
     // check the default page anchors are in the autocomplete dropdown
     expect(".o-autocomplete--dropdown-item:first").toHaveText("#top");
     expect(".o-autocomplete--dropdown-item:last").toHaveText("#bottom");
+});
+
+test("LinkPopover opens in full composer", async () => {
+
+    let htmlEditor;
+    mailModels.MailComposeMessage._views = {
+        "form,false": `
+        <form js_class="mail_composer_form">
+            <field name="body" type="html" widget="html_composer_message"/>
+        </form>`,
+    };
+    patchWithCleanup(HtmlField.prototype, {
+        onEditorLoad(editor) {
+            htmlEditor = editor;
+            return super.onEditorLoad(...arguments);
+        },
+    });
+    await start();
+    await openFormView("res.partner", serverState.partnerId);
+    await mailClick("button", { text: "Log note" });
+    await mailClick("button[title='Open Full Composer']");
+    await waitFor(".odoo-editor-editable");
+    await insertText(htmlEditor, "test");
+    const node = queryOne(".odoo-editor-editable div.o-paragraph");
+    setSelection({ anchorNode: node, anchorOffset: 0, focusNode: node, focusOffset: 1 });
+    await mailClick(".o-we-toolbar .fa-link");
+    await waitFor(".o-we-linkpopover");
+    await animationFrame();
+    expect(".o-we-linkpopover").toHaveCount(1);
 });


### PR DESCRIPTION
Issue: 
currently, the linkpopover get closed as soon as it is open, due to fact that autofocus hooks do not work as expected when working inside full composer

we have faces same issue previously, fixed by odoo/odoo@99a01a66e3bda18a7655581ddc5c768ed92c14d1 but issue arises again after odoo/odoo@deaeecc54a10519656338546c18eb091ac84ff4e overrides the the original component and relies on `useAutofocus` again.

Step to reproduce:
- open crm
- open a record and click on "Log note" -> full composer
- enter some text
- select it and try to add link form toolba

observation: The LinkPopover opens and closes immediately

Fix:
- we manually focus on the input instead of using autofocus

opw-4874775


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
