### PR TITLE
[IMP] orm: exists for one2many searches

### DIFF
--- a/odoo/addons/base/tests/test_expression.py
+++ b/odoo/addons/base/tests/test_expression.py
@@ -2143,11 +2143,11 @@ class TestOne2many(TransactionCase):
         with self.assertQueries(['''
             SELECT "res_partner"."id"
             FROM "res_partner"
-            WHERE "res_partner"."id" IN (
-                SELECT "res_partner_bank"."partner_id"
+            WHERE EXISTS (SELECT FROM (
+                SELECT "res_partner_bank"."partner_id" AS __inverse
                 FROM "res_partner_bank"
                 WHERE "res_partner_bank"."id" IN %s
-            )
+            ) WHERE __inverse = "res_partner"."id")
             ORDER BY "res_partner"."complete_name"asc,"res_partner"."id"desc
         ''']):
             self.Partner.search([('bank_ids', 'in', self.partner.bank_ids.ids)])
@@ -2155,11 +2155,11 @@ class TestOne2many(TransactionCase):
         with self.assertQueries(['''
             SELECT "res_partner"."id"
             FROM "res_partner"
-            WHERE "res_partner"."id" IN (
-                SELECT "res_partner_bank"."partner_id"
+            WHERE EXISTS (SELECT FROM (
+                SELECT "res_partner_bank"."partner_id" AS __inverse
                 FROM "res_partner_bank"
                 WHERE "res_partner_bank"."sanitized_acc_number" LIKE %s
-            )
+            ) WHERE __inverse = "res_partner"."id")
             ORDER BY "res_partner"."complete_name"asc,"res_partner"."id"desc
         ''']):
             self.Partner.search([('bank_ids.sanitized_acc_number', 'like', '12')])
@@ -2167,19 +2167,19 @@ class TestOne2many(TransactionCase):
         with self.assertQueries(['''
             SELECT "res_partner"."id"
             FROM "res_partner"
-            WHERE "res_partner"."id" IN (
-                SELECT "res_partner"."parent_id"
+            WHERE EXISTS (SELECT FROM (
+                SELECT "res_partner"."parent_id" AS __inverse
                 FROM "res_partner"
                 WHERE (
                     "res_partner"."active" IS TRUE
-                    AND "res_partner"."id" IN (
-                        SELECT "res_partner_bank"."partner_id"
+                    AND EXISTS (SELECT FROM (
+                        SELECT "res_partner_bank"."partner_id" AS __inverse
                         FROM "res_partner_bank"
                         WHERE "res_partner_bank"."sanitized_acc_number" LIKE %s
-                    )
+                    ) WHERE __inverse = "res_partner"."id")
                     AND "res_partner"."parent_id" IS NOT NULL
                 )
-            )
+            ) WHERE __inverse = "res_partner"."id")
             ORDER BY "res_partner"."complete_name"asc,"res_partner"."id"desc
         ''']):
             self.Partner.search([('child_ids.bank_ids.sanitized_acc_number', 'like', '12')])
@@ -2194,11 +2194,11 @@ class TestOne2many(TransactionCase):
         with self.assertQueries(['''
             SELECT "res_partner"."id"
             FROM "res_partner"
-            WHERE "res_partner"."id" IN (
-                SELECT "res_partner_bank"."partner_id"
+            WHERE EXISTS (SELECT FROM (
+                SELECT "res_partner_bank"."partner_id" AS __inverse
                 FROM "res_partner_bank"
                 WHERE "res_partner_bank"."id" IN %s
-            )
+            ) WHERE __inverse = "res_partner"."id")
             ORDER BY "res_partner"."complete_name"asc,"res_partner"."id"desc
         ''']):
             self.Partner.search([('bank_ids', 'in', self.partner.bank_ids.ids)])
@@ -2206,11 +2206,11 @@ class TestOne2many(TransactionCase):
         with self.assertQueries(['''
             SELECT "res_partner"."id"
             FROM "res_partner"
-            WHERE "res_partner"."id" IN (
-                SELECT "res_partner_bank"."partner_id"
+            WHERE EXISTS (SELECT FROM (
+                SELECT "res_partner_bank"."partner_id" AS __inverse
                 FROM "res_partner_bank"
                 WHERE "res_partner_bank"."sanitized_acc_number" LIKE %s
-            )
+            ) WHERE __inverse = "res_partner"."id")
             ORDER BY "res_partner"."complete_name"asc,"res_partner"."id"desc
         ''']):
             self.Partner.search([('bank_ids.sanitized_acc_number', 'like', '12')])
