### PR TITLE
[FIX] event: fix slot creation tz

### DIFF
--- a/addons/event/static/src/views/event_slot_calendar/event_slot_calendar_model.js
+++ b/addons/event/static/src/views/event_slot_calendar/event_slot_calendar_model.js
@@ -18,12 +18,16 @@ export class EventSlotCalendarModel extends CalendarModel {
     /**
      * @override
      * Instead of the local tz, express the times in the related event tz or fallback on utc.
+     *
+     * After conversion to event tz, changing the 'zone' param back to local without changing
+     * the already converted datetimes. This is to make sure the calendar renders records correctly
+     * as it always expects datetimes expressed in the 'local' tz.
      */
     normalizeRecord(rawRecord) {
         const normalizedRecord = super.normalizeRecord(rawRecord);
         const tz = rawRecord.date_tz || 'utc';
-        normalizedRecord.start = normalizedRecord.start.setZone(tz);
-        normalizedRecord.end = normalizedRecord.end.setZone(tz);
+        normalizedRecord.start = normalizedRecord.start.setZone(tz).setZone('local', {keepLocalTime: true});
+        normalizedRecord.end = normalizedRecord.end.setZone(tz).setZone('local', {keepLocalTime: true});
         return normalizedRecord;
     }
 


### PR DESCRIPTION
Purpose
=======
Fix the creation of slots at the wrong date.

Specification
=============
User timezone: Europe/Brussels
Event timezone: America/Los Angeles
When creating a slot on the calendar on the 10th of April from 8PM to 11PM,
the slot is created from 8PM to 11PM but on the 11th of April.

In scenario where the conversion from the local tz to the event tz
changes the date, the slot is created at the wrong date.

=> After conversion, the DateTime 'zone' param needs to be set back
to the local tz (without changing the converted times) to make sure
the calendar renders records correctly as it always expects datetimes
expressed in the 'local' tz.

related PR: https://github.com/odoo/odoo/pull/205945

Task-4743999

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
