### PR TITLE
[FIX] pos_restaurant: update payment line when tipping after

### DIFF
--- a/addons/pos_restaurant/static/src/app/tip_screen/tip_screen.js
+++ b/addons/pos_restaurant/static/src/app/tip_screen/tip_screen.js
@@ -80,8 +80,11 @@ export class TipScreen extends Component {
         order.state = "paid";
 
         const paymentline = this.pos.get_order().payment_ids[0];
+        paymentline.amount += amount;
+        await this.pos.data.write("pos.payment", [paymentline.id], {
+            amount: paymentline.amount,
+        });
         if (paymentline.payment_method_id.payment_terminal) {
-            paymentline.amount += amount;
             await paymentline.payment_method_id.payment_terminal.send_payment_adjust(
                 paymentline.uuid
             );

--- a/addons/pos_restaurant/static/tests/tours/tip_screen_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/tip_screen_tour.js
@@ -69,7 +69,9 @@ registry.category("web_tour.tours").add("PosResTipScreenTour", {
             TipScreen.percentAmountIs("25%", "0.50"),
             TipScreen.clickPercentTip("20%"),
             TipScreen.inputAmountIs("0.40"),
-            ProductScreen.back(),
+            TipScreen.clickSettle(),
+            ReceiptScreen.isShown(),
+            ReceiptScreen.clickNextOrder(),
             FloorScreen.isShown(),
             Chrome.clickMenuOption("Orders"),
 

--- a/addons/pos_restaurant/tests/test_frontend.py
+++ b/addons/pos_restaurant/tests/test_frontend.py
@@ -259,6 +259,7 @@ class TestFrontend(TestFrontendCommon):
         order5 = self.env['pos.order'].search([('pos_reference', 'ilike', '%-0005')], limit=1, order='id desc')
 
         self.assertTrue(order1.is_tipped and order1.tip_amount == 0.40)
+        self.assertEqual(order1.payment_ids.amount, 2.4)
         self.assertTrue(order2.is_tipped and order2.tip_amount == 1.00)
         self.assertTrue(order3.is_tipped and order3.tip_amount == 1.50)
         self.assertTrue(order4.is_tipped and order4.tip_amount == 1.00)


### PR DESCRIPTION
Steps to reproduce:
-------------------
1. Enable tipping after payment
2. Make an order, pay it with customer account, then tip an amount X
3. On the receipt, that amount X is shown as 'change'!!
4. Close the PoS session
5. On backend, go to Sessions, and choose the session you just closed
6. It won't be closed, as there are still a diff of X amount, so click
   'Close Session & Post Entries' (the purple button), and confirm the
   prompt about posting the diff X into the receivable PoS account
7. Go to journal items (the magical button), and observe that the tip
   amount X is on a different move line labeled 'Difference at closing
   PoS session', and is not even in the name of the customer

Why the problem:
----------------
Before 17.4, we had a function `set_tip` on the backend that updated the
payment line to add the tip amount whenever we tip after [1]. However,
after commit https://github.com/odoo/odoo/commit/2a5f1abf2e98ee09fa7a912b87d71879b5ff260b, the logic of
`set_tip` was moved to the frontend [2], or most of it, as it seems
that we missed moving the logic that updates the payment line.

The fix:
--------
This commit updates the payment line following the old logic that was in
`set_tip` of the python code before https://github.com/odoo/odoo/commit/2a5f1abf2e98ee09fa7a912b87d71879b5ff260b.
Note that we had to manually write the changes to the backend with
`this.pos.data.write....`, otherwise, the changes are not reflected and
the issue persists.

[1]: https://github.com/odoo-dev/odoo/blob/636606d12cec79a0196ed0f9b7bb71a78d4fe65a/addons/pos_restaurant/models/pos_order.py#L206
[2]: https://github.com/odoo/odoo/blob/d5baeec9b60bdf3a5ab9d1243f46e957c0489877/addons/pos_restaurant/static/src/app/tip_screen/tip_screen.js#L90-L96

opw-4736154