### PR TITLE
[FIX] web: calendar: keep side panel width

### DIFF
--- a/addons/web/static/src/views/calendar/calendar_controller.scss
+++ b/addons/web/static/src/views/calendar/calendar_controller.scss
@@ -45,7 +45,7 @@ $o-cw-filter-avatar-size: 20px;
 
     .o_calendar_sidebar {
         @include o-webclient-padding($top: $o-horizontal-padding/2);
-        max-width: calc(#{$o-datetime-picker-width} + 2 * #{map-get($spacers, 3)});
+        width: calc(#{$o-datetime-picker-width} + 2 * #{map-get($spacers, 3)});
 
         .o_datetime_picker {
             padding-right: 0 !important;


### PR DESCRIPTION
Before this commit, the width of the calendar side panel varied depending on the content.

Steps to reproduce:
- Go to Timesheet
- Select the calendar view
- Click on the "+" button  and click on the filter button.

task-4921562

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
