### PR TITLE
[IMP] hr_expense: create receipts for employee paid expenses

### DIFF
--- a/addons/hr_expense/tests/test_expenses.py
+++ b/addons/hr_expense/tests/test_expenses.py
@@ -96,7 +96,7 @@ class TestExpenses(TestExpenseCommon):
             {'state': 'approved', 'account_move_id': False},
             {'state': 'approved', 'account_move_id': False},
         ])
-        # Post a payment for 'company_account' (and its move(s)) and a vendor bill for 'own_account'
+        # Post a payment for 'company_account' (and its move(s)) and a receipt  for 'own_account'
         expenses_by_company.action_post()
         self.post_expenses_with_wizard(expenses_by_employee[0], date=date(2021, 10, 10))
         self.post_expenses_with_wizard(expenses_by_employee[1], date=date(2021, 10, 31))

--- a/addons/hr_expense/wizard/hr_expense_post_wizard.py
+++ b/addons/hr_expense/wizard/hr_expense_post_wizard.py
@@ -45,15 +45,15 @@ class HrExpensePostWizard(models.TransientModel):
         expenses = self.env['hr.expense'].browse(self.env.context['active_ids'])
         if not self.env['account.move'].has_access('create'):
             raise UserError(_("You don't have the rights to create accounting entries."))
-        expense_bill_vals_list  = [
+        expense_receipt_vals_list = [
             {
-                **new_bill_vals,
+                **new_receipt_vals,
                 'journal_id': self.employee_journal_id.id,
                 'invoice_date': self.accounting_date,
             }
-            for new_bill_vals in expenses._prepare_bills_vals()
+            for new_receipt_vals in expenses._prepare_receipts_vals()
         ]
-        moves = self.env['account.move'].sudo().create(expense_bill_vals_list)
+        moves = self.env['account.move'].sudo().create(expense_receipt_vals_list)
         for move in moves:
             move._message_set_main_attachment_id(move.attachment_ids, force=True, filter_xml=False)
         moves.action_post()


### PR DESCRIPTION
Employee-paid expenses previously generated vendor bills to reflect company debt, but this caused confusion and legal issues in some countries.

To address this, employee-paid expenses will now create receipts instead of vendor bills.

task-4686900



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
