### PR TITLE
Close the linktools on "discard" after creation (in iframe)

### DIFF
--- a/addons/html_editor/static/src/main/link/link_plugin.js
+++ b/addons/html_editor/static/src/main/link/link_plugin.js
@@ -559,6 +559,9 @@ export class LinkPlugin extends Plugin {
                 this.restoreSavePoint();
                 if (linkElement.isConnected) {
                     this.openLinkTools(linkElement);
+                } else {
+                    this.linkInDocument = null;
+                    this.currentOverlay.close();
                 }
                 this.dependencies.selection.focusEditable();
             },

--- a/addons/html_editor/static/tests/link/popover.test.js
+++ b/addons/html_editor/static/tests/link/popover.test.js
@@ -441,6 +441,15 @@ describe("Link creation", () => {
             );
             expect(cleanLinkArtifacts(getContent(el))).toBe('<p><a href="#">Hello[]</a></p>');
         });
+        test("discard should close the popover (in iframe)", async () => {
+            await setupEditor("<p>[Hello]</p>", { props: { iframe: true } });
+            await waitFor(".o-we-toolbar");
+            await click(".o-we-toolbar .fa-link");
+            await waitFor(".o-we-linkpopover", { timeout: 1500 });
+            await click(".o_we_discard_link");
+            await animationFrame();
+            expect(".o-we-linkpopover").toHaveCount(0);
+        });
         test("should convert valid url to https link", async () => {
             const { el } = await setupEditor("<p>[Hello]</p>");
             await waitFor(".o-we-toolbar");


### PR DESCRIPTION
Steps to reproduce:
- Open website builder
- Select some text and "Add a link" with the toolbar
- Fill the URL field
- Select "Button Primary"
- Click "Discard"
- Bugs: The link popover does not closes The dom changes are discarded, but it still shows the same info

task-4367641
