### PR TITLE
[FIX] website_sale : singleton error if two delivery line

### DIFF
--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -1839,7 +1839,7 @@ class WebsiteSale(payment_portal.PaymentPortal):
             'shipping_info_required': order._has_deliverable_products(),
             # Todo: remove in master
             'delivery_amount': payment_utils.to_minor_currency_units(
-                order.order_line.filtered(lambda l: l.is_delivery).price_total, order.currency_id
+                order.amount_total - order._compute_amount_total_without_delivery(), order.currency_id
             ),
             'shipping_address_update_route': self._express_checkout_delivery_route,
         })


### PR DESCRIPTION
Before this commit an error can appear if there two delivery line. Use method in delivery module to compute delivery amont. This method can compute if there are two line with delivery https://github.com/odoo/odoo/blob/18.0/addons/delivery/models/sale_order.py#L27

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
