### PR TITLE
[IMP] hr: improve hr_presence_status widget

### DIFF
--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -93,12 +93,12 @@ class HrEmployee(models.Model):
         ('present', 'Present'),
         ('absent', 'Absent'),
         ('archive', 'Archived'),
-        ('out_of_working_hour', 'Out of Working hours')], compute='_compute_presence_state', default='out_of_working_hour')
+        ('out_of_working_hour', 'Off-Hours')], compute='_compute_presence_state', default='out_of_working_hour')
     last_activity = fields.Date(compute="_compute_last_activity")
     last_activity_time = fields.Char(compute="_compute_last_activity")
     hr_icon_display = fields.Selection([
         ('presence_present', 'Present'),
-        ('presence_out_of_working_hour', 'Out of Working hours'),
+        ('presence_out_of_working_hour', 'Off-Hours'),
         ('presence_absent', 'Absent'),
         ('presence_archive', 'Archived'),
         ('presence_undetermined', 'Undetermined')], compute='_compute_presence_icon')

--- a/addons/hr/models/hr_employee_public.py
+++ b/addons/hr/models/hr_employee_public.py
@@ -43,7 +43,7 @@ class HrEmployeePublic(models.Model):
         ('present', 'Present'),
         ('absent', 'Absent'),
         ('archive', 'Archived'),
-        ('out_of_working_hour', 'Out of Working hours')], compute='_compute_presence_state', default='out_of_working_hour')
+        ('out_of_working_hour', 'Off-Hours')], compute='_compute_presence_state', default='out_of_working_hour')
     hr_icon_display = fields.Selection(
         selection='_get_selection_hr_icon_display',
         compute='_compute_presence_icon')

--- a/addons/hr/static/src/components/avatar_card_resource/avatar_card_resource_popover.xml
+++ b/addons/hr/static/src/components/avatar_card_resource/avatar_card_resource_popover.xml
@@ -11,7 +11,7 @@
                 <!-- Employee is not present/connected and it is normal according to his work schedule -->
                 <i t-if="record.hr_icon_display == 'presence_absent'" class="fa fa-fw fa-circle text-warning" title="Absent" role="img" aria-label="Absent"/>
                 <!-- Employee is connected but according to his work schedule, he should not work for now  -->
-                <i t-if="record.hr_icon_display == 'presence_out_of_working_hour'" class="fa fa-fw fa-circle text-muted" title="Out of Working Hours" role="img" aria-label="Out of Working Hours"/>
+                <i t-if="record.hr_icon_display == 'presence_out_of_working_hour'" class="fa fa-fw fa-circle text-muted" title="Off-Hours" role="img" aria-label="Off-Hours"/>
             </span>
         </xpath>
     </t>

--- a/addons/hr/static/src/components/hr_presence_status_pill/hr_presence_status_pill.js
+++ b/addons/hr/static/src/components/hr_presence_status_pill/hr_presence_status_pill.js
@@ -1,0 +1,35 @@
+import { registry } from "@web/core/registry";
+import { HrPresenceStatus, hrPresenceStatus } from "../hr_presence_status/hr_presence_status";
+
+export class HrPresenceStatusPill extends HrPresenceStatus {
+    static template = "hr.HrPresenceStatusPill";
+
+    /** @override */
+    get classNames() {
+        const classNames = ["fw-bold", "text-center", "btn", "rounded-pill", "cursor-default"];
+        classNames.push(this.color);
+        return classNames.join(" ");
+    }
+
+    /** @override */
+    get color() {
+        switch (this.value) {
+            case "presence_present":
+                return "btn-outline-success";
+            case "presence_absent":
+                return "btn-outline-warning";
+            case "presence_out_of_working_hour":
+            case "presence_archive":
+                return "btn-outline-secondary text-muted";
+            default:
+                return "";
+        }
+    }
+}
+
+export const hrPresenceStatusPill = {
+    ...hrPresenceStatus,
+    component: HrPresenceStatusPill,
+};
+
+registry.category("fields").add("form.hr_presence_status", hrPresenceStatusPill);

