### PR TITLE
[FIX] account_edi_ubl_cii: fix FacturX validation issues

### DIFF
--- a/addons/account_edi_ubl_cii/data/cii_22_templates.xml
+++ b/addons/account_edi_ubl_cii/data/cii_22_templates.xml
@@ -5,7 +5,9 @@
             <t t-set="line" t-value="line_vals['line']"/>
             <t  xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100"
                 xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100"
-                xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100">
+                xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100"
+                xmlns:qdt="urn:un:unece:uncefact:data:standard:QualifiedDataType:100"
+                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
                 <ram:IncludedSupplyChainTradeLineItem>
                     <!-- Line number. -->
@@ -104,7 +106,9 @@
         <template id="account_invoice_partner_facturx_export_22">
             <t  xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100"
                 xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100"
-                xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100">
+                xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100"
+                xmlns:qdt="urn:un:unece:uncefact:data:standard:QualifiedDataType:100"
+                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
                 <!-- Contact. -->
                 <ram:Name t-out="partner.display_name"/>
                 <ram:SpecifiedLegalOrganization t-if="specified_legal_organization_val">
@@ -130,7 +134,9 @@
         <template id="account_invoice_address_facturx_export_22">
             <t  xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100"
                 xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100"
-                xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100">
+                xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100"
+                xmlns:qdt="urn:un:unece:uncefact:data:standard:QualifiedDataType:100"
+                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
                 <!-- Address. -->
                 <ram:PostalTradeAddress>
                     <ram:PostcodeCode t-out="partner.zip"/>
@@ -147,7 +153,9 @@
             <rsm:CrossIndustryInvoice
                 xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100"
                 xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100"
-                xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100">
+                xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100"
+                xmlns:qdt="urn:un:unece:uncefact:data:standard:QualifiedDataType:100"
+                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
                 <!-- Factur-x level:
                     * minimum or basicwl:   urn:factur-x.eu:1p0...
                     * basic:                urn:cen.eu:en16931:2017:compliant:factur-x.eu:1p0:basic
@@ -246,7 +254,7 @@
 
                         <!-- Bank account. -->
                         <ram:SpecifiedTradeSettlementPaymentMeans t-if="record.partner_bank_id.sanitized_acc_number">
-                            <ram:TypeCode>42</ram:TypeCode>
+                            <ram:TypeCode t-out="payment_means_code"/>
                             <ram:PayeePartyCreditorFinancialAccount>
                                 <ram:IBANID
                                     t-if="record.partner_bank_id.acc_type == 'iban'"

--- a/addons/account_edi_ubl_cii/models/account_edi_xml_cii_facturx.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_cii_facturx.py
@@ -11,6 +11,12 @@ _logger = logging.getLogger(__name__)
 
 DEFAULT_FACTURX_DATE_FORMAT = '%Y%m%d'
 
+# Imcomplete, full list on https://service.unece.org/trade/untdid/d16b/tred/tred4461.htm
+PAYMENT_MEAN_CODES = {
+    'Payment to bank account': 42,
+    'SEPA direct debit': 59
+}
+
 
 class AccountEdiXmlCII(models.AbstractModel):
     _name = "account.edi.xml.cii"
@@ -234,6 +240,11 @@ class AccountEdiXmlCII(models.AbstractModel):
         # Fixed taxes: set the total adjusted amounts on the document level
         template_values['tax_basis_total_amount'] = tax_details['base_amount_currency']
         template_values['tax_total_amount'] = tax_details['tax_amount_currency']
+
+        if invoice._fields.get('sdd_mandate_id') and invoice.sdd_mandate_id:
+            template_values['payment_means_code'] = PAYMENT_MEAN_CODES['SEPA direct debit']
+        else:
+            template_values['payment_means_code'] = PAYMENT_MEAN_CODES['Payment to bank account']
 
         return template_values
 


### PR DESCRIPTION
### Issue:
There are several issues with the XML of FacturX.

### Steps to reproduce:
- Create a partner with a direct debit mandate
- In the Accounting tab of the partner select "FacturX" as eInvoice format
- Create an invoice with this partner, pay with SDD, confirm
- Send to FacturX
- Verify the PDF with https://www.portinvoice.com/
	1 Missing namespaces
3. In the XML the code for the payment means does not adapt to the payment method: 42 (Payment to bank account) and not 59 (SDD)

### Cause:
1. The namespaces are not there ([doc](https://fnfe-mpe.org/factur-x/factur-x_en/)).
3. We always input "42" as payment mean

### Solution:
1. Added namespaces `xmlns:qdt="urn:un:unece:uncefact:data:standard:QualifiedDataType:100"` and `xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"`
3. Added the code "59" for SDD, a lot of codes could be added but this commit only handles this one

Ticket [link](https://www.odoo.com/odoo/project/967/tasks/4907827)
opw-4907827