### PR TITLE
[FIX] sale: prevent error on clicking Edit Configuration

### DIFF
--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -73,7 +73,7 @@ class SaleOrderLine(models.Model):
     is_configurable_product = fields.Boolean(
         string="Is the product configurable?",
         related='product_template_id.has_configurable_attributes',
-        depends=['product_id'])
+        depends=['product_template_id'])
     is_downpayment = fields.Boolean(
         string="Is a down payment",
         help="Down payments are made when creating invoices from a sales order."


### PR DESCRIPTION
Currently, when a user adds a configurable product to an order line, and remove the name of product and click on `Edit Configuration` (pencil icon) error is encountered.

**Steps to Reproduce:**
- Install Sales module
- Create a Quotation
- Add a product(e.g Acoustic Bloc Screen), then only remove the name from the orderline and click on **edit button(pencil Icon)**.

**Error:**
`TypeError: SaleProductConfiguratorController.sale_product_configurator_get_values()`
 `missing 1 required positional argument: 'product_template_id'`

**Root Cause:**
When a user clicks on Edit configuration, the client-side JavaScript makes an RPC call to the server, targeting the `sale_product_configurator_get_values`. which expects product_template_id at [1] and since it is removed from order line the error is encountered.

[1]- https://github.com/odoo/odoo/blob/1b657cf1e1ce43874a3ede307b2f8ad68216aa56/addons/sale/controllers/product_configurator.py#L11-L13

**Solution:**
This commit prevents the error by correcting `depends` on the field
`is_configurable_product`, which will ensure that edit button will be only
present if the configurable product is selected.

Sentry-5741581459, 6925770690
