### PR TITLE
[FIX] website_sale: recompute prices on address change

### DIFF
--- a/addons/website_sale/models/res_partner.py
+++ b/addons/website_sale/models/res_partner.py
@@ -57,7 +57,10 @@ class ResPartner(models.Model):
             if orders_sudo:
                 fpos_by_order = {so.id: so.fiscal_position_id.id for so in orders_sudo}
                 self.env.add_to_compute(orders_sudo._fields['fiscal_position_id'], orders_sudo)
-                orders_sudo.filtered(
+                fpos_changed = orders_sudo.filtered(
                     lambda so: so.fiscal_position_id.id != fpos_by_order[so.id],
-                )._recompute_taxes()
+                )
+                if fpos_changed:
+                    fpos_changed._recompute_taxes()
+                    fpos_changed._recompute_prices()
         return res


### PR DESCRIPTION
Versions
--------
- 16.0
- 17.0

Fixed in FW starting from 18.0

Steps
-----
1. Have a price included & a price excluded tax;
2. have a fiscal position that maps one unto the other;
3. open a cart on /shop by adding a product with the relevant taxes;
4. check the untaxed amount;
5. in Portal view, change your address to trigger a new fiscal position;
6. check the untaxed amount.

Issue
-----
The taxes have changed, but so has the untaxed amount.

Cause
-----
Commit 39b2bb36df9d6 recomputes fiscal position & taxes on address change, but doesn't recompute the prices.

Solution
--------
After recomputing the taxes, recompute the prices.

opw-4844132