### PR TITLE
[FIX] html_builder: separator style fix

### DIFF
--- a/addons/html_builder/static/src/plugins/separator_option.xml
+++ b/addons/html_builder/static/src/plugins/separator_option.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
 <t t-name="html_builder.SeparatorOption">
-    <BorderConfigurator withRoundCorner="false" label.translate="Border" direction="'top'"/>
+    <BorderConfigurator withRoundCorner="false" withBSClass="false" label.translate="Border" direction="'top'"/>
     <BuilderRow label.translate="Width">
         <BuilderSelect>
             <BuilderSelectItem classAction="'w-25'">25%</BuilderSelectItem>


### PR DESCRIPTION
Steps to reproduce bug
- Add text snippet
- Add a separator
- Click on the separator
- Set color/style
- Click on the width
- Change the width either by inserting another number or with up/down arrows
=> the color and style get reverted

After this commit the separator style does not get reverted
