### PR TITLE
[FIX] domain: empty coquery

### DIFF
--- a/odoo/addons/test_orm/tests/test_search.py
+++ b/odoo/addons/test_orm/tests/test_search.py
@@ -379,6 +379,16 @@ class TestSubqueries(TransactionCase):
                     ('tags.name', 'like', 'z'),
             ])
 
+    def test_empty_many2many(self):
+        sub_query = self.env['test_orm.multi'].tags._as_query()
+        with self.assertQueries(["""
+            SELECT "test_orm_multi"."id"
+            FROM "test_orm_multi"
+            WHERE FALSE
+            ORDER BY "test_orm_multi"."id"
+        """]):
+            self.env['test_orm.multi'].search([('tags', 'any', sub_query)])
+
     def test_related_simple(self):
         model = self.env['test_orm.related'].with_user(self.env.ref('base.user_admin'))
         self.env['ir.rule'].create({

--- a/odoo/orm/fields_relational.py
+++ b/odoo/orm/fields_relational.py
@@ -1631,14 +1631,14 @@ class Many2many(_RelationalMulti):
 
     def _condition_to_sql_relational(self, model: BaseModel, alias: str, exists: bool, coquery: Query, query: Query) -> SQL:
         assert not self.auto_join, f"auto_join not implemented for many2many fields ({self})"
+        if coquery.is_empty():
+            return SQL("FALSE") if exists else SQL("TRUE")
         rel_table, rel_id1, rel_id2 = self.relation, self.column1, self.column2
         rel_alias = query.make_alias(alias, self.name)
         if not coquery.where_clause:
             # case: no constraints on table and we have foreign keys
-            # so we can inverse the operator and check against empty query
-            coquery = model.browse()._as_query()
+            # so we can inverse the operator and check existence
             exists = not exists
-        if coquery.is_empty():
             return SQL(
                 "%sEXISTS (SELECT 1 FROM %s AS %s WHERE %s = %s)",
                 SQL("NOT ") if exists else SQL(),


### PR DESCRIPTION
When filtering using an empty coquery, the any operator should return a `FALSE` condition in SQL because no records will be found.

For the query `(xxx_m2m, 'any', empty_query)`.
Before: WHERE NOT EXIST (SELECT 1 FROM table_link WHERE table.id = table_link.a)
After: WHERE FALSE

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
