### PR TITLE
[FIX] html_editor: multiple formats not getting removed

### DIFF
--- a/addons/html_editor/static/src/core/format_plugin.js
+++ b/addons/html_editor/static/src/core/format_plugin.js
@@ -1,6 +1,6 @@
 import { Plugin } from "../plugin";
 import { closestBlock, isBlock } from "../utils/blocks";
-import { hasAnyNodesColor } from "@html_editor/utils/color";
+import { hasAnyNodesColor, TEXT_CLASSES_REGEX, BG_CLASSES_REGEX } from "@html_editor/utils/color";
 import { cleanTextNode, splitTextNode, unwrapContents } from "../utils/dom";
 import {
     areSimilarElements,
@@ -154,7 +154,6 @@ export class FormatPlugin extends Plugin {
 
     removeFormat() {
         const targetedNodes = this.dependencies.selection.getTargetedNodes();
-        this.dispatchTo("remove_format_handlers");
         for (const format of Object.keys(formatsSpecs)) {
             if (
                 !formatsSpecs[format].removeStyle ||
@@ -164,6 +163,7 @@ export class FormatPlugin extends Plugin {
             }
             this._formatSelection(format, { applyStyle: false });
         }
+        this.dispatchTo("remove_format_handlers");
         this.dependencies.history.addStep();
     }
 
@@ -289,7 +289,12 @@ export class FormatPlugin extends Plugin {
                 !isBlock(parentNode) &&
                 !this.dependencies.split.isUnsplittable(parentNode) &&
                 (parentNode.classList.length === 0 ||
-                    [...parentNode.classList].every((cls) => FONT_SIZE_CLASSES.includes(cls)))
+                    [...parentNode.classList].every(
+                        (cls) =>
+                            FONT_SIZE_CLASSES.includes(cls) ||
+                            TEXT_CLASSES_REGEX.test(cls) ||
+                            BG_CLASSES_REGEX.test(cls)
+                    ))
             ) {
                 const isUselessZws =
                     parentNode.tagName === "SPAN" &&

--- a/addons/html_editor/static/src/utils/formatting.js
+++ b/addons/html_editor/static/src/utils/formatting.js
@@ -1,7 +1,8 @@
 import { normalizeCSSColor } from "@web/core/utils/colors";
 import { removeClass } from "./dom";
 import { isBold, isDirectionSwitched, isItalic, isStrikeThrough, isUnderline } from "./dom_info";
-import { closestElement } from "./dom_traversal";
+import { closestElement, closestPath, findNode } from "./dom_traversal";
+import { isBlock } from "./blocks";
 
 /**
  * Array of all the classes used by the editor to change the font size.
@@ -82,7 +83,8 @@ export const formatsSpecs = {
             ),
     },
     fontSize: {
-        isFormatted: (node) => closestElement(node)?.style["font-size"],
+        isFormatted: (node) =>
+            !!findNode(closestPath(node), (el) => el.style?.["font-size"], isBlock),
         hasStyle: (node) => node.style && node.style["font-size"],
         addStyle: (node, props) => {
             node.style["font-size"] = props.size;
@@ -92,7 +94,11 @@ export const formatsSpecs = {
     },
     setFontSizeClassName: {
         isFormatted: (node) =>
-            FONT_SIZE_CLASSES.find((cls) => closestElement(node)?.classList?.contains(cls)),
+            !!findNode(
+                closestPath(node),
+                (el) => FONT_SIZE_CLASSES.find((cls) => el.classList?.contains(cls)),
+                isBlock
+            ),
         hasStyle: (node, props) => FONT_SIZE_CLASSES.find((cls) => node.classList.contains(cls)),
         addStyle: (node, props) => {
             node.style.removeProperty("font-size");

--- a/addons/html_editor/static/tests/format/remove_format.test.js
+++ b/addons/html_editor/static/tests/format/remove_format.test.js
@@ -708,6 +708,33 @@ test("should remove backgroundColor from selected cells using removeFormat (2)",
     });
 });
 
+test("should remove all formats when having multiple formats", async () => {
+    await testEditor({
+        contentBefore:
+            '<p><span class="display-4-fs"><font style="color: rgb(255, 156, 0);"><strong>[test]</strong></font></span></p>',
+        stepFunction: (editor) => execCommand(editor, "removeFormat"),
+        contentAfter: "<p>[test]</p>",
+    });
+});
+
+test("should remove all formats when having multiple formats (2)", async () => {
+    await testEditor({
+        contentBefore:
+            '<p><span style="font-size: 24px"><font style="color: rgb(255, 156, 0);"><strong>[test]</strong></font></span></p>',
+        stepFunction: (editor) => execCommand(editor, "removeFormat"),
+        contentAfter: "<p>[test]</p>",
+    });
+});
+
+test("should remove all formats when having multiple formats (3)", async () => {
+    await testEditor({
+        contentBefore:
+            '<p><span class="display-4-fs"><font class="text-o-color-1"><strong>[test]</strong></font></span></p>',
+        stepFunction: (editor) => execCommand(editor, "removeFormat"),
+        contentAfter: "<p>[test]</p>",
+    });
+});
+
 describe("Toolbar", () => {
     async function removeFormatClick() {
         await expectElementCount(".o-we-toolbar", 1);


### PR DESCRIPTION
**Current behaviour before PR:**

Steps to reproduce:

- Select a text
- Apply font size
- Apply color
- Apply bold
- Clicking on removeFormat button doesn't remove all formats

User has to click on removeFormat button twice to remove the format.

**Desired behaviour after PR is merged:**

Now, all formats are getting removed at once when clicking on removeFormat button.

task-4911199



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
