### PR TITLE
[FIX] l10n_sa: missing reverse charge entry on tax 15% RC

### DIFF
--- a/addons/l10n_sa/data/account_tax_template_data.xml
+++ b/addons/l10n_sa/data/account_tax_template_data.xml
@@ -169,6 +169,12 @@
                 'account_id': ref('sa_account_104041'),
                 'plus_report_expression_ids': [ref('tax_report_line_imports_subject_tp_reverse_charge_mechanism_tax_tag')],
             }),
+            (0,0, {
+                'factor_percent': -100,
+                'repartition_type': 'tax',
+                'account_id': ref('sa_account_201017'),
+                'plus_report_expression_ids': [ref('tax_report_line_imports_subject_tp_reverse_charge_mechanism_tax_tag')],
+            }),
         ]"/>
             <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
             (0,0, {
@@ -178,6 +184,12 @@
             (0,0, {
                 'repartition_type': 'tax',
                 'account_id': ref('sa_account_104041'),
+                'minus_report_expression_ids': [ref('tax_report_line_imports_subject_tp_reverse_charge_mechanism_tax_tag')],
+            }),
+            (0,0, {
+                'factor_percent': -100,
+                'repartition_type': 'tax',
+                'account_id': ref('sa_account_201017'),
                 'minus_report_expression_ids': [ref('tax_report_line_imports_subject_tp_reverse_charge_mechanism_tax_tag')],
             }),
         ]"/>


### PR DESCRIPTION
Steps to reproduce:
- With a SA Company setup
- Create a Vendor Bill
- Add a Service product and apply 15% R C tax
- Confirm

Issue: The reverse charge account is not hit by the tax amount, no reverse charge entry is created and it does not show on the VAT filling report

opw-4755993
