### PR TITLE
[FIX] product: prevent error on clearing the product description from an invoice line

### DIFF
--- a/addons/product/static/src/product_name_and_description/product_name_and_description.js
+++ b/addons/product/static/src/product_name_and_description/product_name_and_description.js
@@ -90,7 +90,7 @@ export class ProductNameAndDescriptionField extends Component {
     }
 
     get productName() {
-        return this.props.record.data[this.props.name].display_name;
+        return this.props.record.data[this.props.name].display_name || "";
     }
 
     get label() {


### PR DESCRIPTION
Currently, On removing a product name and its description from the account move line causing an error.

Steps to Reproduce:
- Install Invoicing app
- Navigate to Invoicing>Customers>Invoices
- Create New Invoice and add a product.
- Now remove only product name and its description from the account move line(Invoice Line)
- click anywhere on the screen.

Error:
`KeyError: 'name'`

Root Cause:
since [this commit](https://github.com/odoo/odoo/commit/7e553d25890d1e236123f0fa7e11ce86f59448ab),
the method `updateLabel` was removed from the [product_label_section_and_note_field](https://github.com/odoo/odoo/blob/547167ca3ed2ee727ce81c18afaae8aee7a436b4/addons/account/static/src/components/product_label_section_and_note_field/product_label_section_and_note_field.js) component
Now, when a user removes the product's description from the invoice line, the
`updateLabel` method at [1] is called. In this scenario the value of
`[this.descriptionColumn]: value || this.productName` looks like
`name= '' || undefined` since this is a falsy condition JS assigns
undefined as the value of `name` which is recieved by the onchange
method causing an error

[1]- https://github.com/odoo/odoo/blob/c04bcaac02b97583f06265e98be8a721538830f6/addons/product/static/src/product_name_and_description/product_name_and_description.js#L131-L135

Solution:
This commit prevents the error by ensuring `undefined` value is not
sent to the server.

sentry-6327760196