### PR TITLE
[IMP] hw_drivers: remove USB prefix

### DIFF
--- a/addons/hw_drivers/iot_handlers/drivers/PrinterDriver_L.py
+++ b/addons/hw_drivers/iot_handlers/drivers/PrinterDriver_L.py
@@ -47,8 +47,7 @@ class PrinterDriver(Driver):
         self.device_type = 'printer'
         self.device_connection = device['device-class'].lower()
         self.connected_by_usb = self.device_connection == 'direct'
-        connection_prefix = "[USB] " if self.connected_by_usb else ""
-        self.device_name = connection_prefix + device['device-make-and-model']
+        self.device_name = device['device-make-and-model']
         self.state = {
             'status': 'connecting',
             'message': 'Connecting to printer',

--- a/addons/hw_drivers/iot_handlers/drivers/PrinterDriver_W.py
+++ b/addons/hw_drivers/iot_handlers/drivers/PrinterDriver_W.py
@@ -40,8 +40,7 @@ class PrinterDriver(Driver):
         super().__init__(identifier, device)
         self.device_type = 'printer'
         self.device_connection = self._compute_device_connection(device)
-        connection_prefix = "[USB] " if self.device_connection == 'direct' else ""
-        self.device_name = connection_prefix + device.get('identifier')
+        self.device_name = device.get('identifier')
         self.printer_handle = device.get('printer_handle')
         self.state = {
             'status': 'connecting',


### PR DESCRIPTION
Now that the frontend is showing the device connection type, we can remove this prefix since it is showing duplicate information.

task-4922608

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
