### PR TITLE
Master stock replenishment horizon snd

### DIFF
--- a/addons/mrp/__manifest__.py
+++ b/addons/mrp/__manifest__.py
@@ -40,6 +40,7 @@
         'views/mrp_unbuild_views.xml',
         'views/res_config_settings_views.xml',
         'views/stock_scrap_views.xml',
+        'wizard/stock_replenishment_info.xml',  # needs views/mrp_workcenter_views.xml to load first
         'report/report_deliveryslip.xml',
         'report/mrp_report_views_main.xml',
         'report/mrp_report_bom_structure.xml',

--- a/addons/mrp/data/mrp_demo.xml
+++ b/addons/mrp/data/mrp_demo.xml
@@ -15,11 +15,6 @@
             <field name="implied_ids" eval="[(4, ref('mrp.group_mrp_routings'))]"/>
         </record>
 
-        <!-- Resource: res.company -->
-        <record id="stock.res_company_1" model="res.company">
-            <field eval="1.0" name="manufacturing_lead"/>
-        </record>
-
         <!-- Resource: mrp.workcenter -->
 
         <record id="mrp_workcenter_3" model="mrp.workcenter">

--- a/addons/mrp/models/mrp_bom.py
+++ b/addons/mrp/models/mrp_bom.py
@@ -86,8 +86,7 @@ class MrpBom(models.Model):
         help="Average lead time in days to manufacture this product. In the case of multi-level BOM, the manufacturing lead times of the components will be added. In case the product is subcontracted, this can be used to determine the date at which components should be sent to the subcontractor.")
     days_to_prepare_mo = fields.Integer(
         string="Days to prepare Manufacturing Order", default=0,
-        help="Create and confirm Manufacturing Orders this many days in advance, to have enough time to replenish components or manufacture semi-finished products.\n"
-             "Note that security lead times will also be considered when appropriate.")
+        help="Create and confirm Manufacturing Orders this many days in advance, to have enough time to replenish components or manufacture semi-finished products.")
 
     _qty_positive = models.Constraint(
         'check (product_qty > 0)',

--- a/addons/mrp/models/res_company.py
+++ b/addons/mrp/models/res_company.py
@@ -7,10 +7,6 @@ from odoo import api, fields, models
 class ResCompany(models.Model):
     _inherit = 'res.company'
 
-    manufacturing_lead = fields.Float(
-        'Manufacturing Lead Time', default=0.0, required=True,
-        help="Security days for each manufacturing operation.")
-
     def _create_unbuild_sequence(self):
         unbuild_vals = []
         for company in self:

--- a/addons/mrp/models/res_config_settings.py
+++ b/addons/mrp/models/res_config_settings.py
@@ -7,8 +7,6 @@ from odoo import api, fields, models
 class ResConfigSettings(models.TransientModel):
     _inherit = 'res.config.settings'
 
-    manufacturing_lead = fields.Float(related='company_id.manufacturing_lead', string="Manufacturing Lead Time", readonly=False)
-    use_manufacturing_lead = fields.Boolean(string="Default Manufacturing Lead Time", config_parameter='mrp.use_manufacturing_lead')
     group_mrp_byproducts = fields.Boolean("By-Products",
         implied_group='mrp.group_mrp_byproducts')
     module_mrp_mps = fields.Boolean("Master Production Schedule")
@@ -36,11 +34,6 @@ class ResConfigSettings(models.TransientModel):
         if not self.group_mrp_workorder_dependencies:
             # Disabling this option should not interfere with currently planned productions
             self.env['mrp.bom'].sudo().search([('allow_operation_dependencies', '=', True)]).allow_operation_dependencies = False
-
-    @api.onchange('use_manufacturing_lead')
-    def _onchange_use_manufacturing_lead(self):
-        if not self.use_manufacturing_lead:
-            self.manufacturing_lead = 0.0
 
     @api.onchange('group_unlocked_by_default')
     def _onchange_group_unlocked_by_default(self):

--- a/addons/mrp/models/stock_orderpoint.py
+++ b/addons/mrp/models/stock_orderpoint.py
@@ -37,6 +37,11 @@ class StockWarehouseOrderpoint(models.Model):
             }
         return super()._get_replenishment_order_notification()
 
+    @api.depends('bom_id', 'product_id.bom_ids.produce_delay')
+    def _compute_deadline_date(self):
+        """ Extend to add more depends values """
+        super()._compute_deadline_date()
+
     @api.depends('bom_id', 'bom_id.product_uom_id', 'product_id.bom_ids', 'product_id.bom_ids.product_uom_id')
     def _compute_qty_to_order_computed(self):
         """ Extend to add more depends values """

--- a/addons/mrp/models/stock_orderpoint.py
+++ b/addons/mrp/models/stock_orderpoint.py
@@ -42,6 +42,12 @@ class StockWarehouseOrderpoint(models.Model):
         """ Extend to add more depends values """
         super()._compute_deadline_date()
 
+    def _get_lead_days_values(self):
+        values = super()._get_lead_days_values()
+        if self.bom_id:
+            values['bom'] = self.bom_id
+        return values
+
     @api.depends('bom_id', 'bom_id.product_uom_id', 'product_id.bom_ids', 'product_id.bom_ids.product_uom_id')
     def _compute_qty_to_order_computed(self):
         """ Extend to add more depends values """
@@ -77,7 +83,7 @@ class StockWarehouseOrderpoint(models.Model):
         orderpoints_with_bom = self.filtered(lambda orderpoint: orderpoint.product_id.variant_bom_ids or orderpoint.product_id.bom_ids)
         for orderpoint in orderpoints_with_bom:
             if 'manufacture' in orderpoint.rule_ids.mapped('action'):
-                boms = (orderpoint.product_id.variant_bom_ids or orderpoint.product_id.bom_ids)
+                boms = orderpoint.bom_id or orderpoint.product_id.variant_bom_ids or orderpoint.product_id.bom_ids
                 orderpoint.days_to_order = boms and boms[0].days_to_prepare_mo or 0
         return res
 

--- a/addons/mrp/models/stock_orderpoint.py
+++ b/addons/mrp/models/stock_orderpoint.py
@@ -49,6 +49,13 @@ class StockWarehouseOrderpoint(models.Model):
             if 'manufacture' in orderpoint.rule_ids.mapped('action'):
                 orderpoint.allowed_replenishment_uom_ids += orderpoint.product_id.bom_ids.product_uom_id
 
+    def _compute_show_supply_warning(self):
+        for orderpoint in self:
+            if 'manufacture' in orderpoint.rule_ids.mapped('action') and not orderpoint.show_supply_warning:
+                orderpoint.show_supply_warning = not orderpoint.product_id.bom_ids
+                continue
+            super(StockWarehouseOrderpoint, orderpoint)._compute_show_supply_warning()
+
     @api.depends('route_id')
     def _compute_show_bom(self):
         manufacture_route = []

--- a/addons/mrp/models/stock_rule.py
+++ b/addons/mrp/models/stock_rule.py
@@ -211,6 +211,7 @@ class StockRule(models.Model):
         delays['total_delay'] += manufacture_delay
         delays['manufacture_delay'] += manufacture_delay
         if not bypass_delay_description:
+            delay_description.append((_('Production End Date'), manufacture_delay))
             delay_description.append((_('Manufacturing Lead Time'), _('+ %d day(s)', manufacture_delay)))
         if bom.type == 'normal':
             # pre-production rules
@@ -225,6 +226,7 @@ class StockRule(models.Model):
         days_to_order = values.get('days_to_order', bom.days_to_prepare_mo)
         delays['total_delay'] += days_to_order
         if not bypass_delay_description:
+            delay_description.append((_('Production Start Date'), days_to_order))
             delay_description.append((_('Days to Supply Components'), _('+ %d day(s)', days_to_order)))
         return delays, delay_description
 

--- a/addons/mrp/models/stock_rule.py
+++ b/addons/mrp/models/stock_rule.py
@@ -222,13 +222,6 @@ class StockRule(models.Model):
                     for key, value in extra_delays.items():
                         delays[key] += value
                     delay_description += extra_delay_description
-            # manufacturing security lead time
-            for comp in self.picking_type_id.company_id:
-                security_delay = comp.manufacturing_lead
-                delays['total_delay'] += security_delay
-                delays['security_lead_days'] += security_delay
-            if not bypass_delay_description:
-                delay_description.append((_('Manufacture Security Lead Time'), _('+ %d day(s)', security_delay)))
         days_to_order = values.get('days_to_order', bom.days_to_prepare_mo)
         delays['total_delay'] += days_to_order
         if not bypass_delay_description:

--- a/addons/mrp/models/stock_rule.py
+++ b/addons/mrp/models/stock_rule.py
@@ -218,7 +218,7 @@ class StockRule(models.Model):
             for wh in warehouse:
                 if wh.manufacture_steps != 'mrp_one_step':
                     wh_manufacture_rules = product._get_rules_from_location(product.property_stock_production, route_ids=wh.pbm_route_id)
-                    extra_delays, extra_delay_description = (wh_manufacture_rules - self).with_context(global_visibility_days=0)._get_lead_days(product, **values)
+                    extra_delays, extra_delay_description = (wh_manufacture_rules - self).with_context(global_horizon_days=0)._get_lead_days(product, **values)
                     for key, value in extra_delays.items():
                         delays[key] += value
                     delay_description += extra_delay_description

--- a/addons/mrp/report/mrp_report_bom_structure.py
+++ b/addons/mrp/report/mrp_report_bom_structure.py
@@ -631,13 +631,12 @@ class ReportMrpReport_Bom_Structure(models.AbstractModel):
             wh_manufacture_rules = product._get_rules_from_location(product.property_stock_production, route_ids=warehouse.route_ids)
             wh_manufacture_rules -= rules
             rules_delay += sum(rule.delay for rule in wh_manufacture_rules)
-            manufacturing_lead = bom.company_id.manufacturing_lead if bom and bom.company_id else 0
             return {
                 'route_type': 'manufacture',
                 'route_name': manufacture_rules[0].route_id.display_name,
                 'route_detail': bom.display_name,
-                'lead_time': bom.produce_delay + rules_delay + manufacturing_lead + bom.days_to_prepare_mo,
-                'manufacture_delay': bom.produce_delay + rules_delay + manufacturing_lead,
+                'lead_time': bom.produce_delay + rules_delay + bom.days_to_prepare_mo,
+                'manufacture_delay': bom.produce_delay + rules_delay,
                 'bom': bom,
             }
         return {}

--- a/addons/mrp/tests/test_order.py
+++ b/addons/mrp/tests/test_order.py
@@ -4085,6 +4085,7 @@ class TestMrpOrder(TestMrpCommon):
     def test_manufacture_lead_days(self):
         """Test the lead days computation for manufacturing route.
         """
+        self.env.company.horizon_days = 0
         warehouse = self.warehouse_1
         rule = warehouse.manufacture_pull_id
 

--- a/addons/mrp/tests/test_order.py
+++ b/addons/mrp/tests/test_order.py
@@ -4089,17 +4089,16 @@ class TestMrpOrder(TestMrpCommon):
         warehouse = self.warehouse_1
         rule = warehouse.manufacture_pull_id
 
-        self.env.company.manufacturing_lead = 1
         self.bom_1.days_to_prepare_mo = 2
         self.bom_1.produce_delay = 3
         delays, _ = rule._get_lead_days(self.bom_1.product_id, bom=self.bom_1)
-        self.assertEqual(delays['total_delay'], self.env.company.manufacturing_lead + self.bom_1.days_to_prepare_mo + self.bom_1.produce_delay)
+        self.assertEqual(delays['total_delay'], + self.bom_1.days_to_prepare_mo + self.bom_1.produce_delay)
 
         # switch to the 3 steps, only pre-production rules delays will be taken into account
         warehouse.manufacture_steps = 'pbm_sam'
         warehouse.pbm_route_id.rule_ids.delay = 100
         delays, _ = rule._get_lead_days(self.bom_1.product_id, bom=self.bom_1)
