### PR TITLE
[FIX] tools: consider new image data attributes as safe

### DIFF
--- a/odoo/tools/mail.py
+++ b/odoo/tools/mail.py
@@ -76,6 +76,7 @@ safe_attrs = defs.safe_attrs | frozenset(
      'data-publish', 'data-id', 'data-res_id', 'data-interval', 'data-member_id', 'data-scroll-background-ratio', 'data-view-id',
      'data-class', 'data-mimetype', 'data-original-src', 'data-original-id', 'data-gl-filter', 'data-quality', 'data-resize-width',
      'data-shape', 'data-shape-colors', 'data-file-name', 'data-original-mimetype',
+     'data-attachment-id', 'data-format-mimetype',
      'data-ai-field',
      'data-heading-link-id',
      'data-mimetype-before-conversion',


### PR DESCRIPTION
When adding `html_builder`, some new data attributes were added on images. Those new attributes were not made safe, and might therefore be lost during HTML sanitization.

This commit adds the new data attributes to the while list.

Steps to reproduce:
- Install `website_forum`.
- Login as administrator.
- Go to "Forum" then "About this forum".
- Edit, add an image inside the FAQ and save.
- If you inspect the image, it has `data-attachment-id` and `data-format-mimetype` attributes.
- Go to Setting.
- Setup a "Restricted Editor" user.
- In debug mode, go to "Access Rights".
- Add write access to `forum.forum` model for "Role / Member" users.
- Logout.
- Login as the "Restricted Editor" user.
- Go to the forum's FAQ page.
- Edit, change the text, save.

=> The attributes `data-attachment-id` and `data-format-mimetype` were lost.

task-4367641
