### PR TITLE
[FIX] l10n_mx: Fixing diot tags.

### DIFF
--- a/addons/l10n_mx/data/account.account.tag.csv
+++ b/addons/l10n_mx/data/account.account.tag.csv
@@ -3,20 +3,30 @@ tag_iva,IVA,taxes,base.mx,0
 tag_isr,ISR,taxes,base.mx,0
 tag_ieps,IEPS,taxes,base.mx,0
 tag_diot_16,DIOT: 16%,taxes,base.mx,0
+tag_diot_16_tax,DIOT: 16% TAX,taxes,base.mx,0
 tag_diot_16_non_cre,DIOT: 16% NO ACREDITABLE,taxes,base.mx,0
+tag_diot_16_non_cre_tax,DIOT: 16% NO ACREDITABLE TAX,taxes,base.mx,0
 tag_diot_16_refund,DIOT: 16% REFUNDS,taxes,base.mx,0
 tag_diot_16_imp,DIOT: 16% IMPORTACIÓN,taxes,base.mx,0
+tag_diot_16_imp_tax,DIOT: 16% IMPORTACIÓN TAX,taxes,base.mx,0
 tag_diot_16_imp_non_cre,DIOT: 16% IMPORTACIÓN NO ACREDITABLE,taxes,base.mx,0
+tag_diot_16_imp_non_cre_tax,DIOT: 16% IMPORTACIÓN NO ACREDITABLE TAX,taxes,base.mx,0
 tag_diot_16_imp_refund,DIOT: 16% IMPORTACIÓN REFUNDS,taxes,base.mx,0
 tag_diot_0,DIOT: 0%,taxes,base.mx,0
 tag_diot_8,DIOT: 8% N.,taxes,base.mx,0
+tag_diot_8_tax,DIOT: 8% N. TAX,taxes,base.mx,0
 tag_diot_8_non_cre,DIOT: 8% N. NO ACREDITABLE,taxes,base.mx,0
+tag_diot_8_non_cre_tax,DIOT: 8% N. NO ACREDITABLE TAX,taxes,base.mx,0
 tag_diot_8_refund,DIOT: 8% N. REFUNDS,taxes,base.mx,0
 tag_diot_8_south,DIOT: 8% S.,taxes,base.mx,0
+tag_diot_8_south_tax,DIOT: 8% S. TAX,taxes,base.mx,0
 tag_diot_8_south_non_cre,DIOT: 8% S. NO ACREDITABLE,taxes,base.mx,0
+tag_diot_8_south_non_cre_tax,DIOT: 8% S. NO ACREDITABLE TAX,taxes,base.mx,0
 tag_diot_8_south_refund,DIOT: 8% S. REFUNDS,taxes,base.mx,0
 tag_diot_16_imp_int,DIOT: 16% IMPORTACIÓN INTANGIBLES,taxes,base.mx,0
+tag_diot_16_imp_int_tax,DIOT: 16% IMPORTACIÓN INTANGIBLES TAX,taxes,base.mx,0
 tag_diot_16_imp_int_non_cre,DIOT: 16% IMPORTACIÓN INTANGIBLES NO ACREDITABLE,taxes,base.mx,0
+tag_diot_16_imp_int_non_cre_tax,DIOT: 16% IMPORTACIÓN INTANGIBLES NO ACREDITABLE TAX,taxes,base.mx,0
 tag_diot_16_imp_int_refund,DIOT: 16% IMPORTACIÓN INTANGIBLES REFUNDS,taxes,base.mx,0
 tag_diot_ret,DIOT: Retención,taxes,base.mx,0
 tag_diot_exento,DIOT: Exento,taxes,base.mx,0

--- a/addons/l10n_mx/data/account_tax_data.xml
+++ b/addons/l10n_mx/data/account_tax_data.xml
@@ -645,6 +645,7 @@
             (0,0, {
                 'repartition_type': 'tax',
                 'account_id': ref('cuenta118_01'),
+                'tag_ids': [ref('tag_diot_16_tax')],
             }),
         ]"/>
             <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
@@ -678,6 +679,7 @@
             (0,0, {
                 'repartition_type': 'tax',
                 'account_id': ref('cuenta118_01_02'),
+                'tag_ids': [ref('tag_diot_8_tax')],
             }),
         ]"/>
             <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
@@ -747,6 +749,7 @@
             (0,0, {
                 'repartition_type': 'tax',
                 'account_id': ref('cuenta601_58'),
+                'tag_ids': [ref('tag_diot_16_non_cre_tax')],
             }),
         ]"/>
             <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
@@ -780,6 +783,7 @@
             (0,0, {
                 'repartition_type': 'tax',
                 'account_id': ref('cuenta118_02'),
+                'tag_ids': [ref('tag_diot_16_imp_tax')],
             }),
         ]"/>
             <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
@@ -813,6 +817,7 @@
             (0,0, {
                 'repartition_type': 'tax',
                 'account_id': ref('cuenta118_02'),
+                'tag_ids': [ref('tag_diot_16_imp_int_tax')],
             }),
         ]"/>
             <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
@@ -846,6 +851,7 @@
             (0,0, {
                 'repartition_type': 'tax',
                 'account_id': ref('cuenta118_01_02'),
+                'tag_ids': [ref('tag_diot_8_south_tax')],
             }),
         ]"/>
             <field name="refund_repartition_line_ids" eval="[(5, 0, 0),


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
The language used in the DIOT documentation was confusing and even though we had the exact same description for two columns it turns out they were different, so we need to change the logic of a few columns to make it work as needed.

Current behavior before PR:
In the DIOT, the columns Paid 8% N, Paid 8% s, Paid 16%, Importation 16% and Intangible imports 16% are sums of taxes paid with this type of tax. And all the tax columns are based in the base not in the tax part.

Desired behavior after PR is merged:
- Behavior after this PR. Taxes now have a correction in their tags so that the columns in the DIOT report are calculated correctly, Tax columns only contains tax values, not base values.

Backport of https://github.com/odoo/odoo/pull/217441

opw-4920577

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
