### PR TITLE
[FIX] l10n_it_edi_ndd: prevent wrong value error

### DIFF
--- a/addons/l10n_it_edi_ndd/i18n/it.po
+++ b/addons/l10n_it_edi_ndd/i18n/it.po
@@ -76,6 +76,13 @@ msgid "Document Type"
 msgstr "Tipi di documento"
 
 #. module: l10n_it_edi_ndd
+#. odoo-python
+#: code:addons/l10n_it_edi_ndd/models/l10n_it_document_type.py:0
+#, python-format
+msgid "Document Type code must be unique."
+msgstr "Il codice del tipo di documento deve essere univoco."
+
+#. module: l10n_it_edi_ndd
 #: model:ir.model.fields,field_description:l10n_it_edi_ndd.field_l10n_it_document_type__id
 msgid "ID"
 msgstr ""

--- a/addons/l10n_it_edi_ndd/i18n/l10n_it_edi_ndd.pot
+++ b/addons/l10n_it_edi_ndd/i18n/l10n_it_edi_ndd.pot
@@ -76,6 +76,13 @@ msgid "Document Type"
 msgstr ""
 
 #. module: l10n_it_edi_ndd
+#. odoo-python
+#: code:addons/l10n_it_edi_ndd/models/l10n_it_document_type.py:0
+#, python-format
+msgid "Document Type code must be unique."
+msgstr ""
+
+#. module: l10n_it_edi_ndd
 #: model:ir.model.fields,field_description:l10n_it_edi_ndd.field_l10n_it_document_type__id
 msgid "ID"
 msgstr ""

--- a/addons/l10n_it_edi_ndd/models/l10n_it_document_type.py
+++ b/addons/l10n_it_edi_ndd/models/l10n_it_document_type.py
@@ -1,4 +1,5 @@
-from odoo import fields, models
+from odoo import _, api, fields, models
+from odoo.exceptions import ValidationError
 
 
 class L10nItDocumentType(models.Model):
@@ -18,3 +19,15 @@ class L10nItDocumentType(models.Model):
     def _compute_display_name(self):
         for document_type in self:
             document_type.display_name = f"{document_type.code} - {document_type.name}"
+
+    @api.constrains('code')
+    def _check_code_unique(self):
+        duplicate = self._read_group(
+            domain=[],
+            groupby=['code'],
+            aggregates=['id:recordset'],
+            having=[('__count', '>', 1)],
+            limit=1,
+        )
+        if duplicate:
+            raise ValidationError(_('Document Type code must be unique.'))


### PR DESCRIPTION
**Issue** : The computation of `l10n_it_document_type` fails when multiple `l10n_it.document.type` records share the same code. This can happen if a user duplicates an existing Document Type or creates a new one with the same code, causing `get()` on the grouped recordset to return multiple results.

**Traceback :** 
```python
  File "/home/odoo/odoo/codebase/odoo/17.0/odoo/fields.py", line 3252, in convert_to_cache
    raise ValueError("Wrong value for %s: %r" % (self, value))
ValueError: Wrong value for account.move.l10n_it_document_type: l10n_it.document.type(1, 23)
```

**Steps to Reproduce:**
1. Install the `l10n_it_edi_ndd` module.
2. Go to Customer Invoices and create a new invoice.
3. Set a Document Type, then confirm the invoice.
4. Open that Document Type and duplicate it.
5. Create another invoice without setting a Document Type, then confirm it.

observation: you will receive a traceback for wrong value error

**Solution :** This fix adds a check to ensure that the `code` field remains unique across all `l10n_it.document.type` records.

opw - 4902513
related upgrade pr : https://github.com/odoo/upgrade/pull/8032

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
