### PR TITLE
[IMP] website[_sale]: make more options previewable

### DIFF
--- a/addons/website/static/src/builder/plugins/header_navbar_option.xml
+++ b/addons/website/static/src/builder/plugins/header_navbar_option.xml
@@ -142,17 +142,16 @@
         </BuilderSelect>
     </BuilderRow>
     <BuilderRow label.translate="Sub Menus" t-if="!hasSomeViews(['website.template_header_hamburger'])">
-        <BuilderSelect action="'websiteConfig'">
+        <!-- <t t-set="previewSelectorParent" t-value="'header'"/> -->
+        <BuilderSelect action="'previewableWebsiteConfig'">
             <BuilderSelectItem
                 id="header_dropdown_on_click_opt"
                 label.translate="On Click"
-                actionParam="{views: []}"
-                className=""
+                actionParam="{views: [], previewClass: ''}"
             >On Click</BuilderSelectItem>
             <BuilderSelectItem
                 label.translate="On Hover"
-                actionParam="{views: ['website.header_hoverable_dropdown']}"
-                className="'o_hoverable_dropdown'"
+                actionParam="{views: ['website.header_hoverable_dropdown'], previewClass: 'o_hoverable_dropdown'}"
             >On Hover</BuilderSelectItem>
         </BuilderSelect>
     </BuilderRow>

--- a/addons/website/static/src/builder/plugins/header_navbar_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/header_navbar_option_plugin.js
@@ -14,7 +14,7 @@ class HeaderNavbarOptionPlugin extends Plugin {
                 },
                 OptionComponent: HeaderNavbarOption,
                 editableOnly: false,
-                selector: "#wrapwrap > header nav.navbar",
+                selector: "#wrapwrap > header",
                 groups: ["website.group_website_designer"],
                 reloadTarget: true,
             },

--- a/addons/website/static/src/builder/plugins/options/footer_option.xml
+++ b/addons/website/static/src/builder/plugins/options/footer_option.xml
@@ -50,14 +50,14 @@
 
 <t t-name="website.FooterWidthOption">
     <BuilderRow label.translate="Content width">
-        <BuilderButtonGroup action="'websiteConfig'">
-            <BuilderButton classAction="'o_container_small'" actionParam="{ views: ['website.footer_copyright_content_width_small'] }">
+        <BuilderButtonGroup action="'previewableWebsiteConfig'">
+            <BuilderButton actionParam="{ views: ['website.footer_copyright_content_width_small'], previewClass: 'o_container_small'}">
                 <Img src="'/website/static/src/img/snippets_options/content_width_small.svg'"/>
             </BuilderButton>
-            <BuilderButton classAction="'container'" actionParam="{ views: [] }">
+            <BuilderButton actionParam="{ views: [], previewClass: 'container'}">
                 <Img src="'/website/static/src/img/snippets_options/content_width_normal.svg'"/>
             </BuilderButton>
-            <BuilderButton classAction="'container-fluid'" actionParam="{ views: ['website.footer_copyright_content_width_fluid'] }">
+            <BuilderButton actionParam="{ views: ['website.footer_copyright_content_width_fluid'], previewClass: 'container-fluid'}">
                 <Img src="'/website/static/src/img/snippets_options/content_width_full.svg'"/>
             </BuilderButton>
         </BuilderButtonGroup>

--- a/addons/website/static/src/builder/plugins/options/header_option.xml
+++ b/addons/website/static/src/builder/plugins/options/header_option.xml
@@ -188,16 +188,16 @@
 
 <t t-name="website.headerContentWidthOption">
     <BuilderRow t-if="!isActiveItem('header_sidebar_opt')" label.translate="Content Width">
-        <BuilderButtonGroup action="'websiteConfig'">
+        <BuilderButtonGroup action="'previewableWebsiteConfig'" applyTo="'#o_main_nav'">
             <BuilderButton title.translate="Small"
                 iconImg="'/website/static/src/img/snippets_options/content_width_small.svg'"
