### PR TITLE
[IMP] mail: improve discuss in mobile

### DIFF
--- a/addons/mail/static/src/core/common/message.js
+++ b/addons/mail/static/src/core/common/message.js
@@ -41,6 +41,7 @@ import { rpc } from "@web/core/network/rpc";
 import { MessageActionMenuMobile } from "./message_action_menu_mobile";
 import { discussComponentRegistry } from "./discuss_component_registry";
 import { NotificationMessage } from "./notification_message";
+import { useLongPress } from "@mail/utils/common/hooks";
 
 /**
  * @typedef {Object} Props
@@ -110,6 +111,9 @@ export class Message extends Component {
         /** @type {ShadowRoot} */
         this.shadowRoot;
         this.root = useRef("root");
+        if (isMobileOS()) {
+            useLongPress("root", () => this.openMobileActions());
+        }
         onWillUpdateProps((nextProps) => {
             this.props.registerMessageRef?.(this.props.message, null);
         });
@@ -215,6 +219,7 @@ export class Message extends Component {
 
     get attClass() {
         return {
+            "user-select-none": isMobileOS(),
             [this.props.className]: true,
             "o-card p-2 ps-1 mx-1 mt-1 mb-1 border border-dark shadow-sm rounded-3":
                 this.props.asCard,

--- a/addons/mail/static/src/core/common/message.js
+++ b/addons/mail/static/src/core/common/message.js
@@ -451,7 +451,10 @@ export class Message extends Component {
                 openReactionMenu: () => this.openReactionMenu(),
                 state: this.state,
             },
-            { context: this, onClose: () => (this.state.actionMenuMobileOpen = false) }
+            {
+                context: this,
+                onClose: () => console.warn("close") || (this.state.actionMenuMobileOpen = false),
+            }
         );
     }
 

--- a/addons/mail/static/src/core/common/message.scss
+++ b/addons/mail/static/src/core/common/message.scss
@@ -158,18 +158,6 @@
     z-index: $o-mail-NavigableList-zIndex;
 }
 
-.o-mail-Message-openActionMobile {
-    opacity: 10% !important;
-
-    .o-mail-Message.o-card & {
-        opacity: 15% !important;
-    }
-
-    &:active {
-        opacity: 75% !important;
-    }
-} 
-
 .o-mail-Message-pendingProgress {
     animation: o-mail-message-pendingProgress-animation 0s ease-in 0.5s forwards;
     visibility: hidden;

--- a/addons/mail/static/src/core/common/message.xml
+++ b/addons/mail/static/src/core/common/message.xml
@@ -154,27 +154,16 @@
 </t>
 
 <t t-name="mail.Message.actions">
-    <div t-if="props.hasActions and message.hasActions and !isEditing and !env.inChatter?.disabled" class="o-mail-Message-actions d-print-none d-flex align-items-start"
+    <div t-if="props.hasActions and message.hasActions and !isEditing and !env.inChatter?.disabled" class="o-mail-Message-actions d-print-none d-flex align-items-start mx-1"
         t-att-class="{
             'start-0': isAlignedRight,
-            'mx-1': !isMobileOS,
             'mt-1': message.bubbleColor and !props.asCard and !isMobileOS,
             'my-n2': !message.bubbleColor and !props.asCard and !isMobileOS,
             'invisible': !isActive and !isMobileOS,
             'o-expanded': optionsDropdown.isOpen
         }"
     >
-        <t t-if="isMobileOS">
-            <t t-if="isAlignedRight">
-                <t t-call="mail.Message.emptyQuickAction"/>
-                <t t-if="!props.asCard" t-call="mail.Message.expandAction"/>
-            </t>
-            <t t-else="">
-                <t t-call="mail.Message.expandAction"/>
-                <t t-if="!props.asCard" t-call="mail.Message.emptyQuickAction"/>
-            </t>
-        </t>
-        <t t-else="">
+        <t t-if="!isMobileOS">
             <t t-set="isReverse" t-value="env.inChatWindow and isAlignedRight"/>
             <div class="d-flex rounded-1 overflow-hidden gap-1" t-att-class="{ 'flex-row-reverse': isReverse }">
                 <t t-set="quickActions" t-value="messageActions.actions.slice(0, messageActions.actions.length gt quickActionCount ? quickActionCount - 1 : quickActionCount)"/>
