### PR TITLE
[FIX] l10n_tr_nilvera_edispatch: Update Delivery Customer in XML & modify ZIP usage

### DIFF
--- a/addons/l10n_tr_nilvera_edispatch/i18n/l10n_tr_nilvera_edispatch.pot
+++ b/addons/l10n_tr_nilvera_edispatch/i18n/l10n_tr_nilvera_edispatch.pot
@@ -6,14 +6,21 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 17.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-07-01 11:55+0000\n"
-"PO-Revision-Date: 2025-07-01 11:55+0000\n"
+"POT-Creation-Date: 2025-08-17 14:00+0000\n"
+"PO-Revision-Date: 2025-08-17 14:00+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
 "Plural-Forms: \n"
+
+#. module: l10n_tr_nilvera_edispatch
+#. odoo-python
+#: code:addons/l10n_tr_nilvera_edispatch/models/res_partner.py:0
+#, python-format
+msgid "%(name)s's %(errors)s."
+msgstr ""
 
 #. module: l10n_tr_nilvera_edispatch
 #. odoo-python
@@ -34,13 +41,6 @@ msgstr ""
 #: code:addons/l10n_tr_nilvera_edispatch/models/stock_picking.py:0
 #, python-format
 msgid "%s's"
-msgstr ""
-
-#. module: l10n_tr_nilvera_edispatch
-#. odoo-python
-#: code:addons/l10n_tr_nilvera_edispatch/models/res_partner.py:0
-#, python-format
-msgid "%s's %s."
 msgstr ""
 
 #. module: l10n_tr_nilvera_edispatch
@@ -476,6 +476,14 @@ msgstr ""
 #: code:addons/l10n_tr_nilvera_edispatch/models/stock_picking.py:0
 #, python-format
 msgid "e-Dispatch XML file generated successfully."
+msgstr ""
+
+#. module: l10n_tr_nilvera_edispatch
+#. odoo-python
+#: code:addons/l10n_tr_nilvera_edispatch/models/stock_picking.py:0
+#: code:addons/l10n_tr_nilvera_edispatch/models/stock_picking.py:0
+#, python-format
+msgid "e-Dispatch will not be generated as the Delivery Address is not set."
 msgstr ""
 
 #. module: l10n_tr_nilvera_edispatch

--- a/addons/l10n_tr_nilvera_edispatch/i18n/tr.po
+++ b/addons/l10n_tr_nilvera_edispatch/i18n/tr.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 17.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-06-27 13:26+0000\n"
-"PO-Revision-Date: 2025-07-01 11:00+0400\n"
+"POT-Creation-Date: 2025-08-11 06:16+0000\n"
+"PO-Revision-Date: 2025-08-11 14:53+0400\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "Language: tr_TR\n"
@@ -19,17 +19,24 @@ msgstr ""
 
 #. module: l10n_tr_nilvera_edispatch
 #. odoo-python
+#: code:addons/l10n_tr_nilvera_edispatch/models/res_partner.py:0
+#, python-format
+msgid "%(name)s's %(errors)s."
+msgstr "%(name)s'nin %(errors)s."
+
+#. module: l10n_tr_nilvera_edispatch
+#. odoo-python
 #: code:addons/l10n_tr_nilvera_edispatch/models/stock_picking.py:0
 #, python-format
 msgid "%s TCKN is required."
-msgstr "%s TCKN gereklidir."
+msgstr "%s TCKN zorunludur."
 
 #. module: l10n_tr_nilvera_edispatch
 #. odoo-python
 #: code:addons/l10n_tr_nilvera_edispatch/models/res_partner.py:0
 #, python-format
 msgid "%s is required"
-msgstr "%s gereklidir"
+msgstr "%s zorunludur"
 
 #. module: l10n_tr_nilvera_edispatch
 #. odoo-python
@@ -39,28 +46,21 @@ msgid "%s's"
 msgstr "%s'nin"
 
 #. module: l10n_tr_nilvera_edispatch
-#. odoo-python
-#: code:addons/l10n_tr_nilvera_edispatch/models/res_partner.py:0
-#, python-format
-msgid "%s's %s."
-msgstr "%s'nin %s."
-
-#. module: l10n_tr_nilvera_edispatch
 #: model:ir.model.constraint,message:l10n_tr_nilvera_edispatch.constraint_l10n_tr_nilvera_trailer_plate_name_unique
 msgid "A Plate Number with that type already exists."
