### PR TITLE
[FIX] website: fix image on floating blocks vertical alignment

### DIFF
--- a/addons/website/static/src/builder/plugins/floating_blocks/floating_blocks_option.xml
+++ b/addons/website/static/src/builder/plugins/floating_blocks/floating_blocks_option.xml
@@ -43,11 +43,11 @@
     <BuilderRow label.translate="Vert. Alignment" tooltip.translate="Vertical Alignment" t-if="state.isMobileView">
         <BuilderButtonGroup>
             <BuilderButton title.translate="Align Top" classAction="'align-self-start'"
-                    iconImg="'/website/static/src/img/snippets_options/align_solo_top.svg'"/>
+                    iconImg="'/html_builder/static/img/snippets_options/align_solo_top.svg'"/>
             <BuilderButton title.translate="Align Middle" classAction="'align-self-center'"
-                    iconImg="'/website/static/src/img/snippets_options/align_solo_middle.svg'"/>
+                    iconImg="'/html_builder/static/img/snippets_options/align_solo_middle.svg'"/>
             <BuilderButton title.translate="Align Bottom" classAction="'align-self-end'"
-                    iconImg="'/website/static/src/img/snippets_options/align_solo_bottom.svg'"/>
+                    iconImg="'/html_builder/static/img/snippets_options/align_solo_bottom.svg'"/>
         </BuilderButtonGroup>
     </BuilderRow>
 </t>


### PR DESCRIPTION
Commit [1] added vertical alignment options for the s_floating_blocks cards on mobile, but the icon src was wrong.

[1]: https://github.com/odoo/odoo/commit/35f184680d7cdc8dc7d2e619baf7ad0ec02de31c

task-4367641