### PR TITLE
[IMP] base: add `simple_display_name` to partner.

### DIFF
--- a/odoo/addons/base/models/res_partner.py
+++ b/odoo/addons/base/models/res_partner.py
@@ -1006,10 +1006,13 @@ class ResPartner(models.Model):
     @api.depends('complete_name', 'email', 'vat', 'state_id', 'country_id', 'commercial_company_name')
     @api.depends_context(
         'show_address', 'partner_show_db_id',
-        'show_email', 'show_vat', 'lang', 'formatted_display_name'
+        'show_email', 'show_vat', 'lang', 'formatted_display_name', 'simple_display_name',
     )
     def _compute_display_name(self):
         for partner in self:
+            if partner.env.context.get("simple_display_name"):
+                partner.display_name = partner.name or ""
+                continue
             if partner.env.context.get("formatted_display_name"):
                 name = partner.name or ''
                 if partner.parent_id or partner.company_name:


### PR DESCRIPTION
This commit adds the context key `simple_display_name` that is coherent with the existing `formatted_display_name` to only display the partner name as the display_name.

This was needed for the first time in the VoIP module in the list view of voip.call model.

Task-4791182

Enterprise: https://github.com/odoo/enterprise/pull/84981
