### PR TITLE
[FIX] html_editor: image link shouldn't extend on selecting text around it

### DIFF
--- a/addons/html_editor/static/src/main/link/link_plugin.js
+++ b/addons/html_editor/static/src/main/link/link_plugin.js
@@ -413,7 +413,10 @@ export class LinkPlugin extends Plugin {
                 } else {
                     this.linkInDocument.removeAttribute("class");
                 }
-                if (this.linkInDocument.childElementCount == 0 && cleanZWChars(this.linkInDocument.innerText) !== label) {
+                if (
+                    this.linkInDocument.childElementCount == 0 &&
+                    cleanZWChars(this.linkInDocument.innerText) !== label
+                ) {
                     this.linkInDocument.innerText = label;
                     cursorsToRestore = null;
                 }
@@ -616,9 +619,16 @@ export class LinkPlugin extends Plugin {
             this.linkInDocument = null;
             this.closeLinkTools();
         } else if (!selection.isCollapsed) {
-            // Open the link tool only if we have an image selected
+            // Open the link tool only if we have an image selected and the selection
+            // is fully contained in the image parent link.
             const imageNode = findInSelection(selection, "img");
-            if (imageNode?.parentNode?.tagName === "A" && this.isLinkAllowedOnSelection()) {
+            const parentElement = imageNode?.parentElement;
+            if (
+                imageNode?.parentNode?.tagName === "A" &&
+                this.isLinkAllowedOnSelection() &&
+                parentElement.contains(selection.anchorNode) &&
+                parentElement.contains(selection.focusNode)
+            ) {
                 this.openLinkTools(imageNode.parentElement);
             } else {
                 this.linkInDocument = null;

--- a/addons/html_editor/static/tests/link/popover.test.js
+++ b/addons/html_editor/static/tests/link/popover.test.js
@@ -1113,6 +1113,17 @@ describe("links with inline image", () => {
 
         expect(cleanLinkArtifacts(getContent(el))).toBe(`<p>ab[]c</p>`);
     });
+    test("selecting text and a image with link should not extend the link element", async () => {
+        const { el } = await setupEditor(`<p>ab<a href="#">cd<img src="${base64Img}">ef</a>g</p>`);
+        setContent(el, `<p>ab<a href="#">c]d<img src="${base64Img}">e[f</a>g</p>`);
+        await waitFor(".o-we-linkpopover", { timeout: 1500 });
+        await waitFor(".o-we-toolbar");
+        setContent(el, `<p>a]b<a href="#">cd<img src="${base64Img}">e[f</a>g</p>`);
+        await waitForNone(".o-we-linkpopover", { timeout: 1500 });
+        expect(cleanLinkArtifacts(getContent(el))).toBe(
+            `<p>a]b<a href="#">cd<img src="${base64Img}">e[f</a>g</p>`
+        );
+    });
 });
 
 describe("readonly mode", () => {


### PR DESCRIPTION
Reproduction:
1. In Todo, add some text, insert an image right after the text, insert some text after the image
2. add a link to the image, select text around the image (before and after it)
3. after the selection, the selected text is part of the link

**Before this Commit:**
For non-collapsed selections, the link popover opens when an image is included in the selection. However, the `openLinkTools` method may unintentionally extend the link, causing the link to spread on text outside of the link element.

**After this Commit:**
Stricter conditions are applied to ensure `openLinkTools` is only called when the non-collapsed selection includes an image, the parent element is a link, and the selection is entirely contained within the parent link element.

task-4903904

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
