### PR TITLE
[FIX] website_sale: compare pricelist tour

### DIFF
--- a/addons/website_sale/tests/test_website_sale_show_compare_list_price.py
+++ b/addons/website_sale/tests/test_website_sale_show_compare_list_price.py
@@ -103,5 +103,8 @@ class WebsiteSaleShopPriceListCompareListPriceDispayTests(AccountTestInvoicingHt
         })
 
     def test_compare_list_price_price_list_display(self):
-        self.env['res.config.settings'].create({'group_product_price_comparison': True}).execute()
+        self.env['res.config.settings'].create({
+            'group_product_pricelist': True,
+            'group_product_price_comparison': True,
+        }).execute()
         self.start_tour("/", 'compare_list_price_price_list_display', login=self.env.user.login)


### PR DESCRIPTION
Before this commit, the `compare_list_price_price_list_display` tour failed due to a missing feature flag. The user was unable to select a pricelist as only one was available.

This commit enables the pricelist feature before the tour, ensuring that the drop-down selector displays all the configured pricelists.

runbot-162702
