### PR TITLE
[IMP] core: improve manifest for_addons

### DIFF
--- a/addons/base_import_module/models/ir_module.py
+++ b/addons/base_import_module/models/ir_module.py
@@ -56,7 +56,7 @@ class IrModuleModule(models.Model):
         IrAttachment = self.env['ir.attachment']
 
         for module in modules:
-            if Manifest.for_addon(module, downloaded=True, display_warning=False):
+            if Manifest.for_addon(module, display_warning=False):
                 continue
             for lang in langs:
                 for lang_ in get_base_langs(lang):

--- a/odoo/addons/base/models/ir_module.py
+++ b/odoo/addons/base/models/ir_module.py
@@ -156,7 +156,7 @@ class IrModuleModule(models.Model):
         if isinstance(name, str):
             # we have no info for studio_customization
             # imported modules are not found using this method
-            return modules.Manifest.for_addon(name, downloaded=True, display_warning=False) or {}
+            return modules.Manifest.for_addon(name, display_warning=False) or {}
         if isinstance(name, modules.Manifest):
             return name
         return {}
@@ -946,7 +946,7 @@ class IrModuleModule(models.Model):
         translation_importer = TranslationImporter(self.env.cr, verbose=False)
 
         for module_name in modules:
-            if not Manifest.for_addon(module_name, downloaded=True, display_warning=False):
+            if not Manifest.for_addon(module_name, display_warning=False):
                 continue
             for lang in langs:
                 for po_path in get_po_paths(module_name, lang):

--- a/odoo/modules/module.py
+++ b/odoo/modules/module.py
@@ -278,11 +278,10 @@ class Manifest(Mapping[str, typing.Any]):
         return None
 
     @staticmethod
-    def for_addon(module_name: str, *, downloaded: bool = False, display_warning: bool = True) -> Manifest | None:
+    def for_addon(module_name: str, *, display_warning: bool = True) -> Manifest | None:
         """Get the module's manifest from a name.
 
         :param module: module's name
-        :param downloaded: whether to check odoo's data directory
         :param display_warning: log a warning if the module is not found
         """
         if not MODULE_NAME_RE.match(module_name):
@@ -290,10 +289,6 @@ class Manifest(Mapping[str, typing.Any]):
             return None
         if mod := Manifest._get_manifest_from_addons(module_name):
             return mod
-        if downloaded:
-            path = opj(tools.config.addons_data_dir, module_name)
-            if mod := Manifest._from_path(path):
-                return mod
         if display_warning:
             _logger.warning('module %s: manifest not found', module_name)
         return None
@@ -330,7 +325,7 @@ class Manifest(Mapping[str, typing.Any]):
         return sorted(modules.values(), key=lambda m: m.name)
 
 
-def get_module_path(module: str, downloaded: bool = False, display_warning: bool = True) -> str | None:
+def get_module_path(module: str, display_warning: bool = True) -> str | None:
     """Return the path of the given module.
 
     Search the addons paths and return the first path where the given
@@ -339,7 +334,7 @@ def get_module_path(module: str, downloaded: bool = False, display_warning: bool
 
     """
     # TODO deprecate
-    mod = Manifest.for_addon(module, downloaded=downloaded, display_warning=display_warning)
+    mod = Manifest.for_addon(module, display_warning=display_warning)
     return mod.path if mod else None
 
 
@@ -397,7 +392,7 @@ def load_manifest(module: str, mod_path: str | None = None) -> dict:
         mod = Manifest._from_path(mod_path)
         assert mod.path == mod_path
     else:
-        mod = Manifest.for_addon(module, downloaded=True)
+        mod = Manifest.for_addon(module)
     if not mod:
         _logger.debug('module %s: no manifest file found %s', module, MANIFEST_NAMES)
         return {}
@@ -478,7 +473,7 @@ def get_manifest(module: str, mod_path: str | None = None) -> Mapping[str, typin
         if mod and mod.name != module:
             raise ValueError(f"Invalid path for module {module}: {mod_path}")
     else:
-        mod = Manifest.for_addon(module, downloaded=True, display_warning=False)
+        mod = Manifest.for_addon(module, display_warning=False)
     return mod if mod is not None else {}
 
 

--- a/odoo/tools/translate.py
+++ b/odoo/tools/translate.py
@@ -1776,7 +1776,7 @@ def get_po_paths(module_name: str, lang: str) -> Iterator[str]:
 def get_datafile_translation_path(module_name: str) -> Iterator[str]:
     from odoo.modules import Manifest  # noqa: PLC0415
     # if we are importing a module, we have an env, hide warnings
-    manifest = Manifest.for_addon(module_name, downloaded=True, display_warning=False) or {}
+    manifest = Manifest.for_addon(module_name, display_warning=False) or {}
     for data_type in ('data', 'demo'):
         for path in manifest.get(data_type, ()):
             if path.endswith(('.xml', '.csv')):


### PR DESCRIPTION
tools.config.addons_data_dir is already in odoo.addons.__path__, the parameter ``downloaded`` is not necessary.

https://github.com/odoo/upgrade-util/pull/292

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