@@ -2218,15 +2218,16 @@ class TestOne2many(TransactionCase):
         with self.assertQueries(['''
             SELECT "res_partner"."id"
             FROM "res_partner"
-            WHERE ("res_partner"."id" IN (
-                SELECT "res_partner_bank"."partner_id"
+            WHERE (EXISTS (SELECT FROM (
+                SELECT "res_partner_bank"."partner_id" AS __inverse
                 FROM "res_partner_bank"
                 WHERE "res_partner_bank"."sanitized_acc_number" LIKE %s
-            ) AND "res_partner"."id" IN (
-                SELECT "res_partner_bank"."partner_id"
+            ) WHERE __inverse = "res_partner"."id")
+            AND EXISTS (SELECT FROM (
+                SELECT "res_partner_bank"."partner_id" AS __inverse
                 FROM "res_partner_bank"
                 WHERE "res_partner_bank"."sanitized_acc_number" LIKE %s
-            ))
+            ) WHERE __inverse = "res_partner"."id"))
             ORDER BY "res_partner"."complete_name"asc,"res_partner"."id"desc
         ''']):
             self.Partner.search([
@@ -2237,19 +2238,19 @@ class TestOne2many(TransactionCase):
         with self.assertQueries(['''
             SELECT "res_partner"."id"
             FROM "res_partner"
-            WHERE "res_partner"."id" IN (
-                SELECT "res_partner"."parent_id"
+            WHERE EXISTS (SELECT FROM (
+                SELECT "res_partner"."parent_id" AS __inverse
                 FROM "res_partner"
                 WHERE (
                     "res_partner"."active" IS TRUE
-                    AND "res_partner"."id" IN (
-                        SELECT "res_partner_bank"."partner_id"
+                    AND EXISTS (SELECT FROM (
+                        SELECT "res_partner_bank"."partner_id" AS __inverse
                         FROM "res_partner_bank"
                         WHERE "res_partner_bank"."sanitized_acc_number" LIKE %s
-                    )
+                    ) WHERE __inverse = "res_partner"."id")
                     AND "res_partner"."parent_id" IS NOT NULL
                 )
-            )
+            ) WHERE __inverse = "res_partner"."id")
             ORDER BY "res_partner"."complete_name"asc,"res_partner"."id"desc
         ''']):
             self.Partner.search([('child_ids.bank_ids.sanitized_acc_number', 'like', '12')])
@@ -2263,22 +2264,22 @@ class TestOne2many(TransactionCase):
         with self.assertQueries(['''
             SELECT "res_partner"."id"
             FROM "res_partner"
-            WHERE "res_partner"."id" IN (
-                SELECT "res_partner"."parent_id"
+            WHERE EXISTS (SELECT FROM (
+                SELECT "res_partner"."parent_id" AS __inverse
                 FROM "res_partner"
                 WHERE (
-                    "res_partner"."id" IN (
-                        SELECT "res_partner_bank"."partner_id"
+                    EXISTS (SELECT FROM (
+                        SELECT "res_partner_bank"."partner_id" AS __inverse
                         FROM "res_partner_bank"
                         WHERE (
                             "res_partner_bank"."id" IN %s
                             AND "res_partner_bank"."sanitized_acc_number" LIKE %s
                         )
-                    )
+                    ) WHERE __inverse = "res_partner"."id")
                     AND ("res_partner"."name" NOT IN %s OR "res_partner"."name" IS NULL)
                     AND "res_partner"."parent_id" IS NOT NULL
                 )
-            )
+            ) WHERE __inverse = "res_partner"."id")
             ORDER BY "res_partner"."complete_name"asc,"res_partner"."id"desc
         ''']):
             self.Partner.search([('child_ids.bank_ids.id', 'in', self.partner.bank_ids.ids)])
@@ -2292,8 +2293,8 @@ class TestOne2many(TransactionCase):
         with self.assertQueries(['''
             SELECT "res_partner"."id"
             FROM "res_partner"
-            WHERE "res_partner"."id" IN (
-                SELECT "res_partner"."parent_id"
+            WHERE EXISTS (SELECT FROM (
+                SELECT "res_partner"."parent_id" AS __inverse
                 FROM "res_partner"
                 LEFT JOIN "res_country_state" AS "res_partner__state_id"
                     ON ("res_partner"."state_id" = "res_partner__state_id"."id")
@@ -2304,7 +2305,7 @@ class TestOne2many(TransactionCase):
                     AND "res_partner"."parent_id" IS NOT NULL
                     AND ("res_partner"."state_id" IS NOT NULL AND "res_partner__state_id__country_id"."code" LIKE %s)
                 )
-            )
+            ) WHERE __inverse = "res_partner"."id")
             ORDER BY "res_partner"."complete_name"asc,"res_partner"."id"desc
         ''']):
             self.Partner.search([('child_ids.state_id.country_id.code', 'like', 'US')])
@@ -2315,11 +2316,11 @@ class TestOne2many(TransactionCase):
         with self.assertQueries(['''
             SELECT "res_partner"."id"
             FROM "res_partner"
-            WHERE "res_partner"."id" IN (
-                SELECT "res_partner_bank"."partner_id"
+            WHERE EXISTS (SELECT FROM (
+                SELECT "res_partner_bank"."partner_id" AS __inverse
                 FROM "res_partner_bank"
                 WHERE "res_partner_bank"."sanitized_acc_number" LIKE %s
-            )
+            ) WHERE __inverse = "res_partner"."id")
             ORDER BY "res_partner"."complete_name"asc,"res_partner"."id"desc
         ''']):
             self.Partner.search([('bank_ids', 'like', '12')])
@@ -2332,10 +2333,10 @@ class TestOne2many(TransactionCase):
         with self.assertQueries(['''
             SELECT "res_partner"."id"
             FROM "res_partner"
-            WHERE "res_partner"."id" IN (
-                SELECT "res_partner_bank"."partner_id"
+            WHERE EXISTS (SELECT FROM (
+                SELECT "res_partner_bank"."partner_id" AS __inverse
                 FROM "res_partner_bank"
-            )
+            ) WHERE __inverse = "res_partner"."id")
             ORDER BY "res_partner"."id"
         ''']):
             self.Partner.search([('bank_ids', '!=', False)], order='id')
@@ -2343,10 +2344,10 @@ class TestOne2many(TransactionCase):
         with self.assertQueries(['''
             SELECT "res_partner"."id"
             FROM "res_partner"
-            WHERE "res_partner"."id" NOT IN (
-                SELECT "res_partner_bank"."partner_id"
+            WHERE NOT EXISTS (SELECT FROM (
+                SELECT "res_partner_bank"."partner_id" AS __inverse
                 FROM "res_partner_bank"
-            )
+            ) WHERE __inverse = "res_partner"."id")
             ORDER BY "res_partner"."id"
         ''']):
             self.Partner.search([('bank_ids', '=', False)], order='id')

--- a/odoo/orm/fields_relational.py
+++ b/odoo/orm/fields_relational.py
@@ -1145,11 +1145,7 @@ class One2many(_RelationalMulti):
 
         comodel = model.env[self.comodel_name].sudo()
         inverse_field = comodel._fields[self.inverse_name]
-        if inverse_field.store:
-            subselect = coquery.subselect(
-                comodel._field_to_sql(coquery.table, inverse_field.name, coquery)
-            )
-        else:
+        if not inverse_field.store:
             # determine ids1 in model related to ids2
             # TODO should we support this in the future?
             recs = comodel.browse(coquery).with_context(prefetch_fields=False)
@@ -1159,12 +1155,21 @@ class One2many(_RelationalMulti):
                 # int values, map them
                 inverses = model.browse(inverse_field.__get__(rec) for rec in recs)
             subselect = inverses._as_query(ordered=False).subselect()
+            return SQL(
+                "%s%s%s",
+                SQL.identifier(alias, 'id'),
+                SQL_OPERATORS['in' if exists else 'not in'],
+                subselect,
+            )
 
+        subselect = coquery.subselect(
+            SQL("%s AS __inverse", comodel._field_to_sql(coquery.table, inverse_field.name, coquery))
+        )
         return SQL(
-            "%s%s%s",
-            SQL.identifier(alias, 'id'),
-            SQL_OPERATORS['in' if exists else 'not in'],
+            "%sEXISTS(SELECT FROM %s WHERE __inverse = %s)",
+            SQL() if exists else SQL("NOT "),
             subselect,
+            SQL.identifier(alias, 'id'),
         )
 
 


### PR DESCRIPTION
Use the EXISTS clause of SQL instead of IN for one2many fields.

```
WHERE tab."id" IN (SELECT "inverse" FROM cotab WHERE ...)
-- becomes
WHERE EXISTS(SELECT FROM (
  SELECT "inverse" AS inv FROM cotab WHERE ...
) WHERE inv = tab."id")
```

The subselect is here to avoid alias name clashes between the main query and the subquery. It is trivial and predicates will be pushed down. Usually postgres can plan better queries for such queries than for IN queries where it often chooses to materialize the subquery before performing the IN operation, especially for NOT EXISTS queries.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
