### PR TITLE
[IMP] base_vat: support new Vietnam VAT formats

### DIFF
--- a/addons/base_vat/models/res_partner.py
+++ b/addons/base_vat/models/res_partner.py
@@ -823,6 +823,26 @@ class ResPartner(models.Model):
         check_func = stdnum.util.get_cc_module('il', 'idnr').is_valid
         return check_func(vat)
 
+    __check_vat_vn_re = re.compile(r'^\d{10}(?:-?\d{3})?$|^\d{12}$')
+
+    def check_vat_vn(self, vat):
+        """
+        VAT format validator for Vietnam.
+        Supported formats:
+        - 10-digit format (Enterprise tax ID): e.g., 0101243150
+        - 13-digit format with branch suffix: e.g., 0101243150-001
+        - 12-digit format (Personal ID / Citizen ID - CCCD): e.g., 079123456789
+          (used as tax ID for individuals from July 1st, 2025)
+
+        Note:
+        - stdnum.vn.mst.validate() currently only supports 10- and 13-digit VAT numbers
+        - and does not accept the 12-digit personal tax ID (CCCD) format introduced from 01/07/2025.
+        - This helper provides a lightweight format-level validator for use in the meantime.
+        - Can be removed once stdnum.vn.mst adds CCCD support.
+        """
+        vat = vat.strip()
+        return bool(self.__check_vat_vn_re.match(vat))
+
     def format_vat_sm(self, vat):
         stdnum_vat_format = stdnum.util.get_cc_module('sm', 'vat').compact
         return stdnum_vat_format('SM' + vat)[2:]

--- a/addons/base_vat/tests/test_validate_ruc.py
+++ b/addons/base_vat/tests/test_validate_ruc.py
@@ -132,6 +132,22 @@ class TestStructure(TransactionCase):
             doc = Document(location=None, transport=Transport())
             new_get_soap_client(doc, 30)
 
+    def test_vat_vn(self):
+        test_partner = self.env['res.partner'].create({'name': "DuongDepTrai", 'country_id': self.env.ref('base.vn').id})
+        # Valid vn vat
+        test_partner.vat = "000012345679"  # individual
+        test_partner.vat = "0123457890"  # enterprise
+        test_partner.vat = "0123457890-111"  # branch
+
+        # Test invalid VAT (should raise a ValidationError)
+        msg = "The VAT number.*does not seem to be valid"
+        with self.assertRaisesRegex(ValidationError, msg):
+            test_partner.write({'vat': '00001234567912'})
+        with self.assertRaisesRegex(ValidationError, msg):
+            test_partner.write({'vat': '10123457890'})
+        with self.assertRaisesRegex(ValidationError, msg):
+            test_partner.write({'vat': '0123457890-11134'})
+
 
 @tagged('-standard', 'external')
 class TestStructureVIES(TestStructure):


### PR DESCRIPTION
The current validation uses stdnum.vn.mst.validate(), which only accepts
10- or 13-digit MST with legacy checksum logic. It does not support the
12-digit CCCD format now required for individuals from 01/07/2025
(per Circular 86/2024/TT-BTC).

* This patch introduces a separate format-level validator for:
  • 10-digit enterprise VAT
  • 13-digit branch VAT (10-digit + suffix)
  • 12-digit CCCD (from 01/07/2025)

* References:
  • Circular 86/2024/TT-BTC (tax registration & CCCD admin):
https://thuvienphapluat.vn/van-ban/Thue-Phi-Le-Phi/Thong-tu-86-2024-TT-BTC-dang-ky-thue-565309.aspx
  • CCCD replacing tax ID from 01 Jul 2025:
https://thuvienphapluat.vn/ma-so-thue/bai-viet/cach-doi-ma-so-thue-sang-ma-so-dinh-danh-ca-nhan-tu-0172025-200926.html
  • VAT ID structure 10/13 digits (Law, TT 105/2020):
https://thuvienphapluat.vn/phap-luat/cau-truc-ma-so-thue-la-10-chu-so-hay-13-chu-so-phan-loai-cau-truc-ma-so-thue-nhu-the-nao-theo-quy-d-796465-178397.html






---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
