### PR TITLE
[IMP] pos_{,restaurant}: add date for future orders and improve time visibility on ticket screen

### DIFF
--- a/addons/point_of_sale/static/src/app/models/pos_order.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order.js
@@ -116,6 +116,14 @@ export class PosOrder extends Base {
         return this.models["pos.order"].getBy("uuid", this.uiState.splittedOrderUuid);
     }
 
+    get presetDate() {
+        return this.preset_time?.toFormat(localization.dateFormat) || "";
+    }
+
+    get isFutureDate() {
+        return this.preset_time?.startOf("day") > DateTime.now().startOf("day");
+    }
+
     get presetTime() {
         return this.preset_time && this.preset_time.isValid
             ? this.preset_time.toFormat("HH:mm")

--- a/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.js
@@ -824,18 +824,18 @@ export class TicketScreen extends Component {
             if (presetTime < DateTime.now()) {
                 return "bg-danger text-white";
             } else {
-                return "bg-light text-dark";
+                return "bg-light text-emphasis";
             }
         }
         if (
             slot.datetime <= presetTime &&
             presetTime < slot.datetime.plus({ minutes: order.preset_id.interval_time })
         ) {
-            return "bg-warning text-dark";
+            return "bg-warning text-white";
         } else if (presetTime < slot.datetime) {
             return "bg-danger text-white";
         } else {
-            return "bg-light text-dark";
+            return "bg-light text-emphasis";
         }
     }
 }

--- a/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.xml
+++ b/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.xml
@@ -54,7 +54,10 @@
                                                 </div>
                                             </td>
                                             <td class="align-middle">
-                                                <div t-if="order.presetTime" t-attf-class="fs-6 badge rounded {{this.getPresetTimeColor(order)}}"><t t-esc="order.presetTime"/></div>
+                                                <t t-if="order.presetTime">
+                                                    <div t-if="order.isFutureDate" class="fw-bolder" t-esc="order.presetDate" />
+                                                    <div t-attf-class="fs-6 badge rounded {{ this.getPresetTimeColor(order) }}" t-esc="order.presetTime"/>
+                                                </t>
                                             </td>
                                             <td t-if="showCardholderName()">
                                                 <div><t t-esc="getCardholderName(order)"></t></div>

--- a/addons/point_of_sale/static/tests/pos/tours/utils/chrome_util.js
+++ b/addons/point_of_sale/static/tests/pos/tours/utils/chrome_util.js
@@ -176,3 +176,10 @@ export function freezeDateTime(millis) {
         },
     ];
 }
+
+export function selectPresetDateButton(formattedDate) {
+    return {
+        trigger: `.modal-body button:contains("${formattedDate}")`,
+        run: "click",
+    };
+}

--- a/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
@@ -671,6 +671,7 @@ registry.category("web_tour.tours").add("test_preset_timing_restaurant", {
     steps: () =>
         [
             Chrome.startPoS(),
+            Chrome.freezeDateTime(1749965940000), // June 15, 2025
             Dialog.confirm("Open Register"),
             FloorScreen.clickNewOrder(),
             ProductScreen.clickDisplayedProduct("Coca-Cola"),
@@ -685,8 +686,17 @@ registry.category("web_tour.tours").add("test_preset_timing_restaurant", {
             Chrome.clickOrders(),
             TicketScreen.nthRowContains(1, "John"),
             TicketScreen.nthRowContains(1, "Takeaway", false),
+            TicketScreen.nthRowNotContains(1, "06/15/2025", false),
             TicketScreen.nthRowContains(2, "002"),
             TicketScreen.nthRowContains(2, "Eat in", false),
+            Chrome.clickPlanButton(),
+            FloorScreen.clickTable("5"),
+            ProductScreen.clickDisplayedProduct("Coca-Cola"),
+            ProductScreen.selectPreset("Eat in", "Takeaway"),
+            Chrome.selectPresetDateButton("06/16/2025"),
+            Chrome.selectPresetTimingSlotHour("11:00"),
+            Chrome.clickOrders(),
+            TicketScreen.nthRowContains(3, "06/16/2025", false),
         ].flat(),
 });
 


### PR DESCRIPTION
Commit 1 - add date for future orders on ticket screen
-----------------

### Before this commit:
- On the ticket screen, only the preset time (e.g., 12:00) was shown for all orders, including future ones.

### After this commit:
- For future orders (e.g., Takeaway scheduled for tomorrow), the ticket screen now shows the date above the time.


Commit 2 - visibility of time slot on ticket screen for takeaway
----------------------------------------
   
###  Before this commit:
 - If we made a Takeaway order and selected the current time as a slot, the time was not clearly visible in dark mode.
   ![image](https://github.com/user-attachments/assets/376b0ce9-16ca-4dfb-89a6-f0f07c8dec7b)
   
###  After this commit:
- The current time slot is now clearly visible on the ticket screen, even in dark mode.
 ![image](https://github.com/user-attachments/assets/47919a98-5a61-4ff8-a039-6140604b4b13)

Task-4916474