### PR TITLE
[IMP] pos_*: improve cashier selection popup

### DIFF
--- a/addons/point_of_sale/static/src/app/components/popups/selection_popup/selection_popup.xml
+++ b/addons/point_of_sale/static/src/app/components/popups/selection_popup/selection_popup.xml
@@ -7,10 +7,16 @@
                     class="selection-item d-flex align-items-center justify-content-between btn btn-lg btn-outline-secondary w-100 p-3 text-start"
                     t-att-class="{ 'selected active': item.isSelected }"
                     t-on-click="() => this.selectItem(item.id)">
-                <div class="d-flex flex-column">
-                    <span t-esc="item.label" />
-                    <span t-esc="item.description" t-if="item.description" />
-                </div>
+
+               <div class="d-flex align-items-center">
+                    <div class="ratio ratio-1x1 me-3" style="width: 40px" t-if="item.image">
+                         <img class="rounded-3" t-att-src="item.image"/>
+                    </div>
+                    <div class="d-flex flex-column">
+                        <span t-esc="item.label" />
+                        <span t-esc="item.description" t-if="item.description" />
+                    </div>
+               </div>
                 <i t-attf-class="{{ item.isSelected ? 'fa fa-check text-action' : 'oi oi-chevron-right' }}"/>
             </button>
         </Dialog>

--- a/addons/pos_hr/static/src/app/components/popups/cashier_selection_popup/cashier_selection_popup.js
+++ b/addons/pos_hr/static/src/app/components/popups/cashier_selection_popup/cashier_selection_popup.js
@@ -1,0 +1,25 @@
+import { Component } from "@odoo/owl";
+import { Dialog } from "@web/core/dialog/dialog";
+import { usePos } from "@point_of_sale/app/hooks/pos_hook";
+export class CashierSelectionPopup extends Component {
+    static template = "pos_hr.CashierSelectionPopup";
+    static components = { Dialog };
+    static props = {
+        close: Function,
+        getPayload: Function,
+        currentCashier: { type: Object, optional: true },
+        employees: { type: Array },
+    };
+
+    setup() {
+        this.pos = usePos();
+    }
+
+    async lock() {
+        await this.pos.showLoginScreen();
+    }
+    selectEmployee(employee) {
+        this.props.getPayload(employee);
+        this.props.close();
+    }
+}

--- a/addons/pos_hr/static/src/app/components/popups/cashier_selection_popup/cashier_selection_popup.xml
+++ b/addons/pos_hr/static/src/app/components/popups/cashier_selection_popup/cashier_selection_popup.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates id="template" xml:space="preserve">
+
+    <t t-name="pos_hr.CashierSelectionPopup">
+        <Dialog title.translate="Select Cashier" footer="false"  size="'md'" bodyClass="'d-flex flex-column gap-2'">
+
+            <div class="d-flex justify-content-between align-items-center btn btn-outline-secondary active p-2 p-sm-3 border-transparent cursor-default text-start"
+                 t-on-click="() => this.props.close()" t-if="props.currentCashier">
+                <t t-set="cashier" t-value="props.currentCashier"/>
+                <div class="d-flex align-items-center ">
+                    <div class="ratio ratio-1x1 me-2 me-sm-3" style="width: 40px">
+                        <img class="rounded-3" t-attf-src="/web/image/hr.employee.public/{{cashier.id}}/avatar_128"/>
+                    </div>
+                    <div class="d-flex flex-column">
+                        <span class="fs-4 fw-bold current-cashier-name" t-out="cashier.name"/>
+                    </div>
+                </div>
+                <div class="d-flex align-items-center ms-1">
+                    <button class="btn-cashier-lock btn btn-lg btn-secondary" title="Lock" t-on-click.stop="() => this.lock()">
+                        <i class="fa fa-fw fa-lock"/>
+                    </button>
+                </div>
+            </div>
+
+            <button t-foreach="props.employees" t-as="employee" t-key="employee.id"
+                    class="selection-item d-flex align-items-center justify-content-between btn btn-outline-secondary p-2 p-sm-3 text-start"
+                    t-on-click="() => this.selectEmployee(employee)">
+                <div class="d-flex align-items-center">
+                    <div class="ratio ratio-1x1 me-2 me-sm-3" style="width: 40px">
+                        <img class="rounded-3" t-attf-src="/web/image/hr.employee.public/{{employee.id}}/avatar_128"/>
+                    </div>
+                    <div class="d-flex flex-column">
+                        <span class="fs-4 fw-bold" t-out="employee.name"/>
+                    </div>
+                </div>
+                <i class="oi oi-chevron-right"/>
+            </button>
+
+        </Dialog>
+    </t>
+
+</templates>

--- a/addons/pos_hr/static/src/app/utils/select_cashier_mixin.js
+++ b/addons/pos_hr/static/src/app/utils/select_cashier_mixin.js
@@ -3,11 +3,11 @@
 import { _t } from "@web/core/l10n/translation";
 
 import { NumberPopup } from "@point_of_sale/app/components/popups/number_popup/number_popup";
-import { SelectionPopup } from "@point_of_sale/app/components/popups/selection_popup/selection_popup";
 import { useBarcodeReader } from "@point_of_sale/app/hooks/barcode_reader_hook";
 import { usePos } from "@point_of_sale/app/hooks/pos_hook";
 import { useService } from "@web/core/utils/hooks";
 import { makeAwaitable, ask } from "@point_of_sale/app/utils/make_awaitable_dialog";
+import { CashierSelectionPopup } from "@pos_hr/app/components/popups/cashier_selection_popup/cashier_selection_popup";
 
 export function useCashierSelector({ exclusive, onScan } = { onScan: () => {}, exclusive: false }) {
     const pos = usePos();
@@ -65,14 +65,6 @@ export function useCashierSelector({ exclusive, onScan } = { onScan: () => {}, e
             return;
         }
 
-        const prepareList = (employees) =>
-            employees.map((employee) => ({
-                id: employee.id,
-                item: employee,
-                label: employee.name,
-                isSelected: false,
-            }));
-
         const wrongPinNotification = () => {
             notification.add(_t("PIN not found"), {
                 type: "warning",
@@ -100,9 +92,9 @@ export function useCashierSelector({ exclusive, onScan } = { onScan: () => {}, e
         }
 
         if (pinMatchEmployees.length > 1 || list) {
-            employee = await makeAwaitable(dialog, SelectionPopup, {
-                title: _t("Change Cashier"),
-                list: prepareList(allEmployees),
+            employee = await makeAwaitable(dialog, CashierSelectionPopup, {
+                currentCashier: pos.getCashier() || undefined,
+                employees: allEmployees,
             });
 
             if (!employee) {


### PR DESCRIPTION
pos_*: point_of_sale, pos_hr

This commit enhances the selection popup by displaying the current cashier’s name and adding the ability to lock the POS directly from this screen. It also adds employee pictures to all available selections.

task-4877282

Related enterprise PR: https://github.com/odoo/enterprise/pull/89835



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
