### PR TITLE
[FIX] website_slides: prevent error when creating the attendee record.

### DIFF
--- a/addons/website_slides/models/slide_channel.py
+++ b/addons/website_slides/models/slide_channel.py
@@ -65,6 +65,9 @@ class SlideChannelPartner(models.Model):
             record.invitation_link = f'{record.channel_id.get_base_url()}/slides/{record.channel_id.id}/invite?invite_partner_id={record.partner_id.id}&invite_hash={invitation_hash}'
 
     def _compute_next_slide_id(self):
+        if not self.ids:
+            self.next_slide_id = False
+            return
         self.env['slide.channel.partner'].flush_model()
         self.env['slide.slide'].flush_model()
         self.env['slide.slide.partner'].flush_model()


### PR DESCRIPTION
Currently an error occurs when creating the attendee records.

Steps to Reproduce:

 - Install the `website_slide` module.
 - Go to `Reporting` > `Attendees`.
 - Go to either the `Graph or Pivot View` and click on any `count` value.
 - Open any attendee record and click on `New`.

`SyntaxError: syntax error at or near ")"
LINE 18: WHERE SCP.id IN ()
^`

This error occurs when creating an Attendee record. The _compute_next_slide_id
method runs every time the record is accessed, which causes the error [1].
As clearly mentioned in [this commit](https://github.com/odoo/odoo/commit/fd2fb88bb155b680147313433d22a2b7388c902c#diff-1ee3fce434db0c4e897973eebf5c1be501196cbd413e6c250ecc973238f939b9L292-R326), when a compute method is declared
without the @api.depends(...) decorator or with no actual dependencies,
the computed field will still be initialized when creating a new record
from a form view.

This commit ensures that when the compute method runs and the record
has not been created yet, the next_slide_id is set to False.

[1]:- https://github.com/odoo/odoo/blob/9f18013bc05e6657f5d41c05931fcdafad827d54/addons/website_slides/models/slide_channel.py#L91

sentry-6465821899

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
