### PR TITLE
[FIX] html_builder, website: quote font family names that contain spaces

### DIFF
--- a/addons/html_builder/static/src/plugins/font/font_plugin.js
+++ b/addons/html_builder/static/src/plugins/font/font_plugin.js
@@ -102,7 +102,7 @@ export class BuilderFontPlugin extends Plugin {
             const fontKey = getCSSVariableValue(`font-number-${realFontNb}`, style);
             allFonts.push(fontKey);
             let fontName = fontKey.slice(1, -1); // Unquote
-            const fontFamilyValue = fontName;
+            const fontFamilyValue = `'${fontName}'`;
             let styleFontFamily = fontName;
             const isSystemFonts = fontName === "SYSTEM_FONTS";
             if (isSystemFonts) {

--- a/addons/website/static/src/builder/plugins/customize_website_plugin.js
+++ b/addons/website/static/src/builder/plugins/customize_website_plugin.js
@@ -715,7 +715,10 @@ export class CustomizeWebsiteVariableAction extends BuilderAction {
     }
     isApplied({ params: { mainParam: variable } = {}, value }) {
         const currentValue = this.dependencies.customizeWebsite.getWebsiteVariableValue(variable);
-        return currentValue === value;
+        return (
+            // There might be unquoted values in existing databases.
+            currentValue === value || `'${currentValue}'` === value
+        );
     }
     getValue({ params: { mainParam: variable } }) {
         const currentValue = this.dependencies.customizeWebsite.getWebsiteVariableValue(variable);

--- a/addons/website/static/tests/tours/font_family.js
+++ b/addons/website/static/tests/tours/font_family.js
@@ -17,7 +17,7 @@ registerWebsitePreviewTour(
         },
         {
             content: "Click on the 'Arvo' font we-button from the font selection list.",
-            trigger: ".o_popover [data-action-value='Arvo']",
+            trigger: `.o_popover [data-action-value="'Arvo'"]`,
             run: "click",
         },
         {


### PR DESCRIPTION
Since `html_builder` was merged, font family selection is not implicitly quoted anymore. This is a problem for font families having names that contain spaces.

This commit puts font family names between quotes before calling `customizeWebsiteVariable`.

Steps to reproduce:
- Go to the Theme tab
- Pick "Open Sans" as font family
- Inspect page

=> The used font was not "Open Sans".

task-4367641
