### PR TITLE
[FIX] pos_self_order: return payment status in rpc controller response

### DIFF
--- a/addons/pos_self_order/controllers/orders.py
+++ b/addons/pos_self_order/controllers/orders.py
@@ -208,7 +208,7 @@ class PosSelfOrderController(http.Controller):
         if not status:
             raise BadRequest("Something went wrong")
 
-        return {'order': self.env['pos.order']._load_pos_self_data_read(order_sudo, pos_config)}
+        return {'order': self.env['pos.order']._load_pos_self_data_read(order_sudo, pos_config), 'payment_status': status}
 
     @http.route('/pos-self-order/change-printer-status', auth='public', type='jsonrpc', website=True)
     def change_printer_status(self, access_token, has_paper):


### PR DESCRIPTION
Steps:
----------
- Open the terminal configured kiosk.
- Try to process the order with terminal payment.

Issue:
----------
- The request was submitted, but showing an error.

Cause:
----------
- The payment response wasn't received in the kiosk.

Fix:
----------
- Added payment response in the payment request controller return value.

task-4791562