### PR TITLE
[IMP] website_{forum|profile|slides}: improve profile breadcrumb

### DIFF
--- a/addons/website_forum/controllers/__init__.py
+++ b/addons/website_forum/controllers/__init__.py
@@ -1,3 +1,4 @@
 # -*- coding: utf-8 -*-
 
+from . import legacy
 from . import website_forum

--- a/addons/website_forum/controllers/legacy.py
+++ b/addons/website_forum/controllers/legacy.py
@@ -1,0 +1,12 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import http
+from odoo.http import request
+
+
+class WebsiteForumLegacy(http.Controller):
+    """ Retro compatibility layer for legacy endpoint """
+
+    @http.route(['/forum/user/<int:user_id>'], type='http', auth="public", website=True)
+    def view_user_forum_profile(self, user_id):
+        return request.redirect(f'/profile/user/{user_id}')

--- a/addons/website_forum/controllers/website_forum.py
+++ b/addons/website_forum/controllers/website_forum.py
@@ -405,7 +405,7 @@ class WebsiteForum(WebsiteProfile):
         user = request.env.user
         if not user.email or not tools.single_email_re.match(user.email):
             return request.redirect(
-                f'/forum/user/{request.session.uid}?forum_id={forum.id}&forum_origin={request.httprequest.path}')
+                f'/profile/user/{request.session.uid}?forum_id={forum.id}')
         values = self._prepare_user_values(forum=forum, searches={}, new_question=True)
         return request.render("website_forum.new_question", values)
 
@@ -660,11 +660,6 @@ class WebsiteForum(WebsiteProfile):
 
     # Profile
     # -----------------------------------
-
-    @http.route(['/forum/user/<int:user_id>'], type='http', auth="public", website=True)
-    def view_user_forum_profile(self, user_id, forum_id='', forum_origin='/forum', **post):
-        forum_origin_query = f'?forum_origin={forum_origin}&forum_id={forum_id}' if forum_id else ''
-        return request.redirect(f'/profile/user/{user_id}{forum_origin_query}')
 
     def _prepare_user_profile_values(self, user, **post):
         values = super(WebsiteForum, self)._prepare_user_profile_values(user, **post)

--- a/addons/website_forum/models/forum_post.py
+++ b/addons/website_forum/models/forum_post.py
@@ -840,7 +840,7 @@ class ForumPost(models.Model):
             res["text"] = self.plain_content or self.name
             res["answerCount"] = self.child_count
         if self.create_uid.sudo().website_published:
-            res["author"]["url"] = self.env['ir.http']._url_for(f"/forum/user/{ self.create_uid.sudo().id }")
+            res["author"]["url"] = self.env['ir.http']._url_for(f"/profile/user/{ self.create_uid.sudo().id }")
         return res
 
     def go_to_website(self):

--- a/addons/website_forum/views/forum_forum_templates_forum_all.xml
+++ b/addons/website_forum/views/forum_forum_templates_forum_all.xml
@@ -98,7 +98,7 @@
                     <h1 class="display-3" style="text-align: center; font-weight: bold;">Community Forums</h1>
                     <p class="lead" style="text-align: center;">Tap into the collective knowledge of our community by asking your questions in our forums,<br/> where helpful members are ready to assist you.</p>
                     <p style="text-align: center;">
-                        <a class="mb-2 o_translate_inline" t-attf-href="/profile/users?forum_origin=#{request.httprequest.path}" data-bs-original-title="" title="" target="_blank">Meet our community members</a>
+                        <a class="mb-2 o_translate_inline" t-attf-href="/profile/users" data-bs-original-title="" title="" target="_blank">Meet our community members</a>
                     </p>
                 </div>
             </section>

--- a/addons/website_forum/views/forum_forum_templates_layout.xml
+++ b/addons/website_forum/views/forum_forum_templates_layout.xml
@@ -275,7 +275,7 @@
         </div>
     </div>
     <div t-if="uid" class="o_wforum_sidebar_section mt-4 mb-2">
