### PR TITLE
[FIX] sale: sale_signature tour

### DIFF
--- a/addons/sale/static/tests/tours/sale_signature.js
+++ b/addons/sale/static/tests/tours/sale_signature.js
@@ -1,5 +1,6 @@
 /** @odoo-module **/
 
+import { waitUntil } from "@odoo/hoot-dom";
 import { registry } from "@web/core/registry";
 import { redirect } from "@web/core/utils/urls";
 
@@ -24,6 +25,18 @@ registry.category("web_tour.tours").add('sale_signature', {
     },
     {
         trigger: ".modal .o_web_sign_name_and_signature input:value(Joel Willis)"
+    },
+    {
+        trigger: ".modal canvas.o_web_sign_signature",
+        async run(helpers) {
+            await waitUntil(() => {
+                const canvas = helpers.anchor;
+                const context = canvas.getContext("2d");
+                const imageData = context.getImageData(0, 0, canvas.width, canvas.height);
+                const pixels = new Uint32Array(imageData.data.buffer);
+                return pixels.some((pixel) => pixel !== 0);
+            });
+        },
     },
     {
         content: "click select style",


### PR DESCRIPTION
In commit, we make sure that the signature is present in the modal before reaching the step where we click on "accept & sign". If the canvas is not yet loaded at this step, then there is an error message "Signature is missing".

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