-msgstr "Bu tür bir plaka numarası zaten mevcuttur."
+msgstr "Bu türde bir plaka numarası zaten mevcut."
 
 #. module: l10n_tr_nilvera_edispatch
 #: model_terms:ir.ui.view,arch_db:l10n_tr_nilvera_edispatch.view_picking_form_inherit_l10n_tr_nilvera_edispatch
 msgid "Additional Information"
-msgstr "Ek Bilgi"
+msgstr "Ek Bilgiler"
 
 #. module: l10n_tr_nilvera_edispatch
 #. odoo-python
 #: code:addons/l10n_tr_nilvera_edispatch/models/stock_picking.py:0
 #, python-format
 msgid "At least one Driver is required."
-msgstr "En az bir sürücü gereklidir."
+msgstr "En az bir şoför zorunludur."
 
 #. module: l10n_tr_nilvera_edispatch
 #: model:ir.model.fields,field_description:l10n_tr_nilvera_edispatch.field_stock_picking__l10n_tr_nilvera_buyer_id
@@ -70,7 +70,7 @@ msgstr "Alıcı"
 #. module: l10n_tr_nilvera_edispatch
 #: model:ir.model.fields,field_description:l10n_tr_nilvera_edispatch.field_stock_picking__l10n_tr_nilvera_buyer_originator_id
 msgid "Buyer Originator"
-msgstr "Alıcı Kaynağı"
+msgstr "Alıcı (İlk Başlatan Taraf)"
 
 #. module: l10n_tr_nilvera_edispatch
 #: model_terms:ir.ui.view,arch_db:l10n_tr_nilvera_edispatch.view_picking_form_inherit_l10n_tr_nilvera_edispatch
@@ -90,7 +90,7 @@ msgid ""
 "Carrier is required (optional when both the Driver and Vehicle Plate are "
 "filled)."
 msgstr ""
-"Taşıyıcı gereklidir (Sürücü ve Araç Plakası bilgileri doldurulduğunda isteğe "
+"Taşıyıcı zorunludur (Şoför ve Araç Plakası birlikte girildiğinde isteğe "
 "bağlıdır)."
 
 #. module: l10n_tr_nilvera_edispatch
@@ -103,7 +103,7 @@ msgstr "Şehir"
 #. module: l10n_tr_nilvera_edispatch
 #: model:ir.model,name:l10n_tr_nilvera_edispatch.model_res_partner
 msgid "Contact"
-msgstr "Kişi"
+msgstr "İrtibat"
 
 #. module: l10n_tr_nilvera_edispatch
 #. odoo-python
@@ -134,12 +134,12 @@ msgstr "Gümrük Posta Kodu"
 #: code:addons/l10n_tr_nilvera_edispatch/models/res_partner.py:0
 #, python-format
 msgid "Customs ZIP of 5 characters must be present"
-msgstr "5 karakterden oluşan gümrük posta kodu girilmelidir."
+msgstr "5 karakterden oluşan gümrük posta kodu girilmelidir"
 
 #. module: l10n_tr_nilvera_edispatch
 #: model:ir.model.fields,field_description:l10n_tr_nilvera_edispatch.field_stock_picking__l10n_tr_nilvera_delivery_notes
 msgid "Delivery Notes"
-msgstr "Sevk İrsaliyeleri"
+msgstr "İrsaliyeler"
 
 #. module: l10n_tr_nilvera_edispatch
 #: model:ir.model.fields,field_description:l10n_tr_nilvera_edispatch.field_stock_picking__l10n_tr_nilvera_dispatch_type
@@ -154,7 +154,7 @@ msgstr "Görünen Ad"
 #. module: l10n_tr_nilvera_edispatch
 #: model_terms:ir.ui.view,arch_db:l10n_tr_nilvera_edispatch.view_picking_form_inherit_l10n_tr_nilvera_edispatch
 msgid "Driver Information"
-msgstr "Sürücü Bilgileri"
+msgstr "Şoför Bilgileri"
 
 #. module: l10n_tr_nilvera_edispatch
 #. odoo-python
