### PR TITLE
[FIX] mail: fix non deterministic presence test

### DIFF
--- a/addons/mail/tests/discuss/test_bus_presence.py
+++ b/addons/mail/tests/discuss/test_bus_presence.py
@@ -9,7 +9,7 @@ except ImportError:
 
 from odoo.tests import tagged, new_test_user
 from odoo.addons.bus.tests.common import WebsocketCase
-from odoo.addons.mail.tests.common import MailCommon
+from odoo.addons.mail.tests.common import MailCommon, freeze_all_time
 from odoo.addons.bus.models.bus import channel_with_db, json_dump
 
 
@@ -51,6 +51,7 @@ class TestBusPresence(WebsocketCase, MailCommon):
             sender_bus_target.id,
         )
 
+    @freeze_all_time()
     def test_receive_presences_as_guest(self):
         guest = self.env["mail.guest"].create({"name": "Guest"})
         bob = new_test_user(self.env, login="bob_user", groups="base.group_user")
@@ -70,6 +71,7 @@ class TestBusPresence(WebsocketCase, MailCommon):
         # Now that they share a channel, guest should receive guest's presence.
         self._receive_presence(sender=other_guest, recipient=guest)
 
+    @freeze_all_time()
     def test_receive_presences_as_portal(self):
         portal = new_test_user(self.env, login="portal_user", groups="base.group_portal")
         bob = new_test_user(self.env, login="bob_user", groups="base.group_user")
@@ -89,6 +91,7 @@ class TestBusPresence(WebsocketCase, MailCommon):
         # Now that they share a channel, portal should receive guest's presence.
         self._receive_presence(sender=guest, recipient=portal)
 
+    @freeze_all_time()
     def test_receive_presences_as_internal(self):
         internal = new_test_user(self.env, login="internal_user", groups="base.group_user")
         guest = self.env["mail.guest"].create({"name": "Guest"})


### PR DESCRIPTION
Since [1], https://github.com/odoo/odoo/pull/207974 websocket timeout has been increased during test. Fetching notification only returns the notifications of the last 50 seconds initially. When runbot is under high load, this can lead to non deterministic failures.

This commit patches the cursor date to bypass this issue.

[1]: https://github.com/odoo/odoo/pull/207974

fixes rubot-223758

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
