### PR TITLE
[REF] http: remove environment properties from Request

### DIFF
--- a/addons/auth_signup/controllers/main.py
+++ b/addons/auth_signup/controllers/main.py
@@ -155,7 +155,7 @@ class AuthSignupHome(Home):
         if values.get('password') != qcontext.get('confirm_password'):
             raise UserError(_("Passwords do not match; please retype them."))
         supported_lang_codes = [code for code, _ in request.env['res.lang'].get_installed()]
-        lang = request.context.get('lang', '')
+        lang = request.env.context.get('lang', '')
         if lang in supported_lang_codes:
             values['lang'] = lang
         return values

--- a/addons/base_import_module/controllers/main.py
+++ b/addons/base_import_module/controllers/main.py
@@ -16,8 +16,8 @@ class ImportModule(Controller):
                 raise Exception(_("Could not select database '%s'", request.db))
             credential = {'login': login, 'password': password, 'type': 'password'}
             request.session.authenticate(request.env, credential)
-            # request.uid is None in case of MFA
-            if request.uid and request.env.user._is_admin():
+            # request.env.uid is None in case of MFA
+            if request.env.uid and request.env.user._is_admin():
                 return request.env['ir.module.module']._import_zipfile(mod_file, force=force == '1')[0]
             raise AccessError(_("Only administrators can upload a module"))
         except Exception as e:

--- a/addons/base_setup/controllers/main.py
+++ b/addons/base_setup/controllers/main.py
@@ -12,7 +12,7 @@ class BaseSetup(http.Controller):
         if not request.env.user.has_group('base.group_erp_manager'):
             raise AccessError(_("Access Denied"))
 
