### PR TITLE
[REF] base: QWeb: centralization of method calls, yields (future stream) and error handling

### DIFF
--- a/addons/hr/tests/test_multi_company.py
+++ b/addons/hr/tests/test_multi_company.py
@@ -2,7 +2,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo.addons.hr.tests.common import TestHrCommon
-from odoo.addons.base.models.ir_qweb import QWebException
 
 from odoo.addons.mail.tests.common import mail_new_test_user
 
@@ -38,7 +37,7 @@ class TestMultiCompanyReport(TestHrCommon):
         self.assertIn(b'Machin', content)
 
     def test_single_company_report(self):
-        with self.assertRaises(QWebException):  # CacheMiss followed by AccessError
+        with self.assertRaises(AccessError):  # CacheMiss followed by AccessError
             self.env['ir.actions.report'].with_user(self.res_users_hr_officer).with_company(
                 self.company_1
             )._render_qweb_pdf('hr.hr_employee_print_badge', res_ids=self.employees.ids)

--- a/addons/http_routing/models/ir_http.py
+++ b/addons/http_routing/models/ir_http.py
@@ -531,7 +531,7 @@ class IrHttp(models.AbstractModel):
             values.update(qweb_exception=exception)
             exception = exception.__cause__ or exception.__context__
 
-        elif isinstance(exception, exceptions.UserError):
+        if isinstance(exception, exceptions.UserError):
             code = exception.http_status
             values['error_message'] = exception.args[0]
         elif isinstance(exception, werkzeug.exceptions.HTTPException):

--- a/addons/http_routing/views/http_routing_template.xml
+++ b/addons/http_routing/views/http_routing_template.xml
@@ -39,13 +39,10 @@
                 <div id="error_qweb" class="collapse show">
                     <div class="card-body">
                         <p>
-                            <strong>Error message:</strong>
-                            <pre t-esc="exception"/>
+                            The error occurred while rendering the template <code t-esc="qweb_exception.template"/>
+                            <t t-if="qweb_exception.element">and evaluating the following expression: <code t-esc="qweb_exception.element"/></t>
                         </p>
-                        <p>
-                            The error occurred while rendering the template <code t-esc="qweb_exception.name"/> 
-                            <t t-if="qweb_exception.html">and evaluating the following expression: <code t-esc="qweb_exception.html"/></t>
-                        </p>
+                        <pre t-esc="str(exception)"/>
                     </div>
                 </div>
             </div>

--- a/addons/test_website/controllers/main.py
+++ b/addons/test_website/controllers/main.py
@@ -16,6 +16,12 @@ class WebsiteTest(Home):
     def test_view(self, **kwargs):
         return request.render('test_website.test_view')
 
+    @http.route('/test_view_access_error', type='http', auth='public', website=True, sitemap=False)
+    def test_view_access_error(self, **kwargs):
+        public = self.env.ref('base.public_user')
+        record = self.env.ref('test_website.test_model_exposed_record_not_published')
+        return request.render('test_website.test_view_access_error', {'record': record.with_user(public)})
+
     @http.route('/ignore_args/converteronly/<string:a>', type='http', auth="public", website=True, sitemap=False)
     def test_ignore_args_converter_only(self, a):
         return request.make_response(json.dumps(dict(a=a, kw=None)))

--- a/addons/test_website/data/test_website_data.xml
+++ b/addons/test_website/data/test_website_data.xml
@@ -124,6 +124,9 @@
                 <p>placeholder</p>
             </xpath>
         </template>
+        <template id="test_view_access_error">
+            <p><t t-out="record.name"/></p>
+        </template>
 
         <!-- RECORDS FOR MODULE OPERATION TESTS -->
         <template id="update_module_base_view">
@@ -157,6 +160,14 @@
         <!-- Test model record -->
         <record id="test_model_record" model="test.model">
             <field name="name">Test Model Record</field>
+        </record>
+        <record id="test_model_exposed_record_published" model="test.model">
+            <field name="name">Test Model Exposed Record (published)</field>
+            <field name="website_published">True</field>
+        </record>
+        <record id="test_model_exposed_record_not_published" model="test.model">
+            <field name="name">Test Model Exposed Record (not published)</field>
+            <field name="website_published">False</field>
         </record>
     </data>
 </odoo>

