### PR TITLE
[FIX] website_sale: prevent error on adding preformatted description

### DIFF
--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -1964,7 +1964,7 @@
                                             </t>
                                         </a>
                                     </t>
-                                    <p
+                                    <div
                                         t-field="product.description_ecommerce"
                                         t-attf-class="oe_structure text-muted {{not product.description_ecommerce and 'mb-0'}}"
                                         placeholder="A detailed, formatted description to promote your product on this page. Use '/' to discover more features."


### PR DESCRIPTION
Currently, an error occurs when a pre-formatted text is directly pasted into the product description using the website editor.

**Steps to reproduce:**
1. Install the eCommerce app.
2. Open the web editor on any product's detail page.
3. Add product description by copy-pasting preformatted text like;
 **Amazing Features** 
 stability, durability, consistency
5. Save the changes.

**Error:**
KeyError - None

**Cause:**
The issue is caused by an invalid HTML structure.
When preformatted/nested block elements are pasted, they get wrapped inside `<p>` block, which is not valid HTML. This leads to missing `data-oe-model` attributes on sub-elements, resulting in an error.

Before saas-18.4, the text block used a `<div>` tag to wrap content. After [this](https://github.com/odoo/odoo/commit/bbb2d98d9ab97ce729d59b9858b63daccf5434e2) commit, the wrapper was changed to a `<p>` tag.

**Fix:**
This commit replaces the wrapper tag with a `<div>` to ensure that preformatted and block-level content can be added and saved.

sentry-6731261789