### PR TITLE
[FIX] stock: report stock picking operations

### DIFF
--- a/addons/stock/report/report_stockpicking_operations.xml
+++ b/addons/stock/report/report_stockpicking_operations.xml
@@ -6,6 +6,7 @@
             <t t-call="web.report_layout">
                 <div class="article o_report_layout_standard">
                     <t t-foreach="docs" t-as="o">
+                        <t t-call="web.external_layout">
                         <t t-set="address" t-value="None"/>
                         <div class="page o_report_stockpicking_operations">
                             <div class="row justify-content-between">
@@ -240,6 +241,7 @@
                             <p t-field="o.note"/>
                             <div class="oe_structure"></div>
                         </div>
+                        </t>
                     </t>
                 </div>
             </t>


### PR DESCRIPTION
Steps:
- Go to Inventory > Delivery Orders
- Open an outgoing transfer (OUT)
- Click Print > Picking Operations

Issue:
- The report is missing header/footer and general layout formatting.

Cause:
- The call to `web.external_layout` was removed from the QWeb template, causing the report to render without the standard layout.

Fix:
- Reintroduced the `web.external_layout` wrapper to restore full report formatting.

I confirm I have signed the CLA and read the PR guidelines at [www.odoo.com/submit-pr](http://www.odoo.com/submit-pr)