### PR TITLE
[18.0][FIX] account: Define the appropriate account_id value and only apply it if display_type is set

### DIFF
--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -1429,8 +1429,8 @@ class AccountMoveLine(models.Model):
             defaults['account_id'] = quick_encode_suggestion['account_id']
             defaults['price_unit'] = quick_encode_suggestion['price_unit']
             defaults['tax_ids'] = [Command.set(quick_encode_suggestion['tax_ids'])]
-        elif (journal := self.env['account.journal'].browse(self.env.context.get('journal_id'))) and journal.default_account_id:
-            defaults['account_id'] = journal.default_account_id
+        elif self.display_type and (journal := self.env['account.journal'].browse(self.env.context.get('journal_id'))) and journal.default_account_id:
+            defaults['account_id'] = journal.default_account_id.id
         return defaults
 
     def _sanitize_vals(self, vals):


### PR DESCRIPTION
Define the appropriate `account_id` value and only apply it if display_type is set

Related to https://github.com/odoo/odoo/commit/3467b5971423f70581c6be2caf7f8a8d86ee70f1#diff-78f3e1847de8ca0acf28d72a412947a549acdb08142d1dadf7646363d7972cb0R1432-R1433

Please @pedrobaeza can you review it?

@Tecnativa

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
