### PR TITLE
[FIX] point_of_sale: prevent price change when changing preset

### DIFF
--- a/addons/point_of_sale/static/src/app/models/pos_order.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order.js
@@ -447,25 +447,14 @@ export class PosOrder extends Base {
             (line) => line.price_type === "original" && line.combo_line_ids?.length
         );
         for (const pLine of combo_parent_lines) {
+            const { childLineFree, childLineExtra } = this.getFreeAndExtraChildLines(pLine);
             attributes_prices[pLine.id] = computeComboItems(
                 pLine.product_id,
-                pLine.combo_line_ids.map((cLine) => {
-                    if (cLine.attribute_value_ids) {
-                        return {
-                            combo_item_id: cLine.combo_item_id,
-                            configuration: {
-                                attribute_value_ids: cLine.attribute_value_ids,
-                            },
-                            qty: pLine.qty,
-                        };
-                    } else {
-                        return { combo_item_id: cLine.combo_item_id, qty: pLine.qty };
-                    }
-                }),
+                childLineFree,
                 pricelist,
                 this.models["decimal.precision"].getAll(),
                 this.models["product.template.attribute.value"].getAllBy("id"),
-                [],
+                childLineExtra,
                 this.config_id.currency_id
             );
         }
@@ -473,12 +462,42 @@ export class PosOrder extends Base {
             (line) => line.price_type === "automatic" && line.combo_parent_id
         );
         combo_children_lines.forEach((line) => {
-            line.setUnitPrice(
-                attributes_prices[line.combo_parent_id.id].find(
-                    (item) => item.combo_item_id.id === line.combo_item_id.id
-                ).price_unit
+            const currentItem = attributes_prices[line.combo_parent_id.id].find(
+                (item) => item.combo_item_id.id === line.combo_item_id.id
+            );
+            line.setUnitPrice(currentItem.price_unit);
+            // Removing to be able to have extras that are the same as free products
+            attributes_prices[line.combo_parent_id.id].splice(
+                attributes_prices[line.combo_parent_id.id].indexOf(currentItem),
+                1
             );
         });
+    }
+
+    getFreeAndExtraChildLines(pLine) {
+        const childLineFree = [];
+        const childLineExtra = [];
+        const comboRemainingFree = {};
+        for (const cLine of pLine.combo_line_ids) {
+            if (!(cLine.combo_item_id.combo_id.id in comboRemainingFree)) {
+                comboRemainingFree[cLine.combo_item_id.combo_id.id] =
+                    cLine.combo_item_id.combo_id.qty_free;
+            }
+            const newQty = comboRemainingFree[cLine.combo_item_id.combo_id.id] - cLine.qty;
+            const baseData = { combo_item_id: cLine.combo_item_id };
+            if (cLine.attribute_value_ids) {
+                baseData.configuration = { attribute_value_ids: cLine.attribute_value_ids };
+            }
+            if (cLine.qty) {
+                if (newQty >= 0) {
+                    comboRemainingFree[cLine.combo_item_id.combo_id.id] = newQty;
+                    childLineFree.push({ ...baseData, qty: cLine.qty });
+                } else {
+                    childLineExtra.push({ ...baseData, qty: cLine.qty });
+                }
+            }
+        }
+        return { childLineFree, childLineExtra };
     }
 
     /**


### PR DESCRIPTION
**Problem:**
When ordering a combo product, you can order more products than the
combo requires, which will the add *base_price* to the combo price.
The problem is that when changing the preset, like going from eat in
to delivery, the pricelist is reconfigured, and it does not take the
extra products from the combo into account. This means that the price
will go back to the combo's price without the extra products.

**Steps to reproduce:**
- Have a combo that can take on multiple free products and has a limit above this free product number
- Order more than the free quantity
- Change the preset (from eat in to delivery)
- The price is recomputed without taking the extra products into account

**Why the fix:**
The extra articles were not accounted for when changing the pricelist,
meaning they would end up free and the price would change. We now
make a separation between the free products (that are from the combo) and
the extra products. The extra products cost the *base_price* of said combo.

To do that, we need to get the extra lines from the combo, which are the
products that are not free in the case where there are more products
selected in the combo than free products defined in the definition of
the combo. To make that happen, we add the non free lines to the
extra lines list once we have at least as many free products as
defined in the combo definition.

In the case where the quantity of a product is greater than the number
of free items, the lines are automatically split. Meaning if we have
a combo with 2 free items but we order 3, we will have a line with
a quantity of 2 and another line with a quantity of 1. In that case,
the first line will be free, but the second line will be an extra.
This logic is implemented here https://github.com/odoo/odoo/blob/0087cc96b2d2190ab107c3d50d3bdd48f7a687e9/addons/point_of_sale/static/src/app/components/popups/combo_configurator_popup/combo_configurator_popup.js#L88-L106
Which is then retrieved here to make the separation in the combo's price
https://github.com/odoo/odoo/blob/0087cc96b2d2190ab107c3d50d3bdd48f7a687e9/addons/point_of_sale/static/src/app/services/pos_store.js#L879

opw-4885574