### PR TITLE
[IMP] hr_holidays: improve time off type configuration

### DIFF
--- a/addons/hr_holidays/data/hr_work_entry_type_data.xml
+++ b/addons/hr_holidays/data/hr_work_entry_type_data.xml
@@ -378,6 +378,38 @@
         <field name="leave_notif_subtype_id" ref="hr_holidays.mt_leave"/>
     </record>
 
+    <record id="hr_work_entry.l10n_be_work_entry_type_non_taxable_political_service" model="hr.work.entry.type">
+        <field name="count_days_as">calendar</field>
+    </record>
+
+    <record id="hr_work_entry.l10n_be_work_entry_type_other_presence" model="hr.work.entry.type">
+        <field name="count_days_as">calendar</field>
+    </record>
+
+    <record id="hr_work_entry.l10n_be_work_entry_type_paid_compensatory_rest" model="hr.work.entry.type">
+        <field name="count_days_as">calendar</field>
+    </record>
+
+    <record id="hr_work_entry.l10n_be_work_entry_type_unpaid_compensatory_rest" model="hr.work.entry.type">
+        <field name="count_days_as">calendar</field>
+    </record>
+   
+    <record id="hr_work_entry.l10n_be_work_entry_type_paid_recovered_compensatory_rest" model="hr.work.entry.type">
+        <field name="count_days_as">calendar</field>
+    </record>
+
+    <record id="hr_work_entry.l10n_be_work_entry_type_unpaid_recovered_compensatory_rest" model="hr.work.entry.type">
+        <field name="count_days_as">calendar</field>
+    </record>
+
+    <record id="hr_work_entry.l10n_be_work_entry_type_sectoral_compensatory_rest" model="hr.work.entry.type">
+        <field name="count_days_as">calendar</field>
+    </record>
+
+    <record id="hr_work_entry.l10n_be_work_entry_type_other_training" model="hr.work.entry.type">
+        <field name="count_days_as">calendar</field>
+    </record>
+
 <!-- CH: Switzerland -->
 
     <record id="hr_work_entry.l10n_ch_swissdec_unpaid_wt" model="hr.work.entry.type">
@@ -446,6 +478,26 @@
         <field name="country_id" ref="base.ch"/>
     </record>
 
+    <record id="hr_work_entry.l10n_ch_swissdec_monthly_wt" model="hr.work.entry.type">
+        <field name="count_days_as">calendar</field>
+    </record>
+
+    <record id="hr_work_entry.l10n_ch_swissdec_hourly_wt" model="hr.work.entry.type">
+        <field name="count_days_as">calendar</field>
+    </record>
+
+    <record id="hr_work_entry.l10n_ch_swissdec_lesson_wt" model="hr.work.entry.type">
+        <field name="count_days_as">calendar</field>
+    </record>
+
+    <record id="hr_work_entry.l10n_ch_swissdec_overtime_wt" model="hr.work.entry.type">
+        <field name="count_days_as">calendar</field>
+    </record>
+
+    <record id="hr_work_entry.l10n_ch_swissdec_overtime_125_wt" model="hr.work.entry.type">
+        <field name="count_days_as">calendar</field>
+    </record>
+
 <!-- EG: Egypt -->
     <record id="hr_work_entry.l10n_eg_work_entry_type_marriage" model="hr.work.entry.type">
         <field name="name">Marriage Leave</field>
@@ -503,6 +555,10 @@
         <field name="request_unit">day</field>
         <field name="unit_of_measure">day</field>
         <field name="country_id" ref="base.eg"/>
+    </record>
+
+    <record id="hr_work_entry.l10n_eg_work_entry_type_overtime_work_days_nighttime" model="hr.work.entry.type">
+        <field name="count_days_as">calendar</field>
     </record>
 
 <!-- HK : Hong Kong -->
@@ -648,6 +704,15 @@
         <field name="country_id" ref="base.id"/>
     </record>
 
+<!-- IQ : Iraq -->
+    <record id="hr_work_entry.iq_work_entry_type_day_overtime" model="hr.work.entry.type">
+        <field name="count_days_as">calendar</field>
+    </record>
+
+    <record id="hr_work_entry.iq_work_entry_type_night_overtime" model="hr.work.entry.type">
+        <field name="count_days_as">calendar</field>
+    </record>
+
 <!-- JO : Jordan -->
     <record id="hr_work_entry.l10n_jo_work_entry_type_sick_leave_unpaid" model="hr.work.entry.type">
         <field name="requires_allocation">False</field>
