### PR TITLE
[16.0][FIX] purchase_stock: fix creating two pickings for negative qty order line and not assigning the delivery address

### DIFF
--- a/addons/mrp_subcontracting_dropshipping/models/purchase.py
+++ b/addons/mrp_subcontracting_dropshipping/models/purchase.py
@@ -25,6 +25,14 @@ class PurchaseOrder(models.Model):
                 'warning': {'title': _('Warning'), 'message': _('Please note this purchase order is for subcontracting purposes.')}
             }
 
+    def _get_locations(self, picking_type):
+        self.ensure_one()
+        if self.default_location_dest_id_is_subcontracting_loc:
+            location = self.partner_id.property_stock_supplier
+            location_dest = self.dest_address_id.property_stock_subcontractor
+            return location, location_dest
+        return super()._get_locations(picking_type)
+
     def _get_destination_location(self):
         self.ensure_one()
         if self.default_location_dest_id_is_subcontracting_loc:

--- a/addons/purchase_stock/tests/test_purchase_order.py
+++ b/addons/purchase_stock/tests/test_purchase_order.py
@@ -706,6 +706,7 @@ class TestPurchaseOrder(ValuationReconciliationTestCommon):
         # one delivery, one receipt
         self.assertEqual(len(po.picking_ids), 1)
         self.assertEqual(po.picking_ids.picking_type_id.code, 'outgoing')
+        self.assertEqual(po.picking_ids.partner_id, po.partner_id)
         po.picking_ids.move_ids.quantity_done = 5
         po.picking_ids.button_validate()
         self.assertEqual(po.order_line.qty_received, po.order_line.product_qty)


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
This PR fixes the issue where creating a purchase order with a negative order line results in no partner being assigned to the related picking and two pickings being created — one in draft state and the other in ready state.

Current behavior before PR:
There is no partner in the related picking, and two pickings are created.

Desired behavior after PR is merged:
There is only one related picking with a partner assigned.

Reference video : https://drive.google.com/file/d/1_Cj45h_HjaruTBtKoaf-JjkHLqbitv7A/view?usp=sharing

#OPW - 4921139
@qrtl QT5390
