### PR TITLE
[IMP] web: make search and highlight behavior accent-insensitive

### DIFF
--- a/addons/web/static/src/core/commands/command_palette.js
+++ b/addons/web/static/src/core/commands/command_palette.js
@@ -7,7 +7,7 @@ import { scrollTo } from "@web/core/utils/scrolling";
 import { fuzzyLookup } from "@web/core/utils/search";
 import { debounce } from "@web/core/utils/timing";
 import { isMacOS, isMobileOS } from "@web/core/browser/feature_detection";
-import { escapeRegExp } from "@web/core/utils/strings";
+import { highlightText } from "@web/core/utils/html";
 
 import {
     Component,
@@ -74,14 +74,6 @@ function commandsWithinCategory(categoryName, categories) {
         const fallbackCategory = categoryName === "default" && !categories.includes(cmd.category);
         return inCurrentCategory || fallbackCategory;
     };
-}
-
-export function splitCommandName(name, searchValue) {
-    if (name) {
-        const splitName = name.split(new RegExp(`(${escapeRegExp(searchValue)})`, "ig"));
-        return searchValue.length && splitName.length > 1 ? splitName : [name];
-    }
-    return [];
 }
 
 export class DefaultCommandItem extends Component {
@@ -235,7 +227,7 @@ export class CommandPalette extends Component {
             commands.slice(0, 100).map((command) => ({
                 ...command,
                 keyId: this.keyId++,
-                splitName: splitCommandName(command.name, options.searchValue),
+                text: highlightText(options.searchValue, command.name, "fw-bolder text-primary"),
             }))
         );
         this.selectCommand(this.state.commands.length ? 0 : -1);

--- a/addons/web/static/src/core/commands/command_palette.xml
+++ b/addons/web/static/src/core/commands/command_palette.xml
@@ -36,12 +36,7 @@
                   <a t-att-href="command.href" t-att-class="command.className">
                     <t t-component="command.Component || DefaultCommandItem" name="command.name" searchValue="state.searchValue" t-props="command.props" executeCommand="() => this.executeCommand(command)">
                       <t t-set-slot="name">
-                        <span class="o_command_name text-ellipsis" t-att-title="command.name">
-                          <t t-foreach="command.splitName" t-as="name" t-key="name_index">
-                            <b t-if="name_index % 2" t-out="name" class="text-primary"/>
-                            <t t-else="" t-out="name"/>
-                          </t>
-                        </span>
+                        <span class="o_command_name text-ellipsis" t-att-title="command.name" t-out="command.text"/>
                       </t>
                       <t t-set-slot="focusMessage">
                           <small t-if="!isMobileOS and command.href and state.selectedCommand === command" class="o_command_focus text-muted"><kbd><t t-if="isMacOS">CMD</t><t t-else="">CTRL</t></kbd>+<kbd>⏎</kbd><span class="ms-1">new tab</span></small>

--- a/addons/web/static/src/core/l10n/utils/normalize.js
+++ b/addons/web/static/src/core/l10n/utils/normalize.js
@@ -78,6 +78,30 @@ export function normalizedMatch(src, substr) {
     return { start: -1, end: -1, match: "" };
 }
 
+/**
+ * Searches for "substr" in "src" as is done in normalizedMatch
+ * but returns an array of all successful matches
+ *
+ * @param {string} src
+ * @param {string} substr
+ * @returns {Array<{match: string, start: number, end: number}>}
+ */
+export function normalizedMatches(src, substr) {
+    const matches = [];
+    let index = 0;
+    while (src.length) {
+        const { start, end, match } = normalizedMatch(src, substr);
+        if (match) {
+            matches.push({ start: index + start, end: index + end, match });
+            index += end;
+            src = src.slice(end);
+        } else {
+            break;
+        }
+    }
+    return matches;
+}
+
 const DECOMPOSITION_BY_LIGATURE = new Map([
     ["Æ", "Ae"], // Danish, Norwegian, Icelandic, French (rare)...
     ["æ", "ae"],

--- a/addons/web/static/src/webclient/settings_form_view/settings/searchable_setting.js
+++ b/addons/web/static/src/webclient/settings_form_view/settings/searchable_setting.js
@@ -1,9 +1,9 @@
-import { escapeRegExp } from "@web/core/utils/strings";
-import { Setting } from "@web/views/form/setting/setting";
 import { onMounted, useRef, useState } from "@odoo/owl";
+import { browser } from "@web/core/browser/browser";
+import { normalizedMatch } from "@web/core/l10n/utils";
+import { Setting } from "@web/views/form/setting/setting";
 import { FormLabelHighlightText } from "../highlight_text/form_label_highlight_text";
 import { HighlightText } from "../highlight_text/highlight_text";
-import { browser } from "@web/core/browser/browser";
 
 export class SearchableSetting extends Setting {
     static template = "web.SearchableSetting";
@@ -49,8 +49,7 @@ export class SearchableSetting extends Setting {
         if (this.state.showAllContainer.showAllContainer) {
             return true;
         }
-        const regexp = new RegExp(escapeRegExp(this.state.search.value), "i");
-        if (regexp.test(this.labels.join())) {
+        if (normalizedMatch(this.labels.join(), this.state.search.value).match) {
             return true;
         }
         return false;

--- a/addons/web/static/tests/core/commands/command_palette.test.js
+++ b/addons/web/static/tests/core/commands/command_palette.test.js
@@ -1273,7 +1273,7 @@ test("bold the searchValue on the commands", async () => {
     await animationFrame();
     expect(".o_command_palette").toHaveCount(1);
     expect(".o_command").toHaveCount(5);
-    expect(queryAllTexts(".o_command b")).toEqual([]);
+    expect(queryAllTexts(".o_command .fw-bolder")).toEqual([]);
 
     await click(".o_command_palette_search input");
     await edit("@test");
@@ -1281,7 +1281,7 @@ test("bold the searchValue on the commands", async () => {
     expect(".o_command").toHaveCount(5);
     expect(
         queryAll(".o_command").map((command) =>
-            queryAllTexts(".o_command_name b", { root: command })
+            queryAllTexts(".o_command_name .fw-bolder", { root: command })
         )
     ).toEqual([["Test"], ["test"], ["test"], ["Test"], ["TeSt", "Test", "TEST"]]);
 });
@@ -1310,7 +1310,34 @@ test("bold the searchValue on the commands with special char", async () => {
     expect(".o_command_palette").toHaveCount(1);
     expect(".o_command").toHaveCount(1);
     expect(queryAllTexts(".o_command")).toEqual(["Test&"]);
-    expect(queryAllTexts(".o_command b")).toEqual(["&"]);
+    expect(queryAllTexts(".o_command .fw-bolder")).toEqual(["&"]);
+});
+
+test("bold the searchValue on the commands with accents", async () => {
+    await mountWithCleanup(MainComponentsContainer);
+    const action = () => {};
+    const providers = [
+        {
+            provide: () => [
+                {
+                    name: "Cédric",
+                    action,
+                },
+            ],
+        },
+    ];
+    const config = {
+        searchValue: "èd",
+        providers,
+    };
+    getService("dialog").add(CommandPalette, {
+        config,
+    });
+    await animationFrame();
+    expect(".o_command_palette").toHaveCount(1);
+    expect(".o_command").toHaveCount(1);
+    expect(queryAllTexts(".o_command")).toEqual(["Cédric"]);
+    expect(queryAllTexts(".o_command .fw-bolder")).toEqual(["éd"]);
 });
 
 test("remove namespace with backspace", async () => {

--- a/addons/web/static/tests/core/commands/command_service.test.js
+++ b/addons/web/static/tests/core/commands/command_service.test.js
@@ -139,9 +139,7 @@ test("useCommand hook with isAvailable", async () => {
     class MyComponent extends TestComponent {
         setup() {
             useCommand("Take the throne", () => {}, {
-                isAvailable: () => {
-                    return available;
-                },
+                isAvailable: () => available,
             });
         }
     }
@@ -336,11 +334,9 @@ test("open command palette with command config", async () => {
     const providers = [{ provide }];
     getService("command").add(
         "test",
-        () => {
-            return {
-                providers,
-            };
-        },
+        () => ({
+            providers,
+        }),
         {
             hotkey,
         }
@@ -1063,7 +1059,7 @@ test("uses openPalette to modify the config used by the command palette", async 
     getService("command").openPalette(configCustom);
     await animationFrame();
     expect(".o_command").toHaveCount(1);
-    expect(queryAllTexts(".o_command span:first-child")).toEqual(["Command2"]);
+    expect(queryAllTexts(".o_command .o_command_name")).toEqual(["Command2"]);
     expect(".o_command_palette_search input").toHaveValue("Command");
 });
 
@@ -1117,6 +1113,6 @@ test("ensure that calling openPalette multiple times successfully loads the last
     await animationFrame();
     // Second config should be loaded properly.
     expect(".o_command").toHaveCount(1);
-    expect(queryAllTexts(".o_command span:first-child")).toEqual(["Command2"]);
+    expect(queryAllTexts(".o_command .o_command_name")).toEqual(["Command2"]);
     expect(".o_command_palette_search input").toHaveValue("Command");
 });

--- a/addons/web/static/tests/core/utils/html.test.js
+++ b/addons/web/static/tests/core/utils/html.test.js
@@ -61,6 +61,12 @@ test("highlightText", () => {
     expect(highlightText(markup`<p>ab</p>`, markup`<p>ab</p>`, "hl").toString()).toBe(
         '<span class="hl"><p>ab</p></span>'
     );
+    expect(highlightText("cè", "Cédric ce cèdre", "hl").toString()).toBe(
+        '<span class="hl">Cé</span>dric <span class="hl">ce</span> <span class="hl">cè</span>dre',
+        {
+            message: "highlightText should be accent insensitive",
+        }
+    );
 });
 
 test("htmlEscape escapes text", () => {

--- a/addons/web/static/tests/webclient/settings_form_view/settings_form_view.test.js
+++ b/addons/web/static/tests/webclient/settings_form_view/settings_form_view.test.js
@@ -2296,3 +2296,32 @@ test("Don't cache settings data", async () => {
         Object.keys(cache.ramCache.ram.onchange || {})?.[0]?.includes("res.config.settings")
     ).toBe(undefined);
 });
+
+test("settings search is accent-insensitive", async () => {
+    await mountView({
+        type: "form",
+        resModel: "res.config.settings",
+        arch: /* xml */ `
+            <form string="Settings" class="oe_form_configuration o_base_settings" js_class="base_settings">
+                <app string="CRM" name="crm">
+                    <block title="Title of group Bâr">
+                        <setting help="this is bàr" documentation="/applications/technical/web/settings/this_is_a_test.html">
+                            <field name="bar"/>
+                            <button name="buttonName" icon="oi-arrow-right" type="action" string="Manage Users" class="btn-link"/>
+                        </setting>
+                        <setting>
+                            <label string="Big BÄZ" for="baz"/>
+                            <div class="text-muted">this is a báz</div>
+                            <field name="baz"/>
+                            <label>label with content</label>
+                        </setting>
+                    </block>
+                </app>
+            </form>
+        `,
+    });
+    await editSearch("bar");
+    expect(queryAllTexts(".highlighter")).toEqual(["Bâr", "Bar", "bàr"]);
+    await editSearch("àz");
+    expect(queryAllTexts(".highlighter")).toEqual(["ÄZ", "áz"]);
+});


### PR DESCRIPTION
This PR improves the search and highlighting behavior across various parts of the web client by making it accent-insensitive and more consistent:

- highlightText is now accent-insensitive, allowing visually consistent highlighting of matched text regardless of the presence of accented characters. This improves usability in components like many2x autocompletes and the settings panel.

- The command palette now uses the centralized highlightText utility instead of a local implementation, ensuring consistent highlighting behavior and benefiting from accent-insensitive support.

- The settings search has been updated to use the normalizedMatch utility, replacing the basic regex matching. This change allows users to find results regardless of accent usage in their queries or the matched content.

task-4816162
