### PR TITLE
[FIX] mrp: prevent error on editing reordering rule

### DIFF
--- a/addons/mrp/models/stock_orderpoint.py
+++ b/addons/mrp/models/stock_orderpoint.py
@@ -134,7 +134,7 @@ class StockWarehouseOrderpoint(models.Model):
         for prod in in_progress_productions:
             date_start, date_finished, orderpoint = prod.date_start, prod.date_finished, prod.orderpoint_id
             lead_days_date = datetime.combine(orderpoint.lead_days_date, time.max)
-            if date_start <= lead_days_date < date_finished:
+            if date_start <= lead_days_date < date_finished and orderpoint.id in res:
                 res[orderpoint.id] += prod.product_uom_id._compute_quantity(
                         prod.product_qty, orderpoint.product_uom, round=False)
         return res

--- a/addons/mrp/static/tests/tours/mrp_onchange_reordering_rule.js
+++ b/addons/mrp/static/tests/tours/mrp_onchange_reordering_rule.js
@@ -1,0 +1,48 @@
+/** @odoo-module **/
+
+import { registry } from "@web/core/registry";
+
+registry.category("web_tour.tours").add('mrp_reordering_rule_onchange_tour', {
+    steps: () => [
+        {
+            trigger: 'button[data-menu-xmlid="mrp.menu_mrp_bom"]',
+            content: 'Open the Products dropdown menu.',
+            run: 'click',
+        },
+        {
+            trigger: '.dropdown-item[data-menu-xmlid="mrp.menu_mrp_product_form"]',
+            content: 'Click on the Products menu item.',
+            run: 'click',
+        },
+        {
+            trigger: '.o_kanban_record:first',
+            content: 'Open the first product in the list (marked as favorite).',
+            run: 'click',
+        },
+        {
+            trigger: '.o_button_more',
+            content: 'Click the "More" dropdown button.',
+            run: 'click',
+        },
+        {
+            trigger: 'button[name="action_view_orderpoints"]',
+            content: 'Click on the Reordering Rules button.',
+            run: 'click',
+        },
+        {
+            trigger: '.o_data_row td[name="product_min_qty"]',
+            content: 'Click on the Min Quantity cell to edit it.',
+            run: 'click',
+        },
+        {
+            trigger: '.o_data_row td[name="product_min_qty"]',
+            content: 'Change the minimum quantity of the first reordering rule.',
+            run: 'edit 15', 
+        },
+        {
+            trigger: '.o_data_row td[name="product_max_qty"]',
+            content: 'Click on the Max Quantity cell to trigger compute methods.',
+            run: 'click',
+        },
+    ]
+});


### PR DESCRIPTION
Currently, an error is encountered while editing a Reordering Rule which is already related to some confirmed MO.

**Setup:**
- Install mrp and sale_management.
- Create a storable product with the Manufacture route enabled and its on-hand quantity set to 0.
- Create a Bill of Materials (BoM) for the product and also add at least 1 component.
- Create a Reordering Rule for the product with Min Quantity 0 and Max Quantity 0.

**steps to reproduce:**
- Create and confirm a Sales Order for 40 units of the product. This generates a Manufacturing Order (MO).
- Navigate to the generated MO and add a line for Work Order(set Expected Duration: 1000min).
- Edit the product's Reordering Rule (e.g., change the min Quantity).

for steps reference you can use [this video](https://drive.google.com/file/d/120srSySVHI0FzaWCruz0LVIBKCjK4oOL/view?usp=sharing)

**Error:**
`KeyError: 1`

**Root Cause:**
- The KeyError is triggered when a reordering rule is edited. At this moment, the system calls the `_quantity_in_progress` method to update the forecast. This method prepares a results dictionary (res) that only knows about the ID of the record currently being edited (which might be a new, unsaved record with a temporary ID).

- The issue arises in the loop that processes confirmed Manufacturing Orders, at [1], the value of orderpoint.id is still `<NewId origin=2>` and on trying to access it at [1] causing an error

[1]- https://github.com/odoo/odoo/blob/f1e11af050aa4d7be40e5179dc67a74ff81de076/addons/mrp/models/stock_orderpoint.py#L138

**Solution:**
This commit ensures that only valid orderpoint IDs are processed at [1]

Sentry-**6135193468**

