### PR TITLE
[IMP] account: disable send button if partner has no email instead showing alert

### DIFF
--- a/addons/account/wizard/account_move_send_wizard.xml
+++ b/addons/account/wizard/account_move_send_wizard.xml
@@ -63,7 +63,14 @@
                             name="action_send_and_print"
                             type="object"
                             class="btn-primary"
-                            invisible="not sending_methods"/>
+                            invisible="not sending_methods or not is_partners_email_available"/>
+                    <button string="Send"
+                            disabled="1"
+                            data-hotkey="q"
+                            name="action_send_and_print"
+                            type="object"
+                            class="btn-primary"
+                            invisible="not sending_methods or is_partners_email_available"/>
                     <button string="Generate"
                             data-hotkey="q"
                             name="action_send_and_print"


### PR DESCRIPTION
- Before this commit: Clicking on `Send and Print` with a partners who has no email would raise a blocking alert. However, this behavior was inconsistent with the Sales module and caused UI issues.

- After this commit: Now, the `Send` button is disabled if the partner has no email. This prevents users from attempting the action in the first place, removes the alert warning, and makes the behavior consistent with the Sales module.

Task-4882552