### PR TITLE
[FIX] html_builder, website: fix rtl in snippet dialog

### DIFF
--- a/addons/html_builder/static/src/snippets/snippet_service.js
+++ b/addons/html_builder/static/src/snippets/snippet_service.js
@@ -114,6 +114,7 @@ export class SnippetModel extends Reactive {
                     this.updateSnippetContent(newSnippetEl);
                 },
                 installSnippetModule: editor.config.installSnippetModule,
+                editor,
             },
             { onClose }
         );

--- a/addons/html_builder/static/src/snippets/snippet_viewer.js
+++ b/addons/html_builder/static/src/snippets/snippet_viewer.js
@@ -20,6 +20,7 @@ export class SnippetViewer extends Component {
         hasSearchResults: Function,
         snippetModel: { type: Object },
         installSnippetModule: { type: Function },
+        frontendDirection: { type: String },
     };
 
     setup() {

--- a/addons/html_builder/static/src/snippets/snippet_viewer.xml
+++ b/addons/html_builder/static/src/snippets/snippet_viewer.xml
@@ -3,7 +3,7 @@
 
 
 <t t-name="html_builder.SnippetViewer">
-    <div t-ref="content" class="row g-0 o_snippets_preview_row">
+    <div t-ref="content" class="row g-0 o_snippets_preview_row" t-att-dir="this.props.frontendDirection">
         <div class="col-lg-6" t-foreach="this.getSnippetColumns()" t-as="snippetsColumn" t-key="snippetsColumn_index">
             <t t-foreach="snippetsColumn" t-as="snippet" t-key="snippet.id">
                 <div t-on-click="() => this.onClick(snippet)"

--- a/addons/website/static/tests/tours/snippet_translation.js
+++ b/addons/website/static/tests/tours/snippet_translation.js
@@ -125,3 +125,29 @@ registerWebsitePreviewTour(
         },
     ]
 );
+registerWebsitePreviewTour(
+    "snippet_dialog_rtl",
+    {
+        url: "/",
+    },
+    () => [
+        ...clickOnEditAndWaitEditMode(),
+        {
+            trigger: ".o_builder_sidebar_open",
+        },
+        {
+            content: "Select a category snippet to show the snippet dialog",
+            trigger: `.o_block_tab:not(.o_we_ongoing_insertion) #snippet_groups .o_snippet[name="Intro"].o_draggable .o_snippet_thumbnail_area`,
+            run: "click",
+        },
+        {
+            content: "Check that the snippets preview is in rtl",
+            trigger: ":iframe .o_snippets_preview_row[dir=rtl]",
+        },
+        {
+            content: "Check that web.assets_frontend CSS bundle is in rtl",
+            trigger:
+                ":iframe link[type='text/css'][href*='/web.assets_frontend.rtl']:not(:visible)",
+        },
+    ],
+);

--- a/addons/website/tests/test_ui.py
+++ b/addons/website/tests/test_ui.py
@@ -258,6 +258,7 @@ class TestUiTranslate(odoo.tests.HttpCase):
             'code': 'pa_GB',
             'iso_code': 'pa_GB',
             'url_code': 'pa_GB',
+            'direction': 'rtl',
         }, {
             'name': 'Fake User Lang',
             'code': 'fu_GB',
@@ -295,6 +296,7 @@ class TestUiTranslate(odoo.tests.HttpCase):
         self.start_tour(f"/website/force/{website.id}", 'snippet_translation', login='admin')
         self.start_tour(f"/website/force/{website_2.id}", 'snippet_translation_changing_lang', login='admin')
         self.start_tour(f"/website/force/{website_2.id}", 'snippet_translation_switching_website', login='admin')
+        self.start_tour(f"/website/force/{website.id}", 'snippet_dialog_rtl', login='admin')
 
 
 @odoo.tests.common.tagged('post_install', '-at_install')


### PR DESCRIPTION
__Current behavior before commit:__
When using a right-to-left (RTL) language on a website, the snippet dialog in the website builder does not correctly apply the RTL direction to the snippet previews. The CSS for the frontend assets is loaded without considering the RTL context of the website.

This is mainly an issue when the website default language has a different direction than the user language.

__Description of the fix:__
This commit corrects the RTL behavior in the snippet dialog by:
- Setting the dir attribute to the snippet preview container based on the direction of the editable element.
- Ensuring the correct CSS bundle (including the RTL version) is loaded for the snippet previews by retrieving the CSS bundle URL from the editor's document similarly as it was done in `web_editor`.
- Adding a tour to test the fix.

Website refactor: https://github.com/odoo/odoo/pull/187419
task-4367641
