### PR TITLE
[IMP] website: use router and new drowpdown

### DIFF
--- a/addons/website/controllers/main.py
+++ b/addons/website/controllers/main.py
@@ -354,6 +354,9 @@ class Website(Home):
         action_url = f"/odoo/action-website.website_configurator?menu_id={request.env.ref('website.menu_website_configuration').id}"
         if step > 1:
             action_url += '&step=' + str(step)
+        info = kwargs.get('info')
+        if info:
+            action_url += f'&info={int(info)}'
         return request.redirect(action_url)
 
     @http.route(['/website/social/<string:social>'], type='http', auth="public", website=True, sitemap=False)

--- a/addons/website/static/src/client_actions/configurator/configurator.js
+++ b/addons/website/static/src/client_actions/configurator/configurator.js
@@ -755,10 +755,12 @@ export class Configurator extends Component {
         });
 
         const initialStep = router.current?.step
+        const infoFromUrl = router.current?.info;
         const store = reactive(new Store(), () => this.updateStorage(store));
 
         this.state = useState({
             currentStep: initialStep,
+            infoFromUrl: infoFromUrl,
         });
 
         useSubEnv({ store });
@@ -785,7 +787,7 @@ export class Configurator extends Component {
     }
 
     get pathname() {
-        return `/website/configurator${this.state.currentStep ? `/${encodeURIComponent(this.state.currentStep)}` : ''}`;
+        return `/website/configurator${this.state.currentStep ? `/${encodeURIComponent(this.state.currentStep)}` : ''}${this.state.infoFromUrl ? `?info=${encodeURIComponent(this.state.infoFromUrl)}` : ''}`;
     }
 
     get storageItemName() {

--- a/addons/website/static/src/client_actions/configurator/configurator.js
+++ b/addons/website/static/src/client_actions/configurator/configurator.js
@@ -754,7 +754,7 @@ export class Configurator extends Component {
             }
         });
 
-        const initialStep = this.props.action.context.params && this.props.action.context.params.step;
+        const initialStep = router.current?.step
         const store = reactive(new Store(), () => this.updateStorage(store));
 
         this.state = useState({


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Since https://github.com/odoo/odoo/pull/216067, we have to use router as a way to get the URL parameters.

This change adds the optional 'info' URL parameters to the website configurator. This is an additional way to communicate information to website_configurator sub component when accessed by a URL.

Current behavior before PR:

Going to `/website/configurator/6` redirects to `/website/configurator/`, so it ends up in the normal configurator rather than the website generator (for example). It is not possible to keep URL parameters when accessing the configurator at a specific step.

Desired behavior after PR is merged:

Going to `/website/configurator/6` redirects to `/website/configurator/6`.
It is now possible to add an 'info' url parameter which is kept when accessing the configurator at a specific step.

Linked to: https://github.com/odoo/enterprise/pull/89742

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
