### PR TITLE
[FIX] html_builder: handle clear button in BuilderDateTimePicker / [FIX] html_builder, website: reintroduce null default for options

### DIFF
--- a/addons/html_builder/static/src/core/building_blocks/builder_datetimepicker.js
+++ b/addons/html_builder/static/src/core/building_blocks/builder_datetimepicker.js
@@ -1,7 +1,6 @@
 import { Component } from "@odoo/owl";
 import { useDateTimePicker } from "@web/core/datetime/datetime_hook";
 import { ConversionError, formatDate, formatDateTime, parseDateTime } from "@web/core/l10n/dates";
-import { useChildRef } from "@web/core/utils/hooks";
 import { pick } from "@web/core/utils/objects";
 import { BuilderComponent } from "./builder_component";
 import { BuilderTextInputBase, textInputBasePassthroughProps } from "./builder_text_input_base";
@@ -33,9 +32,10 @@ export class BuilderDateTimePicker extends Component {
 
     setup() {
         useBuilderComponent();
+        this.defaultValue = DateTime.now().toUnixInteger().toString();
         const { state, commit, preview } = useInputBuilderComponent({
             id: this.props.id,
-            defaultValue: this.props.acceptEmptyDate ? undefined : this.getDefaultValue(),
+            defaultValue: this.props.acceptEmptyDate ? undefined : this.defaultValue,
             formatRawValue: this.formatRawValue.bind(this),
             parseDisplayValue: this.parseDisplayValue.bind(this),
         });
@@ -64,8 +64,6 @@ export class BuilderDateTimePicker extends Component {
             rounding: 0,
         });
 
-        this.inputRef = useChildRef();
-
         this.formatDateTime = this.props.type === "date" ? formatDate : formatDateTime;
 
         this.dateTimePicker = useDateTimePicker({
@@ -75,22 +73,14 @@ export class BuilderDateTimePicker extends Component {
                 return getPickerProps();
             },
             onApply: (value) => {
-                const result = this.commit(this.formatDateTime(value));
-                this.inputRef.el.value = result;
+                this.commit(this.formatDateTime(value));
             },
             onChange: (value) => {
                 const dateString = this.formatDateTime(value);
                 this.preview(dateString);
-                this.inputRef.el.value = dateString;
+                state.value = this.parseDisplayValue(dateString);
             },
         });
-    }
-
-    /**
-     * @returns {String} number of seconds since epoch
-     */
-    getDefaultValue() {
-        return DateTime.now().toUnixInteger().toString();
     }
 
     /**
@@ -131,7 +121,7 @@ export class BuilderDateTimePicker extends Component {
                 return this.oldValue;
             }
         }
-        return this.getDefaultValue();
+        return this.defaultValue;
     }
 
     /**

--- a/addons/html_builder/static/src/core/building_blocks/builder_datetimepicker.xml
+++ b/addons/html_builder/static/src/core/building_blocks/builder_datetimepicker.xml
@@ -6,7 +6,6 @@
         <div t-ref="root" class="w-100">
             <BuilderTextInputBase
                     t-props="textInputBaseProps"
-                    inputRef="inputRef"
                     commit="commit"
                     preview="preview"
                     onFocus.bind="onFocus"

--- a/addons/html_builder/static/src/core/building_blocks/builder_number_input.js
+++ b/addons/html_builder/static/src/core/building_blocks/builder_number_input.js
@@ -19,7 +19,7 @@ export class BuilderNumberInput extends Component {
     static props = {
         ...basicContainerBuilderComponentProps,
         ...textInputBasePassthroughProps,
-        default: { type: Number, optional: true },
+        default: { type: [Number, { value: null }], optional: true },
         unit: { type: String, optional: true },
         saveUnit: { type: String, optional: true },
         step: { type: Number, optional: true },
@@ -32,6 +32,7 @@ export class BuilderNumberInput extends Component {
     static defaultProps = {
         composable: false,
         applyWithUnit: true,
+        default: 0,
     };
 
     setup() {
@@ -42,7 +43,7 @@ export class BuilderNumberInput extends Component {
         useBuilderComponent();
         const { state, commit, preview } = useInputBuilderComponent({
             id: this.props.id,
-            defaultValue: this.props.default?.toString(),
+            defaultValue: this.props.default === null ? null : this.props.default?.toString(),
             formatRawValue: this.formatRawValue.bind(this),
             parseDisplayValue: this.parseDisplayValue.bind(this),
         });
@@ -61,6 +62,9 @@ export class BuilderNumberInput extends Component {
     convertSpaceSplitValues(values, convertSingleValueFn) {
         if (typeof values === "number") {
             return convertSingleValueFn(values.toString());
+        }
+        if (values === null) {
+            return values;
         }
         if (!values) {
             return "";
@@ -98,6 +102,9 @@ export class BuilderNumberInput extends Component {
     }
 
     parseDisplayValue(displayValue) {
+        if (!displayValue) {
+            return displayValue;
+        }
         displayValue = displayValue.replace(/,/g, ".");
         // Only accept 0-9, dot, - sign and space if multiple values are allowed
         if (this.props.composable) {

--- a/addons/html_builder/static/src/core/utils.js
+++ b/addons/html_builder/static/src/core/utils.js
@@ -674,6 +674,9 @@ export function useInputBuilderComponent({
                 withLoadingEffect: withLoadingEffect,
             });
         }
+        if (rawValue === null || (rawValue === defaultValue && rawValue === state.value)) {
+            state.value = rawValue;
+        }
         // If the parsed value is not equivalent to the user input, we want to
         // normalize the displayed value. It is useful in cases of invalid
         // input and allows to fall back to the output of parseDisplayValue.

--- a/addons/html_builder/static/src/plugins/border_configurator_option.xml
+++ b/addons/html_builder/static/src/plugins/border_configurator_option.xml
@@ -3,7 +3,7 @@
 
 <t t-name="html_builder.BorderConfiguratorOption">
     <BuilderRow label="props.label">
-        <BuilderNumberInput action="props.action" actionParam="{ mainParam: getStyleActionParam('width'), extraClass: props.withBSClass and 'border' }" unit="'px'" min="0" default="0" composable="true"/>
+        <BuilderNumberInput action="props.action" actionParam="{ mainParam: getStyleActionParam('width'), extraClass: props.withBSClass and 'border' }" unit="'px'" min="0" composable="true"/>
         <BuilderSelect action="props.action" actionParam="getStyleActionParam('style')" t-if="state.hasBorder">
             <BuilderSelectItem title.translate="Solid" actionValue="'solid'"><div class="o-hb-border-preview" style="border-style: solid;"/></BuilderSelectItem>
             <BuilderSelectItem title.translate="Dashed" actionValue="'dashed'"><div class="o-hb-border-preview" style="border-style: dashed;"/></BuilderSelectItem>
@@ -18,7 +18,7 @@
 
     <!-- TODO: handle the dependency with border_width_opt bg_color_opt-->
     <BuilderRow t-if="props.withRoundCorner" label.translate="Round Corners">
-        <BuilderNumberInput action="props.action" actionParam="{ mainParam: 'border-radius', extraClass: props.withBSClass and 'rounded' }" unit="'px'" default="0" min="0" composable="true"/>
+        <BuilderNumberInput action="props.action" actionParam="{ mainParam: 'border-radius', extraClass: props.withBSClass and 'rounded' }" unit="'px'" min="0" composable="true"/>
     </BuilderRow>
 </t>
 

--- a/addons/website/static/src/builder/plugins/header_navbar_option.xml
+++ b/addons/website/static/src/builder/plugins/header_navbar_option.xml
@@ -42,7 +42,7 @@
         <BuilderFontFamilyPicker action="'customizeWebsiteVariable'" actionParam="'navbar-font'" valueParamName="'actionValue'"/>
     </BuilderRow>
     <BuilderRow label.translate="Format">
-        <BuilderNumberInput action="'customizeWebsiteVariable'" actionParam="'header-font-size'" unit="'px'" saveUnit="'rem'"/>
+        <BuilderNumberInput action="'customizeWebsiteVariable'" actionParam="'header-font-size'" default="null" unit="'px'" saveUnit="'rem'"/>
         <BuilderColorPicker action="'customizeWebsiteVariable'" actionParam="'header-text-color'"
             enabledTabs="['solid', 'custom']"
         />

--- a/addons/website/static/src/builder/plugins/options/animate_option.xml
+++ b/addons/website/static/src/builder/plugins/options/animate_option.xml
@@ -81,7 +81,7 @@
         <BuilderContext t-if="this.isActiveItem('animation_on_appearance_opt')">
             <!-- Start After -->
             <BuilderRow label.translate="Start After" level="1">
-                <BuilderNumberInput styleAction="'animation-delay'" action="'forceAnimation'" default="0" unit="'s'" />
+                <BuilderNumberInput styleAction="'animation-delay'" action="'forceAnimation'" unit="'s'" />
             </BuilderRow>
             <!-- Duration -->
             <BuilderRow label.translate="Duration" level="1">

--- a/addons/website/static/src/builder/plugins/options/header_option.xml
+++ b/addons/website/static/src/builder/plugins/options/header_option.xml
@@ -207,6 +207,7 @@
     <BuilderNumberInput
             action="'customizeWebsiteVariable'"
             actionParam="'sidebar-width'"
+            default="null"
             unit="'px'"
             saveUnit="'rem'"/>
     </BuilderRow>

--- a/addons/website/static/src/builder/plugins/options/navbar_logo_option.xml
+++ b/addons/website/static/src/builder/plugins/options/navbar_logo_option.xml
@@ -10,10 +10,10 @@
             </BuilderSelect>
         </BuilderRow>
         <BuilderRow label.translate="Height" level="1" t-if="!isActiveItem('option_header_brand_none')" action="'customizeWebsiteVariable'">
-            <BuilderNumberInput actionParam="'logo-height'" unit="'px'" saveUnit="'rem'" />
+            <BuilderNumberInput actionParam="'logo-height'" default="null" unit="'px'" saveUnit="'rem'" />
         </BuilderRow>
         <BuilderRow label.translate="Height (Scrolled)" level="1" t-if="!isActiveItem('!header_effect_scroll_opt')" action="'customizeWebsiteVariable'">
-            <BuilderNumberInput actionParam="'fixed-logo-height'" unit="'px'" saveUnit="'rem'"/>
+            <BuilderNumberInput actionParam="'fixed-logo-height'" default="null" unit="'px'" saveUnit="'rem'"/>
         </BuilderRow>
     </t>
 </templates>

--- a/addons/website/static/src/builder/plugins/theme/theme_headings_option.xml
+++ b/addons/website/static/src/builder/plugins/theme/theme_headings_option.xml
@@ -8,16 +8,16 @@
         <!-- We don't use `display-font-sizes.5` and `display-font-sizes.6` -->
         <t t-set="used_display_font_sizes" t-value="[1, 2, 3, 4]"/>
         <BuilderRow label.translate="Font Size" action="'customizeWebsiteVariable'">
-            <BuilderNumberInput title.translate="Heading 1" actionParam="'h1-font-size'" unit="'px'" saveUnit="'rem'"/>
+            <BuilderNumberInput title.translate="Heading 1" actionParam="'h1-font-size'" default="null" unit="'px'" saveUnit="'rem'"/>
             <t t-set-slot="collapse">
                 <t t-foreach="[2, 3, 4, 5, 6]" t-as="depth" t-key="depth">
                     <BuilderRow level="1" label="heading_label + ' ' + depth">
-                        <BuilderNumberInput actionParam="'h' + depth + '-font-size'" unit="'px'" saveUnit="'rem'"/>
+                        <BuilderNumberInput actionParam="'h' + depth + '-font-size'" default="null" unit="'px'" saveUnit="'rem'"/>
                     </BuilderRow>
                 </t>
                 <t t-foreach="used_display_font_sizes" t-as="depth" t-key="depth">
                     <BuilderRow level="1" label="display_label + ' ' + depth">
-                        <BuilderNumberInput actionParam="'display-' + depth + '-font-size'" unit="'px'" saveUnit="'rem'"/>
+                        <BuilderNumberInput actionParam="'display-' + depth + '-font-size'" default="null" unit="'px'" saveUnit="'rem'"/>
                     </BuilderRow>
                 </t>
             </t>
@@ -48,16 +48,16 @@
         </BuilderRow>
         <BuilderRow label.translate="Line Height" action="'customizeWebsiteVariable'">
             <!-- "× ": \u00D7\u2000 -->
-            <BuilderNumberInput title.translate="Heading 1" actionParam="'headings-line-height'" unit="'✕'" saveUnit="''"/>
+            <BuilderNumberInput title.translate="Heading 1" actionParam="'headings-line-height'" default="null" unit="'✕'" saveUnit="''"/>
             <t t-set-slot="collapse">
                 <t t-foreach="[2, 3, 4, 5, 6]" t-as="depth" t-key="depth">
                     <BuilderRow level="1" label="heading_label + ' ' + depth">
-                        <BuilderNumberInput actionParam="'h' + depth + '-line-height'" unit="'✕'" saveUnit="''"/>
+                        <BuilderNumberInput actionParam="'h' + depth + '-line-height'" default="null" unit="'✕'" saveUnit="''"/>
                     </BuilderRow>
                 </t>
                 <t t-foreach="used_display_font_sizes" t-as="depth" t-key="depth">
                     <BuilderRow level="1" label="display_label + ' ' + depth">
-                        <BuilderNumberInput actionParam="'display-' + depth + '-line-height'" unit="'✕'" saveUnit="''"/>
+                        <BuilderNumberInput actionParam="'display-' + depth + '-line-height'" default="null" unit="'✕'" saveUnit="''"/>
                     </BuilderRow>
                 </t>
             </t>

--- a/addons/website/static/src/builder/plugins/theme/theme_tab.xml
+++ b/addons/website/static/src/builder/plugins/theme/theme_tab.xml
@@ -52,10 +52,10 @@
 <t t-name="website.ThemeParagraphOption">
     <BuilderContext preview="false">
         <BuilderRow label.translate="Font Size">
-            <BuilderNumberInput action="'customizeWebsiteVariable'" actionParam="'font-size-base'" unit="'px'" saveUnit="'rem'"/>
+            <BuilderNumberInput action="'customizeWebsiteVariable'" actionParam="'font-size-base'" default="null" unit="'px'" saveUnit="'rem'"/>
             <t t-set-slot="collapse">
                 <BuilderRow label.translate="Small" level="1">
-                    <BuilderNumberInput action="'customizeWebsiteVariable'" actionParam="'small-font-size'" unit="'px'" saveUnit="'rem'"/>
+                    <BuilderNumberInput action="'customizeWebsiteVariable'" actionParam="'small-font-size'" default="null" unit="'px'" saveUnit="'rem'"/>
                 </BuilderRow>
             </t>
         </BuilderRow>
@@ -64,7 +64,7 @@
         </BuilderRow>
         <BuilderRow label.translate="Line Height">
             <!-- "×": \u00D7\u2000 -->
-            <BuilderNumberInput action="'customizeWebsiteVariable'" actionParam="'body-line-height'" unit="'✕'" saveUnit="''"/>
+            <BuilderNumberInput action="'customizeWebsiteVariable'" actionParam="'body-line-height'" default="null" unit="'✕'" saveUnit="''"/>
         </BuilderRow>
         <BuilderRow label.translate="Margins" action="'customizeWebsiteVariable'">
             <BuilderNumberInput title.translate="Top" actionParam="'paragraph-margin-top'" unit="'px'" saveUnit="'px'"/>

--- a/addons/website/static/tests/builder/custom_tab/builder_components/builder_datetimepicker.test.js
+++ b/addons/website/static/tests/builder/custom_tab/builder_components/builder_datetimepicker.test.js
@@ -108,11 +108,13 @@ test("defaults to now when clicking on clear button", async () => {
     await contains(".we-bg-options-container input").edit("04/01/2019 10:00:00");
     expect(".we-bg-options-container input").toHaveValue("04/01/2019 10:00:00");
 
-    await contains(".we-bg-options-container input").click();
-    await contains(".o_datetime_buttons button .fa-eraser").click();
-    await contains(".options-container").click();
-    const dateString = queryOne(".we-bg-options-container input").value;
-    expect(isExpectedDateTime({ dateString })).toBe(true);
+    for (let i = 0; i < 3; i++) {
+        await contains(".we-bg-options-container input").click();
+        await contains(".o_datetime_buttons button .fa-eraser").click();
+        await contains(".options-container").click();
+        const dateString = queryOne(".we-bg-options-container input").value;
+        expect(isExpectedDateTime({ dateString })).toBe(true);
+    }
 });
 
 test("selects a date and properly applies it", async () => {

--- a/addons/website/static/tests/builder/custom_tab/builder_shorthand_action.test.js
+++ b/addons/website/static/tests/builder/custom_tab/builder_shorthand_action.test.js
@@ -102,7 +102,7 @@ describe("styleAction", () => {
         expect(":iframe .test-options-target").toHaveAttribute("style", "width: 101px;"); // no !important
 
         await contains("input").edit("");
-        expect(":iframe .test-options-target").toHaveAttribute("style", "");
+        expect(":iframe .test-options-target").toHaveAttribute("style", "width: 0px;");
     });
     test("should set a style with its associated class", async () => {
         addOption({


### PR DESCRIPTION
[FIX] html_builder: handle clear button in BuilderDateTimePicker
When the `clear` button was used three consecutive times in the
BuilderDateTimePicker, the input field would remain empty instead of
reverting to its previous value.
This occurred because `useDomState` wasn't being triggered due to no
state change.

Additionally, this fix ensures that the input field now updates
immediately upon using the `clear` button, eliminating the need for
subsequent validation or clicking outside the DateTimePicker.

Steps to reproduce:
- Drop `s_countdown` snippet.
- Open DateTimePicker with the "Due Date" option.
- Click the clear button, then apply.
- Repeat the previous step two more times (for a total of three times).
- The input field remains empty instead of displaying the current date.

-------------------------------------------------------------------------------------------------------

[FIX] html_builder, website: reintroduce null default for options
This commit restores the previous behavior where
`data-customize-website-variable="null"` was used to set a null default
value for website options, ensuring that SCSS correctly applies its own
default styles to elements. This functionality was lost during the
website refactor [1].

Additionally, the `BuilderNumberInput` now defaults to 0, aligning
with the previous default in `UnitUserValueWidget`.

[1]: https://github.com/odoo/odoo/commit/9fe45e2b7ddbbfd0445ffe25a859e67a316d02b2
