### PR TITLE
[FIX] html_builder: migrate old image data attributes

### DIFF
--- a/addons/html_builder/static/src/plugins/image/image_tool_option_plugin.js
+++ b/addons/html_builder/static/src/plugins/image/image_tool_option_plugin.js
@@ -17,6 +17,7 @@ import {
 import { ReplaceMediaOption, searchSupportedParentLinkEl } from "./replace_media_option";
 import { computeMaxDisplayWidth } from "@html_builder/plugins/image/image_format_option";
 import { BuilderAction } from "@html_builder/core/builder_action";
+import { selectElements } from "@html_editor/utils/dom_traversal";
 
 export const REPLACE_MEDIA_SELECTOR = "img, .media_iframe_video, span.fa, i.fa";
 export const REPLACE_MEDIA_EXCLUDE =
@@ -109,6 +110,8 @@ class ImageToolOptionPlugin extends Plugin {
                 }
             }
         },
+        // TODO Remove in master.
+        normalize_handlers: this.migrateImages.bind(this),
     };
 
     async canHaveHoverEffect(img) {
@@ -135,6 +138,22 @@ class ImageToolOptionPlugin extends Plugin {
     }
     isImageSupportedForShapes(img, dataset = img.dataset) {
         return dataset.originalId && isImageSupportedForProcessing(getMimetype(img));
+    }
+    // TODO Remove in master.
+    migrateImages(rootEl) {
+        for (const el of selectElements(
+            rootEl,
+            "img[data-original-id]:not([data-attachment-id]), .oe_img_bg[data-original-id]:not([data-attachment-id])"
+        )) {
+            el.dataset.attachmentId = el.dataset.originalId;
+        }
+        for (const el of selectElements(
+            rootEl,
+            "img[data-original-mimetype]:not([data-format-mimetype]), .oe_img_bg[data-original-mimetype]:not([data-format-mimetype])"
+        )) {
+            el.dataset.formatMimetype = el.dataset.originalMimetype;
+            delete el.dataset.originalMimetype;
+        }
     }
 }
 


### PR DESCRIPTION
When `html_builder` was introduced, some data attributes related to images have changed. Unfortunately, the attributes on static data were not adapted accordingly. Because of this, both namings might appear in this version.

This commit migrates images and background images attributes so that, upon edition, a single naming scheme remains used. It should be safe enough given that those attributes are only used by edit mode.

Dataset changes:
- copy `originalId` to `attachmentId`
- rename `originalMimetype` to `formatMimetype`

task-4367641
