### PR TITLE
[IMP] l10n_tr_nilvera_edispatch: Add option to import E-Receipt

### DIFF
--- a/addons/account/models/uom_uom.py
+++ b/addons/account/models/uom_uom.py
@@ -3,6 +3,35 @@
 
 from odoo import fields, models, api
 
+UOM_TO_UNECE_CODE = {
+    'uom.product_uom_unit': 'C62',
+    'uom.product_uom_dozen': 'DZN',
+    'uom.product_uom_kgm': 'KGM',
+    'uom.product_uom_gram': 'GRM',
+    'uom.product_uom_day': 'DAY',
+    'uom.product_uom_hour': 'HUR',
+    'uom.product_uom_ton': 'TNE',
+    'uom.product_uom_meter': 'MTR',
+    'uom.product_uom_km': 'KMT',
+    'uom.product_uom_cm': 'CMT',
+    'uom.product_uom_litre': 'LTR',
+    'uom.product_uom_lb': 'LBR',
+    'uom.product_uom_oz': 'ONZ',
+    'uom.product_uom_inch': 'INH',
+    'uom.product_uom_foot': 'FOT',
+    'uom.product_uom_mile': 'SMI',
+    'uom.product_uom_floz': 'OZA',
+    'uom.product_uom_qt': 'QT',
+    'uom.product_uom_gal': 'GLL',
+    'uom.product_uom_cubic_meter': 'MTQ',
+    'uom.product_uom_cubic_inch': 'INQ',
+    'uom.product_uom_cubic_foot': 'FTQ',
+    'uom.uom_square_meter': 'MTK',
+    'uom.uom_square_foot': 'FTK',
+    'uom.product_uom_yard': 'YRD',
+    'uom.product_uom_millimeter': 'MMT',
+}
+
 
 class UoM(models.Model):
     _inherit = "uom.uom"
@@ -17,34 +46,12 @@ class UoM(models.Model):
     def _get_unece_code(self):
         """ Returns the UNECE code used for international trading for corresponding to the UoM as per
         https://unece.org/fileadmin/DAM/cefact/recommendations/rec20/rec20_rev3_Annex2e.pdf"""
-        mapping = {
-            'uom.product_uom_unit': 'C62',
-            'uom.product_uom_dozen': 'DZN',
-            'uom.product_uom_kgm': 'KGM',
-            'uom.product_uom_gram': 'GRM',
-            'uom.product_uom_day': 'DAY',
-            'uom.product_uom_hour': 'HUR',
-            'uom.product_uom_ton': 'TNE',
-            'uom.product_uom_meter': 'MTR',
-            'uom.product_uom_km': 'KMT',
-            'uom.product_uom_cm': 'CMT',
-            'uom.product_uom_litre': 'LTR',
-            'uom.product_uom_lb': 'LBR',
-            'uom.product_uom_oz': 'ONZ',
-            'uom.product_uom_inch': 'INH',
-            'uom.product_uom_foot': 'FOT',
-            'uom.product_uom_mile': 'SMI',
-            'uom.product_uom_floz': 'OZA',
-            'uom.product_uom_qt': 'QT',
-            'uom.product_uom_gal': 'GLL',
-            'uom.product_uom_cubic_meter': 'MTQ',
-            'uom.product_uom_cubic_inch': 'INQ',
-            'uom.product_uom_cubic_foot': 'FTQ',
-            'uom.uom_square_meter': 'MTK',
-            'uom.uom_square_foot': 'FTK',
-            'uom.product_uom_yard': 'YRD',
-            'uom.product_uom_millimeter': 'MMT',
-        }
         xml_ids = self._get_external_ids().get(self.id, [])
-        matches = list(set(xml_ids) & set(mapping.keys()))
-        return matches and mapping[matches[0]] or 'C62'
+        matches = list(set(xml_ids) & set(UOM_TO_UNECE_CODE.keys()))
+        return matches and UOM_TO_UNECE_CODE[matches[0]] or 'C62'
+
+    @api.model
+    def _get_uom_from_unece_code(self, unece_code):
+        unece_code_to_uom = {v: k for k, v in UOM_TO_UNECE_CODE.items()}
+        uom_xmlid = unece_code_to_uom.get(unece_code, 'uom.product_uom_unit')
+        return self.env.ref(uom_xmlid, raise_if_not_found=False)

--- a/addons/l10n_tr_nilvera_edispatch/__manifest__.py
+++ b/addons/l10n_tr_nilvera_edispatch/__manifest__.py
@@ -14,4 +14,9 @@
         'views/stock_picking_views.xml',
         'templates/l10n_tr_nilvera_edispatch.xml'
     ],
+    'assets': {
+        'web.assets_backend': [
+            'l10n_tr_nilvera_edispatch/static/src/views/**/*',
+        ]
+    }
 }

--- a/addons/l10n_tr_nilvera_edispatch/i18n/l10n_tr_nilvera_edispatch.pot
+++ b/addons/l10n_tr_nilvera_edispatch/i18n/l10n_tr_nilvera_edispatch.pot
@@ -4,10 +4,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 17.0+e\n"
+"Project-Id-Version: Odoo Server 18.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-17 14:00+0000\n"
-"PO-Revision-Date: 2025-08-17 14:00+0000\n"
+"POT-Creation-Date: 2025-10-09 11:01+0000\n"
+"PO-Revision-Date: 2025-10-09 11:01+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -18,28 +18,24 @@ msgstr ""
 #. module: l10n_tr_nilvera_edispatch
 #. odoo-python
 #: code:addons/l10n_tr_nilvera_edispatch/models/res_partner.py:0
-#, python-format
 msgid "%(name)s's %(errors)s."
 msgstr ""
 
 #. module: l10n_tr_nilvera_edispatch
 #. odoo-python
 #: code:addons/l10n_tr_nilvera_edispatch/models/stock_picking.py:0
-#, python-format
 msgid "%s TCKN is required."
 msgstr ""
 
 #. module: l10n_tr_nilvera_edispatch
 #. odoo-python
 #: code:addons/l10n_tr_nilvera_edispatch/models/res_partner.py:0
-#, python-format
 msgid "%s is required"
 msgstr ""
 
 #. module: l10n_tr_nilvera_edispatch
 #. odoo-python
 #: code:addons/l10n_tr_nilvera_edispatch/models/stock_picking.py:0
-#, python-format
 msgid "%s's"
 msgstr ""
 
@@ -56,7 +52,6 @@ msgstr ""
 #. module: l10n_tr_nilvera_edispatch
 #. odoo-python
 #: code:addons/l10n_tr_nilvera_edispatch/models/stock_picking.py:0
-#, python-format
 msgid "At least one Driver is required."
 msgstr ""
 
@@ -83,7 +78,6 @@ msgstr ""
 #. module: l10n_tr_nilvera_edispatch
 #. odoo-python
 #: code:addons/l10n_tr_nilvera_edispatch/models/stock_picking.py:0
-#, python-format
 msgid ""
 "Carrier is required (optional when both the Driver and Vehicle Plate are "
 "filled)."
@@ -92,7 +86,6 @@ msgstr ""
 #. module: l10n_tr_nilvera_edispatch
 #. odoo-python
 #: code:addons/l10n_tr_nilvera_edispatch/models/res_partner.py:0
-#, python-format
 msgid "City"
 msgstr ""
 
@@ -104,7 +97,6 @@ msgstr ""
 #. module: l10n_tr_nilvera_edispatch
 #. odoo-python
 #: code:addons/l10n_tr_nilvera_edispatch/models/res_partner.py:0
-#, python-format
 msgid "Country"
 msgstr ""
 
@@ -128,7 +120,6 @@ msgstr ""
 #. module: l10n_tr_nilvera_edispatch
 #. odoo-python
 #: code:addons/l10n_tr_nilvera_edispatch/models/res_partner.py:0
-#, python-format
 msgid "Customs ZIP of 5 characters must be present"
 msgstr ""
 
@@ -155,19 +146,19 @@ msgstr ""
 #. module: l10n_tr_nilvera_edispatch
 #. odoo-python
 #: code:addons/l10n_tr_nilvera_edispatch/models/stock_picking.py:0
-#: code:addons/l10n_tr_nilvera_edispatch/models/stock_picking.py:0
-#: code:addons/l10n_tr_nilvera_edispatch/models/stock_picking.py:0
-#: code:addons/l10n_tr_nilvera_edispatch/models/stock_picking.py:0
-#: code:addons/l10n_tr_nilvera_edispatch/models/stock_picking.py:0
 #: model:ir.model.fields,field_description:l10n_tr_nilvera_edispatch.field_stock_picking__l10n_tr_nilvera_driver_ids
-#, python-format
 msgid "Drivers"
+msgstr ""
+
+#. module: l10n_tr_nilvera_edispatch
+#. odoo-javascript
+#: code:addons/l10n_tr_nilvera_edispatch/static/src/views/list_view/ereceipt_upload.js:0
+msgid "Error occured in reading following XML file(s): %s"
 msgstr ""
 
 #. module: l10n_tr_nilvera_edispatch
 #. odoo-python
 #: code:addons/l10n_tr_nilvera_edispatch/models/stock_picking.py:0
-#, python-format
 msgid ""
 "Error occurred in generating XML for following records:\n"
 "- %s"
@@ -218,6 +209,12 @@ msgid "ID"
 msgstr ""
 
 #. module: l10n_tr_nilvera_edispatch
+#. odoo-python
+#: code:addons/l10n_tr_nilvera_edispatch/models/stock_picking.py:0
+msgid "Imported E-Receipts"
+msgstr ""
+
+#. module: l10n_tr_nilvera_edispatch
 #: model:ir.model.fields,field_description:l10n_tr_nilvera_edispatch.field_stock_picking__l10n_tr_nilvera_edispatch_warnings
 msgid "L10N Tr Nilvera Edispatch Warnings"
 msgstr ""
@@ -250,17 +247,21 @@ msgstr ""
 #. module: l10n_tr_nilvera_edispatch
 #. odoo-python
 #: code:addons/l10n_tr_nilvera_edispatch/models/stock_picking_type.py:0
-#, python-format
 msgid "Only 3 characters are allowed in the Sequence Prefix by GİB"
 msgstr ""
 
 #. module: l10n_tr_nilvera_edispatch
 #. odoo-python
 #: code:addons/l10n_tr_nilvera_edispatch/models/stock_picking.py:0
-#, python-format
 msgid ""
 "Only Drivers from Türkiye are valid. Please update the Country and enter a "
 "valid TCKN in the Tax ID."
