### PR TITLE
[FIX] website_livechat: fix chat bot multi line step tour

### DIFF
--- a/addons/im_livechat/static/src/embed/common/chatbot/chatbot_model.js
+++ b/addons/im_livechat/static/src/embed/common/chatbot/chatbot_model.js
@@ -10,7 +10,7 @@ export class Chatbot extends Record {
     // Time to wait without user input before considering a multi line step as
     // completed.
     static MULTILINE_STEP_DEBOUNCE_DELAY = 10000;
-    static MULTILINE_STEP_DEBOUNCE_DELAY_TOUR = 500;
+    static MULTILINE_STEP_DEBOUNCE_DELAY_TOUR = 2000;
 
     forwarded;
     isTyping = false;

--- a/addons/website_livechat/static/tests/tours/website_livechat_chatbot_flow.js
+++ b/addons/website_livechat/static/tests/tours/website_livechat_chatbot_flow.js
@@ -1,20 +1,19 @@
-import { registry } from "@web/core/registry";
-import { contains } from "@web/../tests/utils";
 import { patchWithCleanup } from "@web/../tests/helpers/utils";
+import { contains } from "@web/../tests/utils";
+import { registry } from "@web/core/registry";
+import { Deferred } from "@web/core/utils/concurrency";
 import { TourHelpers } from "@web_tour/tour_service/tour_helpers";
 
 const messagesContain = (text) => `.o-livechat-root:shadow .o-mail-Message:contains("${text}")`;
+let chatbotDelayProcessingDef;
 
 registry.category("web_tour.tours").add("website_livechat_chatbot_flow_tour", {
     steps: () => {
-        patchWithCleanup(window, {
-            debounceAnswerCount: 0,
-        });
         patchWithCleanup(odoo.__WOWL_DEBUG__.root.env.services["mail.store"].Chatbot.prototype, {
             // Count the number of times this method is called to check whether the chatbot is regularly
             // checking the user's input in the multi line step until the user finishes typing.
             async _delayThenProcessAnswerAgain(message) {
-                window.debounceAnswerCount++;
+                chatbotDelayProcessingDef?.resolve();
                 return await super._delayThenProcessAnswerAgain(message);
             },
         });
@@ -150,31 +149,26 @@ registry.category("web_tour.tours").add("website_livechat_chatbot_flow_tour", {
             {
                 // Simulate that the user is typing, so the chatbot shouldn't go to the next step
                 trigger: ".o-livechat-root:shadow .o-mail-Composer-input",
-                run() {
-                    const counter = window.debounceAnswerCount;
+                async run() {
                     const target = new TourHelpers(this.anchor);
-                    const delay =
-                        odoo.__WOWL_DEBUG__.root.env.services["mail.store"].Chatbot
-                            .MULTILINE_STEP_DEBOUNCE_DELAY_TOUR;
+                    chatbotDelayProcessingDef = new Deferred();
+                    let failTimeout = setTimeout(() => {
+                        chatbotDelayProcessingDef.reject(
+                            "Chatbot should stay in multi line step when user is typing."
+                        );
+                    }, 5000);
+                    chatbotDelayProcessingDef.then(() => clearTimeout(failTimeout));
                     target.edit("Never mind!");
-                    setTimeout(() => {
-                        if (window.debounceAnswerCount <= counter) {
-                            console.error(
-                                "Chatbot should stay in multi line step when user is typing."
-                            );
-                        }
-                    }, delay);
-                    setTimeout(() => {
-                        target.edit("Never mind!!!!");
-                        const counter = window.debounceAnswerCount;
-                        setTimeout(() => {
-                            if (window.debounceAnswerCount <= counter) {
-                                console.error(
-                                    "Chatbot should stay in multi line step if user isn't done typing."
-                                );
-                            }
-                        }, delay * 2);
-                    }, delay + 200);
+                    await chatbotDelayProcessingDef;
+                    chatbotDelayProcessingDef = new Deferred();
+                    failTimeout = setTimeout(() => {
+                        chatbotDelayProcessingDef.reject(
+                            "Chatbot should stay in multi line step if user isn't done typing."
+                        );
+                    }, 5000);
+                    chatbotDelayProcessingDef.then(() => clearTimeout(failTimeout));
+                    target.edit("Never mind!!!");
+                    await chatbotDelayProcessingDef;
                 },
             },
             {


### PR DESCRIPTION
Before this commit, the `website_livechat_chatbot_flow_tour` tour was sometimes failing. The intent it to ensure the chat bot stops until the user fully wrote his answer. The flow is the following:
- User sends a message (first part of his answer)
- User starts typing: the chat bot waits
- After some time, the user didn't finish his answer afterall, the chat bot continues.

The chat bot uses the `_processAnswerDebounced` function to delay the processing of the step. However, the tour relies on `setTimeout`, expecting to come after the debounce delay. However, multiple messages are sent, and the debounce delay is postponed. As a result, the assertion is made too early, making the test fail.

This commit fixes the issue by awaiting a deferred, resolved when the chat bot actually executes the debounced function.

fixes runbot-113948,227675

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
