### PR TITLE
Master patch test cursor now moc

### DIFF
--- a/addons/auth_passkey/tests/test_passkey_demo.py
+++ b/addons/auth_passkey/tests/test_passkey_demo.py
@@ -131,13 +131,14 @@ class PasskeyTest(HttpCaseWithUserDemo):
             },
         }
 
+        now = self.env.cr.now()
         for key, values in self.passkeys.items():
             self.cr.execute(SQL(
                 """
                 INSERT INTO auth_passkey_key (name, credential_identifier, public_key, create_uid, write_date, create_date)
-                VALUES (%s, %s, %s, %s, NOW() AT TIME ZONE 'UTC', NOW() AT TIME ZONE 'UTC')
+                VALUES (%s, %s, %s, %s, %s, %s)
                 RETURNING id
-                """, key, values['credential_identifier'], values['public_key'], values['user'].id,
+                """, key, values['credential_identifier'], values['public_key'], values['user'].id, now, now
             ))
             passkey_id = self.cr.fetchone()
             values['passkey'] = self.env['auth.passkey.key'].browse(passkey_id)

--- a/addons/bus/tests/test_ir_websocket.py
+++ b/addons/bus/tests/test_ir_websocket.py
@@ -1,4 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
+import os
+import unittest
 
 from odoo.tests import tagged
 from .common import WebsocketCase
@@ -6,6 +8,8 @@ from .common import WebsocketCase
 
 @tagged("-at_install", "post_install")
 class TestIrWebsocket(WebsocketCase):
+
+    @unittest.skipIf(os.getenv('ODOO_FAKETIME_MODE'), "This test does cannot work with faketime")
     def test_only_allow_string_channels_from_frontend(self):
         with self.assertLogs("odoo.addons.bus.websocket", level="ERROR") as log:
             ws = self.websocket_connect()

--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -1659,6 +1659,7 @@ class CrmLead(models.Model):
 
         # Get the active followers (followers whose partner post a message on the
         # leads in the last 30 days) which should be moved on the destination lead
+        now = self.env.cr.now()
         self.env.cr.execute(
             '''
             SELECT MAX(mf.id) AS id
@@ -1667,7 +1668,7 @@ class CrmLead(models.Model):
                 ON mm.author_id = mf.partner_id
                AND mm.res_id = mf.res_id
                AND mm.model = 'crm.lead'
-               AND mm.date > NOW() - INTERVAL '30 DAY'
+               AND mm.date > %(now)s - INTERVAL '30 DAY'
                    /* Check if the partner is already
                       following the destination lead */
          LEFT JOIN mail_followers AS destf
@@ -1681,7 +1682,7 @@ class CrmLead(models.Model):
                AND destf IS NULL
           GROUP BY mf.partner_id
             ''',
-            {'lead_ids': tuple(opportunities.ids), 'lead_id': self.id},
+            {'lead_ids': tuple(opportunities.ids), 'lead_id': self.id, 'now': now},
         )
         followers_to_update = [r[0] for r in self.env.cr.fetchall()]
         followers_to_update = self.env['mail.followers'].browse(followers_to_update).sudo()

--- a/addons/gamification/models/gamification_challenge.py
+++ b/addons/gamification/models/gamification_challenge.py
@@ -275,7 +275,7 @@ class GamificationChallenge(models.Model):
                         FROM gamification_goal as gg
                         JOIN mail_presence as mp ON mp.user_id = gg.user_id
                        WHERE gg.write_date <= mp.last_presence
-                         AND mp.last_presence >= now() AT TIME ZONE 'UTC' - interval '%(session_lifetime)s seconds'
+                         AND mp.last_presence >= %(now)s - interval '%(session_lifetime)s seconds'
                          AND gg.closed IS NOT TRUE
                          AND gg.challenge_id IN %(challenge_ids)s
                          AND (gg.state = 'inprogress'
@@ -284,7 +284,8 @@ class GamificationChallenge(models.Model):
         """, {
             'session_lifetime': SESSION_LIFETIME,
             'challenge_ids': tuple(self.ids),
-            'yesterday': yesterday
+            'yesterday': yesterday,
+            'now': self.env.cr.now(),
         })
 
         Goals.browse(goal_id for [goal_id] in self.env.cr.fetchall()).update_goal()

--- a/addons/project_todo/models/res_users.py
+++ b/addons/project_todo/models/res_users.py
@@ -3,7 +3,7 @@
 
 import json
 
-from odoo import _, api, models, modules
+from odoo import _, api, models, modules, fields
 
 
 class ResUsers(models.Model):
@@ -24,9 +24,9 @@ class ResUsers(models.Model):
         # 2. creating groups for todo and task seperately
         query = """SELECT BOOL(t.project_id) as is_task, count(*), act.res_model, act.res_id,
                        CASE
-                           WHEN CURRENT_DATE - act.date_deadline::date = 0 THEN 'today'
-                           WHEN CURRENT_DATE - act.date_deadline::date > 0 THEN 'overdue'
-                           WHEN CURRENT_DATE - act.date_deadline::date < 0 THEN 'planned'
+                           WHEN %(current_date)s::date - act.date_deadline::date = 0 THEN 'today'
+                           WHEN %(current_date)s::date - act.date_deadline::date > 0 THEN 'overdue'
+                           WHEN %(current_date)s::date - act.date_deadline::date < 0 THEN 'planned'
                         END AS states
                      FROM mail_activity AS act
                      JOIN project_task AS t ON act.res_id = t.id
@@ -36,6 +36,7 @@ class ResUsers(models.Model):
         self.env.cr.execute(query, {
             'user_id': self.env.uid,
             'active': self.env.context.get('active_test', True),
+            'current_date': fields.Date.context_today(self)
         })
         activity_data = self.env.cr.dictfetchall()
         view_type = self.env['project.task']._systray_view

--- a/addons/website/models/website_visitor.py
+++ b/addons/website/models/website_visitor.py
@@ -203,6 +203,7 @@ class WebsiteVisitor(models.Model):
         :return: a tuple containing the visitor id and the upsert result (either
             `inserted` or `updated).
         """
+        now = self.env.cr.now()
         create_values = {
             'access_token': access_token,
             'lang_id': request.lang.id,
@@ -217,26 +218,27 @@ class WebsiteVisitor(models.Model):
             # visitor is linked to a logged in user, in which case its partner_id is
             # used instead as the token.
             'partner_id': None if len(str(access_token)) == 32 else access_token,
+            'now': now,
         }
         query = SQL("""
             INSERT INTO website_visitor (
                 partner_id, access_token, last_connection_datetime, visit_count, lang_id,
                 website_id, timezone, write_uid, create_uid, write_date, create_date, country_id)
             VALUES (
-                %(partner_id)s, %(access_token)s, now() at time zone 'UTC', 1, %(lang_id)s,
+                %(partner_id)s, %(access_token)s, %(now)s, 1, %(lang_id)s,
                 %(website_id)s, %(timezone)s, %(create_uid)s, %(write_uid)s,
-                now() at time zone 'UTC', now() at time zone 'UTC', (
+                %(now)s, %(now)s, (
                     SELECT id FROM res_country WHERE code = %(country_code)s
                 )
             )
             ON CONFLICT (access_token)
             DO UPDATE SET
                 last_connection_datetime=excluded.last_connection_datetime,
-                visit_count = CASE WHEN website_visitor.last_connection_datetime < NOW() AT TIME ZONE 'UTC' - INTERVAL '8 hours'
+                visit_count = CASE WHEN website_visitor.last_connection_datetime < %(now)s - INTERVAL '8 hours'
                                     THEN website_visitor.visit_count + 1
                                     ELSE website_visitor.visit_count
                                 END
-            RETURNING id, CASE WHEN create_date = now() at time zone 'UTC' THEN 'inserted' ELSE 'updated' END AS upsert
+            RETURNING id, CASE WHEN create_date = %(now)s THEN 'inserted' ELSE 'updated' END AS upsert
         """, **create_values)
 
         if force_track_values:
@@ -245,13 +247,14 @@ class WebsiteVisitor(models.Model):
                     %(query)s, %(url)s AS url, %(page_id)s AS page_id
                 ), track AS (
                     INSERT INTO website_track (visitor_id, url, page_id, visit_datetime)
-                    SELECT id, url, page_id::integer, now() at time zone 'UTC' FROM visitor
+                    SELECT id, url, page_id::integer, %(now)s FROM visitor
                 )
                 SELECT id, upsert from visitor;
                 """,
                 query=query,
                 url=force_track_values['url'],
                 page_id=force_track_values.get('page_id'),
+                now=now,
             )
 
         [result] = self.env.execute_query(query)

--- a/addons/website/tests/test_controllers.py
+++ b/addons/website/tests/test_controllers.py
@@ -1,7 +1,9 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import json
+import os
 
+from datetime import datetime, timedelta
 from werkzeug.urls import url_encode
 
 from unittest.mock import patch, Mock
@@ -21,6 +23,8 @@ class TestControllers(tests.HttpCase):
         base_url = self.env['ir.config_parameter'].sudo().get_param('web.base.url')
         suggested_links_url = base_url + '/website/get_suggested_links'
 
+        fake_time_mode = os.getenv('ODOO_FAKETIME_MODE')
+
         old_pages = Page
         for i in range(0, 10):
             new_page = Page.create({
@@ -36,6 +40,8 @@ class TestControllers(tests.HttpCase):
             if i % 2 == 0:
                 old_pages += new_page
             else:
+                if fake_time_mode:
+                    new_page._write({'write_date': datetime.now() + timedelta(hours=1)})
                 last_5_url_edited.append(new_page.url)
 
         self.url_open(url=suggested_links_url, json={'params': {'needle': '/'}})

--- a/addons/website_crm_iap_reveal/models/crm_reveal_view.py
+++ b/addons/website_crm_iap_reveal/models/crm_reveal_view.py
@@ -39,14 +39,15 @@ class CrmRevealView(models.Model):
         # we are avoiding reveal if reveal_view already created for this IP
         rules = self.env['crm.reveal.rule']._match_url(website_id, url, country_code, state_code, rules_excluded)
         if rules:
+            now = self.env.cr.now()
             query = """
                     INSERT INTO crm_reveal_view (reveal_ip, reveal_rule_id, reveal_state, create_date)
