### PR TITLE
[FIX] account: add analytic to early payment bank rec line

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -3391,6 +3391,13 @@ class AccountMove(models.Model):
             'base_lines': defaultdict(lambda: {}),
         }
 
+        epd_analytic_distribution = self.env['account.analytic.distribution.model']._get_distribution({
+            'account_prefix': cash_discount_account.code,
+            'company_id': self.company_id.id,
+            'partner_id': self.commercial_partner_id.id,
+            'partner_category_id': self.partner_id.category_id.ids,
+        })
+
         bases_details = {}
         payment_term_line = self.line_ids.filtered(lambda x: x.display_type == 'payment_term')
         discount_percentage = payment_term_line.move_id.invoice_payment_term_id.discount_percentage
@@ -3419,7 +3426,7 @@ class AccountMove(models.Model):
                     'partner_id': base_line['partner'].id,
                     'currency_id': base_line['currency'].id,
                     'account_id': cash_discount_account.id,
-                    'analytic_distribution': base_line['analytic_distribution'],
+                    'analytic_distribution': base_line['analytic_distribution'] or epd_analytic_distribution,
                 }
                 base_detail = resulting_delta_base_details.setdefault(frozendict(grouping_dict), {
                     'balance': 0.0,
@@ -3512,6 +3519,7 @@ class AccountMove(models.Model):
                 'currency_id': payment_term_line.currency_id.id,
                 'amount_currency': term_amount_currency,
                 'balance': term_balance,
+                'analytic_distribution': epd_analytic_distribution,
             }
 
         return res


### PR DESCRIPTION
# Steps to reproduce:

- Configure an early discount payment term (e.g., 2/7 Net 30).
- Configure the analytic distribution model with the account used when a discount is granted (e.g., 657000 on the BE fiscal position).
- Create an invoice using the early discount payment term.
- On bank reconciliation, register the transaction taking into account the early payment discount (e.g., 98% of the invoice amount_total).

On the third line with account 657000, corresponding to the early discount payment, the analytic distribution model does not apply.

In contrast, when manually registering a payment for the invoice, the analytic is correctly applied.

When the bank reconciliation lines are created, _lines_check_apply_early_payment_discount gets its values for the early payment lines from _get_invoice_counterpart_amls_for_early_payment_discount_per_payment_term_line, which does not check if there is an analytic distribution model.

enterprise pr: https://github.com/odoo/enterprise/pull/90641

opw-4868986



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
