### PR TITLE
[IMP] project: add tooltip on role_ids field in project.task model

### DIFF
--- a/addons/project/models/project_task.py
+++ b/addons/project/models/project_task.py
@@ -186,7 +186,11 @@ class ProjectTask(models.Model):
     allocated_hours = fields.Float("Allocated Time", tracking=True)
     subtask_allocated_hours = fields.Float("Sub-tasks Allocated Time", compute='_compute_subtask_allocated_hours', export_string_translation=False,
         help="Sum of the hours allocated for all the sub-tasks (and their own sub-tasks) linked to this task. Usually less than or equal to the allocated hours of this task.")
-    role_ids = fields.Many2many('project.role', string='Project Roles')
+    role_ids = fields.Many2many(
+        'project.role',
+        string='Project Roles',
+        help="When you create a project from a template, you can choose which employee takes each role. These employees will be added to the tasks, along with anyone already assigned.",
+    )
     # Tracking of this field is done in the write function
     user_ids = fields.Many2many('res.users', relation='project_task_user_rel', column1='task_id', column2='user_id',
         string='Assignees', context={'active_test': False}, tracking=True, default=_default_user_ids, domain="[('share', '=', False), ('active', '=', True)]", falsy_value_label=_lt("👤 Unassigned"))

--- a/addons/project/views/project_role_views.xml
+++ b/addons/project/views/project_role_views.xml
@@ -68,6 +68,10 @@
             <p class="o_view_nocontent_smiling_face">
                 No project role found. Let's create one!
             </p>
+            <p>
+                Assign roles to tasks in your project templates.
+                When creating a new project from the template, choose who will take on each role.
+            </p>
         </field>
     </record>
 


### PR DESCRIPTION
This commit adds a tooltip to make sure the user understands the purpose of role_ids field defined in project.task which is only displayed if the task is a template one.

task-4915942