--- a/addons/hr/static/src/components/hr_presence_status_pill/hr_presence_status_pill.xml
+++ b/addons/hr/static/src/components/hr_presence_status_pill/hr_presence_status_pill.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+
+    <t t-name="hr.HrPresenceStatusPill">
+        <div t-att-class="classNames" t-att-aria-label="label" t-att-title="label">
+            <t t-tag="props.tag" role="img" class="me-1 fa" t-att-class="icon"/>
+            <t t-esc="label"/>
+        </div>
+    </t>
+
+</templates>

--- a/addons/hr/static/src/components/hr_presence_status_private_pill/hr_presence_status_private_pill.js
+++ b/addons/hr/static/src/components/hr_presence_status_private_pill/hr_presence_status_private_pill.js
@@ -1,0 +1,14 @@
+import { registry } from "@web/core/registry";
+import {
+    HrPresenceStatusPill,
+    hrPresenceStatusPill,
+} from "../hr_presence_status_pill/hr_presence_status_pill";
+
+export class HrPresenceStatusPrivatePill extends HrPresenceStatusPill {}
+
+export const hrPresenceStatusPrivatePill = {
+    ...hrPresenceStatusPill,
+    component: HrPresenceStatusPrivatePill,
+};
+
+registry.category("fields").add("form.hr_presence_status_private", hrPresenceStatusPrivatePill);

--- a/addons/hr/static/src/scss/hr.scss
+++ b/addons/hr/static/src/scss/hr.scss
@@ -51,6 +51,12 @@
     .oe_title {
         flex: 1;
     }
