### PR TITLE
[IMP] website: reduce s_intro_pill textbox

### DIFF
--- a/addons/website/views/snippets/s_intro_pill.xml
+++ b/addons/website/views/snippets/s_intro_pill.xml
@@ -5,11 +5,11 @@
     <section class="s_intro_pill pt40 pb40">
         <div class="container-fluid">
             <div class="row o_grid_mode" data-row-count="11">
-                <div class="o_grid_item oe_img_bg o_grid_item_image g-col-lg-5 g-height-9 col-lg-5 order-lg-0" style="order: 2; z-index: 1; grid-area: 1 / 1 / 10 / 6; --grid-item-padding-y: 0px; --grid-item-padding-x: 0px;">
+                <div class="o_grid_item oe_img_bg o_grid_item_image g-col-lg-5 g-height-9 col-lg-5 order-lg-0" style="order: 2; z-index: 1; grid-area: 1 / 1 / 10 / 5; --grid-item-padding-y: 0px; --grid-item-padding-x: 0px;">
                     <img class="img-fluid mx-auto" data-shape="web_editor/geometric_round/geo_round_pill" data-file-name="s_intro_pill_default_image.jpg"
                     data-original-mimetype="image/jpeg" src="/web_editor/image_shape/website.s_intro_pill_default_image/web_editor/geometric_round/geo_round_pill.svg" alt=""/>
                 </div>
-                <div class="o_grid_item g-height-11 g-col-lg-8 col-lg-8 order-lg-0" data-name="Box" style="order: 1; z-index: 3; grid-area: 1 / 3 / 12 / 11; --grid-item-padding-y: 120px;">
+                <div class="o_grid_item g-height-11 g-col-lg-8 col-lg-8 order-lg-0" data-name="Box" style="order: 1; z-index: 3; grid-area: 1 / 4 / 12 / 10; --grid-item-padding-y: 120px;">
                     <h1 class="display-3" style="text-align: center;">Experience the<br/>best quality services</h1>
                     <p>
                         <br/>
@@ -18,7 +18,7 @@
                         <a t-att-href="cta_btn_href" class="btn btn-lg btn-primary o_translate_inline">Get Started</a>
                     </p>
                 </div>
-                <div class="o_grid_item o_grid_item_image g-col-lg-5 g-height-10 d-none d-lg-block col-lg-5 order-lg-0" style="order: 3; z-index: 2; grid-area: 2 / 8 / 12 / 13; --grid-item-padding-y: 0px; --grid-item-padding-x: 0px;">
+                <div class="o_grid_item o_grid_item_image g-col-lg-5 g-height-10 d-none d-lg-block col-lg-5 order-lg-0" style="order: 3; z-index: 2; grid-area: 2 / 9 / 12 / 13; --grid-item-padding-y: 0px; --grid-item-padding-x: 0px;">
                     <img class="img-fluid mx-auto" data-shape="web_editor/geometric_round/geo_round_pill" data-file-name="s_intro_pill_default_image_2.webp" data-original-mimetype="image/webp" src="/web_editor/image_shape/website.s_intro_pill_default_image_2/web_editor/geometric_round/geo_round_pill.svg" alt=""/>
                 </div>
             </div>


### PR DESCRIPTION
Currently `s_intro_pill`'s textbox's width makes hard for users to replace image as the textbox covers the image. This commit reduces the width of the textbox and both images to make it easier for users to replace the image.

task-4914513

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
