### PR TITLE
[IMP] hr_recruitment: recruiters can create employees from applicants

### DIFF
--- a/addons/hr/models/hr_job.py
+++ b/addons/hr/models/hr_job.py
@@ -38,7 +38,7 @@ class HrJob(models.Model):
 
     @api.depends('no_of_recruitment', 'employee_ids.job_id', 'employee_ids.active')
     def _compute_employees(self):
-        employee_data = self.env['hr.employee']._read_group([('job_id', 'in', self.ids)], ['job_id'], ['__count'])
+        employee_data = self.env['hr.employee'].sudo()._read_group([('job_id', 'in', self.ids)], ['job_id'], ['__count'])
         result = {job.id: count for job, count in employee_data}
         for job in self:
             job.no_of_employee = result.get(job.id, 0)

--- a/addons/hr/models/hr_version.py
+++ b/addons/hr/models/hr_version.py
@@ -51,7 +51,7 @@ class HrVersion(models.Model):
     display_name = fields.Char(compute='_compute_display_name')
     active = fields.Boolean(default=True)
 
-    date_version = fields.Date(required=True, default=fields.Date.today, tracking=True, groups="hr.group_hr_user")
+    date_version = fields.Date(required=True, default=fields.Date.today, tracking=True, groups="hr.group_hr_user,hr.group_hr_contract_template_editor")
     last_modified_uid = fields.Many2one('res.users', string='Last Modified by',
                                         default=lambda self: self.env.uid, required=True, groups="hr.group_hr_user")
     last_modified_date = fields.Datetime(string='Last Modified on', default=fields.Datetime.now, required=True,
@@ -107,14 +107,14 @@ class HrVersion(models.Model):
             ('trainee', 'Trainee'),
             ('contractor', 'Contractor'),
             ('freelance', 'Freelancer'),
-        ], string='Employee Type', default='employee', required=True, groups="hr.group_hr_user", tracking=True)
+        ], string='Employee Type', default='employee', required=True, groups="hr.group_hr_user,hr.group_hr_contract_template_editor", tracking=True)
     department_id = fields.Many2one('hr.department', check_company=True, tracking=True)
     member_of_department = fields.Boolean("Member of department", compute='_compute_part_of_department', search='_search_part_of_department',
         help="Whether the employee is a member of the active user's department or one of it's child department.")
     job_id = fields.Many2one('hr.job', check_company=True, tracking=True)
     job_title = fields.Char(compute="_compute_job_title", inverse="_inverse_job_title", store=True, readonly=False,
         string="Job Title", tracking=True)
-    is_custom_job_title = fields.Boolean(compute='_compute_is_custom_job_title', store=True, default=False, groups="hr.group_hr_user")
+    is_custom_job_title = fields.Boolean(compute='_compute_is_custom_job_title', store=True, default=False, groups="hr.group_hr_user,hr.group_hr_contract_template_editor")
     address_id = fields.Many2one(
         'res.partner',
         string='Work Address',
@@ -142,36 +142,36 @@ class HrVersion(models.Model):
     tz = fields.Selection(related='employee_id.tz')
 
     # Contract Information
-    contract_date_start = fields.Date('Contract Start Date', tracking=True, groups="hr.group_hr_user")
+    contract_date_start = fields.Date('Contract Start Date', tracking=True, groups="hr.group_hr_user,hr.group_hr_contract_template_editor")
     contract_date_end = fields.Date(
         'Contract End Date', tracking=True, help="End date of the contract (if it's a fixed-term contract).",
-        groups="hr.group_hr_user")
+        groups="hr.group_hr_user,hr.group_hr_contract_template_editor")
     trial_date_end = fields.Date('End of Trial Period', help="End date of the trial period (if there is one).",
                                  groups="hr.group_hr_user")
