### PR TITLE
[FIX] account: Fix access error

### DIFF
--- a/addons/account/models/res_partner_bank.py
+++ b/addons/account/models/res_partner_bank.py
@@ -75,6 +75,11 @@ class ResPartnerBank(models.Model):
              LEFT JOIN res_partner_bank other ON this.acc_number = other.acc_number
                                              AND this.id != other.id
                  WHERE this.id = ANY(%(ids)s)
+                   AND (
+                        ((this.company_id = other.company_id) OR (this.company_id IS NULL AND other.company_id IS NULL))
+                        OR
+                        other.company_id IS NULL
+                        )
               GROUP BY this.id
             """,
             ids=self.ids,

--- a/addons/account/tests/__init__.py
+++ b/addons/account/tests/__init__.py
@@ -58,3 +58,4 @@ from . import test_account_merge_wizard
 from . import test_account_move_attachment
 from . import test_account_move_auto_post
 from . import test_dict_to_xml
+from . import test_duplicate_res_partner_bank

--- a/addons/account/tests/test_duplicate_res_partner_bank.py
+++ b/addons/account/tests/test_duplicate_res_partner_bank.py
@@ -1,0 +1,36 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+
+from odoo.addons.base.tests.common import SavepointCaseWithUserDemo
+
+
+class TestDuplicatePartnerBank(SavepointCaseWithUserDemo):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.company_a = cls.env['res.company'].create({"name": "companyA"})
+        cls.user_a = cls.env['res.users'].with_company(cls.company_a).create({"name": "userA", "login": "test@test.com"})
+        cls.partner_a = cls.env['res.partner'].with_user(cls.user_a).create({"name": "PartnerA", "company_id": cls.company_a.id})
+        cls.partner_bank_a = cls.env['res.partner.bank'].with_user(cls.user_a).create({"acc_number": "12345", "partner_id": cls.partner_a.id})
+
+        cls.company_b = cls.env['res.company'].create({"name": "companyB"})
+        cls.user_b = cls.env['res.users'].with_company(cls.company_b).create({"name": "userB", "login": "test1@test.com"})
+        cls.partner_b = cls.env['res.partner'].with_user(cls.user_b).create({"name": "PartnerB", "company_id": cls.company_b.id})
+        cls.partner_bank_b = cls.env['res.partner.bank'].with_user(cls.user_b).create({"acc_number": "12345", "partner_id": cls.partner_b.id})
+
+    def test_duplicate_acc_number_different_company(self):
+        self.assertFalse(self.partner_bank_b.duplicate_bank_partner_ids)
+
+    def test_duplicate_acc_number_no_company(self):
+        self.partner_a.company_id = False
+        self.partner_bank_a.company_id = False
+        self.partner_b.company_id = False
+        self.partner_bank_b.company_id = False
+        self.assertTrue(self.partner_bank_a.duplicate_bank_partner_ids, self.partner_a)
+
+    def test_duplicate_acc_number_b_company(self):
+        self.partner_a.company_id = False
+        self.partner_bank_a.company_id = False
+        self.assertTrue(self.partner_bank_b.duplicate_bank_partner_ids, self.partner_a)


### PR DESCRIPTION
Step to reproduce
1. Createdb with account and contact module install in 18.0 version.
2. create 2 company A and B
3. create partner with both company A and B seperate
4. create a user that have only rights of company B and rights of Accounting/setting groups
5. create a Bank account(Contact->Configuration->Bank Account) with partner A in company A
6. Now login with user B and create a bank account number with same account number. Access error will come.

For resolve the access error fetching the correct result according to company so it won't fetch other company result the changes merged last week
https://github.com/odoo/odoo/commit/ad6c9001b447f5ffebafe1581512f48708c7d746#diff-22e97cf61c6826e67cd9a3276bdb292e997cb1117ca44c1749c69d5d01931787R69

```
Access Error

Uh-oh! Looks like you have stumbled upon some top-secret records.

Sorry, Test B (id=7) doesn't have 'read' access to:
- Contact, A (res.partner: 8)

Blame the following rules:
- res.partner company

If you really, really need access, perhaps you can win over your friendly administrator with a batch of freshly baked cookies.

This seems to be a multi-company issue, but you do not have access to the proper company to access the record anyhow.
```

upg-2986193
opw-4876839
tbg-2093



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
