### PR TITLE
[FIX] {account,website}_payment: filter providers per website

### DIFF
--- a/addons/account_payment/controllers/portal.py
+++ b/addons/account_payment/controllers/portal.py
@@ -30,7 +30,8 @@ class PortalAccount(portal.PortalAccount, PaymentPortal):
             invoice_company.id,
             partner_sudo.id,
             invoice.amount_total,
-            currency_id=invoice.currency_id.id
+            currency_id=invoice.currency_id.id,
+            **kwargs,
         )  # In sudo mode to read the fields of providers and partner (if logged out).
         payment_methods_sudo = request.env['payment.method'].sudo()._get_compatible_payment_methods(
             providers_sudo.ids,

--- a/addons/sale/tests/test_payment_flow.py
+++ b/addons/sale/tests/test_payment_flow.py
@@ -1,6 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from unittest.mock import ANY, patch
+from unittest.mock import patch
 
 from odoo.exceptions import AccessError
 from odoo.tests import JsonRpcException, tagged
@@ -39,7 +39,8 @@ class TestSalePayment(AccountPaymentCommon, SaleCommon, PaymentHttpCommon):
             '._compute_show_tokenize_input_mapping'
         ) as patched:
             tx_context = self._get_portal_pay_context(**route_values)
-            patched.assert_called_once_with(ANY, sale_order_id=ANY)
+            patched.assert_called_once()
+            self.assertIn('sale_order_id', patched.call_args[1])
 
         self.assertEqual(tx_context['currency_id'], self.sale_order.currency_id.id)
         self.assertEqual(tx_context['partner_id'], self.sale_order.partner_invoice_id.id)

--- a/addons/website_payment/controllers/__init__.py
+++ b/addons/website_payment/controllers/__init__.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from . import payment
 from . import portal

--- a/addons/website_payment/controllers/payment.py
+++ b/addons/website_payment/controllers/payment.py
@@ -1,0 +1,18 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.http import request, route
+
+from odoo.addons.account_payment.controllers import payment as account_payment
+
+
+class PaymentPortal(account_payment.PaymentPortal):
+
+    @route()
+    def payment_pay(self, *args, **kwargs):
+        """Override of `payment` to make the provider filtering website-aware."""
+        return super().payment_pay(*args, website_id=request.website.id, **kwargs)
+
+    @route()
+    def payment_method(self, **kwargs):
+        """Override of `payment` to make the provider filtering website-aware."""
+        return super().payment_method(website_id=request.website.id, **kwargs)

--- a/addons/website_payment/controllers/portal.py
+++ b/addons/website_payment/controllers/portal.py
@@ -6,6 +6,7 @@ from odoo.exceptions import ValidationError
 from odoo.http import request
 from odoo.tools.json import scriptsafe as json_safe
 
+from odoo.addons.account_payment.controllers import portal as account_payment_portal
 from odoo.addons.payment import utils as payment_utils
 from odoo.addons.payment.controllers import portal as payment_portal
 
@@ -151,3 +152,9 @@ class PaymentPortal(payment_portal.PaymentPortal):
             for provider_sudo in providers_sudo:
                 res[provider_sudo.id] = False
         return res
+
+
+class PortalAccount(account_payment_portal.PortalAccount):
+    def _invoice_get_page_view_values(self, *args, **kwargs):
+        """Override of `account_payment` to make the providers filtering website-aware."""
+        return super()._invoice_get_page_view_values(*args, website_id=request.website.id, **kwargs)


### PR DESCRIPTION
In a multi-website environment, payment providers are often configured specifically for each website using the `website_id` field. While the checkout page (`/shop/payment`) correctly filters providers by the current website, other routes such as `/my/payment_method` or `/payment/pay` flows do not apply this filtering consistently.

This patch ensures that the `website_id` constraint on payment providers is respected across all relevant flows, improving consistency and preventing users from seeing or using providers that are not available for their current website.

Without this patch, users may see or select payment providers that are not intended for their site, leading to potential confusion, incorrect transactions, or access to providers that are not supported on the current website.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
