### PR TITLE
[FIX] bus: all user's groups in building bus channels

### DIFF
--- a/addons/bus/models/ir_websocket.py
+++ b/addons/bus/models/ir_websocket.py
@@ -22,7 +22,7 @@ class IrWebsocket(models.AbstractModel):
         """
         req = request or wsrequest
         channels.append('broadcast')
-        channels.extend(self.env.user.group_ids)
+        channels.extend(self.env.user.all_group_ids)
         if req.session.uid:
             channels.append(self.env.user.partner_id)
         return channels

--- a/addons/bus/tests/test_ir_websocket.py
+++ b/addons/bus/tests/test_ir_websocket.py
@@ -2,7 +2,9 @@
 import os
 import unittest
 
-from odoo.tests import tagged
+from unittest.mock import MagicMock, patch
+
+from odoo.tests import new_test_user, tagged
 from .common import WebsocketCase
 
 
@@ -14,3 +16,23 @@ class TestIrWebsocket(WebsocketCase):
             ws = self.websocket_connect()
             self.subscribe(ws, [("odoo", "discuss.channel", 5)], self.env["bus.bus"]._bus_last_id())
         self.assertIn("bus.Bus only string channels are allowed.", log.output[0])
+
+    def test_build_bus_channel_list(self):
+        test_user = new_test_user(
+            self.env, login="test_user", password="Password!1", groups="base.group_system"
+        )
+        mock_wsrequest = MagicMock()
+        mock_wsrequest.session.uid = test_user.id
+        with patch("odoo.addons.bus.models.ir_websocket.wsrequest", new=mock_wsrequest):
+            ir_websocket_model = self.env["ir.websocket"].with_user(test_user)
+            channels = set(ir_websocket_model._build_bus_channel_list(["test_channel"]))
+        expected_channels = {
+            "test_channel",
+            test_user.partner_id,
+            self.env.ref("base.group_system"),
+            self.env.ref("base.group_user"),
+        }
+        self.assertTrue(
+            expected_channels.issubset(channels),
+            f"The channels list is missing some expected values: {expected_channels - channels}.",
+        )


### PR DESCRIPTION
To target users of a group, bus notifications are sent on group records. To do so, user groups are added to its bus subscription. However, since odoo/odoo#179354, only explicit groups are added, not every implied group. It's
incorrect. For example, sending on the user channel doesn't notify administrators while it should.

Steps to reproduce (note that the steps are only working for admin):
- Click the gear button on the sidebar in discuss page to navigate to the channel kanban view as admin
- Click the `New` button and create a channel with an internal users group as `Auto Subscribe Groups`
- Go back to the discuss main page. The new channel will not be pinned unless you reload the page

See:
https://github.com/odoo/odoo/pull/179354/files#r1954163704
