### PR TITLE
[FIX] pos_sale: fix UoM conversion for quantity and price from sale order

### DIFF
--- a/addons/pos_sale/static/src/overrides/models/pos_store.js
+++ b/addons/pos_sale/static/src/overrides/models/pos_store.js
@@ -144,13 +144,13 @@ patch(PosStore.prototype, {
                 }
             }
 
-            line.has_valued_move_ids = await this.data.call(
+            converted_line.has_valued_move_ids = await this.data.call(
                 "sale.order.line",
                 "has_valued_move_ids",
-                [line.id]
+                [converted_line.id]
             );
-            newLine.setQuantityFromSOL(line);
-            newLine.set_unit_price(line.price_unit);
+            newLine.setQuantityFromSOL(converted_line);
+            newLine.set_unit_price(converted_line.price_unit);
             newLine.set_discount(line.discount);
 
             const product_unit = line.product_id.uom_id;

--- a/addons/pos_sale/tests/test_pos_sale_flow.py
+++ b/addons/pos_sale/tests/test_pos_sale_flow.py
@@ -1408,3 +1408,32 @@ class TestPoSSale(TestPointOfSaleHttpCommon):
         pos_order_id = self.env['pos.order'].sync_from_ui([pos_order])['pos.order'][0]['id']
         pos_order = self.env['pos.order'].browse(pos_order_id)
         self.assertFalse(pos_order.account_move.invoice_payment_term_id)
+
+    def test_settle_order_with_different_uom(self):
+        """Verify that a qty has changed according to UOM"""
+        product_a = self.env['product.product'].create({
+            'name': 'Product A',
+            'available_in_pos': True,
+            'is_storable': True,
+            'lst_price': 10.0,
+        })
+        test_partner = self.env['res.partner'].create({'name': 'Test Partner'})
+        # Create a sale order
+        sale_order = self.env['sale.order'].create({
+            'partner_id': test_partner.id,
+            'order_line': [Command.create({
+                    'product_id': product_a.id,
+                    'name': product_a.name,
+                    'product_uom_qty': 1,
+                    'product_uom':  self.env.ref('uom.product_uom_dozen').id,
+                    'price_unit': product_a.lst_price,
+                })]
+        })
+        sale_order.action_confirm()
+
+        self.main_pos_config.open_ui()
+        self.start_pos_tour('PoSSettleQuotation', login="accountman")
+        pos_order = self.env['pos.order'].search([('partner_id', '=', test_partner.id)], limit=1)
+
+        self.assertEqual(pos_order.lines[0].qty, 12.0, "quantity should be 12.0")
+        self.assertEqual(pos_order.lines[0].price_unit, 0.83, "price of product should be 0.83")


### PR DESCRIPTION
**Steps to reproduce:**
- Install `pos_sale`.
- Create a sale order for a POS product with quantity 1 and UoM `Dozens`.
- Confirm the order.
- Go to Point of Sale → open a session.
- Click Actions → Quotation/Order and select the recently created sale order.
- Check the POS order line quantity.

**Issue:**
- The POS order line shows quantity as 1 unit, while the sale order line used 1 Dozen, so it should be 12 units.

**Cause:**
- The POS order line was directly using the quantity and price from the sale_order_line without applying the proper UoM conversion.
https://github.com/odoo/odoo/blob/8f937d4c4a6c4cece698a5e904ba7a0cf2fbb24c/addons/pos_sale/static/src/overrides/models/pos_store.js#L152-L153

Solution:
- Updated logic to set quantity and price_unit in the POS order line based on the converted sale order lines after UoM calculations.
https://github.com/odoo/odoo/blob/8f937d4c4a6c4cece698a5e904ba7a0cf2fbb24c/addons/pos_sale/static/src/overrides/models/pos_store.js#L84-L86
- Also updated the value assigning of 'has_valued_move_ids' to converted line
  because quantity calculation is based on 'converted_line'.
https://github.com/odoo/odoo/blob/8f937d4c4a6c4cece698a5e904ba7a0cf2fbb24c/addons/pos_sale/static/src/overrides/models/pos_order_line.js#L50-L53

opw-4900767


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
