### PR TITLE
[IMP] account,account_payment,analytic,base_import: remove href="#"

### DIFF
--- a/addons/account/static/src/components/account_file_uploader/account_file_uploader.xml
+++ b/addons/account/static/src/components/account_file_uploader/account_file_uploader.xml
@@ -18,14 +18,14 @@
     </t>
 
     <t t-name="account.JournalUploadLink">
-        <a t-att-class="props.btnClass" href="#" draggable="false">
+        <button t-att-class="props.btnClass" draggable="false">
             <div class="d-sm-none">
                 <i class="fa fa-upload"></i>
             </div>
             <div class="d-none d-sm-block">
                 <t t-out="props.linkText"/>
             </div>
-        </a>
+        </button>
     </t>
 
 </templates>

--- a/addons/account/static/src/components/account_payment_field/account_payment.xml
+++ b/addons/account/static/src/components/account_payment_field/account_payment.xml
@@ -15,14 +15,12 @@
                     <tr>
                     <t t-if="info.outstanding">
                         <td>
-                            <a title="assign to invoice"
-                               role="button"
+                            <button title="assign to invoice"
                                class="oe_form_field btn btn-secondary outstanding_credit_assign d-print-none"
                                t-att-data-id="line.id"
                                style="margin-right: 0px; padding-left: 5px; padding-right: 5px;"
-                               href="#"
                                data-bs-toggle="tooltip"
-                               t-on-click.prevent="() => this.assignOutstandingCredit(info.moveId, line.id)">Add</a>
+                               t-on-click.prevent="() => this.assignOutstandingCredit(info.moveId, line.id)">Add</button>
                         </td>
                         <td style="max-width: 11em;">
                             <a t-att-title="(line.bank_label ? line.bank_label + ' - ' : '') + line.formattedDate"

--- a/addons/account/static/src/components/actionable_errors/actionable_errors.xml
+++ b/addons/account/static/src/components/actionable_errors/actionable_errors.xml
@@ -8,15 +8,14 @@
                     <div t-att-class="`alert alert-${level} m-0 p-1 ps-3`" role="alert">
                         <div t-att-name="error" style="white-space: pre-wrap;">
                             <t t-out="error_value.message"/>
-                            <a class="fw-bold"
+                            <button class="fw-bold btn btn-link p-0"
                                t-if="error_value.action or error_value.action_call"
-                               href="#"
                                t-on-click.prevent="() => this.handleOnClick(error_value)"
                             >
                                 <i class="oi oi-arrow-right ms-1"/>
                                 <span class="ms-1" t-out="error_value.action_text"/>
                                 <i t-if="level === 'danger'" class="fa fa-warning ms-1"/>
-                            </a>
+                            </button>
                         </div>
                     </div>
                 </t>

--- a/addons/account/static/src/components/bill_guide/bill_guide.xml
+++ b/addons/account/static/src/components/bill_guide/bill_guide.xml
@@ -10,15 +10,14 @@
                     <span class="btn account_drag_drop_btn pe-none">Drag &amp; drop</span>
                     <div>
                         <span class="btn pe-none px-1 fw-normal">or</span>
-                        <a class="btn btn-link px-0 fw-normal"
-                            href="#"
+                        <button class="btn btn-link px-0 fw-normal"
                             type="object"
                             name="action_create_vendor_bill"
                             journal_type="purchase"
                             t-on-click="() => this.handleButtonClick('action_create_vendor_bill')"
                         >
                             try our sample
-                        </a>
+                        </button>
                     </div>
                 </div>
             </div>
@@ -43,13 +42,13 @@
                         </div>
                         <div>
                             <span class="btn pe-none px-1 fw-normal">or</span>
-                            <a href="#"
+                            <button
                                 type="object"
                                 class="btn btn-link px-0 fw-normal"
                                 t-on-click="() => this.handleButtonClick('action_create_new')"
                             >
                                 Create manually
-                            </a>
+                            </button>
                         </div>
                     </div>
                 </div>
@@ -61,13 +60,13 @@
                     </div>
                     <div class="text-center mt-2">
                         <div class="">
-                            <a href="#"
+                            <button
                                 type="object"
-                                class="o_invoice_new"
+                                class="o_invoice_new btn btn-link p-0 fw-normal"
                                 t-on-click="() => this.handleButtonClick('action_create_new')"
                             >
                                 Create a bill manually
