### PR TITLE
[FIX] hr_attendance: compute extra hours at creation

### DIFF
--- a/addons/hr_attendance/models/hr_attendance.py
+++ b/addons/hr_attendance/models/hr_attendance.py
@@ -470,6 +470,8 @@ class HrAttendance(models.Model):
     def create(self, vals_list):
         res = super().create(vals_list)
         res._update_overtime()
+        no_validation = res.filtered(lambda att: att.employee_id.company_id.attendance_overtime_validation == 'no_validation')
+        self.env.add_to_compute(self._fields['validated_overtime_hours'], no_validation)
         return res
 
     def write(self, vals):


### PR DESCRIPTION
Introduced by cc81bb59f87540cf4dd8da65510417d8023ef65b

**Steps to reproduce**
1. Create a new automatically validated attendance.
2. Set the employee, check in and check fields before saving the form.
Issue: the "Extra hours" field is not computed. e.g.: if the employee has worked 1 hour more than expected, "Worked Extra Hours" equals 1:00 (ok), but "Extra hours" appears as 0:00.

**Cause**
The previous fix intended to avoid recomputation of the `validated_overtime_hours` field. No better way was found than to exclude records where the `overtime_hours` was different than the `validated_overtime_hours` (meaning it had been manually modified by the user).
The problem comes from the fact that at creation,
`validated_overtime_hours` was sent in the `vals_list` to the create with a value of 0.

**Solution**
Force the computation of the field at creation.
