### PR TITLE
[IMP] html_editor: drop should use internal odoo-editor dataTransfer

### DIFF
--- a/addons/html_editor/static/src/components/html_viewer/html_viewer.js
+++ b/addons/html_editor/static/src/components/html_viewer/html_viewer.js
@@ -11,7 +11,7 @@ import {
 } from "@odoo/owl";
 import { getBundle } from "@web/core/assets";
 import { memoize } from "@web/core/utils/functions";
-import { fillClipboardData } from "@html_editor/utils/clipboard";
+import { fillHtmlTransferData } from "@html_editor/utils/clipboard";
 import { fixInvalidHTML, instanceofMarkup } from "@html_editor/utils/sanitize";
 import { HtmlUpgradeManager } from "@html_editor/html_migrations/html_upgrade_manager";
 import { TableOfContentManager } from "@html_editor/others/embedded_components/core/table_of_content/table_of_content_manager";
@@ -160,7 +160,7 @@ export class HtmlViewer extends Component {
         range.setStart(deepAnchorNode, deepAnchorOffset);
         range.setEnd(deepFocusNode, deepFocusOffset);
         const clonedContents = range.cloneContents();
-        fillClipboardData(ev, clonedContents);
+        fillHtmlTransferData(ev, "clipboardData", clonedContents);
     }
 
     /**

--- a/addons/html_editor/static/src/main/media/image_plugin.js
+++ b/addons/html_editor/static/src/main/media/image_plugin.js
@@ -224,16 +224,15 @@ export class ImagePlugin extends Plugin {
 
     setup() {
         this.imageSize = reactive({ displayName: "Default" });
+        this.addDomListener(this.editable, "pointerdown", (e) => {
+            const selection = this.dependencies.selection.getEditableSelection();
+            if (selection.isCollapsed && e.target.tagName === "IMG") {
+                this.setSelectionAroundImage(e.target);
+            }
+        });
         this.addDomListener(this.editable, "pointerup", (e) => {
             if (e.target.tagName === "IMG") {
-                const [anchorNode, anchorOffset, focusNode, focusOffset] = boundariesOut(e.target);
-                this.dependencies.selection.setSelection({
-                    anchorNode,
-                    anchorOffset,
-                    focusNode,
-                    focusOffset,
-                });
-                this.dependencies.selection.focusEditable();
+                this.setSelectionAroundImage(e.target);
             }
         });
         this.fileViewer = createFileViewer();
@@ -413,5 +412,16 @@ export class ImagePlugin extends Plugin {
 
     updateImageParams() {
         this.imageSize.displayName = this.imageSizeName;
+    }
+
+    setSelectionAroundImage(img) {
+        const [anchorNode, anchorOffset, focusNode, focusOffset] = boundariesOut(img);
+        this.dependencies.selection.setSelection({
+            anchorNode,
+            anchorOffset,
+            focusNode,
+            focusOffset,
+        });
+        this.dependencies.selection.focusEditable();
     }
 }

--- a/addons/html_editor/static/src/others/embedded_components/plugins/caption_plugin/caption_plugin.js
+++ b/addons/html_editor/static/src/others/embedded_components/plugins/caption_plugin/caption_plugin.js
@@ -52,6 +52,9 @@ export class CaptionPlugin extends Plugin {
         ],
         image_name_predicates: [this.getImageName.bind(this)],
         link_compatible_selection_predicates: [this.isLinkAllowedOnSelection.bind(this)],
+
+        /** Processors */
+        clipboard_content_processors: this.processContentForClipboard.bind(this),
     };
 
     setup() {
@@ -308,5 +311,16 @@ export class CaptionPlugin extends Plugin {
                 { normalize: false }
             );
         }
+    }
+
+    /**
+     * @param {DocumentFragment} clonedContents
+     * @param {import("@html_editor/core/selection_plugin").EditorSelection} selection
+     */
+    processContentForClipboard(clonedContents, selection) {
+        if (clonedContents.firstChild.nodeName === "IMG") {
+            clonedContents = selection.commonAncestorContainer.cloneNode(true);
+        }
+        return clonedContents;
     }
 }

