### PR TITLE
[FIX] ir_sequence: prevent an error on generating a sequences

### DIFF
--- a/odoo/addons/base/models/ir_sequence.py
+++ b/odoo/addons/base/models/ir_sequence.py
@@ -234,7 +234,7 @@ class IrSequence(models.Model):
         try:
             interpolated_prefix = _interpolate(self.prefix, d)
             interpolated_suffix = _interpolate(self.suffix, d)
-        except (ValueError, TypeError):
+        except (ValueError, TypeError, KeyError):
             raise UserError(_('Invalid prefix or suffix for sequence %r', self.name))
         return interpolated_prefix, interpolated_suffix
 

--- a/odoo/addons/base/tests/test_ir_sequence.py
+++ b/odoo/addons/base/tests/test_ir_sequence.py
@@ -192,6 +192,20 @@ class TestIrSequenceGenerate(BaseCase):
             with self.assertRaises(UserError):
                 env['ir.sequence'].next_by_code('test_sequence_type_7')
 
+    def test_ir_sequence_suffix(self):
+        """ test whether a user error is raised for an invalid sequence """
+
+        # try to create a sequence with invalid suffix
+        with environment() as env:
+            env['ir.sequence'].create({
+                'code': 'test_sequence_type_8',
+                'name': 'Test sequence',
+                'prefix': '',
+                'suffix': '/%(invalid)s',
+            })
+            with self.assertRaisesRegex(UserError, "Invalid prefix or suffix"):
+                env['ir.sequence'].next_by_code('test_sequence_type_8')
+
     @classmethod
     def tearDownClass(cls):
         drop_sequence('test_sequence_type_5')


### PR DESCRIPTION
Currently, an error is raised when a sequence is generated with an invalid legend in the prefix or suffix.

**Steps to reproduce:**
- Install Sales module.
- Update the sale order sequence prefix to S%(days)s.
- Create a new sale order.

**Error:**
`KeyError - 'days'`

**Cause:**
An error occurs when the user provides an invalid suffix in `ir_sequence` and the system tries to generate that sequence at [1].

[1] - https://github.com/odoo/odoo/blob/18da9b6dfc9dc376700cd948a09ae201bf897990/odoo/addons/base/models/ir_sequence.py#L235-L236

**Fix:**
To resolve the issue, raise a user error for an invalid sequence.

**Ref:** https://github.com/odoo/odoo/commit/18cac1caa21149d70009aa50f3e90dfbc18456a3

Sentry - 6684586181