### PR TITLE
[REF] web,*: ControlPanel's buttons should be direct children

### DIFF
--- a/addons/account/static/src/views/file_upload_kanban/file_upload_kanban_controller.xml
+++ b/addons/account/static/src/views/file_upload_kanban/file_upload_kanban_controller.xml
@@ -1,7 +1,7 @@
 <templates>
 
     <t t-name="account.FileuploadKanbanView.Buttons" t-inherit="web.KanbanView.Buttons" t-inherit-mode="primary">
-        <xpath expr="//div[hasclass('o_cp_buttons')]" position="inside">
+        <xpath expr="." position="inside">
             <t t-call="account.DocumentViewUploadButton"/>
         </xpath>
     </t>

--- a/addons/account/static/src/views/file_upload_list/file_upload_list_controller.xml
+++ b/addons/account/static/src/views/file_upload_list/file_upload_list_controller.xml
@@ -1,7 +1,7 @@
 <templates>
 
     <t t-name="account.FileuploadListView.Buttons" t-inherit="web.ListView.Buttons" t-inherit-mode="primary">
-        <xpath expr="//div[hasclass('o_list_buttons')]" position="inside">
+        <xpath expr="." position="inside">
             <t t-call="account.DocumentViewUploadButton"/>
         </xpath>
     </t>

--- a/addons/data_recycle/static/src/views/data_recycle_list_view.xml
+++ b/addons/data_recycle/static/src/views/data_recycle_list_view.xml
@@ -1,15 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates>
     <t t-name="DataRecycle.buttons" t-inherit="web.ListView.Buttons" t-inherit-mode="primary">
-        <xpath expr="//div[hasclass('o_list_buttons')]" position="inside">
-            <t t-if="hasSelectedRecords">
-                <button type="button" class="btn btn-primary o_data_recycle_validate_button" t-on-click="onValidateClick">
-                    Validate
-                </button>
-                <button type="button" class="btn btn-secondary o_data_recycle_unselect_button" t-on-click="onUnselectClick">
-                    Unselect
-                </button>
-            </t>
+        <xpath expr="." position="inside">
+            <button t-if="hasSelectedRecords" type="button" class="btn btn-primary o_data_recycle_validate_button" t-on-click="onValidateClick">
+                Validate
+            </button>
+            <button t-if="hasSelectedRecords" type="button" class="btn btn-secondary o_data_recycle_unselect_button" t-on-click="onUnselectClick">
+                Unselect
+            </button>
         </xpath>
     </t>
 </templates>

