### PR TITLE
[FIX] pos_self_order: hide categories that contain only special products

### DIFF
--- a/addons/pos_self_order/static/tests/tours/self_order_mobile_tour.js
+++ b/addons/pos_self_order/static/tests/tours/self_order_mobile_tour.js
@@ -269,3 +269,23 @@ registry.category("web_tour.tours").add("SelfOrderOrderNumberTour", {
         Utils.checkIsNoBtn("Ok"),
     ],
 });
+
+registry.category("web_tour.tours").add("self_order_mobile_special_products_category", {
+    steps: () => [
+        Utils.checkIsNoBtn("My Order"),
+        Utils.clickBtn("Order Now"),
+        LandingPage.selectLocation("Test-Takeout"),
+        {
+            content: "Category 'Miscellaneous' is displayed",
+            trigger: ".category-name:contains('Miscellaneous')",
+        },
+        {
+            content: "Category 'Specials' is not displayed",
+            trigger: ".category-name:not(:contains('Specials'))",
+        },
+        {
+            content: "Product 'Special 1' is not displayed",
+            trigger: ".self_order_product_card:not(:contains('Special 1'))",
+        },
+    ],
+});


### PR DESCRIPTION
Steps to reproduce:
- Install the pos_black_box_be module.
- Configure a Belgian restaurant and enable self-ordering.
- Open the self-ordering page.
- The category 'Fiscal category' is displayed even though it does not contain any products.

This commit ensures that categories containing only special products (which are not displayed) will no longer appear on the self-ordering page.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
