### PR TITLE
[FIX] Make MyInvois PoS document linked orders compute for all records

### DIFF
--- a/addons/l10n_my_edi_pos/models/myinvois_document_pos.py
+++ b/addons/l10n_my_edi_pos/models/myinvois_document_pos.py
@@ -55,7 +55,7 @@ class MyInvoisDocumentPoS(models.Model):
     # --------------------------------
 
     def _compute_linked_order_count(self):
-        for consolidated_invoice in self.filtered('pos_order_ids'):
+        for consolidated_invoice in self:
             consolidated_invoice.linked_order_count = len(consolidated_invoice.pos_order_ids)
 
     @api.depends('pos_order_ids')


### PR DESCRIPTION
Otherwise, it causes it fails to assign value to certain records, which is unadvised.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
