### PR TITLE
[FIX] html_editor: fix link test failing non-deterministically

### DIFF
--- a/addons/html_editor/static/tests/link/popover.test.js
+++ b/addons/html_editor/static/tests/link/popover.test.js
@@ -1054,12 +1054,14 @@ describe("upload file via link popover", () => {
 
     describe("hidden label field", () => {
         test("label field should be hidden if <a> content is not text only", async () => {
-            await setupEditor(`<a href="http://test.com/"><img src="${base64Img}">te[]xt</a>`);
+            await setupEditor(
+                `<p><a href="http://test.com/"><img src="${base64Img}">te[]xt</a></p>`
+            );
             await waitFor(".o-we-linkpopover");
             expect(".o-we-linkpopover").toHaveCount(1);
             // open edit mode and check if label input is hidden
             await click(".o_we_edit_link");
-            await waitFor(".input-group", { timeout: 1500 });
+            await waitFor(".o_we_href_input_link", { timeout: 1500 });
             expect(".o_we_label_link").not.toBeVisible();
             expect(".o_we_href_input_link").toHaveValue("http://test.com/");
         });


### PR DESCRIPTION
The fix at [1] did not fix the issue. This is another attempt.

runbot-227759

[1]: https://github.com/odoo/odoo/pull/215168/commits/9a3c9ecca14fb8701e4f934cf5285297cbe26310