+msgstr ""
+
+#. module: l10n_tr_nilvera_edispatch
+#. odoo-javascript
+#: code:addons/l10n_tr_nilvera_edispatch/static/src/views/list_view/ereceipt_upload.js:0
+msgid "Only XML files can be uploaded"
 msgstr ""
 
 #. module: l10n_tr_nilvera_edispatch
@@ -282,7 +283,6 @@ msgstr ""
 #. module: l10n_tr_nilvera_edispatch
 #. odoo-python
 #: code:addons/l10n_tr_nilvera_edispatch/models/stock_picking.py:0
-#, python-format
 msgid "Please validate the transfer first to generate the XML"
 msgstr ""
 
@@ -299,7 +299,6 @@ msgstr ""
 #. module: l10n_tr_nilvera_edispatch
 #. odoo-python
 #: code:addons/l10n_tr_nilvera_edispatch/models/stock_picking.py:0
-#, python-format
 msgid "Printed Delivery Note Date is required."
 msgstr ""
 
@@ -311,7 +310,6 @@ msgstr ""
 #. module: l10n_tr_nilvera_edispatch
 #. odoo-python
 #: code:addons/l10n_tr_nilvera_edispatch/models/stock_picking.py:0
-#, python-format
 msgid "Printed Delivery Note Number of 16 characters is required."
 msgstr ""
 
@@ -326,24 +324,33 @@ msgid "Sent"
 msgstr ""
 
 #. module: l10n_tr_nilvera_edispatch
+#. odoo-javascript
+#: code:addons/l10n_tr_nilvera_edispatch/static/src/views/list_view/ereceipt_upload.js:0
+msgid "Something went wrong. Please try again."
+msgstr ""
+
+#. module: l10n_tr_nilvera_edispatch
 #. odoo-python
 #: code:addons/l10n_tr_nilvera_edispatch/models/res_partner.py:0
-#, python-format
 msgid "State"
 msgstr ""
 
 #. module: l10n_tr_nilvera_edispatch
 #. odoo-python
 #: code:addons/l10n_tr_nilvera_edispatch/models/res_partner.py:0
-#, python-format
 msgid "Street"
 msgstr ""
 
 #. module: l10n_tr_nilvera_edispatch
 #. odoo-python
 #: code:addons/l10n_tr_nilvera_edispatch/models/res_partner.py:0
-#, python-format
 msgid "TCKN/VKN"
+msgstr ""
+
+#. module: l10n_tr_nilvera_edispatch
+#. odoo-javascript
+#: code:addons/l10n_tr_nilvera_edispatch/static/src/views/list_view/ereceipt_upload.js:0
+msgid "The file(s): %s must be of type XML."
 msgstr ""
 
 #. module: l10n_tr_nilvera_edispatch
@@ -367,6 +374,12 @@ msgstr ""
 #. module: l10n_tr_nilvera_edispatch
 #: model:ir.model,name:l10n_tr_nilvera_edispatch.model_stock_picking
 msgid "Transfer"
+msgstr ""
+
+#. module: l10n_tr_nilvera_edispatch
+#. odoo-javascript
+#: code:addons/l10n_tr_nilvera_edispatch/static/src/views/list_view/ereceipt_upload.xml:0
+msgid "Upload e-Receipt (XML)"
 msgstr ""
 
 #. module: l10n_tr_nilvera_edispatch
@@ -434,7 +447,6 @@ msgstr ""
 #. module: l10n_tr_nilvera_edispatch
 #. odoo-python
 #: code:addons/l10n_tr_nilvera_edispatch/models/stock_picking.py:0
-#, python-format
 msgid "Vehicle Plate is required."
 msgstr ""
 
@@ -442,22 +454,18 @@ msgstr ""
 #. odoo-python
 #: code:addons/l10n_tr_nilvera_edispatch/models/res_partner.py:0
 #: code:addons/l10n_tr_nilvera_edispatch/models/stock_picking.py:0
-#: code:addons/l10n_tr_nilvera_edispatch/models/stock_picking.py:0
-#, python-format
 msgid "View %s"
 msgstr ""
 
 #. module: l10n_tr_nilvera_edispatch
 #. odoo-python
 #: code:addons/l10n_tr_nilvera_edispatch/models/res_partner.py:0
-#, python-format
 msgid "View Partner"
 msgstr ""
 
 #. module: l10n_tr_nilvera_edispatch
 #. odoo-python
 #: code:addons/l10n_tr_nilvera_edispatch/models/res_partner.py:0
-#, python-format
 msgid "ZIP"
 msgstr ""
 
@@ -474,7 +482,6 @@ msgstr ""
 #. module: l10n_tr_nilvera_edispatch
 #. odoo-python
 #: code:addons/l10n_tr_nilvera_edispatch/models/stock_picking.py:0
-#, python-format
 msgid "e-Dispatch XML file generated successfully."
 msgstr ""
 
@@ -487,8 +494,15 @@ msgid "e-Dispatch will not be generated as the Delivery Address is not set."
 msgstr ""
 
 #. module: l10n_tr_nilvera_edispatch
-#: model_terms:ir.ui.view,arch_db:l10n_tr_nilvera_edispatch.l10n_tr_edispatch_format
-msgid "false"
+#. odoo-python
+#: code:addons/l10n_tr_nilvera_edispatch/models/stock_picking.py:0
+msgid "e-Receipt uploaded successfully."
+msgstr ""
+
+#. module: l10n_tr_nilvera_edispatch
+#. odoo-javascript
+#: code:addons/l10n_tr_nilvera_edispatch/static/src/views/list_view/ereceipt_upload.js:0
+msgid "e-Receipt(s) Imported Successfully"
 msgstr ""
 
 #. module: l10n_tr_nilvera_edispatch

--- a/addons/l10n_tr_nilvera_edispatch/i18n/tr.po
+++ b/addons/l10n_tr_nilvera_edispatch/i18n/tr.po
@@ -4,51 +4,45 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 17.0+e\n"
+"Project-Id-Version: Odoo Server 18.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-11 06:16+0000\n"
-"PO-Revision-Date: 2025-08-11 14:53+0400\n"
+"POT-Creation-Date: 2025-10-09 11:01+0000\n"
+"PO-Revision-Date: 2025-10-09 11:01+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
-"Language: tr_TR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Generator: Poedit 3.4.2\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
 
 #. module: l10n_tr_nilvera_edispatch
 #. odoo-python
 #: code:addons/l10n_tr_nilvera_edispatch/models/res_partner.py:0
-#, python-format
 msgid "%(name)s's %(errors)s."
-msgstr "%(name)s'nin %(errors)s."
+msgstr "%(name)s'in %(errors)s."
 
 #. module: l10n_tr_nilvera_edispatch
 #. odoo-python
 #: code:addons/l10n_tr_nilvera_edispatch/models/stock_picking.py:0
-#, python-format
 msgid "%s TCKN is required."
-msgstr "%s TCKN zorunludur."
+msgstr "%s TCKN zorunlu."
 
 #. module: l10n_tr_nilvera_edispatch
 #. odoo-python
 #: code:addons/l10n_tr_nilvera_edispatch/models/res_partner.py:0
-#, python-format
-msgid "%s is required"
-msgstr "%s zorunludur"
+msgid "%s is required."
+msgstr "%s gerekli."
 
 #. module: l10n_tr_nilvera_edispatch
 #. odoo-python
 #: code:addons/l10n_tr_nilvera_edispatch/models/stock_picking.py:0
-#, python-format
 msgid "%s's"
-msgstr "%s'nin"
+msgstr "%s ait."
 
 #. module: l10n_tr_nilvera_edispatch
 #: model:ir.model.constraint,message:l10n_tr_nilvera_edispatch.constraint_l10n_tr_nilvera_trailer_plate_name_unique
 msgid "A Plate Number with that type already exists."
-msgstr "Bu türde bir plaka numarası zaten mevcut."
+msgstr "Bu tipte bir plaka numarası zaten mevcut."
 
 #. module: l10n_tr_nilvera_edispatch
 #: model_terms:ir.ui.view,arch_db:l10n_tr_nilvera_edispatch.view_picking_form_inherit_l10n_tr_nilvera_edispatch
@@ -58,9 +52,8 @@ msgstr "Ek Bilgiler"
 #. module: l10n_tr_nilvera_edispatch
 #. odoo-python
 #: code:addons/l10n_tr_nilvera_edispatch/models/stock_picking.py:0
-#, python-format
 msgid "At least one Driver is required."
-msgstr "En az bir şoför zorunludur."
+msgstr "En az bir sürücü gereklidir."
 
 #. module: l10n_tr_nilvera_edispatch
 #: model:ir.model.fields,field_description:l10n_tr_nilvera_edispatch.field_stock_picking__l10n_tr_nilvera_buyer_id
@@ -70,7 +63,7 @@ msgstr "Alıcı"
 #. module: l10n_tr_nilvera_edispatch
 #: model:ir.model.fields,field_description:l10n_tr_nilvera_edispatch.field_stock_picking__l10n_tr_nilvera_buyer_originator_id
 msgid "Buyer Originator"
-msgstr "Alıcı (İlk Başlatan Taraf)"
+msgstr "Alıcı Kaynağı"
 
 #. module: l10n_tr_nilvera_edispatch
 #: model_terms:ir.ui.view,arch_db:l10n_tr_nilvera_edispatch.view_picking_form_inherit_l10n_tr_nilvera_edispatch
@@ -85,42 +78,37 @@ msgstr "Taşıyıcı (TR)"
 #. module: l10n_tr_nilvera_edispatch
 #. odoo-python
 #: code:addons/l10n_tr_nilvera_edispatch/models/stock_picking.py:0
-#, python-format
 msgid ""
 "Carrier is required (optional when both the Driver and Vehicle Plate are "
 "filled)."
-msgstr ""
-"Taşıyıcı zorunludur (Şoför ve Araç Plakası birlikte girildiğinde isteğe "
-"bağlıdır)."
+msgstr "Taşıyıcı gereklidir (Sürücü ve Araç Plakası birlikte girildiğinde isteğe bağlıdır)."
 
 #. module: l10n_tr_nilvera_edispatch
 #. odoo-python
 #: code:addons/l10n_tr_nilvera_edispatch/models/res_partner.py:0
-#, python-format
 msgid "City"
-msgstr "Şehir"
+msgstr "İlçe"
 
 #. module: l10n_tr_nilvera_edispatch
 #: model:ir.model,name:l10n_tr_nilvera_edispatch.model_res_partner
 msgid "Contact"
-msgstr "İrtibat"
+msgstr "Kontak"
 
 #. module: l10n_tr_nilvera_edispatch
 #. odoo-python
 #: code:addons/l10n_tr_nilvera_edispatch/models/res_partner.py:0
