### PR TITLE
[FIX] website: do not implicitly stop parent interactions

### DIFF
--- a/addons/website/static/src/builder/plugins/floating_blocks/floating_blocks_option.xml
+++ b/addons/website/static/src/builder/plugins/floating_blocks/floating_blocks_option.xml
@@ -5,7 +5,7 @@
     <BuilderRow label.translate="Cards">
         <BuilderButton
             title.translate="Add a new Card"
-            action="'addCard'"
+            action="'addFloatingBlockCard'"
             preview="false"
             className="'o_we_bg_success'">
             Add New

--- a/addons/website/static/src/builder/plugins/floating_blocks/floating_blocks_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/floating_blocks/floating_blocks_option_plugin.js
@@ -17,7 +17,7 @@ export class FloatingBlocksOptionPlugin extends Plugin {
         ],
         builder_actions: {
             FloatingBlocksRoundnessAction,
-            AddCardAction,
+            AddFloatingBlockCardAction,
         },
     };
 }
@@ -39,7 +39,8 @@ export class FloatingBlocksRoundnessAction extends BuilderAction {
         editingElement.classList.add(`rounded-${value}`);
     }
 }
-export class AddCardAction extends BuilderAction {
+export class AddFloatingBlockCardAction extends BuilderAction {
+    static id = "addFloatingBlockCard";
     apply({ editingElement: el }) {
         const newCardEl = renderToElement("website.s_floating_blocks.new_card");
         const wrapperEl = el.querySelector(".s_floating_blocks_wrapper");

--- a/addons/website/static/src/core/website_edit_service.js
+++ b/addons/website/static/src/core/website_edit_service.js
@@ -206,6 +206,9 @@ registry.category("services").add("website_edit", {
                         this.configurationSnapshot = snapshot;
                         return true;
                     },
+                    isImpactedBy(el) {
+                        return false;
+                    },
                     insert(...args) {
                         const el = args[0];
                         super.insert(...args);
@@ -219,13 +222,11 @@ registry.category("services").add("website_edit", {
                 }),
                 patch(publicInteractions.constructor.prototype, {
                     shouldStop(el, interaction) {
-                        if (super.shouldStop(el, interaction) || interaction.el.contains(el)) {
-                            if (this.isRefreshing) {
-                                return interaction.interaction.shouldStop();
-                            }
-                            return true;
+                        if (this.isRefreshing) {
+                            const mustBeRefreshed = super.shouldStop(el, interaction) || interaction.interaction.isImpactedBy(el);
+                            return mustBeRefreshed && interaction.interaction.shouldStop();
                         }
-                        return false;
+                        return super.shouldStop(el, interaction);
                     },
                 })
             );

--- a/addons/website/static/src/interactions/image_gallery.edit.js
+++ b/addons/website/static/src/interactions/image_gallery.edit.js
@@ -9,7 +9,7 @@ export class ImageGalleryEdit extends Interaction {
             "t-on-click": this.onAddImage.bind(this),
         },
     };
-    setup() {
+    start() {
         this.renderAt("website.empty_image_gallery_alert", {}, this.el);
     }
     onAddImage() {

--- a/addons/website/static/src/snippets/s_floating_blocks/floating_blocks.edit.js
+++ b/addons/website/static/src/snippets/s_floating_blocks/floating_blocks.edit.js
@@ -9,6 +9,9 @@ const FloatingBlocksEdit = (I) =>
                 "t-on-click": this.onAddCard.bind(this),
             },
         };
+        isImpactedBy(el) {
+            return this.el.contains(el) && el.matches(".s_floating_blocks_block, .s_floating_blocks_wrapper");
+        }
         shouldStop() {
             // The interaction is restarted every time that the content of
             // s_floating_blocks changes. This is needed to provide the correct
@@ -19,8 +22,7 @@ const FloatingBlocksEdit = (I) =>
             // IDs to the blocks and check if their order has changed.
             return true;
         }
-        setup() {
-            super.setup();
+        start() {
             // The "No card" message must be injected *before* the removal of
             // the last block, otherwise the snippet could be automatically
             // removed by the editor during edition:
@@ -30,10 +32,11 @@ const FloatingBlocksEdit = (I) =>
                 {},
                 this.el.querySelector(".s_floating_blocks_wrapper")
             );
+            super.start();
         }
         onAddCard() {
             const applySpec = { editingElement: this.el };
-            this.services["website_edit"].applyAction("addCard", applySpec);
+            this.services["website_edit"].applyAction("addFloatingBlockCard", applySpec);
         }
     };
 


### PR DESCRIPTION
Since [1] interactions are stopped when a child element is edited. This causes issues such as not being restarted (e.g. a blog posts block is stopped right after drop when its content gets added to the DOM) - never to be restarted.

This commit adapts the condition to make interactions opt-in for that feature, by implementing `isImpactedBy` in addition to `shouldStop`, and restricting this behavior to the restarting of interactions (not plain stop).

Additionally, this commit also fixes the floating block's Add Card action missing id, and puts some renders into `start` rather that `setup`.

[1]: https://github.com/odoo/odoo/commit/7240e2dccc441d61937bd5cebfa559dd2eb529d2

task-4367641
