### PR TITLE
[FIX] pos_loyalty: remove pricelists from tests

### DIFF
--- a/addons/pos_loyalty/tests/test_frontend.py
+++ b/addons/pos_loyalty/tests/test_frontend.py
@@ -1140,7 +1140,6 @@ class TestUi(TestPointOfSaleHttpCommon):
             'program_type': 'loyalty',
             'trigger': 'auto',
             'applies_on': 'both',
-            'pricelist_ids': [(4, self.main_pos_config.pricelist_id.id)],
             'pos_ok': True,
             'pos_config_ids': [Command.link(self.main_pos_config.id)],
             'rule_ids': [(0, 0, {
@@ -2937,7 +2936,6 @@ class TestUi(TestPointOfSaleHttpCommon):
             'program_type': 'loyalty',
             'trigger': 'auto',
             'applies_on': 'both',
-            'pricelist_ids': [(4, self.main_pos_config.pricelist_id.id)],
             'pos_ok': True,
             'pos_config_ids': [Command.link(self.main_pos_config.id)],
             'rule_ids': [Command.create({


### PR DESCRIPTION
Since 39b15f1 the pricelists in the loyalty programs creation made them not work if they were only using the community apps. The pricelists were removed from the loyalty program creation so that the tests can be run again.

runbot-229672