### PR TITLE
[IMP] point_of_sale:  prevent date text shifting in login screen

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/login_screen/login_screen.scss
+++ b/addons/point_of_sale/static/src/app/screens/login_screen/login_screen.scss
@@ -5,6 +5,9 @@
         color: var(--homeMenu-bg-color, #{$o-gray-200});
         image: var(--homeMenu-bg-image, url("/hr_attendance/static/img/background-light.svg"));
     }
+    .timer-hours{
+        font-variant-numeric: tabular-nums;
+    }
 }
 
 .screen-login-header {


### PR DESCRIPTION
This commit uses a fixed-width font on the login and screensaver screens to prevent the date and time text from shifting as the seconds update.
