### PR TITLE
[IMP] l10n_latam_check: Allow multiple liquidity lines in own check

### DIFF
--- a/addons/account/models/account_payment.py
+++ b/addons/account/models/account_payment.py
@@ -1,3 +1,5 @@
+from itertools import zip_longest
+
 from odoo import models, fields, api, _, Command
 from odoo.exceptions import UserError, ValidationError
 from odoo.tools import SQL
@@ -936,6 +938,7 @@ class AccountPayment(models.Model):
             # Make sure to preserve the write-off amount.
             # This allows to create a new payment with custom 'line_ids'.
             write_off_line_vals = []
+            valid_account_types = pay._get_valid_payment_account_types()
             if liquidity_lines and counterpart_lines and writeoff_lines:
                 write_off_line_vals.append({
                     'name': writeoff_lines[0].name,
@@ -946,13 +949,24 @@ class AccountPayment(models.Model):
                     'balance': sum(writeoff_lines.mapped('balance')),
                 })
             line_vals_list = pay._prepare_move_line_default_vals(write_off_line_vals=write_off_line_vals)
-            line_ids_commands = [
-                Command.update(liquidity_lines.id, line_vals_list[0]) if liquidity_lines else Command.create(line_vals_list[0]),
-                Command.update(counterpart_lines.id, line_vals_list[1]) if counterpart_lines else Command.create(line_vals_list[1])
-            ]
+            line_ids_commands = []
+            liquidity_lines_vals = [x for x in line_vals_list if x['account_id'] == self.outstanding_account_id.id]
+            for liquidity_line, newline_val in zip_longest(liquidity_lines, liquidity_lines_vals):
+                if liquidity_line and newline_val:
+                    line_ids_commands.append(Command.update(liquidity_line.id, newline_val))
+                elif not liquidity_line and newline_val:
+                    line_ids_commands.append(Command.create(newline_val))
+                elif liquidity_line and not newline_val:
+                    line_ids_commands.append(Command.unlink(liquidity_line.id))
+
+            counterpart_line_vals = [x for x in line_vals_list if x['account_id'] == pay.company_id.transfer_account_id.id or self.env['account.account'].browse(x['account_id']).account_type in valid_account_types]
+            line_ids_commands.append(
+                Command.update(counterpart_lines.id, counterpart_line_vals[0]) if counterpart_lines else Command.create(counterpart_line_vals[0])
+            )
             for line in writeoff_lines:
                 line_ids_commands.append((2, line.id))
-            for extra_line_vals in line_vals_list[2:]:
+            extra_line_vals_index = len(liquidity_lines_vals) + 1
+            for extra_line_vals in line_vals_list[extra_line_vals_index:]:
                 line_ids_commands.append((0, 0, extra_line_vals))
             # Update the existing journal items.
             # If dealing with multiple write-off lines, they are dropped and a new one is generated.

--- a/addons/l10n_latam_check/models/account_payment.py
+++ b/addons/l10n_latam_check/models/account_payment.py
@@ -60,7 +60,6 @@ class AccountPayment(models.Model):
             error_msg = "\n".join(f"* {msg}" for msg in msgs)
             raise ValidationError(error_msg)
         super().action_post()
-        self._l10n_latam_check_split_move()
 
     def _get_latam_checks(self):
         self.ensure_one()
@@ -130,68 +129,6 @@ class AccountPayment(models.Model):
         self._get_reconciled_checks_error()
         super().action_draft()
 
