### PR TITLE
[FIX] account: fix create invoice through email alias from a user without access to the company

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -4834,7 +4834,11 @@ class AccountMove(models.Model):
             'invoice_source_email': from_mail_addresses[0],
             'partner_id': partners and partners[0].id or False,
         }
-        move_ctx = self.with_context(default_move_type=custom_values['move_type'], default_journal_id=custom_values['journal_id'])
+        move_ctx = self.with_context(
+            default_move_type=custom_values['move_type'],
+            default_journal_id=custom_values['journal_id'],
+            default_company_id=company.id,
+        )
         move = super(AccountMove, move_ctx).message_new(msg_dict, custom_values=values)
         move._compute_name()  # because the name is given, we need to recompute in case it is the first invoice of the journal
 

--- a/addons/account/tests/test_account_journal.py
+++ b/addons/account/tests/test_account_journal.py
@@ -6,7 +6,8 @@ from unittest.mock import patch
 from odoo.addons.account.tests.common import AccountTestInvoicingCommon
 from odoo.addons.account.models.account_payment_method import AccountPaymentMethod
 from odoo.addons.mail.tests.common import MailCommon
-from odoo.tests import Form, tagged
+from odoo.addons.test_mail.data.test_mail_data import MAIL_EML_ATTACHMENT
+from odoo.tests import Form, tagged, new_test_user
 from odoo.exceptions import UserError, ValidationError
 
 
@@ -350,3 +351,22 @@ class TestAccountJournalAlias(AccountTestInvoicingCommon, MailCommon):
         })
         self.assertEqual(journal.alias_name, f'test-journal-{company_name}')
         self.assertEqual(journal2.alias_name, f'test-journal-{company_name}-b')
+
+    def test_send_email_to_alias_from_other_company(self):
+        user_company_2 = new_test_user(
+            self.env,
+            name='company 2 user',
+            login='company_2_user',
+            password='company_2_user',
+            email='company_2_user@test.com',
+            company_id=self.company_data_2['company'].id
+        )
+        self.format_and_process(
+            MAIL_EML_ATTACHMENT,
+            user_company_2.email,
+            self.company_data['default_journal_purchase'].alias_email,
+            subject='purchase test mail',
+            target_model='account.move',
+            msg_id='<test-account-move-alias-id>',
+        )
+        self.assertTrue(self.env['account.move'].search([('invoice_source_email', '=', 'company_2_user@test.com')]))


### PR DESCRIPTION
To reproduce the bug:

1- Create a DB with two companies and accounting app
2- Create a user and allow it to access company 2
3- Send a email using the user email to alias from purchase
journal alias of company 2
4- The email will be rejected
5- Send a email using a random email address to alias.
6- The email will be accepted and an account.move is created.

In a normal flow, when a user associated to the email not exists, the user_id is set to odoobot, otherwise, the user accosiated to the email.
In the buggy flow the bug happens because `_compute_company_id` in account_move model, will set `company_id` to empty when user
has no access to the company, as a result the `account_move` will fail.

opw-4853027
