### PR TITLE
[FIX] hr_{recruitment_,}skills: fix employee creation from skilled ap…

### DIFF
--- a/addons/hr_recruitment_skills/tests/test_recruitment_skills.py
+++ b/addons/hr_recruitment_skills/tests/test_recruitment_skills.py
@@ -509,3 +509,32 @@ class TestRecruitmentSkills(TransactionCase):
         self.assertIn(applicant.id, applicants.ids, "The applicant should be in the matching applicants")
         applicant.with_context(context).action_add_to_job()
         self.assertEqual(applicant.job_id, second_job, "The applicant should be moved to the second job")
+
+    def test_create_employee_from_skilled_applicant(self):
+        applicant = self.t_applicant
+        applicant.write({
+            "applicant_skill_ids": [
+                (
+                    0,
+                    0,
+                    {
+                        "skill_id": self.t_skill_1.id,
+                        "skill_level_id": self.t_skill_level_1.id,
+                        "skill_type_id": self.t_skill_type.id,
+                    },
+                ),
+                (
+                    0,
+                    0,
+                    {
+                        "skill_id": self.t_skill_2.id,
+                        "skill_level_id": self.t_skill_level_3.id,
+                        "skill_type_id": self.t_skill_type.id,
+                    },
+                )
+            ]
+        })
+        applicant.create_employee_from_applicant()
+        applicant_skills_name_list = applicant.applicant_skill_ids.mapped(lambda s: (s.skill_id, s.skill_type_id, s.skill_level_id))
+        employee_skills_name_list = applicant.employee_id.employee_skill_ids.mapped(lambda s: (s.skill_id, s.skill_type_id, s.skill_level_id))
+        self.assertCountEqual(applicant_skills_name_list, employee_skills_name_list)

--- a/addons/hr_skills/models/hr_individual_skill_mixin.py
+++ b/addons/hr_skills/models/hr_individual_skill_mixin.py
@@ -344,7 +344,7 @@ class HrIndividualSkillMixin(models.AbstractModel):
             .ids
         )
         for vals in vals_list:
-            individual_skill_id = vals[self._linked_field_name()]
+            individual_skill_id = vals.get(self._linked_field_name(), False)
             skill_id = vals["skill_id"]
             skill_type_id = vals["skill_type_id"]
             skill_level_id = vals["skill_level_id"]


### PR DESCRIPTION
…plicant

Step to reproduce:
------------------

1- Go on Recruitment > All Applications
2- Create an applicant with some skills
3- Click on contract signed in the statusbar
4- Click on create Employee button

You will have a traceback

Reason:
-------

The applicant's employee is not created yet and some employee_skills are already given.

Solution:
---------

Transform vals['employee_id'] into vals.get('employee_id', False)

task-4931239

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
