### PR TITLE
[FIX] account: prevent error when product has multiple vendor UOMs on vendor bills

### DIFF
--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -804,7 +804,7 @@ class AccountMoveLine(models.Model):
         for line in self.filtered(lambda l: l.parent_state == 'draft'):
             # vendor bills should have the product purchase UOM
             if line.move_id.is_purchase_document():
-                line.product_uom_id = line.product_id.seller_ids.filtered(lambda s: s.partner_id == line.partner_id).product_uom_id or line.product_id.uom_id
+                line.product_uom_id = line.product_id.seller_ids.filtered(lambda s: s.partner_id == line.partner_id).product_uom_id[:1] or line.product_id.uom_id
             else:
                 line.product_uom_id = line.product_id.uom_id
 


### PR DESCRIPTION
Currently, an error occurs when creating a `vendor bill` for a product with
multiple purchase `UOMs` are defined for the same vendor.

**Step to produce:**
- Install the `account` and `purchase` modules.
- From the `Settings`, enable `Units of Measure & Packagings`.
- Create a new product, in the `Purchase` tab, add two lines with the same
 `Vendor: Azure Interior`, but with a different `Unit`.
- Create a new vendor bill, set `Vendor: Azure Interior`, click on `Catalog`,
  and select the newly created product.

**Error:**
`ValueError: Wrong value for account.move.line.product_uom_id: uom.uom(4, 5)`

**Root Cause:**
At [1], the field `product_uom_id` is a `Many2one` field expecting a single
record. When multiple UOMs match the vendor, an error occurs.

[1]
https://github.com/odoo/odoo/blob/07b9644b3abf5bc8fd8621bdcfa50db131d7058a/addons/account/models/account_move_line.py#L807

This commit ensures and prevents an error when multiple vendor UOMs exist.

Sentry – 6718849231