### PR TITLE
[IMP] im_livechat: show livechat ended in discuss sidebar

### DIFF
--- a/addons/im_livechat/static/src/core/web/discuss_sidebar_category_patch.js
+++ b/addons/im_livechat/static/src/core/web/discuss_sidebar_category_patch.js
@@ -1,4 +1,7 @@
-import { DiscussSidebarCategory } from "@mail/discuss/core/public_web/discuss_sidebar_categories";
+import {
+    DiscussSidebarCategory,
+    DiscussSidebarChannel,
+} from "@mail/discuss/core/public_web/discuss_sidebar_categories";
 import { patch } from "@web/core/utils/patch";
 
 /** @type {import("@mail/discuss/core/public_web/discuss_sidebar_categories").DiscussSidebarCategory} */
@@ -30,4 +33,27 @@ const DiscussSidebarCategoryPatch = {
     },
 };
 
+/** @type {import("@mail/discuss/core/public_web/discuss_sidebar_categories").DiscussSidebarChannel} */
+const DiscussSidebarChannelPatch = {
+    get attClassContainer() {
+        return {
+            ...super.attClassContainer,
+            "bg-100": this.thread.livechat_end_dt,
+        };
+    },
+    get itemNameAttClass() {
+        return {
+            ...super.itemNameAttClass,
+            "fst-italic text-muted fw-normal": this.thread.livechat_end_dt,
+        };
+    },
+    get threadAvatarAttClass() {
+        return {
+            ...super.threadAvatarAttClass,
+            "o-opacity-65": this.thread.livechat_end_dt,
+        };
+    },
+};
+
 patch(DiscussSidebarCategory.prototype, DiscussSidebarCategoryPatch);
+patch(DiscussSidebarChannel.prototype, DiscussSidebarChannelPatch);

--- a/addons/im_livechat/static/src/core/web/discuss_sidebar_category_patch.xml
+++ b/addons/im_livechat/static/src/core/web/discuss_sidebar_category_patch.xml
@@ -30,7 +30,7 @@
     </t>
 
     <t t-name="im_livechat.LivechatStatusLabelOfThread">
-        <span t-if="livechatThread.channel_type === 'livechat' and ['waiting', 'need_help'].includes(livechatThread.livechat_status)" class="o-livechat-LivechatStatusLabel fa fa-stack" t-att-title="livechatThread.livechatStatusLabel" t-att-class="{
+        <span t-if="livechatThread.channel_type === 'livechat' and (['waiting', 'need_help'].includes(livechatThread.livechat_status) or livechatThread.livechat_end_dt)" class="o-livechat-LivechatStatusLabel fa fa-stack" t-att-title="livechatThread.livechatStatusLabel" t-att-class="{
             'position-absolute top-0 start-0 z-1': env.inDiscussSidebar or env.inChatBubble,
             'm-n1': env.inDiscussSidebar,
             'm-n2': env.inChatBubble,
@@ -40,11 +40,12 @@
             <i class="fa fa-circle o-livechat-LivechatStatusLabel-bubble fa-stack-1x" t-att-class="{
                 'o-warning': livechatThread.livechat_status === 'waiting',
                 'o-info': livechatThread.livechat_status === 'need_help',
+                'o-secondary o-white': livechatThread.livechat_end_dt,
             }"/>
-            <i class="fa-stack-1x o-livechat-LivechatStatusLabel-icon" t-attf-class="{{ store.livechatStatusButtons.find(btn => btn.status === livechatThread.livechat_status)?.icon }}" t-att-class="{
+            <i class="fa-stack-1x o-livechat-LivechatStatusLabel-icon" t-attf-class="{{ livechatThread.livechat_end_dt ? 'fa fa-flag-checkered' : store.livechatStatusButtons.find(btn => btn.status === livechatThread.livechat_status)?.icon }}" t-att-class="{
                 'o-warning': livechatThread.livechat_status === 'waiting',
                 'o-info': livechatThread.livechat_status === 'need_help',
-                'o-white': livechatThread.livechat_status === 'in_progress',
+                'o-white': livechatThread.livechat_end_dt,
             }"/>
         </span>
     </t>

