### PR TITLE
FIX python requirements for ubuntu:jammy

### DIFF
--- a/doc/cla/corporate/puzzle-itc.md
+++ b/doc/cla/corporate/puzzle-itc.md
@@ -1,0 +1,15 @@
+Switzerland, 2025-07-24
+
+Puzzle ITC agrees to the terms of the Odoo Corporate Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Bruno Santschi santschi@puzzle.ch https://github.com/bsantschi
+
+List of contributors:
+
+Daniel Alder alder@puzzle.ch https://github.com/aldpuzz

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ freezegun==1.1.0 ; python_version < '3.11'  # (Jammy)
 freezegun==1.2.1 ; python_version >= '3.11' and python_version < '3.13'
 freezegun==1.5.1 ; python_version >= '3.13'
 geoip2==2.9.0
-gevent==21.8.0 ; sys_platform != 'win32' and python_version == '3.10'  # (Jammy)
+gevent==22.10.2; sys_platform != 'win32' and python_version == '3.10'  # (Jammy)
 gevent==22.10.2; sys_platform != 'win32' and python_version > '3.10' and python_version < '3.12'
 gevent==24.2.1 ; sys_platform != 'win32' and python_version >= '3.12' and python_version < '3.13'  # (Noble)
 gevent==24.11.1 ; sys_platform != 'win32' and python_version >= '3.13'  # (Trixie)

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ gevent==22.10.2; sys_platform != 'win32' and python_version == '3.10'  # (Jammy)
 gevent==22.10.2; sys_platform != 'win32' and python_version > '3.10' and python_version < '3.12'
 gevent==24.2.1 ; sys_platform != 'win32' and python_version >= '3.12' and python_version < '3.13'  # (Noble)
 gevent==24.11.1 ; sys_platform != 'win32' and python_version >= '3.13'  # (Trixie)
-greenlet==1.1.2 ; sys_platform != 'win32' and python_version == '3.10'  # (Jammy)
+greenlet==2.0.2 ; sys_platform != 'win32' and python_version == '3.10'  # (Jammy)
 greenlet==2.0.2 ; sys_platform != 'win32' and python_version > '3.10' and python_version < '3.12'
 greenlet==3.0.3 ; sys_platform != 'win32' and python_version >= '3.12' and python_version < '3.13' # (Noble)
 greenlet==3.1.1 ; sys_platform != 'win32' and python_version >= '3.13'  # (Trixie)

--- a/requirements.txt
+++ b/requirements.txt
@@ -54,7 +54,7 @@ polib==1.1.1
 psutil==5.9.0 ; python_version <= '3.10' 
 psutil==5.9.4 ; python_version > '3.10' and python_version < '3.12' 
 psutil==5.9.8 ; python_version >= '3.12' # (Noble) Mostly to have a wheel package
-psycopg2==2.9.2 ; python_version == '3.10' # (Jammy)
+psycopg2-binary==2.9.2 ; python_version == '3.10' # (Jammy)
 psycopg2==2.9.5 ; python_version == '3.11'
 psycopg2==2.9.9 ; python_version >= '3.12' and python_version < '3.13' # (Noble)
 psycopg2==2.9.10 ; python_version >= '3.13' # (Trixie)


### PR DESCRIPTION
Description of the issue/feature this PR addresses: On a new ubuntu:jammy (python 3.10) (tested in a docker environment), I cannot install the requirements following the requirements.txt file.

Current behavior before PR: 

```
Collecting gevent==21.8.0 (from -r requirements.txt (line 20))
  Downloading gevent-21.8.0.tar.gz (6.2 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 6.2/6.2 MB 10.9 MB/s eta 0:00:00
  Installing build dependencies ... done
  Getting requirements to build wheel ... error
  error: subprocess-exited-with-error
  
  × Getting requirements to build wheel did not run successfully.
  │ exit code: 1

Collecting psycopg2==2.9.2 (from -r requirements.txt (line 52))
  Downloading psycopg2-2.9.2.tar.gz (380 kB)
  Installing build dependencies ... done
  Getting requirements to build wheel ... error
  error: subprocess-exited-with-error
  
  × Getting requirements to build wheel did not run successfully.
  │ exit code: 1
```
(see individual commits for the full error messages)

Test Dockerfile:
```
FROM ubuntu:jammy

RUN apt-get update \
 && apt-get -y install \
	python3 \
	python3-venv \
	libpython3.10-dev \
	build-essential \
	python-all-dev \
	libevent-dev \
	libldap-dev \
	libsasl2-dev \
 && apt-get clean

COPY requirements.txt /code/requirements.txt

RUN cd /code/ \
 && python3 -m venv .venv \
 && . .venv/bin/activate \
 && pip install --upgrade pip \
 && pip install -r requirements.txt
```

Desired behavior after PR is merged:
 * no errors at all, all dependencies install when running pip install -r requirements.txt

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr