### PR TITLE
[FIX] html_builder, website: enable the drop_404_ir_attachment_url test

### DIFF
--- a/addons/html_builder/static/src/plugins/image/image_shape_option_plugin.js
+++ b/addons/html_builder/static/src/plugins/image/image_shape_option_plugin.js
@@ -96,11 +96,8 @@ export class ImageShapeOptionPlugin extends Plugin {
             if (img.naturalWidth) {
                 return img.naturalWidth;
             }
-            await new Promise((resolve, reject) => {
-                img.addEventListener("load", () => resolve(img), { once: true });
-                img.addEventListener("error", reject, { once: true });
-            });
-            return img.naturalWidth;
+            const loadedImgEl = await loadImage(img.getAttribute("src"));
+            return loadedImgEl.naturalWidth;
         };
         const svgWidth = getData("resizeWidth") || getData("width") || (await getNaturalWidth());
 

--- a/addons/website/static/tests/tours/drop_404_ir_attachment_url.js
+++ b/addons/website/static/tests/tours/drop_404_ir_attachment_url.js
@@ -20,7 +20,7 @@ registerWebsitePreviewTour('drop_404_ir_attachment_url', {
         run: "click",
     },
     {
-        trigger: ".snippet-option-ReplaceMedia",
+        trigger: "[data-action-id='replaceMedia']",
     },
     {
         content: 'Once the image UI appears, check the image has no size (404)',
@@ -33,8 +33,12 @@ registerWebsitePreviewTour('drop_404_ir_attachment_url', {
             }
         },
     },
-    changeOption('ImageTools', 'we-select[data-name="shape_img_opt"] we-toggler'),
-    changeOption('ImageTools', 'we-button[data-set-img-shape]'),
+    changeOption("Image", "[data-label='Shape'] .dropdown-toggle"),
+    {
+        content: "Click on the first image shape",
+        trigger: "[data-action-id='setImageShape']",
+        run: "click",
+    },
     {
         content: 'Once the shape is applied, check the image has now a size (placeholder image)',
         trigger: ':iframe .s_404_snippet img[src^="data:"]',

--- a/addons/website/tests/test_ui.py
+++ b/addons/website/tests/test_ui.py
@@ -614,8 +614,6 @@ class TestUi(HttpCaseWithWebsiteUser):
         })
         self.start_tour(self.env['website'].get_client_action_url('/'), 'interaction_lifecycle', login='admin')
 
-    # TODO master-mysterious-egg fix error
-    @unittest.skip("prepare mysterious-egg for merging")
     def test_drop_404_ir_attachment_url(self):
         website_snippets = self.env.ref('website.snippets')
         self.env['ir.ui.view'].create([{


### PR DESCRIPTION
The goal of this commit is to remove the `drop_404_ir_attachment_url` test (introduced by [this commit]) from the skipped tests. To do so, this commit introduces a feature that was missing due to the [website refactoring]; when applying a shape (or any other options) on a 404 image, a placeholder image should be used instead of the 404 to apply the option.

[this commit]: https://github.com/odoo/odoo/commit/fbc6a697c1adf67ee8a90c49b0150d6ca170e081
[website refactoring]: https://github.com/odoo/odoo/commit/9fe45e2b7ddbbfd0445ffe25a859e67a316d02b2
