### PR TITLE
[FIX] mail: message reaction from emoji picker test keeps reaction

### DIFF
--- a/addons/mail/static/tests/message/message.test.js
+++ b/addons/mail/static/tests/message/message.test.js
@@ -693,7 +693,7 @@ test("Reaction summary", async () => {
     }
 });
 
-test("Add the same reaction twice from the emoji picker", async () => {
+test("Select already reacted emoji from the emoji picker keeps the reaction on message", async () => {
     const pyEnv = await startServer();
     const channelId = pyEnv["discuss.channel"].create({
         channel_type: "channel",
@@ -708,9 +708,14 @@ test("Add the same reaction twice from the emoji picker", async () => {
     await start();
     await openDiscuss(channelId);
     await click("[title='Add a Reaction']");
-    await click(".o-Emoji", { text: "😅" });
+    await click(".o-Emoji:contains(😅):eq(0)");
+    await contains(".o-mail-MessageReaction", { text: "😅1" });
     await click("[title='Add a Reaction']");
-    await click(".o-Emoji", { text: "😅" });
+    await click(".o-Emoji:contains(😅):eq(0)");
+    // adding another emoji so that we ensure its rendering also show previous reaction is present on UI
+    await click("[title='Add a Reaction']");
+    await click(".o-Emoji:contains(😯):eq(0)");
+    await contains(".o-mail-MessageReaction", { text: "😯1" });
     await contains(".o-mail-MessageReaction", { text: "😅1" });
 });
 


### PR DESCRIPTION
Before this commit, test "Add the same reaction twice from the emoji picker" may fail non-deterministically in 18.1 on last step: the message reaction is sometimes kept, sometimes removed.

The feature works in 18.0 but no longer in 18.1. The test was still passing though very rarely can fail and actually show the feature doesn't work.

This happens because the test is clicking on reaction too fast and doesn't assert on UI the 1st message reaction has been added, thus it may flicker and keep showing there's 1 message reaction still.

This commit fixes the test in 18.0, in preparation to keep the same test in 18.1 and show the bugged change of behaviour in 18.1 to fix.

Fixes runbot error 229340