### PR TITLE
[FIX] account: prevent crash when vendor has multiple uoms across com…

### DIFF
--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -804,7 +804,8 @@ class AccountMoveLine(models.Model):
         for line in self.filtered(lambda l: l.parent_state == 'draft'):
             # vendor bills should have the product purchase UOM
             if line.move_id.is_purchase_document():
-                line.product_uom_id = line.product_id.seller_ids.filtered(lambda s: s.partner_id == line.partner_id).product_uom_id or line.product_id.uom_id
+                seller_ids = line.product_id.seller_ids._get_filtered_supplier(line.company_id, line.product_id, False)
+                line.product_uom_id = seller_ids[:1].product_uom_id or line.product_id.uom_id
             else:
                 line.product_uom_id = line.product_id.uom_id
 

--- a/addons/account/tests/test_account_move_in_invoice.py
+++ b/addons/account/tests/test_account_move_in_invoice.py
@@ -2772,6 +2772,43 @@ class TestAccountMoveInInvoiceOnchanges(AccountTestInvoicingCommon):
         bill_uom = bill.invoice_line_ids[0].product_uom_id
         self.assertEqual(bill_uom, uom_kgm)
 
+    def test_vendor_uom_per_company(self):
+        """Vendor bill should use correct seller UoM per company."""
+        uom_unit = self.env.ref('uom.product_uom_unit')
+        uom_gram = self.env.ref('uom.product_uom_gram')
+        uom_kgm = self.env.ref('uom.product_uom_kgm')
+        other_company = self.setup_other_company()['company']
+
+        product = self.env['product.product'].create({
+            'name': "Shared Product",
+            'uom_id': uom_kgm.id,
+            'standard_price': 100.0,
+            'seller_ids': [
+                Command.create({
+                    'partner_id': self.partner_a.id,
+                    'company_id': self.env.company.id,
+                    'product_uom_id': uom_unit.id,
+                }),
+                Command.create({
+                    'partner_id': self.partner_a.id,
+                    'company_id': self.env.company.id,
+                    'product_uom_id': uom_gram.id,
+                }),
+                Command.create({
+                    'partner_id': self.partner_a.id,
+                    'company_id': other_company.id,
+                    'product_uom_id': uom_kgm.id,
+                }),
+            ]
+        })
+
+        bill_1 = self.init_invoice(move_type='in_invoice', products=[product])
+        self.assertIn(
+            bill_1.invoice_line_ids[0].product_uom_id,
+            [uom_unit, uom_gram],
+            "The selected UoM should be either Unit or Gram for the seller in the bill's company."
+        )
+
     def test_manual_label_change_on_payment_term_line(self):
         """
         Ensure label of the payment term line can be changed manually


### PR DESCRIPTION
**Step to reproduce:** 
1. Install purchase and account module. 
2. Enable the uom option (Purchase > Configuration > Settings).
3. Create a vendor (partner).
4. Set up companies (have at least two companies).
5. Create a product (Vendors bills > Product) that is shared across two companies.
6. Go to Vendors > Product : in the product’s Purchase tab:
                    - Add the same vendor twice - one line for each company.
                    - Assign different UoMs (e.g., “Unit(s)” for US company and “Kilogram(s)” for AT company).
7. Switch to one company. 
8. Create a vendor bill in one of the companies using that product and vendor.

**Issue:** 

A ValueError is raised when creating the vendor bill:

`ValueError: Wrong value for account.move.line.product_uom_id: uom.uom(1, 2)`

https://github.com/odoo/odoo/blob/0e23327c322acbdf6acfecd52385ffee0266220c/addons/account/models/account_move_line.py#L806-L807

**Cause:** 

During the computation of product_uom_id  where retrieves all seller records
matching the partner_id  but fails to limit the result.

**Solution:** 

To fix this, retrieve sellers by both partner_id and company_id and first matching 
seller is used. This ensures the UoM is correctly set according to the company also.

opw-4877577

Co-authored-by: PIYUSH <pish@odoo.com>