-        self.assertEqual(delays['total_delay'], self.env.company.manufacturing_lead + self.bom_1.days_to_prepare_mo + self.bom_1.produce_delay + 100 * 2)
+        self.assertEqual(delays['total_delay'], + self.bom_1.days_to_prepare_mo + self.bom_1.produce_delay + 100 * 2)
 
     def test_use_kit_as_component_in_production_without_bom(self):
         """

--- a/addons/mrp/tests/test_replenish.py
+++ b/addons/mrp/tests/test_replenish.py
@@ -28,18 +28,13 @@ class TestMrpReplenish(TestMrpCommon):
         route = self.warehouse_1.manufacture_pull_id.route_id
         product = self.product_4
         product.route_ids = route
-        self.env.company.manufacturing_lead = 0
-        self.env['ir.config_parameter'].sudo().set_param('mrp.use_manufacturing_lead', True)
 
         with freeze_time("2023-01-01"):
             wizard = self._create_wizard(product, self.warehouse_1)
             self.assertEqual(fields.Datetime.from_string('2023-01-01 00:00:00'), wizard.date_planned)
-            self.env.company.manufacturing_lead = 3
-            wizard2 = self._create_wizard(product, self.warehouse_1)
-            self.assertEqual(fields.Datetime.from_string('2023-01-04 00:00:00'), wizard2.date_planned)
             route.rule_ids[0].delay = 2
             wizard3 = self._create_wizard(product, self.warehouse_1)
-            self.assertEqual(fields.Datetime.from_string('2023-01-06 00:00:00'), wizard3.date_planned)
+            self.assertEqual(fields.Datetime.from_string('2023-01-03 00:00:00'), wizard3.date_planned)
 
     def test_mrp_orderpoint_leadtime(self):
         self.env.company.horizon_days = 0
@@ -100,7 +95,6 @@ class TestMrpReplenish(TestMrpCommon):
         product = self.product_4
         bom = product.bom_ids
         product.route_ids = route
-        self.env.company.manufacturing_lead = 0
         with freeze_time("2023-01-01"):
             wizard = self._create_wizard(product, self.warehouse_1)
             self.assertEqual(fields.Datetime.from_string('2023-01-01 00:00:00'), wizard.date_planned)

--- a/addons/mrp/tests/test_replenish.py
+++ b/addons/mrp/tests/test_replenish.py
@@ -287,3 +287,22 @@ class TestMrpReplenish(TestMrpCommon):
 
         self.assertEqual(len(mo_final), 1, "Expected one MO for the final product.")
         self.assertEqual(len(mo_component), 1, "Expected one MO for the manufactured BOM component.")
+
+    def test_orderpoint_warning_mrp(self):
+        """ Checks that the warning correctly computes depending on if there's a bom. """
+        orderpoint = self.env['stock.warehouse.orderpoint'].create({
+            'product_id': self.product_4.id,
+            'product_min_qty': 10,
+            'product_max_qty': 50,
+        })
+        self.assertTrue(orderpoint.show_supply_warning)
+
+        # Add a manufacture route to the product
+        self.product_4.route_ids |= self.route_manufacture
+        orderpoint.invalidate_recordset(fnames=['show_supply_warning'])
+        self.assertFalse(orderpoint.show_supply_warning)
+
+        # Archive the boms linked to the product
+        self.product_4.bom_ids.active = False
+        orderpoint.invalidate_recordset(fnames=['show_supply_warning'])
+        self.assertTrue(orderpoint.show_supply_warning)

--- a/addons/mrp/tests/test_replenish.py
+++ b/addons/mrp/tests/test_replenish.py
@@ -42,6 +42,7 @@ class TestMrpReplenish(TestMrpCommon):
             self.assertEqual(fields.Datetime.from_string('2023-01-06 00:00:00'), wizard3.date_planned)
 
     def test_mrp_orderpoint_leadtime(self):
+        self.env.company.horizon_days = 0
         route_manufacture = self.warehouse_1.manufacture_pull_id.route_id
         route_manufacture.supplied_wh_id = self.warehouse_1
         route_manufacture.supplier_wh_id = self.warehouse_1
@@ -182,8 +183,8 @@ class TestMrpReplenish(TestMrpCommon):
         self.assertEqual(move_to_scrap.quantity, 10, "Scrapped component should return to qty 10")
         self.assertEqual(move_other.quantity, 10, "Other component should still be qty 10")
 
-    def test_global_visibility_days_affect_lead_time_manufacture_rule(self):
-        """ Ensure global visibility days will only be captured one time in an orderpoint's
+    def test_global_horizon_days_affect_lead_time_manufacture_rule(self):
+        """ Ensure global horizon days will only be captured one time in an orderpoint's
         lead_days/json_lead_days.
         """
         self.warehouse_1.manufacture_steps = 'pbm'
@@ -205,12 +206,12 @@ class TestMrpReplenish(TestMrpCommon):
                 'location_dest_id': self.customer_location.id,
             })],
         })
-        out_picking.with_context(global_visibility_days=365).action_assign()
+        out_picking.with_context(global_horizon_days=365).action_assign()
         r = orderpoint.action_stock_replenishment_info()
         repl_info = self.env[r['res_model']].browse(r['res_id'])
-        lead_days_date = datetime.strptime(
-            loads(repl_info.json_lead_days)['lead_days_date'], '%m/%d/%Y').date()
-        self.assertEqual(lead_days_date, fields.Date.today() + timedelta(days=365))
+        lead_horizon_date = datetime.strptime(
+            loads(repl_info.json_lead_days)['lead_horizon_date'], '%m/%d/%Y').date()
+        self.assertEqual(lead_horizon_date, fields.Date.today() + timedelta(days=365))
 
     def test_orderpoint_onchange_reordering_rule(self):
         """ Ensure onchange logic works properly when editing a reordering rule
@@ -231,7 +232,7 @@ class TestMrpReplenish(TestMrpCommon):
         orderpoint.action_replenish()
 
         prod = self.env['mrp.production'].search([('origin', '=', orderpoint.name)])
-        # Error is triggered for date_start <= lead_days_date < date_finished
+        # Error is triggered for date_start <= lead_horizon_date < date_finished
         prod.date_start = fields.Date.today() + timedelta(days=1)
 
         with Form(orderpoint, view='stock.view_warehouse_orderpoint_tree_editable') as form:

--- a/addons/mrp/tests/test_replenish.py
+++ b/addons/mrp/tests/test_replenish.py
@@ -301,3 +301,13 @@ class TestMrpReplenish(TestMrpCommon):
         self.product_4.bom_ids.active = False
         orderpoint.invalidate_recordset(fnames=['show_supply_warning'])
         self.assertTrue(orderpoint.show_supply_warning)
+
+    def test_set_bom_on_orderpoint(self):
+        """ Test that action_set_bom_on_orderpoint correctly sets a bom on selected orderpoint. """
+        orderpoint = self.env['stock.warehouse.orderpoint'].create({
+            'product_id': self.product_4.id,
+            'product_min_qty': 10,
+            'product_max_qty': 50,
+        })
+        self.product_4.bom_ids.with_context(orderpoint_id=orderpoint.id).action_set_bom_on_orderpoint()
+        self.assertEqual(orderpoint.bom_id.id, self.product_4.bom_ids.id)

--- a/addons/mrp/views/mrp_bom_views.xml
+++ b/addons/mrp/views/mrp_bom_views.xml
@@ -156,8 +156,7 @@
                                     <div>
                                         <field name="days_to_prepare_mo" class="oe_inline"/> days
                                         <button name="action_compute_bom_days" string="Compute" type="object"
-                                                help="Compute the days required to resupply all components from BoM, by either buying or manufacturing the components and/or subassemblies.
-                                                      Also note that purchase security lead times will be added when appropriate."
+                                                help="Compute the days required to resupply all components from BoM, by either buying or manufacturing the components and/or subassemblies."
                                                 class="oe_link pt-0"/>
                                     </div>
                                 </group>

--- a/addons/mrp/views/res_config_settings_views.xml
+++ b/addons/mrp/views/res_config_settings_views.xml
@@ -61,14 +61,6 @@
                             <setting id="mrp_mps" help="Plan manufacturing or purchase orders based on forecasts" documentation="/applications/inventory_and_mrp/manufacturing/management/use_mps.html" title="Using a MPS report to schedule your reordering and manufacturing operations is useful if you have long lead time and if you produce based on sales forecasts.">
                                 <field name="module_mrp_mps" widget="upgrade_boolean"/>
                             </setting>
-                            <setting id="security_lead_time" string="Security Lead Time" company_dependent="1" help="Schedule manufacturing orders earlier to avoid delays" documentation="/applications/inventory_and_mrp/inventory/management/planning/scheduled_dates.html">
-                                <field name="use_manufacturing_lead"/>
-                                <div class="content-group" invisible="not use_manufacturing_lead">
-                                    <div class="mt16" >
-                                        <field name="manufacturing_lead" class="oe_inline" digits="[42, 0]"/> days before
-                                    </div>
-                                </div>
-                            </setting>
                         </block>
                     </app>
                 </xpath>

--- a/addons/mrp/wizard/__init__.py
+++ b/addons/mrp/wizard/__init__.py
@@ -9,3 +9,4 @@ from . import product_replenish
 from . import mrp_production_split
 from . import stock_label_type
 from . import mrp_production_serial_numbers
+from . import stock_replenishment_info

--- a/addons/mrp/wizard/product_replenish.py
+++ b/addons/mrp/wizard/product_replenish.py
@@ -38,8 +38,6 @@ class ProductReplenish(models.TransientModel):
             return date
         delay = 0
         product_tmpl_id = kwargs.get('product_tmpl_id') or self.product_tmpl_id
-        if bool(self.env['ir.config_parameter'].sudo().get_param('mrp.use_manufacturing_lead')):
-            delay += self.env.company.manufacturing_lead
         if product_tmpl_id and product_tmpl_id.bom_ids:
             delay += product_tmpl_id.bom_ids[0].produce_delay + product_tmpl_id.bom_ids[0].days_to_prepare_mo
         return fields.Datetime.add(date, days=delay)

--- a/addons/mrp/wizard/stock_replenishment_info.py
+++ b/addons/mrp/wizard/stock_replenishment_info.py
@@ -1,0 +1,26 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import api, fields, models
+
+
+class StockReplenishmentInfo(models.TransientModel):
+    _inherit = 'stock.replenishment.info'
+    _description = 'Stock supplier replenishment information'
+
+    bom_id = fields.Many2one(related='orderpoint_id.bom_id')
+    bom_ids = fields.Many2many('mrp.bom', compute='_compute_bom_ids', store=True)
+    show_bom_tab = fields.Boolean(compute='_compute_show_bom_tab')
+
+    @api.depends('orderpoint_id')
+    def _compute_bom_ids(self):
+        for replenishment_info in self:
+            replenishment_info.bom_ids = replenishment_info.product_id.bom_ids
+
+    @api.depends('orderpoint_id')
+    def _compute_show_bom_tab(self):
+        for replenishment_info in self:
+            orderpoint = replenishment_info.orderpoint_id
+            replenishment_info.show_bom_tab = not orderpoint.route_id or (
+                    orderpoint.route_id
+                    and 'manufacture' in orderpoint.rule_ids.mapped('action')
+            )

--- a/addons/mrp/wizard/stock_replenishment_info.xml
+++ b/addons/mrp/wizard/stock_replenishment_info.xml
@@ -1,0 +1,32 @@
+<odoo>
+    <record id="mrp_bom_replenishment_tree_view" model="ir.ui.view">
+        <field name="name">mrp.bom.replenishment.list.view</field>
+        <field name="model">mrp.bom</field>
+        <field name="inherit_id" ref="mrp.mrp_bom_tree_view"/>
+        <field name="mode">primary</field>
+        <field name="priority">100</field>
+        <field name="arch" type="xml">
+            <field name="product_uom_id" position="after">
+                <field name="show_set_bom_button" column_invisible="True"/>
+                <button name="action_set_bom_on_orderpoint" type="object" string="Set as Bill of Materials" class="btn btn-link" invisible="not show_set_bom_button"/>
+            </field>
+            <field name="company_id" position="attributes">
+                <attribute name="optional">hide</attribute>
+            </field>
+        </field>
+    </record>
+
+    <record id="view_stock_replenishment_info_stock_mrp_inherit" model="ir.ui.view">
+        <field name="name">stock.replenishment.information.mrp.stock.inherit</field>
+        <field name="model">stock.replenishment.info</field>
+        <field name="inherit_id" ref="stock.view_stock_replenishment_info"/>
+        <field name="arch" type="xml">
+            <xpath expr="//page" position="before">
+                <page string="Bills of Materials" name="page_boms" invisible="not show_bom_tab">
+                    <field name="bom_id" invisible="1"/>
+                    <field name="bom_ids" readonly="1" context="{'list_view_ref': 'mrp.mrp_bom_replenishment_tree_view', 'stock_replenishment_info_id': id, 'orderpoint_id': orderpoint_id}"/>
+                </page>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/addons/mrp_subcontracting_purchase/models/stock_rule.py
+++ b/addons/mrp_subcontracting_purchase/models/stock_rule.py
@@ -8,7 +8,7 @@ class StockRule(models.Model):
         """For subcontracting, we need to consider both vendor lead time and
         manufacturing lead time, and DTPMO (Days To Prepare MO).
         Subcontracting delay =
-            max(Vendor lead time, Manufacturing lead time + DTPMO) + Days to Purchase + Purchase security lead time
+            max(Vendor lead time, Manufacturing lead time + DTPMO) + Days to Purchase
         """
         bypass_delay_description = self.env.context.get('bypass_delay_description')
         buy_rule = self.filtered(lambda r: r.action == 'buy')

