### PR TITLE
[FIX] l10n_si: Add domestic fiscal position for non-VAT customers

### DIFF
--- a/addons/l10n_si/data/template/account.fiscal.position-si.csv
+++ b/addons/l10n_si/data/template/account.fiscal.position-si.csv
@@ -1,5 +1,6 @@
 "id","name","sequence","auto_apply","vat_required","country_id","country_group_id","tax_ids/tax_src_id","tax_ids/tax_dest_id","account_ids/account_src_id","account_ids/account_dest_id","name@sl"
 "gd_fp_do","Domestic partner","20","1","1","base.si","","","","","","Domači partner"
+"gd_fp_do_no_vat","Domestic partner (non VAT)","25","1","","base.si","","","","","","Domači partner (brez DDV)"
 "gd_fp_eu","Partner EU","30","1","1","","base.europe","gd_taxr_3","gd_taxe_out_0_eu_goods_1","gd_acc_120000","gd_acc_121000","Partner EU"
 "","","","","","","","gd_taxr_2","gd_taxe_out_0_eu_goods_1","","",""
 "","","","","","","","l10n_si_vat_5_sale","gd_taxe_out_0_eu_goods_1","","",""


### PR DESCRIPTION
Before this PR:
- Domestic customers without VAT were incorrectly mapped
  to EU fiscal position, causing domestic revenue accounts (760000) to be
  mapped to EU accounts (761000).

After this PR:
- Added new domestic fiscal position for non-VAT customers
  to ensure proper account mapping for domestic transactions.

Task-4918960
