### PR TITLE
[FIX] web_editor: adjust toolbar positioning based on visibility

### DIFF
--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/style.scss
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/style.scss
@@ -145,6 +145,7 @@
     width: fit-content;
     padding-left: 5px;
     padding-right: 5px;
+    top: 0;
     background: #222222;
     color: white;
 


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

- Commit [189a7c96](https://github.com/odoo/odoo/commit/189a7c96e6e26825dc05c0c6466576fe63aa091e#diff-de0d67e89972b45b101a9c4b04f316824314b0d69aba6208528586f1edb4f01cL25-L40) moved scrollbar from `#wrapwrap` element to `<body>`, caused the space below the footer visible for the floating toolbar.

Current behavior before PR:

- Space below the footer was always visible, even when the toolbar was hidden.

Desired behavior after PR is merged:

- `top: 0;` is applied on `.oe-toolbar` to ensure it stays out of the layout flow.
- This prevents unnecessary layout space and ensures correct toolbar positioning.

task-4652202

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
