### PR TITLE
[IMP] l10n_fr: adapt invoice layout for better readability

### DIFF
--- a/addons/l10n_fr_account/i18n/fr.po
+++ b/addons/l10n_fr_account/i18n/fr.po
@@ -235,19 +235,19 @@ msgstr "9B - Taux réduit 10 % (taxe)"
 #. module: l10n_fr_account
 #: model_terms:ir.ui.view,arch_db:l10n_fr_account.report_invoice_document
 msgid ""
-"<strong>Customer Address:</strong>\n"
+"<strong>Customer Address</strong>\n"
 "                    <br/>"
 msgstr ""
-"<strong>Adresse du client :</strong>\n"
+"<strong>Adresse du client </strong>\n"
 "                    <br/>"
 
 #. module: l10n_fr_account
 #: model_terms:ir.ui.view,arch_db:l10n_fr_account.report_invoice_document
 msgid ""
-"<strong>Operation Type:</strong>\n"
+"<strong>Operation Type</strong>\n"
 "                    <br/>"
 msgstr ""
-"<strong>Type d'opération :</strong>\n"
+"<strong>Type d'opération </strong>\n"
 "                    <br/>"
 
 #. module: l10n_fr_account

--- a/addons/l10n_fr_account/i18n/l10n_fr_account.pot
+++ b/addons/l10n_fr_account/i18n/l10n_fr_account.pot
@@ -4,10 +4,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 18.0\n"
+"Project-Id-Version: Odoo Server 18.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-11-04 08:46+0000\n"
-"PO-Revision-Date: 2024-11-04 08:46+0000\n"
+"POT-Creation-Date: 2025-07-10 06:53+0000\n"
+"PO-Revision-Date: 2025-07-10 06:53+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -231,14 +231,14 @@ msgstr ""
 #. module: l10n_fr_account
 #: model_terms:ir.ui.view,arch_db:l10n_fr_account.report_invoice_document
 msgid ""
-"<strong>Customer Address:</strong>\n"
+"<strong>Customer Address</strong>\n"
 "                    <br/>"
 msgstr ""
 
 #. module: l10n_fr_account
 #: model_terms:ir.ui.view,arch_db:l10n_fr_account.report_invoice_document
 msgid ""
-"<strong>Operation Type:</strong>\n"
+"<strong>Operation Type</strong>\n"
 "                    <br/>"
 msgstr ""
 

--- a/addons/l10n_fr_account/views/report_invoice.xml
+++ b/addons/l10n_fr_account/views/report_invoice.xml
@@ -20,8 +20,8 @@
         <xpath expr="//div[@id='informations']" position="inside">
             <t t-if="o.l10n_fr_is_company_french and o.partner_id.commercial_partner_id != o.partner_id and o.move_type.startswith('out_')">
                 <t t-set="partner" t-value="o.partner_id.commercial_partner_id"/>
-                <div t-attf-class="#{'col-auto col-3 mw-100' if report_type != 'html' else 'col'} mb-2" name="customer_address">
-                    <strong>Customer Address:</strong>
+                <div name="customer_address" class="col">
+                    <strong>Customer Address</strong>
                     <br/>
                     <address t-field="partner.self" class="m-0" t-options="{'widget': 'contact', 'fields': ['address'], 'no_marker': True}"/>
                 </div>
@@ -34,8 +34,8 @@
                 <t t-set="has_service" t-value="'service' in tax_scopes"/>
                 <t t-set="has_consu" t-value="'consu' in tax_scopes"/>
 
-                <div t-if="has_service or has_consu" t-attf-class="#{'col-auto col-3 mw-100' if report_type != 'html' else 'col'} mb-2" name="operation_type">
-                    <strong>Operation Type:</strong>
+                <div t-if="has_service or has_consu" name="operation_type" class="col">
+                    <strong>Operation Type</strong>
                     <br/>
                     <span t-if="has_service and has_consu">
                         Mixed Operation


### PR DESCRIPTION
Backport of: https://github.com/odoo/odoo/commit/7f93cd1c82b0f0250b3f19e4b408775fb211482a

This commit https://github.com/odoo/odoo/commit/d10174e49759a58058aed6c44026060a4d293cc3 made a change in the report invoice information block and changed the class to only use col which was not changed in the french localisation.

Adapted the layout to be more readable by using proper spacing and column sizing when displaying a lot of information (Sales reference, delivery address, incoterm, customer address, operation type).

Task ID: 4555856




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
