### PR TITLE
[REM] orm: one2many condition on not stored inverse

### DIFF
--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -2318,7 +2318,7 @@ actual arch.
                         model=Model._name, field=name, use=use,
                     )
                     self._raise_view_error(msg, node)
-                if not field._description_searchable:
+                if not field._description_searchable(self.env.registry):
                     msg = _(
                         'Unsearchable field “%(field)s” in path “%(field_path)s” in %(use)s)',
                         field=name, field_path=field_path, use=use,

--- a/odoo/orm/fields.py
+++ b/odoo/orm/fields.py
@@ -631,7 +631,7 @@ class Field(typing.Generic[T]):
         self.compute = self._compute_related
         if self.inherited or not (self.readonly or field.readonly):
             self.inverse = self._inverse_related
-        if not self.store and field._description_searchable:
+        if not self.store and field._description_searchable(model.env.registry):
             # allow searching on self only if the related field is searchable
             self.search = self._search_related
 
@@ -857,7 +857,7 @@ class Field(typing.Generic[T]):
                     warnings.warn(f"Field {self} cannot be precomputed as it depends on non-precomputed field {field}", stacklevel=1)
                     self.precompute = False
 
-                if field_seq and not field_seq[-1]._description_searchable:
+                if field_seq and not field_seq[-1]._description_searchable(registry):
                     # the field before this one is not searchable, so there is
                     # no way to know which on records to recompute self
                     warnings.warn(
@@ -922,8 +922,7 @@ class Field(typing.Generic[T]):
     def _description_depends(self, env: Environment):
         return env.registry.field_depends[self]
 
-    @property
-    def _description_searchable(self) -> bool:
+    def _description_searchable(self, registry: Registry) -> bool:
         return bool(self.store or self.search)
 
     def _description_sortable(self, env: Environment):

--- a/odoo/orm/fields_relational.py
+++ b/odoo/orm/fields_relational.py
@@ -861,6 +861,13 @@ class One2many(_RelationalMulti):
 
     _description_relation_field = property(attrgetter('inverse_name'))
 
+    def _description_searchable(self, registry):
+        if self.comodel_name and self.inverse_name:
+            comodel = registry[self.comodel_name]
+            inverse_field = comodel._fields[self.inverse_name]
+            return inverse_field.store
+        return False
+
     def update_db(self, model, columns):
         if self.comodel_name in model.env:
             comodel = model.env[self.comodel_name]

--- a/odoo/orm/fields_relational.py
+++ b/odoo/orm/fields_relational.py
@@ -1133,21 +1133,9 @@ class One2many(_RelationalMulti):
 
         comodel = model.env[self.comodel_name].sudo()
         inverse_field = comodel._fields[self.inverse_name]
-        if inverse_field.store:
-            subselect = coquery.subselect(
-                comodel._field_to_sql(coquery.table, inverse_field.name, coquery)
-            )
-        else:
-            # determine ids1 in model related to ids2
-            # TODO should we support this in the future?
-            recs = comodel.browse(coquery).with_context(prefetch_fields=False)
-            if inverse_field.relational:
-                inverses = inverse_field.__get__(recs)
-            else:
-                # int values, map them
-                inverses = model.browse(inverse_field.__get__(rec) for rec in recs)
-            subselect = inverses._as_query(ordered=False).subselect()
-
+        subselect = coquery.subselect(
+            comodel._field_to_sql(coquery.table, inverse_field.name, coquery)
+        )
         return SQL(
             "%s%s%s",
             SQL.identifier(alias, 'id'),


### PR DESCRIPTION
The inverse field should be stored (`_field_to_sql`) on the one2many. We should not support and try to find the values of non-stored inverses.

This could be a performance issue and the alternative is to create a computed one2many field.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
