### PR TITLE
[IMP] point_of_sale: add config option to group products by category

### DIFF
--- a/addons/point_of_sale/models/pos_config.py
+++ b/addons/point_of_sale/models/pos_config.py
@@ -99,6 +99,7 @@ class PosConfig(models.Model):
     iface_print_via_proxy = fields.Boolean(string='Print via Proxy', help="Bypass browser printing and prints via the hardware proxy.")
     iface_scan_via_proxy = fields.Boolean(string='Scan via Proxy', help="Enable barcode scanning with a remotely connected barcode scanner and card swiping with a Vantiv card reader.")
     iface_big_scrollbars = fields.Boolean('Large Scrollbars', help='For imprecise industrial touchscreens.')
+    iface_group_by_categ = fields.Boolean("Group products by categories", help='Display products grouped by categories.')
     iface_print_auto = fields.Boolean(string='Automatic Receipt Printing', default=False,
         help='The receipt will automatically be printed at the end of each order.')
     iface_print_skip_screen = fields.Boolean(string='Skip Preview Screen', default=True,

--- a/addons/point_of_sale/models/res_config_settings.py
+++ b/addons/point_of_sale/models/res_config_settings.py
@@ -69,6 +69,7 @@ class ResConfigSettings(models.TransientModel):
     pos_has_active_session = fields.Boolean(related='pos_config_id.has_active_session')
     pos_iface_available_categ_ids = fields.Many2many('pos.category', string='Available PoS Product Categories', compute='_compute_pos_iface_available_categ_ids', readonly=False, store=True)
     pos_iface_big_scrollbars = fields.Boolean(related='pos_config_id.iface_big_scrollbars', readonly=False)
+    pos_iface_group_by_categ = fields.Boolean(related='pos_config_id.iface_group_by_categ', readonly=False)
     pos_iface_cashdrawer = fields.Boolean(string='Cashdrawer', compute='_compute_pos_iface_cashdrawer', readonly=False, store=True)
     pos_iface_electronic_scale = fields.Boolean(string='Electronic Scale', compute='_compute_pos_iface_electronic_scale', readonly=False, store=True)
     pos_iface_print_auto = fields.Boolean(related='pos_config_id.iface_print_auto', readonly=False)

--- a/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.xml
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.xml
@@ -25,21 +25,23 @@
                 <div class="position-relative d-flex flex-column flex-grow-1 overflow-hidden">
                     <CategorySelector t-if="!ui.isSmall || !pos.scanning" />
                     <BarcodeVideoScanner t-if="pos.scanning" t-props="barcodeVideoScannerProps" />
-                    <div t-elif="pos.productsToDisplay.length > 0" class="product-list d-grid gap-1 gap-lg-2 overflow-y-auto px-2 pt-0 pb-2" t-on-scroll="onScroll">
-                        <ProductCard
-                            t-foreach="pos.productsToDisplay" t-as="product" t-key="product.id"
-                            productId="product.id"
-                            product="product"
-                            class="pos.productViewMode"
-                            name="getProductName(product)"
-                            color="product.color || product.pos_categ_ids?.at(-1)?.color"
-                            imageUrl="pos.config.show_product_images and this.getProductImage(product)"
-                            onClick.bind="() => this.addProductToOrder(product)"
-                            t-on-mousedown="(event) => this.onMouseDown(event, product)"
-                            t-on-mouseup="longPressHandlers.onMouseUp"
-                            t-on-touchstart="(event) => this.onTouchStart(product)"
-                            t-on-touchend="longPressHandlers.onTouchEnd"
-                            productCartQty="this.state.quantityByProductTmplId[product.id]" />
+                    <div t-elif="pos.productToDisplayByCateg.length > 0" class="overflow-y-auto" t-on-scroll="onScroll">
+                        <div t-foreach="pos.productToDisplayByCateg" t-as="productCateg" t-key="productCateg[0]" class="product-list d-grid gap-1 gap-lg-2 px-2 pt-0 pb-2">
+                            <ProductCard
+                                t-foreach="productCateg[1]" t-as="product" t-key="product.id"
+                                productId="product.id"
+                                product="product"
+                                class="pos.productViewMode"
+                                name="getProductName(product)"
+                                color="product.color || product.pos_categ_ids?.at(-1)?.color"
+                                imageUrl="pos.config.show_product_images and this.getProductImage(product)"
+                                onClick.bind="() => this.addProductToOrder(product)"
+                                t-on-mousedown="(event) => this.onMouseDown(event, product)"
+                                t-on-mouseup="longPressHandlers.onMouseUp"
+                                t-on-touchstart="(event) => this.onTouchStart(product)"
+                                t-on-touchend="longPressHandlers.onTouchEnd"
+                                productCartQty="this.state.quantityByProductTmplId[product.id]" />
+                        </div>
                     </div>
                     <div t-else="" class="flex-grow-1 text-center mt-5">
                         <p t-if="searchWord">No products found for <b>"<t t-esc="searchWord"/>"</b> in this category.</p>

--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -2473,6 +2473,33 @@ export class PosStore extends WithLazyGetterTrap {
               });
     }
 
+    get productToDisplayByCateg() {
+        const sortedProducts = this.productsToDisplay;
+        if (!this.config.iface_group_by_categ) {
+            return sortedProducts.length ? [[0, sortedProducts]] : [];
+        } else {
+            const groupedByCategory = {};
+            for (const product of sortedProducts) {
+                for (const categ of product.pos_categ_ids) {
+                    if (!groupedByCategory[categ.id]) {
+                        groupedByCategory[categ.id] = [];
+                    }
+                    groupedByCategory[categ.id].push(product);
+                }
+            }
+            const res = Object.entries(groupedByCategory).sort(([a], [b]) => {
+                const catA = this.models["pos.category"].get(a);
+                const catB = this.models["pos.category"].get(b);
+
+                const isRootA = !catA.parent_id;
+                const isRootB = !catB.parent_id;
+
+                return isRootA !== isRootB ? (isRootA ? -1 : 1) : catA.sequence - catB.sequence;
+            });
+            return res;
+        }
+    }
+
     sortByWordIndex(products, words) {
         return products.sort((a, b) => {
             const nameA = normalize(a.name);

--- a/addons/point_of_sale/views/res_config_settings_views.xml
+++ b/addons/point_of_sale/views/res_config_settings_views.xml
@@ -171,6 +171,9 @@
                                         </div>
                                     </div>
                                 </setting>
+                                <setting invisible="is_kiosk_mode" help="Display products grouped by categories.">
+                                    <field name="pos_iface_group_by_categ"/>
+                                </setting>
                             </block>
                             <block id="product_and_category_block" title="Product &amp; PoS categories">
                                 <setting help="Pick which product PoS categories are available">


### PR DESCRIPTION
- Introduced a new setting `iface_group_by_categ` in `pos.config` to display products grouped by categories in the PoS product screen.

task-id: 4916574


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
