### PR TITLE
[FIX] web: add lanczos resampling for webp image processing

### DIFF
--- a/addons/html_editor/static/src/fields/x2many_field/x2many_media_viewer.js
+++ b/addons/html_editor/static/src/fields/x2many_field/x2many_media_viewer.js
@@ -78,23 +78,7 @@ export class X2ManyMediaViewer extends X2ManyField {
                 let referenceId = undefined;
 
                 for (const size of [originalSize, ...smallerSizes]) {
-                    const ratio = size / originalSize;
-                    const canvas = document.createElement("canvas");
-                    canvas.width = image.width * ratio;
-                    canvas.height = image.height * ratio;
-                    const ctx = canvas.getContext("2d");
-                    ctx.drawImage(
-                        image,
-                        0,
-                        0,
-                        image.width,
-                        image.height,
-                        0,
-                        0,
-                        canvas.width,
-                        canvas.height
-                    );
-
+                    const canvas = lanczos.resizeImageWithResampling(image, size, originalSize);
                     // WebP format
                     const webpData = canvas.toDataURL("image/webp", 0.75).split(",")[1];
                     const [resizedId] = await this.orm.call("ir.attachment", "create_unique", [

--- a/addons/html_editor/static/src/main/media/media_plugin.js
+++ b/addons/html_editor/static/src/main/media/media_plugin.js
@@ -326,24 +326,7 @@ export class MediaPlugin extends Plugin {
             const originalSize = Math.max(image.width, image.height);
             const smallerSizes = [1024, 512, 256, 128].filter((size) => size < originalSize);
             for (const size of [originalSize, ...smallerSizes]) {
-                const ratio = size / originalSize;
-                const canvas = document.createElement("canvas");
-                canvas.width = image.width * ratio;
-                canvas.height = image.height * ratio;
-                const ctx = canvas.getContext("2d");
-                ctx.fillStyle = "rgb(255, 255, 255)";
-                ctx.fillRect(0, 0, canvas.width, canvas.height);
-                ctx.drawImage(
-                    image,
-                    0,
-                    0,
-                    image.width,
-                    image.height,
-                    0,
-                    0,
-                    canvas.width,
-                    canvas.height
-                );
+                const canvas = lanczos.resizeImageWithResampling(image, size, originalSize);
                 altData[size] = {
                     "image/jpeg": canvas.toDataURL("image/jpeg", 0.75).split(",")[1],
                 };

--- a/addons/web/__manifest__.py
+++ b/addons/web/__manifest__.py
@@ -96,6 +96,7 @@ This module provides the core of the Odoo Web Client.
             'web/static/src/libs/bootstrap.js',
 
             'web/static/lib/dompurify/DOMpurify.js',
+            'web/static/lib/lanczos/lanczos.js',
 
             'base/static/src/css/modules.css',
 
@@ -220,6 +221,7 @@ This module provides the core of the Odoo Web Client.
             'web/static/src/libs/bootstrap.js',
             'web/static/src/legacy/js/libs/jquery.js',
             'web/static/src/legacy/js/core/class.js',
+            'web/static/lib/lanczos/lanczos.js',
 
             'web/static/src/env.js',
             'web/static/src/core/utils/transitions.scss',  # included early because used by other files
@@ -492,6 +494,7 @@ This module provides the core of the Odoo Web Client.
             'web/static/lib/stacktracejs/stacktrace.js',
             ('include', "web.chartjs_lib"),
             'web/static/lib/signature_pad/signature_pad.umd.js',
+            'web/static/lib/lanczos/lanczos.js',
 
             'web/static/tests/legacy/helpers/**/*.js',
             'web/static/tests/legacy/views/helpers.js',

--- a/addons/web/static/lib/lanczos/LICENSE
+++ b/addons/web/static/lib/lanczos/LICENSE
@@ -1,0 +1,27 @@
+@license -------------------------------------------------------------------
+   module: Lanczos Resampling
+      src: http://blog.yoz.sk/2010/11/lanczos-resampling-with-actionscript/
+  authors: Jozef Chutka
+copyright: (c) 2009-2010 Jozef Chutka
+  license: MIT
+-------------------------------------------------------------------
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the "Software"), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.

--- a/addons/web/static/lib/lanczos/lanczos.js
+++ b/addons/web/static/lib/lanczos/lanczos.js
@@ -1,0 +1,162 @@
+(function (exports) {
+    'use strict';
+
+    const CACHE_PRECISION = 1000;
+    const FILTER_SIZE = 3;
+
+    function lanczos(size, x) {
+        if (x >= size || x <= -size) return 0;
+        if (Math.abs(x) < Number.EPSILON) return 1; // x ~ 0 with floating-point precision
+        const xpi = x * Math.PI;
+        return size * Math.sin(xpi) * Math.sin(xpi / size) / (xpi * xpi);
+    };
+
+    function createCache(kernel, precision, filterSize) {
+        const cache = {};
+        const max = filterSize * filterSize * precision;
+        const iprecision = 1.0 / precision;
+        let value;
+        // Kernel always computed on positive value
+        for (let cacheKey = 0; cacheKey < max; cacheKey++) {
+            value = kernel(filterSize, Math.sqrt(cacheKey * iprecision));
+            cache[cacheKey] = value < 0 ? 0 : value;
+        }
+        return cache;
+    };
+
+    function createCanvas(width, height) {
+        const canvas = document.createElement("canvas");
+        canvas.width = width;
+        canvas.height = height;
+        return canvas;
+    };
+
+    function resampleLanczos(img, width, height, options = {}) {
+        const {
+            filterSize = FILTER_SIZE,
+            cachePrecision = CACHE_PRECISION
+        } = options;
+        // Store filter results in cache for performance
+        const cache = createCache(lanczos, cachePrecision, filterSize);
+
+        const inputCanvas = createCanvas(img.width, img.height);
+        const inputCtx = inputCanvas.getContext("2d");
+        inputCtx.drawImage(img, 0, 0);
+
+        const src = inputCtx.getImageData(0, 0, img.width, img.height);
+        const dst = inputCtx.createImageData(width, height);
+        const srcData = src.data;
+        const dstData = dst.data;
+
+        const sx = width / img.width;
+        const sy = height / img.height;
+        const xmax = img.width - 1;
+        const ymax = img.height - 1;
+        const sx2 = Math.min(1, sx) ** 2;
+        const sy2 = Math.min(1, sy) ** 2;
+        // Precompute inverse for faster operation
+        const isx = 1.0 / sx;
+        const isy = 1.0 / sy;
+        const iw = 1.0 / width;
+        const ih = 1.0 / height;
+        // Loops variables
+        let a, r, g, b;
+        let idx;
+        let x1, x1s, x1e;
+        let y1, y1s, y1e;
+        let srcOffset, dstOffset;
+        // Subpixel shifts
+        let cx, cy;
+        let centerX, centerY;
+        let weight, sum, distY;
+
+        for (let y = 0; y < height; y++) {
+            centerY = (y + 0.5) * isy;
+            // Clamping Y
+            y1s = centerY - filterSize;
+            if (y1s < 0) y1s = 0;
+            y1e = centerY + filterSize;
+            if (y1e > ymax) y1e = ymax;
+
+            cy = y * ih - centerY;
+            dstOffset = y * width;
+            for (let x = 0; x < width; x++) {
+                centerX = (x + 0.5) * isx;
+                // Clamping X
+                x1s = centerX - filterSize;
+                if (x1s < 0) x1s = 0;
+                x1e = centerX + filterSize;
+                if (x1e > xmax) x1e = xmax;
+
+                cx = x * iw - centerX;
+                sum = a = r = g = b = 0;
+                for (y1 = y1s >> 0; y1 <= y1e; y1++) {
+                    srcOffset = y1 * img.width;
+                    distY = (y1 + cy) * (y1 + cy) * sy2;
+                    for (x1 = x1s >> 0; x1 <= x1e; x1++) {
+                        // Weight computation with cache
+                        weight = cache[((x1 + cx) * (x1 + cx) * sx2 + distY) * cachePrecision >> 0] || 0;
+                        sum += weight;
+                        // Color accumulation
+                        idx = (srcOffset + x1) << 2;
+                        r += srcData[idx] * weight;
+                        g += srcData[idx + 1] * weight;
+                        b += srcData[idx + 2] * weight;
+                        a += srcData[idx + 3] * weight;
+                    }
+                }
+                sum = sum > 0 ? 1.0 / sum : 0.0;
+                idx = (dstOffset + x) << 2;
+                dstData[idx] = r * sum;
+                dstData[idx + 1] = g * sum;
+                dstData[idx + 2] = b * sum;
+                dstData[idx + 3] = a * sum;
+            }
+        }
+        const outputCanvas = createCanvas(dst.width, dst.height);
+        const outputCtx = outputCanvas.getContext("2d");
+        outputCtx.putImageData(dst, 0, 0)
+        return outputCanvas;
+    }
+
+    function resizeLanczos(img, newWidth, newHeight, options = {}) {
+        // Avoid decimal sizes
+        const newW = Math.floor(newWidth);
+        const newH = Math.floor(newHeight);
+        const canvas = resampleLanczos(img, newW, newH, options);
+        return canvas;
+    }
+
+    function resizeCanvas(image, newWidth, newHeight) {
+        const canvas = createCanvas(newWidth, newHeight);
+        const ctx = canvas.getContext("2d");
+        ctx.fillStyle = "transparent";
+        ctx.fillRect(0, 0, canvas.width, canvas.height);
+        ctx.imageSmoothingEnabled = true;
+        ctx.imageSmoothingQuality = "high";
+        ctx.drawImage(
+            image,
+            0, 0, image.width, image.height,
+            0, 0, canvas.width, canvas.height
+        );
+        return canvas;
+    }
+
+    function resizeImageWithResampling(image, newSize, originalSize, options = {}) {
+        const ratio = newSize / originalSize;
+        const newWidth = image.width * ratio;
+        const newHeight = image.height * ratio;
+        // Keep it thumbnails only for now to avoid performance issues
+        if (newSize < originalSize && newSize < 1920) {
+            try {
+                return resizeLanczos(image, newWidth, newHeight, options);
+            } catch (error) {
+                console.warn("Lanczos resizing failed, falling back to canvas resizing:", error);
+            }
+        }
+        return resizeCanvas(image, newWidth, newHeight);
+    }
+
+    exports.resizeImageWithResampling = resizeImageWithResampling;
+
+})(this.lanczos = this.lanczos || {});

--- a/addons/web/static/src/views/fields/image/image_field.js
+++ b/addons/web/static/src/views/fields/image/image_field.js
@@ -180,26 +180,7 @@ export class ImageField extends Component {
             const smallerSizes = [1024, 512, 256, 128].filter((size) => size < originalSize);
             let referenceId = undefined;
             for (const size of [originalSize, ...smallerSizes]) {
-                const ratio = size / originalSize;
-                const canvas = document.createElement("canvas");
-                canvas.width = image.width * ratio;
-                canvas.height = image.height * ratio;
-                const ctx = canvas.getContext("2d");
-                ctx.fillStyle = "transparent";
-                ctx.fillRect(0, 0, canvas.width, canvas.height);
-                ctx.imageSmoothingEnabled = true;
-                ctx.imageSmoothingQuality = "high";
-                ctx.drawImage(
-                    image,
-                    0,
-                    0,
-                    image.width,
-                    image.height,
-                    0,
-                    0,
-                    canvas.width,
-                    canvas.height
-                );
+                const canvas = lanczos.resizeImageWithResampling(image, size, originalSize);
                 const [resizedId] = await this.orm.call("ir.attachment", "create_unique", [
                     [
                         {

--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -3681,14 +3681,7 @@ export class Wysiwyg extends Component {
             const originalSize = Math.max(image.width, image.height);
             const smallerSizes = [1024, 512, 256, 128].filter(size => size < originalSize);
             for (const size of [originalSize, ...smallerSizes]) {
-                const ratio = size / originalSize;
-                const canvas = document.createElement('canvas');
-                canvas.width = image.width * ratio;
-                canvas.height = image.height * ratio;
-                const ctx = canvas.getContext('2d');
-                ctx.fillStyle = 'rgb(255, 255, 255)';
-                ctx.fillRect(0, 0, canvas.width, canvas.height);
-                ctx.drawImage(image, 0, 0, image.width, image.height, 0, 0, canvas.width, canvas.height);
+                const canvas = lanczos.resizeImageWithResampling(image, size, originalSize);
                 altData[size] = {
                     'image/jpeg': canvas.toDataURL('image/jpeg', 0.75).split(',')[1],
                 };

--- a/addons/website_sale/static/src/js/website_sale.editor.js
+++ b/addons/website_sale/static/src/js/website_sale.editor.js
@@ -731,14 +731,7 @@ options.registry.WebsiteSaleProductPage = options.Class.extend({
         const mimetype = `image/${format}`;
         let referenceId = undefined;
         for (const size of [originalSize, ...smallerSizes]) {
-            const ratio = size / originalSize;
-            const canvas = document.createElement("canvas");
-            canvas.width = imgEl.width * ratio;
-            canvas.height = imgEl.height * ratio;
-            const ctx = canvas.getContext("2d");
-            ctx.fillStyle = 'transparent';
-            ctx.fillRect(0, 0, canvas.width, canvas.height);
-            ctx.drawImage(imgEl, 0, 0, imgEl.width, imgEl.height, 0, 0, canvas.width, canvas.height);
+            const canvas = lanczos.resizeImageWithResampling(imgEl, size, originalSize);
             const [resizedId] = await this.orm.call("ir.attachment", "create_unique", [[{
                 name: webpName,
                 description: size === originalSize ? "" : `resize: ${size}`,


### PR DESCRIPTION
**Steps to reproduce:**
- Install eCommerce app
- Go to the shop of the website
- Activate the editor
- Click on 'New' in the top right
- Create new product with image
- Image is automatically converted to 1920x1920 in webp format
- Thumbnails have low quality when computed in JS (visible artifacts such as dotted diagonal lines and aliasing), especially on Firefox

**Issue:**
For other image formats, the resizing is done in the backend and use a specific downsampling algorithm (Lanczos) with PIL to improve the output quality. But as we are moving to use .webp format as the default, which is processed directly in JS for security reasons (and browser dependent), this algorithm is not applied anymore (which leads to some visual degradation in the thumbnails).

WebP format is not supported on the python side due to `Pillow` dependency to `libwebp` which is considered unsafe at the moment.

Using higher resolution images and downsizing them using css sometimes fix the issue, but it mainly works on Firefox, which seems to apply a different downsampling with css and with canvas drawing.

**Fix:**
Implemented Lanczos resampling for the webp format when processed in the browser.

related : https://github.com/odoo/odoo/commit/d1292a96a62b18a88a852c69ed7732d16ae0344e

Not sure about the licensing needed, as I used this old implementation as a reference: https://github.com/mudcube/Lanczos.js

opw-4561958

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
