### PR TITLE
[FIX] crm: avoid wrong defaults when creating salesperson 

### DIFF
--- a/addons/crm/models/res_partner.py
+++ b/addons/crm/models/res_partner.py
@@ -15,28 +15,6 @@ class Partner(models.Model):
         compute='_compute_opportunity_count',
     )
 
-    @api.model
-    def default_get(self, fields):
-        rec = super(Partner, self).default_get(fields)
-        active_model = self.env.context.get('active_model')
-        if active_model == 'crm.lead' and len(self.env.context.get('active_ids', [])) <= 1:
-            lead = self.env[active_model].browse(self.env.context.get('active_id')).exists()
-            if lead:
-                rec.update(
-                    phone=lead.phone,
-                    mobile=lead.mobile,
-                    function=lead.function,
-                    title=lead.title.id,
-                    website=lead.website,
-                    street=lead.street,
-                    street2=lead.street2,
-                    city=lead.city,
-                    state_id=lead.state_id.id,
-                    country_id=lead.country_id.id,
-                    zip=lead.zip,
-                )
-        return rec
-
     def _compute_opportunity_count(self):
         self.opportunity_count = 0
         if not self.env.user._has_group('sales_team.group_sale_salesman'):


### PR DESCRIPTION
To reproduce:
=============
1- add a lead
2- add a phone and a mobile number
3- convert it to opportunity
4- create salesperson from that view
5- salesperson contains lead number

Problem:
=========

Before this fix, creating a Salesperson inherited the global context,
which included unrelated values as active_model was set to crm.lead.

This led to incorrect default values being applied.
https://github.com/odoo/odoo/blob/d155edfd729ab9b53f38939fe24b6d1e7b578083/addons/web/models/models.py#L872C13-L872C21

The default values contained the lead phone and lead number and was applied
in the creation of salesperson.

Solution:
==========
Since we have some synchronization of some fields (email, phone) that
is automatically done normally, it's reasonable to remove the code and
see what it gives.

opw-4871069