### PR TITLE
[IMP] product: Remove the redundant create button from product document kanban view

### DIFF
--- a/addons/product/views/product_document_views.xml
+++ b/addons/product/views/product_document_views.xml
@@ -50,7 +50,7 @@
         <field name="name">product.document.kanban</field>
         <field name="model">product.document</field>
         <field name="arch" type="xml">
-            <kanban js_class="product_documents_kanban" can_open="0">
+            <kanban js_class="product_documents_kanban" create="false" can_open="0">
                 <field name="sequence" widget="handle"/>
                 <field name="ir_attachment_id"/>
                 <field name="mimetype"/>


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
Currently, there are two document creation buttons in the product document kanban view. Since the upload button is more powerful and user-friendly, we can remove the create button.

**Current behavior before PR:**
<img width="667" alt="image" src="https://github.com/user-attachments/assets/1671e565-377e-44ef-89db-44bb1e326aab" />
<img width="1016" alt="image" src="https://github.com/user-attachments/assets/2269dbf5-ee5e-4351-b456-de5fa4f64b87" />


**Desired behavior after PR is merged:**
<img width="660" alt="image" src="https://github.com/user-attachments/assets/181b05f7-4ed6-4d10-8c59-d4a25bda5093" />




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
