### PR TITLE
[FIX] l10n_es_edi_sii: Display clear error message for missing tax scope

### DIFF
--- a/addons/l10n_es_edi_sii/models/account_edi_format.py
+++ b/addons/l10n_es_edi_sii/models/account_edi_format.py
@@ -606,8 +606,10 @@ class AccountEdiFormat(models.Model):
 
         if not move.company_id.vat:
             res.append(_("VAT number is missing on company %s", move.company_id.display_name))
+        total_taxes = self.env['account.tax']
         for line in move.invoice_line_ids.filtered(lambda line: line.display_type not in ('line_note', 'line_section')):
             taxes = line.tax_ids.flatten_taxes_hierarchy()
+            total_taxes |= taxes
             recargo_count = taxes.mapped('l10n_es_type').count('recargo')
             retention_count = taxes.mapped('l10n_es_type').count('retencion')
             sujeto_count = taxes.mapped('l10n_es_type').count('sujeto')
@@ -625,6 +627,18 @@ class AccountEdiFormat(models.Model):
                 res.append(_("Line %s should only have one no sujeto (localizations) tax.", line.display_name))
             if sujeto_count + no_sujeto_loc_count + no_sujeto_count > 1:
                 res.append(_("Line %s should only have one main tax.", line.display_name))
+        if (
+            move.is_inbound()
+            and (
+                move.commercial_partner_id.country_id.code not in ('ES', False)
+                or (move.commercial_partner_id.vat or '').startswith("ESN")
+            )
+            and not any(t.tax_scope for t in total_taxes)
+        ):
+            res.append(
+                _("In case of a foreign customer, you need to configure the tax scope on taxes:\n%s",
+                  "\n".join(total_taxes.mapped('name')))
+            )
         if move.move_type in ('in_invoice', 'in_refund'):
             if not move.ref:
                 res.append(_("You should put a vendor reference on this vendor bill. "))


### PR DESCRIPTION
**Steps to reproduce:**
- l10n_es_edi installed
- SII Agencia tributaria test mode selected
- Create invoice with foreign client (not spain)
- Add an invoice line with a service product
- Add a 0% RC tax to that line (with no tax scope)
- Process invoice

**Issue:**
A "Networking error" is displayed, with not much information about the modification to make (Adding tax scope).

**Solution:**
Adding a clear error message indicating that the tax scope should be set.

opw-4762973
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
