### PR TITLE
[FIX] website: do not display quality settings if formats are unknown

### DIFF
--- a/addons/html_builder/static/src/plugins/image/image_format_option.xml
+++ b/addons/html_builder/static/src/plugins/image/image_format_option.xml
@@ -14,7 +14,7 @@
             </t>
         </BuilderSelect>
     </BuilderRow>
-    <BuilderRow label.translate="Quality" t-if="state.showQuality" level="this.props.level">
+    <BuilderRow label.translate="Quality" t-if="state.showQuality and state.formats.length" level="this.props.level">
         <BuilderRange
             action="'setImageQuality'"
             min="0"


### PR DESCRIPTION
When an image is added from a CORS URL, the image data cannot be obtained from the web browser. Because of this, converting the image to another format, adjusting its quality or other manipulations are not possible.
Currently the "Quality" option appears for CORS image - but disappear when trying to use it, which also corrupts the image.

This commit hides the "Quality" option when converting to another format is anyway unavailable.

Steps to reproduce:
- drop an image block
- replace an image by using "Add URL" and specify a [non-CORS image]
- "Quality" option was available and could be used
- replace an image by using "Add URL" and specify a [CORS image]

=> "Quality" option was available, but should not have been. Upon use, image was lost and "Quality" option disappeared.

[non-CORS image]: https://upload.wikimedia.org/wikipedia/commons/thumb/2/2f/Thysanoptera.jpg/420px-Thysanoptera.jpg
[CORS image]: https://tinyjpg.com/images/social/website.jpg

task-4367641
