### PR TITLE
[IMP] account: rename label of non deductible account on journal

### DIFF
--- a/addons/account/models/account_journal.py
+++ b/addons/account/models/account_journal.py
@@ -123,7 +123,7 @@ class AccountJournal(models.Model):
     non_deductible_account_id = fields.Many2one(
         comodel_name='account.account',
         check_company=True,
-        string='Private Part Account',
+        string='Private Share Account',
         readonly=False,
         store=True,
         domain="[('deprecated', '=', False)]",


### PR DESCRIPTION
Change label of `non_deductible_account_id` field on `account.journal` from `Private Part Account` to `Private Share Account` as private part means something else in english.

task-4868244