--- a/addons/mrp_subcontracting_purchase/models/stock_rule.py
+++ b/addons/mrp_subcontracting_purchase/models/stock_rule.py
@@ -25,7 +25,7 @@ class StockRule(models.Model):
             return super()._get_lead_days(product, **values)
 
         delays, delay_description = super(StockRule, self - buy_rule)._get_lead_days(product, **values)
-        extra_delays, extra_delay_description = super(StockRule, buy_rule.with_context(ignore_vendor_lead_time=True, global_visibility_days=0))._get_lead_days(product, **values)
+        extra_delays, extra_delay_description = super(StockRule, buy_rule.with_context(ignore_vendor_lead_time=True, global_horizon_days=0))._get_lead_days(product, **values)
         if seller.delay >= bom.produce_delay + bom.days_to_prepare_mo:
             delays['total_delay'] += seller.delay
             delays['purchase_delay'] += seller.delay

--- a/addons/mrp_subcontracting_purchase/models/stock_rule.py
+++ b/addons/mrp_subcontracting_purchase/models/stock_rule.py
@@ -30,6 +30,7 @@ class StockRule(models.Model):
             delays['total_delay'] += seller.delay
             delays['purchase_delay'] += seller.delay
             if not bypass_delay_description:
+                delay_description.append((_('Receipt Date'), int(seller.delay)))
                 delay_description.append((_('Vendor Lead Time'), _('+ %d day(s)', seller.delay)))
         else:
             manufacture_delay = bom.produce_delay
@@ -37,13 +38,15 @@ class StockRule(models.Model):
             # set manufacture_delay to purchase_delay so that PO can be created with correct date
             delays['purchase_delay'] += manufacture_delay
             if not bypass_delay_description:
+                delay_description.append((_('Receipt Date'), manufacture_delay))
                 delay_description.append((_('Manufacturing Lead Time'), _('+ %d day(s)', manufacture_delay)))
             days_to_order = bom.days_to_prepare_mo
             delays['total_delay'] += days_to_order
             # add dtpmo to purchase_delay so that PO can be created with correct date
             delays['purchase_delay'] += days_to_order
             if not bypass_delay_description:
-                extra_delay_description.append((_('Days to Supply Components'), _('+ %d day(s)', days_to_order)))
+                delay_description.append((_('Production Start Date'), days_to_order))
+                delay_description.append((_('Days to Supply Components'), _('+ %d day(s)', days_to_order)))
 
         for key, value in extra_delays.items():
             delays[key] += value

--- a/addons/mrp_subcontracting_purchase/report/mrp_report_bom_structure.py
+++ b/addons/mrp_subcontracting_purchase/report/mrp_report_bom_structure.py
@@ -15,8 +15,8 @@ class ReportMrpReport_Bom_Structure(models.AbstractModel):
     def _get_resupply_availability(self, route_info, components):
         resupply_state, resupply_delay = super()._get_resupply_availability(route_info, components)
         if route_info.get('route_type') == 'subcontract' and resupply_delay:
-            # always add `Purchase security lead days` and `Days to Purchase`
-            extra_delay = route_info['bom'].company_id.po_lead + route_info['bom'].company_id.days_to_purchase
+            # always add `Days to Purchase`
+            extra_delay = route_info['bom'].company_id.days_to_purchase
             route_info['lead_time'] += extra_delay
             route_info['manufacture_delay'] += extra_delay
             subcontract_delay = resupply_delay + extra_delay

--- a/addons/purchase/models/res_company.py
+++ b/addons/purchase/models/res_company.py
@@ -7,12 +7,6 @@ from odoo import fields, models
 class ResCompany(models.Model):
     _inherit = 'res.company'
 
-    po_lead = fields.Float(string='Purchase Lead Time', required=True,
-        help="Margin of error for vendor lead times. When the system "
-             "generates Purchase Orders for procuring products, "
-             "they will be scheduled that many days earlier "
-             "to cope with unexpected vendor delays.", default=0.0)
-
     po_lock = fields.Selection([
         ('edit', 'Allow to edit purchase orders'),
         ('lock', 'Confirmed purchase orders are not editable')

--- a/addons/purchase/models/res_config_settings.py
+++ b/addons/purchase/models/res_config_settings.py
@@ -17,19 +17,9 @@ class ResConfigSettings(models.TransientModel):
     module_account_3way_match = fields.Boolean("3-way matching: purchases, receptions and bills")
     module_purchase_requisition = fields.Boolean("Purchase Agreements")
     module_purchase_product_matrix = fields.Boolean("Purchase Grid Entry")
-    po_lead = fields.Float(related='company_id.po_lead', readonly=False)
-    use_po_lead = fields.Boolean(
-        string="Security Lead Time for Purchase",
-        config_parameter='purchase.use_po_lead',
-        help="Margin of error for vendor lead times. When the system generates Purchase Orders for reordering products,they will be scheduled that many days earlier to cope with unexpected vendor delays.")
 
     group_send_reminder = fields.Boolean("Receipt Reminder", implied_group='purchase.group_send_reminder', default=True,
         help="Allow automatically send email to remind your vendor the receipt date")
-
-    @api.onchange('use_po_lead')
-    def _onchange_use_po_lead(self):
-        if not self.use_po_lead:
-            self.po_lead = 0.0
 
     @api.onchange('group_product_variant')
     def _onchange_group_product_variant_purchase(self):

--- a/addons/purchase_mrp/report/mrp_report_bom_structure.py
+++ b/addons/purchase_mrp/report/mrp_report_bom_structure.py
@@ -17,7 +17,7 @@ class ReportMrpReport_Bom_Structure(models.AbstractModel):
                 # If no vendor found for the right quantity, we still want to display a vendor for the lead times
                 supplier = product._select_seller(quantity=None, uom_id=product.uom_id)
             parent_bom = self.env.context.get('parent_bom')
-            purchase_lead = parent_bom.company_id.days_to_purchase + parent_bom.company_id.po_lead if parent_bom and parent_bom.company_id else 0
+            purchase_lead = parent_bom.company_id.days_to_purchase if parent_bom and parent_bom.company_id else 0
             if supplier:
                 qty_supplier_uom = product.uom_id._compute_quantity(quantity, supplier.product_uom_id)
                 return {

--- a/addons/purchase_mrp/tests/test_purchase_mrp_flow.py
+++ b/addons/purchase_mrp/tests/test_purchase_mrp_flow.py
@@ -724,6 +724,9 @@ class TestPurchaseMrpFlow(AccountTestInvoicingCommon):
         self.env.company.po_lead = 20
         # set manufacturing security lead time to 25 days
         self.env.company.manufacturing_lead = 25
+        # set horizon days to 0
+        self.env.company.horizon_days = 0
+
         product = self.env['product.product'].create({
             'name': 'super product',
             'is_storable': True,
@@ -750,8 +753,8 @@ class TestPurchaseMrpFlow(AccountTestInvoicingCommon):
             'warehouse_id': self.warehouse.id,
             'route_id': self.env.ref('mrp.route_warehouse0_manufacture').id,
         })
-        # lead_days_date should be today + manufacturing security lead time + product manufacturing lead time
-        self.assertEqual(orderpoint.lead_days_date, (fields.Date.today() + timedelta(days=25) + timedelta(days=1)))
+        # lead_horizon_date should be today + horizon days + manufacturing security lead time + product manufacturing lead time
+        self.assertEqual(orderpoint.lead_horizon_date, (fields.Date.today() + timedelta(days=25) + timedelta(days=1)))
         orderpoint.action_replenish()
         mo = self.env['mrp.production'].search([('product_id', '=', product.id)])
         self.assertEqual(mo.product_uom_qty, 5)

--- a/addons/purchase_stock/data/purchase_stock_demo.xml
+++ b/addons/purchase_stock/data/purchase_stock_demo.xml
@@ -2,10 +2,6 @@
 <odoo>
     <data noupdate="1">
 
-        <record id="stock.res_company_1" model="res.company">
-            <field eval="1.0" name="po_lead"/>
-        </record>
-
         <record id="product.product_delivery_01" model="product.product">
             <field name="route_ids" eval="[(4,ref('route_warehouse0_buy'))]"></field>
         </record>

--- a/addons/purchase_stock/models/stock.py
+++ b/addons/purchase_stock/models/stock.py
@@ -118,7 +118,6 @@ class StockWarehouseOrderpoint(models.Model):
         'product.supplierinfo', string='Vendor Pricelist', check_company=True,
         domain="['|', ('product_id', '=', product_id), '&', ('product_id', '=', False), ('product_tmpl_id', '=', product_tmpl_id)]")
     vendor_ids = fields.One2many(related='product_id.seller_ids', string="Vendors")
-    purchase_visibility_days = fields.Float(default=0.0, help="Visibility Days applied on the purchase routes.")
     product_supplier_id = fields.Many2one('res.partner', compute='_compute_product_supplier_id', store=True, string='Product Supplier')
 
     @api.depends('product_id.purchase_order_line_ids.product_qty', 'product_id.purchase_order_line_ids.state', 'supplier_id', 'supplier_id.product_uom_id', 'product_id.seller_ids', 'product_id.seller_ids.product_uom_id')
@@ -132,24 +131,10 @@ class StockWarehouseOrderpoint(models.Model):
     def _compute_lead_days(self):
         return super()._compute_lead_days()
 
-    def _compute_visibility_days(self):
-        res = super()._compute_visibility_days()
-        for orderpoint in self:
-            if 'buy' in orderpoint.rule_ids.mapped('action'):
-                orderpoint.visibility_days = orderpoint.purchase_visibility_days
-        return res
-
     @api.depends('product_tmpl_id', 'product_tmpl_id.seller_ids', 'product_tmpl_id.seller_ids.sequence', 'product_tmpl_id.seller_ids.partner_id')
     def _compute_product_supplier_id(self):
         for orderpoint in self:
             orderpoint.product_supplier_id = orderpoint.product_tmpl_id.seller_ids.sorted('sequence')[:1].partner_id.id
-
-    def _set_visibility_days(self):
-        res = super()._set_visibility_days()
-        for orderpoint in self:
-            if 'buy' in orderpoint.rule_ids.mapped('action'):
-                orderpoint.purchase_visibility_days = orderpoint.visibility_days
-        return res
 
     def _compute_days_to_order(self):
         res = super()._compute_days_to_order()

--- a/addons/purchase_stock/models/stock.py
+++ b/addons/purchase_stock/models/stock.py
@@ -120,6 +120,11 @@ class StockWarehouseOrderpoint(models.Model):
     vendor_ids = fields.One2many(related='product_id.seller_ids', string="Vendors")
     product_supplier_id = fields.Many2one('res.partner', compute='_compute_product_supplier_id', store=True, string='Product Supplier')
 
+    @api.depends('supplier_id')
+    def _compute_deadline_date(self):
+        """ Extend to add more depends values """
+        super()._compute_deadline_date()
+
     @api.depends('product_id.purchase_order_line_ids.product_qty', 'product_id.purchase_order_line_ids.state', 'supplier_id', 'supplier_id.product_uom_id', 'product_id.seller_ids', 'product_id.seller_ids.product_uom_id')
     def _compute_qty_to_order_computed(self):
         """ Extend to add more depends values

--- a/addons/purchase_stock/models/stock_rule.py
+++ b/addons/purchase_stock/models/stock_rule.py
@@ -172,9 +172,7 @@ class StockRule(models.Model):
         pass  # Override in sale_purchase_stock and purchase_mrp to notify salesperson or MO responsible
 
     def _get_lead_days(self, product, **values):
-        """Add the company security lead time and the supplier delay to the cumulative delay
-        and cumulative description. The company lead time is always displayed for onboarding
-        purpose in order to indicate that those options are available.
+        """Add the supplier delay to the cumulative delay and cumulative description.
         """
         delays, delay_description = super()._get_lead_days(product, **values)
         bypass_delay_description = self.env.context.get('bypass_delay_description')
@@ -189,11 +187,6 @@ class StockRule(models.Model):
             delays['purchase_delay'] += supplier_delay
             if not bypass_delay_description:
                 delay_description.append((_('Vendor Lead Time'), _('+ %d day(s)', supplier_delay)))
-        security_delay = buy_rule.picking_type_id.company_id.po_lead
-        delays['total_delay'] += security_delay
-        delays['security_lead_days'] += security_delay
-        if not bypass_delay_description:
-            delay_description.append((_('Purchase Security Lead Time'), _('+ %d day(s)', security_delay)))
         days_to_order = buy_rule.company_id.days_to_purchase
         delays['total_delay'] += days_to_order
         if not bypass_delay_description:

--- a/addons/purchase_stock/models/stock_rule.py
+++ b/addons/purchase_stock/models/stock_rule.py
@@ -178,18 +178,20 @@ class StockRule(models.Model):
         bypass_delay_description = self.env.context.get('bypass_delay_description')
         buy_rule = self.filtered(lambda r: r.action == 'buy')
         seller = 'supplierinfo' in values and values['supplierinfo'] or product.with_company(buy_rule.company_id)._select_seller(quantity=None)
-        if not buy_rule or not seller:
+        if not buy_rule:
             return delays, delay_description
         buy_rule.ensure_one()
         if not self.env.context.get('ignore_vendor_lead_time'):
-            supplier_delay = seller[0].delay
+            supplier_delay = seller[:1].delay
             delays['total_delay'] += supplier_delay
             delays['purchase_delay'] += supplier_delay
             if not bypass_delay_description:
+                delay_description.append((_('Receipt Date'), supplier_delay))
                 delay_description.append((_('Vendor Lead Time'), _('+ %d day(s)', supplier_delay)))
         days_to_order = buy_rule.company_id.days_to_purchase
         delays['total_delay'] += days_to_order
         if not bypass_delay_description:
+            delay_description.append((_('Order Deadline'), days_to_order))
             delay_description.append((_('Days to Purchase'), _('+ %d day(s)', days_to_order)))
         return delays, delay_description
 

--- a/addons/purchase_stock/tests/test_old_rules.py
+++ b/addons/purchase_stock/tests/test_old_rules.py
@@ -229,9 +229,6 @@ class TestPurchaseOldRules(PurchaseTestCommon):
         """ In order to check dates, set product's Delivery Lead Time
             and warehouse route's delay."""
 
-        company = self.env.ref('base.main_company')
-        company.po_lead = 1.00
-
         warehouse = self.warehouse_3_steps
         # Set delay on push rule
         for push_rule in warehouse.reception_route_id.rule_ids:

--- a/addons/purchase_stock/tests/test_purchase_lead_time.py
+++ b/addons/purchase_stock/tests/test_purchase_lead_time.py
@@ -15,11 +15,6 @@ class TestPurchaseLeadTime(PurchaseTestCommon):
         """ To check dates, set product's Delivery Lead Time
             and company's Purchase Lead Time."""
 
-        company = self.env.ref('base.main_company')
-
-        # Update company with Purchase Lead Time
-        company.write({'po_lead': 3.00})
-
         # Make procurement request from product_1's form view, create procurement and check it's state
         date_planned = fields.Datetime.now() + timedelta(days=10)
         self._create_make_procurement(self.product_1, 15.00, date_planned=date_planned)
@@ -47,9 +42,6 @@ class TestPurchaseLeadTime(PurchaseTestCommon):
         """ To check schedule dates of multiple purchase order line of the same purchase order,
             we create two procurements for the two different product with same vendor
             and different Delivery Lead Time."""
-
-        company = self.env.ref('base.main_company')
-        company.write({'po_lead': 0.00})
 
         # Make procurement request from product_1's form view, create procurement and check it's state
         date_planned1 = fields.Datetime.now() + timedelta(days=10)
@@ -140,8 +132,6 @@ class TestPurchaseLeadTime(PurchaseTestCommon):
 
     def test_merge_po_line_3(self):
         """Change merging po line if same procurement is done depending on custom values."""
-        company = self.env.ref('base.main_company')
-        company.write({'po_lead': 0.00})
 
         # The seller has a specific product name and code which must be kept in the PO line
         self.t_shirt.seller_ids.write({
@@ -206,7 +196,6 @@ class TestPurchaseLeadTime(PurchaseTestCommon):
         company2 = self.env['res.company'].create({
             'name': 'Second Company',
         })
-        company.write({'po_lead': 0.00})
         self.patcher = patch('odoo.addons.stock.models.stock_orderpoint.fields.Date', wraps=fields.Date)
         self.mock_date = self.startPatcher(self.patcher)
 
@@ -217,7 +206,7 @@ class TestPurchaseLeadTime(PurchaseTestCommon):
             'name': 'Delhaize'
         })
 
-        self.env.company.days_to_purchase = 2.0
+        company.days_to_purchase = 2.0
 
         # Test if the orderpoint is created when opening the replenishment view
         prod = self.env['product.product'].create({

--- a/addons/purchase_stock/tests/test_purchase_lead_time.py
+++ b/addons/purchase_stock/tests/test_purchase_lead_time.py
@@ -202,6 +202,7 @@ class TestPurchaseLeadTime(PurchaseTestCommon):
 
     def test_reordering_days_to_purchase(self):
         company = self.env.ref('base.main_company')
+        company.horizon_days = 0
         company2 = self.env['res.company'].create({
             'name': 'Second Company',
         })
@@ -254,7 +255,7 @@ class TestPurchaseLeadTime(PurchaseTestCommon):
         orderpoint_form = Form(self.env['stock.warehouse.orderpoint'])
         orderpoint_form.product_id = product
         orderpoint_form.product_min_qty = 0.0
-        orderpoint_form.visibility_days = 1.0
+        company.horizon_days = 1
         orderpoint_form.save()
 
         orderpoint_form = Form(self.env['stock.warehouse.orderpoint'].with_company(company2))

--- a/addons/purchase_stock/tests/test_reordering_rule.py
+++ b/addons/purchase_stock/tests/test_reordering_rule.py
@@ -1551,3 +1551,16 @@ class TestReorderingRule(TransactionCase):
         self.assertRecordValues(purchase_order_line, [
             {'product_uom_qty': 100, 'move_dest_ids': [delivery.move_ids.id, delivery.backorder_ids.move_ids.id]}
         ])
+
+    def test_orderpoint_warning_purchase_stock(self):
+        """ Checks that the warning correctly computes depending on if there's a vendor. """
+        orderpoint = self.env['stock.warehouse.orderpoint'].create({
+            'product_id': self.product_01.id,
+            'product_min_qty': 10,
+            'product_max_qty': 50,
+        })
+        self.assertFalse(orderpoint.show_supply_warning)
+
+        self.product_01.seller_ids = False
+        orderpoint.invalidate_recordset(fnames=['show_supply_warning'])
+        self.assertTrue(orderpoint.show_supply_warning)

--- a/addons/purchase_stock/tests/test_replenish_wizard.py
+++ b/addons/purchase_stock/tests/test_replenish_wizard.py
@@ -363,7 +363,6 @@ class TestReplenishWizard(PurchaseTestCommon):
             'min_qty': 2,
             'delay' : 0
         })
-        self.env['ir.config_parameter'].sudo().set_param('purchase.use_po_lead', True)
         self.env.company.days_to_purchase = 0
 
         with freeze_time("2023-01-01"):
@@ -396,7 +395,6 @@ class TestReplenishWizard(PurchaseTestCommon):
             'min_qty': 2,
             'delay': 2
         })
