### PR TITLE
[IMP] hr_holidays: Improve Time Off UX

### DIFF
--- a/addons/hr_holidays/models/hr_employee.py
+++ b/addons/hr_holidays/models/hr_employee.py
@@ -269,14 +269,16 @@ class HrEmployee(models.Model):
         return super()._get_user_m2o_to_empty_on_archived_employees() + ['leave_manager_id']
 
     def action_time_off_dashboard(self):
-        action = self.env['ir.actions.act_window']._for_xml_id('hr_holidays.hr_leave_action_action_approve_department')
-        action['context'] = dict(literal_eval(action['context']))
-        action['context']['show_dashboard'] = True
-        action['context'].pop('search_default_waiting_for_me', False)
-        action['context'].pop('search_default_waiting_for_me_manager', False)
-        action['context']['default_employee_id'] = self.id
-        action['domain'] = [('employee_id', 'in', self.ids)]
-        return action
+        return {
+            'name': _('Time Off Dashboard'),
+            'type': 'ir.actions.act_window',
+            'res_model': 'hr.leave',
+            'views': [[self.env.ref('hr_holidays.hr_leave_employee_view_dashboard').id, 'calendar']],
+            'domain': [('employee_id', 'in', self.ids)],
+            'context': {
+                'employee_id': self.ids,
+            },
+        }
 
     def get_mandatory_days(self, start_date, end_date):
         all_days = {}

--- a/addons/hr_holidays/models/hr_employee_public.py
+++ b/addons/hr_holidays/models/hr_employee_public.py
@@ -54,3 +54,19 @@ class HrEmployeePublic(models.Model):
         self.ensure_one()
         if self.is_user:
             return self.employee_id.action_time_off_dashboard()
+
+    def action_open_time_off_calendar(self):
+        """Open the time off calendar filtered on this employee."""
+        self.ensure_one()
+        action = self.env.ref('hr_holidays.action_my_days_off_dashboard_calendar').sudo().read()[0]
+        action['domain'] = [('employee_id', '=', self.id)]
+        ctx = ({
+            'active_employee_id': self.id,
+            'search_default_employee_id': [self.id],
+            'search_default_my_leaves': 0,
+            'search_default_team': 0,
+            'search_default_current_year': 1,
+            'hide_employee_name': 1,
+        })
+        action['context'] = ctx
+        return action

--- a/addons/hr_holidays/report/hr_leave_report_calendar.xml
+++ b/addons/hr_holidays/report/hr_leave_report_calendar.xml
@@ -23,6 +23,29 @@
         </field>
     </record>
 
+    <record id="hr_leave_report_calendar_year_view" model="ir.ui.view">
+        <field name="name">hr.leave.report.calendar.year.view</field>
+        <field name="model">hr.leave.report.calendar</field>
+        <field name="arch" type="xml">
+            <calendar
+                string="Time Off"
+                date_start="start_datetime"
+                date_stop="stop_datetime"
+                mode="year"
+                quick_create="0"
+                color="employee_id"
+                event_open_popup="True"
+                js_class="time_off_report_calendar"
+                show_unusual_days="True">
+                <field name="name"/>
+                <field name="employee_id" filters="1" invisible="1"/>
+                <field name="is_hatched" invisible="1"/>
+                <field name="state" invisible="1"/>
+                <field name="leave_manager_id" invisible="1"/>
+            </calendar>
+        </field>
+    </record>
+
     <record id="hr_leave_report_calendar_view_form" model="ir.ui.view">
         <field name="name">hr.leave.report.calendar.view.form</field>
         <field name="model">hr.leave.report.calendar</field>
@@ -97,6 +120,18 @@
         <field name="help" type="html">
             <p class="o_view_nocontent_smiling_face">
                 Nobody here ? All of the people you're looking for will be working at that time.
+            </p>
+        </field>
+    </record>
+
+    <record id="action_my_days_off_dashboard_calendar" model="ir.actions.act_window">
+        <field name="name">Dashboard</field>
+        <field name="res_model">hr.leave.report.calendar</field>
+        <field name="view_mode">calendar</field>
+        <field name="view_id" ref="hr_leave_report_calendar_year_view"/>
+        <field name="help" type="html">
+            <p class="o_view_nocontent_smiling_face">
+                You have no time off yet!
             </p>
         </field>
     </record>

