### PR TITLE
[FIX] pos_loyalty: fix program selection

### DIFF
--- a/addons/pos_loyalty/static/src/app/services/pos_store.js
+++ b/addons/pos_loyalty/static/src/app/services/pos_store.js
@@ -356,9 +356,12 @@ patch(PosStore.prototype, {
         const order = this.getOrder();
         const linkedPrograms = [
             ...new Set(
-                productIds.flatMap(
-                    (id) => this.models["loyalty.program"].getBy("trigger_product_ids", id) || []
-                )
+                productIds
+                    .flatMap(
+                        (id) =>
+                            this.models["loyalty.program"].getBy("trigger_product_ids", id) || []
+                    )
+                    .filter((p) => ["gift_card", "ewallet"].includes(p.program_type))
             ),
         ];
         let selectedProgram = null;

--- a/addons/pos_loyalty/static/tests/tours/pos_loyalty_loyalty_program_tour.js
+++ b/addons/pos_loyalty/static/tests/tours/pos_loyalty_loyalty_program_tour.js
@@ -8,6 +8,7 @@ import * as combo from "@point_of_sale/../tests/pos/tours/utils/combo_popup_util
 import * as Order from "@point_of_sale/../tests/generic_helpers/order_widget_util";
 import { inLeftSide } from "@point_of_sale/../tests/pos/tours/utils/common";
 import { registry } from "@web/core/registry";
+import { negate } from "@point_of_sale/../tests/generic_helpers/utils";
 
 registry.category("web_tour.tours").add("PosLoyaltyLoyaltyProgram1", {
     steps: () =>
@@ -345,5 +346,20 @@ registry.category("web_tour.tours").add("test_buy_x_get_y_reward_qty", {
             PosLoyalty.claimReward("Free Product - Whiteboard Pen"),
             PosLoyalty.hasRewardLine("Free Product - Whiteboard Pen", "-9.60", "3.00"),
             PosLoyalty.finalizeOrder("Cash", "32"),
+        ].flat(),
+});
+
+registry.category("web_tour.tours").add("test_multiple_loyalty_products", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            ProductScreen.clickDisplayedProduct("Whiteboard Pen"),
+            {
+                content: "Check that selection popup is not opened",
+                trigger: negate(`.selection-item`),
+            },
+            Order.hasLine({ productName: "Whiteboard Pen", quantity: "1" }),
+            Order.hasLine({ productName: "10% on your order", quantity: "1" }),
         ].flat(),
 });


### PR DESCRIPTION
When clicking on a product that is linked to multiple loyalty programs you are prompted to select one of them everytime you add one item via the ui.

Steps to reproduce:
-------------------
* Create 2 loyalty programs activated when buying a certain product
* Open PoS and click on the product
> Observation: You will get a prompt everytime you click on the product

Why the fix:
------------
The variable `selected_program` is actually only usefull if the program selected is gift card or an eWallet program. So we filter it before and only prompt when the output will be usefull.

opw-4187037