### PR TITLE
[FIX] account: align taxable base calculation with SUNAT logic

### DIFF
--- a/addons/account/models/account_tax.py
+++ b/addons/account/models/account_tax.py
@@ -873,10 +873,10 @@ class AccountTax(models.Model):
 
     @api.model
     def _compute_taxes_for_single_line(self, base_line, handle_price_include=True, include_caba_tags=False, early_pay_discount_computation=None, early_pay_discount_percentage=None):
-        orig_price_unit_after_discount = base_line['price_unit'] * (1 - (base_line['discount'] / 100.0))
+        currency = base_line['currency'] or self.env.company.currency_id
+        orig_price_unit_after_discount = base_line['price_unit'] - currency.round(base_line['price_unit'] * (base_line['discount'] or 0.0) / 100.0)
         price_unit_after_discount = orig_price_unit_after_discount
         taxes = base_line['taxes']._origin
-        currency = base_line['currency'] or self.env.company.currency_id
         rate = base_line['rate']
 
         if early_pay_discount_computation in ('included', 'excluded'):


### PR DESCRIPTION
Context and steps to reproduce:
1. Install l10n_pe
2. Go to the PE company
3. Change decimal accuracy for “Discount” to 5 decimal places
4. Create an invoice with a partner named “Transportes Torres”
5. Create an invoice line with an amount of 883.11 with a 50% discount
6. Confirm the invoice then click on “Process now” at the top banner and an error should appear

When you give Odoo a line with a gross amount of 883.11 PEN and a 50.00000 % discount we  first subtracts the discount and then rounds the result. In code-speak, we do:
Calculate 883.11 × (1 – 0.50) = 441.555
Round that to two decimals: 441.56
So Odoo tells SUNAT that the “taxable base” (the amount on which tax is computed) is 441.56 PEN.

SUNAT, however, applies the opposite sequence:
Compute the raw discount: 883.11 × 0.50 = 441.555
Round that discount to two decimals:  441.56
Subtract the rounded discount from gross: 883.11 – 441.56 = 441.55 SUNAT then compares the base you declared (441.56) to its own calculation (441.55). Because they differ by one cent, it throws error 3272: “the taxable base differs…”.

To fix this from the source, I changed Odoo’s tax computation so that it follows SUNAT’s steps exactly:

First round the discount amount to two decimals.
Then subtract that rounded discount from the gross unit price.

OPW-4716526




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
