### PR TITLE
[IMP] project*: use Domain

### DIFF
--- a/addons/project/controllers/thread.py
+++ b/addons/project/controllers/thread.py
@@ -1,7 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from odoo.fields import Domain
 from odoo.http import request
-from odoo.osv import expression
 from odoo.addons.mail.controllers import thread
 
 
@@ -19,7 +19,7 @@ class ThreadController(thread.ThreadController):
                     ("res_id", "=", thread.project_id.id),
                     ("partner_id", "in", partners.ids),
                 ]
-                domain = expression.OR([domain, project_domain])
+                domain = Domain.OR([domain, project_domain])
             # sudo: mail.followers - filtering partners that are followers is acceptable
             return request.env["mail.followers"].sudo().search(domain).partner_id
         return super()._filter_message_post_partners(thread, partners)

--- a/addons/project/models/project_tags.py
+++ b/addons/project/models/project_tags.py
@@ -1,10 +1,9 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from random import randint
 
 from odoo import api, fields, models
-from odoo.osv import expression
+from odoo.fields import Domain
 from odoo.tools import SQL
 
 
@@ -36,14 +35,14 @@ class ProjectTags(models.Model):
     def formatted_read_group(self, domain, groupby=(), aggregates=(), having=(), offset=0, limit=None, order=None) -> list[dict]:
         if 'project_id' in self.env.context:
             tag_ids = [id_ for id_, _label in self.name_search()]
-            domain = expression.AND([domain, [('id', 'in', tag_ids)]])
+            domain = Domain.AND([domain, [('id', 'in', tag_ids)]])
         return super().formatted_read_group(domain, groupby, aggregates, having=having, offset=offset, limit=limit, order=order)
 
     @api.model
     def search_read(self, domain=None, fields=None, offset=0, limit=None, order=None):
         if 'project_id' in self.env.context:
             tag_ids = [id_ for id_, _label in self.name_search()]
-            domain = expression.AND([domain, [('id', 'in', tag_ids)]])
+            domain = Domain.AND([domain, [('id', 'in', tag_ids)]])
             return self.arrange_tag_list_by_id(super().search_read(domain=domain, fields=fields, offset=offset, limit=limit), tag_ids)
         return super().search_read(domain=domain, fields=fields, offset=offset, limit=limit, order=order)
 
@@ -66,7 +65,7 @@ class ProjectTags(models.Model):
         if limit is None:
             return super().name_search(name, domain, operator, limit)
         tags = self.browse()
-        domain = expression.AND([self._search_display_name(operator, name), domain or []])
+        domain = Domain.AND([self._search_display_name(operator, name), domain or Domain.TRUE])
         if self.env.context.get('project_id'):
             # optimisation for large projects, we look first for tags present on the last 1000 tasks of said project.
             # when not enough results are found, we complete them with a fallback on a regular search
