### PR TITLE
[FIX] website: fix customizeWebsiteColor test

### DIFF
--- a/addons/website/static/tests/builder/website_builder/customize_website_color.test.js
+++ b/addons/website/static/tests/builder/website_builder/customize_website_color.test.js
@@ -1,5 +1,5 @@
 import { expect, test } from "@odoo/hoot";
-import { animationFrame, Deferred } from "@odoo/hoot-dom";
+import { animationFrame, Deferred, tick } from "@odoo/hoot-dom";
 import { xml } from "@odoo/owl";
 import { contains, defineModels, models, onRpc } from "@web/../tests/web_test_helpers";
 import { addOption, defineWebsiteModels, setupWebsiteBuilder } from "../website_helpers";
@@ -7,6 +7,7 @@ import { addOption, defineWebsiteModels, setupWebsiteBuilder } from "../website_
 defineWebsiteModels();
 
 test("BuilderColorPicker with action “customizeWebsiteColor” is correctly displayed", async () => {
+
     class WebEditorAssets extends models.Model {
         _name = "web_editor.assets";
         make_scss_customization(location, changes) {
@@ -48,7 +49,8 @@ test("BuilderColorPicker with action “customizeWebsiteColor” is correctly di
     expect.step("set preset");
     await contains("button.o_we_color_preview").click();
     await contains("button[data-color='o_cc4'").click();
-    await animationFrame();
+    await tick(); // customizeWebsiteColors
+    await tick(); // reloadBundles
     expect.verifySteps([
         "set preset",
         '/website/static/src/scss/options/colors/user_color_palette.scss {"test":4}',
@@ -60,7 +62,8 @@ test("BuilderColorPicker with action “customizeWebsiteColor” is correctly di
     await contains("button.o_we_color_preview").click();
     await contains("button.custom-tab").click();
     await contains("button[data-color='400']").click();
-    await animationFrame();
+    await tick(); // customizeWebsiteColors
+    await tick(); // reloadBundles
     expect.verifySteps([
         "set solid color",
         '/website/static/src/scss/options/colors/user_color_palette.scss {"test-custom":"#CED4DA"}',
@@ -72,7 +75,8 @@ test("BuilderColorPicker with action “customizeWebsiteColor” is correctly di
     expect.step("set preset on solid color");
     await contains("button.o_we_color_preview").click();
     await contains("button[data-color='o_cc3'").click();
-    await animationFrame();
+    await tick(); // customizeWebsiteColors
+    await tick(); // reloadBundles
     expect.verifySteps([
         "set preset on solid color",
         '/website/static/src/scss/options/colors/user_color_palette.scss {"test":3}',
@@ -84,7 +88,9 @@ test("BuilderColorPicker with action “customizeWebsiteColor” is correctly di
     await contains("button.o_we_color_preview").click();
     await contains("button.gradient-tab").click();
     await contains("button.o_gradient_color_button").click();
-    await animationFrame();
+    await tick(); // customizeWebsiteColors
+    await tick(); // customizeWebsiteVariables
+    await tick(); // reloadBundles
     expect.verifySteps([
         "set gradient",
         '/website/static/src/scss/options/colors/user_color_palette.scss {"test-custom":"NULL"}',
@@ -96,7 +102,8 @@ test("BuilderColorPicker with action “customizeWebsiteColor” is correctly di
     expect.step("set preset on gradient");
     await contains("button.o_we_color_preview").click();
     await contains("button[data-color='o_cc4'").click();
-    await animationFrame();
+    await tick(); // customizeWebsiteColors
+    await tick(); // reloadBundles
     expect.verifySteps([
         "set preset on gradient",
         '/website/static/src/scss/options/colors/user_color_palette.scss {"test":4}',
@@ -107,7 +114,9 @@ test("BuilderColorPicker with action “customizeWebsiteColor” is correctly di
     expect.step("reset");
     await contains("button.o_we_color_preview").click();
     await contains(".o_font_color_selector .fa-trash").click();
-    await animationFrame();
+    await tick(); // customizeWebsiteColors
+    await tick(); // customizeWebsiteVariables
+    await tick(); // reloadBundles
     expect.verifySteps([
         "reset",
         '/website/static/src/scss/options/colors/user_color_palette.scss {"test-custom":"NULL","test":"NULL"}',


### PR DESCRIPTION
Waiting an animationFrame after each click (fix done in [1]) was not
sufficient, we actually need to wait for 2 or 3 separate ticks depending
on the case, because `customizeWebsiteColors` calls between 2 and 3
debounced functions (`debouncedSCSSColorsCusto`, possibly
`debouncedSCSSVariablesCusto`, and finally `reloadBundles`) with a 0-ms
delay.

[1]: https://github.com/odoo/odoo/commit/cbcd1b142e2a1c6a245fa8a993ecc8ebd72eece4

runbot-229604
runbot-229686