--- a/addons/html_editor/static/src/others/embedded_components/plugins/caption_plugin/caption_plugin.js
+++ b/addons/html_editor/static/src/others/embedded_components/plugins/caption_plugin/caption_plugin.js
@@ -42,6 +42,8 @@ export class CaptionPlugin extends Plugin {
         clean_for_save_handlers: this.cleanForSave.bind(this),
         mount_component_handlers: this.setupNewCaption.bind(this),
         delete_handlers: this.afterDelete.bind(this),
+        before_cut_handlers: this.expandSelectionToCaption.bind(this),
+        before_drag_handlers: this.expandSelectionToCaption.bind(this),
         delete_image_overrides: this.handleDeleteImage.bind(this),
         after_save_media_dialog_handlers: this.onImageReplaced.bind(this),
         hints: [{ selector: "FIGCAPTION", text: _t("Write a caption...") }],
@@ -292,6 +294,19 @@ export class CaptionPlugin extends Plugin {
             });
             this.dependencies.history.addStep();
             return true;
+        }
+    }
+
+    expandSelectionToCaption(selection) {
+        const startFigure = closestElement(selection.anchorNode, "figure");
+        const endFigure = closestElement(selection.focusNode, "figure");
+
+        if (startFigure && startFigure === endFigure) {
+            const [anchorNode, anchorOffset, focusNode, focusOffset] = boundariesOut(startFigure);
+            this.dependencies.selection.setSelection(
+                { anchorNode, anchorOffset, focusNode, focusOffset },
+                { normalize: false }
+            );
         }
     }
 }

--- a/addons/html_editor/static/src/utils/clipboard.js
+++ b/addons/html_editor/static/src/utils/clipboard.js
@@ -13,20 +13,30 @@ function prependOriginToImages(doc, origin) {
 }
 
 /**
- * Fills clipboard data, also with the
- * application/vnd.odoo.odoo-editor mimetype so that it can recognized
- * on paste inside an editor.
- * @param {ClipboardEvent} ev copy event
+ * Fills clipboard or dataTransfer data, including the
+ * application/vnd.odoo.odoo-editor MIME type so it can be recognized
+ * when pasted or dropped inside an editor.
+ *
+ * @param {ClipboardEvent | DragEvent} ev - The event on which to set the data.
+ * @param {'clipboardData' | 'dataTransfer'} transferObjectProperty
  * @param {DocumentFragment} clonedContents
+ * @param {Object} [options]
+ * @param {boolean} [options.setEditorTransferData=true]
  */
-export function fillClipboardData(ev, clonedContents, { fillEditorClipboard = true } = {}) {
+
+export function fillHtmlTransferData(
+    ev,
+    transferObjectProperty,
+    clonedContents,
+    { setEditorTransferData = true } = {}
+) {
     const doc = ev.target.ownerDocument;
     const dataHtmlElement = doc.createElement("data");
     dataHtmlElement.append(clonedContents);
     prependOriginToImages(dataHtmlElement, doc.defaultView.location.origin);
     const htmlContent = dataHtmlElement.innerHTML;
-    ev.clipboardData.setData("text/html", htmlContent);
-    if (fillEditorClipboard) {
-        ev.clipboardData.setData("application/vnd.odoo.odoo-editor", htmlContent);
+    ev[transferObjectProperty].setData("text/html", htmlContent);
+    if (setEditorTransferData) {
+        ev[transferObjectProperty].setData("application/vnd.odoo.odoo-editor", htmlContent);
     }
 }

--- a/addons/html_editor/static/tests/caption.test.js
+++ b/addons/html_editor/static/tests/caption.test.js
@@ -1186,6 +1186,45 @@ test("should cut an image and its caption as a single embedded figure", async ()
     );
 });
 