-        <a t-attf-href="/forum/user/#{ uid }?forum_id=#{ forum.id if forum else '' }&amp;forum_origin=#{ request.httprequest.path }"
+        <a t-attf-href="/profile/user/#{ uid }?forum_id=#{ forum.id if forum else '' }"
             class="btn w-100 py-1 text-start d-flex align-items-center" data-bs-toggle="tooltip" data-trigger="hover"
             title="My profile">
             <img class="o_wforum_avatar rounded-circle object-fit-cover" t-att-src="request.website.image_url(user, 'avatar_128', '60x60')" alt="Avatar"/>
@@ -306,12 +306,12 @@
             </a>
         </t>
         <!-- People -->
-        <a t-attf-class="nav-link my-1 py-1 text-reset" t-attf-href="/profile/users?forum_origin=#{request.httprequest.path}">
+        <a t-attf-class="nav-link my-1 py-1 text-reset" t-attf-href="/profile/users">
             <i class="fa fa-users fa-fw opacity-50"/> People
         </a>
 
         <!-- Badges -->
-        <a t-attf-class="nav-link my-1 py-1 text-reset" t-attf-href="/profile/ranks_badges?forum_origin=#{request.httprequest.path}">
+        <a t-attf-class="nav-link my-1 py-1 text-reset" t-attf-href="/profile/ranks_badges">
             <i class="fa fa-shield fa-fw opacity-50"/> Badges
         </a>
     </div>

--- a/addons/website_forum/views/forum_forum_templates_tools.xml
+++ b/addons/website_forum/views/forum_forum_templates_tools.xml
@@ -145,7 +145,7 @@
          data-bs-placement="top">
         <t t-set="user_profile_url" t-value="False"/>
         <t t-if="'forum_id' in object and (object.create_uid.id == request.session.uid or object.create_uid.sudo().website_published)">
-            <t t-set="user_profile_url" t-valuef="/forum/user/#{ object.create_uid.id }?forum_id=#{ object.forum_id.id }&amp;forum_origin=#{ request.httprequest.path }"/>
+            <t t-set="user_profile_url" t-valuef="/profile/user/#{ object.create_uid.id }?forum_id=#{ object.forum_id.id }"/>
         </t>
         <a t-if="show_image" t-att-href="user_profile_url or '#'" t-attf-class="o_wforum_author_pic position-relative #{ 'pe-none' if not user_profile_url else '' }">
             <img t-attf-class="o_wforum_avatar rounded-circle object-fit-cover #{'me-2' if show_name or show_date or show_karma else '' } #{_image_classes}" t-att-src="website.image_url(object.create_uid, 'avatar_128', '60x60')" alt="Avatar"/>

--- a/addons/website_forum/views/website_profile_templates.xml
+++ b/addons/website_forum/views/website_profile_templates.xml
@@ -9,17 +9,6 @@
         </xpath>
     </template>
 
-    <template id="user_profile_sub_nav" inherit_id="website_profile.user_profile_sub_nav">
-        <xpath expr="//nav" position="before">
-            <div t-if="request.params.get('forum_origin')" class="o_wprofile_all_users_nav_btn_container col pe-0 flex-grow-0">
-                <a t-att-href="(request.website.domain or '') + '/' + request.params.get('forum_origin').lstrip('/')"
-                    class="o_wprofile_all_users_nav_btn btn text-nowrap">
-                    <i class="oi oi-chevron-left small"/> Back
-                </a>
-            </div>
-        </xpath>
-    </template>
-
     <template id="user_profile_content" inherit_id="website_profile.user_profile_content">
         <xpath expr="//table[@id='o_wprofile_sidebar_table']//tr[last()]" position="after">
             <t t-if="forum and (up_votes or down_votes)">

--- a/addons/website_profile/tests/test_website_profile.py
+++ b/addons/website_profile/tests/test_website_profile.py
@@ -2,10 +2,37 @@
 
 import odoo.tests
 from odoo.addons.gamification.tests.common import HttpCaseGamification
+from odoo.addons.http_routing.tests.common import MockRequest
+from odoo.addons.website_profile.controllers.main import WebsiteProfile
 
 
 @odoo.tests.tagged('post_install', '-at_install')
 class TestWebsiteProfile(HttpCaseGamification):
