### PR TITLE
[FIX] web: restore correct color selection in custom color picker

### DIFF
--- a/addons/web/static/src/core/color_picker/color_picker.xml
+++ b/addons/web/static/src/core/color_picker/color_picker.xml
@@ -106,7 +106,7 @@
                     <button data-color="white" class="o_color_button btn p-0 bg-white"></button>
                 </div>
                 <CustomColorPicker
-                    defaultColor="this.state.currentCustomColor"
+                    selectedColor = "this.state.currentCustomColor"
                     onColorSelect.bind="(color) => this.applyColor(color.hex)"
                     onColorPreview.bind="onCustomColorPreview"
                     showRgbaField="props.showRgbaField"

--- a/addons/web/static/src/core/color_picker/custom_color_picker/custom_color_picker.js
+++ b/addons/web/static/src/core/color_picker/custom_color_picker/custom_color_picker.js
@@ -41,7 +41,9 @@ export class CustomColorPicker extends Component {
         this.colorComponents = {};
         this.uniqueId = uniqueId("colorpicker");
         this.selectedHexValue = "";
-
+        if (!this.props.selectedColor || this.props.selectedColor === "#00000000") {
+            this.props.selectedColor = this.props.defaultColor;
+        }
         this.debouncedOnChangeInputs = debounce(this.onChangeInputs.bind(this), 10, true);
 
         this.elRef = useRef("el");

--- a/addons/web/static/tests/core/color_picker.test.js
+++ b/addons/web/static/tests/core/color_picker.test.js
@@ -2,6 +2,7 @@ import { test, expect } from "@odoo/hoot";
 import { press, click, animationFrame } from "@odoo/hoot-dom";
 import { mountWithCleanup } from "@web/../tests/web_test_helpers";
 import { ColorPicker, DEFAULT_COLORS } from "@web/core/color_picker/color_picker";
+import { CustomColorPicker } from "@web/core/color_picker/custom_color_picker/custom_color_picker";
 
 test("basic rendering", async () => {
     await mountWithCleanup(ColorPicker, {
@@ -140,4 +141,13 @@ test("keyboard navigation", async () => {
     expect(
         ".o_font_color_selector .o_color_section .o_color_button[data-color]:last-of-type"
     ).toBeFocused();
+});
+
+test("custom color picker sets default color as selected", async () => {
+    await mountWithCleanup(CustomColorPicker, {
+        props: {
+            defaultColor: "#FF0000",
+        },
+    });
+    expect("input.o_hex_input").toHaveValue("#FF0000");
 });


### PR DESCRIPTION
This commit adds back functionality that was present in <=18.3 versions.
Steps to reproduce the issue:
- Open Website and start editing;
- Drop a 'text - image' snippet and click on it
- Open the background colorpicker
- Click on a green hue

=> We don't get green, we get a fully transparent black, and to get
green we have to change the saturation and value, which shouldn't be the
case. Also, when no color is selected, the red color should be highlighted.
