### PR TITLE
[FIX] website: avoid that fallback iframe disturbs resize

### DIFF
--- a/addons/website/static/src/client_actions/website_preview/website_builder_action.scss
+++ b/addons/website/static/src/client_actions/website_preview/website_builder_action.scss
@@ -66,6 +66,10 @@
             position: absolute;
             width: 100%;
             height: 100%;
+
+            &.o_ignore_in_tour {
+                pointer-events: none;
+            }
         }
     }
 

--- a/addons/website/static/src/client_actions/website_preview/website_builder_action.xml
+++ b/addons/website/static/src/client_actions/website_preview/website_builder_action.xml
@@ -6,6 +6,7 @@
         <div class="o_website_preview border-top flex-grow-1" t-ref="website_preview">
             <div class="o_iframe_container">
                 <iframe t-if="!testMode" t-att-src="iframeFallbackUrl"
+                    class="o_ignore_in_tour"
                     t-ref="iframefallback"/>
                 <iframe t-att-src="initialUrl" t-ref="iframe" t-on-load="onIframeLoad" />
                 <div t-if="this.websiteContext.isMobile" class="o_mobile_preview_layout">


### PR DESCRIPTION
Since [1] when the fallback iframe was reintroduced in `html_builder`-based website builder, the resize operations do not behave properly anymore - some mouse events seem to be caught by the wrong iframe.

This commit avoids this by sending the fallback iframe a bit below the main one.

[1]: https://github.com/odoo/odoo/commit/e167c3b4bfeda7b4482a755563dbd0fb90d70cbe

task-4367641
