### PR TITLE
[FIX] mrp: can't pause all work order at once

### DIFF
--- a/addons/mrp/views/mrp_workorder_views.xml
+++ b/addons/mrp/views/mrp_workorder_views.xml
@@ -64,7 +64,7 @@
             <tree editable="bottom" multi_edit="1">
                 <header>
                     <button name="button_start" type="object" string="Start" class="btn btn-success text-uppercase"/>
-                    <button name="button_pending" type="object" string="Pause" class="btn btn-warning text-uppercase"/>
+                    <button name="end_all" type="object" string="Pause" class="btn btn-warning text-uppercase"/>
                     <button name="action_mark_as_done" type="object" string="Done" class="btn btn-danger text-uppercase"/>
                 </header>
                 <field name="consumption" column_invisible="True"/>


### PR DESCRIPTION
* STEP TO REPRODUCE: go to work order list view, start some WO and then select some of them to Pause all but only one work order pause at a time

* Fix by using correct method in header of list view, use end_all method

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
