### PR TITLE
[FIX] l10n_it_edi: fix for line with ScontoMaggiorazione and price 0.00

### DIFF
--- a/addons/l10n_it_edi/models/account_move.py
+++ b/addons/l10n_it_edi/models/account_move.py
@@ -1336,7 +1336,7 @@ class AccountMove(models.Model):
                 move_line.tax_ids = [Command.set(fitting_taxes)]
 
         # Discounts
-        if discounts := element.xpath('.//ScontoMaggiorazione'):
+        if (discounts := element.xpath('.//ScontoMaggiorazione')) and not float_is_zero(move_line.price_unit, precision_rounding=move_line.currency_id.rounding):
             current_unit_price = move_line.price_unit
             # We apply the discounts in the order they are found in the XML.
             # The first discount is applied to the unit price, the second to the result of the first, etc.
@@ -1346,7 +1346,7 @@ class AccountMove(models.Model):
             for discount in discounts:
                 discount_type = get_text(discount, './/Tipo')
                 discount_sign = -1 if discount_type == 'MG' else 1
-                if discount_percentage := get_float(discount, './/Percentuale'):
+                if (discount_percentage := get_float(discount, './/Percentuale')) and not float_is_zero(discount_percentage, precision_rounding=move_line.currency_id.rounding):
                     current_unit_price *= discount_sign * (100 - discount_percentage) / 100
                 elif discount_amount := get_float(discount, './/Importo'):
                     current_unit_price -= discount_sign * discount_amount

--- a/addons/l10n_it_edi/tests/import_xmls/IT01234567890_DISC1.xml
+++ b/addons/l10n_it_edi/tests/import_xmls/IT01234567890_DISC1.xml
@@ -113,6 +113,18 @@
                 <PrezzoTotale>23.75</PrezzoTotale>
                 <AliquotaIVA>22</AliquotaIVA>
             </DettaglioLinee>
+            <DettaglioLinee>
+                <NumeroLinea>3</NumeroLinea>
+                <Descrizione>RIGA DESCRITTIVA A 0</Descrizione>
+                <Quantita>1.00</Quantita>
+                <PrezzoUnitario>0.00</PrezzoUnitario>
+                <ScontoMaggiorazione>
+                    <Tipo>SC</Tipo>
+                    <Importo>0.00</Importo>
+                </ScontoMaggiorazione>
+                <PrezzoTotale>0.00</PrezzoTotale>
+                <AliquotaIVA>22</AliquotaIVA>
+            </DettaglioLinee>
             <DatiRiepilogo>
                 <AliquotaIVA>22.00</AliquotaIVA>
                 <ImponibileImporto>28.75</ImponibileImporto>

--- a/addons/l10n_it_edi/tests/test_edi_import.py
+++ b/addons/l10n_it_edi/tests/test_edi_import.py
@@ -89,6 +89,12 @@ class TestItEdiImport(TestItEdi):
                 'price_unit': 10.0,
                 'discount': 52.5,
                 'debit': 23.75,
+            },
+            {
+                'quantity': 1.0,
+                'price_unit': 0.0,
+                'discount': 0.0,
+                'debit': 0.0,
             }],
         }])
 


### PR DESCRIPTION
Error "division by zero" raised when importing a XML invoice with `price_unit == 0` and `ScontoMaggiorazione == 0` introduced by #206238