### PR TITLE
[IMP] mail: improve mobile message actions

### DIFF
--- a/addons/mail/static/src/core/common/composer.xml
+++ b/addons/mail/static/src/core/common/composer.xml
@@ -65,7 +65,7 @@
                             'o-mail-Composer-inputStyle form-control border-0': true,
                             'ps-2': partitionedActions.other.length === 0
                         }"/>
-                        <textarea class="o-mail-Composer-input o-mail-Composer-bg shadow-none overflow-auto o-scrollbar-thin text-body"
+                        <textarea class="o-mail-Composer-input o-mail-Composer-bg shadow-none overflow-auto o-scrollbar-thin text-body user-select-auto"
                             t-att-class="inputClasses"
                             t-ref="textarea"
                             t-on-keydown="onKeydown"

--- a/addons/mail/static/src/core/common/message.js
+++ b/addons/mail/static/src/core/common/message.js
@@ -41,6 +41,7 @@ import { rpc } from "@web/core/network/rpc";
 import { MessageActionMenuMobile } from "./message_action_menu_mobile";
 import { discussComponentRegistry } from "./discuss_component_registry";
 import { NotificationMessage } from "./notification_message";
+import { useLongPress } from "@mail/utils/common/hooks";
 
 /**
  * @typedef {Object} Props
@@ -110,6 +111,12 @@ export class Message extends Component {
         /** @type {ShadowRoot} */
         this.shadowRoot;
         this.root = useRef("root");
+        if (isMobileOS()) {
+            useLongPress("root", {
+                action: () => this.openMobileActions(),
+                predicate: () => !this.isEditing,
+            });
+        }
         onWillUpdateProps((nextProps) => {
             this.props.registerMessageRef?.(this.props.message, null);
         });
@@ -215,6 +222,7 @@ export class Message extends Component {
 
     get attClass() {
         return {
+            "user-select-none": isMobileOS(),
             [this.props.className]: true,
             "o-card p-2 ps-1 mx-1 mt-1 mb-1 border border-dark shadow-sm rounded-3":
                 this.props.asCard,

--- a/addons/mail/static/src/core/common/message.js
+++ b/addons/mail/static/src/core/common/message.js
@@ -464,7 +464,10 @@ export class Message extends Component {
                 openReactionMenu: () => this.openReactionMenu(),
                 state: this.state,
             },
-            { context: this, onClose: () => (this.state.actionMenuMobileOpen = false) }
+            {
+                context: this,
+                onClose: () => (this.state.actionMenuMobileOpen = false),
+            }
         );
     }
 

--- a/addons/mail/static/src/core/common/message_action_menu_mobile.scss
+++ b/addons/mail/static/src/core/common/message_action_menu_mobile.scss
@@ -8,3 +8,8 @@
         border: none !important;
     }
 }
+
+.o_inactive_modal:has(.o-discuss-mobileContextMenu) {
+    // Avoid double modal backdrop
+    background-color: transparent;
+}

--- a/addons/mail/static/src/core/common/message_action_menu_mobile.xml
+++ b/addons/mail/static/src/core/common/message_action_menu_mobile.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <templates xml:space="preserve">
     <t t-name="mail.MessageActionMenuMobile">
-        <Dialog size="'lg'" header="false" footer="false" contentClass="'o-discuss-mobileContextMenu d-flex position-absolute bottom-0 rounded-0 h-50 bg-100'" modalRef="modalRef" withBodyPadding="false">
+        <Dialog size="'lg'" header="false" footer="false" contentClass="'o-discuss-mobileContextMenu d-flex position-absolute bottom-0 rounded-4 rounded-bottom-0 h-50 bg-100'" modalRef="modalRef" withBodyPadding="false">
             <div class="btn-group d-flex flex-column rounded-3 gap-1 p-3" t-on-click.stop="">
                 <t t-foreach="messageActions.actions.slice(quickActionCount)" t-as="action" t-key="action.id">
