### PR TITLE
[FIX] account_edi_ubl_cii: Fix ClassifiedTaxCategory

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_20.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_20.py
@@ -1775,6 +1775,7 @@ class AccountEdiXmlUBL20(models.AbstractModel):
         line_node.setdefault('cac:Item', {})['cac:ClassifiedTaxCategory'] = [
             self._get_tax_category_node({**vals, 'grouping_key': grouping_key})
             for grouping_key in aggregated_tax_details
+            if grouping_key
         ]
 
     def _add_document_line_tax_total_nodes(self, line_node, vals):


### PR DESCRIPTION
Before this commit:
If a tax detail of an invoice line has the None tax grouping key, there is a traceback when generating the UBL InvoiceLine/ClassifiedTaxCategory

After this commit:
We exclude tax details that have the None grouping key when generating the InvoiceLine/ClassifiedTaxCategory.

task-none