### PR TITLE
[FIX] website_sale: handle translated express checkout partners

### DIFF
--- a/addons/website_sale/controllers/delivery.py
+++ b/addons/website_sale/controllers/delivery.py
@@ -77,7 +77,7 @@ class WebsiteSaleDelivery(WebsiteSale):
             # the price with another pricelist at this state since the customer has already accepted
             # the amount and validated the payment.
             order_sudo.env.remove_to_compute(order_sudo._fields['pricelist_id'], order_sudo)
-        elif order_sudo.partner_shipping_id.name.endswith(order_sudo.name):
+        elif order_sudo.name in order_sudo.partner_shipping_id.name:
             self._create_or_edit_partner(
                 partial_shipping_address,
                 edit=True,

--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -1457,7 +1457,7 @@ class WebsiteSale(payment_portal.PaymentPortal):
             #in order to not override shippig address, it's checked separately from shipping option
             self._include_country_and_state_in_address(shipping_address)
 
-            if order_sudo.partner_shipping_id.name.endswith(order_sudo.name):
+            if order_sudo.name in order_sudo.partner_shipping_id.name:
                 # The existing partner was created by `process_express_checkout_delivery_choice`, it
                 # means that the partner is missing information, so we update it.
                 order_sudo.partner_shipping_id = self._create_or_edit_partner(


### PR DESCRIPTION
[FIX] website_sale: handle translated express checkout partners

Versions
--------
- 17.0+

Steps
-----
1. Change website language to Spanish
2. add a deliverable order to cart;
3. go via express checkout.

Issue
-----
The express checkout partner doesn't get updated as expected.

Cause
-----
Before this commit, it checks whether the express checkout partner's name ends with the order reference, as is the case in English. In Spanish however, the order reference gets used in the middle of the name.

As a consequence, the `_create_or_edit_partner` method does not get called.

Solution
--------
Check whether the order reference is part of the partner name.

opw-4894059
