### PR TITLE
[FIX] website: live update of link preview while typing URL

### DIFF
--- a/addons/website/static/src/js/editor/html_editor.js
+++ b/addons/website/static/src/js/editor/html_editor.js
@@ -123,9 +123,11 @@ patch(LinkPopover.prototype, {
 
     onSelect(value) {
         this.state.url = value;
+        this.onChange();
     },
 
     updateValue(val) {
         this.state.url = val;
+        this.onChange();
     },
 });

--- a/addons/website/static/tests/builder/linkpopover_url_autocomplete.test.js
+++ b/addons/website/static/tests/builder/linkpopover_url_autocomplete.test.js
@@ -45,6 +45,8 @@ test("autocomplete should shown and able to edit the link", async () => {
     // autocomplete dropdown should be there
     await press(["ctrl", "a"]);
     await press("c");
+    // Should update preview with typed URL.
+    expect(cleanLinkArtifacts(getContent(el))).toBe('<p>this is a <a href="c">link</a></p>');
     await waitFor(".o-autocomplete--dropdown-menu", { timeout: 3000 });
     expect.verifySteps(["/website/get_suggested_links"]);
 
@@ -52,6 +54,10 @@ test("autocomplete should shown and able to edit the link", async () => {
     expect(".o-autocomplete--dropdown-item img").toHaveCount(1);
 
     await click(".o-autocomplete--dropdown-item:first");
+    // Should update preview with selected item.
+    expect(cleanLinkArtifacts(getContent(el))).toBe(
+        '<p>this is a <a href="/contactus">link</a></p>'
+    );
     await click(".o_we_apply_link");
     // the url should be applied after selecting a dropdown item
     expect(cleanLinkArtifacts(getContent(el))).toBe(


### PR DESCRIPTION
### Steps to reproduce:

- Install the Website module.
- Go to a To-Do  and type a slash command, e.g., /link.
- Enter a label for the link.
- Type in the URL input — observe the preview.
- Select a suggestion from autocomplete dropdown — observe the preview.

### Description of the issue/feature this PR addresses:

- The link preview did not update while typing in the URL input.
- It also did not update after selecting an item from autocomplete dropdown.

### Desired behavior after PR is merged:

- The link preview updates live while typing and upon selecting a suggestion.

task-4910827

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
