### PR TITLE
[FIX] website: ensure atleast one website is available

### DIFF
--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -304,6 +304,9 @@ class Website(models.Model):
         default_website = self.env.ref('website.default_website', raise_if_not_found=False)
         if default_website and default_website in self:
             raise UserError(_("You cannot delete default website %s. Try to change its settings instead", default_website.name))
+        website = self.search_count([('id', 'not in', self.ids)])
+        if not website:
+            raise UserError(_('You must keep at least one website.'))
 
     def unlink(self):
         self._remove_attachments_on_website_unlink()


### PR DESCRIPTION
Currently, an error occurs when the user deletes all the websites and tries to open the website.

Steps to Reproduce:
- Install website
- Navigate to Settings>Technical>External Identifier and Search `default_website`, delete that record
- Navigate to website>configuration>websites
- Delete all available website.
- Tries to access or open the website

Error:
ValueError: Expected singleton: website()

Root Cause:
Since https://github.com/odoo/odoo/commit/60adaf5632ddfe3f68da369a2e9642ad639da37e , the check preventing the deletion of the last website was changed. The new constraint only prevents the deletion of the default website via the external identifier website.default_website. But if the user deleted the external identifier of the default website and deleted all the websites it leads to a traceback.

Solution:
This commit ensures that at least one website exists.

sentry-5900356108
