### PR TITLE
[IMP] stock_picking_batch: show picking name in detailed operations

### DIFF
--- a/addons/stock_picking_batch/models/stock_move.py
+++ b/addons/stock_picking_batch/models/stock_move.py
@@ -42,6 +42,8 @@ class StockMove(models.Model):
 
     def action_show_details(self):
         action = super().action_show_details()
-        if self.picking_id.batch_id:
+        if self.env.context.get('show_picking') and self.picking_id.batch_id:
+            action['name'] = self.env._('Open: Stock Move')
             action['context']['default_picking_id'] = self.picking_id.id
+            action['context']['display_name_partner'] = True
         return action

--- a/addons/stock_picking_batch/models/stock_picking.py
+++ b/addons/stock_picking_batch/models/stock_picking.py
@@ -323,3 +323,15 @@ class StockPicking(models.Model):
             'res_id': self.batch_id.id,
             'view_mode': 'form'
         }
+
+    @api.depends('partner_id')
+    @api.depends_context('display_name_partner')
+    def _compute_display_name(self):
+        res = super()._compute_display_name()
+        if not self.env.context.get('display_name_partner'):
+            return res
+        for picking in self:
+            if not picking.partner_id:
+                continue
+            picking.display_name = f"{picking.display_name} - {picking.partner_id.display_name}"
+        return res

--- a/addons/stock_picking_batch/static/tests/tours/stock_picking_batch_tour.js
+++ b/addons/stock_picking_batch/static/tests/tours/stock_picking_batch_tour.js
@@ -28,24 +28,24 @@ registry.category("web_tour.tours").add("test_stock_picking_batch_sm_to_sml_sync
             run: "click",
         },
         {
-            trigger: ".modal:contains(detailed operations)",
+            trigger: ".modal:contains(Open: Stock Move)",
         },
         {
             trigger:
-                ".modal:contains(detailed operations) .o_field_pick_from > .o_many2one:contains('WH/Stock/Shelf A')",
+                ".modal:contains(Open: Stock Move) .o_field_pick_from > .o_many2one:contains('WH/Stock/Shelf A')",
             run: "click",
         },
         {
-            trigger: ".modal:contains(detailed operations) .o_list_number[name=quantity] input",
+            trigger: ".modal:contains(Open: Stock Move) .o_list_number[name=quantity] input",
             run: "edit 2 && press Tab",
         },
         {
             trigger:
-                ".modal:contains(detailed operations) .o_list_footer .o_list_number > span:contains('8')",
+                ".modal:contains(Open: Stock Move) .o_list_footer .o_list_number > span:contains('8')",
         },
         {
             content: "Click Save",
-            trigger: ".modal:contains(detailed operations) .o_form_button_save",
+            trigger: ".modal:contains(Open: Stock Move) .o_form_button_save",
             run: "click",
         },
         {
@@ -62,21 +62,21 @@ registry.category("web_tour.tours").add("test_stock_picking_batch_sm_to_sml_sync
             run: "click",
         },
         {
-            trigger: "h4:contains(detailed operations)",
+            trigger: "h4:contains(Open: Stock Move)",
         },
         {
             content: "Click in cell to start edition",
             trigger:
-                ".modal:contains(detailed operations) .o_field_pick_from > .o_many2one:contains('WH/Stock/Shelf A')",
+                ".modal:contains(Open: Stock Move) .o_field_pick_from > .o_many2one:contains('WH/Stock/Shelf A')",
             run: "click",
         },
         {
-            trigger: ".modal:contains(detailed operations) .o_list_number[name=quantity] input",
+            trigger: ".modal:contains(Open: Stock Move) .o_list_number[name=quantity] input",
             run: "edit 27",
         },
         {
             content: "Click Save",
-            trigger: ".modal:contains(detailed operations) .o_form_button_save:contains(save)",
+            trigger: ".modal:contains(Open: Stock Move) .o_form_button_save:contains(save)",
             run: "click",
         },
         {
@@ -93,11 +93,11 @@ registry.category("web_tour.tours").add("test_stock_picking_batch_sm_to_sml_sync
             run: "click",
         },
         {
-            trigger: ".modal:contains(detailed operations) .o_data_row > td:contains(7)",
+            trigger: ".modal:contains(Open: Stock Move) .o_data_row > td:contains(7)",
         },
         {
             content: "Click Save",
-            trigger: ".modal:contains(detailed operations) .o_form_button_save",
+            trigger: ".modal:contains(Open: Stock Move) .o_form_button_save",
             run: "click",
         },
         {

--- a/addons/stock_picking_batch/views/stock_move_line_views.xml
+++ b/addons/stock_picking_batch/views/stock_move_line_views.xml
@@ -26,4 +26,15 @@
             </filter>
         </field>
     </record>
+
+    <record id="view_stock_move_operations" model="ir.ui.view">
+        <field name="name">stock.move.operations.form.inherit.stock.picking.batch</field>
+        <field name="model">stock.move</field>
+        <field name="inherit_id" ref="stock.view_stock_move_operations"/>
+        <field name="arch" type="xml">
+            <xpath expr="//group[@name='product_qty']/group[last()]" position="inside">
+                <field name="picking_id" string="Transfer:" readonly="True" invisible="not context.get('show_picking')"/>
+            </xpath>
+        </field>
+    </record>
 </odoo>

--- a/addons/stock_picking_batch/views/stock_picking_batch_views.xml
+++ b/addons/stock_picking_batch/views/stock_picking_batch_views.xml
@@ -12,6 +12,9 @@
                     <field name="state" widget="statusbar" statusbar_visible="draft,confirmed,assigned,done"/>
                 </header>
             </xpath>
+            <xpath expr="//button[@name='action_show_details']" position="attributes">
+                <attribute name="context">{'show_picking': True}</attribute>
+            </xpath>
         </field>
     </record>
 
@@ -39,7 +42,7 @@
             <xpath expr="//field[@name='product_uom']" position="after">
                 <field name="picked" optional="hide"/>
                 <button name="action_show_details" type="object" title="Details"
-                        icon="fa-list" invisible="not show_details_visible"/>
+                    string="Details" context="{'show_picking': True}" invisible="not show_details_visible"/>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
In this commit, we display the picking display name (a combination of the picking name and partner name)
in the detailed operation wizard (opened via the Details button on a move)
when accessed from a batch or wave.

Additionally, we replaced the fa-list icon with a Details button on moves to align with other views.

This enhancement helps users quickly identify which picking a move belongs to,
especially in batch/wave operations where multiple pickings can exist,
improving overall clarity when adding or reviewing moves/moves line during batch/wave processing.

task - [3866855](https://www.odoo.com/odoo/project/966/tasks/3866855)

