### PR TITLE
[FIX] web: don't show separator in field selection

### DIFF
--- a/addons/web/static/src/core/model_field_selector/model_field_selector_popover.js
+++ b/addons/web/static/src/core/model_field_selector/model_field_selector_popover.js
@@ -104,7 +104,7 @@ export class ModelFieldSelectorPopover extends Component {
         update: Function,
     };
     static defaultProps = {
-        filter: (value) => value.searchable && value.type != "json",
+        filter: (value) => value.searchable && value.type != "json" && value.type !== "separator",
         isDebugMode: false,
         followRelations: true,
     };

--- a/addons/web/static/src/search/search_model.js
+++ b/addons/web/static/src/search/search_model.js
@@ -1159,7 +1159,7 @@ export class SearchModel extends EventBus {
                         selection: definition.selection,
                         sortable: true,
                         store: true,
-                        string: `${definition.string} (${definitionRecordName})`,
+                        string: definition.string,
                         type: definition.type,
                         relatedPropertyField: field,
                     };

--- a/addons/web/static/src/search/search_model.js
+++ b/addons/web/static/src/search/search_model.js
@@ -1164,7 +1164,7 @@ export class SearchModel extends EventBus {
                         relatedPropertyField: field,
                     };
 
-                    if (!searchItemsNames.includes(fullName)) {
+                    if (!searchItemsNames.includes(fullName) && definition.type !== "separator") {
                         const groupByItem = {
                             description: definition.string,
                             definitionRecordId,

--- a/addons/web/static/src/views/fields/dynamic_widget/dynamic_model_field_selector_char.js
+++ b/addons/web/static/src/views/fields/dynamic_widget/dynamic_model_field_selector_char.js
@@ -45,6 +45,10 @@ export class DynamicModelFieldSelectorChar extends CharField {
     }
 
     filter(fieldDef) {
+        if (fieldDef.type === "separator") {
+            // Don't show properties separator
+            return false;
+        }
         return !this.props.onlySearchable || fieldDef.searchable;
     }
 


### PR DESCRIPTION
Bug 1
=====
When inserting properties in a domain, or in the server action form
view, the property separator should not be visible.

Don't show separator in group by.

Bug 2
=====
Name change in list view after grouping by a property

1. Add a property in the list view
2. Group by a property
=> The name of the parent is added in the column.

Task-4896271