### PR TITLE
[FIX] website: no round corner field inside font awesome option

### DIFF
--- a/addons/website/static/src/builder/plugins/font_awesome_option.xml
+++ b/addons/website/static/src/builder/plugins/font_awesome_option.xml
@@ -21,7 +21,7 @@
     </BuilderRow>
 
     <!-- TODO: check if that (should?) work in mass mailing -->
-    <BorderConfigurator label.translate="Border"/>
+    <BorderConfigurator label.translate="Border" withRoundCorner="false"/>
 </t>
 
 </templates>


### PR DESCRIPTION
The `BorderConfigurator` used in `FontAwesomeOption` did include the field to specify "Round Corners". This was unintended.

This commit removes the "Round Corners" field from the "Icon"'s options.

task-4367641
