### PR TITLE
[FIX] mail: message reaction from emoji picker test removes reaction

### DIFF
--- a/addons/mail/static/tests/message/message.test.js
+++ b/addons/mail/static/tests/message/message.test.js
@@ -774,7 +774,7 @@ test("Reaction summary", async () => {
     }
 });
 
-test("Add the same reaction twice from the emoji picker", async () => {
+test("Select already reacted emoji from quick reaction removes the reaction on message", async () => {
     const pyEnv = await startServer();
     const channelId = pyEnv["discuss.channel"].create({
         channel_type: "channel",
@@ -790,9 +790,10 @@ test("Add the same reaction twice from the emoji picker", async () => {
     await openDiscuss(channelId);
     await click("[title='Add a Reaction']");
     await click(".o-mail-QuickReactionMenu button", { text: "😅" });
+    await contains(".o-mail-MessageReaction", { text: "😅1" });
     await click("[title='Add a Reaction']");
     await click(".o-mail-QuickReactionMenu button", { text: "😅" });
-    await contains(".o-mail-MessageReaction", { text: "😅1" });
+    await contains(".o-mail-MessageReaction", { count: 0 });
 });
 
 test("basic rendering of message", async () => {


### PR DESCRIPTION
Before this commit, test "Add the same reaction twice from the emoji picker" may fail non-deterministically in 18.1 on last step: the message reaction is sometimes kept, sometimes removed.

The feature in 18.0 was keeping the emoji, whereas in 18.1 it now toggles the add / remove of reaction. This change of behaviour felt best with the addition of QuickReactionMenu, and for consistency this also works that way in emoji picker of message reaction.

The test was not adapted but passed because the bus notifications were coming later than the burst of user actions to add emoji, thus there's flicker of showing message reaction at end when it's only temporarily and would be removed a fraction of seconds later.

This commit fixes the test with the newer behaviour that it should toggle the reaction.

Fixes runbot error 229340