### PR TITLE
[IMP] account: show reset to draft button when invoice is not hashed

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -1796,12 +1796,11 @@ class AccountMove(models.Model):
         for move in self:
             move.has_reconciled_entries = len(move.line_ids._reconciled_lines()) > 1
 
-    @api.depends('restrict_mode_hash_table', 'state', 'inalterable_hash')
+    @api.depends('state', 'inalterable_hash')
     def _compute_show_reset_to_draft_button(self):
         for move in self:
             move.show_reset_to_draft_button = (
-                not self._is_move_restricted(move) \
-                and not move.inalterable_hash
+                not move.inalterable_hash
                 and (move.state == 'cancel' or (move.state == 'posted' and not move.need_cancel_request))
             )
 


### PR DESCRIPTION
Previously, the `Reset to Draft` button was hidden for all invoices in hashed journals, even if the invoice itself was not hashed. Now, the button is visible for invoices that are not hashed.

Steps to reproduce:
- Create and post a customer invoice dated Feb 2, 2023.
- Set the Sales Lock Date to Feb 28, 2023.
- Enable the hash setting on the Sales journal.
- The 2023 invoice is not hashed due to the lock date.
- Create and post a second invoice in 2025 (this one is hashed).
- Remove the Sales Lock Date.
- Open the 2023 invoice.

Before: `Reset to Draft` button was not visible for the 2023 invoice.
After:  `Reset to Draft` button is now visible for the 2023 invoice.

task-4911601

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
