### PR TITLE
[FIX] stock_acount: create correct svl update qty cross company

### DIFF
--- a/addons/stock_account/models/stock_move.py
+++ b/addons/stock_account/models/stock_move.py
@@ -56,7 +56,7 @@ class StockMove(models.Model):
             layers |= layers.stock_valuation_layer_ids
             quantity = sum(layers.mapped("quantity"))
             return sum(layers.mapped("value")) / quantity if not float_is_zero(quantity, precision_rounding=layers.uom_id.rounding) else 0
-        return price_unit if not float_is_zero(price_unit, precision) or self._should_force_price_unit() else self.product_id.standard_price
+        return price_unit if not float_is_zero(price_unit, precision) or self._should_force_price_unit() else self.product_id.with_company(self.company_id).standard_price
 
     @api.model
     def _get_valued_types(self):

--- a/addons/stock_account/tests/test_stockvaluationlayer.py
+++ b/addons/stock_account/tests/test_stockvaluationlayer.py
@@ -7,6 +7,7 @@ from odoo.addons.account.tests.common import AccountTestInvoicingCommon
 from odoo.addons.stock_account.tests.test_stockvaluation import _create_accounting_data
 from odoo.tests import Form, tagged
 from odoo.tests.common import TransactionCase
+from odoo import Command
 
 
 class TestStockValuationCommon(TransactionCase):
@@ -616,6 +617,53 @@ class TestStockValuationAVCO(TestStockValuationCommon):
         self.assertAlmostEqual(abs(move3.stock_valuation_layer_ids[0].value), abs(move4.stock_valuation_layer_ids[0].value))
         self.assertAlmostEqual(self.product1.value_svl, 25.33)
         self.assertEqual(self.product1.quantity_svl, 2)
+
+    def test_change_quantity_from_other_company(self):
+        """
+        checks that a move on company A from a user logged in company B creates a svl with correct values (the ones from company A)
+        """
+        # Give user access of company A + B, with default A
+        company_A = self.env.company
+        company_B = self.env['res.company'].create({
+            'name': 'Super Company',
+        })
+        self.env.user.write({'company_ids': [(6, 0, [company_A.id, company_B.id])], 'company_id': company_A.id})
+        warehouse_B = self.env.user.with_company(company_B)._get_default_warehouse_id()
+        if not warehouse_B:
+            warehouse_B = self.env['stock.warehouse'].sudo().create({'name': 'WH', 'code': 'WH-B', 'company_id': company_B.id})
+            self.assertEqual(self.env.user.with_company(company_B)._get_default_warehouse_id(), warehouse_B)
+        warehouse_A = self.env.user.with_company(company_A)._get_default_warehouse_id()
+        # set product1 property cost method also in comp B
+        self.product1.with_company(company_B).product_tmpl_id.categ_id.property_cost_method = 'average'
+        # make both in moves so that the product has a standard price of 100 in comp A and 10 in comp B
+        self.env.user.company_id = company_A
+        move_comp_A = self._make_in_move(self.product1, 1, unit_cost=100)
+        self.assertEqual(self.env['stock.valuation.layer'].search([('stock_move_id', '=', move_comp_A.id)]).value, 100)
+        self.env.user.company_id = company_B
+        move_comp_B = self._make_in_move(self.product1, 1, unit_cost=10, create_picking=True, loc_dest=warehouse_B.lot_stock_id, pick_type=warehouse_B.in_type_id)
+        self.assertEqual(self.env['stock.valuation.layer'].search([('stock_move_id', '=', move_comp_B.id)]).value, 10)
+        # make the cross move
+        picking = self.env['stock.picking'].create({
+            'picking_type_id': warehouse_A.in_type_id.id,
+            'location_id': self.supplier_location.id,
+            'location_dest_id': warehouse_A.lot_stock_id.id,
+            'move_ids': [Command.create({
+                'name': 'moveC',
+                'product_id': self.product1.id,
+                'location_id': self.supplier_location.id,
+                'location_dest_id': warehouse_A.lot_stock_id.id,
+                'product_uom': self.uom_unit.id,
+                'product_uom_qty': 1,
+                'picking_type_id': warehouse_A.in_type_id.id,
+                'company_id': company_A.id,
+            })],
+        })
+        cross_move = picking.move_ids[0]
+        picking.action_confirm()
+        picking.action_assign()
+        cross_move.picked = True
+        picking._action_done()
+        self.assertEqual(self.env['stock.valuation.layer'].search([('stock_move_id', '=', cross_move.id)]).value, 100)
 
 
 class TestStockValuationFIFO(TestStockValuationCommon):


### PR DESCRIPTION
**Problem:**
when updating quantity of a product in company A
from a user logged in on company B the svl
are created with wrong values and standard price
is incorrectly updated

**Steps to reproduce:**
- check two companies on the top right of the screen (comp A and comp B)
- create a storable product with a avco category
- make sure that the cost method of the category is avco both when logged in with company A and B
(the cost method is company dependent)
- while logged in with comp A create, confirm, receive and validate a PO for a quantity of 1 and a unit price of 100
- do the same while logged in with comp B but with a unit price of 10
- open the product form (cost should be 100 or 10 depending on the company)
- while logged in on comp B click on the 'on hand' smart button
- update from 1 to 2 the on hand quantity in the WH of comp A
- switch to comp A and come back to prodcut form

**Current behavior:**
the standard price is 55.
additionaly, when opening inventory/reporting/valuation and chossing the product we see that the svl created has a value of 55

**Expected behavior:**
standard price should stay at 100 and the svl
should be created with a value of 100

**Cause of the issue:**
Product_price_udpate_before_done calls get_price_unit to compute the new standard price.
https://github.com/odoo/odoo/blob/750265bac921936a7c29cf73f8f9e926eea4a926/addons/stock_account/models/stock_move.py#L345 Inside get_price_unit, because the move has no unit_price we use self.product_id.standard_price which will take the standard price of comp B
https://github.com/odoo/odoo/blob/750265bac921936a7c29cf73f8f9e926eea4a926/addons/stock_account/models/stock_move.py#L59

opw-4852096