### PR TITLE
[FIX] barcodes_gs1_nomenclature: odoo exception on failed date parse

### DIFF
--- a/addons/barcodes_gs1_nomenclature/models/barcode_nomenclature.py
+++ b/addons/barcodes_gs1_nomenclature/models/barcode_nomenclature.py
@@ -51,7 +51,13 @@ class BarcodeNomenclature(models.Model):
             date = datetime.datetime.strptime(str(year) + gs1_date[2:4], '%Y%m')
             date = date.replace(day=calendar.monthrange(year, int(gs1_date[2:4]))[1])
         else:
-            date = datetime.datetime.strptime(str(year) + gs1_date[2:], '%Y%m%d')
+            try:
+                date = datetime.datetime.strptime(str(year) + gs1_date[2:], '%Y%m%d')
+            except ValueError as e:
+                raise ValidationError(_(
+                    "A GS1 barcode nomenclature pattern was matched. However, the barcode failed to be converted to a valid date: '%(error_message)'",
+                    error_message=e
+                ))
         return date.date()
 
     def parse_gs1_rule_pattern(self, match, rule):


### PR DESCRIPTION
**Current behavior:**
Traceback if an invalid date is input in the barcode scanner where a gs1 rule is matched and expects a numerical date representation.

**Expected behavior:**
No traceback

**Steps to reproduce:**
1. enable gs1 nomenclature, scan a barcode from the main menu like: `15123456` -> `15` should precede a date like: 'yy-mm-dd'

opw-4825538