### PR TITLE
[FIX] website: avoid potential undeterminism in test

### DIFF
--- a/addons/website/static/tests/tours/drop_404_ir_attachment_url.js
+++ b/addons/website/static/tests/tours/drop_404_ir_attachment_url.js
@@ -1,6 +1,7 @@
 /** @odoo-module **/
 
 import wTourUtils from '@website/js/tours/tour_utils';
+import wUtils from '@website/js/utils';
 
 wTourUtils.registerWebsitePreviewTour('drop_404_ir_attachment_url', {
     test: true,
@@ -18,11 +19,10 @@ wTourUtils.registerWebsitePreviewTour('drop_404_ir_attachment_url', {
         content: 'Once the image UI appears, check the image has no size (404)',
         trigger: 'iframe .s_404_snippet img',
         extra_trigger: '.snippet-option-ReplaceMedia',
-        run: function () {
+        run: async function () {
             const imgEl = this.$anchor[0];
-            if (!imgEl.complete
-                    || imgEl.naturalWidth !== 0
-                    || imgEl.naturalHeight !== 0) {
+            await wUtils.onceAllImagesLoaded(this.$anchor);
+            if (imgEl.naturalWidth !== 0 || imgEl.naturalHeight !== 0) {
                 console.error('This is supposed to be a 404 image');
             }
         },
@@ -32,11 +32,10 @@ wTourUtils.registerWebsitePreviewTour('drop_404_ir_attachment_url', {
     {
         content: 'Once the shape is applied, check the image has now a size (placeholder image)',
         trigger: 'iframe .s_404_snippet img[src^="data:"]',
-        run: function () {
+        run: async function () {
             const imgEl = this.$anchor[0];
-            if (!imgEl.complete
-                    || imgEl.naturalWidth === 0
-                    || imgEl.naturalHeight === 0) {
+            await wUtils.onceAllImagesLoaded(this.$anchor);
+            if (imgEl.naturalWidth === 0 || imgEl.naturalHeight === 0) {
                 console.error('Even though the original image was a 404, the option should have been applied on the placeholder image');
             }
         },


### PR DESCRIPTION
The goal of this commit is to avoid potential undeterminism that could
occur in the `drop_404_ir_attachment_url` test (introduced by
[this commit]). Before this commit, an error was thrown if the image was
not loaded at the time the test checks the `naturalWidth` and
`naturalHeight` property of the image. This could lead to
undeterministic error as nothing ensures that the image is loaded at
that time. To solve the problem this commit first waits for the image to
be loaded before accessing the `naturalWidth` and `naturalHeight`
property of the image.
Side note: even if the source of the image is of type `data:` it is not
directly loaded.

[this commit]: https://github.com/odoo/odoo/commit/fbc6a697c1adf67ee8a90c49b0150d6ca170e081

task-4931144

