### PR TITLE
[FIX] web: print support on Android devices

### DIFF
--- a/addons/web/static/lib/pdfjs/web/viewer.js
+++ b/addons/web/static/lib/pdfjs/web/viewer.js
@@ -18115,6 +18115,8 @@ PDFPrintService.prototype = {
     const pageSize = this.pagesOverview[0];
     this.pageStyleSheet.textContent = "@page { size: " + pageSize.width + "pt " + pageSize.height + "pt;}";
     body.append(this.pageStyleSheet);
+    // ODOO PATCH PRINT PREVIEW MOBILE
+    this.hasFinishPrint = null;
   },
 
   destroy() {
@@ -18193,17 +18195,25 @@ PDFPrintService.prototype = {
 
   performPrint() {
     this.throwIfInactive();
-    return new Promise(resolve => {
-      setTimeout(() => {
-        if (!this.active) {
-          resolve();
-          return;
-        }
-
-        print.call(window);
+    // ODOO PATCH PRINT PREVIEW MOBILE
+    const hasFinishPrintPromise = new Promise((resolve) => {
+      if ("afterprint" in window) {
+        this.hasFinishPrint = resolve;
+      } else {
         setTimeout(resolve, 20);
-      }, 0);
+      }
     });
+    setTimeout(() => {
+      if (!this.active) {
+        // ODOO PATCH PRINT PREVIEW MOBILE
+        this.hasFinishPrint();
+        return;
+      }
+
+      print.call(window);
+    }, 0);
+    // ODOO PATCH PRINT PREVIEW MOBILE
+    return hasFinishPrintPromise;
   },
 
   get active() {
@@ -18245,12 +18255,17 @@ window.print = function () {
     }
 
     const activeServiceOnEntry = activeService;
+    // ODOO: FIX MOBILE PRINT PREVIEW
+    const timeBeforeRendering = new Date().getTime();
     activeService.renderPages().then(function () {
-      return activeServiceOnEntry.performPrint();
+      // ODOO: FIX MOBILE PRINT PREVIEW
+      return Promise.all([
+        activeServiceOnEntry.performPrint(),
+        new Promise(resolve => setTimeout(resolve, 1000 + new Date().getTime() - timeBeforeRendering))
+      ]);
     }).catch(function () {}).then(function () {
       if (activeServiceOnEntry.active) {
-        // ODOO Patch: https://github.com/mozilla/pdf.js/issues/10630#issuecomment-855754913
-        setTimeout(abort, 1000);
+        abort();
       }
     });
   }
@@ -18297,6 +18312,11 @@ window.addEventListener("keydown", function (event) {
 
 if ("onbeforeprint" in window) {
   const stopPropagationIfNeeded = function (event) {
+    // ODOO PATCH PRINT PREVIEW MOBILE
+    if (activeService?.hasFinishPrint && event.type === "afterprint") {
+      activeService.hasFinishPrint();
+      return;
+    }
     if (event.detail !== "custom" && event.stopImmediatePropagation) {
       event.stopImmediatePropagation();
     }


### PR DESCRIPTION

Currently, pdf.js does not support printing from mobile browsers, and
the pdf.js team will not fix this issue [1].

I investigated and found that sometimes `window.print()` is
asynchronous [2].
On Android, the print preview dialog re-renders the entire PDF
within the preview, which can obviously take some time and the abort
method is call before the preview rendering is complete.

opw-4190135

[1]: https://github.com/mozilla/pdf.js/issues/12020
[2]: https://github.com/mozilla/pdf.js/blob/2d0ba7db08fb6bb597ba718635314d8e8998a7d0/web/pdf_print_service.js#L226


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
