### PR TITLE
hr_work_entry: Remove duplicate _get_duration_batch function

### DIFF
--- a/addons/hr_work_entry/models/hr_work_entry.py
+++ b/addons/hr_work_entry/models/hr_work_entry.py
@@ -151,24 +151,6 @@ class HrWorkEntry(models.Model):
         return self.work_entry_type_id and self.work_entry_type_id.is_leave
 
     def _get_duration_batch(self):
-        result = {}
-        cached_periods = defaultdict(float)
-        for work_entry in self:
-            date_start = work_entry.date_start
-            date_stop = work_entry.date_stop
-            if not date_start or not date_stop:
-                result[work_entry.id] = 0.0
-                continue
-            if (date_start, date_stop) in cached_periods:
-                result[work_entry.id] = cached_periods[(date_start, date_stop)]
-            else:
-                dt = date_stop - date_start
-                duration = dt.days * 24 + round(dt.total_seconds()) / 3600  # Number of hours
-                cached_periods[(date_start, date_stop)] = duration
-                result[work_entry.id] = duration
-        return result
-
-    def _get_duration_batch(self):
         no_version_work_entries = self.env['hr.work.entry']
         result = {}
         # {(date_start, date_stop): {calendar: employees}}


### PR DESCRIPTION
Description of the issue/feature this PR addresses: Following the merge of contracts into versions, a duplicate function _get_duration_batch was created where the old and new ones existed simultaneously with the same function skeleton, this commit removes the old _get_duration_batch

Current behavior before PR: No behavior affected

Desired behavior after PR is merged: dead code removed




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
