### PR TITLE
[IMP] mail: improve link preview card

### DIFF
--- a/addons/mail/models/mail_link_preview.py
+++ b/addons/mail/models/mail_link_preview.py
@@ -73,7 +73,7 @@ class MailLinkPreview(models.Model):
                 len(message_link_previews_ok)
                 + len(message_link_previews_values)
                 + len(link_previews_values)
-                > 5
+                > 4
             ):
                 break
         new_link_preview_by_url = {

--- a/addons/mail/static/src/core/common/link_preview.js
+++ b/addons/mail/static/src/core/common/link_preview.js
@@ -18,8 +18,10 @@ export class LinkPreview extends Component {
     setup() {
         super.setup();
         this.dialogService = useService("dialog");
+        this.ui = useService("ui");
         this.state = useState({ startVideo: false, videoLoaded: false });
         this.videoRef = useRef("video");
+        this.imageRef = useRef("image");
         useEffect(
             (el) => {
                 if (el) {
@@ -42,6 +44,13 @@ export class LinkPreview extends Component {
     }
 
     onImageLoaded() {
+        const img = this.imageRef?.el;
+        if (!img || !img.naturalWidth || !img.naturalHeight) {
+            return;
+        }
+        const aspectRatio = img.naturalWidth / img.naturalHeight;
+        // Determine if image is squarish (aspect ratio between 2:3 and 3:2)
+        this.linkPreview.hasSquarishCardImage = aspectRatio >= 0.67 && aspectRatio <= 1.5;
         this.env.onImageLoaded?.();
     }
 }

--- a/addons/mail/static/src/core/common/link_preview.scss
+++ b/addons/mail/static/src/core/common/link_preview.scss
@@ -1,28 +1,41 @@
 .o-mail-LinkPreviewCard {
     max-width: $o-mail-LinkPreview-width;
-
-    .row {
-        min-height: $o-mail-LinkPreviewCard-height;
-    }
 }
 
-.o-mail-LinkPreviewCard-description {
+.o-mail-LinkPreviewCardImage {
+    max-height: $o-mail-LinkPreviewImage-height;
+}
+
+.o-mail-LinkPreviewCardImage-squarish {
+    max-width: $o-mail-LinkPreviewCard-squarishImageSize;
+    max-height: $o-mail-LinkPreviewCard-squarishImageSize;
+}
+.o-mail-LinkPreviewCard-noImage {
+    width: fit-content;
+}
+
+.o-mail-LinkPreviewCard-title, .o-mail-LinkPreviewCard-description {
     display: -webkit-box;
     -webkit-box-orient: vertical;
+    overflow: hidden;
+}
+
+.o-mail-LinkPreviewCard-title {
     -webkit-line-clamp: 2;
 }
 
-.o-mail-LinkPreviewCard-imageLinkWrap {
-    border-right: 1px solid $card-border-color;
+.o-mail-LinkPreviewCard-description {
+    -webkit-line-clamp: 3;
 }
 
-.o-mail-LinkPreviewImage img {
-    max-height: $o-mail-LinkPreview-height;
-    max-width: $o-mail-LinkPreview-width;
-}
-
-.o-mail-ChatWindow .o-mail-LinkPreviewImage img {
-    max-width: 100%;
+.o-mail-LinkPreviewImage {
+    img {
+        max-width: $o-mail-LinkPreview-width;
+        max-height: $o-mail-LinkPreviewImage-height;
+    }
+    .o-mail-ChatWindow & img {
+        max-width: 100%;
+    }
 }
 
 .o-mail-LinkPreviewVideo {
@@ -107,5 +120,11 @@ $o-mail-LinkPreviewVideo-providerBorderWidth: 4px;
         .o-mail-LinkPreview-aside {
             display: block;
         }
+    }
+}
+
+@media (min-width: 576px) {
+    .o-mail-LinkPreview-dialog {
+        max-width: $o-mail-LinkPreview-dialogWidth;
     }
 }

--- a/addons/mail/static/src/core/common/link_preview.xml
+++ b/addons/mail/static/src/core/common/link_preview.xml
@@ -7,42 +7,67 @@
         <t t-if="linkPreview.isImage" t-call="mail.LinkPreviewImage"/>
     </t>
 
+    <t t-name="mail.LinkPreviewCard.content">
+        <span t-if="linkPreview.og_site_name" class="text-muted smaller" t-out="linkPreview.og_site_name"/>
+        <p class="o-mail-LinkPreviewCard-title mb-0" t-att-class="{ 'me-4': !linkPreview.og_site_name }">
+            <a t-att-href="linkPreview.source_url" target="_blank" t-out="linkPreview.og_title"/>
+        </p>
+        <p t-if="linkPreview.og_description" class="o-mail-LinkPreviewCard-description mt-1 mb-0 text-muted smaller" t-out="linkPreview.og_description"/>
+    </t>
     <t t-name="mail.LinkPreviewCard">
-        <div class="o-mail-LinkPreviewCard card position-relative w-100 mb-2 rounded bg-view shadow-sm overflow-hidden" t-att-class="{ 'me-2': env.inChatter }" t-attf-class="{{ className }}">
-            <div class="row g-0 flex-row-reverse h-100">
-                <div class="col min-w-0" t-att-class="{ 'd-flex align-items-center': !linkPreview.og_description }">
-                    <div class="px-3 py-2">
-                        <h6 class="card-title mb-0 me-2" t-attf-class="{{ linkPreview.og_description ? 'text-truncate' : 'overflow-hidden' }}">
-                            <a t-att-href="linkPreview.source_url" target="_blank" t-out="linkPreview.og_title"/>
-                        </h6>
-                        <span t-if="linkPreview.og_site_name" t-out="linkPreview.og_site_name"/>
-                        <p t-if="linkPreview.og_description" class="o-mail-LinkPreviewCard-description card-text mb-0 mt-2 text-muted small overflow-hidden" t-out="linkPreview.og_description"/>
+        <div class="o-mail-LinkPreviewCard card mb-1 rounded bg-view shadow-sm overflow-hidden" t-att-class="{ 'o-mail-LinkPreviewCard-noImage': !linkPreview.og_image, 'w-100': ui.isSmall or env.inChatWindow }" t-attf-class="{{ className }}">
+            <t t-if="linkPreview.og_image and linkPreview.hasSquarishCardImage and linkPreview.og_description">
+                <div class="d-flex align-items-center px-2 o-pt-0_5 pb-1 w-100">
+                    <div class="flex-grow-1 pe-1">
+                        <t t-call="mail.LinkPreviewCard.content"/>
+                    </div>
+                    <div class="position-relative d-flex align-items-center o-pt-0_5">
+                        <a t-att-href="linkPreview.source_url" target="_blank">
+                            <img t-ref="image" class="o-mail-LinkPreviewCardImage-squarish rounded object-fit-contain" t-att-src="linkPreview.og_image" t-att-alt="linkPreview.og_title" t-on-load="onImageLoaded"/>
+                        </a>
+                    </div>
+                    <t t-call="mail.LinkPreview.aside">
+                        <t t-set="className" t-value="'btn btn-dark btn-sm mt-1 me-1 rounded opacity-75 opacity-100-hover py-0 px-1'"/>
+                    </t>
+                </div>
+            </t>
+            <t t-elif="linkPreview.og_image">
+                <div class="d-flex flex-column h-100">
+                    <div class="px-2 o-pt-0_5 pb-1">
+                        <t t-call="mail.LinkPreviewCard.content"/>
+                    </div>
+                    <div class="px-2 pb-2 d-flex justify-content-center">
+                        <a t-att-href="linkPreview.source_url" target="_blank">
+                            <img t-ref="image" class="o-mail-LinkPreviewCardImage w-100 rounded object-fit-contain" t-att-src="linkPreview.og_image" t-att-alt="linkPreview.og_title" t-on-load="onImageLoaded"/>
+                        </a>
                     </div>
                 </div>
-                <div class="o-mail-LinkPreviewCard-imageLinkWrap col-4 d-block">
-                    <a t-att-href="linkPreview.source_url" target="_blank">
-                        <img t-if="linkPreview.og_image" class="w-100 h-100 object-fit-cover" t-att-src="linkPreview.og_image" t-att-alt="linkPreview.og_title" t-on-load="onImageLoaded"/>
-                        <span t-else="" class="d-flex align-items-center justify-content-center w-100 h-100 bg-100 text-300">
-                            <i class="fa fa-camera fa-2x"/>
-                        </span>
-                    </a>
+                <t t-call="mail.LinkPreview.aside">
+                    <t t-set="className" t-value="'fa fa-stack p-0 opacity-75 opacity-100-hover'"/>
+                </t>
+            </t>
+            <t t-else="">
+                <div class="border-start border-4 px-2 py-1">
+                    <t t-call="mail.LinkPreviewCard.content"/>
+                    <t t-call="mail.LinkPreview.aside">
+                        <t t-set="className" t-value="'fa fa-stack p-0 opacity-75 opacity-100-hover'"/>
+                    </t>
                 </div>
-            </div>
-            <t t-call="mail.LinkPreview.aside">
-                <t t-set="className" t-value="'fa fa-stack p-0 opacity-75 opacity-100-hover'"/>
             </t>
         </div>
     </t>
 
     <t t-name="mail.LinkPreviewImage">
-        <div class="o-mail-LinkPreviewImage position-relative mb-2 rounded" t-att-class="{ 'me-2': env.inChatter }" t-attf-class="{{ className }}">
-            <a t-if="linkPreview.imageUrl" t-att-href="linkPreview.imageUrl" target="_blank">
-                <Gif t-if="linkPreview.isGif" paused="props.messageLinkPreview.gifPaused" class="'h-auto w-auto rounded'" src="linkPreview.imageUrl" onLoad.bind="onImageLoaded"/>
-                <img t-else="" class="h-auto w-auto rounded" t-att-src="linkPreview.imageUrl" t-on-load="onImageLoaded"/>
-            </a>
-            <t t-call="mail.LinkPreview.aside">
-                <t t-set="className" t-value="'btn btn-sm btn-dark mt-2 me-2 rounded opacity-75 opacity-100-hover'"/>
-            </t>
+        <div class="o-mail-LinkPreviewImage mb-2 rounded" t-att-class="{ 'me-2': env.inChatter }" t-attf-class="{{ className }}">
+            <div class="position-relative d-inline-block">
+                <a t-if="linkPreview.imageUrl" t-att-href="linkPreview.imageUrl" target="_blank">
+                    <Gif t-if="linkPreview.isGif" paused="props.messageLinkPreview.gifPaused" class="'h-auto w-auto rounded'" src="linkPreview.imageUrl" onLoad.bind="onImageLoaded"/>
+                    <img t-else="" class="h-auto w-auto rounded" t-att-src="linkPreview.imageUrl" t-on-load="onImageLoaded"/>
+                </a>
+                <t t-call="mail.LinkPreview.aside">
+                    <t t-set="className" t-value="'btn btn-sm btn-dark mt-2 me-2 rounded opacity-75 opacity-100-hover'"/>
+                </t>
+            </div>
         </div>
     </t>
 

--- a/addons/mail/static/src/core/common/link_preview_confirm_delete.xml
+++ b/addons/mail/static/src/core/common/link_preview_confirm_delete.xml
@@ -1,9 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="mail.LinkPreviewConfirmDelete">
-        <Dialog size="'md'" title.translate="Confirmation" modalRef="modalRef">
+        <Dialog size="'md'" title.translate="Confirmation" modalRef="modalRef" contentClass="'o-bg-body o-mail-LinkPreview-dialog'">
             <p class="mx-3 mb-3">Do you really want to delete this preview?</p>
-            <t t-component="props.LinkPreview" messageLinkPreview="props.messageLinkPreview"/>
+            <div class="d-flex flex-column ms-md-2">
+                <blockquote>
+                    <t t-component="props.LinkPreview" messageLinkPreview="props.messageLinkPreview"/>
+                </blockquote>
+            </div>
             <t t-set-slot="footer">
                 <button class="btn btn-danger me-2" t-on-click="onClickOk">Delete</button>
                 <button t-if="props.messageLinkPreview.hasDeleteAll" class="btn btn-outline-danger me-2" t-on-click="onClickDeleteAll">Delete all previews</button>

--- a/addons/mail/static/src/core/common/link_preview_model.js
+++ b/addons/mail/static/src/core/common/link_preview_model.js
@@ -12,6 +12,8 @@ export class LinkPreview extends Record {
     message_link_preview_ids = fields.Many("mail.message.link.preview", {
         inverse: "link_preview_id",
     });
+    /** @type {boolean} */
+    hasSquarishCardImage;
     /** @type {string} */
     image_mimetype;
     /** @type {string} */

--- a/addons/mail/static/src/core/common/message_link_preview_list.xml
+++ b/addons/mail/static/src/core/common/message_link_preview_list.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="mail.MessageLinkPreviewList">
-        <div class="o-mail-LinkPreviewList d-flex flex-column mt-2" t-att-class="{ 'me-2 pe-4': env.inChatWindow and !env.alignedRight, 'ms-2 ps-4': env.inChatWindow and env.alignedRight }">
-            <div class="d-flex flex-grow-1 flex-wrap">
+        <div class="o-mail-LinkPreviewList d-flex flex-column mt-1" t-att-class="{ 'me-2 pe-4': env.inChatWindow and !env.alignedRight, 'ms-2 ps-4': env.inChatWindow and env.alignedRight }">
+            <div class="d-flex flex-column">
                 <LinkPreview t-foreach="props.messageLinkPreviews" t-as="messageLinkPreview" t-key="messageLinkPreview.id" messageLinkPreview="messageLinkPreview"/>
             </div>
         </div>

--- a/addons/mail/static/src/core/common/primary_variables.scss
+++ b/addons/mail/static/src/core/common/primary_variables.scss
@@ -11,9 +11,11 @@ $o-mail-ChatBubble-zindex: 1001 !default;
 $o-RoundedRectangle-small: .2rem !default;
 $o-RoundedRectangle-large: 3 * $o-RoundedRectangle-small !default;
 
-$o-mail-LinkPreview-width: 320px !default;
-$o-mail-LinkPreview-height: 240px !default;
+$o-mail-LinkPreview-width: 380px !default;
+$o-mail-LinkPreviewImage-height: 210px !default;
+$o-mail-LinkPreviewCard-squarishImageSize: 120px !default;
 $o-mail-LinkPreviewCard-height: 80px !default;
+$o-mail-LinkPreview-dialogWidth: 420px !default;
 
 $o-mail-Message-sidebarSmallWidth: 36px !default;
 $o-mail-Message-sidebarWidth: 48px !default;

--- a/addons/mail/static/tests/message/link_preview.test.js
+++ b/addons/mail/static/tests/message/link_preview.test.js
@@ -83,7 +83,7 @@ test("simplest card layout", async () => {
     await start();
     await openDiscuss(channelId);
     await contains(".o-mail-LinkPreviewCard");
-    await contains(".o-mail-LinkPreviewCard h6:text('Article title')");
+    await contains(".o-mail-LinkPreviewCard p:text('Article title')");
     await contains(".o-mail-LinkPreviewCard p:text('Description')");
 });
 
@@ -107,7 +107,7 @@ test("simplest card layout with image", async () => {
     await start();
     await openDiscuss(channelId);
     await contains(".o-mail-LinkPreviewCard");
-    await contains(".o-mail-LinkPreviewCard h6:text('Article title')");
+    await contains(".o-mail-LinkPreviewCard p:text('Article title')");
     await contains(".o-mail-LinkPreviewCard p:text('Description')");
     await contains(".o-mail-LinkPreviewCard img");
 });


### PR DESCRIPTION
**Purpose of this PR:**

Previously, link previews had poor readability.The horizontal layout (image left, text right) split the available width, forcing titles to truncate aggressively and making descriptions hard to read. Additionally, images were cropped into fixed square containers, cutting off important visual content particularly for screenshots and infographics.

This commit switches to a vertical layout to solve these issues:
- Title positioned at top with full width for 2-line wrapping
- Image below title displays in full without cropping
- Description at bottom with 4-line capacity for better readability
- Text-only preview for links whose previews don't contain images, preventing excessive vertical space

**Before:**
<img width="492" height="180" alt="image" src="https://github.com/user-attachments/assets/9135d148-225f-4232-b603-cff2c1338689" />

**After:**
<img width="590" height="435" alt="image" src="https://github.com/user-attachments/assets/e80a9387-70d1-43d6-b6a5-377087ff3aa5" />

Task-4690329