### PR TITLE
[FIX] website_sale: prevent traceback when toggling search box view visibility

### DIFF
--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -1133,7 +1133,7 @@
                 <button type="button" class="btn-close" data-bs-dismiss="offcanvas" aria-label="Close"/>
             </div>
             <div
-                if="is_view_active('website_sale.search') and (opt_wsale_attributes or opt_wsale_attributes_top)"
+                t-if="is_view_active('website_sale.search') and (opt_wsale_attributes or opt_wsale_attributes_top)"
                 class="offcanvas-body flex-grow-0 overflow-visible"
             >
                 <t t-call="website_sale.search">


### PR DESCRIPTION
**Before this PR:**

- Toggling the active field of the search box view from the backend caused a traceback on the shop page when loading the      frontend.

**After this commit:**

- The shop page now loads correctly even when the search box view is deactivated or reactivated via the backend. The toggling behavior works as expected without raising errors.

**opw - 4918722**