### PR TITLE
[FIX] web: prevent error when clicking Export All action

### DIFF
--- a/addons/web/controllers/export.py
+++ b/addons/web/controllers/export.py
@@ -90,6 +90,8 @@ class GroupsTreeNode:
         return aggregate_func((child.aggregated_values.get(field_name) for child in self.children.values()))
 
     def _get_avg_aggregate(self, field_name, data):
+        if not self.count:
+            return 0
         aggregate_func = OPERATOR_MAPPING.get('sum')
         if self.data:
             return aggregate_func(data) / self.count


### PR DESCRIPTION
Currently an error occurs when we try to export CRM forecast.

Steps to replicate:
- Go to CRM > Reports > Forecast.
- Click on the gear menu and click `Export All`.

Error:
`ZeroDivisionError: division by zero`

This error occurs after a recent [change](https://github.com/odoo/odoo/pull/194090/commits/45affb06ddf5021e751ac47a87686d9f4ec8140f) in the actions of List and Kanban views, where both are combined together to work as DynamicList this caused the `Export All` option to show up on the CRM Forecast view that can have empty stages and causes the error through line [1] as `self.count` becomes zero for stages with no records.

[1] - https://github.com/odoo/odoo/blob/6be0e8ad57c531fb88dc33e126df884430f1ab21/addons/web/controllers/export.py#L97

This commit solves this issue by returning a default value `zero` when data is empty.

sentry-6720460271
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
