### PR TITLE
[FIX] website_sale_collect: always show an out-of-stock message

### DIFF
--- a/addons/website_sale_collect/static/src/xml/product_availability.xml
+++ b/addons/website_sale_collect/static/src/xml/product_availability.xml
@@ -3,9 +3,6 @@
 <templates>
 
     <t t-inherit="website_sale_stock.product_availability" t-inherit-mode="extension">
-        <div id="out_of_stock_message" position="replace">
-            <t t-if="!in_store_stock">$0</t>
-        </div>
         <div id="threshold_message" position="attributes">
             <attribute name="t-elif" add="!in_store_stock" separator=" and "/>
         </div>


### PR DESCRIPTION
Before the commit, when a 'pick up in store' was published, the out-of-stock message was hidden to avoid confusion. However, customers want to benefit from it, and now we reintroduce it.

opw-4791969
