### PR TITLE
[FIX] purchase_stock: zero out sufficiently small price unit diff

### DIFF
--- a/addons/purchase_stock/models/account_move_line.py
+++ b/addons/purchase_stock/models/account_move_line.py
@@ -242,6 +242,13 @@ class AccountMoveLine(models.Model):
         aml_price_unit = aml.product_uom_id._compute_price(aml_price_unit, self.product_id.uom_id)
 
         unit_valuation_difference = aml_price_unit - layer_price_unit
+        precision_digits = max(
+            aml.currency_id.decimal_places,
+            layer.currency_id.decimal_places,
+            self.env['decimal.precision'].precision_get('Product Price'),
+        )
+        if float_is_zero(unit_valuation_difference, precision_digits=precision_digits):
+            unit_valuation_difference = 0
 
         # Generate the AML values for the already out quantities
         # convert from company currency to aml currency

--- a/addons/purchase_stock/tests/test_anglo_saxon_valuation_reconciliation.py
+++ b/addons/purchase_stock/tests/test_anglo_saxon_valuation_reconciliation.py
@@ -712,3 +712,36 @@ class TestValuationReconciliation(ValuationReconciliationTestCommon):
                 {'journal_id': stock_journal_id,    'balance':  -1.79},
             ],
         )
+
+    def test_currency_exchange_and_modified_product_price_precision_valuation_items(self):
+        """ Small price unit diff with sufficiently large quantity -> problematic correction SVL"""
+        euro = self.env.ref('base.EUR')
+        euro.active = True
+        self.env['decimal.precision'].search([('name', '=', 'Product Price')]).digits = 3
+        self.env['res.currency.rate'].create({
+            'name': fields.Date.today(),
+            'rate': 0.2710027100271003,
+            'currency_id': euro.id,
+            'company_id': self.env.company.id,
+        })
+        avco_product = self.test_product_delivery
+        avco_product.categ_id.property_cost_method = 'average'
+        avco_product.standard_price = 0.875
+        purchase_order = self.env['purchase.order'].create({
+            'partner_id': self.partner_a.id,
+            'currency_id': euro.id,
+            'order_line': [Command.create({
+                'product_id': avco_product.id,
+                'price_unit': 0.237,
+                'product_qty': 5500,
+            })],
+        })
+        purchase_order.button_confirm()
+        receipt = purchase_order.picking_ids
+        receipt.button_validate()
+        purchase_order.action_create_invoice()
+        bill = purchase_order.invoice_ids
+        bill.invoice_date = fields.Date.today()
+        bill.action_post()
+        svls = self.env['stock.valuation.layer'].search([])
+        self.assertRecordValues(svls, [{'value': 4809.92, 'remaining_value': 4809.92, 'unit_cost': 0.875}])


### PR DESCRIPTION
**Current behavior:**
Modifying the "Product Price" global precision and purchasing some product in a foreign currency sometimes leads to problematic SVL creation, which will make a posted vendor bill unable to be reset to draft when it logically should be permitted.

**Expected behavior:**
No SVL, can reset vendor bill.

**Steps to reproduce:**
1. Activate a foreign currency, set the "Product Price" precision from 2 -> 3, make an exchange rate to the foreign currency with a rate: `0.2710027100271003`

2. Make a product with avg costing, real time valuation, with a standard price = `0.875`

3. Create a purchase order in the foreign currency for the avco product:
* `price_unit: 0.237`
* `product_qty: 5500`

4. Confirm -> receive -> create invoice -> post
* Can't reset the bill to draft
* There is an additional SVL that shouldn't have been generated

**Cause of the issue:**
There will be a negligible rounding diff between the price units of the journal item and SVL created on reception. When the invoice is posted, this will captured and when multiplied by a large enough invoicing qty, will create a large enough value to trigger creation of pdiff SVL.

**Fix:**
Zero out the price unit difference if it is functionally equivalent to zero when rounded according to the maximally precise "precision record" involved in the sequence, that is:

A) The bill currency
B) The SVL currency
C) The "Product Price" global precision value

opw-4873246