### PR TITLE
[FIX] mail:  remove link preview when msg no longer contains the link

### DIFF
--- a/addons/mail/static/src/core/common/message_model.js
+++ b/addons/mail/static/src/core/common/message_model.js
@@ -483,6 +483,7 @@ export class Message extends Record {
             mentionedChannels,
             mentionedPartners,
         });
+        const hadLink = this.hasLink;
         const data = await rpc("/mail/message/update_content", {
             attachment_ids: attachments
                 .concat(this.attachment_ids)
@@ -496,7 +497,7 @@ export class Message extends Record {
             ...this.thread.rpcParams,
         });
         this.store.insert(data, { html: true });
-        if (this.hasLink && this.store.hasLinkPreviewFeature) {
+        if ((hadLink || this.hasLink) && this.store.hasLinkPreviewFeature) {
             rpc("/mail/link_preview", { message_id: this.id }, { silent: true });
         }
         return data;

--- a/addons/mail/static/src/core/common/message_model.js
+++ b/addons/mail/static/src/core/common/message_model.js
@@ -484,6 +484,7 @@ export class Message extends Record {
             mentionedChannels,
             mentionedPartners,
         });
+        const hadLink = this.hasLink;
         const data = await rpc("/mail/message/update_content", {
             attachment_ids: attachments
                 .concat(this.attachment_ids)
@@ -497,7 +498,7 @@ export class Message extends Record {
             ...this.thread.rpcParams,
         });
         this.store.insert(data, { html: true });
-        if (this.hasLink && this.store.hasLinkPreviewFeature) {
+        if ((hadLink || this.hasLink) && this.store.hasLinkPreviewFeature) {
             rpc("/mail/link_preview", { message_id: this.id }, { silent: true });
         }
         return data;

--- a/addons/mail/static/tests/message/message.test.js
+++ b/addons/mail/static/tests/message/message.test.js
@@ -1968,3 +1968,20 @@ test("Copy Message Link", async () => {
     await click(".o-mail-Composer-send:enabled");
     await contains(".o-mail-Message", { text: url(`/mail/message/${messageId_2}`) });
 });
+
+test("Remove link preview when message no longer contains the link", async () => {
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({ name: "EditPreviewTest" });
+    onRpcBefore("/mail/link_preview", () => expect.step("link_preview"));
+    await start();
+    await openDiscuss(channelId);
+    await insertText(".o-mail-Composer-input", "https://make-link-preview.com");
+    await click(".o-mail-Composer-send:enabled");
+    await contains(".o-mail-LinkPreviewCard");
+    await click(".o-mail-Message [title='Expand']");
+    await click(".o-mail-Message-moreMenu [title='Edit']");
+    await insertText(".o-mail-Message.o-editing .o-mail-Composer-input", "Hi", { replace: true });
+    await press("Enter");
+    await contains(".o-mail-Message:has(:text('Hi (edited)'))");
+    expect.verifySteps(["link_preview", "link_preview"]);
+});

--- a/addons/mail/static/tests/message/message.test.js
+++ b/addons/mail/static/tests/message/message.test.js
@@ -1972,3 +1972,19 @@ test("Copy Message Link", async () => {
     await click(".o-mail-Composer-send:enabled");
     await contains(".o-mail-Message", { text: url(`/mail/message/${messageId_2}`) });
 });
+
+test("Remove link preview when message no longer contains the link", async () => {
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({ name: "EditPreviewTest" });
+    await start();
+    await openDiscuss(channelId);
+    await insertText(".o-mail-Composer-input", "https://make-link-preview.com");
+    await click(".o-mail-Composer-send:enabled");
+    await contains(".o-mail-LinkPreviewCard", { count: 1 });
+    await click(".o-mail-Message [title='Expand']");
+    await click(".o-mail-Message-moreMenu [title='Edit']");
+    await insertText(".o-mail-Message.o-editing .o-mail-Composer-input", "Hi", { replace: true });
+    await press("Enter");
+    await contains(".o-mail-Message-body:text('Hi (edited)')");
+    await contains(".o-mail-LinkPreviewCard", { count: 0 });
+});

--- a/addons/mail/static/tests/mock_server/mail_mock_server.js
+++ b/addons/mail/static/tests/mock_server/mail_mock_server.js
@@ -566,6 +566,22 @@ async function mail_link_preview(request) {
             "mail.record/insert",
             new mailDataHelpers.Store(MailLinkPreview.browse(linkPreviewId)).get_result()
         );
+    } else {
+        const linkPreviewIds = MailLinkPreview.search([["message_id", "=", message_id]]);
+        for (const linkPreviewId of linkPreviewIds) {
+            BusBus._sendone(
+                MailMessage._bus_notification_target(message_id),
+                "mail.record/insert",
+                new mailDataHelpers.Store(MailMessage.browse(message_id), {
+                    linkPreviews: mailDataHelpers.Store.many(
+                        MailLinkPreview.browse(linkPreviewId),
+                        "DELETE",
+                        makeKwArgs({ only_id: true })
+                    ),
+                }).get_result()
+            );
+        }
+        MailLinkPreview.unlink(linkPreviewIds);
     }
 }
 


### PR DESCRIPTION
Previously, when a message containing a link was edited and the link was
replaced with plain text, the link preview remained visible.

This PR ensures that the link preview is removed when the message is
edited and the link is no longer present in the message content, keeping the
UI consistent with the actual message text.

task-4836167

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
