### PR TITLE
[IMP] l10n_tr_nilvera: simplify and standardize logging

### DIFF
--- a/addons/l10n_tr_nilvera/lib/nilvera_client.py
+++ b/addons/l10n_tr_nilvera/lib/nilvera_client.py
@@ -2,7 +2,6 @@ import logging
 import requests
 from datetime import datetime
 from json import JSONDecodeError
-from pprint import pformat
 
 from odoo.exceptions import UserError
 
@@ -59,15 +58,12 @@ class NilveraClient:
 
     def _log_request(self, method, start, end, url, params, json, response):
         _logger.info(
-            "%(method)s\nstart=%(start)s\nend=%(end)s\nurl=%(url)s\nparams=%(params)s\njson=%(json)s\nresponse=%(response)s",
+            '"%(method)s %(url)s" %(status)s %(duration).3f',
             {
-                "method": method,
-                "start": start,
-                "end": end,
-                "url": pformat(url),
-                "params": pformat(params),
-                "json": pformat(json),
-                "response": pformat(response),
+                'method': method,
+                'url': url,
+                'status': response.status_code,
+                'duration': (end - start).total_seconds(),
             },
         )
 


### PR DESCRIPTION
This change streamlines the Nilvera API request logs to a single-line format,
making them easier to parse and visualize in tools like Grafana. The new format
includes only the HTTP method, URL, response status, and request duration,
removing parameters and payloads to avoid leaking sensitive information and to
ensure user privacy.

No task