### PR TITLE
  [FIX] hr_expense: allow navigating back to list view from dashboard filters

### DIFF
--- a/addons/hr_expense/static/src/components/expense_dashboard.js
+++ b/addons/hr_expense/static/src/components/expense_dashboard.js
@@ -32,7 +32,6 @@ export class ExpenseDashboard extends Component {
         const action = actionId ? await this.actionService.loadAction(actionId) : {};
 
         action['context'] = { [`search_default_${filterName}`]: 1 };
-        action['tag'] = 'menu'; //disables breadcrumb change on filter change
-        return this.actionService.doAction(action);
+        return this.actionService.doAction(action, {clearBreadcrumbs: true});
     }
 }


### PR DESCRIPTION
**Steps to reproduce:**
- Install the `hr_expense` module.
- Go to the Expense menu and click on "To Submit" in the My Expense dashboard.
- Open any record from the list view.

**Observation:**
- You can't go back to the list view after opening a record.

**Cause:**
- A tag `menu` was added to the action to hide breadcrumbs, but it removed all breadcrumb navigation, unable to go back.
https://github.com/odoo/odoo/blob/92993d7790bb641e5822a5358db35c7fcc7bd091/addons/hr_expense/static/src/components/expense_dashboard.js#L44

**Solution:**
- Used a better way by passing `{ clearBreadcrumbs: true }` to stop the breadcrumb from changing when a filter is applied.

opw-4790643

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
