### PR TITLE
[FIX] l10n_es_edi_tbai: send correct variable name for previous document

### DIFF
--- a/addons/l10n_es_edi_tbai/models/l10n_es_edi_tbai_document.py
+++ b/addons/l10n_es_edi_tbai/models/l10n_es_edi_tbai_document.py
@@ -413,7 +413,7 @@ class L10nEsEdiTbaiDocument(models.Model):
 
     def _get_sale_values(self, values):
         sale_values = {
-            'prev_doc': self.company_id._get_l10n_es_tbai_last_chained_document(),
+            'chain_prev_document': self.company_id._get_l10n_es_tbai_last_chained_document(),
             **self._get_regime_code_value(values['taxes'], values['is_simplified']),
         }
 


### PR DESCRIPTION
Before, the previous document chaining was not sent in the XML because with the t-if, if the variable name is unknown, it will not complain and just see it as False. (like for the first invoice that has no previous)

Now, passing the correct variable name, the previous document will be included

opw-4814241

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
