### PR TITLE
[FIX] auth_passkey: check identity not working with passkey

### DIFF
--- a/addons/auth_passkey/views/res_users_identitycheck_views.xml
+++ b/addons/auth_passkey/views/res_users_identitycheck_views.xml
@@ -15,7 +15,7 @@
                 </div>
             </xpath>
             <xpath expr="//footer/button[@id='password_confirm']" position="before">
-                <button string="Use Passkey" type="object" name="run_check" class="btn btn-primary" data-hotkey="q" invisible="auth_method != 'webauthn'"/>
+                <button string="Use Passkey" type="object" name="run_check" class="btn btn-primary" data-hotkey="q" invisible="auth_method != 'webauthn'" context="{'password': password}"/>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
26f982cd26deb5e8a971617d8c1d6d4e840eaee3 introduced the idea of passing the password in the context instead of saving it to the database.

However it forgot to add the password for webauthn flows, so this is a simple correction.