+test("should copy an image along with its caption", async () => {
+    const captionId = 1;
+    const caption = "Hello";
+    const { el, editor } = await setupEditorWithEmbeddedCaption(
+        unformat(`
+            <p>a</p>
+            <figure contenteditable="false">
+                <img class="img-fluid test-image o_editable_media" src="${base64Img}">
+                <figcaption>${caption}</figcaption>
+            </figure>
+            <p>[]<br></p>
+        `)
+    );
+    const imgElement = el.querySelector("img");
+    const parent = imgElement.parentElement;
+    const index = childNodeIndex(imgElement);
+    setSelection({
+        anchorNode: parent,
+        anchorOffset: index,
+        focusNode: parent,
+        focusOffset: index + 1,
+    });
+
+    const clipboardData = new DataTransfer();
+    await press(["ctrl", "c"], { dataTransfer: clipboardData });
+    const copiedContent = clipboardData.getData("application/vnd.odoo.odoo-editor");
+    const fragment = parseHTML(editor.document, copiedContent);
+    expect(getContent(fragment)).toBe(
+        unformat(`
+            <figure contenteditable="false">
+                <img class="img-fluid test-image o_editable_media" src="${base64Img}" data-caption-id="${captionId}" data-caption="${caption}">
+                <figcaption ${getFigcaptionAttributes(captionId, caption)}>
+                    <input ${CAPTION_INPUT_ATTRIBUTES}>
+                </figcaption>
+            </figure>
+        `)
+    );
+});
+
 test("should properly parse figure without fig caption", async () => {
     await testEditor({
         config: configWithEmbeddedCaption,

--- a/addons/html_editor/static/tests/caption.test.js
+++ b/addons/html_editor/static/tests/caption.test.js
@@ -1,7 +1,7 @@
 import { expect, test } from "@odoo/hoot";
 import { manuallyDispatchProgrammaticEvent, click, press, queryOne, waitFor } from "@odoo/hoot-dom";
 import { animationFrame } from "@odoo/hoot-mock";
-import { contains, makeMockEnv, onRpc } from "@web/../tests/web_test_helpers";
+import { contains, makeMockEnv, onRpc, patchWithCleanup } from "@web/../tests/web_test_helpers";
 import { CaptionPlugin } from "@html_editor/others/embedded_components/plugins/caption_plugin/caption_plugin";
 import { MAIN_PLUGINS, EMBEDDED_COMPONENT_PLUGINS } from "@html_editor/plugin_sets";
 import { MAIN_EMBEDDINGS } from "@html_editor/others/embedded_components/embedding_sets";
@@ -10,8 +10,10 @@ import { setupEditor, testEditor } from "./_helpers/editor";
 import { unformat } from "./_helpers/format";
 import { deleteBackward, deleteForward, insertText } from "./_helpers/user_actions";
 import { cleanHints } from "./_helpers/dispatch";
-import { getContent } from "./_helpers/selection";
+import { getContent, setSelection } from "./_helpers/selection";
 import { expectElementCount } from "./_helpers/ui_expectations";
+import { childNodeIndex, nodeSize } from "@html_editor/utils/position";
+import { parseHTML } from "@html_editor/utils/html";
 
 class CaptionPluginWithPredictableId extends CaptionPlugin {
     getCaptionId() {
@@ -962,6 +964,173 @@ test("previewing an image without caption doesn't show the caption as title (eve
     await animationFrame();
     titleSpan = queryOne(".o-FileViewer .o-FileViewer-header span.text-truncate");
     expect(titleSpan.textContent).toBe(base64Img.replaceAll("\n", "%0A"));
+});
+
+test("should drag and drop image with its caption", async () => {
+    const captionId = 1;
+    const caption = "Hello";
+    const { el } = await setupEditorWithEmbeddedCaption(
+        unformat(`
+            <p>a</p>
+            <figure contenteditable="false">
+                <img class="img-fluid test-image o_editable_media" src="${base64Img}">
+                <figcaption>${caption}</figcaption>
+            </figure>
+            <p>b</p>
+        `)
+    );
+    const imgElement = el.querySelector("img");
+    const parent = imgElement.parentElement;
+    const index = childNodeIndex(imgElement);
+    setSelection({
+        anchorNode: parent,
+        anchorOffset: index,
+        focusNode: parent,
+        focusOffset: index + 1,
+    });
+    const targetNodeForDrop = el.lastChild;
+    patchWithCleanup(document, {
+        caretPositionFromPoint: () => ({
+            offsetNode: targetNodeForDrop,
+            offset: nodeSize(targetNodeForDrop),
+        }),
+    });
+
+    const dragdata = new DataTransfer();
+    await manuallyDispatchProgrammaticEvent(imgElement, "dragstart", { dataTransfer: dragdata });
+    await animationFrame();
+    const imageHTML = dragdata.getData("application/vnd.odoo.odoo-editor");
+    const dropData = new DataTransfer();
+    dropData.setData(
+        "text/html",
+        `<meta http-equiv="Content-Type" content="text/html;charset=UTF-8"><img src="${base64Img}">`
+    );
+    // Simulate the application/vnd.odoo.odoo-editor data that the browser would do.
+    dropData.setData("application/vnd.odoo.odoo-editor", imageHTML);
+    await manuallyDispatchProgrammaticEvent(targetNodeForDrop, "drop", { dataTransfer: dropData });
+    await animationFrame();
+
+    expect(getContent(el)).toBe(
+        unformat(`
+            <p>a</p>
+            <p>b</p>
+            <figure contenteditable="false">
+                <img class="img-fluid test-image o_editable_media" src="${base64Img}" data-caption-id="${captionId}" data-caption="${caption}">
+                <figcaption ${getFigcaptionAttributes(captionId, caption)}>
+                    <input ${CAPTION_INPUT_ATTRIBUTES}>
+                </figcaption>
+            </figure>
+            <p o-we-hint-text='Type "/" for commands' class="o-we-hint">[]<br></p>
+        `)
+    );
+});
+
+test("should drag and drop image with caption along with selected text", async () => {
+    const captionId = 1;
+    const caption = "Hello";
+    const { el } = await setupEditorWithEmbeddedCaption(
+        unformat(`
+            <p>[a</p>
+            <figure contenteditable="false">
+                <img class="img-fluid test-image o_editable_media" src="${base64Img}">
+                <figcaption>${caption}</figcaption>
+            </figure>
+            <p>b]</p>
+            <p>c</p>
+        `)
+    );
+    const imgElement = el.querySelector("img");
+    const targetNodeForDrop = el.lastChild;
+    patchWithCleanup(document, {
+        caretPositionFromPoint: () => ({
+            offsetNode: targetNodeForDrop,
+            offset: nodeSize(targetNodeForDrop),
+        }),
+    });
+
+    const dragdata = new DataTransfer();
+    await manuallyDispatchProgrammaticEvent(imgElement, "dragstart", { dataTransfer: dragdata });
+    await animationFrame();
+    const odooEditorData = dragdata.getData("application/vnd.odoo.odoo-editor");
+    const textHtml = dragdata.getData("text/html");
+    const dropData = new DataTransfer();
+    dropData.setData("text/html", textHtml);
+    // Simulate the application/vnd.odoo.odoo-editor data that the browser would do.
+    dropData.setData("application/vnd.odoo.odoo-editor", odooEditorData);
+    await manuallyDispatchProgrammaticEvent(targetNodeForDrop, "drop", { dataTransfer: dropData });
+    await animationFrame();
+
+    expect(getContent(el)).toBe(
+        unformat(`
+            <p><br></p>
+            <p>ca</p>
+            <figure contenteditable="false">
+                <img class="img-fluid test-image o_editable_media" src="${base64Img}" data-caption-id="${captionId}" data-caption="${caption}">
+                <figcaption ${getFigcaptionAttributes(captionId, caption)}>
+                    <input ${CAPTION_INPUT_ATTRIBUTES}>
+                </figcaption>
+            </figure>
+            <p>b[]</p>
+        `)
+    );
+});
+
+test("should cut an image and its caption as a single embedded figure", async () => {
+    const captionId = 1;
+    const captionText = "Hello";
+
+    const { el: editorRoot, editor } = await setupEditorWithEmbeddedCaption(
+        unformat(`
+            <p>a</p>
+            <p>b</p>
+            <figure contenteditable="false">
+                <img class="img-fluid test-image o_editable_media" src="${base64Img}">
+                <figcaption>${captionText}</figcaption>
+            </figure>
+            <p>c</p>
+        `)
+    );
+
+    const image = editorRoot.querySelector("img");
+    const figure = image.parentElement;
+    const imageIndex = childNodeIndex(image);
+
+    // Select the image node for cutting
+    setSelection({
+        anchorNode: figure,
+        anchorOffset: imageIndex,
+        focusNode: figure,
+        focusOffset: imageIndex + 1,
+    });
+
+    const clipboard = new DataTransfer();
+    const cutEvent = new ClipboardEvent("cut", { clipboardData: clipboard });
+    editor.editable.dispatchEvent(cutEvent);
+    await animationFrame();
+
+    // Verify editor content after cut
+    expect(getContent(editorRoot)).toBe(
+        unformat(`
+            <p>a</p>
+            <p>b</p>
+            <p>[]c</p>
+        `)
+    );
+
+    // Verify cut fragment stored inside clipboard data
+    const cutPayload = clipboard.getData("application/vnd.odoo.odoo-editor");
+    const fragment = parseHTML(editor.document, cutPayload);
+
+    expect(getContent(fragment)).toBe(
+        unformat(`
+            <figure contenteditable="false">
+                <img class="img-fluid test-image o_editable_media" src="${base64Img}" data-caption-id="${captionId}" data-caption="${captionText}">
+                <figcaption ${getFigcaptionAttributes(captionId, captionText)}>
+                    <input ${CAPTION_INPUT_ATTRIBUTES}>
+                </figcaption>
+            </figure>
+        `)
+    );
 });
 
 test("should properly parse figure without fig caption", async () => {

--- a/addons/html_editor/static/tests/image.test.js
+++ b/addons/html_editor/static/tests/image.test.js
@@ -1,5 +1,14 @@
 import { expect, test } from "@odoo/hoot";
-import { click, dblclick, pointerUp, press, queryOne, waitFor, waitForNone } from "@odoo/hoot-dom";
+import {
+    click,
+    dblclick,
+    pointerUp,
+    press,
+    queryOne,
+    waitFor,
+    waitForNone,
+    manuallyDispatchProgrammaticEvent,
+} from "@odoo/hoot-dom";
 import { animationFrame } from "@odoo/hoot-mock";
 import { contains } from "@web/../tests/web_test_helpers";
 import { base64Img, setupEditor } from "./_helpers/editor";
@@ -330,7 +339,9 @@ test("Image transformation disappears on backspace/delete", async () => {
     `);
     click("img.test-image");
     await expectElementCount(".o-we-toolbar", 1);
-    await contains(".o-we-toolbar div[name='image_modifiers'] button[name='image_transform']").click();
+    await contains(
+        ".o-we-toolbar div[name='image_modifiers'] button[name='image_transform']"
+    ).click();
     await expectElementCount(".transfo-container", 1);
     press("backspace");
     await expectElementCount(".transfo-container", 0);
@@ -338,12 +349,13 @@ test("Image transformation disappears on backspace/delete", async () => {
     click("img.test-image");
     await waitFor(".o-we-toolbar");
     await expectElementCount(".o-we-toolbar", 1);
-    await contains(".o-we-toolbar div[name='image_modifiers'] button[name='image_transform']").click();
+    await contains(
+        ".o-we-toolbar div[name='image_modifiers'] button[name='image_transform']"
+    ).click();
     await expectElementCount(".transfo-container", 1);
     press("delete");
     await expectElementCount(".transfo-container", 0);
 });
-
 
 test("Image transformation disappears on character key press", async () => {
     const { editor } = await setupEditor(`
@@ -351,7 +363,9 @@ test("Image transformation disappears on character key press", async () => {
     `);
     click("img.test-image");
     await expectElementCount(".o-we-toolbar", 1);
-    await contains(".o-we-toolbar div[name='image_modifiers'] button[name='image_transform']").click();
+    await contains(
+        ".o-we-toolbar div[name='image_modifiers'] button[name='image_transform']"
+    ).click();
     await expectElementCount(".transfo-container", 1);
     insertText(editor, "a");
     await expectElementCount(".transfo-container", 0);
@@ -578,4 +592,20 @@ test("Preview an image on dblclick", async () => {
     await dblclick("img.test-image");
     await animationFrame();
     expect(".o-FileViewer").toHaveCount(1);
+});
+
+test("should select image on pointerdown", async () => {
+    const { plugins } = await setupEditor(`
+        <img src="${base64Img}">
+        <p>test[]</p>
+    `);
+
+    const imgElement = document.querySelector("img");
+    await manuallyDispatchProgrammaticEvent(imgElement, "pointerdown");
+    await animationFrame();
+
+    const selectionPlugin = plugins.get("selection");
+    const selectedNode = selectionPlugin.getTargetedNodes()[0];
+
+    expect(selectedNode.tagName).toBe("IMG");
 });

--- a/addons/html_editor/static/tests/paste.test.js
+++ b/addons/html_editor/static/tests/paste.test.js
@@ -4342,6 +4342,130 @@ describe("onDrop", () => {
             `<p>ab<img class="img-fluid" data-file-name="image.png" src="${base64Image}">[]c</p>`
         );
     });
+    test("should drag and drop an image after another image", async () => {
+        const base64Image =
+            "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAgAAAAIAQMAAAD+wSzIAAAABlBMVEX///+/v7+jQ3Y5AAAADklEQVQI12P4AIX8EAgALgAD/aNpbtEAAAAASUVORK5CYII=";
+        const base64Image2 =
+            "data:image/png;base64, iVBORw0KGgoAAAANSUhEUgAAAAUA\n        AAAFCAYAAACNbyblAAAAHElEQVQI12P4//8/w38GIAXDIBKE0DHxgljNBAAO\n            9TXL0Y4OHwAAAABJRU5ErkJggg==";
+
+        const { el } = await setupEditor(
+            `<p>[<img class="img-fluid" data-file-name="image.png" src="${base64Image}">]<img class="img-fluid" data-file-name="image.png" src="${base64Image2}"></p>`
+        );
+        const pElement = el.firstChild;
+        const firstImage = pElement.childNodes[0];
+
+        patchWithCleanup(document, {
+            caretPositionFromPoint: () => ({
+                offsetNode: pElement,
+                offset: pElement.childNodes.length,
+            }),
+        });
+
+        const dragdata = new DataTransfer();
+        await dispatch(firstImage, "dragstart", { dataTransfer: dragdata });
+        await animationFrame();
+        const imageHTML = dragdata.getData("application/vnd.odoo.odoo-editor");
+        expect(imageHTML).toBe(
+            `<p><img class="img-fluid" data-file-name="image.png" src="${base64Image}"></p>`
+        );
+
+        const dropData = new DataTransfer();
+        dropData.setData(
+            "text/html",
+            `<meta http-equiv="Content-Type" content="text/html;charset=UTF-8"><img src="${base64Image}">`
+        );
+        // Simulate the application/vnd.odoo.odoo-editor data that the browser would do.
+        dropData.setData("application/vnd.odoo.odoo-editor", imageHTML);
+        await dispatch(pElement, "drop", { dataTransfer: dropData });
+        await animationFrame();
+
+        expect(getContent(el)).toBe(
+            `<p><img class="img-fluid" data-file-name="image.png" src="${base64Image2}"><img class="img-fluid" data-file-name="image.png" src="${base64Image}">[]</p>`
+        );
+    });
+    test("should drag and drop third image after first image", async () => {
+        const base64Image1 =
+            "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAAFUlEQVR42mP8z8BQz0AEYBxVSF+FABJADveWkH6oAAAAAElFTkSuQmCC";
+        const base64Image2 =
+            "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAgAAAAIAQMAAAD+wSzIAAAABlBMVEX///+/v7+jQ3Y5AAAADklEQVQI12P4AIX8EAgALgAD/aNpbtEAAAAASUVORK5CYII=";
+        const base64Image3 =
+            "data:image/png;base64, iVBORw0KGgoAAAANSUhEUgAAAAUA\n        AAAFCAYAAACNbyblAAAAHElEQVQI12P4//8/w38GIAXDIBKE0DHxgljNBAAO\n            9TXL0Y4OHwAAAABJRU5ErkJggg==";
+
+        const { el } = await setupEditor(
+            `<p><img class="img-fluid" data-file-name="image.png" src="${base64Image1}"><img class="img-fluid" data-file-name="image.png" src="${base64Image2}">[<img class="img-fluid" data-file-name="image.png" src="${base64Image3}">]</p>`
+        );
+        const pElement = el.firstChild;
+        const firstImage = pElement.childNodes[0];
+
+        patchWithCleanup(document, {
+            caretPositionFromPoint: () => ({ offsetNode: pElement, offset: 1 }),
+        });
+
+        const dragdata = new DataTransfer();
+        await dispatch(firstImage, "dragstart", { dataTransfer: dragdata });
+        await animationFrame();
+        const imageHTML = dragdata.getData("application/vnd.odoo.odoo-editor");
+        expect(imageHTML).toBe(
+            `<p><img class="img-fluid" data-file-name="image.png" src="${base64Image3}"></p>`
+        );
+
+        const dropData = new DataTransfer();
+        dropData.setData(
+            "text/html",
+            `<meta http-equiv="Content-Type" content="text/html;charset=UTF-8"><img src="${base64Image3}">`
+        );
+        // Simulate the application/vnd.odoo.odoo-editor data that the browser would do.
+        dropData.setData("application/vnd.odoo.odoo-editor", imageHTML);
+        await dispatch(pElement, "drop", { dataTransfer: dropData });
+        await animationFrame();
+
+        expect(getContent(el)).toBe(
+            `<p><img class="img-fluid" data-file-name="image.png" src="${base64Image1}"><img class="img-fluid" data-file-name="image.png" src="${base64Image3}">[]<img class="img-fluid" data-file-name="image.png" src="${base64Image2}"></p>`
+        );
+    });
+    test("should drag and drop multiple images after another image", async () => {
+        const base64Image1 =
+            "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAAFUlEQVR42mP8z8BQz0AEYBxVSF+FABJADveWkH6oAAAAAElFTkSuQmCC";
+        const base64Image2 =
+            "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAgAAAAIAQMAAAD+wSzIAAAABlBMVEX///+/v7+jQ3Y5AAAADklEQVQI12P4AIX8EAgALgAD/aNpbtEAAAAASUVORK5CYII=";
+        const base64Image3 =
+            "data:image/png;base64, iVBORw0KGgoAAAANSUhEUgAAAAUA\n        AAAFCAYAAACNbyblAAAAHElEQVQI12P4//8/w38GIAXDIBKE0DHxgljNBAAO\n            9TXL0Y4OHwAAAABJRU5ErkJggg==";
+
+        const { el } = await setupEditor(
+            `<p>[<img class="img-fluid" data-file-name="image.png" src="${base64Image1}"><img class="img-fluid" data-file-name="image.png" src="${base64Image2}">]<img class="img-fluid" data-file-name="image.png" src="${base64Image3}"></p>`
+        );
+        const pElement = el.firstChild;
+        const firstImage = pElement.childNodes[0];
+
+        patchWithCleanup(document, {
+            caretPositionFromPoint: () => ({
+                offsetNode: pElement,
+                offset: pElement.childNodes.length,
+            }),
+        });
+
+        const dragdata = new DataTransfer();
+        await dispatch(firstImage, "dragstart", { dataTransfer: dragdata });
+        await animationFrame();
+        const imageHTML = dragdata.getData("application/vnd.odoo.odoo-editor");
+        expect(imageHTML).toBe(
+            `<p><img class="img-fluid" data-file-name="image.png" src="${base64Image1}"><img class="img-fluid" data-file-name="image.png" src="${base64Image2}"></p>`
+        );
+
+        const dropData = new DataTransfer();
+        dropData.setData(
+            "text/html",
+            `<meta http-equiv="Content-Type" content="text/html;charset=UTF-8"><img src="${base64Image1}"><img src="${base64Image2}">`
+        );
+        // Simulate the application/vnd.odoo.odoo-editor data that the browser would do.
+        dropData.setData("application/vnd.odoo.odoo-editor", imageHTML);
+        await dispatch(pElement, "drop", { dataTransfer: dropData });
+        await animationFrame();
+
+        expect(getContent(el)).toBe(
+            `<p><img class="img-fluid" data-file-name="image.png" src="${base64Image3}"><img class="img-fluid" data-file-name="image.png" src="${base64Image1}"><img class="img-fluid" data-file-name="image.png" src="${base64Image2}">[]</p>`
+        );
+    });
     test("should drag and drop banner", async () => {
         const { el } = await setupEditor(
             `<p>[a</p>


### PR DESCRIPTION
**Current behavior before PR:**

- When dragging and dropping elements with attributes and classes, any non-whitelisted attributes and classes were removed during the `cleanForPaste` process. This caused structural issues and loss of formatting after the drop.

- When an image had a caption and only the image was selected and cut, the image was removed but the caption incorrectly remained

- When dragging and dropping an image without an active selection on the image, the image was not removed during the drop. This resulted in the image being duplicated, one at the original position and another at the drop location.

- When selecting an image with a caption and performing copy-paste, only the image was copied and pasted.

**Desired behavior after PR is merged:**

- An `application/vnd.odoo.odoo-editor` dataTransfer type is now set during `dragstart` for editor elements. As a result, we no longer need to clean the `dataTransfer` content during drop, preserving the original structure and preventing the loss of attributes and classes.

- Cutting an image that contains a caption now correctly removes both the image and its associated caption.

- The image is now selected on pointerdown event . As a result, when the image is dropped, deleteSelection correctly removes the original image before inserting the new one, preventing duplication.

-  Now, when an image with a caption is selected and copy-pasted, the entire image along with its caption is correctly copied and pasted.


task: 4914451