### PR TITLE
[REM] mail: removed unused user settings unmute cron

### DIFF
--- a/addons/mail/data/ir_cron_data.xml
+++ b/addons/mail/data/ir_cron_data.xml
@@ -84,14 +84,5 @@
             <field name="code">model._cleanup_expired_mutes()</field>
             <field name="state">code</field>
         </record>
-
-        <record id="ir_cron_discuss_users_settings_unmute" model="ir.cron">
-            <field name="name">Discuss: users settings unmute</field>
-            <field name="interval_number">1</field>
-            <field name="interval_type">days</field>
-            <field name="model_id" ref="model_res_users_settings"/>
-            <field name="code">model._cleanup_expired_mutes()</field>
-            <field name="state">code</field>
-        </record>
     </data>
 </odoo>


### PR DESCRIPTION
This commit removes a cron job that called a method removed in odoo/odoo/pull/215866.