### PR TITLE
[REF] *: update scrollTo imports to use method from the html_builder

### DIFF
--- a/addons/survey/static/src/js/survey_form.js
+++ b/addons/survey/static/src/js/survey_form.js
@@ -3,7 +3,7 @@ import { _t } from "@web/core/l10n/translation";
 import { rpc } from "@web/core/network/rpc";
 import { cookie } from "@web/core/browser/cookie";
 import { utils as uiUtils } from "@web/core/ui/ui_service";
-import { scrollTo } from "@web_editor/js/common/scrolling";
+import { scrollTo } from "@web/core/utils/scrolling";
 
 import SurveyPreloadImageMixin from "@survey/js/survey_preload_image_mixin";
 import { SurveyImageZoomer } from "@survey/js/survey_image_zoomer";

--- a/addons/website/__manifest__.py
+++ b/addons/website/__manifest__.py
@@ -221,6 +221,7 @@
             "website/static/src/**/common/**/*",
         ],
         'web.assets_frontend': [
+            'html_builder/static/src/utils/scrolling.js',
             'website/static/src/interactions/**/*',
             'website/static/src/core/**/*',
             'website/static/src/utils/**/*',
@@ -351,6 +352,7 @@
             'website/static/tests/mock_server/**/*',
         ],
         'web.assets_unit_tests_setup': [
+            'html_builder/static/src/utils/scrolling.js',
             'web/static/src/legacy/js/core/class.js',
             'web/static/src/legacy/js/public/lazyloader.js',
             'web/static/src/legacy/js/public/minimal_dom.js',

--- a/addons/website/static/src/interactions/anchor_slide.js
+++ b/addons/website/static/src/interactions/anchor_slide.js
@@ -1,7 +1,6 @@
+import { scrollTo } from "@html_builder/utils/scrolling";
 import { Interaction } from "@web/public/interaction";
 import { registry } from "@web/core/registry";
-
-import { scrollTo } from "@web_editor/js/common/scrolling";
 
 export class AnchorSlide extends Interaction {
     static selector = "a[href^='/'][href*='#'], a[href^='#']";

--- a/addons/website/static/src/snippets/s_website_form/form.js
+++ b/addons/website/static/src/snippets/s_website_form/form.js
@@ -1,3 +1,4 @@
+import { scrollTo } from "@html_builder/utils/scrolling";
 import { Interaction } from "@web/public/interaction";
 import { registry } from "@web/core/registry";
 
@@ -17,7 +18,6 @@ import {
     serializeDate,
     serializeDateTime,
 } from "@web/core/l10n/dates";
-import { scrollTo } from "@web_editor/js/common/scrolling";
 import wUtils from "@website/js/utils";
 
 const { DateTime } = luxon;

--- a/addons/website_blog/static/src/interactions/website_blog.js
+++ b/addons/website_blog/static/src/interactions/website_blog.js
@@ -1,9 +1,9 @@
+import { scrollTo } from "@html_builder/utils/scrolling";
 import { Interaction } from "@web/public/interaction";
 import { registry } from "@web/core/registry";
 
 import { browser } from "@web/core/browser/browser";
 import { _t } from "@web/core/l10n/translation";
-import { scrollTo } from "@web_editor/js/common/scrolling";
 import { verifyHttpsUrl } from "@website/utils/misc";
 
 export class WebsiteBlog extends Interaction {

--- a/addons/website_event_track/static/src/interactions/website_event_track_proposal_form.js
+++ b/addons/website_event_track/static/src/interactions/website_event_track_proposal_form.js
@@ -1,9 +1,9 @@
+import { scrollTo } from "@html_builder/utils/scrolling";
 import { _t } from "@web/core/l10n/translation";
 import { post } from "@web/core/network/http_service";
 import { registry } from "@web/core/registry";
 import { renderToElement } from "@web/core/utils/render";
 import { Interaction } from "@web/public/interaction";
-import { scrollTo } from "@web_editor/js/common/scrolling";
 
 export class WebsiteEventTrackProposalForm extends Interaction {
     static selector = ".o_website_event_track_proposal_form";

--- a/addons/website_forum/static/src/interactions/website_forum.js
+++ b/addons/website_forum/static/src/interactions/website_forum.js
@@ -1,15 +1,15 @@
+import { scrollTo, closestScrollable } from "@html_builder/utils/scrolling";
 import { Interaction } from "@web/public/interaction";
 import { registry } from "@web/core/registry";
 import { htmlJoin } from "@mail/utils/common/html";
 import { markup } from "@odoo/owl";
 import { browser } from "@web/core/browser/browser";
-import { cookie } from "@web/core/browser/cookie";;
+import { cookie } from "@web/core/browser/cookie";
 import { ConfirmationDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
 import { _t } from "@web/core/l10n/translation";
 import { rpc } from "@web/core/network/rpc";
 import { escape } from "@web/core/utils/strings";
 import { session } from "@web/session";
-import { scrollTo, closestScrollable } from "@web_editor/js/common/scrolling";
 import { loadWysiwygFromTextarea } from "@web_editor/js/frontend/loadWysiwygFromTextarea";
 import { FlagMarkAsOffensiveDialog } from "../components/flag_mark_as_offensive/flag_mark_as_offensive";
 import { WebsiteForumTagsWrapper } from "../components/website_forum_tags_wrapper";


### PR DESCRIPTION
*: survey, website, website_blog, website_event, website_forum. 
Updates imports to use the new html_builder scrollTo method 
instead of the deprecated web_editor one.
Part of the [html_builder refactoring]

[html_builder refactoring]: https://github.com/odoo/odoo/commit/9fe45e2b7ddb 
Related to task-4367641