### PR TITLE
[FIX] web_editor: prevent direct writing to history

### DIFF
--- a/addons/web_editor/models/html_field_history_mixin.py
+++ b/addons/web_editor/models/html_field_history_mixin.py
@@ -40,7 +40,15 @@ class HtmlFieldHistory(models.AbstractModel):
                         history_metadata[field_name].append(metadata)
             rec.html_field_history_metadata = history_metadata
 
+    def copy_data(self, default=None):
+        vals = super().copy_data(default)
+        if 'html_field_history' in vals:
+            del vals['html_field_history']
+        return vals
+
     def write(self, vals):
+        if 'html_field_history' in vals:
+            del vals['html_field_history']
         new_revisions = False
         db_contents = None
         versioned_fields = self._get_versioned_fields()


### PR DESCRIPTION
This commit prevent direct write to history, also, removes it from copy_data as it would fail anyway when trying to write the history
