### PR TITLE
[FIX] mail: correct domain for filtering templates in email composer

### DIFF
--- a/addons/mail/static/src/core/web/mail_composer_template_selector.js
+++ b/addons/mail/static/src/core/web/mail_composer_template_selector.js
@@ -37,7 +37,7 @@ export class MailComposerTemplateSelector extends Component {
         if (templates.length < this.limit) {
             templates.push(...await this.orm.searchRead("mail.template", [
                 ["model", "=", this.props.record.data.render_model],
-                ["user_id", "!=", user.userId]
+                ["user_id", "=", false]
             ], fields, { limit: this.limit - templates.length }));
         }
         this.state.templates = templates;

--- a/addons/mail/static/tests/tours/mail_composer_test_tour.js
+++ b/addons/mail/static/tests/tours/mail_composer_test_tour.js
@@ -122,6 +122,17 @@ registry.category("web_tour.tours").add("mail/static/tests/tours/mail_composer_t
                 '.mail-composer-template-dropdown.popover .o-dropdown-item:contains("Test template")',
         },
         {
+            content: "Verify admin template is NOT listed",
+            trigger: ".mail-composer-template-dropdown.popover",
+            run() {
+                const hasAdminTemplate = [...document.querySelectorAll('.o-dropdown-item')]
+                    .some(item => item.textContent.includes("Test template for admin"));
+                if (hasAdminTemplate) {
+                    console.error("Template assigned to the admin is visible to a non-assigned user! This should not happen.");
+                }
+            },
+        },
+        {
             content: "Send message from full composer",
             trigger: ".o_mail_send",
             run: "click",

--- a/addons/mail/tests/test_mail_composer.py
+++ b/addons/mail/tests/test_mail_composer.py
@@ -265,13 +265,25 @@ class TestMailComposerRendering(TestMailComposer):
 class TestMailComposerUI(MailCommon, HttpCase):
 
     def test_mail_composer_test_tour(self):
-        self.env['mail.template'].create({
-            'auto_delete': True,
-            'lang': '{{ object.lang }}',
-            'model_id': self.env['ir.model']._get_id('res.partner'),
-            'name': 'Test template',
-            'partner_to': '{{ object.id }}',
-        })
+        template_data = [
+            {
+                'name': 'Test template',
+                'partner_to': '{{ object.id }}',
+            },
+            {
+                'name': 'Test template for admin',
+                'user_id': self.env.ref('base.user_admin').id,
+            },
+        ]
+        self.env['mail.template'].create([
+            {
+                **data,
+                'auto_delete': True,
+                'lang': '{{ object.lang }}',
+                'model_id': self.env['ir.model']._get_id('res.partner'),
+            }
+            for data in template_data
+        ])
         self.user_employee.write({
             'groups_id': [(4, self.env.ref('base.group_partner_manager').id)],
         })


### PR DESCRIPTION
**Steps to reproduce:**
1. Install Sales.
2. Create an email template for the 'sale.order' model and assign it to the admin user under the settings page in the 'User' field.
3. Log in as the demo user.
4. Create a quotation and click the 'Send by Email' button.
5. In the wizard, click the three dots between the attachment and AI logo in the footer.
6. Observe the templates list.

**Issue:**
  - The template created for the admin user appears for the demo user as well.

**Cause:**
https://github.com/odoo/odoo/blob/07626050bd0104fecd8799b56d30245d00da3f27/addons/mail/static/src/core/web/mail_composer_template_selector.js#L31-L44
 - The domain used to fetch templates was incorrectly filtering for templates
  assigned to any user (instead of filtering for templates assigned to
  the current user or not assigned at all).

**Solution:**
 - Corrected the domain to include only templates assigned to
  the current user and not assigned to anyone.

opw-4901492