-        self.env['ir.config_parameter'].sudo().set_param('purchase.use_po_lead', True)
         self.env.company.days_to_purchase = 5
 
         with freeze_time("2023-01-01"):

--- a/addons/purchase_stock/views/res_config_settings_views.xml
+++ b/addons/purchase_stock/views/res_config_settings_views.xml
@@ -31,14 +31,6 @@
 		<field name="inherit_id" ref="stock.res_config_settings_view_form"/>
 		<field name="arch" type="xml">
 			<div id="purchase_po_lead" position="replace">
-				<setting company_dependent="1" help="Schedule request for quotations earlier to avoid delays" documentation="/applications/inventory_and_mrp/inventory/management/planning/scheduled_dates.html" title="Margin of error for vendor lead times. When the system generates Purchase Orders for reordering products,they will be scheduled that many days earlier to cope with unexpected vendor delays." name="schedule_receivings_setting_container">
-					<field name="use_po_lead"/>
-					<div class="content-group">
-						<div class="mt16" invisible="not use_po_lead">
-							<span>Move forward expected request creation date by <field name="po_lead" class="oe_inline"/> days</span>
-						</div>
-					</div>
-				</setting>
 				<setting company_dependent="1" help="Days needed to confirm a PO">
 					<field name="days_to_purchase" class="oe_inline"/><span> days</span>
 				</setting>

--- a/addons/purchase_stock/views/res_config_settings_views.xml
+++ b/addons/purchase_stock/views/res_config_settings_views.xml
@@ -30,9 +30,6 @@
 		<field name="model">res.config.settings</field>
 		<field name="inherit_id" ref="stock.res_config_settings_view_form"/>
 		<field name="arch" type="xml">
-			<xpath expr="//block[@id='schedule_info']" position="attributes">
-				<attribute name="invisible">0</attribute>
-			</xpath>
 			<div id="purchase_po_lead" position="replace">
 				<setting company_dependent="1" help="Schedule request for quotations earlier to avoid delays" documentation="/applications/inventory_and_mrp/inventory/management/planning/scheduled_dates.html" title="Margin of error for vendor lead times. When the system generates Purchase Orders for reordering products,they will be scheduled that many days earlier to cope with unexpected vendor delays." name="schedule_receivings_setting_container">
 					<field name="use_po_lead"/>

--- a/addons/purchase_stock/views/stock_views.xml
+++ b/addons/purchase_stock/views/stock_views.xml
@@ -43,7 +43,7 @@
             <field name="inherit_id" ref="stock.stock_reorder_report_search"/>
             <field name="arch" type="xml">
                 <xpath expr="//search" position="inside">
-                    <field name="vendor_id"/>
+                    <field name="vendor_ids"/>
                 </xpath>
             </field>
         </record>

--- a/addons/purchase_stock/wizard/product_replenish.py
+++ b/addons/purchase_stock/wizard/product_replenish.py
@@ -85,8 +85,6 @@ class ProductReplenish(models.TransientModel):
 
         delay = supplier.delay + self.env.company.days_to_purchase
 
-        if bool(self.env['ir.config_parameter'].sudo().get_param('purchase.use_po_lead')):
-            delay += self.env.company.po_lead
         return fields.Datetime.add(date, days=delay)
 
     def _get_route_domain(self, product_tmpl_id):

--- a/addons/purchase_stock/wizard/stock_replenishment_info.py
+++ b/addons/purchase_stock/wizard/stock_replenishment_info.py
@@ -9,14 +9,22 @@ class StockReplenishmentInfo(models.TransientModel):
     _description = 'Stock supplier replenishment information'
 
     supplierinfo_id = fields.Many2one(related='orderpoint_id.supplier_id')
-    supplierinfo_ids = fields.Many2many(
-        'product.supplierinfo', compute='_compute_supplierinfo_ids',
-        store=True)
+    supplierinfo_ids = fields.Many2many('product.supplierinfo', compute='_compute_supplierinfo_ids', store=True)
+    show_vendor_tab = fields.Boolean(compute='_compute_show_vendor_tab')
 
     @api.depends('orderpoint_id')
     def _compute_supplierinfo_ids(self):
         for replenishment_info in self:
             replenishment_info.supplierinfo_ids = replenishment_info.product_id.seller_ids
+
+    @api.depends('orderpoint_id')
+    def _compute_show_vendor_tab(self):
+        for replenishment_info in self:
+            orderpoint = replenishment_info.orderpoint_id
+            replenishment_info.show_vendor_tab = not orderpoint.route_id or (
+                    orderpoint.route_id
+                    and 'buy' in orderpoint.rule_ids.mapped('action')
+            )
 
 
 class StockReplenishmentOption(models.TransientModel):

