### PR TITLE
[FIX] point_of_sale: improve pos inalterability check report

### DIFF
--- a/addons/l10n_fr_pos_cert/models/pos.py
+++ b/addons/l10n_fr_pos_cert/models/pos.py
@@ -8,6 +8,7 @@ from odoo import models, api, fields
 from odoo.fields import Datetime
 from odoo.tools.translate import _, _lt
 from odoo.exceptions import UserError
+from collections import defaultdict
 
 
 class pos_config(models.Model):
@@ -76,23 +77,76 @@ class pos_order(models.Model):
         return hash_string.hexdigest()
 
     def _compute_string_to_hash(self):
-        def _getattrstring(obj, field_str):
-            field_value = obj[field_str]
-            if obj._fields[field_str].type == 'many2one':
-                field_value = field_value.id
-            if obj._fields[field_str].type in ['many2many', 'one2many']:
-                field_value = field_value.sorted().ids
+        def _getattrstring(field_value, field_type, model_name=None):
+            if field_type in ('many2many', 'one2many'):
+                if field_value:
+                    sorted_ids = sorted_relational_ids.get(model_name, [])
+                    value_set = set(field_value)
+                    field_value = [id for id in sorted_ids if id in value_set]
+                else:
+                    field_value = []
             return str(field_value)
+
+        def collect_sorted_relational_ids(orders_data, lines_data, order_field_defs, line_field_defs):
+            relational_ids = defaultdict(set)
+
+            for data_list, field_names, field_defs in (
+                (orders_data, ORDER_FIELDS, order_field_defs),
+                (lines_data, LINE_FIELDS, line_field_defs),
+            ):
+                for record in data_list:
+                    for field in field_names:
+                        field_def = field_defs.get(field)
+                        if field_def and field_def['type'] in ('many2many', 'one2many'):
+                            ids = record.get(field) or []
+                            relational_ids[field_def['comodel']].update(ids)
+
+            sorted_relational_ids = {}
+            for model_name, ids in relational_ids.items():
+                if ids:
+                    # Use search() to get IDs sorted by _order the same way Odoo ORM does for relational fields
+                    sorted_relational_ids[model_name] = self.env[model_name].search([('id', 'in', list(ids))]).ids
+
+            return sorted_relational_ids
+
+        orders_data = self.read(ORDER_FIELDS + ['id'], load='')
+        lines_data = self.lines.read(LINE_FIELDS + ['id', 'order_id'], load='')
+
+        orders_by_id = {order['id']: order for order in orders_data}
+        lines_by_order = defaultdict(list)
+        for line in lines_data:
+            lines_by_order[line['order_id']].append(line)
+        order_field_defs = {
+            field: {
+                'type': self._fields[field].type,
+                'comodel': self._fields[field].comodel_name if hasattr(self._fields[field], 'comodel_name') else None
+            }
+            for field in ORDER_FIELDS
+        }
+        line_field_defs = {
+            field: {
+                'type': self.lines._fields[field].type,
+                'comodel': self.lines._fields[field].comodel_name if hasattr(self.lines._fields[field], 'comodel_name') else None
+            }
+            for field in LINE_FIELDS
+        }
+
+        sorted_relational_ids = collect_sorted_relational_ids(orders_data, lines_data, order_field_defs, line_field_defs)
 
         for order in self:
             values = {}
-            for field in ORDER_FIELDS:
-                values[field] = _getattrstring(order, field)
+            order_data = orders_by_id[order.id]
 
-            for line in order.lines:
+            for field in ORDER_FIELDS:
+                field_def = order_field_defs[field]
+                values[field] = _getattrstring(order_data.get(field), field_def['type'], field_def['comodel'])
+
+            for line in lines_by_order[order.id]:
                 for field in LINE_FIELDS:
-                    k = 'line_%d_%s' % (line.id, field)
-                    values[k] = _getattrstring(line, field)
+                    k = 'line_%d_%s' % (line['id'], field)
+                    field_def = line_field_defs[field]
+                    values[k] = _getattrstring(line.get(field), field_def['type'], field_def['comodel'])
+
             #make the json serialization canonical
             #  (https://tools.ietf.org/html/draft-staykov-hu-json-canonical-form-00)
             order.l10n_fr_string_to_hash = dumps(values, sort_keys=True,

--- a/addons/l10n_fr_pos_cert/tests/__init__.py
+++ b/addons/l10n_fr_pos_cert/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_string_to_hash

--- a/addons/l10n_fr_pos_cert/tests/test_string_to_hash.py
+++ b/addons/l10n_fr_pos_cert/tests/test_string_to_hash.py
@@ -1,0 +1,110 @@
+from odoo.addons.point_of_sale.tests.common import TestPointOfSaleCommon
+from odoo.tests import tagged
+from ..models.pos import ORDER_FIELDS, LINE_FIELDS
+from json import dumps
+
+
+@tagged('post_install_l10n', 'post_install', '-at_install')
+class TestStringToHash(TestPointOfSaleCommon):
+
+    @classmethod
+    def setUpClass(cls, chart_template_ref="l10n_fr.l10n_fr_pcg_chart_template"):
+        super().setUpClass(chart_template_ref=chart_template_ref)
+
+        cls.pricelist = cls.env['product.pricelist'].create({
+            'name': 'Test Pricelist',
+            'currency_id': cls.company_data['company'].currency_id.id,
+        })
+        cls.company.country_id = cls.env.company.account_fiscal_country_id.id
+
+    def _compute_string_to_hash_original(self, orders):
+        def _getattrstring(obj, field_str):
+            field_value = obj[field_str]
+            if obj._fields[field_str].type == 'many2one':
+                field_value = field_value.id
+            if obj._fields[field_str].type in ['many2many', 'one2many']:
+                field_value = field_value.sorted().ids
+            return str(field_value)
+
+        for order in orders:
+            values = {}
+            for field in ORDER_FIELDS:
+                values[field] = _getattrstring(order, field)
+
+            for line in order.lines:
+                for field in LINE_FIELDS:
+                    k = 'line_%d_%s' % (line.id, field)
+                    values[k] = _getattrstring(line, field)
+            # make the json serialization canonical
+            #  (https://tools.ietf.org/html/draft-staykov-hu-json-canonical-form-00)
+            return dumps(values, sort_keys=True,
+                            ensure_ascii=True, indent=None,
+                            separators=(',', ':'))
+
+    def _create_and_pay_pos_order(self, line_data_list, payments):
+        currency = self.company_data['company'].currency_id
+        lines = []
+        total_tax = 0.0
+        total_amount = 0.0
+
+        for idx, line_data in enumerate(line_data_list):
+            product = line_data.get('product', self.product_a)
+            qty = line_data['qty']
+            price_unit = line_data['price_unit']
+            taxes = line_data.get('tax_ids', self.tax_sale_a)
+
+            line_tax = sum((tax.amount / 100) * qty * price_unit for tax in taxes)
+            line_total = qty * price_unit + line_tax
+
+            total_tax += line_tax
+            total_amount += qty * price_unit
+
+            rounded_total = currency.round(line_total)
+
+            lines.append((0, 0, {
+                'name': f"OL/000{idx + 1}",
+                'product_id': product.id,
+                'price_unit': price_unit,
+                'qty': qty,
+                'tax_ids': [(6, 0, taxes.ids)],
+                'price_subtotal': qty * price_unit,
+                'price_subtotal_incl': rounded_total,
+            }))
+
+        order = self.env['pos.order'].create({
+            'company_id': self.company_data['company'].id,
+            'partner_id': self.partner_a.id,
+            'session_id': self.pos_config.current_session_id.id,
+            'lines': lines,
+            'amount_total': currency.round(total_amount + total_tax),
+            'amount_tax': currency.round(total_tax),
+            'amount_paid': 0,
+            'amount_return': 0,
+            'pricelist_id': self.pricelist.id
+        })
+
+        for payment in payments:
+            context_payment = {
+                "active_ids": [order.id],
+                "active_id": order.id
+            }
+            pos_make_payment = self.env['pos.make.payment'].with_context(context_payment).create({
+                'amount': payment['amount'],
+                'payment_method_id': payment['payment_method'].id,
+            })
+            pos_make_payment.with_context(context_payment).check()
+        return order
+
+    def test_string_to_hash(self):
+        self.pos_config.open_ui()
+        order = self._create_and_pay_pos_order([
+            {'qty': 1, 'price_unit': 10000, 'product': self.product_a, 'tax_ids': self.tax_sale_a},
+            {'qty': 2, 'price_unit': 5000, 'product': self.product_a, 'tax_ids': self.tax_sale_b},
+            {'qty': 3, 'price_unit': 2000, 'tax_ids': self.tax_sale_b | self.tax_sale_b}
+        ], [
+            {'amount': 10000, 'payment_method': self.bank_payment_method},
+            {'amount': 1200, 'payment_method': self.cash_payment_method},
+            {'amount': 20000, 'payment_method': self.credit_payment_method}
+        ])
+        self.pos_config.current_session_id.action_pos_session_closing_control()
+        self.assertEqual(order.l10n_fr_string_to_hash, self._compute_string_to_hash_original(order))


### PR DESCRIPTION
### Problem:
Pos inalterability Check report is specific to French localization. It verifies whether POS orders have been modified by computing a hash of the order data and comparing it to the previously stored hash. _compute_string_to_hash method is computationally expensive and leads to significant performance and memory issues when processing more than 50,000 orders.

### Benchmark
Before:

| Orders | Time    | Memory |
|--------|---------|--------|
| 1k     | 15s     | 10MB   |
| 10k    | 77s     | 81MB   |
| 20k    | 102s    | 110MB  |
| 40K    | timeout | 256MB  |

After:

| Orders | Time | Memory |
|--------|------|--------|
| 1k     | 5s   | 7MB    |
| 10k    | 9s   | 42MB   |
| 40K    | 20s  | 174MB  |
| 100k   | 42s  | 550MB  |
| 330k   | 126s | 1.2GB  |

### Solution:
Fetching only required fields to compute _compute_string_to_hash opw-4901994
