### PR TITLE
[FIX] mail, account: prevent error when sending invoices in batch

### DIFF
--- a/addons/account/tests/test_account_move_send.py
+++ b/addons/account/tests/test_account_move_send.py
@@ -687,6 +687,10 @@ class TestAccountMoveSend(TestAccountMoveSendCommon):
             self.init_invoice("out_invoice", partner=self.partner_a, amounts=[1000], post=True) +
             self.init_invoice("out_invoice", partner=self.partner_b, amounts=[1000], post=True)
         )
+        template = self.env.ref('account.email_template_edi_invoice')
+        with Form(template) as template_form:
+            template_form.use_default_to = False
+            template_form.email_cc = 'demo@gmail.com'
 
         move_send_batch_wizard = Form(self.env['account.move.send.batch.wizard'].with_context(
             active_model='account.move', active_ids=invoices.ids))

--- a/addons/account/wizard/account_move_send_batch_wizard.py
+++ b/addons/account/wizard/account_move_send_batch_wizard.py
@@ -40,7 +40,7 @@ class AccountMoveSendBatchWizard(models.TransientModel):
             edi_counter = Counter()
             sending_method_counter = Counter()
 
-            for move in wizard.move_ids:
+            for move in wizard.move_ids._origin:
                 edi_counter += Counter([edi for edi in self._get_default_extra_edis(move)])
                 sending_settings = self._get_default_sending_settings(move)
                 sending_method_counter += Counter([
@@ -60,8 +60,8 @@ class AccountMoveSendBatchWizard(models.TransientModel):
     @api.depends('summary_data')
     def _compute_alerts(self):
         for wizard in self:
-            moves_data = {move: self._get_default_sending_settings(move) for move in wizard.move_ids}
-            wizard.alerts = self._get_alerts(wizard.move_ids, moves_data)
+            moves_data = {move: self._get_default_sending_settings(move) for move in wizard.move_ids._origin}
+            wizard.alerts = self._get_alerts(wizard.move_ids._origin, moves_data)
 
     # -------------------------------------------------------------------------
     # CONSTRAINS

--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -1979,7 +1979,7 @@ class MailThread(models.AbstractModel):
             self.ensure_one()
         return self._partner_find_from_emails(
             {self: emails}, avoid_alias=avoid_alias, filter_found=filter_found, additional_values=additional_values, no_create=no_create
-        )[self._origin.id]
+        )[self.id]
 
     def _partner_find_from_emails(self, records_emails, avoid_alias=True, ban_emails=None,
                                   filter_found=None, additional_values=None, no_create=False):


### PR DESCRIPTION
Currently, an error occurs when sending invoices in bulk.

Steps to Reproduce:
 - Install the `account` module.
 - Go to `Email Templates` and open `Invoice: Sending`.
 - In the `Email Configuration`, uncheck `Default Recipients` and enter 
   `demo@gmail.com` in the `cc` field.
 - Go to `Invoices`.
 - Select multiple invoices and click `Send`.

`KeyError: <NewId origin=33>`

This error occurs when sending invoices in bulk. As mentioned in commit https://github.com/odoo/odoo/commit/058d324855a6e2fe3df51386aa153d46419766bf,
the issue was introduced in commit https://github.com/odoo/odoo/commit/39d1907d77ca9c88431e7e9dc9e8c938c79a2987, where the _compute_alerts method attempts 
to set an alert in the wizard. However,since this is a computed field, the 
wizard record has a NewId and calls the method with a transient record [1]. 
When trying to access record.id, it returns a NewId [2], and later, when this 
NewId is used as a res_id [3],it raises a KeyError.

[1]-https://github.com/odoo/odoo/blob/aff5f006d5b1996ea3ecc67998067cd0e292cf2a/addons/account/wizard/account_move_send_batch_wizard.py#L63

[2]- https://github.com/odoo/odoo/blob/c70bca77d0447b005b3898e1861facc2828475fc/addons/mail/models/mail_thread.py#L2037

[3]- https://github.com/odoo/odoo/blob/c70bca77d0447b005b3898e1861facc2828475fc/addons/mail/models/mail_thread.py#L2084

This commit fixes the above issue by using move_ids._origin, ensuring that the method is 
always called with real records, and removes the changes from the previous commit https://github.com/odoo/odoo/commit/058d324855a6e2fe3df51386aa153d46419766bf.

sentry-6562659542


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
