### PR TITLE
[IMP] calendar: add booking contact details into description

### DIFF
--- a/addons/calendar/static/src/scss/calendar.scss
+++ b/addons/calendar/static/src/scss/calendar.scss
@@ -16,6 +16,15 @@
     padding-top: 0px !important;
 }
 
+.o_cw_body li:has(.o_field_html[name="description"]){
+    span:has(i) {
+        align-self: flex-start;
+    }
+    .o_field_html {
+        text-wrap: wrap;
+    }
+}
+
 .o_field_many2manyattendeeexpandable .o_field_tags {
     flex-direction: column;
 

--- a/addons/calendar/tests/test_access_rights.py
+++ b/addons/calendar/tests/test_access_rights.py
@@ -232,7 +232,16 @@ class TestAccessRights(TransactionCase):
             self.assertEqual(hidden_information, value, "The field '%s' information must be hidden, even for uninvited admins." % field)
 
         # For the public event, ensure that the same fields can be read by the admin.
-        for (field, value) in [('name', 'pub'), ('location', 'loc_2'), ('description', "<p>pub</p>")]:
+        for (field, value) in [
+            ('name', 'pub'),
+            ('location', 'loc_2'),
+            ('description', '<div>pub<br>'
+                '<strong>Organized by</strong><br>'
+                'john (base.group_user)<br><a href="mailto:j.j@example.com">j.j@example.com</a><br><br>'
+                '<strong>Contact Details</strong><br>'
+                'george (base.group_user)<br><a href="mailto:g.g@example.com">g.g@example.com</a></div>',
+            ),
+        ]:
             field_information = self.read_event(self.admin_user, john_public_evt, field)
             self.assertEqual(str(field_information), value, "The field '%s' information must be readable by the admin." % field)
 

--- a/addons/google_calendar/models/calendar.py
+++ b/addons/google_calendar/models/calendar.py
@@ -56,8 +56,9 @@ class CalendarEvent(models.Model):
 
     @api.model_create_multi
     def create(self, vals_list):
+        description_context = self.env.context.get('skip_contact_description', False)
         notify_context = self.env.context.get('dont_notify', False)
-        return super(CalendarEvent, self.with_context(dont_notify=notify_context)).create([
+        return super(CalendarEvent, self.with_context(dont_notify=notify_context, skip_contact_description=description_context)).create([
             dict(vals, need_sync=False) if vals.get('recurrence_id') or vals.get('recurrency') else vals
             for vals in vals_list
         ])

--- a/addons/google_calendar/models/calendar_recurrence_rule.py
+++ b/addons/google_calendar/models/calendar_recurrence_rule.py
@@ -43,7 +43,7 @@ class CalendarRecurrence(models.Model):
                 }]
                 event.with_user(event._get_event_user())._google_delete(google_service, event.google_id)
                 event.google_id = False
-        self.env['calendar.event'].create(vals)
+        self.env['calendar.event'].with_context(skip_contact_description=True).create(vals)
 
         self.calendar_event_ids.need_sync = False
         return detached_events
@@ -174,7 +174,7 @@ class CalendarRecurrence(models.Model):
             # Google reuse the event google_id to identify the recurrence in that case
             base_event = self.env['calendar.event'].search([('google_id', '=', vals['google_id'])])
             if not base_event:
-                base_event = self.env['calendar.event'].create(base_values)
+                base_event = self.env['calendar.event'].with_context(skip_contact_description=True).create(base_values)
             else:
                 # We override the base_event values because they could have been changed in Google interface
                 # The event google_id will be recalculated once the recurrence is created

--- a/addons/google_calendar/models/google_sync.py
+++ b/addons/google_calendar/models/google_sync.py
@@ -169,7 +169,7 @@ class GoogleCalendarSync(models.AbstractModel):
             dict(self._odoo_values(e, default_reminders), need_sync=False)
             for e in new
         ]
-        new_odoo = self.with_context(dont_notify=True)._create_from_google(new, odoo_values)
+        new_odoo = self.with_context(dont_notify=True, skip_contact_description=True)._create_from_google(new, odoo_values)
         cancelled = existing.cancelled()
         cancelled_odoo = self.browse(cancelled.odoo_ids(self.env))
 

--- a/addons/google_calendar/tests/test_sync_google2odoo.py
+++ b/addons/google_calendar/tests/test_sync_google2odoo.py
@@ -121,7 +121,12 @@ class TestSyncGoogle2Odoo(TestSyncGoogle):
 
     @patch_api
     def test_new_google_event(self):