-                            </a>
+                            </button>
                         </div>
                     </div>
                 </div>

--- a/addons/account/static/src/components/grouped_view_widget/grouped_view_widget.xml
+++ b/addons/account/static/src/components/grouped_view_widget/grouped_view_widget.xml
@@ -34,8 +34,4 @@
         </t>
     </tr>
 
-    <t t-name="account.OpenMoveTemplate">
-        <a href="#" t-out="widget.value"/>
-    </t>
-
 </templates>

--- a/addons/account/static/src/components/onboarding/onboarding.xml
+++ b/addons/account/static/src/components/onboarding/onboarding.xml
@@ -8,7 +8,8 @@
                     'fa-circle text-secondary': step.state == 'not_done',
                     'fa-check-circle text-success': step.state != 'not_done',
                 }"/>
-                <a href="#"
+                <button
+                   class="btn btn-link p-0 fw-normal"
                    t-att-data-method="step.action"
                    data-model="onboarding.onboarding.step"
                    t-out="step.title"

--- a/addons/account/static/src/components/open_move_widget/open_move_widget.xml
+++ b/addons/account/static/src/components/open_move_widget/open_move_widget.xml
@@ -2,7 +2,9 @@
 <templates>
 
     <t t-name="account.OpenMoveWidget">
-        <a href="#" t-out="props.record.data[props.name] || '/'" t-on-click.prevent.stop="(ev) => this.openMove()"/>
+        <div class="d-flex">
+            <button class="btn btn-link p-0 fw-normal text-truncate" t-out="props.record.data[props.name] || '/'" t-on-click.prevent.stop="(ev) => this.openMove()"/>
+        </div>
     </t>
 
 </templates>

