### PR TITLE
[FIX] html_editor: update font size of headings

### DIFF
--- a/addons/html_editor/static/src/core/format_plugin.js
+++ b/addons/html_editor/static/src/core/format_plugin.js
@@ -191,7 +191,7 @@ export class FormatPlugin extends Plugin {
     hasSelectionFormat(format, targetedNodes = this.dependencies.selection.getTargetedNodes()) {
         const targetedTextNodes = targetedNodes.filter(isTextNode);
         const isFormatted = formatsSpecs[format].isFormatted;
-        return targetedTextNodes.some((n) => isFormatted(n, this.editable));
+        return targetedTextNodes.some((n) => isFormatted(n));
     }
     /**
      * Return true if the current selection on the editable appears as the given

--- a/addons/html_editor/static/src/utils/formatting.js
+++ b/addons/html_editor/static/src/utils/formatting.js
@@ -93,7 +93,13 @@ export const formatsSpecs = {
         removeStyle: (node) => removeStyle(node, "font-family"),
     },
     fontSize: {
-        isFormatted: (node) => closestElement(node)?.style["font-size"],
+        isFormatted: (node, props) => {
+            const hasFontSize = closestElement(node)?.style["font-size"];
+            if (props?.size) {
+                return hasFontSize && closestElement(node).style["font-size"] === props.size;
+            }
+            return hasFontSize;
+        },
         hasStyle: (node) => node.style && node.style["font-size"],
         addStyle: (node, props) => {
             node.style["font-size"] = props.size;
@@ -102,9 +108,16 @@ export const formatsSpecs = {
         removeStyle: (node) => removeStyle(node, "font-size"),
     },
     setFontSizeClassName: {
-        isFormatted: (node) =>
-            FONT_SIZE_CLASSES.find((cls) => closestElement(node)?.classList?.contains(cls)),
-        hasStyle: (node, props) => FONT_SIZE_CLASSES.find((cls) => node.classList.contains(cls)),
+        isFormatted: (node, props) => {
+            if (props?.className) {
+                return (
+                    FONT_SIZE_CLASSES.includes(props.className) &&
+                    closestElement(node)?.classList.contains(props.className)
+                );
+            }
+            return FONT_SIZE_CLASSES.find((cls) => closestElement(node)?.classList?.contains(cls));
+        },
+        hasStyle: (node) => FONT_SIZE_CLASSES.find((cls) => node.classList.contains(cls)),
         addStyle: (node, props) => {
             node.style.removeProperty("font-size");
             node.classList.add(props.className);

--- a/addons/html_editor/static/tests/_helpers/user_actions.js
+++ b/addons/html_editor/static/tests/_helpers/user_actions.js
@@ -158,6 +158,9 @@ export function strikeThrough(editor) {
 export function setFontSize(size) {
     return (editor) => execCommand(editor, "formatFontSize", { size });
 }
+export function setFontSizeClassName(className) {
+    return (editor) => execCommand(editor, "formatFontSizeClassName", { className });
+}
 export function setFontFamily(fontFamily) {
     return (editor) => {
         editor.shared.format.formatSelection("fontFamily", {

--- a/addons/html_editor/static/tests/format/font_size.test.js
+++ b/addons/html_editor/static/tests/format/font_size.test.js
@@ -2,7 +2,7 @@ import { test, expect } from "@odoo/hoot";
 import { setupEditor, testEditor } from "../_helpers/editor";
 import { unformat } from "../_helpers/format";
 import { strong } from "../_helpers/tags";
-import { setFontSize, tripleClick } from "../_helpers/user_actions";
+import { setFontSize, setFontSizeClassName, tripleClick } from "../_helpers/user_actions";
 import { Plugin } from "@html_editor/plugin";
 import { MAIN_PLUGINS } from "@html_editor/plugin_sets";
 import { animationFrame } from "@odoo/hoot-mock";
@@ -216,4 +216,12 @@ test("should add style to br except line-break br (2)", async () => {
     expect(getContent(el)).toBe(
         `<p><span style="font-size: 36px;">[abc</span><br><span style="font-size: 36px;"><br>]</span><br></p>`
     );
+});
+
+test("should update the font class if the parent already has one", async () => {
+    await testEditor({
+        contentBefore: '<h2 class="h4-fs">[abcdefg]</h2>',
+        stepFunction: setFontSizeClassName("h3-fs"),
+        contentAfter: '<h2 class="h4-fs"><span class="h3-fs">[abcdefg]</span></h2>',
+    });
 });


### PR DESCRIPTION
Steps to reproduce:
- In the website builder, drop a snippet with a heading that has a font-size class (e.g. `<h2 class="h4-fs">`). For instance "Key benefits"
- Select the text of the heading and try to change its size => It doesn't work. The class remains, and no span child is created.

Until [1], in such a case, a span child was created, but the original class was not removed. This is a best effort with the current editor: ideally, the new class should be applied on the heading tag itself (to avoid weird line heights).
The behavior was introduced with [2] but was not replicated in the html_editor refactoring [3], which did not need it at that time.

[1]: https://github.com/odoo/odoo/commit/9fe45e2b7ddbbfd0445ffe25a859e67a316d02b2
[2]: https://github.com/odoo/odoo/commit/194f73a9bbad8c3c3fb5c378e7bdfa704aaacdc0
[3]: https://github.com/odoo/odoo/commit/97117e70a1766ad24f5ec14ffef303127d56b76b

task-4367641