-    date_start = fields.Date(compute='_compute_dates', groups="hr.group_hr_user")
-    date_end = fields.Date(compute='_compute_dates', groups="hr.group_hr_user")
+    date_start = fields.Date(compute='_compute_dates', groups="hr.group_hr_user,hr.group_hr_contract_template_editor")
+    date_end = fields.Date(compute='_compute_dates', groups="hr.group_hr_user,hr.group_hr_contract_template_editor")
     is_current = fields.Boolean(compute='_compute_is_current', groups="hr.group_hr_user")
     is_past = fields.Boolean(compute='_compute_is_past', groups="hr.group_hr_user")
     is_future = fields.Boolean(compute='_compute_is_future', groups="hr.group_hr_user")
     is_in_contract = fields.Boolean(compute='_compute_is_in_contract', groups="hr.group_hr_user")
 
     contract_template_id = fields.Many2one(
-        'hr.version', string="Contract Template", groups="hr.group_hr_user",
+        'hr.version', string="Contract Template", groups="hr.group_hr_user,hr.group_hr_contract_template_editor",
         domain="[('company_id', '=', company_id), ('employee_id', '=', False)]", tracking=True,
         help="Select a contract template to auto-fill the contract form with predefined values. You can still edit the fields as needed after applying the template.")
     structure_type_id = fields.Many2one('hr.payroll.structure.type', string="Salary Structure Type",
                                         compute="_compute_structure_type_id", readonly=False, store=True, tracking=True,
-                                        groups="hr.group_hr_user", default=_default_salary_structure)
+                                        groups="hr.group_hr_user,hr.group_hr_contract_template_editor", default=_default_salary_structure)
     active_employee = fields.Boolean(related="employee_id.active", string="Active Employee", groups="hr.group_hr_user")
     currency_id = fields.Many2one(string="Currency", related='company_id.currency_id', readonly=True)
     wage = fields.Monetary('Wage', tracking=True, help="Employee's monthly gross wage.", aggregator="avg",
-                           groups="hr.group_hr_user")
+                           groups="hr.group_hr_user,hr.group_hr_contract_template_editor")
     contract_wage = fields.Monetary('Contract Wage', compute='_compute_contract_wage', groups="hr.group_hr_user")
     company_country_id = fields.Many2one('res.country', string="Company country",
                                          related='company_id.country_id', readonly=True)
     country_code = fields.Char(related='company_country_id.code', depends=['company_country_id'], readonly=True)
     contract_type_id = fields.Many2one('hr.contract.type', "Contract Type", tracking=True,
-                                       groups="hr.group_hr_user")
+                                       groups="hr.group_hr_user,hr.group_hr_contract_template_editor")
     additional_note = fields.Text(string='Additional Note', groups="hr.group_hr_user", tracking=True)
 
     def _get_hr_responsible_domain(self):
@@ -554,6 +554,8 @@ class HrVersion(models.Model):
 
     def _inverse_resource_calendar_id(self):
         for employee, versions in self.grouped('employee_id').items():
+            if not employee:
+                continue
             current_version = employee.current_version_id
             for version in versions:
                 if version == current_version:

--- a/addons/hr/security/hr_security.xml
+++ b/addons/hr/security/hr_security.xml
@@ -1,5 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
+    <record id="group_hr_contract_template_editor" model="res.groups">
+        <field name="name">Contract Template Editor</field>
+        <field name="implied_ids" eval="[(4, ref('base.group_user'))]"/>
+    </record>
 
     <record model="res.groups.privilege" id="res_groups_privilege_employees">
         <field name="name">Employees</field>
@@ -112,6 +116,17 @@
         <field name="name">HR Contract: Multi Company</field>
         <field name="model_id" ref="model_hr_version"/>
         <field name="domain_force">[('company_id', 'in', company_ids)]</field>
+    </record>
+
+    <record id="ir_rule_hr_contract_template_editor" model="ir.rule">
+        <field name="name">HR Contract: Contract Template Editor</field>
+        <field name="model_id" ref="hr.model_hr_version"/>
+        <field name="domain_force">[('company_id', 'in', [False] + company_ids), ('employee_id', '=', False)]</field>
+        <field name="groups" eval="[(4, ref('group_hr_contract_template_editor'))]"/>
+        <field name="perm_read" eval="True"/>
+        <field name="perm_write" eval="True"/>
+        <field name="perm_create" eval="False"/>
+        <field name="perm_unlink" eval="False"/>
     </record>
 
     <record id="ir_rule_hr_payroll_structure_type_multi_company" model="ir.rule">

--- a/addons/hr/security/ir.model.access.csv
+++ b/addons/hr/security/ir.model.access.csv
@@ -16,6 +16,7 @@ access_hr_departure_reason,access_hr_departure_reason_user,model_hr_departure_re
 access_hr_contract_type_manager,hr.contract.type.manager,model_hr_contract_type,group_hr_user,1,1,1,1
 access_hr_version_manager,hr.version.manager,model_hr_version,group_hr_manager,1,1,1,1
 access_hr_version_user,hr.version.user,model_hr_version,group_hr_user,1,1,1,1