@@ -82,9 +81,9 @@ class ProjectTags(models.Model):
                     LIMIT 1000
                 ) AS project_tasks_tags
             )""", project_id=self.env.context['project_id'])
-            tags += self.search_fetch(expression.AND([[('id', 'in', tag_sql)], domain]), ['display_name'], limit=limit)
+            tags += self.search_fetch(Domain('id', 'in', tag_sql) & domain, ['display_name'], limit=limit)
         if len(tags) < limit:
-            tags += self.search_fetch(expression.AND([[('id', 'not in', tags.ids)], domain]), ['display_name'], limit=limit - len(tags))
+            tags += self.search_fetch(Domain('id', 'not in', tags.ids) & domain, ['display_name'], limit=limit - len(tags))
         return [(tag.id, tag.display_name) for tag in tags.sudo()]
 
     @api.model

--- a/addons/project/models/project_update.py
+++ b/addons/project/models/project_update.py
@@ -1,12 +1,9 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from datetime import timedelta
 from dateutil.relativedelta import relativedelta
-from werkzeug.urls import url_encode
 
 from odoo import api, fields, models
-from odoo.osv import expression
+from odoo.fields import Domain
 from odoo.tools import format_amount, formatLang
 
 STATUS_COLOR = {
@@ -139,9 +136,9 @@ class ProjectUpdate(models.Model):
             [('project_id', '=', project.id),
              '|', ('deadline', '<', fields.Date.context_today(self) + relativedelta(years=1)), ('deadline', '=', False)])._get_data_list()
         updated_milestones = self._get_last_updated_milestone(project)
-        domain = [('project_id', '=', project.id)]
+        domain = Domain('project_id', '=', project.id)
         if project.last_update_id.create_date:
-            domain = expression.AND([domain, [('create_date', '>', project.last_update_id.create_date)]])
+            domain &= Domain('create_date', '>', project.last_update_id.create_date)
         created_milestones = Milestone.search(domain)._get_data_list()
         return {
             'show_section': (list_milestones or updated_milestones or created_milestones) and True or False,

--- a/addons/project/tests/test_burndown_chart.py
+++ b/addons/project/tests/test_burndown_chart.py
@@ -1,11 +1,9 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from freezegun import freeze_time
 from datetime import datetime
 
-from odoo import Command
-from odoo.osv.expression import AND, OR
+from odoo.fields import Command, Domain
 from odoo.tests.common import tagged, HttpCase
 from .test_project_base import TestProjectCommon
 
@@ -150,7 +148,7 @@ class TestBurndownChartCommon(TestProjectCommon):
         })
         cls.set_create_date('project_task', cls.task_bis.id, create_date)
 
-        cls.deleted_domain = AND([[('project_id', '!=', False)], [('project_id', '=', cls.project_1.id)]])
+        cls.deleted_domain = Domain('project_id', '!=', False) & Domain('project_id', '=', cls.project_1.id)
 
         # Precommit to have the records in db and allow to rollback at the end of test
         cls.env.cr.flush()
@@ -297,12 +295,12 @@ class TestBurndownChart(TestBurndownChartCommon):
             project_expected_is_closed_dict[(month_key, 'closed')] = 6
 
         # Check that we get the expected results for the complete data of `self.project`.
-        self.check_read_group_results(AND([burndown_chart_domain, project_domain]), project_expected_dict)
-        self.check_read_group_is_closed_results(AND([burndown_chart_domain, project_domain]), project_expected_is_closed_dict)
+        self.check_read_group_results(Domain.AND([burndown_chart_domain, project_domain]), project_expected_dict)
+        self.check_read_group_is_closed_results(Domain.AND([burndown_chart_domain, project_domain]), project_expected_is_closed_dict)
 
         # Check that we get the expected results for the complete data of `self.project` & `self.project_2` using an
         # `ilike` in the domain.
-        all_projects_domain_with_ilike = OR([project_domain, [('project_id', 'ilike', 'mySearchTag')]])
+        all_projects_domain_with_ilike = Domain.OR([project_domain, [('project_id', 'ilike', 'mySearchTag')]])
         project_expected_dict = {key: val if key[1] != self.todo_stage.id else val + 2 for key, val in project_expected_dict.items()}
         project_expected_is_closed_dict = {key: val if key[1] == 'closed' else val + 2 for key, val in project_expected_is_closed_dict.items()}
         for i in range(2, 11):
@@ -311,8 +309,8 @@ class TestBurndownChart(TestBurndownChartCommon):
         project_expected_is_closed_dict[(f"{months[11]} {self.current_year - 1}", 'open')] = 2
         for i in range(current_month):
             project_expected_is_closed_dict[(f"{months[i]} {self.current_year}", 'open')] = 2
-        self.check_read_group_results(AND([burndown_chart_domain, all_projects_domain_with_ilike]), project_expected_dict)
-        self.check_read_group_is_closed_results(AND([burndown_chart_domain, all_projects_domain_with_ilike]), project_expected_is_closed_dict)
+        self.check_read_group_results(Domain.AND([burndown_chart_domain, all_projects_domain_with_ilike]), project_expected_dict)
+        self.check_read_group_is_closed_results(Domain.AND([burndown_chart_domain, all_projects_domain_with_ilike]), project_expected_is_closed_dict)
 
         date_from, date_to = ('%s-01-01' % (self.current_year - 1), '%s-03-01' % (self.current_year - 1))
         date_from_is_closed, date_to_is_closed = ('%s-10-01' % (self.current_year - 1), '%s-12-01' % (self.current_year - 1))
@@ -323,11 +321,11 @@ class TestBurndownChart(TestBurndownChartCommon):
             ('February %s' % (self.current_year - 1), self.todo_stage.id): 1,
             ('February %s' % (self.current_year - 1), self.in_progress_stage.id): 2,
         }
-        complex_domain = AND([burndown_chart_domain, all_projects_domain_with_ilike, date_and_user_domain])
+        complex_domain = Domain.AND([burndown_chart_domain, all_projects_domain_with_ilike, date_and_user_domain])
         self.check_read_group_results(complex_domain, complex_domain_expected_dict)
 
         date_and_user_domain = [('date', '>=', date_from_is_closed), ('date', '<', date_to_is_closed), ('user_ids', 'ilike', 'ProjectUser')]
-        complex_domain = AND([burndown_chart_domain, all_projects_domain_with_ilike, date_and_user_domain])
+        complex_domain = Domain.AND([burndown_chart_domain, all_projects_domain_with_ilike, date_and_user_domain])
         complex_domain_expected_dict = {
             ('October %s' % (self.current_year - 1), 'closed'): 2.0,
             ('October %s' % (self.current_year - 1), 'open'): 1.0,
@@ -338,7 +336,7 @@ class TestBurndownChart(TestBurndownChartCommon):
 
         date_and_user_domain = [('date', '>=', date_from), ('date', '<', date_to), ('user_ids', 'ilike', 'ProjectManager')]
         milestone_domain = [('milestone_id', 'ilike', 'Test')]
-        complex_domain = AND([burndown_chart_domain, all_projects_domain_with_ilike, date_and_user_domain, milestone_domain])
+        complex_domain = Domain.AND([burndown_chart_domain, all_projects_domain_with_ilike, date_and_user_domain, milestone_domain])
         complex_domain_expected_dict = {
             ('January %s' % (self.current_year - 1), self.todo_stage.id): 1,
             ('February %s' % (self.current_year - 1), self.todo_stage.id): 1,
@@ -347,7 +345,7 @@ class TestBurndownChart(TestBurndownChartCommon):
 
         date_and_user_domain = [('date', '>=', date_from_is_closed), ('date', '<', date_to_is_closed), ('user_ids', 'ilike', 'ProjectManager')]
         milestone_domain = [('milestone_id', 'ilike', 'Test')]
-        complex_domain = AND([burndown_chart_domain, all_projects_domain_with_ilike, date_and_user_domain, milestone_domain])
+        complex_domain = Domain.AND([burndown_chart_domain, all_projects_domain_with_ilike, date_and_user_domain, milestone_domain])
         complex_domain_expected_dict = {
             ('October %s' % (self.current_year - 1), 'open'): 1.0,
             ('November %s' % (self.current_year - 1), 'closed'): 1.0

--- a/addons/project/tests/test_project_sharing.py
+++ b/addons/project/tests/test_project_sharing.py
@@ -1,8 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import Command
-from odoo.osv import expression
 from odoo.exceptions import AccessError
+from odoo.fields import Command, Domain
 from odoo.tests import Form, tagged
 from odoo.tools import mute_logger
 
@@ -521,51 +520,37 @@ class TestProjectSharing(TestProjectSharingCommon):
         self.task_portal.with_user(self.user_portal).write({'stage_id': self.project_portal.type_ids[-1].id})
 
     def test_orm_method_with_true_false_domain(self):
-        """ Test orm method overriden in project for project sharing works with TRUE_LEAF/FALSE_LEAF
+        """ Test orm method overriden in project for project sharing works
 
             Test Case
             =========
             1) Share a project in edit mode for portal user
-            2) Search the portal task contained in the project shared by using a domain with TRUE_LEAF
+            2) Search the portal task contained in the project shared by using a TRUE domain
             3) Check the task is found with the `search` method
-            4) filter the task with `TRUE_DOMAIN` and check if the task is always returned by `filtered_domain` method
-            5) filter the task with `FALSE_DOMAIN` and check if no task is returned by `filtered_domain` method
-            6) Search the task with `FALSE_LEAF` and check no task is found with `search` method
-            7) Call `read_group` method with `TRUE_LEAF` in the domain and check if the task is found
-            8) Call `read_group` method with `FALSE_LEAF` in the domain and check if no task is found
+            4) Search the task with `FALSE` and check no task is found with `search` method
+            5) Call `read_group` method with `TRUE` in the domain and check if the task is found
+            6) Call `read_group` method with `FALSE` in the domain and check if no task is found
         """
-        domain = [('id', '=', self.task_portal.id)]
+        domain = Domain('id', '=', self.task_portal.id)
         self.project_portal.write({
             'collaborator_ids': [Command.create({
                 'partner_id': self.user_portal.partner_id.id,
             })],
         })
-        task = self.env['project.task'].with_user(self.user_portal).search(
-            expression.AND([
-                expression.TRUE_DOMAIN,
-                domain,
-            ])
-        )
+        task = self.env['project.task'].with_user(self.user_portal).search(domain)
         self.assertTrue(task, 'The task should be found.')
-        self.assertEqual(task, task.filtered_domain(expression.TRUE_DOMAIN), 'The task found should be kept since the domain is truly')
-        self.assertFalse(task.filtered_domain(expression.FALSE_DOMAIN), 'The task should not be found since the domain is falsy')
-        task = self.env['project.task'].with_user(self.user_portal).search(
-            expression.AND([
-                expression.FALSE_DOMAIN,
-                domain,
-            ]),
-        )
+        task = self.env['project.task'].with_user(self.user_portal).search(Domain.FALSE)
         self.assertFalse(task, 'No task should be found since the domain contained a falsy tuple.')
 
         task_read_group = self.env['project.task'].formatted_read_group(
-            expression.AND([expression.TRUE_DOMAIN, domain]),
+            domain,
             aggregates=['id:min', '__count'],
         )
         self.assertEqual(task_read_group[0]['__count'], 1, 'The task should be found with the formatted_read_group method containing a truly tuple.')
         self.assertEqual(task_read_group[0]['id:min'], self.task_portal.id, 'The task should be found with the formatted_read_group method containing a truly tuple.')
 
         task_read_group = self.env['project.task'].formatted_read_group(
-            expression.AND([expression.FALSE_DOMAIN, domain]),
+            Domain.FALSE,
             aggregates=['__count'],
         )
         self.assertFalse(task_read_group[0]['__count'], 'No result should found with the formatted_read_group since the domain is falsy.')

