### PR TITLE
[FIX] mail: prevent fetching private messages

### DIFF
--- a/addons/calendar/static/tests/tours/calendar_tour.js
+++ b/addons/calendar/static/tests/tours/calendar_tour.js
@@ -13,6 +13,12 @@ const todayDate = function () {
     return `${month}/${day}/${year} 10:00:00`;
 };
 
+function assert(current, expected, info) {
+    if (current !== expected) {
+        console.error(info + ': "' + current + '" instead of "' + expected + '".');
+    }
+}
+
 registry.category("web_tour.tours").add("calendar_appointments_hour_tour", {
     url: "/odoo",
     steps: () => [
@@ -150,6 +156,41 @@ registry.category("web_tour.tours").add("test_calendar_decline_with_everybody_fi
         {
             content: "Wait declined status",
             trigger: ".o_attendee_status_declined",
+        },
+    ],
+});
+
+registry.category("web_tour.tours").add("test_messages_shown_through_technical_messages", {
+    url: '/odoo',
+    steps: () => [
+        stepUtils.showAppsMenuItem(),
+        {
+            content: "Open Sign App",
+            trigger: '.o_app[data-menu-xmlid="base.menu_administration"]',
+            run: "click",
+        },
+        {
+            content: "Enable Debug mode",
+            trigger: 'div[id="developer_tool"] a.d-block',
+            run: "click",
+        },
+        {
+            content: "Click on Technical Menu",
+            trigger: 'button[data-menu-xmlid="base.menu_custom"]',
+            run: "click",
+        },
+        {
+            content: "Click on Messages",
+            trigger: 'a[data-menu-xmlid="mail.menu_mail_message"]',
+            run: "click",
+        },
+        {
+            content: "Check number of messages",
+            trigger: 'table thead',
+            run:  () => {
+                assert(Array.from(document.querySelectorAll('tbody.ui-sortable tr')).filter((x) => x.children['res_id'].textContent == 'pub').length,2);
+                assert(Array.from(document.querySelectorAll('tbody.ui-sortable tr')).filter((x) => x.children['res_id'].textContent == 'priv').length,0);
+            },
         },
     ],
 });

--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -459,15 +459,19 @@ class MailThread(models.AbstractModel):
         DocModel = self.env[model_name] if model_name else self
         create_allow = getattr(DocModel, '_mail_post_access', 'write')
 
-        if operation in ['write', 'unlink']:
-            check_operation = 'write'
-        elif operation == 'create' and create_allow in ['create', 'read', 'write', 'unlink']:
-            check_operation = create_allow
+        valid_operations = {'read', 'write', 'unlink', 'create'}
+        if operation not in valid_operations:
+            raise ValueError(_('Invalid message operation, should be a valid ORM operation type'))
+        if create_allow not in valid_operations:
+            raise ValueError(_('Invalid _mail_post_access, should be a valid ORM operation type'))
+
+        if operation == 'read':
+            check_access = 'read'
         elif operation == 'create':
-            check_operation = 'write'
+            check_access = create_allow
         else:
-            check_operation = operation
-        return check_operation
+            check_access = 'write'
+        return check_access
 
     def _valid_field_parameter(self, field, name):
         # allow tracking on models inheriting from 'mail.thread'

--- a/addons/test_mail/models/mail_test_access.py
+++ b/addons/test_mail/models/mail_test_access.py
@@ -57,4 +57,8 @@ class MailTestAccessCusto(models.Model):
                 raise exceptions.AccessError('Cannot post on locked records')
             else:
                 return "read"
+        elif operation == "read":
+            if any(record.is_locked for record in self.browse(res_ids)):
+                return "write"
+            return 'read'
         return super()._get_mail_message_access(res_ids, operation, model_name=model_name)

--- a/addons/test_mail/security/test_mail_security.xml
+++ b/addons/test_mail/security/test_mail_security.xml
@@ -55,14 +55,29 @@
         <field name="groups" eval="[(4, ref('base.group_system'))]"/>
     </record>
 
-
-    <record id="mail_test_multi_company_rule" model="ir.rule">
-        <field name="name">Mail Test Multi Company</field>
-        <field name="model_id" ref="test_mail.model_mail_test_multi_company"/>
-        <field eval="True" name="global"/>
-        <field name="domain_force">['|', ('company_id', '=', False), ('company_id', 'in', company_ids)]</field>
+    <!-- mail.test.access.custo -->
+    <record id="ir_rule_mail_test_access_custo_update_internal" model="ir.rule">
+        <field name="name">Internal: write/unlink unlocked</field>
+        <field name="model_id" ref="test_mail.model_mail_test_access_custo"/>
+        <field name="domain_force">[('is_locked', '=', False)]</field>
+        <field name="groups" eval="[(4, ref('base.group_user'))]"/>
+        <field name="perm_read" eval="False"/>
+        <field name="perm_write" eval="True"/>
+        <field name="perm_create" eval="False"/>
+        <field name="perm_unlink" eval="True"/>
+    </record>
+    <record id="ir_rule_mail_test_access_custo_update_admin" model="ir.rule">
+        <field name="name">Admin: all</field>
+        <field name="model_id" ref="test_mail.model_mail_test_access_custo"/>
+        <field name="domain_force">[(1, '=', 1)]</field>
+        <field name="groups" eval="[(4, ref('base.group_system'))]"/>
+        <field name="perm_read" eval="True"/>
+        <field name="perm_write" eval="True"/>
+        <field name="perm_create" eval="True"/>
+        <field name="perm_unlink" eval="True"/>
     </record>
 
+    <!-- MAIL.TEST.MULTI.COMPANY(.*) -->
     <record id="mail_test_multi_company_rule" model="ir.rule">
         <field name="name">Mail Test Multi Company</field>
         <field name="model_id" ref="test_mail.model_mail_test_multi_company"/>


### PR DESCRIPTION
#### Steps to reproduce the bug:
With account 1:
- create a private event
- send messages in the event

With account 2:
- Go to Settings > Technical > Messages

#### Current behavior:
- Get an access right error

#### Expected behavior:
- Show allowed messages only

#### Cause of the bug:
To get messages it uses web_search_read :
- in the first time, it fetches all messages it got 'read' access rights on. As everyone got 'read' access rights to all calendar events it reads all messages linked to calendar events.
- then with a `web_read` it triggers `_search`. This triggers [`_get_mail_messages_access()`](https://github.com/odoo/odoo/blob/18.0/addons/calendar/models/calendar_event.py#L841-L847) which replaces the 'read' call by a 'write' call for messages linked to a calendar event. Therefore on `check_access` it triggers [the `ir.rule`](https://github.com/odoo/odoo/blob/18.0/addons/calendar/security/calendar_security.xml#L26-L34) which restricts 'write' access on private calendar event. This raises an access rights error.

#### Fix:
- remove messages the user doesn't have access to from messages fetched at first.

#### Consequences:
- Prevent uninvited user from seeing messages on private calendar event
- the commit fixes the test on access rights for messages of a private calendar event. The test use to check if it was possible to access messages from a private event from the record. However, messages are not displayed this way. They fetch all messages, then restrict to those they have 'read' access to the parent record. Therefore the commit adds a second test to check this behavior.
- as the fix adds a query to the database it updates some tests counting the number of queries sent to the database.

opw-4785878

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