@@ -687,6 +752,14 @@
         <field name="unit_of_measure">day</field>
         <field name="leave_validation_type">hr</field>
         <field name="country_id" ref="base.jo"/>
+    </record>
+
+    <record id="hr_work_entry.l10n_jo_work_entry_type_rest_days_overtime" model="hr.work.entry.type">
+        <field name="count_days_as">calendar</field>
+    </record>
+
+    <record id="hr_work_entry.l10n_jo_work_entry_type_week_days_overtime" model="hr.work.entry.type">
+        <field name="count_days_as">calendar</field>
     </record>
 
 <!-- LU : Luxemburg -->

--- a/addons/hr_holidays/models/hr_employee.py
+++ b/addons/hr_holidays/models/hr_employee.py
@@ -735,11 +735,12 @@ class HrEmployee(models.Model):
         super()._store_im_status_fields(res)
         res.attr("leave_date_to")
 
-    def _get_hours_for_date(self, target_date, day_period=None):
+    def _get_hours_for_date(self, target_date, day_period=None, count_non_working_days=False):
         """
         An instance method on a calendar to get the start and end float hours for a given date.
         :param target_date: The date to find working hours.
         :param day_period: Optional string ('morning', 'afternoon') to filter for half-days.
+        :param count_non_working_days: Optional Boolean to treat non-working days as full working days
         :return: A tuple of floats (hour_from, hour_to).
         """
         if self:
@@ -752,10 +753,12 @@ class HrEmployee(models.Model):
             version = self._get_version(target_date)
             if version.is_fully_flexible:
                 return (0, 24)
-            if version.is_flexible or version.resource_calendar_id._is_duration_based_on_date(target_date):
+            if version.is_flexible or version.resource_calendar_id._is_duration_based_on_date(target_date) or count_non_working_days:
                 # Quick calculation to center flexible hours around 12PM midday
                 if version.is_flexible:
                     hours_day = version.hours_per_day
+                elif count_non_working_days:
+                    hours_day = version.resource_calendar_id.hours_per_day
                 else:
                     hours_day = self.resource_calendar_id._get_duration_based_work_hours_on_date(target_date)
                 datetimes = [12.0 - hours_day / 2.0, 12.0, 12.0 + hours_day / 2.0]

--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -5,6 +5,7 @@ from collections import defaultdict
 from datetime import datetime, timedelta, time, UTC
 from zoneinfo import ZoneInfo
 
+from dateutil import rrule
 from dateutil.relativedelta import relativedelta
 from math import ceil
 from markupsafe import Markup
@@ -13,7 +14,7 @@ from odoo import api, fields, models
 from odoo.addons.base.models.res_partner import _tz_get
 from odoo.addons.resource.models.utils import HOURS_PER_DAY
 from odoo.exceptions import AccessError, UserError, ValidationError
-from odoo.tools.date_utils import float_to_time
+from odoo.tools.date_utils import float_to_time, sum_intervals
 from odoo.fields import Command, Date, Domain
 from odoo.tools.float_utils import float_round, float_compare, float_is_zero
 from odoo.tools.intervals import Intervals
@@ -446,6 +447,7 @@ class HrLeave(models.Model):
                  'request_date_from', 'request_date_to', 'work_entry_type_request_unit', 'employee_id')
     def _compute_date_from_to(self):
         for holiday in self:
+            is_calendar_leave = holiday.work_entry_type_id.count_days_as == 'calendar'
             if not holiday.request_date_from or not holiday.request_date_to:
                 holiday.date_from = False
                 holiday.date_to = False
@@ -474,13 +476,13 @@ class HrLeave(models.Model):
                 if holiday.request_date_from == holiday.request_date_to:
                     day_period = from_period if from_period == to_period else None
                     hour_from, hour_to = holiday._get_hour_from_to(holiday.request_date_from, holiday.request_date_to,
-                        day_period)
+                        day_period, count_non_working_days=is_calendar_leave)
                 else:
-                    hour_from, _ = holiday._get_hour_from_to(holiday.request_date_from, holiday.request_date_from, from_period)
-                    _, hour_to = holiday._get_hour_from_to(holiday.request_date_to, holiday.request_date_to, to_period)
+                    hour_from, _ = holiday._get_hour_from_to(holiday.request_date_from, holiday.request_date_from, from_period, count_non_working_days=is_calendar_leave)
+                    _, hour_to = holiday._get_hour_from_to(holiday.request_date_to, holiday.request_date_to, to_period, count_non_working_days=is_calendar_leave)
 
             else:
