### PR TITLE
[FIX] point_of_sale: prevent error when opening decrease quantity popup

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/product_screen/order_summary/order_summary.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/order_summary/order_summary.js
@@ -8,7 +8,7 @@ import { _t } from "@web/core/l10n/translation";
 import { makeAwaitable } from "@point_of_sale/app/store/make_awaitable_dialog";
 import { NumberPopup } from "@point_of_sale/app/utils/input_popups/number_popup";
 import { parseFloat } from "@web/views/fields/parsers";
-import { getButtons } from "@point_of_sale/app/generic_components/numpad/numpad";
+import { enhancedButtons } from "@point_of_sale/app/generic_components/numpad/numpad";
 
 export class OrderSummary extends Component {
     static template = "point_of_sale.OrderSummary";
@@ -60,7 +60,7 @@ export class OrderSummary extends Component {
     }
     handleOrderLineQuantityChange(selectedLine, buffer, currentQuantity, lastId) {
         const parsedInput = (buffer && parseFloat(buffer)) || 0;
-        if (lastId != selectedLine.cid || parsedInput < currentQuantity) {
+        if (lastId != selectedLine.uuid || parsedInput < currentQuantity) {
             this._showDecreaseQuantityPopup();
         } else if (currentQuantity < parsedInput) {
             this._setValue(buffer);
@@ -199,7 +199,7 @@ export class OrderSummary extends Component {
         line.set_unit_price(price);
     }
     async _getShowDecreaseQuantityPopupButtons() {
-        return getButtons();
+        return enhancedButtons();
     }
     async _showDecreaseQuantityPopup() {
         this.numberBuffer.reset();


### PR DESCRIPTION
Before this commit, an error occurred when `pos_blackbox_be` was not installed and the system attempted to open the decrease quantity popup, due to a missing argument. Also, the decrease quantity popup was incorrectly shown when increasing the quantity, as `cid` was mistakenly used for comparison.

opw-4914775

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
