### PR TITLE
[FIX] hr_attendance : Change the out_mode if the absence got modified

### DIFF
--- a/addons/hr_attendance/models/hr_attendance.py
+++ b/addons/hr_attendance/models/hr_attendance.py
@@ -480,6 +480,11 @@ class HrAttendance(models.Model):
             not self.env.user.has_group('hr_attendance.group_hr_attendance_officer'):
             raise AccessError(_("Do not have access, user cannot edit the attendances that are not his own."))
         attendances_dates = self._get_attendances_dates()
+
+        if vals.get('check_out') and self.out_mode == 'technical':
+            vals.update({'out_mode': 'manual'})
+        if vals.get('check_in') and self.in_mode == 'technical':
+            vals.update({'in_mode': 'manual'})
         result = super(HrAttendance, self).write(vals)
         if any(field in vals for field in ['employee_id', 'check_in', 'check_out']):
             # Merge attendance dates before and after write to recompute the


### PR DESCRIPTION
### Steps to reproduce:
	- Run Absence detection cron
	- Navigate to the attendances got created in list view
	- Notice all of them are in red color
	- Modify the check in and check out dates to correct them as normal attendance
	- Notice the color didn't change in the view and it is still shows as red

### Cause:
This is happening because color of the record is dependant on the check out mode, so if it is technical it means it is absence so we give it red color.

https://github.com/odoo/odoo/blob/a7a29ed691db4f1607c0d12929c56845681164fa/addons/hr_attendance/models/hr_attendance.py#L84-L89

Also, the check out mode cannot be changed in any way.

### Fix:
When updating the check out and check in time we check if the mode is technical we change it to manual.

opw-4865524