### PR TITLE
[FIX] mrp: stock user can not access MO

### DIFF
--- a/addons/mrp/security/ir.model.access.csv
+++ b/addons/mrp/security/ir.model.access.csv
@@ -22,6 +22,7 @@ access_product_supplierinfo_user,product.supplierinfo user,product.model_product
 access_res_partner,res.partner,base.model_res_partner,mrp.group_mrp_user,1,0,0,0
 access_mrp_workorder_mrp_user,mrp.workorder.user,model_mrp_workorder,mrp.group_mrp_user,1,1,1,1
 access_mrp_workorder_mrp_manager,mrp.workorder,model_mrp_workorder,mrp.group_mrp_manager,1,1,1,1
+access_mrp_workorder_stock_user,mrp.workorder.stock_user,model_mrp_workorder,stock.group_stock_user,1,0,0,0
 access_resource_calendar_leaves_user,mrp.resource.calendar.leaves.user,resource.model_resource_calendar_leaves,mrp.group_mrp_user,1,1,1,1
 access_resource_calendar_leaves_manager,mrp.resource.calendar.leaves.manager,resource.model_resource_calendar_leaves,mrp.group_mrp_manager,1,0,0,0
 access_resource_calendar_attendance_mrp_user,mrp.resource.calendar.attendance.mrp.user,resource.model_resource_calendar_attendance,mrp.group_mrp_user,1,1,1,1
@@ -46,6 +47,7 @@ access_product_tag_mrp_manager,product.tag.mrp.manager,product.model_product_tag
 access_resource_calendar_manufacturinguser,resource.calendar manufacturing.user,resource.model_resource_calendar,mrp.group_mrp_user,1,0,0,0
 access_mrp_unbuild,mrp.unbuild,model_mrp_unbuild,group_mrp_user,1,1,1,1
 access_mrp_unbuild_manager,mrp.unbuild manager,model_mrp_unbuild,group_mrp_manager,1,1,1,1
+access_mrp_unbuild_stock_user,mrp.unbuild.stock_user,model_mrp_unbuild,stock.group_stock_user,1,0,0,0
 access_mrp_document_mrp_manager,mrp.document group_user,model_mrp_document,group_mrp_manager,1,1,1,1
 access_mrp_document_mrp_user,mrp.document group_user,model_mrp_document,group_mrp_user,1,1,1,1
 access_change_production_qty,access.change.production.qty,model_change_production_qty,mrp.group_mrp_user,1,1,1,0


### PR DESCRIPTION
* STEP TO REPRODUCE: User A with only Stock user right -> access any MO -> Raise access error

* Reason: Althought we have read right for stock user, but when fetching some field of MO, workorder and mrp.unbuild model for example, stock user does't have read right on those stuff

* Fix by adding permission to read for work order and mrp unbuild

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
