### PR TITLE
[FIX] html_editor: remove font-size format when changing tag type

### DIFF
--- a/addons/html_editor/static/src/core/dom_plugin.js
+++ b/addons/html_editor/static/src/core/dom_plugin.js
@@ -563,6 +563,7 @@ export class DomPlugin extends Plugin {
             newCandidate = baseContainer;
         }
         const cursors = this.dependencies.selection.preserveSelection();
+        const newEls = [];
         for (const block of this.getBlocksToTag()) {
             if (isParagraphRelatedElement(block) || isListItemElement(block)) {
                 if (newCandidate.matches(baseContainerGlobalSelector) && isListItemElement(block)) {
@@ -584,6 +585,7 @@ export class DomPlugin extends Plugin {
                 if (block.nodeName === "LI") {
                     this.delegateTo("set_tag_overrides", block, newEl);
                 }
+                newEls.push(newEl);
             } else {
                 // eg do not change a <div> into a h1: insert the h1
                 // into it instead.
@@ -593,6 +595,7 @@ export class DomPlugin extends Plugin {
             }
         }
         cursors.restore();
+        this.dispatchTo("set_tag_handlers", newEls);
         this.dependencies.history.addStep();
     }
 

--- a/addons/html_editor/static/src/main/align/align_plugin.js
+++ b/addons/html_editor/static/src/main/align/align_plugin.js
@@ -61,7 +61,7 @@ export class AlignPlugin extends Plugin {
         selectionchange_handlers: this.updateAlignmentParams.bind(this),
         post_undo_handlers: this.updateAlignmentParams.bind(this),
         post_redo_handlers: this.updateAlignmentParams.bind(this),
-        remove_format_handlers: this.setAlignment.bind(this),
+        remove_all_formats_handlers: this.setAlignment.bind(this),
 
         /** Predicates */
         has_format_predicates: (node) => closestBlock(node)?.style.textAlign,

--- a/addons/html_editor/static/src/main/font/color_plugin.js
+++ b/addons/html_editor/static/src/main/font/color_plugin.js
@@ -73,7 +73,7 @@ export class ColorPlugin extends Plugin {
 
         /** Handlers */
         selectionchange_handlers: this.updateSelectedColor.bind(this),
-        remove_format_handlers: this.removeAllColor.bind(this),
+        remove_all_formats_handlers: this.removeAllColor.bind(this),
         color_combination_getters: getColorCombinationFromClass,
 
         /** Overridables */

--- a/addons/html_editor/static/src/main/table/table_align_plugin.js
+++ b/addons/html_editor/static/src/main/table/table_align_plugin.js
@@ -62,7 +62,7 @@ export class TableAlignPlugin extends Plugin {
         selectionchange_handlers: this.updateVerticalAlignParams.bind(this),
         post_undo_handlers: this.updateVerticalAlignParams.bind(this),
         post_redo_handlers: this.updateVerticalAlignParams.bind(this),
-        remove_format_handlers: this.setVerticalAlignment.bind(this),
+        remove_all_formats_handlers: this.setVerticalAlignment.bind(this),
 
         /** Predicates */
         has_format_predicates: (node) => closestElement(node, "td, th")?.style.verticalAlign,

--- a/addons/html_editor/static/tests/tags.test.js
+++ b/addons/html_editor/static/tests/tags.test.js
@@ -123,6 +123,15 @@ describe("to paragraph", () => {
         await press("enter");
         expect(getContent(el)).toBe("<p>ab[]cd</p>");
     });
+
+    test("should remove current font-size formatting when changing to a paragraph", async () => {
+        await testEditor({
+            contentBefore:
+                '<h3 class="h4-fs" style="text-align: center;">[abc<span style="font-size: 32px;">de</span><strong>fg</strong>]</h3>',
+            stepFunction: setTag("p"),
+            contentAfter: '<p style="text-align: center;">[abcde<strong>fg]</strong></p>',
+        });
+    });
 });
 
 describe("to heading 1", () => {
@@ -208,6 +217,15 @@ describe("to heading 1", () => {
             contentAfter: '<ul><li class="nav-item"><h1>[abcd]</h1></li></ul>',
         });
     });
+
+    test("should remove current font-size formatting when changing to a heading 1", async () => {
+        await testEditor({
+            contentBefore:
+                '<h2 class="h4-fs" style="text-align: center;">[abc<span style="font-size: 32px;">de</span><strong>fg</strong>]</h2>',
+            stepFunction: setTag("h1"),
+            contentAfter: '<h1 style="text-align: center;">[abcde<strong>fg]</strong></h1>',
+        });
+    });
 });
 
 describe("to heading 2", () => {
@@ -267,6 +285,15 @@ describe("to heading 2", () => {
             contentBefore: '<ul><li class="nav-item">[abcd]</li></ul>',
             stepFunction: setTag("h2"),
             contentAfter: '<ul><li class="nav-item"><h2>[abcd]</h2></li></ul>',
+        });
+    });
+
+    test("should remove current font-size formatting when changing to a heading 2", async () => {
+        await testEditor({
+            contentBefore:
+                '<h3 class="h4-fs" style="text-align: center;">[abc<span style="font-size: 32px;">de</span><strong>fg</strong>]</h3>',
+            stepFunction: setTag("h2"),
+            contentAfter: '<h2 style="text-align: center;">[abcde<strong>fg]</strong></h2>',
         });
     });
 });