-                hour_from, hour_to = holiday._get_hour_from_to(holiday.request_date_from, holiday.request_date_to)
+                hour_from, hour_to = holiday._get_hour_from_to(holiday.request_date_from, holiday.request_date_to, count_non_working_days=is_calendar_leave)
 
             holiday.date_from = self._to_utc(holiday.request_date_from, hour_from, holiday.employee_id or holiday)
             holiday.date_to = self._to_utc(holiday.request_date_to, hour_to, holiday.employee_id or holiday)
@@ -600,35 +602,110 @@ class HrLeave(models.Model):
             (date_from, date_to, include_public_holidays_in_duration, calendar): employees._get_work_days_data_batch(date_from, date_to, compute_leaves=not include_public_holidays_in_duration, domain=domain, calendar=calendar)
             for (date_from, date_to, include_public_holidays_in_duration, calendar), employees in employees_by_dates_calendar.items()
         }
+
+        min_start = max_end = False
+        for rec in self:
+            start = rec.request_date_from
+            end = rec.request_date_to
+            if start:
+                min_start = start if not min_start or start < min_start else min_start
+            if end:
+                max_end = end if not max_end or end > max_end else max_end
+
+        public_holidays = self.env['resource.calendar.leaves']
+        if min_start and max_end:
+            public_holidays = public_holidays.search([
+                ('resource_id', '=', False),
+                ('company_id', 'in', self.company_id.ids),
+                ('date_from', '<=', max_end),
+                ('date_to', '>=', min_start),
+            ])
+
+        public_holiday_dates_per_company = defaultdict(set)
+
+        for ph in public_holidays:
+            start = ph.date_from.date()
+            end = ph.date_to.date()
+            days = (end - start).days + 1
+            company_id = ph.company_id.id
+            for day in rrule.rrule(rrule.DAILY, dtstart=start, until=start + timedelta(days=days)):
+                public_holiday_dates_per_company[company_id].add(day.date())
         for leave in self:
             calendar = resource_calendar or leave.resource_calendar_id
             if not leave.date_from or not leave.date_to or (not calendar and not leave.employee_id):
                 result[leave.id] = (0, 0)
                 continue
+            if leave.work_entry_type_id.count_days_as == 'calendar':
+                start_date = leave.request_date_from
+                end_date = leave.request_date_to
+                include_public = leave.work_entry_type_id.include_public_holidays_in_duration
+                company = leave.company_id
+                day_start, day_end = leave.employee_id.sudo()._get_hours_for_date(start_date, count_non_working_days=True)
+
+                if leave.work_entry_type_request_unit == 'day':
+                    if include_public:
+                        days = (end_date - start_date).days + 1
+                    else:
+                        filtered_public_holiday = public_holidays.filtered(lambda h:
+                            (h.calendar_id == calendar or not h.calendar_id) and
+                            h.company_id == company
+                        )
+                        days = ceil(leave._subtract_public_holidays(filtered_public_holiday) / 24)
+                    hours = days * (day_end - day_start)
+                else:
+                    # Partial Day Leave
+                    work_days_data = work_days_data_mapped[leave.date_from, leave.date_to, include_public, calendar][leave.employee_id.id]
+                    hours, days = work_days_data['hours'], work_days_data['days']
+
+                    # sudo as is_flexible is on version model and employee does not have access to it.
+                    if leave.employee_id.sudo().is_flexible:
+                        result[leave.id] = (days, hours)
+                        continue
+                    # Identify workin days
+                    work_time_per_day_list = work_time_per_day_mapped[leave.date_from, leave.date_to, include_public, calendar][leave.employee_id.id]
+                    working_dates = {interval[0] for interval in work_time_per_day_list}
+
+                    total_dates = {
+                        day.date()
+                        for day in rrule.rrule(rrule.DAILY,
+                                            dtstart=leave.request_date_from,
+                                            until=leave.request_date_from + timedelta(days=(end_date - start_date).days)
+                                        )
+                    }
+                    weekend_dates = total_dates - working_dates - public_holiday_dates_per_company[leave.company_id.id]
+
+                    if weekend_dates:
+                        if start_date == end_date:
+                            # Count only the hours within the calendar working range
+                            day_hours = min(day_end, leave.request_hour_to) - max(day_start, leave.request_hour_from)
+                            hours += max(0, day_hours)
+                            days += day_hours / calendar.hours_per_day
+                            weekend_dates.remove(leave.date_from.date())
+                        else:
+                            if start_date in weekend_dates:
+                                days += 0.5 if leave.request_date_from_period == 'pm' else 1
+                                hours += max(0, day_end - max(day_start, leave.request_hour_from))
+                                weekend_dates.remove(start_date)
+                            if end_date in weekend_dates:
+                                days += 1 if leave.request_date_to_period == 'pm' else 0.5
+                                hours += max(0, min(day_end, leave.request_hour_to) - day_start)
+                                weekend_dates.remove(end_date)
+
+                        days += len(weekend_dates)
+                        hours += len(weekend_dates) * calendar.hours_per_day
+
+                result[leave.id] = (days, hours)
+                continue
             hours, days = (0, 0)
             if leave.employee_id:
