### PR TITLE
[FIX] web_unsplash: prevent chunk error on data transfer

### DIFF
--- a/addons/web_unsplash/controllers/main.py
+++ b/addons/web_unsplash/controllers/main.py
@@ -97,6 +97,9 @@ class Web_Unsplash(http.Controller):
             except requests.exceptions.Timeout as e:
                 logger.exception("Timeout: " + str(e))
                 continue
+            except requests.exceptions.ChunkedEncodingError as e:
+                logger.exception("Chunked Encoding Error: %s", e)
+                continue
 
             image = tools.image_process(image, verify_resolution=True)
             mimetype = guess_mimetype(image)


### PR DESCRIPTION
This PR enhances the error handling in the `web_unsplash` controller, particularly for situations where image downloads from Unsplash fail due to `incomplete data transfers`.

**Error:-**
`ChunkedEncodingError: (Connection broken: IncompleteRead(303138 bytes read,
 793090 more expected), IncompleteRead(303138 bytes read, 793090 more expected)`

**Root Cause:-**
- At [1], we can see that there is a possibility of errors when `incomplete data transfer` occurs, as well as `connection errors` and `timeouts`.
-  At [2], we have already handled the `connection` and `timeout` errors.

[1]
https://github.com/odoo/odoo/blob/ca7de6b2fbe4626583b67a34d77bbb523d972f79/addons/web_unsplash/controllers/main.py#L88

[2]
https://github.com/odoo/odoo/blob/ca7de6b2fbe4626583b67a34d77bbb523d972f79/addons/web_unsplash/controllers/main.py#L94-L99

**Solution:-**
- In this commit, we apply the same fix for `ChunkedEncodingError` that we implemented for other exceptions.

**Sentry-6209237744**

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