-        cr = request.cr
+        cr = self.env.cr
         cr.execute("""
             SELECT count(*)
               FROM res_users

--- a/addons/event/controllers/main.py
+++ b/addons/event/controllers/main.py
@@ -13,7 +13,7 @@ class EventController(Controller):
 
     @route(['''/event/<model("event.event"):event>/ics'''], type='http', auth="public")
     def event_ics_file(self, event, **kwargs):
-        lang = request.context.get('lang', request.env.user.lang)
+        lang = request.env.context.get('lang', request.env.user.lang)
         if request.env.user._is_public():
             lang = request.cookies.get('frontend_lang')
         event = event.with_context(lang=lang)

--- a/addons/html_editor/controllers/main.py
+++ b/addons/html_editor/controllers/main.py
@@ -214,7 +214,7 @@ class HTML_Editor(http.Controller):
 
     def _clean_context(self):
         # avoid allowed_company_ids which may erroneously restrict based on website
-        context = dict(request.context)
+        context = dict(request.env.context)
         context.pop('allowed_company_ids', None)
         request.update_env(context=context)
 

--- a/addons/http_routing/tests/common.py
+++ b/addons/http_routing/tests/common.py
@@ -62,9 +62,6 @@ def MockRequest(
         db=env.registry.db_name,
         env=env,
         registry=env.registry,
-        cr=env.cr,
-        uid=env.uid,
-        context=env.context,
         cookies=cookies,
         lang=env['res.lang']._get_data(code=lang_code),
         website=website,
@@ -100,8 +97,7 @@ def MockRequest(
         match.side_effect = NotFound
 
     def update_context(**overrides):
-        request.env = request.env(context=dict(request.context, **overrides))
-        request.context = request.env.context
+        request.env = request.env(context=dict(request.env.context, **overrides))
 
     request.update_context = update_context
 

--- a/addons/mail_plugin/controllers/authenticate.py
+++ b/addons/mail_plugin/controllers/authenticate.py
@@ -106,7 +106,7 @@ class Authenticate(http.Controller):
             'name': name,
             'timestamp': int(datetime.datetime.utcnow().timestamp()),
             # <- elapsed time should be < 3 mins when verifying
-            'uid': request.uid,
+            'uid': request.env.uid,
         }
         auth_message = json.dumps(auth_dict, sort_keys=True).encode()
         signature = odoo.tools.misc.hmac(request.env(su=True), 'mail_plugin', auth_message).encode()

--- a/addons/mail_plugin/controllers/mail_plugin.py
+++ b/addons/mail_plugin/controllers/mail_plugin.py
@@ -454,7 +454,7 @@ class MailPluginController(http.Controller):
         return ['mail_plugin']
 
     def _prepare_translations(self):
-        lang = request.env['res.users'].browse(request.uid).lang
+        lang = request.env['res.users'].browse(request.env.uid).lang
         translations_per_module = request.env["ir.http"].get_translations_for_webclient(
             self._translation_modules_whitelist(), lang)[0]
         translations_dict = {}

--- a/addons/payment_adyen/controllers/main.py
+++ b/addons/payment_adyen/controllers/main.py
@@ -43,7 +43,7 @@ class AdyenController(http.Controller):
         # Adyen only supports a limited set of languages but, instead of looking for the closest
         # match in https://docs.adyen.com/checkout/components-web/localization-components, we simply
         # provide the lang string as is (after adapting the format) and let Adyen find the best fit.
-        lang_code = py_to_js_locale(request.context.get('lang')) or 'en-US'
+        lang_code = py_to_js_locale(request.env.context.get('lang')) or 'en-US'
         shopper_reference = partner_sudo and f'ODOO_PARTNER_{partner_sudo.id}'
         partner_country_code = (
             partner_sudo.country_id.code or provider_sudo.company_id.country_id.code or 'NL'

--- a/addons/test_website/controllers/main.py
+++ b/addons/test_website/controllers/main.py
@@ -42,7 +42,7 @@ class WebsiteTest(Home):
 
     @http.route('/multi_company_website', type='http', auth="public", website=True, sitemap=False)
     def test_company_context(self):
-        return request.make_response(json.dumps(request.context.get('allowed_company_ids')))
+        return request.make_response(json.dumps(request.env.context.get('allowed_company_ids')))
 
     @http.route('/test_lang_url/<model("res.country"):country>', type='http', auth='public', website=True, sitemap=False)
     def test_lang_url(self, **kwargs):

--- a/addons/web_editor/controllers/main.py
+++ b/addons/web_editor/controllers/main.py
@@ -259,10 +259,9 @@ class Web_Editor(http.Controller):
             attachments_to_remove.unlink()
         return removal_blocked_by
 
-
     def _clean_context(self):
         # avoid allowed_company_ids which may erroneously restrict based on website
-        context = dict(request.context)
+        context = dict(request.env.context)
         context.pop('allowed_company_ids', None)
         request.update_env(context=context)
 

--- a/addons/website/models/ir_http.py
+++ b/addons/website/models/ir_http.py
@@ -178,7 +178,7 @@ class IrHttp(models.AbstractModel):
             if website:
                 request.update_env(user=website._get_cached('user_id'))
 
-        if not request.uid:
+        if not request.env.uid:
             super()._auth_method_public()
 
     @classmethod
@@ -236,7 +236,7 @@ class IrHttp(models.AbstractModel):
     def _frontend_pre_dispatch(cls):
         super()._frontend_pre_dispatch()
 
-        if not request.context.get('tz'):
+        if not request.env.context.get('tz'):
             with contextlib.suppress(pytz.UnknownTimeZoneError):
                 request.update_context(tz=pytz.timezone(request.geoip.location.time_zone).zone)
 
@@ -263,7 +263,7 @@ class IrHttp(models.AbstractModel):
             **cls._get_web_editor_context(),
         )
 
-        request.website = website.with_context(request.context)
+        request.website = website.with_context(request.env.context)
 
     @classmethod
     def _post_dispatch(cls, response):
@@ -414,7 +414,7 @@ class IrHttp(models.AbstractModel):
                     )
                     values['view'] = values['view'] and values['view'][0]
         # Needed to show reset template on translated pages (`_prepare_environment` will set it for main lang)
-        values['editable'] = request.uid and request.env.user.has_group('website.group_website_designer')
+        values['editable'] = request.env.uid and request.env.user.has_group('website.group_website_designer')
         return values
 
     @classmethod

--- a/addons/website/models/ir_module_module.py
+++ b/addons/website/models/ir_module_module.py
@@ -76,7 +76,7 @@ class IrModuleModule(models.Model):
 
                     -> We want to upgrade every website using this theme.
         """
-        if request and request.db and request.env and request.context.get('apply_new_theme'):
+        if request and request.db and request.env and request.env.context.get('apply_new_theme'):
             self = self.with_context(apply_new_theme=True)
 
         for module in self:

--- a/addons/website/tests/test_lang_url.py
+++ b/addons/website/tests/test_lang_url.py
@@ -46,8 +46,8 @@ class TestLangUrl(HttpCase):
 
     def test_04_url_cook_lang_not_available(self):
         """ `nearest_lang` should filter out lang not available in frontend.
-        Eg: 1. go in backend in english -> request.context['lang'] = `en_US`
-            2. go in frontend, the request.context['lang'] is passed through
+        Eg: 1. go in backend in english -> request.env.context['lang'] = `en_US`
+            2. go in frontend, the request.env.context['lang'] is passed through
                `nearest_lang` which should not return english. More then a
                misbehavior it will crash in website language selector template.
         """

--- a/addons/website_blog/controllers/main.py
+++ b/addons/website_blog/controllers/main.py
@@ -35,7 +35,7 @@ class WebsiteBlog(http.Controller):
             dom, groupby=['post_date:month'])
 
         locale = get_lang(request.env).code