-                actionParam="{ views: ['website.header_width_small'] }"/>
+                actionParam="{ views: ['website.header_width_small'], previewClass: `o_container_small`}"/>
             <BuilderButton title.translate="Regular"
                 iconImg="'/website/static/src/img/snippets_options/content_width_normal.svg'"
-                actionParam="{ views: [] }"/>
+                actionParam="{ views: [], previewClass: `container`}"/>
             <BuilderButton title.translate="Full"
                 iconImg="'/website/static/src/img/snippets_options/content_width_full.svg'"
-                actionParam="{ views: ['website.header_width_full'] }"/>
+                actionParam="{ views: ['website.header_width_full'], previewClass: `container-fluid`}"/>
         </BuilderButtonGroup>
     </BuilderRow>
 </t>

--- a/addons/website_sale/static/src/website_builder/products_list_page_option.xml
+++ b/addons/website_sale/static/src/website_builder/products_list_page_option.xml
@@ -62,7 +62,6 @@
 
     <BuilderRow label.translate="Gap" level="1">
         <BuilderRange
-            styleAction="'--o-wsale-products-grid-gap'"
             action="'setGap'"
             min="0"
             max="28"
@@ -107,7 +106,7 @@
                         classAction="style.className"
                         actionParam="[
                             {action: 'websiteConfig', actionParam: {views: style.views}},
-                            {action: 'setDefaultGap', actionValue: style.gap + 'px'},
+                            {action: 'setGap', actionValue: style.gap + 'px'},
                         ]"
                         t-out="style.label"
                 />

--- a/addons/website_sale/static/src/website_builder/products_list_page_option.xml
+++ b/addons/website_sale/static/src/website_builder/products_list_page_option.xml
@@ -6,17 +6,15 @@
     <div class="d-none o_wsale_products_list_page_options"/>
 
     <BuilderRow label.translate="Content Width">
-        <BuilderButtonGroup action="'websiteConfig'">
+        <BuilderButtonGroup action="'previewableWebsiteConfig'">
             <BuilderButton
                     title.translate="Regular"
-                    classAction="'container'"
-                    actionParam="{views: []}"
+                    actionParam="{views: [], previewClass: 'container'}"
                     iconImg="'/website/static/src/img/snippets_options/content_width_normal.svg'"
             />
             <BuilderButton
                     title.translate="Full"
-                    classAction="'container-fluid o_wsale_page_fluid'"
-                    actionParam="{views: ['website_sale.shop_fullwidth']}"
+                    actionParam="{views: ['website_sale.shop_fullwidth'], previewClass: 'container-fluid o_wsale_page_fluid'}"
                     iconImg="'/website/static/src/img/snippets_options/content_width_full.svg'"
             />
         </BuilderButtonGroup>
@@ -115,27 +113,25 @@
     </BuilderRow>
 
     <BuilderRow label.translate="Images Size" level="1">
-        <BuilderSelect action="'websiteConfig'">
-            <BuilderSelectItem classAction="'o_wsale_context_thumb_4_3'" actionParam="{views: ['website_sale.products_thumb_4_3']}">Landscape (4/3)</BuilderSelectItem>
-            <BuilderSelectItem classAction="''" actionParam="{views: []}">Default (1/1)</BuilderSelectItem>
-            <BuilderSelectItem classAction="'o_wsale_context_thumb_4_5'" actionParam="{views: ['website_sale.products_thumb_4_5']}">Portrait (4/5)</BuilderSelectItem>
-            <BuilderSelectItem classAction="'o_wsale_context_thumb_2_3'" actionParam="{views: ['website_sale.products_thumb_2_3']}">Vertical (2/3)</BuilderSelectItem>
+        <BuilderSelect action="'previewableWebsiteConfig'">
+            <BuilderSelectItem actionParam="{views: ['website_sale.products_thumb_4_3'], previewClass: 'o_wsale_context_thumb_4_3'}">Landscape (4/3)</BuilderSelectItem>
+            <BuilderSelectItem actionParam="{views: [], previewClass: ''}">Default (1/1)</BuilderSelectItem>
+            <BuilderSelectItem actionParam="{views: ['website_sale.products_thumb_4_5'], previewClass: 'o_wsale_context_thumb_4_5'}">Portrait (4/5)</BuilderSelectItem>
+            <BuilderSelectItem actionParam="{views: ['website_sale.products_thumb_2_3'], previewClass: 'o_wsale_context_thumb_2_3'}">Vertical (2/3)</BuilderSelectItem>
         </BuilderSelect>
 
         <t t-set-slot="collapse">
             <BuilderRow label.translate="Images Fill" level="2">
