### PR TITLE
[16.0][FIX] hr_holidays_attendance: Avoid access error in _check_overtime_deductible()

### DIFF
--- a/addons/hr_holidays_attendance/models/hr_leave.py
+++ b/addons/hr_holidays_attendance/models/hr_leave.py
@@ -52,7 +52,7 @@ class HRLeave(models.Model):
         # If the type of leave is overtime deductible, we have to check that the employee has enough extra hours
         for leave in leaves:
             if not leave.overtime_deductible:
-                leave.overtime_id.sudo().unlink()
+                leave.sudo().overtime_id.unlink()
                 continue
             employee = leave.employee_id.sudo()
             duration = leave.number_of_hours_display


### PR DESCRIPTION
Avoid access error in _check_overtime_deductible()

Related to https://github.com/odoo/odoo/commit/1b1a085117ae2e1401fbfeff6b78a04d1ba71976

If a hr.leave is created by a user an access error occurs because he does not have sufficient permissions in the overtime_id field.

```
File "/opt/odoo/auto/addons/hr_holidays_attendance/models/hr_leave.py", line 55, in _check_overtime_deductible
    leave.overtime_id.sudo().unlink()
  File "/opt/odoo/custom/src/odoo/odoo/fields.py", line 2824, in __get__
    return super().__get__(records, owner)
  File "/opt/odoo/custom/src/odoo/odoo/fields.py", line 1189, in __get__
    record._fetch_field(self)
  File "/opt/odoo/custom/src/odoo/odoo/models.py", line 3230, in _fetch_field
    self.check_field_access_rights('read', [field.name])
  File "/opt/odoo/custom/src/odoo/odoo/models.py", line 2986, in check_field_access_rights
    raise AccessError(_(
odoo.exceptions.AccessError: The requested operation can not be completed due to security restrictions. Document type: Time Off (hr.leave)
Operation: read
User: 96
Fields:
- overtime_id (allowed for groups 'Time Off / Officer : Manage all requests')
```

Please @pedrobaeza can you review it?

@Tecnativa

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
