### PR TITLE
[FIX] website: prevent traceback when iframe has no src

### DIFF
--- a/addons/website/static/src/client_actions/website_preview/website_builder_action.js
+++ b/addons/website/static/src/client_actions/website_preview/website_builder_action.js
@@ -558,7 +558,7 @@ export class WebsiteBuilderClientAction extends Component {
 
     cleanIframeFallback() {
         // Remove autoplay in all iframes urls so videos are not
-        const iframesEl = this.iframefallback.el.contentDocument.querySelectorAll("iframe");
+        const iframesEl = this.iframefallback.el.contentDocument.querySelectorAll('iframe[src]:not([src=""])');
         for (const iframeEl of iframesEl) {
             const url = new URL(iframeEl.src);
             url.searchParams.delete('autoplay');


### PR DESCRIPTION
A recent commit [1] reintroduced the iframe fallback mechanism in the website builder, lost during the refactoring to owl. Unfortunately, someone (me) was not careful enough, and missed a subsequent fix [2].

The issue lies in the code removing the autoplay attribute in iframes present in the page. Since it targeted all iframes, even ones without a src attribute, the new Url(src) would crash. So, with this commit, we ensure that we ony target iframes with a src attribute. This reintroduces commit [2].

[1] 36db9c82b00e9ae276edb059f980b23eb93df02b
[2] 755ab306190be4d1bfb11d8b9fd5e7cf4cc34b3f

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
