### PR TITLE
[FIX] point_of_sale: minimal rights employee should not put `qty < 0`

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
@@ -11,6 +11,7 @@ import {
     Numpad,
     getButtons,
     DEFAULT_LAST_ROW,
+    SWITCHSIGN,
 } from "@point_of_sale/app/components/numpad/numpad";
 import { ActionpadWidget } from "@point_of_sale/app/screens/product_screen/action_pad/action_pad";
 import { Orderline } from "@point_of_sale/app/components/orderline/orderline";
@@ -138,6 +139,9 @@ export class ProductScreen extends Component {
             BACKSPACE,
         ]).map((button) => ({
             ...button,
+            disabled:
+                button.disabled ||
+                (button.value === SWITCHSIGN.value && this.pos.cashier._role === "minimal"),
             class: `
                 ${defaultLastRowValues.includes(button.value) ? "" : ""}
                 ${colorClassMap[button.value] || ""}


### PR DESCRIPTION
Fix issue where minimum rights employee were able to put negative orderline qty in the cart with the `+/-` button

task-id: 4922318

enterprise PR: https://github.com/odoo/enterprise/pull/89669

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
