### PR TITLE
[FIX] point_of_sale,pos_hr: refund minimal rights

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.xml
+++ b/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.xml
@@ -188,7 +188,6 @@
                                 <div class="subpads d-flex flex-column">
                                     <Numpad class="'pb-2'" buttons="getNumpadButtons()"/>
                                         <ActionpadWidget
-                                            t-if="this.pos.cashier._role !== 'minimal'"
                                             partner="getSelectedOrder()?.getPartner()"
                                             actionName.translate="Refund"
                                             actionToTrigger.bind="onDoRefund"

--- a/addons/pos_hr/static/src/app/screens/ticket_screen/ticket_screen.xml
+++ b/addons/pos_hr/static/src/app/screens/ticket_screen/ticket_screen.xml
@@ -4,5 +4,8 @@
         <xpath expr="//button[hasclass('edit-order-payment')]" position="attributes">
             <attribute name="t-if">!this.pos.config.module_pos_hr || this.pos.employeeIsAdmin</attribute>
         </xpath>
+        <xpath expr="//div[hasclass('ticket-screen')]//div[hasclass('subpads d-flex flex-column')]" position="attributes">
+            <attribute name="t-if">!this.pos.config.module_pos_hr or this.pos.cashier._role !== 'minimal'</attribute>
+        </xpath>
     </t>
 </templates>

--- a/addons/pos_hr/static/tests/tours/pos_hr_tour.js
+++ b/addons/pos_hr/static/tests/tours/pos_hr_tour.js
@@ -184,6 +184,29 @@ registry.category("web_tour.tours").add("test_change_on_rights_reflected_directl
         ].flat(),
 });
 
+registry.category("web_tour.tours").add("test_minimal_employee_refund", {
+    steps: () =>
+        [
+            Chrome.clickBtn("Unlock Register"),
+            PosHr.loginScreenIsShown(),
+            PosHr.clickLoginButton(),
+            SelectionPopup.has("Minimal Employee", { run: "click" }),
+            Chrome.clickOrders(),
+            TicketScreen.selectFilter("Paid"),
+            TicketScreen.selectOrder("001"),
+            {
+                trigger: negate(".subpads"),
+            },
+            PosHr.clickCashierName(),
+            SelectionPopup.has("Mitchell Admin", { run: "click" }),
+            TicketScreen.selectFilter("Paid"),
+            TicketScreen.selectOrder("001"),
+            {
+                trigger: ".subpads",
+            },
+        ].flat(),
+});
+
 registry.category("web_tour.tours").add("test_cashier_changed_in_receipt", {
     steps: () =>
         [


### PR DESCRIPTION
Employee with minimal rights should not be able to refund a ticket an order.

Steps to reproduce:
-------------------
* Install pos_hr module
* In the PoS settings set any employee as a cashier with minimal rights
* Open a PoS session with that employee
* Create a new order and validate it
* Go to the order list screen
* Select the order you just validated
> Observation: The numpad is displayed and you can refund the order

Why the fix:
------------
We hide the numpad for employees with minimal rights, so they cannot refund an order. We also moved the condition to the right module in pos_hr instead of point_of_sale.

opw-4778508