### PR TITLE
[FIX] lunch: consider overdraft amount when creating a lunch order

### DIFF
--- a/addons/lunch/controllers/main.py
+++ b/addons/lunch/controllers/main.py
@@ -116,6 +116,7 @@ class LunchController(http.Controller):
             'username': user.sudo().name,
             'userimage': '/web/image?model=res.users&id=%s&field=avatar_128' % user.id,
             'wallet': request.env['lunch.cashmove'].get_wallet_balance(user, False),
+            'wallet_with_config': request.env['lunch.cashmove'].get_wallet_balance(user),
             'is_manager': is_manager,
             'group_portal_id': request.env.ref('base.group_portal').id,
             'locations': request.env['lunch.location'].search_read([], ['name']),

--- a/addons/lunch/models/lunch_order.py
+++ b/addons/lunch/models/lunch_order.py
@@ -87,7 +87,7 @@ class LunchOrder(models.Model):
             if user_new_orders:
                 user_new_orders = user_new_orders.filtered(lambda lunch_order: lunch_order.date == order.date)
                 price = sum(order.price for order in user_new_orders)
-            wallet_amount = self.env['lunch.cashmove'].get_wallet_balance(order.user_id, False) - price
+            wallet_amount = self.env['lunch.cashmove'].get_wallet_balance(order.user_id) - price
             order.display_add_button = wallet_amount >= order.price
 
     @api.depends_context('show_reorder_button')

--- a/addons/lunch/static/src/components/lunch_dashboard.js
+++ b/addons/lunch/static/src/components/lunch_dashboard.js
@@ -37,7 +37,7 @@ export class LunchOrderLine extends Component {
         let price = this.line.product[3]
         this.line.toppings.forEach((line) => price += line[3])
         const unpaid = parseFloat(this.props.infos.unpaid_subtotal)
-        return this.canEdit && (this.props.infos.wallet - unpaid) > price;
+        return this.canEdit && (this.props.infos.wallet_with_config - unpaid) >= price;
     }
 
     get canEdit() {

--- a/addons/lunch/static/tests/lunch_kanban.test.js
+++ b/addons/lunch/static/tests/lunch_kanban.test.js
@@ -14,6 +14,7 @@ import {
 const lunchInfos = {
     username: "Johnny Hache",
     wallet: 12.05,
+    wallet_with_config: 12.05,
     is_manager: false,
     currency: {
         symbol: "€",

--- a/addons/lunch/tests/test_supplier.py
+++ b/addons/lunch/tests/test_supplier.py
@@ -244,3 +244,18 @@ env['lunch.supplier'].browse([{self.supplier_kothai.id}])._send_auto_email()""")
             'topping_ids_3': [(2, supplier.topping_ids_3.id)],
         })
         self.assertFalse(supplier.topping_ids_3)
+
+    def test_lunch_order_with_minimum_threshold(self):
+        """ Test that lunch order is allowed within the overdraft threshold. """
+
+        self.env.company.lunch_minimum_threshold = 200.0
+        order = self.env['lunch.order'].create({
+            'product_id': self.product_pizza.id,
+            'date': self.monday_1pm.date(),
+            'supplier_id': self.supplier_pizza_inn.id,
+            'quantity': 11,
+        })
+        self.assertTrue(order.display_add_button)
+
+        order.action_order()
+        self.assertEqual(order.state, "ordered")


### PR DESCRIPTION
**Current Behavior:**

The overdraft amount (`lunch_minimum_threshold`) is configured in Lunch
 settings is ignored when employees create or update lunch orders.

As a result, even if the total order amount is within the allowed overdraft limit, 
the system blocks the action.

**Steps to Reproduce:**

1) Install the Lunch module.
2) Set an overdraft amount in the Lunch settings.
3) Ensure an employee's wallet balance is less than a desired order total.
4) Attempt to create a lunch order or increase product quantity such that
   the total is more than the wallet balance but within the wallet + overdraft 
   amount.

**Issue:**

- In both the product view (`_compute_display_add_button`) and
the dashboard (`canAdd` logic), the wallet balance is calculated using
`get_wallet_balance(include_config=False)`.

- This call excludes the overdraft threshold, causing incorrect warnings
and hiding of the `Add to Cart` or `+` buttons.

**Solution:**

- Remove the explicit `include_config=False` argument 
so the default True is used, ensuring the overdraft is included.

- In the dashboard logic, enhance _make_info() to return a 
wallet_with_config key using get_wallet_balance(include_config=True) 
and update the canAdd check to use this value.

opw-4782564
