### PR TITLE
[FIX] pos_self_order*: restrict kiosk to only configured payment methods

### DIFF
--- a/addons/pos_online_payment_self_order/models/pos_payment_method.py
+++ b/addons/pos_online_payment_self_order/models/pos_payment_method.py
@@ -13,4 +13,4 @@ class PosPaymentMethod(models.Model):
             domain = expression.OR([[('is_online_payment', '=', True), ('id', 'in', config['payment_method_ids'])], domain])
             return domain
         else:
-            return [('is_online_payment', '=', True)]
+            return [('is_online_payment', '=', True), ('id', '=', config['self_order_online_payment_method_id'])]

--- a/addons/pos_self_order/models/pos_payment_method.py
+++ b/addons/pos_self_order/models/pos_payment_method.py
@@ -8,9 +8,7 @@ class PosPaymentMethod(models.Model):
     def _payment_request_from_kiosk(self, order):
         pass
 
+    # will be overridden.
     @api.model
     def _load_pos_self_data_domain(self, data):
-        if data['pos.config'][0]['self_ordering_mode'] == 'kiosk':
-            return [('use_payment_terminal', 'in', ['adyen', 'stripe']), ('id', 'in', data['pos.config'][0]['payment_method_ids']) ]
-        else:
-            [('id', '=', False)]
+        return [('id', '=', False)]

--- a/addons/pos_self_order/static/src/app/services/self_order_service.js
+++ b/addons/pos_self_order/static/src/app/services/self_order_service.js
@@ -333,6 +333,7 @@ export class SelfOrder extends Reactive {
         }
     }
 
+    // TODO: Remove in master. This method is redundant as the same logic exists in _load_pos_self_data_domain.
     filterPaymentMethods(pms) {
         //based on _load_pos_self_data_domain from pos_payment_method.py
         return this.config.self_ordering_mode === "kiosk"

--- a/addons/pos_self_order_adyen/models/pos_payment_method.py
+++ b/addons/pos_self_order_adyen/models/pos_payment_method.py
@@ -1,6 +1,7 @@
 from datetime import datetime, timezone
 import random
 from odoo import models, api
+from odoo.osv import expression
 from odoo.addons.pos_adyen.models.pos_payment_method import UNPREDICTABLE_ADYEN_DATA
 
 
@@ -53,3 +54,13 @@ class PosPaymentMethod(models.Model):
             req = self.proxy_adyen_request(data)
 
             return req and (isinstance(req, bool) or not req.get('error'))
+
+    @api.model
+    def _load_pos_self_data_domain(self, data):
+        domain = super()._load_pos_self_data_domain(data)
+        if data['pos.config'][0]['self_ordering_mode'] == 'kiosk':
+            domain = expression.OR([
+                [('use_payment_terminal', '=', 'adyen'), ('id', 'in', data['pos.config'][0]['payment_method_ids'])],
+                domain
+            ])
+        return domain

--- a/addons/pos_self_order_razorpay/models/pos_payment_method.py
+++ b/addons/pos_self_order_razorpay/models/pos_payment_method.py
@@ -20,5 +20,8 @@ class PosPaymentMethod(models.Model):
     def _load_pos_self_data_domain(self, data):
         domain = super()._load_pos_self_data_domain(data)
         if data['pos.config'][0]['self_ordering_mode'] == 'kiosk':
-            domain = expression.OR([[('use_payment_terminal', '=', 'razorpay')], domain])
+            domain = expression.OR([
+                [('use_payment_terminal', '=', 'razorpay'), ('id', 'in', data['pos.config'][0]['payment_method_ids'])],
+                domain
+            ])
         return domain

--- a/addons/pos_self_order_stripe/__manifest__.py
+++ b/addons/pos_self_order_stripe/__manifest__.py
@@ -10,7 +10,10 @@
     ],
     'assets': {
         'pos_self_order.assets': [
-            'pos_self_order_stripe/static/**/*',
+            'pos_self_order_stripe/static/src/**/*',
+        ],
+        'pos_self_order.assets_tests': [
+            'pos_self_order_stripe/static/tests/tours/**/*',
         ],
     },
     "license": "LGPL-3",

