### PR TITLE
[FIX] account: prevent company currency update

### DIFF
--- a/addons/account/models/company.py
+++ b/addons/account/models/company.py
@@ -390,7 +390,7 @@ class ResCompany(models.Model):
 
             #forbid the change of currency_id if there are already some accounting entries existing
             if 'currency_id' in values and values['currency_id'] != company.currency_id.id:
-                if self.env['account.move.line'].search([('company_id', '=', company.id)]):
+                if self.env['account.move.line'].sudo().search([('company_id', '=', company.id)]):
                     raise UserError(_('You cannot change the currency of the company since some journal items already exist'))
 
         return super(ResCompany, self).write(values)

--- a/addons/account/tests/test_settings.py
+++ b/addons/account/tests/test_settings.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
+from odoo import Command
 from odoo.addons.account.tests.common import AccountTestInvoicingCommon
+from odoo.exceptions import UserError
 from odoo.tests import tagged
 
 
@@ -55,3 +57,63 @@ class TestSettings(AccountTestInvoicingCommon):
         config = Settings.create({})
 
         self.switch_tax_settings(config)
+
+    def test_switch_company_currency(self):
+        """
+        A user should not be able to switch the currency of another company
+        when that company already has posted account move lines.
+        """
+        # Create company A (user's company)
+        company_a = self.env['res.company'].create({
+            'name': "Company A",
+        })
+
+        # Get company B from test setup
+        company_b = self.company_data['company']
+
+        # Create a purchase journal for company B
+        journal = self.env['account.journal'].create({
+            'name': "Vendor Bills Journal",
+            'code': "VEND",
+            'type': "purchase",
+            'company_id': company_b.id,
+            'currency_id': company_b.currency_id.id,
+        })
+
+        # Create an invoice for company B
+        invoice = self.env['account.move'].create({
+            'move_type': "in_invoice",
+            'extract_state': "waiting_extraction",
+            'company_id': company_b.id,
+            'journal_id': journal.id,
+        })
+        invoice.currency_id = self.env.ref('base.EUR').id
+
+        # Add a line to the invoice using an expense account
+        self.env['account.move.line'].create({
+            'move_id': invoice.id,
+            'account_id': self.company_data["default_account_expense"].id,
+            'name': "Test Invoice Line",
+            'company_id': company_b.id,
+        })
+
+        # Create a user that only belongs to company A
+        user = self.env['res.users'].create({
+            'name': "User A",
+            'login': "user_a@example.com",
+            'email': "user_a@example.com",
+            'company_id': company_a.id,
+            'company_ids': [Command.set([company_a.id])],
+            'groups_id': [Command.set([
+                self.env.ref('base.group_system').id,
+                self.env.ref('base.group_erp_manager').id,
+                self.env.ref('account.group_account_user').id,
+            ])],
+        })
+
+        # Try to change company B's currency as user A (should raise UserError)
+        user_env = self.env(user=user)
+        with self.assertRaises(UserError):
+            user_env['res.company'].browse(company_b.id).write({
+                'currency_id': self.env.ref('base.EUR').id,
+            })


### PR DESCRIPTION
To_reproduce:
==============
1- switch company.
2- update any other company currency that has journal items. 3- company currency changed.

Problem:
=========
- When switching companies, users could update the other company's currency even when journal items existed for that company. Solution:

Solution:
=========
- Added .sudo() to the account.move.line search to bypass access rights and properly detect existing journal items in that company.

opw-4920206
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
