### PR TITLE
[FIX] {sale_}stock: prevent crash when cancelling SO with nested returns

### DIFF
--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -2223,7 +2223,7 @@ Please change the quantity done or the rounding precision of your unit of measur
         return self.picking_id or False
 
     def _get_upstream_documents_and_responsibles(self, visited):
-        if self.move_orig_ids and any(m.state not in ('done', 'cancel') for m in self.move_orig_ids):
+        if self not in visited and self.move_orig_ids and any(m.state not in ('done', 'cancel') for m in self.move_orig_ids):
             result = set()
             visited |= self
             for move in self.move_orig_ids:


### PR DESCRIPTION
The system crashes with a `RecursionError` during the `Sale Order` cancellation with nested `returns`.

**Steps to produce:-**
- Install the `Purchase Stock` and `Sales` modules.
- Create a new `Sales Order` (SO) with `Product A`.
- Confirm the `Sales Order` and click on the `Delivery` button.
- Click on `Return > Return all`.
- In the new window, also click on `Return > Return all`.
- Return to the `Sales Order` and attempt to `Cancel` it.

**Error:-**
`RecursionError: maximum recursion depth exceeded`

**Solution:-**
- Added a check for the self not already visited in the method `_get_upstream_documents_and_responsibles` to prevent revisiting the same move multiple times and `avoid infinite recursion`.

**Sentry - 6693197358**

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
