### PR TITLE
[FIX] base_setup: rename help intercompany rules

### DIFF
--- a/addons/base_setup/views/res_config_settings_views.xml
+++ b/addons/base_setup/views/res_config_settings_views.xml
@@ -91,7 +91,7 @@
                                     </div>
                                 </setting>
                                 <field name="company_id" invisible="1"/>
-                                <setting id="inter_company" string="Inter-Company Transactions" company_dependent="1" help="Create corresponding in/out orders and invoices when you sell/buy between your companies" groups="base.group_multi_company" title="Configure company rules to automatically create SO/PO when one of your company sells/buys to another of your company.">
+                                <setting id="inter_company" string="Inter-Company Transactions" company_dependent="1" help="Create corresponding in/out orders and bills when you sell/buy between your companies" groups="base.group_multi_company" title="Configure company rules to automatically create SO/PO when one of your company sells/buys to another of your company.">
                                     <field name="module_account_inter_company_rules" widget="upgrade_boolean"/>
                                     <div class="content-group" invisible="not module_account_inter_company_rules" id="inter_companies_rules">
                                         <div class="mt16 text-warning"><strong>Save</strong> this page and come back here to set up the feature.</div>


### PR DESCRIPTION
This commit: https://github.com/odoo/odoo/commit/e2a0c6edb8c9c1fd0aba2f92f9187678e68971a9 change a help in the intercompany rules. The help sentence is wrong since we don't create invoice but bills.

task-4907810




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