--- a/addons/account/static/tests/account_widgets.test.js
+++ b/addons/account/static/tests/account_widgets.test.js
@@ -117,7 +117,7 @@ describe("AccountFileUploader", () => {
 
         expect(".o_widget_account_file_uploader").toHaveCount(1);
         const file = new File(["test"], "fake_file.txt", { type: "text/plain" });
-        await contains(".o_widget_account_file_uploader a").click();
+        await contains(".o_widget_account_file_uploader button").click();
         await setInputFiles([file]);
         await expect.waitForSteps([
             "create ir.attachment",

--- a/addons/account/views/account_portal_templates.xml
+++ b/addons/account/views/account_portal_templates.xml
@@ -225,7 +225,7 @@
     <template id="portal_invoice_error" name="Invoice error/warning display">
         <div class="row mr16">
             <div t-attf-class="'col-lg-12 mr16 ml16 alert alert-dismissable' #{'alert-danger' if error else 'alert-warning'}" role="alert">
-                <a href="#" class="close" data-bs-dismiss="alert" aria-label="close" title="close">×</a>
+                <button class="close btn btn-link p-0" data-bs-dismiss="alert" aria-label="close" title="close">×</button>
                 <t t-if="error == 'generic'" name="generic">
                     There was an error processing this page.
                 </t>
@@ -236,7 +236,7 @@
     <template id="portal_invoice_success" name="Invoice success display">
         <div class="row mr16">
             <div class="col-lg-12 mr16 ml16 alert alert-dismissable alert-success" role="status">
-                <a href="#" class="close" data-bs-dismiss="alert" aria-label="close" title="close">×</a>
+                <button class="close btn btn-link p-0" data-bs-dismiss="alert" aria-label="close" title="close">×</button>
             </div>
         </div>
     </template>

--- a/addons/account_payment/views/account_portal_templates.xml
+++ b/addons/account_payment/views/account_portal_templates.xml
@@ -263,13 +263,12 @@
             </div>
         </xpath>
         <xpath expr="//t[@t-set='entries']//div[hasclass('o_download_pdf')]" position="before">
-            <a t-if="invoice._has_to_be_paid()"
-                href="#"
+            <button t-if="invoice._has_to_be_paid()"
                 class="btn btn-primary"
                 data-bs-toggle="modal"
                 data-bs-target="#pay_with">
                 <i class="fa fa-fw fa-arrow-circle-right"/> Pay Now
-            </a>
+            </button>
         </xpath>
         <xpath expr="//div[@id='invoice_content']//div[hasclass('o_portal_html_view')]" position="before">
             <t t-set="tx" t-value="invoice.get_portal_last_transaction()"/>
@@ -311,7 +310,7 @@
 
     <template id="portal_invoice_success" name="Invoice success display: payment success"
             inherit_id="account.portal_invoice_success">
-        <xpath expr="//a[hasclass('close')]" position="after">
+        <xpath expr="//button[hasclass('close')]" position="after">
             <t t-if="success == 'pay_invoice'">
                 <t t-set="tx_sudo" t-value="invoice.get_portal_last_transaction()"/>
                 <span t-if="tx_sudo.provider_id.sudo().done_msg" t-out="tx_sudo.provider_id.sudo().done_msg"/>

--- a/addons/analytic/static/src/components/analytic_distribution/analytic_distribution.xml
+++ b/addons/analytic/static/src/components/analytic_distribution/analytic_distribution.xml
@@ -76,7 +76,7 @@
                         </tr>
                         <tr>
                             <td t-on-click.stop.prevent="addLine" class="o_field_x2many_list_row_add" t-att-colspan="allPlans.length + 2 + valueColumnEnabled">
-                                <a href="#" t-ref="addLineButton" tabindex="0">Add a Line</a>
+                                <button class="btn btn-link p-0 fw-normal" t-ref="addLineButton" tabindex="0">Add a Line</button>
                             </td>
                         </tr>
                     </tbody>

--- a/addons/analytic/static/tests/analytic_distribution.test.js
+++ b/addons/analytic/static/tests/analytic_distribution.test.js
@@ -167,7 +167,7 @@ test("analytic field in form view basic features", async () => {
 
     // add a line
     await contains(
-        ".analytic_distribution_popup table:eq(0) .o_field_x2many_list_row_add a"
+        ".analytic_distribution_popup table:eq(0) .o_field_x2many_list_row_add button"
     ).click();
     expect(
         ".analytic_distribution_popup table:eq(0) tr:nth-of-type(3) .o_field_percentage input"

--- a/addons/base_import/static/src/import_data_column_error/import_data_column_error.xml
+++ b/addons/base_import/static/src/import_data_column_error/import_data_column_error.xml
@@ -10,9 +10,9 @@
                 </p>
                 <ul>
                     <t t-foreach="props.errors" t-as="error" t-key="error_index">
-                        <a t-if="error_index === 3" href="#" class="o_import_report_count" t-on-click="() => this.state.isExpanded = !this.state.isExpanded">
+                        <button t-if="error_index === 3" class="o_import_report_count btn btn-link p-0" t-on-click="() => this.state.isExpanded = !this.state.isExpanded">
                             <i t-attf-class="fa fa-chevron-{{state.isExpanded ? 'up' : 'down'}}"></i> <t t-esc="props.errors.length - error_index"/> more
-                        </a>
+                        </button>
                         <li t-if="isErrorVisible(error_index)" t-attf-class="o_import_report_more p-0 text-{{error.priority}} {{error_index > 2 ? 'list-unstyled' : ''}}">
                             <t t-if="error.rows.from === error.rows.to">
                                 <b t-esc="error.value"/> at row <t t-esc="error.rows.from + 1"/>
@@ -29,9 +29,9 @@
             <t t-if="moreInfo">
                 <t t-if="typeof moreInfo === 'string'" t-esc="moreInfo"/>
                 <div t-else="" class="o_import_moreinfo" t-on-click="onMoreInfoClicked">
-                    <a href="#" class="o_import_see_all">
+                    <button class="o_import_see_all btn btn-link p-0">
                         <i class="oi oi-arrow-right"></i> See possible values
-                    </a>
+                    </button>
                 </div>
                 <ul t-if="state.moreInfoContent" class="o_import_report_more">
                     <li t-foreach="state.moreInfoContent" t-as="msg" t-key="msg_index"><t t-esc="msg"/></li>


### PR DESCRIPTION
We use `href="#"` to activate <a> elements, but the default behavior of clicking this link is prevented. However, this creates an inconsistency for middle-click and Ctrl+Click, as these events are not prevented by default.

This commit removes `href="#"` and replaces it with the appropriate element or class to activate the <a> elements correctly.

Task [link](https://www.odoo.com/odoo/project.task/4380519)
task-4380519
