### PR TITLE
[IMP] product: speed up product document kanban view

### DIFF
--- a/addons/product/views/product_document_views.xml
+++ b/addons/product/views/product_document_views.xml
@@ -73,7 +73,7 @@
                                 t-value="new RegExp('(image|video|application/pdf|text)').test(record.mimetype.value) &amp;&amp; record.type.raw_value === 'binary'"/>
                             <div t-attf-class="o_kanban_image_wrapper #{(webimage or binaryPreviewable) ? 'o_kanban_previewer' : ''}">
                                 <div t-if="record.type.raw_value == 'url'" class="fa fa-link fa-3x text-muted" aria-label="Image is a link"/>
-                                <img t-elif="webimage" t-attf-src="/web/image/#{record.ir_attachment_id.raw_value}" width="100" height="100" alt="Document" class="o_attachment_image"/>
+                                <img t-elif="webimage" t-attf-src="/web/image/#{record.ir_attachment_id.raw_value}/100x100" width="100" height="100" alt="Document" class="o_attachment_image"/>
                                 <div t-else="" class="o_image o_image_thumbnail" t-att-data-mimetype="record.mimetype.value"/>
                             </div>
                         </aside>


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
Speed up product document kanban view

**Current behavior before PR:**
Loading all full size pictures, make it very slow to open the product document kanban view.Also the `<img>` tag is set with `width="100" height="100"`

**Desired behavior after PR is merged:**
Load small size pictures.




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
