### PR TITLE
[FIX] mail: fix tour finished dirty form view (composer_autosave)

### DIFF
--- a/addons/mail/static/tests/tours/mail_composer_autosave_tour.js
+++ b/addons/mail/static/tests/tours/mail_composer_autosave_tour.js
@@ -36,6 +36,9 @@ registry.category("web_tour.tours").add("mail/static/tests/tours/mail_composer_a
             content: "Check message is shown",
             trigger: '.o-mail-Message-body:contains("Hello")',
         },
+        {
+            trigger: ".o_form_saved",
+        },
         ...stepUtils.toggleHomeMenu(),
     ],
 });


### PR DESCRIPTION
Before this commit, tour "test_mail_composer_autosave_tour" could fail at end with the following error:

```
Tour finished with a dirty form view being open.

Dirty form views are automatically saved when the page is closed, which leads to stray network requests and inconsistencies.
```

This happens because test creates a new record and posts a message in full composer. It checks that message is present in chatter and then leave the form view. When posting the message, the form view is saved, but this can happen with a small delay after message is visible on chatter like after tour has ended.

This commit fixes the issue by awaiting form view is saved, so that tour doesn't panic at end there's a form view with unsaved changes, as the form view is properly saved with sending a message.

Fixes runbot error 198583
Fixes runbot error 222676
Fixes runbot error 226772
Fixes runbot error 222676
