### PR TITLE
[PERF] website: optimize method _search_fetch

### DIFF
--- a/addons/website/models/mixins.py
+++ b/addons/website/models/mixins.py
@@ -367,7 +367,7 @@ class WebsiteSearchableMixin(models.AbstractModel):
             limit=limit,
             order=search_detail.get('order', order)
         )
-        count = model.search_count(domain)
+        count = model.search_count(domain) if limit and limit == len(results) else len(results)
         return results, count
 
     def _search_render_results(self, fetch_fields, mapping, icon, limit):

--- a/addons/website_blog/tests/test_performance.py
+++ b/addons/website_blog/tests/test_performance.py
@@ -45,8 +45,8 @@ class TestBlogPerformance(UtilPerf):
         } for blog in blogs])
 
     def test_10_perf_sql_blog_standard_data(self):
-        self.assertEqual(self._get_url_hot_query('/blog'), 11)
-        self.assertEqual(self._get_url_hot_query('/blog', cache=False), 21)
+        self.assertEqual(self._get_url_hot_query('/blog'), 10)
+        self.assertEqual(self._get_url_hot_query('/blog', cache=False), 20)
 
     def test_20_perf_sql_blog_bigger_data_scaling(self):
         BlogPost = self.env['blog.post']


### PR DESCRIPTION
Issue
-----
Currently, we call `model.search()` and `model.search_count()` back-to-back, the second of which is unnecessary if there is no limit on the query.

Solution
-----
If we have no limit, directly take the length of the previously returned results to avoid an extra query.

opw-4882609