### PR TITLE
[IMP] hr,hr_work_entry: UX refactor of contract template

### DIFF
--- a/addons/hr/static/src/scss/hr.scss
+++ b/addons/hr/static/src/scss/hr.scss
@@ -71,6 +71,14 @@
     }
 }
 
+.o_hr_percentage_narrow_field input {
+    max-width: 8rem !important;
+    width: 8rem !important;
+    * {
+        max-width: 100%;
+    }
+}
+
 @for $size from 1 through 15 {
     .o_hr_narrow_field-#{$size} {
         width: #{$size}rem!important;

--- a/addons/hr/views/hr_contract_template_views.xml
+++ b/addons/hr/views/hr_contract_template_views.xml
@@ -25,24 +25,26 @@
                                        domain="['|', ('country_id', '=', False), ('country_id', '=', company_country_id)]"/>
                             </div>
                             <field name="resource_calendar_id"/>
+                            <field name="hr_responsible_id" widget="many2one_avatar_user" groups="hr.group_hr_user"/>
                         </group>
                     </group>
                     <notebook>
                         <page string="Salary Information" name="information" class="o_hr_contract_salary_information">
+                            <field name="currency_id" invisible="1"/> <!-- for monetary field-->
                             <group name="salary_info">
-                                <group name="salary">
-                                    <label for="wage"/>
-                                    <div class="o_row mw-50" name="wage">
+                                <group name="salary_left">
+                                    <label for="wage" groups="hr.group_hr_user"/>
+                                    <div class="o_row" name="wage" groups="hr.group_hr_user">
                                         <field name="wage" class="oe_inline o_hr_narrow_field" nolabel="1"/>
-                                        <div class="mb-3" name="wage_period_label">/ month</div>
+                                        <div name="wage_period_label">/ month</div>
                                     </div>
+                                </group>
+                                <group name="salary_right">
                                 </group>
                             </group>
                         </page>
                         <page string="Details" name="other" groups="hr.group_hr_manager">
-                            <group name="contract_details_0"/>
-                            <group name="contract_details" col="2"/>
-                            <group name="contract_details_2"/>
+                            <group name="other"/>
                         </page>
                     </notebook>
                 </sheet>

--- a/addons/hr_work_entry/__manifest__.py
+++ b/addons/hr_work_entry/__manifest__.py
@@ -1,4 +1,3 @@
-#-*- coding:utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 {
@@ -17,6 +16,7 @@
         'data/ir_cron_data.xml',
         'views/hr_work_entry_views.xml',
         'views/hr_employee_views.xml',
+        'views/hr_contract_template_views.xml',
         'views/resource_calendar_views.xml',
         'wizard/hr_work_entry_regeneration_wizard_views.xml',
     ],

--- a/addons/hr_work_entry/views/hr_contract_template_views.xml
+++ b/addons/hr_work_entry/views/hr_contract_template_views.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="hr_contract_template_view_form" model="ir.ui.view">
+        <field name="name">hr.contract.template.view.form.inherit.hr_work_entry</field>
+        <field name="model">hr.version</field>
+        <field name="inherit_id" ref="hr.hr_contract_template_form_view"/>
+        <field name="arch" type="xml">
+            <div name="wage" position="after">
+                <field name="work_entry_source" invisible="1"/>
+            </div>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Since the merge of hr and contract, we only have a form view for contracts for templates. Thus, during the merge, a lot of info has been lost on contract template form view.
This commit, reintroduce fields that were present in saas-18.3 and re-organize them.

task-4904024

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
