### PR TITLE
[FIX] purchase_stock: Proper attribute description without purchase_product_matrix

### DIFF
--- a/addons/purchase_stock/tests/test_create_picking.py
+++ b/addons/purchase_stock/tests/test_create_picking.py
@@ -883,7 +883,7 @@ class TestCreatePicking(ProductVariantsCommon):
             'partner_id': self.partner_id.id,
             'order_line': [Command.create({
                     'product_id': product_with_description.product_variant_ids.filtered(lambda p: p.product_template_attribute_value_ids.name == 'red').id,
-                    'product_no_variant_attribute_value_ids': [Command.set(product_with_description.attribute_line_ids[1].product_template_value_ids[0].ids)],
+                    'product_no_variant_attribute_value_ids': product_matrix_installed and [Command.set(product_with_description.attribute_line_ids[1].product_template_value_ids[0].ids)],
                     'product_qty': 1,
                 }),
             ]


### PR DESCRIPTION
### Description of the issue/feature this PR addresses:
[build_error-227711](https://runbot.odoo.com/odoo/error/227711)

### Current behavior before PR:
When testing for proper move descriptions, we add a second (no variant) attribute to the product only if the module `purchase_product_matrix` is installed.
In its absence (such as in a single-app test), we only have a single attribute_line, and referring to a second line throws an IndexError:
```
Traceback (most recent call last):
  File "/data/build/odoo/addons/purchase_stock/tests/test_create_picking.py", line 886, in test_move_description
    'product_no_variant_attribute_value_ids': [Command.set(product_with_description.attribute_line_ids[1].product_template_value_ids[0].ids)],
                                                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^
  File "/data/build/odoo/odoo/orm/models.py", line 6375, in __getitem__
    return self.browse((self._ids[key],))
                        ~~~~~~~~~^^^^^
IndexError: tuple index out of range
```


### Desired behavior after PR is merged:

Instead, we should only populate the `product_no_variant_attribute_value_ids` of the order line when the no_variant attribute is present in the product, i.e. only when the optional module is installed.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
