### PR TITLE
[IMP] account_payment: get payment providers based on amount to pay

### DIFF
--- a/addons/account_payment/static/src/interactions/portal_invoice_page_payment.js
+++ b/addons/account_payment/static/src/interactions/portal_invoice_page_payment.js
@@ -3,11 +3,57 @@ import { registry } from "@web/core/registry";
 
 export class PortalInvoicePagePayment extends Interaction {
     static selector = "#portal_pay";
+    dynamicContent = {
+        "#o_payment_tabs": { "t-on-shown.bs.tab": this.onTabChanged }
+    };
 
     setup() {
         if (this.el.dataset.payment) {
             (new Modal("#pay_with")).show();
         }
+    }
+
+    onTabChanged(ev) {
+        const activeTabId = ev.target.id;
+        const providersInput = document.querySelector("input[name='providers_by_amount']");
+        if (!providersInput) {
+            return;
+        }
+        const providersByAmount = JSON.parse(providersInput.value);
+
+        let availableProviders = [];
+        if (activeTabId === "o_payment_installments_tab") {
+            availableProviders = providersByAmount.next_amount || [];
+        } else if (activeTabId === "o_payment_full_tab") {
+            availableProviders = providersByAmount.total || [];
+        }
+
+        let firstVisibleSet = false;
+
+        document.querySelectorAll("li[name='o_payment_option']").forEach(li => {
+            const input = li.querySelector("input[name='o_payment_radio'][data-provider-id]");
+            if (!input) {
+                return;
+            }
+
+            const providerId = parseInt(input.dataset.providerId, 10);
+
+            if (availableProviders.includes(providerId)) {
+                li.classList.add("list-group-item"); // fix list corner radius
+                li.classList.remove("d-none");
+
+                if (!firstVisibleSet) {
+                    input.checked = true;
+                    firstVisibleSet = true;
+
+                    input.dispatchEvent(new Event("change", { bubbles: true }));
+                }
+            } else {
+                li.classList.remove("list-group-item"); // fix list corner radius
+                li.classList.add("d-none");
+                input.checked = false;
+            }
+        });
     }
 }
 

--- a/addons/account_payment/views/account_portal_templates.xml
+++ b/addons/account_payment/views/account_portal_templates.xml
@@ -227,6 +227,7 @@
                                             </t>
                                         </div>
                                     </div>
+                                    <input name="providers_by_amount" type="hidden" t-att-value="json.dumps(providers_by_amount)"/>
                                     <!-- set default amount as the max. amount due, the 'amount'
                                          will be updated/set js-side depending the active tab -->
                                     <t t-call="account_payment.form">


### PR DESCRIPTION
Steps to reproduce:

- Configure a payment provider (e.g., the demo provider) with a maximum transaction amount of 15,000.
- Create a customer invoice with a total amount of 20,000.
- Generate a payment link for a partial payment of 14,000.
- Open the generated link.

Issue:
No payment provider is available, even though the link amount is below the provider’s limit.

Cause:
When generating a payment link, available payment providers are filtered based on the total invoice amount, rather than the payment link amount.
This prevents the use of partial payments for invoices that exceed the provider's configured limits.

Fix:
Adjusted the logic to validate payment providers based on the actual amount in the payment link, not the invoice total.
Providers will now appear if they support the specified link amount, enabling partial payments on high-value invoices.

Result:
Payment links for partial amounts can now be used even if the invoice total exceeds provider limits.


I confirm I have signed the CLA and read the PR guidelines at [www.odoo.com/submit-pr](http://www.odoo.com/submit-pr)
