### PR TITLE
[FIX] website: include website_id when loading snippets

### DIFF
--- a/addons/website/static/src/client_actions/website_preview/website_builder_action.js
+++ b/addons/website/static/src/client_actions/website_preview/website_builder_action.js
@@ -137,6 +137,7 @@ export class WebsiteBuilderClientAction extends Component {
                 loadBundle("website.website_builder_assets").then(() => {
                     this.env.services["html_builder.snippets"].reload({
                         lang: this.websiteService.currentWebsite?.default_lang_id.code,
+                        website_id: this.websiteService.currentWebsite?.id,
                     });
                 });
             }

--- a/addons/website/static/tests/tours/snippet_cache_across_websites.js
+++ b/addons/website/static/tests/tours/snippet_cache_across_websites.js
@@ -11,7 +11,7 @@ registerWebsitePreviewTour('snippet_cache_across_websites', {
 }, () => [
     {
         content: "Click on the Custom category block",
-        trigger: "#oe_snippets .oe_snippet[name='Custom'].o_we_draggable .oe_snippet_thumbnail",
+        trigger: ".o-website-builder_sidebar .o_snippet[name='Custom'].o_draggable .o_snippet_thumbnail_area",
         run: "click",
     },
     {
@@ -29,6 +29,6 @@ registerWebsitePreviewTour('snippet_cache_across_websites', {
     ...clickOnEditAndWaitEditMode(),
     {
         content: "Check that the custom snippet category is not here",
-        trigger: "#oe_snippets:not(:has(.oe_snippet[name='Custom']))",
+        trigger: ".o-website-builder_sidebar:not(:has(.o_snippet[name='Custom']))",
     },
 ]);

--- a/addons/website/tests/test_ui.py
+++ b/addons/website/tests/test_ui.py
@@ -498,8 +498,6 @@ class TestUi(HttpCaseWithWebsiteUser):
     def test_23_website_multi_edition(self):
         self.start_tour('/@/', 'website_multi_edition', login='admin')
 
-    # TODO master-mysterious-egg fix error
-    @unittest.skip("prepare mysterious-egg for merging")
     def test_24_snippet_cache_across_websites(self):
         default_website = self.env.ref('website.default_website')
         website = self.env['website'].create({


### PR DESCRIPTION
Steps to reproduce:
- Create a custom snippet.
- Switch website and enter in edit mode.

-> Problem: the custom snippet is present in edit mode on the second website while it should only be available on the first one.

The commit adds back the `website_id` information when loading the snippets. The information was missing since [the website refactoring].

Related to task-4367641

[the website refactoring]: https://github.com/odoo/odoo/commit/9fe45e2b7ddbbfd0445ffe25a859e67a316d02b2