+    def test_prepare_url_from_info(self):
+        controller = WebsiteProfile()
+        base_url = self.base_url()
+        base_url_other = 'https://other-domain.com'
+        no_url_from = {'url_from': None, 'url_from_label': None}
+        for referer, expected in (
+            ('/forum?p=1#f=2', {'url_from': '/forum?p=1#f=2', 'url_from_label': 'Forum'}),
+            ('/forum/test?p=1#f=2', {'url_from': '/forum/test?p=1#f=2', 'url_from_label': 'Forum'}),
+            ('/slides?p=1#f=2', {'url_from': '/slides?p=1#f=2', 'url_from_label': 'All Courses'}),
+
+            ('/profile', no_url_from),
+            (None, no_url_from),
+        ):
+            with (MockRequest(self.env, url_root=base_url, path='/profile/user/1') as mock_request,
+                  self.subTest(referer=referer)):
+                mock_request.httprequest.headers = {'Referer': f'{base_url}{referer}' if referer else None}
+                expected_with_base_url = {
+                    'url_from': f'{base_url}{expected["url_from"]}' if expected.get("url_from") else None,
+                    'url_from_label': expected["url_from_label"],
+                }
+                self.assertEqual(controller._prepare_url_from_info(), expected_with_base_url)
+
+                mock_request.httprequest.headers = {'Referer': f'{base_url_other}{referer}' if referer else None}
+                self.assertEqual(controller._prepare_url_from_info(), {'url_from': None, 'url_from_label': None})
+
     def test_save_change_description(self):
         odoo.tests.new_test_user(
             self.env, 'test_user',

--- a/addons/website_profile/views/website_profile.xml
+++ b/addons/website_profile/views/website_profile.xml
@@ -150,7 +150,7 @@
                             <div t-if="user.rank_id" class="d-flex align-items-center">
                                 <small class="fw-bold me-2">Current rank:</small>
                                 <img t-att-src="website.image_url(user.rank_id, 'image_128')" width="16" height="16" alt="" class="object-fit-cover me-1"/>
-                                <a t-attf-href="/profile/ranks_badges?url_origin=#{request.httprequest.path}&amp;name_origin=#{user.name}" t-field="user.rank_id"/>
+                                <a t-attf-href="/profile/ranks_badges" t-field="user.rank_id"/>
                             </div>
                             <button class="btn btn-sm d-md-none bg-white border" type="button" data-bs-toggle="collapse" data-bs-target="#o_wprofile_sidebar_collapse" aria-expanded="false" aria-controls="o_wprofile_sidebar_collapse">More info</button>
                         </div>
@@ -292,18 +292,18 @@
         </div>
          <div class="mb-3" t-elif="request.env.user == user">
             Badges are your collection of achievements. Wear them proudly! <br />
-            <a t-if="not user.badge_ids and badge_category" t-attf-href="/profile/ranks_badges?badge_category=#{badge_category}&amp;url_origin=#{request.httprequest.path}&amp;name_origin=#{user.name}"
+            <a t-if="not user.badge_ids and badge_category" t-attf-href="/profile/ranks_badges?badge_category=#{badge_category}"
             class="btn-link"><i class="fa fa-arrow-right"/> Get Badges</a>
-            <a t-else="" t-attf-href="/profile/ranks_badges?url_origin=#{request.httprequest.path}&amp;name_origin=#{user.name}"
+            <a t-else="" t-attf-href="/profile/ranks_badges"
             class="btn-link"><i class="fa fa-arrow-right"/> Get Badges</a>
         </div>
         <div t-else="" class="mb-3 d-inline-block">
             <p class="text-muted">No badges yet!</p>
         </div>
         <div t-if="request.env.user.id != user.id" class="text-end d-inline-block pull-right">
-            <a t-if="not user.badge_ids and badge_category" t-attf-href="/profile/ranks_badges?badge_category=#{badge_category}&amp;url_origin=#{request.httprequest.path}&amp;name_origin=#{user.name}"
+            <a t-if="not user.badge_ids and badge_category" t-attf-href="/profile/ranks_badges?badge_category=#{badge_category}"
             class="btn-link btn-sm"><i class="oi oi-arrow-right"/> All Badges</a>
-            <a t-else="" t-attf-href="/profile/ranks_badges?url_origin=#{request.httprequest.path}&amp;name_origin=#{user.name}"
+            <a t-else="" t-attf-href="/profile/ranks_badges"
             class="btn-link btn-sm"><i class="oi oi-arrow-right me-1"/>All Badges</a>
         </div>
     </template>
@@ -312,10 +312,10 @@
     <template id="rank_badge_main" name="Ranks Page">
         <t t-call="website.layout">
             <div class="container mb32 mt48">
-                <nav t-if="request.params.get('url_origin') and request.params.get('name_origin')" aria-label="breadcrumb">
+                <nav t-if="url_from" aria-label="breadcrumb">
                     <ol class="breadcrumb p-0 bg-white">
                         <li class="breadcrumb-item">
-                            <a t-att-href="(request.website.domain or '') + '/' + request.params.get('url_origin').lstrip('/')" t-out="request.params.get('name_origin')"/>
+                            <a t-att-href="url_from" t-out="url_from_label"/>
                         </li>
                         <li class="breadcrumb-item">Badges</li>
                     </ol>

--- a/addons/website_profile/views/website_profile.xml
+++ b/addons/website_profile/views/website_profile.xml
@@ -6,6 +6,11 @@
             <div class="container">
                 <div class="row align-items-center justify-content-between">
                     <!-- Desktop Mode -->
+                    <div t-if="url_from" class="o_wprofile_all_users_nav_btn_container col pe-0 flex-grow-0 d-none d-md-flex">
+                        <a t-att-href="url_from" class="o_wprofile_all_users_nav_btn btn text-nowrap">
+                            <i class="oi oi-chevron-left small"/> <t t-out="url_from_label"/>
+                        </a>
+                    </div>
                     <nav aria-label="breadcrumb" class="col d-none d-md-flex">
                         <ol class="breadcrumb bg-transparent mb-0 ps-0 py-0">
                             <li t-attf-class="breadcrumb-item #{'active' if not view_user else ''}">
@@ -31,9 +36,15 @@
                     </div>
 
                     <!-- Mobile Mode -->
-                    <div class="col d-md-none py-1 o_wprofile_user_profile_sub_nav_mobile_col">
-                        <div class="btn-group w-100 position-relative" role="group" aria-label="Mobile sub-nav">
-                            <div class="btn-group w-100 ms-2">
+                    <div class="col d-md-none py-1">
+                        <div class="btn-group d-flex justify-content-between gap-1" role="group" aria-label="Mobile sub-nav">
+                            <div t-if="url_from" class="btn-group">
+                                <a t-att-href="url_from" class="btn bg-black-25 text-white">
+                                    <i class="oi oi-chevron-left small"/>
+                                </a>
+                            </div>
+
+                            <div class="btn-group flex-grow-1">
                                 <a class="btn bg-black-25 text-white dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Nav</a>
 
                                 <ul class="dropdown-menu">
@@ -43,9 +54,9 @@
                                 </ul>
                             </div>
 
-                            <div class="btn-group ms-1 position-static me-2">
+                            <div class="btn-group">
                                 <a class="btn bg-black-25 text-white dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false"><i class="fa fa-search"></i></a>
-                                <div class="dropdown-menu dropdown-menu-end w-100" style="right: 10px;">
+                                <div class="dropdown-menu dropdown-menu-end w-100">
                                     <form class="px-3" t-attf-action="/profile/users" role="search" method="get">
                                         <div class="input-group">
                                             <input type="text" class="form-control" name="search" placeholder="Search users"/>


### PR DESCRIPTION
We improve the website_profile breadcrumb by adding at the beginning of it, a link from where we come from in those 2 cases:
- coming from the forum, we add a link to the forum, labeled as the forum name
- coming from the elearning home page, we add a link to elearning home page

[IMP] website_{forum|helpdesk_forum|profile}: remove origin parameters

Remove the following parameters as we use the referer instead:
- forum_origin
- url_origin
- name_origin

We also remove the route /forum/user/<int:user_id> which was an alias of /profile/user/<int:user_id> to set forum_origin by default to /forum.

Task-4921396