### PR TITLE
[FIX] html_editor: add index on original_id

### DIFF
--- a/addons/html_editor/models/ir_attachment.py
+++ b/addons/html_editor/models/ir_attachment.py
@@ -25,7 +25,7 @@ class IrAttachment(models.Model):
     image_src = fields.Char(compute='_compute_image_src')
     image_width = fields.Integer(compute='_compute_image_size')
     image_height = fields.Integer(compute='_compute_image_size')
-    original_id = fields.Many2one('ir.attachment', string="Original (unoptimized, unresized) attachment")
+    original_id = fields.Many2one('ir.attachment', string="Original (unoptimized, unresized) attachment", index='btree_not_null')
 
     def _compute_local_url(self):
         for attachment in self:


### PR DESCRIPTION
On a DB with 15M+ attachments, deleting a single attachment takes several seconds. Most of the time is spent on the circular `original_id` foreign key.

We add back the index which was removed in [1]

```
 Delete on ir_attachment  (cost=0.43..8.45 rows=0 width=0) (actual time=0.274..0.274 rows=0 loops=1)
   ->  Index Scan using ir_attachment_pkey on ir_attachment  (cost=0.43..8.45 rows=1 width=6) (actual time=0.252..0.253 rows=1 loops=1)
         Index Cond: (id = 82807)
 Planning Time: 0.049 ms
 Trigger for constraint ir_attachment_original_id_fkey: time=2330.796 calls=1
```

[1] https://github.com/odoo/odoo/commit/eedf37d6e286b995c47b946be1a6b66817094eff

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
