### PR TITLE
[FIX] html_builder, website, *: fix custom dynamic snippets on save

### DIFF
--- a/addons/website/static/src/builder/plugins/edit_interaction_plugin.js
+++ b/addons/website/static/src/builder/plugins/edit_interaction_plugin.js
@@ -18,11 +18,21 @@ export class EditInteractionPlugin extends Plugin {
             // The clonedEl is implicitly started because it is a newly
             // inserted content.
         },
+        // Resource definitions:
+        skip_refresh_on_snippet_save: [
+            // List of snippet selectors for which interaction refresh should be
+            // disabled on save. This is mainly because the interaction clears
+            // the content before it can be cloned and saved.
+        ],
         on_will_save_snippet_handlers: ({ snippetEl }) => {
-            this.stopInteractions(snippetEl);
+            if (!snippetEl.matches(this.getResource("skip_refresh_on_snippet_save").join(", "))) {
+                this.stopInteractions(snippetEl);
+            }
         },
         on_saved_snippet_handlers: ({ snippetEl }) => {
-            this.restartInteractions(snippetEl);
+            if (!snippetEl.matches(this.getResource("skip_refresh_on_snippet_save").join(", "))) {
+                this.restartInteractions(snippetEl);
+            }
         },
     };
 

--- a/addons/website/static/src/builder/plugins/options/dynamic_snippet_carousel_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/dynamic_snippet_carousel_option_plugin.js
@@ -26,6 +26,7 @@ class DynamicSnippetCarouselOptionPlugin extends Plugin {
         }),
         dynamic_snippet_template_updated: this.onTemplateUpdated.bind(this),
         on_snippet_dropped_handlers: this.onSnippetDropped.bind(this),
+        skip_refresh_on_snippet_save: [this.selector],
     };
     onTemplateUpdated({ el, template }) {
         if (el.matches(this.selector)) {

--- a/addons/website/static/src/builder/plugins/options/dynamic_snippet_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/dynamic_snippet_option_plugin.js
@@ -35,6 +35,7 @@ class DynamicSnippetOptionPlugin extends Plugin {
             CustomizeTemplateAction,
         },
         on_snippet_dropped_handlers: this.onSnippetDropped.bind(this),
+        skip_refresh_on_snippet_save: [this.selector],
     };
     setup() {
         this.dynamicFiltersCache = new Cache(this._fetchDynamicFilters, JSON.stringify);

--- a/addons/website_blog/static/src/website_builder/dynamic_snippet_blog_posts_option_plugin.js
+++ b/addons/website_blog/static/src/website_builder/dynamic_snippet_blog_posts_option_plugin.js
@@ -22,6 +22,7 @@ class DynamicSnippetBlogPostsOptionPlugin extends Plugin {
             selector: this.selector,
         }),
         on_snippet_dropped_handlers: this.onSnippetDropped.bind(this),
+        skip_refresh_on_snippet_save: [this.selector],
     };
     setup() {
         this.blogs = undefined;

--- a/addons/website_event/static/src/website_builder/dynamic_snippet_events_option_plugin.js
+++ b/addons/website_event/static/src/website_builder/dynamic_snippet_events_option_plugin.js
@@ -21,6 +21,7 @@ class DynamicSnippetEventsOptionPlugin extends Plugin {
             selector: this.selector,
         }),
         on_snippet_dropped_handlers: this.onSnippetDropped.bind(this),
+        skip_refresh_on_snippet_save: [this.selector],
     };
     async onSnippetDropped({ snippetEl }) {
         if (snippetEl.matches(this.selector)) {

--- a/addons/website_sale/static/src/website_builder/dynamic_snippet_products_option_plugin.js
+++ b/addons/website_sale/static/src/website_builder/dynamic_snippet_products_option_plugin.js
@@ -24,6 +24,7 @@ class DynamicSnippetProductsOptionPlugin extends Plugin {
         }),
         dynamic_snippet_template_updated: this.onTemplateUpdated.bind(this),
         on_snippet_dropped_handlers: this.onSnippetDropped.bind(this),
+        skip_refresh_on_snippet_save: [this.selector],
     };
     setup() {
         this.categories = undefined;


### PR DESCRIPTION
*: website_blog, website_event, website_sale

Steps to reproduce:

1. In the website "Edit" mode, drop a dynamic snippet and try to save it
as a custom block.

3. Click on the "Custom" snippet category to add the saved block.

4. The snippet will be empty in the dialog, but once selected and added
to the DOM, its content will be displayed correctly.

Starting from [1], new handlers were introduced before and after cloning
a snippet for saving (`EditInteractionPlugin` used them to stop the
interactions before saving a custom snippet and restart the interactions
after saving it).

Since the "dynamic snippets" interaction empties its content on
`destroy()`, the code will clone empty content after stopping the
interactions.

This behavior was impossible to notice before [2], which fixed the fact
that a "dynamic snippet" block was stopped right after drop when its
content was added to the DOM...

The goal of this commit is to simply allow disabling the refresh of
interactions in this case.

[1]: https://github.com/odoo/odoo/commit/f7fd3cb7a6bb52043f4a50f14bce590c1084def4
[2]: https://github.com/odoo/odoo/commit/4a616bf256ee0351623aee0a44caabbba88c0072

related to task-4280375