### PR TITLE
[FIX] html_builder: replace `web_editor` with `html_builder` in shapeId

### DIFF
--- a/addons/html_builder/static/src/plugins/image/image_shape_option_plugin.js
+++ b/addons/html_builder/static/src/plugins/image/image_shape_option_plugin.js
@@ -82,11 +82,16 @@ export class ImageShapeOptionPlugin extends Plugin {
     async processImageWarmup(img, newDataset) {
         const getData = (propName) =>
             propName in newDataset ? newDataset[propName] : img.dataset[propName];
-        const shapeId = getData("shape");
+        let shapeId = getData("shape");
         // todo: should we reset some data if shapeName is not defined?
         if (!shapeId) {
             return;
         }
+        // todo: probably we should replace `web_editor` with `html_builder` in
+        // `data-shape` in every snippet, but this will require a migration
+        // script, and it's too late for 18.4.
+        shapeId = shapeId.replace(/^web_editor/, "html_builder");
+
         const isNewShape = "shape" in newDataset && newDataset.shape !== img.dataset.shape;
         const shapeSvgText = await this.getShapeSvgText(shapeId);
 


### PR DESCRIPTION
**Problem**
Some snippets contain shapes whose ID starts with `web_editor` instead of `html_builder`. These IDs are not listed in `imageShapeDefinitions` [1], and this generates a traceback when trying to apply shape tranformations.

**How to reproduce**
1. Insert the snippet `s_images_constellation`
2. Click on the bottom left image having the "Double Pill" shape
3. Click on any "Transform" button under the "Shape" row in the "Image" section
4. Problem: traceback pops up

**Solution**
When retrieving the shape ID, a check is performed. If `web_editor` is found at the beginning of the string, it is replaced with `html_builder`.

[1] addons/html_builder/static/src/plugins/image/image_shapes_definition.js

task-4367641
