### PR TITLE
[IMP] hw_posbox_homepage: connect/disconnect databse buttons

### DIFF
--- a/addons/hw_posbox_homepage/static/src/app/components/dialog/ServerDialog.js
+++ b/addons/hw_posbox_homepage/static/src/app/components/dialog/ServerDialog.js
@@ -57,30 +57,30 @@ export class ServerDialog extends Component {
 
         <BootstrapDialog identifier="'server-configuration'" btnName="'Configure'">
             <t t-set-slot="header">
-                Configure Odoo Server
+                Configure Odoo Database
             </t>
             <t t-set-slot="body">
-                <div class="alert alert-warning fs-6 pb-0" role="alert">
+                <div class="alert alert-warning fs-6 pb-0" role="alert" t-if="!store.base.server_status">
                     <ol>
                         <li>Install <b>IoT App</b> on your database,</li>
                         <li>From the IoT App click on <b>Connect</b> button.</li>
                     </ol>
                 </div>
                 <div class="mt-3">
-                    <div class="input-group-sm mb-3">
+                    <div class="input-group-sm mb-3" t-if="!store.base.server_status">
                         <input type="text" class="form-control" t-model="form.token" placeholder="Server token"/>
                     </div>
-                    <div class="small" t-if="store.base.server_status">
+                    <div class="small" t-else="">
                         <p class="m-0">
-                            Your current server is: <br/> 
+                            Your current database is: <br/> 
                             <strong t-esc="store.base.server_status" />
                         </p>
                     </div>
                 </div>
             </t>
             <t t-set-slot="footer">
-                <button type="submit" class="btn btn-primary btn-sm" t-att-disabled="state.loading or !form.token" t-on-click="connectToServer">Connect</button>
-                <button type="button" class="btn btn-secondary btn-sm" t-if="store.base.server_status" t-on-click="clearConfiguration">Disconnect from current</button>
+                <button type="submit" class="btn btn-primary btn-sm" t-if="!store.base.server_status" t-on-click="connectToServer" t-att-disabled="state.loading or !form.token" >Connect</button>
+                <button type="button" class="btn btn-danger btn-sm" t-if="store.base.server_status" t-on-click="clearConfiguration">Disconnect</button>
                 <button type="button" class="btn btn-secondary btn-sm" data-bs-dismiss="modal">Close</button>
             </t>
         </BootstrapDialog>


### PR DESCRIPTION
We renamed the "Disconnect from current" button to "Disconnect", and removed the possibility to configure a new database if one is already configured. This eases user experience, by reducing the amount of information on the screen.

Task: 4922634