-    def _l10n_latam_check_split_move(self):
-        for payment in self.filtered(lambda x: x.payment_method_code == 'own_checks' and x.payment_type == 'outbound'):
-            if len(payment.l10n_latam_new_check_ids) == 1:
-                liquidity_line = payment._seek_for_lines()[0]
-                payment.l10n_latam_new_check_ids.outstanding_line_id = liquidity_line.id
-                continue
-
-            vals = {
-                'journal_id': payment.journal_id.id,
-                'move_type': 'entry',
-                'line_ids': [],
-            }
-            payment_liquidity_line = payment._seek_for_lines()[0]
-
-            # One line per check
-            checks_total = sum(payment.l10n_latam_new_check_ids.mapped('amount'))
-            liquidity_balance_total = 0.0
-            liquidity_balance = 0.0
-            for check in payment.l10n_latam_new_check_ids:
-                liquidity_amount_currency = -check.amount
-
-                if check == payment.l10n_latam_new_check_ids[-1]:
-                    liquidity_balance = payment.currency_id.round(payment_liquidity_line.balance - liquidity_balance)
-                else:
-                    liquidity_balance = payment.currency_id.round(payment_liquidity_line.balance * check.amount / checks_total)
-                    liquidity_balance_total += liquidity_balance
-
-                vals['line_ids'].append(
-                    Command.create({
-                        'name': _(
-                            'Check %(check_number)s - %(suffix)s',
-                            check_number=check.name,
-                            suffix=''.join([item[1] for item in payment._get_aml_default_display_name_list()])),
-                        'date_maturity': check.payment_date,
-                        'amount_currency': liquidity_amount_currency,
-                        'currency_id': check.currency_id.id,
-                        'debit': max(0.0, liquidity_balance),
-                        'credit': -min(liquidity_balance, 0.0),
-                        'partner_id': payment_liquidity_line.partner_id.id,
-                        'account_id': payment_liquidity_line.account_id.id,
-                        'l10n_latam_check_ids': [Command.link(check.id)]
-                    }),
-                )
-
-            # Cancel payment line
-            vals['line_ids'].append(
-                Command.create({
-                    'name': payment_liquidity_line.name,
-                    'date_maturity': payment_liquidity_line.date_maturity,
-                    'amount_currency': -payment_liquidity_line.amount_currency,
-                    'currency_id': payment_liquidity_line.currency_id.id,
-                    'debit': -payment_liquidity_line.debit,
-                    'credit': -payment_liquidity_line.credit,
-                    'partner_id': payment_liquidity_line.partner_id.id,
-                    'account_id': payment_liquidity_line.account_id.id,
-                }),
-            )
-            move_id = self.env['account.move'].create(vals)
-            move_id.action_post()
-            split_move_counterpart_line = move_id.line_ids.filtered(lambda x: x.amount_currency == -payment_liquidity_line.amount_currency)
-            (split_move_counterpart_line + payment_liquidity_line).reconcile()
-
     def _l10n_latam_check_unlink_split_move(self):
         self.ensure_one()
         for check in self.l10n_latam_new_check_ids:
@@ -245,15 +182,39 @@ class AccountPayment(models.Model):
         """ Add check name and operation on liquidity line """
         res = super()._prepare_move_line_default_vals(write_off_line_vals=write_off_line_vals, force_balance=force_balance)
 
-        # if only one check we don't create the split line, we add same data on liquidity line
-        if self.payment_method_code == 'own_checks' and self.payment_type == 'outbound' and len(self.l10n_latam_new_check_ids) == 1:
-            res[0].update({
-                'name': _(
-                    'Check %(check_number)s - %(suffix)s',
-                    check_number=self.l10n_latam_new_check_ids.name,
-                    suffix=''.join([item[1] for item in self._get_aml_default_display_name_list()])),
-                'date_maturity': self.l10n_latam_new_check_ids.payment_date,
-            })
+        if self.payment_method_code == 'own_checks' and self.payment_type == 'outbound':
+            del res[0]
+            for check_id in self.l10n_latam_new_check_ids:
+                if self.payment_type == 'inbound':
+                    # Receive money.
+                    liquidity_amount_currency = check_id.amount
+                elif self.payment_type == 'outbound':
+                    # Send money.
+                    liquidity_amount_currency = -check_id.amount
+                else:
+                    liquidity_amount_currency = 0.0
+
+                liquidity_balance = self.currency_id._convert(
+                    liquidity_amount_currency,
+                    self.company_id.currency_id,
+                    self.company_id,
+                    self
+                )
+
+                res.insert(0, {
+                            'name': _(
+                                'Check %(check_number)s - %(suffix)s',
+                                check_number=check_id.name,
+                                suffix=''.join([item[1] for item in self._get_aml_default_display_name_list()])),
+                            'date_maturity': check_id.payment_date,
+                            'amount_currency': liquidity_amount_currency,
+                            'currency_id':   check_id.currency_id.id,
+                            'debit': liquidity_balance if liquidity_balance > 0.0 else 0.0,
+                            'credit': -liquidity_balance if liquidity_balance < 0.0 else 0.0,
+                            'partner_id': self.partner_id.id,
+                            'account_id': self.outstanding_account_id.id,
+                            'l10n_latam_check_ids': [Command.link(check_id.id)],
+                })
         # we dont check the payment method code because when deposited on bank/cash journals pay method is manual but we still change the label
         # we dont want this names on the own checks because it doesn't add value, already each split/check line will have it name
         elif (self.l10n_latam_new_check_ids or self.l10n_latam_move_check_ids) and self.payment_method_code != 'own_checks':

--- a/addons/l10n_latam_check/models/account_payment.py
+++ b/addons/l10n_latam_check/models/account_payment.py
@@ -181,10 +181,10 @@ class AccountPayment(models.Model):
     def _prepare_move_line_default_vals(self, write_off_line_vals=None, force_balance=None):
         """ Add check name and operation on liquidity line """
         res = super()._prepare_move_line_default_vals(write_off_line_vals=write_off_line_vals, force_balance=force_balance)