-#, python-format
 msgid "Country"
 msgstr "Ülke"
 
 #. module: l10n_tr_nilvera_edispatch
 #: model:ir.model.fields,field_description:l10n_tr_nilvera_edispatch.field_l10n_tr_nilvera_trailer_plate__create_uid
 msgid "Created by"
-msgstr "Oluşturan:"
+msgstr "Oluşturan"
 
 #. module: l10n_tr_nilvera_edispatch
 #: model:ir.model.fields,field_description:l10n_tr_nilvera_edispatch.field_l10n_tr_nilvera_trailer_plate__create_date
 msgid "Created on"
-msgstr "Oluşturulma tarihi:"
+msgstr "Oluşturulma Tarihi"
 
 #. module: l10n_tr_nilvera_edispatch
 #: model:ir.model.fields,field_description:l10n_tr_nilvera_edispatch.field_res_partner__l10n_tr_nilvera_edispatch_customs_zip
@@ -132,19 +120,18 @@ msgstr "Gümrük Posta Kodu"
 #. module: l10n_tr_nilvera_edispatch
 #. odoo-python
 #: code:addons/l10n_tr_nilvera_edispatch/models/res_partner.py:0
-#, python-format
 msgid "Customs ZIP of 5 characters must be present"
-msgstr "5 karakterden oluşan gümrük posta kodu girilmelidir"
+msgstr "5 karakter uzunluğunda bir gümrük posta kodu girilmelidir."
 
 #. module: l10n_tr_nilvera_edispatch
 #: model:ir.model.fields,field_description:l10n_tr_nilvera_edispatch.field_stock_picking__l10n_tr_nilvera_delivery_notes
 msgid "Delivery Notes"
-msgstr "İrsaliyeler"
+msgstr "Teslimat Notları"
 
 #. module: l10n_tr_nilvera_edispatch
 #: model:ir.model.fields,field_description:l10n_tr_nilvera_edispatch.field_stock_picking__l10n_tr_nilvera_dispatch_type
 msgid "Dispatch Type"
-msgstr "Sevk Türü"
+msgstr "İrsaliye Tipi"
 
 #. module: l10n_tr_nilvera_edispatch
 #: model:ir.model.fields,field_description:l10n_tr_nilvera_edispatch.field_l10n_tr_nilvera_trailer_plate__display_name
@@ -154,25 +141,29 @@ msgstr "Görünen Ad"
 #. module: l10n_tr_nilvera_edispatch
 #: model_terms:ir.ui.view,arch_db:l10n_tr_nilvera_edispatch.view_picking_form_inherit_l10n_tr_nilvera_edispatch
 msgid "Driver Information"
-msgstr "Şoför Bilgileri"
+msgstr "Sürücü Bilgileri"
 
 #. module: l10n_tr_nilvera_edispatch
 #. odoo-python
 #: code:addons/l10n_tr_nilvera_edispatch/models/stock_picking.py:0
 #: model:ir.model.fields,field_description:l10n_tr_nilvera_edispatch.field_stock_picking__l10n_tr_nilvera_driver_ids
-#, python-format
 msgid "Drivers"
-msgstr "Şoförler"
+msgstr "Sürücüler"
+
+#. module: l10n_tr_nilvera_edispatch
+#. odoo-javascript
+#: code:addons/l10n_tr_nilvera_edispatch/static/src/views/list_view/ereceipt_upload.js:0
+msgid "Error occured in reading following XML file(s): %s"
+msgstr "Aşağıdaki XML dosyaları okunurken bir hata oluştu: %s"
 
 #. module: l10n_tr_nilvera_edispatch
 #. odoo-python
 #: code:addons/l10n_tr_nilvera_edispatch/models/stock_picking.py:0
-#, python-format
 msgid ""
 "Error occurred in generating XML for following records:\n"
 "- %s"
 msgstr ""
-"Aşağıdaki kayıtlar için XML oluşturulurken hata oluştu:\n"
+"Aşağıdaki kayıtlar için XML oluşturulurken bir hata oluştu:\n"
 "- %s"
 
 #. module: l10n_tr_nilvera_edispatch
@@ -202,7 +193,7 @@ msgstr "GİB Plaka Numaraları"
 #. module: l10n_tr_nilvera_edispatch
 #: model:ir.model,name:l10n_tr_nilvera_edispatch.model_l10n_tr_nilvera_trailer_plate
 msgid "GİB Plate numbers"
-msgstr "GİB plaka numaraları"
+msgstr "GİB Plaka Numaraları"
 
 #. module: l10n_tr_nilvera_edispatch
 #: model:ir.ui.menu,name:l10n_tr_nilvera_edispatch.menu_l10n_tr_nilvera
@@ -217,12 +208,18 @@ msgstr "GİB e-İrsaliye Durumu"
 #. module: l10n_tr_nilvera_edispatch
 #: model:ir.model.fields,field_description:l10n_tr_nilvera_edispatch.field_l10n_tr_nilvera_trailer_plate__id
 msgid "ID"
-msgstr "Belge Kimliği"
+msgstr ""
+
+#. module: l10n_tr_nilvera_edispatch
+#. odoo-python
+#: code:addons/l10n_tr_nilvera_edispatch/models/stock_picking.py:0
+msgid "Imported E-Receipts"
+msgstr "İçe Aktarılan e-İrsaliyeler"
 
 #. module: l10n_tr_nilvera_edispatch
 #: model:ir.model.fields,field_description:l10n_tr_nilvera_edispatch.field_stock_picking__l10n_tr_nilvera_edispatch_warnings
 msgid "L10N Tr Nilvera Edispatch Warnings"
-msgstr "Nilvera e-İrsaliye Uyarıları"
+msgstr "L10N TR Nilvera e-İrsaliye Uyarıları"
 
 #. module: l10n_tr_nilvera_edispatch
 #: model:ir.model.fields,field_description:l10n_tr_nilvera_edispatch.field_l10n_tr_nilvera_trailer_plate__write_uid
@@ -232,45 +229,49 @@ msgstr "Son Güncelleyen"
 #. module: l10n_tr_nilvera_edispatch
 #: model:ir.model.fields,field_description:l10n_tr_nilvera_edispatch.field_l10n_tr_nilvera_trailer_plate__write_date
 msgid "Last Updated on"
-msgstr "Son Güncelleme Tarihi"
+msgstr "Son Güncellenme Tarihi"
 
 #. module: l10n_tr_nilvera_edispatch
 #: model_terms:ir.ui.view,arch_db:l10n_tr_nilvera_edispatch.l10n_tr_edispatch_format
-msgid "MATBU"
-msgstr "MATBU"
+msgid "Pre-printed"
+msgstr "Matbu"
 
 #. module: l10n_tr_nilvera_edispatch
 #: model:ir.actions.server,name:l10n_tr_nilvera_edispatch.action_mark_l10n_tr_nilvera_edispatch_status
 msgid "Mark as sent (GİB e-Dispatch)"
-msgstr "Gönderildi olarak işaretle (GİB e-İrsaliye)"
+msgstr "Gönderildi Olarak İşaretle (GİB e-İrsaliye)"
 
 #. module: l10n_tr_nilvera_edispatch
 #: model:ir.model.fields.selection,name:l10n_tr_nilvera_edispatch.selection__stock_picking__l10n_tr_nilvera_dispatch_type__sevk
 msgid "Online"
-msgstr "Çevrim içi"
+msgstr "Çevrimiçi"
 
 #. module: l10n_tr_nilvera_edispatch
 #. odoo-python
 #: code:addons/l10n_tr_nilvera_edispatch/models/stock_picking_type.py:0
-#, python-format
 msgid "Only 3 characters are allowed in the Sequence Prefix by GİB"
-msgstr "GİB tarafından sıra ön ekinde yalnızca 3 karaktere izin verilir"
+msgstr "GİB kurallarına göre, sıra ön ekinde en fazla 3 karakter kullanılabilir."
 
 #. module: l10n_tr_nilvera_edispatch
 #. odoo-python
 #: code:addons/l10n_tr_nilvera_edispatch/models/stock_picking.py:0
-#, python-format
 msgid ""
 "Only Drivers from Türkiye are valid. Please update the Country and enter a "
 "valid TCKN in the Tax ID."
 msgstr ""
-"Yalnızca Türkiye’den şoförler geçerlidir. Lütfen Ülke bilgisini güncelleyin "
-"ve Vergi Kimlik Numarası alanına geçerli bir TCKN girin."
+"Yalnızca Türkiye'den sürücüler geçerlidir. Lütfen ülke bilgisini güncelleyin ve "
+"Vergi Kimlik Numarası (TCKN) alanına geçerli bir değer girin."
+
+#. module: l10n_tr_nilvera_edispatch
+#. odoo-javascript
+#: code:addons/l10n_tr_nilvera_edispatch/static/src/views/list_view/ereceipt_upload.js:0
+msgid "Only XML files can be uploaded."
+msgstr "Sadece XML dosyaları yüklenebilir."
 
 #. module: l10n_tr_nilvera_edispatch
 #: model:ir.model,name:l10n_tr_nilvera_edispatch.model_stock_picking_type
 msgid "Picking Type"
-msgstr "Sevk Türü"
+msgstr "İşlem Tipi"
 
 #. module: l10n_tr_nilvera_edispatch
 #: model:ir.model.fields.selection,name:l10n_tr_nilvera_edispatch.selection__l10n_tr_nilvera_trailer_plate__plate_number_type__trailer
@@ -286,9 +287,8 @@ msgstr "Plaka Numarası"
 #. module: l10n_tr_nilvera_edispatch
 #. odoo-python
 #: code:addons/l10n_tr_nilvera_edispatch/models/stock_picking.py:0
-#, python-format
 msgid "Please validate the transfer first to generate the XML"
-msgstr "XML oluşturmak için lütfen önce transferi doğrulayın"
+msgstr "XML oluşturmak için lütfen önce transferi onaylayın/doğrulayın"
 
 #. module: l10n_tr_nilvera_edispatch
 #: model:ir.model.fields.selection,name:l10n_tr_nilvera_edispatch.selection__stock_picking__l10n_tr_nilvera_dispatch_type__matbudan
@@ -298,26 +298,24 @@ msgstr "Matbu"
 #. module: l10n_tr_nilvera_edispatch
 #: model:ir.model.fields,field_description:l10n_tr_nilvera_edispatch.field_stock_picking__l10n_tr_nilvera_delivery_date
 msgid "Printed Delivery Note Date"
