### PR TITLE
[FIX] point_of_sale: enable search for special products

### DIFF
--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -2397,19 +2397,21 @@ export class PosStore extends WithLazyGetterTrap {
         const searchWord = this.searchProductWord.trim();
         const allProducts = this.models["product.template"].getAll();
         let list = [];
+        const isSearchByWord = searchWord !== "";
+        const isSelectedCategory = this.selectedCategory?.id;
 
-        if (searchWord !== "") {
+        if (isSearchByWord) {
             if (!this._searchTriggered) {
                 this.setSelectedCategory(0);
                 this._searchTriggered = true;
             }
             list = this.getProductsBySearchWord(
                 searchWord,
-                this.selectedCategory?.id ? this.selectedCategory.associatedProducts : allProducts
+                isSelectedCategory ? this.selectedCategory.associatedProducts : allProducts
             );
         } else {
             this._searchTriggered = false;
-            if (this.selectedCategory?.id) {
+            if (isSelectedCategory) {
                 list = this.selectedCategory.associatedProducts;
             } else {
                 list = allProducts;
@@ -2442,11 +2444,11 @@ export class PosStore extends WithLazyGetterTrap {
             filteredList.push(p);
         }
 
-        if (this.areAllProductsSpecial(filteredList)) {
+        if (!isSearchByWord && !isSelectedCategory && this.areAllProductsSpecial(filteredList)) {
             return [];
         }
 
-        return searchWord !== ""
+        return isSearchByWord
             ? filteredList.sort((a, b) => b.is_favorite - a.is_favorite)
             : filteredList.sort((a, b) => {
                   if (b.is_favorite !== a.is_favorite) {


### PR DESCRIPTION
After commit https://github.com/odoo/odoo/commit/2668181c98de4a9c6f33787372adefc01cf1d0bc, it was no longer possible to locate special products via the search function. Additionally, if these products belonged to a specific category, they would not be visible when filtering by that category.

opw-4925867

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
