### PR TITLE
[FIX] html_builder: make grid resing work properly

### DIFF
--- a/addons/html_builder/static/src/core/builder_overlay/builder_overlay.js
+++ b/addons/html_builder/static/src/core/builder_overlay/builder_overlay.js
@@ -511,6 +511,10 @@ export class BuilderOverlay {
 
         this.overlayElement.classList.remove("o_handlers_idle");
 
+        if (handleEl.setPointerCapture && ev.pointerId !== undefined) {
+            handleEl.setPointerCapture(ev.pointerId);
+        }
+
         const onSizingMove = (ev) => {
             for (const dir of directions) {
                 const configValues = dir.config.values;
@@ -572,6 +576,9 @@ export class BuilderOverlay {
 
         const onSizingStop = (ev) => {
             ev.preventDefault();
+            if (handleEl.releasePointerCapture && ev.pointerId !== undefined) {
+                handleEl.releasePointerCapture(ev.pointerId);
+            }
             window.removeEventListener("pointermove", onSizingMove);
             window.removeEventListener("pointerup", onSizingStop);
             window.document.body.classList.remove(cursorClass);

--- a/addons/website/static/tests/tours/website_update_column_count.js
+++ b/addons/website/static/tests/tours/website_update_column_count.js
@@ -103,6 +103,7 @@ registerWebsitePreviewTour("website_update_column_count", {
                 clientX: x,
                 clientY: y,
                 pointerType: 'mouse',
+                pointerId: 1,
             });
             (type === "pointermove" ? window : overlayEl).dispatchEvent(event);
         };


### PR DESCRIPTION
Before this commit, grid resizing wasn't working properly, 
because of the pointer up event not firing.
To reproduce the issue:
- open website, start editing
- drop the "pills" snippet
- click on text and try to resize its 'boundaries'

=> It's not working as expected
This commit follows the [html_builder refactoring]

[html_builder refactoring]: odoo/odoo@9fe45e2b7ddb
Related to task-4367641