### PR TITLE
[FIX] web: Hoot - datatransfer types

### DIFF
--- a/addons/web/static/lib/hoot-dom/helpers/events.js
+++ b/addons/web/static/lib/hoot-dom/helpers/events.js
@@ -233,23 +233,19 @@ function constrainScrollY(target, y) {
 function createDataTransfer(options) {
     const dataTransfer =
         options?.dataTransfer instanceof DataTransfer ? options.dataTransfer : new DataTransfer();
-    const types = new Set();
     for (const file of options?.files || []) {
         if (!(file instanceof File)) {
             throw new TypeError(`'DataTransfer.files' list only accepts 'File' objects`);
         }
         dataTransfer.items.add(file);
-        types.add("Files");
     }
     for (const [data, type] of options?.items || []) {
         dataTransfer.items.add(data, type);
-        types.add(type);
     }
 
     $defineProperties(dataTransfer, {
         dropEffect: { value: options?.dropEffect || "none", writable: true },
         effectAllowed: { value: options?.effectAllowed || "all", writable: true },
-        types: { value: [...types], writable: true },
     });
 
     return dataTransfer;

--- a/addons/web/static/lib/hoot/tests/hoot-dom/events.test.js
+++ b/addons/web/static/lib/hoot/tests/hoot-dom/events.test.js
@@ -804,6 +804,11 @@ describe(parseUrl(import.meta.url), () => {
         expect(dataTransfer.items).toHaveLength(2);
         expect(dataTransfer.types).toEqual(["text/plain", "text/html"]);
 
+        dataTransfer.setData("custom-data", "yes");
+
+        expect(dataTransfer.items).toHaveLength(3);
+        expect(dataTransfer.types).toEqual(["text/plain", "text/html", "custom-data"]);
+
         for (const event of dragEvents) {
             expect(event.dataTransfer).toBe(dataTransfer, {
                 message: `drag event "${event.type}" should share the same dataTransfer object`,


### PR DESCRIPTION
Before this commit, the 'types' property of datatransfers used in Hoot interactions was mocked to insert the initial types of the given 'items' and 'files'.

However, this didn't account for the items added dynamically on the datatransfer object.

The good thing is that it doesn't actually need to be mocked, since it already works with the given 'files' and 'items' types without having to override the 'types' descriptor. So the mock has been removed.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