-
-        if self.payment_method_code == 'own_checks' and self.payment_type == 'outbound':
+        latam_checks = self.l10n_latam_new_check_ids | self.l10n_latam_move_check_ids
+        if latam_checks:
             del res[0]
-            for check_id in self.l10n_latam_new_check_ids:
+            for check_id in latam_checks:
                 if self.payment_type == 'inbound':
                     # Receive money.
                     liquidity_amount_currency = check_id.amount
@@ -215,17 +215,6 @@ class AccountPayment(models.Model):
                             'account_id': self.outstanding_account_id.id,
                             'l10n_latam_check_ids': [Command.link(check_id.id)],
                 })
-        # we dont check the payment method code because when deposited on bank/cash journals pay method is manual but we still change the label
-        # we dont want this names on the own checks because it doesn't add value, already each split/check line will have it name
-        elif (self.l10n_latam_new_check_ids or self.l10n_latam_move_check_ids) and self.payment_method_code != 'own_checks':
-            check_name = [check_name for check_name in (self.l10n_latam_new_check_ids | self.l10n_latam_move_check_ids).mapped('name') if check_name]
-            document_name = (
-                _('Checks %s received') if self.payment_type == 'inbound' else _('Checks %s delivered')) % (
-                ', '.join(check_name)
-            )
-            res[0].update({
-                'name': document_name + ' - ' + ''.join([item[1] for item in self._get_aml_default_display_name_list()]),
-            })
         return res
 
     @api.depends('l10n_latam_move_check_ids')

--- a/addons/l10n_latam_check/models/l10n_latam_check.py
+++ b/addons/l10n_latam_check/models/l10n_latam_check.py
@@ -100,7 +100,7 @@ class L10n_LatamCheck(models.Model):
     @api.depends('outstanding_line_id.amount_residual')
     def _compute_issue_state(self):
         for rec in self:
-            if not rec.outstanding_line_id:
+            if rec.payment_id.payment_method_code not in 'own_checks' or not rec.outstanding_line_id:
                 rec.issue_state = False
             elif rec.amount and not rec.outstanding_line_id.amount_residual:
                 if any(

--- a/addons/l10n_latam_check/views/l10n_latam_check_view.xml
+++ b/addons/l10n_latam_check/views/l10n_latam_check_view.xml
@@ -105,7 +105,6 @@
         <field name="model">l10n_latam.check</field>
         <field name="arch" type="xml">
             <form create="false" edit="false" delete="false">
-                <field name="outstanding_line_id" invisible="True"/>
                 <header>
                     <button name="action_void" string="Void Check" invisible="issue_state != 'handed'" type="object" class="oe_highlight" confirm="Marking a check as void will cancel the check and generate a new entry that will re-open the debt."  data-hotkey="v"/>
                     <field name="issue_state" statusbar_visible="issue_state" widget="statusbar"/>
@@ -117,9 +116,6 @@
                         </button>
                         <button  icon="fa-bars" type="object" name="button_open_payment" invisible="payment_method_code != 'own_checks'">
                             <span>Payment</span>
-                        </button>
-                        <button  icon="fa-bars" type="object" invisible="not outstanding_line_id" name="action_show_journal_entry" groups="account.group_account_user,account.group_account_readonly">
-                            <span>Journal Entry</span>
                         </button>
                         <button  icon="fa-bars" type="object" invisible="not issue_state or issue_state == 'handed'" name="action_show_reconciled_move" groups="account.group_account_user,account.group_account_readonly">
                             <span>Reconciled move</span>


### PR DESCRIPTION
This PR introduces an improvement to the account and l10n_latam_check modules that allows for multiple liquidity lines (one per check) to be recorded in a single journal entry. Currently, a split journal entry is created for each liquidity line, which presents several disadvantages:

Incorrect computation of payment and invoice states Simplified workflow: By using a single journal entry for all liquidity lines, the workflow is significantly simplified and accounting complexity is reduced. First step towards a refactor: This improvement is a first step towards a broader refactor that will allow adapting the own check flow in payment registration without the need to create journal entries. Changes made:

Enhanced _synchronize_to_moves() method: - Allows for the creation and update of multiple liquidity lines within a single journal entry. - Removes excess liquidity lines if _prepare_move_line_default_vals() returns fewer lines than currently exist. - Account type-based counterparty identification: Replaces the previous position-based identification with an approach based on account types. - The starting index for extra line values is now dynamic, determined by the number of liquidity lines

Removed _l10n_latam_check_split_move method:

This method is no longer necessary given the new implementation that supports multiple liquidity lines in a single journal entry. Modified _prepare_move_line_default_vals() method: - Now returns one liquidity line for each registered own check, simplifying the generation of journal entries.

Preserved _l10n_latam_check_unlink_split_move() method:

Maintained for backward compatibility purposes, allowing payments containing split moves to be set to draft status.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