--- a/addons/purchase_stock/wizard/stock_replenishment_info.xml
+++ b/addons/purchase_stock/wizard/stock_replenishment_info.xml
@@ -10,21 +10,29 @@
         <field name="arch" type="xml">
             <field name="delay" position="after">
                 <field name="show_set_supplier_button" column_invisible="True"/>
-                <field name="last_purchase_date"/>
+                <field name="last_purchase_date" width="auto"/>
                 <button name="action_set_supplier" type="object" string="Set as Supplier" class="btn btn-link"
                         invisible="not show_set_supplier_button"/>
             </field>
             <xpath expr="//list" position="attributes">
                 <attribute name="decoration-bf">parent.supplierinfo_id == id</attribute>
             </xpath>
+            <field name="sequence" position="attributes">
+                <attribute name="column_invisible">True</attribute>
+            </field>
             <field name="min_qty" position="attributes">
                 <attribute name="decoration-danger">min_qty &gt; parent.qty_to_order</attribute>
             </field>
             <field name="company_id" position="attributes">
                 <attribute name="optional">hide</attribute>
             </field>
+            <field name="product_uom_id" position="attributes">
+                <attribute name="widget"/>
+            </field>
             <field name="delay" position="attributes">
+                <attribute name="string">Delivery Time</attribute>
                 <attribute name="optional">show</attribute>
+                <attribute name="width">auto</attribute>
             </field>
         </field>
     </record>
@@ -35,7 +43,7 @@
         <field name="inherit_id" ref="stock.view_stock_replenishment_info"/>
         <field name="arch" type="xml">
             <xpath expr="//page" position="before">
-                <page string="Vendors" name="page_vendors">
+                <page string="Vendors" name="page_vendors" invisible="not show_vendor_tab">
                     <field name="supplierinfo_id" invisible="1"/>
                     <field name="supplierinfo_ids" readonly="1" context="{'list_view_ref': 'purchase_stock.product_supplierinfo_replenishment_tree_view', 'stock_replenishment_info_id': id, 'orderpoint_id': orderpoint_id}"/>
                 </page>

--- a/addons/sale_mrp/tests/test_sale_mrp_lead_time.py
+++ b/addons/sale_mrp/tests/test_sale_mrp_lead_time.py
@@ -63,8 +63,7 @@ class TestSaleMrpLeadTime(TestStockCommon):
         company = self.env.ref('base.main_company')
 
         # Update company with Manufacturing Lead Time and Sales Safety Days
-        company.write({'manufacturing_lead': 3.0,
-                       'security_lead': 3.0})
+        company.security_lead = 3
 
         # Create sale order of product_1
         order_form = Form(self.env['sale.order'])
@@ -95,7 +94,7 @@ class TestSaleMrpLeadTime(TestStockCommon):
         )
 
         # Check schedule date and deadline of manufacturing order
-        mo_date_start = out_date - timedelta(days=manufacturing_order.bom_id.produce_delay) - timedelta(days=company.manufacturing_lead)
+        mo_date_start = out_date - timedelta(days=manufacturing_order.bom_id.produce_delay)
         self.assertAlmostEqual(
             fields.Datetime.from_string(manufacturing_order.date_start), mo_date_start,
             delta=timedelta(seconds=1),
@@ -168,7 +167,7 @@ class TestSaleMrpLeadTime(TestStockCommon):
         )
 
         # Check schedule date and deadline date of manufacturing order