@@ -162,7 +162,7 @@ msgstr "Sürücü Bilgileri"
 #: model:ir.model.fields,field_description:l10n_tr_nilvera_edispatch.field_stock_picking__l10n_tr_nilvera_driver_ids
 #, python-format
 msgid "Drivers"
-msgstr "Sürücüler"
+msgstr "Şoförler"
 
 #. module: l10n_tr_nilvera_edispatch
 #. odoo-python
@@ -184,7 +184,7 @@ msgstr "Genel Bilgiler"
 #: model:ir.actions.server,name:l10n_tr_nilvera_edispatch.action_export_l10n_tr_nilvera_edispatch_list
 #: model_terms:ir.ui.view,arch_db:l10n_tr_nilvera_edispatch.view_picking_form_inherit_l10n_tr_nilvera_edispatch
 msgid "Generate GİB e-Dispatch (XML)"
-msgstr "GİB e-İrsaliye (XML) oluştur"
+msgstr "GİB e-İrsaliye (XML) Oluştur"
 
 #. module: l10n_tr_nilvera_edispatch
 #: model:ir.model.fields,field_description:l10n_tr_nilvera_edispatch.field_l10n_tr_nilvera_trailer_plate__name
@@ -202,7 +202,7 @@ msgstr "GİB Plaka Numaraları"
 #. module: l10n_tr_nilvera_edispatch
 #: model:ir.model,name:l10n_tr_nilvera_edispatch.model_l10n_tr_nilvera_trailer_plate
 msgid "GİB Plate numbers"
-msgstr "GİB Plaka numaraları"
+msgstr "GİB plaka numaraları"
 
 #. module: l10n_tr_nilvera_edispatch
 #: model:ir.ui.menu,name:l10n_tr_nilvera_edispatch.menu_l10n_tr_nilvera
@@ -222,7 +222,7 @@ msgstr "Belge Kimliği"
 #. module: l10n_tr_nilvera_edispatch
 #: model:ir.model.fields,field_description:l10n_tr_nilvera_edispatch.field_stock_picking__l10n_tr_nilvera_edispatch_warnings
 msgid "L10N Tr Nilvera Edispatch Warnings"
-msgstr "L10N Tr Nilvera e-İrsaliye Uyarıları"
+msgstr "Nilvera e-İrsaliye Uyarıları"
 
 #. module: l10n_tr_nilvera_edispatch
 #: model:ir.model.fields,field_description:l10n_tr_nilvera_edispatch.field_l10n_tr_nilvera_trailer_plate__write_uid
@@ -254,7 +254,7 @@ msgstr "Çevrim içi"
 #: code:addons/l10n_tr_nilvera_edispatch/models/stock_picking_type.py:0
 #, python-format
 msgid "Only 3 characters are allowed in the Sequence Prefix by GİB"
-msgstr "GİB tarafından Sıra Ön Ekinde yalnızca 3 karaktere izin verilmektedir"
+msgstr "GİB tarafından sıra ön ekinde yalnızca 3 karaktere izin verilir"
 
 #. module: l10n_tr_nilvera_edispatch
 #. odoo-python
@@ -264,7 +264,7 @@ msgid ""
 "Only Drivers from Türkiye are valid. Please update the Country and enter a "
 "valid TCKN in the Tax ID."
 msgstr ""
-"Yalnızca Türkiye'den sürücüler geçerlidir. Lütfen Ülke bilgisini güncelleyin "
+"Yalnızca Türkiye’den şoförler geçerlidir. Lütfen Ülke bilgisini güncelleyin "
 "ve Vergi Kimlik Numarası alanına geçerli bir TCKN girin."
 
 #. module: l10n_tr_nilvera_edispatch
@@ -293,31 +293,31 @@ msgstr "XML oluşturmak için lütfen önce transferi doğrulayın"
 #. module: l10n_tr_nilvera_edispatch
 #: model:ir.model.fields.selection,name:l10n_tr_nilvera_edispatch.selection__stock_picking__l10n_tr_nilvera_dispatch_type__matbudan
 msgid "Pre-printed"
-msgstr "Önceden basılı"
+msgstr "Matbu"
 
 #. module: l10n_tr_nilvera_edispatch
 #: model:ir.model.fields,field_description:l10n_tr_nilvera_edispatch.field_stock_picking__l10n_tr_nilvera_delivery_date
 msgid "Printed Delivery Note Date"