-msgstr "Basılı İrsaliye Tarihi"
+msgstr "Matbu Sevk İrsaliyesi Tarihi"
 
 #. module: l10n_tr_nilvera_edispatch
 #. odoo-python
 #: code:addons/l10n_tr_nilvera_edispatch/models/stock_picking.py:0
-#, python-format
 msgid "Printed Delivery Note Date is required."
-msgstr "Basılı irsaliye tarihi zorunludur."
+msgstr "Matbu Sevk İrsaliyesi Tarihi gereklidir."
 
 #. module: l10n_tr_nilvera_edispatch
 #: model:ir.model.fields,field_description:l10n_tr_nilvera_edispatch.field_stock_picking__l10n_tr_nilvera_delivery_printed_number
 msgid "Printed Delivery Note Number"
-msgstr "Basılı İrsaliye Numarası"
+msgstr "Matbu Sevk İrsaliyesi Numarası"
 
 #. module: l10n_tr_nilvera_edispatch
 #. odoo-python
 #: code:addons/l10n_tr_nilvera_edispatch/models/stock_picking.py:0
-#, python-format
 msgid "Printed Delivery Note Number of 16 characters is required."
-msgstr "16 karakterden oluşan basılı irsaliye numarası girilmelidir."
+msgstr "16 karakterli Matbu Sevk İrsaliyesi Numarası gereklidir."
 
 #. module: l10n_tr_nilvera_edispatch
 #: model:ir.model.fields,field_description:l10n_tr_nilvera_edispatch.field_stock_picking__l10n_tr_nilvera_seller_supplier_id
@@ -330,25 +328,34 @@ msgid "Sent"
 msgstr "Gönderildi"
 
 #. module: l10n_tr_nilvera_edispatch
+#. odoo-javascript
+#: code:addons/l10n_tr_nilvera_edispatch/static/src/views/list_view/ereceipt_upload.js:0
+msgid "Something went wrong. Please try again."
+msgstr "Bir hata oluştu. Lütfen tekrar deneyin.	"
+
+#. module: l10n_tr_nilvera_edispatch
 #. odoo-python
 #: code:addons/l10n_tr_nilvera_edispatch/models/res_partner.py:0
-#, python-format
 msgid "State"
-msgstr "Durum"
+msgstr "İl"
 
 #. module: l10n_tr_nilvera_edispatch
 #. odoo-python
 #: code:addons/l10n_tr_nilvera_edispatch/models/res_partner.py:0
-#, python-format
 msgid "Street"
-msgstr "Cadde"
+msgstr "Adres"
 
 #. module: l10n_tr_nilvera_edispatch
 #. odoo-python
 #: code:addons/l10n_tr_nilvera_edispatch/models/res_partner.py:0
-#, python-format
-msgid "TCKN/VKN"
+msgid "Identity Number/Tax ID"
 msgstr "TCKN/VKN"
+
+#. module: l10n_tr_nilvera_edispatch
+#. odoo-javascript
+#: code:addons/l10n_tr_nilvera_edispatch/static/src/views/list_view/ereceipt_upload.js:0
+msgid "The file(s): %s must be of type XML."
+msgstr "Dosya(lar): %s XML türünde olmalıdır."
 
 #. module: l10n_tr_nilvera_edispatch
 #: model:ir.model.fields,help:l10n_tr_nilvera_edispatch.field_res_partner__l10n_tr_nilvera_edispatch_customs_zip
@@ -357,7 +364,7 @@ msgid ""
 "The postal code of the customs office used to ship to the destination "
 "country."
 msgstr ""
-"Varış ülkesine yapılan sevkiyatta kullanılan gümrük idaresinin posta kodu."
+"Hedef ülkeye sevkiyat için kullanılan gümrük ofisinin posta kodu."
 
 #. module: l10n_tr_nilvera_edispatch
 #: model:ir.model.fields.selection,name:l10n_tr_nilvera_edispatch.selection__stock_picking__l10n_tr_nilvera_dispatch_state__to_send
@@ -372,51 +379,57 @@ msgstr "Römork Plakaları"
 #. module: l10n_tr_nilvera_edispatch
 #: model:ir.model,name:l10n_tr_nilvera_edispatch.model_stock_picking
 msgid "Transfer"
-msgstr "Transfer"
+msgstr "Nakil"
+
+#. module: l10n_tr_nilvera_edispatch
+#. odoo-javascript
+#: code:addons/l10n_tr_nilvera_edispatch/static/src/views/list_view/ereceipt_upload.xml:0
+msgid "Upload e-Receipt (XML)"
+msgstr "Gelen e-İrsaliye Yükle (XML)"
 
 #. module: l10n_tr_nilvera_edispatch
 #: model:ir.model.fields,help:l10n_tr_nilvera_edispatch.field_stock_picking__l10n_tr_nilvera_driver_ids
 msgid "Used for the individuals driving the truck."
-msgstr "Kamyonu kullanan kişiler için kullanılır."
+msgstr "Kamyonu/tırı kullanan kişiler için kullanılır."
 
 #. module: l10n_tr_nilvera_edispatch
 #: model:ir.model.fields,help:l10n_tr_nilvera_edispatch.field_stock_picking__l10n_tr_nilvera_seller_supplier_id
 msgid ""
 "Used for the information of the supplier of the goods in the delivery note."
-msgstr "İrsaliyede malın tedarikçisine dair bilgiler için kullanılır."
+msgstr ""
+"Sevk irsaliyesindeki malların tedarikçisi bilgileri için kullanılır."
 
 #. module: l10n_tr_nilvera_edispatch
 #: model:ir.model.fields,help:l10n_tr_nilvera_edispatch.field_stock_picking__l10n_tr_nilvera_buyer_originator_id
 msgid ""
 "Used for the original initiator of the goods acquisition and requesting "
 "process."
-msgstr "Mal edinme ve talep sürecinin asıl başlatıcısı için kullanılır."
+msgstr ""
+"Mal tedariki ve talep sürecini başlatan orijinal taraf için kullanılır."
 
 #. module: l10n_tr_nilvera_edispatch
 #: model:ir.model.fields,help:l10n_tr_nilvera_edispatch.field_stock_picking__l10n_tr_nilvera_buyer_id
 msgid ""
-"Used for the original party who purchases the good when the Delivery Address "
-"is for another recipient"
+"Used for the original party who purchases the good when the Delivery Address"
+" is for another recipient"
 msgstr ""
-"Teslimat Adresi başka bir alıcıya ait olduğunda malı satın alan asıl taraf "
-"için kullanılır"
+"Teslimat adresi başka bir alıcı için olduğunda, malı satın alan orijinal "
+"taraf için kullanılır."
 
 #. module: l10n_tr_nilvera_edispatch
 #: model:ir.model.fields,help:l10n_tr_nilvera_edispatch.field_stock_picking__l10n_tr_vehicle_plate
 msgid "Used to input the plate number of the truck."
-msgstr "Kamyonun plaka numarasının girilmesi için kullanılır."
+msgstr "Kamyonun/tırın plaka numarasını girmek için kullanılır."
 
 #. module: l10n_tr_nilvera_edispatch
 #: model:ir.model.fields,help:l10n_tr_nilvera_edispatch.field_stock_picking__l10n_tr_nilvera_trailer_plate_ids
 msgid "Used to input the plate numbers of the trailers attached to the truck."
-msgstr ""
-"Kamyonun arkasına takılan römorkların plaka numaralarının girilmesi için "
-"kullanılır."
+msgstr "Kamyona/tıra bağlı römorkların plaka numaralarını girmek için kullanılır."
 
 #. module: l10n_tr_nilvera_edispatch
 #: model:ir.model.fields,help:l10n_tr_nilvera_edispatch.field_stock_picking__l10n_tr_nilvera_dispatch_type
 msgid "Used to populate the type of dispatch."
-msgstr "Sevk türünün belirtilmesi için kullanılır."
+msgstr "Sevk türünü doldurmak için kullanılır."
 
 #. module: l10n_tr_nilvera_edispatch
 #: model:ir.model.fields,help:l10n_tr_nilvera_edispatch.field_stock_picking__l10n_tr_nilvera_carrier_id
@@ -424,9 +437,8 @@ msgid ""
 "Used when the dispatch is made through a third-party carrier company. "
 "Populating this makes the Vehicle Plate and Drivers optional."
 msgstr ""
-"Sevkiyat üçüncü taraf bir taşıyıcı firma aracılığıyla yapıldığında "
-"kullanılır. Bu alan doldurulduğunda Araç Plakası ve Şoför bilgileri isteğe "
-"bağlı hale gelir."
+"Sevkiyatın üçüncü taraf bir taşıyıcı şirket aracılığıyla yapılması durumunda kullanılır."
+"Bu alanın doldurulması Araç Plakası ve Sürücüler alanlarını isteğe bağlı yapar."
 
 #. module: l10n_tr_nilvera_edispatch
 #: model:ir.model.fields.selection,name:l10n_tr_nilvera_edispatch.selection__l10n_tr_nilvera_trailer_plate__plate_number_type__vehicle
@@ -446,29 +458,25 @@ msgstr "Araç Plakası"
 #. module: l10n_tr_nilvera_edispatch
 #. odoo-python
 #: code:addons/l10n_tr_nilvera_edispatch/models/stock_picking.py:0
-#, python-format
 msgid "Vehicle Plate is required."
-msgstr "Araç plakası zorunludur."
+msgstr "Araç Plakası zorunludur."
 
 #. module: l10n_tr_nilvera_edispatch
 #. odoo-python
 #: code:addons/l10n_tr_nilvera_edispatch/models/res_partner.py:0
 #: code:addons/l10n_tr_nilvera_edispatch/models/stock_picking.py:0
-#, python-format
 msgid "View %s"
 msgstr "%s'i Görüntüle"
 
 #. module: l10n_tr_nilvera_edispatch
 #. odoo-python
 #: code:addons/l10n_tr_nilvera_edispatch/models/res_partner.py:0
-#, python-format
 msgid "View Partner"
-msgstr "Partneri Görüntüle"
+msgstr "İş Ortağını Görüntüle"
 
 #. module: l10n_tr_nilvera_edispatch
 #. odoo-python
 #: code:addons/l10n_tr_nilvera_edispatch/models/res_partner.py:0
-#, python-format
 msgid "ZIP"
 msgstr "Posta Kodu"
 
@@ -485,16 +493,26 @@ msgstr "e-İrsaliye Durumu"
 #. module: l10n_tr_nilvera_edispatch
 #. odoo-python
 #: code:addons/l10n_tr_nilvera_edispatch/models/stock_picking.py:0
