### PR TITLE
[FIX] mrp: remove default company context routing workcenter view

### DIFF
--- a/addons/mrp/views/mrp_routing_views.xml
+++ b/addons/mrp/views/mrp_routing_views.xml
@@ -95,7 +95,7 @@
                                 <field name="company_id" invisible="1"/>
                                 <field name="name"/>
                                 <field name="bom_id" invisible="context.get('bom_id_invisible', False)" domain="[]" readonly="context.get('default_bom_id', False)"/>
-                                <field name="workcenter_id" context="{'default_company_id': company_id}"/>
+                                <field name="workcenter_id"/>
                                 <field name="possible_bom_product_template_attribute_value_ids" invisible="1"/>
                                 <field name="bom_product_template_attribute_value_ids" widget="many2many_tags" options="{'no_create': True}" groups="product.group_product_variant"/>
                                 <field name="allow_operation_dependencies" invisible="1"/>


### PR DESCRIPTION
**Current behavior:**
Can't create a workcenter from the operations (workorder) form view without having a BoM filled in (due to company check issue).

**Expected behavior:**
Can

**Steps to reproduce:**
Open `Manufacturing / Configuration / Operations` -> create new -> type in a new workcenter name -> hit create -> error

**Cause of the issue:**
in `mrp_routing_workcenter_form_view` we get some context for a
`default_company_id`- it's not only unnecessary because
`Mrp.Workcenter` will get a default company just fine via its
its `resource.mixin` inheritance.

The currently provided company comes from the BoM, thus the
issue happens when the BoM has not yet been filled in on the
view.

**Fix:**
Remove the context in the view.

opw-4836904