### PR TITLE
[FIX] html_editor: do not sanitize t-out attributes

### DIFF
--- a/addons/html_editor/static/src/core/sanitize_plugin.js
+++ b/addons/html_editor/static/src/core/sanitize_plugin.js
@@ -31,7 +31,7 @@ export class SanitizePlugin extends Plugin {
         return this.DOMPurify.sanitize(elem, {
             IN_PLACE: true,
             ADD_TAGS: ["#document-fragment", "fake-el"],
-            ADD_ATTR: ["contenteditable"],
+            ADD_ATTR: ["contenteditable", "t-field", "t-out", "t-esc"],
         });
     }
 

--- a/addons/html_editor/static/src/main/chatgpt/chatgpt_translate_plugin.js
+++ b/addons/html_editor/static/src/main/chatgpt/chatgpt_translate_plugin.js
@@ -27,16 +27,11 @@ export class ChatGPTTranslatePlugin extends Plugin {
                 id: "translate",
                 groupId: "ai",
                 description: _t("Translate with AI"),
-                isAvailable: (selection) => {
-                    return !selection.isCollapsed && user.userId;
-                },
+                isAvailable: (selection) => !selection.isCollapsed && user.userId,
                 isDisabled: this.isNotReplaceableByAI.bind(this),
                 Component: LanguageSelector,
                 props: {
                     onSelected: (language) => this.openDialog({ language }),
-                    isDisabled: (selection) => {
-                        return this.isNotReplaceableByAI(selection);
-                    },
                 },
             },
         ],
