### PR TITLE
[FIX] website_slides_survey: fix unlink except linked to course translation issue

### DIFF
--- a/addons/website_slides_survey/models/survey_survey.py
+++ b/addons/website_slides_survey/models/survey_survey.py
@@ -32,7 +32,7 @@ class SurveySurvey(models.Model):
         certifications = self.sudo().slide_ids.filtered(lambda slide: slide.slide_type == "certification").mapped('survey_id').exists()
         if certifications:
             certifications_course_mapping = [
-                _(
+                self.env._(
                     "- %(certification)s (Courses - %(courses)s)",
                     certification=certi.title,
                     courses=certi.slide_channel_ids.mapped("name"),


### PR DESCRIPTION
Issue:
Prior to this commit, a translation issue occurred due to the use of a list comprehension. The _get_translation_source function attempts to scan the local variables, but in the context of a list comprehension, only variables defined within the comprehension are accessible. As a result, variables like uuid and cursor were not available to the _get_lang function, ultimately leading to an error.

Fix:
Replaced the '_' function comprehension with 'self.env._' for proper access to the 'self' and 'env' object.

runbot-159884