### PR TITLE
[IMP] website_sale: align fullwidth layout on `.container-fluid`

### DIFF
--- a/addons/website_sale/static/src/scss/website_sale.scss
+++ b/addons/website_sale/static/src/scss/website_sale.scss
@@ -12,25 +12,6 @@ $input-border-color: $gray-400;
     &.o_wsale_page_fluid {
         @include media-breakpoint-up(xl) {
             --o-wsale-sidebar-maxwidth: 18rem;
-            --o-wsale-container-fluid-padding-xl: #{$container-padding-x * 2};
-            --gutter-x: var(--o-wsale-container-fluid-padding-xl);
-
-            .o_wsale_products_main_row {
-                margin-right: calc(var(--o-wsale-container-fluid-padding-xl) * -0.5);
-                margin-left: calc(var(--o-wsale-container-fluid-padding-xl) * -0.5);
-
-                #products_grid_before, #products_grid {
-                    --gutter-x: #{$container-padding-x};
-                }
-
-                #products_grid_before {
-                    padding-left: calc(var(--o-wsale-container-fluid-padding-xl) * 0.5);
-                }
-
-                #products_grid {
-                    padding-right: calc(var(--o-wsale-container-fluid-padding-xl) * 0.5);
-                }
-            }
         }
     }
 
@@ -62,7 +43,7 @@ $input-border-color: $gray-400;
         --o-wsale-card-info-text-grow: 1;
         --o-wsale-card-padding: calc(var(--o-wsale-products-grid-gap-y) * 0.5) calc(var(--o-wsale-products-grid-gap, 16px) * 0.5);
         --o-wsale-topbar-padding-left: #{$container-padding-x * 0.5};
-        --o-wsale-topbar-padding-right: calc(var(--o-wsale-container-fluid-padding-xl, var(--gutter-x)) * 0.5);
+        --o-wsale-topbar-padding-right: calc(var(--gutter-x) * 0.5);
         --o-wsale-topbar-border-width: 0 0 #{$border-width};
         --o-border-color: #{$gray-300};
         --border-color: #{$gray-300};
@@ -1081,7 +1062,7 @@ body:not(.editor_enable) #category_header {
 
             @include media-breakpoint-up(lg) {
                 --o-wsale-card-thumb-size: calc(126px * var(--o-wsale-card-thumb-aspect-ratio, 1));
-                --o-wsale-card-info-padding: 0 calc(var(--o-wsale-container-fluid-padding-xl, #{$container-padding-x}) * 0.5);
+                --o-wsale-card-info-padding: 0 #{$container-padding-x * 0.5};
                 --o-wsale-card-sub-align-items: center;
 
                 .oe_product_image_link {
@@ -1124,7 +1105,7 @@ body:not(.editor_enable) #category_header {
 
 // ==== Floating Bar
 #o_wsale_floating_bar_rail {
-    --_container-gap: calc(var(--o-wsale-container-fluid-padding-xl, var(--gutter-x)) * 0.5);
+    --_container-gap: calc(var(--gutter-x) * 0.5);
     right: calc(var(--_container-gap) + #{$border-width});
     width: 0;
 


### PR DESCRIPTION
This PR removes the custom padding defined on `website_sale/shop` page in order to align the `fullwidth` layout on the `.container-fluid` values.

Prior to this PR, the `website_sale/shop` page was enforcing a bigger padding on the side of the sidebar and the main content to prevent this specific layout to be close to edges.

While this desserved the design of the shop page, it created a misalignment with the regular values defined for `.container-fluid`.

This would result in a misalignment between :

- The `/shop` page, that uses a custom value ;
- Header, snippets, footer that uses the default `container-fluid` value.

Ideally, the `website_sale` approach should be make global and apply to every `container-fluid`, we there are some technical caveat with snippets, which leads us to revert that improvement for now.

task-4921832
part of task-4840034

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
