### PR TITLE
[FIX] website: prevent crash when switching theme

### DIFF
--- a/addons/website/models/ir_module_module.py
+++ b/addons/website/models/ir_module_module.py
@@ -416,7 +416,6 @@ class IrModuleModule(models.Model):
         self._theme_upgrade_upstream()
 
         result = website.button_go_website()
-        result['params']['with_loader'] = True
         return result
 
     def button_remove_theme(self):

--- a/addons/website/static/src/client_actions/configurator/configurator.js
+++ b/addons/website/static/src/client_actions/configurator/configurator.js
@@ -754,7 +754,7 @@ export class Configurator extends Component {
             }
         });
 
-        const initialStep = this.props.action.context.params && this.props.action.context.params.step;
+        const initialStep = router.current.step;
         const store = reactive(new Store(), () => this.updateStorage(store));
 
         this.state = useState({

--- a/addons/website/static/src/client_actions/website_preview/website_builder_action.js
+++ b/addons/website/static/src/client_actions/website_preview/website_builder_action.js
@@ -45,7 +45,6 @@ export class WebsiteBuilderClientAction extends Component {
         enableEditor: { type: Boolean, optional: true },
         path: { type: String, optional: true },
         websiteId: { type: [Number, { value: false }], optional: true },
-        withLoader: { type: Boolean, optonal: true },
     };
 
     static extractProps(action) {
@@ -54,7 +53,6 @@ export class WebsiteBuilderClientAction extends Component {
             enableEditor: action.params?.enable_editor || false,
             path: action.params?.path,
             websiteId: action.params?.website_id || false,
-            withLoader: action.params?.with_loader || false,
         }
     }
 
@@ -367,10 +365,7 @@ export class WebsiteBuilderClientAction extends Component {
         this.replaceBrowserUrl();
         this.resolveIframeLoaded();
         this.addWelcomeMessage();
-
-        if (this.withLoader) {
-            this.websiteService.hideLoader();
-        }
+        this.websiteService.hideLoader();
     }
 
     blockIframe() {
@@ -458,10 +453,6 @@ export class WebsiteBuilderClientAction extends Component {
         return this.props.websiteId || router.current.website_id || false;
     }
 
-
-    get withLoader() {
-        return this.props.withLoader || !!router.current.with_loader;
-    }
 
     waitForIframeReady() {
         return new Promise((resolve) => {

--- a/addons/website/static/src/components/views/theme_preview_form.js
+++ b/addons/website/static/src/components/views/theme_preview_form.js
@@ -30,7 +30,7 @@ export function useLoaderOnClick() {
                     if (callback) {
                         callback.target = 'main';
                         await action.doAction(callback);
-                        if (callback.tag === 'website_preview' && callback.context.params.with_loader) {
+                        if (callback.tag === 'website_preview') {
                             keepLoader = true;
                         }
                     }

--- a/addons/website/static/src/components/website_loader/website_loader.js
+++ b/addons/website/static/src/components/website_loader/website_loader.js
@@ -137,6 +137,9 @@ export class WebsiteLoader extends Component {
             this.state.showLoader = props && props.showLoader !== false;
         });
         useBus(this.props.bus, "HIDE-WEBSITE-LOADER", () => {
+            if (!this.state.isVisible) {
+                return;
+            }
             for (const key of Object.keys(initialState)) {
                 this.state[key] = initialState[key];
             }

--- a/addons/website/static/tests/tours/website_configurator.js
+++ b/addons/website/static/tests/tours/website_configurator.js
@@ -1,0 +1,10 @@
+import { registry } from "@web/core/registry";
+
+registry.category("web_tour.tours").add("configurator_params_step", {
+    steps: () => [
+        {
+            content: "Check if we are at the palette selection screen",
+            trigger: ".o_palette_selection_screen",
+        },
+    ],
+});

--- a/addons/website/tests/test_configurator.py
+++ b/addons/website/tests/test_configurator.py
@@ -90,6 +90,14 @@ class TestConfiguratorCommon(odoo.tests.HttpCase):
         patcher = patch('odoo.addons.website.models.ir_module_module.IrModuleModule._theme_upgrade_upstream', wraps=self._theme_upgrade_upstream)
         self.startPatcher(patcher)
 
+
+@odoo.tests.common.tagged('post_install', '-at_install')
+class TestConfigurator(TestConfiguratorCommon):
+
+    def test_configurator_params_step(self):
+        self.start_tour('/website/configurator/3', 'configurator_params_step', login='admin')
+
+
 @odoo.tests.common.tagged('post_install', '-at_install')
 class TestConfiguratorTranslation(TestConfiguratorCommon):
 


### PR DESCRIPTION
This commit fixes 2 little oversights of [`1b86bd7`][1] that removed
`params` from `context`:
- We can directly retrieve the configurator initial step from the
`router` service.
- `with_loader` was introduced by [`ccfca27`][2] to make sure the loader
was still visible until the editor is open. Now it's only set by
`button_choose_theme` and always to `True`. We can therefore remove it
and `keepLoader` will still be set to `true` after we call
`button_choose_theme`.


[1]: https://github.com/odoo/odoo/commit/1b86bd7ecf4d
[2]: https://github.com/odoo/odoo/commit/ccfca271b902