@@ -334,6 +361,15 @@ describe("to heading 3", () => {
             contentAfter: '<ul><li class="nav-item"><h3>[abcd]</h3></li></ul>',
         });
     });
+
+    test("should remove current font-size formatting when changing to a heading 3", async () => {
+        await testEditor({
+            contentBefore:
+                '<h2 class="h4-fs" style="text-align: center;">[abc<span style="font-size: 32px;">de</span><strong>fg]</strong></h2>',
+            stepFunction: setTag("h3"),
+            contentAfter: '<h3 style="text-align: center;">[abcde<strong>fg]</strong></h3>',
+        });
+    });
 });
 
 describe("to pre", () => {
@@ -396,6 +432,15 @@ describe("to pre", () => {
 
         await press("enter");
         expect(getContent(el)).toBe("<pre>ab[]cd</pre>");
+    });
+
+    test("should remove current font-size formatting when changing to a pre", async () => {
+        await testEditor({
+            contentBefore:
+                '<h3 class="h4-fs" style="text-align: center;">[abc<span style="font-size: 32px;">de</span><strong>fg</strong>]</h3>',
+            stepFunction: setTag("pre"),
+            contentAfter: '<pre style="text-align: center;">[abcde<strong>fg]</strong></pre>',
+        });
     });
 });
 

--- a/addons/website/static/src/builder/plugins/highlight/highlight_plugin.js
+++ b/addons/website/static/src/builder/plugins/highlight/highlight_plugin.js
@@ -55,7 +55,7 @@ export class HighlightPlugin extends Plugin {
         selectionchange_handlers: this.updateSelectedHighlight.bind(this),
         collapsed_selection_toolbar_predicate: (selectionData) =>
             !!closestElement(selectionData.editableSelection.anchorNode, ".o_text_highlight"),
-        remove_format_handlers: () => {
+        remove_all_formats_handlers: () => {
             // we rely on the normalize handler to start it again
             this.dependencies.edit_interaction.stopInteraction("website.text_highlight");
         },


### PR DESCRIPTION
Replacing an element by a paragraph related element should remove its
font-size formatting (style and classes), while retaining other
formatting (bold, color, etc.):

```
<h2 class="h3-fs">
	<strong>[Some</strong> <span style="font-size: 10px">title]</span>
</h2>
```

should become:
`<h4><strong>[Some</strong> title]</h4>`

task-4935753