### PR TITLE
[FIX] account: Fix receipt selector for refunds

### DIFF
--- a/addons/account/static/src/components/receipt_selector/receipt_selector.xml
+++ b/addons/account/static/src/components/receipt_selector/receipt_selector.xml
@@ -3,7 +3,7 @@
 
     <t t-name="account.ReceiptSelector">
         <div>
-            <t t-if="props.readonly || (!show_sale_receipts.value and ['out_invoice', 'out_receipt'].includes(value))">
+            <t t-if="props.readonly || ['in_refund', 'out_refund'].includes(value) || (!show_sale_receipts.value and ['out_invoice', 'out_receipt'].includes(value))">
                 <span t-esc="string" t-att-raw-value="value" />
             </t>
             <t t-else="">


### PR DESCRIPTION
Currently, when creating a refund, the move type selector shows all possible move_type out there. We obviously don't want that...

Solution: show only the current move type for refunds.

task-4926014

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
