### PR TITLE
[FIX] account: avoid partner_id on journal entry duplication

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -2422,7 +2422,7 @@ class AccountMove(models.Model):
                     if command == Command.CREATE
                 ]
             elif move.move_type == 'entry':
-                if 'partner_id' not in data:
+                if 'partner_id' not in data or not self._context.get('move_reverse_cancel'):
                     data['partner_id'] = False
         if not self.journal_id.active and 'journal_id' in data_list:
             del default['journal_id']

--- a/addons/account/tests/test_account_move_entry.py
+++ b/addons/account/tests/test_account_move_entry.py
@@ -1236,3 +1236,19 @@ class TestAccountMove(AccountTestInvoicingCommon):
         self.assertRecordValues(line, [
             {'amount_currency': 10.00, 'balance': 10.00},
         ])
+
+    def test_no_partner_id_on_duplication(self):
+        """ Test that when a account_move is duplicated the partner_id is not included in the duplicated_move """
+        move = self.env['account.move'].create({
+            'move_type': 'entry',
+            'partner_id': self.partner_a.id,
+            'date': fields.Date.from_string('2019-01-01'),
+            'currency_id': self.currency_data['currency'].id,
+            'line_ids': [
+                Command.create(self.entry_line_vals_1),
+                Command.create(self.entry_line_vals_2),
+            ],
+        })
+        move_duplicate = move.copy()
+        self.assertTrue(move_duplicate)
+        self.assertFalse(move_duplicate.partner_id)


### PR DESCRIPTION
When changing `partner_id` on the `account.move.line`s of a duplicated journal entry if this journal entry already had a partner_id, it will stay the same (possible to see from list view) but the move line will be correctly changed.

Step to reproduce:

- Select a journal entry of type PBNK
- Duplicate the journal entry
- Change the partner on the journal items and save
- Go back to the list view, the partner name displayed is from the original journal entry

When clicking on duplicate it will call the function copy and super.copy() will call copy_data from account_move;

This line allow to copy the partner_id (which is needed since invoices revert goes through copy) Since there is no condition on the type of entry, it will also copy the partner_id in our case:
https://github.com/odoo/odoo/blob/22c333d0ed7eba1165f6462e668998d37fcabb73/addons/account/models/account_move.py#L2424-L2426

The introduction of this change introduced our issue, It allow for all duplication to copy the partner_id.
Original fix : https://github.com/odoo/odoo/commit/e1d18960b57b36b8bf69bc787ef6078dcba8c855

opw-4907648