### PR TITLE
[FIX] l10n_in_ewaybill: use document date instead of e-waybill date.

### DIFF
--- a/addons/l10n_in_ewaybill/report/ewaybill_report.xml
+++ b/addons/l10n_in_ewaybill/report/ewaybill_report.xml
@@ -64,7 +64,7 @@
                                             Type: <t t-out="doc.supply_type"/> - <t t-out="doc.type_id.sub_type"/>
                                         </td>
                                         <td colspan="2">
-                                            Document Details:<t t-out="doc.type_id.name"/> - <t t-out="doc.document_number"/> - <t t-out="doc.ewaybill_date.strftime('%d/%m/%Y')"/>
+                                            Document Details:<t t-out="doc.type_id.name"/> - <t t-out="doc.document_number"/> - <t t-out="doc.document_date.strftime('%d/%m/%Y')"/>
                                         </td>
                                         <td>Transaction Type:
                                             <t t-if="generate_json['transactionType'] == 2">


### PR DESCRIPTION
- The E-Waybill report currently displays the E-Waybill generation date in 
  The "Document Details" section of the report.

Steps to reproduce:
  1) Enable the Indian E-Waybill configuration from Settings.
  2) Create an invoice with a past/future date.
  3) Print the E-Waybill.
  4) The "Document Details" section incorrectly shows the E-Waybill date.

- This fix ensures that the document date is displayed instead of the E-Waybill 
  date.

task-4919913