### PR TITLE
[FIX] crm_livechat: fix error in create lead and forward step

### DIFF
--- a/addons/crm_livechat/models/chatbot_script_step.py
+++ b/addons/crm_livechat/models/chatbot_script_step.py
@@ -105,10 +105,12 @@ class ChatbotScriptStep(models.Model):
             and lead.filtered_domain(literal_eval(member.assignment_domain or "[]"))
         ]
         previous_operator = discuss_channel.livechat_operator_id
-        # sudo: im_livechat.channel - getting available operators is acceptable
-        users = discuss_channel.livechat_channel_id.sudo()._get_available_operators_by_livechat_channel(
-            self.env["res.users"].browse(assignable_user_ids)
-        )[discuss_channel.livechat_channel_id]
+        users = self.env["res.users"]
+        if discuss_channel.livechat_channel_id:
+            # sudo: im_livechat.channel - getting available operators is acceptable
+            users = discuss_channel.livechat_channel_id.sudo()._get_available_operators_by_livechat_channel(
+                self.env["res.users"].browse(assignable_user_ids)
+            )[discuss_channel.livechat_channel_id]
         message = self._process_step_forward_operator(discuss_channel, users=users)
         if previous_operator != discuss_channel.livechat_operator_id:
             user = next(user for user in users if user.partner_id == discuss_channel.livechat_operator_id)


### PR DESCRIPTION
When user tests the chatbot with create lead and forward step,
A traceback will appear.

Steps to reproduce the error:
- Install ``website_crm_livechat`` module
- Go to Livechat > Configuration >  Chatbots > Open Welcome Bot >
  Add a line > Step Type: Create Lead & Forward > Save & Close
- Test > the chat will open > Click on ``I have a pricing question`` >
  The Bot will ask for an email > Enter a valid email > Send

Traceback:
```
KeyError: im_livechat.channel()
```

When user clicks the Test button a discuss channel is created as shown in [1].
In this case, the discuss channel created for the chatbot test script
does not have a ``livechat_channel_id``.

https://github.com/odoo/odoo/blob/5c7a4716ef1b1c55e1ce8848c11c27c79768d1ec/addons/crm_livechat/models/chatbot_script_step.py#L109-L111
Here, ``livechat_channel_id`` will be an empty record.
So, It will raise the above traceback.

[1]: https://github.com/odoo/odoo/blob/5c7a4716ef1b1c55e1ce8848c11c27c79768d1ec/addons/website_livechat/controllers/chatbot.py#L52

sentry-6729421960

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
