### PR TITLE
[IMP] website: adapt and re-enable tours

### DIFF
--- a/addons/website/static/tests/tours/website_page_options.js
+++ b/addons/website/static/tests/tours/website_page_options.js
@@ -1,5 +1,5 @@
 import {
-    changeOption,
+    changeOptionInPopover,
     clickOnEditAndWaitEditMode,
     clickOnSave,
     clickOnSnippet,
@@ -12,8 +12,7 @@ registerWebsitePreviewTour('website_page_options', {
     edition: true,
 }, () => [
     ...clickOnSnippet({id: 'o_header_standard', name: 'Header'}),
-    changeOption('TopMenuVisibility', 'we-select:has([data-visibility]) we-toggler'),
-    changeOption('TopMenuVisibility', 'we-button[data-visibility="transparent"]'),
+    ...changeOptionInPopover("Header", "Header Position", "Over the content"),
     // It's important to test saving right after changing that option only as
     // this is why this test was made in the first place: the page was not
     // marked as dirty when that option was the only one that was changed.
@@ -24,21 +23,37 @@ registerWebsitePreviewTour('website_page_options', {
     },
     ...clickOnEditAndWaitEditMode(),
     ...clickOnSnippet({id: 'o_header_standard', name: 'Header'}),
-    changeOption('topMenuColor', 'we-select.o_we_so_color_palette'),
-    changeOption('topMenuColor', 'button[data-color="black-50"]', 'background color', 'bottom', true),
+    {
+        content: "Open the color picker to change the backaground color of the header",
+        trigger:"div[data-container-title='Header'] .hb-row-sublevel-1[data-label='Background'] button",
+        run: "click",
+    },
+    {
+        content: "Select the color black-600",
+        trigger: ".popover button[data-color='600']",
+        run: "click",
+    },
     ...clickOnSave(),
     {
-        content: "Check that the header is in black-50",
-        trigger: ':iframe header#top.bg-black-50',
+        content: "Check that the header is in black-600",
+        trigger: ":iframe header#top.bg-600",
     },
     ...clickOnEditAndWaitEditMode(),
     ...clickOnSnippet({id: 'o_header_standard', name: 'Header'}),
-    changeOption("topMenuColor", '[data-page-option-name="header_text_color"]'),
-    changeOption("topMenuColor", 'button[style="background-color:#FF0000;"]', "text color", "bottom", true),
+    {
+        content: "Open the color picker to change the text color of the header",
+        trigger: "div[data-container-title='Header'] .hb-row-sublevel-1[data-label='Text Color'] button",
+        run: "click",
+    },
+    {
+        content: "Select the color red",
+        trigger: ".popover button[data-color='#FF0000']",
+        run: "click",
+    },
     ...clickOnSave(),
     {
         content: "Check that text color of the header is in red",
-        trigger: ':iframe header#top[style=" color: #FF0000;"]',
+        trigger: ':iframe header#top[style=" color: #ff0000;"]',
     },
     {
         content: "Enable the mobile view",
@@ -61,8 +76,7 @@ registerWebsitePreviewTour('website_page_options', {
     },
     ...clickOnEditAndWaitEditMode(),
     ...clickOnSnippet({id: "o_header_standard", name: "Header"}),
-    changeOption('TopMenuVisibility', 'we-select:has([data-visibility]) we-toggler'),
-    changeOption('TopMenuVisibility', 'we-button[data-visibility="hidden"]'),
+    ...changeOptionInPopover("Header", "Header Position", "Hidden"),
     ...clickOnSave(),
     {
         content: "Check that the header is hidden",
@@ -75,13 +89,18 @@ registerWebsitePreviewTour('website_page_options', {
         run: "click",
     },
     ...clickOnSnippet({id: 'o_footer', name: 'Footer'}),
-    changeOption('HideFooter', 'we-button[data-name="hide_footer_page_opt"] we-checkbox'),
+    {
+        content: "Click on the visibility toggle to change the visibility of the footer",
+        trigger: "div[data-container-title='Footer'] div[data-label='Page Visibility'] div[data-action-id='setWebsiteFooterVisible'] input",
+        run: "click",
+    },
     ...clickOnSave(),
     {
-        trigger: ":iframe #wrapwrap header#top:not(.d-none)",
+        content: "Check that the header is hidden",
+        trigger: ":iframe #wrapwrap:has(header#top.d-none.o_snippet_invisible)",
     },
     {
-        content: "Check that the footer is hidden and the header is visible",
+        content: "Check that the footer is hidden",
         trigger: ':iframe #wrapwrap:has(.o_footer.d-none.o_snippet_invisible)',
     },
 ]);

--- a/addons/website/tests/test_ui.py
+++ b/addons/website/tests/test_ui.py
@@ -477,8 +477,6 @@ class TestUi(HttpCaseWithWebsiteUser):
     def test_18_website_snippets_menu_tabs(self):
         self.start_tour('/', 'website_snippets_menu_tabs', login='admin')
 
-    # TODO master-mysterious-egg fix error
-    @unittest.skip("prepare mysterious-egg for merging")
     def test_19_website_page_options(self):
         self.start_tour("/odoo", "website_page_options", login="admin")
 


### PR DESCRIPTION
The `website_page_options` tour was previously
broken due to DOM structure changes introduced by the new website
builder and was consequently disabled.

This commit updates the tour steps to align with the new DOM and
re-enables the associated test.

Also previously, header visibility was not maintained after clicking header
in invisible options. since it maintains visibility now, the tour is
adapted accordingly.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr