### PR TITLE
[FIX] l10n_vn: Remove trailing zero when creating account with code_d…

### DIFF
--- a/addons/l10n_vn/models/template_vn.py
+++ b/addons/l10n_vn/models/template_vn.py
@@ -9,7 +9,7 @@ class AccountChartTemplate(models.AbstractModel):
     @template('vn')
     def _get_vn_template_data(self):
         return {
-            'code_digits': '4',
+            'code_digits': '3',
             'property_account_receivable_id': 'chart131',
             'property_account_payable_id': 'chart331',
             'property_account_expense_categ_id': 'chart1561',


### PR DESCRIPTION
…igits = 4

When creating an account with `code_digits = 4`, the system incorrectly appends a trailing zero to the account code (e.g. '111' becomes '1110'). This fix ensures that account codes are preserved exactly as entered, without unwanted padding.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
