### PR TITLE
[IMP] calendar, test_(mail): remove trigger next activity

### DIFF
--- a/addons/calendar/views/mail_activity_views.xml
+++ b/addons/calendar/views/mail_activity_views.xml
@@ -19,7 +19,7 @@
                   <attribute name="invisible">activity_category != 'phonecall' and not id</attribute>
             </xpath>
             <xpath expr="//button[@name='action_done']" position="attributes">
-                  <attribute name="invisible">activity_category == 'meeting' or chaining_type == 'trigger'</attribute>
+                  <attribute name="invisible">activity_category == 'meeting'</attribute>
             </xpath>
             <xpath expr="//field[@name='note']" position="attributes">
                   <attribute name="invisible">activity_category == 'meeting'</attribute>

--- a/addons/mail/models/mail_activity_plan_template.py
+++ b/addons/mail/models/mail_activity_plan_template.py
@@ -51,9 +51,7 @@ class MailActivityPlanTemplate(models.Model):
         'Assigned to',
         check_company=True, compute="_compute_responsible_id", store=True, readonly=False)
     note = fields.Html('Note', compute="_compute_note", store=True, readonly=False)
-    next_activity_ids = fields.Many2many(
-        'mail.activity.type', string='Next Activities',
-        compute='_compute_next_activity_ids', readonly=False, store=True)
+    suggested_next_type_id = fields.Many2one(string='Suggested Next Activity', related='activity_type_id.suggested_next_type_id')
 
     @api.constrains('activity_type_id', 'plan_id')
     def _check_activity_type_res_model(self):
@@ -79,19 +77,6 @@ class MailActivityPlanTemplate(models.Model):
         for template in self:
             if template.responsible_type == 'other' and not template.responsible_id:
                 raise ValidationError(_('When selecting "Default user" assignment, you must specify a responsible.'))
-
-    @api.depends('activity_type_id')
-    def _compute_next_activity_ids(self):
-        """ Update next activities only when changing activity type on template.
-        Any change on type configuration should not be propagated. """
-        for template in self:
-            activity_type = template.activity_type_id
-            if activity_type.triggered_next_type_id:
-                template.next_activity_ids = activity_type.triggered_next_type_id.ids
-            elif activity_type.suggested_next_type_ids:
-                template.next_activity_ids = activity_type.suggested_next_type_ids.ids
-            else:
-                template.next_activity_ids = False
 
     @api.depends('activity_type_id')
     def _compute_note(self):

