### PR TITLE
[IMP] crm: rename customer field to contact

### DIFF
--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -169,7 +169,7 @@ class CrmLead(models.Model):
         compute='_compute_commercial_partner_id', readonly=False, store=False,
     )
     partner_id = fields.Many2one(
-        'res.partner', string='Customer', check_company=True, index=True, tracking=10,
+        'res.partner', string='Contact', check_company=True, index=True, tracking=10,
         help="Linked partner (optional). Usually created when converting the lead. You can find a partner by its Name, TIN, Email or Internal Reference.")
     partner_is_blacklisted = fields.Boolean('Partner is blacklisted', related='partner_id.is_blacklisted', readonly=True)
     contact_name = fields.Char(

--- a/addons/crm/views/crm_lead_views.xml
+++ b/addons/crm/views/crm_lead_views.xml
@@ -134,7 +134,6 @@
                             <group name="opportunity_partner" invisible="type == 'lead'">
                                 <field name="partner_id"
                                     widget="res_partner_many2one"
-                                    string="Contact"
                                     context="{'res_partner_search_mode': type == 'opportunity' and 'customer' or False,
                                         'default_name': contact_name or partner_name,
                                         'default_street': street,
@@ -441,7 +440,6 @@
                                 nolabel="1"
                                 class="o_field_highlight w-100 mb-0"
                                 placeholder='Contact'
-                                string='Contact'
                                 context="{
                                 'res_partner_search_mode': type == 'opportunity' and 'customer' or False,
                                 'partner_display_name_hide_company': commercial_partner_id,


### PR DESCRIPTION
Purpose:
--------
The partner_id field on leads is called "Contact" in the views, but "Customer" in backend. The field is renamed to "Contact" so that it's easier for users to find the field to insert it in a template or in an AI field prompt.

Task-4762422