-#, python-format
 msgid "e-Dispatch XML file generated successfully."
 msgstr "e-İrsaliye XML dosyası başarıyla oluşturuldu."
 
 #. module: l10n_tr_nilvera_edispatch
 #. odoo-python
 #: code:addons/l10n_tr_nilvera_edispatch/models/stock_picking.py:0
-#, python-format
 msgid "e-Dispatch will not be generated as the Delivery Address is not set."
-msgstr "Teslimat Adresi belirtilmediği için e-İrsaliye oluşturulmayacaktır."
+msgstr "Teslimat Adresi belirlenmediği için e-İrsaliye oluşturulmayacaktır."
+
+#. module: l10n_tr_nilvera_edispatch
+#. odoo-python
+#: code:addons/l10n_tr_nilvera_edispatch/models/stock_picking.py:0
+msgid "e-Receipt uploaded successfully."
+msgstr "e-İrsaliye başarıyla yüklendi."
+
+#. module: l10n_tr_nilvera_edispatch
+#. odoo-javascript
+#: code:addons/l10n_tr_nilvera_edispatch/static/src/views/list_view/ereceipt_upload.js:0
+msgid "e-Receipt(s) Imported Successfully"
+msgstr "e-İrsaliye başarıyla yüklendi."
 
 #. module: l10n_tr_nilvera_edispatch
 #: model_terms:ir.ui.view,arch_db:l10n_tr_nilvera_edispatch.l10n_tr_edispatch_format

--- a/addons/l10n_tr_nilvera_edispatch/models/stock_picking.py
+++ b/addons/l10n_tr_nilvera_edispatch/models/stock_picking.py
@@ -1,9 +1,14 @@
 import base64
 import uuid
+
 from lxml import etree
-from odoo import _, api, fields, models
+
+from odoo import Command, _, api, fields, models
 from odoo.exceptions import UserError
 from odoo.tools import cleanup_xml_node
+from odoo.tools.xml_utils import find_xml_value
+
+from odoo.addons.account_edi_ubl_cii.models.account_edi_xml_ubl_20 import UBL_NAMESPACES
 
 
 class StockPicking(models.Model):
@@ -270,3 +275,267 @@ class StockPicking(models.Model):
         self.filtered(
             lambda p: p.country_code == 'TR' and p.picking_type_code == 'outgoing'
         ).l10n_tr_nilvera_dispatch_state = 'sent'
+
+    def _get_tag_text(self, xpath, tree, default=''):
+        return find_xml_value(xpath, tree, UBL_NAMESPACES) or default
+
+    def _get_partner_vals_from_xml(self, tree, xpath):
+        party = tree.find(xpath, namespaces=UBL_NAMESPACES)
+        if party is None:
+            return
+        return {
+            'name': self._get_tag_text('./cac:PartyName/cbc:Name', party) or
+                    f"{self._get_tag_text('./cac:Person/cbc:FirstName', party)} {self._get_tag_text('./cac:Person/cbc:FamilyName', party)}",
+            'vat': self._get_tag_text('./cac:PartyIdentification/cbc:ID[@schemeID="VKN" or @schemeID="TCKN"]', party),
+            'street': self._get_tag_text('./cac:PostalAddress/cbc:StreetName', party),
+            'city': self._get_tag_text('./cac:PostalAddress/cbc:CitySubdivisionName', party),
+            'zip': self._get_tag_text('./cac:PostalAddress/cbc:PostalZone', party),
+            'state': self._get_tag_text('./cac:PostalAddress/cbc:CityName', party),
+            'country': self._get_tag_text('./cac:PostalAddress/cac:Country/cbc:Name', party),
+            'phone': self._get_tag_text('./cac:Contact/cbc:Telephone', party),
+            'email': self._get_tag_text('./cac:Contact/cbc:ElectronicMail', party),
+        }
+
+    def _create_partner_from_xml(self, partner_vals):
+        if (state := partner_vals.pop('state', None)) and (
+            state_id := self.env['res.country.state'].search([('name', '=', state)], limit=1)
+        ):
+            partner_vals.pop('country')
+            partner_vals.update({
+                'state_id': state_id.id,
+                'country_id': state_id.country_id.id,
+                'code': state_id.country_id.code
+            })
+        elif (country := partner_vals.pop('country', None)) and (
+            country_id := self.env['res.country'].with_context(lang='tr_TR').search([('name', '=', country)], limit=1)
+        ):
+            partner_vals.update({'country_id': country_id.id, 'code': country_id.code})
+
+        if (code := partner_vals.pop('code', None)) and code != 'TR':
+            partner_vals['l10n_tr_nilvera_edispatch_customs_zip'] = partner_vals.pop('zip', '')
+
+        partner = self.env['res.partner'].with_context(no_vat_validation=True).create(partner_vals)
+        return partner.id
+
+    def _find_or_create_products_from_xml(self, receipt_lines):
+        product_names = [
+            self._get_tag_text('./cac:Item/cbc:Name', receipt) for receipt in receipt_lines
+        ]
+        existing_products = dict(self.env['product.product']._read_group(
+            [('name', 'in', product_names)], ['name'], ['id:min'],
+        ))
+
+        products_to_create = []
+        for receipt in receipt_lines:
+            name = self._get_tag_text('./cac:Item/cbc:Name', receipt)
+            if name not in existing_products:
+                unece_code = receipt.find('./cbc:DeliveredQuantity', namespaces=UBL_NAMESPACES).get('unitCode', '')
+                products_to_create.append({
+                    'name': name,
+                    'default_code': self._get_tag_text('./cac:Item/cac:SellersItemIdentification/cbc:ID', receipt),
+                    'uom_id': self.env['uom.uom']._get_uom_from_unece_code(unece_code).id,
+                })
+
+        if products_to_create:
+            created_products = self.env['product.product'].create(products_to_create)
+            existing_products.update({product.name: product.id for product in created_products})
+
+        return existing_products
+
+    def _import_receipt_lines(self, tree):
+        receipt_lines = tree.findall('./cac:DespatchLine', namespaces=UBL_NAMESPACES)
+        if not receipt_lines:
+            return []
+
+        products_dict = self._find_or_create_products_from_xml(receipt_lines)
+        origin = self._get_tag_text('./cbc:ID', tree)
+        source_location = self.picking_type_id.default_location_src_id
+
+        values = []
+        for receipt in receipt_lines:
+            name = self._get_tag_text('./cac:Item/cbc:Name', receipt)
+            values.append({
+                'name': f"E-Receipt Import - {origin}",
+                'description_picking': name,
+                'product_id': products_dict[name],
+                'product_uom_qty': self._get_tag_text('./cbc:DeliveredQuantity', receipt),
+                'picking_id': self.id,
+                'location_dest_id': self.location_dest_id.id,
+                'location_id': source_location.id,
+            })
+        return values
+
+    def _import_vehicle_plate(self, tree):
+        vehicle_plate = self._get_tag_text('.//cac:RoadTransport/cbc:LicensePlateID', tree)
+        if not vehicle_plate:
+            return
+        vehicle_plate_id = self.env['l10n_tr.nilvera.trailer.plate'].search_fetch(
+            [('name', '=', vehicle_plate), ('plate_number_type', '=', 'vehicle')], ['id'], limit=1,
+        )
+        if not vehicle_plate_id:
+            vehicle_plate_id = self.env['l10n_tr.nilvera.trailer.plate'].create({
+                'name': vehicle_plate,
+                'plate_number_type': 'vehicle',
+            })
+        return vehicle_plate_id.id
+
+    def _import_trailer_plate_ids(self, tree):
+        plate_ids = []
+        trailer_plates = tree.findall('.//cac:TransportHandlingUnit/cac:TransportEquipment', namespaces=UBL_NAMESPACES)
+        existing_plates = dict(self.env['l10n_tr.nilvera.trailer.plate']._read_group(
+            [('plate_number_type', '=', 'trailer')], ['name'], ['id:min'],
+        ))
+
+        for plate in trailer_plates:
+            if not (plate_name := self._get_tag_text('./cbc:ID', plate)):
+                continue
+            if plate_name in existing_plates:
+                plate_ids.append(existing_plates[plate_name])
+            else:
+                trailer_plate = self.env['l10n_tr.nilvera.trailer.plate'].create({
+                    'name': plate_name,
+                    'plate_number_type': 'trailer',
+                })
+                plate_ids.append(trailer_plate.id)
+        return plate_ids
+
+    def _import_drivers(self, tree):
+        ResPartner = self.env['res.partner']
+        existing_partners = dict(ResPartner.with_context(active_test=False)._read_group(
+            [('country_id.code', '=', 'TR'), ('is_company', '=', False)], ['name'], ['id:min'],
+        ))
+        country_id = self.env.ref('base.tr', raise_if_not_found=False)
+        driver_ids = []
+        partners_to_create = []
+        for driver in tree.findall('.//cac:DriverPerson', namespaces=UBL_NAMESPACES):
+            name = f"{self._get_tag_text('./cbc:FirstName', driver)} {self._get_tag_text('./cbc:FamilyName', driver)}"
+            if name in existing_partners:
+                driver_ids.append(existing_partners[name])
+            else:
+                partners_to_create.append({
+                    'name': name,
+                    'vat': self._get_tag_text('./cbc:NationalityID', driver),
+                    'country_id': country_id.id
+                })
+        if partners_to_create:
+            partner_id = ResPartner.with_context(no_vat_validation=True).create(partners_to_create)
+            driver_ids += partner_id.ids
+        return driver_ids
+
+    def _import_matbudan_data(self, tree):
+        additional_doc_infos = tree.findall('.//cac:AdditionalDocumentReference', namespaces=UBL_NAMESPACES)
+        for doc in additional_doc_infos:
+            if self._get_tag_text('./cbc:DocumentType', doc) == 'MATBU':
+                return {
+                    'l10n_tr_nilvera_delivery_date': self._get_tag_text('./cbc:IssueDate', doc),
+                    'l10n_tr_nilvera_delivery_printed_number': self._get_tag_text('./cbc:ID', doc)
+                }
+
+    def _import_partners(self, tree):
+        xpath_to_field = {
+            './/cac:DespatchSupplierParty/cac:Party': 'partner_id',
+            './/cac:CarrierParty': 'l10n_tr_nilvera_carrier_id',
+            './/cac:BuyerCustomerParty/cac:Party': 'l10n_tr_nilvera_buyer_id',
+            './/cac:SellerSupplierParty/cac:Party': 'l10n_tr_nilvera_seller_supplier_id',
+            './/cac:OriginatorCustomerParty/cac:Party': 'l10n_tr_nilvera_buyer_originator_id',
+        }
+
+        partner_data = [
+            (xpath, self._get_partner_vals_from_xml(tree, xpath))
+            for xpath in xpath_to_field
+        ]
+        partner_data = {xpath: vals for xpath, vals in partner_data if vals}
+
+        existing_partners = self.env['res.partner'].with_context(active_test=False).search_read(
+            ['|', ('vat', 'in', [vals.get('vat') for vals in partner_data.values() if vals.get('vat')]),
+             ('name', 'in', [vals.get('name') for vals in partner_data.values() if vals.get('name')])],
+            ['id', 'vat', 'name'],
+        )
+        existing_dict = {partner['vat'] or partner['name']: partner['id'] for partner in existing_partners}
+
+        partners_vals = {}
+        for xpath, vals in partner_data.items():
+            key = vals.get('vat') or vals.get('name')
+            partners_vals[xpath_to_field[xpath]] = existing_dict.get(key) or self._create_partner_from_xml(vals)
+
+        return partners_vals
+
+    def _import_edispatch_fields(self, tree):
+        vals = {
+            'l10n_tr_vehicle_plate': self._import_vehicle_plate(tree),
+            'l10n_tr_nilvera_trailer_plate_ids': self._import_trailer_plate_ids(tree),
+            'l10n_tr_nilvera_driver_ids': self._import_drivers(tree),
+            'l10n_tr_nilvera_delivery_notes': self._get_tag_text('./cbc:Note', tree),
+            'l10n_tr_nilvera_dispatch_type': self._get_tag_text('./cbc:DespatchAdviceTypeCode', tree),
+        }
+
+        if vals['l10n_tr_nilvera_dispatch_type'] == 'MATBUDAN' and (matbu_info := self._import_matbudan_data(tree)):
+            vals.update(matbu_info)
+        return vals
+
+    def _update_data_from_xml(self, file_data):
+        tree = file_data['xml_tree']
+        # Dispatch Scheduled Date & Time
+        scheduled_datetime = self._get_tag_text('./cbc:IssueDate', tree) + " " + self._get_tag_text('./cbc:IssueTime', tree)
+
+        vals_to_update = {
+            'scheduled_date': scheduled_datetime,
+            'origin': self._get_tag_text('./cbc:ID', tree),  # sequence of the e-Receipt obtained from XML.
+            'move_ids_without_package': [Command.create(value) for value in self._import_receipt_lines(tree)],
+        }
+
+        # Import Partners (Supplier, Carrier, Buyer, Seller, Originator)
+        vals_to_update.update(self._import_partners(tree))
+
+        # Import e-Dispatch Fields
+        vals_to_update.update(self._import_edispatch_fields(tree))
+
+        self.write(vals_to_update)
+        self.message_post(body=_("e-Receipt uploaded successfully."), attachment_ids=[file_data['attachment'].id])
+
+    def _l10n_tr_create_receipts_from_attachment(self, attachments):
+        files_with_errors = []
+        picking_ids = self.env['stock.picking']
+        warehouse = self.env.user._get_default_warehouse_id()
+
+        for attachment in attachments:
+            file_data = attachment._decode_edi_xml(attachment.name, attachment.raw)
+            # `_decode_edi_xml` returns empty array & logs the exception if error occurs while decoding the XML.
+            if not file_data:
+                files_with_errors.append(attachment.name)
+                continue
+            picking = self.create({
+                'picking_type_id': warehouse.in_type_id.id,
+                'location_dest_id': warehouse.lot_stock_id.id,
+            })
+            picking._update_data_from_xml(file_data[0])
+            picking_ids |= picking
+        return picking_ids, files_with_errors
+
+    def l10n_tr_import_ereceipts(self, attachment_ids):
+        result = {}
+
+        attachments_to_process = self.env['ir.attachment'].browse(attachment_ids)
+        picking_ids, files_with_errors = self._l10n_tr_create_receipts_from_attachment(attachments_to_process)
+        if picking_ids:
+            action_vals = {
+                'type': 'ir.actions.act_window',
+                'name': _("Imported E-Receipts"),
+                'res_model': 'stock.picking',
+                'domain': [('id', 'in', picking_ids.ids)],
+            }
+            if len(picking_ids) == 1:
+                action_vals.update({
+                    'views': [[False, "form"]],
+                    'view_mode': 'form',
+                    'res_id': picking_ids[0].id,
+                })
+            else:
+                action_vals.update({
+                    'views': [[False, "list"], [False, "form"]],
+                    'view_mode': 'list, form',
+                })
+            result['action'] = action_vals
+        if files_with_errors:
+            result['skipped_xmls'] = files_with_errors
+        return result

