### PR TITLE
[FIX] project: project not editable from contact task view

### DIFF
--- a/addons/project/views/project_task_views.xml
+++ b/addons/project/views/project_task_views.xml
@@ -730,7 +730,7 @@
                     <field name="id" optional="hide" options="{'enable_formatting': False}"/>
                     <field name="priority" widget="priority" optional="show" width="70px"/>
                     <field name="name" string="Title" widget="name_with_subtask_count"/>
-                    <field name="project_id" widget="project" optional="show" options="{'no_open': 1}" readonly="1" column_invisible="context.get('default_project_id')"/>
+                    <field name="project_id" widget="project" optional="show" options="{'no_open': 1}" readonly="not context.get('default_partner_id')" column_invisible="context.get('default_project_id')"/>
                     <field name="milestone_id" invisible="not allow_milestones" context="{'default_project_id': project_id}" groups="project.group_project_milestone" optional="hide"/>
                     <field name="partner_id" optional="hide" widget="res_partner_many2one" invisible="not project_id" options="{'no_open': True}"/>
                     <field name="user_ids" optional="show" widget="many2many_avatar_user"/>


### PR DESCRIPTION
**PROBLEM**
When creating task from the contact tasks list view, it no longer goes to the form view. The project field is readonly in the list view, which force the user to goes to the form view to edit it.

**STEP TO REPRODUCE**
1. Go to a contact, and click on the tasks smart button.
2. From the form view, create 2 tasks.
3. Go back to the contact, and reclick on the tasks smart button.
4. Try to create a new task from the list view, notice the task is created on the private project (project id 0) and you can't change the project from the list view.

**CAUSE**
https://github.com/odoo/odoo/commit/15afb3346ca6ef5390da5887241d56fed32ac7cf made the view list editable. Because it's now editable, when click on new it create the task in the list view. Before, it would use the form view which is the next view that is editable. The list view we see inherits `project_task_view_tree_main_base`. In this view, project_id is readonly.

**FIX**
Makes project_id readonly for the list view, except when accessing the tasks from a contact. This fixes the ux by allowing the user to set the right project when creating a task for a contact, instead of being force to do it from the form view.

opw-4794209