### PR TITLE
[FIX] base: prevent error when update path is not defined in automation action

### DIFF
--- a/odoo/addons/base/models/ir_actions.py
+++ b/odoo/addons/base/models/ir_actions.py
@@ -842,7 +842,7 @@ class IrActionsServer(models.Model):
             record_cached = self._context['onchange_self']
             for field, new_value in res.items():
                 record_cached[field] = new_value
-        else:
+        elif self.update_path:
             starting_record = self.env[self.model_id.model].browse(self._context.get('active_id'))
             _, _, target_records = self._traverse_path(record=starting_record)
             target_records.write(res)


### PR DESCRIPTION
When executing an automation rule with an "Update Record" action, if no update path is configured, an error occurs.

**Steps to reproduce:**
1. Install the **CRM** and **Automation Rules** modules.
2. Create a new **automation rule**:
   - Model = Lead, Trigger = After Creation
3. Add an **action**. Type = Update Record (do not configure the update path)
 (Tip: select another action type and switch back to reset the path.)
5. Create a new lead.
6. Run the scheduled action: Automation Rules: check and execute.

**Error:**
```
AttributeError: 'bool' object has no attribute 'split'
....
ValueError: AttributeError("'bool' object has no attribute 'split'") while
evaluating 'model._cron_process_time_based_actions()'
```

**Cause:**
In `_traverse_path`, the `update_path` is expected to be a string for `.split()`, but if not configured, it is `False`, leading to the traceback. - [1]

[1] - https://github.com/odoo/odoo/blob/5842c9f4821772fe44cfe7244162edec1ffff88e/odoo/addons/base/models/ir_actions.py#L701

**Fix:**
This commit ensures that no action is performed if the update path is not defined, avoiding the traceback.

sentry-6722927119