### PR TITLE
[FIX] website: BuilderSelect opens outside the screen

### DIFF
--- a/addons/html_builder/static/src/core/building_blocks/builder_select.xml
+++ b/addons/html_builder/static/src/core/building_blocks/builder_select.xml
@@ -12,7 +12,7 @@
                     <t t-slot="fixedButton"/>
                 </button>
                 <t t-set-slot="content">
-                    <div t-att-class="props.dropdownContainerClass" data-prevent-closing-overlay="true">
+                    <div t-att-class="props.dropdownContainerClass" data-prevent-closing-overlay="true" style="max-height: 50vh;">
                         <t t-slot="default" />
                     </div>
                 </t>


### PR DESCRIPTION
The goal of this commit is to prevent the BuilderSelect from having part of its dropdown outside the screen. This makes some of the elements in the dropdown inaccessible.

This problem is linked to a popover limit that should be set in the future.

Solution:
We will set a limit of 50% of the screen for the height in BuilderSelect

To reproduce:
- Have a BuilderSelect containing many items For example, Type when a Field is selected in a Form.
- Click on the BuilderSelect

Before this commit:
    Part of the dropdown is outside the screen and therefore few elements
    are impossible to select.

After this commit:
    The size of the dropdown is limited to prevent it from being outside the screen.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
