### PR TITLE
[FIX] hr_skills: fix resume_one2many width

### DIFF
--- a/addons/hr_skills/static/src/fields/resume_one2many/resume_one2many.scss
+++ b/addons/hr_skills/static/src/fields/resume_one2many/resume_one2many.scss
@@ -10,6 +10,7 @@
         padding: $o-hrs-timeline-entry-padding;
 
         &.o_resume_timeline_cell {
+            overflow: hidden !important;
             div {
                 width: $o-hrs-timeline-dot-size;
                 height: $o-hrs-timeline-dot-size;
@@ -31,6 +32,10 @@
                 }
             }
         }
+    }
+
+    .o_resume_line_desc {
+        overflow: auto;
     }
 
     .o_resume_line_title, .o_resume_line_desc {

--- a/addons/hr_skills/static/src/fields/skills_one2many/skills_one2many.scss
+++ b/addons/hr_skills/static/src/fields/skills_one2many/skills_one2many.scss
@@ -11,14 +11,18 @@
     }
 }
 
-table.o_skill_table, .o_hr_skills_dialog_form {
-    .o_progressbar {
-        display: flex;
-        align-items: center;
+table.o_skill_table {
+    .o_hr_skills_dialog_form {
+        .o_progressbar {
+            display: flex;
+            align-items: center;
 
-        .o_progressbar_value input {
-            width: auto;
+            .o_progressbar_value input {
+                width: auto;
+            }
         }
     }
+
+    table-layout: fixed;
 }
 


### PR DESCRIPTION
Steps to reproduce:
    1- Go on employee app
    2- Click on resume section
    3- Click on Add on resume tab
    4- Put on description a big table with at least 20 columns
    5- Save
The resume table and the buttons "add", "delete" with be hidden by the skill table.

Reason:
    The skill table element is too wide

Solution:
    The skill table's width is fixed and is contained in resume section element

task-4881917

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
