### PR TITLE
[FIX] account: reset currency rate after company currency change

### DIFF
--- a/addons/account/models/company.py
+++ b/addons/account/models/company.py
@@ -393,6 +393,12 @@ class ResCompany(models.Model):
                 if self.env['account.move.line'].search([('company_id', '=', company.id)]):
                     raise UserError(_('You cannot change the currency of the company since some journal items already exist'))
 
+                # We delete rate in the new company currency rate to avoid conversion issues
+                self.env['res.currency.rate'].search([
+                    ('currency_id', '=', values['currency_id']),
+                    ('company_id', '=', company.id),
+                ]).unlink()
+
         return super(ResCompany, self).write(values)
 
     @api.model


### PR DESCRIPTION
Steps to reproduce:
- Create a company with EUR as the main currency
- Enable another currency and define a rate (e.g. 0.5 USD = 1 EUR)
- Create a vendor bill of 100 USD → correctly converted to 200 EUR
- Delete the bill
- Change the company currency to USD
- Create a new bill of 100 EUR → it is converted to 50 USD although no conversion rate "exists" from EUR to USD, since the company rate is not show to end users.

It mainly affects databases that changed currency setup after initial configuration, and had automatic currency rates enabled before starting actual accounting.

opw-4876863