### PR TITLE
[FIX] website_event: keep slug filters across pages

### DIFF
--- a/addons/website_event/controllers/main.py
+++ b/addons/website_event/controllers/main.py
@@ -41,7 +41,16 @@ class WebsiteEventController(http.Controller):
             'country': post.get('country'),
         }
 
-    @http.route(['/event', '/event/page/<int:page>', '/events', '/events/page/<int:page>', '/event/tags/<string:slug_tags>'], type='http', auth="public", website=True, sitemap=sitemap_event)
+    @http.route([
+        path
+        for base in ('event', 'events')
+        for path in [
+            f'/{base}',
+            f'/{base}/page/<int:page>',
+            f'/{base}/tags/<string:slug_tags>',
+            f'/{base}/tags/<string:slug_tags>/page/<int:page>',
+        ]
+    ], type='http', auth="public", website=True, sitemap=sitemap_event)
     def events(self, page=1, slug_tags=None, **searches):
         if (slug_tags or searches.get('tags', '[]').count(',') > 0) and request.httprequest.method == 'GET' and not searches.get('prevent_redirect'):
             # Previously, the tags were searched using GET, which caused issues with crawlers (too many hits)
@@ -113,7 +122,7 @@ class WebsiteEventController(http.Controller):
             current_country = request.env['res.country'].browse(int(searches['country']))
 
         pager = website.pager(
-            url="/event",
+            url=f"/event/tags/{slug_tags}" if slug_tags else "/event",
             url_args=searches,
             total=event_count,
             page=page,

--- a/addons/website_event/static/tests/tours/website_event_search.js
+++ b/addons/website_event/static/tests/tours/website_event_search.js
@@ -1,0 +1,29 @@
+import { registry } from "@web/core/registry";
+
+registry.category("web_tour.tours").add("test_website_event_search", {
+    steps: () => [
+        {
+            trigger: '.btn[title="Filter by category"]:contains(Test Category)',
+            run: 'click'
+        },
+        {
+            trigger: '.post_link:contains(tag 1)',
+            run: 'click'
+        },
+        {
+            trigger: '.badge.bg-primary:contains(1)',
+        },
+        {
+            trigger: '.page-link:contains(2)',
+            run: 'click'
+        },
+        {
+            trigger: '.input-group .search-query.form-control',
+            run: 'edit Event 0 && click body',
+        },
+        {
+            trigger: '.badge.bg-primary:contains(1)',
+            run: () => {}
+        },
+    ],
+});

--- a/addons/website_event/tests/test_website_event.py
+++ b/addons/website_event/tests/test_website_event.py
@@ -171,6 +171,30 @@ class TestUi(HttpCaseWithUserDemo, HttpCaseWithUserPortal):
             lambda answer: answer.question_id.title == 'How did you learn about this event?'
         ).value_answer_id.name, 'A friend')
 
+    def test_website_event_search(self):
+        """ Ensure filters are not reset when changing pages or performing a search. """
+        tag_category = self.env['event.tag.category'].create({'name': 'Test Category'})
+
+        tags = self.env['event.tag'].create([
+            {'name': 'tag 1', 'category_id': tag_category.id},
+            {'name': 'tag 2', 'category_id': tag_category.id},
+        ])
+
+        # Need to create a bunch of events to have severals pages
+        self.env['event.event'].create([
+            {
+                'name': f'Filter Test Event - {tag.name}',
+                'website_published': True,
+                'date_begin': datetime.today() - timedelta(days=1),
+                'date_end': datetime.today() + timedelta(days=1),
+                'tag_ids': tag,
+            }
+            for tag in tags
+            for _ in range(20)
+        ])
+
+        self.start_tour('/event', 'test_website_event_search', login='admin')
+
 
 @tagged('post_install', '-at_install')
 class TestWebsiteAccess(HttpCaseWithUserDemo, OnlineEventCase):


### PR DESCRIPTION
**Issue**:
In the event page on the website, filters are lost when changing pages.

**Steps to reproduce**:
- Ensure enough events exist with multiple type for a category and sufficient quantity (e.g., 24 per type)
- Go to the website app > events:
    - Filter events by a type
    - Click "Next page" or perform a search
    - The filter is lost

**Cause**:
Commit [7b188cf](https://github.com/odoo/odoo/commit/7b188cfedcdd14d2eef12da54084e46f81221350) introduced slug-based filtering. However, the implementation was not fully complete: the slug_tags were not retained in the `url_args` of the pager. As a result, when changing pages, the generated URLs lacked the necessary slug information, causing filters to be lost and search results to reset unexpectedly.

**Solution**:
Hardcode the slug_tags directly into the URL. This way, the slug_tags are preserved without modifying the XML files.

opw-4887189