-msgstr "Basılı Sevk İrsaliyesi Tarihi"
+msgstr "Basılı İrsaliye Tarihi"
 
 #. module: l10n_tr_nilvera_edispatch
 #. odoo-python
 #: code:addons/l10n_tr_nilvera_edispatch/models/stock_picking.py:0
 #, python-format
 msgid "Printed Delivery Note Date is required."
-msgstr "Basılı Sevk İrsaliyesi Tarihi zorunludur."
+msgstr "Basılı irsaliye tarihi zorunludur."
 
 #. module: l10n_tr_nilvera_edispatch
 #: model:ir.model.fields,field_description:l10n_tr_nilvera_edispatch.field_stock_picking__l10n_tr_nilvera_delivery_printed_number
 msgid "Printed Delivery Note Number"
-msgstr "Basılı Sevk İrsaliyesi Numarası "
+msgstr "Basılı İrsaliye Numarası"
 
 #. module: l10n_tr_nilvera_edispatch
 #. odoo-python
 #: code:addons/l10n_tr_nilvera_edispatch/models/stock_picking.py:0
 #, python-format
 msgid "Printed Delivery Note Number of 16 characters is required."
-msgstr "16 karakterden oluşan Basılı Sevk İrsaliyesi Numarası zorunludur."
+msgstr "16 karakterden oluşan basılı irsaliye numarası girilmelidir."
 
 #. module: l10n_tr_nilvera_edispatch
 #: model:ir.model.fields,field_description:l10n_tr_nilvera_edispatch.field_stock_picking__l10n_tr_nilvera_seller_supplier_id
@@ -357,7 +357,7 @@ msgid ""
 "The postal code of the customs office used to ship to the destination "
 "country."
 msgstr ""
-"Varış ülkesine yapılan sevkiyatlarda kullanılan gümrük ofisinin posta kodu."
+"Varış ülkesine yapılan sevkiyatta kullanılan gümrük idaresinin posta kodu."
 
 #. module: l10n_tr_nilvera_edispatch
 #: model:ir.model.fields.selection,name:l10n_tr_nilvera_edispatch.selection__stock_picking__l10n_tr_nilvera_dispatch_state__to_send
@@ -377,13 +377,13 @@ msgstr "Transfer"
 #. module: l10n_tr_nilvera_edispatch
 #: model:ir.model.fields,help:l10n_tr_nilvera_edispatch.field_stock_picking__l10n_tr_nilvera_driver_ids
 msgid "Used for the individuals driving the truck."
-msgstr "Kamyonu süren kişiler için kullanılır."
+msgstr "Kamyonu kullanan kişiler için kullanılır."
 
 #. module: l10n_tr_nilvera_edispatch
 #: model:ir.model.fields,help:l10n_tr_nilvera_edispatch.field_stock_picking__l10n_tr_nilvera_seller_supplier_id
 msgid ""
 "Used for the information of the supplier of the goods in the delivery note."
-msgstr "Sevk irsaliyesindeki malın tedarikçi bilgisi için kullanılır."
+msgstr "İrsaliyede malın tedarikçisine dair bilgiler için kullanılır."
 
 #. module: l10n_tr_nilvera_edispatch
 #: model:ir.model.fields,help:l10n_tr_nilvera_edispatch.field_stock_picking__l10n_tr_nilvera_buyer_originator_id
@@ -424,7 +424,7 @@ msgid ""
 "Used when the dispatch is made through a third-party carrier company. "
 "Populating this makes the Vehicle Plate and Drivers optional."
 msgstr ""
-"Sevkiyatın üçüncü taraf bir taşıyıcı firma aracılığıyla yapılması durumunda "
+"Sevkiyat üçüncü taraf bir taşıyıcı firma aracılığıyla yapıldığında "
 "kullanılır. Bu alan doldurulduğunda Araç Plakası ve Şoför bilgileri isteğe "
 "bağlı hale gelir."
 
@@ -448,7 +448,7 @@ msgstr "Araç Plakası"
 #: code:addons/l10n_tr_nilvera_edispatch/models/stock_picking.py:0
 #, python-format
 msgid "Vehicle Plate is required."
-msgstr "Araç Plakası zorunludur."
+msgstr "Araç plakası zorunludur."
 
 #. module: l10n_tr_nilvera_edispatch
 #. odoo-python
