### PR TITLE
[FIX] sale_mrp: prevent traceback when reconfirming canceled SO with kit

### DIFF
--- a/addons/sale_mrp/models/stock_rule.py
+++ b/addons/sale_mrp/models/stock_rule.py
@@ -14,10 +14,12 @@ class StockRule(models.Model):
         move_values = super()._get_stock_move_values(product_id, product_qty, product_uom, location_dest_id, name, origin, company_id, values)
         if (sol_id := values.get('sale_line_id')) is not None and 'product_id' in move_values:
             # if the SOL is for a kit
-            if move_values['product_id'] != self.env['sale.order.line'].browse(sol_id).product_id.id:
-                bom_line_id = self.env['sale.order.line'].browse(sol_id).move_ids.bom_line_id.filtered(
+            sol = self.env['sale.order.line'].browse(sol_id)
+            if move_values['product_id'] != sol.product_id.id:
+                active_moves = sol.move_ids.filtered(lambda m: m.state != 'cancel')
+                bom_line_id = active_moves.bom_line_id.filtered(
                     lambda bl: bl.product_id.id == move_values.get('product_id')
-                ).id
+                )[:1].id
                 if bom_line_id:
                     move_values['bom_line_id'] = bom_line_id
         return move_values

--- a/addons/sale_mrp/tests/test_sale_mrp_flow.py
+++ b/addons/sale_mrp/tests/test_sale_mrp_flow.py
@@ -2661,3 +2661,61 @@ class TestSaleMrpFlow(TestSaleMrpFlowCommon):
         self.assertEqual(sale_order.mrp_production_count, 1)
         mo = sale_order.mrp_production_ids
         self.assertEqual(mo.sale_order_count, 1)
+
+    def test_so_with_kit_and_multiple_same_component(self):
+        """Test that a Sale Order with a kit product containing multiple identical components
+        can be confirmed, and that the picking is created correctly. Then verify that the
+        Sale Order can be cancelled and re-confirmed, resulting in a new picking with moves
+        properly linked to each BOM line. Finally, test returning a kit component for exchange."""
+        # Create a kit product with two identical components by duplicating the first BOM line
+        self.bom_kit_1.bom_line_ids = self.bom_kit_1.bom_line_ids[0]
+        self.env['mrp.bom.line'].create([
+            {'product_id': self.bom_kit_1.bom_line_ids[0].product_id.id, 'product_qty': 1.0, 'bom_id': self.bom_kit_1.id},
+        ])
+        # Create a Sale Order with the kit product
+        so = self.env['sale.order'].create({
+            'partner_id': self.partner.id,
+            'order_line': [Command.create({
+                'product_id': self.kit_1.id,
+                'product_uom_qty': 1.0,
+            })],
+        })
+        so.action_confirm()
+
+        # Check that the picking has 2 moves for the same component
+        picking = so.picking_ids
+        self.assertEqual(len(picking.move_ids), 2, "There should be 2 moves for the same component in the picking")
+        self.assertEqual(picking.move_ids.product_id, self.component_a, "All moves should be for the same component")
+        self.assertEqual(picking.move_ids.bom_line_id, self.bom_kit_1.bom_line_ids, "Each move should be linked to a BOM line of the kit")
+
+        # Cancel the Sale Order
+        so._action_cancel()
+        self.assertEqual(so.state, 'cancel', "The Sale Order should be cancelled")
+        self.assertEqual(picking.state, 'cancel', "The picking should be cancelled when the Sale Order is cancelled")
+
+        # Set the Sale Order back to draft and confirm again
+        so.action_draft()
+        so.action_confirm()
+
+        # Check that a new picking is created with correct moves
+        second_picking = so.picking_ids - picking
+        self.assertEqual(len(second_picking.move_ids), 2, "The second picking should have 2 moves for the component")
+        self.assertEqual(second_picking.move_ids.product_id, self.component_a, "All moves in the second picking should be for the same component")
+        self.assertEqual(second_picking.move_ids.bom_line_id, self.bom_kit_1.bom_line_ids, "Each move in the second picking should be linked to a BOM line of the kit")
+        # Returning for exchange a kit's component
+        self.env['stock.quant']._update_available_quantity(self.component_a, self.company_data['default_warehouse'].lot_stock_id, quantity=10)
+        second_picking.action_assign()
+        second_picking.button_validate()
+        return_picking_form = Form(self.env['stock.return.picking'].with_context(active_id=second_picking.id, active_model='stock.picking'))
+        return_wizard = return_picking_form.save()
+        return_wizard.product_return_moves.filtered(lambda prm: prm.product_id == self.component_a).quantity = 1
+        res = return_wizard.action_create_exchanges()
+        return_picking = self.env['stock.picking'].browse(res['res_id'])
+        return_picking.button_validate()
+        exchange_picking = so.picking_ids.filtered(lambda so: so.state == 'assigned')
+        exchange_picking.button_validate()
+        so.order_line._compute_qty_delivered()
+        # In the case where the kit has multiple identical components, only the first BOM line
+        # is linked to all moves (this is a known limitation).
+        self.assertEqual(exchange_picking.move_ids.bom_line_id, self.bom_kit_1.bom_line_ids[0], "All moves in the exchange picking should be linked to the first BOM line.")
+        self.assertEqual(exchange_picking.move_ids.quantity, 2)


### PR DESCRIPTION
Bug introduced in: https://github.com/odoo/odoo/pull/207955

Steps to reproduce the bug:
- Create a kit product:
    - BoM:
    - Components:
        - 1 unit of C1
        - 1 unit of C1 (same product)

- Create a SO with one unit of kit
- Confirm the SO
- The delivery is created
- Cancel the SO → the delivery is canceled.
- Set the SO back to quotation and confirm again

Problem:
A traceback is triggered:
    raise ValueError("Expected singleton: %s" % record)
ValueError: Expected singleton: mrp.bom.line(24, 25)

When a kit's BoM contains the same product multiple times, multiple bom_line_ids match a given move. Assigning them causes an error. Additionally, cancelled moves were incorrectly considered.

Solution:
Filter out cancelled stock moves before accessing the bom_line_id to ensure only active moves are considered.

opw-4919875
