### PR TITLE
[FIX] point_of_sale: ensure favorite products are prioritized in POS

### DIFF
--- a/addons/point_of_sale/models/product_template.py
+++ b/addons/point_of_sale/models/product_template.py
@@ -80,7 +80,7 @@ class ProductTemplate(models.Model):
                         FROM %s
                     LEFT JOIN pm ON product_template.id = pm.product_tmpl_id
                         WHERE %s
-                    ORDER BY product_template.is_favorite DESC,
+                    ORDER BY product_template.is_favorite DESC NULLS LAST,
                         CASE WHEN product_template.type = 'service' THEN 1 ELSE 0 END DESC,
                         pm.date DESC NULLS LAST,
                         product_template.write_date DESC


### PR DESCRIPTION
- Make sure `is_favorite` products are prioritized to be loaded inside POS when using `pos_limited_loading`.
- Added `NULLS LAST` to `ORDER BY is_favorite` to avoid getting `NULLS` records before `TRUE` ones.

task-id: 4920408



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
