### PR TITLE
[FIX] pos_sale: fix double picking multiple lots

### DIFF
--- a/addons/pos_sale/models/sale_order.py
+++ b/addons/pos_sale/models/sale_order.py
@@ -111,6 +111,7 @@ class SaleOrderLine(models.Model):
                 item = sale_line.read(field_names, load=False)[0]
                 if sale_line.product_id.tracking != 'none':
                     item['lot_names'] = sale_line.move_ids.move_line_ids.lot_id.mapped('name')
+                    item['lot_qty_by_name'] = {line.lot_id.name: line.quantity for line in sale_line.move_ids.move_line_ids}
                 if product_uom == sale_line_uom:
                     results.append(item)
                     continue

--- a/addons/pos_sale/static/src/overrides/models/pos_store.js
+++ b/addons/pos_sale/static/src/overrides/models/pos_store.js
@@ -167,6 +167,22 @@ patch(PosStore.prototype, {
                     remaining_quantity -= splitted_line.qty;
                 }
             }
+
+            // Order line can only hold one lot, so we need to split the line if there are multiple lots
+            if (line.product_id.tracking == "lot") {
+                newLine.delete();
+                for (const lot of converted_line.lot_names) {
+                    const splitted_line = this.models["pos.order.line"].create({
+                        ...newLineValues,
+                    });
+                    splitted_line.set_quantity(converted_line.lot_qty_by_name[lot] || 0, true);
+                    splitted_line.setPackLotLines({
+                        modifiedPackLotLines: [],
+                        newPackLotLines: [{ lot_name: lot }],
+                        setQuantity: false,
+                    });
+                }
+            }
         }
     },
     async downPaymentSO(sale_order, isPercentage) {

--- a/addons/pos_sale/static/tests/tours/pos_sale_tour.js
+++ b/addons/pos_sale/static/tests/tours/pos_sale_tour.js
@@ -493,3 +493,23 @@ registry.category("web_tour.tours").add("test_sale_order_fp_different_from_partn
             ReceiptScreen.clickNextOrder(),
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("test_multiple_lots_sale_order", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            PosSale.settleNthOrder(1, { loadSN: true }),
+            PosSale.selectedOrderLinesHasLots("Product", ["1002"]),
+            Utils.negateStep(...PosSale.selectedOrderLinesHasLots("Product", ["1001"])),
+            ProductScreen.selectedOrderlineHas("Product", "2.00"),
+            ProductScreen.clickOrderline("Product", "1"),
+            PosSale.selectedOrderLinesHasLots("Product", ["1001"]),
+            ProductScreen.selectedOrderlineHas("Product", "1.00"),
+            Utils.negateStep(...PosSale.selectedOrderLinesHasLots("Product", ["1002"])),
+            ProductScreen.clickPayButton(),
+            PaymentScreen.clickPaymentMethod("Bank"),
+            PaymentScreen.clickValidate(),
+            ReceiptScreen.isShown(),
+        ].flat(),
+});


### PR DESCRIPTION
When creating a sale order for a product, confirming it, and then
modifying the stock move to use 2 different lots. Then paying the order
in the POS, the picking created for the pos order will have double qty

Steps to reproduce:
-------------------
* Create a product tracked by lot
* Create 2 lots for that product
* Create a sale order for that 3 quantity of that product
* Confirm the sale order
* Modify the stock move to use 2 different lots, for example:
  - Lot 1001: 2 units
  - Lot 1002: 1 unit
* Pay the order in the POS
* Check the picking created for the pos order
> Observation: The picking created for the pos order has double the
  quantity for the lots.

Why the fix:
------------
A PoS line can only hold one lot, so when we import a sale order with
multiple lots, we need to split the line into multiple lines, each with
a single lot

opw-4804704