### PR TITLE
[FIX] mail: fix runbot error 222093 (o-mail-Message:contains(cheese))

### DIFF
--- a/addons/mail/static/src/core/common/message.xml
+++ b/addons/mail/static/src/core/common/message.xml
@@ -9,6 +9,7 @@
         <ActionSwiper t-else="" onRightSwipe="hasTouch() and props.thread?.eq(store.inbox) ? { action: () => this.message.setDone(), bgColor: 'bg-success', icon: 'fa-check-circle' } : undefined">
             <div class="o-mail-Message position-relative rounded-0"
                 t-att-data-starred="message.starred"
+                t-att-data-persistent="message.persistent"
                 t-att-class="attClass"
                 role="group"
                 t-att-aria-label="messageTypeText"

--- a/addons/mail/static/src/core/common/message_model.js
+++ b/addons/mail/static/src/core/common/message_model.js
@@ -297,6 +297,10 @@ export class Message extends Record {
         return candidates.has(this.subject?.toLowerCase());
     }
 
+    get persistent() {
+        return Number.isInteger(this.id);
+    }
+
     get resUrl() {
         return url(stateToUrl({ model: this.thread.model, resId: this.thread.id }));
     }

--- a/addons/mail/static/src/js/tours/discuss_channel_tour.js
+++ b/addons/mail/static/src/js/tours/discuss_channel_tour.js
@@ -52,7 +52,7 @@ registry.category("web_tour.tours").add("discuss_channel_tour", {
             run: "press Enter",
         },
         {
-            trigger: ".o-mail-Message:contains(today at)",
+            trigger: ".o-mail-Message[data-persistent]:contains(today at)",
             content: _t("Hover on your message and mark as todo"),
             tooltipPosition: "top",
             run: "hover && click .o-mail-Message [title='Mark as Todo']",

--- a/addons/mail/static/tests/tours/discuss_channel_public_tour.js
+++ b/addons/mail/static/tests/tours/discuss_channel_public_tour.js
@@ -104,7 +104,7 @@ registry.category("web_tour.tours").add("discuss_channel_public_tour.js", {
             trigger: '.o-mail-Message .o-mail-AttachmentCard:contains("text.txt")',
         },
         {
-            trigger: ".o-mail-Message-textContent:contains(cheese)",
+            trigger: ".o-mail-Message[data-persistent]:contains(cheese)",
             run: "hover && click .o-mail-Message [title='Add a Reaction']",
         },
         {
@@ -139,7 +139,7 @@ registry.category("web_tour.tours").add("discuss_channel_public_tour.js", {
         },
         {
             content: "Click on more menu",
-            trigger: ".o-mail-Message-textContent:contains(cheese)",
+            trigger: ".o-mail-Message[data-persistent]:contains(cheese)",
             run: "hover && click .o-mail-Message [title='Expand']",
         },
         {


### PR DESCRIPTION
Before this commit, tour "test_discuss_channel_public_page_as_guest" would crash in test after posting a message in which we attempt to add a reaction.

This happens because the step is a `hover && click 'Add a reaction'`, so it hovers on selector `o-mail-Message:contains(cheese)` then clicks on the 'Add a reaction' action.

In discuss channels, when sending a message, the message is immediately shown on UI before there's a genuine message that is created in DB. This optimistic behavior gives impression the app is fast, but some actions require a genuine message like 'Add a reaction'. The problem of test is that selector `.o-mail-Message:contains(cheese)` passes with temporary / transient message of optimistic behavior, so the `hover` step would be triggered on the temporary / transient message and 'Add a reaction' action is awaited for click.

Problem is that when genuine message data is received, implementation detail deletes the temporary / transient message and then shows the genuine message. Because the genuine message is different, component identity is different (it uses message.localId in `t-key`), thus it awaits `Add a reaction` on UI but it's not visible because we need to hover again, this time on genuine message.

This commit fixes the issue by awaiting message is shown on UI is the persistent, i.e. non-temporary and non-transient, so that hover and click on the 'Add a reaction' action works without issue.

fixes runbot errors 181660
fixes runbot errors 222093
fixes runbot errors 227756