### PR TITLE
[FIX] account: Open CoA from branch without error

### DIFF
--- a/addons/account/models/account_account.py
+++ b/addons/account/models/account_account.py
@@ -104,6 +104,7 @@ class AccountAccount(models.Model):
         context={'append_type_to_tax_name': True})
     note = fields.Text('Internal Notes', tracking=True)
     company_ids = fields.Many2many('res.company', string='Companies', required=True, readonly=False,
+        depends_context=('uid',),  # To avoid cache pollution between sudo / non-sudo uses of the field
         default=lambda self: self.env.company)
     code_mapping_ids = fields.One2many(comodel_name='account.code.mapping', inverse_name='account_id')
     # Ensure `code_mapping_ids` is written before `company_ids` so we don't trigger the `_ensure_code_is_unique`
@@ -1035,6 +1036,10 @@ class AccountAccount(models.Model):
         res = super(AccountAccount, self.with_context(defer_account_code_checks=True)).write(vals)
 
         if not self.env.context.get('defer_account_code_checks') and {'company_ids', 'code', 'code_mapping_ids'} & vals.keys():
+            if 'company_ids' in vals:
+                # Because writing on the field without sudo won't update the sudo cache (and vice versa)
+                # we need to invalidate so that the sudo cache is up-to-date
+                self.invalidate_recordset(fnames=['company_ids'])
             self._ensure_code_is_unique()
 
         return res


### PR DESCRIPTION
#### Steps to reproduce
- Create a branch in a company that has a CoA installed.
- Create a user that only has access to the branch
- Login as the user
- Try to open Accounting > Configuration > Chart of Accounts
- You get an AccessError in your face.

#### Analysis
- When calling `web_search_read` on `account.account`, the `company_ids` field is loaded into cache by `search_fetch`.
- Since the user does not have access to the parent company, the parent company will not be in the account's `company_ids` in cache.
- When calling `_check_access` in `fetch`, the `filtered_domain` (even though it is called behind `sudo`) will use the `company_ids` in cache to determine whether the accounts can be accessed, triggering the `AccessError`.

#### Solution
- Set `depends_context=('uid',)` on the `company_ids` field to keep separate sudo / non-sudo caches for the field.

opw-4730107