### PR TITLE
[FIX] spreadsheet: remove empty text default value

### DIFF
--- a/addons/spreadsheet/static/src/o_spreadsheet/migration.js
+++ b/addons/spreadsheet/static/src/o_spreadsheet/migration.js
@@ -57,7 +57,11 @@ migrationStepRegistry.add("18.4.10", {
     migrate(data) {
         for (const globalFilter of data.globalFilters || []) {
             if (globalFilter.type === "text" && typeof globalFilter.defaultValue == "string") {
-                globalFilter.defaultValue = [globalFilter.defaultValue];
+                if (globalFilter.defaultValue === "") {
+                    delete globalFilter.defaultValue;
+                } else {
+                    globalFilter.defaultValue = [globalFilter.defaultValue];
+                }
             }
             if (globalFilter.type === "text" && globalFilter.rangeOfAllowedValues) {
                 globalFilter.rangesOfAllowedValues = [globalFilter.rangeOfAllowedValues];

--- a/addons/spreadsheet/static/tests/migrations/migrations.test.js
+++ b/addons/spreadsheet/static/tests/migrations/migrations.test.js
@@ -613,6 +613,11 @@ test("text global filter default value is now an array of strings", () => {
                 id: "2",
                 type: "text",
             },
+            {
+                id: "3",
+                type: "text",
+                defaultValue: "",
+            },
         ],
     };
     const migratedData = load(data);
@@ -622,6 +627,7 @@ test("text global filter default value is now an array of strings", () => {
     expect(migratedData.globalFilters[1].defaultValue).toBe(undefined);
     expect(migratedData.globalFilters[1].rangeOfAllowedValues).toBe(undefined);
     expect(migratedData.globalFilters[1].rangesOfAllowedValues).toBe(undefined);
+    expect(migratedData.globalFilters[2].defaultValue).toBe(undefined);
 });
 
 test("Date with antepenultimate_year is not supported anymore", () => {


### PR DESCRIPTION
The upgrade script from saas-18.3 to saas-18.4 converting the default value of text filter is wrong.
It didn't account for the empty string which should be considered as "no default value"

`defaultValue: "hello"` --> `defaultValue: ["hello"]` correct
`defaultValue: ""` --> `defaultValue: [""]` not correct

Task: 4926326



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