-        tzinfo = pytz.timezone(request.context.get('tz', 'utc') or 'utc')
+        tzinfo = pytz.timezone(request.env.context.get('tz', 'utc') or 'utc')
         fmt = tools.DEFAULT_SERVER_DATETIME_FORMAT
 
         res = defaultdict(list)

--- a/addons/website_crm/controllers/website_form.py
+++ b/addons/website_crm/controllers/website_form.py
@@ -76,7 +76,7 @@ class WebsiteForm(form.WebsiteForm):
                     values['partner_id'] = visitor_partner.id
             if 'company_id' not in values:
                 values['company_id'] = request.website.company_id.id
-            lang = request.context.get('lang', False)
+            lang = request.env.context.get('lang', False)
             values['lang_id'] = values.get('lang_id') or request.env['res.lang']._get_data(code=lang).id
 
         result = super().insert_record(request, model_sudo, values, custom, meta=meta)

--- a/addons/website_event_track/controllers/event_track.py
+++ b/addons/website_event_track/controllers/event_track.py
@@ -451,7 +451,7 @@ class EventTrackController(http.Controller):
             return {'success': False, 'message': error_message}
 
         template.sudo().with_context(
-            lang=request.cookies.get('frontend_lang') if request.env.user._is_public() else request.context.get('lang', request.env.user.lang)
+            lang=request.cookies.get('frontend_lang') if request.env.user._is_public() else request.env.context.get('lang', request.env.user.lang)
         ).send_mail(track.id, email_values={'email_to': valid_email_to})
         return {'success': True}
 
@@ -538,7 +538,7 @@ class EventTrackController(http.Controller):
 
     @http.route(['''/event/<model("event.event"):event>/track/<model("event.track"):track>/ics'''], type='http', auth="public")
     def event_track_ics_file(self, event, track):
-        lang = request.context.get('lang', request.env.user.lang)
+        lang = request.env.context.get('lang', request.env.user.lang)
         if request.env.user._is_public():
             lang = request.cookies.get('frontend_lang')
         track = track.with_context(lang=lang)

--- a/addons/website_profile/controllers/main.py
+++ b/addons/website_profile/controllers/main.py
@@ -116,7 +116,7 @@ class WebsiteProfile(http.Controller):
         if 'image_1920' in kwargs:
             values['image_1920'] = kwargs.get('image_1920')
 
-        if request.uid == user.id:  # the controller allows to edit only its own privacy settings; use partner management for other cases
+        if request.env.uid == user.id:  # the controller allows to edit only its own privacy settings; use partner management for other cases
             values['website_published'] = kwargs.get('website_published')
         return values
 

--- a/odoo/addons/base/models/ir_http.py
+++ b/odoo/addons/base/models/ir_http.py
@@ -68,7 +68,7 @@ class ModelConverter(werkzeug.routing.BaseConverter):
 
     def to_python(self, value: str) -> models.BaseModel:
         _uid = RequestUID(value=value, converter=self)
-        env = api.Environment(request.cr, _uid, request.context)
+        env = api.Environment(request.env.cr, _uid, request.env.context)
         return env[self.model].browse(self.unslug(value)[1])
 
     def to_url(self, value: models.BaseModel) -> str:
@@ -84,7 +84,7 @@ class ModelsConverter(werkzeug.routing.BaseConverter):
 
     def to_python(self, value: str) -> models.BaseModel:
         _uid = RequestUID(value=value, converter=self)
-        env = api.Environment(request.cr, _uid, request.context)
+        env = api.Environment(request.env.cr, _uid, request.env.context)
         return env[self.model].browse(int(v) for v in value.split(','))
 
     def to_url(self, value: models.BaseModel) -> str:

--- a/odoo/http.py
+++ b/odoo/http.py
@@ -1729,6 +1729,7 @@ class Request:
 
     @property
     def context(self):
+        warnings.warn("Since 19.0, use request.env.context directly", DeprecationWarning, stacklevel=2)
         return self.env.context
 
     @context.setter
@@ -1737,6 +1738,7 @@ class Request:
 
     @property
     def uid(self):
+        warnings.warn("Since 19.0, use request.env.uid directly", DeprecationWarning, stacklevel=2)
         return self.env.uid
 
     @uid.setter
@@ -1745,6 +1747,7 @@ class Request:
 
     @property
     def cr(self):
+        warnings.warn("Since 19.0, use request.env.cr directly", DeprecationWarning, stacklevel=2)
         return self.env.cr
 
     @cr.setter


### PR DESCRIPTION
These properties are accessible on the `Request.env` already. This just adds an overhead and is not often used.

odoo/enterprise#89656

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
