### PR TITLE
[FIX] l10n_sa_edi: increase size of the ZATCA QR code

### DIFF
--- a/addons/l10n_sa/views/report_invoice.xml
+++ b/addons/l10n_sa/views/report_invoice.xml
@@ -24,7 +24,7 @@
                     <p class="col-6 me-3">
                         <img t-if="o.l10n_sa_qr_code_str"
                             style="display:block;"
-                            t-att-src="'/report/barcode/?barcode_type=%s&amp;value=%s&amp;width=%s&amp;height=%s'%('QR', quote_plus(o.l10n_sa_qr_code_str), 200, 200)"/>
+                            t-att-src="'/report/barcode/?barcode_type=%s&amp;value=%s&amp;width=%s&amp;height=%s'%('QR', quote_plus(o.l10n_sa_qr_code_str), 300, 300)"/>
                     </p>
                     <div class="col-6" t-if="o.partner_shipping_id and (o.partner_shipping_id != o.partner_id)" groups="account.group_delivery_invoice_address" name="shipping_address_block">
                         <strong>Shipping Address:</strong>


### PR DESCRIPTION
### Steps to reproduce:
- Install 'l10n_sa_edi' and switch to a Saudi company
- Create an invoice for a Saudi company, confirm and send to ZATCA
- Send & Print
- Sometimes the QR code on the invoice cannot be read by the official ZATCA app

### Cause:
Real cause not pinpointed but the resolution of the qr code is a good theory.

### Solution:
Increase the resolution.

opw-4899938