### PR TITLE
[FIX] l10n_tr_nilvera_einvoice: exclude ID without schemeID

### DIFF
--- a/addons/l10n_tr_nilvera_einvoice/models/account_edi_xml_ubl_tr.py
+++ b/addons/l10n_tr_nilvera_einvoice/models/account_edi_xml_ubl_tr.py
@@ -42,6 +42,9 @@ class AccountEdiXmlUblTr(models.AbstractModel):
             'pricing_currency_code': invoice.currency_id.name.upper() if invoice.currency_id != invoice.company_id.currency_id else False,
             'currency_dp': 2,
         })
+        # Nilvera will reject any <BuyerReference> tag, so remove it
+        if vals['vals'].get('buyer_reference'):
+            del vals['vals']['buyer_reference']
         return vals
 
     def _get_country_vals(self, country):
@@ -53,6 +56,9 @@ class AccountEdiXmlUblTr(models.AbstractModel):
     def _get_partner_party_identification_vals_list(self, partner):
         # EXTENDS account.edi.xml.ubl_21
         vals = super()._get_partner_party_identification_vals_list(partner)
+        # Nilvera will reject any <ID> without a <schemeID>, so remove all items not
+        # having the following structure : {'id': '...', 'id_attrs': {'schemeID': '...'}}
+        vals = [v for v in vals if v.get('id') and v.get('id_attrs', {}).get('schemeID')]
         vals.append({
             'id_attrs': {
                 'schemeID': 'VKN' if partner.is_company else 'TCKN',


### PR DESCRIPTION
[FIX] l10n_tr_nilvera_einvoice: exclude ID without schemeID
Nilvera expects a `<schemeID>` with every `<ID>`. In Odoo currently, we only
support VKN or TCKN as a schemeID that get impacted from the VAT Number.
Also, Nilvera reject any `<BuyerReference>` tag.

Before:
- The generated XML contains some `<ID>` tags without 'schemeID'
attribute.
- The generated XML contains some `<BuyerReference>` tag.
After:
- The `<ID>` tags with no 'schemeID' are removed from the XML.
- The `<BuyerReference>` tag is removed from the XML.

Task-4822777

This PR is a backport of the commit https://github.com/odoo/odoo/commit/2a157ae83856708bccf829478b98b2ce8888faf5

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