--- a/addons/pos_self_order_stripe/models/pos_payment_method.py
+++ b/addons/pos_self_order_stripe/models/pos_payment_method.py
@@ -1,4 +1,5 @@
-from odoo import models
+from odoo import api, models
+from odoo.osv import expression
 
 
 class PosPaymentMethod(models.Model):
@@ -9,3 +10,13 @@ class PosPaymentMethod(models.Model):
             return super()._payment_request_from_kiosk(order)
         else:
             return self.stripe_payment_intent(order.amount_total)
+
+    @api.model
+    def _load_pos_self_data_domain(self, data):
+        domain = super()._load_pos_self_data_domain(data)
+        if data['pos.config'][0]['self_ordering_mode'] == 'kiosk':
+            domain = expression.OR([
+                [('use_payment_terminal', '=', 'stripe'), ('id', 'in', data['pos.config'][0]['payment_method_ids'])],
+                domain
+            ])
+        return domain

--- a/addons/pos_self_order_stripe/static/tests/tours/pos_self_order_kiosk_stripe_tours.js
+++ b/addons/pos_self_order_stripe/static/tests/tours/pos_self_order_kiosk_stripe_tours.js
@@ -1,0 +1,17 @@
+import { registry } from "@web/core/registry";
+import * as Utils from "@pos_self_order/../tests/tours/utils/common";
+import * as CartPage from "@pos_self_order/../tests/tours/utils/cart_page_util";
+import * as ProductPage from "@pos_self_order/../tests/tours/utils/product_page_util";
+import * as ConfirmationPage from "@pos_self_order/../tests/tours/utils/confirmation_page_util";
+
+registry.category("web_tour.tours").add("test_kiosk_without_payment_terminal", {
+    steps: () => [
+        Utils.checkIsNoBtn("My Order"),
+        Utils.clickBtn("Order Now"),
+        ProductPage.clickProduct("Coca-Cola"),
+        Utils.clickBtn("Order"),
+        CartPage.checkProduct("Coca-Cola", "2.53", "1"),
+        Utils.clickBtn("Pay"),
+        ConfirmationPage.isShown(),
+    ],
+});

--- a/addons/pos_self_order_stripe/tests/test_self_order_kiosk_stripe.py
+++ b/addons/pos_self_order_stripe/tests/test_self_order_kiosk_stripe.py
@@ -96,3 +96,21 @@ class TestSelfOrderKioskStripe(SelfOrderCommonTest):
                 payload = self._build_payload({'access_token': 'access_token', 'order_access_token': 'order_access', 'payment_intent_id': '1', 'payment_method_id': self.stripe.id})
                 self.url_open('/pos-self-order/stripe-capture-payment', data=json.dumps(payload), headers=self.headers, timeout=60000)
                 self.assertTrue(order.state == 'paid', 'The order should be paid')
+
+    def test_kiosk_without_payment_terminal(self):
+        """ Verify that kiosk should not ask for payment when valid payment method is not configured. """
+        invalid_pm = self.bank_payment_method  # 'Bank' is not a valid payment method for kiosk mode
+        self.pos_config.write({
+            'self_ordering_mode': 'kiosk',
+            'self_ordering_service_mode': 'counter',
+            'use_presets': False,
+            'payment_method_ids': [(6, 0, invalid_pm.ids)],
+        })
+        self.pos_config.with_user(self.pos_user).open_ui()
+        self.pos_config.current_session_id.set_opening_control(0, "")
+        self_route = self.pos_config._get_self_order_route()
+        self.start_tour(self_route, "test_kiosk_without_payment_terminal")
+
+        order = self.pos_config.current_session_id.order_ids[0]
+        self.assertEqual(order.state, 'draft', 'The order should be draft')
+        self.assertFalse(order.payment_ids, 'No payments should be registered for the order')


### PR DESCRIPTION
pos_self_order*: pos_online_paymnet_self_order, pos_self_order_razorpay, pos_self_order_stripe

Ensure the kiosk only uses payment methods that are explicitly configured.

**Steps to reproduce:**
- Set up an online payment method (do not assign it to the kiosk)
- Open a kiosk session.
- Try to validate an order.

**Issue:**
- The kiosk prompts for an online payment method, even though none are configured.

**Fix:**
- Restrict the kiosk to use only the payment methods explicitly configured in its settings.
- Prevent loading of any unconfigured payment methods to the kiosk.

Task: 4911495
Related: https://github.com/odoo/enterprise/pull/89490