### PR TITLE
[FIX] point_of_sale: use default pricelist/fp when not set on preset

### DIFF
--- a/addons/point_of_sale/static/src/app/models/pos_order.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order.js
@@ -142,8 +142,9 @@ export class PosOrder extends Base {
     }
 
     setPreset(preset) {
-        this.setPricelist(preset.pricelist_id);
-        this.fiscal_position_id = preset.fiscal_position_id;
+        this.setPricelist(preset.pricelist_id || this.config.pricelist_id);
+        this.fiscal_position_id =
+            preset.fiscal_position_id || this.config.default_fiscal_position_id;
         this.preset_id = preset;
         if (preset.is_return) {
             this.lines.forEach((l) => l.setQuantity(-Math.abs(l.getQuantity())));


### PR DESCRIPTION
Before this commit, if the pricelist or fiscal position was not explicitly set on a preset, the order would not inherit the default values defined in the PoS config. This fix ensures that the system now correctly falls back to using the default pricelist and fiscal position from the PoS configuration when they are not specified on the preset.

opw-4913400

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
