### PR TITLE
[FIX] hr: Add default Structure to employee admin

### DIFF
--- a/addons/hr/data/hr_data.xml
+++ b/addons/hr/data/hr_data.xml
@@ -3,7 +3,7 @@
     <data noupdate="1">
 
         <record id="dep_administration" model="hr.department">
-          <field name="name">Administration</field>
+            <field name="name">Administration</field>
         </record>
 
         <record id="employee_admin" model="hr.employee">
@@ -215,6 +215,11 @@
             <field name="parent_id" ref="mt_contract_pending"/>
             <field name="relation_field">department_id</field>
             <field name="description">Contract about to expire</field>
+        </record>
+
+        <!-- Add default Structure to employee admin -->
+        <record id="employee_admin" model="hr.employee">
+            <field name="structure_type_id" ref="hr.structure_type_employee"/>
         </record>
     </data>
 </odoo>


### PR DESCRIPTION
Reproduce:
1. create a DB without demo data
2. install hr_payroll
3. try to edit the Admin employee

Issue:
When a database is created without demo data, the admin employee lacks a `structure_type_id`. Since this field is required by the `hr_payroll` module, any attempt to edit the admin employee fails unless the field is manually set.

Now:
This commit adds a default `structure_type_id` for the admin employee in base HR data, ensuring compatibility with `hr_payroll` regardless of demo data.

Task: 4925858


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
