### PR TITLE
[FIX] hr_recruitment: fix recruiter and interviewers domain when company is unset

### DIFF
--- a/addons/hr_recruitment/tests/__init__.py
+++ b/addons/hr_recruitment/tests/__init__.py
@@ -5,3 +5,4 @@ from . import test_recruitment_process
 from . import test_recruitment
 from . import test_utm
 from . import test_recruitment_interviewer
+from . import test_recruitment_allowed_user_ids

--- a/addons/hr_recruitment/tests/test_recruitment_allowed_user_ids.py
+++ b/addons/hr_recruitment/tests/test_recruitment_allowed_user_ids.py
@@ -1,0 +1,68 @@
+from odoo.tests import tagged, TransactionCase
+
+
+@tagged('recruitment_allowed_user_ids')
+class TestRecruitmentAllowedUserIds(TransactionCase):
+
+    def setUp(self):
+        super().setUp()
+
+        self.env = self.env(context=dict(self.env.context, tracking_disable=True))
+
+        self.company_a = self.env['res.company'].create({'name': 'Company A'})
+        self.company_b = self.env['res.company'].create({'name': 'Company BBS'})
+
+        # Internal user in company A
+        self.user_a = self.env['res.users'].create({
+            'name': 'User A',
+            'login': 'usera@test.com',
+            'email': 'usera@test.com',
+            'share': False,
+            'company_ids': [self.company_a.id],
+            'company_id': self.company_a.id,
+        })
+
+        # Internal user in company B
+        self.user_b = self.env['res.users'].create({
+            'name': 'User B',
+            'login': 'userb@test.com',
+            'email': 'userb@test.com',
+            'share': False,
+            'company_ids': [self.company_b.id],
+            'company_id': self.company_b.id,
+        })
+
+    def test_recruiter_allowed_user_ids_with_company(self):
+        job = self.env['hr.job'].create({
+            'name': 'Job Position Company A',
+            'company_id': self.company_a.id,
+        })
+        job._compute_allowed_user_ids()
+
+        matched_users = job.allowed_user_ids
+
+        self.assertIn(self.user_a, matched_users)
+        self.assertNotIn(self.user_b, matched_users)
+
+        job = self.env['hr.job'].create({
+            'name': 'Job Position Company B',
+            'company_id': self.company_b.id,
+        })
+        job._compute_allowed_user_ids()
+
+        matched_users = job.allowed_user_ids
+
+        self.assertIn(self.user_b, matched_users)
+        self.assertNotIn(self.user_a, matched_users)
+
+    def test_recruiter_allowed_user_ids_without_company(self):
+        job = self.env['hr.job'].create({
+            'name': 'Job Position',
+            'company_id': False,
+        })
+        job._compute_allowed_user_ids()
+
+        matched_users = job.allowed_user_ids
+
+        self.assertIn(self.user_a, matched_users)
+        self.assertIn(self.user_b, matched_users)

--- a/addons/hr_recruitment/views/hr_job_views.xml
+++ b/addons/hr_recruitment/views/hr_job_views.xml
@@ -22,6 +22,7 @@
                 <field name="new_application_count"/>
                 <field name="no_of_hired_employee"/>
                 <field name="manager_id"/>
+                <field name="allowed_user_ids" invisible="1"/>
                 <field name="user_id"/>
                 <field name="application_count"/>
                 <templates>
@@ -180,8 +181,9 @@
         <field name="inherit_id" ref="hr.view_hr_job_form"/>
         <field name="arch" type="xml">
             <div name="recruitment_target" position="after">
+                <field name="allowed_user_ids" invisible="1"/>
                 <field name="user_id" widget="many2one_avatar_user"/>
-                <field name="interviewer_ids" widget="many2many_tags_avatar" options="{'no_create': True, 'no_create_edit': True}" />
+                <field name="interviewer_ids" widget="many2many_tags_avatar" options="{'no_create': True, 'no_create_edit': True}"/>
             </div>
             <xpath expr="//field[@name='department_id']" position="after">
                 <label for="address_id"/>
@@ -274,6 +276,7 @@
             <field name="no_of_recruitment" position="after">
                 <field name="alias_name" column_invisible="True"/>
                 <field name="alias_id" invisible="not alias_name" optional="hide"/>
+                <field name="allowed_user_ids" invisible="1"/>
                 <field name="user_id" widget="many2one_avatar_user" optional="hide"/>
             </field>
         </field>


### PR DESCRIPTION
In the Job Position form, the 'Recruiter' and 'Interviewers' fields were empty when no company was selected. This was due to the static domain using 'company_id' directly without taking into consideration that company_id can be False.
This fix introduces computed domain fields (, ) that dynamically adapt based on the selected company. If a company is set, users belonging to that company are shown. If not, only internal users are listed regardless their companies.
Related task: 4926154.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
