### PR TITLE
[REF] hr_holidays: changing the way accruals days are computed

### DIFF
--- a/addons/hr_holidays/data/ir_cron_data.xml
+++ b/addons/hr_holidays/data/ir_cron_data.xml
@@ -5,7 +5,7 @@
         <field name="name">Accrual Time Off: Updates the number of time off</field>
         <field name="model_id" ref="model_hr_leave_allocation"/>
         <field name="state">code</field>
-        <field name="code">model._update_accrual()</field>
+        <field name="code">model._get_to_update_accrual_allocations()._update_accrual()</field>
         <field name="interval_number">1</field>
         <field name="interval_type">days</field>
     </record>

--- a/addons/hr_holidays/models/hr_employee.py
+++ b/addons/hr_holidays/models/hr_employee.py
@@ -533,11 +533,10 @@ class HrEmployee(models.Model):
             return self.browse(ctx.get('default_employee_id'))
         return self.env.user.employee_id
 
-    def _get_consumed_leaves(self, work_entry_types, target_date=False, ignore_future=False):
-        """ This method won't call `_get_future_leaves_on` for the allocations contained by this variable (it will only use the current value of
-            the `number_of_days` of the allocation, alias `number_of_hours_display`)
-
-            `precomputed_allocations`: context variable (recordset) which can be used to pass allocation that are considered to be already computed
+    def _get_consumed_leaves(self, work_entry_types, target_date=False, ignore_future=False, precomputed_allocations={}):
+        """ The unit of the value returned in the dict is defined by the matching allocation.work_entry_type.unit_of_measure
+            :param precomputed_allocations: this method won't call `_get_additionnal_future_leaves_on` for
+            the allocations contained by this variable (they are considered to be already updated for 'target_date')
         """
         employees = self or self._get_contextual_employee()
         leaves_domain = [
@@ -614,21 +613,18 @@ class HrEmployee(models.Model):
                 'to_recheck_leaves': self.env['hr.leave']
             })
         )
-        precomputed_allocations = self.env.context.get('precomputed_allocations')
         for allocation in allocations:
             allocation_data = allocations_leaves_consumed[allocation.employee_id][allocation.work_entry_type_id][allocation]
-            precomputed = False
-            if precomputed_allocations:
-                if allocation.id in precomputed_allocations.ids:
-                    allocation = precomputed_allocations.filtered(lambda alloc: alloc._origin.id == allocation.id)[0]
-                    precomputed = True
             future_leaves = 0
-            if allocation.accrual_plan_id and not precomputed and not ignore_future:
-                future_leaves = allocation._get_future_leaves_on(target_date)
-            max_leaves = allocation.number_of_hours_display\
-                if allocation.work_entry_type_id.unit_of_measure == 'hour'\
-                else allocation.number_of_days_display
-            max_leaves += future_leaves
+            if precomputed_alloc := precomputed_allocations.get(allocation):
+                max_leaves = allocation._convert_from_type_request_unit(
+                    precomputed_alloc['allocated_duration'], allocation.work_entry_type_id.unit_of_measure, precomputed_alloc)
+            else:
+                if allocation.accrual_plan_id and not ignore_future:
+                    future_leaves = allocation._get_additionnal_future_leaves_on(target_date, precomputed_allocations)
+                max_leaves = (allocation.number_of_hours_display
+                    if allocation.work_entry_type_id.unit_of_measure == 'hour'
+                    else allocation.number_of_days) + future_leaves
             allocation_data.update({
                 'max_leaves': max_leaves,
                 'accrual_bonus': future_leaves,
@@ -641,7 +637,7 @@ class HrEmployee(models.Model):
         for employee in employees:
             for work_entry_type in work_entry_types:
                 if not work_entry_type.requires_allocation:
-                    # Ensure that leave types that do not require allocation are
+                    # Ensure that time types that do not require allocation are
                     # still stored in the consumed allocation leaves.
                     # False is the special key used for this type of leave
                     allocations_leaves_consumed[employee][
@@ -756,7 +752,7 @@ class HrEmployee(models.Model):
                     virtual_remaining = 0
                     additional_leaves_duration = 0
                     for allocation in consumed_content:
-                        latest_accrual_bonus += allocation and allocation._get_future_leaves_on(date_to_simulate)
+                        latest_accrual_bonus += allocation and allocation._get_additionnal_future_leaves_on(date_to_simulate, precomputed_allocations)
                         date_accrual_bonus += consumed_content[allocation]['accrual_bonus']
                         virtual_remaining += consumed_content[allocation]['virtual_remaining_leaves']
                     for leave in content['to_recheck_leaves']:

--- a/addons/hr_holidays/models/hr_employee.py
+++ b/addons/hr_holidays/models/hr_employee.py
@@ -485,7 +485,7 @@ class HrEmployee(models.Model):
             return self.browse(ctx.get('default_employee_id'))
         return self.env.user.employee_id
 
-    def _get_consumed_leaves(self, work_entry_types, target_date=False, ignore_future=False):
+    def _get_consumed_leaves(self, work_entry_types, target_date=False, ignore_future=False, precomputed_allocations=None):
         employees = self or self._get_contextual_employee()
         leaves_domain = [
             ('work_entry_type_id', 'in', work_entry_types.ids),
@@ -564,12 +564,18 @@ class HrEmployee(models.Model):
         for allocation in allocations:
             allocation_data = allocations_leaves_consumed[allocation.employee_id][allocation.work_entry_type_id][allocation]
             future_leaves = 0
-            if allocation.allocation_type == 'accrual':
-                future_leaves = allocation._get_future_leaves_on(target_date)
-            max_leaves = allocation.number_of_hours_display\
-                if allocation.work_entry_type_id.unit_of_measure == 'hour'\
-                else allocation.number_of_days_display
-            max_leaves += future_leaves
+            if precomputed_allocations and allocation in precomputed_allocations:
+                precomputed_allocation_data = precomputed_allocations[allocation]
+                max_leaves = precomputed_allocation_data['number_of_days']
+                if allocation.work_entry_type_id.unit_of_measure == 'hour':
+                    max_leaves *= allocation._get_employee_hours_per_day(precomputed_allocation_data)
+            else:
+                max_leaves = allocation.number_of_days
+                if allocation.work_entry_type_id.unit_of_measure == 'hour':
+                    max_leaves *= allocation._get_employee_hours_per_day()
+                if allocation.allocation_type == 'accrual':
+                    future_leaves = allocation._get_additionnal_future_leaves_on(target_date, precomputed_allocations)
+                    max_leaves += future_leaves
             allocation_data.update({
                 'max_leaves': max_leaves,
                 'accrual_bonus': future_leaves,
@@ -582,7 +588,7 @@ class HrEmployee(models.Model):
         for employee in employees:
             for work_entry_type in work_entry_types:
                 if not work_entry_type.requires_allocation:
-                    # Ensure that leave types that do not require allocation are
+                    # Ensure that work entry types that do not require allocation are
                     # still stored in the consumed allocation leaves.
                     # False is the special key used for this type of leave
                     allocations_leaves_consumed[employee][
@@ -693,7 +699,7 @@ class HrEmployee(models.Model):
                     virtual_remaining = 0
                     additional_leaves_duration = 0
                     for allocation in consumed_content:
-                        latest_accrual_bonus += allocation and allocation._get_future_leaves_on(date_to_simulate)
+                        latest_accrual_bonus += allocation and allocation._get_additionnal_future_leaves_on(date_to_simulate, precomputed_allocations)
                         date_accrual_bonus += consumed_content[allocation]['accrual_bonus']
                         virtual_remaining += consumed_content[allocation]['virtual_remaining_leaves']
                     for leave in content['to_recheck_leaves']:

--- a/addons/hr_holidays/models/hr_leave_accrual_plan.py
+++ b/addons/hr_holidays/models/hr_leave_accrual_plan.py
@@ -1,8 +1,10 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 from calendar import monthrange
+from datetime import date
 
 from odoo import api, fields, models, _
 from odoo.exceptions import ValidationError
+from dateutil.relativedelta import relativedelta
 
 from odoo.addons.hr_holidays.models.hr_leave_accrual_plan_level import _get_selection_days
 
@@ -161,3 +163,68 @@ class HrLeaveAccrualPlan(models.Model):
             if not vals.get("name", False):
                 vals['name'] = self.env._("Unnamed Plan")
         return super().create(vals_list)
+
+    def _get_lvls_boundaries(self, date_from) -> list[date]:
+        """ Returns a list containing intervals boundaries of each level.
+            The start of the level x is the end date of the previous level.
+
+            For instance, if there are 2 levels, this function will return a list of 2 dates :
+            the start of the first level, and the start of the second level
+        """
+        self.ensure_one()
+
+        if not self.level_ids:
+            return None
+        sorted_levels = self.level_ids.sorted('sequence')
+
+        boundaries = [sorted_levels[0]._get_start_date(date_from)]
+        if len(sorted_levels) == 1:
+            return boundaries
+
+        if self.transition_mode == 'immediately':
+            for i in range(1, len(sorted_levels)):
+                boundaries.append(sorted_levels[i]._get_start_date(date_from))
+            return boundaries
+
+        for i in range(1, len(sorted_levels)):
+            expected_lvl_start = sorted_levels[i]._get_start_date(date_from)
+            current_lvl = sorted_levels[i]
+            lvl_start = current_lvl._get_next_date(expected_lvl_start + relativedelta(days=-1))
+            boundaries.append(lvl_start)
+        return boundaries
+
+    def _get_lvl_last_date(self, date_from, level_idx, lvls_boundaries=None):
+        self.ensure_one()
+        lvls_boundaries = lvls_boundaries or self._get_lvls_boundaries(date_from)
+        if level_idx == len(lvls_boundaries) - 1:
+            return None
+        return lvls_boundaries[level_idx + 1]
+
+    def _get_current_accrual_plan_levels(self, date, lvls_boundaries) -> dict[str, tuple] | None:
+        """ Returns a dict of tuples (lvl, idx) containing the level(s) we are currently in depending on `date` parameter.
+            It can return up to 2 entries (during level transition), "current_level" and "previous_level" (optional).
+            Return example:  {
+                "previous_level": (lvl3, lvl3_idx),         -> "previous_level" is an optional entry
+                "current_level": (lvl4, lvl4_idx),
+            }
+        """
+        self.ensure_one()
+        if not self.level_ids or lvls_boundaries[0] > date:
+            return None
+
+        sorted_levels = self.level_ids.sorted('sequence')
+        current_lvl_start = False
+        current_lvl_idx = False
+        for lvl_idx, lvl_start in enumerate(lvls_boundaries):
+            if date >= lvl_start:
+                current_lvl_idx = lvl_idx
+                current_lvl_start = lvl_start
+
+        # if `date` is a level transition
+        if current_lvl_idx > 0 and date == current_lvl_start:
+            return {
+                "previous_level": (sorted_levels[current_lvl_idx - 1], current_lvl_idx - 1),
+                "current_level": (sorted_levels[current_lvl_idx], current_lvl_idx),
+            }
+
+        return {"current_level": (sorted_levels[current_lvl_idx], current_lvl_idx)}

--- a/addons/hr_holidays/models/hr_leave_accrual_plan_level.py
+++ b/addons/hr_holidays/models/hr_leave_accrual_plan_level.py
@@ -4,6 +4,7 @@ from dateutil.relativedelta import relativedelta
 
 from odoo import _, api, fields, models
 from odoo.exceptions import ValidationError, UserError
+from odoo.tools.date_utils import get_timedelta
 
 
 def _get_selection_days(self):
@@ -104,12 +105,14 @@ class HrLeaveAccrualLevel(models.Model):
         export_string_translation=False)
     cap_accrued_time = fields.Boolean(export_string_translation=False,
         help="When the field is checked the balance of an allocation using this accrual plan will never exceed the specified amount.")
+    # Unit defined by `added_value_type`
     maximum_leave = fields.Float(
         digits=(16, 2), compute="_compute_maximum_leave", default=0, readonly=False, store=True,
         help="Choose a cap for this accrual.", export_string_translation=False)
     cap_accrued_time_yearly = fields.Boolean(export_string_translation=False,
         store=True, readonly=False,
         help="When the field is checked the total amount accrued each year will be capped at the specified amount")
+    # Unit defined by `added_value_type`
     maximum_leave_yearly = fields.Float(digits=(16, 2), export_string_translation=False)
     can_be_carryover = fields.Boolean(related='accrual_plan_id.can_be_carryover', readonly=True,
         export_string_translation=False)
@@ -132,7 +135,8 @@ class HrLeaveAccrualLevel(models.Model):
         default='unlimited', required=True,
         help="You can limit the accrued time carried over for the next period."
     )
-    postpone_max_days = fields.Integer(export_string_translation=False,
+    # Unit defined by `added_value_type`
+    max_carriedover_duration = fields.Integer(export_string_translation=False,
         help="Set a maximum of accruals an allocation keeps at the end of the year.")
     can_modify_value_type = fields.Boolean(compute="_compute_can_modify_value_type", default=False,
         export_string_translation=False)
@@ -155,8 +159,8 @@ class HrLeaveAccrualLevel(models.Model):
         'CHECK(added_value > 0)',
         'You must give a rate greater than 0 in accrual plan levels.',
     )
-    _valid_postpone_max_days_value = models.Constraint(
-        "CHECK(action_with_unused_accruals <> 'all' OR carryover_options <> 'limited' OR COALESCE(postpone_max_days, 0) > 0)",
+    _valid_max_carriedover_duration_value = models.Constraint(
+        "CHECK(action_with_unused_accruals <> 'all' OR carryover_options <> 'limited' OR COALESCE(max_carriedover_duration, 0) > 0)",
         'You cannot have a maximum quantity to carryover set to 0.',
     )
     _valid_accrual_validity_value = models.Constraint(
@@ -296,8 +300,7 @@ class HrLeaveAccrualLevel(models.Model):
         return ['hourly']
 
     def _get_next_date(self, last_call):
-        """
-        Returns the next date with the given last call
+        """ Returns the next date the allocation will be accrued with the given last call (last_call not included)
         """
         self.ensure_one()
         if self.frequency in self._get_hourly_frequencies() + ['daily']:
@@ -365,7 +368,7 @@ class HrLeaveAccrualLevel(models.Model):
             date = last_call + relativedelta(day=int(self.first_day))
             if last_call >= date:
                 return date
-            return last_call + relativedelta(day=int(self.first_day), months=-1, days=1)
+            return last_call + relativedelta(day=int(self.first_day), months=-1)
 
         if self.frequency == 'biyearly':
             first_date = last_call + relativedelta(month=int(self.first_month), day=int(self.first_month_day))
@@ -395,3 +398,7 @@ class HrLeaveAccrualLevel(models.Model):
 
     def action_save_new(self):
         return self.accrual_plan_id.action_create_accrual_plan_level()
+
+    def _get_start_date(self, date_from):
+        self.ensure_one()
+        return date_from + get_timedelta(self.start_count, self.start_type)

--- a/addons/hr_holidays/models/hr_leave_accrual_plan_level.py
+++ b/addons/hr_holidays/models/hr_leave_accrual_plan_level.py
@@ -4,6 +4,7 @@ from dateutil.relativedelta import relativedelta
 
 from odoo import _, api, fields, models
 from odoo.exceptions import ValidationError, UserError
+from odoo.tools.date_utils import get_timedelta
 
 
 def _get_selection_days(self):
@@ -131,7 +132,8 @@ class HrLeaveAccrualLevel(models.Model):
         default='unlimited', required=True,
         help="You can limit the accrued time carried over for the next period."
     )
-    postpone_max_days = fields.Integer(export_string_translation=False,
+    # `max_carriedover_duration` unit is defined by `added_value_type`
+    max_carriedover_duration = fields.Integer(export_string_translation=False,
         help="Set a maximum of accruals an allocation keeps at the end of the year.")
     can_modify_value_type = fields.Boolean(compute="_compute_can_modify_value_type", default=False,
         export_string_translation=False)
@@ -153,8 +155,8 @@ class HrLeaveAccrualLevel(models.Model):
         'CHECK(added_value > 0)',
         'You must give a rate greater than 0 in accrual plan levels.',
     )
-    _valid_postpone_max_days_value = models.Constraint(
-        "CHECK(action_with_unused_accruals <> 'all' OR carryover_options <> 'limited' OR COALESCE(postpone_max_days, 0) > 0)",
+    _valid_max_carriedover_duration_value = models.Constraint(
+        "CHECK(action_with_unused_accruals <> 'all' OR carryover_options <> 'limited' OR COALESCE(max_carriedover_duration, 0) > 0)",
         'You cannot have a maximum quantity to carryover set to 0.',
     )
     _valid_accrual_validity_value = models.Constraint(
@@ -367,3 +369,6 @@ class HrLeaveAccrualLevel(models.Model):
 
     def action_save_new(self):
         return self.accrual_plan_id.action_create_accrual_plan_level()
+
+    def _get_start_date(self, date_from):
+        return date_from + get_timedelta(self.start_count, self.start_type)

--- a/addons/hr_holidays/models/hr_leave_allocation.py
+++ b/addons/hr_holidays/models/hr_leave_allocation.py
@@ -2,21 +2,31 @@
 
 # Copyright (c) 2005-2006 Axelor SARL. (http://www.axelor.com)
 from calendar import monthrange
-from datetime import datetime, date, time
+from datetime import datetime, date, time, timedelta
 from dateutil.relativedelta import relativedelta
 from zoneinfo import ZoneInfo
 
 from odoo import api, fields, models, _
 from odoo.tools import format_date
+from odoo.fields import Domain
 from odoo.addons.hr_holidays.models.hr_leave import get_employee_from_context
 from odoo.exceptions import UserError, ValidationError
-from odoo.fields import Domain
 from odoo.tools.float_utils import float_round
-from odoo.tools.date_utils import get_timedelta
 
 
 class HrLeaveAllocation(models.Model):
-    """ Allocation Requests Access specifications: similar to leave requests """
+    """ Allocation Requests Access specifications: similar to leave requests
+
+        Some of the methods of this class are tagged with 'Possibly accrual inconsistent' or 'Accrual inconsistent'.
+        This means:
+        - They mustn't read allocation fields that are not listed in `_get_accrual_to_update_fields`, but should
+          instead use the values of the parameter `allocation_data`
+        - They mustn't write any field of the allocation, but should update the `allocation_data` parameter
+
+        Some of these methods have `allocation_data={}`. In the case `allocation_data` is set to `{}`, those
+        methods can directly use/modify any of the allocation field. In this case, those method will be tagged
+        'Possibly accrual inconsistent', and not 'Accrual inconsistent'.
+    """
     _name = 'hr.leave.allocation'
     _description = "Time Off Allocation"
     _order = "create_date desc"
@@ -100,17 +110,17 @@ class HrLeaveAllocation(models.Model):
     notes = fields.Text('Reasons', readonly=False)
     # duration
     number_of_days = fields.Float(
-        'Number of Days', compute='_compute_number_of_days', store=True, readonly=False, tracking=True, default=1,
+        'Number of Days', readonly=False, tracking=True, default=1,
         help='Duration in days. Reference field to use when necessary.')
     number_of_days_display = fields.Float(
-        'Duration (days)', compute='_compute_number_of_days_display',
+        'Duration (days)', compute='_compute_number_of_days_display', inverse='_inverse_number_of_days_display',
         help="For an Accrual Allocation, this field contains the theorical amount of time given to the employee, due to a previous start date, on the first run of the plan. This can be manually edited.")
     number_of_hours_display = fields.Float(
         'Duration (hours)', default_export_compatible=True, compute='_compute_number_of_hours_display', store=True,
+        inverse='_inverse_number_of_hours_display',
         help="For an Accrual Allocation, this field contains the theorical amount of time given to the employee, due to a previous start date, on the first run of the plan. This can be manually edited.")
     duration_display = fields.Char('Allocated (Days/Hours)', compute='_compute_duration_display',
         help="Field allowing to see the allocation duration in days or hours depending on the type_request_unit")
-    last_executed_carryover_date = fields.Date(export_string_translation=False)
     # details
     approver_id = fields.Many2one(
         'hr.employee', string='First Approval', readonly=True, copy=False,
@@ -128,21 +138,23 @@ class HrLeaveAllocation(models.Model):
         ('day', 'Day'),
     ], compute="_compute_type_request_unit")
     department_id = fields.Many2one('hr.department', compute='_compute_department_id', store=True, string='Department', readonly=False)
-    # accrual configuration
-    lastcall = fields.Date("Date of the last accrual allocation", readonly=True)
-    # lastcall is only updated on accrual date. On other dates such as carryover date,
-    # actual_lastcall will store the date of the lastcall of the accrual allocation
-    actual_lastcall = fields.Date(export_string_translation=False)
-    nextcall = fields.Date("Date of the next accrual allocation", readonly=True, default=False)
-    already_accrued = fields.Boolean()
-    yearly_accrued_amount = fields.Float(export_string_translation=False)
     is_officer = fields.Boolean(compute='_compute_is_officer')
-    accrual_plan_id = fields.Many2one('hr.leave.accrual.plan', index='btree_not_null', tracking=True)
+    # max_leaves, leaves_taken and virtual_remaining_leaves are for display purpose only
+    # Do not use them for computation, use the result of _process_accrual_plans instead !
     max_leaves = fields.Float(compute='_compute_leaves')
     leaves_taken = fields.Float(compute='_compute_leaves', string='Time off Taken')
     virtual_remaining_leaves = fields.Float(compute='_compute_leaves', string='Available Time Off')
-    expiring_carryover_days = fields.Float("The number of carried over days that will expire on carried_over_days_expiration_date")
-    carried_over_days_expiration_date = fields.Date("Carried over days expiration date")
+
+    # ============================== Accrual type allocation fields ==============================
+    accrual_plan_id = fields.Many2one('hr.leave.accrual.plan', index='btree_not_null', tracking=True)
+    # `last_accrual`, `lastcall` and `nextcall` will be assigned a value when:
+    # `date_from <= first_level_start <= today` AND `_process_accrual_plans` has been called
+    last_accrual = fields.Date("Date of the last accrual allocation", export_string_translation=False)
+    lastcall = fields.Date('Date of the last executed accrual event (accrual, carryover date, expiring carriedover days, ...)', export_string_translation=False)
+    nextcall = fields.Date('Date of the closest next accrual event (accrual, carryover date, expiring carriedover days, ...)', export_string_translation=False)
+    yearly_accrued_days = fields.Float('Number of accrued days since the last carryover', export_string_translation=False)
+    previous_carryover_number_of_days = fields.Float('The number of days on previous carryover date', export_string_translation=False)
+    carried_over_days_expiration_date = fields.Date('Carried over days expiration date', export_string_translation=False)
 
     @api.constrains('date_from', 'date_to')
     def _check_date_from_date_to(self):
@@ -155,6 +167,13 @@ class HrLeaveAllocation(models.Model):
     @api.depends('accrual_plan_id')
     def _compute_is_officer(self):
         self.is_officer = self.env.user.has_group("hr_holidays.group_hr_holidays_user")
+
+    def _get_employee_hours_per_day(self, allocation_data={}):
+        """ Possibly accrual inconsistent (see the comment under the class declaration) """
+        self.ensure_one()
+        date_from = allocation_data.get('nextcall', self.nextcall) or self.date_from \
+            if self.accrual_plan_id else self.date_from
+        return self.employee_id._get_hours_per_day(date_from)
 
     def _get_title(self):
         self.ensure_one()
@@ -212,7 +231,7 @@ class HrLeaveAllocation(models.Model):
                 )
             allocation.name_validity = name_validity
 
-    @api.depends('employee_id', 'work_entry_type_id')
+    @api.depends('employee_id', 'work_entry_type_id', 'nextcall')
     def _compute_leaves(self):
         date_from = fields.Date.context_today(self)
         employee_days_per_allocation = self.employee_id._get_consumed_leaves(self.work_entry_type_id, date_from, ignore_future=True)[0]
@@ -233,7 +252,7 @@ class HrLeaveAllocation(models.Model):
         for allocation in self:
             if not allocation.employee_id:
                 continue
-            allocation.number_of_hours_display = (allocation.number_of_days * allocation.employee_id._get_hours_per_day(allocation.date_from))
+            allocation.number_of_hours_display = (allocation.number_of_days * allocation._get_employee_hours_per_day())
 
     @api.depends('number_of_hours_display', 'number_of_days_display')
     def _compute_duration_display(self):
@@ -289,14 +308,14 @@ class HrLeaveAllocation(models.Model):
                     default_work_entry_type_id = self._default_work_entry_type_id()
                 allocation.work_entry_type_id = default_work_entry_type_id
 
-    @api.depends('work_entry_type_id', 'number_of_hours_display', 'number_of_days_display', 'type_request_unit', 'employee_id')
-    def _compute_number_of_days(self):
+    def _inverse_number_of_days_display(self):
         for allocation in self:
-            allocation_unit = allocation.type_request_unit
-            if allocation_unit != 'hour':
-                allocation.number_of_days = allocation.number_of_days_display
-            elif allocation_unit == 'hour' and allocation.employee_id:
-                allocation.number_of_days = allocation.number_of_hours_display / allocation.employee_id._get_hours_per_day(allocation.date_from)
+            allocation.number_of_days = allocation.number_of_days_display
+
+    @api.onchange('employee_id')
+    def _inverse_number_of_hours_display(self):
+        for allocation in self.filtered('employee_id'):
+            allocation.number_of_days = allocation.number_of_hours_display / allocation._get_employee_hours_per_day()
 
     @api.constrains('number_of_days', 'work_entry_type_id', 'employee_id')
     def _check_negative_allocation(self):
@@ -343,7 +362,8 @@ class HrLeaveAllocation(models.Model):
         for allocation in self:
             allocation.type_request_unit = allocation._get_request_unit()
 
-    def _get_carryover_date(self, date_from):
+    def _get_next_carryover_date(self, date_from, date_from_included=True):
+        """ Returns the next carry-over date, `date_from` included or not """
         self.ensure_one()
         carryover_time = self.accrual_plan_id.carryover_date
         accrual_plan = self.accrual_plan_id
@@ -357,399 +377,430 @@ class HrLeaveAllocation(models.Model):
             # 2020/2/31 will be changed to 2020/2/29
             day = min(monthrange(date_from.year, month)[1], int(accrual_plan.carryover_day))
             carryover_date = date(date_from.year, month, day)
-        if date_from > carryover_date:
+
+        if date_from > carryover_date or (not date_from_included and carryover_date == date_from):
             carryover_date += relativedelta(years=1)
         return carryover_date
 
-    def _add_days_to_allocation(self, current_level, current_level_maximum_leave, leaves_taken, period_start, period_end):
-        start_date = self.env.context.get('start_date') or self.lastcall
-        end_date = self.env.context.get('end_date') or self.nextcall
-        days_to_add = self._process_accrual_plan_level(
-            current_level, period_start, start_date, period_end, end_date)
-        if current_level.cap_accrued_time_yearly:
-            maximum_leave_yearly = current_level.maximum_leave_yearly\
-                if current_level.added_value_type != 'hour'\
-                else current_level.maximum_leave_yearly / self.employee_id._get_hours_per_day(self.nextcall)
-            yearly_remaining_amount = maximum_leave_yearly - self.yearly_accrued_amount
-            days_to_add = min(days_to_add, yearly_remaining_amount)
-        if current_level.cap_accrued_time:
-            capped_total_balance = leaves_taken + current_level_maximum_leave
-            days_to_add = min(days_to_add, capped_total_balance - self.number_of_days)
-        self.number_of_days += days_to_add
-        self.yearly_accrued_amount += days_to_add
+    def _convert_to_type_request_unit(self, duration, duration_unit, allocation_data={}):
+        """ Possibly accrual inconsistent (see the comment under the class declaration) """
+        self.ensure_one()
+        return self._convert_duration(duration, duration_unit, self.type_request_unit, allocation_data)
 
-    def _get_current_accrual_plan_level_id(self, date, level_ids=False):
-        """
-        Returns a pair (accrual_plan_level, idx) where accrual_plan_level is the level for the given date
-        and idx is the index for the plan in the ordered set of levels
+    def _convert_from_type_request_unit(self, duration, duration_unit, allocation_data={}):
+        """ Possibly accrual inconsistent (see the comment under the class declaration) """
+        self.ensure_one()
+        return self._convert_duration(duration, self.type_request_unit, duration_unit, allocation_data)
+
+    def _convert_duration(self, duration, src_unit, dst_unit, allocation_data={}):
+        """ Possibly accrual inconsistent (see the comment under the class declaration) """
+        self.ensure_one()
+        assert all(unit in ('hour', 'half_day', 'day') for unit in (src_unit, dst_unit))
+        if dst_unit == 'hour' and src_unit in ('day', 'half_day'):
+            return duration * self._get_employee_hours_per_day(allocation_data)
+        if dst_unit in ('day', 'half_day') and src_unit == 'hour':
+            return duration / self._get_employee_hours_per_day(allocation_data)
+        return duration
+
+    def _add_days_to_allocation(self, allocation_data, current_level, period_start, period_end, start_date, end_date):
+        """ Accrual inconsistent (see the comment under the class declaration) """
+        self.ensure_one()
+        added_duration = self._get_period_added_duration(
+            allocation_data, current_level, period_start, start_date, period_end, end_date)
+        if current_level.cap_accrued_time_yearly:
+            maximum_leave_yearly = self._convert_to_type_request_unit(
+                current_level.maximum_leave_yearly, current_level.added_value_type, allocation_data)
+            yearly_remaining_duration = max(0, maximum_leave_yearly - allocation_data['yearly_accrued_duration'])
+            added_duration = min(added_duration, yearly_remaining_duration)
+        if current_level.cap_accrued_time:
+            lvl_max_leave_duration = self._convert_to_type_request_unit(
+                current_level.maximum_leave, current_level.added_value_type, allocation_data)
+            capped_total_balance = allocation_data['leaves_taken'] + lvl_max_leave_duration
+            added_duration = min(added_duration, capped_total_balance - allocation_data['allocated_duration'])
+        allocation_data['allocated_duration'] += added_duration
+        allocation_data['yearly_accrued_duration'] += added_duration
+        allocation_data['last_accrual'] = allocation_data['nextcall']
+
+    def _get_current_accrual_plan_levels(self, target_date) -> dict[str, tuple] | None:
+        """ Returns a dict of tuples (lvl, idx) containing the level(s) we are currently in depending on `target_date` parameter.
+            It can return up to 2 entries (when target_date is a level transition), "current_level" and "previous_level" (optional).
+            Return example:  {
+                "previous_level": (lvl3, lvl3_idx),         -> "previous_level" is an optional entry
+                "current_level": (lvl4, lvl4_idx),
+            }
         """
         self.ensure_one()
-        if not self.accrual_plan_id.level_ids:
-            return (False, False)
-        # Sort by sequence which should be equivalent to the level
-        if not level_ids:
-            level_ids = self.accrual_plan_id.level_ids.sorted('sequence')
-        current_level = False
-        current_level_idx = -1
-        for idx, level in enumerate(level_ids):
-            if date > self.date_from + get_timedelta(level.start_count, level.start_type):
-                current_level = level
-                current_level_idx = idx
-        # If transition_mode is set to `immediately` or we are currently on the first level
-        # the current_level is simply the first level in the list.
-        if current_level_idx <= 0 or self.accrual_plan_id.transition_mode == "immediately":
-            return (current_level, current_level_idx)
-        # In this case we have to verify that the 'previous level' is not the current one due to `end_of_accrual`
-        level_start_date = self.date_from + get_timedelta(current_level.start_count, current_level.start_type)
-        previous_level = level_ids[current_level_idx - 1]
-        # If the next date from the current level's start date is before the last call of the previous level
-        # return the previous level
-        if current_level._get_next_date(level_start_date) < previous_level._get_next_date(level_start_date):
-            return (previous_level, current_level_idx - 1)
-        return (current_level, current_level_idx)
+        if not self.accrual_plan_id or not self.accrual_plan_id.level_ids or (self.date_to and target_date > self.date_to):
+            return None
+        lvls_boundaries = self._get_lvls_boundaries()
+        if target_date < lvls_boundaries[0]:
+            return None
+
+        sorted_levels = self.accrual_plan_id.level_ids
+        current_lvl_start = False
+        current_lvl_idx = False
+        for lvl_idx, lvl_start in enumerate(lvls_boundaries):
+            if target_date >= lvl_start:
+                current_lvl_idx = lvl_idx
+                current_lvl_start = lvl_start
+
+        # if `target_date` is a level transition
+        if current_lvl_idx > 0 and target_date == current_lvl_start:
+            return {
+                "previous_level": (sorted_levels[current_lvl_idx - 1], current_lvl_idx - 1),
+                "current_level": (sorted_levels[current_lvl_idx], current_lvl_idx),
+            }
+
+        return {"current_level": (sorted_levels[current_lvl_idx], current_lvl_idx)}
+
+    def _get_current_accrual_plan_level_idx(self, date):
+        """ Returns (current_level, index). If `date` is a levels transition, the returned `current_level` is the
+            one that starts later of the two levels """
+        self.ensure_one()
+        current_levels = self._get_current_accrual_plan_level_idx_for_accrual(date)
+        return current_levels['current_level'] if current_levels else (None, None)
+
+    def _get_current_accrual_plan_level_idx_for_accrual(self, target_date):
+        """ Unlike `_get_current_accrual_plan_level_idx`, takes the levels transition into account.
+            For example, if `date` is a level transition and `accrued_gain_time` is "end", then we want to
+            get the "previous" plan level as we need to compute `number_of_days`, `expiring_days`, ... depending on the
+            "previous" level policy.
+
+            Returns a `dict` with the following entries:
+            - "current_level": (current_level, current_level_idx)     -> Current level
+            - "accrual_level": (accrual_level, accrual_level_idx)     -> Current level considering levels transition
+        """
+        self.ensure_one()
+        plan_levels = self._get_current_accrual_plan_levels(target_date)
+        if not plan_levels:
+            return None
+        accrual_level = plan_levels['previous_level'] if 'previous_level' in plan_levels\
+            and self.accrual_plan_id.accrued_gain_time == 'end' else plan_levels['current_level']
+        return {'current_level': plan_levels['current_level'], 'accrual_level': accrual_level}
 
     def _get_accrual_plan_level_work_entry_prorata(self, level, start_period, start_date, end_period, end_date):
+        """ Possibly accrual inconsistent (see the comment under the class declaration) """
         self.ensure_one()
-        datetime_min_time = datetime.min.time()
+        if level.frequency not in level._get_hourly_frequencies() and not level.accrual_plan_id.is_based_on_worked_time:
+            return 1
+
         version = self.employee_id._get_version(start_date)
         resource_tz = ZoneInfo(version._get_tz() or 'UTC')
-        start_dt = datetime.combine(start_date, datetime_min_time, tzinfo=resource_tz)
-        end_dt = datetime.combine(end_date, datetime_min_time, tzinfo=resource_tz)
-        leaves_eligible = self.employee_id.sudo()._get_leave_days_data_batch(start_dt, end_dt,
-            calendar=self.employee_id._get_calendars(start_dt)[self.employee_id.id],
+        start_dt = datetime.combine(start_date, time.min, tzinfo=resource_tz)
+        end_dt = datetime.combine(end_date, time.min, tzinfo=resource_tz)
+        calendar = self.employee_id._get_calendars(start_dt)[self.employee_id.id]
+        worked_hours = self.employee_id._get_work_days_data_batch(start_dt, end_dt, calendar=calendar)[self.employee_id.id]['hours']
+        worked_hours += self.employee_id.sudo()._get_leave_days_data_batch(start_dt, end_dt, calendar=calendar,
             domain=[('count_as', '=', 'absence'), ('elligible_for_accrual_rate', '=', True)])[self.employee_id.id]['hours']
-        worked = self.employee_id._get_work_days_data_batch(start_dt, end_dt,
-            calendar=self.employee_id.resource_calendar_id)[self.employee_id.id]['hours']
-        worked += leaves_eligible
         if start_period != start_date or end_period != end_date:
             version = self.employee_id._get_version(start_period)
             resource_tz = ZoneInfo(version._get_tz() or 'UTC')
-            start_dt = datetime.combine(start_period, datetime_min_time, tzinfo=resource_tz)
-            end_dt = datetime.combine(end_period, datetime_min_time, tzinfo=resource_tz)
-            leaves_eligible = self.employee_id.sudo()._get_leave_days_data_batch(start_dt, end_dt,
-                calendar=self.employee_id._get_calendars(start_dt)[self.employee_id.id],
+            start_dt = datetime.combine(start_period, time.min, tzinfo=resource_tz)
+            end_dt = datetime.combine(end_period, time.min, tzinfo=resource_tz)
+            period_worked_hours = self.employee_id._get_work_days_data_batch(start_dt, end_dt, calendar=calendar)[self.employee_id.id]['hours']
+            period_worked_hours += self.employee_id.sudo()._get_leave_days_data_batch(start_dt, end_dt, calendar=calendar,
                 domain=[('count_as', '=', 'absence'), ('elligible_for_accrual_rate', '=', True)])[self.employee_id.id]['hours']
-            planned_worked = self.employee_id._get_work_days_data_batch(start_dt, end_dt,
-                calendar=self.employee_id.resource_calendar_id)[self.employee_id.id]['hours']
-            planned_worked += leaves_eligible
         else:
-            planned_worked = worked
-        left = self.employee_id.sudo()._get_leave_days_data_batch(start_dt, end_dt,
-            calendar=self.employee_id._get_calendars(start_dt)[self.employee_id.id],
+            period_worked_hours = worked_hours
+
+        left = self.employee_id.sudo()._get_leave_days_data_batch(start_dt, end_dt, calendar=calendar,
             domain=[('count_as', '=', 'absence'), ('elligible_for_accrual_rate', '=', False)])[self.employee_id.id]['hours']
         if level.frequency in level._get_hourly_frequencies():
-            if level.accrual_plan_id.is_based_on_worked_time:
-                work_entry_prorata = planned_worked
-            else:
-                work_entry_prorata = planned_worked + left
-        else:
-            work_entry_prorata = worked / (left + planned_worked) if (left + planned_worked) else 0
-        return work_entry_prorata
+            return period_worked_hours if level.accrual_plan_id.is_based_on_worked_time \
+                else period_worked_hours + left
+        return worked_hours / (left + period_worked_hours) if (left + period_worked_hours) else 0
 
-    def _process_accrual_plan_level(self, level, start_period, start_date, end_period, end_date):
-        """
-        Returns the added days for that level
-        """
+    def _get_period_added_duration(self, allocation_data, level, period_start, start_date, period_end, end_date):
+        """ Accrual inconsistent (see the comment under the class declaration) """
         self.ensure_one()
-        if level.frequency in level._get_hourly_frequencies() or level.accrual_plan_id.is_based_on_worked_time:
-            work_entry_prorata = self._get_accrual_plan_level_work_entry_prorata(level, start_period, start_date, end_period, end_date)
-            added_value = work_entry_prorata * level.added_value
-        else:
-            added_value = level.added_value
-        # Convert time in hours to time in days in case the level is encoded in hours
-        if level.added_value_type == 'hour':
-            added_value = added_value / self.employee_id._get_hours_per_day(self.date_from)
+        work_entry_prorata = self._get_accrual_plan_level_work_entry_prorata(level, period_start, start_date, period_end, end_date)
+        added_value = work_entry_prorata * level.added_value
+        added_duration = self._convert_to_type_request_unit(added_value, level.added_value_type, allocation_data)
         period_prorata = 1
-        if (start_period != start_date or end_period != end_date) and not level.accrual_plan_id.is_based_on_worked_time:
-            period_days = (end_period - start_period)
-            call_days = (end_date - start_date)
-            period_prorata = min(1, call_days / period_days) if period_days else 1
-        return added_value * period_prorata
-
-    def _process_accrual_plans(self, date_to=False, force_period=False, log=True):
-        """
-        This method is part of the cron's process.
-        The goal of this method is to retroactively apply accrual plan levels and progress from nextcall to date_to or today.
-        If force_period is set, the accrual will run until date_to in a prorated way (used for end of year accrual actions).
-        """
-        def _get_leaves_taken(allocation):
-            precomputed_allocations = allocation
-            if context_precomputed := self.env.context.get('precomputed_allocations'):
-                precomputed_allocations |= context_precomputed
-            # By setting `precomputed_allocations`, avoid infinite loop (otherwise _get_consumed_leaves -> _get_future_leaves_on -> _process_accrual_plans -> ...)
-            employee_days_per_allocation = allocation.employee_id.with_context(precomputed_allocations=precomputed_allocations)._get_consumed_leaves(
-                allocation.work_entry_type_id, allocation.nextcall, ignore_future=True)[0]
-            origin = allocation._origin
-            leaves_taken = employee_days_per_allocation[origin.employee_id][origin.work_entry_type_id][origin]['leaves_taken']
-            return leaves_taken
-
-        def _get_period_start_date(allocation, period_start, current_level, current_level_idx, level_ids, first_level_start_date):
-            start_date = period_start
-            if current_level_idx > 0:
-                prev_level_end = current_level._get_level_transition_date(allocation.date_from)
-                if allocation.accrual_plan_id.transition_mode == 'end_of_accrual':
-                    prev_level = level_ids[current_level_idx - 1]
-                    # If period doesn't end on level transition then get next period end
-                    if prev_level._get_previous_date(prev_level_end) != prev_level_end:
-                        prev_level_end = prev_level._get_next_date(prev_level_end)
-                start_date = max(start_date, prev_level_end)
-            else:
-                start_date = max(start_date, first_level_start_date)
-
-        date_to = date_to or fields.Date.context_today(self)
-        already_accrued = {allocation.id: allocation.already_accrued or (allocation.number_of_days != 0 and allocation.accrual_plan_id.accrued_gain_time == 'start') for allocation in self}
-        first_allocation = _("""This allocation have already ran once, any modification won't be effective to the days allocated to the employee. If you need to change the configuration of the allocation, delete and create a new one.""")
-        for allocation in self:
-            expiration_date = False
-            if not allocation.accrual_plan_id:
-                continue
-            level_ids = allocation.accrual_plan_id.level_ids
-            if not level_ids:
-                continue
-            # "cache" leaves taken, as it gets recomputed every time allocation.number_of_days is assigned to. Without this,
-            # every loop will take 1+ second. It can be removed if computes don't chain in a way to always reassign accrual plan
-            # even if the value doesn't change. This is the best performance atm.
-            first_level = level_ids[0]
-            first_level_start_date = allocation.date_from + get_timedelta(first_level.start_count, first_level.start_type)
-            allocation.already_accrued = already_accrued[allocation.id]
-            # first time the plan is run, initialize nextcall and take carryover / level transition into account
-            if not allocation.nextcall:
-                # Accrual plan is not configured properly or has not started
-                if date_to < first_level_start_date:
-                    continue
-                allocation.lastcall = max(allocation.lastcall, first_level_start_date)
-                allocation.actual_lastcall = allocation.lastcall
-                allocation.nextcall = first_level._get_next_date(allocation.lastcall)
-                # adjust nextcall for carryover
-                carryover_date = allocation._get_carryover_date(allocation.nextcall)
-                allocation.nextcall = min(carryover_date, allocation.nextcall)
-                # adjust nextcall for level_transition
-                if len(level_ids) > 1:
-                    second_level_start_date = allocation.date_from + get_timedelta(level_ids[1].start_count, level_ids[1].start_type)
-                    allocation.nextcall = min(second_level_start_date, allocation.nextcall)
-                if log:
-                    allocation._message_log(body=first_allocation)
-            (current_level, current_level_idx) = (False, 0)
-            current_level_maximum_leave = 0.0
-            # all subsequent runs, at every loop:
-            # get current level and normal period boundaries, then set nextcall, adjusted for level transition and carryover
-            # add days, trimmed if there is a maximum_leave
-            while allocation.nextcall <= date_to:
-                if allocation.work_entry_type_id.unit_of_measure == 'day':
-                    leaves_taken = _get_leaves_taken(allocation)
-                else:
-                    leaves_taken = _get_leaves_taken(allocation) / allocation.employee_id._get_hours_per_day(allocation.nextcall or allocation.date_from)
-                (current_level, current_level_idx) = allocation._get_current_accrual_plan_level_id(allocation.nextcall)
-                if not current_level:
-                    break
-                if current_level.cap_accrued_time:
-                    if current_level.added_value_type == "day":
-                        current_level_maximum_leave = current_level.maximum_leave
-                    else:
-                        current_level_maximum_leave = current_level.maximum_leave / allocation.employee_id._get_hours_per_day(allocation.nextcall or allocation.date_from)
-                nextcall = current_level._get_next_date(allocation.nextcall)
-                period_start = current_level._get_previous_date(allocation.lastcall)
-                period_end = current_level._get_next_date(allocation.lastcall)
-                # There are 3 cases where nextcall could be closer than the normal period:
-                # 1. Passing from one level to another, if mode is set to 'immediately'
-                current_level_last_date = False
-                on_level_transition = False
-                if current_level_idx < (len(level_ids) - 1) and allocation.accrual_plan_id.transition_mode == 'immediately':
-                    next_level = level_ids[current_level_idx + 1]
-                    current_level_last_date = allocation.date_from + get_timedelta(next_level.start_count, next_level.start_type)
-                    if allocation.nextcall != current_level_last_date:
-                        nextcall = min(nextcall, current_level_last_date)
-                    else:
-                        on_level_transition = True
-                # 2. On carry-over date
-                carryover_date = allocation._get_carryover_date(allocation.nextcall)
-                if allocation.nextcall < carryover_date < nextcall:
-                    nextcall = min(nextcall, carryover_date)
-
-                if current_level.accrual_validity:
-                    # 3. On carried over days expiration date
-                    expiration_date = allocation.carried_over_days_expiration_date
-                    # - not expiration_date -> expiration_date needs to be initialized.
-                    # - allocation.nextcall > expiration_date -> the expiration date has passed and the new one should be computed.
-                    # - allocation.expiring_carryover_days == 0 -> If the carryover date of the accrual plan was changed or if a level
-                    #   transition occurred, then the expiration date needs to be updated. However, if allocation.expiring_carryover_days != 0,
-                    #   then this means that some days will expire on expiration_date and that expiration date should be respected and
-                    #   Expiration date will be updated correctly when allocation.nextcall is greater than expiration_date.
-                    if not expiration_date or allocation.nextcall > expiration_date or allocation.expiring_carryover_days == 0:
-                        expiration_date = carryover_date + relativedelta(**{current_level.accrual_validity_type + 's': current_level.accrual_validity_count})
-                        allocation.carried_over_days_expiration_date = expiration_date
-                    if allocation.nextcall < expiration_date < nextcall:
-                        nextcall = expiration_date
-                    if allocation.nextcall == expiration_date:
-                        # Given that allocation.number_of_days = employee time off balance + leaves_taken. So,
-                        # the leaves_taken are included in allocation.number_of_days.
-                        # Also, allocation.expiring_carryover_days includes the leaves_taken before the carryover date
-                        # and allocation.leaves_taken includes all the leaves_taken before the carryover date + all the leaves_taken
-                        # between the carryover date and the expiration_date. So, the number of expiring days will be
-                        # allocation.expiring_carryover_days - allocation.leaves_taken or 0 if all the expiring days were used
-                        # to take time off.
-                        # This ensures that only the days that weren't used to take time off will expire.
-                        expiring_days = max(0, allocation.expiring_carryover_days - leaves_taken)
-                        allocation.number_of_days = max(0, allocation.number_of_days - expiring_days)
-                        allocation.expiring_carryover_days = 0
-
-                is_accrual_date = allocation.nextcall == period_end or allocation.nextcall == current_level_last_date
-                if not allocation.already_accrued and (is_accrual_date or on_level_transition) and \
-                        allocation.accrual_plan_id.accrued_gain_time == 'start':
-                    start_date = _get_period_start_date(allocation, period_start, current_level, current_level_idx, level_ids, first_level_start_date)
-                    allocation.with_context({'start_date': start_date})._add_days_to_allocation(
-                        current_level, current_level_maximum_leave, leaves_taken, period_start, period_end)
-
-                if allocation.nextcall == carryover_date:
-                    allocation.last_executed_carryover_date = carryover_date
-                    if current_level.action_with_unused_accruals == 'lost' or current_level.carryover_options == 'limited':
-                        allocated_days_left = allocation.number_of_days - leaves_taken
-                        allocation_max_days = 0 # default if unused_accrual are lost
-                        if current_level.carryover_options == 'limited':
-                            if current_level.added_value_type == 'day':
-                                postpone_max_days = current_level.postpone_max_days
-                            else:
-                                postpone_max_days = current_level.postpone_max_days / allocation.employee_id._get_hours_per_day(allocation.date_from)
-                            allocation_max_days = min(postpone_max_days, allocated_days_left)
-                        allocation.number_of_days = min(allocation.number_of_days, allocation_max_days) + leaves_taken
-                    allocation.expiring_carryover_days = allocation.number_of_days
-
-                if not allocation.already_accrued and (is_accrual_date or on_level_transition)\
-                        and allocation.accrual_plan_id.accrued_gain_time == 'end':
-                    start_date = _get_period_start_date(allocation, period_start, current_level, current_level_idx, level_ids, first_level_start_date)
-                    allocation.with_context({'start_date': start_date})._add_days_to_allocation(
-                        current_level, current_level_maximum_leave, leaves_taken, period_start, period_end)
-
-                if allocation.nextcall == carryover_date:
-                    allocation.yearly_accrued_amount = 0
-
-                # 1. When accrued_gain_time == 'start', all the days are accrued on the start of the accrual period. For example, if the accrual period
-                #    is from 01/01/2023 to 01/01/2024, then the days will be accrued on 01/01/2023. Given that the carryover date will be >= the start of the accrual period
-                #    (01/01/2023 in the example) the carryover policy should apply to any day accrued during the period from 01/01/2023 to 01/01/2024.
-                # 2.However, if a level transistion occurred, the carryover policy should apply to the days that were accrued during the carryover level only.
-                #   Any days accrued after the carryover level should be excluded.
-                #   So, if carryover date was 01/06/2023, it should be applied to any day accrued between 01/01/2023 and 01/01/2024. If a level transition
-                #   occurred on 01/09/2023 for example, then the carryover should be applied to any day accrued between 01/01/2023 and 01/09/2023.
-                # 3. The following if block will handle the carryover for days accrued after carryover_date until carryover_period_end. Carryover period end is
-                #    adjusted if a level transition occurred. The carryover for days accrued before carryover_date is handled above.
-                if allocation.accrual_plan_id.accrued_gain_time == 'start' and allocation.last_executed_carryover_date:
-                    last_carryover_date = allocation.last_executed_carryover_date
-                    carryover_level, carryover_level_idx = allocation._get_current_accrual_plan_level_id(last_carryover_date)
-                    carryover_period_start = carryover_level._get_previous_date(last_carryover_date)
-                    carryover_period_end = carryover_level._get_next_date(last_carryover_date)
-                    # Adjust carryover_period_end based on level_transition.
-                    if carryover_level_idx < (len(level_ids) - 1) and allocation.accrual_plan_id.transition_mode == 'immediately':
-                        next_level = level_ids[carryover_level_idx + 1]
-                        carryover_level_last_date = allocation.date_from + get_timedelta(next_level.start_count, next_level.start_type)
-                        carryover_period_end = min(carryover_period_end, carryover_level_last_date)
-                    # Handle the special case for hourly/daily accruals. Carryover_period_end should be equal to last_carryover_date
-                    # because the carryover period is just 1 day.
-                    if carryover_level.frequency in carryover_level._get_hourly_frequencies() + ['daily']:
-                        carryover_period_end = last_carryover_date
-                    # Carryover policy should be only applied to the days accrued on period_end.
-                    # Days accrued on level transition date aren't subject to the carryover policy.
-                    # That is why (allocation.nextcall == period_end) is used instead of (is_accrual_date)
-                    accrued = not allocation.already_accrued and allocation.nextcall == period_end
-                    # If the days were accrued on the carryover period, then apply the carryover policy
-                    # If allocation.actual_lastcall == carryover_period_start, it means this loop has already been run once (skip to avoid applying the carryover twice)
-                    if accrued and last_carryover_date <= allocation.nextcall <= carryover_period_end and allocation.actual_lastcall != carryover_period_start:
-                        if carryover_level.action_with_unused_accruals == 'lost' or carryover_level.carryover_options == 'limited':
-                            allocation.last_executed_carryover_date = carryover_date
-                            allocated_days_left = allocation.number_of_days - leaves_taken
-                            postpone_max_days = current_level.postpone_max_days if current_level.added_value_type == 'day' \
-                                else current_level.postpone_max_days / allocation.employee_id._get_hours_per_day(allocation.date_from)
-                            allocated_days_left = allocation.number_of_days - leaves_taken
-                            allocation_max_days = 0 # default if unused_accrual are lost
-                            if current_level.carryover_options == 'limited':
-                                postpone_max_days = current_level.postpone_max_days
-                                allocation_max_days = min(postpone_max_days, allocated_days_left)
-                            allocation.number_of_days = min(allocation.number_of_days, allocation_max_days) + leaves_taken
-
-                if is_accrual_date:
-                    allocation.lastcall = allocation.nextcall
-                allocation.actual_lastcall = allocation.nextcall
-                allocation.nextcall = nextcall
-                allocation.already_accrued = False
-                if force_period and allocation.nextcall > date_to:
-                    allocation.nextcall = date_to
-                    force_period = False
-
-            # if plan.accrued_gain_time == 'start', process next period and set flag 'already_accrued', this will skip adding days
-            # once, preventing double allocation.
-            if allocation.accrual_plan_id.accrued_gain_time == 'start':
-                # check that we are at the start of a period, not on a carry-over or level transition date
-                level_starts = {level._get_level_transition_date(allocation.date_from): level for level in level_ids}
-                current_level = level_starts.get(allocation.actual_lastcall) or current_level or first_level
-                period_start = current_level._get_previous_date(allocation.actual_lastcall)
-                if allocation.actual_lastcall in {period_start, allocation.date_from} | set(level_starts.keys())\
-                        or (allocation.actual_lastcall - get_timedelta(current_level.accrual_validity_count, current_level.accrual_validity_type)
-                        in {period_start, allocation.date_from} | set(level_starts.keys())):
-                    period_end = current_level._get_next_date(allocation.lastcall)
-                    # Take level transition into account for the end_date
-                    end_date = None
-                    if allocation.accrual_plan_id.transition_mode == 'immediately':
-                        for level_idx, level in enumerate(level_ids):
-                            if level == current_level:
-                                if level_idx < len(level_ids) - 1:
-                                    end_date = min(period_end, level_ids[level_idx + 1]._get_level_transition_date(allocation.date_from))
-                                break
-                    if current_level.cap_accrued_time:
-                        current_level_maximum_leave = current_level.maximum_leave if current_level.added_value_type == "day"\
-                            else current_level.maximum_leave / allocation.employee_id._get_hours_per_day(allocation.lastcall)
-                    leaves_taken = _get_leaves_taken(allocation)
-                    ctx_allocation = allocation.with_context({'start_date': allocation.lastcall, 'end_date': end_date or period_end})
-                    ctx_allocation._add_days_to_allocation(current_level, current_level_maximum_leave, leaves_taken, period_start, period_end)
-                    allocation.already_accrued = True
+        if (period_start != start_date or period_end != end_date) and not level.accrual_plan_id.is_based_on_worked_time:
+            period_days = period_end - period_start + timedelta(days=1)
+            days = end_date - start_date + timedelta(days=1)
+            period_prorata = min(1, days / period_days) if period_days else 1
+        return added_duration * period_prorata
 
     @api.model
-    def _update_accrual(self):
+    def _get_days_after_expiration(self, allocation_data):
+        """ Accrual inconsistent (see the comment under the class declaration) """
+        expiring_days = allocation_data['previous_carryover_allocated_duration'] - allocation_data['leaves_taken']
+        return max(allocation_data['allocated_duration'] - expiring_days, allocation_data['leaves_taken'])
+
+    def _process_carryover_date(self, allocation_data, current_level, carryover_date):
+        """ Accrual inconsistent (see the comment under the class declaration) """
+        self.ensure_one()
+        if current_level.action_with_unused_accruals == 'lost' or not self.accrual_plan_id.can_be_carryover:
+            allocation_data['allocated_duration'] = allocation_data['leaves_taken']
+        else:
+            if current_level.accrual_validity:
+                allocation_data['carried_over_days_expiration_date'] = carryover_date + relativedelta(
+                    **{current_level.accrual_validity_type + 's': current_level.accrual_validity_count})
+
+            if current_level.carryover_options == 'limited':
+                left_allocated_duration = allocation_data['allocated_duration'] - allocation_data['leaves_taken']
+                max_carriedover_duration = self._convert_to_type_request_unit(
+                    current_level.max_carriedover_duration, current_level.added_value_type, allocation_data)
+                carriedover_duration = min(max_carriedover_duration, left_allocated_duration)
+                allocation_data['allocated_duration'] = carriedover_duration + allocation_data['leaves_taken']
+        allocation_data['previous_carryover_allocated_duration'] = allocation_data['allocated_duration']
+
+    def _process_accrual_start(self, allocation_data, current_level, next_accrual):
+        """ Add duration to this allocation if `allocation_data['nextcall']` is an accrual date
+            Called only on accrual allocations with `accrued_gain_time=start`
+            Accrual inconsistent (see the comment under the class declaration)
         """
-        Method called by the cron task in order to increment the number_of_days when
-        necessary.
+        self.ensure_one()
+        period_start = current_level._get_previous_date(allocation_data['nextcall'])
+        current_lvl_start_date = current_level._get_start_date(self.date_from)
+        if allocation_data['nextcall'] == period_start or allocation_data['nextcall'] == current_lvl_start_date:
+            accrual_start_date = allocation_data['nextcall']
+            accrual_end_date = next_accrual
+            period_end = current_level._get_next_date(allocation_data['nextcall'])
+            if current_level.frequency not in current_level._get_hourly_frequencies() + ['daily']:
+                accrual_end_date -= relativedelta(days=1)
+                period_end -= relativedelta(days=1)
+            self._add_days_to_allocation(allocation_data, current_level, period_start, period_end, accrual_start_date, accrual_end_date)
+
+    def _process_accrual_end(self, allocation_data, current_level, current_level_idx, first_level_start_date):
+        """ Add duration to this allocation if `allocation_data['nextcall']` is an accrual date
+            Called only on accrual allocations with `accrued_gain_time=end`
+            Accrual inconsistent (see the comment under the class declaration)
         """
-        today = datetime.combine(fields.Date.today(), time(0, 0, 0))
-        allocations = self.search([
+        self.ensure_one()
+        next_date = current_level._get_next_date(allocation_data['lastcall'])
+        current_level_last_date = self._get_next_lvl_start(current_level_idx)
+        if allocation_data['nextcall'] == next_date or allocation_data['nextcall'] == current_level_last_date:
+            accrual_start_date = allocation_data['last_accrual'] or first_level_start_date
+            accrual_end_date = allocation_data['nextcall']
+            period_start = current_level._get_previous_date(allocation_data['lastcall'])
+            period_end = next_date
+            if current_level.frequency not in current_level._get_hourly_frequencies() + ['daily']:
+                accrual_end_date -= relativedelta(days=1)
+                period_end -= relativedelta(days=1)
+            self._add_days_to_allocation(allocation_data, current_level, period_start, period_end, accrual_start_date, accrual_end_date)
+
+    def _has_expiring_days(self, allocation_data):
+        """ Accrual inconsistent (see the comment under the class declaration) """
+        self.ensure_one()
+        expiration_date = allocation_data['carried_over_days_expiration_date']
+        return allocation_data['nextcall'] and expiration_date and allocation_data['nextcall'] <= expiration_date
+
+    def _init_accrual_calls(self, allocation_data):
+        """ Initialize `last_accrual`, `lastcall` and `nextcall`
+            Accrual inconsistent (see the comment under the class declaration)
+        """
+        self.ensure_one()
+        first_level = self.accrual_plan_id.level_ids[0]
+        lastcall = first_level._get_start_date(self.date_from)
+        if self.accrual_plan_id.accrued_gain_time == 'start':
+            nextcall = lastcall
+        else:
+            nextcall = first_level._get_next_date(lastcall)
+            if self.accrual_plan_id.can_be_carryover:
+                carryover_date = self._get_next_carryover_date(lastcall)
+                nextcall = min(carryover_date, nextcall)
+            if len(self.accrual_plan_id.level_ids) > 1:
+                second_level_start_date = self._get_next_lvl_start(level_idx=0)
+                nextcall = min(second_level_start_date, nextcall)
+        allocation_data['last_accrual'] = None
+        allocation_data['lastcall'] = lastcall
+        allocation_data['nextcall'] = nextcall
+
+    def _get_lvls_boundaries(self) -> list[date] | None:
+        """ Returns a list containing intervals boundaries of each level.
+            The start of the level x is the end date of the previous level.
+
+            For instance, if there are 2 levels, this function will return a list of 2 dates:
+            the start of the first level and the start of the second level
+        """
+        self.ensure_one()
+        if self.accrual_plan_id.transition_mode == 'immediately':
+            return self.accrual_plan_id.level_ids.mapped(lambda lvl: lvl._get_start_date(self.date_from))
+
+        boundaries = [self.accrual_plan_id.level_ids[0]._get_start_date(self.date_from)]
+        for level in self.accrual_plan_id.level_ids[1:]:
+            expected_lvl_start = level._get_start_date(self.date_from)
+            lvl_start = level._get_next_date(expected_lvl_start + relativedelta(days=-1))
+            boundaries.append(lvl_start)
+        return boundaries
+
+    def _get_next_lvl_start(self, level_idx):
+        self.ensure_one()
+        lvls_boundaries = self._get_lvls_boundaries()
+        if level_idx == len(lvls_boundaries) - 1:
+            return None
+        return lvls_boundaries[level_idx + 1]
+
+    def _process_accrual_plans(self, date_to=None, precomputed_allocations={}):
+        """ This method is part of the cron's process.
+            The goal of this method is to retroactively apply accrual plan levels and progress from nextcall to `date_to` or `today`.
+        """
+        def _get_leaves_taken(allocation, allocation_data):
+            if len(precomputed_allocations):
+                allocations = dict(precomputed_allocations)
+                allocations[allocation] = allocation_data
+            else:
+                allocations = {allocation: allocation_data}
+            # By setting `precomputed_allocations`, avoid infinite loop (otherwise _get_consumed_leaves -> _get_additionnal_future_leaves_on -> _process_accrual_plans -> ...)
+            employee_days_per_allocation = allocation.employee_id._get_consumed_leaves(
+                allocation.work_entry_type_id, allocation_data['nextcall'], ignore_future=True,
+                precomputed_allocations=allocations)[0]
+            leaves_taken = employee_days_per_allocation[allocation.employee_id][allocation.work_entry_type_id][allocation]['leaves_taken']
+            return allocation._convert_to_type_request_unit(
+                leaves_taken, allocation.work_entry_type_id.unit_of_measure or 'day', allocation_data)
+
+        accrual_allocations = self.filtered('accrual_plan_id')
+        precomputed_alloc_recordset = accrual_allocations.filtered(lambda alloc: alloc in precomputed_allocations)
+        allocations_data = (accrual_allocations - precomputed_alloc_recordset)._get_accrual_allocation_data()
+        allocations_data.update({allocation: dict(precomputed_allocations[allocation]) for allocation in precomputed_allocations})
+        accrual_plan_with_levels = accrual_allocations.filtered('accrual_plan_id.level_ids')
+        for allocation in accrual_plan_with_levels:
+            allocation_data = allocations_data[allocation]
+            level_ids = allocation.accrual_plan_id.level_ids
+            first_level = level_ids[0]
+            first_level_start_date = first_level._get_start_date(allocation.date_from)
+            date_to = date_to or date.today()
+            if date_to < first_level_start_date:
+                allocation_data['leaves_taken'] = 0
+                continue
+
+            if not allocation_data['nextcall']:
+                # First time the plan is run for this allocation
+                allocation._init_accrual_calls(allocation_data)
+
+            while allocation_data['nextcall'] <= date_to:
+                allocation_data['leaves_taken'] = _get_leaves_taken(allocation, allocation_data)
+                plan_levels = allocation._get_current_accrual_plan_level_idx_for_accrual(allocation_data['nextcall'])
+                (current_level, current_level_idx), (accrual_level, accrual_level_idx) = plan_levels["current_level"], plan_levels["accrual_level"]
+                nextcall = current_level._get_next_date(allocation_data['nextcall'])
+
+                # There are 3 more accrual "events" (added to the start-end of each period of each level):
+                # Level transition, carryover date and carriedover expiring days date
+                # 1. Take level transition into account
+                current_level_last_date = allocation._get_next_lvl_start(current_level_idx)
+                if current_level_last_date and allocation_data['nextcall'] < current_level_last_date:
+                    nextcall = min(nextcall, current_level_last_date)
+
+                next_accrual = nextcall
+                carryover_date = allocation._get_next_carryover_date(allocation_data['nextcall'])
+                # 2. Take carryover date into account
+                if allocation_data['nextcall'] == carryover_date and allocation_data['nextcall'] != allocation.date_from \
+                        and allocation_data['nextcall'] != first_level_start_date:
+                    allocation._process_carryover_date(allocation_data, current_level, carryover_date)
+                elif allocation_data['nextcall'] != carryover_date:
+                    nextcall = min(nextcall, carryover_date)
+
+                if allocation._has_expiring_days(allocation_data) and allocation_data['carried_over_days_expiration_date'] > allocation_data['nextcall']:
+                    nextcall = min(allocation_data['carried_over_days_expiration_date'], nextcall)
+
+                if current_level.accrual_validity or allocation._has_expiring_days(allocation_data):
+                    # 3. Take expiring days into account
+                    if allocation_data['nextcall'] == allocation_data['carried_over_days_expiration_date']:
+                        allocation_data['allocated_duration'] = allocation._get_days_after_expiration(allocation_data)
+
+                if allocation.accrual_plan_id.accrued_gain_time == 'start':
+                    if allocation_data['nextcall'] == carryover_date:
+                        allocation_data['yearly_accrued_duration'] = 0
+                    allocation._process_accrual_start(allocation_data, accrual_level, next_accrual)
+                else:
+                    allocation._process_accrual_end(
+                        allocation_data, accrual_level, accrual_level_idx, first_level_start_date)
+                    if allocation_data['nextcall'] == carryover_date:
+                        allocation_data['yearly_accrued_duration'] = 0
+
+                allocation_data['lastcall'] = allocation_data['nextcall']
+                allocation_data['nextcall'] = nextcall
+
+            if allocation_data['leaves_taken'] is None:
+                allocation_data['leaves_taken'] = _get_leaves_taken(allocation, allocation_data)
+
+        for allocation in (accrual_allocations - accrual_plan_with_levels):
+            allocations_data[allocation]['leaves_taken'] = _get_leaves_taken(allocation, allocations_data[allocation])
+
+        return allocations_data
+
+    def _get_accrual_allocation_data(self):
+        allocation_data = {}
+        for allocation in self:
+            allocation_data[allocation] = {
+                'last_accrual': allocation.last_accrual,
+                'lastcall': allocation.lastcall,
+                'nextcall': allocation.nextcall,
+                'allocated_duration': allocation._convert_to_type_request_unit(allocation.number_of_days, 'day'),
+                'yearly_accrued_duration': allocation._convert_to_type_request_unit(allocation.yearly_accrued_days, 'day'),
+                'carried_over_days_expiration_date': allocation.carried_over_days_expiration_date,
+                'previous_carryover_allocated_duration':
+                    allocation._convert_to_type_request_unit(allocation.previous_carryover_number_of_days, 'day'),
+                # -------- Fields that won't be written on the allocation (see _update_accrual)
+                'leaves_taken': None,
+            }
+        return allocation_data
+
+    def _update_accrual(self, date_to=None):
+        """ Run by a cron in order to update the `number_of_days` (which represents the "credit" this allocation is granting)
+            depending on the linked accrual plan configuration
+            Update the accrual allocations until `date_to`
+        """
+        allocations_data = self._process_accrual_plans(date_to)
+        to_update_fields = ('last_accrual', 'lastcall', 'nextcall', 'carried_over_days_expiration_date')
+        for allocation in self:
+            values = allocations_data[allocation]
+            to_update_values = {field: values[field] for field in to_update_fields}
+            to_update_values.update({
+                'yearly_accrued_days':
+                    allocation._convert_from_type_request_unit(values['yearly_accrued_duration'], 'day', values),
+                'previous_carryover_number_of_days':
+                    allocation._convert_from_type_request_unit(values['previous_carryover_allocated_duration'], 'day', values),
+            })
+            to_update_values['number_of_days'] = allocation._convert_from_type_request_unit(values['allocated_duration'], 'day', values)
+            allocation.write(to_update_values)
+
+    @api.model
+    def _get_to_update_accrual_allocations(self):
+        today = fields.Date.context_today(self)
+        return self.search([
             ('state', '=', 'validate'),
-            ('accrual_plan_id', '!=', False), ('employee_id', '!=', False),
-            '|', ('date_to', '=', False), ('date_to', '>', fields.Datetime.now()),
-            '|', ('nextcall', '=', False), ('nextcall', '<=', today)])
-        allocations._process_accrual_plans()
+            ('accrual_plan_id', '!=', False),
+            ('date_from', '<=', today),
+            '|', ('date_to', '=', False), ('date_to', '>=', today),
+            '|', ('nextcall', '=', False), ('nextcall', '<=', today),
+        ])
 
-    def _discard_fake_allocation(self):
-        """Discard temporary allocations used for accrual simulation.
-
-        Invalidating a new record clears its cache but does not remove it
-        from the pending recomputation queue. Since a new record has no
-        database row from which computed fields can be recomputed, remove
-        it from the recomputation queue before discarding it.
+    def _get_additionnal_future_leaves_on(self, accrual_date, allocations_data={}):
+        """ Possibly accrual inconsistent (see the comment under the class declaration)
+            :param allocations_data: dict containing the allocation mapped to their data. If `allocations_data` is a dict,
+            then this function will return the additionnal leaves compared to the leaves in the `allocations_data` (instead of
+            comparing it to `self.number_of_days` or `self.number_of_hours_display`)
+            :returns: added allocated duration expressed in the unit of the work entry type `unit_of_measure` of the allocation
         """
-        self.invalidate_recordset()
-        for field in list(self.env.transaction.tocompute):
-            if field.model_name == self._name:
-                self.env.remove_to_compute(field, self)
-
-    def _get_future_leaves_on(self, accrual_date):
-        # As computing future accrual allocation days automatically updates the allocation,
-        # We need to create a temporary copy of that allocation to return the difference in number of days
-        # to see how much more days will be allocated from now until that date.
         self.ensure_one()
         if not accrual_date or accrual_date <= date.today():
             return 0
 
+        if self in allocations_data:
+            allocation_data = allocations_data[self]
+            nextcall = allocation_data['nextcall']
+        else:
+            allocation_data = {}
+            nextcall = self.nextcall
         if not (self.accrual_plan_id
                 and self.state == 'validate'
                 and (not self.date_to or self.date_to > accrual_date)
-                and (not self.nextcall or self.nextcall <= accrual_date)):
+                and (not nextcall or nextcall <= accrual_date)):
             return 0
 
-        fake_allocation = self.env['hr.leave.allocation'].new(origin=self)
-        fake_allocation.sudo()._process_accrual_plans(accrual_date, log=False)
-        if self.work_entry_type_id.unit_of_measure == 'hour':
-            res = float_round(fake_allocation.number_of_hours_display - self.number_of_hours_display, precision_digits=2)
+        future_alloc_data = self.sudo()._process_accrual_plans(accrual_date, precomputed_allocations=allocations_data)[self]
+        if 'allocated_duration' in allocation_data:
+            current_allocated_duration = self._convert_from_type_request_unit(
+                allocation_data['allocated_duration'], self.work_entry_type_id.unit_of_measure, allocation_data)
         else:
-            res = round((fake_allocation.number_of_days - self.number_of_days), 2)
-        fake_allocation._discard_fake_allocation()
-        return res
+            current_allocated_duration = self._convert_duration(self.number_of_days, 'day', self.work_entry_type_id.unit_of_measure)
+        future_allocated_duration = self._convert_from_type_request_unit(
+            future_alloc_data['allocated_duration'], self.work_entry_type_id.unit_of_measure, allocation_data)
+        return float_round(future_allocated_duration - current_allocated_duration, precision_digits=2)
 
     def _get_next_states_by_state(self):
         self.ensure_one()
@@ -810,40 +861,6 @@ class HrLeaveAllocation(models.Model):
                 target=allocation.employee_id.name,
             )
 
-    def _add_lastcalls(self):
-        today = fields.Date.context_today(self)
-        for allocation in self:
-            if not allocation.accrual_plan_id or not allocation.accrual_plan_id.level_ids:
-                continue
-            (current_level, current_level_idx) = allocation._get_current_accrual_plan_level_id(today)
-            if not current_level:
-                first_level = allocation.accrual_plan_id.level_ids[0]
-                first_level_start = allocation.date_from + get_timedelta(first_level.start_count, first_level.start_type)
-                if first_level_start == today:
-                    current_level = first_level
-                    current_level_idx = 0
-            if not allocation.lastcall:
-                if not current_level:
-                    allocation.lastcall = today
-                    allocation.actual_lastcall = allocation.lastcall
-                    continue
-                allocation.lastcall = max(
-                    current_level._get_previous_date(today),
-                    allocation.date_from + get_timedelta(current_level.start_count, current_level.start_type)
-                )
-                allocation.actual_lastcall = allocation.lastcall
-            if current_level and not allocation.nextcall:
-                accrual_plan = allocation.accrual_plan_id
-                allocation.nextcall = current_level._get_next_date(allocation.lastcall)
-                if current_level_idx < (len(accrual_plan.level_ids) - 1) and accrual_plan.transition_mode == 'immediately':
-                    next_level = accrual_plan.level_ids[current_level_idx + 1]
-                    next_level_start = allocation.date_from + get_timedelta(next_level.start_count, next_level.start_type)
-                    allocation.nextcall = min(allocation.nextcall, next_level_start)
-                # If the expiration date didn't pass (expiration date is in the future)
-                expiration_date = allocation.carried_over_days_expiration_date
-                if expiration_date and expiration_date > allocation.lastcall:
-                    allocation.nextcall = min(allocation.nextcall, expiration_date)
-
     def add_follower(self, employee_id):
         employee = self.env['hr.employee'].browse(employee_id)
         if employee.user_id:
@@ -859,7 +876,6 @@ class HrLeaveAllocation(models.Model):
             if not values.get('department_id'):
                 values.update({'department_id': self.env['hr.employee'].sudo().browse(employee_id).department_id.id})
         allocations = super(HrLeaveAllocation, self.with_context(mail_create_nosubscribe=True)).create(vals_list)
-        allocations._add_lastcalls()
         for allocation in allocations:
             partners_to_subscribe = set()
             if allocation.employee_id.user_id:
@@ -885,10 +901,7 @@ class HrLeaveAllocation(models.Model):
         tracked_fields = {'number_of_days_display', 'number_of_hours_display', 'state', 'date_to'}
         tracked_updates = tracked_fields.intersection(values)
         if not tracked_updates:
-            res = super().write(values)
-            if 'accrual_plan_id' in values:
-                self._add_lastcalls()
-            return res
+            return super().write(values)
 
         def total_excess(extra_data):
             excess_days = extra_data.get('excess_days', {})
@@ -899,8 +912,6 @@ class HrLeaveAllocation(models.Model):
         result = super().write(values)
         consumed_leaves = self.employee_id._get_consumed_leaves(work_entry_types=self.work_entry_type_id)
 
-        if 'accrual_plan_id' in values:
-            self._add_lastcalls()
         for allocation in self:
             current_extra_data = dict(consumed_leaves[1]).get(allocation.employee_id, {}) \
                 .get(allocation.work_entry_type_id, {})
@@ -1030,16 +1041,14 @@ class HrLeaveAllocation(models.Model):
                 return False
         return True
 
-    def _get_initialize_accrual_plan_values(self, date_from):
+    def _get_init_accrual_plan_values(self):
         return {
-            'lastcall': date_from,
+            'last_accrual': False,
+            'lastcall': False,
             'nextcall': False,
             'number_of_days': 0.0,
-            'number_of_days_display': 0.0,
-            'number_of_hours_display': 0.0,
-            'already_accrued': False,
             'carried_over_days_expiration_date': False,
-            'expiring_carryover_days': 0
+            'previous_carryover_number_of_days': 0,
         }
 
     @api.onchange('accrual_plan_id')
@@ -1050,19 +1059,15 @@ class HrLeaveAllocation(models.Model):
             self.number_of_days = 1.0
 
     # Allows user to simulate how many days an accrual plan would give from a certain start date.
-    # it uses the actual computation function but resets values of lastcall, nextcall and nbr of days
-    # before every run, as if it was run from date_from, after an optional change in the allocation value
-    # the user can simply confirm and validate the allocation. The record is in correct state for the next
-    # call of the cron job.
     @api.onchange('date_from', 'accrual_plan_id', 'date_to', 'employee_id')
-    def _onchange_date_from(self):
+    def _onchange_process_accrual_plans(self):
         if not self.date_from or not self.accrual_plan_id or self.state == 'validate'\
            or not self.employee_id:
             return
-        update_vals = self._get_initialize_accrual_plan_values(self.date_from)
+        update_vals = self._get_init_accrual_plan_values()
         self.update(update_vals)
         date_to = min(self.date_to, date.today()) if self.date_to else False
-        self._process_accrual_plans(date_to)
+        self._update_accrual(date_to)
 
     # ------------------------------------------------------------
     # Activity methods

--- a/addons/hr_holidays/models/hr_leave_allocation.py
+++ b/addons/hr_holidays/models/hr_leave_allocation.py
@@ -7,15 +7,25 @@ from dateutil.relativedelta import relativedelta
 
 from odoo import api, fields, models, _
 from odoo.tools import format_date
+from odoo.fields import Domain
 from odoo.addons.hr_holidays.models.hr_leave import get_employee_from_context
 from odoo.exceptions import UserError, ValidationError
-from odoo.fields import Domain
 from odoo.tools.float_utils import float_round
-from odoo.tools.date_utils import get_timedelta
 
 
 class HrLeaveAllocation(models.Model):
-    """ Allocation Requests Access specifications: similar to leave requests """
+    """ Allocation Requests Access specifications: similar to leave requests
+
+        Some of the methods of this class are tagged with 'Possibly accrual inconsistent' or 'Accrual inconsistent'.
+        This means:
+        - They mustn't read allocation fields that are not listed in `_get_accrual_to_update_fields`, but should
+          instead use the values of the parameter `allocation_data`
+        - They mustn't write any field of the allocation, but should update the `allocation_data` parameter
+
+        Some of these methods have `allocation_data=None`. In the case `allocation_data` is set to `None`, those
+        methods can directly use/modify any of the allocation field. In this case, those method will be tagged
+        'Possibly accrual inconsistent', and not 'Accrual inconsistent'.
+    """
     _name = 'hr.leave.allocation'
     _description = "Time Off Allocation"
     _order = "create_date desc"
@@ -88,7 +98,6 @@ class HrLeaveAllocation(models.Model):
         help="For an Accrual Allocation, this field contains the theorical amount of time given to the employee, due to a previous start date, on the first run of the plan. This can be manually edited.")
     duration_display = fields.Char('Allocated (Days/Hours)', compute='_compute_duration_display',
         help="Field allowing to see the allocation duration in days or hours depending on the type_request_unit")
-    last_executed_carryover_date = fields.Date(export_string_translation=False)
     # details
     approver_id = fields.Many2one(
         'hr.employee', string='First Approval', readonly=True, copy=False,
@@ -106,25 +115,24 @@ class HrLeaveAllocation(models.Model):
         ('day', 'Day'),
     ], compute="_compute_type_request_unit")
     department_id = fields.Many2one('hr.department', compute='_compute_department_id', store=True, string='Department', readonly=False)
-    # accrual configuration
-    lastcall = fields.Date("Date of the last accrual allocation", readonly=True)
-    # lastcall is only updated on accrual date. On other dates such as carryover date,
-    # actual_lastcall will store the date of the lastcall of the accrual allocation
-    actual_lastcall = fields.Date(export_string_translation=False)
-    nextcall = fields.Date("Date of the next accrual allocation", readonly=True, default=False)
-    already_accrued = fields.Boolean()
-    yearly_accrued_amount = fields.Float(export_string_translation=False)
     allocation_type = fields.Selection([
         ('regular', 'Regular Allocation'),
         ('accrual', 'Accrual Allocation')
     ], string="Allocation Type", default="regular", required=True, readonly=True)
     is_officer = fields.Boolean(compute='_compute_is_officer')
-    accrual_plan_id = fields.Many2one('hr.leave.accrual.plan', compute="_compute_accrual_plan_id",
-    inverse="_inverse_accrual_plan_id", store=True, index='btree_not_null', readonly=False, tracking=True)
     max_leaves = fields.Float(compute='_compute_leaves')
     leaves_taken = fields.Float(compute='_compute_leaves', string='Time off Taken')
     virtual_remaining_leaves = fields.Float(compute='_compute_leaves', string='Available Time Off')
-    expiring_carryover_days = fields.Float("The number of carried over days that will expire on carried_over_days_expiration_date")
+
+    # ============================== Accrual type allocation fields ==============================
+    accrual_plan_id = fields.Many2one('hr.leave.accrual.plan', compute="_compute_accrual_plan_id",
+        inverse="_inverse_accrual_plan_id", store=True, index='btree_not_null', readonly=False, tracking=True)
+    # Only when date_from <= today [<= date_to] and `_provess_accrual_plans` has been called, `last_accrual`, `lastcall` and `nextcall` will be assigned a value !
+    last_accrual = fields.Date("Date of the last accrual allocation")
+    lastcall = fields.Date("Date of the last executed accrual event (accrual, carryover date, expiring carriedover days, ...)", export_string_translation=False)
+    nextcall = fields.Date("Date of the closest next accrual event (accrual, carryover date, expiring carriedover days, ...)", default=False)
+    yearly_accrued_amount = fields.Float(export_string_translation=False)
+    previous_carryover_number_of_days = fields.Float("The number of carried over days that will expire on carried_over_days_expiration_date")
     carried_over_days_expiration_date = fields.Date("Carried over days expiration date")
 
     @api.constrains('date_from', 'date_to')
@@ -138,6 +146,16 @@ class HrLeaveAllocation(models.Model):
     @api.depends('allocation_type')
     def _compute_is_officer(self):
         self.is_officer = self.env.user.has_group("hr_holidays.group_hr_holidays_user")
+
+    def _get_employee_hours_per_day(self, allocation_data=None):
+        """ Possibly accrual inconsistent (see this class comment) """
+        self.ensure_one()
+        if self.allocation_type == 'accrual':
+            nextcall = allocation_data['nextcall'] if allocation_data else self.nextcall
+            date_from = nextcall or self.date_from
+        else:
+            date_from = self.date_from
+        return self.employee_id._get_hours_per_day(date_from)
 
     def _get_title(self):
         self.ensure_one()
@@ -216,7 +234,7 @@ class HrLeaveAllocation(models.Model):
         for allocation in self:
             if not allocation.employee_id:
                 continue
-            allocation.number_of_hours_display = (allocation.number_of_days * allocation.employee_id._get_hours_per_day(allocation.date_from))
+            allocation.number_of_hours_display = (allocation.number_of_days * allocation._get_employee_hours_per_day())
 
     @api.depends('number_of_hours_display', 'number_of_days_display')
     def _compute_duration_display(self):
@@ -268,7 +286,7 @@ class HrLeaveAllocation(models.Model):
             if allocation_unit != 'hour':
                 allocation.number_of_days = allocation.number_of_days_display
             elif allocation_unit == 'hour' and allocation.employee_id:
-                allocation.number_of_days = allocation.number_of_hours_display / allocation.employee_id._get_hours_per_day(allocation.date_from)
+                allocation.number_of_days = allocation.number_of_hours_display / allocation._get_employee_hours_per_day()
 
     @api.constrains('number_of_days', 'work_entry_type_id', 'employee_id')
     def _check_negative_allocation(self):
@@ -309,7 +327,8 @@ class HrLeaveAllocation(models.Model):
         for allocation in self:
             allocation.type_request_unit = allocation._get_request_unit()
 
-    def _get_carryover_date(self, date_from):
+    def _get_next_carryover_date(self, date_from, date_from_included=True):
+        """ Returns the next carry-over date, `date_from` included or not """
         self.ensure_one()
         carryover_time = self.accrual_plan_id.carryover_date
         accrual_plan = self.accrual_plan_id
@@ -325,54 +344,70 @@ class HrLeaveAllocation(models.Model):
             carryover_date = date(date_from.year, month, day)
         if date_from > carryover_date:
             carryover_date += relativedelta(years=1)
+
+        if not date_from_included and carryover_date == date_from:
+            return carryover_date + relativedelta(years=1)
         return carryover_date
 
-    def _add_days_to_allocation(self, current_level, current_level_maximum_leave, leaves_taken, period_start, period_end):
-        days_to_add = self._process_accrual_plan_level(
-            current_level, period_start, self.lastcall, period_end, self.nextcall)
+    def _get_maximum_leave_yearly_days(self, level, allocation_data=None):
+        """ Possibly accrual inconsistent (see this class comment) """
+        if level.added_value_type != 'hour':
+            return level.maximum_leave_yearly
+        return level.maximum_leave_yearly / self._get_employee_hours_per_day(allocation_data)
+
+    def _add_days_to_allocation(self, allocation_data, current_level, period_start, period_end, start_date, end_date):
+        """ Accrual inconsistent (see this class comment) """
+        self.ensure_one()
+        days_to_add = self._get_period_added_days(allocation_data, current_level, period_start, start_date, period_end, end_date)
         if current_level.cap_accrued_time_yearly:
-            maximum_leave_yearly = current_level.maximum_leave_yearly\
-                if current_level.added_value_type != 'hour'\
-                else current_level.maximum_leave_yearly / self.employee_id._get_hours_per_day(self.date_from)
-            yearly_remaining_amount = maximum_leave_yearly - self.yearly_accrued_amount
+            maximum_leave_yearly = self._get_maximum_leave_yearly_days(current_level, allocation_data)
+            yearly_remaining_amount = maximum_leave_yearly - allocation_data['yearly_accrued_amount']
             days_to_add = min(days_to_add, yearly_remaining_amount)
         if current_level.cap_accrued_time:
-            capped_total_balance = leaves_taken + current_level_maximum_leave
-            days_to_add = min(days_to_add, capped_total_balance - self.number_of_days)
-        self.number_of_days += days_to_add
-        self.yearly_accrued_amount += days_to_add
+            capped_total_balance = allocation_data['leaves_taken'] + self._get_lvl_max_leave_days(current_level, allocation_data)
+            days_to_add = min(days_to_add, capped_total_balance - allocation_data['number_of_days'])
+        allocation_data['number_of_days'] += days_to_add
+        allocation_data['yearly_accrued_amount'] += days_to_add
+        allocation_data['last_accrual'] = allocation_data['nextcall']
 
-    def _get_current_accrual_plan_level_id(self, date, level_ids=False):
-        """
-        Returns a pair (accrual_plan_level, idx) where accrual_plan_level is the level for the given date
-        and idx is the index for the plan in the ordered set of levels
+    def _get_current_accrual_plan_levels(self, date, lvls_intervals=None):
+        """ Wrapper for `accrual_plan_id._get_current_accrual_plan_levels` """
+        self.ensure_one()
+        if not self.accrual_plan_id or (self.date_to and date > self.date_to):
+            return None
+        if not lvls_intervals:
+            lvls_intervals = self.accrual_plan_id._get_lvls_boundaries(self.date_from)
+        return self.accrual_plan_id._get_current_accrual_plan_levels(date, lvls_intervals)
+
+    def _get_current_accrual_plan_level_idx(self, date, lvls_intervals=None):
+        """ Returns (current_level, index). If `date` is a levels transition, the returned `current_level` is the
+            one that starts later of the two levels """
+        self.ensure_one()
+        current_levels = self._get_current_accrual_plan_level_idx_for_accrual(date, lvls_intervals)
+        return current_levels['current_level'] if current_levels else (None, None)
+
+    def _get_current_accrual_plan_level_idx_for_accrual(self, date, lvl_boundaries=None):
+        """ Unlike `_get_current_accrual_plan_level_idx`, takes the levels transition into account.
+            For example, if `date` is a level transition and `accrued_gain_time` is "end", then we want to
+            get the "previous" plan level as we need to compute `number_of_days`, `expiring_days`, ... depending on the
+            "previous" level policy.
+
+            Returns a `dict` with the following entries:
+            - "current_level": (current_level, current_level_idx)     -> Current level
+            - "accrual_level": (accrual_level, accrual_level_idx)     -> Current level considering levels transition
+
+            See `hr.leave.accrual.plan.level._get_current_accrual_plan_levels` for more info
         """
         self.ensure_one()
-        if not self.accrual_plan_id.level_ids:
-            return (False, False)
-        # Sort by sequence which should be equivalent to the level
-        if not level_ids:
-            level_ids = self.accrual_plan_id.level_ids.sorted('sequence')
-        current_level = False
-        current_level_idx = -1
-        for idx, level in enumerate(level_ids):
-            if date > self.date_from + get_timedelta(level.start_count, level.start_type):
-                current_level = level
-                current_level_idx = idx
-        # If transition_mode is set to `immediately` or we are currently on the first level
-        # the current_level is simply the first level in the list.
-        if current_level_idx <= 0 or self.accrual_plan_id.transition_mode == "immediately":
-            return (current_level, current_level_idx)
-        # In this case we have to verify that the 'previous level' is not the current one due to `end_of_accrual`
-        level_start_date = self.date_from + get_timedelta(current_level.start_count, current_level.start_type)
-        previous_level = level_ids[current_level_idx - 1]
-        # If the next date from the current level's start date is before the last call of the previous level
-        # return the previous level
-        if current_level._get_next_date(level_start_date) < previous_level._get_next_date(level_start_date):
-            return (previous_level, current_level_idx - 1)
-        return (current_level, current_level_idx)
+        plan_levels = self._get_current_accrual_plan_levels(date, lvl_boundaries)
+        if not plan_levels:
+            return None
+        accrual_level = plan_levels["previous_level"] if "previous_level" in plan_levels\
+            and self.accrual_plan_id.accrued_gain_time == 'end' else plan_levels["current_level"]
+        return {"current_level": plan_levels["current_level"], "accrual_level": accrual_level}
 
     def _get_accrual_plan_level_work_entry_prorata(self, level, start_period, start_date, end_period, end_date):
+        """ Possibly accrual inconsistent (see this class comment) """
         self.ensure_one()
         datetime_min_time = datetime.min.time()
         start_dt = datetime.combine(start_date, datetime_min_time)
@@ -406,260 +441,289 @@ class HrLeaveAllocation(models.Model):
             work_entry_prorata = worked / (left + planned_worked) if (left + planned_worked) else 0
         return work_entry_prorata
 
-    def _process_accrual_plan_level(self, level, start_period, start_date, end_period, end_date):
-        """
-        Returns the added days for that level
-        """
+    def _get_period_added_days(self, allocation_data, level, period_start, start_date, period_end, end_date):
+        """ Accrual inconsistent (see this class comment) """
         self.ensure_one()
         if level.frequency in level._get_hourly_frequencies() or level.accrual_plan_id.is_based_on_worked_time:
-            work_entry_prorata = self._get_accrual_plan_level_work_entry_prorata(level, start_period, start_date, end_period, end_date)
-            added_value = work_entry_prorata * level.added_value
+            work_entry_prorata = self._get_accrual_plan_level_work_entry_prorata(level, period_start, start_date, period_end, end_date)
+            added_days = work_entry_prorata * level.added_value
         else:
-            added_value = level.added_value
+            added_days = level.added_value
         # Convert time in hours to time in days in case the level is encoded in hours
         if level.added_value_type == 'hour':
-            added_value = added_value / self.employee_id._get_hours_per_day(self.date_from)
+            added_days = added_days / self._get_employee_hours_per_day(allocation_data)
         period_prorata = 1
-        if (start_period != start_date or end_period != end_date) and not level.accrual_plan_id.is_based_on_worked_time:
-            period_days = (end_period - start_period)
+        if (period_start != start_date or period_end != end_date) and not level.accrual_plan_id.is_based_on_worked_time:
+            period_days = (period_end - period_start)
             call_days = (end_date - start_date)
             period_prorata = min(1, call_days / period_days) if period_days else 1
-        return added_value * period_prorata
+        return added_days * period_prorata
 
-    def _process_accrual_plans(self, date_to=False, force_period=False, log=True):
-        """
-        This method is part of the cron's process.
-        The goal of this method is to retroactively apply accrual plan levels and progress from nextcall to date_to or today.
-        If force_period is set, the accrual will run until date_to in a prorated way (used for end of year accrual actions).
-        """
-
-        date_to = date_to or fields.Date.today()
-        already_accrued = {allocation.id: allocation.already_accrued or (allocation.number_of_days != 0 and allocation.accrual_plan_id.accrued_gain_time == 'start') for allocation in self}
-        first_allocation = _("""This allocation have already ran once, any modification won't be effective to the days allocated to the employee. If you need to change the configuration of the allocation, delete and create a new one.""")
-        for allocation in self:
-            expiration_date = False
-            if allocation.allocation_type != 'accrual':
-                continue
-            level_ids = allocation.accrual_plan_id.level_ids.sorted('sequence')
-            if not level_ids:
-                continue
-            # "cache" leaves taken, as it gets recomputed every time allocation.number_of_days is assigned to. Without this,
-            # every loop will take 1+ second. It can be removed if computes don't chain in a way to always reassign accrual plan
-            # even if the value doesn't change. This is the best performance atm.
-            first_level = level_ids[0]
-            first_level_start_date = allocation.date_from + get_timedelta(first_level.start_count, first_level.start_type)
-            if allocation.work_entry_type_id.request_unit in ["day", "half_day"]:
-                leaves_taken = allocation.leaves_taken
-            else:
-                leaves_taken = allocation.leaves_taken / allocation.employee_id._get_hours_per_day(allocation.date_from)
-            allocation.already_accrued = already_accrued[allocation.id]
-            # first time the plan is run, initialize nextcall and take carryover / level transition into account
-            if not allocation.nextcall:
-                # Accrual plan is not configured properly or has not started
-                if date_to < first_level_start_date:
-                    continue
-                allocation.lastcall = max(allocation.lastcall, first_level_start_date)
-                allocation.actual_lastcall = allocation.lastcall
-                allocation.nextcall = first_level._get_next_date(allocation.lastcall)
-                # adjust nextcall for carryover
-                carryover_date = allocation._get_carryover_date(allocation.nextcall)
-                allocation.nextcall = min(carryover_date, allocation.nextcall)
-                # adjust nextcall for level_transition
-                if len(level_ids) > 1:
-                    second_level_start_date = allocation.date_from + get_timedelta(level_ids[1].start_count, level_ids[1].start_type)
-                    allocation.nextcall = min(second_level_start_date, allocation.nextcall)
-                if log:
-                    allocation._message_log(body=first_allocation)
-            (current_level, current_level_idx) = (False, 0)
-            current_level_maximum_leave = 0.0
-            # all subsequent runs, at every loop:
-            # get current level and normal period boundaries, then set nextcall, adjusted for level transition and carryover
-            # add days, trimmed if there is a maximum_leave
-            while allocation.nextcall <= date_to:
-                (current_level, current_level_idx) = allocation._get_current_accrual_plan_level_id(allocation.nextcall)
-                if not current_level:
-                    break
-                if current_level.cap_accrued_time:
-                    if current_level.added_value_type == "day":
-                        current_level_maximum_leave = current_level.maximum_leave
-                    else:
-                        current_level_maximum_leave = current_level.maximum_leave / allocation.employee_id._get_hours_per_day(allocation.date_from)
-                nextcall = current_level._get_next_date(allocation.nextcall)
-                # Since _get_previous_date returns the given date if it corresponds to a call date
-                # this will always return lastcall except possibly on the first call
-                # this is used to prorate the first number of days given to the employee
-                period_start = current_level._get_previous_date(allocation.lastcall)
-                period_end = current_level._get_next_date(allocation.lastcall)
-                # There are 3 cases where nextcall could be closer than the normal period:
-                # 1. Passing from one level to another, if mode is set to 'immediately'
-                current_level_last_date = False
-                if current_level_idx < (len(level_ids) - 1) and allocation.accrual_plan_id.transition_mode == 'immediately':
-                    next_level = level_ids[current_level_idx + 1]
-                    current_level_last_date = allocation.date_from + get_timedelta(next_level.start_count, next_level.start_type)
-                    if allocation.nextcall != current_level_last_date:
-                        nextcall = min(nextcall, current_level_last_date)
-                # 2. On carry-over date
-                carryover_date = allocation._get_carryover_date(allocation.nextcall)
-                if allocation.nextcall < carryover_date < nextcall:
-                    nextcall = min(nextcall, carryover_date)
-
-                if current_level.accrual_validity:
-                    # 3. On carried over days expiration date
-                    expiration_date = allocation.carried_over_days_expiration_date
-                    # - not expiration_date -> expiration_date needs to be initialized.
-                    # - allocation.nextcall > expiration_date -> the expiration date has passed and the new one should be computed.
-                    # - allocation.expiring_carryover_days == 0 -> If the carryover date of the accrual plan was changed or if a level
-                    #   transition occurred, then the expiration date needs to be updated. However, if allocation.expiring_carryover_days != 0,
-                    #   then this means that some days will expire on expiration_date and that expiration date should be respected and
-                    #   Expiration date will be updated correctly when allocation.nextcall is greater than expiration_date.
-                    if not expiration_date or allocation.nextcall > expiration_date or allocation.expiring_carryover_days == 0:
-                        expiration_date = carryover_date + relativedelta(**{current_level.accrual_validity_type + 's': current_level.accrual_validity_count})
-                        allocation.carried_over_days_expiration_date = expiration_date
-                    if allocation.nextcall < expiration_date < nextcall:
-                        nextcall = expiration_date
-                    if allocation.nextcall == expiration_date:
-                        # Given that allocation.number_of_days = employee time off balance + leaves_taken. So,
-                        # the leaves_taken are included in allocation.number_of_days.
-                        # Also, allocation.expiring_carryover_days includes the leaves_taken before the carryover date
-                        # and allocation.leaves_taken includes all the leaves_taken before the carryover date + all the leaves_taken
-                        # between the carryover date and the expiration_date. So, the number of expiring days will be
-                        # allocation.expiring_carryover_days - allocation.leaves_taken or 0 if all the expiring days were used
-                        # to take time off.
-                        # This ensures that only the days that weren't used to take time off will expire.
-                        expiring_days = max(0, allocation.expiring_carryover_days - allocation.leaves_taken)
-                        allocation.number_of_days = max(0, allocation.number_of_days - expiring_days)
-                        allocation.expiring_carryover_days = 0
-
-                is_accrual_date = allocation.nextcall == period_end or allocation.nextcall == current_level_last_date
-                if not allocation.already_accrued and is_accrual_date and allocation.accrual_plan_id.accrued_gain_time == 'start':
-                    allocation._add_days_to_allocation(current_level, current_level_maximum_leave, leaves_taken, period_start, period_end)
-
-                # if it's the carry-over date, adjust days using current level's carry-over policy
-                if allocation.nextcall == carryover_date:
-                    allocation.last_executed_carryover_date = carryover_date
-                    if current_level.action_with_unused_accruals == 'lost' or current_level.carryover_options == 'limited':
-                        allocated_days_left = allocation.number_of_days - leaves_taken
-                        allocation_max_days = 0 # default if unused_accrual are lost
-                        if current_level.carryover_options == 'limited':
-                            if current_level.added_value_type == 'day':
-                                postpone_max_days = current_level.postpone_max_days
-                            else:
-                                postpone_max_days = current_level.postpone_max_days / allocation.employee_id._get_hours_per_day(allocation.date_from)
-                            allocation_max_days = min(postpone_max_days, allocated_days_left)
-                        allocation.number_of_days = min(allocation.number_of_days, allocation_max_days) + leaves_taken
-                    allocation.expiring_carryover_days = allocation.number_of_days
-
-                if not allocation.already_accrued and is_accrual_date and allocation.accrual_plan_id.accrued_gain_time == 'end':
-                    allocation._add_days_to_allocation(current_level, current_level_maximum_leave, leaves_taken, period_start, period_end)
-
-                if allocation.nextcall == carryover_date:
-                    allocation.yearly_accrued_amount = 0
-
-                # 1. When accrued_gain_time == 'start', all the days are accrued on the start of the accrual period. For example, if the accrual period
-                #    is from 01/01/2023 to 01/01/2024, then the days will be accrued on 01/01/2023. Given that the carryover date will be >= the start of the accrual period
-                #    (01/01/2023 in the example) the carryover policy should apply to any day accrued during the period from 01/01/2023 to 01/01/2024.
-                # 2.However, if a level transistion occurred, the carryover policy should apply to the days that were accrued during the carryover level only.
-                #   Any days accrued after the carryover level should be excluded.
-                #   So, if carryover date was 01/06/2023, it should be applied to any day accrued between 01/01/2023 and 01/01/2024. If a level transition
-                #   occurred on 01/09/2023 for example, then the carryover should be applied to any day accrued between 01/01/2023 and 01/09/2023.
-                # 3. The following if block will handle the carryover for days accrued after carryover_date until carryover_period_end. Carryover period end is
-                #    adjusted if a level transition occurred. The carryover for days accrued before carryover_date is handled above.
-                if allocation.accrual_plan_id.accrued_gain_time == 'start' and allocation.last_executed_carryover_date:
-                    last_carryover_date = allocation.last_executed_carryover_date
-                    carryover_level, carryover_level_idx = allocation._get_current_accrual_plan_level_id(last_carryover_date)
-                    carryover_period_start = carryover_level._get_previous_date(last_carryover_date)
-                    carryover_period_end = carryover_level._get_next_date(last_carryover_date)
-                    # Adjust carryover_period_end based on level_transition.
-                    if carryover_level_idx < (len(level_ids) - 1) and allocation.accrual_plan_id.transition_mode == 'immediately':
-                        next_level = level_ids[carryover_level_idx + 1]
-                        carryover_level_last_date = allocation.date_from + get_timedelta(next_level.start_count, next_level.start_type)
-                        carryover_period_end = min(carryover_period_end, carryover_level_last_date)
-                    # Handle the special case for hourly/daily accruals. Carryover_period_end should be equal to last_carryover_date
-                    # because the carryover period is just 1 day.
-                    if carryover_level.frequency in carryover_level._get_hourly_frequencies() + ['daily']:
-                        carryover_period_end = last_carryover_date
-                    # Carryover policy should be only applied to the days accrued on period_end.
-                    # Days accrued on level transition date aren't subject to the carryover policy.
-                    # That is why (allocation.nextcall == period_end) is used instead of (is_accrual_date)
-                    accrued = not allocation.already_accrued and allocation.nextcall == period_end
-                    # If the days were accrued on the carryover period, then apply the carryover policy
-                    # If allocation.actual_lastcall == carryover_period_start, it means this loop has already been run once (skip to avoid applying the carryover twice)
-                    if accrued and last_carryover_date <= allocation.nextcall <= carryover_period_end and allocation.actual_lastcall != carryover_period_start:
-                        if carryover_level.action_with_unused_accruals == 'lost' or carryover_level.carryover_options == 'limited':
-                            allocation.last_executed_carryover_date = carryover_date
-                            allocated_days_left = allocation.number_of_days - leaves_taken
-                            postpone_max_days = current_level.postpone_max_days if current_level.added_value_type == 'day' \
-                                else current_level.postpone_max_days / allocation.employee_id._get_hours_per_day(allocation.date_from)
-                            allocated_days_left = allocation.number_of_days - leaves_taken
-                            allocation_max_days = 0 # default if unused_accrual are lost
-                            if current_level.carryover_options == 'limited':
-                                postpone_max_days = current_level.postpone_max_days
-                                allocation_max_days = min(postpone_max_days, allocated_days_left)
-                            allocation.number_of_days = min(allocation.number_of_days, allocation_max_days) + leaves_taken
-
-                if is_accrual_date:
-                    allocation.lastcall = allocation.nextcall
-                allocation.actual_lastcall = allocation.nextcall
-                allocation.nextcall = nextcall
-                allocation.already_accrued = False
-                if force_period and allocation.nextcall > date_to:
-                    allocation.nextcall = date_to
-                    force_period = False
-
-            # if plan.accrued_gain_time == 'start', process next period and set flag 'already_accrued', this will skip adding days
-            # once, preventing double allocation.
-            if allocation.accrual_plan_id.accrued_gain_time == 'start':
-                # check that we are at the start of a period, not on a carry-over or level transition date
-                level_start = {level._get_level_transition_date(allocation.date_from): level for level in allocation.accrual_plan_id.level_ids}
-                current_level = level_start.get(allocation.actual_lastcall) or current_level or allocation.accrual_plan_id.level_ids[0]
-                period_start = current_level._get_previous_date(allocation.actual_lastcall)
-                if current_level.cap_accrued_time:
-                    if current_level.added_value_type == "day":
-                        current_level_maximum_leave = current_level.maximum_leave
-                    else:
-                        current_level_maximum_leave = current_level.maximum_leave / allocation.employee_id._get_hours_per_day(allocation.date_from)
-                if allocation.actual_lastcall in {period_start, allocation.date_from} | set(level_start.keys())\
-                        or (allocation.actual_lastcall - get_timedelta(current_level.accrual_validity_count, current_level.accrual_validity_type)
-                            in {period_start, allocation.date_from} | set(level_start.keys())):
-                    allocation._add_days_to_allocation(current_level, current_level_maximum_leave, leaves_taken, period_start, allocation.nextcall)
-                    allocation.already_accrued = True
+    def _get_lvl_max_leave_days(self, level, allocation_data=None):
+        """ Possibly accrual inconsistent (see this class comment) """
+        self.ensure_one()
+        if level.added_value_type == "day":
+            return level.maximum_leave
+        return level.maximum_leave / self._get_employee_hours_per_day(allocation_data)
 
     @api.model
-    def _update_accrual(self):
+    def _update_carryover_expiration_date(self, allocation_data, current_carryover_date, current_level):
+        """ Accrual inconsistent (see this class comment) """
+        allocation_data['carried_over_days_expiration_date'] = current_carryover_date +\
+            relativedelta(**{current_level.accrual_validity_type + 's': current_level.accrual_validity_count})\
+            if current_level.accrual_validity else None
+
+    @api.model
+    def _process_expiration_date(self, allocation_data, current_level, carryover_date):
+        """ Accrual inconsistent (see this class comment) """
+        expiring_days = max(0, allocation_data['previous_carryover_number_of_days'] - allocation_data['leaves_taken'])
+        allocation_data['number_of_days'] = max(0, allocation_data['number_of_days'] - expiring_days)
+        self._update_carryover_expiration_date(allocation_data, carryover_date, current_level)
+
+    def _get_max_carriedover_days(self, current_level, allocation_data=None):
+        """ Possibly accrual inconsistent (see this class comment) """
+        if current_level.added_value_type == 'day':
+            return current_level.max_carriedover_duration
+        return current_level.max_carriedover_duration / self._get_employee_hours_per_day(allocation_data)
+
+    def _process_carryover_date(self, allocation_data, current_level, carryover_date):
+        """ Accrual inconsistent (see this class comment) """
+        self.ensure_one()
+        if current_level.action_with_unused_accruals == 'lost' or current_level.carryover_options == 'limited'\
+                or not self.accrual_plan_id.can_be_carryover:
+            allocation_max_days = 0
+            if current_level.carryover_options == 'limited' and self.accrual_plan_id.can_be_carryover:
+                allocated_days_left = allocation_data['number_of_days'] - allocation_data['leaves_taken']
+                max_carriedover_duration = self._get_max_carriedover_days(current_level)
+                allocation_max_days = min(max_carriedover_duration, allocated_days_left)
+            allocation_data['number_of_days'] = min(allocation_data['number_of_days'], allocation_max_days) + allocation_data['leaves_taken']
+
+        allocation_data['previous_carryover_number_of_days'] = allocation_data['number_of_days']
+        self._update_carryover_expiration_date(allocation_data, carryover_date, current_level)
+
+    def _process_accrual_start(self, allocation_data, current_level, next_accrual):
+        """ Process accrual based on self.nextcall when accrued_gain_time is `start`
+            Accrual inconsistent (see this class comment)
+        """
+        self.ensure_one()
+        period_start = current_level._get_previous_date(allocation_data['nextcall'])
+        current_lvl_start_date = current_level._get_start_date(self.date_from)
+        if allocation_data['nextcall'] == period_start or allocation_data['nextcall'] == current_lvl_start_date:
+            accrual_start_date = allocation_data['nextcall']
+            accrual_end_date = next_accrual
+            period_end = current_level._get_next_date(allocation_data['nextcall'])
+            self._add_days_to_allocation(allocation_data, current_level, period_start, period_end, accrual_start_date, accrual_end_date)
+
+    def _process_accrual_end(self, allocation_data, current_level, current_level_idx, lvl_intervals, first_level_start_date):
+        """ Process accrual based on self.nextcall when accrued_gain_time is `end`
+            Accrual inconsistent (see this class comment)
+        """
+        self.ensure_one()
+        period_end = current_level._get_next_date(allocation_data['lastcall'])
+        current_level_last_date = self.accrual_plan_id._get_lvl_last_date(self.date_from, current_level_idx, lvl_intervals)
+        if allocation_data['nextcall'] == period_end or allocation_data['nextcall'] == current_level_last_date:
+            accrual_start_date = allocation_data['last_accrual'] or first_level_start_date
+            accrual_end_date = allocation_data['nextcall']
+            period_start = current_level._get_previous_date(allocation_data['lastcall'])
+            self._add_days_to_allocation(allocation_data, current_level, period_start, period_end, accrual_start_date, accrual_end_date)
+
+    def _has_expiring_days(self, allocation_data):
+        """ Accrual inconsistent (see this class comment) """
+        self.ensure_one()
+        expiration_date = allocation_data['carried_over_days_expiration_date']
+        return allocation_data['nextcall'] and expiration_date and allocation_data['nextcall'] <= expiration_date
+
+    def _init_accrual_calls(self, allocation_data):
+        """ Initialize `last_accrual`, `lastcall` and `nextcall`
+            Accrual inconsistent (see this class comment)
+        """
+        self.ensure_one()
+        levels = self.accrual_plan_id.level_ids.sorted('sequence')
+        first_level = levels[0]
+        lastcall = first_level._get_start_date(self.date_from)
+        if self.accrual_plan_id.accrued_gain_time == 'start':
+            nextcall = lastcall
+        else:
+            nextcall = first_level._get_next_date(lastcall)
+            if self.accrual_plan_id.can_be_carryover:
+                carryover_date = self._get_next_carryover_date(lastcall)
+                nextcall = min(carryover_date, nextcall)
+            if len(levels) > 1:
+                second_level_start_date = self.accrual_plan_id._get_lvl_last_date(self.date_from, level_idx=0)
+                nextcall = min(second_level_start_date, nextcall)
+        allocation_data['last_accrual'] = None
+        allocation_data['lastcall'] = lastcall
+        allocation_data['nextcall'] = nextcall
+        allocation_data['accrual_initialized'] = True
+
+    def _get_accrual_allocation_data(self):
+        allocation_data = {}
+        for allocation in self:
+            allocation_data[allocation] = {
+                'last_accrual': allocation.last_accrual,
+                'lastcall': allocation.lastcall,
+                'nextcall': allocation.nextcall,
+                'number_of_days': allocation.number_of_days,
+                'yearly_accrued_amount': allocation.yearly_accrued_amount,
+                'carried_over_days_expiration_date': allocation.carried_over_days_expiration_date,
+                'previous_carryover_number_of_days': allocation.previous_carryover_number_of_days,
+                # -------- Not updated fields (see _get_accrual_to_update_fields)
+                'leaves_taken': None,
+                'accrual_initialized': False,
+            }
+        return allocation_data
+
+    @api.model
+    def _get_accrual_to_update_fields(self):
+        return ['last_accrual', 'lastcall', 'nextcall', 'number_of_days', 'yearly_accrued_amount',
+            'carried_over_days_expiration_date', 'previous_carryover_number_of_days']
+
+    def _update_accrual_from_data(self, allocations_data, log=True):
+        to_update_fields = self._get_accrual_to_update_fields()
+        first_allocation_msg = _("""This allocation have already ran once, any modification won't be effective to the days allocated to the employee. If you need to change the configuration of the allocation, delete and create a new one.""")
+        for allocation in self:
+            values = allocations_data[allocation]
+            to_update_values = {field: values[field] for field in to_update_fields}
+            allocation.write(to_update_values)
+            if log and values['accrual_initialized']:
+                allocation._message_log(body=first_allocation_msg)
+
+    def _process_accrual_plans(self, date_to=None, precomputed_allocations=None):
+        """ This method is part of the cron's process.
+            The goal of this method is to retroactively apply accrual plan levels and progress from nextcall to date_to or today.
+        """
+        def _get_leaves_taken(allocation, allocation_data):
+            if precomputed_allocations:
+                allocations = dict(precomputed_allocations)
+                allocations[allocation] = allocation_data
+            else:
+                allocations = {allocation: allocation_data}
+            # By setting `precomputed_allocations`, avoid infinite loop (otherwise _get_consumed_leaves -> _get_additionnal_future_leaves_on -> _process_accrual_plans -> ...)
+            employee_days_per_allocation = allocation.employee_id._get_consumed_leaves(
+                allocation.work_entry_type_id, allocation_data['nextcall'], ignore_future=True, precomputed_allocations=allocations)[0]
+            leaves_taken = employee_days_per_allocation[allocation.employee_id][allocation.work_entry_type_id][allocation]['leaves_taken']
+            if allocation.work_entry_type_id.unit_of_measure == 'hour':
+                leaves_taken /= allocation.employee_id._get_hours_per_day(allocation_data['nextcall'] or allocation.date_from)
+            return leaves_taken
+
+        date_to = date_to or fields.Date.today()
+        accrual_allocations = self.filtered(lambda alloc: alloc.allocation_type == 'accrual')
+        allocations_data = self._get_accrual_allocation_data()
+        for allocation in accrual_allocations:
+            allocation_data = dict(precomputed_allocations[allocation]) if precomputed_allocations and\
+                allocation in precomputed_allocations else allocations_data[allocation]
+
+            if not allocation.accrual_plan_id.level_ids:
+                allocation_data['leaves_taken'] = 0
+                continue
+            level_ids = allocation.accrual_plan_id.level_ids.sorted('sequence')
+            first_level = level_ids[0]
+            first_level_start_date = first_level._get_start_date(allocation.date_from)
+            if date_to < first_level_start_date:
+                allocation_data['leaves_taken'] = 0
+                continue
+
+            if not allocation_data['nextcall']:
+                # First time the plan is run
+                allocation._init_accrual_calls(allocation_data)
+
+            lvls_boundaries = allocation.accrual_plan_id._get_lvls_boundaries(allocation.date_from)
+            while allocation_data['nextcall'] <= date_to:
+                allocation_data['leaves_taken'] = _get_leaves_taken(allocation, allocation_data)
+                plan_levels = allocation._get_current_accrual_plan_level_idx_for_accrual(allocation_data['nextcall'], lvls_boundaries)
+                if not plan_levels:
+                    break
+
+                (current_level, current_level_idx), (accrual_level, accrual_level_idx) = plan_levels["current_level"], plan_levels["accrual_level"]
+                nextcall = current_level._get_next_date(allocation_data['nextcall'])
+
+                # There are 3 more accrual "events" (added to the start-end of each period of each level): level transition, carryover date and carriedover expiring days date
+                # 1. Take level transition into account
+                current_level_last_date = allocation.accrual_plan_id._get_lvl_last_date(allocation.date_from, current_level_idx, lvls_boundaries)
+                if current_level_last_date and allocation_data['nextcall'] < current_level_last_date:
+                    nextcall = min(nextcall, current_level_last_date)
+
+                next_accrual = nextcall
+                carryover_date = allocation._get_next_carryover_date(allocation_data['nextcall'])
+                # 2. Take carryover date into account
+                if allocation_data['nextcall'] < carryover_date:
+                    nextcall = min(nextcall, carryover_date)
+
+                if allocation_data['nextcall'] == carryover_date:
+                    allocation._process_carryover_date(allocation_data, current_level, carryover_date)
+                if current_level.accrual_validity or allocation._has_expiring_days(allocation_data):
+                    # 3. Take expiring days into account
+                    if allocation._has_expiring_days(allocation_data) and allocation_data['carried_over_days_expiration_date'] > allocation_data['nextcall']:
+                        nextcall = min(allocation_data['carried_over_days_expiration_date'], nextcall)
+
+                    if allocation_data['nextcall'] == allocation_data['carried_over_days_expiration_date']:
+                        allocation._process_expiration_date(allocation_data, current_level, carryover_date)
+
+                if allocation.accrual_plan_id.accrued_gain_time == 'start':
+                    if allocation_data['nextcall'] == carryover_date:
+                        allocation_data['yearly_accrued_amount'] = 0
+                    allocation._process_accrual_start(allocation_data, accrual_level, next_accrual)
+                else:
+                    allocation._process_accrual_end(
+                        allocation_data, accrual_level, accrual_level_idx, lvls_boundaries, first_level_start_date)
+                    if allocation_data['nextcall'] == carryover_date:
+                        allocation_data['yearly_accrued_amount'] = 0
+
+                allocation_data['lastcall'] = allocation_data['nextcall']
+                allocation_data['nextcall'] = nextcall
+            if allocation_data['leaves_taken'] is None:
+                allocation_data['leaves_taken'] = _get_leaves_taken(allocation, allocation_data)
+        return allocations_data
+
+    @api.model
+    def _update_accrual(self, employee_ids=None):
         """
         Method called by the cron task in order to increment the number_of_days when
         necessary.
         """
         today = datetime.combine(fields.Date.today(), time(0, 0, 0))
         allocations = self.search([
-            ('allocation_type', '=', 'accrual'), ('state', '=', 'validate'),
-            ('accrual_plan_id', '!=', False), ('employee_id', '!=', False),
-            '|', ('date_to', '=', False), ('date_to', '>', fields.Datetime.now()),
-            '|', ('nextcall', '=', False), ('nextcall', '<=', today)])
-        allocations._process_accrual_plans()
+            ('allocation_type', '=', 'accrual'),
+            ('state', '=', 'validate'),
+            ('accrual_plan_id', '!=', False),
+            ('employee_id', 'in', employee_ids) if employee_ids else ('employee_id', '!=', False),
+            '|', ('date_to', '=', False), ('date_to', '>=', fields.Datetime.now()),
+            '|', ('nextcall', '=', False), ('nextcall', '<=', today),
+        ])
+        allocations_data = allocations._process_accrual_plans()
+        allocations._update_accrual_from_data(allocations_data)
 
-    def _get_future_leaves_on(self, accrual_date):
-        # As computing future accrual allocation days automatically updates the allocation,
-        # We need to create a temporary copy of that allocation to return the difference in number of days
-        # to see how much more days will be allocated from now until that date.
+    def _get_additionnal_future_leaves_on(self, accrual_date, allocations_data=None):
+        """ Possibly accrual inconsistent (see this class comment)
+            :param allocations_data: can be a dict containing the allocation mapped to their data. If `allocations_data` is a dict,
+            then this function will return the additionnal leaves compared to the leaves in the allocations_data (instead of
+            comparing it to self.number_of_days)
+        """
         self.ensure_one()
         if not accrual_date or accrual_date <= date.today():
             return 0
 
+        if allocations_data and self in allocations_data:
+            allocation_data = allocations_data[self]
+            nextcall = allocation_data['nextcall']
+        else:
+            allocation_data = None
+            nextcall = self.nextcall
         if not (self.accrual_plan_id
                 and self.state == 'validate'
                 and self.allocation_type == 'accrual'
                 and (not self.date_to or self.date_to > accrual_date)
-                and (not self.nextcall or self.nextcall <= accrual_date)):
+                and (not nextcall or nextcall <= accrual_date)):
             return 0
 
-        fake_allocation = self.env['hr.leave.allocation'].with_context(default_date_from=accrual_date).new(origin=self)
-        fake_allocation.sudo().with_context(default_date_from=accrual_date)._process_accrual_plans(accrual_date, log=False)
-        if self.work_entry_type_id.unit_of_measure in ['hour']:
-            res = float_round(fake_allocation.number_of_hours_display - self.number_of_hours_display, precision_digits=2)
+        future_alloc_data = self.sudo()._process_accrual_plans(accrual_date, precomputed_allocations=allocations_data)[self]
+        current_number_of_days = allocation_data['number_of_days'] if allocation_data else self.number_of_days
+        if self.work_entry_type_id.unit_of_measure == 'hour':
+            future_leave_hours = future_alloc_data['number_of_days'] * self._get_employee_hours_per_day(future_alloc_data)
+            current_leave_hours = current_number_of_days * self._get_employee_hours_per_day(allocation_data)
+            res = float_round(future_leave_hours - current_leave_hours, precision_digits=2)
         else:
-            res = round((fake_allocation.number_of_days - self.number_of_days), 2)
-        fake_allocation.invalidate_recordset()
+            res = round((future_alloc_data['number_of_days'] - current_number_of_days), 2)
         return res
 
     def _get_next_states_by_state(self):
@@ -721,34 +785,6 @@ class HrLeaveAllocation(models.Model):
                 target=allocation.employee_id.name,
             )
 
-    def _add_lastcalls(self):
-        for allocation in self:
-            if allocation.allocation_type != 'accrual':
-                continue
-            today = fields.Date.today()
-            (current_level, current_level_idx) = allocation._get_current_accrual_plan_level_id(today)
-            if not allocation.lastcall:
-                if not current_level:
-                    allocation.lastcall = today
-                    allocation.actual_lastcall = allocation.lastcall
-                    continue
-                allocation.lastcall = max(
-                    current_level._get_previous_date(today),
-                    allocation.date_from + get_timedelta(current_level.start_count, current_level.start_type)
-                )
-                allocation.actual_lastcall = allocation.lastcall
-            if current_level and not allocation.nextcall:
-                accrual_plan = allocation.accrual_plan_id
-                allocation.nextcall = current_level._get_next_date(allocation.lastcall)
-                if current_level_idx < (len(accrual_plan.level_ids) - 1) and accrual_plan.transition_mode == 'immediately':
-                    next_level = accrual_plan.level_ids[current_level_idx + 1]
-                    next_level_start = allocation.date_from + get_timedelta(next_level.start_count, next_level.start_type)
-                    allocation.nextcall = min(allocation.nextcall, next_level_start)
-                # If the expiration date didn't pass (expiration date is in the future)
-                expiration_date = allocation.carried_over_days_expiration_date
-                if expiration_date and expiration_date > allocation.lastcall:
-                    allocation.nextcall = min(allocation.nextcall, expiration_date)
-
     def add_follower(self, employee_id):
         employee = self.env['hr.employee'].browse(employee_id)
         if employee.user_id:
@@ -764,7 +800,6 @@ class HrLeaveAllocation(models.Model):
             if not values.get('department_id'):
                 values.update({'department_id': self.env['hr.employee'].sudo().browse(employee_id).department_id.id})
         allocations = super(HrLeaveAllocation, self.with_context(mail_create_nosubscribe=True)).create(vals_list)
-        allocations._add_lastcalls()
         for allocation in allocations:
             partners_to_subscribe = set()
             if allocation.employee_id.user_id:
@@ -788,17 +823,12 @@ class HrLeaveAllocation(models.Model):
         self.add_follower(employee_id)
 
         if 'number_of_days_display' not in values and 'number_of_hours_display' not in values and 'state' not in values:
-            res = super().write(values)
-            if 'allocation_type' in values:
-                self._add_lastcalls()
-            return res
+            return super().write(values)
 
         previous_consumed_leaves = self.employee_id._get_consumed_leaves(work_entry_types=self.work_entry_type_id)
         result = super().write(values)
         consumed_leaves = self.employee_id._get_consumed_leaves(work_entry_types=self.work_entry_type_id)
 
-        if 'allocation_type' in values:
-            self._add_lastcalls()
         for allocation in self:
             current_excess = dict(consumed_leaves[1]).get(allocation.employee_id, {}) \
                 .get(allocation.work_entry_type_id, {}).get('excess_days', {})
@@ -936,25 +966,22 @@ class HrLeaveAllocation(models.Model):
             self.number_of_days = 1.0
 
     # Allows user to simulate how many days an accrual plan would give from a certain start date.
-    # it uses the actual computation function but resets values of lastcall, nextcall and nbr of days
-    # before every run, as if it was run from date_from, after an optional change in the allocation value
-    # the user can simply confirm and validate the allocation. The record is in correct state for the next
-    # call of the cron job.
     @api.onchange('date_from', 'accrual_plan_id', 'date_to', 'employee_id')
-    def _onchange_date_from(self):
+    def _onchange_process_accrual_plans(self):
         if not self.date_from or self.allocation_type != 'accrual' or self.state == 'validate' or not self.accrual_plan_id\
            or not self.employee_id:
             return
-        self.lastcall = self.date_from
-        self.nextcall = False
+        self.last_accrual = None
+        self.lastcall = None
+        self.nextcall = None
         self.number_of_days_display = 0.0
         self.number_of_hours_display = 0.0
         self.number_of_days = 0.0
-        self.already_accrued = False
-        self.carried_over_days_expiration_date = False
-        self.expiring_carryover_days = 0
-        date_to = min(self.date_to, date.today()) if self.date_to else False
-        self._process_accrual_plans(date_to)
+        self.carried_over_days_expiration_date = None
+        self.previous_carryover_number_of_days = 0
+        date_to = min(self.date_to, date.today()) if self.date_to else None
+        allocations_data = self._process_accrual_plans(date_to)
+        self._update_accrual_from_data(allocations_data, log=bool(self._origin))
 
     # ------------------------------------------------------------
     # Activity methods

--- a/addons/hr_holidays/models/hr_work_entry_type.py
+++ b/addons/hr_holidays/models/hr_work_entry_type.py
@@ -7,8 +7,6 @@ import operator as py_operator
 from collections import defaultdict
 from datetime import date, datetime, time, UTC
 
-from dateutil.relativedelta import relativedelta
-
 from odoo import api, fields, models
 from odoo.exceptions import UserError, ValidationError
 from odoo.fields import Domain
@@ -642,32 +640,27 @@ been taken for this time off type. Changing it now would affect existing employe
 
     def _get_closest_expiring_leaves_date_and_count(self, allocations, remaining_leaves, target_date):
         # Get the expiration date and carryover date of all allocations and compute the closest expiration date
-        expiration_dates_per_allocation = defaultdict(lambda: {'expiration_date': fields.Date(), 'carryover_date': fields.Date(), 'carried_over_days_expiration_date': fields.Date()})
+        expiration_dates_per_allocation = {}
         expiration_dates = list()
         carried_over_days_expiration_data = self._get_carried_over_days_expiration_data(allocations, target_date)
         for allocation in allocations:
             expiration_date = allocation.date_to
 
-            accrual_plan_level = allocation.sudo()._get_current_accrual_plan_level_id(target_date)[0]
-            carryover_date = False
-            if accrual_plan_level and (accrual_plan_level.action_with_unused_accruals == 'lost'
-            or accrual_plan_level.carryover_options == 'limited'):
-                carryover_date = allocation.sudo()._get_carryover_date(target_date)
-                # If carry over date == target date, then add 1 year to carry over date.
-                # Rational: for example if carry over date = 01/01 this year and target date = 01/01 this year,
-                # then any accrued days on 01/01 this year will have their carry over date 01/01 next year
-                # and not 01/01 this year.
-                if carryover_date == target_date:
-                    carryover_date += relativedelta(years=1)
+            current_lvl, _ = allocation.sudo()._get_current_accrual_plan_level_idx(target_date)
+            carryover_date = None
+            if current_lvl and (current_lvl.action_with_unused_accruals == 'lost' or current_lvl.carryover_options == 'limited'):
+                carryover_date = allocation.sudo()._get_next_carryover_date(target_date, date_from_included=False)
 
             carried_over_days_expiration_date = carried_over_days_expiration_data[allocation]['expiration_date']
 
             expiration_dates.extend([expiration_date, carryover_date, carried_over_days_expiration_date])
-            expiration_dates_per_allocation[allocation]['expiration_date'] = expiration_date
-            expiration_dates_per_allocation[allocation]['carryover_date'] = carryover_date
-            expiration_dates_per_allocation[allocation]['carried_over_days_expiration_date'] = carried_over_days_expiration_date
+            expiration_dates_per_allocation[allocation] = {
+                'expiration_date': expiration_date,
+                'carryover_date': carryover_date,
+                'carried_over_days_expiration_date': carried_over_days_expiration_date,
+            }
 
-        expiration_dates = list(filter(lambda date: date is not False, expiration_dates))
+        expiration_dates = list(filter(bool, expiration_dates))
         expiration_dates.sort()
         # Compute the number of expiring leaves
         for closest_expiration_date in expiration_dates:
@@ -680,8 +673,10 @@ been taken for this time off type. Changing it now would affect existing employe
                 if expiration_date and expiration_date == closest_expiration_date:
                     expiring_leaves_count += remaining_leaves[allocation]['virtual_remaining_leaves']
                 elif carryover_date and carryover_date == closest_expiration_date:
-                    accrual_plan_level = allocation.sudo()._get_current_accrual_plan_level_id(target_date)[0]
-                    expiring_leaves_count += max(0, remaining_leaves[allocation]['virtual_remaining_leaves'] - accrual_plan_level.postpone_max_days)
+                    current_lvl = allocation.sudo()._get_current_accrual_plan_level_idx(target_date)[0]
+                    max_carried_over_duration = allocation._convert_from_type_request_unit(
+                        current_lvl.max_carriedover_duration, allocation.work_entry_type_id.unit_of_measure)
+                    expiring_leaves_count += max(0, remaining_leaves[allocation]['virtual_remaining_leaves'] - max_carried_over_duration)
                 elif carried_over_days_expiration_date and carried_over_days_expiration_date == closest_expiration_date:
                     expiring_leaves_count += carried_over_days_expiration_data[allocation]['no_expiring_days']
 
@@ -689,20 +684,25 @@ been taken for this time off type. Changing it now would affect existing employe
                 return closest_expiration_date, expiring_leaves_count
 
         # No leaves will expire
-        return False, 0
+        return None, 0
 
     def _get_carried_over_days_expiration_data(self, allocations, target_date):
-        fake_allocations = self.env['hr.leave.allocation']
+        updated_alloc_data = allocations.sudo()._process_accrual_plans(target_date)
+        carried_over_days_expiration_data = {}
         for allocation in allocations:
-            fake_allocations |= self.env['hr.leave.allocation'].new(origin=allocation)
-        fake_allocations.sudo()._process_accrual_plans(target_date, log=False)
-        carried_over_days_expiration_data = {
-            fake_allocation._origin:
-            {
-                'expiration_date': fake_allocation.carried_over_days_expiration_date,
-                'no_expiring_days': max(0, fake_allocation.expiring_carryover_days - fake_allocation.leaves_taken)
+            if not allocation.accrual_plan_id:
+                carried_over_days_expiration_data[allocation] = {
+                    'expiration_date': None,
+                    'no_expiring_days': 0,
+                }
+                continue
+            allocation_data = updated_alloc_data[allocation]
+            prev_carryover_allocated_duration = allocation._convert_from_type_request_unit(
+                allocation_data['previous_carryover_allocated_duration'], allocation.work_entry_type_id.unit_of_measure, allocation_data)
+            leaves_taken = allocation_data['leaves_taken']
+            carried_over_days_expiration_data[allocation] = {
+                'expiration_date': allocation_data['carried_over_days_expiration_date'],
+                'no_expiring_days':
+                    max(0, prev_carryover_allocated_duration - leaves_taken),
             }
-            for fake_allocation in fake_allocations
-        }
-        fake_allocations._discard_fake_allocation()
         return carried_over_days_expiration_data

--- a/addons/hr_holidays/models/hr_work_entry_type.py
+++ b/addons/hr_holidays/models/hr_work_entry_type.py
@@ -7,8 +7,6 @@ import operator as py_operator
 from collections import defaultdict
 from datetime import date, datetime, time, UTC
 
-from dateutil.relativedelta import relativedelta
-
 from odoo import api, fields, models
 from odoo.exceptions import UserError, ValidationError
 from odoo.fields import Domain
@@ -592,32 +590,27 @@ class HrWorkEntryType(models.Model):
 
     def _get_closest_expiring_leaves_date_and_count(self, allocations, remaining_leaves, target_date):
         # Get the expiration date and carryover date of all allocations and compute the closest expiration date
-        expiration_dates_per_allocation = defaultdict(lambda: {'expiration_date': fields.Date(), 'carryover_date': fields.Date(), 'carried_over_days_expiration_date': fields.Date()})
+        expiration_dates_per_allocation = {}
         expiration_dates = list()
         carried_over_days_expiration_data = self._get_carried_over_days_expiration_data(allocations, target_date)
         for allocation in allocations:
             expiration_date = allocation.date_to
 
-            accrual_plan_level = allocation.sudo()._get_current_accrual_plan_level_id(target_date)[0]
-            carryover_date = False
-            if accrual_plan_level and (accrual_plan_level.action_with_unused_accruals == 'lost'
-            or accrual_plan_level.carryover_options == 'limited'):
-                carryover_date = allocation.sudo()._get_carryover_date(target_date)
-                # If carry over date == target date, then add 1 year to carry over date.
-                # Rational: for example if carry over date = 01/01 this year and target date = 01/01 this year,
-                # then any accrued days on 01/01 this year will have their carry over date 01/01 next year
-                # and not 01/01 this year.
-                if carryover_date == target_date:
-                    carryover_date += relativedelta(years=1)
+            current_lvl, _ = allocation.sudo()._get_current_accrual_plan_level_idx(target_date)
+            carryover_date = None
+            if current_lvl and (current_lvl.action_with_unused_accruals == 'lost' or current_lvl.carryover_options == 'limited'):
+                carryover_date = allocation.sudo()._get_next_carryover_date(target_date, date_from_included=False)
 
             carried_over_days_expiration_date = carried_over_days_expiration_data[allocation]['expiration_date']
 
             expiration_dates.extend([expiration_date, carryover_date, carried_over_days_expiration_date])
-            expiration_dates_per_allocation[allocation]['expiration_date'] = expiration_date
-            expiration_dates_per_allocation[allocation]['carryover_date'] = carryover_date
-            expiration_dates_per_allocation[allocation]['carried_over_days_expiration_date'] = carried_over_days_expiration_date
+            expiration_dates_per_allocation[allocation] = {
+                'expiration_date': expiration_date,
+                'carryover_date': carryover_date,
+                'carried_over_days_expiration_date': carried_over_days_expiration_date,
+            }
 
-        expiration_dates = list(filter(lambda date: date is not False, expiration_dates))
+        expiration_dates = list(filter(bool, expiration_dates))
         expiration_dates.sort()
         # Compute the number of expiring leaves
         for closest_expiration_date in expiration_dates:
@@ -630,8 +623,8 @@ class HrWorkEntryType(models.Model):
                 if expiration_date and expiration_date == closest_expiration_date:
                     expiring_leaves_count += remaining_leaves[allocation]['virtual_remaining_leaves']
                 elif carryover_date and carryover_date == closest_expiration_date:
-                    accrual_plan_level = allocation.sudo()._get_current_accrual_plan_level_id(target_date)[0]
-                    expiring_leaves_count += max(0, remaining_leaves[allocation]['virtual_remaining_leaves'] - accrual_plan_level.postpone_max_days)
+                    current_lvl, _ = allocation.sudo()._get_current_accrual_plan_level_idx(target_date)
+                    expiring_leaves_count += max(0, remaining_leaves[allocation]['virtual_remaining_leaves'] - current_lvl.max_carriedover_duration)
                 elif carried_over_days_expiration_date and carried_over_days_expiration_date == closest_expiration_date:
                     expiring_leaves_count += carried_over_days_expiration_data[allocation]['no_expiring_days']
 
@@ -639,20 +632,22 @@ class HrWorkEntryType(models.Model):
                 return closest_expiration_date, expiring_leaves_count
 
         # No leaves will expire
-        return False, 0
+        return None, 0
 
     def _get_carried_over_days_expiration_data(self, allocations, target_date):
-        fake_allocations = self.env['hr.leave.allocation']
-        for allocation in allocations:
-            fake_allocations |= self.env['hr.leave.allocation'].with_context(default_date_from=target_date).new(origin=allocation)
-        fake_allocations.sudo().with_context(default_date_from=target_date)._process_accrual_plans(target_date, log=False)
-        carried_over_days_expiration_data = {
-            fake_allocation._origin:
-            {
-                'expiration_date': fake_allocation.carried_over_days_expiration_date,
-                'no_expiring_days': max(0, fake_allocation.expiring_carryover_days - fake_allocation.leaves_taken)
+        accrual_allocations = allocations.filtered(lambda alloc: alloc.allocation_type == 'accrual')
+        updated_alloc_data = accrual_allocations.sudo()._process_accrual_plans(target_date)
+        carried_over_days_expiration_data = {}
+        for allocation in accrual_allocations:
+            expiring_days = updated_alloc_data[allocation]['previous_carryover_number_of_days']
+            leaves_taken = updated_alloc_data[allocation]['leaves_taken']
+            carried_over_days_expiration_data[allocation] = {
+                'expiration_date': updated_alloc_data[allocation]['carried_over_days_expiration_date'],
+                'no_expiring_days': max(0, expiring_days - leaves_taken),
             }
-            for fake_allocation in fake_allocations
-        }
-        fake_allocations.invalidate_recordset()
+        for allocation in allocations - accrual_allocations:
+            carried_over_days_expiration_data[allocation] = {
+                'expiration_date': None,
+                'no_expiring_days': 0,
+            }
         return carried_over_days_expiration_data

--- a/addons/hr_holidays/static/src/components/accrual_level/accrual_levels.xml
+++ b/addons/hr_holidays/static/src/components/accrual_level/accrual_levels.xml
@@ -83,7 +83,7 @@
                                     <br/>
                                 </t>
                                 <t t-else="">
-                                    Unused days will be transferred with a max of <t t-out="level.data.postpone_max_days"/> <t t-out="level.data.added_value_type"/>
+                                    Unused days will be transferred with a max of <t t-esc="level.data.max_carriedover_duration"/> <t t-esc="level.data.added_value_type"/>
                                     on each <t t-out="this.state.carryOverDate"/>.
                                     <br/>
                                 </t>

--- a/addons/hr_holidays/static/src/components/accrual_level/accrual_levels.xml
+++ b/addons/hr_holidays/static/src/components/accrual_level/accrual_levels.xml
@@ -83,7 +83,7 @@
                                     <br/>
                                 </t>
                                 <t t-else="">
-                                    Unused days will be transferred with a max of <t t-out="level.data.postpone_max_days"/> <t t-out="this.durationTypes[level.data.added_value_type] || level.data.added_value_type"/>
+                                    Unused days will be transferred with a max of <t t-out="level.data.max_carriedover_duration"/> <t t-out="this.durationTypes[level.data.added_value_type] || level.data.added_value_type"/>
                                     on each <t t-out="this.state.carryOverDate"/>.
                                     <br/>
                                 </t>

--- a/addons/hr_holidays/static/tests/mock_server/mock_models/hr_leave_accrual_level.js
+++ b/addons/hr_holidays/static/tests/mock_server/mock_models/hr_leave_accrual_level.js
@@ -41,7 +41,7 @@ export class HrLeaveAccrualLevel extends models.ServerModel {
             added_value_type: "day",
             action_with_unused_accruals: "all",
             carryover_options: "limited",
-            postpone_max_days: 10,
+            max_carriedover_duration: 10,
             maximum_leave: 25,
         },
         // Level 4: After 5 Years, Yearly accrual with yearly cap & balance cap

--- a/addons/hr_holidays/tests/common.py
+++ b/addons/hr_holidays/tests/common.py
@@ -135,29 +135,50 @@ class TestHrHolidaysCommon(common.TransactionCase):
         cls.rd_dept.write({'manager_id': cls.employee_hruser_id})
         cls.hours_per_day = cls.employee_emp.resource_id.calendar_id.hours_per_day or 8
 
-    def assert_remaining_leaves_equal(self, work_entry_type, value, employee, date=None, digits=None):
-        allocation_data = work_entry_type.get_allocation_data(employee, date)
-        if not date:
-            date = fields.Date.today()
-        if digits:
-            self.assertAlmostEqual(allocation_data[employee][0][1]['remaining_leaves'], value,
-                digits, f"Remaining leaves for date '{date}' are incorrect.")
-        else:
-            self.assertEqual(allocation_data[employee][0][1]['remaining_leaves'],
-                value, f"Remaining leaves for date '{date}' are incorrect.")
+    def _assert_allocation_balance(self, allocation, expected_duration=None, expected_remaining_leaves=None,
+            target_date=None, msg=None, digits=3):
+        """ Assert `_get_allocation_data` returns the specified `expected_duration` and `expected_remaining_leaves`
+            for the work entry type of the given `allocation` at the given `target_date`
+            :param expected_duration: expressed in `allocation.work_entry_type_id.unit_of_measure`
+            :param target_date: default is today
+        """
+        return self._assert_work_entry_type_allocations_balance(
+            allocation.work_entry_type_id, allocation.employee_id, expected_duration, expected_remaining_leaves, target_date, msg, digits)
 
-    def _take_leave(self, employee, work_entry_type, date_from, date_to):
-        leave = self.env['hr.leave'].create({
+    def _assert_work_entry_type_allocations_balance(self, work_entry_type, employee, expected_duration=None, expected_remaining_leaves=None,
+            target_date=None, msg=None, digits=3):
+        """ Assert `_get_allocation_data` returns the specified `expected_duration` and `expected_remaining_leaves`
+            for the given `work_entry_type`
+            :param expected_duration: expressed in `allocation.work_entry_type_id.unit_of_measure`
+            :param target_date: default is today
+        """
+        work_entry_type_data = work_entry_type.get_allocation_data(employee, target_date)
+        remaining_leaves = work_entry_type_data[employee][0][1]['remaining_leaves']
+
+        modified_msg = f'Error on {target_date or fields.Date.today()}' + (f' - {msg}' if msg else '')
+        if expected_duration:
+            leaves_taken = work_entry_type_data[employee][0][1]['leaves_taken']
+            allocation_value = remaining_leaves + leaves_taken
+            self.assertAlmostEqual(allocation_value, expected_duration, places=digits, msg=modified_msg)
+        if expected_remaining_leaves:
+            self.assertAlmostEqual(remaining_leaves, expected_remaining_leaves, places=digits, msg=modified_msg)
+
+    def _create_leave(self, employee, work_entry_type, date_from, date_to, hour_from=False, hour_to=False, validate=False, user=None, additionnal_ctx={}):
+        leave = self.env['hr.leave'].with_context(tracking_disable=True, **additionnal_ctx).with_user(user or self.env.user).create({
             'name': 'Leave',
             'employee_id': employee.id,
             'work_entry_type_id': work_entry_type.id,
             'request_date_from': date_from,
             'request_date_to': date_to,
+            'request_hour_from': hour_from,
+            'request_hour_to': hour_to,
         })
+        if validate:
+            leave.action_approve()
         return leave
 
-    def _create_form_test_accrual_allocation(self, work_entry_type, date_from, employee, accrual_plan, date_to=None, creator_user=None):
-        allocation = self.env['hr.leave.allocation']
+    def _create_form_test_accrual_allocation(self, work_entry_type, date_from, employee, accrual_plan, date_to=None, creator_user=None, number_of_days=None):
+        allocation = self.env['hr.leave.allocation'].with_context(tracking_disable=True)
         if creator_user:
             allocation = allocation.with_user(creator_user)
         with Form(allocation, 'hr_holidays.hr_leave_allocation_view_form_manager') as form:
@@ -168,9 +189,11 @@ class TestHrHolidaysCommon(common.TransactionCase):
             form.date_from = date_from
             if date_to:
                 form.date_to = date_to
+            if number_of_days:
+                form.number_of_days = number_of_days
         return form.record
 
-    def _create_form_test_regular_allocation(self, work_entry_type, date_from, employee, number_of_days, date_to=None, creator_user=None):
+    def _create_form_test_regular_allocation(self, work_entry_type, date_from, employee, duration, date_to=None, creator_user=None):
         allocation = self.env['hr.leave.allocation']
         if creator_user:
             allocation = allocation.with_user(creator_user)
@@ -179,7 +202,10 @@ class TestHrHolidaysCommon(common.TransactionCase):
             form.employee_id = employee
             form.work_entry_type_id = work_entry_type
             form.date_from = date_from
-            form.number_of_days_display = number_of_days
+            if not work_entry_type.unit_of_measure or work_entry_type.unit_of_measure == 'day':
+                form.number_of_days_display = duration
+            else:
+                form.number_of_hours_display = duration
             if date_to:
                 form.date_to = date_to
         return form.record

--- a/addons/hr_holidays/tests/common.py
+++ b/addons/hr_holidays/tests/common.py
@@ -135,19 +135,20 @@ class TestHrHolidaysCommon(common.TransactionCase):
         cls.rd_dept.write({'manager_id': cls.employee_hruser_id})
         cls.hours_per_day = cls.employee_emp.resource_id.calendar_id.hours_per_day or 8
 
-    def assert_remaining_leaves_equal(self, work_entry_type, value, employee, date=None, digits=None):
-        allocation_data = work_entry_type.get_allocation_data(employee, date)
-        if not date:
-            date = fields.Date.today()
-        if digits:
-            self.assertAlmostEqual(allocation_data[employee][0][1]['remaining_leaves'], value,
-                digits, f"Remaining leaves for date '{date}' are incorrect.")
-        else:
-            self.assertEqual(allocation_data[employee][0][1]['remaining_leaves'],
-                value, f"Remaining leaves for date '{date}' are incorrect.")
+    def _assert_allocation_nbr_of_days_and_remaining_leaves_equal(self, allocation, expected_duration, expected_remaining_leaves,
+            msg=None, target_date=None, digits=3):
+        """ The unit of `expected_duration` is `allocation.work_entry_type_id.unit_of_measure` """
+        work_entry_type_data = allocation.work_entry_type_id.get_allocation_data(allocation.employee_id, target_date)
+        remaining_leaves = work_entry_type_data[allocation.employee_id][0][1]['remaining_leaves']
+        leaves_taken = work_entry_type_data[allocation.employee_id][0][1]['leaves_taken']
+        allocation_value = remaining_leaves + leaves_taken
+
+        modified_msg = f'Error on {target_date or fields.Date.today()}' + f' - {msg}' if msg else ''
+        self.assertAlmostEqual(allocation_value, expected_duration, places=digits, msg=modified_msg)
+        self.assertAlmostEqual(remaining_leaves, expected_remaining_leaves, places=digits, msg=modified_msg)
 
     def _create_form_test_accrual_allocation(self, work_entry_type, date_from, employee, accrual_plan, date_to=None, creator_user=None):
-        allocation = self.env['hr.leave.allocation']
+        allocation = self.env['hr.leave.allocation'].with_context(tracking_disable=True)
         if creator_user:
             allocation = allocation.with_user(creator_user)
         with Form(allocation, 'hr_holidays.hr_leave_allocation_view_form_manager') as form:

--- a/addons/hr_holidays/tests/test_accrual_allocations.py
+++ b/addons/hr_holidays/tests/test_accrual_allocations.py
@@ -1,54 +1,116 @@
 import datetime
-from freezegun import freeze_time
+import inspect
 from datetime import date
-from dateutil.relativedelta import relativedelta
+
+from freezegun import freeze_time
 from psycopg2 import IntegrityError
 
-from odoo import Command, fields
-from odoo.api import NewId
-from odoo.exceptions import UserError
+from odoo import Command
 from odoo.tests import tagged, Form
-from odoo.exceptions import ValidationError
+from odoo.exceptions import UserError, ValidationError
 from odoo.tools import mute_logger
+from odoo.tools.date_utils import parse_iso_date
 
 from odoo.addons.hr_holidays.tests.common import TestHrHolidaysCommon
+
+
+class AccrualPlanDuplicataError(Exception):
+    """ Happens when there are 2 "identical" accrual plans """
+
+
+class ArgumentsError(Exception):
+    """ Happens when the arguments of the function are invalid """
 
 
 @tagged('post_install', '-at_install', 'accruals')
 class TestAccrualAllocations(TestHrHolidaysCommon):
     @classmethod
     def setUpClass(cls):
-        super(TestAccrualAllocations, cls).setUpClass()
+        super().setUpClass()
         cls.department = cls.env['hr.department'].create({
             'name': 'Test Department',
         })
-        cls.work_entry_type = cls.env['hr.work.entry.type'].create({
-            'name': 'Paid Time Off',
-            'code': 'Paid Time Off',
+
+        accrual_plan_by_signature = {}
+        work_entry_type_by_signature = {}
+
+        def _create_accrual_plan(accrual_plan_by_signature, vals_list):
+            """ Creates an accrual plan
+                This function has 2 additionnal purposes:
+                    - Avoid accrual plan duplicata
+                    - Making you wonder whether the test you're adding hasn't already been created
+                        Indeed, the tests below are mostly defined by the accrual plan(s) they are using, so if an accrual plan
+                        already exists, it may mean that your test can be merge in an existing test / that an existing test should be improved
+                        (to avoid creating more allocation and makin more database request)
+            """
+            vals_list['name'] = f'Accrual plan line {inspect.getouterframes(inspect.currentframe())[1].frame.f_lineno}'
+            accrual_plan = cls.env['hr.leave.accrual.plan'].create(vals_list)
+            plan_signature = _get_accrual_plan_signature(accrual_plan)
+            if plan_signature in accrual_plan_by_signature:
+                raise AccrualPlanDuplicataError(
+                    f'Accrual plan duplicata detected with accrual plan named:\n{accrual_plan_by_signature[plan_signature]}\nSignature:\n{plan_signature}\nPlease take a look at the description of the "_create_accrual_plan" function')
+            accrual_plan_by_signature[plan_signature] = accrual_plan.name
+            return accrual_plan
+
+        def _create_work_entry_type(work_entry_type_by_signature, vals_list):
+            vals_list['name'] = vals_list['code'] = f'Work entry type line {inspect.getouterframes(inspect.currentframe())[1].frame.f_lineno}'
+            work_entry_type = cls.env['hr.work.entry.type'].create(vals_list)
+            work_entry_type_signature = _get_work_entry_type_signature(work_entry_type)
+            if work_entry_type_signature in work_entry_type_by_signature:
+                raise AccrualPlanDuplicataError(
+                    f'Work entry type duplicata detected with work entry type named:\n{work_entry_type_by_signature[work_entry_type_signature]}\nSignature:\n{work_entry_type_signature}')
+            work_entry_type_by_signature[work_entry_type_signature] = work_entry_type.name
+            return work_entry_type
+
+        def _get_accrual_plan_signature(accrual_plan):
+            """ Returns the signature of the plan
+
+                This function only takes what are considered the "most important" parameters into account, because considering the number
+                of option an accrual plan has, it would be too heavy to create one unit test per combination of parameters.
+
+                If you still wish to create a new test case for an accrual plan that has the same hash, simply modify the fields at the beginning
+                of the new test.
+            """
+            plan_signature = (f"{accrual_plan.transition_mode},{accrual_plan.is_based_on_worked_time},{accrual_plan.accrued_gain_time}"
+                f",{'carryover' if accrual_plan.can_be_carryover else 'no_carryover'},{accrual_plan.carryover_date}")
+            for level in accrual_plan.level_ids:
+                plan_signature += (f",{level.start_count},{level.start_type},{level.frequency},{level.added_value_type},"
+                    f"{level.action_with_unused_accruals},{level.carryover_options},{'expiring' if level.accrual_validity else 'not_expiring'},{'capped' if level.cap_accrued_time else 'uncapped'},{'capped_y' if level.cap_accrued_time_yearly else 'uncapped_y'},")
+            return plan_signature[:-1]
+
+        def _get_work_entry_type_signature(work_entry_type):
+            return (f"{work_entry_type.count_as},{work_entry_type.requires_allocation},{work_entry_type.elligible_for_accrual_rate},{work_entry_type.request_unit},"
+                f"{work_entry_type.unit_of_measure},{work_entry_type.allocation_validation_type},{work_entry_type.allows_negative}")
+
+        cls.work_entry_type = _create_work_entry_type(work_entry_type_by_signature, {
             'count_as': 'absence',
             'requires_allocation': True,
             'allocation_validation_type': 'hr',
             'request_unit': 'day',
             'unit_of_measure': 'day',
         })
-        cls.work_entry_type_hour = cls.env['hr.work.entry.type'].create({
-            'name': 'Paid Time Off hours',
-            'code': 'Paid Time Off hours',
+        cls.work_entry_type_hour = _create_work_entry_type(work_entry_type_by_signature, {
             'count_as': 'absence',
             'requires_allocation': True,
             'allocation_validation_type': 'hr',
             'request_unit': 'hour',
             'unit_of_measure': 'hour',
         })
-        cls.work_entry_type_hour_day = cls.env['hr.work.entry.type'].create({
-            'name': 'Paid Time Off hours',
-            'code': 'Paid Time Off hours Test',
+        cls.work_entry_type_hour_day = _create_work_entry_type(work_entry_type_by_signature, {
             'count_as': 'absence',
             'requires_allocation': True,
             'allocation_validation_type': 'hr',
             'request_unit': 'day',
             'unit_of_measure': 'hour',
         })
+        cls.work_entry_type_day_hour = _create_work_entry_type(work_entry_type_by_signature, {
+            'count_as': 'absence',
+            'requires_allocation': True,
+            'allocation_validation_type': 'hr',
+            'request_unit': 'hour',
+            'unit_of_measure': 'day',
+        })
+
         accrual_plan1_levels_fields = {
             'added_value_type': 'day',
             'frequency': 'monthly',
@@ -71,33 +133,28 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'added_value': 2,
             }),
         ]
-        cls.accrual_plan_start1 = cls.env['hr.leave.accrual.plan'].create({
-            'name': 'Accrual Plan 1 start',
+        cls.accrual_plan_start1 = _create_accrual_plan(accrual_plan_by_signature, {
             'is_based_on_worked_time': False,
             'accrued_gain_time': 'start',
             'carryover_date': 'allocation',
             'can_be_carryover': True,
             'level_ids': accrual_plan1_levels,
         })
-        cls.accrual_plan_end1 = cls.env['hr.leave.accrual.plan'].create({
-            'name': 'Accrual Plan 1 end',
+        cls.accrual_plan_end1 = _create_accrual_plan(accrual_plan_by_signature, {
             'is_based_on_worked_time': False,
             'accrued_gain_time': 'end',
             'carryover_date': 'allocation',
             'can_be_carryover': True,
             'level_ids': accrual_plan1_levels,
         })
-        cls.work_entry_type_day = cls.env['hr.work.entry.type'].create({
-            'name': 'Test Leave Type Days',
-            'code': 'Test Leave Type Days',
+        cls.work_entry_type_day = _create_work_entry_type(work_entry_type_by_signature, {
             'count_as': 'absence',
             'requires_allocation': 'yes',
             'allocation_validation_type': 'no_validation',
             'request_unit': 'day',
             'unit_of_measure': 'day',
         })
-        cls.accrual_plan_monthly_end = cls.env['hr.leave.accrual.plan'].create({
-            'name': 'Accrual Plan For Test',
+        cls.accrual_plan_monthly_end = _create_accrual_plan(accrual_plan_by_signature, {
             'is_based_on_worked_time': False,
             'accrued_gain_time': 'end',
             'carryover_date': 'allocation',
@@ -108,10 +165,39 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'added_value': 2,
                 'frequency': 'monthly',
                 'action_with_unused_accruals': 'all',
-                'cap_accrued_time': False,
             })],
         })
-        cls.accrual_plan_monthly_end_max_leaves = cls.env['hr.leave.accrual.plan'].create({
+
+        accrual_plan2_levels_fields = {
+            'added_value_type': 'day',
+            'frequency': 'monthly',
+            'accrual_validity': True,
+            'accrual_validity_count': 3,
+            'accrual_validity_type': 'month',
+            'action_with_unused_accruals': 'all',
+        }
+        cls.accrual_plan2 = _create_accrual_plan(accrual_plan_by_signature, {
+            'is_based_on_worked_time': False,
+            'accrued_gain_time': 'end',
+            'carryover_date': 'allocation',
+            'can_be_carryover': True,
+            'transition_mode': 'end_of_accrual',
+            'level_ids': [
+                Command.create({
+                    **accrual_plan2_levels_fields,
+                    'milestone_date': 'creation',
+                    'added_value': 1,
+                }),
+                Command.create({
+                    **accrual_plan2_levels_fields,
+                    'milestone_date': 'after',
+                    'start_count': 1,
+                    'start_type': 'month',
+                    'added_value': 2,
+                }),
+            ],
+        })
+        cls.accrual_plan_monthly_end_max_leaves = _create_accrual_plan(accrual_plan_by_signature, {
             'name': 'Accrual Plan For Test',
             'is_based_on_worked_time': False,
             'accrued_gain_time': 'end',
@@ -127,7 +213,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'maximum_leave': 10,
             })],
         })
-        cls.accrual_plan_yearly_max_postponed_days_start = cls.env['hr.leave.accrual.plan'].create({
+        cls.accrual_plan_yearly_max_carriedover_days_start = _create_accrual_plan(accrual_plan_by_signature, {
             'name': '21 days per year, 5 carryover max',
             'transition_mode': 'immediately',
             'carryover_date': 'year_start',
@@ -135,18 +221,16 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
             'can_be_carryover': True,
             'level_ids': [
                 Command.create({
-                    "start_count": 0,
-                    "added_value": 21,
-                    "frequency": "yearly",
-                    "yearly_day": 1,
-                    "yearly_month": "1",
+                    'milestone_date': 'creation',
+                    'added_value': 21,
+                    'frequency': 'yearly',
                     "action_with_unused_accruals": "all",
                     "carryover_options": "limited",
-                    "postpone_max_days": 5,
-                })
+                    "max_carriedover_duration": 5,
+                }),
             ],
         })
-        cls.accrual_plan_monthly_start_carryover_lost = cls.env['hr.leave.accrual.plan'].create({
+        cls.accrual_plan_monthly_start_carryover_lost = _create_accrual_plan(accrual_plan_by_signature, {
             'name': '1 day per month start - carryover 1st of Mai',
             'carryover_date': 'other',
             'carryover_day': 1,
@@ -162,7 +246,6 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 }),
             ],
         })
-
         first_accrual_plan_level = Command.create({
             'milestone_date': 'creation',
             'added_value_type': 'day',
@@ -181,18 +264,14 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
             'first_day': 15,
             'action_with_unused_accruals': 'all',
         })
-
-        cls.accrual_plan_monthly_end_carryover_year_start = cls.env['hr.leave.accrual.plan'].create({
-            'name': 'Accrual Plan For Test',
+        cls.accrual_plan_monthly_start_carryover_year_start = _create_accrual_plan(accrual_plan_by_signature, {
             'is_based_on_worked_time': False,
             'accrued_gain_time': 'start',
             'can_be_carryover': True,
             'carryover_date': 'year_start',
             'level_ids': [first_accrual_plan_level],
         })
-
-        cls.accrual_plan_monthly_end_carryover_year_end = cls.env['hr.leave.accrual.plan'].create({
-            'name': 'Accrual Plan For Test',
+        cls.accrual_plan_monthly_end_carryover_year_start = _create_accrual_plan(accrual_plan_by_signature, {
             'is_based_on_worked_time': False,
             'accrued_gain_time': 'end',
             'can_be_carryover': True,
@@ -200,8 +279,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
             'level_ids': [first_accrual_plan_level],
         })
 
-        cls.accrual_plan_monthly_end_carryover_year_start_2_lvls = cls.env['hr.leave.accrual.plan'].create({
-            'name': 'Accrual Plan For Test',
+        cls.accrual_plan_monthly_end_carryover_year_start_2_lvls = _create_accrual_plan(accrual_plan_by_signature, {
             'is_based_on_worked_time': False,
             'accrued_gain_time': 'end',
             'can_be_carryover': True,
@@ -210,8 +288,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
             'level_ids': [first_accrual_plan_level, second_accrual_plan_level],
         })
 
-        cls.accrual_plan_monthly_start_carryover_year_start_2_lvls = cls.env['hr.leave.accrual.plan'].create({
-            'name': 'Accrual Plan For Test',
+        cls.accrual_plan_monthly_start_carryover_year_start_2_lvls = _create_accrual_plan(accrual_plan_by_signature, {
             'is_based_on_worked_time': False,
             'accrued_gain_time': 'start',
             'can_be_carryover': True,
@@ -220,31 +297,237 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
             'level_ids': [first_accrual_plan_level, second_accrual_plan_level],
         })
 
-    def setAllocationCreateDate(self, allocation_id, date):
-        """ This method is a hack in order to be able to define/redefine the create_date
-            of the allocations.
-            This is done in SQL because ORM does not allow to write onto the create_date field.
-        """
-        self.env.cr.execute("""
-                       UPDATE
-                       hr_leave_allocation
-                       SET create_date = '%s'
-                       WHERE id = %s
-                       """ % (date, allocation_id))
+        cls.accrual_plan_monthly_start_carryover_lost_hour = _create_accrual_plan(accrual_plan_by_signature, {
+            'carryover_date': 'other',
+            'carryover_day': 1,
+            'carryover_month': '5',
+            'accrued_gain_time': 'start',
+            'can_be_carryover': True,
+            'level_ids': [
+                Command.create({
+                    'milestone_date': 'creation',
+                    "added_value": 8,
+                    'added_value_type': 'hour',
+                    "frequency": "monthly",
+                    "action_with_unused_accruals": "lost",
+                }),
+            ],
+        })
 
-    def assert_allocation_and_balance(self, allocation, expected_allocation_value, expected_balance_value, msg):
-        unit = allocation.accrual_plan_id.added_value_type
-        allocation_value = allocation.number_of_hours_display if unit == 'hour' else allocation.number_of_days
+        cls.based_on_work_time_accrual_plan_daily = _create_accrual_plan(accrual_plan_by_signature, {
+            'is_based_on_worked_time': True,
+            'can_be_carryover': True,
+            'level_ids': [(0, 0, {
+                'milestone_date': 'creation',
+                'added_value': 1,
+                'added_value_type': 'day',
+                'frequency': 'daily',
+            })],
+        })
 
-        work_entry_type_data = allocation.work_entry_type_id.get_allocation_data(self.employee_emp)
-        remaining_leaves = work_entry_type_data[self.employee_emp][0][1]['remaining_leaves']
+        cls.accrual_plan_daily_end_max_1_leave = _create_accrual_plan(accrual_plan_by_signature, {
+            'can_be_carryover': True,
+            'level_ids': [(0, 0, {
+                'milestone_date': 'after',
+                'start_count': 1,
+                'start_type': 'day',
+                'added_value': 1,
+                'added_value_type': 'day',
+                'frequency': 'daily',
+                'cap_accrued_time': True,
+                'maximum_leave': 1,
+                'action_with_unused_accruals': 'all',
+            })],
+        })
 
-        self.assertAlmostEqual(allocation_value, expected_allocation_value, places=1, msg=msg)
-        self.assertAlmostEqual(remaining_leaves, expected_balance_value, places=1, msg=msg)
+        cls.accrual_plan_daily_1_hour_4_max_leave = _create_accrual_plan(accrual_plan_by_signature, {
+            'can_be_carryover': True,
+            'level_ids': [(0, 0, {
+                'milestone_date': 'after',
+                'start_count': 1,
+                'start_type': 'day',
+                'added_value': 1,
+                'added_value_type': 'hour',
+                'frequency': 'daily',
+                'cap_accrued_time': True,
+                'maximum_leave': 4,
+                'action_with_unused_accruals': 'all',
+            })],
+        })
 
-    def test_consistency_between_cap_accrued_time_and_maximum_leave(self):
-        accrual_plan = self.env['hr.leave.accrual.plan'].create({
-            'name': 'Accrual Plan For Test',
+        cls.weekly_accrual_plan = _create_accrual_plan(accrual_plan_by_signature, {
+            'can_be_carryover': True,
+            'carryover_date': 'allocation',
+            'level_ids': [(0, 0, {
+                'added_value_type': 'day',
+                'milestone_date': 'creation',
+                'added_value': 1,
+                'frequency': 'daily',
+                'cap_accrued_time': False,
+                'action_with_unused_accruals': 'lost',
+            })],
+        })
+
+        cls.accrual_plan_monthly_end_carry_over_lost_year_start = _create_accrual_plan(accrual_plan_by_signature, {
+            'can_be_carryover': True,
+            'carryover_date': 'year_start',
+            'accrued_gain_time': 'end',
+            'level_ids': [(0, 0, {
+                'added_value_type': 'day',
+                'milestone_date': 'creation',
+                'added_value': 1,
+                'frequency': 'monthly',
+                'first_day': '31',
+                'cap_accrued_time': False,
+                'action_with_unused_accruals': 'lost',
+            })],
+        })
+
+        cls.work_entry_type_no_negative = cls.env['hr.work.entry.type'].create({
+            'name': 'Test Accrual - No negative',
+            'code': 'Test Accrual - No negative',
+            'count_as': 'absence',
+            'requires_allocation': True,
+            'allocation_validation_type': 'no_validation',
+            'leave_validation_type': 'no_validation',
+            'allows_negative': False,
+            'request_unit': 'day',
+            'unit_of_measure': 'day',
+        })
+        cls.work_entry_type_negative = cls.env['hr.work.entry.type'].create({
+            'name': 'Test Accrual - Negative',
+            'code': 'Test Accrual - Negative',
+            'count_as': 'absence',
+            'requires_allocation': True,
+            'allocation_validation_type': 'no_validation',
+            'leave_validation_type': 'no_validation',
+            'allows_negative': True,
+            'max_allowed_negative': 1,
+            'request_unit': 'day',
+            'unit_of_measure': 'day',
+        })
+
+        cls.accrual_plan_period_end_montlhy_max_carryover_year_start = _create_accrual_plan(accrual_plan_by_signature, {
+            'can_be_carryover': True,
+            'carryover_date': 'year_start',
+            'accrued_gain_time': 'end',
+            'level_ids': [(0, 0, {
+                'added_value_type': 'day',
+                'milestone_date': 'creation',
+                'added_value': 1,
+                'frequency': 'monthly',
+                'first_day': '31',
+                'action_with_unused_accruals': 'all',
+                'carryover_options': 'limited',
+                'max_carriedover_duration': 5,
+            })],
+        })
+        cls.dummy_accrual_plan = _create_accrual_plan(accrual_plan_by_signature, {
+            'can_be_carryover': True,
+        })
+        cls.accrual_plan_hourly_based_on_work = _create_accrual_plan(accrual_plan_by_signature, {
+            'is_based_on_worked_time': True,
+            'can_be_carryover': True,
+            'level_ids': [(0, 0, {
+                'milestone_date': 'after',
+                'start_count': 1,
+                'start_type': 'day',
+                'added_value': 1,
+                'added_value_type': 'day',
+                'frequency': 'hourly',
+                'action_with_unused_accruals': 'all',
+            })],
+        })
+        cls.accrual_plan_daily_end = _create_accrual_plan(accrual_plan_by_signature, {
+            'is_based_on_worked_time': False,
+            'accrued_gain_time': 'end',
+            'carryover_date': 'allocation',
+            'level_ids': [Command.create({
+                'milestone_date': 'creation',
+                'added_value': 1,
+                'added_value_type': 'day',
+                'frequency': 'daily',
+                'action_with_unused_accruals': 'all',
+                'cap_accrued_time': False,
+            })],
+        })
+        cls.accrual_plan_daily_end_after_1d = _create_accrual_plan(accrual_plan_by_signature, {
+            'is_based_on_worked_time': False,
+            'accrued_gain_time': 'end',
+            'carryover_date': 'allocation',
+            'level_ids': [Command.create({
+                'milestone_date': 'after',
+                'start_count': 1,
+                'added_value': 1,
+                'added_value_type': 'day',
+                'frequency': 'daily',
+                'action_with_unused_accruals': 'all',
+                'cap_accrued_time': False,
+            })],
+        })
+        cls.accrual_plan_weekly = _create_accrual_plan(accrual_plan_by_signature, {
+            'can_be_carryover': True,
+            'level_ids': [(0, 0, {
+                'milestone_date': 'after',
+                'start_count': 1,
+                'added_value_type': 'day',
+                'start_type': 'day',
+                'added_value': 1,
+                'frequency': 'weekly',
+                'action_with_unused_accruals': 'all',
+            })],
+        })
+        cls.accrual_plan_bimonthly = _create_accrual_plan(accrual_plan_by_signature, {
+            'can_be_carryover': True,
+            'level_ids': [(0, 0, {
+                'added_value_type': 'day',
+                'milestone_date': 'after',
+                'start_count': 1,
+                'start_type': 'day',
+                'added_value': 1,
+                'frequency': 'bimonthly',
+                'first_day': 1,
+                'second_day': 15,
+                'action_with_unused_accruals': 'all',
+            })],
+        })
+        cls.accrual_plan_monthly = _create_accrual_plan(accrual_plan_by_signature, {
+            'can_be_carryover': True,
+            'level_ids': [(0, 0, {
+                'milestone_date': 'after',
+                'start_count': 1,
+                'added_value_type': 'day',
+                'start_type': 'day',
+                'added_value': 1,
+                'frequency': 'monthly',
+                'action_with_unused_accruals': 'all',
+            })],
+        })
+        cls.accrual_plan_biyearly = _create_accrual_plan(accrual_plan_by_signature, {
+            'can_be_carryover': True,
+            'level_ids': [(0, 0, {
+                'added_value_type': 'day',
+                'milestone_date': 'after',
+                'start_count': 1,
+                'start_type': 'day',
+                'added_value': 1,
+                'frequency': 'biyearly',
+                'action_with_unused_accruals': 'all',
+            })],
+        })
+        cls.accrual_plan_yearly = _create_accrual_plan(accrual_plan_by_signature, {
+            'can_be_carryover': True,
+            'level_ids': [(0, 0, {
+                'added_value_type': 'day',
+                'milestone_date': 'after',
+                'start_count': 1,
+                'start_type': 'day',
+                'added_value': 1,
+                'frequency': 'yearly',
+                'action_with_unused_accruals': 'all',
+            })],
+        })
+        cls.accrual_plan_hourly = _create_accrual_plan(accrual_plan_by_signature, {
             'can_be_carryover': True,
             'level_ids': [(0, 0, {
                 'milestone_date': 'after',
@@ -255,1159 +538,110 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'frequency': 'hourly',
                 'action_with_unused_accruals': 'all',
                 'cap_accrued_time': True,
-                'maximum_leave': 10000
+                'maximum_leave': 10000,
             })],
         })
-        level = accrual_plan.level_ids
-        level.maximum_leave = 10
-        self.assertEqual(accrual_plan.level_ids.maximum_leave, 10)
-
-        with self.assertRaises(UserError):
-            level.maximum_leave = 0
-
-        level.cap_accrued_time = False
-        self.assertEqual(accrual_plan.level_ids.maximum_leave, 0)
-
-    def test_accrual_unlink(self):
-        accrual_plan = self.env['hr.leave.accrual.plan'].create({
-            'name': 'Accrual Plan For Test',
-            'can_be_carryover': True,
-        })
-
-        allocation = self.env['hr.leave.allocation'].with_user(self.user_hrmanager_id).create({
-            'name': 'Accrual allocation for employee',
-            'accrual_plan_id': accrual_plan.id,
-            'employee_id': self.employee_emp.id,
-            'work_entry_type_id': self.work_entry_type.id,
-            'number_of_days': 0,
-        })
-
-        with self.assertRaises(ValidationError):
-            accrual_plan.unlink()
-
-        allocation.unlink()
-        accrual_plan.unlink()
-
-    def test_frequency_hourly_calendar(self):
-        with freeze_time("2017-12-05"):
-            accrual_plan = self.env['hr.leave.accrual.plan'].create({
-                'name': 'Accrual Plan For Test',
-                'can_be_carryover': True,
-                'level_ids': [(0, 0, {
-                    'milestone_date': 'after',
-                    'start_count': 1,
-                    'start_type': 'day',
-                    'added_value': 1,
-                    'added_value_type': 'day',
-                    'frequency': 'hourly',
-                    'action_with_unused_accruals': 'all',
-                    'cap_accrued_time': True,
-                    'maximum_leave': 10000
-                })],
-            })
-            allocation = self.env['hr.leave.allocation'].with_user(self.user_hrmanager_id).create({
-                'name': 'Accrual allocation for employee',
-                'accrual_plan_id': accrual_plan.id,
-                'employee_id': self.employee_emp.id,
-                'work_entry_type_id': self.work_entry_type.id,
-                'number_of_days': 0,
-            })
-            allocation.action_approve()
-            self.assertFalse(allocation.nextcall, 'There should be no nextcall set on the allocation.')
-            self.assertEqual(allocation.number_of_days, 0, 'There should be no days allocated yet.')
-            allocation._update_accrual()
-            tomorrow = datetime.date.today() + relativedelta(days=2)
-            self.assertEqual(allocation.number_of_days, 0, 'There should be no days allocated yet. The accrual starts tomorrow.')
-
-            with freeze_time(tomorrow):
-                allocation._update_accrual()
-                nextcall = datetime.date.today() + relativedelta(days=1)
-                self.assertEqual(allocation.number_of_days, 8, 'There should be 8 day allocated.')
-                self.assertEqual(allocation.nextcall, nextcall, 'The next call date of the cron should be in 2 days.')
-                allocation._update_accrual()
-                self.assertEqual(allocation.number_of_days, 8, 'There should be only 8 day allocated.')
-
-    def test_frequency_hourly_worked_hours(self):
-        with freeze_time("2017-12-05"):
-            accrual_plan = self.env['hr.leave.accrual.plan'].create({
-                'is_based_on_worked_time': True,
-                'can_be_carryover': True,
-                'level_ids': [(0, 0, {
-                    'milestone_date': 'after',
-                    'start_count': 1,
-                    'start_type': 'day',
-                    'added_value': 1,
-                    'added_value_type': 'day',
-                    'frequency': 'hourly',
-                    'cap_accrued_time': True,
-                    'maximum_leave': 10000,
-                    'action_with_unused_accruals': 'all',
-                })],
-            })
-            allocation = self.env['hr.leave.allocation'].with_user(self.user_hrmanager_id).create({
-                'name': 'Accrual allocation for employee',
-                'accrual_plan_id': accrual_plan.id,
-                'employee_id': self.employee_emp.id,
-                'work_entry_type_id': self.work_entry_type.id,
-                'number_of_days': 0,
-            })
-            allocation.action_approve()
-            self.assertFalse(allocation.nextcall, 'There should be no nextcall set on the allocation.')
-            self.assertEqual(allocation.number_of_days, 0, 'There should be no days allocated yet.')
-            allocation._update_accrual()
-            tomorrow = datetime.date.today() + relativedelta(days=2)
-            self.assertEqual(allocation.number_of_days, 0, 'There should be no days allocated yet. The accrual starts tomorrow.')
-
-            work_entry_type = self.env['hr.work.entry.type'].create({
-                'name': 'Paid Time Off 2',
-                'code': 'Paid Time Off 2',
-                'requires_allocation': False,
-                'count_as': 'absence',
-                'request_unit': 'half_day',
-                'unit_of_measure': 'day',
-            })
-            leave = self.env['hr.leave'].create({
-                'name': 'leave',
-                'employee_id': self.employee_emp.id,
-                'work_entry_type_id': work_entry_type.id,
-                'request_date_from': '2017-12-06 08:00:00',
-                'request_date_to': '2017-12-06 17:00:00',
-                'request_date_from_period': 'am',
-                'request_date_to_period': 'am',
-            })
-            leave.action_approve()
-
-            with freeze_time(tomorrow):
-                allocation._update_accrual()
-                nextcall = datetime.date.today() + relativedelta(days=1)
-                self.assertEqual(allocation.number_of_days, 4, 'There should be 4 day allocated.')
-                self.assertEqual(allocation.nextcall, nextcall, 'The next call date of the cron should be in 2 days.')
-                allocation._update_accrual()
-                self.assertEqual(allocation.number_of_days, 4, 'There should be only 4 day allocated.')
-
-    def test_frequency_daily(self):
-        with freeze_time("2017-12-05"):
-            accrual_plan = self.env['hr.leave.accrual.plan'].create({
-                'name': 'Accrual Plan For Test',
-                'can_be_carryover': True,
-                'level_ids': [(0, 0, {
-                    'milestone_date': 'after',
-                    'start_count': 1,
-                    'start_type': 'day',
-                    'added_value': 1,
-                    'added_value_type': 'day',
-                    'frequency': 'daily',
-                    'cap_accrued_time': True,
-                    'maximum_leave': 10000,
-                    'action_with_unused_accruals': 'all',
-                })],
-            })
-            allocation = self.env['hr.leave.allocation'].with_user(self.user_hrmanager_id).create({
-                'name': 'Accrual allocation for employee',
-                'accrual_plan_id': accrual_plan.id,
-                'employee_id': self.employee_emp.id,
-                'work_entry_type_id': self.work_entry_type.id,
-                'number_of_days': 0,
-            })
-            allocation.action_approve()
-            self.assertFalse(allocation.nextcall, 'There should be no nextcall set on the allocation.')
-            self.assertEqual(allocation.number_of_days, 0, 'There should be no days allocated yet.')
-            allocation._update_accrual()
-            tomorrow = datetime.date.today() + relativedelta(days=2)
-            self.assertEqual(allocation.number_of_days, 0, 'There should be no days allocated yet. The accrual starts tomorrow.')
-
-            with freeze_time(tomorrow):
-                allocation._update_accrual()
-                nextcall = datetime.date.today() + relativedelta(days=1)
-                self.assertEqual(allocation.number_of_days, 1, 'There should be 1 day allocated.')
-                self.assertEqual(allocation.nextcall, nextcall, 'The next call date of the cron should be in 2 days.')
-                allocation._update_accrual()
-                self.assertEqual(allocation.number_of_days, 1, 'There should be only 1 day allocated.')
-
-    @freeze_time('2025-09-01')
-    def test_frequency_daily_worked_time_non_utc_timezone(self):
-        calendar = self.env['resource.calendar'].create({
-            'name': 'Brisbane 40 Hours',
-            'hours_per_day': 8,
-            'attendance_ids': [
-                Command.create({
-                    'dayofweek': str(weekday),
-                    'hour_from': 8,
-                    'hour_to': 12,
-                })
-                for weekday in range(5)
-            ] + [
-                Command.create({
-                    'dayofweek': str(weekday),
-                    'hour_from': 13,
-                    'hour_to': 17,
-                })
-                for weekday in range(5)
-            ],
-        })
-        self.employee_emp.tz = 'Australia/Brisbane'
-        self.employee_emp.resource_calendar_id = calendar
-        self.user_hrmanager.tz = 'Australia/Brisbane'
-        accrual_plan = self.env['hr.leave.accrual.plan'].create({
-            'name': 'Daily Worked Time Accrual',
+        cls.accrual_plan_based_on_worked_time = _create_accrual_plan(accrual_plan_by_signature, {
             'is_based_on_worked_time': True,
-            'accrued_gain_time': 'end',
             'can_be_carryover': True,
-            'carryover_date': 'allocation',
             'level_ids': [Command.create({
-                'milestone_date': 'creation',
+                'added_value_type': 'day',
+                'milestone_date': 'after',
+                'start_count': 1,
+                'start_type': 'day',
                 'added_value': 5,
-                'added_value_type': 'hour',
-                'frequency': 'daily',
+                'frequency': 'weekly',
                 'action_with_unused_accruals': 'all',
             })],
         })
-        allocation = self.env['hr.leave.allocation'].with_user(self.user_hrmanager).create({
-            'name': 'Brisbane Daily Accrual',
-            'accrual_plan_id': accrual_plan.id,
-            'employee_id': self.employee_emp.id,
-            'work_entry_type_id': self.work_entry_type_hour.id,
-            'date_from': date(2025, 9, 1),
-            'number_of_days': 0,
-        })
-        allocation.action_approve()
-
-        balances = []
-        for day in range(2, 9):
-            allocation._process_accrual_plans(date(2025, 9, day))
-            balances.append(allocation.number_of_hours_display)
-
-        self.assertEqual(balances, [5, 10, 15, 20, 25, 25, 25])
-
-    def test_frequency_weekly(self):
-        with freeze_time("2017-12-05"):
-            accrual_plan = self.env['hr.leave.accrual.plan'].create({
-                'name': 'Accrual Plan For Test',
-                'can_be_carryover': True,
-                'level_ids': [(0, 0, {
-                    'added_value_type': 'day',
-                    'milestone_date': 'after',
-                    'start_count': 1,
-                    'start_type': 'day',
-                    'added_value': 1,
-                    'frequency': 'weekly',
-                    'cap_accrued_time': True,
-                    'maximum_leave': 10000,
-                    'action_with_unused_accruals': 'all',
-                })],
-            })
-            allocation = self.env['hr.leave.allocation'].with_user(self.user_hrmanager_id).create({
-                'name': 'Accrual allocation for employee',
-                'accrual_plan_id': accrual_plan.id,
-                'employee_id': self.employee_emp.id,
-                'work_entry_type_id': self.work_entry_type.id,
-                'number_of_days': 0,
-                'date_from': '2021-09-03',
-            })
-            with freeze_time(datetime.date.today() + relativedelta(days=2)):
-                allocation.action_approve()
-                self.assertFalse(allocation.nextcall, 'There should be no nextcall set on the allocation.')
-                self.assertEqual(allocation.number_of_days, 0, 'There should be no days allocated yet.')
-                allocation._update_accrual()
-                nextWeek = allocation.date_from + relativedelta(days=1, weekday=0)
-                self.assertEqual(allocation.number_of_days, 0, 'There should be no days allocated yet. The accrual starts tomorrow.')
-
-            with freeze_time(nextWeek):
-                allocation._update_accrual()
-                nextWeek = datetime.date.today() + relativedelta(days=1, weekday=0)
-                # Prorated
-                self.assertAlmostEqual(allocation.number_of_days, 0.2857, 4, 'There should be 0.2857 day allocated.')
-                self.assertEqual(allocation.nextcall, nextWeek, 'The next call date of the cron should be in 2 weeks')
-
-            with freeze_time(nextWeek):
-                allocation._update_accrual()
-                nextWeek = datetime.date.today() + relativedelta(days=1, weekday=0)
-                self.assertAlmostEqual(allocation.number_of_days, 1.2857, 4, 'There should be 1.2857 day allocated.')
-                self.assertEqual(allocation.nextcall, nextWeek, 'The next call date of the cron should be in 2 weeks')
-
-    def test_frequency_bimonthly(self):
-        with freeze_time('2021-09-01'):
-            accrual_plan = self.env['hr.leave.accrual.plan'].create({
-                'name': 'Accrual Plan For Test',
-                'can_be_carryover': True,
-                'level_ids': [(0, 0, {
-                    'added_value_type': 'day',
-                    'milestone_date': 'after',
-                    'start_count': 1,
-                    'start_type': 'day',
-                    'added_value': 1,
-                    'frequency': 'bimonthly',
-                    'first_day': 1,
-                    'second_day': 15,
-                    'cap_accrued_time': True,
-                    'maximum_leave': 10000,
-                    'action_with_unused_accruals': 'all',
-                })],
-            })
-            allocation = self.env['hr.leave.allocation'].with_user(self.user_hrmanager_id).create({
-                'name': 'Accrual allocation for employee',
-                'accrual_plan_id': accrual_plan.id,
-                'employee_id': self.employee_emp.id,
-                'work_entry_type_id': self.work_entry_type.id,
-                'number_of_days': 0,
-                'date_from': '2021-09-03',
-            })
-            self.setAllocationCreateDate(allocation.id, '2021-09-01 00:00:00')
-            allocation.action_approve()
-            self.assertFalse(allocation.nextcall, 'There should be no nextcall set on the allocation.')
-            self.assertEqual(allocation.number_of_days, 0, 'There should be no days allocated yet.')
-            allocation._update_accrual()
-            next_date = datetime.date(2021, 9, 15)
-            self.assertEqual(allocation.number_of_days, 0, 'There should be no days allocated yet. The accrual starts tomorrow.')
-
-        with freeze_time(next_date):
-            next_date = datetime.date(2021, 10, 1)
-            allocation._update_accrual()
-            # Prorated
-            self.assertAlmostEqual(allocation.number_of_days, 0.7857, 4, 'There should be 0.7857 day allocated.')
-            self.assertEqual(allocation.nextcall, next_date, 'The next call date of the cron should be October 1st')
-
-        with freeze_time(next_date):
-            allocation._update_accrual()
-            # Not Prorated
-            self.assertAlmostEqual(allocation.number_of_days, 1.7857, 4, 'There should be 1.7857 day allocated.')
-
-    def test_frequency_monthly(self):
-        with freeze_time('2021-09-01'):
-            accrual_plan = self.env['hr.leave.accrual.plan'].create({
-                'name': 'Accrual Plan For Test',
-                'can_be_carryover': True,
-                'level_ids': [(0, 0, {
-                    'added_value_type': 'day',
-                    'milestone_date': 'after',
-                    'start_count': 1,
-                    'start_type': 'day',
-                    'added_value': 1,
-                    'frequency': 'monthly',
-                    'cap_accrued_time': True,
-                    'maximum_leave': 10000,
-                    'action_with_unused_accruals': 'all',
-                })],
-            })
-            allocation = self._create_form_test_accrual_allocation(self.work_entry_type, '2021-08-31', self.employee_emp, accrual_plan, creator_user=self.user_hrmanager_id)
-            self.setAllocationCreateDate(allocation.id, '2021-09-01 00:00:00')
-            allocation.action_approve()
-            self.assertEqual(allocation.nextcall, datetime.date(2021, 10, 1))
-            self.assertEqual(allocation.number_of_days, 0, 'There should be no days allocated yet.')
-            allocation._update_accrual()
-            next_date = datetime.date(2021, 10, 1)
-            self.assertEqual(allocation.number_of_days, 0, 'There should be no days allocated yet. The accrual starts tomorrow.')
-
-        with freeze_time(next_date):
-            next_date = datetime.date(2021, 11, 1)
-            allocation._update_accrual()
-            # Prorata = 1 since a whole month passed
-            self.assertEqual(allocation.number_of_days, 1, 'There should be 1 day allocated.')
-            self.assertEqual(allocation.nextcall, next_date, 'The next call date of the cron should be November 1st')
-
-    def test_frequency_biyearly(self):
-        with freeze_time('2021-09-01'):
-            accrual_plan = self.env['hr.leave.accrual.plan'].create({
-                'name': 'Accrual Plan For Test',
-                'can_be_carryover': True,
-                'level_ids': [(0, 0, {
-                    'added_value_type': 'day',
-                    'milestone_date': 'after',
-                    'start_count': 1,
-                    'start_type': 'day',
-                    'added_value': 1,
-                    'frequency': 'biyearly',
-                    'cap_accrued_time': True,
-                    'maximum_leave': 10000,
-                    'action_with_unused_accruals': 'all',
-                })],
-            })
-            # this sets up an accrual on the 1st of January and the 1st of July
-            allocation = self.env['hr.leave.allocation'].with_user(self.user_hrmanager_id).create({
-                'name': 'Accrual allocation for employee',
-                'accrual_plan_id': accrual_plan.id,
-                'employee_id': self.employee_emp.id,
-                'work_entry_type_id': self.work_entry_type.id,
-                'number_of_days': 0,
-            })
-            self.setAllocationCreateDate(allocation.id, '2021-09-01 00:00:00')
-            allocation.action_approve()
-            self.assertFalse(allocation.nextcall, 'There should be no nextcall set on the allocation.')
-            self.assertEqual(allocation.number_of_days, 0, 'There should be no days allocated yet.')
-            allocation._update_accrual()
-            next_date = datetime.date(2022, 1, 1)
-            self.assertEqual(allocation.number_of_days, 0, 'There should be no days allocated yet. The accrual starts tomorrow.')
-
-        with freeze_time(next_date):
-            next_date = datetime.date(2022, 7, 1)
-            allocation._update_accrual()
-            # Prorated
-            self.assertAlmostEqual(allocation.number_of_days, 0.6576, 4, 'There should be 0.6576 day allocated.')
-            self.assertEqual(allocation.nextcall, next_date, 'The next call date of the cron should be July 1st')
-
-        with freeze_time(next_date):
-            allocation._update_accrual()
-            # Not Prorated
-            self.assertAlmostEqual(allocation.number_of_days, 1.6576, 4, 'There should be 1.6576 day allocated.')
-
-    def test_frequency_yearly(self):
-        with freeze_time('2021-09-01'):
-            accrual_plan = self.env['hr.leave.accrual.plan'].create({
-                'name': 'Accrual Plan For Test',
-                'can_be_carryover': True,
-                'level_ids': [(0, 0, {
-                    'added_value_type': 'day',
-                    'milestone_date': 'after',
-                    'start_count': 1,
-                    'start_type': 'day',
-                    'added_value': 1,
-                    'frequency': 'yearly',
-                    'cap_accrued_time': True,
-                    'maximum_leave': 10000,
-                    'action_with_unused_accruals': 'all',
-                })],
-            })
-            # this sets up an accrual on the 1st of January
-            allocation = self.env['hr.leave.allocation'].with_user(self.user_hrmanager_id).create({
-                'name': 'Accrual allocation for employee',
-                'accrual_plan_id': accrual_plan.id,
-                'employee_id': self.employee_emp.id,
-                'work_entry_type_id': self.work_entry_type.id,
-                'number_of_days': 0,
-            })
-            self.setAllocationCreateDate(allocation.id, '2021-09-01 00:00:00')
-            allocation.action_approve()
-            self.assertFalse(allocation.nextcall, 'There should be no nextcall set on the allocation.')
-            self.assertEqual(allocation.number_of_days, 0, 'There should be no days allocated yet.')
-            allocation._update_accrual()
-            next_date = datetime.date(2022, 1, 1)
-            self.assertEqual(allocation.number_of_days, 0, 'There should be no days allocated yet. The accrual starts tomorrow.')
-
-        with freeze_time(next_date):
-            next_date = datetime.date(2023, 1, 1)
-            allocation._update_accrual()
-            self.assertAlmostEqual(allocation.number_of_days, 0.3315, 4, 'There should be 0.3315 day allocated.')
-            self.assertEqual(allocation.nextcall, next_date, 'The next call date of the cron should be January 1st 2023')
-
-        with freeze_time(next_date):
-            allocation._update_accrual()
-            self.assertAlmostEqual(allocation.number_of_days, 1.3315, 4, 'There should be 1.3315 day allocated.')
-
-    def test_check_gain(self):
-        # 2 accruals, one based on worked time, one not
-        # check gain
-        with freeze_time('2021-08-30'):
-            attendances = []
-            for index in range(5):
-                attendances.append((0, 0, {
-                    'hour_from': 8,
-                    'hour_to': 12,
-                    'dayofweek': str(index),
-                }))
-                attendances.append((0, 0, {
-                    'hour_from': 13,
-                    'hour_to': 17,
-                    'dayofweek': str(index),
-                }))
-            calendar_emp = self.env['resource.calendar'].create({
-                'name': '40 Hours',
-                'attendance_ids': attendances,
-            })
-            self.employee_emp.resource_calendar_id = calendar_emp.id
-
-            accrual_plan_not_based_on_worked_time = self.env['hr.leave.accrual.plan'].create({
-                'name': 'Accrual Plan For Test',
-                'can_be_carryover': True,
-                'level_ids': [(0, 0, {
-                    'added_value_type': 'day',
-                    'milestone_date': 'after',
-                    'start_count': 1,
-                    'start_type': 'day',
-                    'added_value': 5,
-                    'frequency': 'weekly',
-                    'cap_accrued_time': True,
-                    'maximum_leave': 10000,
-                    'action_with_unused_accruals': 'all',
-                })],
-            })
-            accrual_plan_based_on_worked_time = self.env['hr.leave.accrual.plan'].create({
-                'is_based_on_worked_time': True,
-                'can_be_carryover': True,
-                'level_ids': [(0, 0, {
-                    'added_value_type': 'day',
-                    'milestone_date': 'after',
-                    'start_count': 1,
-                    'start_type': 'day',
-                    'added_value': 5,
-                    'frequency': 'weekly',
-                    'cap_accrued_time': True,
-                    'maximum_leave': 10000,
-                    'action_with_unused_accruals': 'all',
-                })],
-            })
-            allocation_not_worked_time = self.env['hr.leave.allocation'].with_user(self.user_hrmanager_id).create({
-                'name': 'Accrual allocation for employee',
-                'accrual_plan_id': accrual_plan_not_based_on_worked_time.id,
-                'employee_id': self.employee_emp.id,
-                'work_entry_type_id': self.work_entry_type.id,
-                'number_of_days': 0,
-                'state': 'confirm',
-            })
-            allocation_worked_time = self.env['hr.leave.allocation'].with_user(self.user_hrmanager_id).create({
-                'name': 'Accrual allocation for employee',
-                'accrual_plan_id': accrual_plan_based_on_worked_time.id,
-                'employee_id': self.employee_emp.id,
-                'work_entry_type_id': self.work_entry_type.id,
-                'number_of_days': 0,
-                'state': 'confirm',
-            })
-            (allocation_not_worked_time | allocation_worked_time).action_approve()
-            self.setAllocationCreateDate(allocation_not_worked_time.id, '2021-08-01 00:00:00')
-            self.setAllocationCreateDate(allocation_worked_time.id, '2021-08-01 00:00:00')
-            work_entry_type = self.env['hr.work.entry.type'].create({
-                'name': 'Paid Time Off 2',
-                'code': 'Paid Time Off 2',
-                'requires_allocation': False,
-                'count_as': 'absence',
-                'request_unit': 'day',
-                'unit_of_measure': 'day',
-            })
-            leave = self.env['hr.leave'].create({
-                'name': 'leave',
-                'employee_id': self.employee_emp.id,
-                'work_entry_type_id': work_entry_type.id,
-                'request_date_from': '2021-09-02',
-                'request_date_to': '2021-09-02',
-            })
-            leave.action_approve()
-            self.assertFalse(allocation_not_worked_time.nextcall, 'There should be no nextcall set on the allocation.')
-            self.assertFalse(allocation_worked_time.nextcall, 'There should be no nextcall set on the allocation.')
-            self.assertEqual(allocation_not_worked_time.number_of_days, 0, 'There should be no days allocated yet.')
-            self.assertEqual(allocation_worked_time.number_of_days, 0, 'There should be no days allocated yet.')
-
-        next_date = datetime.date(2021, 9, 6)
-        with freeze_time(next_date):
-            # next_date = datetime.date(2021, 9, 13)
-            self.env['hr.leave.allocation']._update_accrual()
-            # Prorated
-            self.assertAlmostEqual(allocation_not_worked_time.number_of_days, 4.2857, 4, 'There should be 4.2857 days allocated.')
-            # 3.75 -> starts 1 day after allocation date -> 31/08-3/09 => 4 days - 1 days time off => (3 / 4) * 5 days
-            # ^ result without prorata
-            # Prorated
-            self.assertAlmostEqual(allocation_worked_time.number_of_days, 3, 4, 'There should be 3 days allocated.')
-            self.assertEqual(allocation_not_worked_time.nextcall, datetime.date(2021, 9, 13), 'The next call date of the cron should be the September 13th')
-            self.assertEqual(allocation_worked_time.nextcall, datetime.date(2021, 9, 13), 'The next call date of the cron should be the September 13th')
-
-        with freeze_time(next_date + relativedelta(days=7)):
-            next_date = datetime.date(2021, 9, 20)
-            self.env['hr.leave.allocation']._update_accrual()
-            self.assertAlmostEqual(allocation_not_worked_time.number_of_days, 9.2857, 4, 'There should be 9.2857 days allocated.')
-            self.assertEqual(allocation_not_worked_time.nextcall, next_date, 'The next call date of the cron should be September 20th')
-            self.assertAlmostEqual(allocation_worked_time.number_of_days, 8, 4, 'There should be 8 days allocated.')
-            self.assertEqual(allocation_worked_time.nextcall, next_date, 'The next call date of the cron should be September 20th')
-
-    @freeze_time('2025-09-01')  # Monday
-    def test_non_elligible_leaves(self):
-        accrual_plan = self.env['hr.leave.accrual.plan'].create({
-            'is_based_on_worked_time': True,
+        cls.accrual_plan_monthly_31th_max_carryover_duration = _create_accrual_plan(accrual_plan_by_signature, {
             'can_be_carryover': True,
             'level_ids': [(0, 0, {
-                'milestone_date': 'creation',
+                'milestone_date': 'after',
+                'start_count': 1,
+                'start_type': 'day',
+                'added_value': 1,
+                'added_value_type': 'hour',
+                'first_day': 31,
+                'frequency': 'monthly',
+                'action_with_unused_accruals': 'all',
+                'carryover_options': 'limited',
+                'max_carriedover_duration': 4,
+            })],
+        })
+        cls.accrual_plan_2_lvls_weekly = _create_accrual_plan(accrual_plan_by_signature, {
+            'can_be_carryover': True,
+            'level_ids': [(0, 0, {
+                'added_value_type': 'day',
+                'milestone_date': 'after',
+                'start_count': 1,
+                'start_type': 'day',
+                'added_value': 1,
+                'frequency': 'weekly',
+                'cap_accrued_time': True,
+                'maximum_leave': 1,
+            }), (0, 0, {
+                'milestone_date': 'after',
+                'start_count': 10,
+                'start_type': 'day',
+                'added_value': 1,
+                'frequency': 'weekly',
+                'cap_accrued_time': True,
+                'maximum_leave': 1,
+                'action_with_unused_accruals': 'all',
+            })],
+        })
+        cls.accrual_plan_daily_carryover_lost = _create_accrual_plan(accrual_plan_by_signature, {
+            'can_be_carryover': True,
+            'level_ids': [(0, 0, {
+                'milestone_date': 'after',
+                'start_count': 1,
+                'start_type': 'day',
                 'added_value': 1,
                 'added_value_type': 'day',
                 'frequency': 'daily',
                 'cap_accrued_time': True,
-                'maximum_leave': 10000,
+                'maximum_leave': 20,
+                'action_with_unused_accruals': 'lost',
             })],
         })
-        allocation_worked_time = self.env['hr.leave.allocation'].with_user(self.user_hrmanager_id).create({
-            'name': 'Accrual allocation for employee',
-            'accrual_plan_id': accrual_plan.id,
-            'employee_id': self.employee_emp.id,
-            'work_entry_type_id': self.work_entry_type.id,
-            'number_of_days': 0,
-        })
-        allocation_worked_time.action_approve()
-        self.assertEqual(allocation_worked_time.number_of_days, 0, 'There should be no days allocated yet.')
-
-        with freeze_time('2025-09-13'):  # Saturday 10 working days
-            allocation_worked_time._update_accrual()
-            self.assertEqual(allocation_worked_time.number_of_days, 10, 'There should be 10 days allocated.')
-
-        timeoff_type = self.env['hr.work.entry.type'].create({
-            'name': 'Paid Time Off 2',
-            'code': 'Paid Time Off 2',
-            'count_as': 'absence',
-            'requires_allocation': False,
-            'elligible_for_accrual_rate': False,
-            'request_unit': 'day',
-            'unit_of_measure': 'day',
-        })
-        timeoff = self.env['hr.leave'].create({
-            'name': 'Paid Time Off',
-            'employee_id': self.employee_emp.id,
-            'work_entry_type_id': timeoff_type.id,
-            'request_date_from': '2025-09-16',
-            'request_date_to': '2025-09-18',
-        })
-        timeoff.action_approve()
-
-        with freeze_time('2025-09-20'):  # Saturday 15 working days - 3 leaves
-            allocation_worked_time._update_accrual()
-            self.assertEqual(allocation_worked_time.number_of_days, 12, 'There should be 12 days allocated.')
-
-    @freeze_time('2025-09-01')  # Monday
-    def test_elligible_leaves(self):
-        accrual_plan = self.env['hr.leave.accrual.plan'].create({
-            'is_based_on_worked_time': True,
+        cls.accrual_plan_yearly_carryover_limited_10 = _create_accrual_plan(accrual_plan_by_signature, {
             'can_be_carryover': True,
             'level_ids': [(0, 0, {
                 'milestone_date': 'creation',
-                'added_value': 1,
+                'added_value': 2,
                 'added_value_type': 'day',
-                'frequency': 'daily',
-                'cap_accrued_time': True,
-                'maximum_leave': 10000,
+                'frequency': 'yearly',
+                'action_with_unused_accruals': 'all',
+                'carryover_options': 'limited',
+                'max_carriedover_duration': 10,
             })],
         })
-        allocation_worked_time = self.env['hr.leave.allocation'].with_user(self.user_hrmanager_id).create({
-            'name': 'Accrual allocation for employee',
-            'accrual_plan_id': accrual_plan.id,
-            'employee_id': self.employee_emp.id,
-            'work_entry_type_id': self.work_entry_type.id,
-            'number_of_days': 0,
-        })
-        allocation_worked_time.action_approve()
-        self.assertEqual(allocation_worked_time.number_of_days, 0, 'There should be no days allocated yet.')
-
-        with freeze_time('2025-09-13'):  # Saturday 10 working days
-            allocation_worked_time._update_accrual()
-            self.assertEqual(allocation_worked_time.number_of_days, 10, 'There should be 10 days allocated.')
-
-        timeoff_eligible_type = self.env['hr.work.entry.type'].create({
-            'name': 'Paid Time Off 2',
-            'code': 'Paid Time Off 2',
-            'count_as': 'absence',
-            'requires_allocation': False,
-            'elligible_for_accrual_rate': True,
-            'request_unit': 'day',
-            'unit_of_measure': 'day',
-        })
-        timeoff_eligible = self.env['hr.leave'].create({
-            'name': 'Paid Time Off',
-            'employee_id': self.employee_emp.id,
-            'work_entry_type_id': timeoff_eligible_type.id,
-            'request_date_from': '2025-09-16',
-            'request_date_to': '2025-09-18',
-        })
-        timeoff_eligible.action_approve()
-
-        with freeze_time('2025-09-20'):  # Saturday 15 working days
-            allocation_worked_time._update_accrual()
-            self.assertEqual(allocation_worked_time.number_of_days, 15, 'There should be 15 days allocated.')
-
-    @freeze_time('2025-09-01')  # Monday
-    def test_worked_leaves(self):
-        accrual_plan = self.env['hr.leave.accrual.plan'].create({
-            'is_based_on_worked_time': True,
+        cls.accrual_plan_daily_max_leave_carryover_limited = _create_accrual_plan(accrual_plan_by_signature, {
+            'accrued_gain_time': 'start',
             'can_be_carryover': True,
             'level_ids': [(0, 0, {
-                'milestone_date': 'creation',
-                'added_value': 1,
                 'added_value_type': 'day',
+                'milestone_date': 'after',
+                'start_count': 1,
+                'start_type': 'day',
+                'added_value': 1,
                 'frequency': 'daily',
                 'cap_accrued_time': True,
-                'maximum_leave': 10000,
+                'maximum_leave': 25,
+                'action_with_unused_accruals': 'all',
+                'carryover_options': 'limited',
+                'max_carriedover_duration': 15,
             })],
         })
-        allocation_worked_time = self.env['hr.leave.allocation'].with_user(self.user_hrmanager_id).create({
-            'name': 'Accrual allocation for employee',
-            'accrual_plan_id': accrual_plan.id,
-            'employee_id': self.employee_emp.id,
-            'work_entry_type_id': self.work_entry_type.id,
-            'number_of_days': 0,
-        })
-        allocation_worked_time.action_approve()
-        self.assertEqual(allocation_worked_time.number_of_days, 0, 'There should be no days allocated yet.')
-
-        with freeze_time('2025-09-13'):  # Saturday 10 working days
-            allocation_worked_time._update_accrual()
-            self.assertEqual(allocation_worked_time.number_of_days, 10, 'There should be 10 days allocated.')
-
-        remote_work_type = self.env['hr.work.entry.type'].create({
-            'name': 'Remote Work',
-            'code': 'Remote Work',
-            'count_as': 'working_time',
-            'requires_allocation': False,
-            'request_unit': 'day',
-            'unit_of_measure': 'day',
-        })
-        remote_work = self.env['hr.leave'].create({
-            'name': 'Remote Work',
-            'employee_id': self.employee_emp.id,
-            'work_entry_type_id': remote_work_type.id,
-            'request_date_from': '2025-09-16',
-            'request_date_to': '2025-09-18',
-        })
-        remote_work.action_approve()
-
-        with freeze_time('2025-09-20'):  # Saturday 15 working days
-            allocation_worked_time._update_accrual()
-            self.assertEqual(allocation_worked_time.number_of_days, 15, 'There should be 15 days allocated.')
-
-    def test_check_max_value(self):
-        with freeze_time("2017-12-05"):
-            accrual_plan = self.env['hr.leave.accrual.plan'].create({
-                'name': 'Accrual Plan For Test',
-                'can_be_carryover': True,
-                'level_ids': [(0, 0, {
-                    'added_value_type': 'day',
-                    'milestone_date': 'after',
-                    'start_count': 1,
-                    'start_type': 'day',
-                    'added_value': 1,
-                    'frequency': 'daily',
-                    'cap_accrued_time': True,
-                    'maximum_leave': 1,
-                    'action_with_unused_accruals': 'all',
-                })],
-            })
-            allocation = self.env['hr.leave.allocation'].with_user(self.user_hrmanager_id).create({
-                'name': 'Accrual allocation for employee',
-                'accrual_plan_id': accrual_plan.id,
-                'employee_id': self.employee_emp.id,
-                'work_entry_type_id': self.work_entry_type.id,
-                'number_of_days': 0,
-            })
-            allocation.action_approve()
-            allocation._update_accrual()
-            tomorrow = datetime.date.today() + relativedelta(days=2)
-            self.assertEqual(allocation.number_of_days, 0, 'There should be no days allocated yet. The accrual starts tomorrow.')
-
-            with freeze_time(tomorrow):
-                allocation._update_accrual()
-                nextcall = datetime.date.today() + relativedelta(days=1)
-                allocation._update_accrual()
-                self.assertEqual(allocation.number_of_days, 1, 'There should be only 1 day allocated.')
-
-            with freeze_time(nextcall):
-                allocation._update_accrual()
-                nextcall = datetime.date.today() + relativedelta(days=1)
-                # The maximum value is 1 so this shouldn't change anything
-                allocation._update_accrual()
-                self.assertEqual(allocation.number_of_days, 1, 'There should be only 1 day allocated.')
-
-    def test_check_max_value_hours(self):
-        with freeze_time("2017-12-05"):
-            accrual_plan = self.env['hr.leave.accrual.plan'].create({
-                'name': 'Accrual Plan For Test',
-                'can_be_carryover': True,
-                'level_ids': [(0, 0, {
-                    'added_value_type': 'hour',
-                    'milestone_date': 'after',
-                    'start_count': 1,
-                    'start_type': 'day',
-                    'added_value': 1,
-                    'frequency': 'daily',
-                    'cap_accrued_time': True,
-                    'maximum_leave': 4,
-                    'action_with_unused_accruals': 'all',
-                })],
-            })
-            allocation = self.env['hr.leave.allocation'].with_user(self.user_hrmanager_id).create({
-                'name': 'Accrual allocation for employee',
-                'accrual_plan_id': accrual_plan.id,
-                'employee_id': self.employee_emp.id,
-                'work_entry_type_id': self.work_entry_type.id,
-                'number_of_days': 0,
-            })
-            allocation.action_approve()
-            allocation._update_accrual()
-            tomorrow = datetime.date.today() + relativedelta(days=2)
-            self.assertEqual(allocation.number_of_days, 0, 'There should be no days allocated yet. The accrual starts tomorrow.')
-
-            with freeze_time(tomorrow):
-                allocation._update_accrual()
-                nextcall = datetime.date.today() + relativedelta(days=10)
-                allocation._update_accrual()
-                self.assertEqual(allocation.number_of_days, 0.125, 'There should be only 0.125 days allocated.')
-
-            with freeze_time(nextcall):
-                allocation._update_accrual()
-                nextcall = datetime.date.today() + relativedelta(days=1)
-                # The maximum value is 1 so this shouldn't change anything
-                allocation._update_accrual()
-                self.assertEqual(allocation.number_of_days, 0.5, 'There should be only 0.5 days allocated.')
-
-    def test_accrual_hours_with_max_carryover(self):
-        with freeze_time("2024-10-10"):
-            accrual_plan = self.env['hr.leave.accrual.plan'].create({
-                'name': 'Accrual plan - hours and max postpone',
-                'can_be_carryover': True,
-                'level_ids': [(0, 0, {
-                    'added_value_type': 'hour',
-                    'milestone_date': 'after',
-                    'start_count': 1,
-                    'start_type': 'day',
-                    'added_value': 1,
-                    'first_day': 31,
-                    'frequency': 'monthly',
-                    'action_with_unused_accruals': 'all',
-                    'carryover_options': 'limited',
-                    'postpone_max_days': 4,  # confusing name but is in hours when added_value_type == 'hour'
-                })],
-            })
-            allocation = self.env['hr.leave.allocation'].with_user(self.user_hrmanager_id).create({
-                'name': 'Accrual allocation for employee',
-                'date_from': datetime.date(2025, 1, 1),
-                'accrual_plan_id': accrual_plan.id,
-                'employee_id': self.employee_emp.id,
-                'work_entry_type_id': self.work_entry_type.id,
-                'number_of_days': 0,
-            })
-            allocation.action_approve()
-            allocation._update_accrual()
-            self.assertEqual(allocation.number_of_days, 0)
-
-            hours_per_day = self.employee_emp.resource_calendar_id.hours_per_day
-            allocation_data = self.work_entry_type.get_allocation_data(self.employee_emp, "2025-12-02")[self.employee_emp][0][1]
-            self.assertAlmostEqual(allocation_data["remaining_leaves"], 11 / hours_per_day, 1, '11 hours accrued.')
-
-            allocation_data = self.work_entry_type.get_allocation_data(self.employee_emp, "2026-02-02")[self.employee_emp][0][1]
-            self.assertAlmostEqual(allocation_data["remaining_leaves"], 5 / hours_per_day, 1, '5 hours accrued.')
-
-    def test_accrual_transition_immediately(self):
-        with freeze_time("2017-12-05"):
-            # 1 accrual with 2 levels and level transition immediately
-            accrual_plan = self.env['hr.leave.accrual.plan'].create({
-                'transition_mode': 'immediately',
-                'can_be_carryover': True,
-                'level_ids': [(0, 0, {
-                    'added_value_type': 'day',
-                    'milestone_date': 'after',
-                    'start_count': 1,
-                    'start_type': 'day',
-                    'added_value': 1,
-                    'frequency': 'weekly',
-                    'cap_accrued_time': True,
-                    'maximum_leave': 1,
-                }), (0, 0, {
-                    'milestone_date': 'after',
-                    'start_count': 10,
-                    'start_type': 'day',
-                    'added_value': 1,
-                    'frequency': 'weekly',
-                    'cap_accrued_time': True,
-                    'maximum_leave': 1,
-                    'action_with_unused_accruals': 'all',
-                })],
-            })
-            allocation = self.env['hr.leave.allocation'].with_user(self.user_hrmanager_id).create({
-                'name': 'Accrual allocation for employee',
-                'accrual_plan_id': accrual_plan.id,
-                'employee_id': self.employee_emp.id,
-                'work_entry_type_id': self.work_entry_type.id,
-                'number_of_days': 0,
-            })
-            allocation.action_approve()
-            next_date = datetime.date.today() + relativedelta(days=11)
-            second_level = self.env['hr.leave.accrual.level'].search([('accrual_plan_id', '=', accrual_plan.id), ('start_count', '=', 10)])
-            self.assertEqual(allocation._get_current_accrual_plan_level_id(next_date)[0], second_level, 'The second level should be selected')
-
-    def test_accrual_transition_after_period(self):
-        with freeze_time("2017-12-05"):
-            # 1 accrual with 2 levels and level transition after
-            accrual_plan = self.env['hr.leave.accrual.plan'].create({
-                'transition_mode': 'end_of_accrual',
-                'can_be_carryover': True,
-                'level_ids': [(0, 0, {
-                    'added_value_type': 'day',
-                    'milestone_date': 'after',
-                    'start_count': 1,
-                    'start_type': 'day',
-                    'added_value': 1,
-                    'frequency': 'weekly',
-                    'cap_accrued_time': True,
-                    'maximum_leave': 1,
-                }), (0, 0, {
-                    'milestone_date': 'after',
-                    'start_count': 10,
-                    'start_type': 'day',
-                    'added_value': 1,
-                    'frequency': 'weekly',
-                    'cap_accrued_time': True,
-                    'maximum_leave': 1,
-                    'action_with_unused_accruals': 'all',
-                })],
-            })
-            allocation = self.env['hr.leave.allocation'].with_user(self.user_hrmanager_id).create({
-                'name': 'Accrual allocation for employee',
-                'accrual_plan_id': accrual_plan.id,
-                'employee_id': self.employee_emp.id,
-                'work_entry_type_id': self.work_entry_type.id,
-                'number_of_days': 0,
-            })
-            allocation.action_approve()
-            next_date = datetime.date.today() + relativedelta(days=11)
-            second_level = self.env['hr.leave.accrual.level'].search([('accrual_plan_id', '=', accrual_plan.id), ('start_count', '=', 10)])
-            self.assertEqual(allocation._get_current_accrual_plan_level_id(next_date)[0], second_level, 'The second level should be selected')
-
-    def test_unused_accrual_lost(self):
-        """
-        Create an accrual plan:
-            - Carryover date:  January 1st.
-        Create a milestone:
-            - Number of accrued days: 1
-            - Frequency: daily
-            - Start accrual 1 day after the allocation start date.
-            - Carryover policy: No days carry over.
-            - Accrued days cap: 20 days.
-        Create an allocation:
-            - Start date: 15/12/2021
-            - Type: Accrual
-            - Accrual Plan: Use the one defined above.
-            - Number of days (given to the employee on the first run of the accrual plan): 10 days
-
-        The employee is given 10 days on the first run of the accrual plan.
-        From 15/12/2021, to 31/12/2021 10 days are accrued to the employee (It should be 16 but the accrued days cap is 20 days).
-        On 01/01/2022
-            - No days will carry over from the 25 days that the employee has.
-            - 1 day is accrued.
-            - The total number of days that the employee has is 1 day.
-        """
-        with freeze_time('2021-12-15'):
-            accrual_plan = self.env['hr.leave.accrual.plan'].create({
-                'name': 'Accrual Plan For Test',
-                'can_be_carryover': True,
-                'level_ids': [(0, 0, {
-                    'added_value_type': 'day',
-                    'milestone_date': 'after',
-                    'start_count': 1,
-                    'start_type': 'day',
-                    'added_value': 1,
-                    'frequency': 'daily',
-                    'cap_accrued_time': True,
-                    'maximum_leave': 20,
-                    'action_with_unused_accruals': 'lost',
-                })],
-            })
-            allocation = self.env['hr.leave.allocation'].with_user(self.user_hrmanager_id).create({
-                'name': 'Accrual allocation for employee',
-                'accrual_plan_id': accrual_plan.id,
-                'employee_id': self.employee_emp.id,
-                'work_entry_type_id': self.work_entry_type.id,
-                'number_of_days': 10,
-            })
-            allocation.action_approve()
-
-        # Reset the cron's lastcall
-        accrual_cron = self.env['ir.cron'].sudo().env.ref('hr_holidays.hr_leave_allocation_cron_accrual')
-        accrual_cron.lastcall = datetime.date(2021, 12, 15)
-        with freeze_time('2022-01-01'):
-            allocation._update_accrual()
-            self.assertEqual(allocation.number_of_days, 1,
-                             'The number of days should reset and 1 day will be accrued on 01/01/2022.')
-
-    def test_unused_accrual_postponed(self):
-        # 1 accrual with 2 levels and level transition after
-        # This also tests retroactivity
-        with freeze_time('2021-12-15'):
-            accrual_plan = self.env['hr.leave.accrual.plan'].create({
-                'name': 'Accrual Plan For Test',
-                'can_be_carryover': True,
-                'level_ids': [(0, 0, {
-                    'added_value_type': 'day',
-                    'milestone_date': 'after',
-                    'start_count': 1,
-                    'start_type': 'day',
-                    'added_value': 1,
-                    'frequency': 'daily',
-                    'cap_accrued_time': True,
-                    'maximum_leave': 25,
-                    'action_with_unused_accruals': 'all',
-                })],
-            })
-            allocation = self.env['hr.leave.allocation'].with_user(self.user_hrmanager_id).create({
-                'name': 'Accrual allocation for employee',
-                'accrual_plan_id': accrual_plan.id,
-                'employee_id': self.employee_emp.id,
-                'work_entry_type_id': self.work_entry_type.id,
-                'number_of_days': 10,
-            })
-            allocation.action_approve()
-
-        # Reset the cron's lastcall
-        accrual_cron = self.env['ir.cron'].sudo().env.ref('hr_holidays.hr_leave_allocation_cron_accrual')
-        accrual_cron.lastcall = datetime.date(2021, 12, 15)
-        with freeze_time('2022-01-01'):
-            allocation._update_accrual()
-        self.assertEqual(allocation.number_of_days, 25, 'The maximum number of days should be reached and kept.')
-
-    def test_unused_accrual_postponed_2(self):
-        with freeze_time('2021-01-01'):
-            accrual_plan = self.env['hr.leave.accrual.plan'].create({
-                'name': 'Accrual Plan For Test',
-                'can_be_carryover': True,
-                'level_ids': [(0, 0, {
-                    'added_value_type': 'day',
-                    'milestone_date': 'creation',
-                    'start_type': 'day',
-                    'added_value': 2,
-                    'frequency': 'yearly',
-                    'cap_accrued_time': True,
-                    'maximum_leave': 100,
-                    'action_with_unused_accruals': 'all',
-                    'carryover_options': 'limited',
-                    'postpone_max_days': 10,
-                })],
-            })
-            allocation = self.env['hr.leave.allocation'].with_user(self.user_hrmanager_id).create({
-                'name': 'Accrual allocation for employee',
-                'accrual_plan_id': accrual_plan.id,
-                'employee_id': self.employee_emp.id,
-                'work_entry_type_id': self.work_entry_type.id,
-                'number_of_days': 0,
-            })
-            allocation.action_approve()
-
-        # Reset the cron's lastcall
-        accrual_cron = self.env['ir.cron'].sudo().env.ref('hr_holidays.hr_leave_allocation_cron_accrual')
-        accrual_cron.lastcall = datetime.date(2021, 1, 1)
-        with freeze_time('2023-01-26'):
-            allocation._update_accrual()
-        self.assertEqual(allocation.number_of_days, 4, 'The maximum number of days should be reached and kept.')
-
-    def test_unused_accrual_postponed_limit(self):
-        """
-        Create an accrual plan:
-            - Carryover date:  January 1st.
-            - The days are accrued at the start of the accrual period.
-        Create a milestone:
-            - Number of accrued days: 1
-            - Frequency: daily
-            - Start accrual 1 day after the allocation start date.
-            - Carryover policy: Carryover with a maximum
-            - Carryover limit: 15 days
-            - Accrued days cap: 25 days.
-        Create an allocation:
-            - Start date: 15/12/2021
-            - Type: Accrual
-            - Accrual Plan: Use the one defined above.
-            - Number of days (given to the employee on the first run of the accrual plan): 10 days
-
-        The employee is given 10 days on the first run of the accrual plan.
-        From 15/12/2021, to 31/12/2021 15 days are accrued to the employee (It should be 16 but the accrued days cap is 25 days).
-        On 01/01/2022
-            - Only 15 days carry over from the 25 days that the employee has.
-            - 1 Additional day is accrued.
-            - The total number of days that the employee has is 16 days.
-        """
-        # 1 accrual with 2 levels and level transition after
-        # This also tests retroactivity
-        with freeze_time('2021-12-15'):
-            accrual_plan = self.env['hr.leave.accrual.plan'].create({
-                'accrued_gain_time': 'start',
-                'can_be_carryover': True,
-                'level_ids': [(0, 0, {
-                    'added_value_type': 'day',
-                    'milestone_date': 'after',
-                    'start_count': 1,
-                    'start_type': 'day',
-                    'added_value': 1,
-                    'frequency': 'daily',
-                    'cap_accrued_time': True,
-                    'maximum_leave': 25,
-                    'action_with_unused_accruals': 'all',
-                    'carryover_options': 'limited',
-                    'postpone_max_days': 15,
-                })],
-            })
-            allocation = self.env['hr.leave.allocation'].with_user(self.user_hrmanager_id).create({
-                'name': 'Accrual allocation for employee',
-                'accrual_plan_id': accrual_plan.id,
-                'employee_id': self.employee_emp.id,
-                'work_entry_type_id': self.work_entry_type.id,
-                'number_of_days': 10,
-            })
-            allocation.action_approve()
-
-        # Reset the cron's lastcall
-        accrual_cron = self.env['ir.cron'].sudo().env.ref('hr_holidays.hr_leave_allocation_cron_accrual')
-        accrual_cron.lastcall = datetime.date(2021, 12, 15)
-        with freeze_time('2022-01-01'):
-            allocation._update_accrual()
-        self.assertEqual(allocation.number_of_days, 16,
-                          '15 days carryover. 1 day is accrued for the new accrual period. The total is 16 days.')
-
-    def test_unused_accrual_postponed_limit_2(self):
-        """
-        Create an accrual plan:
-            - Carryover date:  January 1st.
-        Create a milestone:
-            - Number of accrued days: 15
-            - Frequency: Yearly
-            - Accrual date: January 1st
-            - Carryover policy: Carryover with a maximum
-            - Carryover limit: 7 days
-        Create an allocation:
-            - Start date: 01/01/2021
-            - Type: Accrual
-            - Accrual Plan: Use the one defined above.
-
-        On 01/01/2022, 15 days are accrued to the employee.
-        On 01/01/2023:
-            - Only 7 days carry over from the 15 days that the employee has.
-            - 15 Additional days are accrued.
-            - The total number of days that the employee has is 22 days.
-        """
-        with freeze_time('2021-01-01'):
-            accrual_plan = self.env['hr.leave.accrual.plan'].create({
-                'name': 'Accrual Plan For Test',
-                'can_be_carryover': True,
-                'level_ids': [(0, 0, {
-                    'added_value_type': 'day',
-                    'milestone_date': 'creation',
-                    'start_type': 'day',
-                    'added_value': 15,
-                    'frequency': 'yearly',
-                    'cap_accrued_time': True,
-                    'maximum_leave': 100,
-                    'action_with_unused_accruals': 'all',
-                    'carryover_options': 'limited',
-                    'postpone_max_days': 7,
-                })],
-            })
-            allocation = self.env['hr.leave.allocation'].with_user(self.user_hrmanager_id).create({
-                'name': 'Accrual allocation for employee',
-                'accrual_plan_id': accrual_plan.id,
-                'employee_id': self.employee_emp.id,
-                'work_entry_type_id': self.work_entry_type.id,
-                'number_of_days': 0,
-            })
-            allocation.action_approve()
-
-        # Reset the cron's lastcall
-        accrual_cron = self.env['ir.cron'].sudo().env.ref('hr_holidays.hr_leave_allocation_cron_accrual')
-        accrual_cron.lastcall = datetime.date(2021, 1, 1)
-        with freeze_time('2023-01-26'):
-            allocation._update_accrual()
-        self.assertEqual(allocation.number_of_days, 22,
-                         '7 days carryover from the previous accrual period. 15 days are accrued for the new accrual period. The total is 22 days.')
-
-    def test_accrual_skipped_period(self):
-        # Test that when an allocation is made in the past and the second level is technically reached
-        #  that the first level is not skipped completely.
-        accrual_plan = self.env['hr.leave.accrual.plan'].create({
+        cls.accrual_plan_biyearly_2_levels = _create_accrual_plan(accrual_plan_by_signature, {
             'name': 'Accrual Plan For Test',
             'can_be_carryover': True,
             'level_ids': [(0, 0, {
                 'added_value_type': 'day',
                 'milestone_date': 'creation',
-                'start_type': 'day',
                 'added_value': 15,
                 'frequency': 'biyearly',
-                'cap_accrued_time': True,
-                'maximum_leave': 100,
                 'action_with_unused_accruals': 'all',
             }), (0, 0, {
                 'milestone_date': 'after',
@@ -1415,39 +649,10 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'start_type': 'month',
                 'added_value': 10,
                 'frequency': 'biyearly',
-                'cap_accrued_time': True,
-                'maximum_leave': 500,
                 'action_with_unused_accruals': 'all',
             })],
         })
-        with freeze_time('2020-08-16'):
-            allocation = self.env['hr.leave.allocation'].with_user(self.user_hrmanager_id).create({
-                'name': 'Accrual Allocation - Test',
-                'accrual_plan_id': accrual_plan.id,
-                'employee_id': self.employee_emp.id,
-                'work_entry_type_id': self.work_entry_type.id,
-                'number_of_days': 0,
-                'date_from': datetime.date(2020, 8, 16),
-            })
-            allocation.action_approve()
-
-        assertions = [
-            # Level transition: accrual of the first level:   15 * 122 / 184 = 9.945
-            ('2020-12-16', leaves := 9.945),
-            # Second level accrual: 10 * 16 / 184 (same period from 2020-07-01 to 2021-01-01 = 184d) = 0.869
-            ('2021-01-01', leaves := leaves + 0.869),
-            # Second level accrual: 10 (for period 2021-01-01 - 2021-07-01)
-            ('2021-07-01', leaves := leaves + 10),
-            # Second level accrual: 10 (for period 2021-07-01 - 2022-01-01)
-            ('2022-01-01', leaves + 10),
-        ]
-        for test_date, expected_days in assertions:
-            with freeze_time(test_date):
-                allocation._update_accrual()
-                self.assertAlmostEqual(allocation.number_of_days, expected_days, 2, "Invalid number of days")
-
-    def test_three_levels_accrual(self):
-        accrual_plan = self.env['hr.leave.accrual.plan'].create({
+        cls.accrual_plan_3_levels_monthly_max_leaves = _create_accrual_plan(accrual_plan_by_signature, {
             'name': 'Accrual Plan For Test',
             'can_be_carryover': True,
             'level_ids': [(0, 0, {
@@ -1477,504 +682,102 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'start_type': 'month',
                 'added_value': 1,
                 'frequency': 'monthly',
-                'cap_accrued_time': True,
-                'maximum_leave': 100,
                 'action_with_unused_accruals': 'all',
                 'first_day': 31,
             })],
         })
-        with freeze_time('2022-01-31'):
-            allocation = self.env['hr.leave.allocation'].with_user(self.user_hrmanager_id).create({
-                'name': 'Accrual Allocation - Test',
-                'accrual_plan_id': accrual_plan.id,
-                'employee_id': self.employee_emp.id,
-                'work_entry_type_id': self.work_entry_type.id,
-                'number_of_days': 0,
-                'date_from': datetime.date(2022, 1, 31),
-            })
-            allocation.action_approve()
-        with freeze_time('2022-07-20'):
-            allocation._update_accrual()
-        # The first level gives 3 days
-        # The second level could give 6 days but since the first level was already giving
-        # 3 days, the second level gives 3 days to reach the second level's limit.
-        # The third level gives 1 day since it only counts for one iteration.
-        self.assertAlmostEqual(allocation.number_of_days, 7, 2)
-
-    def test_accrual_lost_previous_days(self):
-        """
-        Test that when an allocation with two levels is made and that the first level has it's action
-        with unused accruals set as lost that the days are effectively lost
-        Create an accrual plan:
-            - Carryover date:  January 1st.
-        Create first milestone:
-            - Number of accrued days: 1
-            - Frequency: monthly
-            - Start accrual 0 day after the allocation start date.
-            - Carryover policy: No days carry over
-            - Accrued days cap: 12 days.
-        Create second milestone:
-            - Same as the first milestone but it starts after 1 year of the allocation start date
-        Create an allocation:
-            - Start date: 01/01/2021
-            - Type: Accrual
-            - Accrual Plan: Use the one defined above.
-
-        From 01/01/2021, to 01/12/2021 11 days are accrued to the employee.
-
-        On 01/01/2022:
-            - No days carry over.
-            - 1 day is accrued (for the period from 01/12/2021 to 31/12/2021).
-
-        From 01/01/2022, to 01/04/2022 3 days are accrued to the employee.
-        The total number of days that the employee has is 1 + 3 = 4 days.
-        """
-        accrual_plan = self.env['hr.leave.accrual.plan'].create({
-            'name': 'Accrual Plan For Test',
-            'can_be_carryover': True,
-            'level_ids': [
-                (0, 0, {
-                    'added_value_type': 'day',
-                    'milestone_date': 'creation',
-                    'start_type': 'day',
-                    'added_value': 1,
-                    'frequency': 'monthly',
-                    'cap_accrued_time': True,
-                    'maximum_leave': 12,
-                    'action_with_unused_accruals': 'lost',
-                }),
-                (0, 0, {
-                    'milestone_date': 'after',
-                    'start_count': 1,
-                    'start_type': 'year',
-                    'added_value': 1,
-                    'frequency': 'monthly',
-                    'cap_accrued_time': True,
-                    'maximum_leave': 12,
-                    'action_with_unused_accruals': 'lost',
-                }),
-            ],
-        })
-        with freeze_time('2021-01-01'):
-            allocation = self.env['hr.leave.allocation'].with_user(self.user_hrmanager_id).create({
-                'name': 'Accrual Allocation - Test',
-                'accrual_plan_id': accrual_plan.id,
-                'employee_id': self.employee_emp.id,
-                'work_entry_type_id': self.work_entry_type.id,
-                'number_of_days': 0,
-                'date_from': datetime.date(2021, 1, 1),
-            })
-            allocation.action_approve()
-        with freeze_time('2022-04-04'):
-            allocation._update_accrual()
-        self.assertEqual(allocation.number_of_days, 4, "Invalid number of days")
-
-    def test_accrual_lost_first_january(self):
-        """
-        Create an accrual plan:
-            - Carryover date:  January 1st.
-            - The days are accrued at the start of the accrual period.
-        Create a milestone:
-            - Number of accrued days: 3
-            - Frequency: yearly
-            - Start accrual immediately on the allocation start date.
-            - Carryover policy: No days carry over
-            - Accrued days cap: 12 days.
-        Create an allocation:
-            - Start date: 01/01/2019
-            - Type: Accrual
-            - Accrual Plan: Use the one defined above.
-
-        On 01/01/2019, 3 days are accrued.
-        On 01/01/2020, the previous 3 days are lost due to carryover. 3 days are accrued.
-        On 01/01/2021, the previous 3 days are lost due to carryover. 3 days are accrued.
-        On 01/01/2022, the previous 3 days are lost due to carryover. 3 days are accrued.
-        The total number of days should be 3.
-        """
-        accrual_plan = self.env['hr.leave.accrual.plan'].create({
+        cls.accrual_plan_yearly_carryover_lost = _create_accrual_plan(accrual_plan_by_signature, {
             'accrued_gain_time': 'start',
             'can_be_carryover': True,
             'level_ids': [
                 (0, 0, {
-                    'added_value_type': 'day',
                     'milestone_date': 'creation',
-                    'start_type': 'day',
                     'added_value': 3,
+                    'added_value_type': 'day',
                     'frequency': 'yearly',
-                    'cap_accrued_time': True,
-                    'maximum_leave': 12,
                     'action_with_unused_accruals': 'lost',
-                })
+                }),
             ],
         })
-        with freeze_time('2019-01-01'):
-            allocation = self.env['hr.leave.allocation'].with_user(self.user_hrmanager_id).create({
-                'name': 'Accrual Allocation - Test',
-                'accrual_plan_id': accrual_plan.id,
-                'employee_id': self.employee_emp.id,
-                'work_entry_type_id': self.work_entry_type.id,
-                'number_of_days': 0,
-                'date_from': datetime.date(2019, 1, 1),
-            })
-            allocation.action_approve()
-
-        with freeze_time('2022-04-01'):
-            allocation._update_accrual()
-        self.assertAlmostEqual(allocation.number_of_days, 3, 2, "Invalid number of days")
-
-    def test_accrual_maximum_leaves(self):
-        accrual_plan = self.env['hr.leave.accrual.plan'].create({
+        cls.accrual_plan_weekly_5_max_leave = _create_accrual_plan(accrual_plan_by_signature, {
             'name': 'Accrual Plan For Test',
             'can_be_carryover': True,
             'level_ids': [(0, 0, {
-                'added_value_type': 'day',
-                'milestone_date': 'after',
-                'start_count': 1,
-                'start_type': 'day',
-                'added_value': 1,
-                'frequency': 'daily',
-                'cap_accrued_time': True,
-                'maximum_leave': 5,
-                'action_with_unused_accruals': 'all',
-            })],
-        })
-        with freeze_time("2021-09-03"):
-            allocation = self.env['hr.leave.allocation'].with_user(self.user_hrmanager_id).create({
-                'name': 'Accrual allocation for employee',
-                'accrual_plan_id': accrual_plan.id,
-                'employee_id': self.employee_emp.id,
-                'work_entry_type_id': self.work_entry_type.id,
-                'number_of_days': 0,
-                'date_from': '2021-09-03',
-            })
-
-        with freeze_time("2021-10-03"):
-            allocation.action_approve()
-            allocation._update_accrual()
-
-            self.assertEqual(allocation.number_of_days, 5, "Should accrue maximum 5 days")
-
-    def test_accrual_maximum_leaves_no_limit(self):
-        accrual_plan = self.env['hr.leave.accrual.plan'].create({
-            'name': 'Accrual Plan For Test',
-            'can_be_carryover': True,
-            'level_ids': [(0, 0, {
-                'added_value_type': 'day',
-                'milestone_date': 'after',
-                'start_count': 1,
-                'start_type': 'day',
-                'added_value': 1,
-                'frequency': 'daily',
-                'cap_accrued_time': False,
-                'action_with_unused_accruals': 'all',
-            })],
-        })
-        with freeze_time("2021-09-03"):
-            allocation = self.env['hr.leave.allocation'].with_user(self.user_hrmanager_id).create({
-                'name': 'Accrual allocation for employee',
-                'accrual_plan_id': accrual_plan.id,
-                'employee_id': self.employee_emp.id,
-                'work_entry_type_id': self.work_entry_type.id,
-                'number_of_days': 0,
-                'date_from': '2021-09-03',
-            })
-
-        with freeze_time("2021-10-03"):
-            allocation.action_approve()
-            allocation._update_accrual()
-
-            self.assertEqual(allocation.number_of_days, 29, "No limits for accrued days")
-
-    def test_accrual_leaves_taken_maximum(self):
-        accrual_plan = self.env['hr.leave.accrual.plan'].create({
-            'name': 'Accrual Plan For Test',
-            'can_be_carryover': True,
-            'level_ids': [(0, 0, {
-                'added_value_type': 'day',
                 'milestone_date': 'creation',
-                'start_type': 'day',
                 'added_value': 1,
+                'added_value_type': 'day',
                 'frequency': 'weekly',
-                'week_day': '0',
                 'cap_accrued_time': True,
                 'maximum_leave': 5,
                 'action_with_unused_accruals': 'all',
             })],
         })
-        with freeze_time("2022-01-01"):
-            allocation = self.env['hr.leave.allocation'].with_user(self.user_hrmanager_id).create({
-                'name': 'Accrual allocation for employee',
-                'accrual_plan_id': accrual_plan.id,
-                'employee_id': self.employee_emp.id,
-                'work_entry_type_id': self.work_entry_type.id,
-                'number_of_days': 0,
-                'date_from': '2022-01-01',
-            })
-            allocation.action_approve()
-
-        with freeze_time("2022-03-02"):
-            allocation._update_accrual()
-
-        self.assertEqual(allocation.number_of_days, 5, "Maximum of 5 days accrued")
-
-        leave = self.env['hr.leave'].create({
-            'name': 'leave',
-            'employee_id': self.employee_emp.id,
-            'work_entry_type_id': self.work_entry_type.id,
-            'request_date_from': '2022-03-07',
-            'request_date_to': '2022-03-11',
-        })
-        leave.action_approve()
-
-        with freeze_time("2022-06-01"):
-            allocation._update_accrual()
-        self.assertEqual(allocation.number_of_days, 10, "Should accrue 5 additional days")
-
-    def test_accrual_leaves_taken_maximum_hours(self):
-        accrual_plan = self.env['hr.leave.accrual.plan'].create({
+        cls.accrual_plan_weekly_hour_max_leaves = _create_accrual_plan(accrual_plan_by_signature, {
             'name': 'Accrual Plan For Test',
             'can_be_carryover': True,
             'level_ids': [(0, 0, {
+                'milestone_date': 'creation',
+                'added_value': 3,
                 'added_value_type': 'hour',
-                'milestone_date': 'creation',
-                'start_type': 'day',
-                'added_value': 1,
                 'frequency': 'weekly',
-                'week_day': '0',
                 'cap_accrued_time': True,
                 'maximum_leave': 10,
                 'action_with_unused_accruals': 'all',
             })],
         })
-        with freeze_time(datetime.date(2022, 1, 1)):
-            allocation = self.env['hr.leave.allocation'].with_user(self.user_hrmanager_id).create({
-                'name': 'Accrual allocation for employee',
-                'accrual_plan_id': accrual_plan.id,
-                'employee_id': self.employee_emp.id,
-                'work_entry_type_id': self.work_entry_type_hour.id,
-                'number_of_days': 0,
-                'date_from': '2022-01-01',
-            })
-            allocation.action_approve()
-
-        with freeze_time(datetime.date(2022, 4, 1)):
-            allocation._update_accrual()
-
-        self.assertEqual(allocation.number_of_days, 10 / self.hours_per_day, "Maximum of 10 hours accrued")
-
-        leave = self.env['hr.leave'].create({
-            'name': 'leave',
-            'employee_id': self.employee_emp.id,
-            'work_entry_type_id': self.work_entry_type_hour.id,
-            'request_date_from': '2022-03-07',
-            'request_date_to': '2022-03-07',
-        })
-        leave.action_approve()
-
-        with freeze_time(datetime.date(2022, 6, 1)):
-            allocation._update_accrual()
-        self.assertEqual(allocation.number_of_days, 18 / self.hours_per_day, "Should accrue 8 additional hours")
-
-    @mute_logger('odoo.sql_db')
-    def test_yearly_cap_constraint(self):
-        accrual_plan = self.env['hr.leave.accrual.plan'].create({
-            'accrued_gain_time': 'end',
+        cls.accrual_plan_daily_5_max_leaves = _create_accrual_plan(accrual_plan_by_signature, {
             'can_be_carryover': True,
             'level_ids': [(0, 0, {
                 'added_value_type': 'day',
                 'milestone_date': 'creation',
-                'start_type': 'day',
                 'added_value': 1,
                 'frequency': 'daily',
-                'week_day': '0',
                 'cap_accrued_time': True,
                 'maximum_leave': 5,
                 'action_with_unused_accruals': 'all',
             })],
         })
-        with self.assertRaises(IntegrityError):
-            accrual_plan.level_ids[0].write({
-                'cap_accrued_time_yearly': True,
-                'maximum_leave_yearly': 0,
-            })
-        accrual_plan.level_ids[0].write({
-            'cap_accrued_time_yearly': True,
-            'maximum_leave_yearly': 1,
-        })
-        accrual_plan.level_ids[0].write({
-            'cap_accrued_time_yearly': False,
-            'maximum_leave_yearly': 0,
-        })
-        self.env.cr.precommit.run()
-        self.env.flush_all()
-
-    def test_yearly_cap(self):
-        work_entry_type = self.env['hr.work.entry.type'].create({
-            'name': 'Hour Time Off',
-            'code': 'Hour Time Off',
-            'count_as': 'absence',
-            'requires_allocation': True,
-            'allocation_validation_type': 'no_validation',
-            'leave_validation_type': 'no_validation',
-            'request_unit': 'hour',
-            'unit_of_measure': 'hour',
-        })
-        accrual_plan = self.env['hr.leave.accrual.plan'].create({
-            'accrued_gain_time': 'end',
+        cls.accrual_plan_hourly_max_leaves_capped_yearly = _create_accrual_plan(accrual_plan_by_signature, {
             'can_be_carryover': True,
             'level_ids': [(0, 0, {
-                'added_value_type': 'hour',
                 'milestone_date': 'creation',
-                'start_type': 'day',
-                'added_value': 0.06,
-                'frequency': 'hourly',
-                'week_day': '0',
-                'cap_accrued_time': True,
-                'maximum_leave': 180,
-                'cap_accrued_time_yearly': True,
-                'maximum_leave_yearly': 120,
-                'action_with_unused_accruals': 'all',
-            })],
-        })
-
-        with freeze_time('2024-01-01'):
-            allocation = self.env['hr.leave.allocation'].with_user(self.user_hrmanager_id).create({
-                'name': 'Accrual allocation for employee',
-                'employee_id': self.employee_emp.id,
-                'work_entry_type_id': work_entry_type.id,
-                'accrual_plan_id': accrual_plan.id,
-                'number_of_days': 0,
-            })
-
-        with freeze_time('2024-12-20'):
-            allocation._update_accrual()
-            self.assert_allocation_and_balance(allocation, 120, 120,
-                "The yearly cap should be reached.")
-            leave = self.env['hr.leave'].create({
-                'name': "Leave for employee",
-                'employee_id': self.employee_emp.id,
-                'work_entry_type_id': work_entry_type.id,
-                'request_date_from': datetime.date(2024, 12, 19),
-                'request_date_to': datetime.date(2024, 12, 19),
-                'request_hour_from': '10',
-                'request_hour_to': '12',
-            })
-            self.assertEqual(leave.number_of_hours, 2)
-            self.assertEqual(allocation.leaves_taken, 2)
-            self.assert_allocation_and_balance(allocation, 120, 118,
-                "The 2 hours should be deduced from the balance")
-
-        with freeze_time('2024-12-31'):
-            allocation._update_accrual()
-            self.assert_allocation_and_balance(allocation, 120, 118,
-                "The amount shouldn't exceed the yearly amount as all days days have already been accrued.")
-
-        with freeze_time('2025-01-06'):
-            allocation._update_accrual()
-            self.assertAlmostEqual(allocation.number_of_hours_display, 121.44)
-
-        with freeze_time('2025-07-03'):
-            allocation._update_accrual()
-            self.assert_allocation_and_balance(allocation, 182, 180, "The global cap should be reached.")
-            leave = self.env['hr.leave'].create({
-                'name': "Leave for employee",
-                'employee_id': self.employee_emp.id,
-                'work_entry_type_id': work_entry_type.id,
-                'request_date_from': datetime.date(2025, 6, 2),
-                'request_date_to': datetime.date(2025, 6, 11),
-            })
-            self.assertEqual(leave.number_of_hours, 64)
-            self.assertEqual(allocation.leaves_taken, 66)
-            self.assert_allocation_and_balance(allocation, 182, 116,
-                "The leave hours should be deduced from the balance.")
-
-        with freeze_time('2025-12-25'):
-            allocation._update_accrual()
-            self.assert_allocation_and_balance(allocation, 240, 174,
-                "The total yearly amount should be reached.")
-
-        with freeze_time('2025-12-31'):
-            allocation._update_accrual()
-            self.assert_allocation_and_balance(allocation, 240, 174,
-                "Nothing more should have been accrued since the yearly cap was already reached.")
-
-    def test_accrual_period_start(self):
-        accrual_plan = self.env['hr.leave.accrual.plan'].create({
-            'accrued_gain_time': 'end',
-            'can_be_carryover': True,
-            'level_ids': [(0, 0, {
-                'added_value_type': 'day',
-                'milestone_date': 'creation',
-                'start_type': 'day',
                 'added_value': 1,
-                'frequency': 'weekly',
-                'week_day': '0',
+                'added_value_type': 'hour',
+                'frequency': 'hourly',
                 'cap_accrued_time': True,
-                'maximum_leave': 5,
+                'maximum_leave': 24,
+                'cap_accrued_time_yearly': True,
+                'maximum_leave_yearly': 16,
                 'action_with_unused_accruals': 'all',
             })],
         })
-        with freeze_time("2023-04-24"):
-            allocation = self.env['hr.leave.allocation'].with_user(self.user_hrmanager_id).create({
-                'name': 'Accrual allocation for employee',
-                'accrual_plan_id': accrual_plan.id,
-                'employee_id': self.employee_emp.id,
-                'work_entry_type_id': self.work_entry_type.id,
-                'number_of_days': 0,
-                'date_from': '2023-04-24',
-            })
-            allocation.action_approve()
-
-            allocation._update_accrual()
-
-        self.assertEqual(allocation.number_of_days, 0, "Should accrue 0 days, because the period is not done yet.")
-
-        accrual_plan.accrued_gain_time = 'start'
-        with freeze_time("2023-04-24"):
-            allocation = self._create_form_test_accrual_allocation(self.work_entry_type, '2023-04-24', self.employee_emp, accrual_plan, creator_user=self.user_hrmanager_id)
-            allocation.action_approve()
-        self.assertEqual(allocation.number_of_days, 1, "Should accrue 1 day, at the start of the period.")
-
-    def test_accrual_period_start_multiple_runs(self):
-        accrual_plan = self.env['hr.leave.accrual.plan'].create({
+        cls.accrual_plan_monthly_start_15_max_leaves = _create_accrual_plan(accrual_plan_by_signature, {
             'accrued_gain_time': 'start',
             'can_be_carryover': True,
             'level_ids': [(0, 0, {
-                'added_value_type': 'day',
                 'milestone_date': 'creation',
-                'start_type': 'day',
                 'added_value': 1.5,
+                'added_value_type': 'day',
                 'frequency': 'monthly',
                 'first_day': 13,
                 'cap_accrued_time': True,
-                'maximum_leave': 15,
+                'maximum_leave': 4,
                 'action_with_unused_accruals': 'all',
             })],
         })
-        with freeze_time("2023-4-13"):
-            allocation = self._create_form_test_accrual_allocation(self.work_entry_type, '2023-04-13', self.employee_emp, accrual_plan, creator_user=self.user_hrmanager_id)
-            allocation.action_approve()
-        self.assertAlmostEqual(allocation.number_of_days, 1.5, 2)
 
-        with freeze_time("2023-09-13"):
-            allocation._update_accrual()
-
-        self.assertAlmostEqual(allocation.number_of_days, 9, 2)
-
-    def test_accrual_period_start_level_transfer(self):
-        accrual_plan = self.env['hr.leave.accrual.plan'].create({
+        cls.accrual_plan_2_lvls_start_weekly_max_leaves = _create_accrual_plan(accrual_plan_by_signature, {
             'accrued_gain_time': 'start',
             'can_be_carryover': True,
             'level_ids': [
                 (0, 0, {
                     'added_value_type': 'day',
                     'milestone_date': 'creation',
-                    'start_type': 'day',
                     'added_value': 1,
                     'frequency': 'weekly',
                     'week_day': '2',
                     'cap_accrued_time': True,
-                    'maximum_leave': 10,
+                    'maximum_leave': 8,
                 }),
                 (0, 0, {
                     'milestone_date': 'after',
@@ -1985,161 +788,61 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                     'week_day': '2',
                     'cap_accrued_time': True,
                     'maximum_leave': 5,
-                })
+                }),
             ],
         })
-        with freeze_time("2023-04-26"):
-            allocation = self._create_form_test_accrual_allocation(self.work_entry_type, '2023-04-26', self.employee_emp, accrual_plan, creator_user=self.user_hrmanager_id)
-            allocation.action_approve()
-        self.assertEqual(allocation.number_of_days, 1, "Should accrue 1 day, at the start of the period.")
-
-        with freeze_time("2023-07-05"):
-            allocation._update_accrual()
-        self.assertEqual(allocation.number_of_days, 10, "Should accrue 10 days, days received, but not over limit.")
-
-        # first wednesday at the second level
-        with freeze_time("2023-08-02"):
-            allocation._update_accrual()
-        self.assertEqual(allocation.number_of_days, 5, "Should accrue 5 days, after level transfer 10 are cut to 5")
-
-    def test_accrual_carryover_at_allocation(self):
-        accrual_plan = self.env['hr.leave.accrual.plan'].create({
-            'name': 'Accrual Plan For Test',
-            'accrued_gain_time': 'start',
-            'can_be_carryover': True,
-            'carryover_date': 'allocation',
-            'level_ids': [(0, 0, {
-                'added_value_type': 'day',
-                'milestone_date': 'creation',
-                'start_type': 'day',
-                'added_value': 1,
-                'frequency': 'monthly',
-                'first_day': 27,
-                'cap_accrued_time': False,
-                'action_with_unused_accruals': 'lost',
-            })],
+        cls.work_entry_type_absence_half_day_day = _create_work_entry_type(work_entry_type_by_signature, {
+            'name': 'Paid Time Off 2',
+            'code': 'Paid Time Off 2',
+            'requires_allocation': False,
+            'count_as': 'absence',
+            'request_unit': 'half_day',
+            'unit_of_measure': 'day',
         })
-        with freeze_time("2023-04-26"):
-            allocation = self._create_form_test_accrual_allocation(self.work_entry_type, '2023-04-26', self.employee_emp, accrual_plan)
-            allocation.action_approve()
-        self.assertAlmostEqual(allocation.number_of_days, 0.03, 2, "Should accrue 0.03 days, accrued_gain_time == start.")
-
-        with freeze_time("2023-04-27"):
-            allocation._update_accrual()
-        self.assertAlmostEqual(allocation.number_of_days, 1.03, 2, "Should accrue 1 day, days are added on 27th.")
-
-        with freeze_time("2023-12-27"):
-            allocation._update_accrual()
-        self.assertAlmostEqual(allocation.number_of_days, 9.03, 2, "Should accrue 9 day, after 8 months.")
-
-        with freeze_time("2024-03-27"):
-            allocation._update_accrual()
-        self.assertAlmostEqual(allocation.number_of_days, 12.03, 2, "Should accrue 12 day, after 11 months.")
-
-        with freeze_time("2024-04-26"):
-            allocation._update_accrual()
-        self.assertAlmostEqual(allocation.number_of_days, 0, 2, "Allocations not lost on allocation date (carryover).")
-
-        with freeze_time("2024-04-27"):
-            allocation._update_accrual()
-        self.assertAlmostEqual(allocation.number_of_days, 1, 2, "Allocation monthly accrual should keeps going.")
-
-    def test_accrual_carryover_at_other(self):
-        accrual_plan = self.env['hr.leave.accrual.plan'].create({
-            'name': 'Accrual Plan For Test',
+        cls.work_entry_type_accrual_non_elligible_absence_day_day = _create_work_entry_type(work_entry_type_by_signature, {
+            'name': 'Paid Time Off 2',
+            'code': 'Paid Time Off 2',
+            'count_as': 'absence',
+            'requires_allocation': False,
+            'elligible_for_accrual_rate': False,
+            'request_unit': 'day',
+            'unit_of_measure': 'day',
+        })
+        cls.work_entry_type_accrual_elligible_absence_day_day = _create_work_entry_type(work_entry_type_by_signature, {
+            'name': 'Paid Time Off 2',
+            'code': 'Paid Time Off 2',
+            'count_as': 'absence',
+            'requires_allocation': False,
+            'elligible_for_accrual_rate': True,
+            'request_unit': 'day',
+            'unit_of_measure': 'day',
+        })
+        cls.work_entry_type_working_time_day_day = _create_work_entry_type(work_entry_type_by_signature, {
+            'name': 'Remote Work',
+            'code': 'Remote Work',
+            'count_as': 'working_time',
+            'requires_allocation': False,
+            'request_unit': 'day',
+            'unit_of_measure': 'day',
+        })
+        cls.accrual_plan_monthly_start_max_69_carriedover = _create_accrual_plan(accrual_plan_by_signature, {
             'accrued_gain_time': 'start',
             'can_be_carryover': True,
             'carryover_date': 'other',
             'carryover_day': 20,
             'carryover_month': '4',
             'level_ids': [(0, 0, {
-                'added_value_type': 'day',
                 'milestone_date': 'creation',
-                'start_type': 'day',
                 'added_value': 10,
+                'added_value_type': 'day',
                 'frequency': 'monthly',
                 'first_day': 11,
-                'cap_accrued_time': False,
                 'action_with_unused_accruals': 'all',
                 'carryover_options': 'limited',
-                'postpone_max_days': 69,
+                'max_carriedover_duration': 69,
             })],
         })
-        with freeze_time("2023-04-20"):
-            allocation = self.env['hr.leave.allocation'].with_user(self.user_hrmanager_id).create({
-                'name': 'Accrual allocation for employee',
-                'accrual_plan_id': accrual_plan.id,
-                'employee_id': self.employee_emp.id,
-                'work_entry_type_id': self.work_entry_type.id,
-                'number_of_days': 0,
-                'date_from': '2023-04-20',
-            })
-            allocation.action_approve()
-
-        with freeze_time("2024-04-20"):
-            allocation._update_accrual()
-        self.assertEqual(allocation.number_of_days, 69, msg="Carryover at other date, level's maximum leave is 69")
-
-    def test_accrual_carrover_other_period_end_multi_level(self):
-        """
-        Create an accrual plan:
-            - Carryover date:  June 5th.
-        Create first milestone:
-            - Number of accrued days: 1
-            - Frequency: monthly on the 9th day.
-            - Start accrual 5 days after the allocation start date.
-            - Carryover policy: Carryover with a maximum
-            - Carryover limit: 13 days
-            - Accrued days cap: 15 days.
-        Create second milestone:
-            - Number of accrued days: 2
-            - Frequency: biyearly, on the 17th of February and on the 29th of October
-            - Start accrual 9 months after the allocation start date.
-            - Carryover policy: Carryover with a maximum
-            - Carryover limit: 20 days
-            - Accrued days cap: 10 days.
-        Create third milestone:
-            - Number of accrued days: 12
-            - Frequency: yearly on the 15th of July
-            - Start accrual 17 months after the allocation start date.
-            - Carryover policy: No days carry over
-            - Accrued days cap: 21 days.
-        Create an allocation:
-            - Start date: 04/04/2023
-            - Type: Accrual
-            - Accrual Plan: Use the one defined above.
-            - Number of days (given to the employee on the first run of the accrual plan): 9 days
-
-        Quick Overview:
-        - On 05/06/2026 (carryover date): The allocation will be on the third milestone. All the accrued days will be lost due to the carryover policy.
-        - On 15/07/2026, 12 days will be accrued.
-        The the employee should have 12 days on 01/08/2026
-
-        The detailed execution of the accrual plan is as follows:
-        - The employee is given 9 days at the first run of the accrual plan.
-        - From 09/04/2023, to 09/05/2023 1 day is accrued to the employee.
-        - On 05/06/2023 (carryover date): The employee has 10 days < the carryover limit of 13 days. All days will carry over.
-        - From 09/06/2023 to 09/12/2023: 5 days are accrued to the employee (should be 7 days but the accrued days cap is 15 days).
-        - On 04/01/2024:
-            * 0.7 days are accrued for the period from 09/12/2023 to 04/01/2024.
-            * Total number of days will remain 15 days given that the employee has reached the accrued days cap.
-            * The accrual plan transitions to the second milestone.
-
-        - On 17/02/2024, No days will be accrued to the employee because he has 15 days and the accrued days cap is 10 days. Instead 5 days will be lost.
-        - On 05/06/2024 (carryover date): The employee has 10 days < the carryover limit of 20 days. All days will carry over.
-        - On 04/09/2024
-            * No days will be accrued for the period from 17/02/2024 to 04/09/2024 due to accrued days cap.
-            * Total number of days will remain 10 days.
-            * The accrual plan transitions to the third milestone.
-
-        - On 05/06/2025 (carryover date): All the accrued days will be lost.
-        - On 15/07/2025, around 10 days will be accrued.
-        - On 05/06/2026 (carryover date): All the accrued days will be lost.
-        - On 15/07/2026, 12 days will be accrued.
-        The the employee should have 12 days on 01/08/2026
-        """
-        accrual_plan = self.env['hr.leave.accrual.plan'].create({
-            'name': 'Accrual Plan For Test',
+        cls.accrual_plan_3_lvls_monthly_biyearly_yearly_carryover_policy_change = _create_accrual_plan(accrual_plan_by_signature, {
             'accrued_gain_time': 'end',
             'can_be_carryover': True,
             'carryover_date': 'other',
@@ -2158,7 +861,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                     'maximum_leave': 15,
                     'action_with_unused_accruals': 'all',
                     'carryover_options': 'limited',
-                    'postpone_max_days': 13,
+                    'max_carriedover_duration': 13,
                 }),
                 (0, 0, {
                     'milestone_date': 'after',
@@ -2174,9 +877,8 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                     'maximum_leave': 10,
                     'action_with_unused_accruals': 'all',
                     'carryover_options': 'limited',
-                    'postpone_max_days': 20,
+                    'max_carriedover_duration': 20,
                 }),
-                # 17 months later - 12d / yearly on 15/07 - max 21 leaves - days lost on carryover
                 (0, 0, {
                     'milestone_date': 'after',
                     'start_count': 17,
@@ -2191,66 +893,19 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 }),
             ],
         })
-        with freeze_time("2023-04-04"):
-            allocation = self.env['hr.leave.allocation'].with_user(self.user_hrmanager_id).create({
-                'name': 'Accrual allocation for employee',
-                'accrual_plan_id': accrual_plan.id,
-                'employee_id': self.employee_emp.id,
-                'work_entry_type_id': self.work_entry_type.id,
-                'number_of_days': 9,
-                'date_from': '2023-04-04',
-            })
-            allocation.action_approve()
-
-        with freeze_time("2026-08-01"):
-            allocation._update_accrual()
-
-        # Do not care about the 2 first levels because lvl 3 reset all days to 0 on carryover (06-05)
-        # - ...
-        # - 2024-08-01 : lvl 3 starts
-        # - X postponed leaves
-        # - ...
-        # - 2026-06-05: carryover date: all days lost
-        # - 2026-07-15: yearly accrual: +12d
-        self.assertAlmostEqual(allocation.number_of_days, 12, 3)
-
-    def test_accrual_creation_on_anterior_date(self):
-        accrual_plan = self.env['hr.leave.accrual.plan'].create({
-            'name': 'Weekly accrual',
+        cls.accrual_plan_weekly_carryover_lost = _create_accrual_plan(accrual_plan_by_signature, {
             'can_be_carryover': True,
             'carryover_date': 'allocation',
             'level_ids': [(0, 0, {
                 'added_value_type': 'day',
                 'milestone_date': 'creation',
-                'start_type': 'day',
                 'added_value': 1,
                 'frequency': 'weekly',
                 'cap_accrued_time': False,
                 'action_with_unused_accruals': 'lost',
             })],
         })
-        with freeze_time('2023-09-01'):
-            accrual_allocation = self.env['hr.leave.allocation'].new({
-                'name': 'Employee allocation',
-                'work_entry_type_id': self.work_entry_type.id,
-                'date_from': '2023-01-01',
-                'employee_id': self.employee_emp.id,
-                'accrual_plan_id': accrual_plan.id,
-            })
-            # As the duration is set to a onchange, we need to force that onchange to run
-            accrual_allocation._onchange_date_from()
-            accrual_allocation.action_approve()
-            # The amount of days should be computed as if it was accrued since
-            # the start date of the allocation.
-            self.assertAlmostEqual(accrual_allocation.number_of_days, 34.0, places=0)
-            self.assertFalse(accrual_allocation.lastcall == accrual_allocation.date_from)
-            accrual_allocation._update_accrual()
-            # The amount being already computed, the amount should stay the same after the cron
-            # running on the same day.
-            self.assertAlmostEqual(accrual_allocation.number_of_days, 34.0, places=0)
-
-    def test_future_accural_time(self):
-        work_entry_type = self.env['hr.work.entry.type'].create({
+        cls.work_entry_type_absence_hour_hour = _create_work_entry_type(work_entry_type_by_signature, {
             'name': 'Test Leave Type 2',
             'code': 'Test Leave Type 2',
             'count_as': 'absence',
@@ -2259,98 +914,34 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
             'request_unit': 'hour',
             'unit_of_measure': 'hour',
         })
-        with freeze_time("2023-12-31"):
-            accrual_plan = self.env['hr.leave.accrual.plan'].create({
-                'name': 'Accrual Plan For Test',
-                'is_based_on_worked_time': False,
-                'accrued_gain_time': 'end',
-                'can_be_carryover': True,
-                'carryover_date': 'year_start',
-                'level_ids': [(0, 0, {
-                    'milestone_date': 'after',
-                    'start_count': 1,
-                    'start_type': 'day',
-                    'added_value': 1,
-                    'added_value_type': 'hour',
-                    'frequency': 'monthly',
-                    'cap_accrued_time': True,
-                    'maximum_leave': 100,
-                    'action_with_unused_accruals': 'all',
-                })],
-            })
-            allocation = self.env['hr.leave.allocation'].create({
-                'name': 'Accrual allocation for employee',
-                'accrual_plan_id': accrual_plan.id,
-                'employee_id': self.employee_emp.id,
-                'work_entry_type_id': work_entry_type.id,
-                'number_of_days': 0.125,
-            })
-            allocation.action_approve()
-            allocation_data = work_entry_type.get_allocation_data(self.employee_emp, datetime.date(2024, 2, 1))
-            self.assertEqual(allocation_data[self.employee_emp][0][1]['virtual_remaining_leaves'], 2)
-
-    def test_get_future_leaves_on_clears_pending_recompute(self):
-        """
-        Simulating future accruals creates a temporary allocation using
-        ``new(origin=allocation)``. Once this record is invalidated, it must not
-        remain in the transaction's pending recomputation queue.
-
-        New records with the same origin compare equal, so keeping the invalidated
-        temporary record in ``tocompute`` can make a later recomputation target
-        stale cache data and fail with a ``KeyError``.
-        """
-        accrual_scheme = self.env['hr.leave.accrual.plan'].create({
-            'name': 'Test Accrual Plan',
-            'accrued_gain_time': 'start',
+        cls.accrual_plan_monthly_hour = _create_accrual_plan(accrual_plan_by_signature, {
+            'is_based_on_worked_time': False,
             'can_be_carryover': True,
             'carryover_date': 'year_start',
-            'level_ids': [Command.create({
+            'level_ids': [(0, 0, {
                 'milestone_date': 'after',
                 'start_count': 1,
                 'start_type': 'day',
                 'added_value': 1,
-                'added_value_type': 'day',
+                'added_value_type': 'hour',
                 'frequency': 'monthly',
                 'action_with_unused_accruals': 'all',
-                'accrual_validity': True,
-                'accrual_validity_count': 3,
-                'accrual_validity_type': 'month',
             })],
         })
-
-        with freeze_time('2024-02-01'):
-            leave_allocation = self.env['hr.leave.allocation'].create({
-                'name': 'Accrual allocation',
-                'employee_id': self.employee_emp.id,
-                'work_entry_type_id': self.work_entry_type.id,
-                'date_from': '2024-02-01',
-                'accrual_plan_id': accrual_scheme.id,
-            })
-            leave_allocation._action_validate()
-            leave_allocation._get_future_leaves_on(date(2025, 3, 6))
-
-        allocation_name = self.env['hr.leave.allocation']._fields['name']
-        queued_records = self.env.transaction.tocompute.get(allocation_name, ())
-        origin_matches = [
-            record_id
-            for record_id in queued_records
-            if isinstance(record_id, NewId) and record_id.origin == leave_allocation.id
-        ]
-
-        self.assertFalse(
-            origin_matches,
-            "Invalidating the temporary allocation must remove it from the "
-            "pending recomputation queue.",
-        )
-
-    def test_added_type_during_onchange(self):
-        """
-            The purpose is to test whether the value of the `added_value_type`
-            field is correctly propagated from the first level to the second
-            during creation on the dialog form view.
-        """
-        accrual_plan = self.env['hr.leave.accrual.plan'].create({
-            'name': 'Accrual Plan For Test',
+        cls.accrual_plan_monthly_start_carryover_allocation_lost = _create_accrual_plan(accrual_plan_by_signature, {
+            'accrued_gain_time': 'start',
+            'can_be_carryover': True,
+            'carryover_date': 'allocation',
+            'level_ids': [(0, 0, {
+                'milestone_date': 'creation',
+                'added_value': 1,
+                'added_value_type': 'day',
+                'frequency': 'monthly',
+                'first_day': 27,
+                'action_with_unused_accruals': 'lost',
+            })],
+        })
+        cls.accrual_plan_monthly_carryover_all = _create_accrual_plan(accrual_plan_by_signature, {
             'is_based_on_worked_time': False,
             'accrued_gain_time': 'end',
             'can_be_carryover': True,
@@ -2367,455 +958,1815 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'action_with_unused_accruals': 'all',
             })],
         })
-        # Simulate the onchange of the dialog form view
-        # Trigger the `_compute_added_value_type` method (with virtual records)
-        form = Form(accrual_plan)
-        with form.level_ids.new() as level:
-            self.assertEqual(level.added_value_type, 'hour')
-
-    def test_accrual_immediate_cron_run(self):
-        accrual_plan = self.env['hr.leave.accrual.plan'].create({
-            'name': 'Weekly accrual',
+        cls.accrual_plan_daily_start_max_leaves_carryover_year_start = _create_accrual_plan(accrual_plan_by_signature, {
+            'accrued_gain_time': 'start',
             'can_be_carryover': True,
-            'carryover_date': 'allocation',
+            'carryover_date': 'year_start',
+            'level_ids': [(0, 0, {
+                'milestone_date': 'after',
+                'start_count': 1,
+                'start_type': 'day',
+                'added_value': 1,
+                'added_value_type': 'day',
+                'frequency': 'daily',
+                'cap_accrued_time': True,
+                'maximum_leave': 10,
+                'action_with_unused_accruals': 'all',
+            })],
+        })
+        cls.accrual_plan_daily_carryover_year_start_all_work_time = _create_accrual_plan(accrual_plan_by_signature, {
+            'is_based_on_worked_time': True,
+            'can_be_carryover': True,
+            'carryover_date': 'year_start',
+            'accrued_gain_time': 'end',
+            'level_ids': [
+                (0, 0, {
+                    'added_value_type': 'day',
+                    'milestone_date': 'after',
+                    'start_count': 1,
+                    'start_type': 'day',
+                    'added_value': 1,
+                    'frequency': 'daily',
+                    'action_with_unused_accruals': 'all',
+                }),
+            ],
+        })
+        cls.accrual_plan_2_lvls_yearly_carryover_lost = _create_accrual_plan(accrual_plan_by_signature, {
+            'can_be_carryover': True,
+            'carryover_date': 'other',
+            'carryover_day': 1,
+            'carryover_month': '7',
+            'level_ids': [(0, 0, {
+                'added_value': 12,
+                'added_value_type': 'day',
+                'frequency': 'yearly',
+                'milestone_date': 'creation',
+                'action_with_unused_accruals': 'lost',
+            }),
+            (0, 0, {
+                'added_value': 14,
+                'added_value_type': 'day',
+                'frequency': 'yearly',
+                'milestone_date': 'after',
+                'start_count': 18,
+                'start_type': 'month',
+                'action_with_unused_accruals': 'lost',
+            })],
+        })
+        cls.accrual_plan_2_lvls_monthly_carryover_lost_limited = _create_accrual_plan(accrual_plan_by_signature, {
+            'accrued_gain_time': 'start',
+            'can_be_carryover': True,
+            'carryover_date': 'other',
+            'carryover_day': 1,
+            'carryover_month': '6',
+            'level_ids': [(0, 0, {
+                'added_value': 1,
+                'added_value_type': 'day',
+                'frequency': 'monthly',
+                'milestone_date': 'creation',
+                'action_with_unused_accruals': 'lost',
+            }),
+            (0, 0, {
+                'added_value': 2,
+                'added_value_type': 'day',
+                'frequency': 'monthly',
+                'milestone_date': 'after',
+                'start_count': 9,
+                'start_type': 'month',
+                'action_with_unused_accruals': 'all',
+                'carryover_options': 'limited',
+                'max_carriedover_duration': 5,
+            })],
+        })
+        cls.accrual_plan_2_lvls_start_yearly_carryover_lost_all = _create_accrual_plan(accrual_plan_by_signature, {
+            'accrued_gain_time': 'start',
+            'can_be_carryover': True,
+            'carryover_date': 'other',
+            'carryover_day': 1,
+            'carryover_month': '6',
+            'level_ids': [(0, 0, {
+                'added_value': 10,
+                'added_value_type': 'day',
+                'frequency': 'yearly',
+                'milestone_date': 'creation',
+                'action_with_unused_accruals': 'lost',
+            }),
+            (0, 0, {
+                'added_value': 12,
+                'added_value_type': 'day',
+                'frequency': 'yearly',
+                'milestone_date': 'after',
+                'start_count': 32,
+                'start_type': 'month',
+                'action_with_unused_accruals': 'all',
+            })],
+        })
+        cls.accrual_plan_2_lvls_biyearly_expiring = _create_accrual_plan(accrual_plan_by_signature, {
+            'can_be_carryover': True,
+            'carryover_date': 'other',
+            'carryover_day': 1,
+            'carryover_month': '4',
+            'level_ids': [(0, 0, {
+                'milestone_date': 'creation',
+                'added_value': 10,
+                'added_value_type': 'day',
+                'frequency': 'biyearly',
+                'action_with_unused_accruals': 'all',
+                'accrual_validity': True,
+                'accrual_validity_type': 'month',
+                'accrual_validity_count': 5,
+            }),
+            (0, 0, {
+                'added_value_type': 'day',
+                'milestone_date': 'after',
+                'start_count': 13,
+                'start_type': 'month',
+                'added_value': 15,
+                'frequency': 'biyearly',
+                'action_with_unused_accruals': 'all',
+                'accrual_validity': True,
+                'accrual_validity_type': 'month',
+                'accrual_validity_count': 2,
+            })],
+        })
+        cls.accrual_plan_2_lvls_yearly_monthly_expiring = _create_accrual_plan(accrual_plan_by_signature, {
+            'can_be_carryover': True,
+            'carryover_date': 'other',
+            'carryover_day': 1,
+            'carryover_month': '5',
             'level_ids': [(0, 0, {
                 'added_value_type': 'day',
                 'milestone_date': 'creation',
+                'added_value': 10,
+                'frequency': 'yearly',
+                'action_with_unused_accruals': 'all',
+                'accrual_validity': True,
+                'accrual_validity_type': 'month',
+                'accrual_validity_count': 2,
+            }),
+            (0, 0, {
+                'added_value_type': 'day',
+                'milestone_date': 'after',
+                'start_count': 20,
+                'start_type': 'month',
+                'added_value': 20,
+                'frequency': 'monthly',
+                'action_with_unused_accruals': 'all',
+                'accrual_validity': True,
+                'accrual_validity_type': 'month',
+                'accrual_validity_count': 3,
+            })],
+        })
+        cls.accrual_plan_monthly_expiring = _create_accrual_plan(accrual_plan_by_signature, {
+            'can_be_carryover': True,
+            'carryover_date': 'other',
+            'carryover_day': 1,
+            'carryover_month': '5',
+            'accrued_gain_time': 'start',
+            'level_ids': [(0, 0, {
+                'added_value_type': 'day',
+                'milestone_date': 'creation',
+                'added_value': 1,
+                'frequency': 'monthly',
+                'first_day': 15,
+                'action_with_unused_accruals': 'all',
+                'accrual_validity': True,
+                'accrual_validity_type': 'month',
+                'accrual_validity_count': 2,
+            })],
+        })
+        cls.accrual_plan_yearly_start_max_carriedover_expiring = _create_accrual_plan(accrual_plan_by_signature, {
+            'can_be_carryover': True,
+            'carryover_date': 'other',
+            'accrued_gain_time': 'start',
+            'carryover_day': 20,
+            'carryover_month': '9',
+            'level_ids': [(0, 0, {
+                'added_value_type': 'day',
+                'milestone_date': 'creation',
+                'added_value': 10,
+                'frequency': 'yearly',
+                'action_with_unused_accruals': 'all',
+                'carryover_options': 'limited',
+                'max_carriedover_duration': 5,
+                'accrual_validity': True,
+                'accrual_validity_type': 'month',
+                'accrual_validity_count': 4,
+            })],
+        })
+        cls.accrual_plan_2_levels_biyearly_start_limited_expiring = _create_accrual_plan(accrual_plan_by_signature, {
+            'can_be_carryover': True,
+            'carryover_date': 'other',
+            'carryover_day': 1,
+            'carryover_month': '4',
+            'accrued_gain_time': 'start',
+            'level_ids': [(0, 0, {
+                    'added_value_type': 'day',
+                    'milestone_date': 'creation',
+                    'added_value': 10,
+                    'frequency': 'biyearly',
+                    'action_with_unused_accruals': 'all',
+                    'accrual_validity': True,
+                    'accrual_validity_type': 'month',
+                    'accrual_validity_count': 7,
+                    'carryover_options': 'limited',
+                    'max_carriedover_duration': 5,
+                }), (0, 0, {
+                    'added_value_type': 'day',
+                    'milestone_date': 'after',
+                    'start_count': 8,
+                    'start_type': 'month',
+                    'added_value': 15,
+                    'frequency': 'biyearly',
+                    'action_with_unused_accruals': 'all',
+                    'carryover_options': 'limited',
+                    'max_carriedover_duration': 10,
+                },
+            )],
+        })
+        cls.accrual_plan_yearly_carryover_limited_expiring = _create_accrual_plan(accrual_plan_by_signature, {
+            'can_be_carryover': True,
+            'carryover_date': 'other',
+            'carryover_day': 1,
+            'carryover_month': '4',
+            'level_ids': [(0, 0, {
+                'added_value_type': 'day',
+                'milestone_date': 'creation',
+                'added_value': 10,
+                'frequency': 'yearly',
+                'action_with_unused_accruals': 'all',
+                'carryover_options': 'limited',
+                'max_carriedover_duration': 5,
+                'accrual_validity': True,
+                'accrual_validity_type': 'month',
+                'accrual_validity_count': 5,
+            })],
+        })
+        cls.accrual_plan_yearly_start_max_leave_carryover_limited = _create_accrual_plan(accrual_plan_by_signature, {
+            'transition_mode': 'immediately',
+            'can_be_carryover': True,
+            'carryover_date': 'year_start',
+            'accrued_gain_time': 'start',
+            'level_ids': [(0, 0, {
+                "milestone_date": 'creation',
+                "added_value": 21,
+                "cap_accrued_time": True,
+                "maximum_leave": 28,
+                "frequency": "yearly",
+                "action_with_unused_accruals": "all",
+                "carryover_options": "limited",
+                "max_carriedover_duration": 7,
+            })],
+        })
+        cls.accrual_plan_no_level_start_carryover_year_start = _create_accrual_plan(accrual_plan_by_signature, {
+            'transition_mode': 'immediately',
+            'can_be_carryover': True,
+            'carryover_date': 'year_start',
+            'accrued_gain_time': 'start',
+        })
+        cls.employee_without_calendar = cls.env['hr.employee'].create({
+            'name': 'employee without calendar',
+            'resource_calendar_id': False,
+        })
+        cls.accrual_plan_hourly_work_time = _create_accrual_plan(accrual_plan_by_signature, {
+            'is_based_on_worked_time': True,
+            'can_be_carryover': True,
+            'level_ids': [(0, 0, {
+                'milestone_date': 'after',
+                'start_count': 1,
+                'start_type': 'day',
+                'added_value': 1,
+                'added_value_type': 'hour',
+                'frequency': 'hourly',
+                'action_with_unused_accruals': 'all',
+            })],
+        })
+        cls.accrual_plan_daily_hour = _create_accrual_plan(accrual_plan_by_signature, {
+            'name': 'Accrual Plan For Test',
+            'accrued_gain_time': 'end',
+            'level_ids': [(0, 0, {
+                'added_value_type': 'hour',
+                'start_count': 0,
                 'start_type': 'day',
                 'added_value': 1,
                 'frequency': 'daily',
-                'cap_accrued_time': False,
-                'action_with_unused_accruals': 'lost',
             })],
         })
-        with freeze_time('2023-09-01'):
-            accrual_allocation = self.env['hr.leave.allocation'].new({
-                'name': 'Employee allocation',
-                'work_entry_type_id': self.work_entry_type.id,
-                'date_from': '2023-08-01',
-                'employee_id': self.employee_emp.id,
-                'accrual_plan_id': accrual_plan.id,
-            })
-            # As the duration is set to a onchange, we need to force that onchange to run
-            accrual_allocation._onchange_date_from()
-            accrual_allocation.action_approve()
-            # The amount of days should be computed as if it was accrued since
-            # the start date of the allocation.
-            self.assertEqual(accrual_allocation.number_of_days, 31.0, "The allocation should have given 31 days")
-            accrual_allocation._update_accrual()
-            self.assertEqual(accrual_allocation.number_of_days, 31.0,
-                "the amount shouldn't have changed after running the cron")
-
-    def test_accrual_creation_for_history(self):
-        accrual_plan = self.env['hr.leave.accrual.plan'].create({
-            'name': 'Monthly accrual',
-            'can_be_carryover': True,
-            'carryover_date': 'year_start',
-            'accrued_gain_time': 'end',
-            'level_ids': [(0, 0, {
-                'added_value_type': 'day',
-                'milestone_date': 'creation',
-                'start_type': 'day',
-                'added_value': 1,
-                'frequency': 'monthly',
-                'first_day': '31',
-                'cap_accrued_time': False,
-                'action_with_unused_accruals': 'lost',
-            })],
-        })
-        with freeze_time('2024-03-02'):
-            accrual_allocation = self.env['hr.leave.allocation'].new({
-                'name': 'History allocation',
-                'work_entry_type_id': self.work_entry_type.id,
-                'date_from': '2024-03-01',
-                'employee_id': self.employee_emp.id,
-                'accrual_plan_id': accrual_plan.id,
-            })
-            # As the duration is set to an onchange, we need to force that onchange to run
-            accrual_allocation._onchange_date_from()
-            self.assertAlmostEqual(accrual_allocation.number_of_days, 0, places=0)
-
-            # Yearly Report lost
-            accrual_allocation.write({'date_from': '2022-01-01'})
-            accrual_allocation._onchange_date_from()
-            self.assertAlmostEqual(accrual_allocation.number_of_days, 2, places=0)
-
-            # Update date_to
-            accrual_allocation.write({'date_to': '2022-12-31'})
-            accrual_allocation._onchange_date_from()
-            self.assertAlmostEqual(accrual_allocation.number_of_days, 12, places=0)
-
-    def test_accrual_with_report_creation_for_history(self):
-        accrual_plan = self.env['hr.leave.accrual.plan'].create({
-            'name': 'Monthly accrual',
-            'can_be_carryover': True,
-            'carryover_date': 'year_start',
-            'accrued_gain_time': 'end',
-            'level_ids': [(0, 0, {
-                'added_value_type': 'day',
-                'milestone_date': 'creation',
-                'start_type': 'day',
-                'added_value': 1,
-                'frequency': 'monthly',
-                'first_day': '31',
-                'cap_accrued_time': False,
-                'action_with_unused_accruals': 'all',
-                'carryover_options': 'limited',
-                'postpone_max_days': 5
-            })],
-        })
-        with freeze_time('2024-03-02'):
-            accrual_allocation = self.env['hr.leave.allocation'].new({
-                'name': 'History allocation',
-                'work_entry_type_id': self.work_entry_type.id,
-                'date_from': '2024-03-01',
-                'employee_id': self.employee_emp.id,
-                'accrual_plan_id': accrual_plan.id,
-            })
-            # As the duration is set to an onchange, we need to force that onchange to run
-            accrual_allocation._onchange_date_from()
-            self.assertAlmostEqual(accrual_allocation.number_of_days, 0, places=0)
-
-            # Yearly Report capped to 5 after 2022 and after 2023
-            accrual_allocation.write({'date_from': '2022-01-01'})
-            accrual_allocation._onchange_date_from()
-            self.assertAlmostEqual(accrual_allocation.number_of_days, 7, places=0)
-
-            # Update date_to
-            accrual_allocation.write({'date_to': '2022-12-31'})
-            accrual_allocation._onchange_date_from()
-            self.assertAlmostEqual(accrual_allocation.number_of_days, 12, places=0)
-
-    def test_accrual_period_start_past_start_date(self):
-        accrual_plan = self.env['hr.leave.accrual.plan'].create({
-            'name': 'Monthly accrual',
-            'can_be_carryover': True,
-            'carryover_date': 'year_start',
-            'accrued_gain_time': 'start',
-            'level_ids': [(0, 0, {
-                'added_value_type': 'day',
-                'milestone_date': 'creation',
-                'start_type': 'day',
-                'added_value': 1,
-                'frequency': 'monthly',
-                'first_day': '1',
-                'cap_accrued_time': False,
-                'action_with_unused_accruals': 'all',
-            })],
-        })
-        with freeze_time('2024-03-01'):
-            with Form(self.env['hr.leave.allocation'].with_user(self.user_hrmanager)) as f:
-                f.accrual_plan_id = accrual_plan
-                f.date_from = '2024-01-01'
-                f.employee_id = self.employee_emp
-                f.work_entry_type_id = self.work_entry_type
-                f.name = "Employee Allocation"
-
-            accrual_allocation = f.record
-            accrual_allocation.action_approve()
-            self.assertAlmostEqual(accrual_allocation.number_of_days, 3.0, places=0)
-
-        with freeze_time('2024-04-01'):
-            accrual_allocation._update_accrual()
-            self.assertAlmostEqual(accrual_allocation.number_of_days, 4.0, places=0)
-
-    def test_cancel_invalid_leaves_with_regular_and_accrual_allocations(self):
-        accrual_plan = self.env['hr.leave.accrual.plan'].create({
-            'name': 'Monthly accrual',
-            'can_be_carryover': True,
-            'carryover_date': 'year_start',
-            'accrued_gain_time': 'start',
-            'level_ids': [(0, 0, {
-                'added_value_type': 'day',
-                'milestone_date': 'creation',
-                'start_type': 'day',
-                'added_value': 1,
-                'frequency': 'monthly',
-                'first_day': '1',
-                'cap_accrued_time': False,
-                'action_with_unused_accruals': 'all',
-            })],
-        })
-        allocations = self.env['hr.leave.allocation'].create([
-            {
-                'name': 'Regular allocation',
-                'date_from': '2024-05-01',
-                'work_entry_type_id': self.work_entry_type.id,
-                'employee_id': self.employee_emp.id,
-                'number_of_days': 2,
-            },
-            {
-                'name': 'Accrual allocation',
-                'date_from': '2024-05-01',
-                'work_entry_type_id': self.work_entry_type.id,
-                'employee_id': self.employee_emp.id,
-                'accrual_plan_id': accrual_plan.id,
-                'number_of_days': 3,
-            }
-        ])
-        allocations.action_approve()
-        leave = self.env['hr.leave'].create({
-                'name': 'Leave',
-                'employee_id': self.employee_emp.id,
-                'work_entry_type_id': self.work_entry_type.id,
-                'request_date_from': '2024-05-13',
-                'request_date_to': '2024-05-17',
-            })
-        leave.action_approve()
-        with freeze_time('2024-05-06'):
-            self.env['hr.leave']._cancel_invalid_leaves()
-        self.assertEqual(leave.state, 'validate', "Leave must not be canceled")
-
-    def test_accrual_leaves_cancel_cron(self):
-        work_entry_type_no_negative = self.env['hr.work.entry.type'].create({
-            'name': 'Test Accrual - No negative',
-            'code': 'Test Accrual - No negative',
+        cls.work_entry_type_absence_requires_alloc_half_day_day = _create_work_entry_type(work_entry_type_by_signature, {
+            'name': 'Test Leave Type 2',
+            'code': 'Test Leave Type 2',
             'count_as': 'absence',
             'requires_allocation': True,
             'allocation_validation_type': 'no_validation',
-            'leave_validation_type': 'no_validation',
-            'allows_negative': False,
-            'request_unit': 'day',
+            'request_unit': 'half_day',
             'unit_of_measure': 'day',
         })
-        work_entry_type_negative = self.env['hr.work.entry.type'].create({
-            'name': 'Test Accrual - Negative',
-            'code': 'Test Accrual - Negative',
+        level_vals = {
+            'milestone_date': 'after',
+            'accrual_validity': True,
+            'accrual_validity_count': 6,
+            'accrual_validity_type': 'month',
+            'accrued_gain_time': 'start',
+            'action_with_unused_accruals': 'all',
+            'cap_accrued_time': True,
+            'frequency': 'yearly',
+            'carryover_options': 'limited',
+            'max_carriedover_duration': 5,
+        }
+        cls.accrual_plan_4_lvls_start_max_leaves_carryover_limited_expiring = _create_accrual_plan(accrual_plan_by_signature, {
+            'name': 'Test accrual plan',
+            'accrued_gain_time': 'start',
+            'can_be_carryover': True,
+            'level_ids': [(0, 0, {
+                    **level_vals,
+                    'added_value': 20,
+                    'milestone_date': 'creation',
+                    'maximum_leave': 25,
+                }), (0, 0, {
+                    **level_vals,
+                    'added_value': 21,
+                    'start_count': 2,
+                    'start_type': 'year',
+                    'maximum_leave': 26,
+                }), (0, 0, {
+                    **level_vals,
+                    'added_value': 22,
+                    'start_count': 4,
+                    'start_type': 'year',
+                    'maximum_leave': 27,
+                }), (0, 0, {
+                    **level_vals,
+                    'added_value': 23,
+                    'start_count': 6,
+                    'start_type': 'year',
+                    'maximum_leave': 28,
+                }),
+            ],
+        })
+        cls.accrual_plan_monthly_start = _create_accrual_plan(accrual_plan_by_signature, {
+            'name': '2 Days Every 1st of Month',
+            'accrued_gain_time': 'start',
+            'level_ids': [Command.create({
+                'added_value': 2,
+                'added_value_type': 'day',
+                'frequency': 'monthly',
+                'first_day': 1,
+                'action_with_unused_accruals': 'all',
+                'milestone_date': 'creation',
+            })],
+        })
+        cls.calendar_8h_per_day = cls.env['resource.calendar'].create({
+            'name': 'Standard 40h Test Calendar',
+            'hours_per_day': 8.0,
+        })
+        cls.accrual_plan_monthly_start_carryover_limited_expiring = _create_accrual_plan(accrual_plan_by_signature, {
+            'name': 'Accrual Plan For Test',
+            'accrued_gain_time': 'start',
+            'carryover_date': 'other',
+            'carryover_day': 1,
+            'carryover_month': '11',
+            'can_be_carryover': True,
+            'level_ids': [(0, 0, {
+                'added_value': 2,
+                'added_value_type': 'day',
+                'frequency': 'monthly',
+                'milestone_date': 'creation',
+                'action_with_unused_accruals': 'all',
+                'carryover_options': 'limited',
+                'max_carriedover_duration': 5,
+                'accrual_validity': True,
+                'accrual_validity_type': 'month',
+                'accrual_validity_count': 1,
+            })],
+        })
+        cls.work_entry_type_absence_requires_alloc_negativ = _create_work_entry_type(work_entry_type_by_signature, {
+            'name': 'Test Accrual',
+            'code': 'Test Accrual',
             'count_as': 'absence',
-            'requires_allocation': True,
+            'requires_allocation': 'yes',
             'allocation_validation_type': 'no_validation',
             'leave_validation_type': 'no_validation',
             'allows_negative': True,
-            'max_allowed_negative': 1,
-            'request_unit': 'day',
+            'max_allowed_negative': 2,
             'unit_of_measure': 'day',
         })
-        accrual_plan = self.env['hr.leave.accrual.plan'].create({
-            'name': 'Monthly accrual',
-            'can_be_carryover': True,
-            'carryover_date': 'year_start',
+        cls.dummy_test_employee = cls.env['hr.employee'].create([{
+            'name': 'Department Employee 1',
+            'company_id': cls.company.id,
+        }])
+        cls.accrual_plan_daily_hour_work_time = cls.env['hr.leave.accrual.plan'].create({
+            'name': 'Daily Worked Time Accrual',
+            'is_based_on_worked_time': True,
             'accrued_gain_time': 'end',
-            'level_ids': [(0, 0, {
-                'added_value_type': 'day',
+            'can_be_carryover': True,
+            'carryover_date': 'allocation',
+            'level_ids': [Command.create({
                 'milestone_date': 'creation',
-                'start_type': 'day',
-                'added_value': 1,
-                'frequency': 'monthly',
-                'first_day': '31',
-                'cap_accrued_time': False,
+                'added_value': 5,
+                'added_value_type': 'hour',
+                'frequency': 'daily',
                 'action_with_unused_accruals': 'all',
-                'carryover_options': 'limited',
-                'postpone_max_days': 5
             })],
         })
 
-        with freeze_time("2024-01-01"):
-            self.env['hr.leave.allocation'].create([{
-                'employee_id': self.employee_emp.id,
-                'work_entry_type_id': work_entry_type_no_negative.id,
-                'accrual_plan_id': accrual_plan.id,
-                'number_of_days': 1,
-            }, {
-                'employee_id': self.employee_emp.id,
-                'work_entry_type_id': work_entry_type_negative.id,
-                'accrual_plan_id': accrual_plan.id,
-                'number_of_days': 1,
-            }])
+    def _run_update_accrual_cron(self, target_date=None):
+        self.env['hr.leave.allocation']._get_to_update_accrual_allocations()._update_accrual(target_date)
 
-            excess_leave = self.env['hr.leave'].create([{
-                'employee_id': self.employee_emp.id,
-                'work_entry_type_id': work_entry_type_no_negative.id,
-                'request_date_from': '2024-01-05',
-                'request_date_to': '2024-01-05',
-            }])
-            allowed_negative_leave = self.env['hr.leave'].create([{
-                'employee_id': self.employee_emp.id,
-                'work_entry_type_id': work_entry_type_negative.id,
-                'request_date_from': '2024-01-12',
-                'request_date_to': '2024-01-12',
-            }])
+    def _get_period_days(self, start_date, end_date):
+        """ Parameter `end_date` included """
+        if not (len(start_date) == len(end_date) == 10):
+            raise ArgumentsError('Expected a date (not a datetime) with the format YYYY-MM-DD!')
+        return (parse_iso_date(end_date) - parse_iso_date(start_date)).days + 1
 
-            # As accrual allocation don't take into account future leaves,
-            # it should be possible to take both leaves.
-            self.env['hr.leave'].create([{
-                'employee_id': self.employee_emp.id,
-                'work_entry_type_id': work_entry_type_no_negative.id,
-                'request_date_from': '2024-01-04',
-                'request_date_to': '2024-01-04',
-            }, {
-                'employee_id': self.employee_emp.id,
-                'work_entry_type_id': work_entry_type_negative.id,
-                'request_date_from': '2024-01-11',
-                'request_date_to': '2024-01-11',
-            }])
-            self.env.flush_all()
+    def _assert_accrual_allocation_nbr_of_days_and_nextcall(self, allocation, assertions_by_date):
+        """
+        For each given tuple of the assertion, update the accrual at the given date,
+        then assert the 'number_of_days' and the 'nextcall' of the allocation
+        :param assertions: iterable of tuples with:
+            - test date
+            - ('number_of_days', 'nextcall') tuple
+        """
+        self._assert_accrual_allocation(allocation, assertions_by_date, ('number_of_days', 'nextcall'))
 
-            self.env['hr.leave']._cancel_invalid_leaves()
+    def _build_create_leave_command(self, employee, work_entry_type):
+        return (
+            lambda date_from, date_to, approve=True:
+                lambda: self._create_leave(employee, work_entry_type, date_from, date_to, validate=approve))
 
-            # Since both leave are outside an allocation validity,
-            # they are detected as discrepancies. However, the
-            # leave that is not exceeding the negative amount should be kept
-            # as it is valid according to the configuration.
-            self.assertEqual(excess_leave.state, 'cancel')
-            self.assertEqual(allowed_negative_leave.state, 'validate')
+    def _assert_accrual_allocation(self, allocation, assertions, tested_fields):
+        """ For each assertion, assert allocation `tested_fields` values after running accrual update for the given test date
+            :param assertions: iterable of tuples with:
+                - test date
+                - iterable of the expected values matching `tested_fields`
 
-            self.env['hr.leave'].create([{
-                'employee_id': self.employee_emp.id,
-                'work_entry_type_id': work_entry_type_negative.id,
-                'request_date_from': '2024-01-10',
-                'request_date_to': '2024-01-10',
-            }])
+            For each test date, run the accrual cron and assert field values.
+            :param tested_fields: iterable of the name of the allocation fields to be tested
+        """
+        for target_date, *field_values in assertions:
+            with freeze_time(target_date):
+                self._run_update_accrual_cron()
+                error_msg_suffix = f'Error on {target_date}'
+                for field, expected_value in zip(tested_fields, field_values):
+                    self.assertEqual(allocation[field], expected_value, f'{error_msg_suffix} - wrong value for field {field}')
 
-            self.env['hr.leave']._cancel_invalid_leaves()
+    def _assert_get_allocation_data(self, allocation, allocation_values_by_date, tested_fields):
+        """ Assert allocation and balance data from `get_allocation_data` for each test date.
+            :param allocation_values_by_date: iterable of tuples with:
+                - test date
+                - iterable of the expected values matching `tested_fields`, or a callable
 
-            # The last added leave creates a discrepancy that exceeds the
-            # maximum amount allowed in negative.
-            self.assertEqual(allowed_negative_leave.state, 'cancel')
+            If values are provided, run the accrual cron before asserting.
+            If it's a callable, simply call it at the given date.
+            "Durations" use the allocation request unit.
+            The value for the field 'allocated_duration' should always be specified (give the work entry type allocated duration).
+            If the value for the field 'remaining_leaves' is not specified, it will be considered equal to the 'allocated_duration' (usefull for test case with no leaves).
+        """
+        if 'allocated_duration' not in tested_fields:
+            raise ArgumentsError('The field allocated_duration must be asserted!')
 
-    def test_check_lastcall_change_regular_to_accrual(self):
+        work_entry_allocations = self.env['hr.leave.allocation'].with_context(active_test=False).search([
+            ('employee_id', '=', allocation.employee_id.id),
+            ('work_entry_type_id', '=', allocation.work_entry_type_id.id),
+            ('accrual_plan_id', '!=', False),
+            ('state', '=', 'validate'),
+        ])
+        self.assertEqual(work_entry_allocations, allocation, 'This test helper method only works if there is exactly one accrual allocation linked to the work entry type')
+
+        work_entry_type = allocation.work_entry_type_id
+        employee = allocation.employee_id
+        for i, (target_date, *field_values) in enumerate(allocation_values_by_date):
+            with freeze_time(target_date):
+                if callable(field_values[0]):
+                    field_values[0]()
+                    continue
+
+                self._run_update_accrual_cron()
+                error_msg_suffix = f'On {target_date} - assertion {i}'
+                expected_work_entry_type_remaining_leaves = None
+                expected_work_entry_type_allocated_duration = None
+                for field, expected_value in zip(tested_fields, field_values):
+                    if field == 'allocated_duration':
+                        expected_work_entry_type_allocated_duration = expected_value
+                        continue
+                    if field == 'remaining_leaves':
+                        expected_work_entry_type_remaining_leaves = expected_value
+                        continue
+                    self.assertEqual(allocation[field], expected_value, f'{error_msg_suffix} - wrong value for field {field}')
+
+                if expected_work_entry_type_allocated_duration is None:
+                    raise ArgumentsError('Could not find the field "time_off_type_allocated_duration" in the assertion_structure.')
+
+                if expected_work_entry_type_remaining_leaves is None:
+                    expected_work_entry_type_remaining_leaves = expected_work_entry_type_allocated_duration
+
+                work_entry_type_data = work_entry_type.get_allocation_data(employee, target_date)
+                remaining_leaves = work_entry_type_data[employee][0][1]['remaining_leaves']
+                leaves_taken = work_entry_type_data[employee][0][1]['leaves_taken']
+                work_entry_duration = remaining_leaves + leaves_taken
+                self.assertAlmostEqual(work_entry_duration, expected_work_entry_type_allocated_duration,
+                    msg=f'{error_msg_suffix} - Incorrect allocated duration', delta=0.01)
+                self.assertAlmostEqual(remaining_leaves, expected_work_entry_type_remaining_leaves,
+                    msg=f'{error_msg_suffix} - Incorrect remaining leaves', delta=0.01)
+
+    def _assert_get_allocation_data_future(self, allocation, assertions):
+        """ Assert allocation and balance future data from get_allocation_data for each test date.
+            :param allocation_values_by_date: iterable of tuples with:
+                - test date
+                - (allocated_duration, remaining leaves) tuple for the work entry type of the given allocation,
+                using the unit `allocation.work_entry_type_id.unit_of_measure`
+        """
+        work_entry_type = allocation.work_entry_type_id
+        employee = allocation.employee_id
+        for i, (target_date, *assertion) in enumerate(assertions):
+            if callable(assertion[0]):
+                with freeze_time(target_date):
+                    assertion[0]()
+                    continue
+
+            if len(assertion) == 2:
+                expected_allocated_duration, expected_left_duration = assertion
+            elif len(assertion) == 1:
+                expected_allocated_duration = expected_left_duration = assertion[0]
+            else:
+                raise ArgumentsError(f'One assertion should be compose of 1 or 2 float values, got {assertion}')
+            work_entry_type_data = work_entry_type.get_allocation_data(employee, target_date)
+            remaining_leaves = work_entry_type_data[employee][0][1]['remaining_leaves']
+            leaves_taken = work_entry_type_data[employee][0][1]['leaves_taken']
+            work_entry_duration = remaining_leaves + leaves_taken
+            error_msg_suffix = f'On {target_date} - Assertion {i}'
+            self.assertAlmostEqual(remaining_leaves, expected_left_duration, msg=f'{error_msg_suffix} - Incorrect remaining leaves duration', delta=0.01)
+            self.assertAlmostEqual(work_entry_duration, expected_allocated_duration, msg=f'{error_msg_suffix} - Incorrect allocated duration', delta=0.01)
+
+    @freeze_time('2025-09-01')
+    def test_frequency_daily_worked_time_non_utc_timezone(self):
+        calendar = self.env['resource.calendar'].create({
+            'name': 'Brisbane 40 Hours',
+            'hours_per_day': 8,
+            'attendance_ids': [
+                Command.create({
+                    'dayofweek': str(weekday),
+                    'hour_from': 8,
+                    'hour_to': 12,
+                })
+                for weekday in range(5)
+            ] + [
+                Command.create({
+                    'dayofweek': str(weekday),
+                    'hour_from': 13,
+                    'hour_to': 17,
+                })
+                for weekday in range(5)
+            ],
+        })
+        self.employee_emp.tz = 'Australia/Brisbane'
+        self.employee_emp.resource_calendar_id = calendar
+        self.user_hrmanager.tz = 'Australia/Brisbane'
+        accrual_plan = self.accrual_plan_daily_hour_work_time
+        allocation = self.env['hr.leave.allocation'].with_user(self.user_hrmanager).create({
+            'name': 'Brisbane Daily Accrual',
+            'accrual_plan_id': accrual_plan.id,
+            'employee_id': self.employee_emp.id,
+            'work_entry_type_id': self.work_entry_type_hour.id,
+            'date_from': date(2025, 9, 1),
+            'number_of_days': 0,
+        })
+        allocation.action_approve()
+
+        self._assert_accrual_allocation(allocation, (
+                ("2025-09-02", 5),
+                ("2025-09-03", 10),
+                ("2025-09-04", 15),
+                ("2025-09-05", 20),
+                ("2025-09-06", 25),
+                ("2025-09-07", 25),
+                ("2025-09-08", 25),
+            ),
+            ['number_of_hours_display'],
+        )
+
+    def test_consistency_between_cap_accrued_time_and_maximum_leave(self):
+        accrual_plan = self.accrual_plan_hourly
+        level = accrual_plan.level_ids
+        level.maximum_leave = 10
+        self.assertEqual(accrual_plan.level_ids.maximum_leave, 10)
+
+        with self.assertRaises(UserError):
+            level.maximum_leave = 0
+
+        level.cap_accrued_time = False
+        self.assertEqual(accrual_plan.level_ids.maximum_leave, 0)
+
+    def test_accrual_unlink(self):
+        """ Assert unlinking an accrual plan that is still linked to an allocation raises an error """
+        accrual_plan = self.dummy_accrual_plan
+        allocation = self.env['hr.leave.allocation'].with_user(self.user_hrmanager_id).create({
+            'name': 'Accrual allocation for employee',
+            'accrual_plan_id': accrual_plan.id,
+            'employee_id': self.employee_emp.id,
+            'work_entry_type_id': self.work_entry_type.id,
+            'number_of_days': 0,
+        })
+
+        with self.assertRaises(ValidationError):
+            accrual_plan.unlink()
+
+        allocation.unlink()
+        accrual_plan.unlink()
+
+    def test_frequency_hourly(self):
+        """ Assert number of days and nextcall are computed correctly for a one level hourly accrual plan based on work time """
         with freeze_time("2017-12-05"):
-            accrual_plan = self.env['hr.leave.accrual.plan'].create({
-                'name': 'Accrual Plan For Test',
-                'level_ids': [
-                    Command.create({
-                    'added_value_type': 'day',
-                    'start_count': 0,
-                    'start_type': 'day',
-                    'added_value': 2,
-                    'frequency': 'monthly',
-                })],
-            })
-            allocation = self.env['hr.leave.allocation'].create({
+            accrual_plan = self.accrual_plan_hourly_based_on_work
+            allocation = self.env['hr.leave.allocation'].with_user(self.user_hrmanager_id).create({
                 'name': 'Accrual allocation for employee',
+                'accrual_plan_id': accrual_plan.id,
+                'employee_id': self.employee_emp.id,
+                'work_entry_type_id': self.work_entry_type.id,
+                'number_of_days': 0,
+            })
+            allocation.action_approve()
+            self.assertFalse(allocation.nextcall, 'There should be no nextcall set on the allocation.')
+            self.assertEqual(allocation.number_of_days, 0, 'There should be no days allocated yet.')
+
+        self._assert_accrual_allocation_nbr_of_days_and_nextcall(allocation, (
+            # Assert running the cron doesn't change anything
+            ('2017-12-05', 0, False),
+            ('2017-12-07', 8, date(2017, 12, 8)),
+            # Assert running the cron again doesn't change anything
+            ('2017-12-07', 8, date(2017, 12, 8)),
+        ))
+
+    def test_frequency_hourly_with_leaves(self):
+        """ Assert number of days and nextcall are computed correctly for a one level hourly accrual plan based on work time
+            while taking leaves
+        """
+        with freeze_time("2017-12-05"):
+            accrual_plan = self.accrual_plan_hourly_based_on_work
+            allocation = self.env['hr.leave.allocation'].with_user(self.user_hrmanager_id).create({
+                'name': 'Accrual allocation for employee',
+                'accrual_plan_id': accrual_plan.id,
+                'employee_id': self.employee_emp.id,
+                'work_entry_type_id': self.work_entry_type.id,
+                'number_of_days': 0,
+            })
+            allocation.action_approve()
+            self.assertEqual(allocation.nextcall, False)
+            self.assertEqual(allocation.number_of_days, 0, 'There should be no days allocated yet.')
+
+            self._assert_accrual_allocation_nbr_of_days_and_nextcall(allocation, (
+                # Assert running the cron doesn't change anything
+                ('2017-12-05', 0, False),
+            ))
+
+            work_entry_type = self.work_entry_type_absence_half_day_day
+            leave = self.env['hr.leave'].create({
+                'name': 'leave',
+                'employee_id': self.employee_emp.id,
+                'work_entry_type_id': work_entry_type.id,
+                'request_date_from': '2017-12-06 08:00:00',
+                'request_date_to': '2017-12-06 17:00:00',
+                'request_date_from_period': 'am',
+                'request_date_to_period': 'am',
+            })
+            leave.action_approve()
+
+        self._assert_accrual_allocation_nbr_of_days_and_nextcall(allocation, (
+            # Accrual for the day 2017-12-06:
+            # One day elapsed since the beginning of the first level = 1d * 8 (8 hours of work / day) - 1d * 4 (half a day leave)
+            ('2017-12-07', 4, date(2017, 12, 8)),
+            # Assert running the cron again doesn't change anything
+            ('2017-12-07', 4, date(2017, 12, 8)),
+        ))
+
+    def test_frequency_daily(self):
+        """ Assert number of days and nextcall are computed correctly for a one level daily accrual plan """
+        with freeze_time("2017-12-05"):
+            accrual_plan = self.accrual_plan_daily_end_after_1d
+            allocation = self.env['hr.leave.allocation'].with_user(self.user_hrmanager_id).create({
+                'name': 'Accrual allocation for employee',
+                'accrual_plan_id': accrual_plan.id,
+                'employee_id': self.employee_emp.id,
+                'work_entry_type_id': self.work_entry_type.id,
+                'number_of_days': 0,
+            })
+            allocation.action_approve()
+            self.assertFalse(allocation.nextcall, 'There should be no nextcall set on the allocation.')
+            self.assertEqual(allocation.number_of_days, 0, 'There should be no days allocated yet.')
+
+        self._assert_accrual_allocation_nbr_of_days_and_nextcall(allocation, (
+            # Assert running the cron doesn't change anything
+            ('2017-12-05', 0, False),
+            # One day elapsed since the beginning of the first level
+            ('2017-12-07', 1, date(2017, 12, 8)),
+            # Assert running the cron again doesn't change anything
+            ('2017-12-07', 1, date(2017, 12, 8)),
+        ))
+
+    def test_frequency_weekly(self):
+        """ Assert number of days and nextcall are computed correctly for a one level weekly accrual plan
+            Also do not approve the accrual plan right away
+        """
+        with freeze_time("2017-12-05"):
+            accrual_plan = self.accrual_plan_weekly
+            allocation = self.env['hr.leave.allocation'].with_user(self.user_hrmanager_id).create({
+                'name': 'Accrual allocation for employee',
+                'accrual_plan_id': accrual_plan.id,
+                'employee_id': self.employee_emp.id,
+                'work_entry_type_id': self.work_entry_type.id,
+                'number_of_days': 0,
+                'date_from': '2021-09-03',
+            })
+        self._assert_accrual_allocation_nbr_of_days_and_nextcall(allocation, (
+            # Assert running the cron doesn't change anything
+            ('2017-12-05', 0, False),
+        ))
+
+        with freeze_time("2017-12-07"):
+            allocation.action_approve()
+        self.assertEqual(allocation.nextcall, False)
+        self.assertEqual(allocation.number_of_days, 0, 'There should be no days allocated yet.')
+
+        self._assert_accrual_allocation_nbr_of_days_and_nextcall(allocation, (
+            # Date from is in the future, nextcall should still be None
+            ('2017-12-07', 0, False),
+            # Assert running the cron again doesn't change anything
+            ('2017-12-07', 0, False),
+            # Only 2 days elapsed since the beginning of the first level: 2021-09-04 and 2021-09-05 (don't accrue for the current day)
+            ('2021-09-06', duration := 2 / 7, date(2021, 9, 13)),
+            # An entire week elapsed
+            ('2021-09-13', duration + 1, date(2021, 9, 20)),
+        ))
+
+    def test_frequency_bimonthly(self):
+        """ Assert number of days and nextcall are computed correctly for a one level accruing twice a month accrual plan """
+        with freeze_time('2021-09-01'):
+            accrual_plan = self.accrual_plan_bimonthly
+            allocation = self.env['hr.leave.allocation'].with_user(self.user_hrmanager_id).create({
+                'name': 'Accrual allocation for employee',
+                'accrual_plan_id': accrual_plan.id,
+                'employee_id': self.employee_emp.id,
+                'work_entry_type_id': self.work_entry_type.id,
+                'number_of_days': 0,
+                'date_from': '2021-09-03',
+            })
+            allocation.action_approve()
+            self.assertEqual(allocation.nextcall, False)
+            self.assertEqual(allocation.number_of_days, 0, 'There should be no days allocated yet.')
+
+        self._assert_accrual_allocation_nbr_of_days_and_nextcall(allocation, (
+            # The start of the first plan is in the future, nextcall should be False, no accrued days
+            ('2021-09-01', 0, False),
+            # Assert running the cron again doesn't change anything
+            ('2021-09-01', 0, False),
+            # Second day of the accrual plan is 15
+            # Prorated: 09-04 -> 09-15 (not included)
+            ('2021-09-15', duration := (14 - 3) / 14, date(2021, 10, 1)),
+            # One day before the next accrual
+            ('2021-09-30', duration, date(2021, 10, 1)),
+            # First day of the accrual plan is 1, so there should be an full accrual for 09-15 -> 10-01 (not included)
+            ('2021-10-01', duration + 1, date(2021, 10, 15)),
+        ))
+
+    def test_frequency_monthly(self):
+        """ Assert number of days and nextcall are computed correctly for a one level monthly accrual plan """
+        with freeze_time('2021-09-01'):
+            accrual_plan = self.accrual_plan_monthly
+            allocation = self.env['hr.leave.allocation'].with_user(self.user_hrmanager_id).create({
+                'name': 'Accrual allocation for employee',
+                'accrual_plan_id': accrual_plan.id,
+                'employee_id': self.employee_emp.id,
+                'work_entry_type_id': self.work_entry_type.id,
+                'number_of_days': 0,
+                'date_from': '2021-08-31',
+            })
+            allocation.action_approve()
+            self.assertEqual(allocation.nextcall, False)
+            self.assertEqual(allocation.number_of_days, 0, 'There should be no days allocated yet.')
+
+        self._assert_accrual_allocation_nbr_of_days_and_nextcall(allocation, (
+            # The start of the first level is past, nextcall should be set, no accrued days
+            ('2021-09-01', 0, date(2021, 10, 1)),
+            # Assert running the cron again doesn't change anything
+            ('2021-09-01', 0, date(2021, 10, 1)),
+            # One day before the first accrual, nothing changed
+            ('2021-09-30', 0, date(2021, 10, 1)),
+            # First accrual happens
+            ('2021-10-01', 1, date(2021, 11, 1)),
+            # One day before the second accrual
+            ('2021-10-31', 1, date(2021, 11, 1)),
+            # Second accrual
+            ('2021-11-01', 2, date(2021, 12, 1)),
+        ))
+
+    def test_frequency_biyearly(self):
+        """ Assert number of days and nextcall are computed correctly for a one level accruing twice a year accrual plan """
+        with freeze_time('2021-09-01'):
+            accrual_plan = self.accrual_plan_biyearly
+            allocation = self.env['hr.leave.allocation'].with_user(self.user_hrmanager_id).create({
+                'name': 'Accrual allocation for employee',
+                'accrual_plan_id': accrual_plan.id,
+                'employee_id': self.employee_emp.id,
+                'work_entry_type_id': self.work_entry_type.id,
+                'number_of_days': 0,
+            })
+            allocation.action_approve()
+            self.assertFalse(allocation.nextcall, 'There should be no nextcall set on the allocation.')
+            self.assertEqual(allocation.number_of_days, 0, 'There should be no days allocated yet.')
+
+        self._assert_accrual_allocation_nbr_of_days_and_nextcall(allocation, (
+            # The start of the first plan is in the future (tomorrow), nextcall should be False, no accrued days
+            ('2021-09-01', 0, False),
+            # Assert running the cron again doesn't change anything
+            ('2021-09-01', 0, False),
+            # One day before the first accrual, nothing changed
+            ('2021-12-31', 0, date(2022, 1, 1)),
+            # 2021-09-02 -> 2022-01-01: 4 month out of the 6 month of the first period
+            ('2022-01-01', days := (29 + 31 + 30 + 31) / 184, date(2022, 7, 1)),
+            # One day before the second accrual
+            ('2022-06-30', days, date(2022, 7, 1)),
+            # Second accrual
+            ('2022-07-01', days + 1, date(2023, 1, 1)),
+        ))
+
+    def test_frequency_yearly(self):
+        """ Assert number of days and nextcall are computed correctly for a one level yearly accrual plan """
+        with freeze_time('2021-09-01'):
+            accrual_plan = self.accrual_plan_yearly
+            # this sets up an accrual on the 1st of January
+            allocation = self.env['hr.leave.allocation'].with_user(self.user_hrmanager_id).create({
+                'name': 'Accrual allocation for employee',
+                'accrual_plan_id': accrual_plan.id,
+                'employee_id': self.employee_emp.id,
+                'work_entry_type_id': self.work_entry_type.id,
+                'number_of_days': 0,
+            })
+            allocation.action_approve()
+            self.assertFalse(allocation.nextcall, 'There should be no nextcall set on the allocation.')
+            self.assertEqual(allocation.number_of_days, 0, 'There should be no days allocated yet.')
+
+        self._assert_accrual_allocation_nbr_of_days_and_nextcall(allocation, (
+            # The start of the first plan is in the future (tomorrow), nextcall should be False, no accrued days
+            ('2021-09-01', 0, False),
+            # Assert running the cron again doesn't change anything
+            ('2021-09-01', 0, False),
+            # One day before the first accrual, nothing changed
+            ('2021-12-31', 0, date(2022, 1, 1)),
+            # 2021-09-02 -> 2022-01-01: 4 month out of the 6 month of the first period
+            ('2022-01-01', days := (29 + 31 + 30 + 31) / 365, date(2023, 1, 1)),
+            # One day before the second accrual
+            ('2022-12-31', days, date(2023, 1, 1)),
+            # Second accrual
+            ('2023-01-01', days + 1, date(2024, 1, 1)),
+        ))
+
+    def test_check_gain(self):
+        """ Assert number of days and nextcall are computed correctly for 2 accrual allocations based on
+            one level weekly accrual plans, one of the plan is based on work time, the other isn't
+            Also take a leave
+        """
+        with freeze_time('2021-08-30'):
+            attendances = []
+            for index in range(5):
+                attendances.append((0, 0, {
+                    'hour_from': 8,
+                    'hour_to': 12,
+                    'dayofweek': str(index),
+                }))
+                attendances.append((0, 0, {
+                    'hour_from': 13,
+                    'hour_to': 17,
+                    'dayofweek': str(index),
+                }))
+            calendar_emp = self.env['resource.calendar'].create({
+                'name': '40 Hours',
+                'attendance_ids': attendances,
+            })
+
+            # Get the same configuration as 'accrual_plan_based_on_worked_time', except it is not based on working time
+            self.accrual_plan_weekly.level_ids[0].added_value = 5
+
+            self.employee_emp.resource_calendar_id = calendar_emp.id
+            allocation_not_worked_time = self.env['hr.leave.allocation'].with_user(self.user_hrmanager_id).create({
+                'name': 'Accrual allocation for employee',
+                'accrual_plan_id': self.accrual_plan_weekly.id,
+                'employee_id': self.employee_emp.id,
+                'work_entry_type_id': self.work_entry_type.id,
+                'number_of_days': 0,
+                'state': 'confirm',
+            })
+            allocation_worked_time = self.env['hr.leave.allocation'].with_user(self.user_hrmanager_id).create({
+                'name': 'Accrual allocation for employee',
+                'accrual_plan_id': self.accrual_plan_based_on_worked_time.id,
+                'employee_id': self.employee_emp.id,
+                'work_entry_type_id': self.work_entry_type.id,
+                'number_of_days': 0,
+                'state': 'confirm',
+            })
+            allocations = allocation_not_worked_time | allocation_worked_time
+            allocations.action_approve()
+            work_entry_type = self.work_entry_type_accrual_non_elligible_absence_day_day
+            self._create_leave(self.employee_emp, work_entry_type, '2021-09-02', '2021-09-02', validate=True)
+            self.assertFalse(allocation_not_worked_time.nextcall, 'There should be no nextcall set on the allocation.')
+            self.assertFalse(allocation_worked_time.nextcall, 'There should be no nextcall set on the allocation.')
+            self.assertEqual(allocation_not_worked_time.number_of_days, 0, 'There should be no days allocated yet.')
+            self.assertEqual(allocation_worked_time.number_of_days, 0, 'There should be no days allocated yet.')
+
+        # Running update on Monday (first accrual day)
+        with freeze_time('2021-09-06'):
+            self._run_update_accrual_cron()
+            # First level starts on 2021-08-31 = Tuesday
+            # 6 days out of the 7 days of the week (doesn't take the current day into account = 09-06)
+            self.assertAlmostEqual(allocation_not_worked_time.number_of_days, not_work_time_duration := 6 / 7 * 5, 4)
+            # Worked 3 days: Tuesday, Wednesday and Friday (Thursday is off: 09-02)
+            # Saturday and Sunday aren't in the 'calendar_emp', they don't count
+            self.assertAlmostEqual(allocation_worked_time.number_of_days, work_time_duration := 3)
+            expected_nextcall = datetime.date(2021, 9, 13)
+            self.assertEqual(allocation_not_worked_time.nextcall, expected_nextcall, 'The next call date of the cron should be the September 13th')
+            self.assertEqual(allocation_worked_time.nextcall, expected_nextcall, 'The next call date of the cron should be the September 13th')
+
+        # Running update on next Monday (second accrual day)
+        with freeze_time('2021-09-13'):
+            self._run_update_accrual_cron()
+            self.assertAlmostEqual(allocation_not_worked_time.number_of_days, not_work_time_duration + 5, 4, 'There should be 9.2857 days allocated.')
+            self.assertAlmostEqual(allocation_worked_time.number_of_days, work_time_duration + 5, 4, 'There should be 8 days allocated.')
+
+            expected_nextcall = datetime.date(2021, 9, 20)
+            self.assertEqual(allocation_not_worked_time.nextcall, expected_nextcall, 'The next call date of the cron should be September 20th')
+            self.assertEqual(allocation_worked_time.nextcall, expected_nextcall, 'The next call date of the cron should be September 20th')
+
+    def _test_accrual_allocation_number_of_days_with_leave(self, time_off_type, deducted):
+        """ Assert number of days and nextcall are computed correctly for a one level daily accrual plan
+            while taking a leave that is linked to a `work.entry.type` which is accrual allocation elligible or not
+        """
+        accrual_plan = self.based_on_work_time_accrual_plan_daily
+        with freeze_time('2025-09-01'):  # Monday
+            allocation_worked_time = self.env['hr.leave.allocation'].with_user(self.user_hrmanager_id).create({
+                'name': 'Accrual allocation for employee',
+                'accrual_plan_id': accrual_plan.id,
+                'employee_id': self.employee_emp.id,
+                'work_entry_type_id': self.work_entry_type.id,
+                'number_of_days': 0,
+            })
+            allocation_worked_time.action_approve()
+
+        self._assert_accrual_allocation_nbr_of_days_and_nextcall(allocation_worked_time, (
+            ('2025-09-01', 0, date(2025, 9, 2)),
+            # Saturday: got 10 working days = 10 * 1d
+            ('2025-09-13', 10, date(2025, 9, 14)),
+        ))
+
+        # Accrual elligible or not depending on the injected time_off_type
+        with freeze_time('2025-09-13'):
+            self._create_leave(self.employee_emp, time_off_type, '2025-09-16', '2025-09-18', validate=True)
+
+        self._assert_accrual_allocation_nbr_of_days_and_nextcall(allocation_worked_time, {
+            # On the next Saturday: got 15 working days deducted or not
+            ('2025-09-20', 12 if deducted else 15, date(2025, 9, 21)),
+        })
+
+    def test_non_elligible_leaves(self):
+        timeoff_type = self.work_entry_type_accrual_non_elligible_absence_day_day
+        self._test_accrual_allocation_number_of_days_with_leave(timeoff_type, deducted=True)
+
+    def test_elligible_leaves(self):
+        timeoff_eligible_type = self.work_entry_type_accrual_elligible_absence_day_day
+        self._test_accrual_allocation_number_of_days_with_leave(timeoff_eligible_type, deducted=False)
+
+    def test_worked_leaves(self):
+        remote_work_type = self.work_entry_type_working_time_day_day
+        self._test_accrual_allocation_number_of_days_with_leave(remote_work_type, deducted=False)
+
+    def test_check_max_value(self):
+        """ Assert number of days and nextcall are compted correctly for a one level accrual plan
+            with a maximum number of leave set to 1
+        """
+        accrual_plan = self.accrual_plan_daily_end_max_1_leave
+        with freeze_time("2017-12-05"):
+            allocation = self.env['hr.leave.allocation'].with_user(self.user_hrmanager_id).create({
+                'name': 'Accrual allocation for employee',
+                'accrual_plan_id': accrual_plan.id,
+                'employee_id': self.employee_emp.id,
+                'work_entry_type_id': self.work_entry_type.id,
+                'number_of_days': 0,
+            })
+            allocation.action_approve()
+
+        self._assert_accrual_allocation_nbr_of_days_and_nextcall(allocation, (
+            ('2017-12-05', 0, False),
+            # The plan only starts one day after the start of the allocation
+            ('2017-12-07', 1, date(2017, 12, 8)),
+            # Max number of days is reached
+            ('2017-12-08', 1, date(2017, 12, 9)),
+            ('2017-12-09', 1, date(2017, 12, 10)),
+        ))
+
+    def test_check_max_value_hours(self):
+        """ Assert number of days and nextcall are compted correctly for a one level accrual plan
+            with a maximum number of leave set to 1, and with ''added_value_type' set to 'hour'
+        """
+        with freeze_time("2017-12-05"):
+            accrual_plan = self.accrual_plan_daily_1_hour_4_max_leave
+            allocation = self.env['hr.leave.allocation'].with_user(self.user_hrmanager_id).create({
+                'name': 'Accrual allocation for employee',
+                'accrual_plan_id': accrual_plan.id,
+                'employee_id': self.employee_emp.id,
+                'work_entry_type_id': self.work_entry_type.id,
+                'number_of_days': 0,
+            })
+            allocation.action_approve()
+
+        self._assert_accrual_allocation_nbr_of_days_and_nextcall(allocation, (
+            # First level start date is in the future (tomorrow), nextcall isn't set
+            ('2017-12-05', 0, False),
+            # The plan only starts one day after the start of the allocation
+            ('2017-12-07', 0.125, date(2017, 12, 8)),
+            # Assert the maximum leave is respected (4h = 0.5 day here)
+            ('2017-12-17', 0.5, date(2017, 12, 18)),
+        ))
+
+    @freeze_time("2024-10-10")
+    def test_accrual_hours_with_max_carryover(self):
+        """ Assert get_allocation_data returns a correct number of allocated hours / remaining leaves
+            for an accrual allocation with a monthly accrual plan that only carryover a limited number
+            of hours
+        """
+        accrual_plan = self.accrual_plan_monthly_31th_max_carryover_duration
+        allocation = self.env['hr.leave.allocation'].with_user(self.user_hrmanager_id).create({
+            'name': 'Accrual allocation for employee',
+            'date_from': datetime.date(2025, 1, 1),
+            'accrual_plan_id': accrual_plan.id,
+            'employee_id': self.employee_emp.id,
+            'work_entry_type_id': self.work_entry_type.id,
+            'number_of_days': 0,
+        })
+        allocation.action_approve()
+
+        hours_per_day = self.employee_emp.resource_calendar_id.hours_per_day
+        # The first month covers 2025-01-02 -> 2025-01-31 (29 days)
+        first_period_allocated_duration = 29 / 31 / hours_per_day
+        self._assert_get_allocation_data_future(allocation, (
+            # As the plan still hasn't started yet, assert allocated_duration is 0
+            ('2024-10-10', 0),
+            # One day before the last day of the first period
+            ('2025-01-30', 0),
+            # First accrual happens at the end of the period (2025-01-31)
+            ('2025-01-31', first_period_allocated_duration),
+            # + the next 10 month of accrual (10 * 1 hour)
+            ('2025-12-02', first_period_allocated_duration + 10 / hours_per_day),
+            # Carryover only keeps 4 hours on "2025-01-01" + January accrual (1 hour)
+            ('2026-02-15', 5 / hours_per_day),
+        ))
+
+    def _assert_current_level(self, allocation, assertions):
+        for target_date, expected_level in assertions.items():
+            accrual_plan_level = allocation._get_current_accrual_plan_level_idx(parse_iso_date(target_date))[0]
+            self.assertEqual(accrual_plan_level, expected_level)
+
+    @freeze_time("2017-12-05")
+    def test_accrual_transition_immediately(self):
+        """ Test transition mode 'immediately' """
+        # 1 accrual with 2 levels and level transition immediately
+        accrual_plan = self.accrual_plan_2_lvls_weekly
+        accrual_plan.transition_mode = 'immediately'
+        allocation = self.env['hr.leave.allocation'].with_user(self.user_hrmanager_id).create({
+            'name': 'Accrual allocation for employee',
+            'accrual_plan_id': accrual_plan.id,
+            'employee_id': self.employee_emp.id,
+            'work_entry_type_id': self.work_entry_type.id,
+            'number_of_days': 0,
+        })
+        allocation.action_approve()
+        first_level, second_level = self.accrual_plan_2_lvls_weekly.level_ids
+        self._assert_current_level(allocation, {
+            '2017-12-05': None,
+            # The first level starts 1 day after the date_from of the allocation: 2017-12-06
+            '2017-12-06': first_level,
+            '2017-12-14': first_level,
+            # The second level starts 10 days after the date_from of the allocation: 2017-12-15
+            '2017-12-15': second_level,
+            '2018-01-01': second_level,
+        })
+
+    @freeze_time("2025-07-08")
+    def test_accrual_transition_after_period(self):
+        """ Test transition mode 'end_of_accrual' """
+        accrual_plan = self.accrual_plan_2_lvls_weekly
+        accrual_plan.transition_mode = 'end_of_accrual'
+        allocation = self.env['hr.leave.allocation'].with_user(self.user_hrmanager_id).create({
+            'name': 'Accrual allocation for employee',
+            'accrual_plan_id': accrual_plan.id,
+            'employee_id': self.employee_emp.id,
+            'work_entry_type_id': self.work_entry_type.id,
+            'number_of_days': 0,
+        })
+        allocation.action_approve()
+        first_level, second_level = accrual_plan.level_ids
+        # Second level starts on 2025-07-18 (10 days later), but the 'transition_mode' is set to 'end_of_accrual',
+        # so the first level will "end its period" before transition
+        # ===> 2025-07-18 is a Friday, therefore the second level will start on 2025-07-21 (next Monday)
+        self._assert_current_level(allocation, {
+            '2025-07-08': None,
+            # The first level starts 1 day after the date_from of the allocation: 2025-07-09
+            '2025-07-09': first_level,
+            # Theoritical level transition
+            '2025-07-18': first_level,
+            # Last day before level transition
+            '2025-07-20': first_level,
+            '2025-07-21': second_level,
+            '2026-01-01': second_level,
+        })
+
+    def test_unused_accrual_lost(self):
+        """ Assert the allocated days are reset on carryover while the maximum number of leave is reached """
+        with freeze_time('2021-12-15'):
+            accrual_plan = self.accrual_plan_daily_carryover_lost
+            allocation = self.env['hr.leave.allocation'].with_user(self.user_hrmanager_id).create({
+                'name': 'Accrual allocation for employee',
+                'accrual_plan_id': accrual_plan.id,
                 'employee_id': self.employee_emp.id,
                 'work_entry_type_id': self.work_entry_type.id,
                 'number_of_days': 10,
             })
             allocation.action_approve()
 
-            self.assertEqual(allocation.lastcall, False)
+        self._assert_accrual_allocation_nbr_of_days_and_nextcall(allocation, (
+            # 31 - 16 = 15 * 1 accrued days + the initial number of days > max number of days which is 20
+            ('2021-12-31', 20, date(2022, 1, 1)),
+            # Carryover reset
+            ('2022-01-01', 1, date(2022, 1, 2)),
+            ('2022-01-05', 5, date(2022, 1, 6)),
+        ))
 
-            allocation.action_refuse()
-            allocation.write({
+    def test_unused_accrual_carried_over_2(self):
+        """ Assert the allocated duration is unchanged on carryover when the accrual plan carryover policy is 'limited'
+            and that the allocated duration is under this amount on carryover date
+        """
+        with freeze_time('2021-01-01'):
+            accrual_plan = self.accrual_plan_yearly_carryover_limited_10
+            allocation = self.env['hr.leave.allocation'].with_user(self.user_hrmanager_id).create({
+                'name': 'Accrual allocation for employee',
                 'accrual_plan_id': accrual_plan.id,
+                'employee_id': self.employee_emp.id,
+                'work_entry_type_id': self.work_entry_type.id,
+                'number_of_days': 8,
+            })
+            allocation.action_approve()
+
+        self._assert_accrual_allocation_nbr_of_days_and_nextcall(allocation, (
+            ('2021-12-31', 8, date(2022, 1, 1)),
+            # First accrual happens
+            ('2022-01-01', 10, date(2023, 1, 1)),
+            # One day before the second accrual
+            ('2022-12-31', 10, date(2023, 1, 1)),
+            # Second accrual happens
+            ('2023-01-01', 12, date(2024, 1, 1)),
+            # 10 carriedover days + 2 accrued days for the past year
+            ('2024-01-01', 12, date(2025, 1, 1)),
+        ))
+
+    def test_unused_accrual_carried_over_limit(self):
+        """ Assert the number of days and the nextcall are computed correctly for an accrual allocation with:
+            - Initial number of days set to 10
+            - Daily accrual of 1 day
+            - Accrues at the start of the period
+            - Maximum of 25 leaves
+            - Carryover limited to 15 days at year_start
+        """
+        with freeze_time('2021-12-15'):
+            accrual_plan = self.accrual_plan_daily_max_leave_carryover_limited
+            allocation = self.env['hr.leave.allocation'].with_user(self.user_hrmanager_id).create({
+                'name': 'Accrual allocation for employee',
+                'accrual_plan_id': accrual_plan.id,
+                'employee_id': self.employee_emp.id,
+                'work_entry_type_id': self.work_entry_type.id,
+                'number_of_days': 10,
+            })
+            allocation.action_approve()
+
+        self._assert_accrual_allocation_nbr_of_days_and_nextcall(allocation, (
+            # Nextcall unset because the start of the first level is in the future
+            ('2021-12-15', 10, False),
+            # First level start: nextcall should be set + first accrual
+            ('2021-12-16', 11, date(2021, 12, 17)),
+            # Last day before carryover
+            ('2021-12-31', 25, date(2022, 1, 1)),
+            # Assert max 15 days were carriedover + accrual of the first day of the year
+            ('2022-01-01', 16, date(2022, 1, 2)),
+        ))
+
+    def test_period_prorata(self):
+        """ Assert the number of days and the nextcall are computed correctly for an accrual allocation with:
+            - Initial number of days set to 10
+            - Accrues at the end of the period
+            - With a level:
+                - Starts at allocation
+                - Accrues daily of 15 day
+            - With another level:
+                - Starts 4 months after the allocation (date_from)
+                - Accrues biyearly of 10 days
+        """
+        accrual_plan = self.accrual_plan_biyearly_2_levels
+        with freeze_time('2020-08-16'):
+            allocation = self.env['hr.leave.allocation'].with_user(self.user_hrmanager_id).create({
+                'name': 'Accrual Allocation - Test',
+                'accrual_plan_id': accrual_plan.id,
+                'employee_id': self.employee_emp.id,
+                'work_entry_type_id': self.work_entry_type.id,
+                'number_of_days': 0,
+            })
+            allocation.action_approve()
+
+        first_period_total_days = self._get_period_days('2020-07-01', '2020-12-31')
+        self._assert_accrual_allocation_nbr_of_days_and_nextcall(allocation, (
+            # Level transition -> accrual for the period using the first level
+            ('2020-12-16', duration := 15 * self._get_period_days('2020-08-16', '2020-12-15') / first_period_total_days, date(2021, 1, 1)),
+            # Second level accrual: same period from 2020-07-01 to 2020-12-31
+            ('2021-01-01', duration := duration + 10 * self._get_period_days('2020-12-16', '2020-12-31') / first_period_total_days, date(2021, 7, 1)),
+            # Second level accrual: 10 (for period 2021-01-01 - 2021-06-30)
+            ('2021-07-01', duration := duration + 10, date(2022, 1, 1)),
+            # Second level accrual: 10 (for period 2021-07-01 - 2021-12-31)
+            ('2022-01-01', duration + 10, date(2022, 7, 1)),
+        ))
+
+    def test_maximum_leaves_three_levels_accrual(self):
+        """ Assert number of days respects the level maximum leaves with 3 levels having different
+            'maximum_leaves' config for each level: 3 for the first level, 6 for the second and
+            no limit for the third one
+        """
+        accrual_plan = self.accrual_plan_3_levels_monthly_max_leaves
+        with freeze_time('2022-01-31'):
+            allocation = self.env['hr.leave.allocation'].with_user(self.user_hrmanager_id).create({
+                'name': 'Accrual Allocation - Test',
+                'accrual_plan_id': accrual_plan.id,
+                'employee_id': self.employee_emp.id,
+                'work_entry_type_id': self.work_entry_type.id,
+                'number_of_days': 2,
+            })
+            allocation.action_approve()
+
+        self._assert_accrual_allocation_nbr_of_days_and_nextcall(allocation, (
+            ('2022-01-31', 2, False),
+            # One day before the start of the first level
+            ('2022-03-30', 2, False),
+            # First level starts, nextcall set, 0 days accrued as the day are accrued at the end of the period
+            ('2022-03-31', 2, date(2022, 4, 30)),
+            # First period accrual, use the first level policy for the maximum leaves (3 days)
+            ('2022-04-30', 3, date(2022, 5, 31)),
+            # First period of the second level and also the third level transition
+            # Use the second level policy for the maximum leaves (6 days)
+            ('2022-05-31', 6, date(2022, 6, 30)),
+            # One day before the next accrual
+            ('2022-06-29', 6, date(2022, 6, 30)),
+            # Third level first period: it's now uncapped !
+            ('2022-06-30', 7, date(2022, 7, 31)),
+        ))
+
+    def test_accrual_yearly_on_carryover_lost(self):
+        accrual_plan = self.accrual_plan_yearly_carryover_lost
+        with freeze_time('2019-01-01'):
+            allocation = self.env['hr.leave.allocation'].with_user(self.user_hrmanager_id).create({
+                'name': 'Accrual Allocation - Test',
+                'accrual_plan_id': accrual_plan.id,
+                'employee_id': self.employee_emp.id,
+                'work_entry_type_id': self.work_entry_type.id,
+                'number_of_days': 0,
+            })
+            allocation.action_approve()
+
+        self._assert_accrual_allocation_nbr_of_days_and_nextcall(allocation, (
+            # First level starts immediately, accruing 3 days for the year
+            ('2019-01-01', 3, date(2020, 1, 1)),
+            ('2019-12-31', 3, date(2020, 1, 1)),
+            # All days lost on carryover, then the yearly accrual happens
+            ('2020-01-01', 3, date(2021, 1, 1)),
+        ))
+
+    def test_accrual_leaves_taken_maximum(self):
+        """ Assert the `maximum_leave` is respected for an accrual allocation while taking a 5 days leave """
+        accrual_plan = self.accrual_plan_weekly_5_max_leave
+        # Creating the allocation on a Saturday
+        with freeze_time("2022-01-01"):
+            allocation = self.env['hr.leave.allocation'].with_user(self.user_hrmanager_id).create({
+                'name': 'Accrual allocation for employee',
+                'accrual_plan_id': accrual_plan.id,
+                'employee_id': self.employee_emp.id,
+                'work_entry_type_id': self.work_entry_type.id,
+                'number_of_days': 0,
+            })
+            allocation.action_approve()
+
+        self._assert_accrual_allocation_nbr_of_days_and_nextcall(allocation, (
+            ('2022-01-01', 0, date(2022, 1, 3)),
+            # First accrual for Saturday and Sunday out of the 7 days of the week
+            ('2022-01-03', days := 2 / 7, date(2022, 1, 10)),
+            ('2022-01-10', days + 1, date(2022, 1, 17)),
+            # Maximum reached after 5 weeks of accrual
+            ('2022-02-28', 5, date(2022, 3, 7)),
+        ))
+
+        # 5 days leave
+        self._create_leave(self.employee_emp, self.work_entry_type, '2022-03-07', '2022-03-11', validate=True)
+
+        self._assert_accrual_allocation_nbr_of_days_and_nextcall(allocation, (
+            ('2022-06-01', 10, date(2022, 6, 6)),
+        ))
+
+    def test_accrual_leaves_taken_maximum_hours(self):
+        """ Assert the max amount of leave is respected for an accrual allocation which adds 3 hours weekly """
+        accrual_plan = self.accrual_plan_weekly_hour_max_leaves
+        with freeze_time('2022-01-01'):
+            allocation = self.env['hr.leave.allocation'].with_user(self.user_hrmanager_id).create({
+                'name': 'Accrual allocation for employee',
+                'accrual_plan_id': accrual_plan.id,
+                'employee_id': self.employee_emp.id,
+                'work_entry_type_id': self.work_entry_type_hour.id,
+                'number_of_days': 0,
+            })
+            allocation.action_approve()
+
+        self._assert_accrual_allocation_nbr_of_days_and_nextcall(allocation, (
+            ('2022-01-01', 0, date(2022, 1, 3)),
+            # Monday: first accrual for Saturday and Sunday out of the 7 days of the week
+            ('2022-01-03', (2 / 7 * 3) / self.hours_per_day, date(2022, 1, 10)),
+            # Max number of leave reached (10 hours)
+            ('2022-03-06', 10 / self.hours_per_day, date(2022, 3, 7)),
+        ))
+
+        with freeze_time('2022-03-06'):
+            self._create_leave(self.employee_emp, self.work_entry_type_hour, '2022-03-07', '2022-03-07', validate=True)
+
+        self._assert_accrual_allocation_nbr_of_days_and_nextcall(allocation, (
+            # Should accrue 8 more hours (the maximum is reached once again)
+            ('2022-06-01', 18 / self.hours_per_day, date(2022, 6, 6)),
+        ))
+
+    @mute_logger('odoo.sql_db')
+    def test_yearly_cap_constraint(self):
+        accrual_plan = self.accrual_plan_daily_5_max_leaves
+        with self.assertRaises(IntegrityError):
+            accrual_plan.level_ids[0].write({
+                'cap_accrued_time_yearly': True,
+                'maximum_leave_yearly': 0,
+            })
+        accrual_plan.level_ids[0].write({
+            'cap_accrued_time_yearly': True,
+            'maximum_leave_yearly': 1,
+        })
+        accrual_plan.level_ids[0].write({
+            'cap_accrued_time_yearly': False,
+            'maximum_leave_yearly': 0,
+        })
+        self.env.cr.precommit.run()
+        self.env.flush_all()
+
+    def test_yearly_cap(self):
+        """ Assert combining `maximum_leave_yearly` and a `maximum_leave` works properly """
+        work_entry_type = self.work_entry_type_absence_hour_hour
+        accrual_plan = self.accrual_plan_hourly_max_leaves_capped_yearly
+
+        with freeze_time('2024-12-25'):
+            allocation = self.env['hr.leave.allocation'].with_user(self.user_hrmanager_id).create({
+                'name': 'Accrual allocation for employee',
+                'employee_id': self.employee_emp.id,
+                'work_entry_type_id': work_entry_type.id,
+                'accrual_plan_id': accrual_plan.id,
+                'number_of_days': 0,
             })
 
-            self.assertEqual(allocation.lastcall, datetime.date(2017, 12, 5))
+        assertion_structure = {
+            'number_of_days': 'float',
+            'allocated_duration': 'float',
+            'remaining_leaves': 'float',
+        }
+        self._assert_get_allocation_data(allocation, (
+            # Assert yearly cap is respected (16 hours max)
+            ('2024-12-31', 16 / self.hours_per_day, 16, 16),
+        ), assertion_structure)
 
-    def test_accrual_allocation_data_persists(self):
-        work_entry_type = self.env['hr.work.entry.type'].create({
-            'name': 'Test Leave Type 2',
-            'code': 'Test Leave Type 2',
-            'count_as': 'absence',
-            'requires_allocation': True,
-            'allocation_validation_type': 'no_validation',
-            'request_unit': 'day',
-            'unit_of_measure': 'day',
+        with freeze_time('2024-12-30'):
+            leave = self._create_leave(self.employee_emp, work_entry_type, '2024-12-27', '2024-12-27', 10, 12)
+            self.assertEqual(allocation.leaves_taken, 2)
+            self.assertEqual(leave.number_of_hours, 2)
+
+        self._assert_get_allocation_data(allocation, (
+            # Nothing more accrued because the yearly cap is reached
+            ('2024-12-31', 16 / self.hours_per_day, 16, 14),
+            # Assert the maximum leave is respected: the number_of_days is 24 (max available leaves) + 2 hours of the leave
+            ('2025-01-06', 26 / self.hours_per_day, 26, 24),
+        ), assertion_structure)
+
+    @freeze_time("2023-04-24")
+    def test_accrual_period_start(self):
+        """ Assert everything goes smoothly when changing the accrual plan accruad gain time and then creating another,
+            Running test on a Monday
+        """
+        accrual_plan = self.accrual_plan_weekly_5_max_leave
+        allocation = self.env['hr.leave.allocation'].with_user(self.user_hrmanager_id).create({
+            'name': 'Accrual allocation for employee',
+            'accrual_plan_id': accrual_plan.id,
+            'employee_id': self.employee_emp.id,
+            'work_entry_type_id': self.work_entry_type.id,
+            'number_of_days': 0,
         })
-        accrual_plan = self.env['hr.leave.accrual.plan'].create({
-            'name': 'Accrual Plan For Test',
-            'accrued_gain_time': 'start',
-            'can_be_carryover': True,
-            'carryover_date': 'year_start',
-            'level_ids': [(0, 0, {
-                'milestone_date': 'after',
-                'start_count': 1,
-                'start_type': 'day',
-                'added_value': 1,
-                'added_value_type': 'day',
-                'frequency': 'daily',
-                'cap_accrued_time': True,
-                'maximum_leave': 10,
-                'action_with_unused_accruals': 'all',
-            })],
+        allocation.action_approve()
+
+        self._assert_accrual_allocation_nbr_of_days_and_nextcall(allocation, (
+            # Accruals should happen at the end of the period, on the next Monday
+            ("2023-04-24", 0, date(2023, 5, 1)),
+        ))
+
+        with Form(accrual_plan) as plan_form:
+            plan_form.accrued_gain_time = 'start'
+
+        allocation = self._create_form_test_accrual_allocation(self.work_entry_type, '2023-04-24',
+            self.employee_emp, accrual_plan, creator_user=self.user_hrmanager_id)
+        allocation.action_approve()
+        self._assert_accrual_allocation_nbr_of_days_and_nextcall(allocation, (
+            # Accruals happens at the start of the first level
+            ("2023-04-24", 1, date(2023, 5, 1)),
+        ))
+
+    def test_accrual_period_start_multiple_runs(self):
+        accrual_plan = self.accrual_plan_monthly_start_15_max_leaves
+        with freeze_time("2023-12-25"):
+            allocation = self._create_form_test_accrual_allocation(self.work_entry_type,
+                '2023-12-25', self.employee_emp, accrual_plan, creator_user=self.user_hrmanager_id)
+            allocation.action_approve()
+
+        self._assert_accrual_allocation_nbr_of_days_and_nextcall(allocation, (
+            ('2023-12-25', days := self._get_period_days('2023-12-25', '2024-01-12') / self._get_period_days('2023-12-13', '2024-01-12') * 1.5, date(2024, 1, 1)),
+            # Carryover date, nothing happens
+            ('2024-01-01', days, date(2024, 1, 13)),
+            # One day before the accrual, nothing happens
+            ('2024-01-12', days, date(2024, 1, 13)),
+            # Accruals for the first month
+            ('2024-01-13', days + 1.5, date(2024, 2, 13)),
+            # Maximum number of leave is reached
+            ('2024-05-13', 4, date(2024, 6, 13)),
+        ))
+
+    def test_accrual_period_start_level_transfer(self):
+        """ Assert maximum number of leave is respected when there are 2 levels that are capped and that have different number
+            of maximum leaves
+        """
+        accrual_plan = self.accrual_plan_2_lvls_start_weekly_max_leaves
+        # On a Wednesday
+        with freeze_time("2023-04-26"):
+            allocation = self._create_form_test_accrual_allocation(
+                self.work_entry_type, '2023-04-26', self.employee_emp, accrual_plan, creator_user=self.user_hrmanager_id)
+            allocation.action_approve()
+
+        self._assert_accrual_allocation_nbr_of_days_and_nextcall(allocation, (
+            # Accrual for the entire week
+            ("2023-04-26", 1, date(2023, 5, 3)),
+            # One day before level transition
+            # Assert maximum available leave of the first level is respected
+            ("2023-07-25", 8, date(2023, 7, 26)),
+            # Assert the maximum available leave of the second level is respected
+            ("2023-07-26", 5, date(2023, 8, 2)),
+        ))
+
+    def test_accrual_carryover_at_allocation(self):
+        """ Assert the allocated days are lost on carryover date for an allocation with a accrual plan
+            which accrued gain time is 'start'
+        """
+        accrual_plan = self.accrual_plan_monthly_start_carryover_allocation_lost
+        with freeze_time("2023-04-26"):
+            allocation = self._create_form_test_accrual_allocation(self.work_entry_type, '2023-04-26', self.employee_emp, accrual_plan)
+            allocation.action_approve()
+
+        self._assert_accrual_allocation_nbr_of_days_and_nextcall(allocation, (
+            ("2023-04-26", days := 1 / self._get_period_days('2023-04-26', '2023-05-26'), date(2023, 4, 27)),
+            ("2023-04-27", days := days + 1, date(2023, 5, 27)),
+            # Last accrual before the carryoverdate, nextcall is the next carryover date
+            ("2024-03-27", days := days + 11, date(2024, 4, 26)),
+            # Carryover date happens
+            ("2024-04-26", 0, date(2024, 4, 27)),
+            # First accrual after the carryover date
+            ("2024-04-27", 1, date(2024, 5, 27)),
+            # Accruals keep on going...
+            ("2024-07-27", 4, date(2024, 8, 27)),
+        ))
+
+    def test_accrual_carryover_at_other(self):
+        """ Assert an allocation behaves nicely when creating it on the day of its carryover (using carryover_date: other)
+            with a limited amount of carriedover days
+        """
+        accrual_plan = self.accrual_plan_monthly_start_max_69_carriedover
+        with freeze_time("2023-04-20"):
+            allocation = self.env['hr.leave.allocation'].with_user(self.user_hrmanager_id).create({
+                'name': 'Accrual allocation for employee',
+                'accrual_plan_id': accrual_plan.id,
+                'employee_id': self.employee_emp.id,
+                'work_entry_type_id': self.work_entry_type.id,
+                'number_of_days': 0,
+                'date_from': '2023-04-20',
+            })
+            allocation.action_approve()
+
+        self._assert_accrual_allocation_nbr_of_days_and_nextcall(allocation, (
+            # Accrual at the start of the first level
+            ("2023-04-20", days := (30 - 20 + 1 + 10) / (30 - 11 + 1 + 10) * 10, date(2023, 5, 11)),
+            # Second accrual for an entire month
+            ("2023-05-11", days + 10, date(2023, 6, 11)),
+            # Carryover date: assert maximum number of leave is taken into account
+            ("2024-04-20", days := 69, date(2024, 5, 11)),
+            # Accruals keep on going...
+            ("2024-05-11", days := days + 10, date(2024, 6, 11)),
+            ("2024-06-11", days + 10, date(2024, 7, 11)),
+        ))
+
+    def test_accrual_carrover_other_period_end_multi_level(self):
+        """ Assert the allocated days are computed correctly for a 3 levels accrual allocation
+            that uses different maximum number of leave and carryover policy for each level
+        """
+        accrual_plan = self.accrual_plan_3_lvls_monthly_biyearly_yearly_carryover_policy_change
+        with freeze_time("2023-04-04"):
+            allocation = self.env['hr.leave.allocation'].with_user(self.user_hrmanager_id).create({
+                'name': 'Accrual allocation for employee',
+                'accrual_plan_id': accrual_plan.id,
+                'employee_id': self.employee_emp.id,
+                'work_entry_type_id': self.work_entry_type.id,
+                'number_of_days': 9,
+                'date_from': '2023-04-04',
+            })
+            allocation.action_approve()
+
+        self._assert_accrual_allocation_nbr_of_days_and_nextcall(allocation, (
+            ("2023-04-04", 9, False),
+            # Start of the first level
+            ("2023-04-09", 9, date(2023, 5, 9)),
+            # End of the first period of the first level: accrual happens
+            ("2023-05-09", 10, date(2023, 6, 5)),
+            # Carryover date: nothing changes
+            ("2023-06-05", 10, date(2023, 6, 9)),
+            # Accruals keep on going...
+            ("2023-06-09", 11, date(2023, 7, 9)),
+            # Day of the level transition, accrual of the last period of the first level
+            # Maximum leaves of the first level reached
+            ("2024-01-04", 15, date(2024, 2, 17)),
+            # Second level first accrual
+            ("2024-02-17", 10, date(2024, 6, 5)),
+            # Carryover date: nothing changes
+            ("2024-06-05", 10, date(2024, 9, 4)),
+            # Level transition of the third level
+            # The allocated duration is the same because of the maximum of the second level
+            ("2024-09-04", 10, date(2025, 6, 5)),
+            # All days are lost on carryover
+            ("2025-06-05", 0, date(2025, 7, 15)),
+            # First accrual for the third level
+            ("2025-07-15", self._get_period_days("2024-09-04", "2025-07-14") / self._get_period_days("2024-07-15", "2025-07-14") * 12, date(2026, 6, 5)),
+        ))
+
+    @freeze_time('2023-09-01')
+    def test_accrual_creation_on_anterior_date(self):
+        accrual_plan = self.accrual_plan_weekly_carryover_lost
+        accrual_allocation = self.env['hr.leave.allocation'].new({
+            'name': 'Employee allocation',
+            'work_entry_type_id': self.work_entry_type.id,
+            'date_from': '2023-01-01',
+            'employee_id': self.employee_emp.id,
+            'accrual_plan_id': accrual_plan.id,
         })
+        # As the duration is set to a onchange, we need to force that onchange to run
+        accrual_allocation._onchange_process_accrual_plans()
+        accrual_allocation.action_approve()
+        # The amount of days should be computed as if it was accrued since
+        # the start date of the allocation.
+        self.assertAlmostEqual(accrual_allocation.number_of_days, 34.0, places=0)
+        self.assertFalse(accrual_allocation.last_accrual == accrual_allocation.date_from)
+        self._run_update_accrual_cron()
+        # The amount being already computed, the amount should stay the same after the cron
+        # running on the same day.
+        self.assertAlmostEqual(accrual_allocation.number_of_days, 34.0, places=0)
 
-        def get_remaining_leaves(*args):
-            return work_entry_type.get_allocation_data(self.employee_emp, datetime.date(*args))[self.employee_emp][0][1][
-                'remaining_leaves']
+    @freeze_time("2023-12-31")
+    def test_future_accrual_time(self):
+        """ Check that the carryover is processed correctly when the 'added_value_type' is set to 'hour' """
+        work_entry_type = self.work_entry_type_absence_hour_hour
+        accrual_plan = self.accrual_plan_monthly_hour
+        allocation = self.env['hr.leave.allocation'].create({
+            'name': 'Accrual allocation for employee',
+            'accrual_plan_id': accrual_plan.id,
+            'employee_id': self.employee_emp.id,
+            'work_entry_type_id': work_entry_type.id,
+            'number_of_days': 1 / self.hours_per_day,
+        })
+        allocation.action_approve()
+        self._assert_get_allocation_data_future(allocation, (
+            # First level starts on 2024-01-01 and first period end is 2024-02-01
+            ('2024-01-01', 1, 1),
+            # Accruals keep going on monthly...
+            ('2024-02-01', 2, 2),
+            ('2024-03-01', 3, 3),
+        ))
+        self._create_leave(self.employee_emp, work_entry_type, '2024-02-05', '2024-02-05', 10, 11)
+        self._assert_get_allocation_data_future(allocation, (
+            ('2024-01-01', 1, 1),
+            ('2024-02-01', 2, 2),
+            # The 1 day leave is taken into account, the remaining leaves should decrease
+            ('2024-02-05', 2, 1),
+            ('2024-03-01', 3, 2),
+        ))
 
-        with freeze_time("2024-03-01"):
-            # Simulate creating an allocation from frontend interface
-            with Form(self.env['hr.leave.allocation'].with_user(self.user_hrmanager)) as f:
-                f.accrual_plan_id = accrual_plan
-                f.employee_id = self.employee_emp
-                f.work_entry_type_id = work_entry_type
-                f.date_from = '2024-02-01'
-                f.name = "Accrual allocation for employee"
+    def test_added_type_during_onchange(self):
+        """ The purpose is to test whether the value of the `added_value_type`
+            field is correctly propagated from the first level to the second
+            during creation on the dialog form view.
+        """
+        accrual_plan = self.accrual_plan_monthly_carryover_all
+        # Simulate the onchange of the dialog form view
+        # Trigger the `_compute_added_value_type` method (with virtual records)
+        form = Form(accrual_plan)
+        with form.level_ids.new() as level:
+            self.assertEqual(level.added_value_type, 'hour')
 
-            allocation = f.record
+    @freeze_time('2024-03-02')
+    def test_accrual_creation_for_history(self):
+        """ Assert modifying the form fields of an accrual allocation updates the `number_of_days` properly """
+        with Form(self.env['hr.leave.allocation'], 'hr_holidays.hr_leave_allocation_view_form_manager') as form:
+            form.name = 'Test accrual allocation'
+            form.accrual_plan_id = self.accrual_plan_monthly_end_carry_over_lost_year_start
+            form.employee_id = self.employee_emp
+            form.work_entry_type_id = self.work_entry_type
+            form.date_from = '2024-03-01'
+            self.assertEqual(form.number_of_days, 0)
+            form.date_from = '2023-01-01'
+            # All days are lost on 2024-01-01, then 2 accrual for Jan. and Feb.
+            self.assertEqual(form.number_of_days, 2)
+            form.date_to = '2023-12-31'
+            # The allocation stops 1 day before the carryover date
+            # 11 month accrual + 30 days out of 31 days of December 2023 (because the accrual happens on the 31th of the month)
+            self.assertEqual(form.number_of_days, 11 + 30 / 31)
 
-            first_result = get_remaining_leaves(2024, 2, 21)
-            self.assertEqual(get_remaining_leaves(2024, 2, 21), first_result, "Function return result should persist")
+            form.number_of_days_display = 0
+            self.assertEqual(form.number_of_days_display, 0)
 
+        allocation = form.record
+        self.assertEqual(allocation.number_of_days, 0)
+
+        with Form(allocation, 'hr_holidays.hr_leave_allocation_view_form_manager') as form:
+            form.accrual_plan_id = self.accrual_plan_weekly_hour_max_leaves
+            self.assertEqual(form.type_request_unit, 'hour')
+            form.date_from = '2023-11-01'
+            # Max amount of allocated duration is reached (10h)
+            self.assertEqual(form.number_of_days, 10 / self.hours_per_day)
+
+            form.number_of_hours_display = 0
+            self.assertEqual(form.number_of_hours_display, 0)
+
+        self.assertEqual(allocation.number_of_days, 0)
+
+        with Form(allocation, 'hr_holidays.hr_leave_allocation_view_form_manager') as form:
+            form.work_entry_type_id = self.work_entry_type_hour
+            self.assertEqual(form.number_of_days, 0)
+
+            form.date_from = '2024-01-01'
+            form.date_to = False
+            # Max amount of allocated duration is reached (10h)
+            self.assertEqual(form.number_of_days, 10 / self.hours_per_day)
+
+            form.number_of_hours_display = 5
+            self.assertEqual(form.number_of_hours_display, 5)
+        self.assertEqual(allocation.number_of_days, 5 / self.hours_per_day)
+        allocation.action_approve()
+
+        self._assert_accrual_allocation_nbr_of_days_and_nextcall(allocation, (
+            # On next Monday
+            ('2024-03-04', 8 / self.hours_per_day, date(2024, 3, 11)),
+            # Next Monday, max amount of allocated duration is reached
+            ('2024-03-11', 10 / self.hours_per_day, date(2024, 3, 18)),
+        ))
+
+    def test_accrual_period_start_past_start_date(self):
+        """ Assert the `number_of_days` of an accrual allocation created in the past is computed properly """
+        accrual_plan = self.accrual_plan_monthly_start_carryover_year_start
+        accrual_plan.level_ids[0].write({
+            'added_value': 1,
+            'first_day': 1,
+        })
+        with freeze_time('2024-03-01'):
+            accrual_allocation = self._create_form_test_accrual_allocation(self.work_entry_type, '2024-01-01', self.employee_emp, accrual_plan, creator_user=self.user_hrmanager)
+            accrual_allocation.action_approve()
+
+        self._assert_accrual_allocation_nbr_of_days_and_nextcall(accrual_allocation, (
+            # 3 months elapsed: 3 times accrued
+            ('2024-03-01', 3, date(2024, 4, 1)),
+            # Accruals keep on going...
+            ('2024-04-01', 4, date(2024, 5, 1)),
+        ))
+
+    def test_cancel_invalid_leaves_with_regular_and_accrual_allocations(self):
+        """ Assert `hr.leave._cancel_invalid_leaves` doesn't change the `state` of a valid leave
+            covered by an accrual allocation
+        """
+        accrual_plan = self.accrual_plan_monthly_start_carryover_year_start
+        accrual_plan.level_ids[0].write({
+            'added_value': 1,
+            'first_day': 1,
+        })
+        allocations = self.env['hr.leave.allocation'].create([{
+                'name': 'Regular allocation',
+                'date_from': '2024-05-01',
+                'work_entry_type_id': self.work_entry_type.id,
+                'employee_id': self.employee_emp.id,
+                'number_of_days': 2,
+            }, {
+                'name': 'Accrual allocation',
+                'date_from': '2024-05-01',
+                'work_entry_type_id': self.work_entry_type.id,
+                'employee_id': self.employee_emp.id,
+                'accrual_plan_id': accrual_plan.id,
+                'number_of_days': 3,
+            },
+        ])
+        allocations.action_approve()
+
+        leave = self._create_leave(self.employee_emp, self.work_entry_type, '2024-05-13', '2024-05-17', validate=True)
+
+        with freeze_time('2024-05-06'):
+            self.env['hr.leave']._cancel_invalid_leaves()
+        self.assertEqual(leave.state, 'validate', "Leave must not be canceled")
+
+    @freeze_time("2024-01-01")
+    def test_accrual_leaves_cancel_cron(self):
+        """ Assert `hr.leave._cancel_invalid_leaves` changes the `state` of a leave that is not affordable
+            by an accrual plan, taking the `work.entry.type` `allows_negative` parameter into account
+        """
+        accrual_plan = self.accrual_plan_period_end_montlhy_max_carryover_year_start
+        self.env['hr.leave.allocation'].create([{
+                'employee_id': self.employee_emp.id,
+                'work_entry_type_id': self.work_entry_type_no_negative.id,
+                'accrual_plan_id': accrual_plan.id,
+                'number_of_days': 1,
+            }, {
+                'employee_id': self.employee_emp.id,
+                'work_entry_type_id': self.work_entry_type_negative.id,
+                'accrual_plan_id': accrual_plan.id,
+                'number_of_days': 1,
+            },
+        ])
+
+        excess_leave = self._create_leave(self.employee_emp, self.work_entry_type_no_negative, '2024-01-05', '2024-01-05')
+        allowed_negative_leave = self._create_leave(self.employee_emp, self.work_entry_type_negative, '2024-01-12', '2024-01-12')
+
+        # As accrual allocation don't take into account future leaves,
+        # it should be possible to take both leaves.
+        self._create_leave(self.employee_emp, self.work_entry_type_no_negative, '2024-01-04', '2024-01-04')
+        self._create_leave(self.employee_emp, self.work_entry_type_negative, '2024-01-11', '2024-01-11')
+        self.env.flush_all()
+
+        self.env['hr.leave']._cancel_invalid_leaves()
+
+        # Since both leave are outside an allocation validity,
+        # they are detected as discrepancies. However, the
+        # leave that is not exceeding the negative amount should be kept
+        # as it is valid according to the configuration.
+        self.assertEqual(excess_leave.state, 'cancel')
+        self.assertEqual(allowed_negative_leave.state, 'validate')
+
+        self._create_leave(self.employee_emp, self.work_entry_type_negative, '2024-01-10', '2024-01-10')
+
+        self.env['hr.leave']._cancel_invalid_leaves()
+
+        # The last added leave creates a discrepancy that exceeds the
+        # maximum amount allowed in negative.
+        self.assertEqual(allowed_negative_leave.state, 'cancel')
+
+    @freeze_time("2024-03-01")
     def test_future_accural_time_with_leaves_taken_in_the_past(self):
-        work_entry_type = self.env['hr.work.entry.type'].create({
-            'name': 'Test Leave Type 2',
-            'code': 'Test Leave Type 2',
-            'count_as': 'absence',
-            'requires_allocation': True,
-            'allocation_validation_type': 'no_validation',
-            'request_unit': 'day',
-            'unit_of_measure': 'day',
-        })
-        accrual_plan = self.env['hr.leave.accrual.plan'].create({
-            'name': 'Accrual Plan For Test',
-            'accrued_gain_time': 'start',
-            'can_be_carryover': True,
-            'carryover_date': 'year_start',
-            'level_ids': [(0, 0, {
-                'milestone_date': 'after',
-                'start_count': 1,
-                'start_type': 'day',
-                'added_value': 1,
-                'added_value_type': 'day',
-                'frequency': 'daily',
-                'cap_accrued_time': True,
-                'maximum_leave': 10,
-                'action_with_unused_accruals': 'all',
-            })],
-        })
+        work_entry_type = self.work_entry_type_day
+        accrual_plan = self.accrual_plan_daily_start_max_leaves_carryover_year_start
 
-        def get_remaining_leaves(*args):
-            return work_entry_type.get_allocation_data(self.employee_emp, datetime.date(*args))[self.employee_emp][0][1][
-                'remaining_leaves']
+        allocation = self._create_form_test_accrual_allocation(
+            work_entry_type, '2024-02-01', self.employee_emp, accrual_plan, creator_user=self.user_hrmanager)
 
-        with freeze_time("2024-03-01"):
-            # Simulate creating an allocation from frontend interface
-            with Form(self.env['hr.leave.allocation'].with_user(self.user_hrmanager)) as f:
-                f.accrual_plan_id = accrual_plan
-                f.employee_id = self.employee_emp
-                f.work_entry_type_id = work_entry_type
-                f.date_from = '2024-02-01'
-                f.name = "Accrual allocation for employee"
-
-            self.assertEqual(get_remaining_leaves(2024, 3, 1), 10, "The cap is reached, no more leaves should be accrued")
-
-            leave = self.env['hr.leave'].create({
-                'name': 'leave',
-                'employee_id': self.employee_emp.id,
-                'work_entry_type_id': work_entry_type.id,
-                'request_date_from': '2024-02-26',
-                'request_date_to': '2024-03-01',
-            })
-            leave.action_approve()
-            self.assertEqual(get_remaining_leaves(2024, 3, 1), 5, "5 day should be deduced from the allocation")
-            self.assertEqual(get_remaining_leaves(2024, 3, 3), 7, "2 days should be added to the accrual allocation")
-            self.assertEqual(get_remaining_leaves(2024, 3, 10), 10, "Accrual allocation should be capped at 10")
-
-            leave = self.env['hr.leave'].create({
-                'name': 'leave',
-                'employee_id': self.employee_emp.id,
-                'work_entry_type_id': work_entry_type.id,
-                'request_date_from': '2024-03-04',
-                'request_date_to': '2024-03-08',
-            })
-            leave.action_approve()
-            self.assertEqual(get_remaining_leaves(2024, 3, 4), 3, "5 days should be deduced from the allocation and a new day should be accrued")
-            self.assertEqual(get_remaining_leaves(2024, 3, 11), 10, "Accrual allocation should be capped at 10")
+        self._assert_get_allocation_data_future(allocation, (
+            # The available leaves maximum is reached
+            ('2024-03-01', 10, 10),
+        ))
+        self._create_leave(self.employee_emp, work_entry_type, '2024-02-26', '2024-03-01', validate=True)
+        self._assert_get_allocation_data_future(allocation, (
+            # Only 5 days left
+            ('2024-03-01', 10, 5),
+            ('2024-03-02', 11, 6),
+            ('2024-03-03', 12, 7),
+            ('2024-03-04', 13, 8),
+            # The available leaves maximum is reached again
+            ('2024-03-10', 15, 10),
+        ))
+        # 5 days leave (the 4th is a Monday)
+        self._create_leave(self.employee_emp, work_entry_type, '2024-03-04', '2024-03-08', validate=True)
+        self._assert_get_allocation_data_future(allocation, (
+            # Only 5 hours left
+            ('2024-03-04', 13, 3),
+            # The available leaves maximum is reached again
+            ('2024-03-11', 20, 10),
+        ))
 
     @freeze_time('2024-01-01')
     def test_validate_leaves_with_more_days_than_allocation(self):
+        """ Assert taking leave without having enough allocation raises error """
         allocation = self.env['hr.leave.allocation'].create({
             'name': 'Accrual allocation for employee',
             'employee_id': self.employee_emp.id,
@@ -2824,58 +2775,27 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
         })
 
         allocation.action_approve()
-        with self.assertRaises(ValidationError):
-            self.env['hr.leave'].create([{
-                'employee_id': self.employee_emp.id,
-                'work_entry_type_id': self.work_entry_type.id,
-                'request_date_from': '2024-01-09',
-                'request_date_to': '2024-01-12',
-            }])
+        # Should explode because the allocation doesn't give enough day to cover the entire leave
+        with self.assertRaisesRegex(ValidationError, ' does not have a valid allocation for the leave type '):
+            self._create_leave(self.employee_emp, self.work_entry_type, '2024-01-09', '2024-01-12')
 
-        leave = self.env['hr.leave'].create([{
-                'employee_id': self.employee_emp.id,
-                'work_entry_type_id': self.work_entry_type.id,
-                'request_date_from': '2024-01-09 08:00:00',
-                'request_date_to': '2024-01-09 17:00:00',
-            }])
+        # Number of days given by the allocation is 1 -> enough credits -> no error
+        leave = self._create_leave(self.employee_emp, self.work_entry_type, '2024-01-09 08:00:00', '2024-01-09 17:00:00', validate=True)
 
-        leave.action_approve()
         leave.action_refuse()
         leave.write({
             'request_date_from': '2024-01-09',
             'request_date_to': '2024-01-12',
         })
-
-        with self.assertRaises(ValidationError):
+        # Should explode because the allocation doesn't give enough day to cover the entire leave
+        with self.assertRaisesRegex(ValidationError, ' does not have a valid allocation for the leave type '):
             leave.action_approve()
 
     def test_compute_allocation_days_after_adding_employee(self):
+        """ Assert changing the employee of an accrual allocation updates the `number_of_days`
+            according to its attendances (with a plan based on work time)
         """
-        Test the addition of the employee after the date when creating an allocation
-        will the number_of_days be computed or not. Also that the number_of_days
-        gets recomputed when changing the employee
-        """
-        accrual_plan = self.env['hr.leave.accrual.plan'].create({
-            'name': 'Monthly accrual',
-            'is_based_on_worked_time': True,
-            'transition_mode': 'immediately',
-            'can_be_carryover': True,
-            'carryover_date': 'year_start',
-            'accrued_gain_time': 'end',
-            'level_ids':
-                [(0, 0, {
-                    'added_value_type': 'day',
-                    'milestone_date': 'after',
-                    'start_count': 1,
-                    'start_type': 'day',
-                    'added_value': 1,
-                    'frequency': 'daily',
-                    'first_day': '1',
-                    'cap_accrued_time': False,
-                    'action_with_unused_accruals': 'all',
-                }),
-             ],
-        })
+        accrual_plan = self.accrual_plan_daily_carryover_year_start_all_work_time
 
         with freeze_time('2024-08-19'):
             attendances = []
@@ -2890,203 +2810,30 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                         'hour_from': 11,
                         'hour_to': 13,
                         'dayofweek': str(index),
-                    })
+                    }),
                 ])
             calendar_emp = self.env['resource.calendar'].create({
                 'name': '20 Hours',
                 'attendance_ids': attendances,
             })
             self.employee_hrmanager.resource_calendar_id = calendar_emp.id
-
-            with Form(self.env['hr.leave.allocation'].with_user(self.user_hrmanager)) as f:
-                f.accrual_plan_id = accrual_plan
-                f.date_from = '2024-08-07'
-                f.work_entry_type_id = self.work_entry_type
-                f.employee_id = self.employee_emp
-                f.name = "Employee Allocation"
-
-            accrual_allocation = f.record
-            allocation_days = accrual_allocation.number_of_days
+            accrual_allocation = self._create_form_test_accrual_allocation(
+                self.work_entry_type, '2024-08-07', self.employee_emp, accrual_plan, creator_user=self.user_hrmanager)
+            # First level starts on 08-08, which is a Thursday, so the guy gets 2 days for that week (Thursday and Friday),
+            # plus 5 days for the next week ('til 08-17 included which is a Friday)
             self.assertEqual(accrual_allocation.number_of_days, 7.0)
 
-            with Form(accrual_allocation) as accForm:
-                accForm.employee_id = self.employee_hrmanager
+            with Form(accrual_allocation) as alloc_form:
+                alloc_form.employee_id = self.employee_hrmanager
 
-            updated_allocation = accForm.record
-
-            self.assertNotEqual(updated_allocation.number_of_days, allocation_days)
-            self.assertEqual(updated_allocation.number_of_days, 3.0)
-
-    def test_no_days_accrued_on_carryover_date(self):
-        """
-        All time off days should be accrued on the specified date by the current milestone of the accrual
-        plan. No days should be accrued on a carryover date.
-
-        Create an accrual plan:
-            - Carryover date: July 1st.
-        Create a milestone:
-            - Number of accrued days: 10
-            - Frequency: Yearly
-            - Start accrual immediately on the allocation start date.
-            - Accrual date: January 1st
-            - Carryover policy: All days carry over
-        Create an allocation:
-            - Start date: 01/01/2024
-            - Type: Accrual
-            - Accrual Plan: Use the one defined above.
-
-        On 01/01/2025 (Accrual date), 10 days are accrued to the employee.
-        On 01/07/2025 (Carryover date), no days should be accrued.
-        On 01/01/2026 (Accrual date), 10 days are accrued to the employee. Total accrued days = 20 days.
-        """
-        accrual_plan = self.env['hr.leave.accrual.plan'].create({
-            'name': 'Accrual Plan For Test',
-            'can_be_carryover': True,
-            'carryover_date': 'other',
-            'carryover_day': 1,
-            'carryover_month': '7',
-            'level_ids': [(0, 0, {
-                'added_value': 10,
-                'added_value_type': 'day',
-                'milestone_date': 'creation',
-                'start_type': 'day',
-                'frequency': 'yearly',
-                'action_with_unused_accruals': 'all',
-            })],
-        })
-        with freeze_time('2024-01-01'):
-            allocation = self.env['hr.leave.allocation'].create({
-                'name': 'Accrual allocation for employee',
-                'employee_id': self.employee_emp.id,
-                'work_entry_type_id': self.work_entry_type.id,
-                'number_of_days': 0,
-                'accrual_plan_id': accrual_plan.id,
-                'date_from': datetime.date(2024, 1, 1)
-            })
-            allocation.action_approve()
-
-        with freeze_time('2025-01-01'):
-            allocation._update_accrual()
-        self.assertEqual(allocation.number_of_days, 10, "10 days should be accrued")
-
-        with freeze_time('2025-07-01'):
-            allocation._update_accrual()
-        self.assertEqual(allocation.number_of_days, 10, "No Days should be accrued on the carryover date")
-
-        with freeze_time('2026-01-01'):
-            allocation._update_accrual()
-        self.assertEqual(allocation.number_of_days, 20,
-                         "10 additional days should be accrued on January 1st. The total number of accrued days should be 20")
-
-    def test_matching_accrual_and_carryover_dates(self):
-        """
-        When the accrual date and carry over date are the same, the carry over policy should be applied
-        first, then the time off days should be accrued to the employee
-
-        Create an accrual plan:
-            - Carryover date: January 1st.
-        Create a milestone:
-            - Number of accrued days: 10
-            - Frequency: Yearly
-            - Start accrual immediately on the allocation start date.
-            - Accrual date: January 1st
-            - Carryover policy: No days carry over
-        Create an allocation:
-            - Start date: 01/01/2024
-            - Type: Accrual
-            - Accrual Plan: Use the one defined above.
-
-        On 01/01/2025 (Accrual date), 10 days are accrued to the employee.
-        On 01/01/2026 (Accrual date and carryover date):
-            * The previous 10 days are lost.
-            * 10 days are accrued to the employee.
-            * Total employee should have 10 days.
-        """
-        accrual_plan = self.env['hr.leave.accrual.plan'].create({
-            'name': 'Accrual Plan For Test',
-            'can_be_carryover': True,
-            'carryover_date': 'year_start',
-            'level_ids': [(0, 0, {
-                'added_value': 10,
-                'added_value_type': 'day',
-                'milestone_date': 'creation',
-                'start_type': 'day',
-                'frequency': 'yearly',
-                'action_with_unused_accruals': 'lost'
-            })],
-        })
-        with freeze_time('2024-01-01'):
-            allocation = self.env['hr.leave.allocation'].create({
-                'name': 'Accrual allocation for employee',
-                'employee_id': self.employee_emp.id,
-                'work_entry_type_id': self.work_entry_type.id,
-                'number_of_days': 0,
-                'accrual_plan_id': accrual_plan.id,
-                'date_from': datetime.date(2024, 1, 1)
-            })
-            allocation.action_approve()
-
-        with freeze_time('2025-01-01'):
-            allocation._update_accrual()
-        self.assertEqual(allocation.number_of_days, 10, "10 days are accrued")
-
-        with freeze_time('2026-01-01'):
-            allocation._update_accrual()
-        self.assertEqual(allocation.number_of_days, 10,
-                         "All previous days are lost. 10 new days are added.")
+            # Only 3 days of attendances for the second week of August for that employee: 12, 13 and 14
+            self.assertEqual(accrual_allocation.number_of_days, 3.0)
 
     def test_matching_carryover_and_level_transition_dates(self):
+        """ Assert number_of_days computation is correct for an accrual allocation having 2 levels and
+            the carryover (days are lost) happens on level transition
         """
-        When the carry over date matches the date of a level transition, some days are accrued. The number of
-        accrued days is proportionate to the period that elapsed from the accrual period of the previous
-        level. For example if 24 days are accrued yearly, and only 2 months have passed before the level
-        transition has occurred, then the number of accrued days will be 2/12 * 24 = 4 days
-
-        Create an accrual plan:
-            - Carryover date: July 1st.
-        Create a milestone:
-            - Number of accrued days: 12
-            - Frequency: Yearly
-            - Accrual date: January 1st
-            - Carryover policy: No days carry over
-        Create an allocation:
-            - Start date: 01/01/2024
-            - Type: Accrual
-            - Accrual Plan: Use the one defined above.
-
-        On 01/01/2025 (Accrual date), 12 days are accrued to the employee.
-        On 01/07/2025 (Level transition date and carryover date):
-            - The previous 12 days are lost.
-            - (6/12) * 12 = 6 days are accrued to the employee.
-            - Level tranisition occurs.
-        On 01/01/2026 (Accrual date):
-            - (6/12) / 14 = 7 days are accrued to the employee.
-            - Total number of days = 6 + 7 = 13 days
-        """
-        accrual_plan = self.env['hr.leave.accrual.plan'].create({
-            'name': 'Accrual Plan For Test',
-            'can_be_carryover': True,
-            'carryover_date': 'other',
-            'carryover_day': 1,
-            'carryover_month': '7',
-            'level_ids': [(0, 0, {
-                'added_value': 12,
-                'added_value_type': 'day',
-                'frequency': 'yearly',
-                'milestone_date': 'creation',
-                'start_type': 'day',
-                'action_with_unused_accruals': 'lost'
-            }),
-            (0, 0, {
-                'added_value': 14,
-                'added_value_type': 'day',
-                'frequency': 'yearly',
-                'milestone_date': 'after',
-                'start_count': 18,
-                'start_type': 'month',
-                'action_with_unused_accruals': 'lost'
-            })],
-        })
+        accrual_plan = self.accrual_plan_2_lvls_yearly_carryover_lost
         with freeze_time('2024-01-01'):
             allocation = self.env['hr.leave.allocation'].create({
                 'name': 'Accrual allocation for employee',
@@ -3094,82 +2841,27 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'work_entry_type_id': self.work_entry_type.id,
                 'number_of_days': 0,
                 'accrual_plan_id': accrual_plan.id,
-                'date_from': datetime.date(2024, 1, 1)
             })
             allocation.action_approve()
 
-        with freeze_time('2025-01-01'):
-            allocation._update_accrual()
-        self.assertEqual(allocation.number_of_days, 12, "12 days are accrued")
-
-        with freeze_time('2025-07-01'):
-            allocation._update_accrual()
-        self.assertAlmostEqual(allocation.number_of_days, 6, 1,
-                         "All previous days are lost. 6 new days are added.")
-        with freeze_time('2026-01-01'):
-            allocation._update_accrual()
-        self.assertAlmostEqual(allocation.number_of_days, 13, 1,
-                        "7 days are accrued. Total days = 6 + 7 = 13.")
+        year_2025_days = self._get_period_days("2025-01-01", "2025-12-31")
+        self._assert_accrual_allocation_nbr_of_days_and_nextcall(allocation, (
+            ('2024-01-01', 0, date(2024, 7, 1)),
+            # Carryover happens, nothing changes
+            ('2024-07-01', 0, date(2025, 1, 1)),
+            # Yearly accrual happens
+            ('2025-01-01', 12, date(2025, 7, 1)),
+            # Level transition happens: accrues for the last period of the first level
+            ('2025-07-01', days := self._get_period_days("2025-01-01", "2025-06-30") / year_2025_days * 12, date(2026, 1, 1)),
+            # Accrues for the period beginning at the start of the second level up to now
+            ('2026-01-01', days + self._get_period_days("2025-07-01", "2025-12-31") / year_2025_days * 14, date(2026, 7, 1)),
+        ))
 
     def test_accrual_plan_with_multiple_levels(self):
+        """ Assert the carryover policy of the levels of the accrual allocation are applied correctly (lost then limited)
+            for a 2 levels accrual allocation
         """
-        Test that if an accrual plan with multiple levels accrues days at the start of the accrual period, then the carryover
-        will be executed correctly and that the days are accrued correctly for the level transition.
-
-        Define an accrual plan:
-            1. The days are accrued at the start of the accrual period.
-            2. The carryover date is on June 1st (01/06).
-            3. Has 2 levels:
-                a. First Level:
-                      I. Starts immediately on allocation start date
-                     II. Accrues 1 day monthly.
-                    III. Carryover policy is None (no days are carried over).
-                b. Second level:
-                      I. Starts 20 Months after allocation start date.
-                     II. Accrues 1 days monthly on January 1st (01/01).
-                    III. Carryover policy is carryover with a maximum of 5.
-
-        Create an allocation that starts 01/01/2024 and uses the above accrual plan.
-
-        1. From 01/01/2024 to 01/05/2024: The employee is accrued 5 days.
-        2. On 01/06/2024: The 5 days are lost due to carryover policy. 1 day is accrued for the new month.
-           The employee now has 1 day.
-        3. From 01/07/2024 to 01/08/2024: The employee is accrued 2 days.
-           The employee now has 3 days.
-        4. On 01/09/2024: Transition to new level. 1 day is accrued for the new month.
-           The employee now has 4 days.
-        5. From 01/010/2024 to 01/012/2024: 3 days are accrued.
-           The employee now has 7 days.
-        6. On 01/01/2025: 1 day is accrued.
-        Total number of days =  8 days
-        """
-        accrual_plan = self.env['hr.leave.accrual.plan'].create({
-            'name': 'Accrual Plan For Test',
-            'accrued_gain_time': 'start',
-            'can_be_carryover': True,
-            'carryover_date': 'other',
-            'carryover_day': 1,
-            'carryover_month': '6',
-            'level_ids': [(0, 0, {
-                'added_value': 1,
-                'added_value_type': 'day',
-                'frequency': 'monthly',
-                'milestone_date': 'creation',
-                'start_type': 'day',
-                'action_with_unused_accruals': 'lost'
-            }),
-            (0, 0, {
-                'added_value': 1,
-                'added_value_type': 'day',
-                'frequency': 'monthly',
-                'milestone_date': 'after',
-                'start_count': 20,
-                'start_type': 'month',
-                'action_with_unused_accruals': 'all',
-                'carryover_options': 'limited',
-                'postpone_max_days': 5
-            })],
-        })
+        accrual_plan = self.accrual_plan_2_lvls_monthly_carryover_lost_limited
         with freeze_time('2024-01-01'):
             allocation = self.env['hr.leave.allocation'].create({
                 'name': 'Accrual allocation for employee',
@@ -3177,185 +2869,55 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'work_entry_type_id': self.work_entry_type.id,
                 'number_of_days': 0,
                 'accrual_plan_id': accrual_plan.id,
-                'date_from': datetime.date(2024, 1, 1)
             })
             allocation.action_approve()
 
-        with freeze_time('2024-05-01'):
-            allocation._update_accrual()
-        self.assertEqual(allocation.number_of_days, 5)
-
-        with freeze_time('2024-06-01'):
-            allocation._update_accrual()
-        self.assertEqual(allocation.number_of_days, 1)
-
-        with freeze_time('2024-08-01'):
-            allocation._update_accrual()
-        self.assertEqual(allocation.number_of_days, 3)
-
-        with freeze_time('2024-09-01'):
-            allocation._update_accrual()
-        self.assertEqual(allocation.number_of_days, 4)
-
-        with freeze_time('2024-12-01'):
-            allocation._update_accrual()
-        self.assertEqual(allocation.number_of_days, 7)
-
-        with freeze_time('2025-01-01'):
-            allocation._update_accrual()
-        self.assertEqual(allocation.number_of_days, 8)
+        self._assert_accrual_allocation_nbr_of_days_and_nextcall(allocation, (
+            ('2024-01-01', 1, date(2024, 2, 1)),
+            ('2024-05-01', 5, date(2024, 6, 1)),
+            # Carryover (days are lost) + accrual for the following month
+            ('2024-06-01', 1, date(2024, 7, 1)),
+            # Accruals keep on going...
+            ('2024-07-01', 2, date(2024, 8, 1)),
+            ('2024-08-01', 3, date(2024, 9, 1)),
+            ('2024-09-01', 4, date(2024, 10, 1)),
+            # On level transition
+            # First accrual of the second plan: use the second level 'added_value'
+            ('2024-10-01', 6, date(2024, 11, 1)),
+            ('2025-05-01', 6 + 7 * 2, date(2025, 6, 1)),
+            # Carryover happens, 5 days are kept + accrual for the following month
+            ('2025-06-01', 5 + 2, date(2025, 7, 1)),
+        ))
 
     def test_accrual_plan_with_multiple_levels_2(self):
+        """ Assert the carryover policy of the levels of the accrual allocation are applied correctly (lost then all)
+            for a 2 levels accrual allocation
         """
-        Test that if an accrual plan with multiple levels accrues days at the start of the accrual period, then the carryover
-        will be executed correctly and that the days are accrued correctly for the level transition.
-
-        Define an accrual plan:
-            1. The days are accrued at the start of the accrual period.
-            2. The carryover date is on June 1st (01/06).
-            3. Has 2 levels:
-                a. First Level:
-                      I. Starts immediately on allocation start date
-                     II. Accrues 10 day yearly.
-                    III. Carryover policy is None (no days are carried over).
-                b. Second level:
-                      I. Starts 30 Months after allocation start date.
-                     II. Accrues 12 days yearly on January 1st (01/01).
-                    III. Carryover policy is all (all days carry over).
-
-        Create an allocation that starts 01/01/2024 and uses the above accrual plan.
-
-        1. On 01/01/2024: The employee is accrued 10 days.
-        2. On 01/01/2025: The employee is accrued 10 days.
-        3. On 01/06/2025: All the days are lost due to carryover policy.
-        4. On 01/01/2026: The employee is accrued 10 days.
-        5. On 01/06/2026: All the days are lost due to carryover policy.
-        6. On 01/09/2026: Level transition occurrs. 6.67 days are accrued.
-        7. On 01/01/2027:
-            - 4 days are accrued for the period from 01/09/2026 until 31/12/2026.
-            - 12 days are accrued for the new period (becase days are accrue at the start of the accrual period)
-            - Total number of days is 6.67 + 4 + 12 = 22.67 days.
-        """
-        accrual_plan = self.env['hr.leave.accrual.plan'].create({
-            'name': 'Accrual Plan For Test',
-            'accrued_gain_time': 'start',
-            'can_be_carryover': True,
-            'carryover_date': 'other',
-            'carryover_day': 1,
-            'carryover_month': '6',
-            'level_ids': [(0, 0, {
-                'added_value': 10,
-                'added_value_type': 'day',
-                'frequency': 'yearly',
-                'milestone_date': 'creation',
-                'start_type': 'day',
-                'action_with_unused_accruals': 'lost'
-            }),
-            (0, 0, {
-                'added_value': 12,
-                'added_value_type': 'day',
-                'frequency': 'yearly',
-                'milestone_date': 'after',
-                'start_count': 32,
-                'start_type': 'month',
-                'action_with_unused_accruals': 'all',
-            })],
-        })
+        accrual_plan = self.accrual_plan_2_lvls_start_yearly_carryover_lost_all
         with freeze_time('2024-01-01'):
             allocation = self._create_form_test_accrual_allocation(self.work_entry_type, '2024-01-01', self.employee_emp, accrual_plan)
             allocation.action_approve()
-        self.assertEqual(allocation.number_of_days, 10)
 
-        with freeze_time('2025-01-01'):
-            allocation._update_accrual()
-        self.assertEqual(allocation.number_of_days, 20)
-
-        with freeze_time('2025-06-01'):
-            allocation._update_accrual()
-        self.assertEqual(allocation.number_of_days, 0)
-
-        # Accrual from 2026-01-01 to 2026-09-01 (level transition)
-        with freeze_time('2026-01-01'):
-            allocation._update_accrual()
-        self.assertAlmostEqual(allocation.number_of_days, 6.66, places=2)
-
-        with freeze_time('2026-06-01'):
-            allocation._update_accrual()
-        self.assertEqual(allocation.number_of_days, 0)
-
-        # Level transition happens after 32 month
-        with freeze_time('2026-09-01'):
-            allocation._update_accrual()
-        # Should be 4.01 but anyway (accrual for 2026-09-01 -> 2027-01-01), will be fixed someday
-        self.assertAlmostEqual(allocation.number_of_days, 10.7, places=1)
-
-        # One full accrual (+12 days)
-        with freeze_time('2027-01-01'):
-            allocation._update_accrual()
-        # Should be 16.01 but anyway
-        self.assertAlmostEqual(allocation.number_of_days, 22.67, 2)
+        year_2026_days = self._get_period_days('2026-01-01', '2026-12-31')
+        self._assert_accrual_allocation_nbr_of_days_and_nextcall(allocation, (
+            # First level directly starts and accrues for the next year
+            ('2024-01-01', 10, date(2024, 6, 1)),
+            # All days lost on carryover date
+            ('2024-06-01', 0, date(2025, 1, 1)),
+            # Accrual for year 2025
+            ('2025-01-01', 10, date(2025, 6, 1)),
+            ('2025-06-01', 0, date(2026, 1, 1)),
+            # Accrual 'til the next level transition
+            ('2026-01-01', self._get_period_days('2026-01-01', '2026-08-31') / year_2026_days * 10, date(2026, 6, 1)),
+            ('2026-06-01', 0, date(2026, 9, 1)),
+            ('2026-09-01', days := self._get_period_days('2026-09-01', '2026-12-31') / year_2026_days * 12, date(2027, 1, 1)),
+            ('2027-01-01', days + 12, date(2027, 6, 1)),
+        ))
 
     def test_carried_over_days_expiry_date_computation(self):
+        """ Assert days expiration correctly behaves with a 2 levels accrual allocation
         """
-        Assert that the expiration date is computed correclty in the case of an accrual plan with multiple levels.
-        - Create an accrual plan:
-            - Carryover date: 1 April
-            - First level:
-                - Accrues 10 days.
-                - Accrual date: bi-yearly on 1 January and 1 July
-                - Starts immediately on allocation start date
-                - Carryover policy: all days carry over
-                - Carried over days validity: 5 months.
-            - Second level:
-                - Accrues 20 days.
-                - Accrual date: bi-yearly on 1 January and 1 July
-                - Starts 17 months after accrual start date.
-                - Carryover policy: all days carry over
-                - Carried over days validity: 2 months.
-        - Create an allocation that uses the above accrual plan:
-            - Starts on 01/01/2023
-        - First carryover date 01/04/2024. The carried over days will expire in 5 months.
-        - The expiration date should be 01/09/2024 and not 01/06/2024. In other words, the expiration date
-          should be computed using the first level's validity period and not the second level's expiration period.
-        """
-        accrual_plan = self.env['hr.leave.accrual.plan'].create({
-            'name': 'Accrual Plan For Test',
-            'can_be_carryover': True,
-            'carryover_date': 'other',
-            'carryover_day': 1,
-            'carryover_month': '4',
-            'level_ids': [(0, 0, {
-                'added_value_type': 'day',
-                'milestone_date': 'creation',
-                'start_type': 'day',
-                'added_value': 10,
-                'frequency': 'biyearly',
-                'first_month': '1',
-                'first_month_day': 1,
-                'second_month': '7',
-                'second_month_day': 1,
-                'action_with_unused_accruals': 'all',
-                'accrual_validity': True,
-                'accrual_validity_type': 'month',
-                'accrual_validity_count': 5,
-            }),
-            (0, 0, {
-                'added_value_type': 'day',
-                'milestone_date': 'after',
-                'start_count': 17,
-                'start_type': 'month',
-                'added_value': 20,
-                'frequency': 'biyearly',
-                'first_month': '1',
-                'first_month_day': 1,
-                'second_month': '7',
-                'second_month_day': 1,
-                'action_with_unused_accruals': 'all',
-                'accrual_validity': True,
-                'accrual_validity_type': 'month',
-                'accrual_validity_count': 2,
-            })],
-        })
+        accrual_plan = self.accrual_plan_2_lvls_biyearly_expiring
         with freeze_time('2023-01-01'):
             allocation = self.env['hr.leave.allocation'].with_user(self.user_hrmanager_id).create({
                 'name': 'Accrual allocation for employee',
@@ -3366,139 +2928,37 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
             })
             allocation.action_approve()
 
-        with freeze_time('2024-04-01'):
-            allocation._update_accrual()
-            self.assertEqual(allocation.carried_over_days_expiration_date, datetime.date(2024, 9, 1))
-
-    def test_carried_over_days_expiry_date_computation_2(self):
-        """
-        Assert that the expiration date is computed correclty in the case of an accrual plan with multiple levels.
-        - Create an accrual plan:
-            - Carryover date: 1 April
-            - First level:
-                - Accrues 10 days.
-                - Accrual date: yearly on 1 January
-                - Starts immediately on allocation start date
-                - Carryover policy: all days carry over
-                - Carried over days validity: 2 months.
-            - Second level:
-                - Accrues 20 days.
-                - Accrual date: yearly on 1 January
-                - Starts 2 years after accrual start date.
-                - Carryover policy: all days carry over
-                - Carried over days validity: 3 months.
-        - Create an allocation that uses the above accrual plan:
-            - Starts on 01/01/2023
-        - 01/04/2024 carryover date. The carried over days will expire in 2 months.
-        - 01/06/2024 expiration date .
-        - 01/01/2025 level transition date.
-        - 01/04/2025 carryover date. The carried over days will expire in 3 months.
-        - 01/07/2025 expiration date.
-        """
-        accrual_plan = self.env['hr.leave.accrual.plan'].create({
-            'name': 'Accrual Plan For Test',
-            'can_be_carryover': True,
-            'carryover_date': 'other',
-            'carryover_day': 1,
-            'carryover_month': '4',
-            'level_ids': [(0, 0, {
-                'added_value_type': 'day',
-                'milestone_date': 'creation',
-                'start_type': 'day',
-                'added_value': 10,
-                'frequency': 'yearly',
-                'action_with_unused_accruals': 'all',
-                'accrual_validity': True,
-                'accrual_validity_type': 'month',
-                'accrual_validity_count': 2,
-            }),
-            (0, 0, {
-                'added_value_type': 'day',
-                'milestone_date': 'after',
-                'start_count': 2,
-                'start_type': 'year',
-                'added_value': 20,
-                'frequency': 'yearly',
-                'action_with_unused_accruals': 'all',
-                'accrual_validity': True,
-                'accrual_validity_type': 'month',
-                'accrual_validity_count': 3,
-            })],
-        })
-        with freeze_time('2023-01-01'):
-            allocation = self.env['hr.leave.allocation'].with_user(self.user_hrmanager_id).create({
-                'name': 'Accrual allocation for employee',
-                'accrual_plan_id': accrual_plan.id,
-                'employee_id': self.employee_emp.id,
-                'work_entry_type_id': self.work_entry_type.id,
-                'number_of_days': 0,
-            })
-            allocation.action_approve()
-
-        with freeze_time('2024-04-01'):
-            allocation._update_accrual()
-            self.assertEqual(allocation.carried_over_days_expiration_date, datetime.date(2024, 6, 1))
-
-        with freeze_time('2025-04-01'):
-            allocation._update_accrual()
-            self.assertEqual(allocation.carried_over_days_expiration_date, datetime.date(2025, 7, 1))
+        year_2024_first_period_days = self._get_period_days('2024-01-01', '2024-06-30')
+        self._assert_accrual_allocation_nbr_of_days_and_nextcall(allocation, (
+            # Start of the first level, days will be accrued at the end of the period
+            ('2023-01-01', 0, date(2023, 4, 1)),
+            # Carryover date, nothing changes
+            ('2023-04-01', 0, date(2023, 7, 1)),
+            # Accrual for the first half of the year
+            ('2023-07-01', 10, date(2023, 9, 1)),
+            # Days expire 5 months after the carryover date
+            ('2023-09-01', 10, date(2024, 1, 1)),
+            # Second accrual for the second half of the year
+            ('2024-01-01', days := 20, date(2024, 2, 1)),
+            # Level transition: accrual for 1 month out of the 6 month of the first half of the year
+            ('2024-02-01', days := days + self._get_period_days('2024-01-01', '2024-01-31') /
+                year_2024_first_period_days * 10, date(2024, 4, 1)),
+            # Carryover date, nothing changes
+            ('2024-04-01', days, date(2024, 6, 1)),
+            # Days now expire 2 months later
+            ('2024-06-01', 0, date(2024, 7, 1)),
+            # Accrual for the left 5 months of the first half of the year
+            ('2024-07-01', days := self._get_period_days('2024-02-01', '2024-06-30') /
+                year_2024_first_period_days * 15, date(2025, 1, 1)),
+            # Second level keeps on going
+            ('2025-01-01', days + 15, date(2025, 4, 1)),
+        ))
 
     def test_carried_over_days_expiry_date_computation_3(self):
+        """ Assert the expiration date and nextcall of an accrual allocation are computed correctly for
+            a 2 levels accrual allocation
         """
-        Assert that the expiration date is computed correclty in the case of an accrual plan with multiple levels.
-        - Create an accrual plan:
-            - Carryover date: 1 May
-            - First level:
-                - Accrues 10 days.
-                - Accrual date: yearly on 1 January
-                - Starts immediately on allocation start date
-                - Carryover policy: all days carry over
-                - Carried over days validity: 2 months.
-            - Second level:
-                - Accrues 20 days.
-                - Accrual date: yearly on 1 January
-                - Starts 29 months (2 years and 5 months) after accrual start date.
-                - Carryover policy: all days carry over
-                - Carried over days validity: 3 months.
-        - Create an allocation that uses the above accrual plan:
-            - Starts on 01/01/2023
-        - 01/05/2024 carryover date. The carried over days will expire in 2 months.
-        - 01/07/2024 expiration date .
-        - 01/05/2025 carryover date. The carried over days will expire in 2 months.
-        - 01/06/2025 level transition date. The carried over days on 01/05/2025 should still expire on 01/07/2025
-        - 01/07/2025 expiration date.
-        - 01/01/2026 accrual date (the new expiration date should be computed and set to 01/08/2026)
-        """
-        accrual_plan = self.env['hr.leave.accrual.plan'].create({
-            'name': 'Accrual Plan For Test',
-            'can_be_carryover': True,
-            'carryover_date': 'other',
-            'carryover_day': 1,
-            'carryover_month': '5',
-            'level_ids': [(0, 0, {
-                'added_value_type': 'day',
-                'milestone_date': 'creation',
-                'start_type': 'day',
-                'added_value': 10,
-                'frequency': 'yearly',
-                'action_with_unused_accruals': 'all',
-                'accrual_validity': True,
-                'accrual_validity_type': 'month',
-                'accrual_validity_count': 2,
-            }),
-            (0, 0, {
-                'added_value_type': 'day',
-                'milestone_date': 'after',
-                'start_count': 29,
-                'start_type': 'month',
-                'added_value': 20,
-                'frequency': 'yearly',
-                'action_with_unused_accruals': 'all',
-                'accrual_validity': True,
-                'accrual_validity_type': 'month',
-                'accrual_validity_count': 3,
-            })],
-        })
+        accrual_plan = self.accrual_plan_2_lvls_yearly_monthly_expiring
         with freeze_time('2023-01-01'):
             allocation = self.env['hr.leave.allocation'].with_user(self.user_hrmanager_id).create({
                 'name': 'Accrual allocation for employee',
@@ -3509,57 +2969,37 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
             })
             allocation.action_approve()
 
-        with freeze_time('2024-05-01'):
-            allocation._update_accrual()
-            self.assertEqual(allocation.carried_over_days_expiration_date, datetime.date(2024, 7, 1))
-
-        with freeze_time('2025-05-01'):
-            allocation._update_accrual()
-            self.assertEqual(allocation.carried_over_days_expiration_date, datetime.date(2025, 7, 1))
-
-        with freeze_time('2026-01-01'):
-            allocation._update_accrual()
-            self.assertEqual(allocation.carried_over_days_expiration_date, datetime.date(2026, 8, 1))
+        self._assert_accrual_allocation(allocation, (
+                ('2023-01-01', False, date(2023, 5, 1)),
+                ('2023-04-30', False, date(2023, 5, 1)),
+                # Carryover happens, setting the expiration date in 2 months
+                ('2023-05-01', expiration := date(2023, 7, 1), date(2023, 7, 1)),
+                # Expiration date: nextcall set to the next accrual
+                ('2023-07-01', expiration, date(2024, 1, 1)),
+                # Accrual date: nextcall is set to the next carryover
+                ('2024-01-01', expiration, date(2024, 5, 1)),
+                # One day before carryover: nothing changes
+                ('2024-04-30', expiration, date(2024, 5, 1)),
+                # Carryover happens, setting the expiration date in 2 months
+                ('2024-05-01', expiration := date(2024, 7, 1), date(2024, 7, 1)),
+                # Expiration date: nextcall set to the next accrual
+                ('2024-07-01', expiration, date(2024, 9, 1)),
+                # Level transition: the nextcall is set one month later
+                ('2024-09-01', expiration, date(2024, 10, 1)),
+                # One day before carryover: nothing changes
+                ('2025-04-30', expiration, date(2025, 5, 1)),
+                # Carryover date: expiration date is set 3 months later
+                ('2025-05-01', date(2025, 8, 1), date(2025, 6, 1)),
+            ),
+            ('carried_over_days_expiration_date', 'nextcall'),
+        )
 
     def test_carried_over_days_expiry_date_computation_4(self):
+        """ Assert the carryover of the accrual allocation is computed correclty
+            while modifying the carryover month of the accrual plan
         """
-        Assert that the expiration date is computed correclty when the carryover date changes.
-        - Create an accrual plan:
-            - Carryover date: 1 May
-            - One level:
-                - Accrues 10 days.
-                - Accrual date: yearly on 1 January
-                - Starts immediately on allocation start date
-                - Carryover policy: all days carry over
-                - Carried over days validity: 2 months.
-        - Create an allocation that uses the above accrual plan:
-            - Starts on 01/01/2023
-        - 01/05/2024 carryover date. The carried over days will expire in 2 months.
-        - 01/07/2024 expiration date .
-        - Change carryover date to 1 July.
-        - 01/01/2025 accrual date (The expiration date should be computed and set to 01/09/2025)
-        - 01/07/2025 carryover date. The carried over days will expire in 2 months.
-        - 01/09/2025 expiration date.
-        """
-        accrual_plan = self.env['hr.leave.accrual.plan'].create({
-            'name': 'Accrual Plan For Test',
-            'can_be_carryover': True,
-            'carryover_date': 'other',
-            'carryover_day': 1,
-            'carryover_month': '5',
-            'level_ids': [(0, 0, {
-                'added_value_type': 'day',
-                'milestone_date': 'creation',
-                'start_type': 'day',
-                'added_value': 10,
-                'frequency': 'yearly',
-                'action_with_unused_accruals': 'all',
-                'accrual_validity': True,
-                'accrual_validity_type': 'month',
-                'accrual_validity_count': 2,
-            })],
-        })
-        with freeze_time('2023-01-01'):
+        accrual_plan = self.accrual_plan_monthly_expiring
+        with freeze_time('2023-01-15'):
             allocation = self.env['hr.leave.allocation'].with_user(self.user_hrmanager_id).create({
                 'name': 'Accrual allocation for employee',
                 'accrual_plan_id': accrual_plan.id,
@@ -3569,120 +3009,46 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
             })
             allocation.action_approve()
 
+        assertions_structure = ('carried_over_days_expiration_date', 'number_of_days', 'nextcall')
+        self._assert_accrual_allocation(allocation, (
+            ('2023-04-30', False, 4, date(2023, 5, 1)),
+            # Carryover date: set the expiration date accordingly
+            ('2023-05-01', date(2023, 7, 1), 4, date(2023, 5, 15)),
+        ), assertions_structure)
+
+        # The expiration date should be reset because today < carryover < expiration
         with freeze_time('2024-05-01'):
-            allocation._update_accrual()
-            self.assertEqual(allocation.carried_over_days_expiration_date, datetime.date(2024, 7, 1))
+            accrual_plan.carryover_month = '6'
 
-        accrual_plan.carryover_month = '7'
-        with freeze_time('2025-01-01'):
-            allocation._update_accrual()
-            self.assertEqual(allocation.carried_over_days_expiration_date, datetime.date(2025, 9, 1))
+        self._assert_accrual_allocation(allocation, (
+            # New carryover date: reset the expiration date
+            ('2023-06-01', expiration := date(2023, 8, 1), 5, date(2023, 6, 15)),
+            ('2023-06-15', expiration, 6, date(2023, 7, 15)),
+            ('2023-07-15', expiration, 7, date(2023, 8, 1)),
+            # On carryover date, there was 5 allocated days (make them expire)
+            ('2023-08-01', expiration, 2, date(2023, 8, 15)),
+            # Accruals keep on going
+            ('2023-08-15', expiration, 3, date(2023, 9, 15)),
+        ), assertions_structure)
 
-        with freeze_time('2025-07-01'):
-            allocation._update_accrual()
-            self.assertEqual(allocation.carried_over_days_expiration_date, datetime.date(2025, 9, 1))
+        # Set the carryover to a closer date
+        with freeze_time('2023-09-01'):
+            accrual_plan.carryover_month = '1'
 
-    def test_carried_over_days_expiry_date_computation_5(self):
-        """
-        Assert that the expiration date is computed correclty when the carryover date changes.
-        - Create an accrual plan:
-            - Carryover date: 1 May
-            - One level:
-                - Accrues 10 days.
-                - Accrual date: yearly on 1 January
-                - Starts immediately on allocation start date
-                - Carryover policy: all days carry over
-                - Carried over days validity: 2 months.
-        - Create an allocation that uses the above accrual plan:
-            - Starts on 01/01/2023
-        - 01/05/2024 carryover date. The carried over days will expire in 2 months.
-        - Change carryover date to 1 July. The carried over days on 01/05/2024 should still expire on 01/07/2024
-        - 01/07/2024 expiration date .
-        - 01/01/2025 accrual date (The expiration date should be computed and set to 01/09/2025)
-        - 01/07/2025 carryover date. The carried over days will expire in 2 months.
-        - 01/09/2025 expiration date.
-        """
-        accrual_plan = self.env['hr.leave.accrual.plan'].create({
-            'name': 'Accrual Plan For Test',
-            'can_be_carryover': True,
-            'carryover_date': 'other',
-            'carryover_day': 1,
-            'carryover_month': '5',
-            'level_ids': [(0, 0, {
-                'added_value_type': 'day',
-                'milestone_date': 'creation',
-                'start_type': 'day',
-                'added_value': 10,
-                'frequency': 'monthly',
-                'action_with_unused_accruals': 'all',
-                'accrual_validity': True,
-                'accrual_validity_type': 'month',
-                'accrual_validity_count': 2,
-            })],
-        })
-        with freeze_time('2023-01-01'):
-            allocation = self.env['hr.leave.allocation'].with_user(self.user_hrmanager_id).create({
-                'name': 'Accrual allocation for employee',
-                'accrual_plan_id': accrual_plan.id,
-                'employee_id': self.employee_emp.id,
-                'work_entry_type_id': self.work_entry_type.id,
-                'number_of_days': 0,
-            })
-            allocation.action_approve()
-
-        with freeze_time('2024-05-01'):
-            allocation._update_accrual()
-            self.assertEqual(allocation.carried_over_days_expiration_date, datetime.date(2024, 7, 1))
-
-        with freeze_time('2024-06-01'):
-            accrual_plan.carryover_month = '7'
-            allocation._update_accrual()
-            self.assertEqual(allocation.carried_over_days_expiration_date, datetime.date(2024, 7, 1))
-
-        with freeze_time('2025-01-01'):
-            allocation._update_accrual()
-            self.assertEqual(allocation.carried_over_days_expiration_date, datetime.date(2025, 9, 1))
-
-        with freeze_time('2025-07-01'):
-            allocation._update_accrual()
-            self.assertEqual(allocation.carried_over_days_expiration_date, datetime.date(2025, 9, 1))
+        self._assert_accrual_allocation(allocation, (
+            ('2023-12-15', expiration, 7, date(2024, 1, 1)),
+            # New carryover date, expiration date is set
+            ('2024-01-01', expiration := date(2024, 3, 1), 7, date(2024, 1, 15)),
+            ('2024-01-15', expiration, 8, date(2024, 2, 15)),
+            ('2024-02-15', expiration, 9, date(2024, 3, 1)),
+            # Expiration date
+            ('2024-03-01', expiration, 2, date(2024, 3, 15)),
+        ), assertions_structure)
 
     def test_carried_over_days_expiry(self):
+        """ Assert accrual allocation with expiring days + limited number of carriedover days works properly
         """
-        - Create an accrual plan:
-            - Carryover date: 20 April
-            - One level:
-                - Accrues 10 days.
-                - Accrual date: 1 January
-                - Starts immediately on allocation start date
-                - Carryover policy: carryover with a maximum of 5 days
-                - Carried over days validity: 20 days.
-        - Create an allocation that uses the above accrual plan:
-            - Starts on 01/01/2024
-        - On 01/01/2025: 10 days are accrued.
-        - On 20/04/2025(carryover date): 5 days are lost and 5 days will carry over.
-        - On 10/05/2025(carried over days expiration date): 5 days are lost.
-        """
-        accrual_plan = self.env['hr.leave.accrual.plan'].create({
-            'name': 'Accrual Plan For Test',
-            'can_be_carryover': True,
-            'carryover_date': 'other',
-            'carryover_day': 20,
-            'carryover_month': '4',
-            'level_ids': [(0, 0, {
-                'added_value_type': 'day',
-                'milestone_date': 'creation',
-                'start_type': 'day',
-                'added_value': 10,
-                'frequency': 'yearly',
-                'action_with_unused_accruals': 'all',
-                'carryover_options': 'limited',
-                'postpone_max_days': 5,
-                'accrual_validity': True,
-                'accrual_validity_type': 'day',
-                'accrual_validity_count': 20,
-            })],
-        })
+        accrual_plan = self.accrual_plan_yearly_start_max_carriedover_expiring
         with freeze_time('2024-01-01'):
             allocation = self.env['hr.leave.allocation'].with_user(self.user_hrmanager_id).create({
                 'name': 'Accrual allocation for employee',
@@ -3693,142 +3059,93 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
             })
             allocation.action_approve()
 
-        with freeze_time('2025-01-01'):
-            allocation._update_accrual()
-            self.assertEqual(allocation.number_of_days, 10)
-        with freeze_time('2025-04-20'):
-            allocation._update_accrual()
-            self.assertEqual(allocation.number_of_days, 5)
-        with freeze_time('2025-05-10'):
-            allocation._update_accrual()
-            self.assertEqual(allocation.number_of_days, 0)
+        self._assert_accrual_allocation_nbr_of_days_and_nextcall(allocation, (
+            # Start of the first level
+            ('2024-01-01', 10, date(2024, 9, 20)),
+            # Carryover date, 5 days are carriedover
+            ('2024-09-20', 5, date(2025, 1, 1)),
+            # Second accrual for the following year
+            ('2025-01-01', 15, date(2025, 1, 20)),
+            # Expiration date (5 days are expiring as the allocation had 5 days on carryover date)
+            ('2025-01-20', 10, date(2025, 9, 20)),
+            # Carryover date, 5 days are carriedover
+            ('2025-09-20', 5, date(2026, 1, 1)),
+            # Third accrual for the following year
+            ('2026-01-01', 15, date(2026, 1, 20)),
+            # Expiration date (5 days are expiring as the allocation had 5 days on carryover date)
+            ('2026-01-20', 10, date(2026, 9, 20)),
+        ))
 
+    @freeze_time('2024-01-01')
     def test_time_off_using_expiring_carried_over_days(self):
+        """ Assert get_allocation_data compute future balance properly
+            Also assert number of days and nextcall are computed properly for an accrual plan with 2 levels,
+            a limited carriedover amount and with expiring days only for the first level
         """
-        Assert that the employee balance is set correctly when taking time-off using carried over days
-        that are going to expire soon.
-        - Create an accrual plan:
-            - Carryover date: 1 April
-            - One level:
-                - Accrues 10 days.
-                - Accrual date: bi-yearly on 1 January and 1 July
-                - Starts immediately on allocation start date
-                - Carryover policy: all days carry over
-                - Carried over days validity: 5 months.
-        - Create an allocation that uses the above accrual plan:
-            - Starts on 01/01/2024
-        - On 01/07/2024: 10 days are accrued.
-        - On 01/01/2025: 10 days are accrued. The employee now has 20 days.
-        - On 01/04/2025(carryover date): The 20 days will carryover. The 20 days will expire after 5 months.
-        - On 01/07/2025: 10 days are accrued. The employee now has 30 days.
-        - From 02/07 to 05/07 the employee is on leave (3 days). The employee has 27 days now.
-        - On 01/09/2025(carried over days expiration date): (20 expiring_days - 3 time-off days) 17 days are lost.
-        - The employee's balance should be 10 days at the end.
-        - allocation.number_of_days (employee balance + leaves_taken) should be 13 days at the end.
-        """
-        accrual_plan = self.env['hr.leave.accrual.plan'].create({
-            'name': 'Accrual Plan For Test',
-            'can_be_carryover': True,
-            'carryover_date': 'other',
-            'carryover_day': 1,
-            'carryover_month': '4',
-            'level_ids': [(0, 0, {
-                'added_value_type': 'day',
-                'milestone_date': 'creation',
-                'start_type': 'day',
-                'added_value': 10,
-                'frequency': 'biyearly',
-                'first_month': '1',
-                'first_month_day': 1,
-                'second_month': '7',
-                'second_month_day': 1,
-                'action_with_unused_accruals': 'all',
-                'accrual_validity': True,
-                'accrual_validity_type': 'month',
-                'accrual_validity_count': 5,
-            })],
-        })
-        with freeze_time('2024-01-01'):
-            allocation = self.env['hr.leave.allocation'].with_user(self.user_hrmanager_id).create({
-                'name': 'Accrual allocation for employee',
-                'accrual_plan_id': accrual_plan.id,
-                'employee_id': self.employee_emp.id,
-                'work_entry_type_id': self.work_entry_type.id,
-                'number_of_days': 0,
-            })
-            allocation.action_approve()
-
-        with freeze_time('2024-07-01'):
-            allocation._update_accrual()
-            self.assertEqual(allocation.number_of_days, 10)
-        with freeze_time('2025-01-01'):
-            allocation._update_accrual()
-            self.assertEqual(allocation.number_of_days, 20)
-        with freeze_time('2025-04-01'):
-            allocation._update_accrual()
-            self.assertEqual(allocation.number_of_days, 20)
-        with freeze_time('2025-07-01'):
-            allocation._update_accrual()
-            self.assertEqual(allocation.number_of_days, 30)
-
-        leave = self.env['hr.leave'].create({
-            'name': 'leave',
+        accrual_plan = self.accrual_plan_2_levels_biyearly_start_limited_expiring
+        allocation = self.env['hr.leave.allocation'].create({
+            'name': 'Accrual allocation for employee',
+            'accrual_plan_id': accrual_plan.id,
             'employee_id': self.employee_emp.id,
             'work_entry_type_id': self.work_entry_type.id,
-            'request_date_from': '2025-07-02',
-            'request_date_to': '2025-07-04',
+            'number_of_days': 0,
         })
-        leave.action_approve()
+        allocation.action_approve()
 
-        with freeze_time('2025-09-01'):
-            allocation._update_accrual()
-            self.assert_allocation_and_balance(allocation, 13, 10, "The employee balance should be 10 days.")
+        self._assert_accrual_allocation_nbr_of_days_and_nextcall(allocation, (
+            ('2024-01-01', 10, date(2024, 4, 1)),
+        ))
+
+        # 4 days leave
+        self._create_leave(self.employee_emp, self.work_entry_type, '2024-01-02', '2024-01-07', validate=True)
+        self._assert_get_allocation_data_future(allocation, (
+            # Carryover date, 4 days of leave -> 6 remaining days, only 5 days are carriedover, number of days = remaining + leaves taken
+            ('2024-04-01', 9, 5),
+        ))
+
+        self._assert_get_allocation_data(allocation, (
+                # Assert data are the same after running the cron
+                ('2024-04-01', 9, date(2024, 7, 1), 9, 5),
+            ), ('number_of_days', 'nextcall', 'allocated_duration', 'remaining_leaves'))
+
+        # 2x1 day leave
+        self._create_leave(self.employee_emp, self.work_entry_type, '2024-04-02', '2024-04-02', validate=True)
+        self._create_leave(self.employee_emp, self.work_entry_type, '2024-10-01', '2024-10-01', validate=True)
+
+        year_2024_half_days = self._get_period_days('2024-07-01', '2024-12-31')
+        year_2024_added_duration_1 = self._get_period_days('2024-07-01', '2024-08-31') / year_2024_half_days * 10
+        year_2024_added_duration_2 = self._get_period_days('2024-09-01', '2024-12-31') / year_2024_half_days * 15
+        self._assert_get_allocation_data_future(allocation, (
+            # TBFIR: 'left' should be set to '3 + year_2024_added_duration_1'
+            ('2024-07-01', days := 9 + year_2024_added_duration_1, left := 3 + year_2024_added_duration_1 + 1),
+            # Level transition accrual + days of the first level expires (- 5 + 2 because 2 days were taken in the meantime)
+            ('2024-11-01', days := days + year_2024_added_duration_2 - 3, left := 3 + year_2024_added_duration_1 + year_2024_added_duration_2 - 3),
+            # Second accrual of the second level
+            ('2025-01-01', days := days + 15, left + 15),
+            # Carryover date: only 10 days are carriedover
+            ('2025-04-01', min(days, 10) + 6, 10),
+        ))
+        self._assert_accrual_allocation_nbr_of_days_and_nextcall(allocation, (
+            # Second accrual of the first level
+            ('2024-07-01', days := 9 + year_2024_added_duration_1, date(2024, 9, 1)),
+            # Level transition
+            ('2024-09-01', days := days + year_2024_added_duration_2, date(2024, 11, 1)),
+            # Days of the first level are expiring + the 2 leaves taken in the meantime
+            ('2024-11-01', days := days - 5 + 2, date(2025, 1, 1)),
+            # Expiration date of the first level + accrual for the first period of the year with the second level
+            ('2025-01-01', days := days + 15, date(2025, 4, 1)),
+            # Carryover date, 10 days are carriedover
+            ('2025-04-01', days := min(days, 10) + 6, date(2025, 7, 1)),
+            # Second accrual of the second level
+            ('2025-07-01', days := days + 15, date(2026, 1, 1)),
+        ))
 
     def test_time_off_balance_computation(self):
+        """ Assert `get_allocation_data` computes properly the balance of a time off type
+            which is linked to an accrual allocation with expiring days + limited amount
+            of carriedover duration
         """
-        Assert that the time off balance is computed correctly after applying carryover-policy and after
-        expiring carried over days.
-        - Create an accrual plan:
-            - Carryover date: 1 April
-            - One level:
-                - Accrues 10 days.
-                - Accrual date: yearly on 1 January
-                - Starts immediately on allocation start date
-                - Carryover policy: carry over with a maximum of 5 days.
-                - Carried over days validity: 5 months.
-        - Create an allocation that uses the above accrual plan:
-            - Starts on 01/01/2023
-        - On 01/01/2024: 10 days are accrued.
-        - The employee takes 2 days as time-off. The employee has 8 days now.
-        - On 01/04/2024(carryover date): Only 5 days will carry over. These 5 days will expire after 5 months.
-        - The employee takes 1 day as time-off. The employee has 4 days now.
-        - On 01/09/2024: all days will expire. The employee has 0 days now.
-        - On 01/01/2025: 10 days are accrued. The employee has 10 days now.
-        - The employee takes 3 days off. The employee has 7 days now.
-        - On 01/04/2025 (carryover date): Only 5 days will carryover.
-        - The employee's balance should be 5 days at the end.
-        - allocation.number_of_days (employee balance + leaves_taken) should be 11 days at the end.
-        """
-        accrual_plan = self.env['hr.leave.accrual.plan'].create({
-            'name': 'Accrual Plan For Test',
-            'can_be_carryover': True,
-            'carryover_date': 'other',
-            'carryover_day': 1,
-            'carryover_month': '4',
-            'level_ids': [(0, 0, {
-                'added_value_type': 'day',
-                'milestone_date': 'creation',
-                'start_type': 'day',
-                'added_value': 10,
-                'frequency': 'yearly',
-                'action_with_unused_accruals': 'all',
-                'carryover_options': 'limited',
-                'postpone_max_days': 5,
-                'accrual_validity': True,
-                'accrual_validity_type': 'month',
-                'accrual_validity_count': 5,
-            })]
-        })
+        accrual_plan = self.accrual_plan_yearly_carryover_limited_expiring
         with freeze_time('2023-01-01'):
             allocation = self.env['hr.leave.allocation'].with_user(self.user_hrmanager_id).create({
                 'name': 'Accrual allocation for employee',
@@ -3839,307 +3156,94 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
             })
             allocation.action_approve()
 
-        with freeze_time('2024-01-01'):
-            allocation._update_accrual()
-            self.assert_allocation_and_balance(allocation, 10, 10, "The employee was accrued 10 days")
+        self._assert_get_allocation_data(allocation, (
+                # Accrual for the first period
+                ('2024-01-01', 10, date(2024, 4, 1), 10, 10),
+                ('2024-01-01', lambda:
+                    self._create_leave(self.employee_emp, self.work_entry_type, '2024-03-25', '2024-03-26', validate=True)),
+                # Carryover happens: only five days are kept
+                ('2024-04-01', 7, date(2024, 9, 1), 7, 5),
+                ('2024-04-01', lambda:
+                    self._create_leave(self.employee_emp, self.work_entry_type, '2024-04-02', '2024-04-02', validate=True)),
+                # Expiring date: there are 4 left days, 5 are expiring
+                # Number of days is set to the number of leaves (3d) + the left days (0)
+                ('2024-09-01', 3, date(2025, 1, 1), 3, 0),
+                # Accrual for the year 2024
+                ('2025-01-01', 13, date(2025, 4, 1), 13, 10),
+                ('2025-01-01', lambda:
+                    self._create_leave(self.employee_emp, self.work_entry_type, '2025-01-08', '2025-01-10', validate=True)),
+                # Carryover date: 5 days are carriedover
+                # Number of days = 6 days of leave + the left days (5)
+                ('2025-04-01', 11, date(2025, 9, 1), 11, 5),
+            ),
+            ('number_of_days', 'nextcall', 'allocated_duration', 'remaining_leaves'),
+        )
 
-        leave = self.env['hr.leave'].create({
-            'name': 'leave',
-            'employee_id': self.employee_emp.id,
-            'work_entry_type_id': self.work_entry_type.id,
-            'request_date_from': '2024-03-25',
-            'request_date_to': '2024-03-26',
-        })
-        leave.action_approve()
-
-        with freeze_time('2024-04-01'):
-            allocation._update_accrual()
-            self.assert_allocation_and_balance(allocation, 7, 5, "Only 5 days will carry over")
-
-        leave = self.env['hr.leave'].create({
-            'name': 'leave',
-            'employee_id': self.employee_emp.id,
-            'work_entry_type_id': self.work_entry_type.id,
-            'request_date_from': '2024-04-02',
-            'request_date_to': '2024-04-02',
-        })
-        leave.action_approve()
-
-        with freeze_time('2024-09-01'):
-            allocation._update_accrual()
-            self.assert_allocation_and_balance(allocation, 3, 0, "The 5 carried over days should expire")
-
-        with freeze_time('2025-01-01'):
-            allocation._update_accrual()
-            self.assert_allocation_and_balance(allocation, 13, 10, "The employee was accrued 10 days")
-
-        leave = self.env['hr.leave'].create({
-            'name': 'leave',
-            'employee_id': self.employee_emp.id,
-            'work_entry_type_id': self.work_entry_type.id,
-            'request_date_from': '2025-01-08',
-            'request_date_to': '2025-01-10',
-        })
-        leave.action_approve()
-
-        with freeze_time('2025-04-01'):
-            allocation._update_accrual()
-            self.assert_allocation_and_balance(allocation, 11, 5, "Only 5 days will carry over")
-
-    def test_carriedover_days_expiration_reset(self):
-        """
-        Description:
-
-        Assert that the number of expiring carry-over days and the expiration date of the carry-over days
-        are reset when the start date of the allocation is changed. This should result in the number of accrued days
-        being consistent when setting the allocation start date to some date, changing the start date to another date
-        and then changing the start date back to the first date.
-
-        Steps:
-
-        Create an accrual plan:
-        - Carryover date on allocation start date.
-        - Has 1 level:
-            * Start 0 days after allocation start date.
-            * Accrues 1 day monthly on 1st day of the month.
-            * Carryover policy all accrued time carried over.
-            * Carryover validity 1 month.
-
-        Note: The following dates are in mm/dd/YYYY
-        Create an allocation:
-            * Allocation type: accrual allocation.
-            * Accrual plan: use the one defined above.
-            * Set allocation start date 08/01/2023.
-
-            Assume that today is 09/25/2024
-
-            * Compute the number of accrued days on 09/25/2024 -> 2 days.
-
-            * Change allocation start date to 09/01/2023.
-              - Number of expiring carry-over days will reset to 0
-              - Expiration date of carry-over days will reset to False
-              - Compute the number of accrued days on 09/25/2024 -> 12 days.
-
-            * Change allocation start date back to 08/01/2023.
-              - Number of expiring carry-over days will reset to 0
-              - Expiration date of carry-over days will reset to False
-              - Compute the number of accrued days on 09/25/2024 -> 2 days.
-        """
-        accrual_plan = self.env['hr.leave.accrual.plan'].create({
-            'name': 'Accrual Plan For Test',
-            'can_be_carryover': True,
-            'carryover_date': 'allocation',
-            'level_ids': [(0, 0, {
-                'milestone_date': 'creation',
-                'start_type': 'day',
-                'added_value': 1,
-                'added_value_type': 'day',
-                'frequency': 'monthly',
-                'action_with_unused_accruals': 'all',
-                'accrual_validity': True,
-                'accrual_validity_type': 'month',
-                'accrual_validity_count': 1,
-            })]
-        })
-
-        with freeze_time('2023-08-01'):
-            allocation = self.env['hr.leave.allocation'].with_user(self.user_hrmanager_id).create({
-                'name': 'Accrual allocation for employee',
-                'accrual_plan_id': accrual_plan.id,
-                'employee_id': self.employee_emp.id,
-                'work_entry_type_id': self.work_entry_type.id,
-                'number_of_days': 0,
-                'date_from': '2023-08-01'
-            })
-
-        with freeze_time('2024-09-25'):
-            allocation._onchange_date_from()
-            self.assertEqual(allocation.number_of_days, 2)
-
-            allocation.date_from = '2023-09-01'
-            allocation._onchange_date_from()
-            self.assertEqual(allocation.number_of_days, 12)
-
-            allocation.date_from = '2023-08-01'
-            allocation._onchange_date_from()
-            self.assertEqual(allocation.number_of_days, 2)
-
+    @freeze_time('2024-09-02')
     def test_start_accrual_gain_time_immediately(self):
-        accrual_plan = self.env['hr.leave.accrual.plan'].create({
-            'name': '1.25 days each 1st of the month',
-            'transition_mode': 'immediately',
-            'can_be_carryover': True,
-            'carryover_date': 'year_start',
-            'accrued_gain_time': 'start',
-            'level_ids':
-                [(0, 0, {
-                    'start_type': 'day',
-                    'milestone_date': 'creation',
-                    'added_value_type': 'day',
-                    'added_value': 1.25,
-                    'frequency': 'monthly',
-                    'cap_accrued_time': False,
-                    'action_with_unused_accruals': 'all',
-                })],
+        """ Very simple test for an accrual allocation which accrues monthly at the start of the period
+            while taking a leave
+        """
+        accrual_plan = self.accrual_plan_monthly_start_carryover_year_start
+        accrual_plan.level_ids[0].write({
+            'added_value': 1.25,
+            'first_day': 1,
         })
 
-        with freeze_time('2024-09-02'):
-            allocation = self._create_form_test_accrual_allocation(self.work_entry_type, '2024-09-02', self.employee_emp, accrual_plan)
-            allocation.action_approve()
-            self.assertAlmostEqual(allocation.number_of_days, 1.21, 2, 'Days for the current month should be granted immediately')
+        allocation = self._create_form_test_accrual_allocation(self.work_entry_type, '2024-09-02', self.employee_emp, accrual_plan)
+        allocation.action_approve()
 
-            leave = self.env['hr.leave'].create({
-                'employee_id': self.employee_emp.id,
-                'work_entry_type_id': self.work_entry_type.id,
-                'request_date_from': '2024-09-13 08:00:00',
-                'request_date_to': '2024-09-13 17:00:00',
-            })
-            leave.action_approve()
-            remaining_leaves = self.work_entry_type.get_allocation_data(self.employee_emp, date(2024, 9, 14))[self.employee_emp][0][1]['remaining_leaves']
-            self.assertAlmostEqual(remaining_leaves, 0.21, 2, 'Leave should be deducted from accrued days')
+        create_leave_command = self._build_create_leave_command(self.employee_emp, self.work_entry_type)
+        first_period_days = self._get_period_days('2024-09-02', '2024-09-30')
+        first_accrual_month_days = self._get_period_days('2024-09-01', '2024-09-30')
+        self._assert_get_allocation_data(allocation, (
+                # Accrual for the first period
+                ('2024-09-02', days := first_period_days / first_accrual_month_days * 1.25, date(2024, 10, 1), days, days),
+                # Taking a 1 day leave
+                ('2024-09-02', create_leave_command('2024-09-13 08:00:00', '2024-09-13 17:00:00')),
+                # Assert nothing changed as the taken leave is in the future
+                ('2024-09-02', days, date(2024, 10, 1), days, days),
+                # Assert the remaining leaves are computed accordingly (1 day less)
+                ('2024-09-14', days, date(2024, 10, 1), days, days - 1),
+                # Accrual keeps on going
+                ('2024-10-01', days := days + 1.25, date(2024, 11, 1), days, days - 1),
+            ),
+            ('number_of_days', 'nextcall', 'allocated_duration', 'remaining_leaves'),
+        )
 
-        with freeze_time("2024-10-01"):
-            allocation._update_accrual()
-            self.assertAlmostEqual(allocation.number_of_days, 2.46, 2, 'Days for the upcoming month should be granted on the 1st')
-
-    def test_set_accrual_allocation_to_zero_from_ui(self):
-        with freeze_time('2024-06-15'):
-            accrual_plan = self.env['hr.leave.accrual.plan'].create({
-                'name': '2 days on the 1st of each month',
-                'accrued_gain_time': 'start',
-                'can_be_carryover': True,
-                'carryover_date': 'year_start',
-                'level_ids': [Command.create({
-                    'added_value_type': 'day',
-                    'milestone_date': 'creation',
-                    'start_type': 'day',
-                    'added_value': 2,
-                    'frequency': 'monthly',
-                })],
-            })
-
-            allocation = self.env['hr.leave.allocation'].with_user(self.user_hrmanager_id).create({
-                'name': 'Accrual allocation',
-                'accrual_plan_id': accrual_plan.id,
-                'employee_id': self.employee_emp.id,
-                'work_entry_type_id': self.work_entry_type.id,
-                'number_of_days': 0,
-            })
-
-            with Form(allocation) as f:
-                f.date_from = '2024-01-01'
-                f.number_of_days_display = 0
-            allocation.action_approve()
-
-            remaining_leaves = self.work_entry_type.get_allocation_data(self.employee_emp, date(2024, 7, 15))[self.employee_emp][0][1]['remaining_leaves']
-            self.assertAlmostEqual(remaining_leaves, 2, 2, "Only 2 days gained on 1st of July should be accrued")
-
-    def test_cache_invalidation_with_future_leaves(self):
-        accrual_plan = self.env['hr.leave.accrual.plan'].create({
-            'name': '1 days every last day of the month',
-            'transition_mode': 'immediately',
-            'can_be_carryover': True,
-            'carryover_date': 'year_start',
-            'accrued_gain_time': 'end',
-            'level_ids':
-                [(0, 0, {
-                    'start_type': 'day',
-                    'milestone_date': 'creation',
-                    'added_value_type': 'day',
-                    'added_value': 1,
-                    'frequency': 'monthly',
-                    'cap_accrued_time': False,
-                    'action_with_unused_accruals': 'all',
-                    'first_day': 31,
-                })
-            ],
-        })
-
-        with freeze_time('2024-06-30'):
-            allocation = self.env['hr.leave.allocation'].with_user(self.user_hrmanager_id).create({
-                'name': 'Accrual allocation',
-                'accrual_plan_id': accrual_plan.id,
-                'employee_id': self.employee_emp_id,
-                'work_entry_type_id': self.work_entry_type.id,
-                'number_of_days': 0,
-            })
-            allocation.action_approve()
-            allocation._update_accrual()
-
-            leave = self.env['hr.leave'].create({
-                'employee_id': self.employee_emp_id,
-                'work_entry_type_id': self.work_entry_type.id,
-                'request_date_from': '2024-09-02',
-                'request_date_to': '2024-09-03',
-            })
-            leave.action_approve()
-
-        with freeze_time('2024-07-31'):
-            allocation._update_accrual()
-            self.assertEqual(allocation.number_of_days, 1, 'Days should be allocated even when leave is taken in the future')
-
+    @freeze_time('2024-11-25')
     def test_accrual_days_left_under_carryover_maximum(self):
-        accrual_plan = self.env['hr.leave.accrual.plan'].create({
-            'name': '21 days per year, 28 days cap, 7 carryover max',
-            'transition_mode': 'immediately',
-            'can_be_carryover': True,
-            'carryover_date': 'year_start',
-            'accrued_gain_time': 'start',
-            'level_ids':
-                [(0, 0, {
-                "accrued_gain_time": "start",
-                "action_with_unused_accruals": "all",
-                "carryover_options": "limited",
-                "added_value": 21,
-                "cap_accrued_time": True,
-                "first_day": 1,
-                "first_month": "1",
-                "first_month_day": 1,
-                "frequency": "yearly",
-                "maximum_leave": 28,
-                "postpone_max_days": 7,
-                "start_count": 0,
-                "start_type": "day",
-                "yearly_day": 1,
-                "yearly_month": "1"
-            })
-            ],
-        })
+        """ Assert `get_allocation_data` correctly computes the future balance of a `work.entry.type` linked
+            to an accrual allocation that accrues yearly at the start of the period, with a limited amount
+            of carriedover duration
+        """
+        accrual_plan = self.accrual_plan_yearly_start_max_leave_carryover_limited
+        allocation = self._create_form_test_accrual_allocation(self.work_entry_type, '2024-01-01', self.employee_emp,
+            accrual_plan, creator_user=self.user_hrmanager)
+        allocation.action_approve()
 
-        with freeze_time('2024-11-25'):
-            with Form(self.env['hr.leave.allocation'].with_user(self.user_hrmanager)) as f:
-                f.accrual_plan_id = accrual_plan
-                f.date_from = '2024-01-01'
-                f.employee_id = self.employee_emp
-                f.work_entry_type_id = self.work_entry_type
-                f.name = "Employee Allocation"
+        self._assert_get_allocation_data_future(allocation, (
+            ('2025-01-01', 28, 28),
+            ('2026-01-01', 28, 28),
+            # Take a 15 days leave
+            ('2024-11-25', lambda:
+                self._create_leave(self.employee_emp, self.work_entry_type, '2024-10-07', '2024-10-25', validate=True)),
+            # TBFIR: should be 28 + 15 and 28
+            ('2025-01-01', 27 + 15, 27),
+            ('2026-01-01', 28 + 15, 28),
+        ))
 
-            allocation = f.record
-            allocation.action_approve()
-
-            # take 15 days, left with 6 days on the alloc
-            leave = self.env['hr.leave'].create({
-                'employee_id': self.employee_emp_id,
-                'work_entry_type_id': self.work_entry_type.id,
-                'request_date_from': '2024-10-07',
-                'request_date_to': '2024-10-25',
-            })
-            leave.action_approve()
-            data = self.work_entry_type.get_allocation_data(self.employee_emp, date(2025, 1, 15))
-            remaining_future = data[self.employee_emp][0][1]["remaining_leaves"]
-            self.assertEqual(remaining_future, 27)
-
+    @freeze_time('2024-11-25')
     def test_accrual_unused_accrual_reset_to_lost(self):
-        accrual_plan = self.env['hr.leave.accrual.plan'].create({
-            'name': '21 days per year, 28 days cap, 7 carryover max',
-            'transition_mode': 'immediately',
-            'can_be_carryover': True,
-            'carryover_date': 'year_start',
-            'accrued_gain_time': 'start',
-        })
+        """ Assert `get_allocation_data` correctly computes the future balance of a `work.entry.type` linked
+            to an accrual allocation that accrues yearly at the start of the period, when all days are lost
+            on carryover date
+            Also assert creating the accrual plan only level using a form works
+        """
+        accrual_plan = self.accrual_plan_no_level_start_carryover_year_start
 
         plan = self.env["hr.leave.accrual.level"].create({
-            "accrual_plan_id" : accrual_plan.id,
+            "accrual_plan_id": accrual_plan.id,
         })
 
         with Form(plan) as f:
@@ -4152,105 +3256,49 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
             # Set a maximum carry-over
             f.action_with_unused_accruals = 'all'
             f.carryover_options = 'limited'
-            f.postpone_max_days = 7
+            f.max_carriedover_duration = 7
             # Set it back to 'lost'
             f.action_with_unused_accruals = 'lost'
 
-        with freeze_time('2024-11-25'):
-            with Form(self.env['hr.leave.allocation'].with_user(self.user_hrmanager)) as f:
-                f.accrual_plan_id = accrual_plan
-                f.date_from = '2024-01-01'
-                f.employee_id = self.employee_emp
-                f.work_entry_type_id = self.work_entry_type
-                f.name = "Employee Allocation"
+        allocation = self._create_form_test_accrual_allocation(self.work_entry_type, '2024-01-01', self.employee_emp,
+            accrual_plan, creator_user=self.user_hrmanager)
+        allocation.action_approve()
 
-            allocation = f.record
-            allocation.action_approve()
+        self._assert_get_allocation_data_future(allocation, (
+            ('2025-01-01', 21, 21),
+            ('2026-01-01', 21, 21),
+            # Take a 15 days leave
+            ('2024-11-25', lambda:
+                self._create_leave(self.employee_emp, self.work_entry_type, '2024-10-07', '2024-10-25', validate=True)),
+            # total_allocated_duration: remaining leaves + taken leaves
+            ('2025-01-01', 21 + 15, 21),
+            ('2026-01-01', 21 + 15, 21),
+        ))
 
-            # take 15 days, left with 6 days on the alloc
-            leave = self.env['hr.leave'].create({
-                'employee_id': self.employee_emp_id,
-                'work_entry_type_id': self.work_entry_type.id,
-                'request_date_from': '2024-10-07',
-                'request_date_to': '2024-10-25',
-            })
-            leave.action_approve()
-            data = self.work_entry_type.get_allocation_data(self.employee_emp, date(2025, 1, 15))
-            remaining_future = data[self.employee_emp][0][1]["remaining_leaves"]
-            self.assertEqual(remaining_future, 21)
-
+    @freeze_time("2017-12-05")
     def test_accrual_allocation_without_working_hours(self):
+        """ Assert creating an accrual allocation for an employee without
+            working hours doesn't raise a traceback error
         """
-        check that creating an accrual allocation for an employee without working hours doesn't raise a traceback error
-        """
-        with freeze_time("2017-12-05"):
-            employee_without_calendar = self.env['hr.employee'].create({
-                'name': 'employee without calendar',
-                'resource_calendar_id': False,
-            })
-            accrual_plan = self.env['hr.leave.accrual.plan'].create({
-                'is_based_on_worked_time': True,
-                'can_be_carryover': True,
-                'level_ids': [(0, 0, {
-                    'milestone_date': 'after',
-                    'start_count': 1,
-                    'start_type': 'day',
-                    'added_value': 1,
-                    'added_value_type': 'hour',
-                    'frequency': 'hourly',
-                    'action_with_unused_accruals': 'all',
-                })],
-            })
-            past_date = datetime.date.today() - relativedelta(days=1)
-            allocation = self.env['hr.leave.allocation'].with_user(self.user_hrmanager_id).create({
-                'name': 'accrual allocation for employee without calendar',
-                'accrual_plan_id': accrual_plan.id,
-                'employee_id': employee_without_calendar.id,
-                'work_entry_type_id': self.work_entry_type.id,
-                'number_of_days': 0,
-                'date_from': past_date,
-            })
-            future_date = datetime.date.today() + relativedelta(days=1)
-            allocation._process_accrual_plans(date_to=future_date)
+        employee_without_calendar = self.employee_without_calendar
+        accrual_plan = self.accrual_plan_hourly_work_time
+        self.env['hr.leave.allocation'].with_user(self.user_hrmanager_id).create({
+            'name': 'accrual allocation for employee without calendar',
+            'accrual_plan_id': accrual_plan.id,
+            'employee_id': employee_without_calendar.id,
+            'work_entry_type_id': self.work_entry_type.id,
+            'number_of_days': 0,
+            'date_from': '2017-12-04',
+        })
+        self._run_update_accrual_cron("2017-12-06")
 
     def test_accrual_allocation_with_virtual_future_leaves(self):
-        """ This test considers a case where the employee has an accrual plan with no carryover and
-        also has a virtual leave (leave that isn't validated). When we call the CRON to update the
-        time off based on the accrual allocation and ensure that it goes through successfully without
-        errors due to the pending virtual leaves. Example:
-        Accrual plan with no carryover that grants 8 days on Jan 1 of each year
-        - 8 days allocated on 2024-12-01 (to simulate initial 15day allocation)
-        - Request an unvalidated leave from 2025-01-03 to 2025-01-04 (lies after the carryover date)
-        - Run the CRON on 2025-01-05 to update the accrual allocation: (note how the CRON is run after the leave date)
-           1. The CRON would first make the allocation's number_of_days = 0 because of the carryover policy
-           2. Then it would add 8 days to the allocation's number_of_days
-        - Ensure that the CRON runs successfully without errors during (1) due to the pending virtual leave
+        """ Assert running the accrual CRON after taking a leave that isn't
+            validated (virtual leave) doesn't raise a traceback
         """
-        work_entry_type = self.env['hr.work.entry.type'].create({
-            'name': 'Test Leave Type 2',
-            'code': 'Test Leave Type 2',
-            'count_as': 'absence',
-            'requires_allocation': True,
-            'leave_validation_type': 'hr',
-            'allocation_validation_type': 'hr',
-            'employee_requests': False,
-            'request_unit': 'day',
-            'unit_of_measure': 'day',
-        })
-        accrual_plan = self.env['hr.leave.accrual.plan'].create({
-            'name': 'Accrual Plan with no carryover',
-            'accrued_gain_time': 'start',
-            'can_be_carryover': True,
-            'carryover_date': 'year_start',
-            'level_ids': [Command.create({
-                'added_value': 8,
-                'added_value_type': 'day',
-                'action_with_unused_accruals': 'lost',
-                'frequency': 'yearly',
-                'yearly_month': '1',
-                'yearly_day': '1',
-            })],
-        })
+        work_entry_type = self.work_entry_type
+        accrual_plan = self.accrual_plan_yearly_carryover_lost
+        accrual_plan.level_ids[0].added_value = 8
 
         with freeze_time("2024-12-01"):
             allocation = self.env['hr.leave.allocation'].with_user(self.user_hrmanager_id).create({
@@ -4260,319 +3308,142 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'work_entry_type_id': work_entry_type.id,
                 'date_from': '2024-12-01',
                 'number_of_days': 8,
-                'nextcall': '2025-01-01',
             })
             allocation.action_approve()
             # A virtual leave that is pending approval and will be taken after the carryover date
-            leave = self.env['hr.leave'].with_context(leave_fast_create=True).create({
-                'name': 'Virtual Leave',
-                'employee_id': self.employee_emp.id,
-                'work_entry_type_id': work_entry_type.id,
-                'request_date_from': '2024-12-23',
-                'request_date_to': '2024-12-24',
-            })
+            leave = self._create_leave(self.employee_emp, work_entry_type, '2025-01-02', '2025-01-03', additionnal_ctx={'leave_fast_create': True})
             self.assertNotEqual(leave.state, 'validate', "The leave request should not be in the 'validate' state")
 
-        # This is a case where
-        # - the allocation had a next call day of Jan 1 to reset the leaves as per the accrual plan
-        # - the future leave is to scheduled for Jan 3rd to 4th (future because it comes after the carryover date of accrual)
-        # - the CRON to update the accrual allocation is run on Jan 5th (after the nextcall and requested leave date)
+        # Run the CRON to check that no validation error appears
         with freeze_time("2025-01-05"):
-            allocation._update_accrual()
+            self._run_update_accrual_cron()
+            # Days are lost (carryover) and then accrual for the following year happens (+8d)
             self.assertEqual(allocation.number_of_days, 8, "The number of days should be updated successfully")
 
     def test_accrual_allocation_constraint_1(self):
-        with self.assertRaises(ValidationError):
+        """ Assert bimonthly frequency `first_day` and `second_day` constraint works properly
+        """
+        with self.assertRaisesRegex(ValidationError, 'The first day must be lower than the second day.'):
             self.env['hr.leave.accrual.plan'].create({
                 'name': 'Accrual Plan with no carryover',
                 'accrued_gain_time': 'start',
                 'carryover_date': 'year_start',
                 'level_ids': [Command.create({
-                    'added_value': 8,
-                    'added_value_type': 'day',
-                    'action_with_unused_accruals': 'lost',
                     'frequency': 'bimonthly',
                     'first_day': '20',
                     'second_day': '3',
                 })],
             })
 
+    @freeze_time('2024-01-01')
     def test_accrual_allocation_data_with_different_units(self):
-        '''
-        Test that the allocation data is correctly computed when the request unit
-        is different from that of the accrual plan added value unit
-        '''
-        with freeze_time('2024-01-01'):
-            accrual_plan = self.env['hr.leave.accrual.plan'].create({
-                'name': 'Accrual Plan For Test',
-                'is_based_on_worked_time': False,
-                'accrued_gain_time': 'end',
-                'level_ids': [(0, 0, {
-                    'added_value_type': 'hour',
-                    'start_count': 0,
-                    'start_type': 'day',
-                    'added_value': 1,
-                    'frequency': 'daily',
-                })],
-            })
-            work_entry_type_day = self.env['hr.work.entry.type'].create({
-                'name': 'Test Leave Type 2',
-                'code': 'Test Leave Type 2',
-                'count_as': 'absence',
-                'requires_allocation': True,
-                'allocation_validation_type': 'no_validation',
-                'request_unit': 'day',
-                'unit_of_measure': 'day',
-            })
-
-            allocation = self.env['hr.leave.allocation'].create({
-                'name': 'Accrual allocation for employee',
-                'employee_id': self.employee_emp.id,
-                'work_entry_type_id': work_entry_type_day.id,
-                'number_of_days': 0,
-                'accrual_plan_id': accrual_plan.id,
-                'date_from': '2024-01-01',
-            })
-            allocation.action_approve()
-        with freeze_time('2024-01-09'):
-            allocation._update_accrual()
-            allocation_data = work_entry_type_day.get_allocation_data(self.employee_emp)
-            self.assertEqual(allocation_data[self.employee_emp][0][1]['virtual_remaining_leaves'], 1)
-
-    def test_accrual_allocation_data_with_different_units_half_day(self):
-        '''
-        Test that the allocation data is correctly computed when the request unit
-        is different from that of the accrual plan added value unit
-        and the request unit is half_day, so that it should be displayed as days
-        '''
-        with freeze_time('2024-01-01'):
-            accrual_plan = self.env['hr.leave.accrual.plan'].create({
-                'name': 'Accrual Plan For Test',
-                'is_based_on_worked_time': False,
-                'accrued_gain_time': 'end',
-                'level_ids': [(0, 0, {
-                    'added_value_type': 'hour',
-                    'start_count': 0,
-                    'start_type': 'day',
-                    'added_value': 1,
-                    'frequency': 'daily',
-                })],
-            })
-            work_entry_type_day = self.env['hr.work.entry.type'].create({
-                'name': 'Test Leave Type 2',
-                'code': 'Test Leave Type 2',
-                'count_as': 'absence',
-                'requires_allocation': True,
-                'allocation_validation_type': 'no_validation',
-                'request_unit': 'half_day',
-                'unit_of_measure': 'day',
-            })
-
-            allocation = self.env['hr.leave.allocation'].create({
-                'name': 'Accrual allocation for employee',
-                'employee_id': self.employee_emp.id,
-                'work_entry_type_id': work_entry_type_day.id,
-                'number_of_days': 0,
-                'accrual_plan_id': accrual_plan.id,
-                'date_from': '2024-01-01',
-            })
-            allocation.action_approve()
-        with freeze_time('2024-01-09'):
-            allocation._update_accrual()
-            allocation_data = work_entry_type_day.get_allocation_data(self.employee_emp)
-            self.assertEqual(allocation_data[self.employee_emp][0][1]['virtual_remaining_leaves'], 1)
-
-    def test_accrual_allocation_data_with_different_units_and_used_days(self):
-        '''
-        Test that the allocation data is correctly computed when the request unit
-        is different from that of the accrual plan added value unit
-        and some of the time off days are used
-        '''
-        with freeze_time('2024-01-01'):
-            accrual_plan = self.env['hr.leave.accrual.plan'].create({
-                'name': 'Accrual Plan For Test',
-                'is_based_on_worked_time': False,
-                'accrued_gain_time': 'end',
-                'level_ids': [(0, 0, {
-                    'added_value_type': 'hour',
-                    'start_count': 0,
-                    'start_type': 'day',
-                    'added_value': 1,
-                    'frequency': 'daily',
-                })],
-            })
-            work_entry_type_day = self.env['hr.work.entry.type'].create({
-                'name': 'Test Leave Type 2',
-                'code': 'Test Leave Type 2',
-                'count_as': 'absence',
-                'requires_allocation': True,
-                'allocation_validation_type': 'no_validation',
-                'request_unit': 'day',
-                'unit_of_measure': 'day',
-            })
-
-            allocation = self.env['hr.leave.allocation'].create({
-                'name': 'Accrual allocation for employee',
-                'employee_id': self.employee_emp.id,
-                'work_entry_type_id': work_entry_type_day.id,
-                'number_of_days': 0,
-                'accrual_plan_id': accrual_plan.id,
-                'date_from': '2024-01-01',
-            })
-            allocation.action_approve()
-        with freeze_time('2024-01-17'):
-            allocation._update_accrual()
-            leave = self.env['hr.leave'].create({
-                'name': 'Leave',
-                'employee_id': self.employee_emp.id,
-                'work_entry_type_id': work_entry_type_day.id,
-                'request_date_from': '2024-01-05',
-                'request_date_to': '2024-01-05',
-            })
-            leave.action_approve()
-            allocation_data = work_entry_type_day.get_allocation_data(self.employee_emp)
-            self.assertEqual(allocation_data[self.employee_emp][0][1]['virtual_remaining_leaves'], 1)
-
-    def test_accrual_allocation_with_monthly_31st_milestone(self):
-        '''
-        Test that an accrual allocation with a monthly milestone on the 31st correctly accrues 2 days by the end of January.
-        This test verifies that when an accrual plan is configured to grant 2 days monthly on the 31st of each month,
-        and the gain time is set to 'end' of the period, an allocation starting on January 1st correctly accrues
-        2 days by January 31st.
-        '''
-        accrual_plan = self.env['hr.leave.accrual.plan'].create({
-            'name': '31st Monthly Plan',
-            'accrued_gain_time': 'end',
-            'carryover_date': 'allocation',
-            'level_ids': [(0, 0, {
-                'start_count': 0,
-                'start_type': 'day',
-                'added_value': 2,
-                'added_value_type': 'day',
-                'frequency': 'monthly',
-                'first_day': '31',
-                'cap_accrued_time': True,
-                'maximum_leave': 10000,
-            })],
-        })
-
-        with (freeze_time('2025-01-31')):
-            allocation = self.env['hr.leave.allocation'].new({
-                'name': 'January Allocation',
-                'employee_id': self.employee_emp.id,
-                'accrual_plan_id': accrual_plan.id,
-                'date_from': date(2025, 1, 1),
-                'work_entry_type_id': self.work_entry_type.id,
-            })
-            allocation._onchange_date_from()
-            self.assertEqual(allocation.number_of_days, 2.0)
-
-    @freeze_time('2025-01-01')
-    def test_accrual_allocation_date_in_the_future(self):
-        vals = {
-            'milestone_date': 'after',
-            'accrual_validity': True,
-            'accrual_validity_count': 6,
-            'accrual_validity_type': 'month',
-            'accrued_gain_time': 'start',
-            'action_with_unused_accruals': 'all',
-            'cap_accrued_time_yearly': False,
-            'frequency': 'yearly',
-            'carryover_options': 'limited',
-            'postpone_max_days': 5,
-            'week_day': '0',
-        }
-        accrual_plan = self.env['hr.leave.accrual.plan'].create({
-            'name': 'Test accrual plan',
-            'is_based_on_worked_time': False,
-            'accrued_gain_time': 'start',
-            'can_be_carryover': True,
-            'level_ids': [(0, 0, {
-                **vals,
-                'added_value': 20,
-                'milestone_date': 'creation',
-                'start_type': 'day',
-                'maximum_leave': 25,
-            }),
-            (0, 0, {
-                **vals,
-                'added_value': 21,
-                'start_count': 2,
-                'start_type': 'year',
-                'maximum_leave': 26,
-            }),
-            (0, 0, {
-                **vals,
-                'added_value': 22,
-                'start_count': 4,
-                'start_type': 'year',
-                'maximum_leave': 27,
-            }),
-            (0, 0, {
-               **vals,
-                'added_value': 23,
-                'start_count': 6,
-                'start_type': 'year',
-                'maximum_leave': 28,
-            })]
-        })
-
-        work_entry_type = self.env['hr.work.entry.type'].create({
-            'name': 'Test Leave Type 2',
-            'code': 'Test Leave Type 2',
-            'count_as': 'absence',
-            'requires_allocation': 'yes',
-            'allocation_validation_type': 'no_validation',
-            'request_unit': 'day',
-            'unit_of_measure': 'day',
-        })
+        """ Assert `get_allocation_data` properly computes the balance of a time type with `request_unit = unit_of_measure = 'day'`,
+            while there is an accrual allocation with `added_value_type = 'hour'`
+            Also assert the time type balance is updated correctly when taking a 1 day leave
+        """
+        accrual_plan = self.accrual_plan_daily_hour
+        work_entry_type_day = self.work_entry_type_day
 
         allocation = self.env['hr.leave.allocation'].create({
             'name': 'Accrual allocation for employee',
             'employee_id': self.employee_emp.id,
-            'work_entry_type_id': work_entry_type.id,
-            'number_of_days': 20,
+            'work_entry_type_id': work_entry_type_day.id,
+            'number_of_days': 0,
             'accrual_plan_id': accrual_plan.id,
-            'date_from': '2025-01-01',
+            'date_from': '2024-01-01',
         })
         allocation.action_approve()
-        # On 2026-01-01:
-        # - carryover kicks in, the number of days goes from 25 to 5 (only 5 days are kept and will expire 6 months later)
-        # - accrual time: the allocation is accrued 20 days
-        allocation_data = work_entry_type.get_allocation_data(self.employee_emp, '2026-03-01')
-        self.assertEqual(allocation_data[self.employee_emp][0][1]['virtual_remaining_leaves'], 25, "The carryover did not expire yet so the remaining leaves should be 25")
-        allocation_data = work_entry_type.get_allocation_data(self.employee_emp, '2026-09-01')
-        self.assertEqual(allocation_data[self.employee_emp][0][1]['virtual_remaining_leaves'], 20, "The carryover expired after 6 month so the remaining leaves should be 20")
-        # Test after two years
-        allocation_data = work_entry_type.get_allocation_data(self.employee_emp, '2027-03-01')
-        self.assertEqual(allocation_data[self.employee_emp][0][1]['virtual_remaining_leaves'], 26, "The carryover did not expire yet so the remaining leaves should be 26")
-        allocation_data = work_entry_type.get_allocation_data(self.employee_emp, '2027-09-01')
-        self.assertEqual(allocation_data[self.employee_emp][0][1]['virtual_remaining_leaves'], 21, "The carryover expired after 6 month so the remaining leaves should be 21")
-        # Test after three years
-        allocation_data = work_entry_type.get_allocation_data(self.employee_emp, '2028-03-01')
-        self.assertEqual(allocation_data[self.employee_emp][0][1]['virtual_remaining_leaves'], 26, "The carryover did not expire yet so the remaining leaves should be 26")
-        allocation_data = work_entry_type.get_allocation_data(self.employee_emp, '2028-09-01')
-        self.assertEqual(allocation_data[self.employee_emp][0][1]['virtual_remaining_leaves'], 21, "The carryover expired after 6 month so the remaining leaves should be 21")
-        # Test after four years
-        allocation_data = work_entry_type.get_allocation_data(self.employee_emp, '2029-03-01')
-        self.assertEqual(allocation_data[self.employee_emp][0][1]['virtual_remaining_leaves'], 27, "The carryover did not expire yet so the remaining leaves should be 27")
-        allocation_data = work_entry_type.get_allocation_data(self.employee_emp, '2029-09-01')
-        self.assertEqual(allocation_data[self.employee_emp][0][1]['virtual_remaining_leaves'], 22, "The carryover expired after 6 month so the remaining leaves should be 22")
-        # Test after five years
-        allocation_data = work_entry_type.get_allocation_data(self.employee_emp, '2030-03-01')
-        self.assertEqual(allocation_data[self.employee_emp][0][1]['virtual_remaining_leaves'], 27, "The carryover did not expire yet so the remaining leaves should be 27")
-        allocation_data = work_entry_type.get_allocation_data(self.employee_emp, '2030-09-01')
-        self.assertEqual(allocation_data[self.employee_emp][0][1]['virtual_remaining_leaves'], 22, "The carryover expired after 6 month so the remaining leaves should be 22")
-        # Test after six years
-        allocation_data = work_entry_type.get_allocation_data(self.employee_emp, '2031-03-01')
-        self.assertEqual(allocation_data[self.employee_emp][0][1]['virtual_remaining_leaves'], 28, "The carryover did not expire yet so the remaining leaves should be 28")
-        allocation_data = work_entry_type.get_allocation_data(self.employee_emp, '2031-09-01')
-        self.assertEqual(allocation_data[self.employee_emp][0][1]['virtual_remaining_leaves'], 23, "The carryover expired after 6 month so the remaining leaves should be 23")
+
+        self._assert_get_allocation_data(allocation, (
+                # 1 hour per day, so 8 hours should've been accrued
+                ('2024-01-09', days := 8 / self.hours_per_day, date(2024, 1, 10), days, days),
+                # 9 days of accrual: 9x 1 hour
+                ('2024-01-10', days := 9 / self.hours_per_day, date(2024, 1, 11), days, days),
+                ('2024-01-10', lambda:
+                    self._create_leave(self.employee_emp, work_entry_type_day, '2024-01-05', '2024-01-05', validate=True)),
+                # The leave should be deducted from the remaining leaves
+                ('2024-01-10', days, date(2024, 1, 11), days, days - 1),
+            ),
+            ('number_of_days', 'nextcall', 'allocated_duration', 'remaining_leaves')
+        )
+
+    @freeze_time('2024-01-01')
+    def test_accrual_allocation_data_with_different_units_half_day(self):
+        """ Assert `get_allocation_data` properly computes the balance of a time type
+            with `request_unit = 'half_day'` and `unit_of_measure = 'day'`, while there
+            is an accrual allocation with `added_value_type = 'hour'`
+        """
+        accrual_plan = self.accrual_plan_daily_hour
+        work_entry_type_day = self.work_entry_type_absence_requires_alloc_half_day_day
+
+        allocation = self.env['hr.leave.allocation'].create({
+            'name': 'Accrual allocation for employee',
+            'employee_id': self.employee_emp.id,
+            'work_entry_type_id': work_entry_type_day.id,
+            'number_of_days': 0,
+            'accrual_plan_id': accrual_plan.id,
+        })
+        allocation.action_approve()
+
+        self._assert_get_allocation_data(allocation, (
+                # 1 hour per day, so 8 hours should've been accrued
+                ('2024-01-09', days := 8 / self.hours_per_day, date(2024, 1, 10), days, days),
+            ), ('number_of_days', 'nextcall', 'allocated_duration', 'remaining_leaves'))
+
+    def test_accrual_allocation_date_in_the_future(self):
+        """ Assert `get_allocation_data` properly computes the time type balance with a 4 levels accrual allocation
+            with `maximum_leave` increasing from one level to the other, and max 5 carriedover days
+        """
+        with freeze_time('2025-01-01'):
+            accrual_plan = self.accrual_plan_4_lvls_start_max_leaves_carryover_limited_expiring
+            work_entry_type = self.work_entry_type_day
+            allocation = self.env['hr.leave.allocation'].create({
+                'name': 'Accrual allocation for employee',
+                'employee_id': self.employee_emp.id,
+                'work_entry_type_id': work_entry_type.id,
+                'number_of_days': 20,
+                'accrual_plan_id': accrual_plan.id,
+                'date_from': '2025-01-01',
+            })
+            allocation.action_approve()
+
+        self._assert_get_allocation_data(allocation, (
+                # Accrual on 2025-01-01 -> 20 days
+                # On 2026-01-01:
+                # - carryover kicks in, the number of days goes from 25 to 5 (only 5 days are kept and will expire 6 months later)
+                # - accrual time: the allocation is accrued 20 days
+                ('2026-03-01', 25),
+                # Carryover expires on 2026-06-01 -> 25 - 5 = 20
+                ('2026-09-01', 20),
+                # Accrual on 2027-01-01 -> min(20 + 21, 26) = 26 (maximum_leave=26)
+                ('2027-03-01', 26),
+                # Carryover expires on 2027-06-01 -> 26 - 5 = 21
+                ('2027-09-01', 21),
+                # Accrual on 2028-01-01 -> min(21 + 21, 26) = 26 (maximum_leave=26)
+                ('2028-03-01', 26),
+                # Carryover expires on 2028-06-01 -> 26 - 5 = 21
+                ('2028-09-01', 21),
+                # Accrual on 2029-01-01 -> min(21 + 22, 27) = 27 (maximum_leave=27)
+                ('2029-03-01', 27),
+                # Carryover expires on 2029-06-01 -> 27 - 5 = 22
+                ('2029-09-01', 22),
+                # Accrual on 2030-01-01 -> min(22 + 22, 27) = 27 (maximum_leave=27)
+                ('2030-03-01', 27),
+                # Carryover expires on 2030-06-01 -> 27 - 5 = 22
+                ('2030-09-01', 22),
+                # Accrual on 2031-01-01 -> min(22 + 23, 28) = 28 (maximum_leave=28)
+                ('2031-03-01', 28),
+                # Carryover expires on 2031-06-01 -> 28 - 5 = 23
+                ('2031-09-01', 23),
+            ),
+            ['allocated_duration'],
+        )
 
     def test_accrual_plan_cleared_when_switch_to_regular(self):
-        accrual_plan = self.env['hr.leave.accrual.plan'].create({
-            'name': 'Accrual Plan For Test',
-        })
+        """ Assert the `accrual_plan_id` of an allocation is set to False when switching back to
+            a regular allocation from a form
+        """
+        accrual_plan = self.dummy_accrual_plan
         allocation = self.env['hr.leave.allocation'].create({
             'name': 'Accrual allocation for employee',
             'work_entry_type_id': self.work_entry_type.id,
@@ -4586,261 +3457,227 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
             alloc_form.accrual_plan_id = self.env['hr.leave.accrual.plan']
         self.assertFalse(
             allocation.accrual_plan_id,
-            "accrual_plan_id should be cleared when set to empty."
+            "accrual_plan_id should be cleared when set to empty.",
         )
         self.assertEqual(accrual_plan.employees_count, 0, "Accrual plan should not have any linked employees.")
 
     def test_accrual_plan_start_carryover_expiring_3_months(self):
-        """ Assert that days expires correctly for a monthly accrual plan granting days
-            at the start of the month (with a carryover validity of 3 months).
-
-            - Create an accrual plan:
-                - Carryover date: allocation start
-                - First level:
-                    - Accrues 1 day monthly at the start of each month
-                    - Carryover policy: all days carry over at allocation creation date
-                    - Carried over days validity: 3 months.
-                - Second level:
-                    - Same as firt level, but accrues 2 days instead of 1
-                    - Start after 1 year and 1 month
-            - Create an allocation that uses the above accrual plan on 2025-09-23:
-                - Starts on 2025-07-01
-
-            Expected behavior: 12 days should've been accrued from 2025-07-01 to 2026-06-30 (it will expire on 2026-09-30).
+        """ Assert the allocated duration and the `previous_carryover_number_of_days` for an accrual allocation with
+            2 levels are properly computed when some day are expiring a few months after the carryover date
         """
         with freeze_time('2025-07-01'):
             allocation = self._create_form_test_accrual_allocation(
                 self.work_entry_type_day, '2025-07-01', self.employee_emp, self.accrual_plan_start1)
             allocation.action_approve()
 
-        assertions = [
-            # 12 months  =>  13 accruals as "accrued_gain_time" is "start"  =>  13 * 1 (first level) = 13
-            # Do not include the 1 accrued day for 2026-07-01 for the expiring days
-            # (otherwise it would be like wasting the days the employee earned trough the last month)
-            ('2026-07-01', leaves := 13, 12),
-            # The day before 12 days should expire + level transition -> 2 more second level monthly (2 + 2)
-            ('2026-09-30', leaves := leaves + 4, 12),
-            # Carryover expires + new monthly accrual
-            ('2026-10-01', leaves := leaves + 2 - 12, 0),
-            # Accrual keeps going
-            ('2026-11-01', leaves + 2, 0),
-        ]
-
-        for test_date, remaining_leaves, expiring_days in assertions:
-            with freeze_time(test_date):
-                allocation._update_accrual()
-                self.assert_remaining_leaves_equal(self.work_entry_type_day, remaining_leaves, self.employee_emp, test_date, digits=3)
-                self.assertAlmostEqual(allocation.expiring_carryover_days, expiring_days, 2, msg=f'Incorrect number of expiring days for {test_date}')
+        self._assert_get_allocation_data(allocation, (
+                # 11 months  =>  12 accruals as "accrued_gain_time" is "start"  =>  12 * 1 (first level) = 12
+                # previous_carryover_nbr_of_days should be 0
+                ('2026-06-01', expected_nbr_of_days := 12, 0),
+                # Another monthly accrual
+                # Do not include the 1 accrued day for 2026-07-01 for the previous_carryover_nbr_of_days
+                # (otherwise it would be like wasting the days the employee earned trough the last month)
+                ('2026-07-01', expected_nbr_of_days := expected_nbr_of_days + 1, 12),
+                # The day before 12 days should expire + level transition -> 2 more second level monthly (2 + 2)
+                ('2026-09-30', expected_nbr_of_days := expected_nbr_of_days + 4, 12),
+                # Carryover expires + new monthly accrual
+                ('2026-10-01', expected_nbr_of_days := expected_nbr_of_days - 12 + 2, 12),
+                # Accrual keeps going
+                ('2026-11-01', expected_nbr_of_days + 2, 12),
+            ),
+            ('allocated_duration', 'previous_carryover_number_of_days'),
+        )
 
     def test_accrual_plan_end_carryover_expiring_3_months(self):
-        """
-            Same test than `test_accrual_plan_start_carryover_expiring_3_months`, but for an
+        """ Same test than `test_accrual_plan_start_carryover_expiring_3_months`, but for an
             accrual plan that grants days at the end of the month.
-
-            Expected behavior: 11 days should've been accrued from 2025-07-01 to 2026-06-30 (it will expire on 2026-09-30).
         """
         with freeze_time('2025-07-01'):
             allocation = self._create_form_test_accrual_allocation(
                 self.work_entry_type_day, '2025-07-01', self.employee_emp, self.accrual_plan_end1)
             allocation.action_approve()
 
-        assertions = [
-            # 12 months  =>  12 accruals as "accrued_gain_time" is "end"  =>  12 * 1 (first level) = 12
-            # Do not include the 1 accrued day for 2026-07-01 for the expiring days
-            # (otherwise it would be like wasting the days the employee earned trough the last month)
-            ('2026-07-01', leaves := 12, 11),
-            # The day before 12 days should expire + level transition -> 1 accrual from first level,
-            # and another one from the second level (1 + 2)
-            ('2026-09-30', leaves := leaves + 3, 11),
-            # Carryover expires + new monthly accrual
-            ('2026-10-01', leaves := leaves + 2 - 11, 0),
-            # Accrual keeps going
-            ('2026-11-01', leaves + 2, 0),
-        ]
-
-        for test_date, remaining_leaves, expiring_days in assertions:
-            with freeze_time(test_date):
-                allocation._update_accrual()
-                self.assert_remaining_leaves_equal(self.work_entry_type_day, remaining_leaves, self.employee_emp, test_date, digits=3)
-                self.assertAlmostEqual(allocation.expiring_carryover_days, expiring_days, 2, msg=f'Incorrect number of expiring days for {test_date}')
+        self._assert_get_allocation_data(allocation, (
+                # 11 months  =>  11 accruals as "accrued_gain_time" is "end"  =>  11 * 1 (first level) = 11
+                ('2026-06-01', expected_nbr_of_days := 11, 0),
+                # Another monthly accrual
+                # Do not include the 1 accrued day for 2026-07-01 for the expiring days
+                # (otherwise it would be like wasting the days the employee earned trough the last month)
+                ('2026-07-01', expected_nbr_of_days := expected_nbr_of_days + 1, 11),
+                # The day before 12 days should expire + level transition -> 1 accrual from first level,
+                # and another one from the second level (1 + 2)
+                ('2026-09-30', expected_nbr_of_days := expected_nbr_of_days + 3, 11),
+                # Carryover expires + new monthly accrual
+                ('2026-10-01', expected_nbr_of_days := expected_nbr_of_days - 11 + 2, 11),
+                # Accrual keeps going
+                ('2026-11-01', expected_nbr_of_days + 2, 11),
+            ), ('allocated_duration', 'previous_carryover_number_of_days'),
+        )
 
     @freeze_time("2026-01-26")
-    def test_get_future_leaves_on(self):
-        today = fields.Date.today()
-        future_date = today + relativedelta(months=1, day=15)
-
+    def test_get_additionnal_future_leaves_on(self):
+        """ Assert accrual plan allocation `_get_additionnal_future_leaves_on` uses the
+            `unit_of_measure` and not the `request_unit` of the leave type
+        """
         allocation_day = self.env['hr.leave.allocation'].create({
             'name': 'Daily Accrual',
             'work_entry_type_id': self.work_entry_type_day.id,
             'employee_id': self.employee_emp.id,
             'accrual_plan_id': self.accrual_plan_start1.id,
-            'number_of_days': 1.0,
-            'date_from': today,
+            'number_of_days': 0,
+            'date_from': "2026-01-26",
         })
 
         allocation_day._action_validate()
 
-        res_day = allocation_day._get_future_leaves_on(future_date)
-        self.assertEqual(res_day, 1.0, f"Expected 1.0 day increase, got {res_day}")
+        # First period accrual: 2026-01-26 -> 2026-02-01
+        # Second period accrual: 2026-02-01 -> 2026-03-01: +1 day
+        # _get_additionnal_future_leaves_on round at 2 digits
+        res_day = allocation_day._get_additionnal_future_leaves_on(date(2026, 2, 15))
+        first_period_accrued_days = self._get_period_days('2026-01-26', '2026-01-31') / self._get_period_days('2026-01-01', '2026-01-31')
+        self.assertAlmostEqual(res_day, 1 + first_period_accrued_days, delta=0.01)
 
         # Assuming an 8-hour workday, 2 days = 16.0 hours
-        accrual_plan = self.env['hr.leave.accrual.plan'].create({
-            'name': '2 Days Every 1st of Month',
-            'accrued_gain_time': 'start',
-            'level_ids': [Command.create({
-                'added_value': 2,
-                'added_value_type': 'day',
-                'frequency': 'monthly',
-                'first_day': 1,
-                'action_with_unused_accruals': 'all',
-                'milestone_date': 'creation',
-            })]
-        })
-
-        start_date = date(2026, 1, 1)
-        future_date = date(2026, 2, 2)
-
-        calendar = self.env['resource.calendar'].create({
-            'name': 'Standard 40h Test Calendar',
-            'hours_per_day': 8.0,
-        })
-        self.employee_emp.resource_calendar_id = calendar
-
-        work_entry_type_hour = self.env['hr.work.entry.type'].create({
-            'name': 'Hourly Leave Type',
-            'code': 'Hourly Leave Type',
-            'count_as': 'absence',
-            'requires_allocation': True,
-            'allocation_validation_type': 'hr',
-            'request_unit': 'day',
-            'unit_of_measure': 'hour',
-        })
-
+        accrual_plan = self.accrual_plan_monthly_start
+        self.employee_emp.resource_calendar_id = self.calendar_8h_per_day
+        work_entry_type_hour = self.work_entry_type_hour_day
         allocation_hour = self.env['hr.leave.allocation'].create({
             'name': 'Hourly Allocation with daily accrual',
             'work_entry_type_id': work_entry_type_hour.id,
             'employee_id': self.employee_emp.id,
             'accrual_plan_id': accrual_plan.id,
-            'number_of_hours_display': 0.0,
-            'date_from': start_date,
+            'number_of_days': 0,
+            'date_from': '2026-01-01',
         })
         allocation_hour._action_validate()
 
-        # On Feb 1st, it should trigger the 16-hour (2 days) addition
-        res_hour = allocation_hour._get_future_leaves_on(future_date)
-
-        self.assertEqual(res_hour, 16.0, f"Expected 16.0 hours (2 days) increase, got {res_hour}")
+        # 2026-01-01 -> 2026-02-01: +2 days
+        # 2026-02-01 -> 2026-03-01: +2 days
+        # -> 4 days = 32 hours accordingly to the calendar of the employee
+        res_hour = allocation_hour._get_additionnal_future_leaves_on(date(2026, 2, 2))
+        self.assertEqual(res_hour, 32.0)
 
     def test_accrual_allocation_immediate_monthly_start_day(self):
-        """ Test fix for incorrect accrued days when changing date_from on accrual allocations. """
+        """ Assert modifying the `date_from` from the form of an accrual allocation updates the `number_of_days` accordingly
+            and that carriedover duration expires properly
+        """
         with freeze_time('2024-11-15'):
-            accrual_plan = self.env['hr.leave.accrual.plan'].create({
-                'name': 'Accrual Plan For Test',
-                'accrued_gain_time': 'start',
-                'carryover_date': 'other',
-                'carryover_day': 1,
-                'carryover_month': '1',
-                'level_ids': [(0, 0, {
-                    'added_value': 2,
-                    'added_value_type': 'day',
-                    'frequency': 'monthly',
-                    'cap_accrued_time': True,
-                    'maximum_leave': 10000,
-                    'start_count': 0,
-                    'start_type': 'day',
-                    'action_with_unused_accruals': 'all',
-                })],
-            })
+            accrual_plan = self.accrual_plan_monthly_start_carryover_limited_expiring
 
-            allocation = self.env['hr.leave.allocation'].with_user(self.user_hrmanager_id).create({
-                'name': 'Accrual allocation for employee',
-                'accrual_plan_id': accrual_plan.id,
-                'employee_id': self.employee_emp.id,
-                'work_entry_type_id': self.work_entry_type.id,
-                'number_of_days': 0,
-                'date_from': datetime.date(2024, 11, 1),
-            })
-            allocation._onchange_date_from()
-            self.assertAlmostEqual(allocation.number_of_days_display, 2, places=2, msg="Accrued days should be 2 (2 days for Nov).")
+            with Form(self.env['hr.leave.allocation'], 'hr_holidays.hr_leave_allocation_view_form_manager') as form:
+                form.name = 'Test accrual allocation'
+                form.accrual_plan_id = accrual_plan
+                form.employee_id = self.employee_emp
+                form.work_entry_type_id = self.work_entry_type
 
-            allocation.date_from = datetime.date(2024, 10, 1)
-            allocation._onchange_date_from()
-            allocation._update_accrual()
+                # Accrual for November
+                form.date_from = '2024-11-01'
+                self.assertEqual(form.number_of_days_display, 2)
 
-            self.assertAlmostEqual(allocation.number_of_days_display, 4, places=2, msg="Accrued days should be 4 (4 days for Nov).")
+                # 2 months elapsed = 2 x 2 days
+                form.date_from = '2024-10-01'
+                self.assertEqual(form.number_of_days_display, 4)
+
+                # 4 months elapsed, but only 5 days are kept on carryover date (1st of Nov.)
+                # + accrual for November
+                form.date_from = '2024-08-01'
+                self.assertEqual(form.number_of_days_display, 7)
+
+                # Repeat and see what happens
+                form.date_from = '2024-10-01'
+                self.assertEqual(form.number_of_days_display, 4)
+
+                form.date_from = '2024-08-01'
+                self.assertEqual(form.number_of_days_display, 7)
+
+            allocation = form.record
+            self.assertEqual(allocation.number_of_days_display, 7)
+            allocation.action_approve()
+
+        with freeze_time('2024-12-01'):
+            self._run_update_accrual_cron()
+            # Expiration date: 5 days are expiring, then 2 days are accrued for December
+            self.assertEqual(allocation.number_of_days, 7 - 5 + 2)
 
     def test_modify_cap_accrued_days(self):
+        """ Assert the virtual remaining leaves of the employee drop to `maximum_leave` when setting
+            `cap_accrued_time` of the accrual plan to `True` and the virtual remaining leaves was
+            bigger than `maximum_leave`
         """
-        Context: allocation with a 1 level accrual plan which
-            - Carry all days over
-            - Accrues monthly at the end of the period
-        Assert the virtual remaining leaves of the employee drop to `maximum_leave` when setting `cap_accrued_time` of the accrual plan
-        to `True` and the virtual remaining leaves was bigger than `maximum_leave`
-        """
-        with freeze_time('2020-01-01'):
-            accrued_days = 2
+        with freeze_time('2021-01-01'):
             accrual_plan = self.accrual_plan_monthly_end
             work_entry_type_day = self.work_entry_type_day
-            allocation = self._create_form_test_accrual_allocation(work_entry_type_day, '2020-01-01', self.employee_emp, accrual_plan)
+            allocation = self._create_form_test_accrual_allocation(work_entry_type_day, '2021-01-01', self.employee_emp, accrual_plan)
             allocation.action_approve()
 
         with freeze_time('2022-01-01'):
-            allocation._update_accrual()
-            self.assert_remaining_leaves_equal(work_entry_type_day, 24 * accrued_days, self.employee_emp)
-            self.assert_remaining_leaves_equal(work_entry_type_day, 25 * accrued_days, self.employee_emp, date='2022-02-01')
+            self._run_update_accrual_cron()
+            # 12 months accrual x 2 days
+            self._assert_allocation_balance(allocation, 24, 24)
+            # One more month accrual
+            self._assert_allocation_balance(allocation, 26, 26, '2022-02-01')
 
             accrual_plan.level_ids.update({'maximum_leave': 21, 'cap_accrued_time': True})
-            self.assert_remaining_leaves_equal(work_entry_type_day, 21, self.employee_emp, date='2022-02-01')
+            # Now the number_of_days and remaining leaves are capped to 21
+            self._assert_allocation_balance(allocation, 21, 21, '2022-02-01')
 
         with freeze_time('2022-02-01'):
-            allocation._update_accrual()
-            self.assert_remaining_leaves_equal(work_entry_type_day, 21, self.employee_emp)
+            # Assert we get the same balance when running the cron
+            self._run_update_accrual_cron()
+            self._assert_allocation_balance(allocation, 21, 21)
 
     def test_modify_cap_accrued_days_with_leaves(self):
-        """
-        Context: allocation with a 1 level accrual plan which
-            - Carry all days over
-            - Accrues monthly at the end of the period
-        Assert the virtual remaining leaves of the employee drop to `maximum_leave` when setting `cap_accrued_time` of the accrual plan
-        to `True` and the virtual remaining leaves was bigger than `maximum_leave`
-        Adds leaves in the computation (only difference with `test_modify_cap_accrued_days`)
+        """ Assert the virtual remaining leaves of the employee drop to `maximum_leave` when setting `cap_accrued_time` of the accrual plan
+            to `True` and the virtual remaining leaves was bigger than `maximum_leave`
+            Adds leaves in the computation (only difference with `test_modify_cap_accrued_days`)
         """
         with freeze_time('2020-01-01'):
-            accrued_days = 2
             accrual_plan = self.accrual_plan_monthly_end
             work_entry_type_day = self.work_entry_type_day
             allocation = self._create_form_test_accrual_allocation(work_entry_type_day, '2020-01-01', self.employee_emp, accrual_plan)
             allocation.action_approve()
 
         with freeze_time('2022-01-01'):
-            allocation._update_accrual()
-            self.assert_remaining_leaves_equal(work_entry_type_day, before_leave_days := 24 * accrued_days, self.employee_emp)
+            self._run_update_accrual_cron()
+            # 24 * 2 accrued days
+            self._assert_allocation_balance(allocation, 48, 48)
             # 35 days leave
-            self._take_leave(self.employee_emp, work_entry_type_day, '2022-01-03', '2022-02-18')._action_validate()
+            self._create_leave(self.employee_emp, work_entry_type_day, '2022-01-03', '2022-02-18', validate=True)
             # 10 days leave
-            self._take_leave(self.employee_emp, work_entry_type_day, '2022-03-07', '2022-03-18')._action_validate()
+            self._create_leave(self.employee_emp, work_entry_type_day, '2022-03-07', '2022-03-18', validate=True)
 
         with freeze_time('2022-03-01'):
-            allocation._update_accrual()
-            # before_leave_days - 35 days (first leave) + 2 months accrual
-            self.assert_remaining_leaves_equal(work_entry_type_day, after_leave := before_leave_days - 35 + 2 * accrued_days, self.employee_emp)
-            accrual_plan.level_ids.update({'maximum_leave': 21, 'cap_accrued_time': True})
-            self.assert_remaining_leaves_equal(work_entry_type_day, min(after_leave, 21), self.employee_emp)
+            self._run_update_accrual_cron()
+            self._assert_get_allocation_data_future(allocation, (
+                # number_of_days: 48 + 2 months accrual
+                # remaining duration after the first leave: 48 - 35 + 4
+                ('2022-03-01', 52, 17),
+                ('2022-03-01', lambda:
+                    accrual_plan.level_ids.update({'maximum_leave': 21, 'cap_accrued_time': True})),
+                # Cap isn't reached, is changes nothing
+                ('2022-03-01', 52, 17),
+                # The second leave is taken into account (-10d), +2 days accrued for April
+                ('2022-04-01', 54, 9),
+            ))
 
         with freeze_time('2022-04-01'):
-            allocation._update_accrual()
-            after_leave2 = min(after_leave, 21) - 10
-            self.assert_remaining_leaves_equal(work_entry_type_day, min(after_leave2 + accrued_days, 21), self.employee_emp)
-            self.assert_remaining_leaves_equal(work_entry_type_day, min(after_leave2 + 12 * accrued_days, 21), self.employee_emp, date='2023-03-01')
+            self._run_update_accrual_cron()
+            self._assert_get_allocation_data_future(allocation, (
+                ('2022-04-01', 54, 9),
+                # The max number of leaves is reached one year later so the number_of_days is 45 (leaves) + 21 (max),
+                # and the remaining number of days is 21
+                ('2023-03-01', 66, 21),
+            ))
+
+        with freeze_time('2023-03-01'):
+            self._run_update_accrual_cron()
+            # Assert the cap is still applied after running the cron
+            self._assert_allocation_balance(allocation, 66, 21, '2023-03-01')
 
     def test_get_allocation_actual_future_leaves(self):
-        """
-        Context: allocation with a 1 level accrual plan which
-            - Carry all days over
-            - Accrues monthly at the end of the period
-            - Has maximum 10 leaves
-        Assert the virtual remaining leaves of the employee allocation are not frozen while taking multiple leaves
-        and using `get_allocation_data`.
+        """ Assert `get_allocation_data` properly computes the balance of a `work.entry.type`
+            which is linked to an accrual allocation that has max 10 available leaves while
+            taking multiple leaves (the balance used to be frozen after the first leave)
         """
         with freeze_time('2019-01-01'):
             accrual_plan = self.accrual_plan_monthly_end_max_leaves
@@ -4848,34 +3685,28 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
             allocation = self._create_form_test_accrual_allocation(work_entry_type_day, '2019-01-01', self.employee_emp, accrual_plan)
             allocation.action_approve()
 
-        with freeze_time('2022-01-01'):
-            allocation._update_accrual()
-            self.assert_remaining_leaves_equal(work_entry_type_day, 10, self.employee_emp)
-
-            # 10 days leave
-            self._take_leave(self.employee_emp, work_entry_type_day, '2022-01-03', '2022-01-14')._action_validate()
-            # 10 days leave
-            self._take_leave(self.employee_emp, work_entry_type_day, '2023-01-02', '2023-01-13')._action_validate()
-            # 10 days leaves that shouldn't be taken into account in this test
-            self._take_leave(self.employee_emp, work_entry_type_day, '2025-10-06', '2025-10-17')._action_validate()
-
-        with freeze_time('2023-01-01'):
-            allocation._update_accrual()
-            self.assert_remaining_leaves_equal(work_entry_type_day, 10, self.employee_emp)
-
-        with freeze_time('2023-02-01'):
-            allocation._update_accrual()
-            # 10 days - 10 days (leave) + 2 days (1 month accrual)
-            self.assert_remaining_leaves_equal(work_entry_type_day, 2, self.employee_emp)
+        create_leave_command = self._build_create_leave_command(self.employee_emp, work_entry_type_day)
+        self._assert_get_allocation_data(allocation, (
+                ('2022-01-01', 10, 10, 10),
+                # 10 days leave
+                ('2022-01-01', create_leave_command('2022-01-03', '2022-01-14')),
+                # 10 days leave
+                ('2022-01-01', create_leave_command('2023-01-02', '2023-01-13')),
+                # 10 days leaves that shouldn't be taken into account in this test
+                ('2022-01-01', create_leave_command('2025-10-06', '2025-10-17')),
+                # The first leave is taken into account + accrual for January
+                ('2022-02-01', 12, 12, 2),
+                # The cap is reache again
+                ('2023-01-01', 20, 20, 10),
+                # The first and second leaves are taken into account, + accrual for January
+                ('2023-02-01', 22, 22, 2),
+            ),
+            ('number_of_days', 'allocated_duration', 'remaining_leaves'),
+        )
 
     def test_get_allocation_future_leaves(self):
-        """
-        Context: allocation with a 1 level accrual plan which
-            - Carry all days over
-            - Accrues monthly at the end of the period
-            - Has maximum 10 leaves
-        Assert the virtual remaining leaves of the employee allocation are not frozen while taking multiple leaves
-        and using `get_allocation_data` with the `target_date` parameter set in the future.
+        """ Assert the virtual remaining leaves of the employee allocation are not frozen while taking multiple leaves
+            and using `get_allocation_data` with the `target_date` parameter set in the future.
         """
         with freeze_time('2019-01-01'):
             accrual_plan = self.accrual_plan_monthly_end_max_leaves
@@ -4883,39 +3714,33 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
             allocation = self._create_form_test_accrual_allocation(work_entry_type_day, '2019-01-01', self.employee_emp, accrual_plan)
             allocation.action_approve()
 
+        create_leave_command = self._build_create_leave_command(self.employee_emp, work_entry_type_day)
+
         with freeze_time('2022-01-01'):
-            allocation._update_accrual()
-            # Max number of leaves for the only level of the accrual plan is 10
-            self.assert_remaining_leaves_equal(work_entry_type_day, 10, self.employee_emp)
-            self.assert_remaining_leaves_equal(work_entry_type_day, 10, self.employee_emp, date='2022-02-01')
-
-            # 10 days leave
-            self._take_leave(self.employee_emp, work_entry_type_day, '2022-01-03', '2022-01-14')._action_validate()
-            # 10 days leave
-            self._take_leave(self.employee_emp, work_entry_type_day, '2023-01-02', '2023-01-13')._action_validate()
-
-            # 10 days leaves that shouldn't be taken into account in this test
-            self._take_leave(self.employee_emp, work_entry_type_day, '2025-10-06', '2025-10-17')._action_validate()
-            # Right after spending all the 10 leaves ('2023-01-02' -> '2023-01-13')
-            # 10 days - 10 days (leave) + 2 days (1 month accrual)
-            self.assert_remaining_leaves_equal(work_entry_type_day, 2, self.employee_emp, date='2023-02-01')
+            self._run_update_accrual_cron()
+            self._assert_get_allocation_data_future(allocation, (
+                # Max number of leaves for the only level of the accrual plan is 10
+                ('2022-01-01', 10, 10),
+                ('2022-02-01', 10, 10),
+                # 10 days leave
+                ('2022-01-01', create_leave_command('2022-01-03', '2022-01-14')),
+                # 10 days leave
+                ('2022-01-01', create_leave_command('2023-01-02', '2023-01-13')),
+                # 10 days leaves that shouldn't be taken into account in this test
+                ('2022-01-01', create_leave_command('2025-10-06', '2025-10-17')),
+                # Right after spending all the 10 leaves ('2023-01-02' -> '2023-01-13')
+                # 20 days - 2x10 days (leaves) + 2 days (1 month accrual)
+                ('2023-02-01', 22, 2),
+            ))
 
     def _test_get_allocation_future_leaves_regular(self, regular_before):
-        """
-        Context:
-            1) Allocation with a 1 level accrual plan which
-                - Carry all days over
-                - Accrues monthly at the end of the period
-                - Has maximum 10 leaves
-            2) Regular allocation
-        Assert the virtual remaining leaves of the employee allocation are not frozen while taking multiple leaves
-        and using `get_allocation_data` with the `target_date` parameter set in the future.
-        :param regular_before: set the `date_from` of the regular allocation before the `date_from` of the accrual allocation
+        """ Assert `_get_allocation_data` computes properly the future `work.entry.type` balance while taking multiple leaves
+            :param regular_before: set the `date_from` of the regular allocation before the `date_from` of the accrual allocation
         """
         work_entry_type_day = self.work_entry_type_day
         if regular_before:
             with freeze_time('2018-01-01'):
-                self._create_form_test_regular_allocation(work_entry_type_day, '2018-01-01', self.employee_emp, number_of_days=10)
+                self._create_form_test_regular_allocation(work_entry_type_day, '2018-01-01', self.employee_emp, 10)
 
         with freeze_time('2019-01-01'):
             accrual_plan = self.accrual_plan_monthly_end_max_leaves
@@ -4924,25 +3749,32 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
 
         if not regular_before:
             with freeze_time('2020-01-01'):
-                self._create_form_test_regular_allocation(work_entry_type_day, '2020-01-01', self.employee_emp, number_of_days=10)
+                self._create_form_test_regular_allocation(work_entry_type_day, '2020-01-01', self.employee_emp, 10)
 
+        create_leave_command = self._build_create_leave_command(self.employee_emp, work_entry_type_day)
         with freeze_time('2022-01-01'):
-            accrual_allocation._update_accrual()
-            # Max number of leaves for the only level of the accrual plan is 10 + 10 for the regular allocation
-            self.assert_remaining_leaves_equal(work_entry_type_day, 20, self.employee_emp)
-            self.assert_remaining_leaves_equal(work_entry_type_day, 20, self.employee_emp, date='2022-02-01')
-
-            # 10 days leave
-            self._take_leave(self.employee_emp, work_entry_type_day, '2022-01-03', '2022-01-14')._action_validate()
-            # 10 days leave
-            self._take_leave(self.employee_emp, work_entry_type_day, '2023-01-02', '2023-01-13')._action_validate()
-            self.assert_remaining_leaves_equal(work_entry_type_day, 12, self.employee_emp, date='2023-02-01')
-
-            # 10 days leaves that shouldn't be taken into account in this test
-            self._take_leave(self.employee_emp, work_entry_type_day, '2023-10-06', '2023-10-17')._action_validate()
-            # Right after spending all the 10 leaves ('2023-01-02' -> '2023-01-13')
-            # 10 days - 10 days (leave) + 2 days (1 month accrual)
-            self.assert_remaining_leaves_equal(work_entry_type_day, 12, self.employee_emp, date='2023-02-01')
+            self._run_update_accrual_cron()
+            self._assert_get_allocation_data(accrual_allocation, (
+                # Accrual allocatin maximum is reached (10d) + 10d for the regular allocation
+                ('2022-01-01', 20, 20),
+                ('2022-02-01', 20, 20),
+                # 2x10 days leave
+                ('2022-01-01', create_leave_command('2022-01-03', '2022-01-14')),
+                ('2022-01-01', create_leave_command('2023-01-02', '2023-01-13')),
+                # Assert nothing changed ('cause the leaves are in the future)
+                ('2022-01-01', 20, 20),
+                # The 2 leaves should be covered by the the accrual allocation => 10 days left (regular allocation) + 2 days accrual
+                # Until '2023-01-01', the 'number_of_days' should be stuck to 30:
+                # - 10 days regular alloc
+                # - 20 days accrual alloc (max 10 leaves, but 10 leaves were taken)
+                ('2023-01-01', 30, 20),
+                ('2023-02-01', 32, 12),
+                # 10 days leaves that shouldn't be taken into account in this test
+                ('2022-01-01', create_leave_command('2023-10-06', '2023-10-17')),
+                ('2023-02-01', 32, 12),
+            ),
+            ('allocated_duration', 'remaining_leaves'),
+        )
 
     def test_get_allocation_future_leaves_regular1(self):
         self._test_get_allocation_future_leaves_regular(regular_before=False)
@@ -4959,166 +3791,130 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
         with freeze_time('2025-01-01'):
             allocation = self._create_form_test_accrual_allocation(
                 work_entry_type, '2025-01-01', self.employee_emp, self.accrual_plan_monthly_start_carryover_lost)
+            self.assertEqual(allocation.number_of_days, 1)
             allocation.action_approve()
             # 2x1 day leave
-            self._take_leave(self.employee_emp, work_entry_type, '2025-01-03', '2025-01-03')._action_validate()
-            self._take_leave(self.employee_emp, work_entry_type, '2025-02-03', '2025-02-03')._action_validate()
-        assertions = (
-            ('2025-01-01', 1, 8),
-            # No more remaining leave once on the first leave first day
-            ('2025-01-03', 1, 0),
-            ('2025-02-01', 2, 8),
-            # No more remaining leave once on the second leave first day
-            ('2025-02-03', 2, 0),
-            # Monthly accrual keeps going
-            ('2025-03-01', 3, 8),
-            ('2025-04-01', 4, 16),
-            # Carryover happens and removes the 2 remaining days, then monthly accrual happens (+1d)
-            ('2025-05-01', 3, 8),
-            ('2025-06-01', 4, 16),
-            ('2025-07-01', 5, 24),
+            self._create_leave(self.employee_emp, work_entry_type, '2025-01-03', '2025-01-03', validate=True)
+            self._create_leave(self.employee_emp, work_entry_type, '2025-02-03', '2025-02-03', validate=True)
+
+        self._assert_get_allocation_data(allocation, (
+                # No more remaining leave once on the first leave first day
+                ('2025-01-03', 8, 0),
+                ('2025-02-01', 16, 8),
+                # No more remaining leave once on the second leave first day
+                ('2025-02-03', 16, 0),
+                # Monthly accrual keeps going
+                ('2025-03-01', 24, 8),
+                ('2025-04-01', 32, 16),
+                # Carryover happens and removes the 2 remaining days, then monthly accrual happens (+1d)
+                ('2025-05-01', 24, 8),
+                ('2025-06-01', 32, 16),
+                ('2025-07-01', 40, 24),
+            ),
+            ('allocated_duration', 'remaining_leaves'),
         )
-        for test_date, expected_number_of_days, expected_remaining_leaves in assertions:
-            with freeze_time(test_date):
-                allocation._update_accrual()
-                self.assertEqual(allocation.number_of_days, expected_number_of_days, f'Test failed for {test_date}')
-                self.assert_remaining_leaves_equal(work_entry_type, expected_remaining_leaves, self.employee_emp, test_date)
 
-    def test_accrual_days_left_over_carryover_maximum_with_leaves_around_carryover(self):
-        with freeze_time('2024-11-25'):
-            allocation = self._create_form_test_accrual_allocation(
-                self.work_entry_type_day, '2024-01-01', self.employee_emp, self.accrual_plan_yearly_max_postponed_days_start)
-            allocation.action_approve()
-
-            # take 10 days in the past
-            leave = self._take_leave(self.employee_emp, self.work_entry_type_day, '2024-12-09', '2024-12-20')
-            leave._action_validate()
-            # take 10 days in January
-            leave_2 = self._take_leave(self.employee_emp, self.work_entry_type_day, '2025-01-06', '2025-01-17')
-            leave_2._action_validate()
-
-            # The remaining leaves on a specific date should be:
-            # 25/11/2024 to 08/12/2024: 21 days, no leave are deducted
-            # 09/12/2024 to 31/12/2024: 11 days, the first leave is deducted as its start date is past
-            # 01/01/2025 to 05/01/2025: 26 days, carryover occurred, from the 11 days only 5 are left, then the yearly 21 days are added
-            # from 06/01/2025: 16 days, the second leave is deducted as its start date is past
-            assertions = [
-                ('2024-12-01', 21.0),
-                ('2024-12-15', 11.0),
-                ('2025-01-02', 26.0),
-                ('2025-01-06', 16.0),
-            ]
-            for test_date, expected_remaining_leaves in assertions:
-                self.assert_remaining_leaves_equal(self.work_entry_type_day, expected_remaining_leaves, self.employee_emp, test_date, 2)
-
-    def test_accrual_leaves_cancel_cron_with_refused_allocation(self):
-        """ Test that the _cancel_invalid_leaves cron cancels leaves without valid allocation"""
-        work_entry_type = self.env['hr.work.entry.type'].create({
-            'name': 'Test Accrual',
-            'code': 'Test Accrual',
-            'count_as': 'absence',
-            'requires_allocation': 'yes',
-            'allocation_validation_type': 'no_validation',
-            'leave_validation_type': 'no_validation',
-            'allows_negative': True,
-            'max_allowed_negative': 2,
-            'unit_of_measure': 'day',
-        })
-
-        accrual_plan = self.env['hr.leave.accrual.plan'].create({
-            'name': 'Accrual Plan',
-            'carryover_date': 'year_start',
-            'accrued_gain_time': 'end',
-        })
-
-        with freeze_time("2024-01-01"):
-            allocation = self.env['hr.leave.allocation'].create({
-                'employee_id': self.employee_emp.id,
-                'work_entry_type_id': work_entry_type.id,
-                'accrual_plan_id': accrual_plan.id,
-                'number_of_days': 1,
-            })
-
-            leave = self.env['hr.leave'].create({
-                'employee_id': self.employee_emp.id,
-                'work_entry_type_id': work_entry_type.id,
-                'request_date_from': '2024-01-05',
-                'request_date_to': '2024-01-05',
-            })
-
-            allocation.action_refuse()
-            self.env['hr.leave']._cancel_invalid_leaves()
-            self.assertEqual(leave.state, 'cancel')
-
-    def test_timeoff_allocation_with_unused_accrual_lost(self):
+    def test_work_entry_unit_of_measure_day(self):
+        """ Assert the `work.entry.type` balance is correct when linked to an accrual allocation while using a
+            `work.entry.type` with `unit_of_measure` set to 'hour' and `request_unit` set to 'day', knowing that
+            all days are lost on carryover day
         """
-        Create an accrual plan:
-           * Set the accrued gain time to "At the start of the accrual period"
-           * Set the carry-over time to "At the start of the year"
-        Create a milestone:
-           * Set the number of accrued days to 1
-           * Set the accrual frequency to "monthly" and
-            the carry over to "None.Accrued time reset to 0"
-        Create an allocation:
-           * Set the start date to 2025-01-01
-           * Set the accrual plan to the one created above
-        Use future allocations to see the number of days accrued on
-        2026-02-01(feb). It should be 2.
-        """
+        work_entry_type = self.work_entry_type_day_hour
         with freeze_time('2025-01-01'):
-            accrual_plan = self.env['hr.leave.accrual.plan'].create({
-                'name': 'Accrual Plan For Test',
-                'accrued_gain_time': 'start',
-                'level_ids': [Command.create({
-                    'start_count': 0,
-                    'frequency': 'monthly',
-                    'action_with_unused_accruals': 'lost',
-                })],
-            })
-            allocation = self.env['hr.leave.allocation'].create({
-                'name': 'Accrual allocation for employee',
-                'accrual_plan_id': accrual_plan.id,
-                'employee_id': self.employee_emp.id,
-                'work_entry_type_id': self.work_entry_type.id,
-                'date_from': '2025-01-01',
-                'number_of_days': 0,
-                'already_accrued': False,
-            })
+            allocation = self._create_form_test_accrual_allocation(
+                work_entry_type, '2025-01-01', self.employee_emp, self.accrual_plan_monthly_start_carryover_lost_hour)
             allocation.action_approve()
-            assertions = (
-                # Do not run the update on 2026-01-01 otherwise the bug disappears on 2026-02-01
-                # ('2026-01-01', 1),
-                ('2026-02-01', 2),
-                ('2026-03-01', 3),
-            )
-            for test_date, expected_remaining_leaves in assertions:
-                with freeze_time(test_date):
-                    allocation._update_accrual()
-                    self.assertEqual(allocation.number_of_days, expected_remaining_leaves)
+            # 2x1 day leave
+            self._create_leave(self.employee_emp, work_entry_type, '2025-01-03', '2025-01-03', validate=True)
+            self._create_leave(self.employee_emp, work_entry_type, '2025-02-03', '2025-02-03', validate=True)
+
+        # As 'unit_of_measure = day', get_allocation_data will return remaining and allocated duration in day
+        self._assert_get_allocation_data(allocation, (
+                # Accrual for the first month
+                ('2025-01-01', 1, 1),
+                # First leave is taken into account, remaining leave decreases of 1 day
+                ('2025-01-03', 1, 0),
+                # Accrual for the second month
+                ('2025-02-01', 2, 1),
+                # Second leave happens, remaining leave decreases of 1 day
+                ('2025-02-03', 2, 0),
+                # Third accrual
+                ('2025-03-01', 3, 1),
+                ('2025-04-01', 4, 2),
+                # Carryover happens, days are lost + accrual for May
+                ('2025-05-01', 3, 1),
+                # Accruals keep on going...
+                ('2025-06-01', 4, 2),
+                ('2025-07-01', 5, 3),
+            ),
+            ('allocated_duration', 'remaining_leaves'),
+        )
+
+    @freeze_time('2024-11-25')
+    def test_accrual_days_left_over_carryover_maximum_with_leaves_around_carryover(self):
+        """ Assert `get_allocation_data` properly compute the work entry type balance when it is linked to
+            an accrual allocation while taking some leaves (the remaining leaves used to be frozen)
+        """
+        allocation = self._create_form_test_accrual_allocation(
+            self.work_entry_type_day, '2024-01-01', self.employee_emp, self.accrual_plan_yearly_max_carriedover_days_start)
+        allocation.action_approve()
+
+        # take 10 days in the past
+        self._create_leave(self.employee_emp, self.work_entry_type_day, '2024-12-09', '2024-12-20', validate=True)
+        # take 10 days in January
+        self._create_leave(self.employee_emp, self.work_entry_type_day, '2025-01-06', '2025-01-17', validate=True)
+
+        # The remaining leaves on a specific date should be:
+        # 25/11/2024 to 08/12/2024: 21 days, no leave are deducted
+        # 09/12/2024 to 31/12/2024: 11 days, the first leave is deducted as its start date is past
+        # 01/01/2025 to 05/01/2025: 26 days, carryover occurred, from the 11 days only 5 are left, then the yearly 21 days are added
+        # from 06/01/2025: 16 days, the second leave is deducted as its start date is past
+        self._assert_get_allocation_data(allocation, (
+                # Accrual for the year 2024
+                ('2024-01-01', 21.0, 21.0),
+                ('2024-12-01', 21.0, 21.0),
+                # First leave is taken into account
+                ('2024-12-15', 21.0, 11.0),
+                # 5 days are carriedover, then the accrual for the year 2025 happens
+                ('2025-01-01', 36.0, 26.0),
+                # Second leave is taken into account
+                ('2025-01-06', 36.0, 16.0),
+            ),
+            ('allocated_duration', 'remaining_leaves'),
+        )
+
+    @freeze_time("2024-01-01")
+    def test_accrual_leaves_cancel_cron_with_refused_allocation(self):
+        """ Test that the `_cancel_invalid_leaves` cron cancels a leave that is linked to a work entry
+            type having only a refused accrual allocation
+        """
+        work_entry_type = self.work_entry_type_absence_requires_alloc_negativ
+        accrual_plan = self.dummy_accrual_plan
+        allocation = self.env['hr.leave.allocation'].create({
+            'employee_id': self.employee_emp.id,
+            'work_entry_type_id': work_entry_type.id,
+            'accrual_plan_id': accrual_plan.id,
+            'number_of_days': 1,
+        })
+
+        leave = self._create_leave(self.employee_emp, work_entry_type, '2024-01-05', '2024-01-05')
+
+        allocation.action_refuse()
+        self.env['hr.leave']._cancel_invalid_leaves()
+        self.assertEqual(leave.state, 'cancel')
 
     @freeze_time('2026-01-01')
     def test_department_accrual_allocation(self):
+        """ Assert that `number_of_days` is computed properly on the allocation generated through
+            a multi employee accrual allocation
         """
-        Make sure when creating a multi employee accrual allocation the correct
-        number of days will be assigned to each child allocation
-        """
-        employees = self.env['hr.employee'].create([
-            {
-                'name': 'Test Department Employee',
-                'company_id': self.company.id,
-            },
-            {
-                'name': 'Department Employee 1',
-                'company_id': self.company.id,
-            },
-        ])
-
+        employees = self.dummy_test_employee | self.employee_emp
         multi_employee_allocation = self.env['hr.leave.allocation.generate.multi.wizard'].create({
             'name': 'Multi-Allocation',
-            'employee_ids': [(4, employees[0].id), (4, employees[1].id)],
+            'employee_ids': [Command.link(employee.id) for employee in employees],
             'work_entry_type_id': self.work_entry_type_day.id,
             'date_from': '2026-01-01',
-            'accrual_plan_id': self.accrual_plan_yearly_max_postponed_days_start.id
+            'accrual_plan_id': self.accrual_plan_yearly_max_carriedover_days_start.id,
         })
 
         multi_employee_allocation.action_generate_allocations()
@@ -5129,84 +3925,77 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
         self.assertEqual(children_allocations[0].number_of_days, 21.0)
         self.assertEqual(children_allocations[1].number_of_days, 21.0)
 
+    @freeze_time('2026-03-15')
     def test_multi_allocation_wizard_initializes_accrual(self):
-        accrual_plan_daily_end = self.env['hr.leave.accrual.plan'].create({
-            'name': 'Daily Accrual Plan',
-            'is_based_on_worked_time': False,
-            'accrued_gain_time': 'end',
-            'carryover_date': 'allocation',
-            'level_ids': [Command.create({
-                'start_count': 0,
-                'added_value_type': 'day',
-                'added_value': 1,
-                'frequency': 'daily',
-                'action_with_unused_accruals': 'all',
-                'cap_accrued_time': False,
-            })],
+        """ Assert that the multi-employee wizard generate one allocation when used for one employee
+            Also assert the `number_of_days` of this allocation is updated properly
+        """
+        wizard = self.env['hr.leave.allocation.generate.multi.wizard'].create({
+            'name': 'Compute Accruals',
+            'employee_ids': [Command.link(self.employee_emp.id)],
+            'work_entry_type_id': self.work_entry_type.id,
+            'accrual_plan_id': self.accrual_plan_daily_end.id,
+            'date_from': '2026-03-01',
+            'duration': 0.0,
         })
+        wizard.action_generate_allocations()
 
-        with freeze_time('2026-03-15'):
-            wizard = self.env['hr.leave.allocation.generate.multi.wizard'].create({
-                'name': 'Compute Accruals',
-                'employee_ids': [(4, self.employee_emp.id)],
-                'work_entry_type_id': self.work_entry_type.id,
-                'accrual_plan_id': accrual_plan_daily_end.id,
-                'date_from': '2026-03-01',
-                'duration': 0.0,
-            })
-            wizard.action_generate_allocations()
+        allocations = self.env['hr.leave.allocation'].search([
+            ('employee_id', 'in', [self.employee_emp.id]),
+            ('accrual_plan_id', '=', self.accrual_plan_daily_end.id),
+            ('date_from', '=', datetime.date(2026, 3, 1)),
+        ])
+        self.assertEqual(len(allocations), 1, "Should create one allocation for the employee.")
+        self.assertEqual(allocations.number_of_days, 14.0, "Should compute 14 days of accrual for the employee (from March 1st to March 15th).")
 
-            allocations = self.env['hr.leave.allocation'].search([
-                ('employee_id', 'in', [self.employee_emp.id]),
-                ('accrual_plan_id', '=', accrual_plan_daily_end.id),
-                ('date_from', '=', datetime.date(2026, 3, 1)),
-            ])
-            self.assertEqual(len(allocations), 1, "Should create one allocation for the employee.")
-            self.assertEqual(allocations[0].number_of_days, 14.0, "Should compute 14 days of accrual for the employee (from March 1st to March 15th).")
-
+    @freeze_time('2026-03-15')
     def test_multi_allocation_wizard_does_not_recompute_when_duration_is_set(self):
-        with freeze_time('2026-03-15'):
-            wizard = self.env['hr.leave.allocation.generate.multi.wizard'].create({
-                'name': 'Keep Manual Setting',
-                'employee_ids': [(4, self.employee_emp.id)],
-                'work_entry_type_id': self.work_entry_type.id,
-                'accrual_plan_id': self.accrual_plan_monthly_end.id,
-                'date_from': '2026-03-01',
-                'duration': 3.0,
-            })
-            wizard.action_generate_allocations()
+        """ Assert setting the `duration` of the accrual allocation when using the multi-employee wizard
+            sets the number_of_days of the generated accrual allocation, and that it is not recomputed if
+            the cron is run on the same day
+        """
+        wizard = self.env['hr.leave.allocation.generate.multi.wizard'].create({
+            'name': 'Keep Manual Setting',
+            'employee_ids': [(4, self.employee_emp.id)],
+            'work_entry_type_id': self.work_entry_type.id,
+            'accrual_plan_id': self.accrual_plan_monthly_end.id,
+            'date_from': '2026-03-01',
+            'duration': 3.0,
+        })
+        wizard.action_generate_allocations()
 
-            allocation = self.env['hr.leave.allocation'].search([
-                ('employee_id', '=', self.employee_emp.id),
-                ('accrual_plan_id', '=', self.accrual_plan_monthly_end.id),
-                ('date_from', '=', datetime.date(2026, 3, 1)),
-            ], limit=1)
+        allocation = self.env['hr.leave.allocation'].search([
+            ('employee_id', '=', self.employee_emp.id),
+            ('accrual_plan_id', '=', self.accrual_plan_monthly_end.id),
+            ('date_from', '=', datetime.date(2026, 3, 1)),
+        ], limit=1)
+        self.assertEqual(allocation.number_of_days, 3.0, "The number_of_days should've been set to the duration defined in the wizard")
 
-            self.assertEqual(allocation.number_of_days, 3.0, "The number of days should not be recomputed when duration is set.")
+        self._run_update_accrual_cron()
+        # Assert nothing changes (accrual happens at the end of the month)
+        self.assertEqual(allocation.number_of_days, 3.0, "The number of days should not be recomputed when duration is set.")
 
     def test_carryover_no_extra_accrual_start(self):
-        """ Assert that no accrual happens on carryover date
-            Using a one level accrual plan which :
-            - Adds 2 days at the start of every month on the 15th of the month
-            - Has carryover at the start of the year
+        """ Assert that no accrual happens on carryover date while using an accrual allocation which accrues
+            monthly at the 15th of the month and which carryover happens at the start of the year
         """
         with freeze_time('2025-12-01'):
-            accrual_plan = self.accrual_plan_monthly_end_carryover_year_start
+            accrual_plan = self.accrual_plan_monthly_start_carryover_year_start
             allocation = self._create_form_test_accrual_allocation(self.work_entry_type_day, '2025-12-01', self.employee_emp, accrual_plan)
             allocation.action_approve()
 
-        assertions = [
-            # 2025-12-01 -> 2025-12-15 : 15 days / 31 days + 2 days accrual for 2025-12-15 -> 2026-01-15
-            ('2025-12-15', days := 2 * 15 / 31 + 2),
-            # 2026-01-01: carryover date, nothing happens
-            ('2026-01-01', days),
-            # 2026-01-15: monthly accrual keeps going
-            ('2026-01-15', days + 2),
-        ]
-        for test_date, expected_days in assertions:
-            with freeze_time(test_date):
-                allocation._update_accrual()
-                self.assert_remaining_leaves_equal(self.work_entry_type_day, expected_days, self.employee_emp, test_date, 2)
+        first_period_days = self._get_period_days('2025-12-01', '2025-12-14')
+        first_period_total_days = self._get_period_days('2025-11-15', '2025-12-14')
+        self._assert_get_allocation_data(allocation, (
+                # Accrual for 2025-12-01 -> 2025-12-14 (partial period) and 2025-12-15 -> 2026-01-14
+                ('2025-12-15', days := first_period_days / first_period_total_days * 2 + 2),
+                # 2026-01-01: carryover date, nothing happens
+                ('2026-01-01', days),
+                # 2026-01-15: monthly accrual keeps going
+                ('2026-01-15', days + 2),
+            ),
+            ('allocated_duration',),
+        )
 
     def test_carryover_no_extra_accrual_end(self):
         """ Assert that no accrual happens on carryover date
@@ -5215,43 +4004,23 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
             - Has carryover at the start of the year
         """
         with freeze_time('2025-12-01'):
-            accrual_plan = self.accrual_plan_monthly_end_carryover_year_end
+            accrual_plan = self.accrual_plan_monthly_end_carryover_year_start
             allocation = self._create_form_test_accrual_allocation(self.work_entry_type_day, '2025-12-01', self.employee_emp, accrual_plan)
             allocation.action_approve()
 
-        assertions = [
-            # 2025-12-01 -> 2025-12-15 : 15 days
-            ('2025-12-15', days := 2 * 15 / 31),
-            # 2026-01-01: carryover date, nothing happens
-            ('2026-01-01', days),
-            # 2026-01-15: monthly accrual keeps going
-            ('2026-01-15', days + 2),
-        ]
-        for test_date, expected_days in assertions:
-            with freeze_time(test_date):
-                allocation._update_accrual()
-                self.assert_remaining_leaves_equal(self.work_entry_type_day, expected_days, self.employee_emp, test_date, 2)
-
-    def test_carryover_no_extra_accrual_end_2(self):
-        """ Assert that no accrual happens on carryover date
-            Using a one level accrual plan which :
-            - Adds 2 days at the end of every month on the 15th of the month
-            - Has carryover at the start of the year
-        """
-        with freeze_time('2025-11-01'):
-            accrual_plan = self.accrual_plan_monthly_end_carryover_year_end
-            allocation = self._create_form_test_accrual_allocation(self.work_entry_type_day, '2025-11-01', self.employee_emp, accrual_plan, date_to='2025-11-15')
-            allocation.action_approve()
-            allocation._process_accrual_plans()
-
-        assertions = [
-            ('2025-11-01', 0),
-            ('2025-11-15', 14 / 30 * 2),
-        ]
-        for test_date, expected_days in assertions:
-            with freeze_time(test_date):
-                allocation._process_accrual_plans()
-                self.assert_remaining_leaves_equal(self.work_entry_type_day, expected_days, self.employee_emp, test_date, 2)
+        first_period_days = self._get_period_days('2025-12-01', '2025-12-14')
+        first_period_total_days = self._get_period_days('2025-11-15', '2025-12-14')
+        self._assert_get_allocation_data(allocation, (
+                ('2025-12-01', 0),
+                # 2025-12-01 -> 2025-12-14 : 14 days
+                ('2025-12-15', duration := first_period_days / first_period_total_days * 2),
+                # 2026-01-01: carryover date, nothing happens
+                ('2026-01-01', duration),
+                # 2026-01-15: monthly accrual keeps going
+                ('2026-01-15', duration + 2),
+            ),
+            ('allocated_duration',),
+        )
 
     def test_carryover_no_extra_accrual_end_multi_level(self):
         """ Assert that no accrual happens on carryover date when the carryover is the last event before the carryover date
@@ -5265,26 +4034,24 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
             allocation = self._create_form_test_accrual_allocation(self.work_entry_type_day, '2025-12-16', self.employee_emp, accrual_plan)
             allocation.action_approve()
 
-        assertions = [
-            # Beginning of the accrual: 0 days
-            ('2025-12-16', expected_leaves := 0),
-            # Carryover date, nothing happens
-            ('2026-01-01', expected_leaves),
-            # Monthly accrual keeps going 2025-12-16 -> 2026-01-15 : 30 / 31
-            ('2026-01-15', expected_leaves := 30 / 31 * 2),
-            # Last accrual before level transition
-            ('2026-12-15', expected_leaves := expected_leaves + 11 * 2),
-            # Level transition: accrual happens: 2026-12-15 -> 2026-12-16 : 1 / 31
-            ('2026-12-16', expected_leaves := expected_leaves + 1 / 31 * 2),
-            # Carryover: nothing happens
-            ('2027-01-01', expected_leaves),
-            # Monthly accrual keeps going for the second level: 2026-12-16 -> 2027-01-15: 30 / 31
-            ('2027-01-15', expected_leaves := expected_leaves + 30 / 31 * 3),
-        ]
-        for test_date, expected_days in assertions:
-            with freeze_time(test_date):
-                allocation._update_accrual()
-                self.assert_remaining_leaves_equal(self.work_entry_type_day, expected_days, self.employee_emp, test_date, 2)
+        self._assert_get_allocation_data(allocation, (
+                # Beginning of the accrual: 0 days
+                ('2025-12-16', duration := 0),
+                # Carryover date, nothing happens
+                ('2026-01-01', duration),
+                # Monthly accrual keeps going 2025-12-16 -> 2026-01-15 : 30 / 31
+                ('2026-01-15', duration := 30 / 31 * 2),
+                # Last accrual before level transition
+                ('2026-12-15', duration := duration + 11 * 2),
+                # Level transition: accrual happens: 2026-12-15 -> 2026-12-16 : 1 / 31
+                ('2026-12-16', duration := duration + 1 / 31 * 2),
+                # Carryover: nothing happens
+                ('2027-01-01', duration),
+                # Monthly accrual keeps going for the second level: 2026-12-16 -> 2027-01-15: 30 / 31
+                ('2027-01-15', duration := duration + 30 / 31 * 3),
+            ),
+            ('allocated_duration',),
+        )
 
     def test_carryover_no_extra_accrual_start_multi_level(self):
         """ Assert that no accrual happens on carryover date when the carryover is the last event before the carryover date
@@ -5298,23 +4065,47 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
             allocation = self._create_form_test_accrual_allocation(self.work_entry_type_day, '2025-12-16', self.employee_emp, accrual_plan)
             allocation.action_approve()
 
-        assertions = [
-            # Beginning of the accrual: 2025-12-16 -> 2026-01-15: 30 / 31
-            ('2025-12-16', expected_leaves := 30 / 31 * 2),
-            # Carryover date, nothing happens
-            ('2026-01-01', expected_leaves),
-            # Monthly accrual keeps going
-            ('2026-01-15', expected_leaves := expected_leaves + 2),
-            # Last accrual before level transition: 10 month accrual + 2026-12-15 -> 2026-12-16 = 1 / 31
-            ('2026-12-15', expected_leaves := expected_leaves + 10 * 2 + 1 / 31 * 2),
-            # Level transition: accrual happens: adding the 30 days left
-            ('2026-12-16', expected_leaves := expected_leaves + 30 / 31 * 3),
-            # Carryover: nothing happens
-            ('2027-01-01', expected_leaves),
-            # Monthly accrual keeps going for the second level
-            ('2027-01-15', expected_leaves := expected_leaves + 3),
-        ]
-        for test_date, expected_days in assertions:
-            with freeze_time(test_date):
-                allocation._update_accrual()
-                self.assert_remaining_leaves_equal(self.work_entry_type_day, expected_days, self.employee_emp, test_date, 2)
+        self._assert_get_allocation_data(allocation, (
+                # Beginning of the accrual: 2025-12-16 -> 2026-01-15: 30 / 31
+                ('2025-12-16', duration := 30 / 31 * 2),
+                # Carryover date, nothing happens
+                ('2026-01-01', duration),
+                # Monthly accrual keeps going
+                ('2026-01-15', duration := duration + 2),
+                # Last accrual before level transition: 10 month accrual + 2026-12-15 -> 2026-12-16 = 1 / 31
+                ('2026-12-15', duration := duration + 10 * 2 + 1 / 31 * 2),
+                # Level transition: accrual happens: adding the 30 days left
+                ('2026-12-16', duration := duration + 30 / 31 * 3),
+                # Carryover: nothing happens
+                ('2027-01-01', duration),
+                # Monthly accrual keeps going for the second level
+                ('2027-01-15', duration := duration + 3),
+            ),
+            ('allocated_duration',),
+        )
+
+    def test_transition_mode_accrual_plan_end(self):
+        """ When transition mode of an accrual plan is set to `end_of_accrual` and that it accrues the days at
+            the end of the period, assert the previous level is used when we are past the level transition, but
+            we are still in the previous level last period
+
+            Here the accrual plan first level accrues 1 day monthly
+            Second level start after 1 month and accrues 2 days monthly
+        """
+        with freeze_time('2026-01-15'):
+            allocation = self._create_form_test_accrual_allocation(
+                self.work_entry_type_day, '2026-01-15', self.employee_emp, self.accrual_plan2)
+            allocation.action_approve()
+
+        self._assert_accrual_allocation_nbr_of_days_and_nextcall(allocation, (
+            # Accrual plan accrued time is 'end', so 0 days at the start
+            ('2026-01-15', number_of_days := 0, date(2026, 2, 1)),
+            # Accrual from 15 to 31 of January
+            ('2026-02-01', number_of_days := number_of_days + (31 - 15 + 1) / 31, date(2026, 3, 1)),
+            # Transition mode is set to 'end_of_accrual', nothing happens here
+            ('2026-02-15', number_of_days, date(2026, 3, 1)),
+            # We are past the first level, but the first level should still be used for this accrual
+            ('2026-03-01', number_of_days := number_of_days + 1, date(2026, 4, 1)),
+            # Second level is used for this accrual
+            ('2026-04-01', number_of_days := number_of_days + 2, date(2026, 5, 1)),
+        ))

--- a/addons/hr_holidays/tests/test_accrual_allocations.py
+++ b/addons/hr_holidays/tests/test_accrual_allocations.py
@@ -83,8 +83,38 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
             'request_unit': 'day',
             'unit_of_measure': 'day',
         })
+        accrual_plan2_levels_fields = {
+            'added_value_type': 'day',
+            'frequency': 'monthly',
+            'accrual_validity': True,
+            'accrual_validity_count': 3,
+            'accrual_validity_type': 'month',
+            'action_with_unused_accruals': 'all',
+        }
+        cls.accrual_plan2 = cls.env['hr.leave.accrual.plan'].create({
+            'name': 'Accrual Plan 2',
+            'is_based_on_worked_time': False,
+            'accrued_gain_time': 'end',
+            'carryover_date': 'allocation',
+            'can_be_carryover': True,
+            'transition_mode': 'end_of_accrual',
+            'level_ids': [
+                Command.create({
+                    **accrual_plan2_levels_fields,
+                    'milestone_date': 'creation',
+                    'added_value': 1,
+                }),
+                Command.create({
+                    **accrual_plan2_levels_fields,
+                    'milestone_date': 'after',
+                    'start_count': 1,
+                    'start_type': 'month',
+                    'added_value': 2,
+                }),
+            ],
+        })
 
-    def setAllocationCreateDate(self, allocation_id, date):
+    def _set_allocation_create_date(self, allocation_id, date):
         """ This method is a hack in order to be able to define/redefine the create_date
             of the allocations.
             This is done in SQL because ORM does not allow to write onto the create_date field.
@@ -95,16 +125,6 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                        SET create_date = '%s'
                        WHERE id = %s
                        """ % (date, allocation_id))
-
-    def assert_allocation_and_balance(self, allocation, expected_allocation_value, expected_balance_value, msg):
-        unit = allocation.accrual_plan_id.added_value_type
-        allocation_value = allocation.number_of_hours_display if unit == 'hour' else allocation.number_of_days
-
-        work_entry_type_data = allocation.work_entry_type_id.get_allocation_data(self.employee_emp)
-        remaining_leaves = work_entry_type_data[self.employee_emp][0][1]['remaining_leaves']
-
-        self.assertAlmostEqual(allocation_value, expected_allocation_value, places=1, msg=msg)
-        self.assertAlmostEqual(remaining_leaves, expected_balance_value, places=1, msg=msg)
 
     def test_consistency_between_cap_accrued_time_and_maximum_leave(self):
         accrual_plan = self.env['hr.leave.accrual.plan'].with_context(tracking_disable=True).create({
@@ -367,7 +387,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'allocation_type': 'accrual',
                 'date_from': '2021-09-03',
             })
-            self.setAllocationCreateDate(allocation.id, '2021-09-01 00:00:00')
+            self._set_allocation_create_date(allocation.id, '2021-09-01 00:00:00')
             allocation.action_approve()
             self.assertFalse(allocation.nextcall, 'There should be no nextcall set on the allocation.')
             self.assertEqual(allocation.number_of_days, 0, 'There should be no days allocated yet.')
@@ -413,7 +433,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'allocation_type': 'accrual',
                 'date_from': '2021-08-31',
             })
-            self.setAllocationCreateDate(allocation.id, '2021-09-01 00:00:00')
+            self._set_allocation_create_date(allocation.id, '2021-09-01 00:00:00')
             allocation.action_approve()
             self.assertFalse(allocation.nextcall, 'There should be no nextcall set on the allocation.')
             self.assertEqual(allocation.number_of_days, 0, 'There should be no days allocated yet.')
@@ -454,7 +474,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'number_of_days': 0,
                 'allocation_type': 'accrual',
             })
-            self.setAllocationCreateDate(allocation.id, '2021-09-01 00:00:00')
+            self._set_allocation_create_date(allocation.id, '2021-09-01 00:00:00')
             allocation.action_approve()
             self.assertFalse(allocation.nextcall, 'There should be no nextcall set on the allocation.')
             self.assertEqual(allocation.number_of_days, 0, 'There should be no days allocated yet.')
@@ -500,7 +520,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'number_of_days': 0,
                 'allocation_type': 'accrual',
             })
-            self.setAllocationCreateDate(allocation.id, '2021-09-01 00:00:00')
+            self._set_allocation_create_date(allocation.id, '2021-09-01 00:00:00')
             allocation.action_approve()
             self.assertFalse(allocation.nextcall, 'There should be no nextcall set on the allocation.')
             self.assertEqual(allocation.number_of_days, 0, 'There should be no days allocated yet.')
@@ -589,10 +609,10 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'state': 'confirm',
             })
             (allocation_not_worked_time | allocation_worked_time).action_approve()
-            self.setAllocationCreateDate(allocation_not_worked_time.id, '2021-08-01 00:00:00')
-            self.setAllocationCreateDate(allocation_worked_time.id, '2021-08-01 00:00:00')
+            self._set_allocation_create_date(allocation_not_worked_time.id, '2021-08-01 00:00:00')
+            self._set_allocation_create_date(allocation_worked_time.id, '2021-08-01 00:00:00')
             work_entry_type = self.env['hr.work.entry.type'].create({
-                'name': 'Paid Time Off 2',
+                'name': 'Paid Time Off',
                 'code': 'Paid Time Off 2',
                 'requires_allocation': False,
                 'count_as': 'absence',
@@ -886,7 +906,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                     'frequency': 'monthly',
                     'action_with_unused_accruals': 'all',
                     'carryover_options': 'limited',
-                    'postpone_max_days': 4,  # confusing name but is in hours when added_value_type == 'hour'
+                    'max_carriedover_duration': 4,  # confusing name but is in hours when added_value_type == 'hour'
                 })],
             })
             allocation = self.env['hr.leave.allocation'].with_user(self.user_hrmanager_id).with_context(tracking_disable=True).create({
@@ -946,11 +966,10 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
             allocation.action_approve()
             next_date = datetime.date.today() + relativedelta(days=11)
             second_level = self.env['hr.leave.accrual.level'].search([('accrual_plan_id', '=', accrual_plan.id), ('start_count', '=', 10)])
-            self.assertEqual(allocation._get_current_accrual_plan_level_id(next_date)[0], second_level, 'The second level should be selected')
+            self.assertEqual(allocation._get_current_accrual_plan_level_idx(next_date)[0], second_level, 'The second level should be selected')
 
     def test_accrual_transition_after_period(self):
-        with freeze_time("2017-12-05"):
-            # 1 accrual with 2 levels and level transition after
+        with freeze_time("2025-07-08"):
             accrual_plan = self.env['hr.leave.accrual.plan'].with_context(tracking_disable=True).create({
                 'transition_mode': 'end_of_accrual',
                 'can_be_carryover': True,
@@ -983,9 +1002,18 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'allocation_type': 'accrual',
             })
             allocation.action_approve()
-            next_date = datetime.date.today() + relativedelta(days=11)
+            # Second level starts on 2025-07-18, but first level 'transition_mode' is set to 'end_of_accrual', so the first level will
+            # end its period before transition
+            # ===> 2025-07-18 is a Friday, therefore the second level will start on 2025-07-21 (next Monday)
+            # "2025-07-19" still belongs to the first level
+            first_level = self.env['hr.leave.accrual.level'].search([('accrual_plan_id', '=', accrual_plan.id), ('start_count', '=', 1)])
+            current_lvl, _ = allocation._get_current_accrual_plan_level_idx(datetime.date(2025, 7, 19))
+            self.assertEqual(current_lvl, first_level, 'The first level should be selected')
+
+            # "2025-07-21" belongs to the second level
             second_level = self.env['hr.leave.accrual.level'].search([('accrual_plan_id', '=', accrual_plan.id), ('start_count', '=', 10)])
-            self.assertEqual(allocation._get_current_accrual_plan_level_id(next_date)[0], second_level, 'The second level should be selected')
+            current_lvl, _ = allocation._get_current_accrual_plan_level_idx(datetime.date(2025, 7, 21))
+            self.assertEqual(current_lvl, second_level, 'The second level should be selected')
 
     def test_unused_accrual_lost(self):
         """
@@ -1044,7 +1072,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
             self.assertEqual(allocation.number_of_days, 1,
                              'The number of days should reset and 1 day will be accrued on 01/01/2022.')
 
-    def test_unused_accrual_postponed(self):
+    def test_unused_accrual_carried_over(self):
         # 1 accrual with 2 levels and level transition after
         # This also tests retroactivity
         with freeze_time('2021-12-15'):
@@ -1080,7 +1108,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
             allocation._update_accrual()
         self.assertEqual(allocation.number_of_days, 25, 'The maximum number of days should be reached and kept.')
 
-    def test_unused_accrual_postponed_2(self):
+    def test_unused_accrual_carried_over_2(self):
         with freeze_time('2021-01-01'):
             accrual_plan = self.env['hr.leave.accrual.plan'].with_context(tracking_disable=True).create({
                 'name': 'Accrual Plan For Test',
@@ -1088,14 +1116,13 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'level_ids': [(0, 0, {
                     'added_value_type': 'day',
                     'milestone_date': 'creation',
-                    'start_type': 'day',
                     'added_value': 2,
                     'frequency': 'yearly',
                     'cap_accrued_time': True,
                     'maximum_leave': 100,
                     'action_with_unused_accruals': 'all',
                     'carryover_options': 'limited',
-                    'postpone_max_days': 10,
+                    'max_carriedover_duration': 10,
                 })],
             })
             allocation = self.env['hr.leave.allocation'].with_user(self.user_hrmanager_id).with_context(tracking_disable=True).create({
@@ -1115,7 +1142,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
             allocation._update_accrual()
         self.assertEqual(allocation.number_of_days, 4, 'The maximum number of days should be reached and kept.')
 
-    def test_unused_accrual_postponed_limit(self):
+    def test_unused_accrual_carried_over_limit(self):
         """
         Create an accrual plan:
             - Carryover date:  January 1st.
@@ -1157,7 +1184,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                     'maximum_leave': 25,
                     'action_with_unused_accruals': 'all',
                     'carryover_options': 'limited',
-                    'postpone_max_days': 15,
+                    'max_carriedover_duration': 15,
                 })],
             })
             allocation = self.env['hr.leave.allocation'].with_user(self.user_hrmanager_id).with_context(tracking_disable=True).create({
@@ -1178,7 +1205,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
         self.assertEqual(allocation.number_of_days, 16,
                           '15 days carryover. 1 day is accrued for the new accrual period. The total is 16 days.')
 
-    def test_unused_accrual_postponed_limit_2(self):
+    def test_unused_accrual_carried_over_limit_2(self):
         """
         Create an accrual plan:
             - Carryover date:  January 1st.
@@ -1206,14 +1233,13 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'level_ids': [(0, 0, {
                     'added_value_type': 'day',
                     'milestone_date': 'creation',
-                    'start_type': 'day',
                     'added_value': 15,
                     'frequency': 'yearly',
                     'cap_accrued_time': True,
                     'maximum_leave': 100,
                     'action_with_unused_accruals': 'all',
                     'carryover_options': 'limited',
-                    'postpone_max_days': 7,
+                    'max_carriedover_duration': 7,
                 })],
             })
             allocation = self.env['hr.leave.allocation'].with_user(self.user_hrmanager_id).with_context(tracking_disable=True).create({
@@ -1243,7 +1269,6 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
             'level_ids': [(0, 0, {
                 'added_value_type': 'day',
                 'milestone_date': 'creation',
-                'start_type': 'day',
                 'added_value': 15,
                 'frequency': 'biyearly',
                 'cap_accrued_time': True,
@@ -1366,7 +1391,6 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 (0, 0, {
                     'added_value_type': 'day',
                     'milestone_date': 'creation',
-                    'start_type': 'day',
                     'added_value': 1,
                     'frequency': 'monthly',
                     'cap_accrued_time': True,
@@ -1429,7 +1453,6 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 (0, 0, {
                     'added_value_type': 'day',
                     'milestone_date': 'creation',
-                    'start_type': 'day',
                     'added_value': 3,
                     'frequency': 'yearly',
                     'cap_accrued_time': True,
@@ -1526,7 +1549,6 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
             'level_ids': [(0, 0, {
                 'added_value_type': 'day',
                 'milestone_date': 'creation',
-                'start_type': 'day',
                 'added_value': 1,
                 'frequency': 'weekly',
                 'week_day': '0',
@@ -1572,7 +1594,6 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
             'level_ids': [(0, 0, {
                 'added_value_type': 'hour',
                 'milestone_date': 'creation',
-                'start_type': 'day',
                 'added_value': 1,
                 'frequency': 'weekly',
                 'week_day': '0',
@@ -1619,7 +1640,6 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
             'level_ids': [(0, 0, {
                 'added_value_type': 'day',
                 'milestone_date': 'creation',
-                'start_type': 'day',
                 'added_value': 1,
                 'frequency': 'daily',
                 'week_day': '0',
@@ -1661,7 +1681,6 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
             'level_ids': [(0, 0, {
                 'added_value_type': 'hour',
                 'milestone_date': 'creation',
-                'start_type': 'day',
                 'added_value': 0.06,
                 'frequency': 'hourly',
                 'week_day': '0',
@@ -1685,7 +1704,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
 
         with freeze_time('2024-12-20'):
             allocation._update_accrual()
-            self.assert_allocation_and_balance(allocation, 120, 120,
+            self._assert_allocation_nbr_of_days_and_remaining_leaves_equal(allocation, 120, 120,
                 "The yearly cap should be reached.")
             leave = self.env['hr.leave'].create({
                 'name': "Leave for employee",
@@ -1698,21 +1717,22 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
             })
             self.assertEqual(leave.number_of_hours, 2)
             self.assertEqual(allocation.leaves_taken, 2)
-            self.assert_allocation_and_balance(allocation, 120, 118,
+            self._assert_allocation_nbr_of_days_and_remaining_leaves_equal(allocation, 120, 118,
                 "The 2 hours should be deduced from the balance")
 
         with freeze_time('2024-12-31'):
             allocation._update_accrual()
-            self.assert_allocation_and_balance(allocation, 120, 118,
+            self._assert_allocation_nbr_of_days_and_remaining_leaves_equal(allocation, 120, 118,
                 "The amount shouldn't exceed the yearly amount as all days days have already been accrued.")
 
         with freeze_time('2025-01-06'):
             allocation._update_accrual()
-            self.assertAlmostEqual(allocation.number_of_hours_display, 121.44)
+            self.assertAlmostEqual(allocation.number_of_hours_display, 121.44,
+                msg="Past 2025-01-06 (carryover), the number of days of the allocation should not be capped to 120 anymore")
 
         with freeze_time('2025-07-03'):
             allocation._update_accrual()
-            self.assert_allocation_and_balance(allocation, 182, 180, "The global cap should be reached.")
+            self._assert_allocation_nbr_of_days_and_remaining_leaves_equal(allocation, 182, 180, "The global cap should be reached.")
             leave = self.env['hr.leave'].create({
                 'name': "Leave for employee",
                 'employee_id': self.employee_emp.id,
@@ -1722,17 +1742,17 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
             })
             self.assertEqual(leave.number_of_hours, 64)
             self.assertEqual(allocation.leaves_taken, 66)
-            self.assert_allocation_and_balance(allocation, 182, 116,
+            self._assert_allocation_nbr_of_days_and_remaining_leaves_equal(allocation, 182, 116,
                 "The leave hours should be deduced from the balance.")
 
         with freeze_time('2025-12-25'):
             allocation._update_accrual()
-            self.assert_allocation_and_balance(allocation, 240, 174,
+            self._assert_allocation_nbr_of_days_and_remaining_leaves_equal(allocation, 240, 174,
                 "The total yearly amount should be reached.")
 
         with freeze_time('2025-12-31'):
             allocation._update_accrual()
-            self.assert_allocation_and_balance(allocation, 240, 174,
+            self._assert_allocation_nbr_of_days_and_remaining_leaves_equal(allocation, 240, 174,
                 "Nothing more should have been accrued since the yearly cap was already reached.")
 
     def test_accrual_period_start(self):
@@ -1742,7 +1762,6 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
             'level_ids': [(0, 0, {
                 'added_value_type': 'day',
                 'milestone_date': 'creation',
-                'start_type': 'day',
                 'added_value': 1,
                 'frequency': 'weekly',
                 'week_day': '0',
@@ -1791,7 +1810,6 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
             'level_ids': [(0, 0, {
                 'added_value_type': 'day',
                 'milestone_date': 'creation',
-                'start_type': 'day',
                 'added_value': 1.5,
                 'frequency': 'monthly',
                 'first_day': 13,
@@ -1828,7 +1846,6 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 (0, 0, {
                     'added_value_type': 'day',
                     'milestone_date': 'creation',
-                    'start_type': 'day',
                     'added_value': 1,
                     'frequency': 'weekly',
                     'week_day': '2',
@@ -1879,7 +1896,6 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
             'level_ids': [(0, 0, {
                 'added_value_type': 'day',
                 'milestone_date': 'creation',
-                'start_type': 'day',
                 'added_value': 1,
                 'frequency': 'monthly',
                 'first_day': 27,
@@ -1928,14 +1944,13 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
             'level_ids': [(0, 0, {
                 'added_value_type': 'day',
                 'milestone_date': 'creation',
-                'start_type': 'day',
                 'added_value': 10,
                 'frequency': 'monthly',
                 'first_day': 11,
                 'cap_accrued_time': False,
                 'action_with_unused_accruals': 'all',
                 'carryover_options': 'limited',
-                'postpone_max_days': 69,
+                'max_carriedover_duration': 69,
             })],
         })
         with freeze_time("2023-04-20"):
@@ -2032,7 +2047,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                     'maximum_leave': 15,
                     'action_with_unused_accruals': 'all',
                     'carryover_options': 'limited',
-                    'postpone_max_days': 13,
+                    'max_carriedover_duration': 13,
                 }),
                 (0, 0, {
                     'milestone_date': 'after',
@@ -2048,7 +2063,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                     'maximum_leave': 10,
                     'action_with_unused_accruals': 'all',
                     'carryover_options': 'limited',
-                    'postpone_max_days': 20,
+                    'max_carriedover_duration': 20,
                 }),
                 (0, 0, {
                     'milestone_date': 'after',
@@ -2088,7 +2103,6 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
             'level_ids': [(0, 0, {
                 'added_value_type': 'day',
                 'milestone_date': 'creation',
-                'start_type': 'day',
                 'added_value': 1,
                 'frequency': 'weekly',
                 'cap_accrued_time': False,
@@ -2105,18 +2119,21 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'accrual_plan_id': accrual_plan.id,
             })
             # As the duration is set to a onchange, we need to force that onchange to run
-            accrual_allocation._onchange_date_from()
+            accrual_allocation._onchange_process_accrual_plans()
             accrual_allocation.action_approve()
             # The amount of days should be computed as if it was accrued since
             # the start date of the allocation.
             self.assertAlmostEqual(accrual_allocation.number_of_days, 34.0, places=0)
-            self.assertFalse(accrual_allocation.lastcall == accrual_allocation.date_from)
+            self.assertFalse(accrual_allocation.last_accrual == accrual_allocation.date_from)
             accrual_allocation._update_accrual()
             # The amount being already computed, the amount should stay the same after the cron
             # running on the same day.
             self.assertAlmostEqual(accrual_allocation.number_of_days, 34.0, places=0)
 
-    def test_future_accural_time(self):
+    def test_future_accrual_time(self):
+        """
+        Check that the carryover is processed correctly when the 'added_value_type' is set to 'hour'
+        """
         work_entry_type = self.env['hr.work.entry.type'].create({
             'name': 'Test Leave Type 2',
             'code': 'Test Leave Type 2',
@@ -2145,7 +2162,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                     'action_with_unused_accruals': 'all',
                 })],
             })
-            allocation = self.env['hr.leave.allocation'].create({
+            allocation = self.env['hr.leave.allocation'].with_context(tracking_disable=True).create({
                 'name': 'Accrual allocation for employee',
                 'accrual_plan_id': accrual_plan.id,
                 'employee_id': self.employee_emp.id,
@@ -2154,8 +2171,12 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'allocation_type': 'accrual',
             })
             allocation.action_approve()
-            allocation_data = work_entry_type.get_allocation_data(self.employee_emp, datetime.date(2024, 2, 1))
-            self.assertEqual(allocation_data[self.employee_emp][0][1]['virtual_remaining_leaves'], 2)
+            # First level starts on 2024-01-01 and first period end is 2024-02-01
+            # So one hour is accrued: 0.125 of day if we consider the employee works 8 hours a day
+            # The number of hours should be 0.125 + 0.125 accrued days = 2 hours
+            self.assertEqual(allocation._get_employee_hours_per_day(), 8,
+                "If the employee hours per day is not 8, the following statement will fail.")
+            self._assert_allocation_nbr_of_days_and_remaining_leaves_equal(allocation, 2, 2, target_date='2024-02-01')
 
     def test_added_type_during_onchange(self):
         """
@@ -2195,7 +2216,6 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
             'level_ids': [(0, 0, {
                 'added_value_type': 'day',
                 'milestone_date': 'creation',
-                'start_type': 'day',
                 'added_value': 1,
                 'frequency': 'daily',
                 'cap_accrued_time': False,
@@ -2212,7 +2232,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'accrual_plan_id': accrual_plan.id,
             })
             # As the duration is set to a onchange, we need to force that onchange to run
-            accrual_allocation._onchange_date_from()
+            accrual_allocation._onchange_process_accrual_plans()
             accrual_allocation.action_approve()
             # The amount of days should be computed as if it was accrued since
             # the start date of the allocation.
@@ -2230,7 +2250,6 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
             'level_ids': [(0, 0, {
                 'added_value_type': 'day',
                 'milestone_date': 'creation',
-                'start_type': 'day',
                 'added_value': 1,
                 'frequency': 'monthly',
                 'first_day': '31',
@@ -2248,17 +2267,17 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'accrual_plan_id': accrual_plan.id,
             })
             # As the duration is set to an onchange, we need to force that onchange to run
-            accrual_allocation._onchange_date_from()
+            accrual_allocation._onchange_process_accrual_plans()
             self.assertAlmostEqual(accrual_allocation.number_of_days, 0, places=0)
 
             # Yearly Report lost
             accrual_allocation.write({'date_from': '2022-01-01'})
-            accrual_allocation._onchange_date_from()
+            accrual_allocation._onchange_process_accrual_plans()
             self.assertAlmostEqual(accrual_allocation.number_of_days, 2, places=0)
 
             # Update date_to
             accrual_allocation.write({'date_to': '2022-12-31'})
-            accrual_allocation._onchange_date_from()
+            accrual_allocation._onchange_process_accrual_plans()
             self.assertAlmostEqual(accrual_allocation.number_of_days, 12, places=0)
 
     def test_accrual_with_report_creation_for_history(self):
@@ -2270,14 +2289,13 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
             'level_ids': [(0, 0, {
                 'added_value_type': 'day',
                 'milestone_date': 'creation',
-                'start_type': 'day',
                 'added_value': 1,
                 'frequency': 'monthly',
                 'first_day': '31',
                 'cap_accrued_time': False,
                 'action_with_unused_accruals': 'all',
                 'carryover_options': 'limited',
-                'postpone_max_days': 5
+                'max_carriedover_duration': 5
             })],
         })
         with freeze_time('2024-03-02'):
@@ -2290,17 +2308,17 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'accrual_plan_id': accrual_plan.id,
             })
             # As the duration is set to an onchange, we need to force that onchange to run
-            accrual_allocation._onchange_date_from()
+            accrual_allocation._onchange_process_accrual_plans()
             self.assertAlmostEqual(accrual_allocation.number_of_days, 0, places=0)
 
             # Yearly Report capped to 5 after 2022 and after 2023
             accrual_allocation.write({'date_from': '2022-01-01'})
-            accrual_allocation._onchange_date_from()
+            accrual_allocation._onchange_process_accrual_plans()
             self.assertAlmostEqual(accrual_allocation.number_of_days, 7, places=0)
 
             # Update date_to
             accrual_allocation.write({'date_to': '2022-12-31'})
-            accrual_allocation._onchange_date_from()
+            accrual_allocation._onchange_process_accrual_plans()
             self.assertAlmostEqual(accrual_allocation.number_of_days, 12, places=0)
 
     def test_accrual_period_start_past_start_date(self):
@@ -2312,7 +2330,6 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
             'level_ids': [(0, 0, {
                 'added_value_type': 'day',
                 'milestone_date': 'creation',
-                'start_type': 'day',
                 'added_value': 1,
                 'frequency': 'monthly',
                 'first_day': '1',
@@ -2321,15 +2338,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
             })],
         })
         with freeze_time('2024-03-01'):
-            with Form(self.env['hr.leave.allocation'].with_user(self.user_hrmanager)) as f:
-                f.allocation_type = "accrual"
-                f.accrual_plan_id = accrual_plan
-                f.date_from = '2024-01-01'
-                f.employee_id = self.employee_emp
-                f.work_entry_type_id = self.work_entry_type
-                f.name = "Employee Allocation"
-
-            accrual_allocation = f.record
+            accrual_allocation = self._create_form_test_accrual_allocation(self.work_entry_type, '2024-01-01', self.employee_emp, accrual_plan)
             accrual_allocation.action_approve()
             self.assertAlmostEqual(accrual_allocation.number_of_days, 3.0, places=0)
 
@@ -2346,7 +2355,6 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
             'level_ids': [(0, 0, {
                 'added_value_type': 'day',
                 'milestone_date': 'creation',
-                'start_type': 'day',
                 'added_value': 1,
                 'frequency': 'monthly',
                 'first_day': '1',
@@ -2354,7 +2362,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'action_with_unused_accruals': 'all',
             })],
         })
-        allocations = self.env['hr.leave.allocation'].create([
+        allocations = self.env['hr.leave.allocation'].with_context(tracking_disable=True).create([
             {
                 'name': 'Regular allocation',
                 'allocation_type': 'regular',
@@ -2418,19 +2426,18 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
             'level_ids': [(0, 0, {
                 'added_value_type': 'day',
                 'milestone_date': 'creation',
-                'start_type': 'day',
                 'added_value': 1,
                 'frequency': 'monthly',
                 'first_day': '31',
                 'cap_accrued_time': False,
                 'action_with_unused_accruals': 'all',
                 'carryover_options': 'limited',
-                'postpone_max_days': 5
+                'max_carriedover_duration': 5
             })],
         })
 
         with freeze_time("2024-01-01"):
-            self.env['hr.leave.allocation'].create([{
+            self.env['hr.leave.allocation'].with_context(tracking_disable=True).create([{
                 'employee_id': self.employee_emp.id,
                 'work_entry_type_id': work_entry_type_no_negative.id,
                 'allocation_type': 'accrual',
@@ -2494,30 +2501,6 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
             # maximum amount allowed in negative.
             self.assertEqual(allowed_negative_leave.state, 'cancel')
 
-    def test_check_lastcall_change_regular_to_accrual(self):
-        with freeze_time("2017-12-05"):
-            accrual_plan = self.env['hr.leave.accrual.plan'].with_context(tracking_disable=True).create({
-                'name': 'Accrual Plan For Test',
-            })
-            allocation = self.env['hr.leave.allocation'].with_context(tracking_disable=True).create({
-                'name': 'Accrual allocation for employee',
-                'employee_id': self.employee_emp.id,
-                'work_entry_type_id': self.work_entry_type.id,
-                'number_of_days': 10,
-                'allocation_type': 'regular',
-            })
-            allocation.action_approve()
-
-            self.assertEqual(allocation.lastcall, False)
-
-            allocation.action_refuse()
-            allocation.write({
-                'allocation_type': 'accrual',
-                'accrual_plan_id': accrual_plan.id,
-            })
-
-            self.assertEqual(allocation.lastcall, datetime.date(2017, 12, 5))
-
     def test_accrual_allocation_data_persists(self):
         work_entry_type = self.env['hr.work.entry.type'].create({
             'name': 'Test Leave Type 2',
@@ -2551,17 +2534,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'remaining_leaves']
 
         with freeze_time("2024-03-01"):
-            # Simulate creating an allocation from frontend interface
-            with Form(self.env['hr.leave.allocation'].with_user(self.user_hrmanager)) as f:
-                f.allocation_type = "accrual"
-                f.accrual_plan_id = accrual_plan
-                f.employee_id = self.employee_emp
-                f.work_entry_type_id = work_entry_type
-                f.date_from = '2024-02-01'
-                f.name = "Accrual allocation for employee"
-
-            allocation = f.record
-
+            self._create_form_test_accrual_allocation(work_entry_type, '2024-02-01', self.employee_emp, accrual_plan)
             first_result = get_remaining_leaves(2024, 2, 21)
             self.assertEqual(get_remaining_leaves(2024, 2, 21), first_result, "Function return result should persist")
 
@@ -2598,15 +2571,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'remaining_leaves']
 
         with freeze_time("2024-03-01"):
-            # Simulate creating an allocation from frontend interface
-            with Form(self.env['hr.leave.allocation'].with_user(self.user_hrmanager)) as f:
-                f.allocation_type = "accrual"
-                f.accrual_plan_id = accrual_plan
-                f.employee_id = self.employee_emp
-                f.work_entry_type_id = work_entry_type
-                f.date_from = '2024-02-01'
-                f.name = "Accrual allocation for employee"
-
+            self._create_form_test_accrual_allocation(work_entry_type, '2024-02-01', self.employee_emp, accrual_plan, creator_user=self.user_hrmanager)
             self.assertEqual(get_remaining_leaves(2024, 3, 1), 10, "The cap is reached, no more leaves should be accrued")
 
             leave = self.env['hr.leave'].create({
@@ -2716,16 +2681,8 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'attendance_ids': attendances,
             })
             self.employee_hrmanager.resource_calendar_id = calendar_emp.id
-
-            with Form(self.env['hr.leave.allocation'].with_user(self.user_hrmanager)) as f:
-                f.allocation_type = "accrual"
-                f.accrual_plan_id = accrual_plan
-                f.date_from = '2024-08-07'
-                f.work_entry_type_id = self.work_entry_type
-                f.employee_id = self.employee_emp
-                f.name = "Employee Allocation"
-
-            accrual_allocation = f.record
+            accrual_allocation = self._create_form_test_accrual_allocation(self.work_entry_type, '2024-08-07', self.employee_emp,
+                accrual_plan, creator_user=self.user_hrmanager)
             allocation_days = accrual_allocation.number_of_days
             self.assertEqual(accrual_allocation.number_of_days, 7.0)
 
@@ -2769,7 +2726,6 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'added_value': 10,
                 'added_value_type': 'day',
                 'milestone_date': 'creation',
-                'start_type': 'day',
                 'frequency': 'yearly',
                 'action_with_unused_accruals': 'all',
             })],
@@ -2831,7 +2787,6 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'added_value': 10,
                 'added_value_type': 'day',
                 'milestone_date': 'creation',
-                'start_type': 'day',
                 'frequency': 'yearly',
                 'action_with_unused_accruals': 'lost'
             })],
@@ -2896,7 +2851,6 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'added_value_type': 'day',
                 'frequency': 'yearly',
                 'milestone_date': 'creation',
-                'start_type': 'day',
                 'action_with_unused_accruals': 'lost'
             }),
             (0, 0, {
@@ -2978,7 +2932,6 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'added_value_type': 'day',
                 'frequency': 'monthly',
                 'milestone_date': 'creation',
-                'start_type': 'day',
                 'action_with_unused_accruals': 'lost'
             }),
             (0, 0, {
@@ -2990,7 +2943,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'start_type': 'month',
                 'action_with_unused_accruals': 'all',
                 'carryover_options': 'limited',
-                'postpone_max_days': 5
+                'max_carriedover_duration': 5
             })],
         })
         with freeze_time('2024-01-01'):
@@ -3043,22 +2996,11 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                      II. Accrues 10 day yearly.
                     III. Carryover policy is None (no days are carried over).
                 b. Second level:
-                      I. Starts 30 Months after allocation start date.
+                      I. Starts 32 Months after allocation start date.
                      II. Accrues 12 days yearly on January 1st (01/01).
                     III. Carryover policy is all (all days carry over).
 
         Create an allocation that starts 01/01/2024 and uses the above accrual plan.
-
-        1. On 01/01/2024: The employee is accrued 10 days.
-        2. On 01/01/2025: The employee is accrued 10 days.
-        3. On 01/06/2025: All the days are lost due to carryover policy.
-        4. On 01/01/2026: The employee is accrued 10 days.
-        5. On 01/06/2026: All the days are lost due to carryover policy.
-        6. On 01/09/2026: Level transition occurrs. 6.67 days are accrued.
-        7. On 01/01/2027:
-            - 4 days are accrued for the period from 01/09/2026 until 31/12/2026.
-            - 12 days are accrued for the new period (becase days are accrue at the start of the accrual period)
-            - Total number of days is 6.67 + 4 + 12 = 22.67 days.
         """
         accrual_plan = self.env['hr.leave.accrual.plan'].with_context(tracking_disable=True).create({
             'name': 'Accrual Plan For Test',
@@ -3072,7 +3014,6 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'added_value_type': 'day',
                 'frequency': 'yearly',
                 'milestone_date': 'creation',
-                'start_type': 'day',
                 'action_with_unused_accruals': 'lost'
             }),
             (0, 0, {
@@ -3097,33 +3038,45 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
             })
             allocation.action_approve()
 
+        # On 01/01/2024: The employee is accrued 10 days.
         with freeze_time('2024-01-01'):
             allocation._update_accrual()
         self.assertEqual(allocation.number_of_days, 10)
 
+        # On 01/06/2024: All the days are lost due to carryover policy.
+        # On 01/01/2025: The employee is accrued 10 days.
         with freeze_time('2025-01-01'):
             allocation._update_accrual()
-        self.assertEqual(allocation.number_of_days, 20)
+        self.assertEqual(allocation.number_of_days, 10)
 
+        # On 01/06/2025: All the days are lost due to carryover policy.
         with freeze_time('2025-06-01'):
             allocation._update_accrual()
         self.assertEqual(allocation.number_of_days, 0)
 
+        # On 01/01/2026: The employee is accrued days until the end of the first level (1st of August)
+        # 8 first months of 2026: 31 + 28 + 31 + 30 + 31 + 30 + 31 + 30 + 1 = 243
         with freeze_time('2026-01-01'):
             allocation._update_accrual()
-        self.assertEqual(allocation.number_of_days, 10)
+        self.assertAlmostEqual(allocation.number_of_days, 243 / 365 * 10, 4)
 
+        # On 01/06/2026: All the days are lost due to carryover policy.
         with freeze_time('2026-06-01'):
             allocation._update_accrual()
         self.assertEqual(allocation.number_of_days, 0)
 
+        # Second level first accrual occurs
+        # On 01/09/2026: 4 days are accrued for the period from 01/09/2026 until 31/12/2026.
         with freeze_time('2026-09-01'):
             allocation._update_accrual()
-        self.assertAlmostEqual(allocation.number_of_days, 10.7, 1)
+        expected_number_of_days = 12 - 243 / 365 * 12
+        self.assertAlmostEqual(allocation.number_of_days, expected_number_of_days, 4)
 
+        # On 01/01/2027: The employee is accrued 12 days.
         with freeze_time('2027-01-01'):
             allocation._update_accrual()
-        self.assertAlmostEqual(allocation.number_of_days, 22.67, 2)
+        expected_number_of_days += 12
+        self.assertAlmostEqual(allocation.number_of_days, expected_number_of_days, 4)
 
     def test_carried_over_days_expiry_date_computation(self):
         """
@@ -3157,7 +3110,6 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
             'level_ids': [(0, 0, {
                 'added_value_type': 'day',
                 'milestone_date': 'creation',
-                'start_type': 'day',
                 'added_value': 10,
                 'frequency': 'biyearly',
                 'first_month': '1',
@@ -3235,7 +3187,6 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
             'level_ids': [(0, 0, {
                 'added_value_type': 'day',
                 'milestone_date': 'creation',
-                'start_type': 'day',
                 'added_value': 10,
                 'frequency': 'yearly',
                 'action_with_unused_accruals': 'all',
@@ -3310,7 +3261,6 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
             'level_ids': [(0, 0, {
                 'added_value_type': 'day',
                 'milestone_date': 'creation',
-                'start_type': 'day',
                 'added_value': 10,
                 'frequency': 'yearly',
                 'action_with_unused_accruals': 'all',
@@ -3383,7 +3333,6 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
             'level_ids': [(0, 0, {
                 'added_value_type': 'day',
                 'milestone_date': 'creation',
-                'start_type': 'day',
                 'added_value': 10,
                 'frequency': 'yearly',
                 'action_with_unused_accruals': 'all',
@@ -3445,7 +3394,6 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
             'level_ids': [(0, 0, {
                 'added_value_type': 'day',
                 'milestone_date': 'creation',
-                'start_type': 'day',
                 'added_value': 10,
                 'frequency': 'monthly',
                 'action_with_unused_accruals': 'all',
@@ -3507,12 +3455,11 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
             'level_ids': [(0, 0, {
                 'added_value_type': 'day',
                 'milestone_date': 'creation',
-                'start_type': 'day',
                 'added_value': 10,
                 'frequency': 'yearly',
                 'action_with_unused_accruals': 'all',
                 'carryover_options': 'limited',
-                'postpone_max_days': 5,
+                'max_carriedover_duration': 5,
                 'accrual_validity': True,
                 'accrual_validity_type': 'day',
                 'accrual_validity_count': 20,
@@ -3571,7 +3518,6 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
             'level_ids': [(0, 0, {
                 'added_value_type': 'day',
                 'milestone_date': 'creation',
-                'start_type': 'day',
                 'added_value': 10,
                 'frequency': 'biyearly',
                 'first_month': '1',
@@ -3619,7 +3565,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
 
         with freeze_time('2025-09-01'):
             allocation._update_accrual()
-            self.assert_allocation_and_balance(allocation, 13, 10, "The employee balance should be 10 days.")
+            self._assert_allocation_nbr_of_days_and_remaining_leaves_equal(allocation, 13, 10, "The employee balance should be 10 days.")
 
     def test_time_off_balance_computation(self):
         """
@@ -3655,12 +3601,11 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
             'level_ids': [(0, 0, {
                 'added_value_type': 'day',
                 'milestone_date': 'creation',
-                'start_type': 'day',
                 'added_value': 10,
                 'frequency': 'yearly',
                 'action_with_unused_accruals': 'all',
                 'carryover_options': 'limited',
-                'postpone_max_days': 5,
+                'max_carriedover_duration': 5,
                 'accrual_validity': True,
                 'accrual_validity_type': 'month',
                 'accrual_validity_count': 5,
@@ -3679,7 +3624,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
 
         with freeze_time('2024-01-01'):
             allocation._update_accrual()
-            self.assert_allocation_and_balance(allocation, 10, 10, "The employee was accrued 10 days")
+            self._assert_allocation_nbr_of_days_and_remaining_leaves_equal(allocation, 10, 10, "The employee was accrued 10 days")
 
         leave = self.env['hr.leave'].create({
             'name': 'leave',
@@ -3692,7 +3637,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
 
         with freeze_time('2024-04-01'):
             allocation._update_accrual()
-            self.assert_allocation_and_balance(allocation, 7, 5, "Only 5 days will carry over")
+            self._assert_allocation_nbr_of_days_and_remaining_leaves_equal(allocation, 7, 5, "Only 5 days will carry over")
 
         leave = self.env['hr.leave'].create({
             'name': 'leave',
@@ -3705,11 +3650,11 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
 
         with freeze_time('2024-09-01'):
             allocation._update_accrual()
-            self.assert_allocation_and_balance(allocation, 3, 0, "The 5 carried over days should expire")
+            self._assert_allocation_nbr_of_days_and_remaining_leaves_equal(allocation, 3, 0, "The 5 carried over days should expire")
 
         with freeze_time('2025-01-01'):
             allocation._update_accrual()
-            self.assert_allocation_and_balance(allocation, 13, 10, "The employee was accrued 10 days")
+            self._assert_allocation_nbr_of_days_and_remaining_leaves_equal(allocation, 13, 10, "The employee was accrued 10 days")
 
         leave = self.env['hr.leave'].create({
             'name': 'leave',
@@ -3722,7 +3667,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
 
         with freeze_time('2025-04-01'):
             allocation._update_accrual()
-            self.assert_allocation_and_balance(allocation, 11, 5, "Only 5 days will carry over")
+            self._assert_allocation_nbr_of_days_and_remaining_leaves_equal(allocation, 11, 5, "Only 5 days will carry over")
 
     def test_carriedover_days_expiration_reset(self):
         """
@@ -3769,7 +3714,6 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
             'carryover_date': 'allocation',
             'level_ids': [(0, 0, {
                 'milestone_date': 'creation',
-                'start_type': 'day',
                 'added_value': 1,
                 'added_value_type': 'day',
                 'frequency': 'monthly',
@@ -3792,15 +3736,15 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
             })
 
         with freeze_time('2024-09-25'):
-            allocation._onchange_date_from()
+            allocation._onchange_process_accrual_plans()
             self.assertEqual(allocation.number_of_days, 2)
 
             allocation.date_from = '2023-09-01'
-            allocation._onchange_date_from()
+            allocation._onchange_process_accrual_plans()
             self.assertEqual(allocation.number_of_days, 12)
 
             allocation.date_from = '2023-08-01'
-            allocation._onchange_date_from()
+            allocation._onchange_process_accrual_plans()
             self.assertEqual(allocation.number_of_days, 2)
 
     def test_start_accrual_gain_time_immediately(self):
@@ -3812,7 +3756,6 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
             'accrued_gain_time': 'start',
             'level_ids':
                 [(0, 0, {
-                    'start_type': 'day',
                     'milestone_date': 'creation',
                     'added_value_type': 'day',
                     'added_value': 1.25,
@@ -3860,7 +3803,6 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'level_ids': [Command.create({
                     'added_value_type': 'day',
                     'milestone_date': 'creation',
-                    'start_type': 'day',
                     'added_value': 2,
                     'frequency': 'monthly',
                 })],
@@ -3892,7 +3834,6 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
             'accrued_gain_time': 'end',
             'level_ids':
                 [(0, 0, {
-                    'start_type': 'day',
                     'milestone_date': 'creation',
                     'added_value_type': 'day',
                     'added_value': 1,
@@ -3937,7 +3878,6 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
             'accrued_gain_time': 'start',
             'level_ids':
                 [(0, 0, {
-                "accrued_gain_time": "start",
                 "action_with_unused_accruals": "all",
                 "carryover_options": "limited",
                 "added_value": 21,
@@ -3947,7 +3887,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 "first_month_day": 1,
                 "frequency": "yearly",
                 "maximum_leave": 28,
-                "postpone_max_days": 7,
+                "max_carriedover_duration": 7,
                 "start_count": 0,
                 "start_type": "day",
                 "yearly_day": 1,
@@ -3957,15 +3897,8 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
         })
 
         with freeze_time('2024-11-25'):
-            with Form(self.env['hr.leave.allocation'].with_user(self.user_hrmanager)) as f:
-                f.allocation_type = "accrual"
-                f.accrual_plan_id = accrual_plan
-                f.date_from = '2024-01-01'
-                f.employee_id = self.employee_emp
-                f.work_entry_type_id = self.work_entry_type
-                f.name = "Employee Allocation"
-
-            allocation = f.record
+            allocation = self._create_form_test_accrual_allocation(self.work_entry_type, '2024-01-01', self.employee_emp,
+                accrual_plan, creator_user=self.user_hrmanager)
             allocation.action_approve()
 
             # take 15 days, left with 6 days on the alloc
@@ -4003,20 +3936,13 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
             # Set a maximum carry-over
             f.action_with_unused_accruals = 'all'
             f.carryover_options = 'limited'
-            f.postpone_max_days = 7
+            f.max_carriedover_duration = 7
             # Set it back to 'lost'
             f.action_with_unused_accruals = 'lost'
 
         with freeze_time('2024-11-25'):
-            with Form(self.env['hr.leave.allocation'].with_user(self.user_hrmanager)) as f:
-                f.allocation_type = "accrual"
-                f.accrual_plan_id = accrual_plan
-                f.date_from = '2024-01-01'
-                f.employee_id = self.employee_emp
-                f.work_entry_type_id = self.work_entry_type
-                f.name = "Employee Allocation"
-
-            allocation = f.record
+            allocation = self._create_form_test_accrual_allocation(self.work_entry_type, '2024-01-01', self.employee_emp,
+                accrual_plan, creator_user=self.user_hrmanager)
             allocation.action_approve()
 
             # take 15 days, left with 6 days on the alloc
@@ -4114,7 +4040,6 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'date_from': '2024-12-01',
                 'number_of_days': 8,
                 'allocation_type': 'accrual',
-                'nextcall': '2025-01-01',
             })
             allocation.action_approve()
             # A virtual leave that is pending approval and will be taken after the carryover date
@@ -4179,7 +4104,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'unit_of_measure': 'day',
             })
 
-            allocation = self.env['hr.leave.allocation'].create({
+            allocation = self.env['hr.leave.allocation'].with_context(tracking_disable=True).create({
                 'name': 'Accrual allocation for employee',
                 'employee_id': self.employee_emp.id,
                 'work_entry_type_id': work_entry_type_day.id,
@@ -4191,8 +4116,10 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
             allocation.action_approve()
         with freeze_time('2024-01-09'):
             allocation._update_accrual()
-            allocation_data = work_entry_type_day.get_allocation_data(self.employee_emp)
-            self.assertEqual(allocation_data[self.employee_emp][0][1]['virtual_remaining_leaves'], 1)
+            self.assertEqual(allocation._get_employee_hours_per_day(), 8,
+                "If the employee hours per day is not 8, the following statement will fail.")
+            # 1 hour per day, so 8 hours should've been accrued (equals 1 day)
+            self._assert_allocation_nbr_of_days_and_remaining_leaves_equal(allocation, 1, 1, target_date='2024-01-09')
 
     def test_accrual_allocation_data_with_different_units_half_day(self):
         '''
@@ -4223,7 +4150,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'unit_of_measure': 'day',
             })
 
-            allocation = self.env['hr.leave.allocation'].create({
+            allocation = self.env['hr.leave.allocation'].with_context(tracking_disable=True).create({
                 'name': 'Accrual allocation for employee',
                 'employee_id': self.employee_emp.id,
                 'work_entry_type_id': work_entry_type_day.id,
@@ -4235,8 +4162,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
             allocation.action_approve()
         with freeze_time('2024-01-09'):
             allocation._update_accrual()
-            allocation_data = work_entry_type_day.get_allocation_data(self.employee_emp)
-            self.assertEqual(allocation_data[self.employee_emp][0][1]['virtual_remaining_leaves'], 1)
+            self._assert_allocation_nbr_of_days_and_remaining_leaves_equal(allocation, 1, 1, target_date='2024-01-09')
 
     def test_accrual_allocation_data_with_different_units_and_used_days(self):
         '''
@@ -4267,7 +4193,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'unit_of_measure': 'day',
             })
 
-            allocation = self.env['hr.leave.allocation'].create({
+            allocation = self.env['hr.leave.allocation'].with_context(tracking_disable=True).create({
                 'name': 'Accrual allocation for employee',
                 'employee_id': self.employee_emp.id,
                 'work_entry_type_id': work_entry_type_day.id,
@@ -4287,8 +4213,11 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'request_date_to': '2024-01-05',
             })
             leave.action_approve()
-            allocation_data = work_entry_type_day.get_allocation_data(self.employee_emp)
-            self.assertEqual(allocation_data[self.employee_emp][0][1]['virtual_remaining_leaves'], 1)
+            allocation._update_accrual()
+            self.assertEqual(allocation._get_employee_hours_per_day(), 8,
+                "If the employee hours per day is not 8, the following statement will fail.")
+            # 1 hour accrued daily for 16 days = 16 hours => 2 days, and 1 day of remaining leaves
+            self._assert_allocation_nbr_of_days_and_remaining_leaves_equal(allocation, 2, 1, target_date='2024-01-17')
 
     def test_accrual_allocation_with_monthly_31st_milestone(self):
         '''
@@ -4322,109 +4251,113 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'date_from': date(2025, 1, 1),
                 'work_entry_type_id': self.work_entry_type.id,
             })
-            allocation._onchange_date_from()
+            allocation._onchange_process_accrual_plans()
             self.assertEqual(allocation.number_of_days, 2.0)
 
-    @freeze_time('2025-01-01')
     def test_accrual_allocation_date_in_the_future(self):
-        vals = {
-            'milestone_date': 'after',
-            'accrual_validity': True,
-            'accrual_validity_count': 6,
-            'accrual_validity_type': 'month',
-            'accrued_gain_time': 'start',
-            'action_with_unused_accruals': 'all',
-            'cap_accrued_time_yearly': False,
-            'frequency': 'yearly',
-            'carryover_options': 'limited',
-            'postpone_max_days': 5,
-            'week_day': '0',
-        }
-        accrual_plan = self.env['hr.leave.accrual.plan'].create({
-            'name': 'Test accrual plan',
-            'is_based_on_worked_time': False,
-            'accrued_gain_time': 'start',
-            'can_be_carryover': True,
-            'level_ids': [(0, 0, {
+        with freeze_time('2025-01-01'):
+            vals = {
+                'milestone_date': 'after',
+                'accrual_validity': True,
+                'accrual_validity_count': 6,
+                'accrual_validity_type': 'month',
+                'accrued_gain_time': 'start',
+                'action_with_unused_accruals': 'all',
+                'cap_accrued_time_yearly': False,
+                'frequency': 'yearly',
+                'carryover_options': 'limited',
+                'max_carriedover_duration': 5,
+                'week_day': '0',
+            }
+            accrual_plan = self.env['hr.leave.accrual.plan'].create({
+                'name': 'Test accrual plan',
+                'is_based_on_worked_time': False,
+                'accrued_gain_time': 'start',
+                'can_be_carryover': True,
+                'level_ids': [(0, 0, {
+                    **vals,
+                    'added_value': 20,
+                    'milestone_date': 'creation',
+                    'start_type': 'day',
+                    'maximum_leave': 25,
+                }),
+                (0, 0, {
+                    **vals,
+                    'added_value': 21,
+                    'start_count': 2,
+                    'start_type': 'year',
+                    'maximum_leave': 26,
+                }),
+                (0, 0, {
+                    **vals,
+                    'added_value': 22,
+                    'start_count': 4,
+                    'start_type': 'year',
+                    'maximum_leave': 27,
+                }),
+                (0, 0, {
                 **vals,
-                'added_value': 20,
-                'milestone_date': 'creation',
-                'start_type': 'day',
-                'maximum_leave': 25,
-            }),
-            (0, 0, {
-                **vals,
-                'added_value': 21,
-                'start_count': 2,
-                'start_type': 'year',
-                'maximum_leave': 26,
-            }),
-            (0, 0, {
-                **vals,
-                'added_value': 22,
-                'start_count': 4,
-                'start_type': 'year',
-                'maximum_leave': 27,
-            }),
-            (0, 0, {
-               **vals,
-                'added_value': 23,
-                'start_count': 6,
-                'start_type': 'year',
-                'maximum_leave': 28,
-            })]
-        })
+                    'added_value': 23,
+                    'start_count': 6,
+                    'start_type': 'year',
+                    'maximum_leave': 28,
+                })]
+            })
 
-        work_entry_type = self.env['hr.work.entry.type'].create({
-            'name': 'Test Leave Type 2',
-            'code': 'Test Leave Type 2',
-            'count_as': 'absence',
-            'requires_allocation': 'yes',
-            'allocation_validation_type': 'no_validation',
-            'request_unit': 'day',
-            'unit_of_measure': 'day',
-        })
+            work_entry_type = self.env['hr.work.entry.type'].create({
+                'name': 'Test Leave Type',
+                'code': 'Test',
+                'count_as': 'absence',
+                'requires_allocation': 'yes',
+                'allocation_validation_type': 'no_validation',
+                'request_unit': 'day',
+                'unit_of_measure': 'day',
+            })
 
-        allocation = self.env['hr.leave.allocation'].create({
-            'name': 'Accrual allocation for employee',
-            'employee_id': self.employee_emp.id,
-            'work_entry_type_id': work_entry_type.id,
-            'number_of_days': 20,
-            'allocation_type': 'accrual',
-            'accrual_plan_id': accrual_plan.id,
-            'date_from': '2025-01-01',
-        })
-        allocation.action_approve()
-        # Test after one year "Didn't get to any level yet"
-        allocation_data = work_entry_type.get_allocation_data(self.employee_emp, '2026-03-01')
-        self.assertEqual(allocation_data[self.employee_emp][0][1]['virtual_remaining_leaves'], 25, "The carryover did not expire yet so the remaining leaves should be 25")
-        allocation_data = work_entry_type.get_allocation_data(self.employee_emp, '2026-09-01')
-        self.assertEqual(allocation_data[self.employee_emp][0][1]['virtual_remaining_leaves'], 20, "The carryover expired after 6 month so the remaining leaves should be 20")
-        # Test after two years
-        allocation_data = work_entry_type.get_allocation_data(self.employee_emp, '2027-03-01')
-        self.assertEqual(allocation_data[self.employee_emp][0][1]['virtual_remaining_leaves'], 26, "The carryover did not expire yet so the remaining leaves should be 26")
-        allocation_data = work_entry_type.get_allocation_data(self.employee_emp, '2027-09-01')
-        self.assertEqual(allocation_data[self.employee_emp][0][1]['virtual_remaining_leaves'], 21, "The carryover expired after 6 month so the remaining leaves should be 21")
-        # Test after three years
-        allocation_data = work_entry_type.get_allocation_data(self.employee_emp, '2028-03-01')
-        self.assertEqual(allocation_data[self.employee_emp][0][1]['virtual_remaining_leaves'], 26, "The carryover did not expire yet so the remaining leaves should be 26")
-        allocation_data = work_entry_type.get_allocation_data(self.employee_emp, '2028-09-01')
-        self.assertEqual(allocation_data[self.employee_emp][0][1]['virtual_remaining_leaves'], 21, "The carryover expired after 6 month so the remaining leaves should be 21")
-        # Test after four years
-        allocation_data = work_entry_type.get_allocation_data(self.employee_emp, '2029-03-01')
-        self.assertEqual(allocation_data[self.employee_emp][0][1]['virtual_remaining_leaves'], 27, "The carryover did not expire yet so the remaining leaves should be 27")
-        allocation_data = work_entry_type.get_allocation_data(self.employee_emp, '2029-09-01')
-        self.assertEqual(allocation_data[self.employee_emp][0][1]['virtual_remaining_leaves'], 22, "The carryover expired after 6 month so the remaining leaves should be 22")
-        # Test after five years
-        allocation_data = work_entry_type.get_allocation_data(self.employee_emp, '2030-03-01')
-        self.assertEqual(allocation_data[self.employee_emp][0][1]['virtual_remaining_leaves'], 27, "The carryover did not expire yet so the remaining leaves should be 27")
-        allocation_data = work_entry_type.get_allocation_data(self.employee_emp, '2030-09-01')
-        self.assertEqual(allocation_data[self.employee_emp][0][1]['virtual_remaining_leaves'], 22, "The carryover expired after 6 month so the remaining leaves should be 22")
-        # Test after six years
-        allocation_data = work_entry_type.get_allocation_data(self.employee_emp, '2031-03-01')
-        self.assertEqual(allocation_data[self.employee_emp][0][1]['virtual_remaining_leaves'], 28, "The carryover did not expire yet so the remaining leaves should be 28")
-        allocation_data = work_entry_type.get_allocation_data(self.employee_emp, '2031-09-01')
-        self.assertEqual(allocation_data[self.employee_emp][0][1]['virtual_remaining_leaves'], 23, "The carryover expired after 6 month so the remaining leaves should be 23")
+            allocation = self.env['hr.leave.allocation'].with_context(tracking_disable=True).create({
+                'name': 'Accrual allocation for employee',
+                'employee_id': self.employee_emp.id,
+                'work_entry_type_id': work_entry_type.id,
+                'number_of_days': 20,
+                'allocation_type': 'accrual',
+                'accrual_plan_id': accrual_plan.id,
+                'date_from': '2025-01-01',
+            })
+            allocation.action_approve()
+
+        assertions = [
+            # Accrual on 2025-01-01 -> 20 days
+            # Accrual on 2026-01-01 -> min(20 + 20, 25) = 25 (maximum_leave=25)
+            ('2026-03-01', 25),
+            # Carryover expires on 2026-06-01 -> 25 - 5 = 20
+            ('2026-09-01', 20),
+            # Accrual on 2027-01-01 -> min(20 + 21, 26) = 26 (maximum_leave=26)
+            ('2027-03-01', 26),
+            # Carryover expires on 2027-06-01 -> 26 - 5 = 21
+            ('2027-09-01', 21),
+            # Accrual on 2028-01-01 -> min(21 + 21, 26) = 26 (maximum_leave=26)
+            ('2028-03-01', 26),
+            # Carryover expires on 2028-06-01 -> 26 - 5 = 21
+            ('2028-09-01', 21),
+            # Accrual on 2029-01-01 -> min(21 + 22, 27) = 27 (maximum_leave=27)
+            ('2029-03-01', 27),
+            # Carryover expires on 2029-06-01 -> 27 - 5 = 22
+            ('2029-09-01', 22),
+            # Accrual on 2030-01-01 -> min(22 + 22, 27) = 27 (maximum_leave=27)
+            ('2030-03-01', 27),
+            # Carryover expires on 2030-06-01 -> 27 - 5 = 22
+            ('2030-09-01', 22),
+            # Accrual on 2031-01-01 -> min(22 + 23, 28) = 28 (maximum_leave=28)
+            ('2031-03-01', 28),
+            # Carryover expires on 2031-06-01 -> 28 - 5 = 23
+            ('2031-09-01', 23),
+        ]
+
+        for test_date, expected_number_of_days in assertions:
+            with freeze_time(test_date):
+                allocation._update_accrual()
+                self._assert_allocation_nbr_of_days_and_remaining_leaves_equal(
+                    allocation, expected_number_of_days, expected_number_of_days, target_date=test_date)
 
     def test_accrual_plan_cleared_when_switch_to_regular(self):
         accrual_plan = self.env['hr.leave.accrual.plan'].with_context(tracking_disable=True).create({
@@ -4472,23 +4405,28 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
             allocation.action_approve()
 
         assertions = [
-            # 12 months  =>  13 accruals as "accrued_gain_time" is "start"  =>  13 * 1 (first level) = 13
-            # Do not include the 1 accrued day for 2026-07-01 for the expiring days
+            # 11 months  =>  12 accruals as "accrued_gain_time" is "start"  =>  12 * 1 (first level) = 12
+            # previous_carryover_nbr_of_days should be 0
+            ('2026-06-01', expected_nbr_of_days := 12, 0),
+            # Another monthly accrual
+            # Do not include the 1 accrued day for 2026-07-01 for the previous_carryover_nbr_of_days
             # (otherwise it would be like wasting the days the employee earned trough the last month)
-            ('2026-07-01', leaves := 13, 12),
+            ('2026-07-01', expected_nbr_of_days := expected_nbr_of_days + 1, 12),
             # The day before 12 days should expire + level transition -> 2 more second level monthly (2 + 2)
-            ('2026-09-30', leaves := leaves + 4, 12),
+            ('2026-09-30', expected_nbr_of_days := expected_nbr_of_days + 4, 12),
             # Carryover expires + new monthly accrual
-            ('2026-10-01', leaves := leaves + 2 - 12, 0),
+            ('2026-10-01', expected_nbr_of_days := expected_nbr_of_days - 12 + 2, 12),
             # Accrual keeps going
-            ('2026-11-01', leaves + 2, 0),
+            ('2026-11-01', expected_nbr_of_days + 2, 12),
         ]
 
-        for test_date, remaining_leaves, expiring_days in assertions:
+        for test_date, expected_nbr_of_days, previous_carryover_nbr_of_days in assertions:
             with freeze_time(test_date):
                 allocation._update_accrual()
-                self.assert_remaining_leaves_equal(self.work_entry_type_day, remaining_leaves, self.employee_emp, test_date, digits=3)
-                self.assertAlmostEqual(allocation.expiring_carryover_days, expiring_days, 2, msg=f'Incorrect number of expiring days for {test_date}')
+                self._assert_allocation_nbr_of_days_and_remaining_leaves_equal(
+                    allocation, expected_nbr_of_days, expected_nbr_of_days, target_date=test_date)
+                self.assertAlmostEqual(allocation.previous_carryover_number_of_days, previous_carryover_nbr_of_days, 2,
+                    msg=f'Incorrect number of expiring days for {test_date}')
 
     def test_accrual_plan_end_carryover_expiring_3_months(self):
         """
@@ -4503,44 +4441,48 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
             allocation.action_approve()
 
         assertions = [
-            # 12 months  =>  12 accruals as "accrued_gain_time" is "end"  =>  12 * 1 (first level) = 12
+            # 11 months  =>  11 accruals as "accrued_gain_time" is "end"  =>  11 * 1 (first level) = 11
+            ('2026-06-01', expected_nbr_of_days := 11, 0),
+            # Another monthly accrual
             # Do not include the 1 accrued day for 2026-07-01 for the expiring days
             # (otherwise it would be like wasting the days the employee earned trough the last month)
-            ('2026-07-01', leaves := 12, 11),
+            ('2026-07-01', expected_nbr_of_days := expected_nbr_of_days + 1, 11),
             # The day before 12 days should expire + level transition -> 1 accrual from first level,
             # and another one from the second level (1 + 2)
-            ('2026-09-30', leaves := leaves + 3, 11),
+            ('2026-09-30', expected_nbr_of_days := expected_nbr_of_days + 3, 11),
             # Carryover expires + new monthly accrual
-            ('2026-10-01', leaves := leaves + 2 - 11, 0),
+            ('2026-10-01', expected_nbr_of_days := expected_nbr_of_days - 11 + 2, 11),
             # Accrual keeps going
-            ('2026-11-01', leaves + 2, 0),
+            ('2026-11-01', expected_nbr_of_days + 2, 11),
         ]
 
-        for test_date, remaining_leaves, expiring_days in assertions:
+        for test_date, expected_nbr_of_days, expiring_days in assertions:
             with freeze_time(test_date):
                 allocation._update_accrual()
-                self.assert_remaining_leaves_equal(self.work_entry_type_day, remaining_leaves, self.employee_emp, test_date, digits=3)
-                self.assertAlmostEqual(allocation.expiring_carryover_days, expiring_days, 2, msg=f'Incorrect number of expiring days for {test_date}')
+                self._assert_allocation_nbr_of_days_and_remaining_leaves_equal(
+                    allocation, expected_nbr_of_days, expected_nbr_of_days, target_date=test_date)
+                self.assertAlmostEqual(allocation.previous_carryover_number_of_days, expiring_days, 2,
+                    msg=f'Incorrect number of expiring days for {test_date}')
 
     @freeze_time("2026-01-26")
-    def test_get_future_leaves_on(self):
-        today = fields.Date.today()
-        future_date = today + relativedelta(months=1, day=15)
-
-        allocation_day = self.env['hr.leave.allocation'].create({
+    def test_get_additionnal_future_leaves_on(self):
+        """ Assert accrual plan allocation uses the `unit_of_measure` and not the `request_unit` of the leave type """
+        allocation_day = self.env['hr.leave.allocation'].with_context(tracking_disable=True).create({
             'name': 'Daily Accrual',
             'work_entry_type_id': self.work_entry_type_day.id,
             'employee_id': self.employee_emp.id,
             'allocation_type': 'accrual',
             'accrual_plan_id': self.accrual_plan_start1.id,
-            'number_of_days': 1.0,
-            'date_from': today,
+            'number_of_days': 0,
+            'date_from': "2026-01-26",
         })
 
         allocation_day._action_validate()
 
-        res_day = allocation_day._get_future_leaves_on(future_date)
-        self.assertEqual(res_day, 1.0, f"Expected 1.0 day increase, got {res_day}")
+        # 2026-01-26 -> 2026-02-01: +0.19 day
+        # 2026-02-01 -> 2026-03-01: +1 day
+        res_day = allocation_day._get_additionnal_future_leaves_on(date(2026, 2, 15))
+        self.assertAlmostEqual(res_day, 1.19, delta=0.001, msg=f"Expected 1.19 day increase, got {res_day}")
 
         # Assuming an 8-hour workday, 2 days = 16.0 hours
         accrual_plan = self.env['hr.leave.accrual.plan'].create({
@@ -4575,21 +4517,23 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
             'unit_of_measure': 'hour',
         })
 
-        allocation_hour = self.env['hr.leave.allocation'].create({
+        allocation_hour = self.env['hr.leave.allocation'].with_context(tracking_disable=True).create({
             'name': 'Hourly Allocation with daily accrual',
             'work_entry_type_id': work_entry_type_hour.id,
             'employee_id': self.employee_emp.id,
             'allocation_type': 'accrual',
             'accrual_plan_id': accrual_plan.id,
-            'number_of_hours_display': 0.0,
+            'number_of_days': 0,
             'date_from': start_date,
         })
         allocation_hour._action_validate()
 
-        # On Feb 1st, it should trigger the 16-hour (2 days) addition
-        res_hour = allocation_hour._get_future_leaves_on(future_date)
+        # 2026-01-01 -> 2026-02-01: +2 days
+        # 2026-02-01 -> 2026-03-01: +2 days
+        # -> 4 days = 32 hours as of the calendar of the employee
+        res_hour = allocation_hour._get_additionnal_future_leaves_on(future_date)
 
-        self.assertEqual(res_hour, 16.0, f"Expected 16.0 hours (2 days) increase, got {res_hour}")
+        self.assertEqual(res_hour, 32.0, f"Expected 32.0 hours (32 days) increase, got {res_hour}")
 
     def test_accrual_leaves_cancel_cron_with_refused_allocation(self):
         """ Test that the _cancel_invalid_leaves cron cancels leaves without valid allocation"""
@@ -4612,7 +4556,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
         })
 
         with freeze_time("2024-01-01"):
-            allocation = self.env['hr.leave.allocation'].create({
+            allocation = self.env['hr.leave.allocation'].with_context(tracking_disable=True).create({
                 'employee_id': self.employee_emp.id,
                 'work_entry_type_id': work_entry_type.id,
                 'allocation_type': 'accrual',
@@ -4654,9 +4598,10 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                     'start_count': 0,
                     'frequency': 'monthly',
                     'action_with_unused_accruals': 'lost',
+                    'added_value': 1,
                 })],
             })
-            allocation = self.env['hr.leave.allocation'].create({
+            allocation = self.env['hr.leave.allocation'].with_context(tracking_disable=True).create({
                 'name': 'Accrual allocation for employee',
                 'accrual_plan_id': accrual_plan.id,
                 'employee_id': self.employee_emp.id,
@@ -4664,16 +4609,45 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'date_from': '2025-01-01',
                 'allocation_type': 'accrual',
                 'number_of_days': 0,
-                'already_accrued': False,
             })
             allocation.action_approve()
-            assertions = (
-                # Do not run the update on 2026-01-01 otherwise the bug disappears on 2026-02-01
-                # ('2026-01-01', 1),
-                ('2026-02-01', 2),
-                ('2026-03-01', 3),
-            )
-            for test_date, expected_remaining_leaves in assertions:
-                with freeze_time(test_date):
-                    allocation._update_accrual()
-                    self.assertEqual(allocation.number_of_days, expected_remaining_leaves)
+        assertions = (
+            # Do not run the update on 2026-01-01 otherwise the bug disappears on 2026-02-01
+            # ('2026-01-01', 1),
+            ('2026-02-01', 2),
+            ('2026-03-01', 3),
+        )
+        for test_date, expected_remaining_leaves in assertions:
+            with freeze_time(test_date):
+                allocation._update_accrual()
+                self.assertEqual(allocation.number_of_days, expected_remaining_leaves)
+
+    def test_transition_mode_accrual_plan_end(self):
+        """ When transition mode of an accrual plan is set to `end_of_accrual` and that it accrues the days at
+            the end of the period, assert the previous level is used when we are past the level transition, but
+            we are still in the previous level last period
+
+            Here the accrual plan first level accrues 1 day monthly
+            Second level start after 1 month and accrues 2 days monthly
+        """
+        with freeze_time('2026-01-15'):
+            allocation = self._create_form_test_accrual_allocation(
+                self.work_entry_type_day, '2026-01-15', self.employee_emp, self.accrual_plan2)
+            allocation.action_approve()
+
+        assertions = (
+            # Accrual plan accrued time is 'end', so 0 days at the start
+            ('2026-01-15', number_of_days := 0),
+            # Accrual from 15 to 31 of January
+            ('2026-02-01', number_of_days := number_of_days + (31 - 15 + 1) / 31),
+            # Transition mode is set to 'end_of_accrual', nothing happens here
+            ('2026-02-15', number_of_days),
+            # We are past the first level, but the first level should still be used for this accrual
+            ('2026-03-01', number_of_days := number_of_days + 1),
+            # Second level is used for this accrual
+            ('2026-04-01', number_of_days := number_of_days + 2),
+        )
+        for test_date, expected_number_of_days in assertions:
+            with freeze_time(test_date):
+                allocation._update_accrual()
+                self.assertEqual(allocation.number_of_days, expected_number_of_days, f'Wrong number of days for {test_date}')

--- a/addons/hr_holidays/tests/test_allocations.py
+++ b/addons/hr_holidays/tests/test_allocations.py
@@ -137,14 +137,13 @@ class TestAllocations(TestHrHolidaysCommon):
 
         self.assertEqual(employee_allocation.name, "Custom Time Off Test (10.0 day(s))")
 
-    def change_allocation_day_unit(self):
+    def test_change_allocation_day_unit(self):
         self.work_entry_type.write({
             'name': 'Custom Time Off Test',
-            'allocation_validation_type': 'hr'
+            'allocation_validation_type': 'hr',
         })
 
         employee_allocation = self.env['hr.leave.allocation'].create({
-            'holiday_type': 'employee',
             'employee_id': self.employee.id,
             'work_entry_type_id': self.work_entry_type.id,
         })
@@ -203,14 +202,13 @@ class TestAllocations(TestHrHolidaysCommon):
         allocation.number_of_days += 8  # +8 days * 7 hours/day = +56 hours
         self.assertEqual(allocation.number_of_hours_display, 112)  # 56 + 56
 
-    def change_allocation_hours_unit(self):
+    def test_change_allocation_hours_unit(self):
         self.work_entry_type.write({
             'name': 'Custom Time Off Test',
-            'allocation_validation_type': 'hr'
+            'allocation_validation_type': 'hr',
         })
 
         employee_allocation = self.env['hr.leave.allocation'].create({
-            'holiday_type': 'employee',
             'employee_id': self.employee.id,
             'work_entry_type_id': self.work_entry_type.id,
             'type_request_unit': 'hour',
@@ -252,7 +250,7 @@ class TestAllocations(TestHrHolidaysCommon):
         })
         allocation_with_pending_leave.action_approve()
         pending_leave = self._create_leave(
-            self.work_entry_type_paid, self.employee_responsible, date(2024, 1, 15), date(2024, 1, 19),
+            self.employee_responsible, self.work_entry_type_paid, date(2024, 1, 15), date(2024, 1, 19),
             validate=False, user=self.user_responsible,
         )
         self.assertEqual(pending_leave.state, 'confirm')
@@ -704,18 +702,6 @@ class TestAllocations(TestHrHolidaysCommon):
         allocation.action_approve()
         return allocation
 
-    def _create_leave(self, work_entry_type, employee, date_from, date_to, validate=True, user=False):
-        leave = self.env['hr.leave'].with_user(user or self.env.user).create({
-            'name': 'Leave Request',
-            'work_entry_type_id': work_entry_type.id,
-            'request_date_from': date_from,
-            'request_date_to': date_to,
-            'employee_id': employee.id,
-        })
-        if validate:
-            leave.action_approve()
-        return leave
-
     def test_change_regular_allocation_date_to(self):
         allocation = self._create_validated_allocation(
             self.work_entry_type_paid, self.employee, date(2024, 1, 1), date(2024, 1, 30),
@@ -723,7 +709,7 @@ class TestAllocations(TestHrHolidaysCommon):
         allocation.write({'date_to': date(2024, 1, 31)})
         self.assertEqual(allocation.date_to, date(2024, 1, 31))
 
-        self._create_leave(self.work_entry_type_paid, self.employee, date(2024, 1, 5), date(2024, 1, 10))
+        self._create_leave(self.employee, self.work_entry_type_paid, date(2024, 1, 5), date(2024, 1, 10))
         allocation.write({'date_to': date(2024, 1, 10)})
         self.assertEqual(allocation.date_to, date(2024, 1, 10))
 
@@ -763,7 +749,7 @@ class TestAllocations(TestHrHolidaysCommon):
             allocation.write({'date_to': date(2024, 1, 20)})
             self.assertEqual(allocation.date_to, date(2024, 1, 20))
 
-            self._create_leave(work_entry_type, self.employee_emp, date(2024, 1, 10), date(2024, 1, 10))
+            self._create_leave(self.employee_emp, work_entry_type, date(2024, 1, 10), date(2024, 1, 10))
             allocation.write({'date_to': date(2024, 1, 11)})
             self.assertEqual(allocation.date_to, date(2024, 1, 11))
 
@@ -772,7 +758,7 @@ class TestAllocations(TestHrHolidaysCommon):
 
             allocation.write({'date_to': date(2024, 1, 20)})
             pending_leave = self._create_leave(
-                work_entry_type, self.employee_emp, date(2024, 1, 12), date(2024, 1, 12),
+                self.employee_emp, work_entry_type, date(2024, 1, 12), date(2024, 1, 12),
                 validate=False, user=self.user_employee,
             )
             self.assertEqual(pending_leave.state, 'confirm')

--- a/addons/hr_holidays/tests/test_expiring_leaves.py
+++ b/addons/hr_holidays/tests/test_expiring_leaves.py
@@ -4,6 +4,7 @@ from datetime import date
 from dateutil.relativedelta import relativedelta
 from freezegun import freeze_time
 
+from odoo import Command
 from odoo.addons.base.tests.common import HttpCase
 from odoo.tests.common import tagged
 from odoo.tests.common import users
@@ -31,6 +32,7 @@ class TestExpiringLeaves(HttpCase, TestHrHolidaysCommon):
             'carryover_date': 'other',
             'carryover_day': 1,
             'carryover_month': '4',
+            'can_be_carryover': True,
             'level_ids': [
                 (0, 0, {
                 'start_count': 0,
@@ -43,12 +45,48 @@ class TestExpiringLeaves(HttpCase, TestHrHolidaysCommon):
                 'cap_accrued_time': False,
                 'action_with_unused_accruals': 'all',
                 'carryover_options': 'limited',
-                'postpone_max_days': 5,
+                'max_carriedover_duration': 5,
                 'accrual_validity': True,
                 'accrual_validity_count': 3,
                 'accrual_validity_type': 'month',
                 })
             ],
+        })
+        cls.accrual_plan_one_lvl_monthly_validity_10days = cls.env['hr.leave.accrual.plan'].create({
+            'name': 'Test Accrual Plan - expiring_leaves 1',
+            'is_based_on_worked_time': False,
+            'accrued_gain_time': 'start',
+            'can_be_carryover': True,
+            'carryover_date': 'other',
+            'carryover_day': '15',
+            'carryover_month': '2',
+            'level_ids': [Command.create({
+                'milestone_date': 'creation',
+                'added_value': 3,
+                'added_value_type': 'day',
+                'frequency': 'monthly',
+                'action_with_unused_accruals': 'all',
+                'accrual_validity': True,
+                'accrual_validity_count': 10,
+            })],
+        })
+        cls.accrual_plan_one_lvl_monthly_maxcarryover_10days = cls.env['hr.leave.accrual.plan'].create({
+            'name': 'Test Accrual Plan - expiring_leaves 2',
+            'is_based_on_worked_time': False,
+            'accrued_gain_time': 'start',
+            'can_be_carryover': True,
+            'carryover_date': 'other',
+            'carryover_day': '15',
+            'carryover_month': '10',
+            'level_ids': [Command.create({
+                'milestone_date': 'creation',
+                'added_value': 3,
+                'added_value_type': 'day',
+                'frequency': 'monthly',
+                'action_with_unused_accruals': 'all',
+                'carryover_options': 'limited',
+                'max_carriedover_duration': 10,
+            })],
         })
 
     @users('enguerran')
@@ -91,7 +129,7 @@ class TestExpiringLeaves(HttpCase, TestHrHolidaysCommon):
         })
 
         logged_in_emp = self.env.user.employee_id
-        allocation = self.env['hr.leave.allocation'].sudo().create({
+        allocation = self.env['hr.leave.allocation'].sudo().with_context(tracking_disable=True).create({
             'date_from': date(date.today().year, 1, 1),
             'accrual_plan_id': accrual_plan.id,
             'work_entry_type_id': self.work_entry_type.id,
@@ -112,7 +150,7 @@ class TestExpiringLeaves(HttpCase, TestHrHolidaysCommon):
 
         # Assert the date of expiration
         self.assertEqual(allocation_data[logged_in_emp][0][1]['closest_allocation_expire'],
-                    allocation._get_carryover_date(target_date).strftime('%m/%d/%Y'),
+                    allocation._get_next_carryover_date(target_date).strftime('%m/%d/%Y'),
                     "The expiration date should match the carryover date")
 
         # Assert the number of expiring leaves
@@ -159,13 +197,13 @@ class TestExpiringLeaves(HttpCase, TestHrHolidaysCommon):
                 'cap_accrued_time': False,
                 'action_with_unused_accruals': 'all',
                 'carryover_options': 'limited',
-                'postpone_max_days': carryover_limit,
+                'max_carriedover_duration': carryover_limit,
                 })
             ],
         })
 
         logged_in_emp = self.env.user.employee_id
-        allocation = self.env['hr.leave.allocation'].sudo().create({
+        allocation = self.env['hr.leave.allocation'].sudo().with_context(tracking_disable=True).create({
             'date_from': date(date.today().year, 1, 1),
             'accrual_plan_id': accrual_plan.id,
             'work_entry_type_id': self.work_entry_type.id,
@@ -185,7 +223,7 @@ class TestExpiringLeaves(HttpCase, TestHrHolidaysCommon):
 
         # Assert the date of expiration
         self.assertEqual(allocation_data[logged_in_emp][0][1]['closest_allocation_expire'],
-                    allocation._get_carryover_date(target_date).strftime('%m/%d/%Y'),
+                    allocation._get_next_carryover_date(target_date).strftime('%m/%d/%Y'),
                     "The expiration date should match the carryover date")
 
         # Assert the number of expiring leaves
@@ -245,7 +283,7 @@ class TestExpiringLeaves(HttpCase, TestHrHolidaysCommon):
                 'cap_accrued_time': False,
                 'action_with_unused_accruals': 'all',
                 'carryover_options': 'limited',
-                'postpone_max_days': carryover_limit,
+                'max_carriedover_duration': carryover_limit,
                 })
             ],
         })
@@ -270,7 +308,7 @@ class TestExpiringLeaves(HttpCase, TestHrHolidaysCommon):
 
         logged_in_emp = self.env.user.employee_id
         with freeze_time("2024-01-01"):
-            allocation_with_carryover = self.env['hr.leave.allocation'].sudo().create({
+            allocation_with_carryover = self.env['hr.leave.allocation'].sudo().with_context(tracking_disable=True).create({
                 'date_from': '2024-01-01',
                 'accrual_plan_id': accrual_plan_1.id,
                 'work_entry_type_id': self.work_entry_type.id,
@@ -284,7 +322,7 @@ class TestExpiringLeaves(HttpCase, TestHrHolidaysCommon):
                 'request_date_to': '2025-12-05'
             })
             # The expiring allocation
-            self.env['hr.leave.allocation'].sudo().create({
+            self.env['hr.leave.allocation'].sudo().with_context(tracking_disable=True).create({
                 'date_from': '2024-01-01',
                 'date_to': '2025-12-31',
                 'accrual_plan_id': accrual_plan_2.id,
@@ -296,15 +334,15 @@ class TestExpiringLeaves(HttpCase, TestHrHolidaysCommon):
             target_date = date(2025, 12, 30)
             allocation_data = self.work_entry_type.get_allocation_data(logged_in_emp, target_date)
 
-            # Assert the date of expiration
-            self.assertEqual(allocation_data[logged_in_emp][0][1]['closest_allocation_expire'],
-                        allocation_with_carryover._get_carryover_date(target_date).strftime('%m/%d/%Y'),
-                        "The expiration date should match the carryover date")
+        # Assert the date of expiration
+        self.assertEqual(allocation_data[logged_in_emp][0][1]['closest_allocation_expire'],
+                    allocation_with_carryover._get_next_carryover_date(target_date).strftime('%m/%d/%Y'),
+                    "The expiration date should match the carryover date")
 
-            # Assert the number of expiring leaves
-            self.assertEqual(allocation_data[logged_in_emp][0][1]['closest_allocation_remaining'],
-                            (number_of_accrued_days - leave.number_of_days - carryover_limit) + number_of_accrued_days,
-                            "All the remaining days of the allocation will expire")
+        # Assert the number of expiring leaves
+        self.assertEqual(allocation_data[logged_in_emp][0][1]['closest_allocation_remaining'],
+                        (number_of_accrued_days - leave.number_of_days - carryover_limit) + number_of_accrued_days,
+                        "All the remaining days of the allocation will expire")
 
     @users('enguerran')
     def test_expiring_allocation_without_carried_over_leaves(self):
@@ -351,7 +389,7 @@ class TestExpiringLeaves(HttpCase, TestHrHolidaysCommon):
         })
 
         logged_in_emp = self.env.user.employee_id
-        allocation = self.env['hr.leave.allocation'].sudo().create({
+        allocation = self.env['hr.leave.allocation'].sudo().with_context(tracking_disable=True).create({
             'date_from': date(date.today().year, 1, 1),
             'date_to': date(date.today().year + 1, 12, 31),
             'accrual_plan_id': accrual_plan.id,
@@ -366,7 +404,7 @@ class TestExpiringLeaves(HttpCase, TestHrHolidaysCommon):
 
         # Assert the date of expiration
         self.assertEqual(allocation_data[logged_in_emp][0][1]['closest_allocation_expire'],
-                    allocation._get_carryover_date(target_date).strftime('%m/%d/%Y'),
+                    allocation._get_next_carryover_date(target_date).strftime('%m/%d/%Y'),
                     "The expiration date should match the carryover date")
 
         # Assert the number of expiring leaves
@@ -412,13 +450,13 @@ class TestExpiringLeaves(HttpCase, TestHrHolidaysCommon):
                     'cap_accrued_time': False,
                     'action_with_unused_accruals': 'all',
                     'carryover_options': 'limited',
-                    'postpone_max_days': 5,
+                    'max_carriedover_duration': 5,
                     })
                 ],
             })
 
             logged_in_emp = self.env.user.employee_id
-            allocation = self.env['hr.leave.allocation'].sudo().create({
+            allocation = self.env['hr.leave.allocation'].sudo().with_context(tracking_disable=True).create({
                 'date_from': date(2024, 1, 1),
                 'accrual_plan_id': accrual_plan.id,
                 'work_entry_type_id': self.work_entry_type.id,
@@ -472,33 +510,33 @@ class TestExpiringLeaves(HttpCase, TestHrHolidaysCommon):
                 'cap_accrued_time': False,
                 'action_with_unused_accruals': 'all',
                 'carryover_options': 'limited',
-                'postpone_max_days': 5,
+                'max_carriedover_duration': 5,
                 })
             ],
         })
 
         logged_in_emp = self.env.user.employee_id
         with freeze_time("2023-01-01"):
-            # Allocation 1
-            self.env['hr.leave.allocation'].sudo().create({
-                'date_from': '2023-01-01',
-                'accrual_plan_id': accrual_plan.id,
-                'work_entry_type_id': self.work_entry_type.id,
-                'employee_id': logged_in_emp.id,
-                'number_of_days': 0,
-            })
-            # Allocation 2
-            self.env['hr.leave.allocation'].sudo().create({
-                'date_from': '2023-01-01',
-                'date_to': '2024-10-01',
-                'accrual_plan_id': accrual_plan.id,
-                'work_entry_type_id': self.work_entry_type.id,
-                'employee_id': logged_in_emp.id,
-                'number_of_days': 0,
-            })
+            allocations = (
+                self.env['hr.leave.allocation'].sudo().with_context(tracking_disable=True).create({
+                    'date_from': '2023-01-01',
+                    'accrual_plan_id': accrual_plan.id,
+                    'work_entry_type_id': self.work_entry_type.id,
+                    'employee_id': logged_in_emp.id,
+                    'number_of_days': 0,
+                }) |
+                self.env['hr.leave.allocation'].sudo().with_context(tracking_disable=True).create({
+                    'date_from': '2023-01-01',
+                    'date_to': '2024-10-01',
+                    'accrual_plan_id': accrual_plan.id,
+                    'work_entry_type_id': self.work_entry_type.id,
+                    'employee_id': logged_in_emp.id,
+                    'number_of_days': 0,
+                })
+            )
 
         with freeze_time("2024-01-01"):
-            self.env['hr.leave.allocation'].with_user(self.user_hruser)._update_accrual()
+            allocations.with_user(self.user_hruser)._update_accrual()
 
         target_date = date(2024, 1, 1)
         allocation_data = self.work_entry_type.get_allocation_data(logged_in_emp, target_date)
@@ -555,7 +593,7 @@ class TestExpiringLeaves(HttpCase, TestHrHolidaysCommon):
             'hours_per_day': 8.0,
         })
 
-        allocation = self.env['hr.leave.allocation'].sudo().create({
+        allocation = self.env['hr.leave.allocation'].sudo().with_context(tracking_disable=True).create({
             'date_from': date(date.today().year, 1, 1),
             'accrual_plan_id': accrual_plan.id,
             'work_entry_type_id': self.work_entry_type.id,
@@ -576,7 +614,7 @@ class TestExpiringLeaves(HttpCase, TestHrHolidaysCommon):
 
         # Assert the date of expiration
         self.assertEqual(allocation_data[logged_in_emp][0][1]['closest_allocation_expire'],
-                    allocation._get_carryover_date(target_date).strftime('%m/%d/%Y'),
+                    allocation._get_next_carryover_date(target_date).strftime('%m/%d/%Y'),
                     "The expiration date should match the carryover date")
 
         # Assert the number of expiring leaves
@@ -629,7 +667,7 @@ class TestExpiringLeaves(HttpCase, TestHrHolidaysCommon):
         logged_in_emp = self.env.user.employee_id
         logged_in_emp.resource_calendar_id = None       # Set as Fully flexible resource
 
-        allocation = self.env['hr.leave.allocation'].sudo().create({
+        allocation = self.env['hr.leave.allocation'].sudo().with_context(tracking_disable=True).create({
             'date_from': date(date.today().year, 1, 1),
             'accrual_plan_id': accrual_plan.id,
             'work_entry_type_id': self.work_entry_type.id,
@@ -650,7 +688,7 @@ class TestExpiringLeaves(HttpCase, TestHrHolidaysCommon):
 
         # Assert the date of expiration
         self.assertEqual(allocation_data[logged_in_emp][0][1]['closest_allocation_expire'],
-                    allocation._get_carryover_date(target_date).strftime('%m/%d/%Y'),
+                    allocation._get_next_carryover_date(target_date).strftime('%m/%d/%Y'),
                     "The expiration date should match the carryover date")
 
         # Assert the number of expiring leaves
@@ -659,7 +697,7 @@ class TestExpiringLeaves(HttpCase, TestHrHolidaysCommon):
                          "All the remaining days of the allocation will expire")
 
         # Days between the target date and the expiration date (accrual_plan's carryover date)
-        working_days_equivalent_needed = (allocation._get_carryover_date(target_date) - target_date).days + 1
+        working_days_equivalent_needed = (allocation._get_next_carryover_date(target_date) - target_date).days + 1
 
         # Assert the closest allocation duration (number of working days equivalent (8 hours/day) remaining before the allocation expires)
         self.assertEqual(round(allocation_data[logged_in_emp][0][1]['closest_allocation_duration']), working_days_equivalent_needed,
@@ -693,6 +731,7 @@ class TestExpiringLeaves(HttpCase, TestHrHolidaysCommon):
             'carryover_date': 'other',
             'carryover_day': 1,
             'carryover_month': '4',
+            'can_be_carryover': True,
             'level_ids': [
                 (0, 0, {
                 'start_count': 0,
@@ -705,7 +744,7 @@ class TestExpiringLeaves(HttpCase, TestHrHolidaysCommon):
                 'cap_accrued_time': False,
                 'action_with_unused_accruals': 'all',
                 'carryover_options': 'limited',
-                'postpone_max_days': 5,
+                'max_carriedover_duration': 5,
                 })
             ],
         })
@@ -713,7 +752,7 @@ class TestExpiringLeaves(HttpCase, TestHrHolidaysCommon):
         logged_in_emp = self.env.user.employee_id
         with freeze_time("2023-01-01"):
             # Allocation 1
-            self.env['hr.leave.allocation'].sudo().create({
+            allocation1 = self.env['hr.leave.allocation'].sudo().with_context(tracking_disable=True).create({
                 'date_from': '2023-01-01',
                 'date_to': '2024-10-01',
                 'accrual_plan_id': accrual_plan_without_accrual_validity.id,
@@ -722,7 +761,7 @@ class TestExpiringLeaves(HttpCase, TestHrHolidaysCommon):
                 'number_of_days': 0,
             })
             # Allocation 2
-            self.env['hr.leave.allocation'].sudo().create({
+            allocation2 = self.env['hr.leave.allocation'].sudo().with_context(tracking_disable=True).create({
                 'date_from': '2023-01-01',
                 'accrual_plan_id': self.accrual_plan_with_accrual_validity.id,
                 'work_entry_type_id': self.work_entry_type.id,
@@ -731,17 +770,16 @@ class TestExpiringLeaves(HttpCase, TestHrHolidaysCommon):
             })
 
         with freeze_time("2024-04-01"):
-            self.env['hr.leave.allocation'].with_user(self.user_hruser)._update_accrual()
+            (allocation1 | allocation2).with_user(self.user_hruser)._update_accrual()
 
-        target_date = date(2024, 4, 1)
-        allocation_data = self.work_entry_type.get_allocation_data(logged_in_emp, target_date)
-        # Assert the date of expiration
-        self.assertEqual(allocation_data[logged_in_emp][0][1]['closest_allocation_expire'],
-                    (target_date + relativedelta(month=7)).strftime('%m/%d/%Y'),
-                    "The expiration date should be the carried over days expiration date of allocation 3")
+            allocation_data = self.work_entry_type.get_allocation_data(logged_in_emp)
+            # Expiration happens 3 month after the carryover date (happens on the 1st of April)
+            self.assertEqual(allocation_data[logged_in_emp][0][1]['closest_allocation_expire'],
+                '07/01/2024',
+                "The expiration date should be the carried over days expiration date of allocation 3")
 
-        # Assert the number of expiring leaves
-        self.assertEqual(allocation_data[logged_in_emp][0][1]['closest_allocation_remaining'], 3)
+            # Assert the number of expiring leaves
+            self.assertEqual(allocation_data[logged_in_emp][0][1]['closest_allocation_remaining'], 3)
 
     @users('enguerran')
     def test_carried_over_days_expiration_date_2(self):
@@ -768,7 +806,7 @@ class TestExpiringLeaves(HttpCase, TestHrHolidaysCommon):
 
         logged_in_emp = self.env.user.employee_id
         with freeze_time("2023-01-01"):
-            self.env['hr.leave.allocation'].sudo().create({
+            allocation = self.env['hr.leave.allocation'].with_context(tracking_disable=True).create({
                 'date_from': '2023-01-01',
                 'accrual_plan_id': self.accrual_plan_with_accrual_validity.id,
                 'work_entry_type_id': self.work_entry_type.id,
@@ -777,7 +815,7 @@ class TestExpiringLeaves(HttpCase, TestHrHolidaysCommon):
             })
 
         with freeze_time("2024-04-01"):
-            self.env['hr.leave.allocation'].with_user(self.user_hruser)._update_accrual()
+            allocation.with_user(self.user_hruser)._update_accrual()
             leave = self.env['hr.leave'].create({
                 'name': 'leave',
                 'employee_id': logged_in_emp.id,
@@ -785,7 +823,7 @@ class TestExpiringLeaves(HttpCase, TestHrHolidaysCommon):
                 'request_date_from': '2024-04-03',
                 'request_date_to': '2024-04-04',
             })
-            leave.sudo().action_approve()
+            leave.with_user(self.user_hruser).action_approve()
 
         target_date = date(2024, 5, 1)
         allocation_data = self.work_entry_type.get_allocation_data(logged_in_emp, target_date)
@@ -796,3 +834,62 @@ class TestExpiringLeaves(HttpCase, TestHrHolidaysCommon):
 
         # Assert the number of expiring leaves
         self.assertEqual(allocation_data[logged_in_emp][0][1]['closest_allocation_remaining'], 1)
+
+    def test_accrual_plan_start_carryover_expiring_second_period(self):
+        """ Check that the carryover is applied correctly when the accrued gain time is set to "start"
+            and the policy is set to "all", but there is a validity of 10 days """
+        accrual_plan = self.accrual_plan_one_lvl_monthly_validity_10days
+        added_value = accrual_plan.level_ids[0].added_value
+        self.assertEqual(added_value, 3)
+        work_entry_type = self.work_entry_type
+        with freeze_time('2025-01-23'):
+            allocation = self._create_form_test_accrual_allocation(work_entry_type, '2025-01-01', self.employee_emp,
+                accrual_plan=accrual_plan, date_to='2025-06-30')
+            allocation.action_approve()
+
+        assertions = [
+            # First accrual happens on 2025-01-01
+            ('2025-01-23', expected_nbr_of_days := 3),
+            # Second accrual happens on 2025-02-01
+            ('2025-02-01', expected_nbr_of_days := expected_nbr_of_days + 3),
+            # Carryover date do not change the number_of_days
+            ('2025-02-15', expected_nbr_of_days),
+            # Last day before the carry-over expiration
+            ('2025-02-24', expected_nbr_of_days),
+            # Expiration happens on 2025-02-25
+            ('2025-02-25', 0),
+            # Third accrual happens on 2025-03-01
+            ('2025-03-01', 3),
+        ]
+
+        for test_date, expected_nbr_of_days in assertions:
+            with freeze_time(test_date):
+                allocation._update_accrual()
+                self._assert_allocation_balance(
+                    allocation, expected_nbr_of_days, expected_nbr_of_days, target_date=test_date)
+
+    def test_accrual_plan_start_carryover_first_period_expired(self):
+        """ Check that the carryover is applied correctly when it happens on the first period of the first level
+            The accrued gain time is set as "start" and the policy is set to "all", but there is a validity of 10 days
+        """
+        accrual_plan = self.accrual_plan_one_lvl_monthly_validity_10days
+        added_value = accrual_plan.level_ids[0].added_value
+        self.assertEqual(added_value, 3)
+        work_entry_type = self.work_entry_type
+        with freeze_time('2025-02-01'):
+            allocation = self._create_form_test_accrual_allocation(work_entry_type, '2025-02-01', self.employee_emp,
+                accrual_plan=accrual_plan, date_to='2025-06-30')
+            allocation.action_approve()
+
+        assertions = [
+            # First accrual happens on 2025-02-01
+            ('2025-02-01', expected_nbr_of_days := 3),
+            # Last day before the carry-over expiration
+            ('2025-02-24', expected_nbr_of_days),
+            # Expiration happens on 2025-02-25
+            ('2025-02-28', 0),
+        ]
+        for test_date, expected_nbr_of_days in assertions:
+            with freeze_time(test_date):
+                allocation._update_accrual()
+                self._assert_allocation_balance(allocation, expected_nbr_of_days, expected_nbr_of_days, target_date=test_date)

--- a/addons/hr_holidays/tests/test_expiring_leaves.py
+++ b/addons/hr_holidays/tests/test_expiring_leaves.py
@@ -4,6 +4,7 @@ from datetime import date
 from dateutil.relativedelta import relativedelta
 from freezegun import freeze_time
 
+from odoo import Command
 from odoo.addons.base.tests.common import HttpCase
 from odoo.tests.common import tagged
 from odoo.tests.common import users
@@ -31,6 +32,7 @@ class TestExpiringLeaves(HttpCase, TestHrHolidaysCommon):
             'carryover_date': 'other',
             'carryover_day': 1,
             'carryover_month': '4',
+            'can_be_carryover': True,
             'level_ids': [
                 (0, 0, {
                 'start_count': 0,
@@ -43,12 +45,57 @@ class TestExpiringLeaves(HttpCase, TestHrHolidaysCommon):
                 'cap_accrued_time': False,
                 'action_with_unused_accruals': 'all',
                 'carryover_options': 'limited',
-                'postpone_max_days': 5,
+                'max_carriedover_duration': 5,
                 'accrual_validity': True,
                 'accrual_validity_count': 3,
                 'accrual_validity_type': 'month',
                 })
             ],
+        })
+        cls.leave_type_day = cls.env['hr.work.entry.type'].create({
+            'name': 'Test Day Leave Type',
+            'code': 'Test',
+            'count_as': 'absence',
+            'requires_allocation': 'yes',
+            'allocation_validation_type': 'no_validation',
+            'request_unit': 'day',
+            'unit_of_measure': 'day',
+        })
+        cls.accrual_plan_one_lvl_monthly_validity_10days = cls.env['hr.leave.accrual.plan'].create({
+            'name': 'Test Accrual Plan - expiring_leaves 1',
+            'is_based_on_worked_time': False,
+            'accrued_gain_time': 'start',
+            'can_be_carryover': True,
+            'carryover_date': 'other',
+            'carryover_day': '15',
+            'carryover_month': '2',
+            'level_ids': [Command.create({
+                'milestone_date': 'creation',
+                'added_value': 3,
+                'added_value_type': 'day',
+                'frequency': 'monthly',
+                'action_with_unused_accruals': 'all',
+                'accrual_validity': True,
+                'accrual_validity_count': 10,
+            })],
+        })
+        cls.accrual_plan_one_lvl_monthly_maxcarryover_10days = cls.env['hr.leave.accrual.plan'].create({
+            'name': 'Test Accrual Plan - expiring_leaves 2',
+            'is_based_on_worked_time': False,
+            'accrued_gain_time': 'start',
+            'can_be_carryover': True,
+            'carryover_date': 'other',
+            'carryover_day': '15',
+            'carryover_month': '10',
+            'level_ids': [Command.create({
+                'milestone_date': 'creation',
+                'added_value': 3,
+                'added_value_type': 'day',
+                'frequency': 'monthly',
+                'action_with_unused_accruals': 'all',
+                'carryover_options': 'limited',
+                'max_carriedover_duration': 10,
+            })],
         })
 
     @users('enguerran')
@@ -91,7 +138,7 @@ class TestExpiringLeaves(HttpCase, TestHrHolidaysCommon):
         })
 
         logged_in_emp = self.env.user.employee_id
-        allocation = self.env['hr.leave.allocation'].sudo().create({
+        allocation = self.env['hr.leave.allocation'].sudo().with_context(tracking_disable=True).create({
             'date_from': date(date.today().year, 1, 1),
             'allocation_type': 'accrual',
             'accrual_plan_id': accrual_plan.id,
@@ -113,7 +160,7 @@ class TestExpiringLeaves(HttpCase, TestHrHolidaysCommon):
 
         # Assert the date of expiration
         self.assertEqual(allocation_data[logged_in_emp][0][1]['closest_allocation_expire'],
-                    allocation._get_carryover_date(target_date).strftime('%m/%d/%Y'),
+                    allocation._get_next_carryover_date(target_date).strftime('%m/%d/%Y'),
                     "The expiration date should match the carryover date")
 
         # Assert the number of expiring leaves
@@ -160,13 +207,13 @@ class TestExpiringLeaves(HttpCase, TestHrHolidaysCommon):
                 'cap_accrued_time': False,
                 'action_with_unused_accruals': 'all',
                 'carryover_options': 'limited',
-                'postpone_max_days': carryover_limit,
+                'max_carriedover_duration': carryover_limit,
                 })
             ],
         })
 
         logged_in_emp = self.env.user.employee_id
-        allocation = self.env['hr.leave.allocation'].sudo().create({
+        allocation = self.env['hr.leave.allocation'].sudo().with_context(tracking_disable=True).create({
             'date_from': date(date.today().year, 1, 1),
             'allocation_type': 'accrual',
             'accrual_plan_id': accrual_plan.id,
@@ -187,7 +234,7 @@ class TestExpiringLeaves(HttpCase, TestHrHolidaysCommon):
 
         # Assert the date of expiration
         self.assertEqual(allocation_data[logged_in_emp][0][1]['closest_allocation_expire'],
-                    allocation._get_carryover_date(target_date).strftime('%m/%d/%Y'),
+                    allocation._get_next_carryover_date(target_date).strftime('%m/%d/%Y'),
                     "The expiration date should match the carryover date")
 
         # Assert the number of expiring leaves
@@ -247,7 +294,7 @@ class TestExpiringLeaves(HttpCase, TestHrHolidaysCommon):
                 'cap_accrued_time': False,
                 'action_with_unused_accruals': 'all',
                 'carryover_options': 'limited',
-                'postpone_max_days': carryover_limit,
+                'max_carriedover_duration': carryover_limit,
                 })
             ],
         })
@@ -272,7 +319,7 @@ class TestExpiringLeaves(HttpCase, TestHrHolidaysCommon):
 
         logged_in_emp = self.env.user.employee_id
         with freeze_time("2024-01-01"):
-            allocation_with_carryover = self.env['hr.leave.allocation'].sudo().create({
+            allocation_with_carryover = self.env['hr.leave.allocation'].sudo().with_context(tracking_disable=True).create({
                 'date_from': '2024-01-01',
                 'allocation_type': 'accrual',
                 'accrual_plan_id': accrual_plan_1.id,
@@ -287,7 +334,7 @@ class TestExpiringLeaves(HttpCase, TestHrHolidaysCommon):
                 'request_date_to': '2025-12-05'
             })
             # The expiring allocation
-            self.env['hr.leave.allocation'].sudo().create({
+            self.env['hr.leave.allocation'].sudo().with_context(tracking_disable=True).create({
                 'date_from': '2024-01-01',
                 'date_to': '2025-12-31',
                 'allocation_type': 'accrual',
@@ -300,15 +347,15 @@ class TestExpiringLeaves(HttpCase, TestHrHolidaysCommon):
             target_date = date(2025, 12, 30)
             allocation_data = self.work_entry_type.get_allocation_data(logged_in_emp, target_date)
 
-            # Assert the date of expiration
-            self.assertEqual(allocation_data[logged_in_emp][0][1]['closest_allocation_expire'],
-                        allocation_with_carryover._get_carryover_date(target_date).strftime('%m/%d/%Y'),
-                        "The expiration date should match the carryover date")
+        # Assert the date of expiration
+        self.assertEqual(allocation_data[logged_in_emp][0][1]['closest_allocation_expire'],
+                    allocation_with_carryover._get_next_carryover_date(target_date).strftime('%m/%d/%Y'),
+                    "The expiration date should match the carryover date")
 
-            # Assert the number of expiring leaves
-            self.assertEqual(allocation_data[logged_in_emp][0][1]['closest_allocation_remaining'],
-                            (number_of_accrued_days - leave.number_of_days - carryover_limit) + number_of_accrued_days,
-                            "All the remaining days of the allocation will expire")
+        # Assert the number of expiring leaves
+        self.assertEqual(allocation_data[logged_in_emp][0][1]['closest_allocation_remaining'],
+                        (number_of_accrued_days - leave.number_of_days - carryover_limit) + number_of_accrued_days,
+                        "All the remaining days of the allocation will expire")
 
     @users('enguerran')
     def test_expiring_allocation_without_carried_over_leaves(self):
@@ -355,7 +402,7 @@ class TestExpiringLeaves(HttpCase, TestHrHolidaysCommon):
         })
 
         logged_in_emp = self.env.user.employee_id
-        allocation = self.env['hr.leave.allocation'].sudo().create({
+        allocation = self.env['hr.leave.allocation'].sudo().with_context(tracking_disable=True).create({
             'date_from': date(date.today().year, 1, 1),
             'date_to': date(date.today().year + 1, 12, 31),
             'allocation_type': 'accrual',
@@ -371,7 +418,7 @@ class TestExpiringLeaves(HttpCase, TestHrHolidaysCommon):
 
         # Assert the date of expiration
         self.assertEqual(allocation_data[logged_in_emp][0][1]['closest_allocation_expire'],
-                    allocation._get_carryover_date(target_date).strftime('%m/%d/%Y'),
+                    allocation._get_next_carryover_date(target_date).strftime('%m/%d/%Y'),
                     "The expiration date should match the carryover date")
 
         # Assert the number of expiring leaves
@@ -417,13 +464,13 @@ class TestExpiringLeaves(HttpCase, TestHrHolidaysCommon):
                     'cap_accrued_time': False,
                     'action_with_unused_accruals': 'all',
                     'carryover_options': 'limited',
-                    'postpone_max_days': 5,
+                    'max_carriedover_duration': 5,
                     })
                 ],
             })
 
             logged_in_emp = self.env.user.employee_id
-            allocation = self.env['hr.leave.allocation'].sudo().create({
+            allocation = self.env['hr.leave.allocation'].sudo().with_context(tracking_disable=True).create({
                 'date_from': date(2024, 1, 1),
                 'allocation_type': 'accrual',
                 'accrual_plan_id': accrual_plan.id,
@@ -478,7 +525,7 @@ class TestExpiringLeaves(HttpCase, TestHrHolidaysCommon):
                 'cap_accrued_time': False,
                 'action_with_unused_accruals': 'all',
                 'carryover_options': 'limited',
-                'postpone_max_days': 5,
+                'max_carriedover_duration': 5,
                 })
             ],
         })
@@ -486,7 +533,7 @@ class TestExpiringLeaves(HttpCase, TestHrHolidaysCommon):
         logged_in_emp = self.env.user.employee_id
         with freeze_time("2023-01-01"):
             # Allocation 1
-            self.env['hr.leave.allocation'].sudo().create({
+            self.env['hr.leave.allocation'].sudo().with_context(tracking_disable=True).create({
                 'date_from': '2023-01-01',
                 'allocation_type': 'accrual',
                 'accrual_plan_id': accrual_plan.id,
@@ -495,7 +542,7 @@ class TestExpiringLeaves(HttpCase, TestHrHolidaysCommon):
                 'number_of_days': 0,
             })
             # Allocation 2
-            self.env['hr.leave.allocation'].sudo().create({
+            self.env['hr.leave.allocation'].sudo().with_context(tracking_disable=True).create({
                 'date_from': '2023-01-01',
                 'date_to': '2024-10-01',
                 'allocation_type': 'accrual',
@@ -563,7 +610,7 @@ class TestExpiringLeaves(HttpCase, TestHrHolidaysCommon):
             'hours_per_day': 8.0,
         })
 
-        allocation = self.env['hr.leave.allocation'].sudo().create({
+        allocation = self.env['hr.leave.allocation'].sudo().with_context(tracking_disable=True).create({
             'date_from': date(date.today().year, 1, 1),
             'allocation_type': 'accrual',
             'accrual_plan_id': accrual_plan.id,
@@ -585,7 +632,7 @@ class TestExpiringLeaves(HttpCase, TestHrHolidaysCommon):
 
         # Assert the date of expiration
         self.assertEqual(allocation_data[logged_in_emp][0][1]['closest_allocation_expire'],
-                    allocation._get_carryover_date(target_date).strftime('%m/%d/%Y'),
+                    allocation._get_next_carryover_date(target_date).strftime('%m/%d/%Y'),
                     "The expiration date should match the carryover date")
 
         # Assert the number of expiring leaves
@@ -638,7 +685,7 @@ class TestExpiringLeaves(HttpCase, TestHrHolidaysCommon):
         logged_in_emp = self.env.user.employee_id
         logged_in_emp.resource_calendar_id = None       # Set as Fully flexible resource
 
-        allocation = self.env['hr.leave.allocation'].sudo().create({
+        allocation = self.env['hr.leave.allocation'].sudo().with_context(tracking_disable=True).create({
             'date_from': date(date.today().year, 1, 1),
             'allocation_type': 'accrual',
             'accrual_plan_id': accrual_plan.id,
@@ -660,7 +707,7 @@ class TestExpiringLeaves(HttpCase, TestHrHolidaysCommon):
 
         # Assert the date of expiration
         self.assertEqual(allocation_data[logged_in_emp][0][1]['closest_allocation_expire'],
-                    allocation._get_carryover_date(target_date).strftime('%m/%d/%Y'),
+                    allocation._get_next_carryover_date(target_date).strftime('%m/%d/%Y'),
                     "The expiration date should match the carryover date")
 
         # Assert the number of expiring leaves
@@ -669,7 +716,7 @@ class TestExpiringLeaves(HttpCase, TestHrHolidaysCommon):
                          "All the remaining days of the allocation will expire")
 
         # Days between the target date and the expiration date (accrual_plan's carryover date)
-        working_days_equivalent_needed = (allocation._get_carryover_date(target_date) - target_date).days + 1
+        working_days_equivalent_needed = (allocation._get_next_carryover_date(target_date) - target_date).days + 1
 
         # Assert the closest allocation duration (number of working days equivalent (8 hours/day) remaining before the allocation expires)
         self.assertEqual(round(allocation_data[logged_in_emp][0][1]['closest_allocation_duration']), working_days_equivalent_needed,
@@ -703,6 +750,7 @@ class TestExpiringLeaves(HttpCase, TestHrHolidaysCommon):
             'carryover_date': 'other',
             'carryover_day': 1,
             'carryover_month': '4',
+            'can_be_carryover': True,
             'level_ids': [
                 (0, 0, {
                 'start_count': 0,
@@ -715,7 +763,7 @@ class TestExpiringLeaves(HttpCase, TestHrHolidaysCommon):
                 'cap_accrued_time': False,
                 'action_with_unused_accruals': 'all',
                 'carryover_options': 'limited',
-                'postpone_max_days': 5,
+                'max_carriedover_duration': 5,
                 })
             ],
         })
@@ -723,7 +771,7 @@ class TestExpiringLeaves(HttpCase, TestHrHolidaysCommon):
         logged_in_emp = self.env.user.employee_id
         with freeze_time("2023-01-01"):
             # Allocation 1
-            self.env['hr.leave.allocation'].sudo().create({
+            self.env['hr.leave.allocation'].sudo().with_context(tracking_disable=True).create({
                 'date_from': '2023-01-01',
                 'date_to': '2024-10-01',
                 'allocation_type': 'accrual',
@@ -733,7 +781,7 @@ class TestExpiringLeaves(HttpCase, TestHrHolidaysCommon):
                 'number_of_days': 0,
             })
             # Allocation 2
-            self.env['hr.leave.allocation'].sudo().create({
+            self.env['hr.leave.allocation'].sudo().with_context(tracking_disable=True).create({
                 'date_from': '2023-01-01',
                 'allocation_type': 'accrual',
                 'accrual_plan_id': self.accrual_plan_with_accrual_validity.id,
@@ -780,7 +828,7 @@ class TestExpiringLeaves(HttpCase, TestHrHolidaysCommon):
 
         logged_in_emp = self.env.user.employee_id
         with freeze_time("2023-01-01"):
-            self.env['hr.leave.allocation'].sudo().create({
+            self.env['hr.leave.allocation'].with_context(tracking_disable=True).create({
                 'date_from': '2023-01-01',
                 'allocation_type': 'accrual',
                 'accrual_plan_id': self.accrual_plan_with_accrual_validity.id,
@@ -798,7 +846,7 @@ class TestExpiringLeaves(HttpCase, TestHrHolidaysCommon):
                 'request_date_from': '2024-04-03',
                 'request_date_to': '2024-04-04',
             })
-            leave.sudo().action_approve()
+            leave.with_user(self.user_hruser).action_approve()
 
         target_date = date(2024, 5, 1)
         allocation_data = self.work_entry_type.get_allocation_data(logged_in_emp, target_date)
@@ -809,3 +857,63 @@ class TestExpiringLeaves(HttpCase, TestHrHolidaysCommon):
 
         # Assert the number of expiring leaves
         self.assertEqual(allocation_data[logged_in_emp][0][1]['closest_allocation_remaining'], 1)
+
+    def test_accrual_plan_start_carryover_expiring_second_period(self):
+        """ Check that the carryover is applied correctly when the accrued gain time is set to "start"
+            and the policy is set to "all", but there is a validity of 10 days """
+        accrual_plan = self.accrual_plan_one_lvl_monthly_validity_10days
+        added_value = accrual_plan.level_ids[0].added_value
+        self.assertEqual(added_value, 3)
+        leave_type_day = self.leave_type_day
+        with freeze_time('2025-01-23'):
+            allocation = self._create_form_test_accrual_allocation(leave_type_day, '2025-01-01', self.employee_emp,
+                accrual_plan=accrual_plan, date_to='2025-06-30')
+            allocation.action_approve()
+
+        assertions = [
+            # First accrual happens on 2025-01-01
+            ('2025-01-23', expected_nbr_of_days := 3),
+            # Second accrual happens on 2025-02-01
+            ('2025-02-01', expected_nbr_of_days := expected_nbr_of_days + 3),
+            # Carryover date do not change the number_of_days
+            ('2025-02-15', expected_nbr_of_days),
+            # Last day before the carry-over expiration
+            ('2025-02-24', expected_nbr_of_days),
+            # Expiration happens on 2025-02-25
+            ('2025-02-25', 0),
+            # Third accrual happens on 2025-03-01
+            ('2025-03-01', 3),
+        ]
+
+        for test_date, expected_nbr_of_days in assertions:
+            with freeze_time(test_date):
+                allocation._update_accrual()
+                self._assert_allocation_nbr_of_days_and_remaining_leaves_equal(
+                    allocation, expected_nbr_of_days, expected_nbr_of_days, target_date=test_date)
+
+    def test_accrual_plan_start_carryover_first_period_expired(self):
+        """ Check that the carryover is applied correctly when it happens on the first period of the first level
+            The accrued gain time is set as "start" and the policy is set to "all", but there is a validity of 10 days
+        """
+        accrual_plan = self.accrual_plan_one_lvl_monthly_validity_10days
+        added_value = accrual_plan.level_ids[0].added_value
+        self.assertEqual(added_value, 3)
+        leave_type_day = self.leave_type_day
+        with freeze_time('2025-02-01'):
+            allocation = self._create_form_test_accrual_allocation(leave_type_day, '2025-02-01', self.employee_emp,
+                accrual_plan=accrual_plan, date_to='2025-06-30')
+            allocation.action_approve()
+
+        assertions = [
+            # First accrual happens on 2025-02-01
+            ('2025-02-01', expected_nbr_of_days := 3),
+            # Last day before the carry-over expiration
+            ('2025-02-24', expected_nbr_of_days),
+            # Expiration happens on 2025-02-25
+            ('2025-02-28', 0),
+        ]
+        for test_date, expected_nbr_of_days in assertions:
+            with freeze_time(test_date):
+                allocation._update_accrual()
+                self._assert_allocation_nbr_of_days_and_remaining_leaves_equal(
+                    allocation, expected_nbr_of_days, expected_nbr_of_days, target_date=test_date)

--- a/addons/hr_holidays/tests/test_past_accruals.py
+++ b/addons/hr_holidays/tests/test_past_accruals.py
@@ -11,13 +11,13 @@ from odoo.addons.hr_holidays.tests.common import TestHrHolidaysCommon
 class TestAccrualAllocations(TestHrHolidaysCommon):
     @classmethod
     def setUpClass(cls):
-        super(TestAccrualAllocations, cls).setUpClass()
+        super().setUpClass()
         cls.work_entry_type = cls.env['hr.work.entry.type'].create({
             'name': 'Accrual Time Off',
             'code': 'Accrual Time Off',
             'count_as': 'absence',
             'requires_allocation': True,
-            'allocation_validation_type': 'no',
+            'allocation_validation_type': 'no_validation',
             'request_unit': 'day',
             'unit_of_measure': 'day',
         })
@@ -59,7 +59,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
 
     def _test_past_accrual(self):
         with freeze_time("2023-12-01"):
-            allocation = self.env['hr.leave.allocation'].create({
+            allocation = self.env['hr.leave.allocation'].with_context(tracking_disable=True).create({
                 'employee_id': self.employee_emp_id,
                 'accrual_plan_id': self.accrual_plan.id,
                 'work_entry_type_id': self.work_entry_type.id,
@@ -67,6 +67,5 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'number_of_days': 0,
             })
 
-            allocation._process_accrual_plans()
-
+            allocation._update_accrual()
             self.assertEqual(allocation.number_of_days, 0)

--- a/addons/hr_holidays/tests/test_past_accruals.py
+++ b/addons/hr_holidays/tests/test_past_accruals.py
@@ -59,7 +59,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
 
     def _test_past_accrual(self):
         with freeze_time("2023-12-01"):
-            allocation = self.env['hr.leave.allocation'].create({
+            allocation = self.env['hr.leave.allocation'].with_context(tracking_disable=True).create({
                 'employee_id': self.employee_emp_id,
                 'allocation_type': 'accrual',
                 'accrual_plan_id': self.accrual_plan.id,
@@ -68,6 +68,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'number_of_days': 0,
             })
 
-            allocation._process_accrual_plans()
+            allocations_data = allocation._process_accrual_plans()
+            allocation._update_accrual_from_data(allocations_data, log=False)
 
             self.assertEqual(allocation.number_of_days, 0)

--- a/addons/hr_holidays/views/hr_leave_accrual_views.xml
+++ b/addons/hr_holidays/views/hr_leave_accrual_views.xml
@@ -88,7 +88,7 @@
                                            widget="radio_followed_by_element"
                                            options="{'links': {'limited': 'carryover_options_limited'}, 'observe': 'carryover_options'}"/>
                                     <span id="carryover_options_limited" readonly="1">
-                                        <field nolabel="1" class="ms-1 me-1 o_field_accrual" name="postpone_max_days"/>
+                                        <field nolabel="1" class="ms-1 me-1 o_field_accrual" name="max_carriedover_duration"/>
                                         <field nolabel="1" class="o_field_accrual" name="added_value_type" readonly="1"/>
                                     </span>
                                 </span>

--- a/addons/hr_holidays/views/hr_leave_accrual_views.xml
+++ b/addons/hr_holidays/views/hr_leave_accrual_views.xml
@@ -79,7 +79,7 @@
                                            widget="radio_followed_by_element"
                                            options="{'links': {'limited': 'carryover_options_limited'}, 'observe': 'carryover_options'}"/>
                                     <span id="carryover_options_limited" readonly="1">
-                                        <field nolabel="1" class="ms-1 me-1 o_field_accrual" name="postpone_max_days"/>
+                                        <field nolabel="1" class="ms-1 me-1 o_field_accrual" name="max_carriedover_duration"/>
                                         <field nolabel="1" class="o_field_accrual" name="added_value_type" readonly="1"/>
                                     </span>
                                 </span>

--- a/addons/hr_holidays/views/hr_leave_allocation_views.xml
+++ b/addons/hr_holidays/views/hr_leave_allocation_views.xml
@@ -97,12 +97,10 @@
             <form string="Allocation Request" duplicate="false">
                 <field name="can_approve" invisible="1"/>
                 <field name="validation_type" invisible="1"/>
-                <!--
-                The following two lines are required so that the two fields are sent as part of the `vals_list`
-                to the create method when the allocation is created. Otherwise, carried_over_days_expiration_date
-                wouldn't be set and the days won't expire on that date.
-                -->
-                <field name="expiring_carryover_days" invisible="1"/>
+                <field name="lastcall" invisible="1"/>
+                <field name="last_accrual" invisible="1"/>
+                <field name="nextcall" invisible="1"/>
+                <field name="previous_carryover_number_of_days" invisible="1"/>
                 <field name="carried_over_days_expiration_date" invisible="1"/>
                 <header>
                     <button string="Approve" name="action_approve" type="object" class="oe_highlight" invisible="not can_approve or not id" data-hotkey="v"/>
@@ -126,8 +124,6 @@
                         <group id="alloc_left_col">
                             <field name="is_name_custom" invisible="1"/> <!-- needed for triggering reasons -->
                             <field name="type_request_unit" invisible="1"/>
-                            <!-- Save already_accrued when creating record to avoid double allocation when cron runs -->
-                            <field name="already_accrued" invisible="1"/>
                             <div class="o_td_label" name="validity_label" invisible="not is_officer">
                                 <label for="date_from" string="Validity Period"
                                     invisible="accrual_plan_id or state != 'confirm'"/>
@@ -165,12 +161,14 @@
                                     readonly="accrual_plan_id or state == 'validate'"/>
                             </div>
                             <div name="duration_display" class="d-flex gap-2 flex-wrap">
+                                <!-- Add type_request_unit check for the readonly condition of the 2 below fields otherwise we can get inconsistent value when
+                                    saving the form (we only want to save the value of the visible field) -->
                                 <field name="number_of_days_display" nolabel="1" style="width: 6ch;"
                                     invisible="type_request_unit == 'hour'"
-                                    readonly="state == 'refuse' or (state != 'confirm' and not is_officer)"/>
+                                    readonly="type_request_unit == 'hour' or state == 'refuse' or (state != 'confirm' and not is_officer)"/>
                                 <field name="number_of_hours_display" nolabel="1" style="width: 6ch;"
                                     invisible="type_request_unit != 'hour'"
-                                    readonly="state == 'refuse' or (state != 'confirm' and not is_officer)"/>
+                                    readonly="type_request_unit != 'hour' or state == 'refuse' or (state != 'confirm' and not is_officer)"/>
                                 <span class="ml8" invisible="type_request_unit == 'hour'">Days</span>
                                 <span id="hour_display_field" class="ml8" invisible="type_request_unit != 'hour'">Hours</span>
                             </div>

--- a/addons/hr_holidays/views/hr_leave_allocation_views.xml
+++ b/addons/hr_holidays/views/hr_leave_allocation_views.xml
@@ -99,13 +99,12 @@
             <form string="Allocation Request" duplicate="false">
                 <field name="can_approve" invisible="1"/>
                 <field name="validation_type" invisible="1"/>
-                <!--
-                The following two lines are required so that the two fields are sent as part of the `vals_list`
-                to the create method when the allocation is created. Otherwise, carried_over_days_expiration_date
-                wouldn't be set and the days won't expire on that date.
-                -->
-                <field name="expiring_carryover_days" invisible="1"/>
+                <field name="lastcall" invisible="1"/>
+                <field name="last_accrual" invisible="1"/>
+                <field name="nextcall" invisible="1"/>
+                <field name="previous_carryover_number_of_days" invisible="1"/>
                 <field name="carried_over_days_expiration_date" invisible="1"/>
+
                 <header>
                     <button string="Approve" name="action_approve" type="object" class="oe_highlight" invisible="not can_approve or not id"/>
                     <button string="Validate" name="action_approve" invisible="not can_validate or can_approve or not id" type="object" class="oe_highlight"/>
@@ -125,8 +124,6 @@
                         <group id="alloc_left_col">
                             <field name="is_name_custom" invisible="1"/> <!-- needed for triggering reasons -->
                             <field name="type_request_unit" invisible="1"/>
-                            <!-- Save already_accrued when creating record to avoid double allocation when cron runs -->
-                            <field name="already_accrued" invisible="1"/>
                             <div class="o_td_label" name="validity_label" invisible="not is_officer">
                                 <label for="date_from" string="Validity Period"
                                     invisible="allocation_type == 'accrual' or state != 'confirm'"/>

--- a/addons/hr_holidays/wizard/hr_leave_allocation_generate_multi_wizard.py
+++ b/addons/hr_holidays/wizard/hr_leave_allocation_generate_multi_wizard.py
@@ -106,9 +106,10 @@ class HrLeaveAllocationGenerateMultiWizard(models.TransientModel):
             if not self.duration:
                 for date_to, allocation in accrual_allocations.grouped('date_to').items():
                     date_to = min(date_to, date.today()) if date_to else False
-                    update_vals = allocation._get_initialize_accrual_plan_values(self.date_from)
+                    update_vals = allocation._get_init_accrual_plan_values()
+                    update_vals['date_from'] = self.date_from
                     allocation.update(update_vals)
-                    allocation._process_accrual_plans(date_to)
+                    allocation._update_accrual(date_to)
             allocations.filtered(lambda c: c.validation_type not in ('no_validation', 'hr')).action_approve()
             if self.env.user.has_group('hr_holidays.group_hr_holidays_user'):
                 allocations.filtered(lambda c: c.validation_type == 'hr').action_approve()


### PR DESCRIPTION
## Issues
### Accrual allocation initialization issue

For an accrual allocation, due to `_add_lastcall` initialization method, the first carryover date could be skipped. Indeed this method only includes the following accrual "events" in his `nextcall` computation:
- Carryover days expiration date
- Current level next period
- Next level transition

PS: The job of _add_lastcalls was to guess the value of nextcall, lastcall and actual_lastcall after saving the allocation

### Accrual allocation `_process_accrual_plans` issue

For an accrual allocation, to compute the number of days when the "accrued_gain_time" is "start", the code is using a bool field (already_accrued) and was trying to use the same logic as when "accrued_gain_time" is "end", but adding another alternative at the end of the loop. This was a bad idea as it has been proven that it leads to complex, hard to maintain, long, and bug prone code.

Here is the (impossible) challenge of this code:
The function `_process_accrual_plans` tries to update the `number_of_days` according to the accrual "events" (carryover, carryover expiring days, level transition, level period transition-daily-monthly-...). But the problem is that sometimes, it has to process multiple accrual events to compute the `number_of_days` of the allocation in the far future (possible when the user wants to see his number_of_days in the future from the time off dashboard). In this case, when the "accrued_gain_time" is "start" and using 'already_accrued', here's how the function works :
- Run through each accrual event until the nextcall is past the target date (same as when "accrued_gain_time" is "end")
- Run the additionnal alternative

This alternative set 'already_accrued' to True so that the next accrual event in the main loop doesn't accrue the days to the allocation.

But this code also has to take care of each day cron run. In that case, here's how it behaves:
- If the allocation nextcall happens before the target date:
	- Run one iteration of the main loop, which probably doesn't add the accrued days as already_accrued is probably True.
	- Run the additionnal alternative

This means that all the logic has to be at the same time in the main accrual event loop, and in the alternative, which is really hard, and led to the spaghetti we have today (which still contains a lot of bugs).

To avoid this issue, this PR separates the logic of each case ("accrued_gain_time" "start" or "end"), and removes 'already_accrued'.

## Accrual allocation `_process_accrual_plans` new feature

To make it easier to use, this method now returns a dict containing the accrual values of the allocations on the `target_date`, and do not directly apply the changes on the allocation anymore. For instance, this avoid having to create 'fake_allocation' using `new(origin=self)`.

However, it adds a little bit of complexity from the code, as some function now have to pay attention whether they should read the value from the values in the dict representing the data of the allocation, of the fields themselves (see class description for more explanations).

## Behavior correction

Before this PR, a day belonged to a level only if it was between the start of this level (not included), and the start on the following level (included). As the start of the level was not included, this could lead to some small issues like the days are only accrued on the second days of the level, even when "accrued_gain_time" of the accrual plan is "start".

## Tests

As I spend a lot of time making the tests work, I took this opportunity to make a few changes, mostly to make test simpler to understand, or to correct the tests that were doing wrong assertions.

## Accrual allocation refactoring

- Deleting the property "already_accrued"
- Renaming
	- lastcall -> last_accrual : as described in the definition of lastcall, this property contains the "Date of the last accrual allocation"
	- actual_lastcall -> lastcall : simpler name
	- postpone_max_days -> max_carriedover_duration: clearer name, moreover, the unit of time of this field can be either 'Days' or 'Hours'
	- expiring_carryover_days -> previous_carryover_number_of_days: the field expiring_carryover_days contains the number of days the allocation had on the last carryover, so this names fits best
- Adding a few fields to the Form: when creating an allocation with an accrual plan in a Form, everything was running smoothly, and the number_of_days was computed correctly. However, when saving the allocation, as the lastcall, actual_lastcall and nextcall were not saved (no fields matching them in the Form), they needed to be recomputed. So the method _add_lastcall was called to try to approximate what were the values of each of these fields depending on the fields.Date.today().
- Getting out of the infinite compute dependency of `number_of_days`, `number_of_days_display` and `number_of_hours_display`. Those fields were 3 computes fields depending on each other (and the orm was not made to use it that way) -> `number_of_days` is not computed anymore, and the 2 other fields set it using 'inverse' (more standard way of doing things).
    
task-5977748
[upgrade-8081](https://github.com/odoo/upgrade/pull/8081)