### PR TITLE
[IMP] point_of_sale: child `pos_category` should not inherit its color

### DIFF
--- a/addons/point_of_sale/models/pos_category.py
+++ b/addons/point_of_sale/models/pos_category.py
@@ -69,22 +69,6 @@ class PosCategory(models.Model):
         for category in self:
             category.has_image = bool(category.image_128)
 
-    @api.model_create_multi
-    def create(self, vals_list):
-        for vals in vals_list:
-            if vals.get("parent_id"):
-                vals["color"] = self.search_read([("id", "=", vals["parent_id"])])[0][
-                    "color"
-                ]
-        return super().create(vals_list)
-
-    def write(self, vals):
-        if vals.get('parent_id') and not ("color" in vals):
-            vals["color"] = self.search_read([("id", "=", vals["parent_id"])])[0][
-                "color"
-            ]
-        return super().write(vals)
-
     def _get_descendants(self):
         available_categories = self
         for child in self.child_ids:


### PR DESCRIPTION
- When creating/updating a `pos_category`, we don't want it anymore to inherit from its parent color, as it could be confusing.

task-id: 4932860



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
