### PR TITLE
[FIX] website_payment: prevent crash when donation custom amount is None

### DIFF
--- a/addons/website_payment/static/src/snippets/s_donation/donation_snippet.js
+++ b/addons/website_payment/static/src/snippets/s_donation/donation_snippet.js
@@ -98,7 +98,7 @@ export class DonationSnippet extends Interaction {
             if (this.rangeSliderEl) {
                 amount = parseFloat(this.rangeSliderEl.value);
             } else if (donationButtonEls.length) {
-                amount = parseFloat(this.el.querySelector("#s_donation_amount_input").value);
+                amount = parseFloat(this.el.querySelector("#s_donation_amount_input")?.value);
                 let errorMessage = "";
                 const minAmount = parseFloat(this.el.dataset.minimumAmount);
                 if (!amount) {


### PR DESCRIPTION
Since [1], a crash occurs when the Custom Amount option for the `s_donation` snippet is `None` and you use it.

Steps to reproduce:
- Drop `s_donation` snippet
- Set Custom Amount option as `None`
- Save and exit edit mode
- Click on `Donate Now` button
- A traceback occurs instead of showing an error to select an amount

[1]: https://github.com/odoo/odoo/commit/22e777c046521f3f89b62caa5876680beb7f5aba