### PR TITLE
[FIX] website: adapt configurator translation tour

### DIFF
--- a/addons/website/static/src/client_actions/website_preview/website_builder_action.js
+++ b/addons/website/static/src/client_actions/website_preview/website_builder_action.js
@@ -171,7 +171,10 @@ export class WebsiteBuilderClientAction extends Component {
             (isEditing) => {
                 document.querySelector("body").classList.toggle("o_builder_open", isEditing);
                 if (isEditing) {
-                    setTimeout(() => {
+                    // When entering edit mode, the navbar animates upwards.
+                    // To avoid an abrupt disappearance, we delay adding the
+                    // 'd-none' class
+                    this.navBarTimeout = setTimeout(() => {
                         websiteSystrayRegistry.remove("website.WebsiteSystrayItem");
                         websiteSystrayRegistry.trigger("EDIT-WEBSITE");
                         document.querySelector(".o_builder_open .o_main_navbar").classList.add("d-none");
@@ -179,6 +182,7 @@ export class WebsiteBuilderClientAction extends Component {
                 } else {
                     document.querySelector(".o_main_navbar")?.classList.remove("d-none");
                 }
+                return () => clearTimeout(this.navBarTimeout);
             },
             () => [this.state.isEditing]
         );

--- a/addons/website/static/tests/tours/configurator_translation.js
+++ b/addons/website/static/tests/tours/configurator_translation.js
@@ -64,7 +64,8 @@ registry.category("web_tour.tours").add('configurator_translation', {
         run: "click",
     }, {
         content: "Loader should be shown",
-        trigger: '.o_website_loader_container',
+        trigger: ".o_website_loader_container",
+        expectUnloadPage: true,
     }, {
         content: "Wait until the configurator is finished",
         trigger: ":iframe [data-view-xmlid='website.homepage']",
@@ -86,7 +87,7 @@ registry.category("web_tour.tours").add('configurator_translation', {
         // Parseltongue. (The editor should be in the website's default language,
         // which should be parseltongue in this test.)
         content: "exit edit mode",
-        trigger: '.o-snippets-top-actions button.btn-primary:contains("Save_Parseltongue")',
+        trigger: ".o-snippets-top-actions button.btn-success:contains('Save_Parseltongue')",
         run: "click",
     }, {
          content: "wait for editor to be closed",

--- a/addons/website/tests/test_configurator.py
+++ b/addons/website/tests/test_configurator.py
@@ -1,7 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from unittest.mock import patch
-import unittest
 
 import odoo.tests
 
@@ -101,8 +100,6 @@ class TestConfigurator(TestConfiguratorCommon):
 @odoo.tests.common.tagged('post_install', '-at_install')
 class TestConfiguratorTranslation(TestConfiguratorCommon):
 
-    # TODO master-mysterious-egg fix error
-    @unittest.skip("prepare mysterious-egg for merging")
     def test_01_configurator_translation(self):
         parseltongue = self.env['res.lang'].create({
             'name': 'Parseltongue',


### PR DESCRIPTION
**Commit 1:**
Commit re-enables the test_01_configurator_translation test, which was broken and skipped due to the DOM changes introduced by the new Website Builder. It also adapts the tour selectors accordingly.

In the configuration screen, after clicking the "Build My Website" button, the website was taking unexpected time to load. To address this, we added `expectPageUnload` to wait for fill page load. After that, we wait for the configurator to finish.

**Commit 2:**
Steps to reproduce:
Go to edit mode and quickly click "Save" within 200ms.
It will throw the error:
Cannot read properties of null (reading 'classList')

Reason:
In the useEffect of WebsiteBuilderClientAction

1. User enters edit mode → isEditing = true.
2. This adds "o_builder_open" class to <body>.
3. A setTimeout is started to run builder-related DOM updates.
4. Before the timeout runs, user clicks "Save" → isEditing = false.
5. The "o_builder_open" class is removed from <body>.
6. When the timeout executes, it tries to access:
     document.querySelector(".o_builder_open .o_main_navbar")
7. This returns null because ".o_builder_open" no longer exists.
8. Calling .classList.add() on null throws a TypeError.

Fix:
Added a cleanup function to the useEffect hook to ensure that any pending timeouts are cleared when the dependency (`isEditing`) changes. This prevents unexpected DOM updates and ensures consistent behavior when toggling edit mode rapidly.

runbot-226533