### PR TITLE
[REF] html_editor: remove calls to `adjustListPadding` from multiple methods

### DIFF
--- a/addons/html_editor/static/src/core/history_plugin.js
+++ b/addons/html_editor/static/src/core/history_plugin.js
@@ -827,7 +827,9 @@ export class HistoryPlugin extends Plugin {
         this.steps.push(currentStep);
         // @todo @phoenix add this in the linkzws plugin.
         // this._setLinkZws();
-        this.dispatchTo("before_add_step_handlers");
+        this.dispatchTo("before_add_step_handlers", {
+            stepCommonAncestor,
+        });
         if (extraStepInfos) {
             currentStep.extraStepInfos = extraStepInfos;
         }

--- a/addons/html_editor/static/tests/list/indent.test.js
+++ b/addons/html_editor/static/tests/list/indent.test.js
@@ -668,14 +668,14 @@ describe("with selection collapsed", () => {
         await testEditor({
             styleContent: ":root { font: 14px Roboto }",
             contentBefore: unformat(`
-                <ol style="padding-inline-start: 58px;">
+                <ol style="padding-inline-start: 60px;">
                     <li style="font-size: 56px;">abc</li>
                     <li style="font-size: 56px;">def[]</li>
                 </ol>
             `),
             stepFunction: keydownTab,
             contentAfter: unformat(`
-                <ol style="padding-inline-start: 58px;">
+                <ol style="padding-inline-start: 60px;">
                     <li style="font-size: 56px;"><p>abc</p>
                         <ol style="padding-inline-start: 59px;">
                             <li style="font-size: 56px;">def[]</li>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

- In the list_plugin, the `adjustListPadding` method was previously called in multiple places.

Current behavior before PR:

- `adjustListPadding` was invoked from several methods within the plugin.

Desired behavior after PR is merged:

- It is now only called from `before_add_step_handlers`, with all related logic handled inside the method itself.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
