### PR TITLE
[FIX] pos_restaurant: update payment line when tipping after

### DIFF
--- a/addons/pos_restaurant/models/pos_order.py
+++ b/addons/pos_restaurant/models/pos_order.py
@@ -60,3 +60,17 @@ class PosOrder(models.Model):
         if self.table_id:
             self.send_table_count_notification(self.table_id)
         return result
+
+    def set_tip(self, tip_amount, payment_line_id):
+        """Update tip state on `self` and the tip amount on the payment line."""
+
+        self.ensure_one()
+
+        payment_line = self.payment_ids.filtered(lambda line: line.id == payment_line_id)
+        payment_line.write({
+            'amount': payment_line.amount + tip_amount,
+        })
+        self.write({
+            "is_tipped": True,
+            "tip_amount": tip_amount,
+        })

--- a/addons/pos_restaurant/static/src/app/tip_screen/tip_screen.js
+++ b/addons/pos_restaurant/static/src/app/tip_screen/tip_screen.js
@@ -80,8 +80,8 @@ export class TipScreen extends Component {
         order.state = "paid";
 
         const paymentline = this.pos.get_order().payment_ids[0];
+        paymentline.amount += amount;
         if (paymentline.payment_method_id.payment_terminal) {
-            paymentline.amount += amount;
             await paymentline.payment_method_id.payment_terminal.send_payment_adjust(
                 paymentline.uuid
             );
@@ -90,10 +90,13 @@ export class TipScreen extends Component {
         const serializedTipLine = order.get_selected_orderline().serialize({ orm: true });
         order.get_selected_orderline().delete();
         const serverTipLine = await this.pos.data.create("pos.order.line", [serializedTipLine]);
-        await this.pos.data.write("pos.order", [serverId], {
-            is_tipped: true,
-            tip_amount: serverTipLine[0].price_subtotal_incl,
-        });
+
+        await this.pos.data.call("pos.order", "set_tip", [
+            serverId,
+            serverTipLine[0].price_subtotal_incl,
+            paymentline.id,
+        ]);
+
         this.goNextScreen();
     }
     goNextScreen() {

--- a/addons/pos_restaurant/static/tests/tours/tip_screen_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/tip_screen_tour.js
@@ -76,7 +76,9 @@ registry.category("web_tour.tours").add("PosResTipScreenTour", {
             TipScreen.percentAmountIs("25%", "0.50"),
             TipScreen.clickPercentTip("20%"),
             TipScreen.inputAmountIs("0.40"),
-            Chrome.clickPlanButton(),
+            TipScreen.clickSettle(),
+            ReceiptScreen.isShown(),
+            ReceiptScreen.clickNextOrder(),
             FloorScreen.isShown(),
             Chrome.clickMenuOption("Orders"),
 

--- a/addons/pos_restaurant/tests/test_frontend.py
+++ b/addons/pos_restaurant/tests/test_frontend.py
@@ -264,6 +264,9 @@ class TestFrontend(TestFrontendCommon):
         order_tips.sort()
         self.assertEqual(order_tips, [0.0, 0.4, 1.0, 1.0, 1.5])
 
+        order1 = self.env['pos.order'].search([('pos_reference', 'ilike', '%-0001')], limit=1, order='id desc')
+        self.assertEqual(order1.payment_ids.amount, 2.4)
+
         order4 = self.env['pos.order'].search([('pos_reference', 'ilike', '%-0004')], limit=1, order='id desc')
         self.assertEqual(order4.customer_count, 2)
 


### PR DESCRIPTION
Steps to reproduce:
-------------------
1. Enable tipping after payment
2. Make an order, pay it with customer account, then tip an amount X
3. On the receipt, that amount X is shown as 'change'!!
4. Close the PoS session
5. On backend, go to Sessions, and choose the session you just closed
6. It won't be closed, as there are still a diff of X amount, so click 'Close Session & Post Entries' (the purple button), and confirm the prompt about posting the diff X into the receivable PoS account
7. Go to journal items (the magical button), and observe that the tip amount X is on a different move line labeled 'Difference at closing PoS session', and is not even in the name of the customer

Why the problem:
----------------
Before 17.4, we had a function `set_tip` on the backend that updated the payment line to add the tip amount whenever we tip after [1]. However, after commit 2a5f1ab, the logic of
`set_tip` was moved to the frontend [2], or most of it, as it seems that we missed moving the logic that updates the payment line.

The fix:
--------
We now restore the method `set_tip` that was before 2a5f1abf2e98ee09fa7a912b87d71879b5ff260b, which will
update the payment line and the order.

[1]: https://github.com/odoo-dev/odoo/blob/636606d12cec79a0196ed0f9b7bb71a78d4fe65a/addons/pos_restaurant/models/pos_order.py#L206
[2]: https://github.com/odoo/odoo/blob/d5baeec9b60bdf3a5ab9d1243f46e957c0489877/addons/pos_restaurant/static/src/app/tip_screen/tip_screen.js#L90-L96

opw-4736154