### PR TITLE
[FIX] pos_loyalty: compute point rewarded when discount reward updates

### DIFF
--- a/addons/pos_loyalty/static/src/overrides/models/loyalty.js
+++ b/addons/pos_loyalty/static/src/overrides/models/loyalty.js
@@ -363,7 +363,6 @@ patch(Order.prototype, {
             return this._updateLoyaltyPrograms().then(async () => {
                 // Try auto claiming rewards
                 const claimableRewards = this.getClaimableRewards(false, false, true);
-                let changed = false;
                 for (const { coupon_id, reward } of claimableRewards) {
                     if (
                         reward.program_id.rewards.length === 1 &&
@@ -372,14 +371,10 @@ patch(Order.prototype, {
                             (reward.reward_type == "product" && !reward.multi_product))
                     ) {
                         this._applyReward(reward, coupon_id);
-                        changed = true;
                     }
                 }
-                // Rewards may impact the number of points gained
-                if (changed) {
-                    await this._updateLoyaltyPrograms();
-                }
                 this._updateRewardLines();
+                await this._updateLoyaltyPrograms();
             });
         });
     },

--- a/addons/pos_loyalty/static/tests/tours/PosLoyaltyTour.js
+++ b/addons/pos_loyalty/static/tests/tours/PosLoyaltyTour.js
@@ -467,9 +467,11 @@ registry.category("web_tour.tours").add("PosLoyaltyPointsGlobalDiscountProgramNo
             ProductScreen.clickCustomer("AAAA"),
             ProductScreen.addOrderline("product_a", "1"),
             PosLoyalty.hasRewardLine("10% on your order", "-10.00"),
-            PosLoyalty.orderTotalIs("90"),
-            PosLoyalty.pointsAwardedAre("90"),
-            PosLoyalty.finalizeOrder("Cash", "90"),
+            ProductScreen.clickDisplayedProduct("product_a"),
+            PosLoyalty.hasRewardLine("10% on your order", "-20.00"),
+            PosLoyalty.orderTotalIs("180"),
+            PosLoyalty.pointsAwardedAre("180"),
+            PosLoyalty.finalizeOrder("Cash", "180"),
         ].flat(),
 });
 

--- a/addons/pos_loyalty/tests/test_frontend.py
+++ b/addons/pos_loyalty/tests/test_frontend.py
@@ -1855,7 +1855,7 @@ class TestUi(TestPointOfSaleHttpCommon):
             "PosLoyaltyPointsGlobalDiscountProgramNoDomain",
             login="pos_user",
         )
-        self.assertEqual(loyalty_card.points, 90)
+        self.assertEqual(loyalty_card.points, 180)
 
     def test_points_awarded_discount_code_no_domain_program(self):
         """


### PR DESCRIPTION
Currently loyalty points rewarded are not correctly computed when there is a discount reward that updates its prices.

Steps to reproduce:
-------------------
* Create a loyalty program 1 point per $ spent
* Create a promo program, 10% on order, minimum 1 product on the order
* Create a product to sell in the pos, price 1$
* Open pos shop
* Select any customer
* Select the created product once
> Observation: To pay 0.9$, points remarded 0.9 OK
* Select the created product once again
> Observation: To pay 1.8$, points remarded 1.9 NOT OK

Why the fix:
------------
https://github.com/odoo/odoo/blob/b87c896969cc576a799ac63f03501be1e87b0e84/addons/pos_loyalty/static/src/overrides/models/loyalty.js#L362-L384

As the promo program giving the discoutn has already been triggered once, it is not considered claimable again thus `changed` will never be set to true. Thus we never call `_updateLoyaltyPrograms()`.

The recomputation of the price value for the promo discount is done by `_updateRewardLines()`, the points need to be computed afterward .

opw-4804205