@@ -456,7 +456,7 @@ msgstr "Araç Plakası zorunludur."
 #: code:addons/l10n_tr_nilvera_edispatch/models/stock_picking.py:0
 #, python-format
 msgid "View %s"
-msgstr "%s’i görüntüle"
+msgstr "%s'i Görüntüle"
 
 #. module: l10n_tr_nilvera_edispatch
 #. odoo-python
@@ -488,6 +488,13 @@ msgstr "e-İrsaliye Durumu"
 #, python-format
 msgid "e-Dispatch XML file generated successfully."
 msgstr "e-İrsaliye XML dosyası başarıyla oluşturuldu."
+
+#. module: l10n_tr_nilvera_edispatch
+#. odoo-python
+#: code:addons/l10n_tr_nilvera_edispatch/models/stock_picking.py:0
+#, python-format
+msgid "e-Dispatch will not be generated as the Delivery Address is not set."
+msgstr "Teslimat Adresi belirtilmediği için e-İrsaliye oluşturulmayacaktır."
 
 #. module: l10n_tr_nilvera_edispatch
 #: model_terms:ir.ui.view,arch_db:l10n_tr_nilvera_edispatch.l10n_tr_edispatch_format

--- a/addons/l10n_tr_nilvera_edispatch/models/res_partner.py
+++ b/addons/l10n_tr_nilvera_edispatch/models/res_partner.py
@@ -27,7 +27,7 @@ class ResPartner(models.Model):
             if country_code == 'TR' and not record.vat:
                 missing_fields.append(_("TCKN/VKN"))
 
-            if (country_code == 'TR' or is_delivery_partner) and not record.zip:
+            if country_code == 'TR' and not record.zip:
                 missing_fields.append(_("ZIP"))
 
             if missing_fields:
@@ -40,9 +40,11 @@ class ResPartner(models.Model):
                 msg.append(_("Customs ZIP of 5 characters must be present"))
 
             if msg:
