### PR TITLE
[FIX] sale_project_stock: ensure real-time valuation works in tests

### DIFF
--- a/addons/sale_project_stock/tests/test_sale_project_stock_profitability.py
+++ b/addons/sale_project_stock/tests/test_sale_project_stock_profitability.py
@@ -1,71 +1,105 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import Command, fields
-from odoo.addons.sale_project.tests.test_project_profitability import TestProjectProfitabilityCommon
+from odoo.addons.sale_project.tests.test_project_profitability import (
+    TestProjectProfitabilityCommon,
+)
+from odoo.addons.stock_account.tests.test_anglo_saxon_valuation_reconciliation_common import (
+    ValuationReconciliationTestCommon,
+)
+from odoo.tests import tagged
 
 
-class TestSaleProjectStockProfitability(TestProjectProfitabilityCommon):
+tagged("-at_install", "post_install")
+
+
+class TestSaleProjectStockProfitability(
+    TestProjectProfitabilityCommon, ValuationReconciliationTestCommon
+):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
 
-        project_template = cls.env['project.project'].create({
-            'name': 'sale_project_stock project template',
-            'account_id': cls.analytic_account.id,
-        })
-        avco_real_time_product_category = cls.env['product.category'].create({
-            'name': 'avco real time',
-            'property_valuation': 'real_time',
-            'property_cost_method': 'average',
-        })
-        cls.cogs_account = cls.env['account.account'].search([
-            ('name', '=', 'Cost of Goods Sold'),
-            ('company_ids', 'in', cls.env.company.id),
-        ], limit=1)
-        cls.avco_product = cls.env['product.product'].create({
-            'name': 'avco product',
-            'is_storable': True,
-            'categ_id': avco_real_time_product_category.id,
-            'standard_price': 12.0,
-            'list_price': 24.0,
-        })
-        cls.product_superb_service = cls.env['product.product'].create({
-            'name': 'product that creates project on order',
-            'type': 'service',
-            'standard_price': 10.0,
-            'list_price': 20.0,
-            'service_tracking': 'project_only',
-            'project_template_id': project_template.id,
-        })
+        project_template = cls.env["project.project"].create(
+            {
+                "name": "sale_project_stock project template",
+                "account_id": cls.analytic_account.id,
+            }
+        )
+        cls.cogs_account = cls.env["account.account"].search(
+            [
+                ("name", "=", "Cost of Goods Sold"),
+                ("company_ids", "in", cls.env.company.id),
+            ],
+            limit=1,
+        )
+        cls.auto_valuated_product = cls.env["product.product"].create(
+            {
+                "name": "auto valuated product",
+                "is_storable": True,
+                "categ_id": cls.stock_account_product_categ.id,
+                "standard_price": 12.0,
+                "list_price": 24.0,
+            }
+        )
+        cls.product_superb_service = cls.env["product.product"].create(
+            {
+                "name": "product that creates project on order",
+                "type": "service",
+                "standard_price": 10.0,
+                "list_price": 20.0,
+                "service_tracking": "project_only",
+                "project_template_id": project_template.id,
+            }
+        )
 
     def test_report_invoice_items_anglo_saxon_automatic_valuation(self):
-        """ An invoice can have some lines which should be classified/displayed under the 'Costs'
+        """An invoice can have some lines which should be classified/displayed under the 'Costs'
         section of a project's profitability report (specifically, COGS lines).
         """
         self.env.company.anglo_saxon_accounting = True
-        self.avco_product.categ_id.property_account_expense_categ_id = self.cogs_account.id
+        self.stock_account_product_categ.write(
+            {
+                "property_account_expense_categ_id": self.cogs_account.id,
+                "property_cost_method": "average",
+            }
+        )
         service_product = self.product_superb_service
-        avco_product = self.avco_product
-        other_avco_product = self.env['product.product'].create({
-            'name': 'other avco product',
-            'is_storable': True,
-            'categ_id': avco_product.categ_id.id,
-            'standard_price': 16.0,
-            'list_price': 32.0,
-        })
-        sale_order = self.env['sale.order'].create({
-            'partner_id': self.partner.id,
-            'order_line': [Command.create({
-                'product_id': service_product.id,
-                'product_uom_qty': 10,
-            }), Command.create({
-                'product_id': avco_product.id,
-                'product_uom_qty': 10,
-            }), Command.create({
-                'product_id': other_avco_product.id,
-                'product_uom_qty': 10,
-            })],
-        })
+        avco_product = self.auto_valuated_product
+        other_avco_product = self.env["product.product"].create(
+            {
+                "name": "other avco product",
+                "is_storable": True,
+                "categ_id": avco_product.categ_id.id,
+                "standard_price": 16.0,
+                "list_price": 32.0,
+            }
+        )
+        sale_order = self.env["sale.order"].create(
+            {
+                "partner_id": self.partner.id,
+                "order_line": [
+                    Command.create(
+                        {
+                            "product_id": service_product.id,
+                            "product_uom_qty": 10,
+                        }
+                    ),
+                    Command.create(
+                        {
+                            "product_id": avco_product.id,
+                            "product_uom_qty": 10,
+                        }
+                    ),
+                    Command.create(
+                        {
+                            "product_id": other_avco_product.id,
+                            "product_uom_qty": 10,
+                        }
+                    ),
+                ],
+            }
+        )
         sale_order.action_confirm()
         delivery = sale_order.picking_ids
         delivery.move_ids.quantity = 10
@@ -76,22 +110,24 @@ class TestSaleProjectStockProfitability(TestProjectProfitabilityCommon):
         invoice.action_post()
         panel_data = sale_order.project_ids.get_panel_data()
         self.assertEqual(
-            panel_data['profitability_items']['costs'],
+            panel_data["profitability_items"]["costs"],
             {
-                'data': [{
-                    'action': {
-                        'args': f'["cost_of_goods_sold", [["id", "in", [{invoice.id}]]], {invoice.id}]',
-                        'name': 'action_profitability_items',
-                        'type': 'object',
-                    },
-                    'id': 'cost_of_goods_sold',
-                    'billed': -280.0,
-                    'sequence': 21,
-                    'to_bill': 0.0,
-                }],
-                'total': {
-                    'billed': -280.0,
-                    'to_bill': 0.0,
-                }
-            }
+                "data": [
+                    {
+                        "action": {
+                            "args": f'["cost_of_goods_sold", [["id", "in", [{invoice.id}]]], {invoice.id}]',
+                            "name": "action_profitability_items",
+                            "type": "object",
+                        },
+                        "id": "cost_of_goods_sold",
+                        "billed": -280.0,
+                        "sequence": 21,
+                        "to_bill": 0.0,
+                    }
+                ],
+                "total": {
+                    "billed": -280.0,
+                    "to_bill": 0.0,
+                },
+            },
         )


### PR DESCRIPTION
steps to reproduce:
1. Install sale_project_stock module
2. run the test `test_report_invoice_items_anglo_saxon_automatic_valuation`

The issue was the missing stock accounts in the product category configuration. so I created the stock accounts and added them to the product category.

build_error-163668

