### PR TITLE
[FIX] web: prevent dropdown overflow

### DIFF
--- a/addons/web/static/src/core/popover/popover.js
+++ b/addons/web/static/src/core/popover/popover.js
@@ -150,6 +150,7 @@ export class Popover extends Component {
                 this.props.onPositioned?.(el, solution);
             },
             position: this.props.position,
+            shrink: true,
         };
     }
 


### PR DESCRIPTION
With this commit, the dropdown menu tries to stay in the viewport instead of overflowing. The position compute fn still tries to get the best position but it applies a maximum height if the popper overflows.