### PR TITLE
[IMP] mail: improve system internal-note entry

### DIFF
--- a/addons/mail/static/src/core/web/message_patch.xml
+++ b/addons/mail/static/src/core/web/message_patch.xml
@@ -10,11 +10,11 @@
                         </p>
                     </t>
                     <t t-if="message.trackingValues.length">
-                        <ul class="mb-0 ps-4">
+                        <ul class="mb-0 list-unstyled">
                             <t name="trackingValues" t-foreach="message.trackingValues" t-as="trackingValue" t-key="trackingValue.id">
                                 <li class="o-mail-Message-tracking mb-1" role="group">
-                                    <span class="o-mail-Message-trackingOld me-1 px-1 text-muted fw-bold" t-esc="formatTrackingOrNone(trackingValue.fieldInfo, trackingValue.oldValue)"/>
-                                    <i class="o-mail-Message-trackingSeparator fa fa-long-arrow-right mx-1 text-600"/>
+                                    <span class="o-mail-Message-trackingOld text-muted fw-bold" t-esc="formatTrackingOrNone(trackingValue.fieldInfo, trackingValue.oldValue)"/>
+                                    <i class="o-mail-Message-trackingSeparator fa fa-long-arrow-right mx-2 text-600"/>
                                     <span class="o-mail-Message-trackingNew me-1 fw-bold text-info" t-esc="formatTrackingOrNone(trackingValue.fieldInfo, trackingValue.newValue)"/>
                                     <span class="o-mail-Message-trackingField ms-1 fst-italic text-muted">(<t t-esc="trackingValue.fieldInfo.changedField"/>)</span>
                                 </li>


### PR DESCRIPTION
This PR removes the bullet in the system's internal note change messages and gives a more balanced space around the arrow because before there was more space on the left.

It also deleted the unnecessary message when there is a list (changing stage)

task-4798292


| Before | After |
|--------|--------|
| <img width="514" alt="Screenshot 2025-07-03 at 15 37 28" src="https://github.com/user-attachments/assets/bb4520c9-b0c8-4ab5-a269-1380ae41d3bc" /> | <img width="514" alt="Screenshot 2025-07-03 at 15 38 11" src="https://github.com/user-attachments/assets/6e062215-1ee3-4643-af9d-2a67a493b348" /> |



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
