### PR TITLE
[FIX] website: avoid copy style of placeholder snippet image after drop

### DIFF
--- a/addons/website/static/src/builder/plugins/options/image_snippet_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/image_snippet_option_plugin.js
@@ -20,7 +20,6 @@ class ImageSnippetOptionPlugin extends Plugin {
         await new Promise((resolve) => {
             const onClose = this.dependencies.media.openMediaDialog({
                 onlyImages: true,
-                node: snippetEl,
                 save: async (selectedImageEl) => {
                     isImageSelected = true;
                     snippetEl.replaceWith(selectedImageEl);


### PR DESCRIPTION
> [BVR] Drag and drop an "Image" Inner Content block. The image has the opacity-50 class (and also the rounded class — unclear why). The opacity-50 class is probably for the placeholder, but it should be removed for the image

The commit b401f887a2d844720a34d73ba4dcadb78bf7ee29 adds the argument `node` to `openMediaDialog` in
`ImageSnippetOptionPlugin.onSnippetDropped`. This caused the style of the placeholder to be used for the dropped image (including the `opacity-50`)

task-4367641
