### PR TITLE
[REM] core: remove _where_calc

### DIFF
--- a/addons/account/models/account_account.py
+++ b/addons/account/models/account_account.py
@@ -783,7 +783,7 @@ class AccountAccount(models.Model):
         elif move_type in self.env['account.move'].get_outbound_types(include_receipts=True):
             domain.append(('account_id.internal_group', '=', 'expense'))
 
-        query = self.env['account.move.line']._where_calc(domain)
+        query = self.env['account.move.line']._search(domain, bypass_access=True)
         if not filter_never_user_accounts:
             _kind, rhs_table, condition = query._joins['account_move_line__account_id']
             query._joins['account_move_line__account_id'] = (SQL("RIGHT JOIN"), rhs_table, condition)

--- a/addons/account/models/account_code_mapping.py
+++ b/addons/account/models/account_code_mapping.py
@@ -45,7 +45,7 @@ class AccountCodeMapping(models.Model):
             mapping.code = vals['code']
         return mappings
 
-    def _search(self, domain, offset=0, limit=None, order=None) -> Query:
+    def _search(self, domain, offset=0, limit=None, order=None, **kw) -> Query:
         account_ids = []
 
         def get_accounts(condition):

--- a/addons/account/models/account_journal_dashboard.py
+++ b/addons/account/models/account_journal_dashboard.py
@@ -712,25 +712,25 @@ class AccountJournal(models.Model):
             dashboard_data[journal.id]['onboarding'] = onboarding_data[journal.company_id].get(journal_onboarding_map.get(journal.type))
 
     def _get_draft_sales_purchases_query(self):
-        return self.env['account.move']._where_calc([
+        return self.env['account.move']._search([
             *self.env['account.move']._check_company_domain(self.env.companies),
             ('journal_id', 'in', self.ids),
             ('state', '=', 'draft'),
             ('move_type', 'in', self.env['account.move'].get_invoice_types(include_receipts=True)),
-        ])
+        ], bypass_access=True)
 
     def _get_to_pay_select(self):
         return SQL("TRUE AS to_pay")
 
     def _get_open_sale_purchase_query(self, journal_type):
         assert journal_type in ('sale', 'purchase')
