### PR TITLE
[FIX] hr_homeworking: added necessary values to avoid unwanted errors

### DIFF
--- a/addons/hr_homeworking/models/hr_employee_public.py
+++ b/addons/hr_homeworking/models/hr_employee_public.py
@@ -12,3 +12,7 @@ class HrEmployeePublic(models.Model):
     saturday_location_id = fields.Many2one('hr.work.location', string='Saturday')
     sunday_location_id = fields.Many2one('hr.work.location', string='Sunday')
     today_location_name = fields.Char()
+
+    hr_icon_display = fields.Selection(selection_add=[('presence_home', 'At Home'),
+                                                    ('presence_office', 'At Office'),
+                                                    ('presence_other', 'At Other')])


### PR DESCRIPTION
Currently an error occurs when we open Employees app with a non admin account.

Steps to replicate:

- Install `hr_homeworking` with demo data.
- Login with admin and open `Employee > Mitchell Admin` form view.
- On the Work tab you'll find the seven days of the week, set today's field to 'Office'. (For Ex: If Today is monday so fill in Office for monday).
- Now Logout and login through some other account like Marc Demo. Open Employees and you will get the error.

Error:
`ValueError: Wrong value for hr.employee.public.hr_icon_display: 'presence_office'`

This error occurs after a recent [refactor](https://github.com/odoo/odoo/pull/202869) in the code and that time they forgot to add the other values for `hr_icon_display` field.

In saas-18.3 [1], the code  directly  inherited from the  base model `hr.employee.base`. However, in saas-18.4 [2], the refactor split the code into `hr.employee` and `hr.employee.public`, only `hr.employee` includes the new selection items, while `hr.employee.public` does not. This caused the wrong value error.

[1] - https://github.com/odoo/odoo/blob/aa8b09ca61dfd405ebebbeff4e45a08bf7ad84fd/addons/hr_homeworking/models/hr_employee.py#L8-L24

[2] - https://github.com/odoo/odoo/blob/850e575b71b04597d31140cec53a596456370325/addons/hr_homeworking/models/hr_employee.py#L8-L24

This commit solves this issue by adding the necessary values to the `hr_icon_display` field.

sentry-6731346730
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
