### PR TITLE
[FIX] point_of_sale: prevent error with duplicate pricelist names

### DIFF
--- a/addons/point_of_sale/models/product.py
+++ b/addons/point_of_sale/models/product.py
@@ -208,7 +208,7 @@ class ProductProduct(models.Model):
         else:
             pricelists = config.pricelist_id
         price_per_pricelist_id = pricelists._price_get(self, quantity) if pricelists else False
-        pricelist_list = [{'name': pl.name, 'price': price_per_pricelist_id[pl.id]} for pl in pricelists]
+        pricelist_list = [{'id': pl.id, 'name': pl.name, 'price': price_per_pricelist_id[pl.id]} for pl in pricelists]
 
         # Warehouses
         warehouse_list = [

--- a/addons/point_of_sale/static/src/app/screens/product_screen/product_info_popup/product_info_popup.xml
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/product_info_popup/product_info_popup.xml
@@ -65,7 +65,7 @@
                             </tr>
                         </table>
                         <table class="table table-borderless">
-                            <t t-foreach="props.info.productInfo.pricelists" t-as="pricelist" t-key="pricelist.name">
+                            <t t-foreach="props.info.productInfo.pricelists" t-as="pricelist" t-key="pricelist.id">
                                 <tr>
                                     <td t-esc="pricelist.name"/>
                                     <td t-esc="env.utils.formatCurrency(pricelist.price)"/>


### PR DESCRIPTION
Before this commit, an error would occur when opening the product configuration popup if two pricelists shared the same name. This was due to the pricelist name being used as a key, which must be unique.

This commit resolves the issue by switching to the pricelist ID as the key, ensuring uniqueness and preventing errors when duplicate pricelist names exist.

opw-4882900

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
