### PR TITLE
[FIX] point_of_sale: sticky header in res config for pos

### DIFF
--- a/addons/point_of_sale/static/src/scss/pos_dashboard.scss
+++ b/addons/point_of_sale/static/src/scss/pos_dashboard.scss
@@ -27,11 +27,13 @@
   }
 }
 
-.pos_config_content {
-    padding-top: 65px;
+.settingSearchHeader + .pos_res_config_container {
+  margin-top: -10px;
 }
+
 @media screen and (max-width: 768px) {
-    .pos_config_content {
-        padding-top: 98px;
-    }
+  .pos_res_config_container {
+    height: 82vh;
+    overflow-y: auto;
+  }
 }

--- a/addons/point_of_sale/views/res_config_settings_views.xml
+++ b/addons/point_of_sale/views/res_config_settings_views.xml
@@ -19,7 +19,8 @@
                 </t>
 
                 <app data-string="Point of sale" string="Point of Sale" name="point_of_sale" groups="point_of_sale.group_pos_manager">
-                    <div style="z-index:1000;" class="position-fixed w-100 bg-white">
+                    <div class="pos_res_config_container">
+                    <div class="sticky-top w-100 bg-white">
                         <setting type="header" string="Point of Sale">
                             <field name="pos_config_id" options="{'no_open': True, 'no_create': True}" title="Settings on this page will apply to this point of sale."/>
                             <button name="action_pos_config_create_new" type="object" string="+ New Shop" class="btn btn-link"/>
@@ -489,6 +490,7 @@
                                 </setting>
                             </block>
                         </div>
+                    </div>
                     </div>
                 </app>
             </xpath>


### PR DESCRIPTION
## Issue:
- The POS config header did not stay fixed at the top during search, on both mobile and web views.
![image](https://github.com/user-attachments/assets/cae82ccc-75a0-4770-b1a6-7fbf8a7d3436)

## Fix:
- The header now remains properly fixed on scroll in all views.
![image](https://github.com/user-attachments/assets/c8080232-0010-422a-834b-357d53919707)


Task: 4880990