--- a/addons/hr_expense/static/src/views/kanban.js
+++ b/addons/hr_expense/static/src/views/kanban.js
@@ -25,14 +25,12 @@ export class ExpenseDashboardKanbanRenderer extends ExpenseKanbanRenderer {
 
 registry.category('views').add('hr_expense_kanban', {
     ...kanbanView,
-    buttonTemplate: 'hr_expense.KanbanButtons',
     Controller: ExpenseKanbanController,
     Renderer: ExpenseKanbanRenderer,
 });
 
 registry.category('views').add('hr_expense_dashboard_kanban', {
     ...kanbanView,
-    buttonTemplate: 'hr_expense.KanbanButtons',
     Controller: ExpenseKanbanController,
     Renderer: ExpenseDashboardKanbanRenderer,
 });

--- a/addons/hr_expense/static/src/views/kanban.xml
+++ b/addons/hr_expense/static/src/views/kanban.xml
@@ -17,14 +17,6 @@
         </xpath>
     </t>
 
-    <t t-name="hr_expense.KanbanButtons" t-inherit="web.KanbanView.Buttons" t-inherit-mode="primary">
-        <xpath expr="//div[hasclass('o_cp_buttons')]" position="attributes">
-            <!-- Ensure that dropdown items show vertically and not side-by-side -->
-            <attribute name="class" remove="d-flex" separator=" "/>
-            <attribute name="class" add="d-block d-xl-flex" separator=" "/>
-        </xpath>
-    </t>
-
     <t t-name="hr_expense.KanbanView" t-inherit="web.KanbanView" t-inherit-mode="primary">
         <xpath expr="//button[hasclass('o-kanban-button-new')]" position="before">
             <input type="file" name="ufile" class="d-none" t-ref="fileInput" multiple="1" accept="*" t-on-change="onChangeFileInput" />

--- a/addons/hr_expense/static/src/views/list.xml
+++ b/addons/hr_expense/static/src/views/list.xml
@@ -1,14 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="hr_expense.ListButtons" t-inherit="web.ListView.Buttons" t-inherit-mode="primary">
-
-       <!-- hr.expense -->
-        <xpath expr="//div[hasclass('o_list_buttons')]" position="attributes">
-            <!-- Ensure that dropdown items show vertically and not side-by-side -->
-            <attribute name="class" remove="d-flex" separator=" "/>
-            <attribute name="class" add="d-block d-xl-flex" separator=" "/>
-        </xpath>
-        <xpath expr="//div[hasclass('o_list_buttons')]" position="inside">
+        <xpath expr="." position="inside">
             <button t-if="displaySubmit()" class="d-none d-md-block btn btn-secondary" t-on-click="() => this.onClick('action_submit')">
                 Submit
             </button>

--- a/addons/hr_fleet/static/src/views/hr_fleet_kanban/hr_fleet_kanban_controller.xml
+++ b/addons/hr_fleet/static/src/views/hr_fleet_kanban/hr_fleet_kanban_controller.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates>
     <t t-name="hr_fleet.HrFleetKanbanController.Buttons" t-inherit="web.KanbanView.Buttons" t-inherit-mode="primary">
-        <xpath expr="//div[hasclass('o_cp_buttons')]" position="inside">
+        <xpath expr="." position="inside">
             <input type="file" multiple="true" t-ref="uploadFileInput" class="o_input_file o_hidden" t-on-change.stop="onInputChange"/>
             <button type="button" t-att-class="'btn ' + (!env.isSmall ? 'btn-primary' : 'btn-secondary')" t-on-click="() => this.uploadFileInput.el.click()">
                 Upload

--- a/addons/hr_holidays/static/src/views/view_dialog/form_view_dialog.xml
+++ b/addons/hr_holidays/static/src/views/view_dialog/form_view_dialog.xml
@@ -40,15 +40,13 @@
                 t-on-click="() =>this.onClick('action_refuse')"
                 data-hotkey="x">Refuse</button>
         </xpath>
-        <xpath expr="//div" position="inside">
-            <div class="ms-auto d-flex gap-1">
-                <button class="btn btn-danger" t-if="canDelete" t-on-click="deleteRecord" data-hotkey="v">
-                    Delete Time Off
-                </button>
-                <button class="btn btn-danger" t-if="canCancel" t-on-click="cancelRecord" data-hotkey="x">
-                    Cancel Time Off
-                </button>
-            </div>
+        <xpath expr="." position="inside">
+            <button class="btn btn-danger ms-auto" t-if="canDelete" t-on-click="deleteRecord" data-hotkey="v">
+                Delete Time Off
+            </button>
+            <button class="btn btn-danger" t-att-class="{'ms-auto': !canDelete}" t-if="canCancel" t-on-click="cancelRecord" data-hotkey="x">
+                Cancel Time Off
+            </button>
         </xpath>
     </t>
 </templates>

--- a/addons/loyalty/static/src/xml/loyalty_templates.xml
+++ b/addons/loyalty/static/src/xml/loyalty_templates.xml
@@ -57,7 +57,7 @@
     </t>
 
     <t t-name="loyalty.LoyaltyCardListView.buttons" t-inherit-mode="primary" t-inherit="web.ListView.Buttons">
-        <xpath expr="//div[hasclass('o_list_buttons')]" position="inside">
+        <xpath expr="." position="inside">
             <t t-set="supportedProgramTypes" t-value="['coupons', 'gift_card', 'ewallet']"/>
             <button t-if="supportedProgramTypes.includes(props.context.program_type)" type="button" class="btn btn-primary o_loyalty_card_list_button_generate" t-attf-data-tooltip="Generate {{props.context.program_item_name}}"
                 t-on-click.stop.prevent="() => this.actionService.doAction('loyalty.loyalty_generate_wizard_action', { additionalContext: this.props.context, onClose: () => {this.model.load()} })">

--- a/addons/mrp/static/src/components/bom_overview_control_panel/mrp_bom_overview_control_panel.xml
+++ b/addons/mrp/static/src/components/bom_overview_control_panel/mrp_bom_overview_control_panel.xml
@@ -3,20 +3,16 @@
 
     <t t-name="mrp.BomOverviewControlPanel">
         <ControlPanel display="controlPanelDisplay">
-            <t t-if="props.showOptions.mode == 'forecast'" t-set-slot="control-panel-create-button">
-                <button t-on-click="manufactureFromBoM" type="button" class="btn btn-primary">Manufacture</button>
+            <t t-set-slot="control-panel-create-button">
+                <button t-if="props.showOptions.mode == 'forecast'" t-on-click="manufactureFromBoM" type="button" class="btn btn-primary">Manufacture</button>
             </t>
             <t t-set-slot="control-panel-always-buttons">
-                <div class="o_cp_buttons">
-                    <div class="o_list_buttons o_mrp_bom_report_buttons d-xl-flex gap-xl-1">
-                        <button t-on-click="() => this.props.print()" type="button" class="btn btn-secondary">Print</button>
-                        <!-- <t t-if="props.showVariants"> commented, waiting for ui update
-                            <button t-on-click="() => this.props.print(true)" type="button" class="btn btn-secondary text-nowrap">Print All Variants</button>
-                        </t>
-                        </t> -->
-                        <button t-if="props.foldable" t-on-click="clickTogglefold" type="button" class="btn btn-secondary" t-esc="foldButtonText"/>
-                    </div>
-                </div>
+                <button t-on-click="() => this.props.print()" type="button" class="btn btn-secondary">Print</button>
+                <!-- <t t-if="props.showVariants"> commented, waiting for ui update
+                    <button t-on-click="() => this.props.print(true)" type="button" class="btn btn-secondary text-nowrap">Print All Variants</button>
+                </t>
+                </t> -->
+                <button t-if="props.foldable" t-on-click="clickTogglefold" type="button" class="btn btn-secondary" t-esc="foldButtonText"/>
             </t>
             <t t-set-slot="layout-actions">
                 <div t-if="props.showVariants" class="input-group align-items-center">

--- a/addons/mrp/static/tests/mrp_document_kanban.test.js
+++ b/addons/mrp/static/tests/mrp_document_kanban.test.js
@@ -38,7 +38,7 @@ test("MRP documents kanban basic rendering", async () => {
     await contains("button[name='product_upload_document']");
     await contains(".o_kanban_renderer .o_kanban_record:not(.o_kanban_ghost)", { count: 3 });
     // check control panel buttons
-    await contains(".o_cp_buttons .btn-primary", { text: "Upload" });
+    await contains(".o_control_panel_main_buttons .btn-primary", { text: "Upload" });
 });
 
 test("mrp: upload multiple files", async () => {

--- a/addons/product/static/src/js/product_document_kanban/product_document_kanban_controller.xml
+++ b/addons/product/static/src/js/product_document_kanban/product_document_kanban_controller.xml
@@ -5,7 +5,7 @@
         t-inherit="web.KanbanView.Buttons"
         t-inherit-mode="primary"
     >
-        <xpath expr="//div[hasclass('o_cp_buttons')]" position="inside">
+        <xpath expr="." position="inside">
             <UploadButton
                 formData="formData"
                 allowedMIMETypes="allowedMIMETypes"

--- a/addons/project/static/src/views/project_form/project_project_form_controller.xml
+++ b/addons/project/static/src/views/project_form/project_project_form_controller.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
     <t t-name="project.ProjectFormView" t-inherit="resource.FormViewWithHtmlExpander" t-inherit-mode="primary">
         <button class="btn btn-outline-primary o_form_button_create" position="replace">
-            <ProjectTemplateDropdown
+            <ProjectTemplateDropdown t-if="canCreate"
                 onCreate="() => this.create()"
                 newButtonClasses="'btn btn-outline-primary o_form_button_create'"
                 context="props.context"

--- a/addons/project/static/src/views/project_project_kanban/project_project_kanban_controller.xml
+++ b/addons/project/static/src/views/project_project_kanban/project_project_kanban_controller.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
     <t t-name="project.ProjectKanbanView" t-inherit="web.KanbanView" t-inherit-mode="primary">
         <button class="btn btn-primary o-kanban-button-new" position="replace">
-            <ProjectTemplateDropdown
+            <ProjectTemplateDropdown t-if="canCreate and props.showButtons"
                 onCreate="() => this.createRecord()"
                 newButtonClasses="'btn btn-primary o-kanban-button-new'"
                 context="props.context"

--- a/addons/project/static/src/views/project_project_list/project_project_list_controller.xml
+++ b/addons/project/static/src/views/project_project_list/project_project_list_controller.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
     <t t-name="project.ProjectListView" t-inherit="web.ListView" t-inherit-mode="primary">
         <button class="btn btn-primary o_list_button_add" position="replace">
-            <ProjectTemplateDropdown
+            <ProjectTemplateDropdown t-if="!editedRecord and activeActions.create and props.showButtons"
                 onCreate="() => this.onClickCreate()"
                 newButtonClasses="'btn btn-primary o_list_button_add'"
                 context="props.context"

--- a/addons/project/static/src/views/project_task_form/project_task_form_controller.xml
+++ b/addons/project/static/src/views/project_task_form/project_task_form_controller.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
     <t t-name="project.ProjectTaskFormView" t-inherit="resource.FormViewWithHtmlExpander" t-inherit-mode="primary">
         <button class="btn btn-outline-primary o_form_button_create" position="replace">
-            <ProjectTaskTemplateDropdown
+            <ProjectTaskTemplateDropdown t-if="canCreate"
                 projectId="props.context.default_project_id"
                 onCreate="() =&gt; this.create()"
                 newButtonClasses="'btn btn-outline-primary o_form_button_create'"

--- a/addons/project/static/src/views/project_task_kanban/project_task_kanban_controller.xml
+++ b/addons/project/static/src/views/project_task_kanban/project_task_kanban_controller.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
     <t t-name="project.ProjectTaskKanbanView" t-inherit="web.KanbanView" t-inherit-mode="primary">
         <button class="btn btn-primary o-kanban-button-new" position="replace">
-            <ProjectTaskTemplateDropdown
+            <ProjectTaskTemplateDropdown t-if="canCreate and props.showButtons"
                 projectId="props.context.default_project_id"
                 onCreate="() => this.createRecord()"
                 newButtonClasses="'btn btn-primary o-kanban-button-new'"

--- a/addons/project/static/src/views/project_task_list/project_task_list_controller.xml
+++ b/addons/project/static/src/views/project_task_list/project_task_list_controller.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
     <t t-name="project.ProjectTaskListView" t-inherit="web.ListView" t-inherit-mode="primary">
         <button class="btn btn-primary o_list_button_add" position="replace">
-            <ProjectTaskTemplateDropdown 
+            <ProjectTaskTemplateDropdown t-if="!editedRecord and activeActions.create and props.showButtons"
                 projectId="props.context.default_project_id"
                 onCreate="() =&gt; this.onClickCreate()"
                 newButtonClasses="'btn btn-primary o_list_button_add'"

--- a/addons/stock/static/src/components/reception_report_main/stock_reception_report_main.xml
+++ b/addons/stock/static/src/components/reception_report_main/stock_reception_report_main.xml
@@ -4,13 +4,9 @@
     <div t-name="stock.ReceptionReportMain" class="o_action">
         <ControlPanel display="controlPanelDisplay">
             <t t-set-slot="control-panel-always-buttons">
-                <div class="o_cp_buttons" role="toolbar" aria-label="Control panel buttons">
-                    <div class="d-inline-block">
-                        <button t-on-click="onClickPrint" type="button" class="btn btn-primary" title="Print">Print</button>
-                        <button t-on-click="onClickAssignAll" class="btn btn-secondary ms-1" t-att-disabled="isAssignAllDisabled">Assign All</button>
-                        <button t-on-click="onClickPrintLabels" class="btn btn-secondary ms-1" t-att-disabled="isPrintLabelDisabled">Print Labels</button>
-                    </div>
-                </div>
+                <button t-on-click="onClickPrint" type="button" class="btn btn-primary" title="Print">Print</button>
+                <button t-on-click="onClickAssignAll" class="btn btn-secondary" t-att-disabled="isAssignAllDisabled">Assign All</button>
+                <button t-on-click="onClickPrintLabels" class="btn btn-secondary" t-att-disabled="isPrintLabelDisabled">Print Labels</button>
             </t>
         </ControlPanel>
         <div class="o_report_reception container-fluid justify-content-between">

--- a/addons/transifex/static/src/views/reload_code_translations_views.xml
+++ b/addons/transifex/static/src/views/reload_code_translations_views.xml
@@ -2,7 +2,7 @@
 
 <templates>
     <t t-name="transifex.CodeTranslationListView.Buttons" t-inherit="web.ListView.Buttons" t-inherit-mode="primary">
-        <xpath expr="//div[hasclass('o_list_buttons')]" position="inside">
+        <xpath expr="." position="inside">
             <button type="button" class="btn btn-primary" t-on-click="onClickReloadCodeTranslations">Reload</button>
         </xpath>
     </t>

--- a/addons/web/static/src/core/dialog/dialog.scss
+++ b/addons/web/static/src/core/dialog/dialog.scss
@@ -10,20 +10,6 @@
     .modal-footer {
         text-align: left;
 
-        // FIXME: These selectors should not be necessary if we used buttons
-        // as direct children of the modal-footer as normally required
-        footer, .o_form_buttons_edit, .o_form_buttons_view {
-            display: flex;
-            flex-wrap: wrap;
-            flex: 1 1 auto;
-            justify-content: space-around;
-            gap: map-get($spacers, 1);
-
-            @include media-breakpoint-up(md) {
-                justify-content: flex-start;
-            }
-        }
-
         button {
             margin: 0; // Reset boostrap.
         }

--- a/addons/web/static/src/views/form/form_controller.scss
+++ b/addons/web/static/src/views/form/form_controller.scss
@@ -1097,12 +1097,6 @@
     }
 }
 
-// Buttons in ControlPanel
-.o_control_panel .o_form_buttons_view > button:first-child {
-    float: left; // Unfortunately needed for the bounce effect
-    margin-right: 4px;
-}
-
 .o_form_view.o_xxl_form_view {
     flex-flow: row nowrap !important;
 

--- a/addons/web/static/src/views/form/form_controller.xml
+++ b/addons/web/static/src/views/form/form_controller.xml
@@ -6,9 +6,7 @@
             <div class="o_form_view_container">
                 <Layout className="model.useSampleModel ? 'o_view_sample_data' : ''" display="display">
                     <t t-set-slot="control-panel-create-button">
-                        <t t-if="canCreate">
-                            <button type="button" class="btn btn-outline-primary o_form_button_create" data-hotkey="c" t-on-click.stop="create">New</button>
-                        </t>
+                        <button t-if="canCreate" type="button" class="btn btn-outline-primary o_form_button_create" data-hotkey="c" t-on-click.stop="create">New</button>
                     </t>
 
                     <t t-set-slot="layout-buttons">
@@ -44,6 +42,7 @@
                             <FormStatusIndicator model="model" discard.bind="discard" save.bind="saveButtonClicked" />
                         </t>
                     </t>
+
                     <t t-component="props.Renderer" record="model.root" Compiler="props.Compiler" readonly="props.readonly" archInfo="archInfo" translateAlert="translateAlert" onNotebookPageChange.bind="onNotebookPageChange" activeNotebookPages="props.state and props.state.activeNotebookPages"/>
                 </Layout>
             </div>
@@ -51,22 +50,18 @@
     </t>
 
     <t t-name="web.FormView.Buttons">
-        <div t-if="model.root.isInEdition" class="o_form_buttons_edit d-flex gap-1">
-            <button type="button" class="btn btn-primary o_form_button_save" data-hotkey="s" t-on-click.stop="() => this.saveButtonClicked({closable: true})">
-                Save
-            </button>
-            <button type="button" class="btn btn-secondary o_form_button_cancel" data-hotkey="j" t-on-click.stop="discard">
-                Discard
-            </button>
-            <button t-if="props.removeRecord" class="btn btn-secondary o_form_button_remove" t-on-click="props.removeRecord" data-hotkey="x">
-                Remove
-            </button>
-        </div>
-        <div t-elif="canCreate" class="o_form_buttons_view">
-            <button type="button" class="btn btn-secondary o_form_button_create" data-hotkey="c" t-on-click.stop="create">
-                New
-            </button>
-        </div>
+        <button t-if="model.root.isInEdition" type="button" class="btn btn-primary o_form_button_save" data-hotkey="s" t-on-click.stop="() => this.saveButtonClicked({closable: true})">
+            Save
+        </button>
+        <button t-if="model.root.isInEdition" type="button" class="btn btn-secondary o_form_button_cancel" data-hotkey="j" t-on-click.stop="discard">
+            Discard
+        </button>
+        <button t-if="model.root.isInEdition and props.removeRecord" class="btn btn-secondary o_form_button_remove" t-on-click="props.removeRecord" data-hotkey="x">
+            Remove
+        </button>
+        <button t-if="!model.root.isInEdition and canCreate" type="button" class="btn btn-secondary o_form_button_create" data-hotkey="c" t-on-click.stop="create">
+            New
+        </button>
     </t>
 
     <t t-name="web.DefaultButtonsSlot">

--- a/addons/web/static/src/views/kanban/kanban_controller.xml
+++ b/addons/web/static/src/views/kanban/kanban_controller.xml
@@ -5,14 +5,12 @@
         <div t-attf-class="{{ className }} {{ hasSelectedRecords ? 'o_kanban_selection_active' : 'o_kanban_selection_available' }}" t-ref="root">
             <Layout className="model.useSampleModel ? 'o_view_sample_data' : ''" display="display">
                 <t t-set-slot="control-panel-create-button">
-                    <t t-if="canCreate and props.showButtons">
-                        <button type="button" t-att-disabled="isNewButtonDisabled" class="btn btn-primary o-kanban-button-new" accesskey="c" t-on-click="() => this.createRecord()" data-bounce-button="">
-                            New
-                        </button>
-                    </t>
+                    <button t-if="canCreate and props.showButtons" type="button" t-att-disabled="isNewButtonDisabled" class="btn btn-primary o-kanban-button-new" accesskey="c" t-on-click="() => this.createRecord()" data-bounce-button="">
+                        New
+                    </button>
                 </t>
                 <t t-set-slot="layout-buttons">
-                    <t t-call="{{ props.buttonTemplate }}"/>
+                    <t t-if="props.showButtons" t-call="{{ props.buttonTemplate }}"/>
                 </t>
                 <t t-set-slot="control-panel-always-buttons">
                     <t t-foreach="headerButtons" t-as="button" t-key="button.id" t-if="!evalViewModifier(button.invisible)">
@@ -99,8 +97,6 @@
         </div>
     </t>
 
-    <t t-name="web.KanbanView.Buttons">
-        <div t-if="props.showButtons" class="o_cp_buttons d-empty-none d-flex align-items-baseline gap-1" role="toolbar" aria-label="Main actions"/>
-    </t>
+    <t t-name="web.KanbanView.Buttons"/>
 
 </templates>

--- a/addons/web/static/src/views/list/list_controller.xml
+++ b/addons/web/static/src/views/list/list_controller.xml
@@ -5,16 +5,15 @@
         <div t-att-class="className" t-ref="root">
             <Layout className="model.useSampleModel ? 'o_view_sample_data' : ''" display="display">
                 <t t-set-slot="control-panel-create-button">
-                    <t t-if="!editedRecord and activeActions.create and props.showButtons">
-                        <button type="button" class="btn btn-primary o_list_button_add" data-hotkey="c" t-on-click="onClickCreate" data-bounce-button="">
-                            New
-                        </button>
-                    </t>
-                    <t t-if="env.isSmall" t-call="{{ props.buttonTemplate }}"/>
+                    <button t-if="!editedRecord and activeActions.create and props.showButtons" type="button" class="btn btn-primary o_list_button_add" data-hotkey="c" t-on-click="onClickCreate" data-bounce-button="">
+                        New
+                    </button>
+                    <t t-if="props.showButtons and !env.inDialog" t-call="web.ListView.EditableButtons"/>
                 </t>
 
                 <t t-set-slot="layout-buttons">
-                    <t t-if="!env.isSmall" t-call="{{ props.buttonTemplate }}"/>
+                    <t t-if="props.showButtons and env.inDialog" t-call="web.ListView.EditableButtons"/>
+                    <t t-if="props.showButtons" t-call="{{ props.buttonTemplate }}"/>
                 </t>
                 <t t-set-slot="control-panel-always-buttons">
                     <t t-foreach="archInfo.headerButtons" t-as="button" t-key="button.id" t-if="!evalViewModifier(button.invisible)">
@@ -103,17 +102,15 @@
         </div>
     </t>
 
-    <t t-name="web.ListView.Buttons">
-        <div t-if="props.showButtons" class="o_list_buttons d-flex gap-1 d-empty-none align-items-baseline" role="toolbar" aria-label="Main actions">
-            <t t-if="editedRecord">
-                <button type="button" class="btn btn-primary o_list_button_save" data-hotkey="s" t-on-click.stop="onClickSave">
-                    Save
-                </button>
-                <button type="button" class="btn btn-secondary o_list_button_discard" data-hotkey="j" t-on-click.stop="onClickDiscard" t-on-mousedown="onMouseDownDiscard">
-                    Discard
-                </button>
-            </t>
-        </div>
+    <t t-name="web.ListView.Buttons"/>
+
+    <t t-name="web.ListView.EditableButtons">
+        <button t-if="editedRecord" type="button" class="btn btn-primary o_list_button_save" data-hotkey="s" t-on-click.stop="onClickSave">
+            Save
+        </button>
+        <button t-if="editedRecord" type="button" class="btn btn-secondary o_list_button_discard" data-hotkey="j" t-on-click.stop="onClickDiscard" t-on-mousedown="onMouseDownDiscard">
+            Discard
+        </button>
     </t>
 
 </templates>

--- a/addons/web/static/src/webclient/settings_form_view/settings_form_view.js
+++ b/addons/web/static/src/webclient/settings_form_view/settings_form_view.js
@@ -52,7 +52,6 @@ SettingModel.Record = SettingRecord;
 export const settingsFormView = {
     ...formView,
     display: {},
-    buttonTemplate: "web.SettingsFormView.Buttons",
     Model: SettingModel,
     ControlPanel: ControlPanel,
     Controller: SettingsFormController,

--- a/addons/web/static/src/webclient/settings_form_view/settings_form_view.xml
+++ b/addons/web/static/src/webclient/settings_form_view/settings_form_view.xml
@@ -16,7 +16,16 @@
                 </div>
             </t>
         </xpath>
-        <xpath expr="//Layout/t[@t-set-slot='control-panel-status-indicator']" position="replace"/>
+        <xpath expr="//Layout/t[@t-set-slot='control-panel-create-button']" position="replace">
+            <t t-set-slot="control-panel-create-button">
+                <t t-call="{{ props.buttonTemplate }}"/>
+            </t>
+        </xpath>
+        <xpath expr="//Layout/t[@t-set-slot='control-panel-status-indicator']" position="replace">
+            <t t-set-slot="control-panel-status-indicator">
+                <span t-if="model.root.dirty" class="text-muted ms-2 o_dirty_warning">Unsaved changes</span>
+            </t>
+        </xpath>
         <xpath expr="//Layout/t[@t-set-slot='control-panel-additional-actions']" position="replace"/>
         <xpath expr="//Layout/t[@t-component='props.Renderer']" position="attributes">
             <attribute name="initialApp">initialApp</attribute>
@@ -28,20 +37,6 @@
                     <t t-set="description">Try searching for another keyword</t>
                 </t>
             </t>
-        </xpath>
-        <xpath expr="//Layout" position="inside">
-            <t t-set-slot="control-panel-status-indicator">
-                <t t-call="{{ props.buttonTemplate }}"/>
-            </t>
-        </xpath>
-    </t>
-
-    <t t-name="web.SettingsFormView.Buttons" t-inherit="web.FormView.Buttons" t-inherit-mode="primary">
-        <xpath expr="//div" position="attributes">
-            <attribute name="class" add="order-first w-auto" separator=" "/>
-        </xpath>
-        <xpath expr="//div" position="after">
-            <span t-if="model.root.dirty" class="text-muted ms-2 o_dirty_warning">Unsaved changes</span>
         </xpath>
     </t>
 </templates>

--- a/addons/web/static/tests/search/control_panel.test.js
+++ b/addons/web/static/tests/search/control_panel.test.js
@@ -228,8 +228,8 @@ test("control panel layout buttons in dialog", async () => {
     });
     expect(`.o_list_view`).toHaveCount(1);
     await contains(".o_data_cell").click();
-    expect(".modal-footer .o_list_buttons button").toHaveCount(2);
-    expect(".o_control_panel .o_list_buttons button").toHaveCount(0, {
+    expect(".modal-footer button:visible").toHaveCount(2);
+    expect(".o_control_panel_main_buttons button").toHaveCount(0, {
         message: "layout buttons are not replicated in the control panel when inside a dialog",
     });
 });

--- a/addons/web/static/tests/views/fields/many2many_tags_field.test.js
+++ b/addons/web/static/tests/views/fields/many2many_tags_field.test.js
@@ -1136,7 +1136,7 @@ test("Many2ManyTagsField: save&new in edit mode doesn't close edit window on des
     // Create another record and click save & close
     await contains(".modal input").edit("Pikachu");
 
-    await contains(".modal .o_form_buttons_edit .btn-primary:first").click();
+    await contains(".modal .modal-footer .btn-primary:first").click();
     expect(".modal .o_list_view").toHaveCount(0);
     expect('.o_field_many2many_tags[name="timmy"] .badge').toHaveCount(2);
 });
@@ -1340,7 +1340,7 @@ test("failing many2one quick create in a Many2ManyTagsField on desktop", async (
     expect(".modal .o_field_widget[name=name] input").toHaveValue("new partner");
 
     await contains(".modal .o_field_widget[name=color] input").edit(8);
-    await contains(".modal footer .o_form_buttons_edit button").click();
+    await contains(".modal .modal-footer button").click();
 
     expect(".o_field_many2many_tags .badge").toHaveCount(1);
 });

--- a/addons/web/static/tests/webclient/actions/concurrency.test.js
+++ b/addons/web/static/tests/webclient/actions/concurrency.test.js
@@ -462,18 +462,18 @@ test("open a record while reloading the list view", async () => {
     expect(".o_calendar_view").toHaveCount(0);
     expect(".o_list_view").toHaveCount(1);
     expect(".o_list_view .o_data_row").toHaveCount(2);
-    expect(".o_control_panel .o_list_buttons").toHaveCount(1);
+    expect(".o_control_panel .o_list_button_add").toHaveCount(1);
 
     // reload (the search_read RPC will be blocked)
     def = new Deferred();
     await switchView("calendar");
     expect(".o_list_view .o_data_row").toHaveCount(2);
-    expect(".o_control_panel .o_list_buttons").toHaveCount(1);
+    expect(".o_control_panel .o_list_button_add").toHaveCount(1);
 
     // open a record in form view
     await contains(".o_list_view .o_data_cell").click();
     expect(".o_form_view").toHaveCount(1);
-    expect(".o_control_panel .o_list_buttons").toHaveCount(0);
+    expect(".o_control_panel .o_list_button_add").toHaveCount(0);
 
     // unblock the search_read RPC
     def.resolve();
@@ -481,7 +481,7 @@ test("open a record while reloading the list view", async () => {
     expect(".o_form_view").toHaveCount(1);
     expect(".o_list_view").toHaveCount(0);
     expect(".o_calendar_view").toHaveCount(0);
-    expect(".o_control_panel .o_list_buttons").toHaveCount(0);
+    expect(".o_control_panel .o_list_button_add").toHaveCount(0);
 });
 
 test("properly drop client actions after new action is initiated", async () => {

--- a/addons/web/static/tests/webclient/actions/window_action.test.js
+++ b/addons/web/static/tests/webclient/actions/window_action.test.js
@@ -2392,7 +2392,7 @@ test("do not restore after action button clicked", async () => {
     expect(".o_statusbar_buttons button[name=do_something]").toBeVisible();
 
     await contains(".o_statusbar_buttons button[name=do_something]").click();
-    expect(".o_form_buttons_view .o_form_button_save").not.toHaveCount();
+    expect(".o_control_panel_main_buttons .o_form_button_save").not.toHaveCount();
 });
 
 test("debugManager is active for views", async () => {


### PR DESCRIPTION
This commit cleans up and simplifies the structure of the buttons
provided by the views/actions and displayed in the ControlPanel (or
modal's footer for the FormView). The point is to avoid unnecessary
wrapper around them, reducing the DOM and also the rules necessary to
handle the buttons' layout, gap...

task-4277543