### PR TITLE
[FIX] point_of_sale: expand search result with variants

### DIFF
--- a/addons/point_of_sale/static/src/app/models/product_template.js
+++ b/addons/point_of_sale/static/src/app/models/product_template.js
@@ -263,18 +263,10 @@ export class ProductTemplate extends Base {
     }
 
     exactMatch(searchWord) {
-        const fields = ["barcode"];
         const variantMatch = this.product_variant_ids.some(
-            (variant) =>
-                (variant.barcode && variant.barcode.toLowerCase() == searchWord) ||
-                variant.product_template_variant_value_ids.some((vv) =>
-                    vv.name.toLowerCase().includes(searchWord)
-                )
+            (variant) => variant.barcode && variant.barcode.toLowerCase() == searchWord
         );
-        return (
-            variantMatch ||
-            fields.some((field) => this[field] && this[field].toLowerCase() == searchWord)
-        );
+        return variantMatch || (this.barcode && this.barcode.toLowerCase() === searchWord);
     }
 
     _isArchivedCombination(attributeValueIds) {

--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -2472,8 +2472,14 @@ export class PosStore extends WithLazyGetterTrap {
             return this.sortByWordIndex(exactMatches, words);
         }
 
-        const matches = products.filter((p) =>
-            unaccent(p.searchString, false).toLowerCase().includes(words)
+        const matches = products.filter(
+            (p) =>
+                unaccent(p.searchString, false).toLowerCase().includes(words) ||
+                p.product_variant_ids.some((variant) =>
+                    variant.product_template_variant_value_ids.some((vv) =>
+                        unaccent(vv.name, false).toLowerCase().includes(words)
+                    )
+                )
         );
 
         return this.sortByWordIndex(Array.from(new Set([...exactMatches, ...matches])), words);

--- a/addons/point_of_sale/static/tests/pos/tours/product_screen_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/product_screen_tour.js
@@ -542,6 +542,12 @@ registry.category("web_tour.tours").add("ProductSearchTour", {
             ProductScreen.searchProduct("TESTPROD2"),
             ProductScreen.productIsDisplayed("Test Product 1").map(negateStep),
             ProductScreen.productIsDisplayed("Test Product 2"),
+            ProductScreen.searchProduct("galaxy"),
+            ProductScreen.productIsDisplayed("galaxy"),
+            ProductScreen.productIsDisplayed("Test Product variant"),
+            ProductScreen.searchProduct("galaxy variant"),
+            ProductScreen.productIsDisplayed("galaxy").map(negateStep),
+            ProductScreen.productIsDisplayed("Test Product variant"),
         ].flat(),
 });
 registry.category("web_tour.tours").add("SortOrderlinesByCategories", {

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -1746,7 +1746,31 @@ class TestUi(TestPointOfSaleHttpCommon):
                 'taxes_id': False,
                 'available_in_pos': True,
             },
+            {
+                'name': 'galaxy',
+                'list_price': 100,
+                'taxes_id': False,
+                'available_in_pos': True,
+            },
         ])
+
+        att_color = self.env['product.attribute'].create({'name': 'Color', 'sequence': 1})
+
+        att_color_values = self.env['product.attribute.value'].create([
+            {'name': 'galaxy variant', 'attribute_id': att_color.id, 'sequence': 1},
+            {'name': 'blue', 'attribute_id': att_color.id, 'sequence': 2},
+            ])
+
+        self.env['product.template'].create({
+            'name': 'Test Product variant',
+            'attribute_line_ids': [
+                Command.create({
+                    'attribute_id': att_color.id,
+                    'value_ids': [Command.set(att_color_values.mapped('id'))],
+                }),
+            ],
+            'available_in_pos': True,
+        })
 
         self.main_pos_config.with_user(self.pos_user).open_ui()
         self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'ProductSearchTour', login="pos_user")


### PR DESCRIPTION
If you have a product template with variant, ex: Telephone case, variant name : Iphone 15 SE, Samsung Galaxy, Nokia 1999
When doing a search with more then 2 letters you will only find the Telephone case, searh exemple: Iphone 15 SE, Galaxy, Samsung.

** Step to reproduce **
- Create a product called "Telephone case" and add a variant named samsung galaxy S24 ultra
- Create a product called "Samsung galaxy"
- Enable both products for point of sale
- Go to the point of sale app and open a shop that sells both of those products.
- Do a search for the product Samsung galaxy
- Issue : Only the product "Telephone case" will appear.

** Cause of the issue **
Doing a search will call getProductsBySearchWord:

https://github.com/odoo/odoo/blob/5a1fff2cc61bd8676049879039defa3fb2a3f13d/addons/point_of_sale/static/src/app/services/pos_store.js#L2401-L2407

During the product.exactMatch(words) we will get a hit since we will have a name of the product variant:

https://github.com/odoo/odoo/blob/5a1fff2cc61bd8676049879039defa3fb2a3f13d/addons/point_of_sale/static/src/app/models/product_template.js#L265-L278

And the call for the function will finish there since the searchword lenght > 2 and we have a hit.

** Origin of the issue **

The variant search was implemented in "exactMatch()" which block more search if it find a result.

https://github.com/odoo/odoo/commit/05abd586d7adcceed3dae0943526e6357b28dbb4

opw-4864976
