### PR TITLE
[FIX] account_move: fix invoice pdf after draft

### DIFF
--- a/addons/account/tests/__init__.py
+++ b/addons/account/tests/__init__.py
@@ -48,3 +48,4 @@ from . import test_structured_reference
 from . import test_product
 from . import test_mail_tracking_value
 from . import test_account_move_attachment
+from . import test_account_move_redraft

--- a/addons/account/tests/test_account_move_redraft.py
+++ b/addons/account/tests/test_account_move_redraft.py
@@ -1,0 +1,50 @@
+from odoo.tests import tagged
+from odoo import Command
+from odoo.addons.account.tests.common import AccountTestInvoicingCommon
+
+
+@tagged("-at_install", "post_install")
+class TestAccountMoveRedraft(AccountTestInvoicingCommon):
+    def test_add_new_lines_pdf(self):
+
+        invoice = self.env['account.move'].create({
+            'move_type': 'out_invoice',
+            'partner_id': self.partner_a.id,
+            'invoice_line_ids': [
+                Command.create({
+                    'name': 'line1',
+                }),
+            ],
+        })
+
+        template = self.env.ref(invoice._get_mail_template())
+
+        invoice.action_post()
+        self.env['account.move.send']\
+            .with_context(active_model='account.move', active_ids=invoice.ids)\
+            .create({
+                'mail_template_id': template.id,
+            }).action_send_and_print()
+
+        pre_draft_checksum = invoice.invoice_pdf_report_id.checksum
+
+        invoice.button_draft()
+        invoice._compute_linked_attachment_id('invoice_pdf_report_id', 'invoice_pdf_report_file')
+
+        invoice.write({'invoice_line_ids': [
+            Command.create({
+                'name': 'line2',
+            }),
+        ]})
+
+        invoice.action_post()
+        self.env['account.move.send']\
+            .with_context(active_model='account.move', active_ids=invoice.ids)\
+            .create({
+                'mail_template_id': template.id,
+            }).action_send_and_print()
+
+        self.assertNotEqual(
+            invoice.invoice_pdf_report_id.checksum,
+            pre_draft_checksum
+        )


### PR DESCRIPTION
In this bug, the generated invoice pdf is not changed after modifing invoice in draft status.

To reporduce the error:
1- Create an invoice and confirm it
2- Click on send and print
3- Reset to draft, add a new line
4- Send and print again
5- You can see the new line is not added

This bug is only reproducible on 17.0.
On [18.0](https://github.com/odoo/odoo/blob/18.0/addons/account/models/account_move.py#L5308-L5337) it is fixed by detaching the `invoice_pdf_report_file` when the invoice is reset to draft.
Here the same fix is done.

opw-4916398