--- a/addons/mail/static/src/core/common/activity_model.js
+++ b/addons/mail/static/src/core/common/activity_model.js
@@ -35,16 +35,12 @@ export class Activity extends Record {
     attachment_ids;
     /** @type {boolean} */
     can_write;
-    /** @type {'suggest'|'trigger'} */
-    chaining_type;
     create_date = fields.Datetime();
     create_uid = fields.One("res.users");
     date_deadline = fields.Date();
     date_done = fields.Date();
     /** @type {string} */
     display_name;
-    /** @type {boolean} */
-    has_recommended_activities;
     /** @type {string} */
     feedback;
     /** @type {string} */

--- a/addons/mail/static/src/core/web/activity_markasdone_popover.js
+++ b/addons/mail/static/src/core/web/activity_markasdone_popover.js
@@ -13,10 +13,6 @@ export class ActivityMarkAsDone extends Component {
         hasHeader: false,
     };
 
-    get isSuggested() {
-        return this.props.activity.chaining_type === "suggest";
-    }
-
     setup() {
         super.setup();
         this.textArea = useRef("textarea");

--- a/addons/mail/static/src/core/web/activity_markasdone_popover.xml
+++ b/addons/mail/static/src/core/web/activity_markasdone_popover.xml
@@ -9,7 +9,7 @@
                     <button type="button" class="btn btn-sm btn-primary" aria-label="Done and Schedule Next" t-on-click="onClickDoneAndScheduleNext">
                         Done &amp; Schedule Next
                     </button>
-                    <button t-if="isSuggested" type="button" class="btn btn-sm btn-primary mx-2" aria-label="Done" t-on-click="onClickDone" t-att-disabled="state.disableDoneButton">
+                    <button type="button" class="btn btn-sm btn-primary mx-2" aria-label="Done" t-on-click="onClickDone" t-att-disabled="state.disableDoneButton">
                         Done
                     </button>
                     <button type="button" class="btn btn-sm btn-link" t-on-click="props.close">

--- a/addons/mail/static/tests/activity/activity_mark_done_popover.test.js
+++ b/addons/mail/static/tests/activity/activity_mark_done_popover.test.js
@@ -33,30 +33,6 @@ test("activity mark done popover simplest layout", async () => {
     await contains(".o-mail-ActivityMarkAsDone button:text('Discard')");
 });
 
-test("activity with force next mark done popover simplest layout", async () => {
-    const pyEnv = await startServer();
-    const partnerId = pyEnv["res.partner"].create({});
-    const activityTypeId = pyEnv["mail.activity.type"].create({
-        name: "TriggerType",
-        chaining_type: "trigger",
-    });
-    pyEnv["mail.activity"].create({
-        activity_category: "not_upload_file",
-        activity_type_id: activityTypeId,
-        can_write: true,
-        res_id: partnerId,
-        res_model: "res.partner",
-    });
-    await start();
-    await openFormView("res.partner", partnerId);
-    await click(".btn:text('Mark Done')");
-    await contains(".o-mail-ActivityMarkAsDone");
-    await contains(".o-mail-ActivityMarkAsDone textarea[placeholder='Write Feedback']");
-    await contains(".o-mail-ActivityMarkAsDone button[aria-label='Done and Schedule Next']");
-    await contains(".o-mail-ActivityMarkAsDone button[aria-label='Done']", { count: 0 });
-    await contains(".o-mail-ActivityMarkAsDone button:text('Discard')");
-});
-
 test("activity mark done popover mark done without feedback", async () => {
     const pyEnv = await startServer();
     const partnerId = pyEnv["res.partner"].create({});

--- a/addons/mail/static/tests/mock_server/mock_models/mail_activity.js
+++ b/addons/mail/static/tests/mock_server/mock_models/mail_activity.js
@@ -17,7 +17,6 @@ export class MailActivity extends models.ServerModel {
         },
     });
     user_id = fields.Many2one({ relation: "res.users", default: () => serverState.userId });
-    chaining_type = fields.Generic({ default: "suggest" });
     activity_category = fields.Generic({ related: false }); // removes related from server to ease creating activities
     res_model = fields.Char({ string: "Related Document Model", related: false }); // removes related from server to ease creating activities
 

--- a/addons/mail/static/tests/mock_server/mock_models/mail_activity_type.js
+++ b/addons/mail/static/tests/mock_server/mock_models/mail_activity_type.js
@@ -1,9 +1,8 @@
-import { fields, models } from "@web/../tests/web_test_helpers";
+import { models } from "@web/../tests/web_test_helpers";
 
 export class MailActivityType extends models.ServerModel {
     _name = "mail.activity.type";
 
-    chaining_type = fields.Generic({ default: "suggest" });
     _records = [
         {
             id: 1,

--- a/addons/mail/views/mail_activity_plan_template_views.xml
+++ b/addons/mail/views/mail_activity_plan_template_views.xml
@@ -35,6 +35,7 @@
                                 <field class="oe_inline ps-1 pe-2" name="delay_unit"/>
                                 <field class="oe_inline" name="delay_from"/>
                             </div>
+                            <field name="suggested_next_type_id"/>
                         </group>
                         <field name="note" nolabel="1" class="oe-bordered-editor" placeholder="e.g. Log a note"/>
                     </sheet>

--- a/addons/mail/views/mail_activity_plan_views.xml
+++ b/addons/mail/views/mail_activity_plan_views.xml
@@ -81,9 +81,7 @@
                                         <field name="delay_count"/>
                                         <field name="delay_unit" string="Unit"/>
                                         <field name="delay_from"/>
-                                        <field name="next_activity_ids"
-                                            widget="many2many_tags"
-                                            invisible="not next_activity_ids"
+                                        <field name="suggested_next_type_id"
                                             options="{
                                                 'no_quick_create': True,
                                                 'on_tag_click': 'open_form',
@@ -102,13 +100,13 @@
                                                     <field name="activity_type_id"/>
                                                 </div>
                                                 <field name="summary"/>
+                                                <field name="responsible_type"/>
                                                 <div>
                                                     <field name="delay_count"/> <field name="delay_unit"/>
                                                     (<field name="delay_from"/>)
                                                 </div>
-                                                <field name="next_activity_ids" widget="many2many_tags" invisible="not next_activity_ids"/>
+                                                <field name="suggested_next_type_id"/>
                                                 <footer class="p-0">
-                                                    <field name="responsible_type"/>
                                                     <field class="ms-auto" name="responsible_id" widget="many2one_avatar_user" readonly="1"/>
                                                 </footer>
                                             </t>

--- a/addons/mail/views/mail_activity_views.xml
+++ b/addons/mail/views/mail_activity_views.xml
@@ -29,13 +29,9 @@
                                 <field class="oe_inline" name="delay_from"/>
                             </div>
                         </group>
-                        <group name="activity_planning" string="Next Activity">
-                            <field name="chaining_type" invisible="category == 'upload_file'"/>
-                            <field name="triggered_next_type_id" options="{'no_open': True}" context="{'default_res_model': res_model}"
-                                invisible="chaining_type == 'suggest' and category != 'upload_file'"
-                                required="chaining_type == 'trigger' and category != 'upload_file'"/>
-                            <field name="suggested_next_type_ids" widget="many2many_tags" context="{'default_res_model': res_model}"
-                                invisible="chaining_type == 'trigger' or category == 'upload_file'"/>
+                        <group name="activity_planning" string="Next Activity" invisible="category == 'upload_file' and not res_model">
+                            <field name="suggested_next_type_id" string="Default Type" context="{'default_res_model': res_model}"
+                                invisible="category == 'upload_file'"/>
                             <field name="mail_template_ids" widget="many2many_tags"
                                 domain="[('model_id.model', '=', res_model)]"
                                 invisible="not res_model"
@@ -72,9 +68,7 @@
                 <field name="delay_from" string="Type"/>
                 <field name="res_model" column_invisible="context.get('default_res_model')"/>
                 <field name="icon" groups="base.group_no_one"/>
-                <field name="triggered_next_type_id" optional="hide"
-                    string="Triggered Next"/>
-                <field name="suggested_next_type_ids" optional="hide" widget="many2many_tags"
+                <field name="suggested_next_type_id" optional="hide"
                     string="Suggested Next"/>
             </list>
         </field>
@@ -145,14 +139,6 @@
                         <field name="res_model" invisible="1"/>
                         <field name="res_model_id" invisible="1"/>
                         <field name="res_id" invisible="1"/>
-                        <field name="chaining_type" invisible="1"/>
-                        <field name="previous_activity_type_id"/>
-                        <field name="has_recommended_activities"/>
-                    </group>
-                    <group invisible="not has_recommended_activities">
-                        <field name="recommended_activity_type_id" widget="selection_badge"
-                            domain="[('previous_type_ids', '=', previous_activity_type_id)]"
-                            string="Recommended Activities"/>
                     </group>
 
                     <group>
@@ -170,7 +156,7 @@
                             invisible="id" data-hotkey="q"/>
                         <button id="mail_activity_save" string="Save" name="action_close_dialog" type="object" class="btn-primary"
                             invisible="not id" data-hotkey="q"/>
-                        <button invisible="chaining_type == 'trigger'" string="Mark Done" name="action_done"
+                        <button string="Mark Done" name="action_done"
                             type="object" class="btn-secondary" data-hotkey="w"
                             context="{'mail_activity_quick_update': True}"/>
                         <button class="btn-secondary" special="cancel" data-hotkey="x"/>

--- a/addons/mail/wizard/mail_activity_schedule.py
+++ b/addons/mail/wizard/mail_activity_schedule.py
@@ -82,7 +82,6 @@ class MailActivitySchedule(models.TransientModel):
     activity_user_id = fields.Many2one(
         'res.users', 'Assigned to', compute='_compute_activity_user_id',
         readonly=False, store=True)
-    chaining_type = fields.Selection(related='activity_type_id.chaining_type', readonly=True)
     # used in both (plan- and activity- based)
     activity_user_id_fname = fields.Char('User Field', help="Field name of the user to choose on the record")
 
@@ -225,32 +224,6 @@ class MailActivitySchedule(models.TransientModel):
 
                 # append main line before handling next activities
                 schedule_line_values_list.append(schedule_line_values)
-
-                activity_type = template.activity_type_id
-                if activity_type.triggered_next_type_id:
-                    next_activity = activity_type.triggered_next_type_id
-                    schedule_line_values = {
-                        'line_description': next_activity.summary or next_activity.name,
-                        'responsible_user_id': next_activity.default_user_id.id or False
-                    }
-                    if activity_date_deadline:
-                        schedule_line_values['line_date_deadline'] = next_activity.with_context(
-                            activity_previous_deadline=activity_date_deadline
-                        )._get_date_deadline()
-
-                    schedule_line_values_list.append(schedule_line_values)
-                elif activity_type.suggested_next_type_ids:
-                    for suggested in activity_type.suggested_next_type_ids:
-                        schedule_line_values = {
-                            'line_description': suggested.summary or suggested.name,
-                            'responsible_user_id': suggested.default_user_id.id or False,
-                        }
-                        if activity_date_deadline:
-                            schedule_line_values['line_date_deadline'] = suggested.with_context(
-                                activity_previous_deadline=activity_date_deadline
-                            )._get_date_deadline()
-
-                        schedule_line_values_list.append(schedule_line_values)
 
                 scheduler.plan_schedule_line_ids = [(5,)] + [(0, 0, values) for values in schedule_line_values_list]
 

--- a/addons/mail/wizard/mail_activity_schedule_views.xml
+++ b/addons/mail/wizard/mail_activity_schedule_views.xml
@@ -7,7 +7,6 @@
             <field name="arch" type="xml">
                 <form>
                     <field name="activity_category" invisible="1"/>
-                    <field name="chaining_type" invisible="1"/>
                     <field name="company_id" invisible="1"/>
                     <field name="has_error" invisible="1"/>
                     <field name="has_warning" invisible="1"/>
@@ -67,7 +66,7 @@
                         <button name="action_schedule_activities" string="Save" type="object" class="btn-primary"
                                 invisible="has_error" data-hotkey="q"/>
                         <button name="action_schedule_activities_done" string="Mark Done" type="object"
-                            invisible="has_error or chaining_type == 'trigger'"
+                            invisible="has_error"
                             class="btn-secondary"  data-hotkey="w"
                             context="{'mail_activity_quick_update': True}"/>
                         <button class="btn-secondary" special="cancel" data-hotkey="x"/>

--- a/addons/test_mail/data/data.xml
+++ b/addons/test_mail/data/data.xml
@@ -19,23 +19,6 @@
         <field name="category">default</field>
         <field name="res_model">mail.test.activity</field>
     </record>
-    <record id="mail_act_test_chained_2" model="mail.activity.type">
-        <field name="name">Step 2</field>
-        <field name="summary">Take the second step.</field>
-        <field name="category">default</field>
-        <field name="res_model">mail.test.activity</field>
-        <field name="delay_count">10</field>
-        <field name="delay_from">current_date</field>
-        <field name="delay_unit">days</field>
-    </record>
-    <record id="mail_act_test_chained_1" model="mail.activity.type">
-        <field name="name">Step 1</field>
-        <field name="summary">Take the first step.</field>
-        <field name="category">default</field>
-        <field name="res_model">mail.test.activity</field>
-        <field name="chaining_type">trigger</field>
-        <field name="triggered_next_type_id" ref="test_mail.mail_act_test_chained_2"/>
-    </record>
     <record id="mail_act_test_upload_document" model="mail.activity.type">
         <field name="name">Document</field>
         <field name="summary">Document</field>

--- a/addons/test_mail/tests/test_mail_activity.py
+++ b/addons/test_mail/tests/test_mail_activity.py
@@ -557,7 +557,7 @@ class TestActivitySystray(TestActivityCommon, HttpCase):
         lead_act_attachments = self.lead_act_attachments.with_user(self.user_employee)
         self.assertEqual(len(lead_activities), 4, 'Simulate UI where activities are still displayed even if record removed')
         self.assertEqual(len(lead_act_attachments), 4, 'Simulate UI where activities are still displayed even if record removed')
-        messages, _next_activities = lead_activities._action_done()
+        messages = lead_activities._action_done()
         self.assertEqual(len(messages), 3, 'Should have posted one message / live record')
         self.assertEqual(lead_activities.exists(), lead_activities - self.test_activities_removed, 'Mark done should unlink activities linked to removed records')
         self.assertEqual(lead_activities.exists().mapped('active'), [False] * 3)

--- a/addons/test_mail/tests/test_mail_activity_mixin.py
+++ b/addons/test_mail/tests/test_mail_activity_mixin.py
@@ -287,56 +287,6 @@ class TestActivityMixin(TestActivityCommon):
             self.assertEqual(attachment.res_id, activity_message.id)
             self.assertEqual(attachment.res_model, activity_message._name)
 
-    @users('employee')
-    def test_feedback_chained_current_date(self):
-        frozen_now = datetime(2021, 10, 10, 14, 30, 15)
-
-        test_record = self.env['mail.test.activity'].browse(self.test_record.ids)
-        first_activity = self.env['mail.activity'].create({
-            'activity_type_id': self.env.ref('test_mail.mail_act_test_chained_1').id,
-            'date_deadline': frozen_now + relativedelta(days=-2),
-            'res_id': test_record.id,
-            'res_model_id': self.env['ir.model']._get_id('mail.test.activity'),
-            'summary': 'Test',
-        })
-        first_activity_id = first_activity.id
-
-        with freeze_time(frozen_now):
-            first_activity.action_feedback(feedback='Done')
-        self.assertFalse(first_activity.active)
-
-        # check chained activity
-        new_activity = test_record.activity_ids
-        self.assertNotEqual(new_activity.id, first_activity_id)
-        self.assertEqual(new_activity.summary, 'Take the second step.')
-        self.assertEqual(new_activity.date_deadline, frozen_now.date() + relativedelta(days=10))
-
-    @users('employee')
-    def test_feedback_chained_previous(self):
-        self.env.ref('test_mail.mail_act_test_chained_2').sudo().write({'delay_from': 'previous_activity'})
-        frozen_now = datetime(2021, 10, 10, 14, 30, 15)
-
-        test_record = self.env['mail.test.activity'].browse(self.test_record.ids)
-        first_activity = self.env['mail.activity'].create({
-            'activity_type_id': self.env.ref('test_mail.mail_act_test_chained_1').id,
-            'date_deadline': frozen_now + relativedelta(days=-2),
-            'res_id': test_record.id,
-            'res_model_id': self.env['ir.model']._get_id('mail.test.activity'),
-            'summary': 'Test',
-        })
-        first_activity_id = first_activity.id
-
-        with freeze_time(frozen_now):
-            first_activity.action_feedback(feedback='Done')
-        self.assertFalse(first_activity.active)
-
-        # check chained activity
-        new_activity = test_record.activity_ids
-        self.assertNotEqual(new_activity.id, first_activity_id)
-        self.assertEqual(new_activity.summary, 'Take the second step.')
-        self.assertEqual(new_activity.date_deadline, frozen_now.date() + relativedelta(days=8),
-                         'New deadline should take into account original activity deadline, not current date')
-
     def test_mail_activity_state(self):
         """Create 3 activity for 2 different users in 2 different timezones.
 


### PR DESCRIPTION
Purpose:
Simplify the activity flow and improve usability by removing the 'Trigger Next Activity' feature.

Specifications:
This commit removes the 'Trigger Next Activity' feature and the recommended activities list. The next activity flow is now simplified to keep only one 'Suggested Next Activity' on the activity type. When marking an activity as done
and scheduling the next one, this suggested activity is automatically set as the default in the scheduler popup.

Additionally, the 'Done & Schedule Next' flow now consistently uses the scheduler popup (activity schedule wizard), providing a unified experience and allowing the use of activity plans when scheduling the next activity.

Task-4863143