--- a/addons/test_website/static/tests/tours/error_views.js
+++ b/addons/test_website/static/tests/tours/error_views.js
@@ -157,6 +157,31 @@ registry.category("web_tour.tours").add('test_error_website', {
         content: "http access error page debug has traceback closed",
         trigger: 'body:has(div#error_traceback.collapse:not(.show) pre#exception_traceback)',
         run: function () {
+                window.location.href = window.location.origin + '/test_view_access_error?debug=0';
+        },
+        expectUnloadPage: true,
+    },
+    {
+        trigger: 'h1:contains("403: Forbidden")',
+    },
+    {
+        content: "http access error page has title and message",
+        trigger: 'div.container pre:contains("Uh-oh! Looks like you have stumbled upon some top-secret records.")',
+        run: function () {
+                window.location.href = window.location.origin + '/test_view_access_error?debug=1';
+        },
+        expectUnloadPage: true,
+    },
+    {
+        trigger: 'h1:contains("403: Forbidden")',
+    },
+    {
+        content: "http access error page debug has title and message open",
+        trigger: 'div#error_main.collapse.show pre:contains("Uh-oh! Looks like you have stumbled upon some top-secret records.")',
+    }, {
+        content: "http access error page debug has traceback closed",
+        trigger: 'body:has(div#error_traceback.collapse:not(.show) pre#exception_traceback)',
+        run: function () {
                 window.location.href = window.location.origin + '/test_missing_error_http?debug=0';
         },
         expectUnloadPage: true,

--- a/addons/test_website/tests/test_fuzzy.py
+++ b/addons/test_website/tests/test_fuzzy.py
@@ -98,8 +98,8 @@ class TestAutoComplete(TransactionCase):
             )
 
     def test_indirect(self):
-        self._autocomplete('module', 2, 'model')
-        self._autocomplete('rechord', 1, 'record')
+        self._autocomplete('module', 4, 'model')
+        self._autocomplete('rechord', 3, 'record')
         self._autocomplete('suborder', 1, 'submodel')
         # Sub-sub-fields are currently not supported.
         # Adapt expected result if this becomes a feature.

--- a/addons/website/controllers/main.py
+++ b/addons/website/controllers/main.py
@@ -28,7 +28,6 @@ from odoo.http import request, SessionExpiredException
 from odoo.tools import OrderedSet, escape_psql, html_escape as escape, py_to_js_locale
 from odoo.tools.translate import LazyTranslate
 from odoo.addons.base.models.ir_http import EXTENSION_TO_WEB_MIMETYPES
-from odoo.addons.base.models.ir_qweb import QWebException
 from odoo.addons.portal.controllers.portal import pager as portal_pager
 from odoo.addons.portal.controllers.web import Home
 from odoo.addons.web.controllers.binary import Binary
@@ -743,9 +742,12 @@ class Website(Home):
                         'key': template.key,
                         'template': html.tostring(html_tree),
                     })
-                except QWebException as qe:
-                    # Do not fail if theme is not compatible.
-                    logger.warning("Theme not compatible with template %r: %s", template.key, qe)
+                except Exception as error:
+                    if hasattr(error, 'qweb'):
+                        # Do not fail if theme is not compatible.
+                        logger.warning("Theme not compatible with template %r: %s", template.key, error)
+                    else:
+                        raise
             if group['templates']:
                 result.append(group)
         return result

--- a/addons/website/models/ir_http.py
+++ b/addons/website/models/ir_http.py
@@ -391,25 +391,22 @@ class IrHttp(models.AbstractModel):
     @classmethod
     def _get_values_500_error(cls, env, values, exception):
         values = super()._get_values_500_error(env, values, exception)
-        if 'qweb_exception' in values:
-            try:
-                # exception.name might be int, string
-                exception_template = int(exception.name)
-            except ValueError:
-                exception_template = exception.name
+        if hasattr(exception, 'qweb'):
+            qweb_error = exception.qweb
+            exception_template = qweb_error.ref
             View = env["ir.ui.view"].sudo()
-            view = View._get_template_view(exception_template)
-            if exception.html and exception.html in view.arch:
+            view = exception_template and View._get_template_view(exception_template)
+            if not view or qweb_error.element and qweb_error.element in view.arch:
                 values['view'] = view
             else:
                 # There might be 2 cases where the exception code can't be found
                 # in the view, either the error is in a child view or the code
                 # contains branding (<div t-att-data="request.browse('ok')"/>).
                 et = view.with_context(inherit_branding=False)._get_combined_arch()
-                node = et.xpath(exception.path) if exception.path else et
+                node = et.xpath(qweb_error.path) if qweb_error.path else et
                 line = node is not None and len(node) > 0 and etree.tostring(node[0], encoding='unicode')
                 if line:
