### PR TITLE
[FIX] auth_totp: change login page step

### DIFF
--- a/addons/auth_totp/static/tests/totp_flow.js
+++ b/addons/auth_totp/static/tests/totp_flow.js
@@ -141,7 +141,8 @@ registry.category("web_tour.tours").add('totp_login_enabled', {
     url: '/',
     steps: () => [{
     content: "check that we're on the login page or go to it",
-    trigger: 'input#login, a:contains(Sign in)',
+    isActive: ["body:not(:has(input#login))"],
+    trigger: "a:contains(Sign in)",
     run: "click",
     expectUnloadPage: true,
 }, {
@@ -182,7 +183,8 @@ registry.category("web_tour.tours").add('totp_login_device', {
     url: '/',
     steps: () => [{
     content: "check that we're on the login page or go to it",
-    trigger: 'input#login, a:contains(Sign in)',
+    isActive: ["body:not(:has(input#login))"],
+    trigger: "a:contains(Sign in)",
     run: "click",
     expectUnloadPage: true,
 }, {
@@ -288,7 +290,8 @@ registry.category("web_tour.tours").add('totp_login_disabled', {
     url: '/',
     steps: () => [{
     content: "check that we're on the login page or go to it",
-    trigger: 'input#login, a:contains(Sign in)',
+    isActive: ["body:not(:has(input#login))"],
+    trigger: "a:contains(Sign in)",
     run: "click",
     expectUnloadPage: true,
 }, {

--- a/addons/auth_totp_portal/static/tests/totp_portal.js
+++ b/addons/auth_totp_portal/static/tests/totp_portal.js
@@ -50,7 +50,8 @@ registry.category("web_tour.tours").add('totportal_login_enabled', {
     url: '/',
     steps: () => [{
     content: "check that we're on the login page or go to it",
-    trigger: 'input#login, a:contains(Sign in)',
+    isActive: ["body:not(:has(input#login))"],
+    trigger: "a:contains(Sign in)",
     run: "click",
     expectUnloadPage: true,
 }, {
@@ -114,7 +115,8 @@ registry.category("web_tour.tours").add('totportal_login_disabled', {
     url: '/',
     steps: () => [{
     content: "check that we're on the login page or go to it",
-    trigger: 'input#login, a:contains(Sign in)',
+    isActive: ["body:not(:has(input#login))"],
+    trigger: "a:contains(Sign in)",
     run: "click",
     expectUnloadPage: true,
 }, {


### PR DESCRIPTION
In this commit, we change the login page step by a step with isActive property. So this step is only active when the input#login is not on the page and then expectUnloadPage will be only listen when this step is active.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
