### PR TITLE
[FIX] stock: prevent zero rounding error in reordering rules

### DIFF
--- a/addons/stock/models/stock_orderpoint.py
+++ b/addons/stock/models/stock_orderpoint.py
@@ -340,7 +340,7 @@ class StockWarehouseOrderpoint(models.Model):
     @api.depends('qty_multiple', 'qty_forecast', 'product_min_qty', 'product_max_qty', 'visibility_days')
     def _compute_qty_to_order_computed(self):
         def to_compute(orderpoint):
-            rounding = orderpoint.product_uom.rounding
+            rounding = orderpoint.product_uom.rounding or 0.01
             # The check is on purpose. We only want to consider the visibility days if the forecast is negative and
             # there is a already something to ressuply base on lead times.
             return (

--- a/addons/stock/static/tests/tours/stock_reordering_order_tour.js
+++ b/addons/stock/static/tests/tours/stock_reordering_order_tour.js
@@ -1,0 +1,23 @@
+/** @odoo-module **/
+
+import { registry } from "@web/core/registry";
+
+registry.category("web_tour.tours").add('test_reordering_rule_with_variant_product', {
+    steps: () => [
+    {
+        trigger: 'span:contains("KRIP T-Shirt")',
+        run: "click",
+    },
+    {
+        trigger: '.o_button_more',
+        run: "click",
+    },
+    {
+        trigger: "button[name='action_view_orderpoints']",
+        run: "click",
+    },
+    {
+        trigger: '.o_list_button_add',
+        run: "click",
+    }
+]});


### PR DESCRIPTION
The system encounters an error when attempting to `create` a `reordering rule` for products that have `variants`.

**Steps to Reproduce:-**
1. Install the `Inventory` module.
2. Navigate to the `Products` section and create a product with variants (Make sure the `variants` option is `enabled` in the `settings`).
3. Click on `Reordering Rules` for that product and attempt to`create a new rule`.

**Error:-**
`AssertionError: precision_rounding must be positive, got 0.0`

**Root Cause:-**
- When trying to create the reordering rule for a product with variants, the `rounding` value comes as `0.0` at [1]. This occurs because there are `no products` in the `order point`, and consequently, there is `no unit of measure (UoM)` associated with it.

[1]
https://github.com/odoo/odoo/blob/970bd0e13319b2363c3ec186983faae2713ef5ef/addons/stock/models/stock_orderpoint.py#L343

**Solution:-**
- In this commit, set the `rounding` value to `0.01` by default when the value is 0.0. This adjustment will ensure that all float comparisons using that UoM function will work correctly.

**Sentry-6731259843**

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
