### PR TITLE
[FIX] base_geolocalize: fix crash when computing geolocation for unnamed partner

### DIFF
--- a/addons/base_geolocalize/models/res_partner.py
+++ b/addons/base_geolocalize/models/res_partner.py
@@ -57,6 +57,7 @@ class ResPartner(models.Model):
             self.env['bus.bus']._sendone(self.env.user.partner_id, 'simple_notification', {
                 'type': 'danger',
                 'title': _("Warning"),
-                'message': _('No match found for %(partner_names)s address(es).', partner_names=', '.join(partners_not_geo_localized.mapped('name')))
+                'message': _('No match found for %(partner_names)s address(es).',
+                             partner_names=', '.join(partners_not_geo_localized.mapped('display_name')))
             })
         return True

--- a/addons/base_geolocalize/tests/test_geolocalize.py
+++ b/addons/base_geolocalize/tests/test_geolocalize.py
@@ -2,6 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 from odoo.tests import TransactionCase
 from odoo.exceptions import UserError
+from unittest.mock import patch
 
 import odoo.tests
 
@@ -33,3 +34,31 @@ class TestGeoLocalize(TransactionCase):
         self.assertFalse(test_partner.partner_longitude)
         self.assertFalse(test_partner.partner_latitude)
         self.assertFalse(test_partner.date_localization)
+
+
+@odoo.tests.tagged('-at_install', 'post_install')
+class TestPartnerGeoLocalization(TransactionCase):
+
+    def test_geo_localization_notification(self):
+        """ Warning message is sent to the user when geolocation fails. """
+        partner = self.env['res.partner']
+        user_partner = self.env.user.partner_id
+
+        with patch.object(self.env.registry['bus.bus'], '_sendone') as mock_send:
+            partner1 = partner.create({'name': 'Test A'})
+            partner1.with_context(force_geo_localize=True).geo_localize()
+            mock_send.assert_called_with(user_partner, 'simple_notification', {
+                'type': 'danger',
+                'title': "Warning",
+                'message': "No match found for Test A address(es).",
+            })
+            mock_send.reset_mock()
+
+            partner2 = partner.create({'name': "", 'parent_id': partner1.id, 'type': 'other'})
+            partner2.with_context(force_geo_localize=True).geo_localize()
+            mock_send.assert_called_with(user_partner, 'simple_notification', {
+                'type': 'danger',
+                'title': "Warning",
+                'message': "No match found for Test A, Other Address address(es).",
+            })
+            mock_send.reset_mock()


### PR DESCRIPTION
<b>Steps to reproduce:</b>
1. Install base_geolocalize and Contacts > Go to Contacts.
2. Create a new contact or select an existing one (Individual).
3. Go to Contacts & Addresses > Add, leave all fields empty, then Save & Close.
4. Open the newly created sub-contact > Partner Assignment > Geolocation
5. Click "Compute based on address".

<b>Issue:</b>
- Traceback is raised during geolocation computation if the sub-contact has no name Instead of Displaying.

<b>Cause:</b>
- If a partner does not have a name, the value is False.
- The join() operation results in a TypeError because False cannot be concatenated with strings.

<b>Problematic line:</b>
`'message': _('No match found for %(partner_names)s address(es).', partner_names=', '.join(partners_not_geo_localized.mapped('name')))`


<b>Solution:</b>
- Replaced `name` with `display_name` to ensure all elements passed to`join()` are strings.
This also improves readability in the UI when identifying partners without proper names.

opw-4930258