-                    VALUES (%s, %s, 'to_process', now() at time zone 'UTC')
+                    VALUES (%s, %s, 'to_process', %s)
                     ON CONFLICT DO NOTHING;
                     """ * len(rules)
             params = []
             for rule in rules:
-                params += [ip_address, rule['id']]
+                params += [ip_address, rule['id'], now]
                 rules_excluded.append(str(rule['id']))
             self.env.cr.execute(query, params)
             return rules_excluded

--- a/odoo/addons/test_http/tests/test_session.py
+++ b/odoo/addons/test_http/tests/test_session.py
@@ -4,6 +4,7 @@ import datetime
 import json
 import os
 from tempfile import TemporaryDirectory
+from unittest import skipIf
 from unittest.mock import patch
 from urllib.parse import urlencode
 
@@ -331,6 +332,7 @@ class TestHttpSession(TestHttpBase):
         )
 
 
+@skipIf(os.getenv('ODOO_FAKETIME_MODE'), "This test does cannot work with faketime")
 class TestSessionStore(HttpCaseWithUserDemo):
     def setUp(self):
         super().setUp()

--- a/odoo/sql_db.py
+++ b/odoo/sql_db.py
@@ -264,6 +264,9 @@ class BaseCursor(_CursorProtocol):
     def now(self) -> datetime:
         """ Return the transaction's timestamp ``NOW() AT TIME ZONE 'UTC'``. """
         if self._now is None:
+            if os.getenv('ODOO_FAKETIME_MODE'):
+                self._now = datetime.now()
+                return self._now
             self.execute("SELECT (now() AT TIME ZONE 'UTC')")
             row = self.fetchone()
             assert row

--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -1051,6 +1051,7 @@ class TransactionCase(BaseCase):
         cls.startClassPatcher(cls._signal_changes_patcher)
 
         cls.cr = cls.registry.cursor()
+        cls.cr._now = datetime.now()
         cls.addClassCleanup(cast(Cursor, cls.cr).close)
 
         def check_cursor_stack():


### PR DESCRIPTION
- [IMP] testing: patch cursor _now in tests

In order to properly use the faketime tool during tests on runbot, the
cursor `_now`, which uses the postgresql `NOW` function, is replaced by
a pythonic datetime that can be altered by faketime.

- [IMP] sql_db: use a pythonic _now when faketime is used

- [WIP] replace as much as possible now's by a pythonic one

Note that we cannot replace postgresql NOW's in SQL views