### PR TITLE
[IMP] mail: remove unused variable

### DIFF
--- a/addons/mail/static/src/core/common/store_service.js
+++ b/addons/mail/static/src/core/common/store_service.js
@@ -461,7 +461,6 @@ export class Store extends BaseStore {
             mentionedChannels = [],
             mentionedPartners = [],
             mentionedRoles = [],
-            specialMentions = [],
         } = {}
     ) {
         const validMentions = {};


### PR DESCRIPTION
Introduce by https://github.com/odoo-dev/odoo/commit/94d95eb2640ce40b05563b3567230a006333c300
This variable isn't used anywhere, therefore safe to remove.