### PR TITLE
[FIX] l10n_gr_edi: log warning when fetching MyDATA bill fails

### DIFF
--- a/addons/l10n_gr_edi/models/res_company.py
+++ b/addons/l10n_gr_edi/models/res_company.py
@@ -52,7 +52,7 @@ class ResCompany(models.Model):
                 response.raise_for_status()
                 root = etree.fromstring(response.content)
             except (RequestException, ValueError) as err:
-                _logger.error("Something when wrong when fetching MyDATA bill: %s", err)
+                _logger.warning("Something went wrong when fetching MyDATA bill: %s", err)
                 continue
 
             for invoice_element in root.xpath('//*[local-name()="invoice"]'):


### PR DESCRIPTION
Currently, the system logs an error when a `RequestException` or `ValueError` occurs while fetching MyDATA bills.

**Error:**
`Something when wrong when fetching MyDATA bill: HTTPError('403 Client Error: Forbidden for url: https://mydataapidev.aade.gr/RequestDocs?mark=0&dateFrom=03%2F04%2F2025&dateTo=02%2F07%2F2025`

**Root Cause:**
At [1], using `_logger.error` for `RequestException` or `ValueError` causes unnecessary tracebacks for user-side issues, such as forbidden access.

[1]
https://github.com/odoo/odoo/blob/1b657cf1e1ce43874a3ede307b2f8ad68216aa56/addons/l10n_gr_edi/models/res_company.py#L54-L55

This commit ensures `RequestException` or `ValueError` are logged as warnings instead of `error`, preventing unnecessary tracebacks and correcting the `typo` in the log message.

sentry–6713444740