### PR TITLE
[FIX] pos: add wait for menu buttons before clicking

### DIFF
--- a/addons/point_of_sale/static/tests/pos/tours/utils/chrome_util.js
+++ b/addons/point_of_sale/static/tests/pos/tours/utils/chrome_util.js
@@ -14,7 +14,24 @@ export function clickMenuButton() {
     };
 }
 export function clickMenuOption(name, options) {
-    return [clickMenuButton(), clickMenuDropdownOption(name, options)];
+    return [
+        waitForMenuButtons(),
+        clickMenuButton(),
+        waitForMenuOptionsToOpen(),
+        clickMenuDropdownOption(name, options),
+    ];
+}
+export function waitForMenuButtons() {
+    return {
+        content: "Wait for the menu buttons to be available",
+        trigger: ".pos-rightheader button:has(.fa-bars)",
+    };
+}
+export function waitForMenuOptionsToOpen() {
+    return {
+        content: `Wait for the menu options to be available`,
+        trigger: `span.dropdown-item`,
+    };
 }
 export function clickMenuDropdownOption(name, { expectUnloadPage = false } = {}) {
     return {


### PR DESCRIPTION
steps to reproduce:
1. in multi enterprise
2. run the tour `test_02_others`

added a wait step for the menu buttons before clicking the menu button in the `chrome_util.js` file.

build_error-229618