### PR TITLE
[FIX] website: restore image gallery & image wall option order

### DIFF
--- a/addons/website/static/src/builder/plugins/carousel_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/carousel_option_plugin.js
@@ -4,6 +4,11 @@ import { registry } from "@web/core/registry";
 import { CarouselItemHeaderMiddleButtons } from "./carousel_item_header_buttons";
 import { renderToElement } from "@web/core/utils/render";
 import { BuilderAction } from "@html_builder/core/builder_action";
+import { withSequence } from "@html_editor/utils/resource";
+import { between } from "@html_builder/utils/option_sequence";
+import { WEBSITE_BACKGROUND_OPTIONS, BOX_BORDER_SHADOW } from "@website/builder/option_sequence";
+
+export const CAROUSEL_CARDS_SEQUENCE = between(WEBSITE_BACKGROUND_OPTIONS, BOX_BORDER_SHADOW);
 
 const carouselWrapperSelector =
     ".s_carousel_wrapper, .s_carousel_intro_wrapper, .s_carousel_cards_wrapper";
@@ -29,11 +34,11 @@ export class CarouselOptionPlugin extends Plugin {
                 selector: "section",
                 applyTo: ".s_carousel_intro, .s_quotes_carousel_compact",
             },
-            {
+            withSequence(CAROUSEL_CARDS_SEQUENCE, {
                 template: "website.CarouselCardsOption",
                 selector: "section",
                 applyTo: ".s_carousel_cards",
-            },
+            }),
         ],
         builder_header_middle_buttons: {
             Component: CarouselItemHeaderMiddleButtons,

--- a/addons/website/static/src/builder/plugins/options/border_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/border_option_plugin.js
@@ -10,7 +10,7 @@ class BorderOptionPlugin extends Plugin {
         builder_options: [
             withSequence(BOX_BORDER_SHADOW, {
                 template: "website.BorderOption",
-                selector: "section .row > div",
+                selector: "section .row > div, section:has(.s_carousel_cards)",
                 exclude: `.s_col_no_bgcolor, .s_col_no_bgcolor.row > div, .s_image_gallery .row > div, .s_masonry_block .s_col_no_resize, .s_text_cover .row > .o_not_editable, ${CARD_PARENT_HANDLERS}`,
             }),
         ],

--- a/addons/website/static/src/builder/plugins/options/image_gallery_option.xml
+++ b/addons/website/static/src/builder/plugins/options/image_gallery_option.xml
@@ -1,11 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-<t t-name="website.ImageGalleryOption">
+<t t-name="website.ImageGalleryImagesOption">
     <BuilderRow label.translate="Images">
         <BuilderButton type="'success'" className="'flex-grow-1'" preview="false" title.translate="Add Image"  action="'addImage'"> Add </BuilderButton>
         <BuilderButton type="'danger'" className="'flex-grow-1'" preview="false" title.translate="Remove all images" action="'removeAllImages'"> Remove all </BuilderButton>
     </BuilderRow>
+</t>
+
+<t t-name="website.ImageGalleryOption">
     <BuilderRow label.translate="Mode" t-if="!this.state.isSlideShow">
         <BuilderSelect>
             <BuilderSelectItem id="'grid_mode_opt'" action="'setImageGalleryLayout'" actionParam="'grid'">Grid</BuilderSelectItem>

--- a/addons/website/static/src/builder/plugins/options/image_gallery_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/image_gallery_option_plugin.js
@@ -5,6 +5,8 @@ import { ImageGalleryComponent } from "./image_gallery_option";
 import { renderToElement } from "@web/core/utils/render";
 import { updateCarouselIndicators } from "../carousel_option_plugin";
 import { BuilderAction } from "@html_builder/core/builder_action";
+import { withSequence } from "@html_editor/utils/resource";
+import { SNIPPET_SPECIFIC, SNIPPET_SPECIFIC_END } from "@html_builder/utils/option_sequence";
 
 class ImageGalleryOption extends Plugin {
     static id = "imageGalleryOption";
@@ -20,10 +22,14 @@ class ImageGalleryOption extends Plugin {
     static shared = ["processImages", "getMode", "setImages", "restoreSelection", "getColumns"];
     resources = {
         builder_options: [
-            {
+            withSequence(SNIPPET_SPECIFIC, {
+                template: "website.ImageGalleryImagesOption",
+                selector: ".s_image_gallery",
+            }),
+            withSequence(SNIPPET_SPECIFIC_END, {
                 OptionComponent: ImageGalleryComponent,
                 selector: ".s_image_gallery",
-            },
+            }),
         ],
         builder_actions: {
             AddImageAction,


### PR DESCRIPTION
Since the conversion to `html_builder`, the image gallery and image wall options order was shuffled.

This commit restores the initial order by splitting the options in two templates and specifying sequences on each part.

task-4367641
