### PR TITLE
[FIX] mail: remove unused user settings mute

### DIFF
--- a/addons/mail/data/ir_cron_data.xml
+++ b/addons/mail/data/ir_cron_data.xml
@@ -84,14 +84,5 @@
             <field name="code">model._cleanup_expired_mutes()</field>
             <field name="state">code</field>
         </record>
-
-        <record id="ir_cron_discuss_users_settings_unmute" model="ir.cron">
-            <field name="name">Discuss: users settings unmute</field>
-            <field name="interval_number">1</field>
-            <field name="interval_type">days</field>
-            <field name="model_id" ref="model_res_users_settings"/>
-            <field name="code">model._cleanup_expired_mutes()</field>
-            <field name="state">code</field>
-        </record>
     </data>
 </odoo>

--- a/addons/mail/models/res_users_settings.py
+++ b/addons/mail/models/res_users_settings.py
@@ -21,7 +21,6 @@ class ResUsersSettings(models.Model):
         "Channel Notifications",
         help="This setting will only be applied to channels. Mentions only if not specified.",
     )
-    mute_until_dt = fields.Datetime(string="Mute notifications until", index=True, help="If set, the user will not receive notifications from all the channels until this date.")
 
     @api.model
     def _format_settings(self, fields_to_format):

--- a/addons/test_discuss_full/tests/test_performance.py
+++ b/addons/test_discuss_full/tests/test_performance.py
@@ -432,7 +432,6 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
                 "self_partner": {"id": self.users[0].partner_id.id, "type": "partner"},
                 "settings": {
                     "channel_notifications": False,
-                    "mute_until_dt": False,
                     "id": self.env["res.users.settings"]._find_or_create_for_user(self.users[0]).id,
                     "is_discuss_sidebar_category_channel_open": True,
                     "is_discuss_sidebar_category_chat_open": True,


### PR DESCRIPTION
upgrade PR: https://github.com/odoo/upgrade/pull/8018

This commit removes the `mute_until_dt` field of `ResUsersSettings` after it was replaced by busy behavior by https://github.com/odoo/odoo/pull/215866.

This commit also removes the cron job that called a method removed in said PR.
