### PR TITLE
[IMP] discuss: make the call fullscreen feature use global component

### DIFF
--- a/addons/mail/static/src/core/common/mail_fullscreen.js
+++ b/addons/mail/static/src/core/common/mail_fullscreen.js
@@ -1,0 +1,83 @@
+import { Component, reactive } from "@odoo/owl";
+import { useService } from "@web/core/utils/hooks";
+import { registry } from "@web/core/registry";
+
+const DEFAULT_ID = Symbol("default");
+
+export class MailFullscreen extends Component {
+    static props = [];
+    static template = "mail.Fullscreen";
+
+    setup() {
+        super.setup();
+        this.fullscreen = useService("mail.fullscreen");
+    }
+}
+
+export const fullscreenService = {
+    start() {
+        registry.category("main_components").add("mail.fullscreen", { Component: MailFullscreen });
+        const state = reactive({
+            component: undefined,
+            props: undefined,
+            id: undefined,
+            exit,
+            enter,
+        });
+        async function exit(id = state.id) {
+            if (id !== state.id) {
+                return;
+            }
+            state.component = undefined;
+            state.props = undefined;
+            state.id = undefined;
+            const fullscreenElement =
+                document.webkitFullscreenElement || document.fullscreenElement;
+            if (fullscreenElement) {
+                if (document.exitFullscreen) {
+                    await document.exitFullscreen();
+                } else if (document.mozCancelFullScreen) {
+                    await document.mozCancelFullScreen();
+                } else if (document.webkitCancelFullScreen) {
+                    await document.webkitCancelFullScreen();
+                }
+            }
+        }
+        /**
+         * @param component
+         * @param {object} [options]
+         * @param [options.props]
+         * @param {any} [options.id]
+         * @returns {Promise<void>}
+         */
+        async function enter(component, { props, id = DEFAULT_ID } = {}) {
+            this.exit();
+            state.component = component;
+            state.props = props;
+            state.id = id;
+            const el = document.body;
+            try {
+                if (el.requestFullscreen) {
+                    await el.requestFullscreen();
+                } else if (el.mozRequestFullScreen) {
+                    await el.mozRequestFullScreen();
+                } else if (el.webkitRequestFullscreen) {
+                    await el.webkitRequestFullscreen();
+                }
+            } catch {
+                // doing nothing, we're just in non-native fullscreen.
+            }
+        }
+        window.addEventListener("fullscreenchange", () => {
+            const isFullscreen = Boolean(
+                document.webkitFullscreenElement || document.fullscreenElement
+            );
+            if (!isFullscreen) {
+                exit();
+            }
+        });
+        return state;
+    },
+};
+
+registry.category("services").add("mail.fullscreen", fullscreenService);

--- a/addons/mail/static/src/core/common/mail_fullscreen.xml
+++ b/addons/mail/static/src/core/common/mail_fullscreen.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+    <t t-name="mail.Fullscreen">
+        <div t-if="fullscreen.component" class="fixed-top vw-100 vh-100">
+            <t t-component="fullscreen.component" t-props="fullscreen.props"/>
+        </div>
+    </t>
+</templates>

--- a/addons/mail/static/src/discuss/call/common/call.scss
+++ b/addons/mail/static/src/discuss/call/common/call.scss
@@ -21,7 +21,7 @@
         }
     }
 
