### PR TITLE
[FIX] l10n_my_edi_pos: remove enterprise module from test

### DIFF
--- a/addons/l10n_my_edi_pos/tests/test_myinvois_pos.py
+++ b/addons/l10n_my_edi_pos/tests/test_myinvois_pos.py
@@ -10,7 +10,7 @@ from odoo.exceptions import UserError, ValidationError
 from odoo.tests import tagged
 from odoo.tools import file_open, mute_logger
 
-from odoo.addons.account_reports.tests.common import TestAccountReportsCommon
+from odoo.addons.account.tests.common import AccountTestInvoicingCommon
 from odoo.addons.l10n_my_edi.tests.test_file_generation import NS_MAP
 from odoo.addons.point_of_sale.tests.common import TestPoSCommon
 
@@ -21,7 +21,7 @@ CONTACT_PROXY_METHOD = 'odoo.addons.l10n_my_edi.models.account_edi_proxy_user.Ac
 class TestMyInvoisPoS(TestPoSCommon):
 
     @classmethod
-    @TestAccountReportsCommon.setup_country('my')
+    @AccountTestInvoicingCommon.setup_country('my')
     def setUpClass(cls):
         super().setUpClass()
         cls.config = cls.basic_config


### PR DESCRIPTION
The test in this module imports a common setup from account_reports which is not a dependency, and is not auto installed when the test runs with community modules only. This fix replaces the setup by the community one AccountTestInvoicingCommon.




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