-                <BuilderButtonGroup action="'websiteConfig'">
+                <BuilderButtonGroup action="'previewableWebsiteConfig'">
                     <BuilderButton
                             title.translate="Contain within the box"
-                            classAction="''"
-                            actionParam="{views: []}"
+                            actionParam="{views: [], previewClass: ''}"
                             iconImg="'/website/static/src/img/snippets_options/content_width_normal.svg'"
                     />
                     <BuilderButton
                             title.translate="Always Fill the box"
                             id="'thumb_cover'"
-                            classAction="'o_wsale_context_thumb_cover'"
-                            actionParam="{views: ['website_sale.products_thumb_cover']}"
+                            actionParam="{views: ['website_sale.products_thumb_cover'], previewClass: 'o_wsale_context_thumb_cover'}"
                             iconImg="'/website/static/src/img/snippets_options/content_width_full.svg'"
                     />
                 </BuilderButtonGroup>

--- a/addons/website_sale/static/src/website_builder/products_list_page_option_plugin.js
+++ b/addons/website_sale/static/src/website_builder/products_list_page_option_plugin.js
@@ -22,11 +22,21 @@ class ProductsListPageOptionPlugin extends Plugin {
         builder_actions: {
             SetPpgAction,
             SetPprAction,
-            SetDefaultGapAction,
             SetGapAction,
             SetDefaultSortAction,
-        }
+        },
+        save_handlers: this.onSave.bind(this),
     };
+
+    async onSave() {
+        const pageEl = this.editable.querySelector("#o_wsale_container");
+        if (pageEl) {
+            const gapToSave = pageEl.dataset.gapToSave;
+            if (typeof gapToSave !== "undefined") {
+                return rpc("/shop/config/website", { shop_gap: gapToSave });
+            }
+        }
+    }
 }
 
 export class SetPpgAction extends BuilderAction {
@@ -62,22 +72,15 @@ export class SetPprAction extends BuilderAction {
 }
 export class SetGapAction extends BuilderAction {
     static id = "setGap";
-    setup() {
-        this.reload = {};
+    isApplied() {
+        return true;
     }
-    apply({ value }) {
-        return rpc("/shop/config/website", { shop_gap: value });
-    }
-}
-
-export class SetDefaultGapAction extends BuilderAction {
-    static id = "setDefaultGap";
-    setup() {
-        this.reload = {};
+    getValue({ editingElement }) {
+        return editingElement.style.getPropertyValue("--o-wsale-products-grid-gap");
     }
     apply({ editingElement, value }) {
-        editingElement.style.setProperty("--o-wsale-products-grid-gap", value + "px");
-        return rpc("/shop/config/website", { shop_gap: value });
+        editingElement.style.setProperty("--o-wsale-products-grid-gap", value);
+        editingElement.dataset.gapToSave = value;
     }
 }
 


### PR DESCRIPTION
Certain options of the website builder are not previewable because they require an rpc call and a reload. However, some of these options could easily be previewed, because their only effect is the addition or the removal of a class. This PR contains two commits that make this kind of option previewable. The main idea consists of applying the correct class when the option is previewed, deferring the rpc call to a save handler. More details are reported in the individual commit messages.