### PR TITLE
[IMP] point_of_sale: centralised get_unit() reference

### DIFF
--- a/addons/point_of_sale/static/src/app/models/pos_order_line.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order_line.js
@@ -64,7 +64,7 @@ export class PosOrderline extends Base {
 
     get quantityStr() {
         let qtyStr = "";
-        const unit = this.product_id.uom_id;
+        const unit = this.get_unit();
 
         if (unit) {
             if (unit.rounding) {
@@ -237,7 +237,7 @@ export class PosOrderline extends Base {
                 };
             }
         }
-        const unit = this.product_id.uom_id;
+        const unit = this.get_unit();
         if (unit) {
             if (unit.rounding) {
                 const decimals = this.models["decimal.precision"].find(
@@ -268,7 +268,7 @@ export class PosOrderline extends Base {
     }
 
     get_quantity_str_with_unit() {
-        const unit = this.product_id.uom_id;
+        const unit = this.get_unit();
         if (this.is_pos_groupable()) {
             return this.quantityStr + " " + unit.name;
         } else {
@@ -348,9 +348,8 @@ export class PosOrderline extends Base {
     }
 
     is_pos_groupable() {
-        const unit_groupable = this.product_id.uom_id
-            ? this.product_id.uom_id.is_pos_groupable
-            : false;
+        const unit = this.get_unit();
+        const unit_groupable = unit ? unit.is_pos_groupable : false;
         return unit_groupable && !this.isPartOfCombo();
     }
 
@@ -648,11 +647,12 @@ export class PosOrderline extends Base {
     }
 
     getDisplayData() {
+        const unit = this.get_unit();
         return {
             productName: this.get_full_product_name(),
             price: this.getPriceString(),
             qty: this.get_quantity_str(),
-            unit: this.product_id.uom_id ? this.product_id.uom_id.name : "",
+            unit: unit ? unit.name : "",
             unitPrice: formatCurrency(this.get_unit_display_price(), this.currency),
             oldUnitPrice: this.get_old_unit_display_price()
                 ? formatCurrency(this.get_old_unit_display_price(), this.currency)
@@ -725,7 +725,7 @@ export class PosOrderline extends Base {
         return this.quantityStr;
     }
     get_unit() {
-        return this.product_id.uom_id;
+        return this.product_id.get_unit();
     }
     // return the product of this orderline
     get_product() {

--- a/addons/point_of_sale/static/src/app/models/product_product.js
+++ b/addons/point_of_sale/static/src/app/models/product_product.js
@@ -20,8 +20,12 @@ export class ProductProduct extends Base {
         this.cachedPricelistRules = {};
     }
 
+    get_unit() {
+        return this.uom_id;
+    }
+
     isAllowOnlyOneLot() {
-        const productUnit = this.uom_id;
+        const productUnit = this.get_unit();
         return this.tracking === "lot" || !productUnit || !productUnit.is_pos_groupable;
     }
 

--- a/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.js
@@ -266,7 +266,7 @@ export class PaymentScreen extends Component {
             return;
         }
         const linesToRemove = this.currentOrder.lines.filter((line) => {
-            const rounding = line.product_id.uom_id.rounding;
+            const rounding = line.get_unit().rounding;
             const decimals = Math.max(0, Math.ceil(-Math.log10(rounding)));
             return floatIsZero(line.qty, decimals);
         });

--- a/addons/point_of_sale/static/src/app/screens/scale_screen/scale_service.js
+++ b/addons/point_of_sale/static/src/app/screens/scale_screen/scale_service.js
@@ -73,8 +73,8 @@ export class PosScaleService extends Reactive {
     setProduct(product, unitPrice) {
         this.product = {
             name: product.display_name || _t("Unnamed Product"),
-            unitOfMeasure: product.uom_id?.name || "kg",
-            rounding: product.uom_id?.rounding || 0.001,
+            unitOfMeasure: product.get_unit()?.name || "kg",
+            rounding: product.get_unit()?.rounding || 0.001,
             unitPrice,
         };
     }

--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -562,7 +562,7 @@ export class PosStore extends Reactive {
         const formattedUnitPrice = this.env.utils.formatCurrency(this.getProductPrice(product));
 
         if (product.to_weight) {
-            return `${formattedUnitPrice}/${product.uom_id.name}`;
+            return `${formattedUnitPrice}/${product.get_unit().name}`;
         } else {
             return formattedUnitPrice;
         }

--- a/addons/pos_sale/static/src/overrides/models/pos_store.js
+++ b/addons/pos_sale/static/src/overrides/models/pos_store.js
@@ -153,7 +153,7 @@ patch(PosStore.prototype, {
             newLine.set_unit_price(line.price_unit);
             newLine.set_discount(line.discount);
 
-            const product_unit = line.product_id.uom_id;
+            const product_unit = line.product_id.get_unit();
             if (product_unit && !product_unit.is_pos_groupable) {
                 let remaining_quantity = newLine.qty;
                 newLine.delete();


### PR DESCRIPTION
In the PoS application, the uom_id field was referenced directly everywhere, which made it nightmare to create custom modification module, since complete functions had to be overwritten. The pos_order_line object had a get_unit() function anyway, but it was not called from anywhere.

This commit centralizes the reference to the uom_id field by using get_unit() function everywhere.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
