### PR TITLE
[FIX] stock: avoid traceback when creating replenishment

### DIFF
--- a/addons/stock/models/stock_orderpoint.py
+++ b/addons/stock/models/stock_orderpoint.py
@@ -343,7 +343,11 @@ class StockWarehouseOrderpoint(models.Model):
             rounding = orderpoint.product_uom.rounding
             # The check is on purpose. We only want to consider the visibility days if the forecast is negative and
             # there is a already something to ressuply base on lead times.
-            return float_compare(orderpoint.qty_forecast, orderpoint.product_min_qty, precision_rounding=rounding) < 0
+            return (
+                orderpoint.product_id
+                and orderpoint.location_id
+                and float_compare(orderpoint.qty_forecast, orderpoint.product_min_qty, precision_rounding=rounding) < 0
+            )
 
         orderpoints = self.filtered(to_compute)
         qty_in_progress_by_orderpoint = orderpoints._quantity_in_progress()

--- a/addons/stock/tests/test_proc_rule.py
+++ b/addons/stock/tests/test_proc_rule.py
@@ -672,8 +672,15 @@ class TestProcRule(TransactionCase):
             mto_rule.rule_message,
             'The help message should correctly display information for MTSO.'
         )
-        
-        
+
+    def test_replenishment_creation(self):
+        """Test that the default replenishment order values
+        are computed correctly in the tree view."""
+        orderpoint_list_view = Form(self.env['stock.warehouse.orderpoint'], view='stock.view_warehouse_orderpoint_tree_editable')
+        self.assertEqual(orderpoint_list_view.qty_to_order, 0)
+        self.assertFalse(orderpoint_list_view.product_id)
+
+
 class TestProcRuleLoad(TransactionCase):
     def setUp(cls):
         super(TestProcRuleLoad, cls).setUp()


### PR DESCRIPTION
Bug introduced in: https://github.com/odoo/odoo/pull/213154/commits/ea480703b64d88ac572c3e37da3d9fb3327b4445

Steps to reproduce the bug:
- Go to "Inventory" → "Operations" menu → "Replenishment"
- Click "New" to create a new replenishment rule

Problem:
Traceback is triggered:
```
in _float_check_precision assert precision_rounding > 0,\
^^^^^^^^^^^^^^^^^^^^^^ AssertionError: precision_rounding must be
positive, got 0.0
```

As the product is not set, the `product_uom` is not set either,
which leads to a `product_uom.rounding` of 0.0.

Opw-4925719
Opw-4928957
Opw-4926504
Opw-4925919
Opw-4928684
Opw-4925080
Opw-4928788
Opw-4926719
Opw-4927440
opw-4928540
