### PR TITLE
[FIX] web: close popover when navigating

### DIFF
--- a/addons/web/static/tests/core/popover/popover.test.js
+++ b/addons/web/static/tests/core/popover/popover.test.js
@@ -365,6 +365,26 @@ test("popover with arrow and onPositioned", async () => {
     expect(".o_popover > .popover-arrow").toHaveClass("position-absolute z-n1");
 });
 
+test("popover closes when navigating", async () => {
+    history.pushState({}, "", "/"); // Need non-null state
+    history.pushState(null, "", "/aaa"); // Head to other page
+
+    await mountWithCleanup(Popover, {
+        props: {
+            close: () => expect.step("close"),
+            target: getFixture(),
+            component: Content,
+        },
+    });
+
+    expect(".o_popover").toHaveCount(1);
+
+    history.back(); // Head back
+    await animationFrame();
+
+    expect.verifySteps(["close"]);
+});
+
 test("arrow follows target and can get sucked", async () => {
     let container;
     patch(Popover, { animationTime: 0 });


### PR DESCRIPTION
Before this commit, popovers like the datepicker remained open when navigating between pages, using the browser's previous/next page button for example.

In this commit, popovers listen to page changes and are closed when such events are detected.

Task 4812869

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
