### PR TITLE
[FIX] website: adapt configurator translation tour

### DIFF
--- a/addons/website/static/tests/tours/configurator_translation.js
+++ b/addons/website/static/tests/tours/configurator_translation.js
@@ -64,7 +64,8 @@ registry.category("web_tour.tours").add('configurator_translation', {
         run: "click",
     }, {
         content: "Loader should be shown",
-        trigger: '.o_website_loader_container',
+        trigger: ".o_website_loader_container",
+        expectUnloadPage: true,
     }, {
         content: "Wait until the configurator is finished",
         trigger: ":iframe [data-view-xmlid='website.homepage']",
@@ -86,7 +87,7 @@ registry.category("web_tour.tours").add('configurator_translation', {
         // Parseltongue. (The editor should be in the website's default language,
         // which should be parseltongue in this test.)
         content: "exit edit mode",
-        trigger: '.o-snippets-top-actions button.btn-primary:contains("Save_Parseltongue")',
+        trigger: ".o-snippets-top-actions button.btn-success:contains('Save_Parseltongue')",
         run: "click",
     }, {
          content: "wait for editor to be closed",

--- a/addons/website/tests/test_configurator.py
+++ b/addons/website/tests/test_configurator.py
@@ -1,7 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from unittest.mock import patch
-import unittest
 
 import odoo.tests
 
@@ -93,8 +92,6 @@ class TestConfiguratorCommon(odoo.tests.HttpCase):
 @odoo.tests.common.tagged('post_install', '-at_install')
 class TestConfiguratorTranslation(TestConfiguratorCommon):
 
-    # TODO master-mysterious-egg fix error
-    @unittest.skip("prepare mysterious-egg for merging")
     def test_01_configurator_translation(self):
         parseltongue = self.env['res.lang'].create({
             'name': 'Parseltongue',


### PR DESCRIPTION
This PR re-enables the test_01_configurator_translation test, which was broken and skipped due to the DOM changes introduced by the new Website Builder. It also adapts the tour selectors accordingly.

In the configuration screen, after clicking the "Build My Website" button, the website was taking unexpected time to load. To address this, we added `expectPageUnload` to wait for fill page load. After that, we wait for the configurator to finish.