-        description = '<script>alert("boom")</script><p style="white-space: pre"><h1>HELLO</h1></p><ul><li>item 1</li><li>item 2</li></ul>'
+        description = (
+            '<div><p style="white-space: pre"></p>'
+            '<h1>HELLO</h1><ul><li>item 1</li><li>item 2</li></ul><br>'
+            '<strong>Contact Details</strong><br>Public Contact<br>'
+            '<a href="mailto:public_email@example.com">public_email@example.com</a></div>'
+        )
         values = {
             'id': 'oj44nep1ldf8a3ll02uip0c9aa',
             'description': description,
@@ -1398,7 +1403,7 @@ class TestSyncGoogle2Odoo(TestSyncGoogle):
             'start': {'date': str(event.start_date), 'dateTime': None},
             'end': {'date': str(event.stop_date + relativedelta(days=1)), 'dateTime': None},
             'summary': 'coucou',
-            'description': '',
+            'description': event.description,
             'location': '',
             'guestsCanModify': True,
             'organizer': {'email': 'c.c@example.com', 'self': False},

--- a/addons/google_calendar/tests/test_sync_odoo2google.py
+++ b/addons/google_calendar/tests/test_sync_odoo2google.py
@@ -50,7 +50,7 @@ class TestSyncOdoo2Google(TestSyncGoogle):
             'start': {'dateTime': '2020-01-15T08:00:00+00:00', 'date': None},
             'end': {'dateTime': '2020-01-15T18:00:00+00:00', 'date': None},
             'summary': 'Event',
-            'description': tools.html_sanitize(description),
+            'description': event.description,
             'location': '',
             'visibility': 'private',
             'guestsCanModify': True,
@@ -161,7 +161,7 @@ class TestSyncOdoo2Google(TestSyncGoogle):
             'start': {'dateTime': '2020-01-15T08:00:00+00:00', 'date': None},
             'end': {'dateTime': '2020-01-15T18:00:00+00:00', 'date': None},
             'summary': 'Event',
-            'description': '',
+            'description': event.description,
             'location': '',
             'visibility': 'private',
             'guestsCanModify': True,
@@ -383,7 +383,7 @@ class TestSyncOdoo2Google(TestSyncGoogle):
             'start': {'dateTime': '2020-01-15T08:00:00+00:00', 'date': None},
             'end': {'dateTime': '2020-01-15T18:00:00+00:00', 'date': None},
             'summary': 'Event',
-            'description': '',
+            'description': event.description,
             'location': '',
             'guestsCanModify': True,
             'reminders': {'overrides': [], 'useDefault': False},
@@ -550,7 +550,7 @@ class TestSyncOdoo2Google(TestSyncGoogle):
             'start': {'date': str(event.start_date), 'dateTime': None},
             'end': {'date': str(event.stop_date + relativedelta(days=1)), 'dateTime': None},
             'summary': 'Event with attendees',
-            'description': '',
+            'description': event.description,
             'location': '',
             'guestsCanModify': True,
             'organizer': {'email': 'odoobot@example.com', 'self': True},
@@ -838,7 +838,7 @@ class TestSyncOdoo2Google(TestSyncGoogle):
             'start': {'dateTime': '2023-01-15T08:00:00+00:00', 'date': None},
             'end': {'dateTime': '2023-01-15T18:00:00+00:00', 'date': None},
             'summary': 'Event',
-            'description': '',
+            'description': record.description,
             'location': '',
             'guestsCanModify': True,
             'transparency': 'opaque',
@@ -880,7 +880,7 @@ class TestSyncOdoo2Google(TestSyncGoogle):
             'start': {'date': '2024-01-17', 'dateTime': None},
             'end': {'date': '2024-01-18', 'dateTime': None},
             'summary': 'All Day Recurrent Event',
-            'description': '',
+            'description': event.description,
             'location': '',
             'guestsCanModify': True,
             'reminders': {'overrides': [], 'useDefault': False},
@@ -932,7 +932,10 @@ class TestSyncOdoo2Google(TestSyncGoogle):
                 'start': {'dateTime': '2023-01-15T08:00:00+00:00', 'date': None},
                 'end': {'dateTime': '2023-01-15T18:00:00+00:00', 'date': None},
                 'summary': 'Event',
-                'description': '',
+                'description': ('<div><strong>Organized by</strong><br>'
+                    'organizer_user (base.group_user)<br><a href="mailto:o.o@example.com">o.o@example.com</a><br><br>'
+                    '<strong>Contact Details</strong><br>'
+                    'attendee_user (base.group_user)<br><a href="mailto:a.a@example.com">a.a@example.com</a></div>'),
                 'location': '',
                 'guestsCanModify': True,
                 'transparency': 'opaque',
@@ -961,7 +964,7 @@ class TestSyncOdoo2Google(TestSyncGoogle):
             'start': {'date': '2020-01-15', 'dateTime': None},
             'end': {'date': '2020-01-16', 'dateTime': None},
             'summary': 'Event',
-            'description': '',
+            'description': event.description,
             'location': '',
             'guestsCanModify': True,
             'organizer': {'email': self.organizer_user.email, 'self': True},
@@ -979,6 +982,7 @@ class TestSyncOdoo2Google(TestSyncGoogle):
 
         event2 = event.copy()
         event2._sync_odoo2google(self.google_service)
+        event_response_data['description'] = event2.description
         self.assertGoogleEventInsertedMultiTime({
             **event_response_data,
             'extendedProperties': {'shared': {'%s_odoo_id' % self.env.cr.dbname: event2.id}},

--- a/addons/microsoft_calendar/models/calendar.py
+++ b/addons/microsoft_calendar/models/calendar.py
@@ -234,7 +234,9 @@ class CalendarEvent(models.Model):
         """ Copy current event values, delete it and recreate it with the new organizer user. """
         self.ensure_one()
         event_copy = {**self.copy_data()[0], 'microsoft_id': False}
-        self.env['calendar.event'].with_user(sender_user).create({**event_copy, **values})
+        self.env['calendar.event'].with_user(sender_user).with_context(skip_contact_description=True).create(
+            {**event_copy, **values},
+        )
         if self.ms_universal_event_id:
             self._microsoft_delete(self._get_organizer(), self.microsoft_id)
 

--- a/addons/microsoft_calendar/models/calendar_recurrence_rule.py
+++ b/addons/microsoft_calendar/models/calendar_recurrence_rule.py
@@ -48,7 +48,7 @@ class CalendarRecurrence(models.Model):
                 }]
                 event._microsoft_delete(event.user_id, event.microsoft_id)
                 event.ms_universal_event_id = False
-        self.env['calendar.event'].create(vals)
+        self.env['calendar.event'].with_context(skip_contact_description=True).create(vals)
         self.calendar_event_ids.need_sync_m = False
         return detached_events
 

--- a/addons/microsoft_calendar/models/microsoft_sync.py
+++ b/addons/microsoft_calendar/models/microsoft_sync.py
@@ -120,7 +120,7 @@ class MicrosoftCalendarSync(models.AbstractModel):
 
     @api.model
     def _create_from_microsoft(self, microsoft_event, vals_list):
-        return self.with_context(dont_notify=True).create(vals_list)
+        return self.with_context(dont_notify=True, skip_contact_description=True).create(vals_list)
 
     def _sync_odoo2microsoft(self):
         if not self:
@@ -284,7 +284,7 @@ class MicrosoftCalendarSync(models.AbstractModel):
             dict(self._microsoft_to_odoo_values(e, with_ids=True), need_sync_m=False)
             for e in (new - new_recurrence)
         ]
