### PR TITLE
[FIX] mail: fix runbot error (page reload before remove reaction)

### DIFF
--- a/addons/mail/static/tests/tours/discuss_channel_public_tour.js
+++ b/addons/mail/static/tests/tours/discuss_channel_public_tour.js
@@ -122,13 +122,13 @@ registry.category("web_tour.tours").add("discuss_channel_public_tour.js", {
         },
         {
             content: "Reload page (fetch reactions)",
-            trigger: ".o-mail-Message",
+            trigger: ".o-mail-Message:not(:has(.o-mail-MessageReaction:contains('🙂')))",
             run() {
                 location.reload();
             },
         },
         {
-            trigger: ".o-mail-Message:not(:has(.o-mail-MessageReaction))",
+            trigger: ".o-mail-Message:not(:has(.o-mail-MessageReaction:contains('🙂')))",
         },
         {
             content: "Click on more menu",


### PR DESCRIPTION
Before this commit, tour "discuss_channel_public_tour" was failing non-deterministically at the following step:

```
.o-mail-Message:not(:has(.o-mail-MessageReaction))
```

This happens because prio steps added a new reaction and asserted it was shown. It clicks on reaction to remove it and then page reload to see the reaction is gone. Problem is that it can reload page too fast and the RPC to remove the reaction did not have time to occurs.

This commit fixes the issue by awaiting message no longer has reaction before page reload.

Fixes runbot-error-227769
