### PR TITLE
[FIX] pos_self_order: create a picking for free orders too

### DIFF
--- a/addons/pos_self_order/controllers/orders.py
+++ b/addons/pos_self_order/controllers/orders.py
@@ -55,6 +55,9 @@ class PosSelfOrderController(http.Controller):
             'amount_total': amount_total,
         })
 
+        if amount_total == 0:
+            order_ids._process_saved_order(False)
+
         order_ids.send_table_count_notification(order_ids.mapped('table_id'))
         return self._generate_return_values(order_ids, pos_config)
 

--- a/addons/pos_self_order/tests/test_self_order_mobile.py
+++ b/addons/pos_self_order/tests/test_self_order_mobile.py
@@ -110,3 +110,6 @@ class TestSelfOrderMobile(SelfOrderCommonTest):
 
         # Zero priced order
         self.start_tour(self_route, "self_order_mobile_0_price_order")
+
+        order = self.env['pos.order'].search([], limit=1)
+        self.assertEqual(order.picking_count, 1)


### PR DESCRIPTION
Steps to reproduce:
-------------------
1. Create a free product
2. Add it to self_order
3. Make a self order with only that product -> Free order

Sicne it's a free order, you will not be asked to pay, which is normal.
However, the issue is, no picking is created for that order!!

Why the issue?
--------------
For a non free self order, we create a picking for it by calling
`_process_saved_order` [1] with `draft` argument set to `True`, either
after paying using the online payment method [2], or after paying it
from the payment wizard [3]. However, since for free orders, we're not
asked at any point to pay, and hence, we're not calling
`_process_saved_order` with `draft=True` at any point, and as
consequence, we're also not calling `_create_order_picking`, no picking
will be created for it.

The fix
-------
After, marking the free order as 'paid', we manually call
`_process_saved_order(True)`. We only do it for the free orders, since
the flow is working as expected for non-free order.

[1]: https://github.com/odoo/odoo/blob/a7a29ed691db4f1607c0d12929c56845681164fa/addons/point_of_sale/models/pos_order.py#L153C19-L153C31
[2]: https://github.com/odoo/odoo/blob/a7a29ed691db4f1607c0d12929c56845681164fa/addons/pos_online_payment/models/payment_transaction.py#L64
[3]: https://github.com/odoo/odoo/blob/a7a29ed691db4f1607c0d12929c56845681164fa/addons/point_of_sale/wizard/pos_payment.py#L70

opw-4739523