### PR TITLE
[FIX] account: avoid crash if linked distribution account is deleted

### DIFF
--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -1075,7 +1075,7 @@ class AccountMoveLine(models.Model):
                 related_distribution = line._related_analytic_distribution()
                 root_plans = self.env['account.analytic.account'].browse(
                     list({int(account_id) for ids in related_distribution for account_id in ids.split(',')})
-                ).root_plan_id
+                ).exists().root_plan_id
 
                 arguments = frozendict({
                     "product_id": line.product_id.id,


### PR DESCRIPTION
When creating an invoice from a sales order linked to a service-type product that auto-generates a project, deleting the project before invoicing caused an error: "Record does not exist or has been deleted."

This fix filters `browse()` result using `exists()` to ensure that
the linked distribution account still exists.

Steps to reproduce:
- Create a service product that creates a project on order
- Add it to a sales order and confirm
- Delete the project
- Try to create an invoice → error occurs

opw-4891937