### PR TITLE
[FIX] web: show '+' in ListView selection count when exceeding limit

### DIFF
--- a/addons/web/static/src/views/list/list_controller.xml
+++ b/addons/web/static/src/views/list/list_controller.xml
@@ -118,7 +118,7 @@
     <t t-name="web.ListView.Selection">
         <div class="o_list_selection_box list-group flex-row w-auto" t-att-class="{'m-1 gap-1': env.isSmall}" role="alert">
             <span class="list-group-item active d-flex align-items-center pe-0 py-0 rounded-1 gap-1 flex-grow-1" t-att-class="{'shadow': env.isSmall}">
-                <span t-if="isDomainSelected">All <b t-esc="nbTotal"/> selected</span>
+                <span t-if="isDomainSelected">All <b><t t-esc="nbTotal"/><t t-if="model.root.hasLimitedCount">+</t></b> selected</span>
                 <t t-else="">
                     <b t-esc="nbSelected"/> selected
                     <button t-if="!env.isSmall and isPageSelected and (!model.root.isRecordCountTrustable or nbTotal > nbSelected)"
@@ -126,7 +126,7 @@
                         title="Select all records matching the search"
                         t-on-click="onSelectDomain">
                         <i class="oi oi-fw oi-arrow-right"/>
-                        Select all <span t-if="model.root.isRecordCountTrustable" t-esc="nbTotal"/>
+                        Select all <span t-if="model.root.isRecordCountTrustable"><t t-esc="nbTotal"/><t t-if="model.root.hasLimitedCount">+</t></span>
                     </button>
                 </t>
                 <button title="Unselect All" class="o_list_unselect_all btn btn-link ms-auto border-0" t-on-click="onUnselectAll">

--- a/addons/web/static/tests/views/list/list_view.test.js
+++ b/addons/web/static/tests/views/list/list_view.test.js
@@ -3454,6 +3454,20 @@ test(`selection box is properly displayed (multi pages)`, async () => {
     });
 });
 
+test(`selection box shows '+' suffix on selection count beyond count_limit`, async () => {
+    await mountView({
+        resModel: "foo",
+        type: "list",
+        arch: `<list limit="2" count_limit="3"><field name="foo"/><field name="bar"/></list>`,
+    });
+    // select all records of first page
+    await contains(`thead .o_list_record_selector input`).click();
+    expect(`.o_list_selection_box`).toHaveText("2\nselected\n Select all 3+");
+    // select all domain
+    await contains(`.o_list_selection_box .o_list_select_domain`).click();
+    expect(`.o_list_selection_box`).toHaveText("All 3+ selected");
+});
+
 test(`selection box is properly displayed (group list)`, async () => {
     await mountView({
         resModel: "foo",


### PR DESCRIPTION
Previously, when selection was made in domain mode, the system used the global `web.active_ids_limit` config parameter instead of the actual number of records selected (based on session limit). This caused unintended behavior.

For example:
- Open a list view of a model with 25,000 records.
- The pager limit is initially set to 10,000.
- When selecting all 10,000 visible records and performing an action (e.g., archive), the system would incorrectly apply the action to 20,000 records (based on the default value of `web.active_ids_limit`), not the selected 10,000.