### PR TITLE
[FIX] mail: fix non deterministic presence test

### DIFF
--- a/addons/mail/tests/common.py
+++ b/addons/mail/tests/common.py
@@ -2,6 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import base64
+import contextlib
 import email
 import email.policy
 import json
@@ -18,7 +19,7 @@ from random import randint
 from unittest.mock import patch
 from urllib.parse import urlparse, urlencode, parse_qsl
 
-from odoo import tools
+from odoo import tools, fields
 from odoo.addons.base.models.ir_mail_server import IrMail_Server
 from odoo.addons.base.tests.common import MockSmtplibCase
 from odoo.addons.bus.models.bus import BusBus, json_dump
@@ -1977,3 +1978,18 @@ class MailCommon(common.TransactionCase, MailCase):
                 data.pop("rating_avg", None)
                 data.pop("rating_count", None)
         return list(threads_data)
+
+
+@contextlib.contextmanager
+def freeze_all_time(dt=None):
+    """Freeze both `cr.now` and `Datetime.now`. ORM `create_date` and `write_date`
+    are based on `cursor.now()`. Domains often use `Datetime.now()` which can
+    lead to inconsistencies when using `freeze_time`.
+
+    :param dt: Datetime to freeze the time to. Defaults to `Datetime.now()`.
+    :type dt: datetime.datetime
+    """
+    if not dt:
+        dt = fields.Datetime.now()
+    with patch('odoo.sql_db.BaseCursor.now', return_value=dt), freeze_time(dt):
+        yield

--- a/addons/mail/tests/discuss/test_discuss_mail_presence.py
+++ b/addons/mail/tests/discuss/test_discuss_mail_presence.py
@@ -9,7 +9,7 @@ except ImportError:
 
 from odoo.tests import tagged, new_test_user
 from odoo.addons.bus.tests.common import WebsocketCase
-from odoo.addons.mail.tests.common import MailCommon
+from odoo.addons.mail.tests.common import MailCommon, freeze_all_time
 from odoo.addons.bus.models.bus import channel_with_db, json_dump
 
 
@@ -49,6 +49,7 @@ class TestMailPresence(WebsocketCase, MailCommon):
             sender_bus_target.id,
         )
 
+    @freeze_all_time()
     def test_receive_presences_as_guest(self):
         guest = self.env["mail.guest"].create({"name": "Guest"})
         bob = new_test_user(self.env, login="bob_user", groups="base.group_user")
@@ -59,7 +60,6 @@ class TestMailPresence(WebsocketCase, MailCommon):
         channel.add_members(guest_ids=[guest.id], partner_ids=[bob.partner_id.id])
         # Now that they share a channel, guest should receive users's presence.
         self._receive_presence(sender=bob, recipient=guest)
-
         other_guest = self.env["mail.guest"].create({"name": "OtherGuest"})
         # Guest should not receive guest's presence: no common channel.
         with self.assertRaises(ws._exceptions.WebSocketTimeoutException):
@@ -69,6 +69,7 @@ class TestMailPresence(WebsocketCase, MailCommon):
         self._receive_presence(sender=other_guest, recipient=guest)
         self.assertEqual(other_guest.im_status, "online")
 
+    @freeze_all_time()
     def test_receive_presences_as_portal(self):
         portal = new_test_user(self.env, login="portal_user", groups="base.group_portal")
         bob = new_test_user(self.env, login="bob_user", groups="base.group_user")
@@ -79,7 +80,6 @@ class TestMailPresence(WebsocketCase, MailCommon):
         channel.add_members(partner_ids=[portal.partner_id.id, bob.partner_id.id])
         # Now that they share a channel, portal should receive users's presence.
         self._receive_presence(sender=bob, recipient=portal)
-
         guest = self.env["mail.guest"].create({"name": "Guest"})
         # Portal should not receive guest's presence: no common channel.
         with self.assertRaises(ws._exceptions.WebSocketTimeoutException):
@@ -89,6 +89,7 @@ class TestMailPresence(WebsocketCase, MailCommon):
         self._receive_presence(sender=guest, recipient=portal)
         self.assertEqual(guest.im_status, "online")
 
+    @freeze_all_time()
     def test_receive_presences_as_internal(self):
         internal = new_test_user(self.env, login="internal_user", groups="base.group_user")
         guest = self.env["mail.guest"].create({"name": "Guest"})


### PR DESCRIPTION
Since [1], https://github.com/odoo/odoo/pull/207974 websocket timeout has been increased during test. Fetching notification only returns the notifications of the last 50 seconds initially. When runbot is under high load, this can lead to non deterministic failures.

This commit patches the cursor date to bypass this issue.

[1]: https://github.com/odoo/odoo/pull/207974

fixes rubot-223126,223758

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
