### PR TITLE
[FIX] account: search invoices from archived partner

### DIFF
--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -1289,10 +1289,11 @@
                                 '|', '|' , '|', '|',
                                 ('name', 'ilike', self), ('invoice_origin', 'ilike', self),
                                 ('ref', 'ilike', self), ('payment_reference', 'ilike', self),
-                                ('partner_id', 'child_of', self)]"/>
+                                ('partner_id', 'child_of', self)]"
+                            context="{'active_test': False}"/>
                     <field name="journal_id"/>
-                    <field name="partner_id" operator="child_of"/>
-                    <field name="invoice_user_id" string="Salesperson" domain="[('share', '=', False)]"/>
+                    <field name="partner_id" operator="child_of" context="{'active_test': False}" />
+                    <field name="invoice_user_id" string="Salesperson" domain="[('share', '=', False)]" />
                     <field name="date" string="Period"/>
                     <field name="line_ids" string="Invoice Line"/>
                     <filter domain="[('invoice_user_id', '=', uid)]" name="myinvoices" help="My Invoices"/>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Current behavior before PR:

When we have the list of Invoices all invoices appear for both archived and non-archived contacts. However, when we try to do a search by Invoice or Partner of these archived contacts the invoice of this customer does not appear.

Desired behavior after PR is merged:

When searching with filtering by customer or partner, you will see invoices for the entire company even if a partner has been archived.

OPW-4933421

cc: @moduon @chienandalu @sabrinaRMartin MT-10392

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
