### PR TITLE
[FIX] website_sale: correct missed field rename in template

### DIFF
--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -2330,7 +2330,7 @@
     <template id="product_tags" name="Product Tags" active="True">
         <div
             class="o_product_tags o_field_tags d-flex flex-wrap align-items-center gap-2 mb-2 mt-1"
-            t-if="any(tag.visible_on_ecommerce for tag in all_product_tags)"
+            t-if="any(tag.visible_to_customers for tag in all_product_tags)"
         >
             <t t-foreach="all_product_tags" t-as="tag">
                 <t t-if="tag.visible_to_customers">


### PR DESCRIPTION
This commit finalizes the field renaming operation started in PR #206084, where `visible_on_ecommerce` was renamed to `visible_to_customers` . One reference was missed in website_sale/views/templates.xml. This commit updates that remaining usage to ensure consistency across all views.

OPW:4915883

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