--- a/addons/l10n_tr_nilvera_edispatch/models/stock_picking_type.py
+++ b/addons/l10n_tr_nilvera_edispatch/models/stock_picking_type.py
@@ -15,3 +15,8 @@ class StockPickingType(models.Model):
         ):
             raise UserError(_("Only 3 characters are allowed in the Sequence Prefix by GİB"))
         return super()._onchange_sequence_code()
+
+    def _get_action(self, action_xmlid):
+        action = super()._get_action(action_xmlid)
+        action['context']['restricted_picking_type_code'] = self.code
+        return action

--- a/addons/l10n_tr_nilvera_edispatch/static/src/views/list_view/ereceipt_upload.js
+++ b/addons/l10n_tr_nilvera_edispatch/static/src/views/list_view/ereceipt_upload.js
@@ -1,0 +1,125 @@
+/** @odoo-module */
+
+import { _t } from "@web/core/l10n/translation";
+import { Component, onWillStart } from "@odoo/owl";
+import { FileUploader } from "@web/views/fields/file_handler";
+import { ListController } from "@web/views/list/list_controller";
+import { registry } from "@web/core/registry";
+import { standardWidgetProps } from "@web/views/widgets/standard_widget_props";
+import { useService } from "@web/core/utils/hooks";
+import { StockListView } from "@stock/views/stock_empty_list_help";
+
+export class L10nTrEreceiptUploader extends Component {
+    static template = "l10n_tr_nilvera_edispatch.L10nTrEreceiptUploader";
+    static components = { FileUploader };
+    static props = {
+        ...standardWidgetProps,
+        slots: { type: Object, optional: true },
+        record: { type: Object, optional: true },
+    };
+
+    setup() {
+        this.orm = useService("orm");
+        this.notification = useService("notification");
+        this.action = useService("action");
+        this.attachmentIdsToProcess = [];
+        this.invalidAttachments = [];
+    }
+
+    async onEreceiptFileUpload(file) {
+        if (file.type != "text/xml") {
+            this.invalidAttachments.push(file.name);
+            return;
+        }
+        const file_data = {
+            name: file.name,
+            mimetype: file.type,
+            datas: file.data,
+        };
+        const [attachmentId] = await this.orm.create("ir.attachment", [file_data]);
+        this.attachmentIdsToProcess.push(attachmentId);
+    }
+
+    async onEreceiptUploadComplete() {
+        if (this.invalidAttachments.length !== 0) {
+            this.notification.add(
+                _t("The file(s): %s must be of type XML.", this.invalidAttachments.join(", ")),
+                {
+                    title: _t("Only XML files can be uploaded"),
+                    type: "danger",
+                }
+            );
+            this.invalidAttachments = [];
+        }
+        if (this.attachmentIdsToProcess.length === 0) {
+            return;
+        }
+        try {
+            const result = await this.orm.call("stock.picking", "l10n_tr_import_ereceipts", [
+                "",
+                this.attachmentIdsToProcess,
+            ]);
+
+            if (result) {
+                if (result.action) {
+                    this.notification.add(_t("e-Receipt(s) Imported Successfully"), {
+                        type: "success",
+                    });
+                    this.action.doAction(result.action);
+                }
+                if (result.skipped_xmls) {
+                    this.notification.add(
+                        _t(
+                            "Error occured in reading following XML file(s): %s",
+                            result.skipped_xmls.join(", ")
+                        ),
+                        { type: "danger", title: "e-Receipt(s) were not imported", sticky: true }
+                    );
+                }
+            }
+        } catch (e) {
+            this.notification.add(e.data.message, {
+                title: _t("Something went wrong. Please try again."),
+                type: "danger",
+            });
+        } finally {
+            this.attachmentIdsToProcess = [];
+        }
+    }
+}
+
+export class L10nTrNilveraEdispatchListController extends ListController {
+    setup() {
+        this.orm = useService("orm");
+        super.setup();
+        onWillStart(async () => {
+            const currentCompanyId = this.env.services.company.currentCompany.id;
+            this.data = await this.orm.searchRead(
+                "res.company",
+                [["id", "=", currentCompanyId]],
+                ["country_code"]
+            );
+            this.countryCode = this.data[0].country_code;
+        });
+    }
+
+    get isActionDisplayed() {
+        return (
+            this.countryCode === "TR" &&
+            this.props.context.restricted_picking_type_code === "incoming"
+        );
+    }
+}
+
+L10nTrNilveraEdispatchListController.components = {
+    ...L10nTrNilveraEdispatchListController.components,
+    L10nTrEreceiptUploader,
+};
+
+export const L10nTrNilveraEdispatchListView = {
+    ...StockListView,
+    Controller: L10nTrNilveraEdispatchListController,
+    buttonTemplate: "l10n_tr_nilvera_edispatch.ListView.buttons",
+};
+
+registry.category("views").add("l10n_tr_edispatch_tree", L10nTrNilveraEdispatchListView);

--- a/addons/l10n_tr_nilvera_edispatch/static/src/views/list_view/ereceipt_upload.xml
+++ b/addons/l10n_tr_nilvera_edispatch/static/src/views/list_view/ereceipt_upload.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates id="template" xml:space="preserve">
+
+    <t t-name="l10n_tr_nilvera_edispatch.L10nTrEreceiptUploader">
+        <FileUploader
+            acceptedFileExtensions="'.xml'"
+            multiUpload="true"
+            onUploaded.bind="onEreceiptFileUpload"
+            onUploadComplete.bind="onEreceiptUploadComplete"
+            >
+            <t t-set-slot="toggler">
+                <t t-slot="toggler"/>
+            </t>
+        </FileUploader>
+    </t>
+
+    <t t-name="l10n_tr_nilvera_edispatch.EReceiptViewImportButton">
+        <L10nTrEreceiptUploader>
+            <t t-set-slot="toggler">
+                <button type="button" class="btn btn-secondary">
+                    Upload e-Receipt (XML)
+                </button>
+            </t>
+        </L10nTrEreceiptUploader>
+    </t>
+
+    <t t-name="l10n_tr_nilvera_edispatch.ListView.buttons" t-inherit="web.ListView.Buttons" t-inherit-mode="primary">
+        <xpath expr="//div[hasclass('o_list_buttons')]" position="inside">
+            <t t-if="this.isActionDisplayed" t-call="l10n_tr_nilvera_edispatch.EReceiptViewImportButton" />
+        </xpath>
+    </t>
+
+</templates>

