### PR TITLE
[IMP] website, web: adapt search field for website configuration wizard

### DIFF
--- a/addons/web/static/src/core/autocomplete/autocomplete.js
+++ b/addons/web/static/src/core/autocomplete/autocomplete.js
@@ -41,6 +41,8 @@ export class AutoComplete extends Component {
         slots: { type: Object, optional: true },
         menuPositionOptions: { type: Object, optional: true },
         menuCssClass: { type: [String, Array, Object], optional: true },
+        selectOnBlur: { type: Boolean, optional: true },
+        selectOnTab: { type: Boolean, optional: true },
     };
     static defaultProps = {
         value: "",
@@ -328,6 +330,16 @@ export class AutoComplete extends Component {
             this.ignoreBlur = false;
             return;
         }
+        // If selectOnBlur is true, we select the first element
+        // of the autocomplete suggestions list, if this element exists
+        if (this.props.selectOnBlur && this.sources[0]) {
+            const firstOption = this.sources[0].options[0];
+            if (firstOption) {
+                this.state.activeSourceOption = firstOption.unselectable ? null : [0, 0];
+                this.selectOption(this.activeOption);
+                return;
+            }
+        }
         this.props.onBlur({
             inputValue: this.inputRef.el.value,
         });
@@ -397,6 +409,10 @@ export class AutoComplete extends Component {
                     return;
                 }
                 this.selectOption(this.activeOption);
+                if (this.props.selectOnBlur) {
+                    this.ignoreBlur = true;
+                    this.inputRef.el.blur();
+                }
                 break;
             case "escape":
                 if (!this.isOpened) {
@@ -405,6 +421,15 @@ export class AutoComplete extends Component {
                 this.cancel();
                 break;
             case "tab":
+                if (this.props.selectOnTab) {
+                    if (!this.isOpened || !this.state.activeSourceOption) {
+                        return;
+                    }
+                    this.selectOption(this.activeOption);
+                    this.ignoreBlur = true;
+                    this.inputRef.el.blur();
+                    break;
+                }
             case "shift+tab":
                 if (!this.isOpened) {
                     return;

--- a/addons/web/static/src/core/autocomplete/autocomplete.scss
+++ b/addons/web/static/src/core/autocomplete/autocomplete.scss
@@ -8,6 +8,9 @@
     .o-autocomplete--input {
         width: 100%;
     }
+    .o-autocomplete--mark {
+        padding: 0.1875em 0;
+    }
 
     .ui-menu-item {
         > span {

--- a/addons/web/static/src/core/autocomplete/autocomplete.xml
+++ b/addons/web/static/src/core/autocomplete/autocomplete.xml
@@ -66,7 +66,13 @@
                                         t-att-aria-selected="isActiveSourceOption([source_index, option_index]) ? 'true' : 'false'"
                                     >
                                         <t t-slot="{{ source.optionSlot }}" label="option.label" data="option.data">
-                                            <t t-out="option.label"/>
+                                            <t t-if="!option.labelTermOrder" t-out="option.label"/>
+                                            <t t-else="">
+                                                <t t-foreach="option.labelTermOrder.labelBits" t-as="bit" t-key="bit.id">
+                                                    <t t-if="!option.labelTermOrder.searchTermIndexes.includes(bit.id)" t-esc="bit.bit"/>
+                                                    <mark t-else="" class="o-autocomplete--mark" t-esc="bit.bit"/>
+                                                </t>
+                                            </t>
                                         </t>
                                     </t>
                                 </li>

--- a/addons/web/static/src/core/utils/search.js
+++ b/addons/web/static/src/core/utils/search.js
@@ -88,3 +88,80 @@ export function fuzzyLookup(pattern, list, fn) {
 export function fuzzyTest(pattern, string) {
     return _match(pattern, string) !== 0;
 }
+
+/**
+ * Performs fuzzy matching using a Levenshtein distance algorithm
+ * to find matches within an error margin between a pattern
+ * and a list of words.
+ *
+ * If the pattern is found directly inside an item,
+ * it's treated as a perfect match (score 0).
+ * Otherwise, the `getScore` function calculates the distance
+ * between the pattern and each candidate
+ *
+ * @param {string} pattern - The string to match.
+ * @param {string[]} list - The list of strings to compare against the pattern.
+ * @param {number} errorRatio - Controls how many errors can a word have depending of its length.
+ * @returns {string[]} The list of the words that matches within a defined number of errors.
+ */
+export function fuzzyLevenshteinLookup(pattern, list, errorRatio = 3) {
+    // We limit the maximum number of errors depending on the word length
+    // to not have "overcorrections" into words that doesn't have anything
+    // in common with what the user typed
+    const maxNbrCorrection = Math.round(pattern.length / errorRatio);
+    const results = [];
+    list.forEach((candidate) => {
+        let score = -1;
+        if (candidate.includes(pattern)) {
+            score = 0;
+            results.push({ score, elem: pattern });
+        } else {
+            score = getLevenshteinScore(pattern, candidate);
+            if (score >= 0 && score <= maxNbrCorrection) {
+                results.push({ score, elem: candidate });
+            }
+        }
+    });
+    results.sort((a, b) => a.score - b.score);
+    return results.map((r) => r.elem);
+}
+
+
+/**
+ * Computes the Levenshtein distance between two strings.
+ *
+ * @param {string} a
+ * @param {string} b
+ * @returns {number} The Levenshtein distance between `a` and `b`.
+ */
+function getLevenshteinScore(a, b) {
+    let aLength = a.length;
+    let bLength = b.length;
+
+    let distanceMatrix = [];
+    for (let i = 0; i <= aLength; i++) {
+        distanceMatrix[i] = [];
+        for (let j = 0; j <= bLength; j++) {
+            distanceMatrix[i][j] = 0;
+        }
+    }
+
+    for (let i = 0; i <= aLength; i++) {
+        for (let j = 0; j <= bLength; j++) {
+            if (Math.min(i, j) === 0) {
+                distanceMatrix[i][j] = Math.max(i, j);
+            } else {
+                if (a[i - 1] === b[j - 1]) {
+                    distanceMatrix[i][j] = distanceMatrix[i - 1][j - 1];
+                } else {
+                    distanceMatrix[i][j] = Math.min(
+                        distanceMatrix[i - 1][j] + 1,
+                        distanceMatrix[i][j - 1] + 1,
+                        distanceMatrix[i - 1][j - 1] + 1
+                    );
+                }
+            }
+        }
+    }
+    return distanceMatrix[aLength][bLength];
+}

--- a/addons/website/static/src/client_actions/configurator/configurator.js
+++ b/addons/website/static/src/client_actions/configurator/configurator.js
@@ -35,7 +35,7 @@ export const ROUTES = {
 };
 
 export const WEBSITE_TYPES = {
-    1: {id: 1, label: _t("a business website"), name: 'business'},
+    1: {id: 1, label: _t("a website"), name: 'business'},
     2: {id: 2, label: _t("an online store"), name: 'online_store'},
     3: {id: 3, label: _t("a blog"), name: 'blog'},
     4: {id: 4, label: _t("an event website"), name: 'event'},

--- a/addons/website/static/src/client_actions/configurator/configurator.scss
+++ b/addons/website/static/src/client_actions/configurator/configurator.scss
@@ -99,7 +99,6 @@
 
                 input, &::after {
                     height: $line-height-base * 1em;
-                    font-weight: 500;
                     font-style: italic;
                     text-indent: 5px;
                     padding: 0;

--- a/addons/website/static/src/client_actions/configurator/configurator.xml
+++ b/addons/website/static/src/client_actions/configurator/configurator.xml
@@ -73,6 +73,8 @@
                             inputDebounceDelay="400"
                             menuPositionOptions="{ position: 'bottom-fit' }"
                             menuCssClass="'custom-ui-autocomplete shadow-lg border-0 o_configurator_show_fast o_configurator_industry_dropdown'"
+                            selectOnBlur="true"
+                            selectOnTab="true"
                         />
                     </label>
                     <span> business</span>

--- a/addons/website/static/src/client_actions/configurator/configurator.xml
+++ b/addons/website/static/src/client_actions/configurator/configurator.xml
@@ -70,7 +70,7 @@
                             value="state.selectedIndustry?.label ?? ''"
                             sources="sources"
                             onInput.bind="onAutocompleteInput"
-                            inputDebounceDelay="400"
+                            inputDebounceDelay="100"
                             menuPositionOptions="{ position: 'bottom-fit' }"
                             menuCssClass="'custom-ui-autocomplete shadow-lg border-0 o_configurator_show_fast o_configurator_industry_dropdown'"
                             selectOnBlur="true"

--- a/addons/website/static/src/client_actions/configurator/configurator.xml
+++ b/addons/website/static/src/client_actions/configurator/configurator.xml
@@ -66,7 +66,7 @@
                     <!-- Use t-set in order to be able to translate, if put in the attribute directly then export POT file will not exist this text-->
                     <label class="o_configurator_industry_wrapper me-2" t-ref="industrySelection">
                         <AutoComplete
-                            placeholder.translate="Clothes, Marketing, ..."
+                            placeholder.translate="Restaurant, Hair Salon, Clothing Store,..."
                             value="state.selectedIndustry?.label ?? ''"
                             sources="sources"
                             onInput.bind="onAutocompleteInput"


### PR DESCRIPTION
Improved the search algorithm for the industry search bar
in the website configurator.

Typos are now checked to an extend: the autocomplete engine will
look for the nearest word from a dictionnary made with all the words
used in the industry list (labels and synonyms).
For the improvement of the autocorrect, the Levenshtein fuzzy
matching algorithm was used.

Results returned from a synonym match are now inserted at the end
of the match list.

Some text changes:
- In the first dropdown, "a business website" -> "a website"
- The placeholder of the second dropdown became 
"Restaurant, Hair Salon, Clothing Store,..."

linked to https://github.com/odoo/iap-apps/pull/1136

task-4642966

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