--- a/addons/project_account/models/project_project.py
+++ b/addons/project_account/models/project_project.py
@@ -3,9 +3,9 @@
 import json
 from ast import literal_eval
 from collections import defaultdict
-from odoo.osv import expression
 
 from odoo import models
+from odoo.fields import Domain
 
 
 class ProjectProject(models.Model):
@@ -131,10 +131,9 @@ class ProjectProject(models.Model):
         return [('account_id', '=', self.account_id.id), ('move_line_id', '=', False)]
 
     def _get_items_from_aal(self, with_action=True):
-        domain = self._get_domain_aal_with_no_move_line()
-        domain = expression.AND([
-            domain,
-            [('category', 'not in', ['manufacturing_order', 'picking_entry'])]
+        domain = Domain.AND([
+            self._get_domain_aal_with_no_move_line(),
+            Domain('category', 'not in', ['manufacturing_order', 'picking_entry']),
         ])
         aal_other_search = self.env['account.analytic.line'].sudo().search_read(domain, ['id', 'amount', 'currency_id'])
         if not aal_other_search:

--- a/addons/project_hr_expense/models/project_project.py
+++ b/addons/project_hr_expense/models/project_project.py
@@ -3,7 +3,7 @@
 import json
 
 from odoo import models
-from odoo.osv import expression
+from odoo.fields import Domain
 
 
 class ProjectProject(models.Model):
@@ -29,9 +29,9 @@ class ProjectProject(models.Model):
         return action
 
     def _get_add_purchase_items_domain(self):
-        return expression.AND([
+        return Domain.AND([
             super()._get_add_purchase_items_domain(),
-            [('expense_id', '=', False)],
+            Domain('expense_id', '=', False),
         ])
 
     def action_profitability_items(self, section_name, domain=None, res_id=False):
@@ -106,7 +106,7 @@ class ProjectProject(models.Model):
         return expense_profitability_items
 
     def _get_profitability_aal_domain(self):
-        return expression.AND([
+        return Domain.AND([
             super()._get_profitability_aal_domain(),
             ['|', ('move_line_id', '=', False), ('move_line_id.expense_id', '=', False)],
         ])

--- a/addons/project_purchase/models/project_project.py
+++ b/addons/project_purchase/models/project_project.py
@@ -3,7 +3,7 @@
 import json
 
 from odoo import fields, models, _
-from odoo.osv import expression
+from odoo.fields import Domain
 
 
 class ProjectProject(models.Model):
@@ -118,7 +118,7 @@ class ProjectProject(models.Model):
         return buttons
 
     def _get_profitability_aal_domain(self):
-        return expression.AND([
+        return Domain.AND([
             super()._get_profitability_aal_domain(),
             ['|', ('move_line_id', '=', False), ('move_line_id.purchase_line_id', '=', False)],
         ])

--- a/addons/project_stock/models/project_project.py
+++ b/addons/project_stock/models/project_project.py
@@ -1,7 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import models, _
-from odoo.osv.expression import AND
+from odoo.fields import Domain
 
 
 class ProjectProject(models.Model):
@@ -20,10 +20,10 @@ class ProjectProject(models.Model):
         return self._get_picking_action(_('Stock Moves'))
 
     def _get_picking_action(self, action_name, picking_type=None):
-        domain = [('project_id', '=', self.id)]
+        domain = Domain('project_id', '=', self.id)
         context = {'default_project_id': self.id}
         if picking_type:
-            domain = AND([domain, [('picking_type_id.code', '=', picking_type)]])
+            domain &= Domain('picking_type_id.code', '=', picking_type)
             context['restricted_picking_type_code'] = picking_type
             if picking_type == 'outgoing':
                 context['default_partner_id'] = self.partner_id.id

--- a/addons/project_stock_account/models/project_project.py
+++ b/addons/project_stock_account/models/project_project.py
@@ -1,8 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo.osv import expression
-
 from odoo import models, _lt
+from odoo.fields import Domain
 
 
 class Project(models.Model):
@@ -29,11 +28,7 @@ class Project(models.Model):
         return profitability_items
 
     def _get_items_from_aal_picking(self, with_action=True):
-        domain = self._get_domain_aal_with_no_move_line()
-        domain = expression.AND([
-            domain,
-            [('category', '=', 'picking_entry')]
-        ])
+        domain = Domain(self._get_domain_aal_with_no_move_line()) & Domain('category', '=', 'picking_entry')
         aal_other_search = self.env['account.analytic.line'].sudo().search_read(domain, ['id', 'amount', 'currency_id'])
         if not aal_other_search:
             return False

--- a/addons/project_timesheet_holidays/models/account_analytic.py
+++ b/addons/project_timesheet_holidays/models/account_analytic.py
@@ -1,9 +1,8 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import api, fields, models, _
 from odoo.exceptions import RedirectWarning, UserError
-from odoo.osv import expression
+from odoo.fields import Domain
 
 
 class AccountAnalyticLine(models.Model):
@@ -51,7 +50,8 @@ class AccountAnalyticLine(models.Model):
         return  super()._check_can_create()
 
     def _get_favorite_project_id_domain(self, employee_id=False):
-        return expression.AND([
+        return Domain.AND([
             super()._get_favorite_project_id_domain(employee_id),
-            [('holiday_id', '=', False), ('global_leave_id', '=', False)],
+            Domain('holiday_id', '=', False),
+            Domain('global_leave_id', '=', False),
         ])


### PR DESCRIPTION
In order to deprecate odoo.osv, we must first stop using it and replace it with Domain. This covers most of usages in account.

task-4280707
odoo/enterprise#89279


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