--- a/addons/l10n_tr_nilvera_edispatch/tests/__init__.py
+++ b/addons/l10n_tr_nilvera_edispatch/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_ereceipt_upload

--- a/addons/l10n_tr_nilvera_edispatch/tests/test_ereceipt_upload.py
+++ b/addons/l10n_tr_nilvera_edispatch/tests/test_ereceipt_upload.py
@@ -1,0 +1,101 @@
+import base64
+
+from odoo import fields
+from odoo.tests import tagged
+from odoo.tools import file_open
+
+from odoo.addons.stock.tests.common import TestStockCommon
+
+
+@tagged('post_install_l10n', 'post_install', '-at_install')
+class TestTRNilveraEreceiptUpload(TestStockCommon):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.tr_country_id = cls.env.ref('base.tr').id
+        cls.receipt_partner = cls.PartnerObj.with_context(no_vat_validation=True).create({
+            'name': 'Test Kurum İki',
+            'country_id': cls.tr_country_id,
+            'vat': '1234567802',
+        })
+        cls.driver_partner = cls.PartnerObj.with_context(no_vat_validation=True).create({
+            'name': 'Test Driver',
+            'country_id': cls.tr_country_id,
+            'vat': '11234570890',
+        })
+        cls.uom_grm = cls.env.ref('uom.product_uom_gram').id
+        cls.move_product = cls.ProductObj.create({
+            'name': 'Product in GRM',
+            'uom_id': cls.uom_grm,
+        })
+        cls.uom_unit = cls.env.ref('uom.product_uom_unit').id
+        cls.uom_kgm = cls.env.ref('uom.product_uom_kgm').id
+
+    def test_ereceipt_xml_without_errors_upload(self):
+        with file_open('l10n_tr_nilvera_edispatch/tests/test_files/test_ereceipt.xml', 'rb') as f:
+            ereceipt_xml = self.env['ir.attachment'].create({
+                'name': 'E-Receipt Without Errors',
+                'type': 'binary',
+                'datas': base64.b64encode(f.read()),
+            })
+
+        picking, files_with_errors = self.env['stock.picking']._l10n_tr_create_receipts_from_attachment(ereceipt_xml)
+        self.assertEqual(bool(picking), True)
+        self.assertEqual(files_with_errors, [])
+
+        warehouse_id = self.env.user._get_default_warehouse_id()
+
+        self.assertRecordValues(
+            picking,
+            [{
+                'partner_id': self.receipt_partner.id,
+                'picking_type_id': warehouse_id.in_type_id.id,
+                'location_dest_id': warehouse_id.lot_stock_id.id,
+                'scheduled_date': fields.Datetime.from_string('2025-07-29 11:30:00'),
+                'origin': 'EIT2025000000009',
+            }],
+        )
+        self.assertRecordValues(
+            picking.move_ids_without_package,
+            [
+                {
+                    'product_uom_qty': quantity,
+                    'product_uom': uom,
+                    'location_id': self.supplier_location,
+                    'location_dest_id': warehouse_id.lot_stock_id.id,
+                }
+                for quantity, uom in [(1.0, self.uom_unit), (3.0, self.uom_kgm), (4.0, self.uom_grm)]
+            ],
+        )
+        self.assertRecordValues(
+            picking.l10n_tr_nilvera_seller_supplier_id,
+            [{
+                'name': 'Test Seller',
+                'country_id': self.tr_country_id,
+                'vat': '1234567800',
+                'zip': '62800',
+            }],
+        )
+        self.assertRecordValues(
+            picking.l10n_tr_nilvera_buyer_id,
+            [{
+                'name': 'Test Buyer',
+                'country_id': self.env.ref('base.us').id,
+                'vat': '12345678992',
+                'l10n_tr_nilvera_edispatch_customs_zip': '34580',
+            }],
+        )
+        self.assertRecordValues(
+            picking.l10n_tr_nilvera_driver_ids,
+            [
+                {'name': 'Test Driver', 'country_id': self.tr_country_id, 'vat': '11234570890'},
+                {'name': 'Test Driver2', 'country_id': self.tr_country_id, 'vat': '22345670891'},
+            ]
+        )
+        self.assertRecordValues(
+            picking.l10n_tr_nilvera_trailer_plate_ids,
+            [
+                {'name': 'PL01', 'plate_number_type': 'trailer'},
+                {'name': 'PL02', 'plate_number_type': 'trailer'},
+            ],
+        )

