### PR TITLE
[PERF] account: optimize query for company filtering

### DIFF
--- a/addons/account/models/account_bank_statement_line.py
+++ b/addons/account/models/account_bank_statement_line.py
@@ -484,7 +484,7 @@ class AccountBankStatementLine(models.Model):
             # Base domain.
             ('display_type', 'not in', ('line_section', 'line_note')),
             ('parent_state', '=', 'posted'),
-            ('company_id', 'child_of', self.company_id.id),  # allow to match invoices from same or children companies to be consistant with what's shown in the interface
+            ('company_id', 'in', self.env['res.company'].search([('id', 'child_of', self.company_id.id)]).ids),  # allow to match invoices from same or children companies to be consistant with what's shown in the interface
             # Reconciliation domain.
             ('reconciled', '=', False),
             # Domain to use the account_move_line__unreconciled_index


### PR DESCRIPTION
This fix aims to avoid a subquery in the main query and instead use a
IN clause to improve search performance.

On a database with over 37 million journal items, before the fix, the
query to load the 40 potentials journal items to reconcile in the bank
reconciliation widget took around 50 seconds; after the fix, it take
only 3 seconds (with only 1 company to filter).

Subquery when 'child_of' is used:
```
...
AND (
    "account_move_line"."company_id" IN (
        SELECT
            "res_company"."id"
        FROM
            "res_company"
        WHERE
            ("res_company"."parent_path" LIKE '1/%')
    )
)
```

Query after the fix:
```
...
AND ("account_move_line"."company_id" IN (1))
```

opw-4896863