### PR TITLE
[FIX] website: force interpretation of vw unit in snippets modal preview

### DIFF
--- a/addons/website/static/src/snippets/s_color_blocks_2/s_color_blocks_2.edit.scss
+++ b/addons/website/static/src/snippets/s_color_blocks_2/s_color_blocks_2.edit.scss
@@ -1,0 +1,13 @@
+// Snippets Modal Preview
+// ======================
+.o_snippet_preview_wrap {
+    .s_color_blocks_2 {
+        > .container, > .container-fluid, > .o_container_small {
+            > .row > [class*="col-lg-"] {
+                // Force interpretation of vw units.
+                padding-top: 130px;
+                padding-bottom: 130px;
+            }
+        }
+    }
+}


### PR DESCRIPTION
The `s_color_blocks_2` block uses paddings expressed using the `vw` unit. Inside the snippets modal, this makes them evaluated to a value that does not reflect the aspect ratio of the actual block.

This commit forces the padding of the block during preview to fixed values so that it better matches the dropped version inside the page.

At the time of writing, there is no other block that uses that unit.

task-4367641
