### PR TITLE
[FIX] sale: Use default invoice email template for online payments

### DIFF
--- a/addons/sale/models/payment_transaction.py
+++ b/addons/sale/models/payment_transaction.py
@@ -151,10 +151,21 @@ class PaymentTransaction(models.Model):
                 lambda i: not i.is_move_sent and i.state == 'posted' and i._is_ready_to_be_sent()
             )
             invoice_to_send.is_move_sent = True # Mark invoice as sent
+
+            send_context = {'allow_raising': False, 'allow_fallback_pdf': True}
+            default_template_param = (
+                self.env['ir.config_parameter']
+                .sudo()
+                .get_param('sale.default_invoice_email_template', False)
+            )
+            if default_template_param:
+                mail_template = self.env['mail.template'].sudo().browse(int(default_template_param))
+                if mail_template.exists():
+                    send_context['mail_template'] = mail_template
+
             self.env['account.move.send']._generate_and_send_invoices(
                 invoice_to_send,
-                allow_raising=False,
-                allow_fallback_pdf=True,
+                **send_context,
             )
 
     def _cron_send_invoice(self):


### PR DESCRIPTION
When a sales order with online payment is paid, the automatically generated invoice was not consistently using the email template defined by the 'sale.default_invoice_email_template' system parameter.

This was due to the `_send_invoice` method in `payment_transaction` calling `_generate_and_send_invoices` without passing the configured template.

This commit modifies the `_send_invoice` method to retrieve the 'sale.default_invoice_email_template' system parameter. If found and valid, the corresponding mail template record is passed in the context to `_generate_and_send_invoices`, ensuring the correct email template is used for auto-sent invoices after online payments.

Added unit tests for the different scenarios.

## Reproduction Steps:
1.  **Enable Auto-invoicing:** Go to Sales > Configuration > Settings. Under "Invoicing," enable "Automatic Invoicing." Set a specific email template in "Invoice Email Template" (e.g., "Customer Invoice"). Save.
2.  **Configure Payment Acquirer:** Go to Invoicing > Configuration > Payment Acquirers. Activate and configure any payment acquirer (e.g., Bank Transfer). Ensure it's published.
3.  **Create Sales Order:** Go to Sales > Orders > Quotations. Create a new SO, add a product, and Confirm it.
4.  **Simulate Online Payment:** As a customer, navigate to the SO's public portal link. Click "Pay Now," select the configured acquirer, and complete payment.
5.  **Observe the Issue:** Check the communication history on the generated invoice. The email will have been sent using Odoo's default invoice template, ignoring the configured setting.

opw-4865475

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
