### PR TITLE
[FIX] iot_drivers: add device.data to websocket result

### DIFF
--- a/addons/iot_drivers/event_manager.py
+++ b/addons/iot_drivers/event_manager.py
@@ -54,6 +54,7 @@ class EventManager:
         if data:
             # Notify via websocket
             send_to_controller({
+                **device.data,
                 'session_id': data.get('action_args', {}).get('session_id', ''),
                 'iot_box_identifier': helpers.get_identifier(),
                 'device_identifier': device.device_identifier,


### PR DESCRIPTION
Serial drivers use their own way to handle actions. Waiting for a refactoring of their logic to conform to all drivers' one, we need to provide the device data to the websocket response in order to read it using `iot_http` service.

Enterprise PR: odoo/enterprise#89900