### PR TITLE
[FIX] stock: prevent error when location is unset in stock quant form view

### DIFF
--- a/addons/stock/models/stock_quant.py
+++ b/addons/stock/models/stock_quant.py
@@ -603,7 +603,9 @@ class StockQuant(models.Model):
     def _compute_display_name(self):
         """name that will be displayed in the detailed operation"""
         for record in self:
-            name = [record.location_id.display_name]
+            name = []
+            if record.location_id:
+                name.append(record.location_id.display_name)
             if record.lot_id:
                 name.append(record.lot_id.name)
             if record.package_id:

--- a/addons/stock/tests/test_quant.py
+++ b/addons/stock/tests/test_quant.py
@@ -1421,3 +1421,16 @@ class StockQuantRemovalStrategy(TransactionCase):
             ('package_id', '=', package.id),
             ('location_id', '=', self.stock_location.id),
         ]))
+
+    def test_display_name(self):
+        package = self.env['stock.quant.package'].create({})
+        stock_quant = self.env['stock.quant'].create({
+            'product_id': self.product.id,
+            'location_id': self.stock_location.id,
+            'package_id': package.id,
+            'quantity': 10.0,
+        })
+        self.assertEqual(stock_quant.display_name, 'stock_location - ' + package.name)
+
+        stock_quant.location_id = self.env['stock.location']
+        self.assertEqual(stock_quant.display_name, package.name)


### PR DESCRIPTION
Currently, an error is produced when accessing the stock quant form view without a location set.

**Steps to Reproduce: (V18.0)**
- Install the **Inventory** app.
- Create a product with tracking enabled (**Lots/Serial Numbers**).
- Click **"Update Quantity"** (opens list view).
- Click New and then click View on the unsaved record (opens **form view**).
- Remove the **Location** field.

**Error:**
`TypeError - sequence item 0: expected str instance, bool found`

This issue does not occur in v17.0 as the `stock.quant` model has no direct form view.

**Cause:**
In the display name computation ([1]), the code attempts to join name parts where one of them can be `False` if the location is not set.

[1] - https://github.com/odoo/odoo/blob/2e97690e312c7c7e24dd550dd5d0112af6223816/addons/stock/models/stock_quant.py#L613

**Fix:**
The display name generation now checks `location_id` before joining, preventing the error.

Sentry - 6717759358