### PR TITLE
[FIX] im_livechat: fix non deterministic chat bot step tour

### DIFF
--- a/addons/im_livechat/static/tests/tours/im_livechat_chatbot_steps_sequence_tour.js
+++ b/addons/im_livechat/static/tests/tours/im_livechat_chatbot_steps_sequence_tour.js
@@ -1,6 +1,44 @@
+import { waitFor } from "@odoo/hoot-dom";
+
 import { registry } from "@web/core/registry";
 
 import { stepUtils } from "@web_tour/tour_service/tour_utils";
+
+function createChatbotSteps(...stepMessages) {
+    return [
+        {
+            trigger: "div[name='script_step_ids'] .o_field_x2many_list_row_add a",
+            run: "click",
+        },
+        ...stepMessages
+            .map((message) => [
+                {
+                    trigger: ".modal textarea#message_0",
+                    run: `edit ${message}`,
+                },
+                {
+                    trigger: `.modal textarea#message_0`,
+                    run: () => waitFor(`.modal textarea#message_0:value(${message})`),
+                },
+                {
+                    trigger: ".modal button:contains(Save & New)",
+                    run: "click",
+                },
+                {
+                    trigger: `tr:contains(${message})`,
+                },
+                {
+                    trigger: ".modal textarea#message_0",
+                    run: () => waitFor(".modal textarea#message_0:value()"),
+                },
+            ])
+            .flat(),
+        {
+            trigger: ".modal-footer button:contains(Discard)",
+            run: "click",
+        },
+    ];
+}
 
 const commonSteps = [
     stepUtils.showAppsMenuItem(),
@@ -24,36 +62,7 @@ const commonSteps = [
         trigger: 'input[id="title_0"]',
         run: "edit Test Chatbot Sequence",
     },
-    {
-        trigger: 'div[name="script_step_ids"] .o_field_x2many_list_row_add a',
-        run: "click",
-    },
-    {
-        trigger: ".modal textarea#message_0",
-        run: "edit Step 1",
-    },
-    {
-        trigger: ".modal button:contains(Save & New):enabled",
-        run: "click",
-    },
-    {
-        trigger: 'tr:contains("Step 1")',
-    },
-    {
-        trigger: ".modal textarea#message_0",
-        run: "edit Step 2",
-    },
-    {
-        trigger: ".modal button:contains(Save & New):enabled",
-        run: "click",
-    },
-    {
-        trigger: 'tr:contains("Step 2")',
-    },
-    {
-        trigger: ".modal textarea#message_0",
-        run: "edit Step 3",
-    },
+    ...createChatbotSteps("Step 1", "Step 2", "Step 3"),
 ];
 
 /**
@@ -63,10 +72,6 @@ registry.category("web_tour.tours").add("im_livechat_chatbot_steps_sequence_tour
     url: "/odoo",
     steps: () => [
         ...commonSteps,
-        {
-            trigger: ".modal button:contains(Save & Close)",
-            run: "click",
-        },
         {
             trigger: "body.o_web_client:not(.modal-open)",
         },
@@ -80,32 +85,7 @@ registry.category("web_tour.tours").add("im_livechat_chatbot_steps_sequence_with
     url: "/odoo",
     steps: () => [
         ...commonSteps,
-        {
-            trigger: ".modal button:contains(Save & New)",
-            run: "click",
-        },
-        {
-            trigger: 'tr:contains("Step 3")',
-        },
-        {
-            trigger: ".modal textarea#message_0",
-            run: "edit Step 4",
-        },
-        {
-            trigger: 'button:contains("Save & New")',
-            run: "click",
-        },
-        {
-            trigger: 'tr:contains("Step 4")',
-        },
-        {
-            trigger: ".modal textarea#message_0",
-            run: "edit Step 5",
-        },
-        {
-            trigger: ".modal button:contains(Save & Close)",
-            run: "click",
-        },
+        ...createChatbotSteps("Step 4", "Step 5"),
         {
             trigger: "body.o_web_client:not(.modal-open)",
         },
@@ -113,18 +93,7 @@ registry.category("web_tour.tours").add("im_livechat_chatbot_steps_sequence_with
             trigger: 'div[name="script_step_ids"] tr:nth-child(5) .o_row_handle',
             run: 'drag_and_drop(div[name="script_step_ids"] tr:nth-child(2))',
         },
-        {
-            trigger: 'div[name="script_step_ids"] .o_field_x2many_list_row_add a',
-            run: "click",
-        },
-        {
-            trigger: ".modal textarea#message_0",
-            run: "edit Step 6",
-        },
-        {
-            trigger: ".modal button:contains(Save & Close)",
-            run: "click",
-        },
+        ...createChatbotSteps("Step 6"),
         {
             trigger: "body.o_web_client:not(.modal-open)",
         },

--- a/addons/im_livechat/tests/test_chatbot_form_ui.py
+++ b/addons/im_livechat/tests/test_chatbot_form_ui.py
@@ -15,7 +15,6 @@ class TestLivechatChatbotFormUI(HttpCaseWithUserDemo):
             '/odoo',
             'im_livechat_chatbot_steps_sequence_tour',
             login='admin',
-            step_delay=1000
         )
 
         chatbot_script = self.env['chatbot.script'].search([('title', '=', 'Test Chatbot Sequence')])
@@ -39,7 +38,6 @@ class TestLivechatChatbotFormUI(HttpCaseWithUserDemo):
             '/odoo',
             'im_livechat_chatbot_steps_sequence_with_move_tour',
             login='admin',
-            step_delay=1000
         )
 
         chatbot_script = self.env['chatbot.script'].search([('title', '=', 'Test Chatbot Sequence')])


### PR DESCRIPTION
This commit fixes the `test_chatbot_steps_sequence_ui` and the `test_chatbot_steps_sequence_with_move_ui` tours. Those tours create chat bot steps to check their order. To do so, they edit the textarea and click on the save button. However, under high load, the button can be clicked before the textarea is updated. When this occurs, the validation fails and the step is not created.

This commit fixes the issue by waiting for the textarea content to update before clicking on the save button.

fixes runbot-228498

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
