### PR TITLE
[FIX] account: update payment_reference after resequencing invoice names

### DIFF
--- a/addons/account/wizard/account_resequence.py
+++ b/addons/account/wizard/account_resequence.py
@@ -168,3 +168,5 @@ class ReSequenceWizard(models.TransientModel):
                     move_id.name = new_values[str(move_id.id)]['new_by_name']
                 else:
                     move_id.name = new_values[str(move_id.id)]['new_by_date']
+            if move_id.move_type == 'out_invoice' and move_id.state == 'posted':
+                move_id.payment_reference = move_id._get_invoice_computed_reference()


### PR DESCRIPTION
<b>Steps to reproduce:</b>
1. Go to Invoicing > Turn on debug mode.
2. Select a customer invoice and click on Actions > Resequence.
3. After resequencing, observe the "Other Info" tab — the payment reference remains unchanged.
4. Click "Send" on the invoice — the displayed invoice name differs from the payment reference.

<b>Issue:</b>
- The `payment_reference` field is not updated after the invoice `name` is resequenced.

<b>Cause:</b>
- The existing logic does not computes for `payment_reference`. Since resequencing updates the `name` without updating `payment_reference`, it remains outdated.

<b>Solution:</b>
- Manually compute the `payment_reference` for posted customer invoices after resequencing, using `_get_invoice_computed_reference()`.

<b>opw-4903455</b>
