### PR TITLE
[FIX] purchase_stock,stock_account: value 100% discount receipt at 0

### DIFF
--- a/addons/purchase_stock/tests/test_stockvaluation.py
+++ b/addons/purchase_stock/tests/test_stockvaluation.py
@@ -3679,3 +3679,24 @@ class TestStockValuationWithCOA(AccountTestInvoicingCommon):
         bill.invoice_date = fields.Date.today()
         bill.action_post()
         self.assertEqual(avco_prod.standard_price, pre_bill_cost)
+
+    def test_100_percent_discount(self):
+        product = self.product_a
+        product.categ_id.write({'property_cost_method': 'average', 'property_valuation': 'real_time'})
+        purchase_order = self.env['purchase.order'].create({
+            'partner_id': self.partner_a.id,
+            'order_line': [Command.create({
+                'product_id': product.id,
+                'product_qty': 2,
+                'discount': 100,
+            })],
+        })
+        purchase_order.button_confirm()
+        receipt = purchase_order.picking_ids
+        receipt.button_validate()
+        purchase_order.action_create_invoice()
+        bill = purchase_order.invoice_ids
+        bill.invoice_date = fields.Date.today()
+        bill.action_post()
+        svls = self.env['stock.valuation.layer'].search([])
+        self.assertRecordValues(svls, [{'value': 0, 'quantity': 2}])

--- a/addons/stock_account/models/account_move.py
+++ b/addons/stock_account/models/account_move.py
@@ -289,7 +289,7 @@ class AccountMoveLine(models.Model):
             else:
                 price_unit = self.price_subtotal / self.quantity
         else:
-            price_unit = self.price_unit
+            price_unit = 0
 
         return -price_unit if self.move_id.move_type == 'in_refund' else price_unit
 


### PR DESCRIPTION
**Current behavior:**
Receiving some real-time valuated, non-standard cost product from an order with 100% discount will value the product at its `standard_price`.

**Expected behavior:**
Valuated at 0.

**Steps to reproduce:**
1 Create an average cost, real-time valuated product with non-zero `standard_price`
2. Create a purchase order for some of the avco product, confirm and receive
3. Create and post the bill -> check valuation from inventory

**Cause of the issue:**
Currently from 6ba1106ae we will ignore a 100% discount in calculating `_get_gross_unit_price()`.

**Fix:**
Return 0 in this method if we are in a 100% discount case.

opw-4862883