### PR TITLE
[FIX] l10n_lu: missing section number in tax report

### DIFF
--- a/addons/l10n_lu/i18n_extra/fr.po
+++ b/addons/l10n_lu/i18n_extra/fr.po
@@ -1490,8 +1490,8 @@ msgid ""
 "481 - Supplies carried out within the scope of the domestic SME scheme of "
 "article 57bis (7)"
 msgstr ""
-"Opérations réalisées dans le cadre du régime de franchise national de "
-"l'article 57bis (17)"
+"481 - Opérations réalisées dans le cadre du régime de franchise national "
+"de l'article 57bis (17)"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_1b_9_supplies_carried_out_cross_border


### PR DESCRIPTION
French translation is missing the section number for line 481.

---

from feedback on
task-4587067

---

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr