### PR TITLE
[FIX] website: prevent duplicate content by disabling owl-component edit

### DIFF
--- a/addons/website/static/src/components/wysiwyg_adapter/wysiwyg_adapter.js
+++ b/addons/website/static/src/components/wysiwyg_adapter/wysiwyg_adapter.js
@@ -371,7 +371,7 @@ export class WysiwygAdapterComponent extends Wysiwyg {
             .not('[data-oe-readonly]')
             .not('img[data-oe-field="arch"], br[data-oe-field="arch"], input[data-oe-field="arch"]')
             .not('.oe_snippet_editor')
-            .not('hr, br, input, textarea')
+            .not('hr, br, input, textarea, owl-component')
             .not('[data-oe-sanitize-prevent-edition]')
             .add('.o_editable');
     }
@@ -541,7 +541,7 @@ export class WysiwygAdapterComponent extends Wysiwyg {
                 // Mark any savable element dirty if any tracked mutation occurs
                 // inside of it.
                 $savable.not('.o_dirty').each(function () {
-                    if (!this.hasAttribute('data-oe-readonly')) {
+                    if (this.tagName !== 'OWL-COMPONENT' && !this.hasAttribute('data-oe-readonly')) {
                         this.classList.add('o_dirty');
                     }
                 });
@@ -608,7 +608,7 @@ export class WysiwygAdapterComponent extends Wysiwyg {
     _getContentEditableAreas() {
         const $savableZones = $(this.websiteService.pageDocument).find(this.savableSelector);
         const $editableSavableZones = $savableZones
-            .not('input, [data-oe-readonly], ' +
+            .not('input, [data-oe-readonly], owl-component, ' +
                  '[data-oe-type="monetary"], [data-oe-many2one-id], [data-oe-field="arch"]:empty')
             .filter((_, el) => {
                 // The whole record cover is considered editable by the editor,


### PR DESCRIPTION
Problem:
Making `owl-component` editable causes issues. Upon saving, its content gets duplicated because the saved DOM includes both the rendered and injected content.

Solution:
Mark `owl-component` as non-editable to prevent modification and avoid content duplication.

Steps to reproduce:
1. Navigate to Sales → Open a quotation that requires signature
2. Go to Website preview
3. Click "Sign & Pay"
4. Open Web Editor
5. Save. → A duplicate, non-functional signature box appears

opw-4749129

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
