### PR TITLE
[FIX] mail: remove extraneous separator on follower notif

### DIFF
--- a/addons/mail/data/mail_templates_invite.xml
+++ b/addons/mail/data/mail_templates_invite.xml
@@ -7,10 +7,6 @@
                     <t t-set="subtitles" t-value="False" />
                 </t>
             </xpath>
-            <xpath expr="//div[@t-out='message.body']" position="before">
-                <hr width="100%"
-    style="background-color:rgb(204,204,204);border:medium none;clear:both;display:block;font-size:0px;min-height:1px;line-height:0;margin: 10px 0px;"/>
-            </xpath>
             <xpath expr="//div[@t-out='message.body']" position="replace">
                 <div style="font-size:13px;">
                     <div>


### PR DESCRIPTION
When adding an Odoo user as a follower to a lead/task/..., there are two separators between the message header and its body.

This commit removes the extraneous separator.

Steps to reproduce:
- Open a lead/task/...
- Add Marc Demo as a Follower
- Toggle the option to have them notified

task-4889715