### PR TITLE
[FIX] hr_timesheet, sale_project: fix AA generation for project templates in SO

### DIFF
--- a/addons/hr_timesheet/models/project_project.py
+++ b/addons/hr_timesheet/models/project_project.py
@@ -284,7 +284,7 @@ class ProjectProject(models.Model):
         action['context']['allow_timesheets'] = self.allow_timesheets
         return action
 
-    def action_create_from_template(self, values=None, role_to_users_mapping=None):
-        project = super().action_create_from_template(values, role_to_users_mapping)
-        project._create_analytic_account()
-        return project
+    def _toggle_template_mode(self, is_template):
+        if not is_template and self.allow_timesheets and not self.account_id:
+            self._create_analytic_account()
+        super()._toggle_template_mode(is_template)

--- a/addons/hr_timesheet/tests/test_project_template.py
+++ b/addons/hr_timesheet/tests/test_project_template.py
@@ -24,11 +24,33 @@ class TestProjectProjectTemplate(TransactionCase):
         self.assertTrue(normal_project.account_id, "A normal project should have a analytic account")
 
     def test_project_created_from_template_to_have_analytic_account(self):
-        template_project = self.env['project.project'].create({
-            "name": "Template Project",
-            "is_template": True,
-            "allow_timesheets": True,
-        })
+        template_project_timesheet, template_project_no_timesheet = self.env['project.project'].create([
+            {
+                "name": "Template Project Timesheet",
+                "is_template": True,
+                "allow_timesheets": True,
+            },
+            {
+                "name": "Template Project No Timesheet",
+                "is_template": True,
+                "allow_timesheets": False,
+            },
+        ])
 
-        new_project = template_project.action_create_from_template()
-        self.assertTrue(new_project.account_id, "A project created from template should have a analytic account")
+        new_project_1 = template_project_timesheet.action_create_from_template()
+        self.assertTrue(new_project_1.account_id, "A project created from template allowing timesheet should have an analytic account")
+        new_project_2 = template_project_no_timesheet.action_create_from_template()
+        self.assertFalse(new_project_2.account_id, "A project created from template disabling timesheet should not have an analytic account")
+
+    def test_convert_project_template_into_regular_project_analytics(self):
+        template_project = self.env["project.project"].create(
+            {
+                "name": "Template Project Timesheet",
+                "is_template": True,
+                "allow_timesheets": True,
+            }
+        )
+        self.assertFalse(template_project.account_id, "The template project shouldn't have analytic account before conversion")
+        template_project.action_undo_convert_to_template()
+        self.assertFalse(template_project.is_template, "The project should not be a template anymore after conversion")
+        self.assertTrue(template_project.account_id, "Converting a template project with timesheets enabled into a regular project should create an analytic account")


### PR DESCRIPTION
Prior to this commit, when an SO containing products configured to generate projects based on project templates was confirmed, it would generate one analytic account per generated project. Which is not consistent with the previous behavior.
It was due to the fact that in 'hr_timesheet' module, we always created a new analytic account each time a new project is created from a project template, even if an analytic account is already passed in the create values or if the project template was not timesheetable.
Also, when converting a project template having timesheets enabled and no account_id set to a regular project, it did not create a new analytic account, this is now fixed.

version-18.4

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
