### PR TITLE
[FIX] project: calculate profitability items using lines balance

### DIFF
--- a/addons/project_purchase/models/project.py
+++ b/addons/project_purchase/models/project.py
@@ -178,30 +178,24 @@ class Project(models.Model):
             # account_move_line__move_id is the alias of the joined table account_move in the query
             # we can use it, because of the "move_id.move_type" clause in the domain of the query, which generates the join
             # this is faster than a search_read followed by a browse on the move_id to retrieve the move_type of each account.move.line
-            query_string, query_param = query.select('price_subtotal', 'parent_state', 'account_move_line.currency_id', 'account_move_line.analytic_distribution', 'account_move_line__move_id.move_type')
+            query_string, query_param = query.select('balance', 'parent_state', 'account_move_line.company_currency_id', 'account_move_line.analytic_distribution', 'account_move_line__move_id.move_type')
             self._cr.execute(query_string, query_param)
             bills_move_line_read = self._cr.dictfetchall()
             if bills_move_line_read:
 
                 # Get conversion rate from currencies to currency of the project
-                currency_ids = {bml['currency_id'] for bml in bills_move_line_read + [{'currency_id': self.currency_id.id}]}
+                currency_ids = {bml['company_currency_id'] for bml in bills_move_line_read + [{'company_currency_id': self.currency_id.id}]}
                 rates = self.env['res.currency'].browse(list(currency_ids))._get_rates(self.company_id, date.today())
                 conversion_rates = {cid: rates[self.currency_id.id] / rate_from for cid, rate_from in rates.items()}
 
                 amount_invoiced = amount_to_invoice = 0.0
                 for moves_read in bills_move_line_read:
-                    price_subtotal = self.currency_id.round(moves_read['price_subtotal'] * conversion_rates[moves_read['currency_id']])
+                    line_balance = self.currency_id.round(moves_read['balance'] * conversion_rates[moves_read['company_currency_id']])
                     analytic_contribution = moves_read['analytic_distribution'][str(self.analytic_account_id.id)] / 100.
                     if moves_read['parent_state'] == 'draft':
-                        if moves_read['move_type'] == 'in_invoice':
-                            amount_to_invoice -= price_subtotal * analytic_contribution
-                        else:  # moves_read['move_type'] == 'in_refund'
-                            amount_to_invoice += price_subtotal * analytic_contribution
+                        amount_to_invoice -= line_balance * analytic_contribution
                     else:  # moves_read['parent_state'] == 'posted'
-                        if moves_read['move_type'] == 'in_invoice':
-                            amount_invoiced -= price_subtotal * analytic_contribution
-                        else:  # moves_read['move_type'] == 'in_refund'
-                            amount_invoiced += price_subtotal * analytic_contribution
+                        amount_invoiced -= line_balance * analytic_contribution
                 # don't display the section if the final values are both 0 (bill -> vendor credit)
                 if amount_invoiced != 0 or amount_to_invoice != 0:
                     costs = profitability_items['costs']

--- a/addons/project_purchase/tests/test_project_profitability.py
+++ b/addons/project_purchase/tests/test_project_profitability.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from datetime import datetime
+from datetime import datetime, timedelta
 
 from odoo import Command
 from odoo.tests import tagged
-from odoo.tools import float_round
+from odoo.tools import float_round, float_compare
 
 from odoo.addons.project.tests.test_project_profitability import TestProjectProfitabilityCommon
 from odoo.addons.purchase.tests.test_purchase_invoice import TestPurchaseToInvoiceCommon
@@ -384,4 +384,71 @@ class TestProjectPurchaseProfitability(TestProjectProfitabilityCommon, TestPurch
                     'billed': 0.0,
                 },
             },
+        )
+
+    def test_profitability_foreign_currency_rate_on_bill_date(self):
+        """Test that project profitability uses the correct currency rate (on bill date) for vendor bills in foreign currency."""
+        CurrencyRate = self.env['res.currency.rate']
+        company = self.env.company
+
+        # Pick a foreign currency different from company currency
+        foreign_currency = self.env['res.currency'].search([('id', '!=', company.currency_id.id)], limit=1)
+        if not foreign_currency:
+            foreign_currency = self.env['res.currency'].create({'name': 'USD', 'symbol': '$', 'rounding': 0.01, 'decimal_places': 2})
+
+        # Set two rates: yesterday and today
+        today = datetime.today().date()
+        yesterday = today - timedelta(days=1)
+        rate_today = 1.9
+        rate_yesterday = 2.0
+        CurrencyRate.create({
+            'currency_id': foreign_currency.id,
+            'rate': rate_yesterday,
+            'name': yesterday,
+            'company_id': company.id,
+        })
+        CurrencyRate.create({
+            'currency_id': foreign_currency.id,
+            'rate': rate_today,
+            'name': today,
+            'company_id': company.id,
+        })
+
+        # Create a vendor bill in foreign currency, dated yesterday, with analytic distribution to the project
+        price_unit = 150
+        bill = self.env['account.move'].create({
+            "name": "Bill Foreign Currency",
+            "move_type": "in_invoice",
+            "state": "draft",
+            "partner_id": self.partner.id,
+            "invoice_date": yesterday,
+            "currency_id": foreign_currency.id,
+            "invoice_line_ids": [Command.create({
+                "analytic_distribution": {self.analytic_account.id: 100},
+                "product_id": self.product_a.id,
+                "quantity": 1,
+                "product_uom_id": self.product_a.uom_id.id,
+                "price_unit": price_unit,
+            })],
+        })
+
+        # Compute expected value: balance is in company currency, so should be price_unit / rate_yesterday (since bill is in foreign currency)
+        expected_cost = -(price_unit / rate_yesterday)
+
+        # Check profitability before posting (should be in 'to_bill')
+        costs = self.project._get_profitability_items(False)['costs']
+        self.assertEqual(len(costs['data']), 1)
+        actual_to_bill = costs['data'][0]['to_bill']
+        self.assertTrue(
+            float_compare(actual_to_bill, expected_cost, precision_digits=2) == 0,
+            f"Expected to_bill {expected_cost}, got {actual_to_bill}"
+        )
+
+        # Post the bill and check 'billed'
+        bill.action_post()
+        costs = self.project._get_profitability_items(False)['costs']
+        actual_billed = costs['data'][0]['billed']
+        self.assertTrue(
+            float_compare(actual_billed, expected_cost, precision_digits=2) == 0,
+            f"Expected billed {expected_cost}, got {actual_billed}"
         )

