### PR TITLE
[FIX] hr_holidays: fix the display of archived time off in the employee app

### DIFF
--- a/addons/hr_holidays/models/hr_employee_base.py
+++ b/addons/hr_holidays/models/hr_employee_base.py
@@ -321,7 +321,7 @@ class HrEmployeeBase(models.AbstractModel):
             employee_remaining_leaves = 0
             employee_max_leaves = 0
             for leave_type in leaves_taken[employee]:
-                if leave_type.requires_allocation == 'no':
+                if leave_type.requires_allocation == 'no' or not leave_type.active:
                     continue
                 for allocation in leaves_taken[employee][leave_type]:
                     if allocation and allocation.date_from <= current_date\

--- a/addons/hr_holidays/static/src/tours/hr_holidays_tour.js
+++ b/addons/hr_holidays/static/src/tours/hr_holidays_tour.js
@@ -106,3 +106,27 @@ registry.category("web_tour.tours").add('hr_holidays_launch', {
         },
     ]
 });
+
+registry.category("web_tour.tours").add('employee_holidays_archived_tour', {
+    url: '/web',
+    steps: () => [
+        stepUtils.showAppsMenuItem(),
+        {
+            trigger: '.o_app[data-menu-xmlid="hr.menu_hr_root"]',
+            run: "click",
+        },
+        {
+            trigger: '.o_kanban_record:contains("test_user")',
+            run: "click",
+        },
+        {
+            trigger: '.o_stat_info:contains("Time Off")',
+            run: () => {
+                const time_off_stats = $('.o_stat_info:contains("Time Off")');
+                if (time_off_stats.toArray().some(el => $(el).text().includes('10'))) {
+                    throw new Error('The archived time off should not be displayed!');
+                }
+            }
+        },
+    ]
+});

--- a/addons/hr_holidays/tests/test_hr_holidays_tour.py
+++ b/addons/hr_holidays/tests/test_hr_holidays_tour.py
@@ -49,3 +49,37 @@ class TestHrHolidaysTour(HttpCase):
         self.env.ref("base.lang_sr@latin").active = True
         admin_user.lang = "sr@latin"
         self.start_tour("/web", "hr_holidays_launch", login="admin")
+
+    @freeze_time('01/17/2022')
+    def test_employee_holidays_archived_tour(self):
+        admin_user = self.env.ref('base.user_admin')
+
+        test_user = self.env['res.users'].create({
+            'name': 'test_user',
+            'login': 'test_user',
+            'email': 'test_user@yourcompany.com',
+            'company_id': admin_user.company_id.id
+        })
+
+        employee = self.env['hr.employee'].create({
+            'name': 'test_user',
+            'user_id': test_user.id,
+        })
+
+        leave_type = self.env['hr.leave.type'].with_user(admin_user)
+
+        holidays_type_1 = leave_type.create({
+            'name': 'archived_holidays',
+            'active': False
+        })
+
+        self.env['hr.leave.allocation'].create({
+            'name': 'archived_holidays_allocation',
+            'employee_id': employee.id,
+            'holiday_status_id': holidays_type_1.id,
+            'number_of_days': 10,
+            'state': 'confirm',
+            'date_from': '2022-01-01',
+        })
+
+        self.start_tour('/web', 'employee_holidays_archived_tour', login="admin")


### PR DESCRIPTION

In this bug, if a time off type is archived, it is still
displayed in employee app.

Steps to reproduce the bug:
1- Create a database with employee and time off modules
installed
2- Allocate a time off to an employee
3- Archive the time off type
4- Open Employee app and go to the employee profile
5- The archived days are still displayed

opw-4900060
