### PR TITLE
[FIX] point_of_sale: remove unused css variable

### DIFF
--- a/addons/point_of_sale/static/src/app/components/numpad/numpad.scss
+++ b/addons/point_of_sale/static/src/app/components/numpad/numpad.scss
@@ -16,7 +16,7 @@
   @include media-breakpoint-down(xl) {
     padding: 0;
   }
-  background-color: var(--bg, var(--btn-bg));
+  background-color: var(--btn-bg);
   border: $border-width solid var(--hover-bg, var(--border-color));
 
   &::after {
@@ -55,7 +55,7 @@
 
   &.active, &:active {
     --border-color: var(--hover-bg, #{$o-component-active-border});
-    --btn-active-bg: var(--bg, #{$o-component-active-bg});
+    --btn-active-bg: #{$o-component-active-bg};
   }
 
   &:disabled {

--- a/addons/point_of_sale/static/src/app/components/popups/preset_slots_popup/preset_slots_popup.scss
+++ b/addons/point_of_sale/static/src/app/components/popups/preset_slots_popup/preset_slots_popup.scss
@@ -1,3 +1,3 @@
 .pos .preset-slot-button {
-    background-color: var(--bg, var(--btn-bg));
+    background-color: var(--btn-bg);
 }


### PR DESCRIPTION
This commit removes an unused CSS variable that caused the numpad to appear completely black with some browser extensions like Screeny.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