+    .o_employee_form_header_info{
+        flex: 5;
+    }
+    .o_presence_status_pill_wrapper{
+        flex: 3;
+    }
 }
 
 .o_hr_employee_kanban .o_kanban_renderer {

--- a/addons/hr/views/hr_employee_public_views.xml
+++ b/addons/hr/views/hr_employee_public_views.xml
@@ -41,34 +41,36 @@
                         <div class="oe_button_box" name="button_box">
                             <!-- Used by other modules-->
                         </div>
-                        <div class="row align-items-center">
-                            <div class="o_employee_avatar ms-2 p-0 h-100 mw-25">
-                                <field name="hr_icon_display" invisible="not show_hr_icon_display or not id" widget="hr_presence_status"/>
-                                <field name="image_1920" widget='image' class="m-0" options='{"size": [128,158], "zoom": true, "preview_image":"avatar_128"}'/>
+                        <div class="row flex-column flex-sm-row align-items-center">
+                            <div class="o_employee_avatar ms-2 p-0 h-100 mw-25 align-self-start align-self-sm-center">
+                                <field name="image_1920" widget='image' class="m-0" options='{"zoom": true, "preview_image":"avatar_128"}'/>
                                 <field name="show_hr_icon_display" invisible="1" />
                             </div>
-                            <div class="col">
-                                <div class="oe_title mw-75 ps-0 pe-2">
+                            <div class="align-self-start o_employee_form_header_info">
+                                <div class="oe_title ps-0 pe-2 mw-100">
                                     <h1 class="d-flex flex-row align-items-center">
-                                        <div invisible="not user_id" class="me-2">
-                                            <widget name="hr_employee_chat" invisible="not context.get('chat_icon')"/>
-                                        </div>
                                         <field name="name" placeholder="Employee's Name"
                                             required="True" style="font-size: min(4vw, 2.6rem);"/>
                                     </h1>
                                     <p class="d-flex align-items-baseline mb-0">
                                         <i class="fa fa-envelope fa-fw me-1 text-primary" title="Work Email"/>
-                                        <field name="work_email" widget="email" placeholder="e.g. johndoe@example.com" string="Work Email" class="w-75"/>
+                                        <field name="work_email" widget="email" placeholder="e.g. johndoe@example.com" string="Work Email"/>
                                     </p>
                                     <p class="d-flex align-items-baseline mb-0">
                                         <i class="fa fa-phone fa-fw me-1 text-primary" title="Work Phone"/>
-                                        <field name="work_phone" widget="phone" placeholder="Work Phone" string="Work Phone"  class="w-75"/>
+                                        <field name="work_phone" widget="phone" placeholder="Work Phone" string="Work Phone"/>
                                     </p>
                                     <p class="d-flex align-items-baseline mb-0">
                                         <i class="fa fa-mobile fa-fw me-1 text-primary" title="Work Mobile"/>
-                                        <field name="mobile_phone" widget="phone" placeholder="Work Mobile" string="Work Mobile"  class="w-75"/>
+                                        <field name="mobile_phone" widget="phone" placeholder="Work Mobile" string="Work Mobile"/>
                                     </p>
                                 </div>
+                            </div>
+                            <div class="align-self-start w-auto end-0 mt-2 d-flex align-items-center justify-content-end gap-2 o_presence_status_pill_wrapper">
+                                <div invisible="not user_id">
+                                    <widget name="hr_employee_chat" invisible="not context.get('chat_icon')"/>
+                                </div>
+                                <field name="hr_icon_display" invisible="not show_hr_icon_display or not id" widget="hr_presence_status"/>
                             </div>
                         </div>
                         <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" invisible="active"/>

--- a/addons/hr/views/hr_employee_views.xml
+++ b/addons/hr/views/hr_employee_views.xml
@@ -110,32 +110,28 @@
                                 </div>
                             </button>
                         </div>
-                        <div class="row align-items-center">
-                            <div class="o_employee_avatar ms-2 p-0 h-100 mw-25">
-                                <field name="hr_icon_display" invisible="not show_hr_icon_display or not id" widget="hr_presence_status"/>
-                                <field name="image_1920" widget='image' class="m-0" options='{"size": [128,158], "zoom": true, "preview_image":"avatar_128"}'/>
+                        <div class="row flex-column flex-sm-row align-items-center">
+                            <div class="o_employee_avatar ms-2 p-0 h-100 mw-25 align-self-start align-self-sm-center">
+                                <field name="image_1920" widget='image' class="m-0" options='{"zoom": true, "preview_image":"avatar_128"}'/>
                                 <field name="show_hr_icon_display" invisible="1" />
                             </div>
-                            <div class="col">
-                                <div class="oe_title mw-75 ps-0 pe-2">
+                            <div class="align-self-start o_employee_form_header_info">
+                                <div class="oe_title ps-0 pe-2 mw-100">
                                     <h1 class="d-flex flex-row align-items-center">
                                         <field name="name" placeholder="Employee's Name"
                                             required="True" style="font-size: min(4vw, 2.6rem);"/>
-                                        <div invisible="not user_id" class="me-2">
-                                            <widget name="hr_employee_chat" invisible="not context.get('chat_icon')"/>
-                                        </div>
                                     </h1>
                                     <h5 class="d-flex align-items-baseline mb-0">
                                         <i class="fa fa-envelope fa-fw me-1 text-primary" title="Work Email"/>
-                                        <field name="work_email" widget="email" placeholder="e.g. johndoe@example.com" string="Work Email" class="w-75"/>
+                                        <field name="work_email" widget="email" placeholder="e.g. johndoe@example.com" string="Work Email"/>
                                     </h5>
                                     <h5 class="d-flex align-items-baseline mb-0">
                                         <i class="fa fa-phone fa-fw me-1 text-primary" title="Work Phone"/>
-                                        <field name="work_phone" widget="phone" placeholder="Work Phone" string="Work Phone"  class="w-75"/>
+                                        <field name="work_phone" widget="phone" placeholder="Work Phone" string="Work Phone"/>
                                     </h5>
                                     <h5 class="d-flex align-items-baseline mb-0">
                                         <i class="fa fa-mobile fa-fw me-1 text-primary" title="Work Mobile"/>
-                                        <field name="mobile_phone" widget="phone" placeholder="Work Mobile" string="Work Mobile"  class="w-75"/>
+                                        <field name="mobile_phone" widget="phone" placeholder="Work Mobile" string="Work Mobile"/>
                                     </h5>
                                     <h5>
                                         <i class="fa fa-tags fa-fw me-1 text-primary" title="Tags"/>
@@ -144,6 +140,12 @@
                                             placeholder="e.g. Founder, Motorized, Building B, ..." groups="hr.group_hr_user"/>
                                     </h5>
                                 </div>
+                            </div>
+                            <div class="align-self-start w-auto end-0 mt-2 d-flex align-items-center justify-content-end gap-2 o_presence_status_pill_wrapper">
+                                <div invisible="not user_id">
+                                    <widget name="hr_employee_chat" invisible="not context.get('chat_icon')"/>
+                                </div>
+                                <field name="hr_icon_display" invisible="not show_hr_icon_display or not id" widget="hr_presence_status"/>
                             </div>
                         </div>
                         <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" invisible="active"/>

--- a/addons/hr_holidays/static/src/components/hr_presence_status/hr_presence_status.js
+++ b/addons/hr_holidays/static/src/components/hr_presence_status/hr_presence_status.js
@@ -3,6 +3,14 @@ import { patch } from "@web/core/utils/patch";
 
 import { HrPresenceStatus, hrPresenceStatus } from "@hr/components/hr_presence_status/hr_presence_status";
 import { HrPresenceStatusPrivate, hrPresenceStatusPrivate } from "@hr/components/hr_presence_status_private/hr_presence_status_private";
+import {
+    HrPresenceStatusPill,
+    hrPresenceStatusPill,
+} from "@hr/components/hr_presence_status_pill/hr_presence_status_pill";
+import {
+    HrPresenceStatusPrivatePill,
+    hrPresenceStatusPrivatePill,
+} from "@hr/components/hr_presence_status_private_pill/hr_presence_status_private_pill";
 
 const patchHrPresenceStatus = () => ({
 
@@ -39,12 +47,25 @@ const patchHrPresenceStatus = () => ({
     },
 });
 
+const patchHrPresenceStatusPill = () => ({
+    get color() {
+        if (this.value.startsWith("presence_holiday")) {
+            return this.value === "presence_holiday_present"
+                ? "btn-outline-success"
+                : "btn-outline-warning";
+        }
+        return super.color;
+    },
+});
+
 // Applies common patch on both components
 patch(HrPresenceStatus.prototype, patchHrPresenceStatus());
 patch(HrPresenceStatusPrivate.prototype, patchHrPresenceStatus());
 
-// Applies patch to hr_presence_status_private to display the time off type instead of default label
-patch(HrPresenceStatusPrivate.prototype, {
+// Applies patch on one component and the other should be affected also, since it's extended from it.
+patch(HrPresenceStatusPill.prototype, patchHrPresenceStatusPill());
+
+const patchHrPresenceStatusPrivate = () => ({
     get label() {
         return this.props.record.data.current_leave_id
             ? this.props.record.data.current_leave_id.display_name + _t(", back on ") + this.props.record.data['leave_date_to'].toLocaleString(
@@ -55,8 +76,11 @@ patch(HrPresenceStatusPrivate.prototype, {
                 }
             )
             : super.label;
-    }
+    },
 });
+// Applies patch to hr_presence_status_private to display the time off type instead of default label
+patch(HrPresenceStatusPrivate.prototype, patchHrPresenceStatusPrivate());
+patch(HrPresenceStatusPrivatePill.prototype, patchHrPresenceStatusPrivate());
 
 Object.assign(hrPresenceStatus, {
     fieldDependencies: [
@@ -70,5 +94,20 @@ Object.assign(hrPresenceStatusPrivate, {
         ...hrPresenceStatusPrivate.fieldDependencies,
         ...hrPresenceStatus.fieldDependencies,
         { name: "current_leave_id", type:"many2one"},
+    ],
+});
+
+Object.assign(hrPresenceStatusPill, {
+    fieldDependencies: [
+        ...hrPresenceStatusPill.fieldDependencies,
+        { name: "leave_date_to", type: "date" },
+    ],
+});
+
+Object.assign(hrPresenceStatusPrivatePill, {
+    fieldDependencies: [
+        ...hrPresenceStatusPrivatePill.fieldDependencies,
+        ...hrPresenceStatusPill.fieldDependencies,
+        { name: "current_leave_id", type: "many2one" },
     ],
 });

--- a/addons/hr_homeworking/static/src/components/hr_presence_status/hr_presence_status.js
+++ b/addons/hr_homeworking/static/src/components/hr_presence_status/hr_presence_status.js
@@ -2,6 +2,8 @@ import { patch } from "@web/core/utils/patch";
 
 import { HrPresenceStatus, hrPresenceStatus } from "@hr/components/hr_presence_status/hr_presence_status";
 import { HrPresenceStatusPrivate, hrPresenceStatusPrivate } from "@hr/components/hr_presence_status_private/hr_presence_status_private";
+import { HrPresenceStatusPill, hrPresenceStatusPill } from "@hr/components/hr_presence_status_pill/hr_presence_status_pill";
+import { HrPresenceStatusPrivatePill, hrPresenceStatusPrivatePill } from "@hr/components/hr_presence_status_private_pill/hr_presence_status_private_pill";
 import { _t } from "@web/core/l10n/translation";
 
 const patchHrPresenceStatus = () => ({
@@ -42,9 +44,35 @@ const patchHrPresenceStatus = () => ({
     },
 });
 
+const patchHrPresenceStatusPill = () => ({
+    get color() {
+        if (this.location) {
+            let color = "btn-outline-secondary text-muted";
+            if (this.props.record.data.hr_presence_state !== "out_of_working_hour") {
+                color =
+                    this.props.record.data.hr_presence_state === "present"
+                        ? "btn-outline-success"
+                        : "btn-outline-warning";
+            }
+            return color;
+        }
+        return super.color;
+    },
+
+    get label() {
+        if (this.location) {
+            return this.props.record.data.work_location_name || _t("Unspecified");
+        }
+        return super.label;
+    },
+});
+
 // for the both components: first applies the common patch and then applies patch for label
 patch(HrPresenceStatus.prototype, patchHrPresenceStatus());
 patch(HrPresenceStatusPrivate.prototype, patchHrPresenceStatus());
+
+patch(HrPresenceStatusPill.prototype, patchHrPresenceStatusPill());
+patch(HrPresenceStatusPrivatePill.prototype, patchHrPresenceStatusPill());
 
 const additionalFieldDependencies = [
     { name: "hr_presence_state", type: "selection" },
@@ -66,5 +94,23 @@ if (typeof hrPresenceStatus.fieldDependencies === "function") {
 }
 hrPresenceStatusPrivate.fieldDependencies = [
     ...(hrPresenceStatusPrivate.fieldDependencies || []),
+    ...additionalFieldDependencies,
+];
+
+if (typeof hrPresenceStatusPill.fieldDependencies === "function") {
+    const oldFieldDependencies = hrPresenceStatusPill.fieldDependencies;
+    hrPresenceStatusPill.fieldDependencies = (widgetInfo) => {
+        const fieldDependencies = oldFieldDependencies(widgetInfo);
+        fieldDependencies.push(...additionalFieldDependencies);
+        return fieldDependencies;
+    };
+} else {
+    hrPresenceStatusPill.fieldDependencies = [
+        ...(hrPresenceStatusPill.fieldDependencies || []),
+        ...additionalFieldDependencies,
+    ];
+}
+hrPresenceStatusPrivatePill.fieldDependencies = [
+    ...(hrPresenceStatusPrivatePill.fieldDependencies || []),
     ...additionalFieldDependencies,
 ];

--- a/addons/hr_homeworking/static/tests/hr_presence_status.test.js
+++ b/addons/hr_homeworking/static/tests/hr_presence_status.test.js
@@ -38,8 +38,8 @@ test("Office Location (online)", async () => {
     expect("small.fa-building").toHaveCount(1);
     expect("small.fa-home").toHaveCount(0);
     expect("small.fa-map-marker").toHaveCount(0);
-    expect("small").toHaveClass(["text-success", "fa-building"]);; // color == text-success
-    expect("small.fa-building[title='Office 1']").toHaveCount(1);
+    expect("small").toHaveClass(["fa-building"]);
+    expect("div.rounded-pill[title='Office 1']").toHaveCount(1);
 });
 
 test("Home Location (away)", async () => {
@@ -67,6 +67,6 @@ test("Home Location (away)", async () => {
     expect("small.fa-home").toHaveCount(1);
     expect("small.fa-building").toHaveCount(0);
     expect("small.fa-map-marker").toHaveCount(0);
-    expect("small").toHaveClass(["o_icon_employee_absent", "fa-home"]); // color == text-warning
-    expect("small.fa-home[title='Home']").toHaveCount(1);
+    expect("small").toHaveClass(["fa-home"]);
+    expect("div.rounded-pill[title='Home']").toHaveCount(1);
 });

--- a/addons/hr_presence/models/hr_employee.py
+++ b/addons/hr_presence/models/hr_employee.py
@@ -21,7 +21,7 @@ class HrEmployee(models.Model):
     # Stored field used in the presence kanban reporting view
     # to allow group by state.
     hr_presence_state_display = fields.Selection([
-        ('out_of_working_hour', 'Out of Working Hours'),
+        ('out_of_working_hour', 'Off-Hours'),
         ('present', 'Present'),
         ('absent', 'Absent'),
         ], default='out_of_working_hour')

--- a/addons/hr_presence/models/hr_employee_public.py
+++ b/addons/hr_presence/models/hr_employee_public.py
@@ -11,7 +11,7 @@ class HrEmployeePublic(models.Model):
     manually_set_present = fields.Boolean(default=False)
     manually_set_presence = fields.Boolean(default=False)
     hr_presence_state_display = fields.Selection([
-        ('out_of_working_hour', 'Out of Working Hours'),
+        ('out_of_working_hour', 'Off-Hours'),
         ('present', 'Present'),
         ('absent', 'Absent'),
         ], default='out_of_working_hour')

--- a/addons/hr_presence/views/hr_employee_views.xml
+++ b/addons/hr_presence/views/hr_employee_views.xml
@@ -7,7 +7,7 @@
         <field name="arch" type="xml">
             <filter name="at_work" position="after">
                 <filter name="absent" string="Absent" domain="[('hr_presence_state_display', '=', 'absent')]"/>
-                <filter name="out_of_working_hours" string="Out of Working Hours" domain="[('hr_presence_state_display', '=', 'out_of_working_hour')]"/>
+                <filter name="out_of_working_hours" string="Off-Hours" domain="[('hr_presence_state_display', '=', 'out_of_working_hour')]"/>
             </filter>
             <filter name="group_birthday" position="before">
                 <filter name="group_hr_presence_state" string="Presence/Absence" domain="[]" context="{'group_by':'hr_presence_state_display'}" groups="hr.group_hr_manager"/>


### PR DESCRIPTION
This commit improves `hr_presence_status` & `hr_presence_status_private` widgets by adding custom widgets (hr_presence_status_pill & hr_presence_status_private_pill) to the form view modifying the to allow it to render a pill instead of an icon. Moreover, `view_employee_form` and `hr_employee_public_view_form` ui views have been updated to include the `hr_presence_status` widget in the top right side in the form view.

The `Out of Working hours` state is changed to `Off-Hours`
in `hr_icon_display` selection field.

task-4930995

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
