### PR TITLE
[FIX] mail: reintroduced methods for user settings mute

### DIFF
--- a/addons/mail/models/res_users_settings.py
+++ b/addons/mail/models/res_users_settings.py
@@ -24,6 +24,13 @@ class ResUsersSettings(models.Model):
     mute_until_dt = fields.Datetime(string="Mute notifications until", index=True, help="If set, the user will not receive notifications from all the channels until this date.")
 
     @api.model
+    def _cleanup_expired_mutes(self):
+        """ Unused and to be removed together with mute_until_dt """
+
+    def _notify_mute(self):
+        """ Unused and to be removed together with mute_until_dt """
+
+    @api.model
     def _format_settings(self, fields_to_format):
         res = super()._format_settings(fields_to_format)
         if 'volume_settings_ids' in fields_to_format:


### PR DESCRIPTION
This commit reintroduces the methods removed in https://github.com/odoo/odoo/pull/215866 in order to follow stable policy.