+access_hr_contract_template_editor,hr.contract.template.editor,model_hr_version,group_hr_contract_template_editor,1,1,0,0
 access_mail_activity_plan_hr_manager,mail.activity.plan.hr.manager,mail.model_mail_activity_plan,group_hr_manager,1,1,1,1
 access_mail_activity_plan_template_hr_manager,mail.activity.plan.template.hr.manager,mail.model_mail_activity_plan_template,group_hr_manager,1,1,1,1
 access_hr_payroll_structure_type_hr_contract_manager,hr.payroll.structure.type.contract.manager,model_hr_payroll_structure_type,group_hr_manager,1,1,1,1

--- a/addons/hr/views/hr_contract_template_views.xml
+++ b/addons/hr/views/hr_contract_template_views.xml
@@ -13,8 +13,9 @@
                     </div>
                     <group name="top_info">
                         <group name="top_info_left">
-                            <field name="job_id" groups="hr.group_hr_manager"/>
-                            <field name="department_id" groups="hr.group_hr_manager"/>
+                            <field name="job_id" groups="hr.group_hr_manager,hr.group_hr_contract_template_editor"/>
+                            <field name="department_id" groups="hr.group_hr_manager,hr.group_hr_contract_template_editor"/>
+                            <field name="company_id" groups="hr.group_hr_manager,hr.group_hr_contract_template_editor"/>
                         </group>
                         <group name="top_info_right">
                             <label for="contract_type_id" string="Contract Type"/>

--- a/addons/hr_holidays/models/hr_version.py
+++ b/addons/hr_holidays/models/hr_version.py
@@ -72,7 +72,7 @@ class HrVersion(models.Model):
                 for contract in self:
                     resource_calendar_id = vals.get('resource_calendar_id', contract.resource_calendar_id.id)
                     extra_domain = [('resource_calendar_id', '!=', resource_calendar_id)] if resource_calendar_id else None