@@ -217,15 +206,9 @@
 </t>
 
 <t t-name="mail.Message.expandAction">
-    <button class="btn border-0 rounded-0 o-mail-Message-expandBtn" t-att-title="expandText" t-on-click="openMobileActions" t-att-class="{
-        'o-mail-Message-openActionMobile p-2 rounded-circle user-select-none': isMobileOS,
-        'me-n2': isMobileOS and (isAlignedRight and !props.asCard or !isAlignedRight and props.asCard),
-        'ms-n2': isMobileOS and (isAlignedRight and props.asCard or !isAlignedRight and !props.asCard),
-        'mt-n3': isMobileOS and props.asCard,
-        'mt-n1': isMobileOS and !props.asCard,
-        'p-0': !isMobileOS,
-        'rounded-start-1 me-n1': !isMobileOS and isReverse,
-        'rounded-end-1 ms-n1': !isMobileOS and !isReverse,
+    <button class="btn border-0 rounded-0 o-mail-Message-expandBtn p-0" t-att-title="expandText" t-att-class="{
+        'rounded-start-1 me-n1': isReverse,
+        'rounded-end-1 ms-n1': !isReverse,
     }">
         <i class="oi oi-large oi-ellipsis-v" t-att-class="{ 'order-1': props.isInChatWindow, 'fa-fw': isMobileOS }" tabindex="1"/>
     </button>

--- a/addons/mail/static/src/core/common/message_action_menu_mobile.scss
+++ b/addons/mail/static/src/core/common/message_action_menu_mobile.scss
@@ -8,3 +8,8 @@
         border: none !important;
     }
 }
+
+.o_inactive_modal:has(.o-discuss-mobileContextMenu) {
+    // Avoid double modal backdrop
+    background-color: transparent;
+}

--- a/addons/mail/static/src/core/common/message_actions.js
+++ b/addons/mail/static/src/core/common/message_actions.js
@@ -86,6 +86,7 @@ messageActionsRegistry
         title: _t("View Reactions"),
         onClick: (component) => component.openReactionMenu(),
         sequence: 50,
