### PR TITLE
[IMP] hr_holidays: add option to allow mass approval refusal

### DIFF
--- a/addons/hr_holidays/static/src/views/list/holidays_list_controller.js
+++ b/addons/hr_holidays/static/src/views/list/holidays_list_controller.js
@@ -2,59 +2,89 @@ import { useService } from "@web/core/utils/hooks";
 import { registry } from '@web/core/registry';
 import { listView } from '@web/views/list/list_view';
 import { ListController } from "@web/views/list/list_controller";
-import { _t } from "@web/core/l10n/translation";
+import { useSubEnv } from "@odoo/owl";
 
 export class HolidaysListController extends ListController {
+    static template = "hr_holidays.HolidaysListView";
+
     setup() {
         super.setup();
         this.orm = useService("orm");
-    }
 
-    getStaticActionMenuItems() {
-        const menuItems = super.getStaticActionMenuItems();
+        // Store reference to original button click handler for fallback
+        this.onClickViewButton = this.env.onClickViewButton;
 
-        if (this.model.root.selection.every((record) => record.data.can_approve)) {
-            menuItems.approve = {
-                isAvailable: () => { return true;},
-                sequence: 50,
-                description: _t('Approve'),
-                callback: async () => await this.launchAction('action_approve'),
-            };
-        }
-
-        if (this.model.root.selection.every((record) => record.data.can_validate)) {
-            menuItems.validate = {
-                isAvailable: () => { return true; },
-                sequence: 60,
-                description: _t('Validate'),
-                callback: async () => await this.launchAction('action_approve'),
-            };
-        }
-
-        if (this.model.root.selection.every((record) => record.data.can_refuse)) {
-            menuItems.refuse = {
-                sequence: 70,
-                description: _t('Refuse'),
-                callback: async () => await this.launchAction('action_refuse'),
-            };
-        }
-
-        return menuItems;
-    }
-
-    async launchAction(functionName) {
-        await this.orm.call(
-            this.props.resModel,
-            functionName,
-            [this.model.root.selection.map((a) => a.resId)],
-        );
-        await this.actionService.doAction({
-            'type': 'ir.actions.client',
-            'tag': 'soft_reload',
+        useSubEnv({
+            onClickViewButton: (params) => this.handleViewButtonClick(params),
         });
     }
 
+    /**
+     * Returns permission filters for holiday/leave actions.
+     * Each filter checks if a record has the required permissions for the specific action.
+     */
+    get actionFilters() {
+        return {
+            action_approve: (record) => record.data.can_approve || record.data.can_validate,
+            action_refuse: (record) => record.data.can_refuse,
+        };
+    }
+
+    /**
+     * Intercepts button clicks to apply permission-based filtering for holiday actions.
+     * For approve/refuse actions, only processes records that have the required permissions.
+     * Falls back to original handler if no eligible records or for other actions.
+     *
+     * @param {Object} params - Button click parameters containing action details
+     */
+    handleViewButtonClick(params) {
+        const actionName = params.clickParams.name;
+        const filter = this.actionFilters[actionName];
+        if (filter) {
+            const eligibleRecords = this.model.root.selection.filter(filter);
+            if (eligibleRecords.length) {
+                this.executeAction(actionName, eligibleRecords);
+            } else {
+                this.onClickViewButton(params);
+            }
+        }
+    }
+
+    /**
+     * Determines whether a button should be displayed based on current selection and permissions.
+     * Only shows approve/refuse buttons if at least one selected record has the required permissions.
+     *
+     * @param {Object} button - Button configuration object
+     * @returns {boolean} True if button should be displayed
+     */
+    displayButton(button) {
+        const { selection } = this.model.root;
+        if (!selection.length) {
+            return false;
+        }
+        const filter = this.actionFilters[button.clickParams.name];
+        return filter ? selection.some(filter) : false;
+    }
+
+    /**
+     * Executes an action (approve/refuse) on the specified records and refreshes the view.
+     *
+     * @param {string} functionName - Name of the backend method to call
+     * @param {Array} records - Array of record objects to process
+     */
+    async executeAction(functionName, records) {
+        await this.orm.call(
+            this.props.resModel,
+            functionName,
+            [records.map((record) => record.resId)],
+        );
+        await this.actionService.doAction({
+            type: "ir.actions.client",
+            tag: "soft_reload",
+        });
+    }
 }
+
 export const holidaysListView = {
     ...listView,
     Controller: HolidaysListController,

--- a/addons/hr_holidays/static/src/views/list/holidays_list_controller.xml
+++ b/addons/hr_holidays/static/src/views/list/holidays_list_controller.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates>
+    <t t-name="hr_holidays.HolidaysListView" t-inherit="web.ListView" t-inherit-mode="primary">
+        <xpath expr="//t[@t-set-slot='control-panel-selection-actions']//MultiRecordViewButton" position="attributes">
+            <attribute name="t-if">displayButton(button)</attribute>
+        </xpath>
+    </t>
+</templates>

--- a/addons/hr_holidays/views/hr_leave_allocation_views.xml
+++ b/addons/hr_holidays/views/hr_leave_allocation_views.xml
@@ -288,6 +288,18 @@
                         string="New Group Allocation" class="btn btn-secondary"
                         groups="hr_holidays.group_hr_holidays_responsible" display="always"
                     />
+                    <button type="object"
+                        name="action_approve"
+                        string="Approve"
+                        icon="fa-thumbs-up"
+                        class="btn btn-outline-success"
+                    />
+                    <button type="object"
+                        name="action_refuse"
+                        string="Refuse"
+                        icon="fa-times"
+                        class="btn btn-outline-danger"
+                    />
                 </header>
                 <field name="employee_id" decoration-muted="not active_employee" widget="many2one_avatar_employee" readonly="state in ['refuse', 'validate']"/>
                 <field name="department_id" optional="hide" readonly="state not in ['confirm']"/>
@@ -586,18 +598,6 @@
             </p><p>
                 You can create a new allocation or follow the approval status of the current ones.
             </p>
-        </field>
-    </record>
-
-    <record id="ir_actions_server_approve_allocations" model="ir.actions.server">
-        <field name="name">Approve Allocations</field>
-        <field name="model_id" ref="hr_holidays.model_hr_leave_allocation"/>
-        <field name="binding_model_id" ref="hr_holidays.model_hr_leave_allocation"/>
-        <field name="binding_view_types">list,kanban</field>
-        <field name="state">code</field>
-        <field name="code">
-            if records:
-                records.action_approve()
         </field>
     </record>
 </odoo>

--- a/addons/hr_holidays/views/hr_leave_views.xml
+++ b/addons/hr_holidays/views/hr_leave_views.xml
@@ -544,6 +544,18 @@
                         string="New Group Time Off" class="btn btn-secondary"
                         groups="hr_holidays.group_hr_holidays_responsible" display="always"
                     />
+                    <button type="object"
+                        name="action_approve"
+                        string="Approve"
+                        icon="fa-thumbs-up"
+                        class="btn btn-outline-success"
+                    />
+                    <button type="object"
+                        name="action_refuse"
+                        string="Refuse"
+                        icon="fa-times"
+                        class="btn btn-outline-danger"
+                    />
                 </header>
                 <field name="employee_id" widget="many2one_avatar_employee" readonly="state in ['cancel', 'refuse', 'validate', 'validate1']" />
                 <field name="department_id" optional="hidden" readonly="state in ['cancel', 'refuse', 'validate', 'validate1']"/>


### PR DESCRIPTION
Before:
- Mass approval/refusal actions were only accessible via the "Actions" dropdown in the list view.
- No direct buttons were available in the list view header, making the workflow slower.

After:
- Added "Approve" and "Refuse" buttons to the header of the list view for easier bulk actions.
- Removed the actions from the Actions dropdown, as the new buttons serve the same purpose.
- Buttons are now conditionally displayed based on the selected records:
  - If all selected records are in "to approve" status → show both buttons.
  - If all selected records are in "approved" status → show only Refuse button.
  - If all selected records are in "refused" status → show only Approve button.
  - If selected records are mixed → show both buttons.

Task-4885573