@@ -98,10 +93,11 @@ export class ChatGPTTranslatePlugin extends Plugin {
         // collapse to end
         const sanitize = this.dependencies.sanitize.sanitize;
         const originalText = selection.textContent() || "";
-        this.dependencies.dialog.addDialog(
-            ChatGPTTranslateDialog,
-            { ...dialogParams, originalText, sanitize }
-        );
+        this.dependencies.dialog.addDialog(ChatGPTTranslateDialog, {
+            ...dialogParams,
+            originalText,
+            sanitize,
+        });
         if (this.services.ui.isSmall) {
             // TODO: Find a better way and avoid modifying range
             // HACK: In the case of opening through dropdown:

--- a/addons/html_editor/static/src/main/chatgpt/language_selector.js
+++ b/addons/html_editor/static/src/main/chatgpt/language_selector.js
@@ -12,7 +12,6 @@ export class LanguageSelector extends Component {
     static props = {
         ...toolbarButtonProps,
         onSelected: { type: Function },
-        isDisabled: { type: Function, optional: true },
     };
     static components = { Dropdown, DropdownItem };
 

--- a/addons/html_editor/static/src/main/chatgpt/language_selector.xml
+++ b/addons/html_editor/static/src/main/chatgpt/language_selector.xml
@@ -23,7 +23,7 @@
 
     <t t-name="html_editor.translateButton">
         <button class="btn btn-light" name="translate" t-att-title="props.title"
-            t-att-disabled="props.isDisabled()" t-on-click="onClick">
+            t-att-disabled="props.isDisabled" t-on-click="onClick">
             <!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
             <svg class="oe-language-icon" version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
                 viewBox="796 796 200 200" enable-background="new 796 796 200 200" xml:space="preserve">

--- a/addons/html_editor/static/src/main/font/color_selector.xml
+++ b/addons/html_editor/static/src/main/font/color_selector.xml
@@ -1,7 +1,7 @@
 <templates xml:space="preserve">
 
 <t t-name="html_editor.ColorSelector">
-    <button t-ref="root" class="btn btn-light" t-attf-class="o-select-color-{{props.type}} {{this.colorPicker.isOpen ? 'active' : ''}}" t-att-title="props.title">
+    <button t-ref="root" class="btn btn-light" t-attf-class="o-select-color-{{props.type}} {{this.colorPicker.isOpen ? 'active' : ''}}" t-att-title="props.title" t-att-disabled="props.isDisabled">
         <t t-if="props.type === 'foreground'">
             <i class="fa fa-fw fa-font py-1" t-att-style="this.getSelectedColorStyle()"/>
         </t>

--- a/addons/html_editor/static/src/main/font/font_family_selector.xml
+++ b/addons/html_editor/static/src/main/font/font_family_selector.xml
@@ -1,7 +1,7 @@
 <templates xml:space="preserve">
     <t t-name="html_editor.FontFamilySelector">
         <Dropdown menuClass="'o_font_family_selector_menu'">
-            <button class="btn btn-light" t-att-title="props.title" name="font_family">
+            <button class="btn btn-light" t-att-title="props.title" name="font_family" t-att-disabled="props.isDisabled">
                 <span class="px-1" t-esc="props.currentFontFamily.displayName"/>
             </button>
             <t t-set-slot="content">

--- a/addons/html_editor/static/src/main/font/font_selector.xml
+++ b/addons/html_editor/static/src/main/font/font_selector.xml
@@ -1,7 +1,7 @@
 <templates xml:space="preserve">
     <t t-name="html_editor.FontSelector">
         <Dropdown menuClass="'o_font_selector_menu'">
-            <button class="btn btn-light" t-att-title="props.title" name="font">
+            <button class="btn btn-light" t-att-title="props.title" name="font" t-att-disabled="props.isDisabled">
                 <span class="px-1" t-esc="state.displayName"/>
             </button>
             <t t-set-slot="content">

--- a/addons/html_editor/static/src/main/font/font_size_selector.xml
+++ b/addons/html_editor/static/src/main/font/font_size_selector.xml
@@ -1,7 +1,7 @@
 <templates xml:space="preserve">
     <t t-name="html_editor.FontSizeSelector">
         <Dropdown state="dropdown" menuClass="'o_font_size_selector_menu'">
-            <button class="btn btn-light" t-att-title="props.title" name="font_size_selector">
+            <button class="btn btn-light" t-att-title="props.title" name="font_size_selector" t-att-disabled="props.isDisabled">
                 <iframe t-ref="iframeContent" style="width: 4ch; height:100%;"/>
             </button>
             <t t-set-slot="content">

--- a/addons/html_editor/static/src/main/toolbar/toolbar.js
+++ b/addons/html_editor/static/src/main/toolbar/toolbar.js
@@ -25,6 +25,7 @@ export class Toolbar extends Component {
                                         const base = {
                                             id: String,
                                             description: String,
+                                            isDisabled: Boolean,
                                         };
                                         if (button.Component) {
                                             validate(button, {
@@ -39,7 +40,6 @@ export class Toolbar extends Component {
                                                 icon: { type: String, optional: true },
                                                 text: { type: String, optional: true },
                                                 isActive: Boolean,
-                                                isDisabled: Boolean,
                                             });
                                         }
                                         return true;
@@ -66,6 +66,7 @@ export class Toolbar extends Component {
 export const toolbarButtonProps = {
     title: [String, Function],
     getSelection: Function,
+    isDisabled: Boolean,
 };
 
 /** @typedef {import("@html_editor/core/user_command_plugin").UserCommand} UserCommand */

--- a/addons/html_editor/static/src/main/toolbar/toolbar.xml
+++ b/addons/html_editor/static/src/main/toolbar/toolbar.xml
@@ -11,7 +11,8 @@
                                 <t t-component="button.Component"
                                     t-props="button.props"
                                     title="button.description"
-                                    getSelection.bind="props.getSelection"/>
+                                    getSelection.bind="props.getSelection"
+                                    isDisabled="'isDisabled' in button.props ? button.props.isDisabled : !!button.isDisabled"/>
                             </t>
                             <button t-else=""
                                 class="btn btn-light"

--- a/addons/html_editor/static/src/main/toolbar/toolbar_plugin.js
+++ b/addons/html_editor/static/src/main/toolbar/toolbar_plugin.js
@@ -237,7 +237,7 @@ export class ToolbarPlugin extends Plugin {
             this.addDomListener(this.editable, "keydown", (ev) => {
                 // reason for "key?":
                 // On Chrome, if there is a password saved for a login page,
-                // a mouse click trigger a keydown event without any key 
+                // a mouse click trigger a keydown event without any key
                 if (ev.key?.startsWith("Arrow")) {
                     this.closeToolbar();
                     this.onSelectionChangeActive = false;
@@ -425,12 +425,12 @@ export class ToolbarPlugin extends Plugin {
                     .map((button) => ({
                         id: button.id,
                         description: button.description(selection, targetedNodes),
+                        isDisabled: !!button.isDisabled?.(selection, targetedNodes),
                         ...(button.Component
                             ? pick(button, "Component", "props")
                             : {
                                   ...pick(button, "run", "icon", "text"),
                                   isActive: !!button.isActive?.(selection, targetedNodes),
-                                  isDisabled: !!button.isDisabled?.(selection, targetedNodes),
                               }),
                     })),
             }))

--- a/addons/html_editor/static/tests/sanitize.test.js
+++ b/addons/html_editor/static/tests/sanitize.test.js
@@ -16,6 +16,19 @@ test("sanitize should remove nasty elements", async () => {
     ).toBe("<p>abc</p>");
 });
 
+test("sanitize should leave t-field, t-out, t-esc as is", async () => {
+    const { editor } = await setupEditor("");
+    expect(editor.shared.sanitize.sanitize(`<span t-esc="expr"></span>`)).toBe(
+        '<span t-esc="expr"></span>'
+    );
+    expect(editor.shared.sanitize.sanitize(`<span t-out="expr"></span>`)).toBe(
+        '<span t-out="expr"></span>'
+    );
+    expect(editor.shared.sanitize.sanitize(`<span t-field="expr"></span>`)).toBe(
+        '<span t-field="expr"></span>'
+    );
+});
+
 test("sanitize plugin should handle contenteditable attribute with o-contenteditable-[true/false] class", async () => {
     await testEditor({
         contentBefore: `<p class="o-contenteditable-true">a[]</p><p class="o-contenteditable-false">b</p>`,

--- a/addons/website/static/src/builder/plugins/highlight/highlight_plugin.js
+++ b/addons/website/static/src/builder/plugins/highlight/highlight_plugin.js
@@ -14,6 +14,7 @@ import { getCurrentTextHighlight } from "@website/js/highlight_utils";
 import { isCSSColor, rgbaToHex } from "@web/core/utils/colors";
 import { isHtmlContentSupported } from "@html_editor/core/selection_plugin";
 import { nodeSize } from "@html_editor/utils/position";
+import { toolbarButtonProps } from "@html_editor/main/toolbar/toolbar";
 
 export class HighlightPlugin extends Plugin {
     static id = "highlight";
@@ -277,6 +278,7 @@ formatsSpecs.highlight = {
 
 class HighlightToolbarButton extends Component {
     static props = {
+        ...toolbarButtonProps,
         highlightConfiguratorProps: Object,
         onClick: Function,
         title: String,


### PR DESCRIPTION
In the report editor, copy and paste a whole node that has an expression (t-esc, t-field, t-out) Paste it

Before this commit, the expression was sanitized out, after this commit, the expression is kept.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
