### PR TITLE
[FIX] portal: split portal partner from self

### DIFF
--- a/addons/mail/controllers/attachment.py
+++ b/addons/mail/controllers/attachment.py
@@ -4,7 +4,6 @@ import io
 import logging
 import zipfile
 
-from contextlib import suppress
 from werkzeug.exceptions import NotFound
 
 from odoo import _, http
@@ -94,12 +93,11 @@ class AttachmentController(http.Controller):
             [("attachment_ids", "in", attachment.ids)], limit=1)
         message = request.env["mail.message"].sudo(False)._get_with_access(attachment_message.id,
                                                                            "create", **kwargs)
-        with suppress(AccessError):
-            if not request.env.user.share:
-                # Check through standard access rights/rules for internal users.
-                attachment._delete_and_notify(message)
-                return
-        # For non-internal users or internal users that didn't have access to the attachment (e.g. internal users accessing portal document with token), 2 cases are supported:
+        if not request.env.user.share:
+            # Check through standard access rights/rules for internal users.
+            attachment._delete_and_notify(message)
+            return
+        # For non-internal users 2 cases are supported:
         #   - Either the attachment is linked to a message: verify the request is made by the author of the message (portal user or guest).
         #   - Either a valid access token is given: also verify the message is pending (because unfortunately in portal a token is also provided to guest for viewing others' attachments).
         # sudo: ir.attachment: access is validated below with membership of message or access token

--- a/addons/mail/static/src/core/common/follower_model.js
+++ b/addons/mail/static/src/core/common/follower_model.js
@@ -23,7 +23,9 @@ export class Follower extends Record {
     /** @returns {boolean} */
     get isEditable() {
         const hasWriteAccess = this.thread ? this.thread.hasWriteAccess : false;
-        return this.partner.in(this.thread?.selves) ? this.thread.hasReadAccess : hasWriteAccess;
+        return this.partner.eq(this.thread?.effectiveSelf)
+            ? this.thread.hasReadAccess
+            : hasWriteAccess;
     }
 
     async remove() {

--- a/addons/mail/static/src/core/common/message_model.js
+++ b/addons/mail/static/src/core/common/message_model.js
@@ -268,6 +268,7 @@ export class Message extends Record {
      * the cookie-authenticated persona and the partner authenticated with the
      * portal token in the context of the related thread.
      *
+     * @deprecated
      * @returns {import("models").Persona[]}
      */
     get selves() {
@@ -279,7 +280,7 @@ export class Message extends Record {
     }
 
     get isSelfMentioned() {
-        return this.selves.some((s) => s.in(this.recipients));
+        return this.effectiveSelf.in(this.recipients);
     }
 
     get isHighlightedFromMention() {
@@ -291,7 +292,7 @@ export class Message extends Record {
             if (!this.author) {
                 return false;
             }
-            return this.author.in(this.selves);
+            return this.author.eq(this.effectiveSelf);
         },
     });
 

--- a/addons/mail/static/src/core/common/thread_model.js
+++ b/addons/mail/static/src/core/common/thread_model.js
@@ -765,6 +765,7 @@ export class Thread extends Record {
      * the cookie-authenticated persona and the partner authenticated with the
      * portal token in the context of this thread.
      *
+     * @deprecated
      * @returns {import("models").Persona[]}
      */
     get selves() {

--- a/addons/portal/controllers/mail.py
+++ b/addons/portal/controllers/mail.py
@@ -50,19 +50,19 @@ class PortalChatter(http.Controller):
             mode = request.env[thread_model]._get_mail_message_access([thread_id], "create")
             has_react_access = request.env[thread_model]._get_thread_with_access(thread_id, mode, **kwargs)
             can_react = has_react_access
-            if portal_partner := get_portal_partner(
-                thread, kwargs.get("hash"), kwargs.get("pid"), kwargs.get("token")
-            ):
-                store.add(
-                    thread,
-                    {
-                        "portal_partner": Store.one(
-                            portal_partner, fields=["active", "avatar_128", "name", "user"]
-                        )
-                    },
-                    as_thread=True
-                )
             if request.env.user._is_public():
+                if portal_partner := get_portal_partner(
+                    thread, kwargs.get("hash"), kwargs.get("pid"), kwargs.get("token")
+                ):
+                    store.add(
+                        thread,
+                        {
+                            "portal_partner": Store.one(
+                                portal_partner, fields=["active", "avatar_128", "name", "user"]
+                            )
+                        },
+                        as_thread=True,
+                    )
                 can_react = has_react_access and portal_partner
             store.add(
                 thread,

--- a/addons/portal/models/mail_message.py
+++ b/addons/portal/models/mail_message.py
@@ -160,7 +160,7 @@ class MailMessage(models.Model):
 
     def _is_editable_in_portal(self, **kwargs):
         self.ensure_one()
-        if self.model and self.res_id:
+        if self.model and self.res_id and self.env.user._is_public():
             thread = request.env[self.model].browse(self.res_id)
             partner = get_portal_partner(
                 thread, kwargs.get("hash"), kwargs.get("pid"), kwargs.get("token")

--- a/addons/portal/static/src/chatter/frontend/thread_model_patch.js
+++ b/addons/portal/static/src/chatter/frontend/thread_model_patch.js
@@ -14,6 +14,7 @@ patch(Thread.prototype, {
         }
         return super.effectiveSelf;
     },
+    /** @deprecated */
     get selves() {
         const result = super.selves;
         if (this.portal_partner) {

--- a/addons/test_mail_full/tests/test_portal_attachment_controller.py
+++ b/addons/test_mail_full/tests/test_portal_attachment_controller.py
@@ -43,21 +43,3 @@ class TestPortalAttachmentController(TestAttachmentControllerCommon):
                 (self.user_admin, True, hash_pid_param),
             ),
         )
-
-    def test_delete_attachment_as_internal_with_token(self):
-        record = self.env["mail.test.portal"].create(
-            {"name": "Test", "partner_id": self.partner_portal.id}
-        )
-        token_param = {"token": record._portal_ensure_token()}
-        self._authenticate_user(self.user_portal)
-        attachment_id = self._upload_attachment(record.id, "mail.test.portal", token_param)
-        attachment = self.env["ir.attachment"].sudo().search([("id", "=", attachment_id)])
-        message = record.message_post(
-            body="hello!", author_id=self.partner_portal.id, attachment_ids=attachment.ids
-        )
-        self.assertTrue(message.attachment_ids)
-        self._authenticate_user(self.user_employee)
-        with self.assertRaises(odoo.tests.common.JsonRpcException) as exc:
-            self._delete_attachment(attachment, {})
-        self.assertEqual(exc.exception.args[0], "werkzeug.exceptions.NotFound")
-        self._delete_attachment(attachment, token_param)


### PR DESCRIPTION
Since [1], discuss considers both the logged in and the portal partner as "self". However, even if the token grants access to act as the portal partner, it doesn't mean that both users are the same. Visually, it's confusing that every hint in the UI assimilate the current user to the portal partner (messages, mentions, ...).

This commit fixes that by separating the concept of portal partner and "self". The user providing the portal token can access portal partner actions (editing/deleting message) but is considered a different user.

[1]: https://github.com/odoo/odoo/pull/211204

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
