### PR TITLE
[FIX] {sale_,}mrp: compute reserved_packaging_qty for kit products without packaging

### DIFF
--- a/addons/mrp/models/stock_move.py
+++ b/addons/mrp/models/stock_move.py
@@ -86,8 +86,10 @@ class StockMoveLine(models.Model):
     def _compute_product_packaging_qty(self):
         # we catch kit lines where the packaging is still the one from the final product (it has
         # not been changed to a packaging of a component)
-        kit_lines = self.filtered(lambda move_line: move_line.move_id.bom_line_id.bom_id.type == 'phantom' and
-        move_line.product_id != move_line.move_id.product_packaging_id.product_id)
+        kit_lines = self.filtered(lambda move_line:
+            move_line.move_id.bom_line_id.bom_id.type == 'phantom'
+            and move_line.move_id.product_packaging_id
+            and move_line.product_id != move_line.move_id.product_packaging_id.product_id)
         for move_line in kit_lines:
             move = move_line.move_id
             bom_line = move.bom_line_id

--- a/addons/sale_mrp/tests/test_sale_mrp_kit_bom.py
+++ b/addons/sale_mrp/tests/test_sale_mrp_kit_bom.py
@@ -741,7 +741,6 @@ class TestSaleMrpKitBom(TransactionCase):
                     'product_id': comp_product.id,
                     'product_qty': 0.1,
                     'product_uom_id': self.env.ref('uom.product_uom_gram').id
-
                 }),
             ]
         })
@@ -753,14 +752,22 @@ class TestSaleMrpKitBom(TransactionCase):
                     'product_id': kit_product.id,
                     'product_uom_qty': 9,
                     'product_packaging_id': packaging_final_prod.id
-            })],
+                }),
+                Command.create({
+                    'name': kit_product.name,
+                    'product_id': kit_product.id,
+                    'product_uom_qty': 1,
+                }),
+            ],
         })
         so.action_confirm()
         # check that before validating, the product packaging quantity is good, both if we keep the final product packages
         # and if we change to a packages of the component
-        so.picking_ids.move_ids.write({'quantity': 0.9})
+        so.picking_ids.move_ids[0].write({'quantity': 0.9})
+        so.picking_ids.move_ids[1].write({'quantity': 0.1})
         self.assertEqual(so.picking_ids.move_ids.move_line_ids[0].product_packaging_qty, 1)
-        so.picking_ids.move_ids.product_packaging_id = packaging_comp
+        self.assertEqual(so.picking_ids.move_ids.move_line_ids[1].product_packaging_qty, 0)  # there is no packaging on that line
+        so.picking_ids.move_ids[0].product_packaging_id = packaging_comp
         self.assertEqual(so.picking_ids.move_ids.move_line_ids[0].product_packaging_qty, 2)
         # check that after validating, if the packages was changed to a package of the component the quantity is good
         so.picking_ids.button_validate()


### PR DESCRIPTION
### Steps to reproduce:

- In the settings enable "Product Packagings"
- Create a product P with a kit bom: 1 x COMP
- Create and confirm a delivery for 1 unit of P
- Reserve 1 unit of COMP (put the quantity of the move to 1)
- Go to Inventory > Reporting > Moves history
- Add the field "Reserved Packaging Quantity" in the view (with studio)
- remove the "done" filter
#### > Traceback: ZeroDivisionError in _compute_product_packaging_qty

### Cause of the issue:

The computation of the `product_packaging_qty` can not succeed for a kit move line without `packaging_id` on its move since: `move_line.move_id.product_packaging_id.qty` will be 0: https://github.com/odoo/odoo/blob/b87c896969cc576a799ac63f03501be1e87b0e84/addons/mrp/models/stock_move.py#L107 By contrast since if the packaging is set, there should not be an issue since the field is required and since there is a positive constraint: https://github.com/odoo/odoo/blob/b87c896969cc576a799ac63f03501be1e87b0e84/addons/product/models/product_packaging.py#L21-L27

opw-4781180
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
