### PR TITLE
[FIX] partnership: make partnership saleable

### DIFF
--- a/addons/partnership/models/product_template.py
+++ b/addons/partnership/models/product_template.py
@@ -1,6 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class ProductTemplate(models.Model):
@@ -10,3 +10,7 @@ class ProductTemplate(models.Model):
         selection_add=[('partnership', 'Membership / Partnership')], ondelete={'partnership': 'set default'}
     )
     grade_id = fields.Many2one('res.partner.grade', string="Assigned Level")
+
+    @api.model
+    def _get_saleable_tracking_types(self):
+        return super()._get_saleable_tracking_types() + ['partnership']

--- a/addons/partnership/tests/test_partnership.py
+++ b/addons/partnership/tests/test_partnership.py
@@ -2,10 +2,12 @@
 
 from odoo import Command
 from odoo.exceptions import ValidationError
+from odoo.tests import tagged
 
 from .common import PartnershipCommon
 
 
+@tagged('post_install', '-at_install')
 class TestPartnership(PartnershipCommon):
 
     def test_sell_basic_partnership(self):
@@ -32,3 +34,15 @@ class TestPartnership(PartnershipCommon):
         with self.assertRaises(ValidationError):
             # A sale order cannot contain partnership products assigning different grade levels
             self.sale_order_partnership.order_line = [Command.create({'product_id': partnership.id})]
+
+    def test_partnership_product_domain(self):
+        ProductTemplate = self.env['product.template']
+        product_domain = [
+            ('sale_ok', '=', True),
+            ('service_tracking', 'in', ProductTemplate._get_saleable_tracking_types()),
+        ]
+        self.assertIn(
+            self.partnership_product.product_tmpl_id,
+            ProductTemplate.search(product_domain),
+            "Partnership product should be saleable",
+        )


### PR DESCRIPTION
Versions
--------
- saas-18.3+

Steps
-----
1. Have a partnership product;
2. publish it on eCommerce;
3. as Portal or Public user, open /shop;
4. if visible, buy it & go back to /shop.

Issue
-----
Product is not available on /shop (anymore).

Cause
-----
Partnership tracking (partnership created on order) on service products isn't made saleable.

Solution
--------
Add `partnership` to `_get_saleable_tracking_types`.

opw-4926679