### PR TITLE
[FIX] hr_holidays: Prevent crash in overview calendar on mobile

### DIFF
--- a/addons/hr_holidays/static/src/views/calendar/calendar_filter_panel/calendar_mobile_filter_panel.js
+++ b/addons/hr_holidays/static/src/views/calendar/calendar_filter_panel/calendar_mobile_filter_panel.js
@@ -35,6 +35,9 @@ export class TimeOffCalendarMobileFilterPanel extends CalendarMobileFilterPanel 
         }
         const filterData = {};
         const [data,] = await Promise.all(promises);
+        if(!data){
+            return;
+        }
         data.forEach((leave) => {
             filterData[leave[3]] = leave;
         });


### PR DESCRIPTION
Reproduce:
1. Open the "Overview" menu in the Time Off app
2. Switch to mobile view
3. Try to open the calendar mode

Issue:
In mobile view, the side panel tries to read private data and loops over it. When the async call returns undefined (e.g., no data), the loop crashes because it attempts to iterate over a non-iterable value.

Now:
Added a guard to check if the returned promises contain valid data before performing the loop.

Task: 4931233



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
