### PR TITLE
[FIX] mrp: no negative or 0 qty_produced

### DIFF
--- a/addons/mrp/models/mrp_unbuild.py
+++ b/addons/mrp/models/mrp_unbuild.py
@@ -104,10 +104,11 @@ class MrpUnbuild(models.Model):
             self.bom_id = self.mo_id.bom_id
             self.product_uom_id = self.mo_id.product_uom_id
             self.lot_id = self.mo_id.lot_producing_id
-            if self.has_tracking == 'serial':
+            qty_produced = self.mo_id.qty_produced
+            if self.has_tracking == 'serial' or qty_produced < 1:
                 self.product_qty = 1
             else:
-                self.product_qty = self.mo_id.qty_produced
+                self.product_qty = qty_produced
 
 
     @api.onchange('product_id')


### PR DESCRIPTION
if qty_produced is 0 or negative, set product_qty to 1, usually we don't expect the qty_produced to be negative. it can be 0 but code should be robust and expect the unexpected as we let the clients costumize or some flows can lead to it.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
