### PR TITLE
[FIX] website: hide resource editor on changes

### DIFF
--- a/addons/website/static/src/client_actions/website_preview/new_content_systray_item.js
+++ b/addons/website/static/src/client_actions/website_preview/new_content_systray_item.js
@@ -15,6 +15,7 @@ export class NewContentSystrayItem extends Component {
     }
 
     onClick() {
+        this.websiteContext.showResourceEditor = false;
         this.websiteContext.showNewContentModal = !this.websiteContext.showNewContentModal;
     }
 }

--- a/addons/website/static/src/client_actions/website_preview/website_builder_action.js
+++ b/addons/website/static/src/client_actions/website_preview/website_builder_action.js
@@ -254,6 +254,7 @@ export class WebsiteBuilderClientAction extends Component {
     }
 
     async onEditPage() {
+        this.websiteContext.showResourceEditor = false;
         this.blockIframe();
         await this.loadIframeAndBundles(true);
         this.unblockIframe();
@@ -357,7 +358,10 @@ export class WebsiteBuilderClientAction extends Component {
                 }
             }
         }
-
+        if (this.lastPageURL !== iframe.contentWindow.location.href) {
+            // Hide Ace Editor when moving to another page.
+            this.websiteService.context.showResourceEditor = false;
+        }
         this.websiteService.pageDocument = this.websiteContent.el.contentDocument;
         if (this.translation) {
             deleteQueryParam("edit_translations", this.websiteService.contentWindow, true);
@@ -370,6 +374,7 @@ export class WebsiteBuilderClientAction extends Component {
         this.resolveIframeLoaded();
         this.addWelcomeMessage();
         this.websiteService.hideLoader();
+        this.lastPageURL = iframe.contentWindow.location.href;
     }
 
     blockIframe() {

--- a/addons/website/static/tests/tours/html_editor.js
+++ b/addons/website/static/tests/tours/html_editor.js
@@ -359,3 +359,70 @@ registerWebsitePreviewTour(
             .flat(),
     ]
 );
+
+registerWebsitePreviewTour(
+    "test_ace_editor_is_hidden",
+    {
+        url: "/",
+    },
+    () => [
+        {
+            trigger: ":iframe #wrapwrap",
+        },
+        {
+            content: "Open Site menu",
+            trigger: "button[data-menu-xmlid='website.menu_site']",
+            run: "click",
+        },
+        {
+            content: "Open HTML / CSS Editor",
+            trigger: ".o_popover a[data-menu-xmlid='website.menu_ace_editor']:contains(/^HTML/)",
+            run: "click",
+        },
+        {
+            content: "Make sure the editor is open",
+            trigger: ".o_resource_editor",
+        },
+        {
+            content: "Click on edit",
+            trigger: ".o_menu_systray_item.o_edit_website_container > button",
+            run: "click",
+        },
+        {
+            content: "Wait for it to open",
+            trigger: ".o-website-builder_sidebar",
+        },
+        {
+            content: "Make sure the editor has been hidden after starting editing",
+            trigger: ":not(.o_resource_editor)",
+        },
+        {
+            content: "Discard edit mode",
+            trigger: ".o-website-builder_sidebar .o-snippets-top-actions button:contains(Discard)",
+            run: "click",
+        },
+        {
+            content: "Open Site menu",
+            trigger: "button[data-menu-xmlid='website.menu_site']",
+            run: "click",
+        },
+        {
+            content: "Open HTML / CSS Editor",
+            trigger: ".o_popover a[data-menu-xmlid='website.menu_ace_editor']:contains(/^HTML/)",
+            run: "click",
+        },
+        {
+            content: "Make sure the editor is open",
+            trigger: ".o_resource_editor",
+        },
+        {
+            content: "Navigate to contact us page",
+            trigger: ":iframe a[href='/contactus']",
+            run: "click",
+        },
+        {
+            content: "Make sure the editor has been hidden after navigating to other page",
+            trigger: ":not(.o_resource_editor)",
+        },
+    ]
+);

--- a/addons/website/tests/test_ui.py
+++ b/addons/website/tests/test_ui.py
@@ -160,6 +160,9 @@ class TestUiHtmlEditor(HttpCaseWithUserDemo):
         self.start_tour(self.env['website'].get_client_action_url('/contactus'), 'test_html_editor_scss', login='admin')
         self.start_tour(self.env['website'].get_client_action_url('/'), 'test_html_editor_scss_2', login='demo')
 
+    def test_ace_editor_is_hidden(self):
+        self.start_tour(self.env['website'].get_client_action_url('/'), 'test_ace_editor_is_hidden', login='admin')
+
     def test_media_dialog_undraw(self):
         BASE_URL = self.base_url()
         banner = '/website/static/src/img/snippets_demo/s_banner.jpg'


### PR DESCRIPTION
In the [html_builder refactoring] functionality that was hiding the resource editor was lost. 
Before, whenever you had opened the editor and navigated to another page/
started editing/translating, it would hide it. 
**To reproduce the issue:**
1. Open the website and click on "Site" in the navbar.
2. Select the HTML/CSS editor.
3. Click on Edit/New or navigate to another page (e.g., "Contact Us").
Observe that the resource editor remains visible.

[html_builder refactoring]: https://github.com/odoo/odoo/commit/9fe45e2b7ddb
Related to task-4367641.