-                    <button class="btn px-3 py-3 d-flex align-items-center rounded-0 btn-group-item gap-3 user-select-none bg-200" t-att-class="{ 'rounded-top-3': action_first, 'rounded-bottom-3': action_last }" t-on-click="() => this.onClickAction(action)">
+                    <button class="btn px-3 py-3 d-flex align-items-center rounded-4 btn-group-item gap-3 user-select-none bg-200" t-on-click="() => this.onClickAction(action)">
                         <i class="fa-lg fa-fw fs-2" t-att-class="action.icon"/>
                         <span class="fs-4" t-esc="action.title"/>
                     </button>

--- a/addons/mail/static/src/core/common/message_actions.js
+++ b/addons/mail/static/src/core/common/message_actions.js
@@ -8,6 +8,7 @@ import { discussComponentRegistry } from "./discuss_component_registry";
 import { Deferred } from "@web/core/utils/concurrency";
 import { useEmojiPicker } from "@web/core/emoji_picker/emoji_picker";
 import { QuickReactionMenu } from "@mail/core/common/quick_reaction_menu";
+import { isMobileOS } from "@web/core/browser/feature_detection";
 
 const { DateTime } = luxon;
 
@@ -156,6 +157,13 @@ messageActionsRegistry
         onClick: (component) => component.onClickToggleTranslation(),
         sequence: 100,
     })
