### PR TITLE
[FIX] pos_loyalty: load loyalty program for a PoS user

### DIFF
--- a/addons/pos_loyalty/models/loyalty_program.py
+++ b/addons/pos_loyalty/models/loyalty_program.py
@@ -28,6 +28,15 @@ class LoyaltyProgram(models.Model):
             'portal_visible', 'portal_point_name', 'trigger_product_ids', 'rule_ids', 'reward_ids'
         ]
 
+    @api.model
+    def _load_pos_data(self, data):
+        domain = self._load_pos_data_domain(data)
+        fields = self._load_pos_data_fields(data['pos.config']['data'][0]['id'])
+        return {
+            'data': self.sudo().search_read(domain, fields, load=False),
+            'fields': fields,
+        }
+
     @api.depends("communication_plan_ids.pos_report_print_id")
     def _compute_pos_report_print_id(self):
         for program in self:

--- a/addons/pos_loyalty/models/pos_config.py
+++ b/addons/pos_loyalty/models/pos_config.py
@@ -89,7 +89,7 @@ class PosConfig(models.Model):
         if (
             (coupon.expiration_date and coupon.expiration_date < check_date)
             or (program.date_to and program.date_to < today_date)
-            or (program.limit_usage and program.total_order_count >= program.max_usage)
+            or (program.limit_usage and program.sudo().total_order_count >= program.max_usage)
         ):
             error_message = _("This coupon is expired (%s).", code)
         elif program.date_from and program.date_from > today_date:


### PR DESCRIPTION
Before this commit, the loyalty program was not loaded for PoS users who lacked access rights to sale documents. This issue occurred because the system attempted to read the `total_order_count` field, which is computed based on sale orders, causing a failure in loading the loyalty program.

opw-4847852

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
