### PR TITLE
[FIX] l10n_it_edi: neutralize FatturaPA

### DIFF
--- a/addons/l10n_it_edi/data/neutralize.sql
+++ b/addons/l10n_it_edi/data/neutralize.sql
@@ -1,0 +1,3 @@
+-- neutralize Fattura Elettronica (FatturaPA)
+UPDATE res_company
+SET l10n_it_edi_register = false;


### PR DESCRIPTION
**Steps to reproduce:**
- Install l10n_it_edi
- Switch to an Italian company (e.g. IT Company)

- In Accounting settings, activate "Fattura Electronica (FatturaPA)"
- When saving the settings, the system tries to create an EDI proxy user if there is no existing EDI proxy user in "test" or "prod" mode

- Neutralize the database with the following command: `odoo-bin neutralize -d [db_name]`

- Go the settings and save

**Issue:**
Upon save, the system will try to create an EDI proxy user in "prod" mode (or "test" mode if "l10n_it_edi.proxy_user_edi_mode" system parameter is set to "test").
The database is neutralized.
It should not create an EDI proxy user in "prod" mode by default.

**Cause:**
An EDI proxy user is created in "prod" mode automatically when there is no existing proxy user in that mode and "FatturaPA" is activated.
During the neutralization of the database, all proxy users are switched to "demo" mode, but "FatturaPA" is not deactivated.
Therefore, the configuration is set to create a "prod" EDI proxy user.

**Solution:**
As we want to create an EDI proxy user in "prod" mode by default on a non-neutralized database, we can deactivate "FatturaPA" option during the neutralization to prevent the creation of an EDI proxy user on a neutralized database when saving the settings.

opw-4795396




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