-    &.o-pip {
+    &.o-fullSize {
         height: 100%;
         min-height: 100%;
         &.o-minimized {

--- a/addons/mail/static/src/discuss/call/common/call.xml
+++ b/addons/mail/static/src/discuss/call/common/call.xml
@@ -4,11 +4,10 @@
     <t t-name="discuss.Call">
         <PttAdBanner/>
         <div class="o-discuss-Call user-select-none d-flex position-relative shadow-sm" t-att-class="{
-            'o-fullscreen fixed-top vw-100 vh-100': state.isFullscreen,
+            'o-fullSize': isFullSize,
             'o-compact': props.compact and !isMobileOs,
             'o-minimized': minimized,
-            'o-pip': props.isPip,
-            'position-relative rounded-2 o-mx-0_5 o-mt-0_5 p-1': !state.isFullscreen and !props.isPip,
+            'position-relative rounded-2 o-mx-0_5 o-mt-0_5 p-1': !rtc.state.isFullscreen and !props.isPip,
         }">
             <div class="o-discuss-Call-main d-flex flex-grow-1 flex-column align-items-center justify-content-center position-relative overflow-auto o-scrollbar-thin" t-on-mouseleave="onMouseleaveMain">
                 <div
@@ -24,7 +23,7 @@
                         className="'o-discuss-Call-mainCardStyle'"
                         minimized="minimized"
                         compact="props.compact"
-                        thread="props.thread"
+                        thread="channel"
                     />
                     <span t-if="env.inChatWindow and visibleMainCards.length > 6" class="oi oi-ellipsis-h ps-1 pe-1"/>
                     <CallParticipantCard t-if="!env.inChatWindow" t-foreach="visibleMainCards.slice(6)" t-as="cardData" t-key="cardData.key"
@@ -32,7 +31,7 @@
                         className="'o-discuss-Call-mainCardStyle p-1'"
                         minimized="minimized"
                         compact="props.compact"
-                        thread="props.thread"
+                        thread="channel"
                     />
                 </div>
 
@@ -43,26 +42,26 @@
                 </t>
                 <div t-if="state.overlay or !isControllerFloating" class="o-discuss-Call-overlay d-flex justify-content-center w-100 pb-1" t-att-class="{ 'o-isFloating position-absolute z-2 bottom-0 pb-2': isControllerFloating }">
                     <div t-on-mousemove="onMousemoveOverlay">
-                        <CallActionList thread="props.thread" compact="props.compact or props.isPip" fullscreen="{ isActive: state.isFullscreen, enter: () => this.enterFullScreen(), exit: () => this.exitFullScreen() }"/>
+                        <CallActionList thread="channel" compact="props.compact or props.isPip"/>
                     </div>
                 </div>
-                <div t-if="hasCallNotifications" class="position-absolute d-flex flex-column-reverse start-0 bottom-0" t-att-class="{ 'ps-5 pb-5': state.isFullscreen, 'ps-2 pb-2': !state.isFullscreen }">
-                    <span class="text-bg-800 shadow-lg rounded-1 m-1" t-att-class="{ 'p-4 fs-4': state.isFullscreen, 'p-2': !state.isFullscreen }" t-foreach="rtc.notifications.values()" t-as="notification" t-key="notification.id" t-esc="notification.text"/>
+                <div t-if="hasCallNotifications" class="position-absolute d-flex flex-column-reverse start-0 bottom-0" t-att-class="{ 'ps-5 pb-5': rtc.state.isFullscreen, 'ps-2 pb-2': !rtc.state.isFullscreen }">
+                    <span class="text-bg-800 shadow-lg rounded-1 m-1" t-att-class="{ 'p-4 fs-4': rtc.state.isFullscreen, 'p-2': !rtc.state.isFullscreen }" t-foreach="rtc.notifications.values()" t-as="notification" t-key="notification.id" t-esc="notification.text"/>
                 </div>
             </div>
-            <div t-if="state.sidebar and props.thread.activeRtcSession" class="o-discuss-Call-sidebar d-flex align-items-center h-100 flex-column">
+            <div t-if="state.sidebar and channel.activeRtcSession" class="o-discuss-Call-sidebar d-flex align-items-center h-100 flex-column">
                 <CallParticipantCard t-foreach="visibleCards" t-as="cardData" t-key="cardData.key"
                     cardData="cardData"
                     className="'o-discuss-Call-sidebarCard w-100 p-1'"
-                    thread="props.thread"
+                    thread="channel"
                     isSidebarItem="true"
                 />
             </div>
             <CallParticipantCard
-                t-if="props.thread.videoCount > 0 and state.insetCard"
+                t-if="channel.videoCount > 0 and state.insetCard"
                 cardData="state.insetCard"
                 className="'o-discuss-Call-mainCardStyle o-bg-black'"
-                thread="props.thread"
+                thread="channel"
                 inset.bind="setInset"
             />
         </div>

--- a/addons/mail/static/src/discuss/call/common/call_action_list.js
+++ b/addons/mail/static/src/discuss/call/common/call_action_list.js
@@ -12,7 +12,7 @@ import { CALL_PROMOTE_FULLSCREEN } from "@mail/discuss/call/common/thread_model_
 
 export class CallActionList extends Component {
     static components = { CallPopover, CallActionButton };
-    static props = ["thread", "fullscreen?", "compact?"];
+    static props = ["thread", "compact?"];
     static template = "discuss.CallActionList";
 
     setup() {
@@ -44,7 +44,7 @@ export class CallActionList extends Component {
     }
 
     get isSmall() {
-        return Boolean(this.props.compact && !this.props.fullscreen?.isActive);
+        return Boolean(this.props.compact && this.rtc.state.isFullscreen);
     }
 
     get isMobileOS() {
@@ -65,7 +65,7 @@ export class CallActionList extends Component {
      * @param {MouseEvent} ev
      */
     async onClickToggleAudioCall(ev, { camera = false } = {}) {
-        await this.rtc.toggleCall(this.props.thread, { camera, fullscreen: this.props.fullscreen });
+        await this.rtc.toggleCall(this.props.thread, { camera });
     }
 
     onMouseenterMore() {

--- a/addons/mail/static/src/discuss/call/common/call_actions.js
+++ b/addons/mail/static/src/discuss/call/common/call_actions.js
@@ -92,17 +92,18 @@ callActionsRegistry
         sequence: 60,
     })
     .add("fullscreen", {
-        condition: (component) => component.props?.fullscreen && !component.rtc?.state.isPipMode,
+        condition: (component) => Boolean(component.rtc),
         name: (component) =>
-            component.props.fullscreen.isActive ? _t("Exit Fullscreen") : _t("Enter Full Screen"),
-        isActive: (component) => component.props.fullscreen.isActive,
+            component.rtc.state.isFullscreen ? _t("Exit Fullscreen") : _t("Enter Full Screen"),
+        isActive: (component) => component.rtc.state.isFullscreen,
         inactiveIcon: "fa-arrows-alt",
         icon: "fa-compress",
         select: (component) => {
-            if (component.props.fullscreen.isActive) {
-                component.props.fullscreen.exit();
+            if (component.rtc.state.isFullscreen) {
+                component.rtc.exitFullscreen();
             } else {
-                component.props.fullscreen.enter();
+                component.rtc.closePip();
+                component.rtc.enterFullscreen();
             }
         },
         sequence: 70,

--- a/addons/mail/static/src/discuss/call/common/call_components.js
+++ b/addons/mail/static/src/discuss/call/common/call_components.js
@@ -1,0 +1,9 @@
+import { registry } from "@web/core/registry";
+import { Call } from "@mail/discuss/call/common/call";
+
+/**
+ * Registry used to access components while avoiding cycling dependencies.
+ */
+const callComponentsRegistry = registry.category("discuss.call/components");
+
+callComponentsRegistry.add("Call", Call);

--- a/addons/mail/static/src/discuss/call/common/chat_window_patch.xml
+++ b/addons/mail/static/src/discuss/call/common/chat_window_patch.xml
@@ -3,7 +3,7 @@
     <t t-inherit="mail.ChatWindow" t-inherit-mode="extension">
         <xpath expr="//Thread" position="before">
             <PipBanner t-if="rtc.state.isPipMode and thread.eq(rtc.channel)"/>
-            <Call t-elif="thread.rtc_session_ids.length gt 0" thread="thread" compact="true"/>
+            <Call t-elif="thread.showCallView" thread="thread" compact="true"/>
         </xpath>
     </t>
 </templates>

--- a/addons/mail/static/src/discuss/call/common/thread_model_patch.js
+++ b/addons/mail/static/src/discuss/call/common/thread_model_patch.js
@@ -95,5 +95,8 @@ const ThreadPatch = {
             },
         });
     },
+    get showCallView() {
+        return !this.store.rtc.state.isFullscreen && this.rtc_session_ids.length > 0;
+    },
 };
 patch(Thread.prototype, ThreadPatch);

--- a/addons/mail/static/src/discuss/core/public_web/discuss_patch.xml
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_patch.xml
@@ -3,7 +3,7 @@
     <t t-inherit="mail.Discuss" t-inherit-mode="extension">
         <xpath expr="//Thread" position="before">
             <PipBanner t-if="rtc.state.isPipMode and thread.eq(rtc.channel)"/>
-            <Call t-elif="thread.rtc_session_ids.length gt 0" thread="thread"/>
+            <Call t-elif="thread.showCallView" thread="thread"/>
         </xpath>
     </t>
 </templates>

--- a/addons/mail/static/tests/discuss/call/call.test.js
+++ b/addons/mail/static/tests/discuss/call/call.test.js
@@ -59,9 +59,18 @@ test("basic rendering", async () => {
     await click("[title='More']");
     await contains("[title='Raise Hand']");
     await contains("[title='Enter Full Screen']");
-    // screen sharing not available in mobile OS
+});
+
+test("mobile UI", async () => {
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({ name: "General" });
     mockUserAgent("Chrome/0.0.0 Android (OdooMobile; Linux; Android 13; Odoo TestSuite)");
+    await start();
+    await openDiscuss(channelId);
+    await click("[title='Start Call']");
+    await contains(".o-discuss-Call");
     expect(isMobileOS()).toBe(true);
+    await contains(".o-discuss-CallActionList button[aria-label='Deafen']");
     await contains("[title='Share Screen']", { count: 0 });
 });
 


### PR DESCRIPTION
Before this commit, the call fullscreen feature was not using a
global component because this feature did not exist when it was
implemented.

So the previous implementation used the current call view as the
fullscreen target and used props to pass control and state of the
fullscreen where it was needed (the call action list).

This was making the code complicated (due to the state and callbacks
passed as props) and limited the fullscreen capabilities as it was
tied to a pre-existing component.

This commit improves the feature by using a global component and a
service.