### PR TITLE
[FIX] website_sale: prevent error when opening a product in the shop

### DIFF
--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -2330,7 +2330,7 @@
     <template id="product_tags" name="Product Tags" active="True">
         <div
             class="o_product_tags o_field_tags d-flex flex-wrap align-items-center gap-2 mb-2 mt-1"
-            t-if="any(tag.visible_on_ecommerce for tag in all_product_tags)"
+            t-if="any(tag.visible_to_customers for tag in all_product_tags)"
         >
             <t t-foreach="all_product_tags" t-as="tag">
                 <t t-if="tag.visible_to_customers">


### PR DESCRIPTION
Currently, an error occurs when opening the product in the shop.

Steps to Reproduce:
 - Install the `website_sale` module.
 - Go to `Products`, open any product, navigate to the `Sales` tab, and add at least one `tag`.
 - Go to `Website` > `Shop`, and open the same product.

`AttributeError: 'product.tag' object has no attribute 'visible_on_ecommerce'`

This error occurs when opening a product in the shop. In this commit https://github.com/odoo/odoo/pull/206084/commits/6d0d8d96b603d222de5c099ca090919573d4c761, it was mentioned that the field visible_on_ecommerce has been renamed to visible_to_customers. The error started occurring after this commit https://github.com/odoo/odoo/pull/201019/commits/eac892a4ad7373d18f954afbbcd2f1213ac5f281, 
where the visible_on_ecommerce attribute is used as a tag attribute [1], which causes the error.

[1]- https://github.com/odoo/odoo/blob/850e575b71b04597d31140cec53a596456370325/addons/website_sale/views/templates.xml#L2333

This commit ensures that visible_to_customers is used in place of visible_on_ecommerce.

sentry-6731935669


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
