### PR TITLE
[FIX] mail: link attachments to new activities

### DIFF
--- a/addons/mail/models/mail_activity_mixin.py
+++ b/addons/mail/models/mail_activity_mixin.py
@@ -391,7 +391,14 @@ class MailActivityMixin(models.AbstractModel):
             if not create_vals.get('user_id'):
                 create_vals['user_id'] = activity_type.default_user_id.id or self.env.uid
             create_vals_list.append(create_vals)
-        return self.env['mail.activity'].create(create_vals_list)
+
+        activities = self.env['mail.activity'].create(create_vals_list)
+        for activity in activities.filtered('attachment_ids'):
+            activity.attachment_ids.write({
+                'res_model': activity._name,
+                'res_id': activity.id
+            })
+        return activities
 
     def _activity_schedule_with_view(self, act_type_xmlid='', date_deadline=None, summary='', views_or_xmlid='', render_context=None, **act_values):
         """ Helper method: Schedule an activity on each record of the current record set.

--- a/addons/mail/wizard/mail_activity_schedule.py
+++ b/addons/mail/wizard/mail_activity_schedule.py
@@ -2,6 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from markupsafe import Markup
+import re
 
 from odoo import api, fields, models, _
 from odoo.addons.mail.tools.parser import parse_res_ids
@@ -301,7 +302,8 @@ class MailActivitySchedule(models.TransientModel):
             summary=self.summary,
             note=self.note,
             user_id=self.activity_user_id.id,
-            date_deadline=self.date_deadline
+            date_deadline=self.date_deadline,
+            attachment_ids=list(map(int, re.findall(r'href="/web/content/(\d+)\?', str(self.note))))
         )
 
     # ------------------------------------------------------------


### PR DESCRIPTION
Steps to reproduce the issue:
1. Create a new activity on any `mail.thread` (`project.project` for example)
2. On the wizard, upload an attachment
3. Schedule the activity
4. Upgrade the database to any future version

Current behavior before PR:
The attachments created with activities would be deleted due to the query [here](https://github.com/odoo/upgrade/blob/master/migrations/base/0.0.0/pre-clean-transients.py#L69),
because they are linked to the transient model `mail.activity.scheduel`. Attachments linked to these models are deleted during the upgrade.

Desired behavior after PR is merged:
The newly created attachments are linked to the `mail.activity` record directly, avoiding the post-upgrade issue. This change also aligns the feature with attaching a file to a `mail.message` record, where the `res_model` and `res_id` fields move from `mail.compose.message` to the target model after posting the message.

opw-4812659
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
