### PR TITLE
[FIX] mail: do not change user write_date on change of presence

### DIFF
--- a/addons/mail/models/mail_presence.py
+++ b/addons/mail/models/mail_presence.py
@@ -2,7 +2,7 @@
 
 from datetime import timedelta
 
-from odoo import api, Command, fields, models, tools
+from odoo import api, fields, models, tools
 from odoo.service.model import PG_CONCURRENCY_EXCEPTIONS_TO_RETRY
 
 UPDATE_PRESENCE_DELAY = 60
@@ -86,7 +86,9 @@ class MailPresence(models.Model):
         if presence := user_or_guest_sudo.presence_ids:
             presence.write(values)
         else:
-            user_or_guest_sudo.presence_ids = [Command.create(values)]
+            values["guest_id" if user_or_guest._name == "mail.guest" else "user_id"] = user_or_guest.id
+            # sudo: res.users/mail.guest can update presence of accessible user/guest
+            self.env["mail.presence"].sudo().create(values)
 
     def _send_presence(self, im_status=None, bus_target=None):
         """Send notification related to bus presence update.


### PR DESCRIPTION
Before this commit, when user presence changes, it was updating the write_date of user.

This happens because any change of presence what doing a `Command.create()` on the presence_id field of user model. The presence object is automatically unlinked after 12 hours of inactivity, thus most users had their write_date changed every day because of the presence_ids being updated when logging in at least once a day.

This commit fixes the issue by creating the presence rather than write on the user field, so that this is not considered a write on user object and thus it doesn't change the write_date of user. Other than not updating the write_date, the code behavior is functionally unchanged.
