### PR TITLE
[FIX] fleet: fix odometer when a new driver is added

### DIFF
--- a/addons/fleet/models/fleet_vehicle_odometer.py
+++ b/addons/fleet/models/fleet_vehicle_odometer.py
@@ -14,7 +14,13 @@ class FleetVehicleOdometer(models.Model):
     value = fields.Float('Odometer Value', group_operator="max")
     vehicle_id = fields.Many2one('fleet.vehicle', 'Vehicle', required=True)
     unit = fields.Selection(related='vehicle_id.odometer_unit', string="Unit", readonly=True)
-    driver_id = fields.Many2one(related="vehicle_id.driver_id", string="Driver", readonly=False)
+    driver_id = fields.Many2one('res.partner', string="Driver", compute='_compute_driver_id', readonly=False, store=True)
+
+    @api.depends('vehicle_id')
+    def _compute_driver_id(self):
+        for odometer in self:
+            if not odometer.driver_id:
+                odometer.driver_id = odometer.vehicle_id.driver_id
 
     @api.depends('vehicle_id', 'date')
     def _compute_vehicle_log_name(self):

--- a/addons/fleet/tests/__init__.py
+++ b/addons/fleet/tests/__init__.py
@@ -3,3 +3,4 @@
 
 from . import test_access_rights
 from . import test_overdue
+from . import test_odometer

--- a/addons/fleet/tests/test_odometer.py
+++ b/addons/fleet/tests/test_odometer.py
@@ -1,0 +1,37 @@
+from odoo.tests import common, new_test_user
+
+
+class TestFleet(common.TransactionCase):
+
+    def test_new_driver_odometer(self):
+        user1 = new_test_user(self.env, "test user 1", groups="base.group_user")
+        user2 = new_test_user(self.env, "test user 2", groups="base.group_user")
+
+        brand = self.env["fleet.vehicle.model.brand"].create({
+            "name": "Audi",
+        })
+        model = self.env["fleet.vehicle.model"].create({
+            "brand_id": brand.id,
+            "name": "A3",
+        })
+        vehicle = self.env["fleet.vehicle"].create({
+            "model_id": model.id,
+            "driver_id": user1.partner_id.id,
+            "plan_to_change_car": False
+        })
+
+        odometer1 = self.env["fleet.vehicle.odometer"].create({
+            "value": 100,
+            "vehicle_id": vehicle.id
+        })
+
+        self.assertEqual(odometer1.driver_id, user1.partner_id)
+
+        vehicle.driver_id = user2.partner_id.id
+        odometer2 = self.env["fleet.vehicle.odometer"].create({
+            "value": 100,
+            "vehicle_id": vehicle.id
+        })
+
+        self.assertEqual(odometer2.driver_id, user2.partner_id)
+        self.assertEqual(odometer1.driver_id, user1.partner_id)


### PR DESCRIPTION
In this bug, if a new driver is added the odometer driver is
reset to the new driver.

To reproduce the bug:
1- Create a db with fleet installed.
2- Create a vehicle with a driver set to user1
3- Add an odometer
4- Change the driver to user2
5- Add an odometer
6- You can see the prev odometer driver is set to user1

The bug is currently on verion 17.0, 18.0, saas-18.1
This bug is already fixed on version 18.2 but with no test

opw-4910037