### PR TITLE
[FIX] stock: fix generate serial numbers dialog for lot track products

### DIFF
--- a/addons/stock/static/src/widgets/lots_dialog.xml
+++ b/addons/stock/static/src/widgets/lots_dialog.xml
@@ -44,7 +44,7 @@
                                 <div name="next_serial_count" class="o_field_widget o_field_integer">
                                     <input inputmode="numeric" t-ref="nextSerialCount" class="o_input" id="next_serial_count_0" type="text"/>
                                 </div>
-                                <span t-if="props.move.data.has_tracking === 'lot'" t-esc="props.move.data.product_uom[1]"/>
+                                <span t-if="props.move.data.has_tracking === 'lot'" t-esc="props.move.data.product_uom.display_name"/>
                             </div>
                         </div>
                         <div t-if="props.move.data.has_tracking === 'lot'" class="row mb-2">
@@ -55,7 +55,7 @@
                                 <div name="total_received" class="o_field_widget o_field_integer">
                                     <input inputmode="numeric" t-ref="totalReceived" class="o_input" id="total_received_0" type="text"/>
                                 </div>
-                                <span t-esc="props.move.data.product_uom[1]"/>
+                                <span t-esc="props.move.data.product_uom.display_name"/>
                             </div>
                         </div>
                         <div class="row">


### PR DESCRIPTION
This commit adapts the `GenerateDialog` component for generating serial numbers, for the change introduced in odoo/odoo#205486, which changes the value of m2o to be an object instead of an array. Previous to this commit, an error was thrown when the dialog is opened for a lot-tracked product because the template tries to access `move.product_uom[1]`

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