-        query = self.env['account.move']._where_calc([
+        query = self.env['account.move']._search([
             *self.env['account.move']._check_company_domain(self.env.companies),
             ('journal_id', 'in', self.ids),
             ('payment_state', 'in', ('not_paid', 'partial')),
             ('move_type', 'in', ('out_invoice', 'out_refund') if journal_type == 'sale' else ('in_invoice', 'in_refund')),
             ('state', '=', 'posted'),
-        ])
+        ], bypass_access=True)
         selects = [
             SQL("journal_id"),
             SQL("company_id"),

--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -3940,7 +3940,7 @@ class AccountMove(models.Model):
         elif move_type in self.env['account.move'].get_outbound_types(include_receipts=True):
             domain.append(('account_id.internal_group', '=', 'expense'))
 
-        query = self.env['account.move.line']._where_calc(domain)
+        query = self.env['account.move.line']._search(domain, bypass_access=True)
         account_code = self.env['account.account']._field_to_sql('account_move_line__account_id', 'code', query)
         rows = self.env.execute_query(SQL("""
             SELECT COUNT(foo.id), foo.account_id, foo.taxes

--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -727,7 +727,7 @@ class AccountMoveLine(models.Model):
             return
 
         # get the where clause
-        query = self._where_calc(list(self.env.context.get('domain_cumulated_balance') or []))
+        query = self._search(self.env.context.get('domain_cumulated_balance') or [], bypass_access=True)
         sql_order = self._order_to_sql(self.env.context.get('order_cumulated_balance'), query, reverse=True)
         result = dict(self.env.execute_query(query.select(
             SQL.identifier(query.table, "id"),

--- a/addons/account/models/account_move_line_tax_details.py
+++ b/addons/account/models/account_move_line_tax_details.py
@@ -15,12 +15,7 @@ class AccountMoveLine(models.Model):
         :param fallback:    Fallback on an approximated mapping if the mapping failed.
         :return:            query as SQL object
         """
-        self.env['account.move.line'].check_access('read')
-
-        query = self.env['account.move.line']._where_calc(domain)
-
-        # Wrap the query with 'company_id IN (...)' to avoid bypassing company access rights.
-        self.env['account.move.line']._apply_ir_rules(query)
+        query = self.env['account.move.line']._search(domain)
 
         return self._get_query_tax_details(query.from_clause, query.where_clause, fallback=fallback)
 

--- a/addons/account/models/account_report.py
+++ b/addons/account/models/account_report.py
@@ -627,7 +627,7 @@ class AccountReportExpression(models.Model):
         for expression in self.filtered(lambda expr: expr.engine == 'domain'):
             try:
                 domain = ast.literal_eval(expression.formula)
-                self.env['account.move.line']._where_calc(domain)
+                self.env['account.move.line']._search(domain)
             except:
                 raise UserError(_("Invalid domain for expression '%(label)s' of line '%(line)s': %(formula)s",
                                 label=expression.label, line=expression.report_line_name, formula=expression.formula))

--- a/addons/account/models/account_root.py
+++ b/addons/account/models/account_root.py
@@ -21,7 +21,7 @@ class AccountRoot(models.Model):
             ids = (ids,)
         return super().browse(ids)
 
-    def _search(self, domain, offset=0, limit=None, order=None) -> Query:
+    def _search(self, domain, offset=0, limit=None, order=None, **kw) -> Query:
         match list(domain):
             case [('id', 'in', ids)]:
                 return self.browse(sorted(ids))._as_query()

--- a/addons/account/models/account_tax.py
+++ b/addons/account/models/account_tax.py
@@ -547,7 +547,7 @@ class AccountTax(models.Model):
         return ''.join(list_name)
 
     @api.model
-    def _search(self, domain, offset=0, limit=None, order=None):
+    def _search(self, domain, *args, **kwargs):
         """
         Intercept the search on `name` to allow searching more freely on taxes
         when using `like` or `ilike`.
@@ -557,7 +557,7 @@ class AccountTax(models.Model):
                 return Domain('name', cond.operator, AccountTax._parse_name_search(cond.value))
             return cond
         domain = Domain(domain).map_conditions(preprocess_name)
-        return super()._search(domain, offset, limit, order)
+        return super()._search(domain, *args, **kwargs)
 
     def _search_name(self, operator, value):
         if isinstance(value, str):

--- a/addons/account/models/chart_template.py
+++ b/addons/account/models/chart_template.py
@@ -1340,7 +1340,7 @@ class AccountChartTemplate(models.AbstractModel):
 
             self.env[model].flush_model(['id', company_id_field] + translatable_model_fields[model])
 
-            query = self.env[model]._where_calc([(company_id_field, 'in', company_ids)])
+            query = self.env[model]._search([(company_id_field, 'in', company_ids)], bypass_access=True)
 
             # We only want records that have at least 1 missing translation in any of its translatable fields
             missing_translation_clauses = [

--- a/addons/account/models/mail_message.py
+++ b/addons/account/models/mail_message.py
@@ -6,23 +6,23 @@ from odoo.fields import Domain
 bypass_token = object()
 DOMAINS = {
     'res.company':
-        lambda rec, operator, value: [('id', 'in', rec.env['account.move.line']._where_calc([
+        lambda rec, operator, value: [('id', 'in', rec.env['account.move.line']._search([
             ('company_id.restrictive_audit_trail', operator, value),
-        ], active_test=False).subselect('company_id'))],
+        ], active_test=False, bypass_access=True).subselect('company_id'))],
     'account.move':
         lambda rec, operator, value: [('company_id.restrictive_audit_trail', operator, value)],
     'account.account':
         lambda rec, operator, value: [('used', operator, value), ('company_ids.restrictive_audit_trail', operator, value)],
     'account.tax':
-        lambda rec, operator, value: [('id', 'in', rec.env['account.move.line']._where_calc([
+        lambda rec, operator, value: [('id', 'in', rec.env['account.move.line']._search([
             ('tax_line_id', '!=', False),
             ('company_id.restrictive_audit_trail', operator, value),
-        ], active_test=False).subselect('tax_line_id'))],
+        ], active_test=False, bypass_access=True).subselect('tax_line_id'))],
     'res.partner':
-        lambda rec, operator, value: [('id', 'in', rec.env['account.move.line']._where_calc([
+        lambda rec, operator, value: [('id', 'in', rec.env['account.move.line']._search([
             ('partner_id', '!=', False),
             ('company_id.restrictive_audit_trail', operator, value),
-        ], active_test=False).subselect('partner_id'))],
+        ], active_test=False, bypass_access=True).subselect('partner_id'))],
     }
 
 

--- a/addons/account/models/partner.py
+++ b/addons/account/models/partner.py
@@ -358,10 +358,10 @@ class ResPartner(models.Model):
             self.debit = False
             self.credit = False
             return
-        query = self.env['account.move.line']._where_calc([
+        query = self.env['account.move.line']._search([
             ('parent_state', '=', 'posted'),
-            ('company_id', 'child_of', self.env.company.root_id.id)
-        ])
+            ('company_id', 'child_of', self.env.company.root_id.id),
+        ], bypass_access=True)
         self.env['account.move.line'].flush_model(
             ['account_id', 'amount_residual', 'company_id', 'parent_state', 'partner_id', 'reconciled']
         )

--- a/addons/account/wizard/account_merge_wizard.py
+++ b/addons/account/wizard/account_merge_wizard.py
@@ -259,10 +259,10 @@ class AccountMergeWizardLine(models.TransientModel):
     @api.depends('account_id')
     def _compute_account_has_hashed_entries(self):
         # optimization to avoid having to re-check which accounts have hashed entries
-        query = self.env['account.move.line']._where_calc([
+        query = self.env['account.move.line']._search([
             ('account_id', 'in', self.account_id.ids),
             ('move_id.inalterable_hash', '!=', False),
-        ])
+        ], bypass_access=True)
         query_result = self.env.execute_query(query.select(SQL('DISTINCT account_move_line.account_id')))
         accounts_with_hashed_entries_ids = {r[0] for r in query_result}
         wizard_lines_with_hashed_entries = self.filtered(lambda l: l.account_id.id in accounts_with_hashed_entries_ids)

--- a/addons/calendar/models/calendar_event.py
+++ b/addons/calendar/models/calendar_event.py
@@ -984,7 +984,7 @@ class CalendarEvent(models.Model):
 
     def _get_default_privacy_domain(self):
         # Sub query user settings from calendars that are not private ('public' and 'confidential').
-        public_calendars_settings = self.env['res.users.settings'].sudo()._where_calc([('calendar_default_privacy', '!=', 'private')]).select('user_id')
+        public_calendars_settings = self.env['res.users.settings'].sudo()._search([('calendar_default_privacy', '!=', 'private')]).select('user_id')
         # display public, confidential events and events with default privacy when owner's default privacy is not private
         return [
             '|',

--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -2686,7 +2686,7 @@ class CrmLead(models.Model):
             # Get leads values
             self.flush_model()
             # active_test = False as domain should take active into 'active' field it self
-            query = self.env['crm.lead'].with_context(active_test=False)._where_calc(domain)
+            query = self.env['crm.lead'].with_context(active_test=False)._search(domain, bypass_access=True)
             table = query.table
             query.order = SQL("%(table)s.team_id asc, %(table)s.id desc", table=SQL.identifier(table))
             sql_fields = [SQL.identifier(field) for field in pls_fields]

--- a/addons/gamification/models/gamification_badge.py
+++ b/addons/gamification/models/gamification_badge.py
@@ -100,8 +100,8 @@ class GamificationBadge(models.Model):
             return
 
         Users = self.env["res.users"]
-        query = Users._where_calc([])
-        Users._apply_ir_rules(query)
+        query = Users._search([], bypass_access=True)
+        Users._apply_ir_rules(query)  # TODO remove this
         badge_alias = query.join("res_users", "id", "gamification_badge_user", "user_id", "badges")
 
         rows = self.env.execute_query(SQL(

--- a/addons/gamification/models/res_users.py
+++ b/addons/gamification/models/res_users.py
@@ -155,7 +155,7 @@ class ResUsers(models.Model):
         if not self:
             return []
 
-        where_query = self.env['res.users']._where_calc(user_domain)
+        where_query = self.env['res.users']._search(user_domain, bypass_access=True)
 
         sql = SQL("""
 SELECT final.user_id, final.karma_gain_total, final.karma_position
@@ -208,7 +208,7 @@ WHERE final.user_id IN %s""",
         if not self:
             return {}
 
-        where_query = self.env['res.users']._where_calc(user_domain)
+        where_query = self.env['res.users']._search(user_domain, bypass_access=True)
 
         # we search on every user in the DB to get the real positioning (not the one inside the subset)
         # then, we filter to get only the subset.

--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -846,7 +846,7 @@ class HrEmployee(models.Model):
         return res
 
     @api.model
-    def _search(self, domain, offset=0, limit=None, order=None):
+    def _search(self, domain, offset=0, limit=None, order=None, *, bypass_access=False, **kwargs):
         """
             We override the _search because it is the method that checks the access rights
             This is correct to override the _search. That way we enforce the fact that calling
@@ -855,12 +855,12 @@ class HrEmployee(models.Model):
             browsed on the hr.employee model. This can be trusted as the ids of the public
             employees exactly match the ids of the related hr.employee.
         """
-        if self.browse().has_access('read'):
-            return super()._search(domain, offset, limit, order)
+        if self.browse().has_access('read') or bypass_access:
+            return super()._search(domain, offset, limit, order, bypass_access=bypass_access, **kwargs)
         try:
             # HACK: suppress warning if domain is optimized for another model
             domain = list(domain) if isinstance(domain, Domain) else domain
-            ids = self.env['hr.employee.public']._search(domain, offset, limit, order)
+            ids = self.env['hr.employee.public']._search(domain, offset, limit, order, **kwargs)
         except ValueError:
             raise AccessError(_('You do not have access to this document.'))
         # the result is expected from this table, so we should link tables

--- a/addons/hr_holidays/models/hr_leave_type.py
+++ b/addons/hr_holidays/models/hr_leave_type.py
@@ -379,7 +379,7 @@ class HrLeaveType(models.Model):
             record.display_name = name
 
     @api.model
-    def _search(self, domain, offset=0, limit=None, order=None):
+    def _search(self, domain, offset=0, limit=None, order=None, **kwargs):
         """ Override _search to order the results, according to some employee.
         The order is the following
 
@@ -394,11 +394,11 @@ class HrLeaveType(models.Model):
         employee = self.env['hr.employee']._get_contextual_employee()
         if order == self._order and employee:
             # retrieve all leaves, sort them, then apply offset and limit
-            leaves = self.browse(super()._search(domain))
+            leaves = self.browse(super()._search(domain, **kwargs))
             leaves = leaves.sorted(key=self._model_sorting_key, reverse=True)
             leaves = leaves[offset:(offset + limit) if limit else None]
             return leaves._as_query()
-        return super()._search(domain, offset, limit, order)
+        return super()._search(domain, offset, limit, order, **kwargs)
 
     def copy_data(self, default=None):
         vals_list = super().copy_data(default=default)

--- a/addons/hr_timesheet/models/project_project.py
+++ b/addons/hr_timesheet/models/project_project.py
@@ -60,8 +60,9 @@ class ProjectProject(models.Model):
             return NotImplemented
 
         Company = self.env['res.company']
-        sql = Company._where_calc(
-            [('internal_project_id', '!=', False)], active_test=False
+        sql = Company._search(
+            [('internal_project_id', '!=', False)],
+            active_test=False, bypass_access=True,
         ).subselect("internal_project_id")
         return [('id', operator, sql)]
 

--- a/addons/l10n_in/models/account_invoice.py
+++ b/addons/l10n_in/models/account_invoice.py
@@ -441,7 +441,7 @@ class AccountMove(models.Model):
         }
         aggregate_result = {}
         for frequency, frequency_domain in frequency_domains.items():
-            query = self.env['account.move.line']._where_calc(default_domain + frequency_domain)
+            query = self.env['account.move.line']._search(default_domain + frequency_domain, bypass_access=True, active_test=False)
             result = self.env.execute_query_dict(SQL(
                 """
                 SELECT COALESCE(sum(account_move_line.balance), 0) as balance,

--- a/addons/mail/models/mail_activity.py
+++ b/addons/mail/models/mail_activity.py
@@ -342,7 +342,7 @@ class MailActivity(models.Model):
         return super().unlink()
 
     @api.model
-    def _search(self, domain, offset=0, limit=None, order=None):
+    def _search(self, domain, offset=0, limit=None, order=None, *, bypass_access=False, **kwargs):
         """ Override that adds specific access rights of mail.activity, to remove
         ids uid could not see according to our custom rules. Please refer to
         :meth:`_check_access` for more details about those rules.
@@ -350,12 +350,12 @@ class MailActivity(models.Model):
         The method is inspired by what has been done on mail.message. """
 
         # Rules do not apply to administrator
-        if self.env.is_superuser():
-            return super()._search(domain, offset, limit, order)
+        if self.env.is_superuser() or bypass_access:
+            return super()._search(domain, offset, limit, order, bypass_access=True, **kwargs)
 
         # retrieve activities and their corresponding res_model, res_id
         # Don't use the ORM to avoid cache pollution
-        query = super()._search(domain, offset, limit, order)
+        query = super()._search(domain, offset, limit, order, **kwargs)
         fnames_to_read = ['id', 'res_model', 'res_id', 'user_id']
         rows = self.env.execute_query(query.select(
             *[self._field_to_sql(self._table, fname) for fname in fnames_to_read],

--- a/addons/mail/models/mail_scheduled_message.py
+++ b/addons/mail/models/mail_scheduled_message.py
@@ -95,15 +95,15 @@ class MailScheduledMessage(models.Model):
         return scheduled_messages
 
     @api.model
-    def _search(self, domain, offset=0, limit=None, order=None):
+    def _search(self, domain, offset=0, limit=None, order=None, *, bypass_access=False, **kwargs):
         """ Override that add specific access rights to only get the ids of the messages
         that are scheduled on the records on which the user has mail_post (or read) access
         """
-        if self.env.is_superuser():
-            return super()._search(domain, offset, limit, order)
+        if self.env.is_superuser() or bypass_access:
+            return super()._search(domain, offset, limit, order, bypass_access=True, **kwargs)
 
         # don't use the ORM to avoid cache pollution
-        query = super()._search(domain, offset, limit, order)
+        query = super()._search(domain, offset, limit, order, **kwargs)
         fnames_to_read = ['id', 'model', 'res_id']
         rows = self.env.execute_query(query.select(
             *[self._field_to_sql(self._table, fname) for fname in fnames_to_read],

--- a/addons/point_of_sale/models/product_template.py
+++ b/addons/point_of_sale/models/product_template.py
@@ -176,7 +176,7 @@ class ProductTemplate(models.Model):
         limit_count = config.get_limited_product_count()
         pos_limited_loading = self.env.context.get('pos_limited_loading', True)
         if limit_count and pos_limited_loading:
-            query = self._where_calc(self._load_pos_data_domain(data, config))
+            query = self._search(self._load_pos_data_domain(data, config), bypass_access=True)
             sql = SQL(
                 """
                     WITH pm AS (

--- a/addons/product/models/product_product.py
+++ b/addons/product/models/product_product.py
@@ -516,11 +516,11 @@ class ProductProduct(models.Model):
         return new_products
 
     @api.model
-    def _search(self, domain, offset=0, limit=None, order=None):
+    def _search(self, domain, *args, **kwargs):
         # TDE FIXME: strange
         if self.env.context.get('search_default_categ_id'):
             domain = Domain(domain) & Domain('categ_id', 'child_of', self.env.context['search_default_categ_id'])
-        return super()._search(domain, offset, limit, order)
+        return super()._search(domain, *args, **kwargs)
 
     @api.depends('name', 'default_code', 'product_tmpl_id')
     @api.depends_context('display_default_code', 'seller_id', 'company_id', 'partner_id', 'formatted_display_name')

--- a/addons/purchase/tests/test_purchase.py
+++ b/addons/purchase/tests/test_purchase.py
@@ -816,7 +816,7 @@ class TestPurchase(AccountTestInvoicingCommon):
         """
         company_a = self.env.company
         company_b = self.env['res.company'].create({'name': 'Saucisson Inc.'})
-        self.env.company = company_a
+        self.env = company_a.with_company(company_a).env
 
         self.product_a.write({
             'seller_ids': [

--- a/addons/sale_project/models/project_project.py
+++ b/addons/sale_project/models/project_project.py
@@ -397,8 +397,7 @@ class ProjectProject(models.Model):
                 project_domain,
                 billable_project_domain,
             ])
-        project_query = self.env['project.project']._where_calc(project_domain)
-        self._apply_ir_rules(project_query, 'read')
+        project_query = self.env['project.project']._search(project_domain)
         project_sql = project_query.select(f'{self._table}.id ', f'{self._table}.sale_line_id')
 
         Task = self.env['project.task']
@@ -408,8 +407,7 @@ class ProjectProject(models.Model):
                 domain_per_model[Task._name],
                 task_domain,
             ])
-        task_query = Task._where_calc(task_domain)
-        Task._apply_ir_rules(task_query, 'read')
+        task_query = Task._search(task_domain)
         task_sql = task_query.select(f'{Task._table}.project_id AS id', f'{Task._table}.sale_line_id')
 
         ProjectMilestone = self.env['project.milestone']
@@ -420,8 +418,7 @@ class ProjectProject(models.Model):
                 milestone_domain,
                 billable_project_domain,
             ])
-        milestone_query = ProjectMilestone._where_calc(milestone_domain)
-        ProjectMilestone._apply_ir_rules(milestone_query)
+        milestone_query = ProjectMilestone._search(milestone_domain)
         milestone_sql = milestone_query.select(
             f'{ProjectMilestone._table}.project_id AS id',
             f'{ProjectMilestone._table}.sale_line_id',

--- a/addons/sale_project/models/project_project.py
+++ b/addons/sale_project/models/project_project.py
@@ -433,7 +433,7 @@ class ProjectProject(models.Model):
                     ('project_id', 'in', self.ids),
                 ]),
         ]
-        sale_order_line_query = SaleOrderLine._where_calc(sale_order_line_domain)
+        sale_order_line_query = SaleOrderLine._search(sale_order_line_domain, bypass_access=True)
         sale_order_line_sql = sale_order_line_query.select(
             f'{SaleOrderLine._table}.project_id AS id',
             f'{SaleOrderLine._table}.id AS sale_line_id',

--- a/addons/sale_timesheet/models/project_project.py
+++ b/addons/sale_timesheet/models/project_project.py
@@ -307,8 +307,7 @@ class ProjectProject(models.Model):
                 domain_per_model.get(Timesheet._name, []),
                 timesheet_domain,
             ])
-        timesheet_query = Timesheet._where_calc(timesheet_domain)
-        Timesheet._apply_ir_rules(timesheet_query, 'read')
+        timesheet_query = Timesheet._search(timesheet_domain)
         timesheet_sql = timesheet_query.select(
             f'{Timesheet._table}.project_id AS id',
             f'{Timesheet._table}.so_line AS sale_line_id',
@@ -321,8 +320,7 @@ class ProjectProject(models.Model):
                 domain_per_model[EmployeeMapping._name],
                 employee_mapping_domain,
             ])
-        employee_mapping_query = EmployeeMapping._where_calc(employee_mapping_domain)
-        EmployeeMapping._apply_ir_rules(employee_mapping_query, 'read')
+        employee_mapping_query = EmployeeMapping._search(employee_mapping_domain)
         employee_mapping_sql = employee_mapping_query.select(
             f'{EmployeeMapping._table}.project_id AS id',
             f'{EmployeeMapping._table}.sale_line_id',

--- a/addons/stock/models/stock_quant.py
+++ b/addons/stock/models/stock_quant.py
@@ -634,7 +634,7 @@ class StockQuant(models.Model):
     def _run_least_packages_removal_strategy_astar(self, domain, qty):
         # Fetch the available packages and contents
         domain = Domain(domain).optimize(self)
-        query = self._where_calc(domain)
+        query = self._search(domain, bypass_access=True)
         query.groupby = SQL("package_id")
         query.having = SQL("SUM(quantity - reserved_quantity) > 0")
         query.order = SQL("available_qty DESC")

--- a/addons/website_forum/controllers/website_forum.py
+++ b/addons/website_forum/controllers/website_forum.py
@@ -121,7 +121,7 @@ class WebsiteForum(WebsiteProfile):
             # retro-compatibility for V8 and google links
             try:
                 sorting = werkzeug.urls.url_unquote_plus(sorting)
-                Post._order_to_sql(sorting, Post._where_calc([]))
+                Post._order_to_sql(sorting, Post._search([], bypass_access=True))
             except (UserError, ValueError):
                 sorting = False
 

--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -379,8 +379,7 @@ class WebsiteSale(payment_portal.PaymentPortal):
             domain = self._get_shop_domain(search, category, attribute_value_dict)
 
             # This is ~4 times more efficient than a search for the cheapest and most expensive products
-            query = Product._where_calc(domain)
-            Product._apply_ir_rules(query, 'read')
+            query = Product._search(domain)
             sql = query.select(
                 SQL(
                     "COALESCE(MIN(list_price), 0) * %(conversion_rate)s, COALESCE(MAX(list_price), 0) * %(conversion_rate)s",

--- a/odoo/addons/base/models/ir_attachment.py
+++ b/odoo/addons/base/models/ir_attachment.py
@@ -508,9 +508,10 @@ class IrAttachment(models.Model):
         return ret_attachments
 
     @api.model
-    def _search(self, domain, offset=0, limit=None, order=None):
+    def _search(self, domain, offset=0, limit=None, order=None, *, active_test=True, bypass_access=False):
         # add res_field=False in domain if not present; the arg[0] trick below
         # works for domain items and '&'/'|'/'!' operators too
+        assert not self._active_name, "active name not supported on ir.attachment"
         disable_binary_fields_attachments = False
         domain = Domain(domain)
         if (
@@ -520,9 +521,9 @@ class IrAttachment(models.Model):
             disable_binary_fields_attachments = True
             domain &= Domain('res_field', '=', False)
 
-        if self.env.is_superuser():
+        if self.env.is_superuser() or bypass_access:
             # rules do not apply for the superuser
-            return super()._search(domain, offset, limit, order)
+            return super()._search(domain, offset, limit, order, bypass_access=True)
 
         # For attachments, the permissions of the document they are attached to
         # apply, so we must remove attachments for which the user cannot access

--- a/odoo/addons/base/models/res_groups.py
+++ b/odoo/addons/base/models/res_groups.py
@@ -149,14 +149,14 @@ class ResGroups(models.Model):
         return Domain.OR(where_domains)
 
     @api.model
-    def _search(self, domain, offset=0, limit=None, order=None):
+    def _search(self, domain, offset=0, limit=None, order=None, **kwargs):
         # add explicit ordering if search is sorted on full_name
         if order and order.startswith('full_name'):
             groups = super().search(domain)
             groups = groups.sorted('full_name', reverse=order.endswith('DESC'))
             groups = groups[offset:offset+limit] if limit else groups[offset:]
             return groups._as_query(order)
-        return super()._search(domain, offset, limit, order)
+        return super()._search(domain, offset, limit, order, **kwargs)
 
     def copy_data(self, default=None):
         default = dict(default or {})

--- a/odoo/addons/test_lint/tests/_odoo_checker_sql_injection.py
+++ b/odoo/addons/test_lint/tests/_odoo_checker_sql_injection.py
@@ -35,7 +35,7 @@ ATTRIBUTE_WHITELIST = [
 
 FUNCTION_WHITELIST = {
     'create', 'read', 'write', 'browse', 'select', 'get', 'strip', 'items', '_select', '_from', '_where',
-    'any', 'join', 'split', 'tuple', 'get_sql', 'search', 'list', 'set', 'next', '_where_calc', 'SQL'
+    'any', 'join', 'split', 'tuple', 'get_sql', 'search', 'list', 'set', 'next', 'SQL'
 }
 
 function_definitions = collections.defaultdict(list)

--- a/odoo/addons/test_lint/tests/test_checkers.py
+++ b/odoo/addons/test_lint/tests/test_checkers.py
@@ -379,9 +379,8 @@ class TestSqlLint(TestPylintChecks):
             dashboard_graph_model = self._graph_get_model()
             GraphModel = self.env[dashboard_graph_model] 
             graph_table = self._graph_get_table(GraphModel)
-            extra_conditions = self._extra_sql_conditions() 
-            where_query = GraphModel._where_calc([])  
-            GraphModel._apply_ir_rules(where_query, 'read')
+            extra_conditions = self._extra_sql_conditions()
+            where_query = GraphModel._search([])
             from_clause, where_clause, where_clause_params = where_query.get_sql()
             if where_clause:
                 extra_conditions += " AND " + where_clause

--- a/odoo/addons/test_orm/tests/test_fields.py
+++ b/odoo/addons/test_orm/tests/test_fields.py
@@ -1970,6 +1970,12 @@ class TestFields(TransactionCaseWithUserDemo, TransactionExpressionCase):
         Discussion = self.env['test_orm.discussion']
 
         # add an ir.rule that forces reading field 'name'
+        self.env['ir.model.access'].create({
+            'name': 'demo',
+            'model_id': self.env['ir.model']._get(Discussion.categories._name).id,
+            'group_id': self.env.ref('base.group_user').id,
+            'perm_read': True,
+        })
         self.env['ir.rule'].create({
             'model_id': self.env['ir.model']._get(Discussion._name).id,
             'groups': [self.env.ref('base.group_user').id],

--- a/odoo/orm/fields_relational.py
+++ b/odoo/orm/fields_relational.py
@@ -794,11 +794,8 @@ class _RelationalMulti(_Relational):
         if isinstance(value, Domain):
             domain = value & field_domain
             comodel = comodel.with_context(**self.context)
-            if self.auto_join or operator in ('any!', 'not any!'):
-                # bypass access rules for auto-join
-                query = comodel._where_calc(domain)
-            else:
-                query = comodel._search(domain)
+            bypass_access = self.auto_join or operator in ('any!', 'not any!')
+            query = comodel._search(domain, bypass_access=bypass_access)
             assert isinstance(query, Query)
             return query
         if isinstance(value, Query):
@@ -1341,7 +1338,7 @@ class Many2many(_RelationalMulti):
 
         # make the query for the lines
         domain = self.get_comodel_domain(records)
-        query = comodel._where_calc(domain)
+        query = comodel._search(domain, bypass_access=True)
         comodel._apply_ir_rules(query, 'read')
         query.order = comodel._order_to_sql(comodel._order, query)
 

--- a/odoo/orm/models.py
+++ b/odoo/orm/models.py
@@ -1740,7 +1740,7 @@ class BaseModel(metaclass=MetaModel):
             # in order to reuse the mechanism _apply_ir_rules, then inject the
             # query as an extra condition of the left join
             comodel = self.env[field.comodel_name]
-            coquery = comodel._where_calc([], active_test=False)
+            coquery = comodel._search([], active_test=False, bypass_access=True)
             comodel._apply_ir_rules(coquery)
             # LEFT JOIN {field.relation} AS rel_alias ON
             #     alias.id = rel_alias.{field.column1}
@@ -3463,7 +3463,7 @@ class BaseModel(metaclass=MetaModel):
 
         # first determine a query that satisfies the domain and access rules
         if any(field.column_type for field in fields_to_fetch):
-            query = self.with_context(active_test=False)._search([('id', 'in', self.ids)])
+            query = self._search([('id', 'in', self.ids)], active_test=False)
         else:
             try:
                 self.check_access('read')
@@ -4870,35 +4870,6 @@ class BaseModel(metaclass=MetaModel):
 
         return original_self.concat(*(data['record'] for data in data_list))
 
-    @api.model
-    def _where_calc(self, domain: DomainType, active_test: bool = True) -> Query:
-        """Compute the WHERE clause for the `_search` method without applying any security rule.
-
-        :param domain: the domain to compute
-        :param active_test: whether the default filtering of records with
-            ``active`` field set to ``False`` should be applied.
-        :return: the query expressing the given domain as provided in domain
-        """
-        domain = Domain(domain)
-
-        # if the object has an active field ('active', 'x_active'), filter out all
-        # inactive records unless they were explicitly asked for
-        if (
-            self._active_name
-            and active_test
-            and self.env.context.get('active_test', True)
-            and not any(leaf.field_expr == self._active_name for leaf in domain.iter_conditions())
-        ):
-            domain &= Domain(self._active_name, '=', True)
-
-        domain = domain.optimize_full(self)
-        if domain.is_false():
-            return self.browse()._as_query()
-        query = Query(self.env, self._table, self._table_sql)
-        if not domain.is_true():
-            query.add_where(domain._to_sql(self, self._table, query))
-        return query
-
     def _check_qorder(self, word: str) -> None:
         if not regex_order.match(word):
             raise UserError(_(
@@ -5032,6 +5003,9 @@ class BaseModel(metaclass=MetaModel):
         offset: int = 0,
         limit: int | None = None,
         order: str | None = None,
+        *,
+        active_test: bool = True,
+        bypass_access: bool = False,
     ) -> Query:
         """
         Private implementation of search() method.
@@ -5045,27 +5019,43 @@ class BaseModel(metaclass=MetaModel):
         the latter option, though, as it might hurt performance. Indeed, by
         default the returned query object is not actually executed, and it can
         be injected as a value in a domain in order to generate sub-queries.
+
+        The `active_test` flag specifies whether to filter only active records.
+        The `bypass_access` controls whether or not permissions should be
+        checked on the model and record rules should be applied.
         """
-        self.browse().check_access('read')
+        check_access = not (self.env.su or bypass_access)
+        if check_access:
+            self.browse().check_access('read')
 
-        # deletegate to _where_calc
-        query = self._where_calc(domain)
-        if query.is_empty():
-            return query
-
-        # security access domain
-        if self.env.su:
-            sec_domain = Domain.TRUE
-        else:
-            sec_domain = self.env['ir.rule']._compute_domain(self._name, 'read')
-            sec_domain = sec_domain.optimize_full(self.sudo())
+        domain = Domain(domain)
+        # inactive records unless they were explicitly asked for
+        if (
+            self._active_name
+            and active_test
+            and self.env.context.get('active_test', True)
+            and not any(leaf.field_expr == self._active_name for leaf in domain.iter_conditions())
+        ):
+            domain &= Domain(self._active_name, '=', True)
 
         # build the query
-        if sec_domain.is_false() or (not limit and limit is not None and limit is not False):
+        domain = domain.optimize_full(self)
+        if domain.is_false():
             return self.browse()._as_query()
-        if not sec_domain.is_true():
-            query.add_where(sec_domain._to_sql(self.sudo(), self._table, query))
+        query = Query(self.env, self._table, self._table_sql)
+        if not domain.is_true():
+            query.add_where(domain._to_sql(self, self._table, query))
 
+        # security access domain
+        if check_access:
+            sec_domain = self.env['ir.rule']._compute_domain(self._name, 'read')
+            sec_domain = sec_domain.optimize_full(self.sudo())
+            if sec_domain.is_false():
+                return self.browse()._as_query()
+            if not sec_domain.is_true():
+                query.add_where(sec_domain._to_sql(self.sudo(), self._table, query))
+
+        # add order and limits
         if order:
             query.order = self._order_to_sql(order, query)
         if limit is not None:

--- a/odoo/osv/expression.py
+++ b/odoo/osv/expression.py
@@ -435,7 +435,7 @@ class expression(object):
             :attr result: the result of the parsing, as a pair (query, params)
             :attr query: Query object holding the final result
         """
-        warnings.warn("Since 19.0, expression() is deprecated, use Domain or _where_calc instead", DeprecationWarning)
+        warnings.warn("Since 19.0, expression() is deprecated, use Domain or _search instead", DeprecationWarning)
         self._unaccent = model.pool.unaccent
         self._has_trigram = model.pool.has_trigram
         self.root_model = model


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

We integrate both `_where_calc` into `_search` as a boolean flag.

`def _search(..., *, active_test=True, bypass_access=False)`
When `bypass_access=True`, the result is the same as calling previously
`_where_calc`. The `active_test` parameter can be used as an override on
the current model only.

odoo/enterprise#89800



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
