### PR TITLE
[FIX] website_sale: fix suggested product description overflow

### DIFF
--- a/addons/website_sale/static/src/scss/website_sale.scss
+++ b/addons/website_sale/static/src/scss/website_sale.scss
@@ -1109,6 +1109,11 @@ a.no-decoration {
 
         .o_description_line {
             @include o-line-clamp(2);
+
+            &.text-truncate {
+                text-overflow: clip;
+                white-space: normal;
+            }
         }
     }
 

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -2566,7 +2566,7 @@
                                     />
                                 </a>
                                 <div
-                                    class="text-truncate small text-muted"
+                                    class="text-truncate o_description_line overflow-hidden mb-2 small text-muted"
                                     t-field="product.description_sale"
                                 />
                             </div>


### PR DESCRIPTION
This PR fixes an issue about products description overflowing in the context of the suggested accessories in the cart UI.

| saas-18.3 | This PR |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/7d88cda9-62e9-4375-a66c-7223e3dc4a1b) | ![image](https://github.com/user-attachments/assets/cb5387d9-2737-47c0-8388-e0e08404cf17) |

Prior to this PR, a `text-truncate` was applied on the element but the flex layout was preventing the element to truncate correctly.

To fix this issue, we set `.o_description_line` to this element, which will apply the same styling as the regular cart line, making it more consistent.

task-4915440

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