-                if leave.work_entry_type_id.count_as != 'absence' and leave.work_entry_type_id.request_unit == 'hour':
-                    hours = (leave.date_to - leave.date_from).total_seconds() / 3600
-                    days = 1
                 # For flexible employees, if it's a single day leave, we force it to the real duration since the virtual intervals might not match reality on that day, especially for custom hours
                 # sudo as is_flexible is on version model and employee does not have access to it.
-                elif leave.employee_id.sudo().is_flexible and leave.request_date_to == leave.request_date_from:
-                    public_holidays = self.env['resource.calendar.leaves'].search([
-                        ('resource_id', '=', False),
-                        ('date_from', '<', leave.date_to),
-                        ('date_to', '>', leave.date_from),
-                        ('calendar_id', 'in', [False, calendar.id]),
-                        ('company_id', '=', leave.company_id.id)
-                    ])
-                    if public_holidays:
-                        public_holidays_intervals = Intervals([(ph.date_from, ph.date_to, ph) for ph in public_holidays])
-                        leave_intervals = Intervals([(leave.date_from, leave.date_to, leave)])
-                        real_leave_intervals = leave_intervals - public_holidays_intervals
-                        hours = 0
-                        for start, stop, meta in real_leave_intervals:
-                            hours += (stop - start).total_seconds() / 3600
-                    else:
-                        hours = (leave.date_to - leave.date_from).total_seconds() / 3600
+                if leave.employee_id.sudo().is_flexible and leave.request_date_to == leave.request_date_from:
+                    filtered_public_holidays = public_holidays.filtered(lambda h:
+                        (h.calendar_id == calendar or not h.calendar_id) and
+                        h.company_id == leave.company_id
+                    )
+                    hours = leave._subtract_public_holidays(filtered_public_holidays)
                     if leave.work_entry_type_request_unit != 'hour' and not public_holidays:
                         days = 1 if leave.work_entry_type_request_unit != 'half_day' or leave.request_date_from_period != leave.request_date_to_period else 0.5
                     else:
@@ -1114,6 +1191,15 @@ class HrLeave(models.Model):
                 ),
                 partner_ids=notify_partner_ids)
 
+    def _subtract_public_holidays(self, public_holidays):
+        """Subtract public holiday intervals from leave and return hours."""
+        self.ensure_one()
+        public_holidays_intervals = Intervals([])
+        if public_holidays:
+            public_holidays_intervals = Intervals([(ph.date_from, ph.date_to, ph) for ph in public_holidays])
+        leave_intervals = Intervals([(self.date_from, self.date_to, self)])
+        real_leave_intervals = leave_intervals - public_holidays_intervals
+        return sum_intervals(real_leave_intervals)
 
     def _prepare_holidays_meeting_values(self):
         result = defaultdict(list)
@@ -1702,7 +1788,7 @@ class HrLeave(models.Model):
         holiday_tz = ZoneInfo(resource.tz or self.env.user.tz or 'UTC')
         return datetime.combine(date, hour, tzinfo=holiday_tz).astimezone(UTC).replace(tzinfo=None)
 
-    def _get_hour_from_to(self, request_date_from, request_date_to, day_period=None):
+    def _get_hour_from_to(self, request_date_from, request_date_to, day_period=None, count_non_working_days=False):
         """
         Return the hour_from and hour_to for the given request dates, based on
         the resource calendar.
@@ -1711,8 +1797,8 @@ class HrLeave(models.Model):
         the earliest hour_from and latest hour_to that exist in the schedule.
         """
 
-        hour_from, _ = self.employee_id.sudo()._get_hours_for_date(request_date_from, day_period)
-        _, hour_to = self.employee_id.sudo()._get_hours_for_date(request_date_to, day_period)
+        hour_from, _ = self.employee_id.sudo()._get_hours_for_date(request_date_from, day_period, count_non_working_days)
+        _, hour_to = self.employee_id.sudo()._get_hours_for_date(request_date_to, day_period, count_non_working_days)
 
         return (hour_from, hour_to)
 

