### PR TITLE
[FIX] account: improve invoice summary label when reconciled with non-payments

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -1412,6 +1412,7 @@ class AccountMove(models.Model):
                         'account_payment_id': counterpart_line.payment_id.id,
                         'payment_method_name': counterpart_line.payment_id.payment_method_line_id.name,
                         'move_id': counterpart_line.move_id.id,
+                        'is_refund': counterpart_line.move_id.move_type in ['in_refund', 'out_refund'],
                         'ref': reconciliation_ref,
                         # these are necessary for the views to change depending on the values
                         'is_exchange': reconciled_partial['is_exchange'],

--- a/addons/account/static/src/components/account_payment_field/account_payment.xml
+++ b/addons/account/static/src/components/account_payment_field/account_payment.xml
@@ -40,7 +40,11 @@
                            <a role="button" tabindex="0" class="js_payment_info fa fa-info-circle" t-att-index="line_index" style="margin-right:5px;" aria-label="Info" title="Journal Entry Info" data-bs-toggle="tooltip" t-on-click.stop="(ev) => this.onInfoClick(ev, line)"></a>
                         </td>
                         <td t-if="!line.is_exchange">
-                            <i class="o_field_widget text-start o_payment_label">Paid on <t t-out="line.formattedDate"></t></i>
+                            <i class="o_field_widget text-start o_payment_label">
+                                <t t-if="line.is_refund">Reversed on </t>
+                                <t t-else="">Paid on </t>
+                                <t t-out="line.formattedDate"></t>
+                            </i>
                         </td>
                         <td t-if="line.is_exchange" colspan="2">
                             <i class="o_field_widget text-start text-muted text-start">

--- a/addons/account/views/report_invoice.xml
+++ b/addons/account/views/report_invoice.xml
@@ -200,7 +200,11 @@
                                                     <t t-foreach="payments_vals" t-as="payment_vals">
                                                         <tr t-if="payment_vals['is_exchange'] == 0">
                                                             <td>
-                                                                <i class="oe_form_field text-end oe_payment_label">Paid on <t t-out="payment_vals['date']" t-options='{"widget": "date"}'>2021-09-19</t></i>
+                                                                <i class="oe_form_field text-end oe_payment_label">
+                                                                    <t t-if="payment_vals['is_refund']">Reversed on </t>
+                                                                    <t t-else="">Paid on </t>
+                                                                    <t t-out="payment_vals['date']" t-options='{"widget": "date"}'>2021-09-19</t>
+                                                                </i>
                                                             </td>
                                                             <td class="text-end">
                                                                 <span t-out="payment_vals['amount']" t-options='{"widget": "monetary", "display_currency": o.currency_id}'>20.00</span>


### PR DESCRIPTION
Before this PR:
-------------------------------------------------- 
In the invoice summary, the label `Paid on ...` was always shown whenever the invoice was reconciled, regardless of whether the reconciliation was made through an actual payment (bank/cash) or through a credit note or journal entry.

This led to misleading information:
- Credit note reconciliation (partial or full) showed `Paid on ...`
- Even though no real payment occurred
- Full reversals correctly showed status 'Reversed', but the label still said `Paid on ...`

After this PR:
--------------------------------------------------
- The label is now shown as `Reversed on ...` when the reconciliation is done with credit note.
- This avoids confusion and better reflects the actual accounting status of the invoice

This change ensures users are not misled by incorrect payment indications when only a reversal or credit note is involved.

task-4920349
