### PR TITLE
[FIX] account_edi_ubl_cii: fix traceback when printing multiple invoices

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_move.py
+++ b/addons/account_edi_ubl_cii/models/account_move.py
@@ -73,11 +73,12 @@ class AccountMove(models.Model):
             for partner in self.commercial_partner_id
             if (suggested_format := partner ._get_suggested_ubl_cii_edi_format())
         }
-        if self.state == 'posted' and (self.ubl_cii_xml_id or suggested_edi_formats):
+        posted_invoices = self.filtered(lambda move: move.state == 'posted')
+        if posted_invoices.ubl_cii_xml_id or suggested_edi_formats:
             print_items.append({
                 'key': 'download_ubl',
                 'description': _('Export XML'),
-                **self.action_invoice_download_ubl(),
+                **posted_invoices.action_invoice_download_ubl(),
             })
         return print_items
 


### PR DESCRIPTION
<b>Steps to reproduce:</b>
1. Go to Accounting > Customers > Invoices.
2. Select more than one invoice.
3. Click on "Print".

<b>Issue:</b>
When selecting multiple invoices and clicking on "Print", a traceback was raised due to a singleton error.

<b>Cause:</b>
This was introduced in [PR #215389](https://github.com/odoo/odoo/pull/215389). The method did not check for multiple records and used `self.state` and `self.ubl_cii_xml_id` directly, causing a crash when `self` contained more than one invoice.

<b>Solution:</b>
Applied a `filtered()`  to only process invoices that are in 'posted'. This ensures that only valid individual records are handled, and avoids accessing fields directly on a multi-record set.

<b>opw-4912628</b>

