### PR TITLE
[FIX] website: display default values in the spacing option

### DIFF
--- a/addons/website/static/src/builder/plugins/layout_option/spacing_option.xml
+++ b/addons/website/static/src/builder/plugins/layout_option/spacing_option.xml
@@ -3,8 +3,8 @@
 
 <t t-name="website.SpacingOption">
     <BuilderRow label.translate="Spacing (Y, X)" level="props.level" applyTo="props.applyTo">
-        <BuilderNumberInput action="'setGridSpacing'" actionParam="'row-gap'" unit="'px'"/>
-        <BuilderNumberInput action="'setGridSpacing'" actionParam="'column-gap'" unit="'px'" max="60"/>
+        <BuilderNumberInput action="'setGridSpacing'" actionParam="'row-gap'" unit="'px'" default="0" />
+        <BuilderNumberInput action="'setGridSpacing'" actionParam="'column-gap'" unit="'px'" default="0" max="60"/>
     </BuilderRow>
 </t>
 


### PR DESCRIPTION
In the [html_builder refactoring] this behavior has been lost. To reproduce the issue:
- Open Website and start editing
- Add a "Banner" snippet
- Click inside

=> The "spacing" option inputs are empty, but they should display 0. 
Related to task-4367641

[html_builder refactoring]: https://github.com/odoo/odoo/commit/9fe45e2b7ddb