### PR TITLE
[FIX] hr_expense: validate employee and company when creating expenses from attachments

### DIFF
--- a/addons/hr_expense/models/hr_expense.py
+++ b/addons/hr_expense/models/hr_expense.py
@@ -403,6 +403,10 @@ class HrExpense(models.Model):
         if any(attachment.res_id or attachment.res_model != 'hr.expense' for attachment in attachments):
             raise UserError(_("Invalid attachments!"))
 
+        employee = self.env.user.employee_id
+        if not employee or employee.company_id != self.env.company:
+            raise ValidationError(_("The current user has no related employee, or the related employee does not belong to this company."))
+
         product = self.env['product.product'].search([('can_be_expensed', '=', True)])
         if product:
             product = product.filtered(lambda p: p.default_code == "EXP_GEN")[:1] or product[0]


### PR DESCRIPTION
Currently, users in the group_hr_expense_team_approver group don’t necessarily have an assigned employee. As a result, when creating an expense with a user belonging to that group but without a related employee, or with an employee assigned to a different company, the expense creation proceeds from an uploaded file (via the create_expense_from_attachments method). This causes a technical ValidationError that is difficult for the user to understand, unlike the clearer error implemented in the _default_employee_id method.

This change proposes handling the error similarly to _default_employee_id by adding an explicit validation in the create_expense_from_attachments method to ensure that the current user has a related employee and that the employee belongs to the current company. Otherwise, the operation is halted with a clearer message so the user can perform the necessary configurations.

Screenshot of the actual ValidationError:
![image](https://github.com/user-attachments/assets/c5fe588c-cded-486f-a107-bca8b8875a5b)

Screenshot of the proposed ValidationError:
![image](https://github.com/user-attachments/assets/d1e06b8b-cf79-4ef5-8373-d4c164be2ca4)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
