### PR TITLE
[FIX] im_livechat: traceback when accessing ongoing_session_count

### DIFF
--- a/addons/im_livechat/models/im_livechat_channel.py
+++ b/addons/im_livechat/models/im_livechat_channel.py
@@ -98,14 +98,16 @@ class Im_LivechatChannel(models.Model):
 
     @api.depends("channel_ids.livechat_end_dt")
     def _compute_ongoing_sessions_count(self):
-        count_by_channel = self.env["discuss.channel"]._read_group(
-            [
-                ("channel_type", "=", "livechat"),
-                ("livechat_end_dt", "=", False),
-                ("livechat_channel_id", "in", self.ids),
-            ],
-            ["livechat_channel_id"],
-            ["__count"],
+        count_by_channel = dict(
+            self.env["discuss.channel"]._read_group(
+                [
+                    ("channel_type", "=", "livechat"),
+                    ("livechat_end_dt", "=", False),
+                    ("livechat_channel_id", "in", self.ids),
+                ],
+                ["livechat_channel_id"],
+                ["__count"],
+            )
         )
         for channel in self:
             channel.ongoing_session_count = count_by_channel.get(channel, 0)


### PR DESCRIPTION
**Current behavior before PR:**
- accessing 'ongoing_session_count' caused a traceback.

**Desired behavior after PR is merged:**
- 'ongoing_session_count' should be accessible without any traceback.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
