### PR TITLE
[FIX] html_builder, website: remove website dep in html_builder service

### DIFF
--- a/addons/html_builder/static/src/builder.js
+++ b/addons/html_builder/static/src/builder.js
@@ -19,6 +19,7 @@ import { useSetupAction } from "@web/search/action_hook";
 import { InvisibleElementsPanel } from "@html_builder/sidebar/invisible_elements_panel";
 import { BlockTab } from "@html_builder/sidebar/block_tab";
 import { CustomizeTab } from "@html_builder/sidebar/customize_tab";
+import { useSnippets } from "@html_builder/snippets/snippet_service";
 import {
     setBuilderCSSVariables,
     setEditableDocument,
@@ -66,6 +67,8 @@ export class Builder extends Component {
         this.dialog = useService("dialog");
         this.ui = useService("ui");
         this.notification = useService("notification");
+
+        this.snippetModel = useSnippets(this.props.snippetsName);
 
         this.lastTrigerUpdateId = 0;
         this.editorBus = new EventBus();
@@ -129,6 +132,7 @@ export class Builder extends Component {
                         cleanForSaveHandlers,
                         wrapWithSaveSnippetHandlers
                     ),
+                snippetModel: this.snippetModel,
                 getShared: () => this.editor.shared,
                 updateInvisibleElementsPanel: () => this.updateInvisibleEls(),
                 allowCustomStyle: true,
@@ -138,8 +142,6 @@ export class Builder extends Component {
             this.env.services
         );
         this.props.onEditorLoad(this.editor);
-
-        this.snippetModel = useState(useService("html_builder.snippets"));
 
         onWillStart(async () => {
             await this.snippetModel.load();

--- a/addons/html_builder/static/src/builder.xml
+++ b/addons/html_builder/static/src/builder.xml
@@ -34,7 +34,7 @@
         </div>
         <div class="o-tab-content overflow-y-auto overflow-x-hidden flex-grow-1">
             <t t-if="state.activeTab === 'blocks'">
-                <BlockTab />
+                <BlockTab snippetsName="props.snippetsName" />
             </t>
             <t t-if="state.activeTab === 'customize'">
                 <t t-if="!!props.config.customizeTab" t-call="{{props.config.customizeTab}}"/>

--- a/addons/html_builder/static/src/core/disable_snippets_plugin.js
+++ b/addons/html_builder/static/src/core/disable_snippets_plugin.js
@@ -14,7 +14,7 @@ export class DisableSnippetsPlugin extends Plugin {
     };
 
     setup() {
-        this.snippetModel = this.services["html_builder.snippets"];
+        this.snippetModel = this.config.snippetModel;
         this._disableSnippets = this.disableUndroppableSnippets.bind(this);
 
         // TODO only for website ?

--- a/addons/html_builder/static/src/core/drop_zone_plugin.js
+++ b/addons/html_builder/static/src/core/drop_zone_plugin.js
@@ -15,7 +15,7 @@ export class DropZonePlugin extends Plugin {
     ];
 
     setup() {
-        this.snippetModel = this.services["html_builder.snippets"];
+        this.snippetModel = this.config.snippetModel;
         this.dropzoneSelectors = this.getResource("dropzone_selector");
         this.iframe = this.document.defaultView.frameElement;
     }

--- a/addons/html_builder/static/src/core/version_control_plugin.js
+++ b/addons/html_builder/static/src/core/version_control_plugin.js
@@ -14,7 +14,7 @@ export class VersionControlPlugin extends Plugin {
             return this.accessPerOutdatedEl.get(el);
         }
         const snippetKey = el.dataset.snippet;
-        const snippet = this.services["html_builder.snippets"].getOriginalSnippet(snippetKey);
+        const snippet = this.config.snippetModel.getOriginalSnippet(snippetKey);
         let isUpToDate = true;
         if (snippet) {
             const {
@@ -34,7 +34,7 @@ export class VersionControlPlugin extends Plugin {
     }
     replaceWithNewVersion(el) {
         const snippetKey = el.dataset.snippet;
-        const snippet = this.services["html_builder.snippets"].getOriginalSnippet(snippetKey);
+        const snippet = this.config.snippetModel.getOriginalSnippet(snippetKey);
         const cloneEl = snippet.content.cloneNode(true);
         el.replaceWith(cloneEl);
         this.dependencies["builderOptions"].updateContainers(cloneEl);

--- a/addons/html_builder/static/src/sidebar/block_tab.js
+++ b/addons/html_builder/static/src/sidebar/block_tab.js
@@ -5,6 +5,7 @@ import { getScrollingElement } from "@web/core/utils/scrolling";
 import { _t } from "@web/core/l10n/translation";
 import { closest } from "@web/core/utils/ui";
 import { useDragAndDrop } from "@html_editor/utils/drag_and_drop";
+import { useSnippets } from "@html_builder/snippets/snippet_service";
 import { getCSSVariableValue } from "@html_builder/utils/utils_css";
 import { scrollTo } from "@html_builder/utils/scrolling";
 import { Snippet } from "./snippet";
@@ -13,13 +14,15 @@ import { CustomInnerSnippet } from "./custom_inner_snippet";
 export class BlockTab extends Component {
     static template = "html_builder.BlockTab";
     static components = { Snippet, CustomInnerSnippet };
-    static props = {};
+    static props = {
+        snippetsName: String,
+    };
 
     setup() {
         this.dialog = useService("dialog");
         this.orm = useService("orm");
         this.popover = useService("popover");
-        this.snippetModel = useState(useService("html_builder.snippets"));
+        this.snippetModel = useSnippets(this.props.snippetsName);
         this.blockTabRef = useRef("block-tab");
         // Needed to avoid race condition in tours.
         this.state = useState({ ongoingInsertion: false });

--- a/addons/html_builder/static/src/snippets/snippet_viewer.js
+++ b/addons/html_builder/static/src/snippets/snippet_viewer.js
@@ -1,12 +1,4 @@
-import {
-    Component,
-    markup,
-    onMounted,
-    onPatched,
-    onWillUnmount,
-    onWillPatch,
-    useRef,
-} from "@odoo/owl";
+import { Component, markup, useRef } from "@odoo/owl";
 import { _t } from "@web/core/l10n/translation";
 import { useService } from "@web/core/utils/hooks";
 import { InputConfirmationDialog } from "./input_confirmation_dialog";
@@ -26,27 +18,6 @@ export class SnippetViewer extends Component {
     setup() {
         this.dialog = useService("dialog");
         this.content = useRef("content");
-
-        this.websiteService = useService("website");
-        this.innerWebsiteEditService =
-            this.websiteService.websiteRootInstance?.bindService("website_edit");
-        this.previousSearch = "";
-
-        const updatePreview = () => {
-            if (this.innerWebsiteEditService) {
-                this.innerWebsiteEditService.update(this.content.el, "preview");
-            }
-        };
-        const stopPreview = () => {
-            if (this.innerWebsiteEditService) {
-                this.innerWebsiteEditService.stop(this.content.el);
-            }
-        };
-        onMounted(updatePreview);
-        onPatched(updatePreview);
-
-        onWillPatch(stopPreview);
-        onWillUnmount(stopPreview);
     }
 
     onClickRename(snippet) {
@@ -108,7 +79,9 @@ export class SnippetViewer extends Component {
         );
         if (this.previousSearch !== this.props.state.search) {
             this.previousSearch = this.props.state.search;
-            this.content.el.ownerDocument.body.scrollTop = 0;
+            if (this.content.el) {
+                this.content.el.ownerDocument.body.scrollTop = 0;
+            }
         }
         const getClasses = (snippet) => {
             const classes = new Set();

--- a/addons/website/static/src/builder/plugins/snippets_powerbox_plugin.js
+++ b/addons/website/static/src/builder/plugins/snippets_powerbox_plugin.js
@@ -139,7 +139,7 @@ class SnippetsPowerboxPlugin extends Plugin {
     };
 
     insertSnippet(name) {
-        const snippet = this.services["html_builder.snippets"].getSnippetByName(
+        const snippet = this.config.snippetModel.getSnippetByName(
             "snippet_content",
             name
         );

--- a/addons/website/static/src/builder/snippet_viewer.js
+++ b/addons/website/static/src/builder/snippet_viewer.js
@@ -1,0 +1,33 @@
+import { SnippetViewer } from "@html_builder/snippets/snippet_viewer";
+import { onMounted, onPatched, onWillPatch, onWillUnmount } from "@odoo/owl";
+import { useService } from "@web/core/utils/hooks";
+import { patch } from "@web/core/utils/patch";
+
+patch(SnippetViewer.prototype, {
+    setup() {
+        super.setup();
+
+        if (this.props.snippetModel.snippetsName === "website.snippets") {
+            this.websiteService = useService("website");
+            this.innerWebsiteEditService =
+                this.websiteService.websiteRootInstance?.bindService("website_edit");
+            this.previousSearch = "";
+
+            const updatePreview = () => {
+                if (this.innerWebsiteEditService) {
+                    this.innerWebsiteEditService.update(this.content.el, "preview");
+                }
+            };
+            const stopPreview = () => {
+                if (this.innerWebsiteEditService) {
+                    this.innerWebsiteEditService.stop(this.content.el);
+                }
+            };
+            onMounted(updatePreview);
+            onPatched(updatePreview);
+
+            onWillPatch(stopPreview);
+            onWillUnmount(stopPreview);
+        }
+    }
+});

--- a/addons/website/static/src/client_actions/website_preview/website_builder_action.js
+++ b/addons/website/static/src/client_actions/website_preview/website_builder_action.js
@@ -74,6 +74,8 @@ export class WebsiteBuilderClientAction extends Component {
         this.websiteContent = useRef("iframe");
         this.cleanups = [];
 
+        this.snippetsTemplate = "website.snippets";
+
         useSubEnv({
             builderRef: useRef("container"),
         });
@@ -135,10 +137,12 @@ export class WebsiteBuilderClientAction extends Component {
             if (!this.ui.isSmall) {
                 // preload builder and snippets so clicking on "edit" is faster
                 loadBundle("website.website_builder_assets").then(() => {
-                    this.env.services["html_builder.snippets"].reload({
-                        lang: this.websiteService.currentWebsite?.default_lang_id.code,
-                        website_id: this.websiteService.currentWebsite?.id,
-                    });
+                    this.env.services["html_builder.snippets"]
+                        .getSnippetModel(this.snippetsTemplate)
+                        .reload({
+                            lang: this.websiteService.currentWebsite?.default_lang_id.code,
+                            website_id: this.websiteService.currentWebsite?.id,
+                        });
                 });
             }
         });
@@ -185,7 +189,7 @@ export class WebsiteBuilderClientAction extends Component {
     get testMode() {
         return false;
     }
-    
+
     get websiteBuilderProps() {
         const iframeLoaded = this.iframeLoaded.then((el) => {
             return this.waitForIframeReady().then(() => el);
@@ -193,7 +197,7 @@ export class WebsiteBuilderClientAction extends Component {
         const builderProps = {
             closeEditor: this.reloadIframeAndCloseEditor.bind(this),
             reloadEditor: this.reloadEditor.bind(this),
-            snippetsName: "website.snippets",
+            snippetsName: this.snippetsTemplate,
             toggleMobile: this.toggleMobile.bind(this),
             installSnippetModule: this.installSnippetModule.bind(this),
             overlayRef: this.overlayRef,


### PR DESCRIPTION
The html_builder's snippet service was still relying on website. This is removed, and the snippet viewer website dependencies are instead patched in website.

task-4367641