### PR TITLE
[FIX] html_editor: fix non-deterministic font size

### DIFF
--- a/addons/html_editor/static/src/main/list/list_plugin.js
+++ b/addons/html_editor/static/src/main/list/list_plugin.js
@@ -1060,7 +1060,7 @@ export class ListPlugin extends Plugin {
             ) * 2; // 2rem
         // Align the whole list based on the item that requires the largest padding.
         const requiredPaddings = [...list.children].map((li) => {
-            const markerWidth = Math.floor(
+            const markerWidth = Math.round(
                 parseFloat(this.document.defaultView.getComputedStyle(li, "::marker").width)
             );
             // For `UL` with large font size the marker width is so big that more padding is needed.

--- a/addons/html_editor/static/tests/list/list_font_size.test.js
+++ b/addons/html_editor/static/tests/list/list_font_size.test.js
@@ -36,16 +36,16 @@ test("should apply font-size to completely selected list item", async () => {
                 <li>ghi]</li>
             </ol>
         `),
-        stepFunction: setFontSize("72px"),
+        stepFunction: setFontSize("64px"),
         contentAfter: unformat(`
-            <ol style="padding-inline-start: 77px;">
-                <li style="font-size: 72px;">[abc</li>
+            <ol style="padding-inline-start: 69px;">
+                <li style="font-size: 64px;">[abc</li>
                 <li class="oe-nested">
-                    <ol style="padding-inline-start: 75px;">
-                        <li style="font-size: 72px;">def</li>
+                    <ol style="padding-inline-start: 68px;">
+                        <li style="font-size: 64px;">def</li>
                     </ol>
                 </li>
-                <li style="font-size: 72px;">ghi]</li>
+                <li style="font-size: 64px;">ghi]</li>
             </ol>
         `),
     });


### PR DESCRIPTION
This reverts commit [1] which did not fix the issue. In fact I did it too quickly thinking I knew what the issue was and I didn't.

I thought we used round and the real value oscillated around the .5 mark but it's the opposite. We use floor so the real value falls around the .0 mark.

To fix it, I replaced floor with round, hoping this won't cause a different test to fail non-deterministically because the real value for that other test would oscillates around the .5 mark.

Testing with actual pixel values is tricky, but the feature can't be tested otherwise.

[1]: https://github.com/odoo/odoo/pull/216611/commits/eeb3f7c9a5207fb56aa88b06107768b9249ceed1
