### PR TITLE
[FIX] mail,discuss: Keep the opacity of discuss composer buttons uniform

### DIFF
--- a/addons/mail/static/src/core/common/composer.scss
+++ b/addons/mail/static/src/core/common/composer.scss
@@ -64,7 +64,6 @@
         &:disabled {
             --btn-active-color: var(--btn-disabled-color);
             --btn-hover-color: var(--btn-disabled-color);
-            opacity: 25%;
         }
         &.o-mail-Composer-send.btn-link:not(:disabled) {
             background-color: rgba($o-action, .75);


### PR DESCRIPTION
Before this commit, the paper-plane button to send a message was not changing opacity when the composer was empty and the user focused on the composer. Whereas the other buttons such as the emoji picker were changing it.

Now the opacity of this button is changing like the other buttons while still changing when the composer is not empty (like before this commit)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
