### PR TITLE
[FIX] point_of_sale: add customer reference in POS invoice

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -808,6 +808,7 @@ class PosOrder(models.Model):
             'invoice_origin': ', '.join(ref or '' for ref in self.mapped('pos_reference')),
             'pos_refunded_invoice_ids': pos_refunded_invoice_ids,
             'pos_order_ids': self.ids,
+            'ref': self.name if is_single_order else False,
             'journal_id': self.config_id.invoice_journal_id.id,
             'move_type': move_type,
             'partner_id': self.partner_id.address_get(['invoice'])['invoice'],

--- a/addons/point_of_sale/tests/test_point_of_sale_flow.py
+++ b/addons/point_of_sale/tests/test_point_of_sale_flow.py
@@ -810,6 +810,7 @@ class TestPointOfSaleFlow(TestPointOfSaleCommon):
 
         # I test that the total of the attached invoice is correct
         invoice = self.env['account.move'].browse(res['res_id'])
+        self.assertEqual(invoice.ref, invoice.pos_order_ids.display_name)
         if invoice.state != 'posted':
             invoice.action_post()
         self.assertAlmostEqual(


### PR DESCRIPTION
## Short functional explanation of the error
When selling items in the point of sale module with an invoice, when we check said invoice in the backend, the customer reference field is empty.

## Reproduction Steps
1. Go to Point of sale and open a shop interface. Add a random item to the basket and select a customer.
2. Click on payment, then check Invoice, select a payment method, and Validate.
3. Click on the hamburger menu on the top right and click on Backend.
4. Hover the box of the shop you opened with your mouse. In the top right corner of the box should appear a 3-dot menu. Click on it and click on Sessions.
5. Click on the latest session ID. On the top of the page, click on the "Orders" smart button.
6. Click on the order you just finalized. On the top of the page click on the "Invoice" smart button.
7. Click on "Other info" tab.

### Expected behavior
The Customer Reference field should be filled with the name of the order.

### Unexpected behavior
The Customer Reference field is left empty.

## Origin of the issue
When setting the values for the invoice, the field 'Ref' was absent.

opw-4732492

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