-        mo_date_start = out_date - timedelta(days=manufacturing_order.bom_id.produce_delay) - timedelta(days=warehouse.delivery_route_id.rule_ids[0].delay) - timedelta(days=self.env.ref('base.main_company').manufacturing_lead)
+        mo_date_start = out_date - timedelta(days=manufacturing_order.bom_id.produce_delay) - timedelta(days=warehouse.delivery_route_id.rule_ids[0].delay)
         self.assertAlmostEqual(
             fields.Datetime.from_string(manufacturing_order.date_start), mo_date_start,
             delta=timedelta(seconds=1),

--- a/addons/sale_purchase_stock/tests/test_lead_time.py
+++ b/addons/sale_purchase_stock/tests/test_lead_time.py
@@ -29,8 +29,6 @@ class TestLeadTime(TestCommonSalePurchaseNoChart):
     def test_supplier_lead_time(self):
         """ Basic stock configuration and a supplier with a minimum qty and a lead time """
 
-        self.env.user.company_id.po_lead = 7
-
         product = self.env['product.product'].create({
             'name': 'corpse starch',
             'is_storable': True,

--- a/addons/sale_purchase_stock/tests/test_lead_time.py
+++ b/addons/sale_purchase_stock/tests/test_lead_time.py
@@ -61,6 +61,7 @@ class TestLeadTime(TestCommonSalePurchaseNoChart):
         self.assertEqual(po.order_line.price_unit, product.seller_ids.price)
 
     def test_dynamic_lead_time_delay(self):
+        self.env.company.horizon_days = 0
         self.product_a.write({
             'seller_ids': [(0, 0, {
                 'partner_id': self.partner_a.id,

--- a/addons/sale_purchase_stock/tests/test_unwanted_replenish_flow.py
+++ b/addons/sale_purchase_stock/tests/test_unwanted_replenish_flow.py
@@ -9,6 +9,7 @@ class TestWarnUnwantedReplenish(common.TransactionCase):
     def setUpClass(cls):
         super().setUpClass()
 
+        cls.env.company.horizon_days = 0
         cls.buy_route = cls.env.ref('purchase_stock.route_warehouse0_buy')
 
         # Create a vendor (& suppliers) and a customer
@@ -123,10 +124,12 @@ class TestWarnUnwantedReplenish(common.TransactionCase):
             Product B
                 unwanted_replenish SHALL be FALSE
             Product A
-                Modify Visible Days past 1 Week -> unwanted_replenish SHALL be FALSE
+                Modify Horizon Days past 1 Week -> unwanted_replenish SHALL be FALSE
         """
         self.assertTrue(self.orderpoint_A.unwanted_replenish, 'Orderpoint A not set to unwanted_replenish')
         self.assertFalse(self.orderpoint_B.unwanted_replenish, 'Orderpoint B is set to unwanted_replenish')
         #Update Orderpoint A
-        self.orderpoint_A.visibility_days = 10
+        self.env.company.horizon_days = 20
+        self.orderpoint_A.invalidate_recordset(fnames=['lead_horizon_date'])
+        self.orderpoint_A._compute_qty_to_order_computed()
         self.assertFalse(self.orderpoint_A.unwanted_replenish, 'Orderpoint A shall not be set to unwanted_replenish')

--- a/addons/sale_stock/views/res_config_settings_views.xml
+++ b/addons/sale_stock/views/res_config_settings_views.xml
@@ -11,9 +11,6 @@
                     <field name="default_picking_policy" class="o_light_label w-auto" widget="selection"/>
                 </setting>
             </setting>
-            <xpath expr="//block[@id='schedule_info']" position="attributes">
-                <attribute name="invisible">0</attribute>
-            </xpath>
             <div id="sale_security_lead" position="replace">
                 <setting company_dependent="1" help="Schedule deliveries earlier to avoid delays" documentation="/applications/inventory_and_mrp/inventory/management/planning/scheduled_dates.html" title="Margin of error for dates promised to customers. Products will be scheduled for procurement and delivery that many days earlier than the actual promised date, to cope with unexpected delays in the supply chain.">
                     <field name="use_security_lead"/>

--- a/addons/stock/data/stock_data.xml
+++ b/addons/stock/data/stock_data.xml
@@ -122,9 +122,5 @@
             <field name="key">stock.barcode_separator</field>
             <field name="value">,</field>
         </record>
-        <record model="ir.config_parameter" id="visibility_days">
-            <field name="key">stock.visibility_days</field>
-            <field name="value">0</field>
-        </record>
     </data>
 </odoo>

--- a/addons/stock/models/product.py
+++ b/addons/stock/models/product.py
@@ -672,8 +672,8 @@ class ProductProduct(models.Model):
         rules = self._get_rules_from_location(location, route_ids=route_ids)
         delays, _ = rules.with_context(bypass_delay_description=True)._get_lead_days(self)
         return {
-            'date_planned': date - relativedelta(days=delays['security_lead_days']),
-            'date_order': date - relativedelta(days=delays['security_lead_days'] + delays['purchase_delay']),
+            'date_planned': date,
+            'date_order': date - relativedelta(days=delays['purchase_delay']),
         }
 
     def _get_only_qty_available(self):

--- a/addons/stock/models/res_company.py
+++ b/addons/stock/models/res_company.py
@@ -41,6 +41,10 @@ class ResCompany(models.Model):
         string='Day of the month', default=31,
         help="""Day of the month when the annual inventory should occur. If zero or negative, then the first day of the month will be selected instead.
         If greater than the last day of a month, then the last day of the month will be selected instead.""")
+    horizon_days = fields.Float(string="Replenishment Horizon", required=True, default=365,
+                                help="""Configure your horizon to trigger reordering rules earlier to get
+                                a head start on replenishment and avoid delays, or trigger it just-in-time
+                                ('0 days') to avoid overstocking.""")
 
     # used for sending stock text confirmation
     stock_text_confirmation = fields.Boolean("Stock Text Confirmation")

--- a/addons/stock/models/res_config_settings.py
+++ b/addons/stock/models/res_config_settings.py
@@ -56,6 +56,7 @@ class ResConfigSettings(models.TransientModel):
     replenish_on_order = fields.Boolean("Replenish on Order (MTO)", compute='_compute_replenish_on_order', inverse='_inverse_replenish_on_order')
     stock_text_confirmation = fields.Boolean(related='company_id.stock_text_confirmation', string='Stock Text Validation with stock move', readonly=False)
     stock_confirmation_type = fields.Selection(related='company_id.stock_confirmation_type', string='Stock Text Validation type', readonly=False)
+    horizon_days = fields.Float(related='company_id.horizon_days', readonly=False)
 
     def _compute_replenish_on_order(self):
         route = self.env.ref('stock.route_warehouse0_mto', raise_if_not_found=False)

--- a/addons/stock/models/stock_rule.py
+++ b/addons/stock/models/stock_rule.py
@@ -723,6 +723,7 @@ class ProcurementGroup(models.Model):
         domain = self._get_orderpoint_domain(company_id=company_id)
         orderpoints = self.env['stock.warehouse.orderpoint'].search(domain)
         orderpoints.sudo()._compute_qty_to_order_computed()
+        orderpoints.sudo()._compute_deadline_date()
         orderpoints.sudo()._procure_orderpoint_confirm(use_new_cursor=use_new_cursor, company_id=company_id, raise_user_error=False)
 
         if use_new_cursor:

--- a/addons/stock/static/src/scss/stock_replenishment_info.scss
+++ b/addons/stock/static/src/scss/stock_replenishment_info.scss
@@ -1,0 +1,8 @@
+.o_stock_replenishment_info {
+    .o_field_widget.o_small {
+        display: inline;
+        input {
+            width: 40px;
+        }
+    }
+}

--- a/addons/stock/static/src/stock_forecasted/forecasted_details.xml
+++ b/addons/stock/static/src/stock_forecasted/forecasted_details.xml
@@ -83,13 +83,8 @@
                 </tr>
                 <tr t-if="this.props.docs.qty_to_order">
                     <td>To Order</td>
-                    <td t-out="this.props.docs.lead_days_date"/>
+                    <td t-out="this.props.docs.lead_horizon_date"/>
                     <td t-out="_formatFloat(this.props.docs.qty_to_order)" class="text-end"/>
-                </tr>
-                <tr t-if="this.props.docs.qty_to_order !== this.props.docs.qty_to_order_with_visibility_days">
-                    <td>To Order with Visibility Days</td>
-                    <td t-out="this.props.docs.visibility_days_date"/>
-                    <td t-out="_formatFloat(this.props.docs.qty_to_order_with_visibility_days)" class="text-end"/>
                 </tr>
             </tbody>
             <thead>

--- a/addons/stock/static/src/stock_forecasted/stock_forecasted.js
+++ b/addons/stock/static/src/stock_forecasted/stock_forecasted.js
@@ -55,10 +55,8 @@ export class StockForecasted extends Component {
         this.docs = {
             ...reportValues.docs,
             ...reportValues.precision,
-            lead_days_date: this.context.lead_days_date,
+            lead_horizon_date: this.context.lead_horizon_date,
             qty_to_order: this.context.qty_to_order,
-            visibility_days_date: this.context.visibility_days_date,
-            qty_to_order_with_visibility_days: this.context.qty_to_order_with_visibility_days
         };
     }
 

--- a/addons/stock/static/src/views/search/stock_orderpoint_search_model.js
+++ b/addons/stock/static/src/views/search/stock_orderpoint_search_model.js
@@ -9,21 +9,24 @@ export class StockOrderpointSearchModel extends SearchModel {
     setup(services) {
         super.setup(services);
         this.ui = useService("ui");
-        this.applyGlobalVisibilityDays = debounce(
-            this.applyGlobalVisibilityDays.bind(this),
+        this.applyGlobalHorizonDays = debounce(
+            this.applyGlobalHorizonDays.bind(this),
             StockOrderpointSearchModel.DEBOUNCE_DELAY
         );
     }
 
-    async applyGlobalVisibilityDays(globalVisibilityDays) {
+    async applyGlobalHorizonDays(globalHorizonDays) {
         this.ui.block();
         this.globalContext = {
             ...this.globalContext,
-            global_visibility_days: globalVisibilityDays,
+            global_horizon_days: globalHorizonDays,
         };
         this._context = false; // Force rebuild of this.context to take into account the updated this.globalContext
         await this.orm.call("stock.warehouse.orderpoint", "action_open_orderpoints", [], {
-            context: this.context,
+            context: {
+                ...this.context,
+                force_orderpoint_recompute: true,
+            }
         });
         await this._fetchSections(this.categories, this.filters);
         this._notify();

--- a/addons/stock/static/src/views/search/stock_orderpoint_search_panel.js
+++ b/addons/stock/static/src/views/search/stock_orderpoint_search_panel.js
@@ -9,17 +9,17 @@ export class StockOrderpointSearchPanel extends SearchPanel {
     setup() {
         this.orm = useService("orm");
         super.setup(...arguments);
-        this.globalVisibilityDays = useState({value: 0});
-        onWillStart(this.getVisibilityParameter);
+        this.globalHorizonDays = useState({value: 0});
+        onWillStart(this.getHorizonParameter);
     }
 
-    async getVisibilityParameter() {
-        let res = await this.orm.call("stock.warehouse.orderpoint", "get_visibility_days", []);
-        this.globalVisibilityDays.value = Math.abs(parseInt(res)) || 0;
+    async getHorizonParameter() {
+        let res = await this.orm.call("stock.warehouse.orderpoint", "get_horizon_days", [0]);
+        this.globalHorizonDays.value = Math.abs(parseInt(res)) || 0;
     }
 
-    async applyGlobalVisibilityDays(ev) {
-        this.globalVisibilityDays.value = Math.max(parseInt(ev.target.value), 0);
-        await this.env.searchModel.applyGlobalVisibilityDays(this.globalVisibilityDays.value);
+    async applyGlobalHorizonDays(ev) {
+        this.globalHorizonDays.value = Math.max(parseInt(ev.target.value), 0);
+        await this.env.searchModel.applyGlobalHorizonDays(this.globalHorizonDays.value);
     }
 }

--- a/addons/stock/static/src/views/search/stock_orderpoint_search_panel.xml
+++ b/addons/stock/static/src/views/search/stock_orderpoint_search_panel.xml
@@ -10,7 +10,7 @@
                 </header>
 
                 <div class="input-group">
-                    <input type="number" min="0" t-att-value="globalVisibilityDays.value" class="form-control" aria-describedby="days-label" t-on-change="applyGlobalVisibilityDays"/>
+                    <input type="number" min="0" t-att-value="globalHorizonDays.value" class="form-control" aria-describedby="days-label" t-on-change="applyGlobalHorizonDays"/>
                     <span class="input-group-text" id="days-label">days</span>
                 </div>
             </section>

--- a/addons/stock/static/src/views/stock_orderpoint_list_view.xml
+++ b/addons/stock/static/src/views/stock_orderpoint_list_view.xml
@@ -5,7 +5,7 @@
         <xpath expr="//SelectionBox" position="after">
             <Dropdown>
                 <button class="btn btn-secondary">
-                    <span class="o_dropdown_title">Replenish</span>
+                    <span class="o_dropdown_title">Order</span>
                     <i class="fa fa-caret-down ms-1"/>
                 </button>
                 <t t-set-slot="content">

--- a/addons/stock/static/src/widgets/json_widget.xml
+++ b/addons/stock/static/src/widgets/json_widget.xml
@@ -1,22 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <templates id="template" xml:space="preserve">
     <div t-name="stock.leadDays">
-        <h2>Lead Times</h2>
+        <h2>Forecasted Date</h2>
         <hr/>
-        <p>
-            The forecasted stock on the <b t-esc="jsonValue.lead_days_date"/>
-            is <t t-if="jsonValue.qty_to_order &lt;= 0"><b><t t-esc="qtyForecast"/></b></t><t t-else="">
-            below the inventory <b>minimum of <t t-esc="productMinQty"/>
-            : <t t-esc="qtyToOrder"/> should be replenished</b> to reach the maximum of
-            <t t-esc="productMaxQty"/>.</t>
-        </p>
         <table t-if="jsonValue.lead_days_description" class="table table-borderless table-sm">
             <tbody>
-                <tr>
+                <tr class="table-secondary">
                     <td>Today</td>
                     <td class="text-end" t-out="jsonValue.today"/>
                 </tr>
-                <tr t-foreach="jsonValue.lead_days_description" t-key="descr" t-as="descr">
+                <tr t-foreach="jsonValue.lead_days_description" t-key="descr" t-as="descr"
+                    t-attf-class="{{ descr[2] ? 'table-secondary' : '' }}">
                     <td t-out="descr[0]"/>
                     <td class="text-end" t-out="descr[1]"/>
                 </tr>

--- a/addons/stock/static/src/widgets/json_widget.xml
+++ b/addons/stock/static/src/widgets/json_widget.xml
@@ -24,18 +24,19 @@
         </table>
     </div>
 
-    <div t-name="stock.replenishmentHistory">
-        <h2>Sales History</h2>
-        <hr/>
-        <table t-if="jsonValue.replenishment_history" class="table table-borderless">
-            <tbody>
-                <t t-foreach="jsonValue.replenishment_history" t-key="line.name" t-as="line">
-                    <tr>
-                        <td><t t-esc="line.name"/></td>
-                        <td class="text-end text-nowrap" t-esc="line.quantity + ' ' + line.uom_name"/>
-                    </tr>
-                </t>
-            </tbody>
-        </table>
+    <div t-name="stock.replenishmentGraph" class="col-11">
+        <div class="o_replenishment_graph">
+            <canvas t-ref="canvas"/>
+        </div>
+        <div class="d-flex pt-3">
+            <h6 class="row text-muted">
+                <span>Daily Demand: <span t-out="dailyDemand"/> <span t-out="productUomName"/>/day</span>
+                <span class="pt-2">Average Stock: <span t-out="averageStock"/> <span t-out="productUomName"/></span>
+            </h6>
+            <h6 class="row text-muted">
+                <span>Ordering Frequency: <span t-out="orderingPeriod"/> day(s)</span>
+                <span class="pt-2">Lead Time: <span t-out="leadTime"/> day(s)</span>
+            </h6>
+        </div>
     </div>
 </templates>

--- a/addons/stock/static/src/widgets/json_widget.xml
+++ b/addons/stock/static/src/widgets/json_widget.xml
@@ -23,19 +23,7 @@
                 <tr class="table-info">
                     <td>Forecasted Date</td>
                     <td class="text-end text-nowrap">
-                        = <t t-out="jsonValue.lead_days_date"/>
-                    </td>
-                </tr>
-                <tr t-if="jsonValue.visibility_days > 0">
-                    <td>Visibility days</td>
-                    <td class="text-end text-nowrap">
-                        + <t t-out="jsonValue.visibility_days"/> Day(s)
-                    </td>
-                </tr>
-                <tr t-if="jsonValue.visibility_days > 0" class="table-info fw-bold">
-                    <td>Forecasted Date + Visibility Days</td>
-                    <td class="text-end text-nowrap">
-                        = <t t-out="jsonValue.visibility_days_date"/>
+                        = <t t-out="jsonValue.lead_horizon_date"/>
                     </td>
                 </tr>
             </tbody>

--- a/addons/stock/tests/test_proc_rule.py
+++ b/addons/stock/tests/test_proc_rule.py
@@ -2,6 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from datetime import date, datetime, timedelta
+from freezegun import freeze_time
 
 from odoo.fields import Command
 from odoo.tests import Form, TransactionCase
@@ -710,6 +711,132 @@ class TestProcRule(TransactionCase):
         self.product.write({'route_ids': [Command.set(product_route.ids)]})
         orderpoint.invalidate_recordset(fnames=['show_supply_warning'])
         self.assertFalse(orderpoint.show_supply_warning)
+
+    @freeze_time('2025-09-02 14:00:00')
+    def test_orderpoint_deadline_date(self):
+        """ Test that the deadline date is correctly computed. """
+        self.product.is_storable = True
+        product_1 = self.env['product.product'].create({
+            'name': 'product_1',
+            'type': 'consu',
+            'is_storable': True,
+        })
+        product_2 = self.env['product.product'].create({
+            'name': 'product_2',
+            'type': 'consu',
+            'is_storable': True,
+        })
+
+        self.env['stock.quant'].create({
+            'product_id': self.product.id,
+            'location_id': self.env.ref('stock.stock_location_stock').id,
+            'quantity': 20,
+        })
+        self.env['stock.quant'].create({
+            'product_id': product_1.id,
+            'location_id': self.env.ref('stock.stock_location_stock').id,
+            'quantity': 20,
+        })
+        self.env['stock.quant'].create({
+            'product_id': product_2.id,
+            'location_id': self.env.ref('stock.stock_location_stock').id,
+            'quantity': 20,
+        })
+        orderpoint_0 = self.env['stock.warehouse.orderpoint'].create({
+            'product_id': self.product.id,
+            'product_min_qty': 10,
+            'product_max_qty': 50,
+        })
+        orderpoint_1 = self.env['stock.warehouse.orderpoint'].create({
+            'product_id': product_1.id,
+            'product_min_qty': 10,
+            'product_max_qty': 50,
+        })
+        orderpoint_2 = self.env['stock.warehouse.orderpoint'].create({
+            'product_id': product_2.id,
+            'product_min_qty': 10,
+            'product_max_qty': 50,
+        })
+
+        delivery_date_0 = datetime.today() + timedelta(days=15)
+        delivery_date_1 = datetime.today() + timedelta(days=25)
+        delivery_date_2 = datetime.today() + timedelta(days=35)
+
+        stock_moves = self.env['stock.move']
+        # product 0: 15 OUT in 15 days, 10 IN in 25 days -> deadline in 15 days
+        stock_moves |= self.env['stock.move'].create({
+            'product_id': self.product.id,
+            'product_uom': self.product.uom_id.id,
+            'product_uom_qty': 15,
+            'location_id': self.ref('stock.stock_location_stock'),
+            'location_dest_id': self.ref('stock.stock_location_customers'),
+            'date': delivery_date_0,
+        })
+        stock_moves |= self.env['stock.move'].create({
+            'product_id': self.product.id,
+            'product_uom': self.product.uom_id.id,
+            'product_uom_qty': 10,
+            'location_id': self.ref('stock.stock_location_suppliers'),
+            'location_dest_id': self.ref('stock.stock_location_stock'),
+            'date': delivery_date_1,
+        })
+        # product 1: 10 OUT in 25, 5 OUT in 35 days -> deadline in 35 days
+        stock_moves |= self.env['stock.move'].create({
+            'product_id': product_1.id,
+            'product_uom': product_1.uom_id.id,
+            'product_uom_qty': 10,
+            'location_id': self.ref('stock.stock_location_stock'),
+            'location_dest_id': self.ref('stock.stock_location_customers'),
+            'date': delivery_date_1,
+        })
+        stock_moves |= self.env['stock.move'].create({
+            'product_id': product_1.id,
+            'product_uom': product_1.uom_id.id,
+            'product_uom_qty': 5,
+            'location_id': self.ref('stock.stock_location_stock'),
+            'location_dest_id': self.ref('stock.stock_location_customers'),
+            'date': delivery_date_2,
+        })
+        # product 2: 15 OUT in 15 days, 15 IN in 15 days, 15 OUT in 25 days -> deadline in 25 days
+        stock_moves |= self.env['stock.move'].create({
+            'product_id': product_2.id,
+            'product_uom': product_2.uom_id.id,
+            'product_uom_qty': 15,
+            'location_id': self.ref('stock.stock_location_stock'),
+            'location_dest_id': self.ref('stock.stock_location_customers'),
+            'date': delivery_date_0,
+        })
+        stock_moves |= self.env['stock.move'].create({
+            'product_id': product_2.id,
+            'product_uom': product_2.uom_id.id,
+            'product_uom_qty': 15,
+            'location_id': self.ref('stock.stock_location_suppliers'),
+            'location_dest_id': self.ref('stock.stock_location_stock'),
+            'date': delivery_date_0,
+        })
+        stock_moves |= self.env['stock.move'].create({
+            'product_id': product_2.id,
+            'product_uom': product_2.uom_id.id,
+            'product_uom_qty': 15,
+            'location_id': self.ref('stock.stock_location_stock'),
+            'location_dest_id': self.ref('stock.stock_location_customers'),
+            'date': delivery_date_1,
+        })
+
+        # There should be no deadline since no move was confirmed
+        self.assertEqual(orderpoint_0.deadline_date, False)
+        self.assertEqual(orderpoint_1.deadline_date, False)
+        self.assertEqual(orderpoint_2.deadline_date, False)
+        # After confirming the moves, deadline dates should have been applied to all orderpoints
+        stock_moves._action_confirm()
+        self.assertEqual(orderpoint_0.deadline_date, delivery_date_0.date())
+        self.assertEqual(orderpoint_1.deadline_date, delivery_date_2.date())
+        self.assertEqual(orderpoint_2.deadline_date, delivery_date_1.date())
+        # After changing the horizon days, the deadline dates should have been recomputed
+        self.env.company.horizon_days = 30
+        self.assertEqual(orderpoint_0.deadline_date, delivery_date_0.date())
+        self.assertEqual(orderpoint_1.deadline_date, False)
+        self.assertEqual(orderpoint_2.deadline_date, delivery_date_1.date())
 
 
 class TestProcRuleLoad(TransactionCase):

--- a/addons/stock/views/res_config_settings_views.xml
+++ b/addons/stock/views/res_config_settings_views.xml
@@ -199,7 +199,10 @@
                                 </div>
                             </setting>
                         </block>
-                        <block title="Advanced Scheduling" id="schedule_info" invisible="1">
+                        <block title="Advanced Scheduling" id="schedule_info">
+                            <setting company_dependent="1" help="Configure your horizon to trigger reordering rules earlier to get a head start on replenishment and avoid delays, or trigger it just-in-time ('0 days') to avoid overstocking.">
+                                <field name="horizon_days" class="oe_inline"/><span> days</span>
+                            </setting>
                             <div id="sale_security_lead"/>
                             <div id="purchase_po_lead"/>
                         </block>

--- a/addons/stock/views/stock_orderpoint_views.xml
+++ b/addons/stock/views/stock_orderpoint_views.xml
@@ -40,7 +40,8 @@
                 <button name="action_product_forecast_report" type="object" icon="fa-warning text-warning" title="Due to receipts scheduled in the future, you might end up with excessive stock . Check the Forecasted Report  before reordering" invisible="not id or not unwanted_replenish"/>
                 <field name="visibility_days" optional="hidden"/>
                 <field name="route_id" options="{'no_create': True, 'no_open': True}" optional="hidden"/>
-                <button name="action_stock_replenishment_info" type="object" icon="fa-info-circle" title="Replenishment Information" invisible="not id"/>
+                <button name="action_stock_replenishment_info" type="object" icon="fa-info-circle" title="Replenishment Information" invisible="not id or show_supply_warning"/>
+                <button name="action_stock_replenishment_info" type="object" icon="fa-warning text-warning" title="Your product is missing a way to be replenished (Route, Vendor, Bill of Materials)." invisible="not (id and show_supply_warning)"/>
                 <field name="trigger" optional="hide"/>
                 <field name="group_id" optional="hide" groups="stock.group_adv_location"/>
                 <field name="product_min_qty" string="Min" optional="show"/>
@@ -68,13 +69,14 @@
         <field name="arch" type="xml">
             <search string="Replenishment Report Search">
                 <field name="product_id"/>
-                <field name="trigger"/>
                 <field name="product_category_id"/>
                 <field name="group_id" groups="stock.group_adv_location"/>
                 <field name="warehouse_id" groups="stock.group_stock_multi_warehouses"/>
                 <field name="location_id" groups="stock.group_stock_multi_locations"/>
-                <field name="name" string="Reordering Rule"/>
-                <filter string="Trigger Manual" name="filter_creation_trigger" domain="[('trigger', '=', 'manual')]"/>
+                <filter string="Archived" name="inactive" domain="[('active', '=', False)]"/>
+                <separator/>
+                <filter string="Manual" name="filter_creation_manual_trigger" domain="[('trigger', '=', 'manual')]"/>
+                <filter string="Automatic" name="filter_creation_automatic_trigger" domain="[('trigger', '=', 'auto')]"/>
                 <separator/>
                 <filter string="To Reorder" name="filter_to_reorder" domain="[('qty_to_order', '&gt;', 0.0)]"/>
                 <separator/>
@@ -181,11 +183,23 @@
         </field>
     </record>
 
+    <record id="view_warehouse_orderpoint_tree_editable_show_trigger" model="ir.ui.view">
+        <field name="name">stock.warehouse.orderpoint.list.editable.inherit.show_trigger</field>
+        <field name="model">stock.warehouse.orderpoint</field>
+        <field name="inherit_id" ref="stock.view_warehouse_orderpoint_tree_editable"/>
+        <field name="mode">primary</field>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='trigger']" position="attributes">
+                <attribute name="optional">show</attribute>
+            </xpath>
+        </field>
+    </record>
+
     <record id="action_orderpoint" model="ir.actions.act_window">
         <field name="name">Reordering Rules</field>
         <field name="res_model">stock.warehouse.orderpoint</field>
         <field name="view_mode">list,kanban,form</field>
-        <field name="view_id" ref="view_warehouse_orderpoint_tree_editable"/>
+        <field name="view_id" ref="view_warehouse_orderpoint_tree_editable_show_trigger"/>
         <field name="search_view_id" ref="warehouse_orderpoint_search"/>
         <field name="context">{'search_default_trigger': 'auto'}</field>
         <field name="help" type="html">

--- a/addons/stock/views/stock_orderpoint_views.xml
+++ b/addons/stock/views/stock_orderpoint_views.xml
@@ -38,7 +38,6 @@
                 <field name="qty_forecast" force_save="1"/>
                 <button name="action_product_forecast_report" type="object" icon="fa-area-chart" title="Forecast Report" invisible="not id or unwanted_replenish"/>
                 <button name="action_product_forecast_report" type="object" icon="fa-warning text-warning" title="Due to receipts scheduled in the future, you might end up with excessive stock . Check the Forecasted Report  before reordering" invisible="not id or not unwanted_replenish"/>
-                <field name="visibility_days" optional="hidden"/>
                 <field name="route_id" options="{'no_create': True, 'no_open': True}" optional="hidden"/>
                 <button name="action_stock_replenishment_info" type="object" icon="fa-info-circle" title="Replenishment Information" invisible="not id or show_supply_warning"/>
                 <button name="action_stock_replenishment_info" type="object" icon="fa-warning text-warning" title="Your product is missing a way to be replenished (Route, Vendor, Bill of Materials)." invisible="not (id and show_supply_warning)"/>
@@ -158,7 +157,6 @@
                                 <field name="group_id" groups="stock.group_adv_location"/>
                             </div>
                             <field name="company_id" groups="base.group_multi_company" options="{'no_create': True}"/>
-                            <field name="visibility_days"/>
                         </group>
                     </group>
                 </sheet>

--- a/addons/stock/views/stock_orderpoint_views.xml
+++ b/addons/stock/views/stock_orderpoint_views.xml
@@ -51,6 +51,7 @@
                 <button name="action_remove_manual_qty_to_order" type="object" icon="fa-undo" title="Remove manually entered value and replace by the quantity to order based on the forecasted quantities" invisible="not qty_to_order_manual"/>
                 <button name="action_remove_manual_qty_to_order" type="object" icon="fa-undo" title="-" class="disabled opacity-0" invisible="qty_to_order_manual"/>
                 <field name="product_uom_name" string="Unit" groups="uom.group_uom"/>
+                <field name="deadline_date" string="Deadline" optional="hide"/>
                 <field name="company_id" optional="hide" readonly="1" groups="base.group_multi_company"/>
                 <button name="action_replenish" string="Order" type="object" class="o_replenish_buttons" icon="fa-truck"
                     invisible="qty_to_order &lt;= 0.0"/>

--- a/addons/stock/wizard/stock_replenishment_info.py
+++ b/addons/stock/wizard/stock_replenishment_info.py
@@ -9,6 +9,7 @@ from dateutil.relativedelta import relativedelta
 from odoo import api, fields, models, SUPERUSER_ID, _
 from odoo.fields import Domain
 from odoo.tools.date_utils import get_month, subtract
+from odoo.tools.float_utils import float_round
 from odoo.tools.misc import get_lang, format_date
 
 
@@ -20,11 +21,28 @@ class StockReplenishmentInfo(models.TransientModel):
     orderpoint_id = fields.Many2one('stock.warehouse.orderpoint')
     product_id = fields.Many2one('product.product', related='orderpoint_id.product_id')
     product_uom_name = fields.Char(related='orderpoint_id.product_uom_name')
-    product_min_qty = fields.Float(related='orderpoint_id.product_min_qty')
-    product_max_qty = fields.Float(related='orderpoint_id.product_max_qty')
+    product_min_qty = fields.Float('Min', related='orderpoint_id.product_min_qty', readonly=False, related_sudo=False, required=True)
+    product_max_qty = fields.Float('Max', related='orderpoint_id.product_max_qty', readonly=False, related_sudo=False, required=True)
     qty_to_order = fields.Float(related='orderpoint_id.qty_to_order')
     json_lead_days = fields.Char(compute='_compute_json_lead_days')
-    json_replenishment_history = fields.Char(compute='_compute_json_replenishment_history')
+    json_replenishment_graph = fields.Char(compute='_compute_json_replenishment_graph')
+    based_on = fields.Selection(
+        selection=[
+            ('one_week', "Last 7 days"),
+            ('one_month', "Last 30 days"),
+            ('three_months', "Last 3 months"),
+            ('one_year', "Last 12 months"),
+            ('last_year', "Same month last year"),
+            ('last_year_2', "Next month last year"),
+            ('last_year_3', "After next month last year"),
+            ('last_year_quarter', "Last year quarter"),
+        ],
+        default='one_month',
+        string='Based on',
+        help="Estimate the sales volume for the period based on past period or order the forecasted quantity for that period.",
+        required=True
+    )
+    percent_factor = fields.Integer(default=100, required=True)
 
     warehouseinfo_ids = fields.One2many(related='orderpoint_id.warehouse_id.resupply_route_ids')
     wh_replenishment_option_ids = fields.One2many('stock.replenishment.option', 'replenishment_info_id', compute='_compute_wh_replenishment_options')
@@ -36,6 +54,12 @@ class StockReplenishmentInfo(models.TransientModel):
                 {'product_id': replenishment_info.product_id.id, 'route_id': route_id.id, 'replenishment_info_id': replenishment_info.id}
                 for route_id in replenishment_info.warehouseinfo_ids
             ]).sorted(lambda o: o.free_qty, reverse=True)
+
+    def _get_lead_days_and_description(self):
+        self.ensure_one()
+        orderpoint = self.orderpoint_id
+        orderpoints_values = orderpoint._get_lead_days_values()
+        return orderpoint.rule_ids._get_lead_days(orderpoint.product_id, **orderpoints_values)
 
     @api.depends('orderpoint_id')
     def _compute_json_lead_days(self):
@@ -52,12 +76,10 @@ class StockReplenishmentInfo(models.TransientModel):
 
         self.json_lead_days = False
         for replenishment_report in self:
-            if not replenishment_report.orderpoint_id.product_id or not replenishment_report.orderpoint_id.location_id:
+            if not replenishment_report.product_id or not replenishment_report.orderpoint_id.location_id:
                 continue
             orderpoint = replenishment_report.orderpoint_id
-            orderpoints_values = orderpoint._get_lead_days_values()
-            dummy, lead_days_description = orderpoint.rule_ids._get_lead_days(
-                orderpoint.product_id, **orderpoints_values)
+            _, lead_days_description = replenishment_report._get_lead_days_and_description()
             if lead_days_description:
                 lead_days_description = _format_description(lead_days_description)
             replenishment_report.json_lead_days = dumps({
@@ -73,38 +95,101 @@ class StockReplenishmentInfo(models.TransientModel):
                 'virtual': orderpoint.trigger == 'manual' and orderpoint.create_uid.id == SUPERUSER_ID,
             })
 
-    @api.depends('orderpoint_id')
-    def _compute_json_replenishment_history(self):
+    def _get_period_of_time(self):
+        self.ensure_one()
+        today = fields.Datetime.now()
+        start_date = limit_date = today
+        if self.based_on == 'one_week':
+            start_date = start_date - relativedelta(weeks=1)
+        elif self.based_on == 'one_month':
+            start_date = start_date - relativedelta(months=1)
+        elif self.based_on == 'three_months':
+            start_date = start_date - relativedelta(months=3)
+        elif self.based_on == 'one_year':
+            start_date = start_date - relativedelta(years=1)
+        else:  # Relative period of time.
+            start_date = datetime(year=today.year - 1, month=today.month, day=1)
+            if self.based_on == 'last_year_2':
+                start_date += relativedelta(months=1)
+            elif self.based_on == 'last_year_3':
+                start_date += relativedelta(months=2)
+            if self.based_on == 'last_year_quarter':
+                limit_date = start_date + relativedelta(months=3)
+            else:
+                limit_date = start_date + relativedelta(months=1)
+        return start_date, limit_date
+
+    def _prepare_graph_data(self, daily_demand=0):
+        self.ensure_one()
+        if not daily_demand:
+            ordering_period = 0
+            x_axis_vals = ['', ' ']
+            curve_line_vals = []
+        else:
+            qty_diff = self.product_max_qty - self.product_min_qty or 1
+            ordering_period = max(1, int(qty_diff / daily_demand))
+            x_axis_vals = ['']
+            curve_line_vals = [{'x': '', 'y': self.product_max_qty}]
+            for i in range(1, 4):
+                date_string = _("In %s day(s)", int(i * ordering_period))
+                x_axis_vals.append(date_string)
+                curve_line_vals.append({'x': date_string, 'y': self.product_min_qty})
+                curve_line_vals.append({'x': date_string, 'y': self.product_max_qty})
+            curve_line_vals.pop()   # we pop the last value since it would result in an ascending line that we don't need
+
+        max_line_vals = [{'x': date, 'y': self.product_max_qty} for date in x_axis_vals]
+        min_line_vals = [{'x': date, 'y': self.product_min_qty} for date in x_axis_vals]
+        graph_data = {
+            'x_axis_vals': x_axis_vals,
+            'max_line_vals': max_line_vals,
+            'min_line_vals': min_line_vals,
+            'curve_line_vals': curve_line_vals,
+        }
+        return ordering_period, graph_data
+
+    @api.depends('orderpoint_id', 'based_on', 'percent_factor', 'product_min_qty', 'product_max_qty')
+    def _compute_json_replenishment_graph(self):
         for replenishment_report in self:
-            replenishment_history = []
-            today = fields.Datetime.now()
-            first_month = subtract(today, months=2)
-            date_from, dummy = get_month(first_month)
-            dummy, date_to = get_month(today)
-            domain = Domain([
-                ('product_id', '=', replenishment_report.product_id.id),
-                ('date', '>=', date_from),
-                ('date', '<=', datetime.combine(date_to, time.max)),
-                ('state', '=', 'done'),
-                ('company_id', '=', replenishment_report.orderpoint_id.company_id.id)
+            if not replenishment_report.product_id or not replenishment_report.orderpoint_id.location_id:
+                continue
+            lead_days, _ = replenishment_report._get_lead_days_and_description()
+            date_from, date_to = replenishment_report._get_period_of_time()
+            domain = Domain.AND([
+                [('product_id', '=', replenishment_report.product_id.id)],
+                [('date', '>=', date_from)],
+                [('date', '<=', datetime.combine(date_to, time.max))],
+                [('state', '=', 'done')],
+                [('company_id', '=', replenishment_report.orderpoint_id.company_id.id)],
             ])
-            quantity_by_month_out = self.env['stock.move']._read_group(
-                domain & Domain('location_dest_id.usage', '=', 'customer'),
-                ['date:month'], ['product_qty:sum'])
-            quantity_by_month_returned = dict(self.env['stock.move']._read_group(
-                domain & Domain('location_id.usage', '=', 'customer'),
-                ['date:month'], ['product_qty:sum']))
-            locale = get_lang(self.env).code
-            fmt = models.READ_GROUP_DISPLAY_FORMAT['month']
-            for month, product_qty_sum in quantity_by_month_out:
-                replenishment_history.append({
-                    'name': babel.dates.format_datetime(month, format=fmt, locale=locale),
-                    'quantity': product_qty_sum - quantity_by_month_returned.get(month, 0),
-                    'uom_name': replenishment_report.product_id.uom_id.display_name,
-                })
-            replenishment_report.json_replenishment_history = dumps({
-                'template': 'stock.replenishmentHistory',
-                'replenishment_history': replenishment_history
+            quantity_out = self.env['stock.move']._read_group(
+                Domain.AND([domain, [('location_dest_id.usage', '=', 'customer')]]),
+                aggregates=['product_qty:sum'],
+            )[0][0] or 0.0
+            quantity_returned = self.env['stock.move']._read_group(
+                Domain.AND([domain, [('location_id.usage', '=', 'customer')]]),
+                aggregates=['product_qty:sum'],
+            )[0][0] or 0.0
+
+            if replenishment_report.product_max_qty < replenishment_report.product_min_qty:
+                replenishment_report.product_max_qty = replenishment_report.product_min_qty
+            average_stock = replenishment_report.product_min_qty + ((replenishment_report.product_max_qty - replenishment_report.product_min_qty) / 2)
+            lead_time = lead_days.get('total_delay', 0) - replenishment_report.orderpoint_id.get_horizon_days()
+            daily_demand = ((quantity_out - quantity_returned) / (date_to - date_from).days) * (replenishment_report.percent_factor / 100)
+
+            ordering_period, graph_data = replenishment_report._prepare_graph_data(daily_demand=daily_demand)
+            replenishment_report.json_replenishment_graph = dumps({
+                'product_uom_name': replenishment_report.product_uom_name,
+                'product_max_qty': replenishment_report.product_max_qty,
+                'product_min_qty': replenishment_report.product_min_qty,
+                'qty_on_hand': replenishment_report.orderpoint_id.qty_on_hand,
+                'lead_time': lead_time,
+                'daily_demand': float_round(daily_demand, precision_rounding=replenishment_report.product_id.uom_id.rounding),
+                'average_stock': float_round(average_stock, precision_rounding=replenishment_report.product_id.uom_id.rounding),
+                'ordering_period': float_round(ordering_period, precision_rounding=1),
+                'x_axis_vals': graph_data["x_axis_vals"],
+                'max_line_vals': graph_data["max_line_vals"],
+                'min_line_vals': graph_data["min_line_vals"],
+                'curve_line_vals': graph_data["curve_line_vals"],
             })
 
 

--- a/addons/stock/wizard/stock_replenishment_info.py
+++ b/addons/stock/wizard/stock_replenishment_info.py
@@ -45,7 +45,7 @@ class StockReplenishmentInfo(models.TransientModel):
             dummy, lead_days_description = orderpoint.rule_ids._get_lead_days(
                 orderpoint.product_id, **orderpoints_values)
             replenishment_report.json_lead_days = dumps({
-                'lead_days_date': format_date(self.env, replenishment_report.orderpoint_id.lead_days_date),
+                'lead_horizon_date': format_date(self.env, replenishment_report.orderpoint_id.lead_horizon_date),
                 'lead_days_description': lead_days_description,
                 'today': format_date(self.env, fields.Date.today()),
                 'trigger': orderpoint.trigger,
@@ -55,8 +55,6 @@ class StockReplenishmentInfo(models.TransientModel):
                 'product_max_qty': self.env['ir.qweb.field.float'].value_to_html(orderpoint.product_max_qty, {'decimal_precision': 'Product Unit'}),
                 'product_uom_name': orderpoint.product_uom_name,
                 'virtual': orderpoint.trigger == 'manual' and orderpoint.create_uid.id == SUPERUSER_ID,
-                'visibility_days': orderpoint.visibility_days if orderpoint.product_uom.compare(orderpoint.qty_forecast, orderpoint.product_min_qty) < 0 else 0,
-                'visibility_days_date': format_date(self.env, replenishment_report.orderpoint_id.lead_days_date + relativedelta(days=orderpoint.visibility_days))
             })
 
     @api.depends('orderpoint_id')

--- a/addons/stock/wizard/stock_replenishment_info.xml
+++ b/addons/stock/wizard/stock_replenishment_info.xml
@@ -4,18 +4,37 @@
         <field name="name">Stock Replenishment Information</field>
         <field name="model">stock.replenishment.info</field>
         <field name="arch" type="xml">
-            <form>
+            <form class="o_stock_replenishment_info">
                 <field name="orderpoint_id" invisible="1"/>
                 <field name="qty_to_order" invisible="1"/>
                 <div class="alert alert-info" role="alert">
-                    <span>When the stock level at the forecasted date is below the minimum (<field name="product_min_qty"/> <field name="product_uom_name"/>), a replenishment must be done to reach the maximum level of stock (<field name="product_max_qty"/> <field name="product_uom_name"/>).</span>
+                    <span>When the stock level at the forecasted date is below the minimum (<field name="product_min_qty" readonly="True"/> <field name="product_uom_name"/>), a replenishment must be done to reach the maximum level of stock (<field name="product_max_qty" readonly="True"/> <field name="product_uom_name"/>).</span>
                 </div>
                 <group>
                     <group>
                         <field nolabel="1" name="json_lead_days" colspan="2" widget="lead_days_widget"/>
                     </group>
                     <group>
-                        <field nolabel="1" name="json_replenishment_history" colspan="2" widget="replenishment_history_widget"/>
+                        <div>
+                            <h2>Min - Max</h2>
+                            <hr/>
+                            <div>
+                                <label for="based_on"/>
+                                <field name="based_on" class="oe_inline" widget="time_period_selection"/> x
+                                <field name="percent_factor" class="o_small"/> %
+                            </div>
+                            <div>
+                                <label class="o_form_label col-3" for="product_min_qty"/>
+                                <field name="product_min_qty" class="oe_inline"/>
+                                <field name="product_uom_name" class="oe_inline"/>
+                            </div>
+                            <div>
+                                <label class="o_form_label col-3" for="product_max_qty"/>
+                                <field name="product_max_qty" class="oe_inline"/>
+                                <field name="product_uom_name" class="oe_inline"/>
+                            </div>
+                            <field nolabel="1" name="json_replenishment_graph" colspan="2" widget="replenishment_graph_widget"/>
+                        </div>
                     </group>
                 </group>
                 <notebook>

--- a/addons/stock/wizard/stock_replenishment_info.xml
+++ b/addons/stock/wizard/stock_replenishment_info.xml
@@ -7,6 +7,9 @@
             <form>
                 <field name="orderpoint_id" invisible="1"/>
                 <field name="qty_to_order" invisible="1"/>
+                <div class="alert alert-info" role="alert">
+                    <span>When the stock level at the forecasted date is below the minimum (<field name="product_min_qty"/> <field name="product_uom_name"/>), a replenishment must be done to reach the maximum level of stock (<field name="product_max_qty"/> <field name="product_uom_name"/>).</span>
+                </div>
                 <group>
                     <group>
                         <field nolabel="1" name="json_lead_days" colspan="2" widget="lead_days_widget"/>


### PR DESCRIPTION
We are making the following changes to the replenishment orderpoints:

- removing visibility_days (and related fields): it will be replaced by horizon_days which is company-dependent
- adding deadline_date: it gives the date when the next order should be made if at any point the qty_on_hand goes below the product_min_qty
- removing the history on the info wizard: it will be replaced by a graph that shows how the replenishment would go for the next 3 cycles, based on the daily demand of previous periods
- adding a warning sign on orderpoints if no valid route is found (missing route, missing vendor, missing bom)
- adding a bom tab on the info wizard that serves the same purpose as the vendor tab
- reworking the table on the info wizard to show intermediary dates
- some minor changes

We are also completely removing po_lead and manufacturing_lead.

task 4779169

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
