### PR TITLE
[FIX] purchase: convert product prices from other currencies in catalog

### DIFF
--- a/addons/purchase/models/purchase_order.py
+++ b/addons/purchase/models/purchase_order.py
@@ -1078,8 +1078,11 @@ class PurchaseOrder(models.Model):
             params=params
         )
         if seller:
+            price = seller.price_discounted
+            if seller.currency_id != self.currency_id:
+                price = seller.currency_id._convert(seller.price_discounted, self.currency_id)
             product_infos.update(
-                price=seller.price_discounted,
+                price=price,
                 min_qty=seller.min_qty,
             )
         # Check if the product uses some packaging.
@@ -1224,8 +1227,11 @@ class PurchaseOrder(models.Model):
                 date=pol.order_id.date_order and pol.order_id.date_order.date() or fields.Date.context_today(pol),
                 uom_id=pol.product_uom)
             if seller:
+                price = seller.price_discounted
+                if seller.currency_id != self.currency_id:
+                    price = seller.currency_id._convert(seller.price_discounted, self.currency_id)
                 # Fix the PO line's price on the seller's one.
-                pol.price_unit = seller.price_discounted
+                pol.price_unit = price
         return pol.price_unit_discounted
 
     def _create_update_date_activity(self, updated_dates):

--- a/addons/purchase/tests/__init__.py
+++ b/addons/purchase/tests/__init__.py
@@ -8,3 +8,4 @@ from . import test_purchase_invoice
 from . import test_access_rights
 from . import test_accrued_purchase_orders
 from . import test_purchase_dashboard
+from . import test_purchase_product_catalog

--- a/addons/purchase/tests/test_purchase_product_catalog.py
+++ b/addons/purchase/tests/test_purchase_product_catalog.py
@@ -1,0 +1,103 @@
+from odoo import Command, fields
+from odoo.addons.account.tests.common import AccountTestInvoicingCommon
+from odoo.tests import HttpCase, tagged
+
+import json
+
+
+@tagged('-at_install', 'post_install')
+class TestPurchaseProductCatalog(AccountTestInvoicingCommon, HttpCase):
+
+    def test_catalog_price(self):
+        """
+        Products having a SupplierInfo record in a foreign currency should have their price
+        converted in the product catalog
+        When it's the same currency, the price shouldn't be changed
+        """
+        self.authenticate(self.env.user.login, self.env.user.login)
+        company_currency = self.env.company.currency_id
+        other_currency = self.setup_other_currency('HRK', rates=[(fields.Date.today(), 0.5)])
+
+        other_product_price = 100
+        company_product_price = 150
+        other_product_price_converted = other_product_price / 0.5
+
+        other_product = self.env['product.product'].create({
+            'name': 'Other Product',
+            'seller_ids': [
+                Command.create({
+                    'partner_id': self.partner_a.id,
+                    'min_qty': 1,
+                    'price': other_product_price,
+                    'currency_id': other_currency.id,
+                }),
+            ]
+        })
+        company_product = self.env['product.product'].create({
+            'name': 'Company Product',
+            'seller_ids': [
+                Command.create({
+                    'partner_id': self.partner_a.id,
+                    'min_qty': 1,
+                    'price': company_product_price,
+                    'currency_id': company_currency.id,
+                }),
+            ]
+        })
+
+        purchase_order = self.env['purchase.order'].create({
+            'partner_id': self.partner_a.id,
+            'currency_id': company_currency.id,
+        })
+        self.assertNotEqual(other_product.seller_ids[0].currency_id.id, purchase_order.currency_id.id)
+
+        resp = self.url_open(
+            url='/product/catalog/order_lines_info',
+            data=json.dumps({
+                'params': {
+                    'child_field': 'order_line',
+                    'order_id': purchase_order.id,
+                    'product_ids': other_product.ids + company_product.ids,
+                    'res_model': 'purchase.order'
+                }
+            }),
+            headers={'Content-Type': 'application/json'},
+        )
+        self.assertEqual(resp.status_code, 200)
+        catalog_price_other_cur = resp.json()['result'][str(other_product.id)]['price']
+        self.assertEqual(catalog_price_other_cur, other_product_price_converted)
+        catalog_price_company_cur = resp.json()['result'][str(company_product.id)]['price']
+        self.assertEqual(catalog_price_company_cur, company_product_price)
+
+        # The prices are recalculated on product order line update
+        resp = self.url_open(
+            url='/product/catalog/update_order_line_info',
+            data=json.dumps({
+                'params': {
+                    'child_field': 'order_line',
+                    'order_id': purchase_order.id,
+                    'product_id': other_product.id,
+                    'quantity': 1,
+                    'res_model': 'purchase.order'
+                }
+            }),
+            headers={'Content-Type': 'application/json'},
+        )
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json()['result'], other_product_price_converted)
+
+        resp = self.url_open(
+            url='/product/catalog/update_order_line_info',
+            data=json.dumps({
+                'params': {
+                    'child_field': 'order_line',
+                    'order_id': purchase_order.id,
+                    'product_id': company_product.id,
+                    'quantity': 1,
+                    'res_model': 'purchase.order'
+                }
+            }),
+            headers={'Content-Type': 'application/json'},
+        )
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json()['result'], company_product_price)


### PR DESCRIPTION
Before this commit, the unit price in the catalog for purchase order wasn't converted from other currencies to the order one It was just set to the price regardless of the vendor currency

This fix will automatically convert the catalog prices from seller's currency to purchase.order's currency

Steps to reproduce:
- Create a product to Purchase
- Add a vendor in the Purchase Tab
- Set quantity to 1, price to 100 and currency to EUR
- Create a RFQ
- Select the Vendor from the product created
- Check to currency to be USD
- Add the product and take note of the Unit Price
- Remove the product line
- Go to Catalog
- Compare the Price with the Unit Price (They doesn't match before the fix)

opw-4909789