--- a/addons/sale_project/models/project.py
+++ b/addons/sale_project/models/project.py
@@ -487,30 +487,24 @@ class Project(models.Model):
         # account_move_line__move_id is the alias of the joined table account_move in the query
         # we can use it, because of the "move_id.move_type" clause in the domain of the query, which generates the join
         # this is faster than a search_read followed by a browse on the move_id to retrieve the move_type of each account.move.line
-        query_string, query_param = query.select('price_subtotal', 'parent_state', 'account_move_line.currency_id', 'account_move_line.analytic_distribution', 'account_move_line__move_id.move_type')
+        query_string, query_param = query.select('balance', 'parent_state', 'account_move_line.company_currency_id', 'account_move_line.analytic_distribution', 'account_move_line__move_id.move_type')
         self._cr.execute(query_string, query_param)
         invoices_move_line_read = self._cr.dictfetchall()
         if invoices_move_line_read:
 
             # Get conversion rate from currencies to currency of the project
-            currency_ids = {iml['currency_id'] for iml in invoices_move_line_read + [{'currency_id': self.currency_id.id}]}
+            currency_ids = {iml['company_currency_id'] for iml in invoices_move_line_read + [{'company_currency_id': self.currency_id.id}]}
             rates = self.env['res.currency'].browse(list(currency_ids))._get_rates(self.company_id, date.today())
             conversion_rates = {cid: rates[self.currency_id.id] / rate_from for cid, rate_from in rates.items()}
 
             amount_invoiced = amount_to_invoice = 0.0
             for moves_read in invoices_move_line_read:
-                price_subtotal = self.currency_id.round(moves_read['price_subtotal'] * conversion_rates[moves_read['currency_id']])
+                line_balance = self.currency_id.round(moves_read['balance'] * conversion_rates[moves_read['company_currency_id']])
                 analytic_contribution = moves_read['analytic_distribution'][str(self.analytic_account_id.id)] / 100.
                 if moves_read['parent_state'] == 'draft':
-                    if moves_read['move_type'] == 'out_invoice':
-                        amount_to_invoice += price_subtotal * analytic_contribution
-                    else:  # moves_read['move_type'] == 'out_refund'
-                        amount_to_invoice -= price_subtotal * analytic_contribution
+                    amount_to_invoice -= line_balance * analytic_contribution
                 else:  # moves_read['parent_state'] == 'posted'
-                    if moves_read['move_type'] == 'out_invoice':
-                        amount_invoiced += price_subtotal * analytic_contribution
-                    else:  # moves_read['move_type'] == 'out_refund'
-                        amount_invoiced -= price_subtotal * analytic_contribution
+                    amount_invoiced -= line_balance * analytic_contribution
             # don't display the section if the final values are both 0 (invoice -> credit note)
             if amount_invoiced != 0 or amount_to_invoice != 0:
                 section_id = 'other_invoice_revenues'


### PR DESCRIPTION
Issue description:
The profitability items for projects were not matching the numbers from analytic accounting reports due to discrepancies in currency rate calculations. This issue was traced to two main causes:

1. Profitability items were using the currency rate of today, even for old move lines.
```rates = self.env['res.currency'].browse(list(currency_ids))._get_rates(self.company_id, date.today())```
 While this was deemed acceptable for performance reasons in #113146,
 it caused mismatches with analytic accounting reports.

2. Some move lines use a changed currency rate that differs from
the rate stored in the currency table for the same date
(due to manual change in the currency rate), leading to further mismatches.

To resolve this:
- The `balance` is now used instead of `price_subtotal` for calculations.
This ensures accurate amounts without relying on conversion rates
when the project currency matches the company currency.

Steps to Reproduce:
1. Create a project with an associated analytic account.
2. Enable any foreign currency and add different rates for it for today and yesterday.
3. Create a new vendor bill with:
   - Date = yesterday
   - Currency = the new foreign currency
   - Analytic distribution set to the created project's analytic account.
4. Check the project dashboard profitability. You will see the numbers
are incorrect because it uses the currency rate of today.

opw - 4881380

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