-                    values['view'] = View._views_get(exception_template).filtered(
+                    values['view'] = View._views_get(view.id).filtered(
                         lambda v: line in v.arch
                     )
                     values['view'] = values['view'] and values['view'][0]

--- a/addons/website/tests/test_qweb.py
+++ b/addons/website/tests/test_qweb.py
@@ -212,13 +212,13 @@ class TestQweb(TransactionCaseWithUserDemo):
         #     SELECT RECURSIVE arch combine
         # 'base.testing_layout', 'base.testing_header_0'
         #     SELECT id + fields from (xmlid + website_id)
-        #     SELECT RECURSIVE arch combine => TODO: batch me
+        #     SELECT RECURSIVE arch combine
         # 'base.testing_header', 'base.testing_footer'
         #     SELECT id + fields from (xmlid + website_id)
-        #     SELECT RECURSIVE arch combine => TODO: batch me
+        #     SELECT RECURSIVE arch combine
         # 'base.testing_header_1', 'base.testing_footer_0', 'base.testing_footer_1'
         #     SELECT id + fields from (xmlid + website_id)
-        #     SELECT RECURSIVE arch combine => TODO: batch me
+        #     SELECT RECURSIVE arch combine
 
         FIRST_SEARCH_FETCH = 1  # instead of the first SELECT visibility
         OTHER_SEARCH_FETCH = 3  # "SELECT id + fields from xmlid"

--- a/addons/website/views/website_templates.xml
+++ b/addons/website/views/website_templates.xml
@@ -2667,7 +2667,7 @@
         <div class="container" t-if="view and editable">
             <div class="alert alert-danger" role="alert">
                 <h4>Template fallback</h4>
-                <p>An error occurred while rendering the template <code t-out="qweb_exception.name"/>.</p>
+                <p>An error occurred while rendering the template <code t-out="qweb_exception.template"/>.</p>
                 <p>If this error is caused by a change of yours in the templates, you have the possibility to reset the template to its <strong>factory settings</strong>.</p>
                 <form action="#" method="post" id="reset_templates_form">
                     <ul>

--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -1105,14 +1105,18 @@ actual arch.
                 view.key
             except MissingError:
                 view = None
-                error = MissingError(self.env._("Template not found: %s", id_or_xmlid))
+                error = MissingError(self.env._("Template not found: '%s'", id_or_xmlid))
             except UserError as e:
                 view = None
                 error = e
         else:
-            preload = self.sudo()._preload_views([id_or_xmlid])[id_or_xmlid]
-            view = preload['view']
-            error = preload['error']
+            preload = self.sudo()._preload_views([id_or_xmlid])
+            if id_or_xmlid in preload:
+                info = preload[id_or_xmlid]
+                view = info['view']
+                error = info['error']
+            else:
+                error = SyntaxError('Error compiling template')
         info = {
             f: view[f] if view else None
             for f in self._get_cached_template_prefetched_keys()}
@@ -1196,7 +1200,7 @@ actual arch.
             if xmlid not in view_by_id:
                 # push information in cache
                 self._get_cached_template_info(xmlid, _view=False)
-                view_by_id[xmlid] = MissingError(self.env._("Template not found: %s", xmlid))
+                view_by_id[xmlid] = MissingError(self.env._("Template not found: '%s'", xmlid))
         return view_by_id
 
     @tools.ormcache(cache='templates')


### PR DESCRIPTION
[[REF] base: Qweb delegate subcall to '_render_iterall' method]

The complexity is moved to a qweb method instead of being inside the
generated codes. Reduces the method call stack (and memory) requirements
significantly. Allows optimizations such as being able to stream t-calls
and other elements. Internally, yield values ​​are only strings or tuples
with the names of the compiled methods to call.

How it works:

The '_render_iterall' method receives as arguments a reference to a
template, the compiled method to call (or None if we use the default,
which is the render method), and the values.

'_render_iterall' creates a stack.
The elements of the stack mainly include the iterator corresponding to
the template rendering being produced. Other information is associated
with this iterator (values, environment, log information, etc.).
Iterators produce strings or tuples (context, template, method, default
values, scope, directive, log). The interpreter yields the strings and
adds an entry to the stack for each tuple and begins iterating on this
new entry. This new entry uses the environment and values ​​from the
current stack (copying the values ​​or not, depending on the scooping
option).
When an iterator is fully consumed, it is removed from the stack. So
'_render_iterall' streams the content and handles the function and
template cache call. This also makes it easier to handle errors by adding
the path (t-call, t-cache) taken to the error.

Qweb errors are inherited from native errors. This allows you to call
instance of without knowing the structure of the QwebException object
and without having to call __cause__ or __context__.

Qweb error now includes the directive path (t-call and t-cache) to arrive
at the erroneous directive