--- a/addons/im_livechat/static/src/core/web/thread_model_patch.js
+++ b/addons/im_livechat/static/src/core/web/thread_model_patch.js
@@ -23,6 +23,9 @@ patch(Thread.prototype, {
         this.livechat_expertise_ids = fields.Many("im_livechat.expertise");
     },
     get livechatStatusLabel() {
+        if (this.livechat_end_dt) {
+            return _t("Conversation has ended");
+        }
         const status = this.livechat_status;
         if (status === "waiting") {
             return _t("Waiting for customer");

--- a/addons/mail/static/src/core/common/core.dark.scss
+++ b/addons/mail/static/src/core/common/core.dark.scss
@@ -15,3 +15,7 @@ a.o-discuss-mention {
         background-color: $white;
     }
 }
+
+.o-secondary {
+    --o-secondary: #{$o-gray-700};
+}

--- a/addons/mail/static/src/core/common/core.scss
+++ b/addons/mail/static/src/core/common/core.scss
@@ -73,6 +73,10 @@ $o-discuss-talkingColor: lighten($success, 10%);
     opacity: 35%;
 }
 
+.o-opacity-65 {
+    opacity: 65%;
+}
+
 .o-outline-secondary {
     outline: 1px solid $o-gray-300;
 }
@@ -177,6 +181,10 @@ $o-discuss-talkingColor: lighten($success, 10%);
 
 .o-info {
     color: $o-info;
+}
+
+.o-secondary {
+    color: var(--o-secondary, mix($o-gray-200, $o-gray-300));
 }
 
 .o-warning {

--- a/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.js
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.js
@@ -129,9 +129,22 @@ export class DiscussSidebarChannel extends Component {
         return discussSidebarChannelIndicatorsRegistry.getAll();
     }
 
+    get itemNameAttClass() {
+        return {
+            "o-unread fw-bolder":
+                this.thread.selfMember?.message_unread_counter > 0 && !this.thread.isMuted,
+            "text-muted":
+                this.thread.selfMember?.message_unread_counter !== 0 || this.thread.isMuted,
+        };
+    }
+
     /** @returns {import("models").Thread} */
     get thread() {
         return this.props.thread;
+    }
+
+    get threadAvatarAttClass() {
+        return {};
     }
 
     get subChannels() {

--- a/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.xml
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.xml
@@ -162,11 +162,11 @@
         >
             <div class="o-mail-DiscussSidebarChannel-itemMain border-0 rounded-start-2 text-reset d-flex align-items-center p-0" t-att-class="{ 'overflow-hidden': !store.discuss.isSidebarCompact }" t-att-title="store.discuss.isSidebarCompact ? undefined : thread.displayName">
                 <div class="bg-inherit position-relative d-flex flex-shrink-0 o-my-0_5 rounded-3" style="width:32px;height:32px;" name="threadAvatar" t-att-class="{ 'ms-2': !store.discuss.isSidebarCompact }">
-                    <img class="w-100 h-100 rounded-3 o_object_fit_cover shadow-sm" t-att-src="thread.avatarUrl" alt="Thread Image"/>
+                    <img class="w-100 h-100 rounded-3 o_object_fit_cover shadow-sm" t-att-class="threadAvatarAttClass" t-att-src="thread.avatarUrl" alt="Thread Image"/>
                     <ThreadIcon t-if="thread.channel_type?.includes('chat') or (thread.channel_type === 'channel' and !thread.group_public_id)" thread="thread" size="'small'" className="'o-mail-DiscussSidebarChannel-threadIcon position-absolute top-100 start-100 translate-middle mt-n1 ms-n1 d-flex align-items-center justify-content-center rounded-circle bg-inherit'"/>
                     <CountryFlag t-if="thread.showCorrespondentCountry" country="thread.correspondentCountry" class="'position-absolute o-mail-DiscussSidebarChannel-country border shadow-sm'"/>
                 </div>
-                <span t-if="!store.discuss.isSidebarCompact" class="o-mail-DiscussSidebarChannel-itemName mx-2 text-truncate" t-att-class="thread.selfMember?.message_unread_counter > 0 and !thread.isMuted ? 'o-unread fw-bolder' : 'text-muted'">
+                <span t-if="!store.discuss.isSidebarCompact" class="o-mail-DiscussSidebarChannel-itemName mx-2 text-truncate" t-att-class="itemNameAttClass">
                     <t t-esc="thread.displayName"/>
                 </span>
             </div>


### PR DESCRIPTION
Before this commit, seeing whether a livechat has ended, e.g. due to visitor leaving, required opening the conversation and seeing the "livechat has ended" where composer is shown.

This commit improves visibility of livechat that have ended by showing a checkered flag icon on avatar of livechat conversation that have ended. This icon is also shown on chat bubbles.

<img width="293" alt="Screenshot 2025-07-05 at 21 55 16" src="https://github.com/user-attachments/assets/5918fc19-9397-40c7-84ff-be34f6f8552d" />