-                    leaves = contract._get_leaves(
+                    leaves = contract.sudo()._get_leaves(
                         extra_domain=extra_domain
                     )
                     for leave in leaves:

--- a/addons/hr_recruitment/models/hr_employee.py
+++ b/addons/hr_recruitment/models/hr_employee.py
@@ -20,8 +20,9 @@ class HrEmployee(models.Model):
         employees = super().create(vals_list)
         for employee_sudo in employees.sudo():
             if employee_sudo.applicant_ids:
-                employee_sudo.applicant_ids._message_log_with_view(
-                    'hr_recruitment.applicant_hired_template',
-                    render_values={'applicant': employee_sudo.applicant_ids}
+                employee_sudo.applicant_ids.message_post(
+                    body=self.env._("Employee created."),
+                    message_type='comment',
+                    subtype_xmlid='mail.mt_note'
                 )
         return employees

--- a/addons/hr_recruitment/models/hr_job.py
+++ b/addons/hr_recruitment/models/hr_job.py
@@ -194,7 +194,7 @@ class HrJob(models.Model):
     def _compute_employee_count(self):
         res = {
             job.id: count
-            for job, count in self.env['hr.employee']._read_group(
+            for job, count in self.env['hr.employee'].sudo()._read_group(
                 domain=[
                     ('job_id', 'in', self.ids),
                 ],

--- a/addons/hr_recruitment/security/hr_recruitment_security.xml
+++ b/addons/hr_recruitment/security/hr_recruitment_security.xml
@@ -26,7 +26,7 @@
         <field name="name">Officer: Manage all applicants</field>
         <field name="sequence">20</field>
         <field name="privilege_id" ref="res_groups_privilege_recruitment"/>
-        <field name="implied_ids" eval="[(4, ref('group_hr_recruitment_interviewer'))]"/>
+        <field name="implied_ids" eval="[(4, ref('group_hr_recruitment_interviewer')),(4, ref('hr.group_hr_contract_template_editor'))]"/>
     </record>
 
     <record id="group_hr_recruitment_manager" model="res.groups">
@@ -101,5 +101,16 @@
         <field name="model_id" ref="mail.model_mail_activity_plan_template"/>
         <field name="domain_force">[('plan_id.res_model', '=', 'hr.applicant')]</field>
         <field name="perm_read" eval="False"/>
+    </record>
+
+    <record id="ir_rule_hr_contract_template_manager" model="ir.rule">
+        <field name="name">HR Recruitment: Manager can create and delete contract templates</field>
+        <field name="model_id" ref="hr.model_hr_version"/>
+        <field name="domain_force">[('company_id', 'in', company_ids), ('employee_id', '=', False)]</field>
+        <field name="groups" eval="[(4, ref('hr_recruitment.group_hr_recruitment_manager'))]"/>
+        <field name="perm_read" eval="True"/>
+        <field name="perm_write" eval="True"/>
+        <field name="perm_create" eval="True"/>
+        <field name="perm_unlink" eval="True"/>
     </record>
 </odoo>

--- a/addons/hr_recruitment/security/ir.model.access.csv
+++ b/addons/hr_recruitment/security/ir.model.access.csv
@@ -30,3 +30,6 @@ access_talent_pool_add_applicants_interviewer,access.talent.pool.add.applicants.
 access_talent_pool_add_applicants,access.talent.pool.add.applicants,model_talent_pool_add_applicants,group_hr_recruitment_user,1,1,1,1
 access_job_add_applicants_interviewer,access.job.add.applicants.interviewer,model_job_add_applicants,group_hr_recruitment_interviewer,0,0,0,0
 access_job_add_applicants,access.job.add.applicants,model_job_add_applicants,group_hr_recruitment_user,1,1,1,1
+access_hr_recruitment_contract_template_manager,hr.recruitment.contract.template.manager,hr.model_hr_version,hr_recruitment.group_hr_recruitment_manager,1,1,1,1
+access_hr_recruitment_contract_type_recruitment,hr.recruitment.contract.type.recruitment,hr.model_hr_contract_type,hr_recruitment.group_hr_recruitment_user,1,0,0,0
+access_hr_recruitment_payroll_structure_type_recruitment,hr.recruitment.payroll.structure.type.recruitment,hr.model_hr_payroll_structure_type,hr_recruitment.group_hr_recruitment_user,1,0,0,0

--- a/addons/hr_recruitment/views/hr_applicant_views.xml
+++ b/addons/hr_recruitment/views/hr_applicant_views.xml
@@ -85,7 +85,7 @@
             <field name="partner_phone_sanitized" invisible="1"/>
             <field name="emp_is_active" invisible="1"/>
             <header>
-                <button string="Create Employee" name="create_employee_from_applicant" type="object" data-hotkey="q" groups="hr.group_hr_user"
+                <button string="Create Employee" name="create_employee_from_applicant" type="object" data-hotkey="q" groups="hr.group_hr_user,hr_recruitment.group_hr_recruitment_user"
                         class="o_create_employee" invisible="employee_id or not active or not date_closed"/>
                 <button string="Refuse" name="archive_applicant" type="object" invisible="not active or is_pool_applicant" data-hotkey="d"/>
                 <button string="Restore" name="action_unarchive" type="object" invisible="active" data-hotkey="x"/>
@@ -99,7 +99,7 @@
                             type="object"
                             class="oe_stat_button"
                             icon="fa-id-card-o"
-                            groups="hr.group_hr_user"
+                            groups="hr.group_hr_user,hr_recruitment.group_hr_recruitment_user"
                             invisible="not (employee_id or emp_is_active)">
                         <div class="o_field_widget o_stat_info">
                             <span class="o_stat_value"><field name="employee_name" readonly="1"/></span>

--- a/addons/hr_work_entry/models/hr_version.py
+++ b/addons/hr_work_entry/models/hr_version.py
@@ -575,6 +575,7 @@ class HrVersion(models.Model):
         salary_simulation = self.env.context.get('salary_simulation')
         if not salary_simulation and any(key in dependent_fields for key in vals):
             for version in self:
+                version = version.sudo()
                 date_from = max(version.date_start, version.date_generated_from.date())
                 date_to = min(version.date_end or date.max, version.date_generated_to.date())
                 if date_from != date_to and self.employee_id:


### PR DESCRIPTION
Recruiters no longer require full HR Employee rights to perform their core tasks.

Key changes:

New access group: `hr.group_hr_contract_template_editor`
- Access to contract template fields within a subset of `hr.version` records, excluding contract versions on employees.

Recruitment Officers, even without HR rights, can now:
- Create employees from applicants using sudo.
- View and edit existing contract templates (excluding contract versions on employees).
- Create employees and manage offers.
- Access job positions.
- Generate & view offers for applicants.

Recruitment Administrators can:
- Create new contract templates.

Task-4921527
