### PR TITLE
[IMP] mail: hide fold toggle when sidebar category has no visible threads

### DIFF
--- a/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.js
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.js
@@ -225,8 +225,12 @@ export class DiscussSidebarCategory extends Component {
         return [];
     }
 
+    get hasVisibleThreads() {
+        return this.env.filteredThreads(this.category.threads).length > 0;
+    }
+
     toggle() {
-        if (this.store.channels.status === "fetching") {
+        if (this.store.channels.status === "fetching" || !this.hasVisibleThreads) {
             return;
         }
         this.category.open = !this.category.open;

--- a/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.xml
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.xml
@@ -37,12 +37,17 @@
                     <i class="o-mail-DiscussSidebarCategory-chevronCompact position-absolute fa-fw o-xsmaller o-mt-0_5" t-att-class="{
                         'oi oi-chevron-down': category.open,
                         'oi oi-chevron-right': !category.open,
+                        'invisible': !hasVisibleThreads,
                     }"/>
                     <span class="rounded p-1"><i t-if="store.channels.status === 'fetching'" class="fa fa-fw fa-circle-o-notch fa-spin"/><i t-else="" class="fa-fw fa-lg" t-att-class="category.icon ?? 'fa fa-user'"/></span>
                 </t>
                 <t t-else="">
                     <span t-if="store.channels.status === 'fetching'" class="o-visible-short-delay"><i class="o-mail-DiscussSidebarCategory-icon o-xxsmaller fa fa-fw fa-circle-o-notch fa-spin opacity-50 o-mt-0_5"/></span>
-                    <i t-else="" class="o-mail-DiscussSidebarCategory-icon o-xsmaller fa-fw position-absolute ms-n3 align-self-center o-mt-0_5" t-att-class="category.open ? 'oi oi-chevron-down' : 'oi oi-chevron-right'"/>
+                    <i t-else="" class="o-mail-DiscussSidebarCategory-icon o-xsmaller fa-fw position-absolute ms-n3 align-self-center o-mt-0_5" t-att-class="{
+                        'oi oi-chevron-down': category.open,
+                        'oi oi-chevron-right': !category.open,
+                        'invisible': !hasVisibleThreads,
+                    }"/>
                     <span class="o-mail-DiscussSidebarCategory-title text-break smaller"
                         t-att-class="{
                             'fs-bold': category.open,

--- a/addons/mail/static/tests/discuss/core/web/discuss.test.js
+++ b/addons/mail/static/tests/discuss/core/web/discuss.test.js
@@ -172,9 +172,6 @@ test("no conversation selected when opening non-existing channel in discuss", as
     await start();
     await openDiscuss(200); // non-existing id
     await contains("h4", { text: "No conversation selected." });
-    await contains(".o-mail-DiscussSidebarCategory-channel .oi-chevron-down");
-    await click(".o-mail-DiscussSidebar .btn", { text: "Channels" }); // check no crash
-    await contains(".o-mail-DiscussSidebarCategory-channel .oi-chevron-right");
 });
 
 test("can access portal partner profile from avatar popover", async () => {


### PR DESCRIPTION

**Current behavior before PR:**
The fold/unfold toggle icon is shown even when a sidebar category had no visible threads.

**Desired behavior after PR is merged:**
The fold/unfold toggle icon is hidden when there are no visible threads in the sidebar category.

task-[4783313](https://www.odoo.com/odoo/project/1519/tasks/4783313)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
