### PR TITLE
Fix escape of text nodes on save

### DIFF
--- a/addons/html_builder/static/src/core/save_snippet_plugin.js
+++ b/addons/html_builder/static/src/core/save_snippet_plugin.js
@@ -1,3 +1,4 @@
+import { escapeTextNodes } from "@html_builder/utils/escaping";
 import { Plugin } from "@html_editor/plugin";
 import { withSequence } from "@html_editor/utils/resource";
 import { markup } from "@odoo/owl";
@@ -70,7 +71,10 @@ export class SaveSnippetPlugin extends Plugin {
     }
 
     async saveSnippet(el) {
-        const cleanForSaveHandlers = this.getResource("clean_for_save_handlers");
+        const cleanForSaveHandlers = [
+            ...this.getResource("clean_for_save_handlers"),
+            ({ root }) => escapeTextNodes(root),
+        ];
         const savedName = await this.config.saveSnippet(
             el,
             cleanForSaveHandlers,

--- a/addons/html_builder/static/src/utils/escaping.js
+++ b/addons/html_builder/static/src/utils/escaping.js
@@ -1,0 +1,23 @@
+export function escapeTextNodes(el) {
+    const walker = document.createTreeWalker(el, NodeFilter.SHOW_ALL, (node) => {
+        if (
+            node.nodeType === Node.ELEMENT_NODE &&
+            (node.matches("object,iframe,script,style") ||
+                (node.hasAttribute("data-oe-model") &&
+                    node.getAttribute("data-oe-model") !== "ir.ui.view"))
+        ) {
+            return NodeFilter.FILTER_REJECT; // Skip this node and its descendants
+        }
+        if (node.nodeType === Node.TEXT_NODE) {
+            return NodeFilter.FILTER_ACCEPT;
+        }
+        return NodeFilter.FILTER_SKIP; // Skip other nodes, but visit their children
+    });
+
+    const escaper = document.createElement("div");
+    let node;
+    while ((node = walker.nextNode())) {
+        escaper.textContent = node.nodeValue;
+        node.nodeValue = escaper.innerHTML;
+    }
+}

--- a/addons/html_builder/static/src/utils/escaping.js
+++ b/addons/html_builder/static/src/utils/escaping.js
@@ -1,5 +1,5 @@
 export function escapeTextNodes(el) {
-    const walker = document.createTreeWalker(el, NodeFilter.SHOW_ALL, (node) => {
+    const nodeFilter = (node) => {
         if (
             node.nodeType === Node.ELEMENT_NODE &&
             (node.matches("object,iframe,script,style") ||
@@ -12,8 +12,11 @@ export function escapeTextNodes(el) {
             return NodeFilter.FILTER_ACCEPT;
         }
         return NodeFilter.FILTER_SKIP; // Skip other nodes, but visit their children
-    });
-
+    };
+    if (nodeFilter(el) === NodeFilter.FILTER_REJECT) {
+        return;
+    }
+    const walker = document.createTreeWalker(el, NodeFilter.SHOW_ALL, nodeFilter);
     const escaper = document.createElement("div");
     let node;
     while ((node = walker.nextNode())) {


### PR DESCRIPTION
> 65. Special character written in translation are being converted into HTML Entity name like  `<br> => &lt;br&gt;`