--- a/addons/hr_holidays/models/hr_work_entry_type.py
+++ b/addons/hr_holidays/models/hr_work_entry_type.py
@@ -97,6 +97,11 @@ class HrWorkEntryType(models.Model):
         help="If checked, users can request another leave on top of the ones of this type.")
     elligible_for_accrual_rate = fields.Boolean(string='Eligible for Accrual Rate', compute="_compute_eligible_for_accrual_rate", store=True, readonly=False,
         help="If checked, this time type will be taken into account for accruals computation.")
+    count_days_as = fields.Selection([
+        ('working', 'Working Days'),
+        ('calendar', 'Calendar Days'),
+        ], string='Count Days as', default='working',
+        help="If you take a leave on the whole week, worked days will result in a various number based on the working hours of the employee, calendar days will result in 7 in every case.")
     # negative time off
     allows_negative = fields.Boolean(string='Allow Negative',
         help="If checked, users request can exceed the allocated days and balance can go in negative.")
@@ -186,6 +191,16 @@ class HrWorkEntryType(models.Model):
                 if leave_from_date <= public_holiday_to_date and leave_to_date >= public_holiday_from_date:
                     raise ValidationError(_("You cannot modify the 'Public Holiday Included' setting since one or more leaves for that \
                         time type are overlapping with public holidays, meaning that the balance of those employees would be affected by this change."))
