### PR TITLE
[IMP] account: Enable grouping by account root

### DIFF
--- a/addons/account/models/account_account.py
+++ b/addons/account/models/account_account.py
@@ -190,6 +190,11 @@ class AccountAccount(models.Model):
                 account_first_company_root_id=SQL.identifier('account_first_company', 'root_company_id'),
                 to_flush=self._fields['code_store'],
             )
+        if fname == 'root_id':
+            return SQL(
+                "SUBSTRING(%(placeholder_code)s, 1, 2)",
+                placeholder_code=self._field_to_sql(alias, 'placeholder_code', query, flush),
+            )
 
         return super()._field_to_sql(alias, fname, query, flush)
 


### PR DESCRIPTION
Before this commit:
- go to Accounting > Configuration > Chart of Accounts
- in the search bar, you cannot group accounts by account root.

After this commit:
- You can group accounts by account root ('Root').

We do this by implementing `_field_to_sql` for `account.account.root_id` which makes the field groupable.

task-none