### PR TITLE
[FIX] base: menu icon image support

### DIFF
--- a/odoo/addons/base/models/ir_ui_menu.py
+++ b/odoo/addons/base/models/ir_ui_menu.py
@@ -63,7 +63,7 @@ class IrUiMenu(models.Model):
         path_info = path.split(',')
         icon_path = opj(path_info[0], path_info[1])
         try:
-            with tools.file_open(icon_path, 'rb', filter_ext=('.png',)) as icon_file:
+            with tools.file_open(icon_path, 'rb', filter_ext=('.png', '.gif', '.ico', '.jfif', '.jpeg', '.jpg', '.svg', '.webp')) as icon_file:
                 return base64.encodebytes(icon_file.read())
         except FileNotFoundError:
             return False


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

PR #135607 breaks support of image types other than `png` for menu icons.
This puts back the support for previously supported image types.


Current behavior before PR:
You can't use a menu icon which has a type other than `png`.

Desired behavior after PR is merged:
You can use `gif`, `ico`, `jfif`, `jpeg`, `jpg`, `svg` and `webp` files like version `16.0`.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
