### PR TITLE
[FIX] spreadsheet_dashboard: remove faulty code

### DIFF
--- a/addons/spreadsheet_dashboard/static/src/bundle/dashboard_action/dashboard_action.js
+++ b/addons/spreadsheet_dashboard/static/src/bundle/dashboard_action/dashboard_action.js
@@ -122,7 +122,7 @@ export class SpreadsheetDashboardAction extends Component {
         if (this.props.state && this.props.state.activeDashboardId) {
             return this.props.state.activeDashboardId;
         }
-        const params = this.props.action.params || this.props.action.context.params;
+        const params = this.props.action.params;
         if (params && params.dashboard_id) {
             return params.dashboard_id;
         }


### PR DESCRIPTION
`params` was removed from the action context by 1b86bd7ecf4d8

So `this.props.action.context.params` no longer makes any sense. It looks like it was useless. Everything seems to work without it. Let's remove it.




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
