### PR TITLE
[FIX] web: change the hashCode algorithm

### DIFF
--- a/addons/web/static/src/core/utils/strings.js
+++ b/addons/web/static/src/core/utils/strings.js
@@ -228,11 +228,16 @@ export function uuid() {
  * @param {string} str
  * @returns {string}
  */
-export function hashCode(str) {
+export function hashCode(...strings) {
+    const str = strings.join("\x1C");
+
     let hash = 0;
     for (let i = 0; i < str.length; i++) {
-        hash += Math.pow(str.charCodeAt(i) * 31, str.length - i);
-        hash = hash & hash; // Convert to 32bit integer
+        hash = (hash << 5) - hash + str.charCodeAt(i);
+        hash |= 0;
     }
-    return hash;
+
+    // Convert the possibly negative number hash code into an 8 character
+    // hexadecimal string
+    return (hash + 16 ** 8).toString(16).slice(-8);
 }

--- a/addons/web/static/tests/core/l10n/translation.test.js
+++ b/addons/web/static/tests/core/l10n/translation.test.js
@@ -123,7 +123,7 @@ test("[cache] write into the cache", async () => {
         },
         modules: { web: { messages: [{ id: "Hello", string: "Bonjour" }] } },
         multi_lang: false,
-        hash: "6b1bcfb1",
+        hash: "cf48f5f2",
     };
     expect.verifySteps([
         "hash: ",
@@ -223,7 +223,7 @@ test("[cache] update the cache if hash are different - template", async () => {
         },
         modules: { web: { messages: [{ id: "Hello", string: "Bonjour" }] } }, // value was updated in the cache
         multi_lang: false,
-        hash: "6b1bcfb1", // hash was updated in the cache
+        hash: "cf48f5f2", // hash was updated in the cache
     };
     expect.verifySteps([
         "hash: 30b", //Fetch with the hash of the translation in cache
@@ -310,7 +310,7 @@ test("[cache] update the cache if hash are different - js", async () => {
             },
         }, // value was updated in the cache
         multi_lang: false,
-        hash: "6b1bcfb1", // hash was updated in the cache
+        hash: "2a52c9bf", // hash was updated in the cache
     };
     expect.verifySteps([
         "hash: 30b", //Fetch with the hash of the translation in cache


### PR DESCRIPTION
The previous hashCode algorithm produced was distribution-dependent results,
causing errors in the Runbot's nightly tests for different distributions.

The new hashCode algorithm is the same as the one used in Hoot [1], and this
algorithm produces non-distribution-dependent results.

[1]: https://github.com/odoo/odoo/blob/4d7e941939b2d8b644cbf0d9a5a0aa2bb8d4c9e8/addons/web/static/lib/hoot/hoot_utils.js#L941

runbot-error : 227626
