### PR TITLE
[IMP] web: use new get_dashboard_institutions endpoint

### DIFF
--- a/addons/web/tests/test_click_everywhere.py
+++ b/addons/web/tests/test_click_everywhere.py
@@ -40,10 +40,10 @@ class TestMenusAdminLight(odoo.tests.HttpCase):
     @classmethod
     def _request_handler(cls, s: Session, r: PreparedRequest, /, **kw):
         # mock odoofin requests
-        if 'proxy/v1/get_dashboard_institutions' in r.url:
+        if 'proxy/v2/get_dashboard_institutions' in r.url:
             r = Response()
             r.status_code = 200
-            r.json = lambda: {'result': {}}
+            r.json = list
             return r
         return super()._request_handler(s, r, **kw)
 


### PR DESCRIPTION
odoo/odoofin#419 introduces a new more efficient
endpoint to get dashboard institutions.

odoo/enterprise#87487 updates the `account_online_synchronization`
module to use this new endpoint.

In this commit, we switch to the new endpoint.

Task ID: 4801302
