### PR TITLE
[IMP] mail: fine-tune topbar colors in dark mode

### DIFF
--- a/addons/mail/static/src/core/public_web/discuss.dark.scss
+++ b/addons/mail/static/src/core/public_web/discuss.dark.scss
@@ -1,5 +1,5 @@
 .o-mail-Discuss-header {
-    background-color: mix($white, $o-webclient-background-color, 15%);
+    background-color: var(--mail-Discuss-surface-dark);
 }
 
 .o-mail-Discuss-headerActions button {
@@ -15,13 +15,11 @@
     }
 }
 
-.o_web_client:has(.o-mail-Discuss) {
+.o_web_client:where(:has(.o-mail-Discuss)) {
+    --mail-Discuss-surface-dark: #{mix($white, $o-webclient-background-color, 15%)};
+    --NavBar-entry-backgroundColor: var(--mail-Discuss-surface-dark);
 
-    .o_main_navbar {
-        background-color: mix($white, $o-webclient-background-color, 15%);
-    }
-
-    .o_control_panel {
-        background-color: mix($white, $o-webclient-background-color, 15%);
+    .o_main_navbar, .o_control_panel {
+        background-color: var(--mail-Discuss-surface-dark);
     }
 }


### PR DESCRIPTION
This PR fine-tunes the color of the topbar in discuss in dark mode only.

| Master | This PR |
|--------|--------|
| <img width="551" alt="image" src="https://github.com/user-attachments/assets/37cec487-c9ff-4c9c-bfaa-b98b5f8685f3" /> | <img width="426" alt="image" src="https://github.com/user-attachments/assets/dfc691b2-f193-494c-82e3-3063b6924e17" /> | 

Prior to this PR, multiple elements where using the same property with the same value, which could be simplified by using a CSS variable.

There was also an issue about the `background-color` of the navbar entries that was not tweaked while the navbar background was.

This PR fine-tunes the existing approach by defining and using a CSS variable `--mail-Discuss-surface-dark` as well as adapting the background of the navbar entries.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
