### PR TITLE
[IMP] l10n_ar_withholding: create payments on withholding tests.

### DIFF
--- a/addons/l10n_ar_withholding/tests/test_withholding_ar_ri.py
+++ b/addons/l10n_ar_withholding/tests/test_withholding_ar_ri.py
@@ -267,6 +267,7 @@ class TestL10nArWithholdingArRi(TestAr):
         wizard = self.new_payment_register(invoice, taxes)
         wizard.amount -= 2420
         self.assertEqual(wizard.l10n_ar_withholding_ids.amount, 1360)
+        wizard.action_create_payments()
 
     def test_08_earnings_withholding_applied_with_scale_and_minimun_withholdable_amount_set(self):
         """Payment with withholding tax type 'Earnings Scale' and minimun withholdable amount set. Verify withholding amount."""
@@ -281,6 +282,7 @@ class TestL10nArWithholdingArRi(TestAr):
         taxes = [{'id': invoice.partner_id.l10n_ar_partner_tax_ids.tax_id.id, 'base_amount': invoice.amount_untaxed}]
         wizard = self.new_payment_register(invoice, taxes)
         self.assertEqual(wizard.l10n_ar_withholding_ids.amount, 0.0)
+        wizard.action_create_payments()
 
     def test_09_foreign_invoice(self):
         """ Ensure a correct behavior when the invoice has a foreign currency and the payment not. """


### PR DESCRIPTION
It is neccesary to create payments on argentinean withholding tests to ensure that this pr https://github.com/odoo/enterprise/pull/86648 works correctly because there are being reused l10n_ar_withholding tests to verify SICORE export functionality and it is needed to have testing payments with sicore profits withholdings posted when running those tests.

Task latam: 1265
Task Adhoc side: 51853

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
