### PR TITLE
[FIX] mail: handle sql errors during execution of mail queue cron

### DIFF
--- a/addons/mail/models/mail_mail.py
+++ b/addons/mail/models/mail_mail.py
@@ -724,6 +724,9 @@ class MailMail(models.Model):
                     mail.id, mail.message_id)
                 # mail status will stay on ongoing since transaction will be rollback
                 raise
+            except (psycopg2.errors.InFailedSqlTransaction, psycopg2.errors.SerializationFailure) as e:
+                _logger.warning("Mail could not be sent due to follow error: \n%s", str(e))
+                self.env.cr.rollback()
             except (psycopg2.Error, smtplib.SMTPServerDisconnected):
                 # If an error with the database or SMTP session occurs, chances are that the cursor
                 # or SMTP session are unusable, causing further errors when trying to save the state.
@@ -772,6 +775,9 @@ class MailMail(models.Model):
                     raise
 
             if auto_commit is True:
-                self._cr.commit()
+                try:
+                    self._cr.commit()
+                except psycopg2.errors.SerializationFailure as e:
+                    _logger.warning(str(e))
             mail.invalidate_recordset(['body_html'])
         return True


### PR DESCRIPTION
SQL errors can occur during the mail queue cron, often from concurrent updates. These are normally handled during manual mail processing.But they may be missed when running via cron.
The scenario below can trigger this error, though it’s **not the only situation in which it occurs**.

**Steps to replicate:**
* Install `mass_mailing`
* `mass_mailing` > Mailing Lists > Imported Contacts > Import [Contacts](https://docs.google.com/spreadsheets/d/1SWbca3rNodYYOs_1tlVF88Bl7nkSs1Rr/edit?usp=sharing&ouid=102312580340639170507&rtpof=true&sd=true)
* Mailing Lists > Newsletter Send Mailing > Choose template and subject > Send
* Run scheduled action/cron: `Mail: Email Queue Manager`
* Go to Technical>Email>Emails
* Filter all outgoing emails and cancel them quickly while cron is running.

`InFailedSqlTransaction: current transaction is aborted, commands ignored until
 end of transaction block`

**Solution**:
* Catch the error and log a warning using the logger.

**Sentry-6375128449**