-        synced_events = self.with_context(dont_notify=True)._create_from_microsoft(new, odoo_values)
+        synced_events = self.with_context(dont_notify=True, skip_contact_description=True)._create_from_microsoft(new, odoo_values)
         synced_recurrences, updated_events = self._sync_recurrence_microsoft2odoo(existing, new_recurrence)
         synced_events |= updated_events
 

--- a/odoo/tools/mail.py
+++ b/odoo/tools/mail.py
@@ -612,18 +612,19 @@ def html2plaintext(
 
     return html.strip()
 
-def plaintext2html(text: str, container_tag: str | None = None) -> markupsafe.Markup:
+
+def plaintext2html(text: str, container_tag: str | None = None, with_paragraph: bool = True) -> markupsafe.Markup:
     r"""Convert plaintext into html. Content of the text is escaped to manage
     html entities, using :func:`~odoo.tools.misc.html_escape`.
 
     - all ``\n``, ``\r`` are replaced by ``<br/>``
-    - enclose content into ``<p>``
     - convert url into clickable link
-    - 2 or more consecutive ``<br/>`` are considered as paragraph breaks
 
     :param text: plaintext to convert
     :param container_tag: container of the html; by default the content is
         embedded into a ``<div>``
+    :param with_paragraph: whether or not considering 2 or more consecutive ``<br/>``
+        as paragraph breaks and enclosing content in ``<p>``
     """
     assert isinstance(text, str)
     text = misc.html_escape(text)
@@ -635,13 +636,15 @@ def plaintext2html(text: str, container_tag: str | None = None) -> markupsafe.Ma
     text = html_keep_url(text)
 
     # 3-4: form paragraphs
-    idx = 0
-    final = '<p>'
-    br_tags = re.compile(r'(([<]\s*[bB][rR]\s*/?[>]\s*){2,})')
-    for item in re.finditer(br_tags, text):
-        final += text[idx:item.start()] + '</p><p>'
-        idx = item.end()
-    final += text[idx:] + '</p>'
+    final = text
+    if with_paragraph:
+        idx = 0
+        final = '<p>'
+        br_tags = re.compile(r'(([<]\s*[bB][rR]\s*/?[>]\s*){2,})')
+        for item in re.finditer(br_tags, text):
+            final += text[idx:item.start()] + '</p><p>'
+            idx = item.end()
+        final += text[idx:] + '</p>'
 
     # 5. container
     if container_tag: # FIXME: validate that container_tag is just a simple tag?


### PR DESCRIPTION
Purpose
=======
Improve the description field to make sure people have direct access
to more event info from external calendars and the calendar popover.

Specification
=============
Add organizer and first contact partner details with direct email and phone actions.
These details are added in the create method before record creation because
updating the description after creation triggers a second sync with external calendars.

Using the 'skip_contact_description' context key to prevent adding those details
in certain scenarios to avoid duplication as the description already contains the details:
- when copying the event
- when creating recurrent events
- when syncing from external calendars to odoo

Task-4759201
