### PR TITLE
[FIX] point_of_sale: load missing archived products

### DIFF
--- a/addons/point_of_sale/models/product_template.py
+++ b/addons/point_of_sale/models/product_template.py
@@ -57,9 +57,10 @@ class ProductTemplate(models.Model):
 
     @api.model
     def load_product_from_pos(self, config_id, domain, offset=0, limit=0):
+        load_archived = self.env.context.get('load_archived', False)
         domain_obj = Domain(domain)
         config = self.env['pos.config'].browse(config_id)
-        product_tmpls = self._load_product_with_domain(domain_obj, False, offset, limit)
+        product_tmpls = self._load_product_with_domain(domain_obj, load_archived, offset, limit)
 
         # product.combo and product.combo.item loading
         for product_tmpl in product_tmpls:

--- a/addons/point_of_sale/static/src/app/services/data_service.js
+++ b/addons/point_of_sale/static/src/app/services/data_service.js
@@ -704,12 +704,16 @@ export class PosData extends Reactive {
             try {
                 if (["product.product", "product.template"].includes(model)) {
                     const domain = model === "product.product" ? "product_variant_ids.id" : "id";
-                    await this.callRelated("product.template", "load_product_from_pos", [
-                        odoo.pos_config_id,
-                        [[domain, "in", Array.from(ids)]],
-                        0,
-                        0,
-                    ]);
+                    await this.callRelated(
+                        "product.template",
+                        "load_product_from_pos",
+                        [odoo.pos_config_id, [[domain, "in", Array.from(ids)]], 0, 0],
+                        {
+                            context: {
+                                load_archived: true,
+                            },
+                        }
+                    );
                     continue;
                 }
 

--- a/addons/point_of_sale/static/tests/pos/tours/ticket_screen_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/ticket_screen_tour.js
@@ -329,3 +329,18 @@ registry.category("web_tour.tours").add("OrderTimeTour", {
         ].flat();
     },
 });
+
+registry.category("web_tour.tours").add("test_paid_order_with_archived_product_loads", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            Chrome.clickOrders(),
+            TicketScreen.selectFilter("Paid"),
+            TicketScreen.nthRowContains(1, "0002"),
+            TicketScreen.selectOrder("0002"),
+            inLeftSide([
+                ...Order.hasLine({ productName: "Archived Product", withClass: ".selected" }),
+            ]),
+        ].flat(),
+});

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -2393,6 +2393,46 @@ class TestUi(TestPointOfSaleHttpCommon):
             login="pos_user",
         )
 
+    def test_paid_order_with_archived_product_loads(self):
+        """ Test that a paid order with archived products can be loaded in the POS. """
+
+        archived_product = self.env['product.product'].create({
+            'name': 'Archived Product',
+            'available_in_pos': True,
+            'list_price': 10.0,
+            'taxes_id': False,
+            'active': False,  # Archived product
+        })
+
+        self.env['pos.order'].create({
+            'config_id': self.main_pos_config.id,
+            'session_id': self.main_pos_config.current_session_id.id,
+            'company_id': self.main_pos_config.company_id.id,
+            'amount_total': 10.0,
+            'amount_paid': 10.0,
+            'amount_tax': 0.0,
+            'amount_return': 0.0,
+            'to_invoice': False,
+            'partner_id': False,
+            'pricelist_id': self.main_pos_config.pricelist_id.id,
+            'pos_reference': '1000-004-00002',
+            'name': 'Order 0002',
+            'state': 'paid',
+            'lines': [(0, 0, {
+                'name': 'Line 0001',
+                'product_id': archived_product.id,
+                'price_unit': 10.00,
+                'discount': 0,
+                'qty': 1,
+                'tax_ids': False,
+                'price_subtotal': 10.00,
+                'price_subtotal_incl': 10.00,
+            })],
+        })
+
+        self.main_pos_config.with_user(self.pos_user).open_ui()
+        self.start_tour(f"/pos/ui?config_id={self.main_pos_config.id}", 'test_paid_order_with_archived_product_loads', login="pos_user")
+
 
 # This class just runs the same tests as above but with mobile emulation
 class MobileTestUi(TestUi):


### PR DESCRIPTION
Before this commit, the Point of Sale system failed to load archived products when retrieving missing products for loaded records. This caused various issues, for instance, when loading paid orders, any archived products included in those orders would not be loaded, leading to data inconsistencies and operational problems.

opw-4904124

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
