### PR TITLE
[FIX] stock: prevent internal transfers from affecting available quantity in past inventory reports

### DIFF
--- a/addons/stock/models/product.py
+++ b/addons/stock/models/product.py
@@ -321,8 +321,8 @@ class Product(models.Model):
             loc_domain = [('location_id', 'any', paths_domain)]
             dest_loc_domain = [
                 '|',
+                ('location_dest_id', 'any', paths_domain),
                 '&', ('location_final_id', '!=', False), ('location_final_id', 'any', paths_domain),
-                '&', ('location_final_id', '=', False), ('location_dest_id', 'any', paths_domain),
             ]
 
         # returns: (domain_quant_loc, domain_move_in_loc, domain_move_out_loc)

--- a/addons/stock/tests/test_report_stock_quantity.py
+++ b/addons/stock/tests/test_report_stock_quantity.py
@@ -238,3 +238,58 @@ class TestReportStockQuantity(tests.TransactionCase):
             1.0, 2.0,   # in two days
         ]):
             self.assertEqual(qty_rd, qty, f"Incorrect qty for Date '{date_day}' Warehouse '{warehouse.display_name}'")
+
+    def test_past_date_quantity_with_multistep_delivery(self):
+        """
+        Verify that available quantities are correctly computed at different past dates
+        when using multi-step delivery.
+        """
+        def get_inv_qty_at_date(product_id, inv_datetime):
+            inventory_at_date_wizard = self.env['stock.quantity.history'].create({'inventory_datetime': inv_datetime})
+            r = inventory_at_date_wizard.open_at_date()
+            return self.env[r['res_model']].with_context(r['context']).search_read(
+                domain=(r['domain'] + [('id', '=', product_id)]),
+                fields=['qty_available']
+            )[0]['qty_available']
+
+        warehouse = self.wh
+        warehouse.delivery_steps = 'pick_ship'
+        product = self.env['product.product'].create({'name': 'Test', 'is_storable': True})
+
+        with freeze_time(fields.Date.today() - timedelta(days=7)):
+            move_in = self.env['stock.move'].create({
+                'name': 'test_in',
+                'picking_type_id': warehouse.in_type_id.id,
+                'location_id': self.supplier_location.id,
+                'location_dest_id': warehouse.lot_stock_id.id,
+                'product_id': product.id,
+                'product_uom_qty': 100.0,
+            })
+            move_in._action_confirm()
+            move_in.write({'quantity': 100.0, 'picked': True})
+            move_in._action_done()
+
+        move_pick = self.env['stock.move'].create({
+            'name': 'pick',
+            'picking_type_id': warehouse.pick_type_id.id,
+            'location_id': warehouse.lot_stock_id.id,
+            'location_dest_id': warehouse.wh_output_stock_loc_id.id,
+            'location_final_id': self.customer_location.id,
+            'product_id': product.id,
+            'product_uom_qty': 60.0,
+        })
+        move_pick._action_confirm()
+        move_pick.write({'quantity': 60.0, 'picked': True})
+        move_pick._action_done()
+
+        move_out = move_pick.move_dest_ids
+        move_out.write({'quantity': 25.0, 'picked': True})
+        move_out._action_done()
+
+        for date, expected_qty in (
+            (move_in.date - timedelta(days=1), 0.0),
+            (move_out.date - timedelta(days=1), 100.0),
+            (move_out.date, 75.0)
+        ):
+            qty = get_inv_qty_at_date(product.id, date)
+            self.assertEqual(qty, expected_qty)


### PR DESCRIPTION
Before this commit, the available quantity was incorrect when using the "Inventory At" feature with a past date in the inventory report

For products using multi-step delivery routes, the `_compute_quantities_dict()` method incorrectly treated internal moves as outgoing moves As a result, the same outgoing quantity was added multiple times, leading to an overestimation of the available stock

This commit adds a filter to the `domain_move_out_done` domain used for past dates, excluding internal moves based on `location_dest_usage``

## Steps to reproduce:
- Create a new product
- Active the multi-step routes in Settings
- Set the Warehouse's Outgoing Shipments to Pick, Pack, then Deliver
- Create a RFQ for 100 products and Receive Products
- Create a Quotation for 20 products
- Validate each delivery steps
- Go to Inventory -> Report -> Stock
- Click on Inventory At
- Set the date to 2025-01-01
- Search for your product
- The `In Hand` quantity should be 0 but is 40 before the fix

opw-4848473
