### PR TITLE
[IMP] *: deprecate odoo.osv

### DIFF
--- a/addons/crm/models/res_partner.py
+++ b/addons/crm/models/res_partner.py
@@ -1,7 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import _, api, fields, models
-from odoo.osv import expression
 
 
 class ResPartner(models.Model):

--- a/addons/crm_livechat/models/chatbot_script_step.py
+++ b/addons/crm_livechat/models/chatbot_script_step.py
@@ -3,7 +3,7 @@
 from ast import literal_eval
 
 from odoo import models, fields
-from odoo.osv import expression
+from odoo.fields import Domain
 from odoo.tools import html2plaintext
 
 
@@ -84,14 +84,9 @@ class ChatbotScriptStep(models.Model):
         teams = lead.team_id
         if not teams:
             possible_teams = self.env["crm.team"].search(
-                expression.AND(
-                    [
-                        [("assignment_optout", "=", False)],
-                        expression.OR(
-                            [[("use_leads", "=", True)], [("use_opportunities", "=", True)]]
-                        ),
-                    ]
-                )
+                Domain("assignment_optout", "=", False) & (
+                    Domain("use_leads", "=", True) | Domain("use_opportunities", "=", True)
+                ),
             )
             teams = possible_teams.filtered(
                 lambda team: team.assignment_max

--- a/addons/event/models/event_registration.py
+++ b/addons/event/models/event_registration.py
@@ -190,7 +190,7 @@ class EventRegistration(models.Model):
 
     @api.model
     def _search_event_end_date(self, operator, value):
-        return expression.OR([
+        return Domain.OR([
             ["&", ("event_slot_id", "!=", False), ("event_slot_id.end_datetime", operator, value)],
             ["&", ("event_slot_id", "=", False), ("event_id.date_end", operator, value)],
         ])

--- a/addons/event/models/event_registration.py
+++ b/addons/event/models/event_registration.py
@@ -1,12 +1,11 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 import logging
 import os
 
 from odoo import _, api, fields, models, SUPERUSER_ID
-from odoo.osv import expression
-from odoo.tools import email_normalize, email_normalize_all, formataddr
-from odoo.exceptions import AccessError, ValidationError
+from odoo.fields import Domain
+from odoo.tools import email_normalize, formataddr
+from odoo.exceptions import ValidationError
 _logger = logging.getLogger(__name__)
 
 
@@ -179,7 +178,7 @@ class EventRegistration(models.Model):
 
     @api.model
     def _search_event_begin_date(self, operator, value):
-        return expression.OR([
+        return Domain.OR([
             ["&", ("event_slot_id", "!=", False), ("event_slot_id.start_datetime", operator, value)],
             ["&", ("event_slot_id", "=", False), ("event_id.date_begin", operator, value)],
         ])

--- a/addons/lunch/controllers/main.py
+++ b/addons/lunch/controllers/main.py
@@ -1,10 +1,9 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import _, http, fields
 from odoo.exceptions import AccessError
+from odoo.fields import Domain
 from odoo.http import request
-from odoo.osv import expression
 from odoo.tools import float_round, float_repr
 
 
@@ -128,10 +127,10 @@ class LunchController(http.Controller):
         if not user_location or not has_multi_company_access:
             user.last_lunch_location_id = user_location = request.env['lunch.location'].search([], limit=1) or user_location
 
-        alert_domain = expression.AND([
-            [('available_today', '=', True)],
-            [('location_ids', 'in', user_location.id)],
-            [('mode', '=', 'alert')],
+        alert_domain = Domain.AND([
+            Domain('available_today', '=', True),
+            Domain('location_ids', 'in', user_location.id),
+            Domain('mode', '=', 'alert'),
         ])
 
         res.update({

--- a/addons/lunch/models/lunch_order.py
+++ b/addons/lunch/models/lunch_order.py
@@ -3,7 +3,7 @@
 from odoo import api, fields, models, _
 
 from odoo.exceptions import ValidationError, UserError
-from odoo.osv.expression import AND
+from odoo.fields import Domain
 
 
 class LunchOrder(models.Model):
@@ -216,7 +216,7 @@ class LunchOrder(models.Model):
             ('lunch_location_id', '=', values.get('lunch_location_id', default_location_id)),
         ]
         if values.get('state'):
-            domain = AND([domain, [('state', '=', values['state'])]])
+            domain = Domain.AND([domain, [('state', '=', values['state'])]])
         toppings = values.get('toppings', [])
         return self.search(domain).filtered(lambda line: (line.topping_ids_1 | line.topping_ids_2 | line.topping_ids_3).ids == toppings)
 

--- a/addons/lunch/models/lunch_product.py
+++ b/addons/lunch/models/lunch_product.py
@@ -1,13 +1,10 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
-
-import base64
 
 from collections import defaultdict
 
 from odoo import api, fields, models, _
 from odoo.exceptions import UserError
-from odoo.osv import expression
+from odoo.fields import Domain
 
 
 class LunchProduct(models.Model):
@@ -80,13 +77,12 @@ class LunchProduct(models.Model):
             Is available_at is always false when browsing it
             this field is there only to search (see _search_is_available_at)
         """
-        for product in self:
-            product.is_available_at = False
+        self.is_available_at = False
 
     def _search_is_available_at(self, operator, value):
         if operator != 'in':
             return NotImplemented
-        return expression.OR([[('supplier_id.available_location_ids', 'in', value)], [('supplier_id.available_location_ids', '=', False)]])
+        return Domain('supplier_id.available_location_ids', 'in', value) | Domain('supplier_id.available_location_ids', '=', False)
 
     def _sync_active_from_related(self):
         """ Archive/unarchive product after related field is archived/unarchived """

--- a/addons/lunch/models/lunch_supplier.py
+++ b/addons/lunch/models/lunch_supplier.py
@@ -9,7 +9,7 @@ from textwrap import dedent
 
 from odoo import api, fields, models, _
 from odoo.exceptions import UserError
-from odoo.osv import expression
+from odoo.fields import Domain
 from odoo.tools import float_round
 
 from odoo.addons.base.models.res_partner import _tz_get
@@ -323,19 +323,14 @@ class LunchSupplier(models.Model):
         if operator not in ('in', 'not in'):
             return NotImplemented
 
-        now = fields.Datetime.now().replace(tzinfo=pytz.UTC).astimezone(pytz.timezone(self.env.user.tz or 'UTC'))
-        fieldname = WEEKDAY_TO_NAME[now.weekday()]
+        today = fields.Date.context_today(self)
+        fieldname = WEEKDAY_TO_NAME[today.weekday()]
         truth = operator == 'in'
 
-        recurrency_domain = expression.OR([
-            [('recurrency_end_date', '=', False)],
-            [('recurrency_end_date', '>' if truth else '<', now)]
-        ])
+        recurrency_domain = Domain('recurrency_end_date', '=', False) \
+            | Domain('recurrency_end_date', '>' if truth else '<', today)
 
-        return expression.AND([
-            recurrency_domain,
-            [(fieldname, operator, value)]
-        ])
+        return recurrency_domain & Domain(fieldname, operator, value)
 
     def _compute_buttons(self):
         self.env.cr.execute("""

--- a/addons/lunch/tests/test_supplier.py
+++ b/addons/lunch/tests/test_supplier.py
@@ -3,6 +3,7 @@
 import pytz
 
 from datetime import datetime, time, timedelta
+from freezegun import freeze_time
 from unittest.mock import patch
 
 from odoo import fields
@@ -67,11 +68,11 @@ env['lunch.supplier'].browse([{self.supplier_kothai.id}])._send_auto_email()""")
                  (self.saturday_1pm, 13.0, 'sat'), (self.saturday_8pm, 20.0, 'sat')]
 
         for value, rvalue, dayname in tests:
-            with self.subTest(value=value), patch.object(fields.Datetime, 'now', return_value=value):
+            with self.subTest(value=value), freeze_time(value):
                 self.assertEqual(
-                    Supplier._search_available_today('in', [True]),
+                    list(Supplier._search_available_today('in', [True])),
                     ['&', '|', ('recurrency_end_date', '=', False),
-                        ('recurrency_end_date', '>', value.replace(tzinfo=pytz.UTC).astimezone(pytz.timezone(self.env.user.tz))),
+                        ('recurrency_end_date', '>', value.astimezone(pytz.timezone(self.env.user.tz)).date()),
                         (dayname, 'in', [True])],
                 )
 

--- a/addons/mrp_account/models/product.py
+++ b/addons/mrp_account/models/product.py
@@ -1,8 +1,6 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import fields, models
-from odoo.osv import expression
 from odoo.tools import float_round, groupby
 
 

--- a/addons/payment/tests/common.py
+++ b/addons/payment/tests/common.py
@@ -6,8 +6,7 @@ from unittest.mock import patch
 
 from lxml import objectify
 
-from odoo.fields import Command
-from odoo.osv.expression import AND
+from odoo.fields import Command, Domain
 from odoo.tools.misc import hmac as hmac_tool
 
 from odoo.addons.base.tests.common import BaseCommon
@@ -128,7 +127,7 @@ class PaymentCommon(BaseCommon):
         provider_domain = cls._get_provider_domain(code, **kwargs)
 
         provider = cls.env['payment.provider'].sudo().search(
-            AND([provider_domain, [('company_id', '=', company.id)]]), limit=1
+            Domain.AND([provider_domain, [('company_id', '=', company.id)]]), limit=1
         )
         if not provider:
             _logger.error("No payment.provider found for code %s in company %s", code, company.name)

--- a/addons/payment_custom/models/payment_provider.py
+++ b/addons/payment_custom/models/payment_provider.py
@@ -1,7 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import _, api, fields, models
-from odoo.osv.expression import AND
+from odoo.fields import Domain
 
 from odoo.addons.payment_custom import const
 
@@ -54,7 +54,7 @@ class PaymentProvider(models.Model):
     def _get_provider_domain(self, provider_code, *, custom_mode='', **kwargs):
         res = super()._get_provider_domain(provider_code, custom_mode=custom_mode, **kwargs)
         if provider_code == 'custom' and custom_mode:
-            return AND([res, [('custom_mode', '=', custom_mode)]])
+            return Domain.AND([res, [('custom_mode', '=', custom_mode)]])
         return res
 
     @api.model

--- a/addons/payment_custom/tests/common.py
+++ b/addons/payment_custom/tests/common.py
@@ -1,6 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo.osv.expression import AND
+from odoo.fields import Domain
 
 from odoo.addons.payment.tests.common import PaymentCommon
 
@@ -11,5 +11,5 @@ class PaymentCustomCommon(PaymentCommon):
     def _get_provider_domain(cls, code, custom_mode=None):
         domain = super()._get_provider_domain(code)
         if custom_mode:
-            domain = AND([domain, [('custom_mode', '=', custom_mode)]])
+            domain = Domain.AND([domain, [('custom_mode', '=', custom_mode)]])
         return domain

--- a/addons/point_of_sale/controllers/main.py
+++ b/addons/point_of_sale/controllers/main.py
@@ -4,8 +4,8 @@ import logging
 import json
 
 from odoo import http, _
+from odoo.fields import Domain
 from odoo.http import request
-from odoo.osv.expression import AND
 from odoo.tools import format_amount, file_open
 from odoo.addons.account.controllers.portal import PortalAccount
 from datetime import timedelta, datetime
@@ -61,7 +61,7 @@ class PosController(PortalAccount):
                 ('rescue', '=', False)
                 ]
         if config_id and request.env['pos.config'].sudo().browse(int(config_id)).exists():
-            domain = AND([domain,[('config_id', '=', int(config_id))]])
+            domain = Domain.AND([domain, [('config_id', '=', int(config_id))]])
             pos_config = request.env['pos.config'].sudo().browse(int(config_id))
         pos_session = request.env['pos.session'].sudo().search(domain, limit=1)
 

--- a/addons/point_of_sale/models/pos_bill.py
+++ b/addons/point_of_sale/models/pos_bill.py
@@ -1,6 +1,5 @@
 from odoo import api, fields, models, _
 from odoo.exceptions import UserError
-from odoo.osv.expression import OR
 
 
 class PosBill(models.Model):

--- a/addons/point_of_sale/models/pos_load_mixin.py
+++ b/addons/point_of_sale/models/pos_load_mixin.py
@@ -1,6 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
-from odoo import models, api
-from odoo.osv.expression import AND
+from odoo import api, models
+from odoo.fields import Domain
 
 
 class PosLoadMixin(models.AbstractModel):
@@ -36,7 +36,7 @@ class PosLoadMixin(models.AbstractModel):
         model_included = self._name not in ['pos.session', 'pos.config']
 
         if limited_loading and last_server_date and model_included:
-            domain = AND([domain, [('write_date', '>', last_server_date)]])
+            domain = Domain.AND([domain, [('write_date', '>', last_server_date)]])
 
         return domain
 

--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 import logging
-import json
 from datetime import datetime
 from markupsafe import Markup
 from itertools import groupby
@@ -13,10 +11,10 @@ from pprint import pformat
 import psycopg2
 import pytz
 
-from odoo import api, fields, models, tools, _, Command
+from odoo import api, fields, models, tools, _
 from odoo.tools import float_is_zero, float_round, float_repr, float_compare, formatLang
 from odoo.exceptions import ValidationError, UserError
-from odoo.osv.expression import AND
+from odoo.fields import Command, Domain
 import base64
 
 
@@ -1353,11 +1351,9 @@ class PosOrder(models.Model):
     @api.model
     def search_paid_order_ids(self, config_id, domain, limit, offset):
         """Search for 'paid' orders that satisfy the given domain, limit and offset."""
-        default_domain = [('state', '!=', 'draft'), ('state', '!=', 'cancel')]
-        if domain == []:
-            real_domain = AND([[['config_id', '=', config_id]], default_domain])
-        else:
-            real_domain = AND([domain, default_domain])
+        default_domain = Domain('state', '!=', 'draft') & Domain('state', '!=', 'cancel')
+        domain = Domain(domain) or Domain('config_id', '=', config_id)
+        real_domain = domain & default_domain
         orders = self.search(real_domain, limit=limit, offset=offset, order='create_date desc')
         # We clean here the orders that does not have the same currency.
         # As we cannot use currency_id in the domain (because it is not a stored field),

--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -4,11 +4,11 @@ from datetime import timedelta
 from itertools import groupby, starmap
 from markupsafe import Markup
 
-from odoo import api, fields, models, _, Command
+from odoo import api, fields, models, _
 from odoo.exceptions import AccessError, UserError, ValidationError
+from odoo.fields import Command, Domain
 from odoo.tools import float_is_zero, float_compare, frozendict, plaintext2html, split_every
 from odoo.tools.constants import PREFETCH_MAX
-from odoo.osv.expression import AND
 
 
 class PosSession(models.Model):
@@ -241,7 +241,7 @@ class PosSession(models.Model):
             cash_payment_method = session.payment_method_ids.filtered('is_cash_count')[:1]
             if cash_payment_method:
                 total_cash_payment = 0.0
-                captured_cash_payments_domain = AND([session._get_captured_payments_domain(), [('payment_method_id', '=', cash_payment_method.id)]])
+                captured_cash_payments_domain = Domain.AND([session._get_captured_payments_domain(), [('payment_method_id', '=', cash_payment_method.id)]])
                 result = self.env['pos.payment']._read_group(captured_cash_payments_domain, aggregates=['amount:sum'])
                 total_cash_payment = result[0][0] or 0.0
                 if session.state == 'closed':

--- a/addons/point_of_sale/models/product_attribute.py
+++ b/addons/point_of_sale/models/product_attribute.py
@@ -1,5 +1,4 @@
 from odoo import api, fields, models
-from odoo.osv.expression import AND
 
 
 class ProductAttribute(models.Model):
@@ -48,15 +47,16 @@ class ProductTemplateAttributeValue(models.Model):
     def _load_pos_data_domain(self, data, config):
         ptav_ids = {ptav_id for p in data['product.product'] for ptav_id in p['product_template_variant_value_ids']}
         ptav_ids.update({ptav_id for ptal in data['product.template.attribute.line'] for ptav_id in ptal['product_template_value_ids']})
-        return AND([
-            [('ptav_active', '=', True)],
-            [('attribute_id', 'in', [attr['id'] for attr in data['product.attribute']])],
-            [('id', 'in', list(ptav_ids))]
-        ])
+        return [
+            ('ptav_active', '=', True),
+            ('attribute_id', 'in', [attr['id'] for attr in data['product.attribute']]),
+            ('id', 'in', list(ptav_ids)),
+        ]
 
     @api.model
     def _load_pos_data_fields(self, config):
         return ['attribute_id', 'attribute_line_id', 'product_attribute_value_id', 'price_extra', 'name', 'is_custom', 'html_color', 'image', 'exclude_for']
+
 
 class ProductTemplateAttributeExclusion(models.Model):
     _name = 'product.template.attribute.exclusion'

--- a/addons/point_of_sale/models/product_template.py
+++ b/addons/point_of_sale/models/product_template.py
@@ -83,9 +83,9 @@ class ProductTemplate(models.Model):
     @api.model
     def load_product_from_pos(self, config_id, domain, offset=0, limit=0):
         load_archived = self.env.context.get('load_archived', False)
-        domain_obj = Domain(domain)
+        domain = Domain(domain)
         config = self.env['pos.config'].browse(config_id)
-        product_tmpls = self._load_product_with_domain(domain_obj, load_archived, offset, limit)
+        product_tmpls = self._load_product_with_domain(domain, load_archived, offset, limit)
 
         # product.combo and product.combo.item loading
         for product_tmpl in product_tmpls:

--- a/addons/point_of_sale/models/report_sale_details.py
+++ b/addons/point_of_sale/models/report_sale_details.py
@@ -1,11 +1,10 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 from datetime import timedelta
 
 import pytz
 
 from odoo import api, fields, models, _
-from odoo.osv.expression import AND
+from odoo.fields import Domain
 from odoo.tools import SQL
 
 
@@ -35,20 +34,18 @@ class ReportPoint_Of_SaleReport_Saledetails(models.AbstractModel):
         return date_start, date_stop
 
     def _get_domain(self, date_start=False, date_stop=False, config_ids=False, session_ids=False):
-        domain = [('state', 'in', ['paid', 'done'])]
+        domain = Domain('state', 'in', ['paid', 'done'])
 
         if (session_ids):
-            domain = AND([domain, [('session_id', 'in', session_ids)]])
+            domain &= Domain('session_id', 'in', session_ids)
         else:
             date_start, date_stop = self._get_date_start_and_date_stop(date_start, date_stop)
 
-            domain = AND([domain,
-                [('date_order', '>=', fields.Datetime.to_string(date_start)),
-                ('date_order', '<=', fields.Datetime.to_string(date_stop))]
-            ])
+            domain &= Domain('date_order', '>=', fields.Datetime.to_string(date_start))
+            domain &= Domain('date_order', '<=', fields.Datetime.to_string(date_stop))
 
             if config_ids:
-                domain = AND([domain, [('config_id', 'in', config_ids)]])
+                domain &= Domain('config_id', 'in', config_ids)
 
         return domain
 

--- a/addons/purchase_stock/models/product.py
+++ b/addons/purchase_stock/models/product.py
@@ -4,7 +4,6 @@ from dateutil.relativedelta import relativedelta
 
 from odoo import api, fields, models
 from odoo.fields import Domain
-from odoo.osv import expression
 from odoo.tools import formatLang
 
 
@@ -95,12 +94,12 @@ class ProductProduct(models.Model):
 
     def _get_lines_domain(self, location_ids=False, warehouse_ids=False):
         domains = []
-        rfq_domain = [
-            ('state', 'in', ('draft', 'sent', 'to approve')),
-            ('product_id', 'in', self.ids)
-        ]
+        rfq_domain = (
+            Domain('state', 'in', ('draft', 'sent', 'to approve'))
+            & Domain('product_id', 'in', self.ids)
+        )
         if location_ids:
-            domains.append([
+            domains.append(Domain([
                 '|',
                     '&',
                     ('orderpoint_id', '=', False),
@@ -114,9 +113,9 @@ class ProductProduct(models.Model):
                     '&',
                         ('move_dest_ids', '=', False),
                         ('orderpoint_id.location_id', 'in', location_ids)
-            ])
+            ]))
         if warehouse_ids:
-            domains.append([
+            domains.append(Domain([
                 '|',
                     '&',
                         ('orderpoint_id', '=', False),
@@ -124,9 +123,8 @@ class ProductProduct(models.Model):
                     '&',
                         ('move_dest_ids', '=', False),
                         ('orderpoint_id.warehouse_id', 'in', warehouse_ids)
-            ])
-        domains = expression.OR(domains) if domains else []
-        return expression.AND([rfq_domain, domains])
+            ]))
+        return rfq_domain & Domain.OR(domains or [Domain.TRUE])
 
 
 class ProductSupplierinfo(models.Model):

--- a/addons/purchase_stock/report/vendor_delay_report.py
+++ b/addons/purchase_stock/report/vendor_delay_report.py
@@ -1,8 +1,7 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import fields, models, tools
-from odoo.osv import expression
+from odoo.fields import Domain
 from odoo.tools import SQL
 
 
@@ -67,5 +66,5 @@ GROUP  BY m.id
 
     def _read_group(self, domain, groupby=(), aggregates=(), having=(), offset=0, limit=None, order=None):
         if 'on_time_rate:sum' in aggregates:
-            having = expression.AND([having, [('qty_total:sum', '>', '0')]])
+            having = Domain.AND([having, [('qty_total:sum', '>', '0')]])
         return super()._read_group(domain, groupby, aggregates, having, offset, limit, order)

--- a/addons/purchase_stock/wizard/product_replenish.py
+++ b/addons/purchase_stock/wizard/product_replenish.py
@@ -1,8 +1,7 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import _, api, fields, models
-from odoo.osv.expression import AND
+from odoo import api, fields, models
+from odoo.fields import Domain
 
 
 class ProductReplenish(models.TransientModel):
@@ -95,5 +94,5 @@ class ProductReplenish(models.TransientModel):
         domain = super()._get_route_domain(product_tmpl_id)
         buy_route = self.env.ref('purchase_stock.route_warehouse0_buy', raise_if_not_found=False)
         if buy_route and not product_tmpl_id.seller_ids:
-            domain = AND([domain, [('id', '!=', buy_route.id)]])
+            domain = Domain.AND([domain, Domain('id', '!=', buy_route.id)])
         return domain

--- a/addons/survey/models/survey_survey.py
+++ b/addons/survey/models/survey_survey.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import random
@@ -9,7 +8,7 @@ import werkzeug
 
 from odoo import api, exceptions, fields, models, _
 from odoo.exceptions import AccessError, UserError, ValidationError
-from odoo.osv import expression
+from odoo.fields import Domain
 from odoo.tools import is_html_empty
 
 
@@ -675,19 +674,19 @@ class SurveySurvey(models.Model):
         """ Returns the number of attempts left. """
         self.ensure_one()
 
-        domain = [
+        domain = Domain([
             ('survey_id', '=', self.id),
             ('test_entry', '=', False),
             ('state', '=', 'done')
-        ]
+        ])
 
         if partner:
-            domain = expression.AND([domain, [('partner_id', '=', partner.id)]])
+            domain &= Domain('partner_id', '=', partner.id)
         else:
-            domain = expression.AND([domain, [('email', '=', email)]])
+            domain &= Domain('email', '=', email)
 
         if invite_token:
-            domain = expression.AND([domain, [('invite_token', '=', invite_token)]])
+            domain &= Domain('invite_token', '=', invite_token)
 
         return self.attempts_limit - self.env['survey.user_input'].search_count(domain)
 
@@ -867,7 +866,7 @@ class SurveySurvey(models.Model):
                 raise ValueError("Page id is needed for question layout 'page_per_section'")
             page_or_question_id = int(page_id)
             questions = self.env['survey.question'].sudo().search(
-                expression.AND([[('survey_id', '=', self.id)], [('page_id', '=', page_or_question_id)]]))
+                Domain('survey_id', '=', self.id) & Domain('page_id', '=', page_or_question_id))
         elif self.questions_layout == 'page_per_question':
             if not question_id:
                 raise ValueError("Question id is needed for question layout 'page_per_question'")

--- a/odoo/osv/__init__.py
+++ b/odoo/osv/__init__.py
@@ -1,3 +1,4 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
-# TODO deprecate module, show warning when importing
+import warnings
+warnings.warn("Since 19.0, odoo.osv is deprecated use odoo.fields.Domain", DeprecationWarning)

--- a/odoo/osv/expression.py
+++ b/odoo/osv/expression.py
@@ -159,7 +159,7 @@ def normalize_domain(domain):
        have been made explicit. One property of normalized domain expressions is that they
        can be easily combined together as if they were single domain components.
     """
-    # TODO deprecate use Domain()
+    warnings.warn("Since 19.0, use odoo.fields.Domain", DeprecationWarning)
     if isinstance(domain, orm_domains.Domain):
         # already normalized
         return list(domain)
@@ -228,14 +228,13 @@ def combine(operator, unit, zero, domains):
 
 def AND(domains):
     """AND([D1,D2,...]) returns a domain representing D1 and D2 and ... """
-    # TODO deprecate and use Domain.AND(domains)
-    # (note: used in migrations)
+    warnings.warn("Since 19.0, use odoo.fields.Domain", DeprecationWarning)
     return combine(AND_OPERATOR, [TRUE_LEAF], [FALSE_LEAF], domains)
 
 
 def OR(domains):
     """OR([D1,D2,...]) returns a domain representing D1 or D2 or ... """
-    # TODO deprecate and use Domain.OR(domains)
+    warnings.warn("Since 19.0, use odoo.fields.Domain", DeprecationWarning)
     return combine(OR_OPERATOR, [FALSE_LEAF], [TRUE_LEAF], domains)
 
 


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Deprecate `odoo.osv.expression` which is now full replaced by `odoo.fields.Domain`.

task-4280707
odoo/enterprise#89631
odoo/upgrade#8020



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
