### PR TITLE
Update res_partner.py

### DIFF
--- a/odoo/addons/base/models/res_partner.py
+++ b/odoo/addons/base/models/res_partner.py
@@ -191,6 +191,19 @@ class PartnerTitle(models.Model):
 
 
 class Partner(models.Model):
+    @api.constrains('phone', 'email', 'website')
+    def _check_contact_fields(self):
+        import re
+        email_regex = r"^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}$"
+        website_regex = r"^(https?://)?([\w.-]+)\.([a-zA-Z]{2,})(/\S*)?$"
+        phone_regex = r"^[0-9+()\-\s]{6,}$"  # Basic check: at least 6 digits or symbols
+        for rec in self:
+            if rec.email and not re.match(email_regex, rec.email):
+                raise ValidationError(_("Invalid email address: %s" % rec.email))
+            if rec.website and not re.match(website_regex, rec.website):
+                raise ValidationError(_("Invalid website URL: %s" % rec.website))
+            if rec.phone and not re.match(phone_regex, rec.phone):
+                raise ValidationError(_("Invalid phone number: %s" % rec.phone))
     _description = 'Contact'
     _inherit = ['format.address.mixin', 'format.vat.label.mixin', 'avatar.mixin']
     _name = "res.partner"


### PR DESCRIPTION
Added validation for phone, email, and website fields on res.partner

Added validation logic to ensure only properly formatted phone numbers, emails, and website URLs are accepted when creating or updating a customer/contact.

Description of the issue/feature this PR addresses:

Customers could be created with invalid phone, email, or website values.
Current behavior before PR:

No validation exists for the format of phone, email, or website fields on res.partner.
Desired behavior after PR is merged:

Validation is enforced for phone, email, and website fields, preventing the creation or update of a customer/contact with invalid values.

I confirm I have signed the CLA and read the PR guidelines at [www.odoo.com/submit-pr]