### PR TITLE
[FIX] website: adapt subtle input-group disabled state

### DIFF
--- a/addons/website/static/src/scss/website.scss
+++ b/addons/website/static/src/scss/website.scss
@@ -2940,7 +2940,14 @@ input[value*="data-oe-translation-source-sha"] {
     &:has(~ .form-control), &:has(~ .form-select) {
         padding-right: $input-group-addon-padding-x * .5;
     }
-    .form-control:disabled ~ &, .form-control[readonly] ~ &, &:has(~ .form-select:disabled), &:has(~ .form-select[readonly]) {
+    .form-control:disabled ~ &,
+    .form-control[readonly] ~ &,
+    &:has(~ .form-control:disabled),
+    &:has(~ .form-control[readonly]),
+    .form-select:disabled ~ &,
+    .form-select[readonly] ~ &,
+    &:has(~ .form-select:disabled),
+    &:has(~ .form-select[readonly]) {
         background-color: $input-disabled-bg;
         border-color: $input-disabled-border-color;
     }


### PR DESCRIPTION
Prior to this commit, the disabled state of subtle input-group worked partially.
Depending on the type of input and the position of the label (before or after the input), the disabled style was not correctly applied to the label.
This commit adapts the style to cover all possibilities.

task-4930086

| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/7923d8f9-b2f5-44c4-a970-0ad042787cd4) | ![image](https://github.com/user-attachments/assets/e1cf9593-69e8-4d0f-ab7a-041d4b65e80b) |





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
