### PR TITLE
[FIX] website_event_track: avoid crash when date is missing

### DIFF
--- a/addons/website_event_track/models/event_track.py
+++ b/addons/website_event_track/models/event_track.py
@@ -396,7 +396,7 @@ class EventTrack(models.Model):
         UTC as we compute only time deltas here. """
         now_utc = utc.localize(fields.Datetime.now().replace(microsecond=0))
         for track in self:
-            if not track.date:
+            if not (track.date or track.date_end):
                 track.is_track_live = track.is_track_soon = track.is_track_today = track.is_track_upcoming = track.is_track_done = False
                 track.track_start_relative = track.track_start_remaining = 0
                 continue
@@ -438,6 +438,9 @@ class EventTrack(models.Model):
         for track in self:
             # Need to localize because it could begin late and finish early in
             # another timezone
+            if not (track.date or track.date_end):
+                track.is_one_day = False
+                continue
             track = track.with_context(tz=track.event_id.date_tz or 'UTC')
             begin_tz = fields.Datetime.context_timestamp(track, track.date)
             end_tz = fields.Datetime.context_timestamp(track, track.date_end)

--- a/addons/website_event_track/tests/test_website_event_track.py
+++ b/addons/website_event_track/tests/test_website_event_track.py
@@ -46,3 +46,27 @@ class TestWebsiteEventTrack(TestEventOnlineCommon, HttpCase):
                 ]).mail_ids.filtered(lambda m: m.email_to == (user.email or "visitor@odoo.com"))
                 # Check that a mail with track reminders has been created with the submitted email address.
                 self.assertEqual(len(mails), 1)
+
+    def test_compute_is_one_day(self):
+        """Ensure is_one_day is False when both date and date_end are missing."""
+        track = self.env['event.track'].create({
+            'name': 'Track Without Dates',
+            'event_id': self.event_0.id,
+        })
+        self.assertFalse(track.is_one_day, "Expected Is One Day to be False when no date is set.")
+        self.assertTrue(track.name, "Track name should be correctly set.")
+        self.assertTrue(track.event_id, "Track should be linked to the correct event.")
+
+    def test_compute_track_time_data(self):
+        """Test that _compute_track_time_data sets defaults when no date or date_end is set."""
+        track = self.env['event.track'].create({
+            'name': 'Track Without Date Info',
+            'event_id': self.event_0.id,
+        })
+        self.assertFalse(track.is_track_live, "Track should not be live without date.")
+        self.assertFalse(track.is_track_soon, "Track should not be marked as soon without date.")
+        self.assertFalse(track.is_track_today, "Track should not be marked as today without date.")
+        self.assertFalse(track.is_track_upcoming, "Track should not be upcoming without date.")
+        self.assertFalse(track.is_track_done, "Track should not be done without date.")
+        self.assertEqual(track.track_start_relative, 0, "Track start relative should be 0.")
+        self.assertEqual(track.track_start_remaining, 0, "Track start remaining should be 0.")


### PR DESCRIPTION
In saas-18.3, a new mail template [mail_template_data_track_reminder](https://github.com/odoo/odoo/blob/045ebed2c2e4645dd9c36452196f4c72b88d55af/addons/website_event_track/data/mail_template_data.xml#L33) was
introduced for the `event.track` model. This template relies on the computed
field `is_one_day`, which depends on the `date` and `date_end` fields. If the
`date` is not set, evaluating [object.is_one_day](https://github.com/odoo/odoo/blob/045ebed2c2e4645dd9c36452196f4c72b88d55af/addons/website_event_track/data/mail_template_data.xml#L122C1-L123C1) in the template leads to a
traceback during rendering.

This commit resolves the issue by making the `_compute_is_one_day` method more
robust. It now defaults `is_one_day` to False when both `date` and `date_end`
are missing. Similarly, the `_compute_track_time_data` method has been updated
to handle the absence of these fields, preventing any invalid date computations.

The following test cases were added to verify the fix:
- When both `date` and `date_end` are missing, `is_one_day` is correctly set to
False.
- When both fields are missing, all time-related computed fields are set to safe
default values without raising errors.

Steps to Reproduce:
On a saas-18.3 runbot:
1. Create an Event Track record without setting a track date.
2. Try sending the email using the "Add reminder via email" feature.
→ This results in a traceback due to missing date values.

[tbg-2099](https://upgrade.odoo.com/odoo/action-178/2099?debug=1)
opw-4910692

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
