### PR TITLE
[IMP] iot_drivers: adapt print status to iot_http service

### DIFF
--- a/addons/iot_drivers/driver.py
+++ b/addons/iot_drivers/driver.py
@@ -54,7 +54,10 @@ class Driver(Thread):
             _logger.exception("Error while executing action %s with params %s", action, data)
             response = {'status': 'error', 'result': str(e), 'action_args': {**data}}
 
-        event_manager.device_changed(self, response)  # Make response available to /event route or websocket
+        # Make response available to /event route or websocket
+        # printers handle their own events (low on paper, etc.)
+        if self.device_type != "printer":
+            event_manager.device_changed(self, response)
 
     def disconnect(self):
         self._stopped.set()

--- a/addons/iot_drivers/iot_handlers/drivers/printer_driver_L.py
+++ b/addons/iot_drivers/iot_handlers/drivers/printer_driver_L.py
@@ -59,8 +59,8 @@ class PrinterDriver(PrinterDriverBase):
         try:
             self.escpos_device.open()
             self.escpos_device.close()
-        except escpos.exceptions.Error:
-            _logger.exception("Could not initialize escpos class")
+        except escpos.exceptions.Error as e:
+            _logger.info("%s - Could not initialize escpos class: %s", self.device_name, e)
             self.escpos_device = None
 
     @classmethod

--- a/addons/iot_drivers/iot_handlers/drivers/printer_driver_base.py
+++ b/addons/iot_drivers/iot_handlers/drivers/printer_driver_base.py
@@ -84,7 +84,7 @@ class PrinterDriverBase(Driver, ABC):
         :param str status: The value of the status
         :param str message: A comprehensive message describing the status
         """
-        self.data['print_status'] = status
+        self.data['status'] = status
         self.data['message'] = message
         event_manager.device_changed(self)
 


### PR DESCRIPTION
Renamed `print_status` to `status` to conform to the status readable by `iot_http` service.

We also removed the automatic event confirmation for actions on printers, as we later send the actual status of the printer (low on paper, not ready, ...).

Enterprise PR: odoo/enterprise#89638
Task: 4922613
