### PR TITLE
[FIX] l10n_my_edi_extended: refund fix

### DIFF
--- a/addons/l10n_my_edi_extended/models/account_edi_xml_ubl_my.py
+++ b/addons/l10n_my_edi_extended/models/account_edi_xml_ubl_my.py
@@ -76,7 +76,7 @@ class AccountEdiXmlUBLMyInvoisMY(models.AbstractModel):
             counterpart_amls = payment_terms.matched_debit_ids.debit_move_id + payment_terms.matched_credit_ids.credit_move_id
             counterpart_move_type = 'out_invoice' if invoice.move_type == 'out_refund' else 'out_refund'
             has_payments = bool(counterpart_amls.move_id.filtered(lambda move: move.move_type != counterpart_move_type))
-            is_paid = invoice.payment_state == invoice.payment_state in ('in_payment', 'paid', 'reversed')
+            is_paid = invoice.payment_state in ('in_payment', 'paid', 'reversed')
             if is_paid and has_payments:
                 code = '04' if invoice.move_type == 'out_refund' else '14'
             else:


### PR DESCRIPTION
Fixes a small typo in the code which makes the
distinction between credit note and refunds.

Note that the code still works with the typo; which explains why the tests were green.
But it's a weird line so better clean it up.

In 18.1+ it's being fixed during the forward port of the commit that introduced the typo

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
