### PR TITLE
[FIX] hw_drivers: send_all_devices condition fix

### DIFF
--- a/addons/hw_drivers/tools/helpers.py
+++ b/addons/hw_drivers/tools/helpers.py
@@ -268,13 +268,18 @@ def get_img_name():
     major, minor = get_version()[1:].split('.')
     return 'iotboxv%s_%s.zip' % (major, minor)
 
+
 def get_ip():
-    interfaces = netifaces.interfaces()
-    for interface in interfaces:
-        if netifaces.ifaddresses(interface).get(netifaces.AF_INET):
-            addr = netifaces.ifaddresses(interface).get(netifaces.AF_INET)[0]['addr']
-            if addr != '127.0.0.1':
-                return addr
+    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    try:
+        s.connect(('8.8.8.8', 1))  # Google DNS
+        return s.getsockname()[0]
+    except OSError as e:
+        _logger.warning("Could not get local IP address: %s", e)
+        return None
+    finally:
+        s.close()
+
 
 def get_mac_address():
     interfaces = netifaces.interfaces()


### PR DESCRIPTION
Currently we notify the database of any iot changes only if the iot box discovered new devices.
However if its ip address/hostname/mac address/domain/version change the db is never notified.

This PR adds this change + fixes the get_ip() method which was using netifaces which is unreliable on Windows to now use socket to get the iot box ip address