+        mobileCloseAfterClick: false,
         dropdown: true,
     })
     .add("unfollow", {

--- a/addons/mail/static/src/core/common/message_actions.js
+++ b/addons/mail/static/src/core/common/message_actions.js
@@ -8,6 +8,7 @@ import { discussComponentRegistry } from "./discuss_component_registry";
 import { Deferred } from "@web/core/utils/concurrency";
 import { useEmojiPicker } from "@web/core/emoji_picker/emoji_picker";
 import { QuickReactionMenu } from "@mail/core/common/quick_reaction_menu";
+import { htmlToTextContentInline } from "@mail/utils/common/format";
 
 const { DateTime } = luxon;
 
@@ -157,6 +158,14 @@ messageActionsRegistry
         title: (component) => (component.state.showTranslation ? _t("Revert") : _t("Translate")),
         onClick: (component) => component.onClickToggleTranslation(),
         sequence: 100,
+    })
+    .add("copy-text", {
+        condition: (component) => !component.message.isBodyEmpty && navigator.clipboard,
+        onClick: (component) =>
+            navigator.clipboard.writeText(htmlToTextContentInline(component.message.body)),
+        title: _t("Copy"),
+        icon: "fa fa-copy",
+        sequence: 15,
     })
     .add("copy-link", {
         condition: (component) =>

--- a/addons/mail/static/src/core/common/message_reaction_menu.js
+++ b/addons/mail/static/src/core/common/message_reaction_menu.js
@@ -5,6 +5,7 @@ import { Component, onMounted, useEffect, useExternalListener, useRef, useState 
 
 import { Dialog } from "@web/core/dialog/dialog";
 import { useService } from "@web/core/utils/hooks";
+import { isMobileOS } from "@web/core/browser/feature_detection";
 
 export class MessageReactionMenu extends Component {
     static props = ["close", "message", "initialReaction?"];
@@ -58,5 +59,17 @@ export class MessageReactionMenu extends Component {
 
     getEmojiShortcode(reaction) {
         return this.store.emojiLoader.loaded?.emojiValueToShortcodes?.[reaction.content][0] ?? "?";
+    }
+
+    get isMobileView() {
+        return this.ui.isSmall || isMobileOS();
+    }
+
+    get contentClass() {
+        const classes = ["o-mail-MessageReactionMenu", "h-50", "d-flex"];
+        if (this.isMobileView) {
+            classes.push("position-absolute", "bottom-0");
+        }
+        return classes.join(" ");
     }
 }

--- a/addons/mail/static/src/core/common/message_reaction_menu.xml
+++ b/addons/mail/static/src/core/common/message_reaction_menu.xml
@@ -2,9 +2,9 @@
 <templates xml:space="preserve">
 
     <t t-name="mail.MessageReactionMenu">
-        <Dialog size="'md'" header="false" footer="false" contentClass="'o-mail-MessageReactionMenu h-50 d-flex'">
-            <div class="d-flex h-100" t-on-keydown="onKeydown" t-ref="root">
-                <div class="d-flex overflow-auto o-scrollbar-thin flex-column bg-100 p-2 h-100 border-end">
+        <Dialog size="'md'" header="false" footer="false" contentClass="contentClass">
+            <div class="d-flex h-100" t-on-keydown="onKeydown" t-att-class="{'flex-column': isMobileView}" t-ref="root">
+                <div class="d-flex overflow-auto o-scrollbar-thin bg-100 p-1 border-end" t-att-class="{'flex-column h-100 p-2': !isMobileView}">
                     <t t-foreach="props.message.reactions" t-as="reaction" t-key="reaction.content">
                         <button class="btn p-1 rounded-2 mx-2 py-0 d-flex align-items-center" t-att-class="{ 'bg-200 border-primary': reaction.eq(state.reaction) }" t-att-title="getEmojiShortcode(reaction)" t-on-click="() => state.reaction = reaction">
                             <span class="mx-1 fs-2" t-esc="reaction.content"/>

--- a/addons/mail/static/src/utils/common/hooks.js
+++ b/addons/mail/static/src/utils/common/hooks.js
@@ -592,7 +592,6 @@ export function useLongPress(refName, callback) {
         clearTimeout(timer);
         timer = null;
     }
-
     useLazyExternalListener(
         () => ref.el,
         "touchstart",

--- a/addons/web/static/src/core/action_swiper/action_swiper.js
+++ b/addons/web/static/src/core/action_swiper/action_swiper.js
@@ -5,14 +5,12 @@ import { clamp } from "@web/core/utils/numbers";
 import { Component, onMounted, onWillUnmount, useRef, useState } from "@odoo/owl";
 import { Deferred } from "@web/core/utils/concurrency";
 
-const isScrollSwipable = (scrollables) => {
-    return {
-        left: !scrollables.filter((e) => e.scrollLeft !== 0).length,
-        right: !scrollables.filter(
-            (e) => e.scrollLeft + Math.round(e.getBoundingClientRect().width) !== e.scrollWidth
-        ).length,
-    };
-};
+const isScrollSwipable = (scrollables) => ({
+    left: !scrollables.filter((e) => e.scrollLeft !== 0).length,
+    right: !scrollables.filter(
+        (e) => e.scrollLeft + Math.round(e.getBoundingClientRect().width) !== e.scrollWidth
+    ).length,
+});
 
 /**
  * Action Swiper
@@ -219,6 +217,7 @@ export class ActionSwiper extends Component {
                 }, 100);
             }, 100);
         } else {
+            this._reset();
             return action(Promise.resolve());
         }
     }


### PR DESCRIPTION
This PR improves several aspects of discuss on mobile devices:
- Long press to open message actions
- Fix background color issue when opening sub-menu from message actions
- Improve reaction menu position
- Add a copy action for messages

| - | Before  | After |
| -------------| ------------- | ------------- |
| Background |![background_ko](https://github.com/user-attachments/assets/ccb93865-3c09-491b-b408-e1fdba026139)| ![background_ok](https://github.com/user-attachments/assets/5c7ed8c0-5747-4430-8ca2-611bdf4823ce) |
| Reaction menu | ![reaction_menu_ko](https://github.com/user-attachments/assets/2d96d970-657d-43de-b5d7-bd1131b511cc) | ![reaction_menu_ok](https://github.com/user-attachments/assets/1018c250-3832-4d0e-8fdc-24c736f87508) |