-                error_messages[f"invalid_{record.name.replace(' ', '_')}"] = {
-                    'message': _("%s's %s.", record.name, ', '.join(msg)),
-                    'action_text': _("View %s", record.name),
+                # Instead of using name, display_name is used, since name is not required
+                # if contact is of type "Delivery Address".
+                error_messages[f"invalid_partner_{record.id}"] = {
+                    'message': _("%(name)s's %(errors)s.", name=record.display_name, errors=', '.join(msg)),
+                    'action_text': _("View %s", record.display_name),
                     'action': record._get_records_action(name=_("View Partner"))
                 }
         return error_messages

--- a/addons/l10n_tr_nilvera_edispatch/templates/l10n_tr_nilvera_edispatch.xml
+++ b/addons/l10n_tr_nilvera_edispatch/templates/l10n_tr_nilvera_edispatch.xml
@@ -24,7 +24,7 @@
             <cbc:StreetName t-out="partner.street"/>
             <cbc:CitySubdivisionName t-out="partner.city"/>
             <cbc:CityName t-out="partner.state_id.name"/>
-            <cbc:PostalZone t-out="zipcode"/>
+            <cbc:PostalZone t-out="partner.country_id.code == 'TR' and partner.zip or partner.l10n_tr_nilvera_edispatch_customs_zip"/>
             <t t-set="tr_country" t-value="partner.country_id.with_context(lang='tr_TR')"/>
             <cac:Country>
                 <cbc:IdentificationCode t-out="tr_country.code"/>
@@ -109,31 +109,26 @@
             <cac:DespatchSupplierParty>
                 <t t-call="l10n_tr_nilvera_edispatch.nilvera_party_template">
                     <t t-set="partner" t-value="current_company"/>
-                    <t t-set="zipcode" t-value="partner.zip"/>
                 </t>
             </cac:DespatchSupplierParty>
             <cac:DeliveryCustomerParty>
                 <t t-call="l10n_tr_nilvera_edispatch.nilvera_party_template">
-                    <t t-set="partner" t-value="picking.partner_id"/>
-                    <t t-set="zipcode" t-value="partner.zip"/>
+                    <t t-set="partner" t-value="picking.partner_id.commercial_partner_id"/>
                 </t>
             </cac:DeliveryCustomerParty>
             <cac:BuyerCustomerParty t-if="picking.l10n_tr_nilvera_buyer_id">
                 <t t-call="l10n_tr_nilvera_edispatch.nilvera_party_template">
                     <t t-set="partner" t-value="picking.l10n_tr_nilvera_buyer_id"/>
-                    <t t-set="zipcode" t-value="partner.country_id.code == 'TR' and partner.zip or partner.l10n_tr_nilvera_edispatch_customs_zip"/>
                 </t>
             </cac:BuyerCustomerParty>
             <cac:SellerSupplierParty t-if="picking.l10n_tr_nilvera_seller_supplier_id">
                 <t t-call="l10n_tr_nilvera_edispatch.nilvera_party_template">
                     <t t-set="partner" t-value="picking.l10n_tr_nilvera_seller_supplier_id"/>
-                    <t t-set="zipcode" t-value="partner.country_id.code == 'TR' and partner.zip or partner.l10n_tr_nilvera_edispatch_customs_zip"/>
                 </t>
             </cac:SellerSupplierParty>
             <cac:OriginatorCustomerParty t-if="picking.l10n_tr_nilvera_buyer_originator_id">
                 <t t-call="l10n_tr_nilvera_edispatch.nilvera_party_template">
                     <t t-set="partner" t-value="picking.l10n_tr_nilvera_buyer_originator_id"/>
-                    <t t-set="zipcode" t-value="partner.country_id.code == 'TR' and partner.zip or partner.l10n_tr_nilvera_edispatch_customs_zip"/>
                 </t>
             </cac:OriginatorCustomerParty>
             <cac:Shipment>

--- a/addons/l10n_tr_nilvera_edispatch/views/stock_picking_views.xml
+++ b/addons/l10n_tr_nilvera_edispatch/views/stock_picking_views.xml
@@ -22,10 +22,10 @@
         <field name="inherit_id" ref="stock.view_picking_form"/>
         <field name="arch" type="xml">
             <xpath expr="//header" position="inside">
-                <button name="action_generate_l10n_tr_edispatch_xml" type="object" invisible="state != 'done' or country_code != 'TR' or picking_type_code != 'outgoing'" string="Generate GİB e-Dispatch (XML)" />
+                <button name="action_generate_l10n_tr_edispatch_xml" type="object" invisible="country_code != 'TR' or picking_type_code != 'outgoing' or state != 'done' or not partner_id" string="Generate GİB e-Dispatch (XML)" />
             </xpath>
             <xpath expr="//notebook" position="inside">
-                <page name="l10n_tr_edispatch" string="e-Dispatch" invisible="country_code != 'TR' or picking_type_code != 'outgoing'">
+                <page name="l10n_tr_edispatch" string="e-Dispatch" invisible="country_code != 'TR' or picking_type_code != 'outgoing' or not partner_id">
                     <group>
                         <group name="l10n_tr_delivery_details" string="General Information">
                             <field name="l10n_tr_nilvera_dispatch_type"  required="country_code == 'TR'"/>
@@ -54,7 +54,7 @@
             </xpath>
             <xpath expr="//sheet" position="before">
                 <field name="l10n_tr_nilvera_edispatch_warnings" invisible="1"/>
-                <div class="m-0" name="warnings" invisible="not l10n_tr_nilvera_edispatch_warnings">
+                <div class="m-0" name="warnings" invisible="not l10n_tr_nilvera_edispatch_warnings or (state == 'done' and not partner_id)">
                     <field name="l10n_tr_nilvera_edispatch_warnings" class="o_field_html" widget="actionable_errors"/>
                 </div>
             </xpath>


### PR DESCRIPTION
Behaviour before this commit:
- Previously, the picking partner was used for sending both the Delivery Customer and delivery address in the XML.
- Secondly, ZIP was used in Delivery Customer regardless of the country of the partner (Turkish or Non-Turkish)

Desired behaviour after this commit:
- After this commit, the commercial partner of the picking partner will be used for sending the Delivery Customer data and picking partner itself will be used for sending the Delivery Address in the XML.
- Additionally, if the commercial partner is non turkish, customs ZIP will be used in the Delivery Customer in the XML.
- If the delivery is validated without giving Delivery Address, then the 'Generate e-Dispatch (XML)' button will be hidden.

TaskID:4918748

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