--- a/addons/hr_holidays/static/src/scss/time_off.scss
+++ b/addons/hr_holidays/static/src/scss/time_off.scss
@@ -96,6 +96,7 @@
 
     .ribbon {
         --Ribbon-wrapper-width: 6.77rem;
+        height: 5rem;
         span {
             --Ribbon-left-position-default: 0.3rem;
         }
@@ -120,8 +121,9 @@
         @media only screen and (min-width:768px){
             .o_kanban_record {
                 width: 100%;
-                min-height: 6.5rem;
+                max-height: 5.1rem;
                 margin: 0px;
+                justify-content: center;
             }
             .o_hr_holidays_kanban_mobile {
                 display: none;

--- a/addons/hr_holidays/views/hr_leave_allocation_views.xml
+++ b/addons/hr_holidays/views/hr_leave_allocation_views.xml
@@ -418,12 +418,14 @@
                                 <img t-att-src="'/web/image/hr.employee.public/' + record.employee_id.raw_value + '/avatar_128?unique=' + record.write_date.raw_value"
                                     class="o_image_64_cover float-start mb-2 me-2" alt="Employee's image"/>
                             </aside>
-                            <main class="ps-3">
-                                <div class="o_holidays_kanban_card">
-                                    <field class="fw-bold fs-3 mb-2" name="employee_id"/>
+                            <main class="h-100">
+                                <div class="justify-content-center o_holidays_kanban_card">
                                     <div class="d-flex flex-row">
-                                        <div class="col-md-9 col-lg-9 col-10 o_hr_holidays_value">
-                                            <div class="col-md-5 col-lg-7 col-6 o_hr_holidays_name">
+                                        <div class="col-12 align-items-center o_hr_holidays_value">
+                                             <div class="col-4 o_hr_holidays_card">
+                                                <field class="fw-bold fs-3 mb-2" name="employee_id"/>
+                                            </div>
+                                            <div class="col-2 o_hr_holidays_name">
                                                 <div class="o_hr_holidays_card">
                                                     <field name="holiday_status_id" class="fw-bold me-1"/>
                                                     <div class="d-flex flex-wrap">
@@ -431,13 +433,13 @@
                                                     </div>
                                                 </div>
                                             </div>
-                                            <div class="col-3 col-lg-2 o_hr_holidays_card">
+                                            <div class="col-2 o_hr_holidays_card">
                                                 <div class="fw-bold d-flex me-1">
                                                     <field name="duration_display"/>
                                                 </div>
                                                 Amount
                                             </div>
-                                            <div class="col-3 o_hr_holidays_card">
+                                            <div class="col-2 o_hr_holidays_card">
                                                 <div class="fw-bold d-flex gap-1 me-1">
                                                     <field name="virtual_remaining_leaves" widget="float" digits="[3,2]"/>
                                                     /
@@ -447,23 +449,23 @@
                                                     Current balance
                                                 </span>
                                             </div>
-                                        </div>
-                                        <div class="col-md-4 col-lg-3 col-2 o_hr_holidays_button flex-wrap d-flex pe-4 gap-2 justify-content-start">
-                                            <button
-                                                name="action_approve" type="object" class="btn btn-primary"
-                                                t-if="record.can_approve.raw_value">
-                                                Approve
-                                            </button>
-                                            <button
-                                                name="action_approve" type="object" class="btn btn-primary"
-                                                t-if="record.can_validate.raw_value and !record.can_approve.raw_value">
-                                                Validate
-                                            </button>
-                                            <button
-                                                name="action_refuse" type="object" class="btn btn-secondary"
-                                                t-if="record.can_refuse.raw_value">
-                                                Refuse
-                                            </button>
+                                            <div class="col-2 o_hr_holidays_button flex-wrap d-flex pe-4 gap-2 justify-content-start">
+                                                <button
+                                                    name="action_approve" type="object" class="btn btn-primary"
+                                                    t-if="record.can_approve.raw_value">
+                                                    Approve
+                                                </button>
+                                                <button
+                                                    name="action_approve" type="object" class="btn btn-primary"
+                                                    t-if="record.can_validate.raw_value and !record.can_approve.raw_value">
+                                                    Validate
+                                                </button>
+                                                <button
+                                                    name="action_refuse" type="object" class="btn btn-secondary"
+                                                    t-if="record.can_refuse.raw_value">
+                                                    Refuse
+                                                </button>
+                                            </div>
                                         </div>
                                     </div>
                                 </div>

--- a/addons/hr_holidays/views/hr_leave_views.xml
+++ b/addons/hr_holidays/views/hr_leave_views.xml
@@ -124,14 +124,16 @@
                             <widget name="web_ribbon" title="Approved" bg_color="bg-success" invisible="state != 'validate'"/>
                             <aside>
                                 <img t-att-src="'/web/image/hr.employee.public/' + record.employee_id.raw_value + '/avatar_128'"
-                                    class="o_image_64_cover float-start mb-2 me-2" alt="Employee's image"/>
+                                    class="o_image_64_cover float-start me-2" alt="Employee's image"/>
                             </aside>
-                            <main class="ps-3">
-                                <div class="o_holidays_kanban_card">
-                                    <field class="fw-bold fs-3 mb-2" name="employee_id"/>
+                            <main class="h-100">
+                                <div class="justify-content-center o_holidays_kanban_card">
                                     <div class="d-flex flex-row">
-                                        <div class="col-md-9 col-lg-9 col-10 d-flex flex-row o_hr_holidays_value">
-                                            <div class="col-md-5 col-lg-7 col-6 o_hr_holidays_name">
+                                        <div class="col-12 align-items-center o_hr_holidays_value">
+                                            <div class="col-4 o_hr_holidays_card">
+                                                <field class="fw-bold fs-3 mb-2" name="employee_id"/>
+                                            </div>
+                                            <div class="col-2 o_hr_holidays_name">
                                                 <field name="holiday_status_id" class="fw-bold"/>
                                                 <div class="d-flex flex-row">
                                                     <t t-out="luxon.DateTime.fromISO(record.request_date_from.raw_value).toLocaleString({ month: 'short', day: 'numeric'})"/>
@@ -151,13 +153,13 @@
                                                     </t>
                                                 </div>
                                             </div>
-                                            <div class="col-3 col-lg-2 o_hr_holidays_card">
+                                            <div class="col-2 o_hr_holidays_card">
                                                 <div class="fw-bold d-flex me-1">
                                                     <field name="duration_display"/>
                                                 </div>
                                                 Amount
                                             </div>
-                                            <div class="col-3 o_hr_holidays_card">
+                                            <div class="col-2 o_hr_holidays_card">
                                                 <div t-if="record.holiday_status_requires_allocation.raw_value"> <!-- To keep the same space-->
                                                     <div class="fw-bold d-flex gap-1 me-1">
                                                         <field name="virtual_remaining_leaves" widget="float" digits="[3,2]"/>
@@ -169,23 +171,23 @@
                                                     </span>
                                                 </div>
                                             </div>
-                                        </div>
-                                        <div class="col-3 o_hr_holidays_button flex-wrap d-flex pe-4 gap-2 justify-content-start">
-                                            <button
-                                                name="action_approve" type="object" class="btn btn-primary"
-                                                t-if="record.can_approve.raw_value">
-                                                Approve
-                                            </button>
-                                            <button
-                                                name="action_approve" type="object" class="btn btn-primary"
-                                                t-if="record.can_validate.raw_value and !record.can_approve.raw_value">
-                                                Validate
-                                            </button>
-                                            <button
-                                                name="action_refuse" type="object" class="btn btn-secondary"
-                                                t-if="record.can_refuse.raw_value">
-                                                Refuse
-                                            </button>
+                                            <div class="col-2 o_hr_holidays_button flex-wrap d-flex pe-4 gap-2 justify-content-start">
+                                                <button
+                                                    name="action_approve" type="object" class="btn btn-primary"
+                                                    t-if="record.can_approve.raw_value">
+                                                    Approve
+                                                </button>
+                                                <button
+                                                    name="action_approve" type="object" class="btn btn-primary"
+                                                    t-if="record.can_validate.raw_value and !record.can_approve.raw_value">
+                                                    Validate
+                                                </button>
+                                                <button
+                                                    name="action_refuse" type="object" class="btn btn-secondary"
+                                                    t-if="record.can_refuse.raw_value">
+                                                    Refuse
+                                                </button>
+                                            </div>
                                         </div>
                                     </div>
                                 </div>

--- a/addons/hr_holidays/views/hr_views.xml
+++ b/addons/hr_holidays/views/hr_views.xml
@@ -166,6 +166,23 @@
         <field name="arch" type="xml">
             <xpath expr="//div[@name='button_box']" position="inside">
                 <field name="show_leaves" invisible="1"/>
+                <button name="action_open_time_off_calendar"
+                        type="object"
+                        class="oe_stat_button"
+                        icon="fa-calendar"
+                        invisible="show_leaves"
+                        groups="base.group_user"
+                        help="Remaining leaves">
+                    <div class="o_field_widget o_stat_info">
+                        <span class="o_stat_text">
+                            Time Off
+                        </span>
+                    </div>
+                </button>
+            </xpath>
+
+            <xpath expr="//div[@name='button_box']" position="inside">
+                <field name="show_leaves" invisible="1"/>
                 <button name="%(hr_leave_action_new_request)d"
                         type="action"
                         class="oe_stat_button"


### PR DESCRIPTION
In this PR, we improved the time off app ux. 
Main changes:
- Management > Timeoff: align all information in one line.
- hr_employee Time Off smartbutton: revert to 18.2 UI.
- employee.public: Remove the taken amount from the Time Off smartbutton and change the calendar view displayed when clicking on the smartbutton to be similar to the overview one (we don't display the Time Off type in the leave anymore). 
Related task: 4930588.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
