### PR TITLE
[FIX] pos_self_order: show available in self order with no category

### DIFF
--- a/addons/pos_self_order/models/pos_config.py
+++ b/addons/pos_self_order/models/pos_config.py
@@ -159,6 +159,12 @@ class PosConfig(models.Model):
                 vals['self_ordering_service_mode'] = 'table'
 
         res = super().write(vals)
+
+        if vals.get('self_ordering_mode', 'nothing') != 'nothing' or not vals.get('limit_categories', True) or not vals.get('iface_available_categ_ids', True):
+            for config in self:
+                if config.self_ordering_mode != 'nothing' and (not config.limit_categories or not config.iface_available_categ_ids):
+                    self.env['product.template'].search([]).write({'self_order_visible': True})
+                    break
         self._prepare_self_order_custom_btn()
         return res
 


### PR DESCRIPTION
Before this commit, in a PoS config with self-ordering and no category limit, the "Available in Self Order" field was incorrectly missing for some products that should have displayed it.

opw-4914554

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