+
+    @api.constrains('count_days_as')
+    def _check_leaves_for_count_days_as(self):
+        leave_count = self.env['hr.leave'].search_count([
+            ('work_entry_type_id', 'in', self.ids),
+            ('state', 'in', ('validate', 'validate1', 'confirm')),
+        ], limit=1)
+        if leave_count:
+            raise ValidationError(self.env._("You cannot modify the 'Duration Count' setting because one or more leaves have already \
+                been taken for this time off type. Changing it now would affect existing employee balances."))
 
     def get_work_entry_types_with_valid_allocations(self, date_from, date_to, employee_id):
         allocation_by_work_entry_type = dict(self.env['hr.leave.allocation']._read_group(

--- a/addons/hr_holidays/tests/test_hr_work_entry_type.py
+++ b/addons/hr_holidays/tests/test_hr_work_entry_type.py
@@ -1,5 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from datetime import date, datetime
 from freezegun import freeze_time
 
 from odoo.exceptions import AccessError, ValidationError
@@ -130,3 +131,104 @@ class TestHrWorkEntryType(TestHrHolidaysCommon):
             ).search([('has_valid_allocation', '=', True)], limit=1)
 
         self.assertFalse(work_entry_types, "Got valid leaves outside vaild period")
+
+    def test_calendar_duration_excluding_public_holidays(self):
+        """Test calendar duration calculation excluding public holidays"""
+
+        calendar_work_entry_type = self.env['hr.work.entry.type'].create({
+            'name': 'Test Time Off (Exclude PH)',
+            'code': 'Test Time Off 1',
+            'requires_allocation': False,
+            'count_days_as': 'calendar',
+            'include_public_holidays_in_duration': False,
+        })
+
+        self.env['resource.calendar.leaves'].create({
+            'name': 'Public Holiday',
+            'date_from': datetime(2024, 6, 3, 0, 0, 0),
+            'date_to': datetime(2024, 6, 3, 23, 59, 59),
+            'calendar_id': False,
+            'company_id': self.env.company.id,
+        })
+
+        leave = self.env['hr.leave'].create({
+            'employee_id': self.employee_hruser_id,
+            'work_entry_type_id': calendar_work_entry_type.id,
+            'request_date_from': date(2024, 6, 1),
+            'request_date_to': date(2024, 6, 7),
+        })
+
+        days, hours = leave._get_durations()[leave.id]
+        self.assertEqual(days, 6, "Duration should exclude 1 public holiday, resulting in 6 days")
+        self.assertEqual(hours, 48, "Duration should be 6 * 8 hours when excluding public holidays")
+
+    def test_calendar_duration_including_public_holidays(self):
+        """Test calendar duration calculation including public holidays"""
+
+        calendar_work_entry_type = self.env['hr.work.entry.type'].create({
+            'name': 'Test Time Off (Include PH)',
+            'code': 'Test Time Off 2',
+            'requires_allocation': False,
+            'count_days_as': 'calendar',
+            'include_public_holidays_in_duration': True,
+        })
+
+        self.env['resource.calendar.leaves'].create({
+            'name': 'Public Holiday',
+            'date_from': datetime(2024, 6, 3, 0, 0, 0),
+            'date_to': datetime(2024, 6, 3, 23, 59, 59),
+            'calendar_id': False,
+            'company_id': self.env.company.id,
+        })
+
+        leave = self.env['hr.leave'].create({
+            'employee_id': self.employee_hruser_id,
+            'work_entry_type_id': calendar_work_entry_type.id,
+            'request_date_from': date(2024, 6, 1),
+            'request_date_to': date(2024, 6, 7),
+        })
+
+        days, hours = leave._get_durations()[leave.id]
+        self.assertEqual(days, 7, "Duration should include all 7 days even with public holiday")
+        self.assertEqual(hours, 56, "Duration should be 7 * 8 hours when including public holidays")
+
+    def test_count_days_as_working_days(self):
+        """Test duration calculation when count_days_as is worked days"""
+        working_work_entry_type = self.env['hr.work.entry.type'].create({
+            'name': 'Test Time Off',
+            'code': 'Test Time Off 3',
+            'requires_allocation': False,
+            'count_days_as': 'working',
+        })
+        leave = self.env['hr.leave'].create({
+            'employee_id': self.employee_hruser_id,
+            'work_entry_type_id': working_work_entry_type.id,
+            'request_date_from': date(2024, 6, 1),
+            'request_date_to': date(2024, 6, 7),
+        })
+
+        days, hours = leave._get_durations()[leave.id]
+        self.assertEqual(days, 5, "Working days should exclude weekends")
+        self.assertEqual(hours, 40, "Working hours should be 5 * 8 hours")
+
+    def test_change_count_days_as(self):
+        """Changing count_days_as after leave is validated should raise ValidationError"""
+        work_entry_type = self.env['hr.work.entry.type'].create({
+            'name': 'Test Time Off',
+            'code': 'Test Time Off 4',
+            'requires_allocation': False,
+            'count_days_as': 'working',
+        })
+
+        work_entry_type.count_days_as = 'calendar'
+
+        leave = self.env['hr.leave'].create({
+            'employee_id': self.employee_hruser_id,
+            'work_entry_type_id': work_entry_type.id,
+            'request_date_from': date(2024, 7, 1),
+            'request_date_to': date(2024, 7, 5),
+        })
+        leave.action_approve()
+
+        with self.assertRaises(ValidationError):
+            work_entry_type.count_days_as = 'working'

--- a/addons/hr_holidays/views/hr_work_entry_type_views.xml
+++ b/addons/hr_holidays/views/hr_work_entry_type_views.xml
@@ -69,6 +69,7 @@
                             <div class="o_cell o_wrap_label text-break text-900 d-flex flex-row" colspan="2">
                                 <div class="d-flex flex-column gap-2">
                                     <label for="allows_negative" class="me-4" readonly="0" invisible="not requires_allocation"/>
+                                    <label for="count_days_as" class="me-4"/>
                                     <label for="include_public_holidays_in_duration" class="me-4"/>
                                     <label for="hide_on_dashboard" class="me-4"/>
                                     <label for="support_document" class="me-4" string="Require Supporting Document"/>
@@ -85,6 +86,7 @@
                                             <span class="mx-2" invisible="unit_of_measure != 'hour'">hours</span>
                                         </div>
                                     </div>
+                                    <field name="count_days_as" class="mb-2" nolabel="1" widget="radio" options="{'horizontal': true}"/>
                                     <field name="include_public_holidays_in_duration" class="mb-2" nolabel="1"/>
                                     <field name="hide_on_dashboard" class="mb-2" nolabel="1"/>
                                     <field name="support_document" nolabel="1"/>


### PR DESCRIPTION
This PR introduces a new option for calculating leave duration. 

Commit 1:
---
**[IMP] hr_holidays: improve time off type configuration**
This commit introduces a new option for calculating leave duration.

- Time off can now be calculated based on either Worked Days or Calendar Days.
- If the time off type is set to Worked Days, the existing behavior remains unchanged.
- If the time off type is set to Calendar Days, weekends are also included in the leave duration.

 Commit 2:
---
**[IMP] hr_holidays: add test cases**
This commit adds comprehensive test cases to validate the following functionalities
- Verification of leave duration calculation for calendar based and working-day
  based leaves, with both inclusion and exclusion of public holidays.



task-4907728