--- a/addons/l10n_tr_nilvera_edispatch/tests/test_files/test_ereceipt.xml
+++ b/addons/l10n_tr_nilvera_edispatch/tests/test_files/test_ereceipt.xml
@@ -1,0 +1,273 @@
+<DespatchAdvice xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
+    xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2"
+    xmlns:xades="http://uri.etsi.org/01903/v1.3.2#"
+    xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
+    xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2"
+    xmlns="urn:oasis:names:specification:ubl:schema:xsd:DespatchAdvice-2">
+    <cbc:UBLVersionID>2.1</cbc:UBLVersionID>
+    <cbc:CustomizationID>TR1.2.1</cbc:CustomizationID>
+    <cbc:ProfileID>TEMELIRSALIYE</cbc:ProfileID>
+    <cbc:ID>EIT2025000000009</cbc:ID>
+    <cbc:CopyIndicator>false</cbc:CopyIndicator>
+    <cbc:UUID>b6e621a4-56c1-4634-9aaf-ba732d72e2e1</cbc:UUID>
+    <cbc:IssueDate>2025-07-29</cbc:IssueDate>
+    <cbc:IssueTime>11:30:00</cbc:IssueTime>
+    <cbc:DespatchAdviceTypeCode>SEVK</cbc:DespatchAdviceTypeCode>
+    <cbc:LineCountNumeric>1</cbc:LineCountNumeric>
+    <cac:AdditionalDocumentReference>
+        <cbc:ID>e894550a-48c6-40f0-8b14-0c9c0cb6a32f</cbc:ID>
+        <cbc:IssueDate>2025-07-29</cbc:IssueDate>
+        <cbc:DocumentType>XSLT</cbc:DocumentType>
+        <cbc:DocumentDescription>E-İrsaliye stil dosyası.</cbc:DocumentDescription>
+        <cac:Attachment>
+            <cbc:EmbeddedDocumentBinaryObject characterSetCode="UTF-8" encodingCode="Base64"
+                mimeCode="application/xml" filename="e894550a-48c6-40f0-8b14-0c9c0cb6a32f.xslt">
+            </cbc:EmbeddedDocumentBinaryObject>
+        </cac:Attachment>
+    </cac:AdditionalDocumentReference>
+    <cac:DespatchSupplierParty>
+        <cac:Party>
+            <cac:PartyIdentification>
+                <cbc:ID schemeID="HIZMETNO">0222222</cbc:ID>
+            </cac:PartyIdentification>
+            <cac:PartyIdentification>
+                <cbc:ID schemeID="VKN">1234567802</cbc:ID>
+            </cac:PartyIdentification>
+            <cac:PartyName>
+                <cbc:Name>Test Kurum İki</cbc:Name>
+            </cac:PartyName>
+            <cac:PostalAddress>
+                <cbc:StreetName>egribucak mah 15 cadde no:54</cbc:StreetName>
+                <cbc:CitySubdivisionName>Hacılar</cbc:CitySubdivisionName>
+                <cbc:CityName>Kayseri</cbc:CityName>
+                <cbc:PostalZone>38050</cbc:PostalZone>
+                <cac:Country>
+                    <cbc:Name>Türkiye</cbc:Name>
+                </cac:Country>
+            </cac:PostalAddress>
+            <cac:PartyTaxScheme>
+                <cac:TaxScheme>
+                    <cbc:Name>Hacılar Malmüdürlüğü</cbc:Name>
+                </cac:TaxScheme>
+            </cac:PartyTaxScheme>
+            <cac:Contact>
+                <cbc:Telephone>03524013657</cbc:Telephone>
+                <cbc:Telefax />
+                <cbc:ElectronicMail>info@test12.com</cbc:ElectronicMail>
+            </cac:Contact>
+        </cac:Party>
+    </cac:DespatchSupplierParty>
+    <cac:DeliveryCustomerParty>
+        <cac:Party>
+            <cac:PartyIdentification>
+                <cbc:ID schemeID="VKN">1234567801</cbc:ID>
+            </cac:PartyIdentification>
+            <cac:PartyName>
+                <cbc:Name>TEST KULLANICI BİR</cbc:Name>
+            </cac:PartyName>
+            <cac:PostalAddress>
+                <cbc:StreetName>Beyazıt Mahallesi</cbc:StreetName>
+                <cbc:CitySubdivisionName>Kocasinan</cbc:CitySubdivisionName>
+                <cbc:CityName>Kayseri</cbc:CityName>
+                <cbc:PostalZone>38000</cbc:PostalZone>
+                <cac:Country>
+                    <cbc:Name>Türkiye</cbc:Name>
+                </cac:Country>
+            </cac:PostalAddress>
+            <cac:PartyTaxScheme>
+                <cac:TaxScheme>
+                    <cbc:Name>Erciyes</cbc:Name>
+                </cac:TaxScheme>
+            </cac:PartyTaxScheme>
+            <cac:Contact>
+                <cbc:Telephone />
+            </cac:Contact>
+        </cac:Party>
+    </cac:DeliveryCustomerParty>
+    <cac:BuyerCustomerParty>
+        <cac:Party>
+            <cac:PartyIdentification>
+                <cbc:ID schemeID="TCKN">12345678992</cbc:ID>
+            </cac:PartyIdentification>
+            <cac:PostalAddress>
+                <cbc:StreetName>odoo</cbc:StreetName>
+                <cbc:CitySubdivisionName>buffalo</cbc:CitySubdivisionName>
+                <cbc:CityName>New York</cbc:CityName>
+                <cbc:PostalZone>34580</cbc:PostalZone>
+                <cac:Country>
+                    <cbc:IdentificationCode>US</cbc:IdentificationCode>
+                    <cbc:Name>Amerika Birleşik Devletleri</cbc:Name>
+                </cac:Country>
+            </cac:PostalAddress>
+            <cac:Person>
+                <cbc:FirstName>Test</cbc:FirstName>
+                <cbc:FamilyName>Buyer</cbc:FamilyName>
+            </cac:Person>
+        </cac:Party>
+    </cac:BuyerCustomerParty>
+    <cac:SellerSupplierParty>
+        <cac:Party>
+            <cac:PartyIdentification>
+                <cbc:ID schemeID="VKN">1234567800</cbc:ID>
+            </cac:PartyIdentification>
+            <cac:PartyName>
+                <cbc:Name>Test Seller</cbc:Name>
+            </cac:PartyName>
+            <cac:PostalAddress>
+                <cbc:StreetName>street 1</cbc:StreetName>
+                <cbc:CitySubdivisionName>amasya</cbc:CitySubdivisionName>
+                <cbc:CityName>Amasya</cbc:CityName>
+                <cbc:PostalZone>62800</cbc:PostalZone>
+                <cac:Country>
+                    <cbc:IdentificationCode>TR</cbc:IdentificationCode>
+                    <cbc:Name>Türkiye</cbc:Name>
+                </cac:Country>
+            </cac:PostalAddress>
+        </cac:Party>
+    </cac:SellerSupplierParty>
+    <cac:Shipment>
+        <cbc:ID />
+        <cac:GoodsItem>
+            <cbc:ValueAmount currencyID="TRY">4500</cbc:ValueAmount>
+        </cac:GoodsItem>
+        <cac:ShipmentStage>
+            <cac:TransportMeans>
+                <cac:RoadTransport>
+                    <cbc:LicensePlateID schemeID="PLAKA">AED34121</cbc:LicensePlateID>
+                </cac:RoadTransport>
+            </cac:TransportMeans>
+            <cac:DriverPerson>
+                <cbc:FirstName>Test</cbc:FirstName>
+                <cbc:FamilyName>Driver</cbc:FamilyName>
+                <cbc:Title>Şoför</cbc:Title>
+                <cbc:NationalityID schemeID="TCKN">11234570890</cbc:NationalityID>
+            </cac:DriverPerson>
+            <cac:DriverPerson>
+                <cbc:FirstName>Test</cbc:FirstName>
+                <cbc:FamilyName>Driver2</cbc:FamilyName>
+                <cbc:Title>Şoför</cbc:Title>
+                <cbc:NationalityID schemeID="TCKN">22345670891</cbc:NationalityID>
+            </cac:DriverPerson>
+        </cac:ShipmentStage>
+        <cac:Delivery>
+            <cac:DeliveryAddress>
+                <cbc:StreetName>Beyazıt Mahallesi</cbc:StreetName>
+                <cbc:CitySubdivisionName>Kocasinan</cbc:CitySubdivisionName>
+                <cbc:CityName>Kayseri</cbc:CityName>
+                <cbc:PostalZone>38000</cbc:PostalZone>
+                <cac:Country>
+                    <cbc:Name>Türkiye</cbc:Name>
+                </cac:Country>
+            </cac:DeliveryAddress>
+            <cac:Despatch>
+                <cbc:ActualDespatchDate>2025-07-29</cbc:ActualDespatchDate>
+                <cbc:ActualDespatchTime>11:30:00</cbc:ActualDespatchTime>
+            </cac:Despatch>
+        </cac:Delivery>
+        <cac:TransportHandlingUnit>
+            <cac:TransportEquipment>
+                <cbc:ID schemeID="DORSEPLAKA">PL01</cbc:ID>
+            </cac:TransportEquipment>
+            <cac:TransportEquipment>
+                <cbc:ID schemeID="DORSEPLAKA">PL02</cbc:ID>
+            </cac:TransportEquipment>
+        </cac:TransportHandlingUnit>
+    </cac:Shipment>
+    <cac:DespatchLine>
+        <cbc:ID>1</cbc:ID>
+        <cbc:DeliveredQuantity unitCode="C62">1</cbc:DeliveredQuantity>
+        <cac:OrderLineReference>
+            <cbc:LineID>1</cbc:LineID>
+        </cac:OrderLineReference>
+        <cac:Item>
+            <cbc:Name>Test Product 1</cbc:Name>
+            <cac:BuyersItemIdentification>
+                <cbc:ID>SKU-TP1</cbc:ID>
+            </cac:BuyersItemIdentification>
+            <cac:SellersItemIdentification>
+                <cbc:ID>SKU-TP1</cbc:ID>
+            </cac:SellersItemIdentification>
+        </cac:Item>
+        <cac:Shipment>
+            <cbc:ID />
+            <cac:GoodsItem>
+                <cac:InvoiceLine>
+                    <cbc:ID />
+                    <cbc:InvoicedQuantity>1</cbc:InvoicedQuantity>
+                    <cbc:LineExtensionAmount currencyID="TRY">4500</cbc:LineExtensionAmount>
+                    <cac:Item>
+                        <cbc:Name>Test Product 1</cbc:Name>
+                    </cac:Item>
+                    <cac:Price>
+                        <cbc:PriceAmount currencyID="TRY">4500</cbc:PriceAmount>
+                    </cac:Price>
+                </cac:InvoiceLine>
+            </cac:GoodsItem>
+        </cac:Shipment>
+    </cac:DespatchLine>
+    <cac:DespatchLine>
+        <cbc:ID>2</cbc:ID>
+        <cbc:DeliveredQuantity unitCode="KGM">3</cbc:DeliveredQuantity>
+        <cac:OrderLineReference>
+            <cbc:LineID>2</cbc:LineID>
+        </cac:OrderLineReference>
+        <cac:Item>
+            <cbc:Name>Test Product 2</cbc:Name>
+            <cac:BuyersItemIdentification>
+                <cbc:ID>SKU-TP2</cbc:ID>
+            </cac:BuyersItemIdentification>
+            <cac:SellersItemIdentification>
+                <cbc:ID>SKU-TP2</cbc:ID>
+            </cac:SellersItemIdentification>
+        </cac:Item>
+        <cac:Shipment>
+            <cbc:ID />
+            <cac:GoodsItem>
+                <cac:InvoiceLine>
+                    <cbc:ID />
+                    <cbc:InvoicedQuantity>3</cbc:InvoicedQuantity>
+                    <cbc:LineExtensionAmount currencyID="TRY">800</cbc:LineExtensionAmount>
+                    <cac:Item>
+                        <cbc:Name>Test Product 2</cbc:Name>
+                    </cac:Item>
+                    <cac:Price>
+                        <cbc:PriceAmount currencyID="TRY">2400</cbc:PriceAmount>
+                    </cac:Price>
+                </cac:InvoiceLine>
+            </cac:GoodsItem>
+        </cac:Shipment>
+    </cac:DespatchLine>
+    <cac:DespatchLine>
+        <cbc:ID>3</cbc:ID>
+        <cbc:DeliveredQuantity unitCode="GRM">4</cbc:DeliveredQuantity>
+        <cac:OrderLineReference>
+            <cbc:LineID>3</cbc:LineID>
+        </cac:OrderLineReference>
+        <cac:Item>
+            <cbc:Name>Product in GRM</cbc:Name>
+            <cac:BuyersItemIdentification>
+                <cbc:ID>SKU-PGRM</cbc:ID>
+            </cac:BuyersItemIdentification>
+            <cac:SellersItemIdentification>
+                <cbc:ID>SKU-PGRM</cbc:ID>
+            </cac:SellersItemIdentification>
+        </cac:Item>
+        <cac:Shipment>
+            <cbc:ID />
+            <cac:GoodsItem>
+                <cac:InvoiceLine>
+                    <cbc:ID />
+                    <cbc:InvoicedQuantity>4</cbc:InvoicedQuantity>
+                    <cbc:LineExtensionAmount currencyID="TRY">650</cbc:LineExtensionAmount>
+                    <cac:Item>
+                        <cbc:Name>Product in GRM</cbc:Name>
+                    </cac:Item>
+                    <cac:Price>
+                        <cbc:PriceAmount currencyID="TRY">2600</cbc:PriceAmount>
+                    </cac:Price>
+                </cac:InvoiceLine>
+            </cac:GoodsItem>
+        </cac:Shipment>
+    </cac:DespatchLine>
+</DespatchAdvice>

--- a/addons/l10n_tr_nilvera_edispatch/views/stock_picking_views.xml
+++ b/addons/l10n_tr_nilvera_edispatch/views/stock_picking_views.xml
@@ -1,6 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
 
+    <record id="vpicktree_inherit_l10n_tr_nilvera_edispatch" model="ir.ui.view">
+        <field name="name">stock.picking.view.list.inherit</field>
+        <field name="model">stock.picking</field>
+        <field name="inherit_id" ref="stock.vpicktree"/>
+        <field name="arch" type="xml">
+            <list position="attributes">
+                <attribute name="js_class">l10n_tr_edispatch_tree</attribute>
+            </list>
+        </field>
+    </record>
+
     <record id="view_picking_internal_search_inherit_l10n_tr_nilvera_edispatch" model="ir.ui.view">
         <field name="name">stock.picking.internal.search.inherit.l10n.tr.nilvera.edispatch</field>
         <field name="model">stock.picking</field>
@@ -25,7 +36,7 @@
                 <button name="action_generate_l10n_tr_edispatch_xml" type="object" invisible="country_code != 'TR' or picking_type_code != 'outgoing' or state != 'done' or not partner_id" string="Generate GİB e-Dispatch (XML)" />
             </xpath>
             <xpath expr="//notebook" position="inside">
-                <page name="l10n_tr_edispatch" string="e-Dispatch" invisible="country_code != 'TR' or picking_type_code != 'outgoing' or not partner_id">
+                <page name="l10n_tr_edispatch" string="e-Dispatch" invisible="country_code != 'TR' or picking_type_code == 'internal' or not partner_id">
                     <group>
                         <group name="l10n_tr_delivery_details" string="General Information">
                             <field name="l10n_tr_nilvera_dispatch_type"  required="country_code == 'TR'"/>
@@ -38,7 +49,7 @@
                             <field name="l10n_tr_nilvera_seller_supplier_id"/>
                             <field name="l10n_tr_nilvera_buyer_originator_id"/>
                             <field name="l10n_tr_nilvera_delivery_notes"/>
-                            <field name="l10n_tr_nilvera_dispatch_state"/>
+                            <field name="l10n_tr_nilvera_dispatch_state" invisible="picking_type_code != 'outgoing'"/>
                         </group>
                     </group>
                     <group>


### PR DESCRIPTION
This PR introduces a new option to import e-Receipt XML files exported from the Nilvera Portal.
- An "Upload e-Receipt (XML)" button is now added in the list view of Receipts (stock picking).
- Upon upload, draft receipts are created based on the XML data.
- After successful import, the user is redirected to a new view displaying the generated receipts.

TaskID:4452521

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