+    .add("copy-message", {
+        condition: (component) => isMobileOS() && !component.message.isBodyEmpty,
+        onClick: (component) => component.message.copyMessageText(),
+        title: _t("Copy to Clipboard"),
+        icon: "fa fa-copy",
+        sequence: 25,
+    })
     .add("copy-link", {
         condition: (component) =>
             component.message.message_type &&
@@ -196,9 +204,7 @@ function transformAction(component, id, action) {
         },
         /** Determines the order of this action (smaller first). */
         get sequence() {
-            return typeof action.sequence === "function"
-                ? action.sequence(component)
-                : action.sequence;
+            return messageActionsInternal.sequence(component, id, action);
         },
         /** Component setup to execute when this action is registered. */
         setup: action.setup,
@@ -208,6 +214,9 @@ function transformAction(component, id, action) {
 export const messageActionsInternal = {
     condition(component, id, action) {
         return action.condition(component);
+    },
+    sequence(component, id, action) {
+        return typeof action.sequence === "function" ? action.sequence(component) : action.sequence;
     },
 };
 

--- a/addons/mail/static/src/core/common/message_actions.js
+++ b/addons/mail/static/src/core/common/message_actions.js
@@ -85,6 +85,7 @@ messageActionsRegistry
         title: _t("View Reactions"),
         onClick: (component) => component.openReactionMenu(),
         sequence: 50,
+        mobileCloseAfterClick: false,
         dropdown: true,
     })
     .add("unfollow", {

--- a/addons/mail/static/src/core/common/message_model.js
+++ b/addons/mail/static/src/core/common/message_model.js
@@ -506,6 +506,19 @@ export class Message extends Record {
         this.store.env.services.notification.add(notification, { type });
     }
 
+    async copyMessageText() {
+        const messageBody = convertBrToLineBreak(this.body);
+        try {
+            await browser.navigator.clipboard.writeText(messageBody);
+        } catch {
+            this.store.env.services.notification.add(
+                _t("Message Copy Failed (Permission denied?)!"),
+                { type: "danger" }
+            );
+        }
+        this.store.env.services.notification.add(_t("Message Copied!"), { type: "info" });
+    }
+
     async edit(
         body,
         attachments = [],

--- a/addons/mail/static/src/core/common/message_reaction_menu.js
+++ b/addons/mail/static/src/core/common/message_reaction_menu.js
@@ -5,6 +5,7 @@ import { Component, onMounted, useEffect, useExternalListener, useRef, useState 
 
 import { Dialog } from "@web/core/dialog/dialog";
 import { useService } from "@web/core/utils/hooks";
+import { isMobileOS } from "@web/core/browser/feature_detection";
 
 export class MessageReactionMenu extends Component {
     static props = ["close", "message", "initialReaction?"];
@@ -58,5 +59,16 @@ export class MessageReactionMenu extends Component {
 
     getEmojiShortcode(reaction) {
         return this.store.emojiLoader.loaded?.emojiValueToShortcodes?.[reaction.content][0] ?? "?";
+    }
+
+    get contentClass() {
+        const attClass = {
+            "o-mail-MessageReactionMenu h-50 d-flex": true,
+            "position-absolute bottom-0": this.store.useMobileView,
+        };
+        return Object.entries(attClass)
+            .filter(([classNames, value]) => value)
+            .map(([classNames]) => classNames)
+            .join(" ");
     }
 }

--- a/addons/mail/static/src/core/common/message_reaction_menu.js
+++ b/addons/mail/static/src/core/common/message_reaction_menu.js
@@ -5,7 +5,6 @@ import { Component, onMounted, useEffect, useExternalListener, useRef, useState 
 
 import { Dialog } from "@web/core/dialog/dialog";
 import { useService } from "@web/core/utils/hooks";
-import { isMobileOS } from "@web/core/browser/feature_detection";
 
 export class MessageReactionMenu extends Component {
     static props = ["close", "message", "initialReaction?"];

--- a/addons/mail/static/src/core/common/message_reaction_menu.xml
+++ b/addons/mail/static/src/core/common/message_reaction_menu.xml
@@ -2,9 +2,9 @@
 <templates xml:space="preserve">
 
     <t t-name="mail.MessageReactionMenu">
-        <Dialog size="'md'" header="false" footer="false" contentClass="'o-mail-MessageReactionMenu h-50 d-flex'">
-            <div class="d-flex h-100" t-on-keydown="onKeydown" t-ref="root">
-                <div class="d-flex overflow-auto o-scrollbar-thin flex-column bg-100 p-2 h-100 border-end">
+        <Dialog size="'md'" header="false" footer="false" contentClass="contentClass">
+            <div class="d-flex h-100" t-on-keydown="onKeydown" t-att-class="{'flex-column': store.useMobileView}" t-ref="root">
+                <div class="d-flex overflow-auto o-scrollbar-thin bg-100 p-1 border-end" t-att-class="{'flex-column h-100 p-2': !store.useMobileView}">
                     <t t-foreach="props.message.reactions" t-as="reaction" t-key="reaction.content">
                         <button class="btn p-1 rounded-2 mx-2 py-0 d-flex align-items-center" t-att-class="{ 'bg-200 border-primary': reaction.eq(state.reaction) }" t-att-title="getEmojiShortcode(reaction)" t-on-click="() => state.reaction = reaction">
                             <span class="mx-1 fs-2" t-esc="reaction.content"/>

--- a/addons/mail/static/src/core/common/store_service.js
+++ b/addons/mail/static/src/core/common/store_service.js
@@ -14,6 +14,7 @@ import { session } from "@web/session";
 import { browser } from "@web/core/browser/browser";
 import { loader } from "@web/core/emoji_picker/emoji_picker";
 import { patch } from "@web/core/utils/patch";
+import { isMobileOS } from "@web/core/browser/feature_detection";
 
 /**
  * @typedef {{isSpecial: boolean, channel_types: string[], label: string, displayName: string, description: string}} SpecialMention
@@ -87,6 +88,11 @@ export class Store extends BaseStore {
      */
     inPublicPage = false;
     odoobot = fields.One("Persona");
+    useMobileView = fields.Attr(undefined, {
+        compute() {
+            return this.store.env.services.ui.isSmall || isMobileOS();
+        },
+    });
     users = {};
     /** @type {number} */
     internalUserGroupId;

--- a/addons/mail/static/src/utils/common/hooks.js
+++ b/addons/mail/static/src/utils/common/hooks.js
@@ -531,7 +531,6 @@ export function useLongPress(refName, { action, predicate = () => true } = {}) {
         clearTimeout(timer);
         timer = null;
     }
-
     useLazyExternalListener(
         () => ref.el,
         "touchstart",

--- a/addons/mail/static/src/utils/common/hooks.js
+++ b/addons/mail/static/src/utils/common/hooks.js
@@ -508,3 +508,61 @@ export const useMovable = makeDraggableHook({
         return { top, left };
     },
 });
+
+export const LONG_PRESS_DELAY = 400;
+
+/**
+ * Subscribes to long press events on the element matching the given ref name.
+ * It internally prevents false positives caused by scroll gestures.
+ *
+ * @param {string} refName The ref name of the element to listen for long presses on.
+ * @param {Object} options
+ * @param {() => void} [options.action] Function called when a long press is detected.
+ * @param {() => boolean} [options.predicate] Optional function to enable long press detection.
+ */
+export function useLongPress(refName, { action, predicate = () => true } = {}) {
+    const MOVE_TRESHOLD = 10;
+    const ref = useRef(refName);
+    let timer = null;
+    let startX = 0;
+    let startY = 0;
+
+    function reset() {
+        clearTimeout(timer);
+        timer = null;
+    }
+
+    useLazyExternalListener(
+        () => ref.el,
+        "touchstart",
+        (ev) => {
+            if (!predicate()) {
+                return;
+            }
+            const touch = ev.touches[0];
+            startX = touch.clientX;
+            startY = touch.clientY;
+            timer = setTimeout(() => {
+                action();
+                reset();
+            }, LONG_PRESS_DELAY);
+        }
+    );
+    useLazyExternalListener(
+        () => ref.el,
+        "touchmove",
+        (ev) => {
+            if (!timer) {
+                return;
+            }
+            const touch = ev.touches[0];
+            const dx = touch.screenX - startX;
+            const dy = touch.screenY - startY;
+            if (Math.hypot(dx, dy) > MOVE_TRESHOLD) {
+                reset();
+            }
+        }
+    );
+    useLazyExternalListener(() => ref.el, "touchend", reset);
+    useLazyExternalListener(() => ref.el, "touchcancel", reset);
+}

--- a/addons/mail/static/tests/message/message.test.js
+++ b/addons/mail/static/tests/message/message.test.js
@@ -14,9 +14,10 @@ import {
     startServer,
     triggerHotkey,
 } from "@mail/../tests/mail_test_helpers";
+import { LONG_PRESS_DELAY } from "@mail/utils/common/hooks";
 import { describe, expect, test } from "@odoo/hoot";
-import { animationFrame, leave, press, queryFirst } from "@odoo/hoot-dom";
-import { mockDate, mockTouch, mockUserAgent, tick } from "@odoo/hoot-mock";
+import { animationFrame, leave, pointerDown, press, queryFirst } from "@odoo/hoot-dom";
+import { advanceTime, mockDate, mockTouch, mockUserAgent, tick } from "@odoo/hoot-mock";
 import {
     asyncStep,
     contains as webContains,
@@ -144,7 +145,8 @@ test("Can add reaction to a message on an ipad", async () => {
     await start();
     await openDiscuss(channelId);
     await contains(".o-mail-Message");
-    await click(".o-mail-Message [title='Expand']");
+    await pointerDown(".o-mail-Message");
+    await advanceTime(LONG_PRESS_DELAY);
     await click("button:contains('Add a Reaction')");
     await click(".o-EmojiPicker-content .o-Emoji:contains('😀')");
     await contains(".o-mail-MessageReaction:contains('😀\n1')");


### PR DESCRIPTION
Backport of https://github.com/odoo/odoo/pull/217310

This PR improves several aspects of discuss on mobile devices:
- Long press to open message actions
- Fix background color issue when opening sub-menu from message actions
- Improve reaction menu position
- Add a copy action for messages

| - | Before  | After |
| -------------| ------------- | ------------- |
| Background |![background_ko](https://github.com/user-attachments/assets/ccb93865-3c09-491b-b408-e1fdba026139)| ![background_ok](https://github.com/user-attachments/assets/5c7ed8c0-5747-4430-8ca2-611bdf4823ce) |
| Reaction menu | ![reaction_menu_ko](https://github.com/user-attachments/assets/2d96d970-657d-43de-b5d7-bd1131b511cc) | ![reaction_menu_ok](https://github.com/user-attachments/assets/1018c250-3832-4d0e-8fdc-24c736f87508) |


