### PR TITLE
[FIX] purchase: limit image size on portal display

### DIFF
--- a/addons/purchase/__manifest__.py
+++ b/addons/purchase/__manifest__.py
@@ -52,6 +52,7 @@
         'web.assets_frontend': [
             'purchase/static/src/js/purchase_datetimepicker.js',
             'purchase/static/src/js/purchase_portal_sidebar.js',
+            'purchase/static/src/scss/purchase_portal.scss',
         ],
     },
     'license': 'LGPL-3',

--- a/addons/purchase/static/src/scss/purchase_portal.scss
+++ b/addons/purchase/static/src/scss/purchase_portal.scss
@@ -1,0 +1,8 @@
+// Limit product image size
+.o_purchase_portal_product_image {
+    width: 48px;
+    height: 48px;
+    object-fit: contain;
+    margin-right: 3px;
+    margin-left: 3px;
+}

--- a/addons/purchase/views/portal_templates.xml
+++ b/addons/purchase/views/portal_templates.xml
@@ -338,7 +338,7 @@
                             <tr t-att-class="'fw-bold o_line_section' if line.display_type == 'line_section' else 'fst-italic text-break' if line.display_type == 'line_note' else ''">
                                 <t t-if="not line.display_type">
                                     <td id="product_name" class="d-flex">
-                                        <img t-att-src="image_data_uri(resize_to_48(line.product_id.image_1024))" alt="Product" class="d-none d-lg-inline"/>
+                                        <img t-att-src="image_data_uri(line.product_id.image_128)" alt="Product" class="d-none d-lg-inline o_purchase_portal_product_image"/>
                                         <span t-field="line.name"/>
                                     </td>
                                     <td class="text-end">


### PR DESCRIPTION
Issue
-----
Images on the purchase portal are displayed in their original size instead, making it a visual mess.

Steps to reproduce
-----
- Create a product with a large image
- Create a purchase for the product
- Click the cog wheel > Share
- Open the link in a new tab (with no active session, eg private window)

--> The image is way too big

Cause
-----
Images are now converted to Webp:
https://github.com/odoo/odoo/commit/1a978183001e0503104285f4bd5bed983beb0efb

The problem is that Webp images cannot be resized through the Python backend:
https://github.com/odoo/odoo/blob/0c6622294b7117ec5eb1cbf8a9270636b2dd807f/odoo/tools/image.py#L81-L83

However, the product model has multiple sizes for the image:
https://github.com/odoo/odoo/blob/3ddf2bcdf16b5b43db4c4abe2cdbc4384cf683cc/addons/product/models/product_product.py#L91-L94

What we can do is load the smallest possible image and then use styling to limit the display size.

The 48px comes from the hardcoded values in
https://github.com/odoo/odoo/blob/0c6622294b7117ec5eb1cbf8a9270636b2dd807f/addons/purchase/controllers/portal.py#L99

This fix will no longer be needed when (if) Webp images get resized in backend.

Comparison
-----
Left is before, right is after fix.
![image](https://github.com/user-attachments/assets/fac07fa2-5ab7-404c-80ad-fd57a6f55ed3)

Image used
-----
![opw_4625113](https://github.com/user-attachments/assets/cd3e6ea6-1a9a-4ce5-aa71-44f400c612e1)

-----
Ticket:
opw-4625113
