### PR TITLE
[FIX] web: increase test_unit_desktop suite timeout

### DIFF
--- a/addons/web/tests/test_js.py
+++ b/addons/web/tests/test_js.py
@@ -145,7 +145,7 @@ class WebSuite(QunitCommon, HOOTCommon):
     @odoo.tests.no_retry
     def test_unit_desktop(self):
         # Unit tests suite (desktop)
-        self.browser_js(f'/web/tests?headless&loglevel=2&preset=desktop&timeout=15000{self.hoot_filters}', "", "", login='admin', timeout=2100, success_signal="[HOOT] test suite succeeded", error_checker=unit_test_error_checker)
+        self.browser_js(f'/web/tests?headless&loglevel=2&preset=desktop&timeout=15000{self.hoot_filters}', "", "", login='admin', timeout=2400, success_signal="[HOOT] test suite succeeded", error_checker=unit_test_error_checker)
 
     @odoo.tests.no_retry
     def test_hoot(self):


### PR DESCRIPTION
The number of tests in the hoot suite keeps increasing, and we're close to the timeout for the desktop suite. Depending on the CPU load, it happens that the suite timeout. This commit thus shifts it up to 40 minutes.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
