### PR TITLE
[IMP] website: allow parallax block overflow

### DIFF
--- a/addons/html_builder/static/src/core/remove_plugin.js
+++ b/addons/html_builder/static/src/core/remove_plugin.js
@@ -20,7 +20,8 @@ const layoutElementsSelector = [
     ".o_we_shape",
     ".o_we_bg_filter",
     // Website only
-    ".s_parallax_bg",
+    ".s_parallax_bg", // Kept for compatibility.
+    ".s_parallax_bg_wrap",
     ".o_bg_video_container",
 ].join(",");
 

--- a/addons/html_builder/static/src/plugins/background_option/background_position_overlay.edit.scss
+++ b/addons/html_builder/static/src/plugins/background_option/background_position_overlay.edit.scss
@@ -2,6 +2,7 @@
     z-index: 2000 !important;
 }
 
-.o_we_background_positioning>*:not(.s_parallax_bg) {
+// ":not(.s_parallax_bg)" is kept for compatibility.
+.o_we_background_positioning > *:not(.s_parallax_bg_wrap, .s_parallax_bg) {
     visibility: hidden;
 }

--- a/addons/html_builder/static/src/plugins/background_option/background_position_overlay.js
+++ b/addons/html_builder/static/src/plugins/background_option/background_position_overlay.js
@@ -33,9 +33,14 @@ export class BackgroundPositionOverlay extends Component {
         // If there is a Scroll Effect, a span.s_parallax_bg inside the section
         // contains the background. Otherwise it's the section itself.
         // And targetContainerEl should always be the section.
-        this.targetContainerEl = this.props.editingElement.classList.contains("s_parallax_bg")
-            ? this.props.editingElement.parentElement
-            : this.props.editingElement;
+        if (this.props.editingElement.matches(".s_parallax_bg")) {
+            const parallaxBgParentEl = this.props.editingElement.parentElement;
+            this.targetContainerEl = parallaxBgParentEl.matches(".s_parallax_bg_wrap")
+                ? parallaxBgParentEl.parentElement
+                : parallaxBgParentEl; // <- kept for compatibility
+        } else {
+            this.targetContainerEl = this.props.editingElement;
+        }
 
         this._dimensionOverlay = this.dimensionOverlay.bind(this);
 

--- a/addons/html_builder/static/src/scss/background.scss
+++ b/addons/html_builder/static/src/scss/background.scss
@@ -22,7 +22,6 @@
     position: absolute !important;
     display: block;
     overflow: hidden;
-    background-repeat: no-repeat;
     pointer-events: none;
     // For border with all 4 edges of equal value the max function is useless,
     // but in case the border is uneven it approximates the correct roundness

--- a/addons/website/data/website_data.xml
+++ b/addons/website/data/website_data.xml
@@ -33,7 +33,9 @@
             <span class="hidden" data-for="contactus_form" t-att-data-values="contactus_form_values"/>
             <div id="wrap" class="oe_structure oe_empty">
                 <section class="s_title parallax s_parallax_is_fixed bg-black-50 pt24 pb24" data-vcss="001" data-snippet="s_title" data-scroll-background-ratio="1">
-                    <span class="s_parallax_bg oe_img_bg" style="background-image: url('/web/image/website.s_parallax_default_image'); background-position: 50% 0;"/>
+                    <span class="s_parallax_bg_wrap">
+                        <span class="s_parallax_bg oe_img_bg" style="background-image: url('/web/image/website.s_parallax_default_image'); background-position: 50% 0;"/>
+                    </span>
                     <div class="o_we_bg_filter bg-black-50"/>
                     <div class="container">
                         <h1>Contact us</h1>
@@ -299,7 +301,9 @@
             <div id="wrap">
                 <div class="oe_structure">
                     <section class="s_title parallax s_parallax_is_fixed bg-black-50 pt24 pb24" data-vcss="001" data-snippet="s_title" data-scroll-background-ratio="1">
-                        <span class="s_parallax_bg oe_img_bg" style="background-image: url('/web/image/website.s_parallax_default_image'); background-position: 50% 0;"/>
+                        <span class="s_parallax_bg_wrap">
+                            <span class="s_parallax_bg oe_img_bg" style="background-image: url('/web/image/website.s_parallax_default_image'); background-position: 50% 0;"/>
+                        </span>
                         <div class="o_we_bg_filter bg-black-50"/>
                         <div class="container">
                             <h1>About us</h1>
@@ -315,7 +319,9 @@
             <div id="wrap">
                 <div class="oe_structure">
                     <section class="s_title parallax s_parallax_is_fixed bg-black-50 pt24 pb24" data-vcss="001" data-snippet="s_title" data-scroll-background-ratio="1">
-                        <span class="s_parallax_bg oe_img_bg" style="background-image: url('/web/image/website.s_parallax_default_image'); background-position: 50% 0;"/>
+                        <span class="s_parallax_bg_wrap">
+                            <span class="s_parallax_bg oe_img_bg" style="background-image: url('/web/image/website.s_parallax_default_image'); background-position: 50% 0;"/>
+                        </span>
                         <div class="o_we_bg_filter bg-black-50"/>
                         <div class="container">
                             <h1>Services</h1>
@@ -331,7 +337,9 @@
             <div id="wrap">
                 <div class="oe_structure">
                     <section class="s_title parallax s_parallax_is_fixed bg-black-50 pt24 pb24" data-vcss="001" data-snippet="s_title" data-scroll-background-ratio="1">
-                        <span class="s_parallax_bg oe_img_bg" style="background-image: url('/web/image/website.s_parallax_default_image'); background-position: 50% 0;"/>
+                        <span class="s_parallax_bg_wrap">
+                            <span class="s_parallax_bg oe_img_bg" style="background-image: url('/web/image/website.s_parallax_default_image'); background-position: 50% 0;"/>
+                        </span>
                         <div class="o_we_bg_filter bg-black-50"/>
                         <div class="container">
                             <h1>Pricing</h1>
@@ -347,7 +355,9 @@
             <div id="wrap">
                 <div class="oe_structure">
                     <section class="s_title parallax s_parallax_is_fixed bg-black-50 pt24 pb24" data-vcss="001" data-snippet="s_title" data-scroll-background-ratio="1">
-                        <span class="s_parallax_bg oe_img_bg" style="background-image: url('/web/image/website.s_parallax_default_image'); background-position: 50% 0;"/>
+                        <span class="s_parallax_bg_wrap">
+                            <span class="s_parallax_bg oe_img_bg" style="background-image: url('/web/image/website.s_parallax_default_image'); background-position: 50% 0;"/>
+                        </span>
                         <div class="o_we_bg_filter bg-black-50"/>
                         <div class="container">
                             <h1>Privacy Policy</h1>

--- a/addons/website/static/src/builder/plugins/options/background_option.js
+++ b/addons/website/static/src/builder/plugins/options/background_option.js
@@ -21,9 +21,12 @@ export class WebsiteBackgroundOption extends BaseOptionComponent {
         super.setup();
         const { showColorFilter } = useBackgroundOption(this.isActiveItem);
         this.showColorFilter = () => showColorFilter() || this.isActiveItem("toggle_bg_video_id");
+        // ":scope > .s_parallax_bg" is kept for compatibility.
+        const parallaxBgSelector =
+            ":scope > .s_parallax_bg, :scope > .s_parallax_bg_wrap > .s_parallax_bg";
         this.websiteBgOptionDomState = useDomState((el) => ({
             // Only search for .s_parallax_bg that are direct children
-            applyTo: el.querySelector(":scope > .s_parallax_bg") ? ".s_parallax_bg" : "",
+            applyTo: el.querySelector(parallaxBgSelector) ? parallaxBgSelector : "",
         }));
     }
 }

--- a/addons/website/static/src/builder/plugins/options/background_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/background_option_plugin.js
@@ -12,7 +12,8 @@ function getBgVideoOrParallax(editingElement) {
     if (bgVideoEl) {
         return bgVideoEl;
     }
-    return editingElement.querySelector(":scope > .s_parallax_bg");
+    return editingElement.querySelector(":scope > .s_parallax_bg_wrap")
+        || editingElement.querySelector(":scope > .s_parallax_bg"); // Kept for compatibility.
 }
 
 class WebsiteBackgroundImageOptionPlugin extends Plugin {

--- a/addons/website/static/src/interactions/parallax/parallax.js
+++ b/addons/website/static/src/interactions/parallax/parallax.js
@@ -5,7 +5,8 @@ export class Parallax extends Interaction {
     static selector = ".parallax";
     dynamicSelectors = Object.assign(this.dynamicSelectors, {
         _modal: () => this.el.closest(".modal"),
-        _bg: () => this.el.querySelector(":scope > .s_parallax_bg"),
+        // ":scope > .s_parallax_bg" is kept for compatibility
+        _bg: () => this.el.querySelector(":scope > .s_parallax_bg_wrap > .s_parallax_bg, :scope > .s_parallax_bg"),
     });
     dynamicContent = {
         _document: { "t-on-scroll": this.onScroll },

--- a/addons/website/static/src/scss/website.scss
+++ b/addons/website/static/src/scss/website.scss
@@ -1474,14 +1474,18 @@ $-o-carousel-controllers-size: var(--CarouselControllers-size, #{map-get($spacer
 }
 
 // Parallax
+// ".parallax > .s_parallax_bg" selector are kept for compatibility.
 .parallax {
-    // TODO this introduces a limitation: no dropdown will be able to
-    // overflow. Maybe there is a better way to find.
-    &:not(.s_parallax_no_overflow_hidden) {
+    // Kept for compatibility. Before "s_parallax_bg" was wrapped by an
+    // intermediate parent element to clip it ("s_parallax_bg_wrap"), its direct
+    // parent was the section with the "parallax" class, which had the CSS rule
+    // "overflow: hidden". That was not the right solution because it introduced
+    // a limitation: no dropdown could overflow, for example.
+    &:where(:not(.s_parallax_no_overflow_hidden):not(:has(> .s_parallax_bg_wrap))) {
         overflow: hidden;
     }
 
-    > .s_parallax_bg {
+    > .s_parallax_bg, > .s_parallax_bg_wrap > .s_parallax_bg, > .s_parallax_bg_wrap {
         @extend %o-we-background-layer;
     }
     @include media-breakpoint-up(xl) {
@@ -1489,8 +1493,10 @@ $-o-carousel-controllers-size: var(--CarouselControllers-size, #{map-get($spacer
         // which is not a big deal but, on some of them (iOS...), defining the
         // background as fixed breaks the background-size/position props.
         // So we enable this only for >= XL devices.
-        &.s_parallax_is_fixed > .s_parallax_bg {
-            background-attachment: fixed;
+        &.s_parallax_is_fixed {
+            > .s_parallax_bg, > .s_parallax_bg_wrap > .s_parallax_bg {
+                background-attachment: fixed;
+            }
         }
     }
 }

--- a/addons/website/static/tests/builder/website_builder/background_option.test.js
+++ b/addons/website/static/tests/builder/website_builder/background_option.test.js
@@ -403,7 +403,9 @@ test("remove background image removes color filter", async () => {
     const backgroundImageUrl = "url('/web/image/123/transparent.png')";
     await setupWebsiteBuilder(`
         <section>
-            <span class='s_parallax_bg oe_img_bg o_bg_img_center' style="background-image: ${backgroundImageUrl} !important;">aaa</span>
+            <span class="s_parallax_bg_wrap">
+                <span class='s_parallax_bg oe_img_bg o_bg_img_center' style="background-image: ${backgroundImageUrl} !important;">aaa</span>
+            </span>
             <div class="o_we_bg_filter bg-black-50 o-paragraph"><br></div>
         </section>`);
     await contains(":iframe section").click();

--- a/addons/website/static/tests/builder/website_builder/parallax_option.test.js
+++ b/addons/website/static/tests/builder/website_builder/parallax_option.test.js
@@ -30,7 +30,9 @@ test("remove parallax changes editing element", async () => {
     const backgroundImageUrl = "url('/web/image/123/transparent.png')";
     await setupWebsiteBuilder(`
         <section>
-            <span class='s_parallax_bg oe_img_bg o_bg_img_center' style="background-image: ${backgroundImageUrl} !important;">aaa</span>
+            <span class="s_parallax_bg_wrap">
+                <span class="s_parallax_bg oe_img_bg o_bg_img_center" style="background-image: ${backgroundImageUrl} !important;">aaa</span>
+            </span>
         </section>`);
     await contains(":iframe section").click();
     await contains("[data-label='Scroll Effect'] button.o-dropdown").click();
@@ -45,18 +47,20 @@ test("remove parallax from block containing an inner block with parallax", async
     await setupWebsiteBuilder(`
         <section id="section_a" style="background-image: ${backgroundImageUrl} !important;">
             <section id="section_b">
-                <span class='s_parallax_bg oe_img_bg o_bg_img_center' style="background-image: ${backgroundImageUrl} !important;">aaa</span>
+                <span class="s_parallax_bg_wrap">
+                    <span class="s_parallax_bg oe_img_bg o_bg_img_center" style="background-image: ${backgroundImageUrl} !important;">aaa</span>
+                </span>
             </section>
         </section>`);
     await contains(":iframe section#section_a").click();
     await contains("[data-label='Scroll Effect'] button.o-dropdown").click();
     await contains("[data-action-value='top']").click();
     expect(":iframe section#section_a").toHaveClass("parallax");
-    expect(":iframe section#section_a > .s_parallax_bg").toHaveCount();
+    expect(":iframe section#section_a > .s_parallax_bg_wrap > .s_parallax_bg").toHaveCount();
     await contains("[data-label='Scroll Effect'] button.o-dropdown").click();
     await contains("[data-action-value='none']").click();
-    expect(":iframe section#section_a > .s_parallax_bg").not.toHaveCount();
-    expect(":iframe section#section_b > .s_parallax_bg").toHaveCount();
+    expect(":iframe section#section_a > .s_parallax_bg_wrap > .s_parallax_bg").not.toHaveCount();
+    expect(":iframe section#section_b > .s_parallax_bg_wrap > .s_parallax_bg").toHaveCount();
 });
 
 test("remove parallax from inner block", async () => {
@@ -77,13 +81,13 @@ test("remove parallax from inner block", async () => {
     ).click();
     await contains("[data-action-value='top']").click();
     expect(":iframe section#section_b").toHaveClass("parallax");
-    expect(":iframe section#section_b > .s_parallax_bg").toHaveCount();
+    expect(":iframe section#section_b > .s_parallax_bg_wrap > .s_parallax_bg").toHaveCount();
 
     await contains(
         "[data-container-title='SectionB'] [data-label='Scroll Effect'] button.o-dropdown"
     ).click();
     await contains("[data-action-value='none']").click();
-    expect(":iframe section#section_b > .s_parallax_bg").not.toHaveCount();
+    expect(":iframe section#section_b > .s_parallax_bg_wrap > .s_parallax_bg").not.toHaveCount();
 });
 
 test("parallax scroll effect 'none' doesn't remove the color filter", async () => {

--- a/addons/website/static/tests/interactions/parallax.test.js
+++ b/addons/website/static/tests/interactions/parallax.test.js
@@ -16,7 +16,9 @@ const getTemplate = function (options = {}) {
     return `
         <section style="height: ${height}px; background-color: #CCCCFF;"></section>
         <section class="parallax" data-scroll-background-ratio="${speed}" style="min-height: 100px; z-index: -1000;">
-            <div class="s_parallax_bg" style="background-color: #CCFFCC; height: 500px; overflow: hidden;"></div>
+            <span class="s_parallax_bg_wrap">
+                <div class="s_parallax_bg" style="background-color: #CCFFCC; height: 500px; overflow: hidden;"></div>
+            </span>
         </section>
         <section style="height: ${height}px; background-color: #FFCCCC;"></section>
     `;

--- a/addons/website/views/snippets/s_banner_connected.xml
+++ b/addons/website/views/snippets/s_banner_connected.xml
@@ -8,10 +8,12 @@
         data-scroll-background-ratio="0.75"
         data-parallax-type="zoomOut"
         >
-        <span
-            class="s_parallax_bg oe_img_bg"
-            style="background-image: url('/web/image/website.s_banner_connected_default_image'); background-position: 50% 75%;"
-            />
+        <span class="s_parallax_bg_wrap">
+            <span
+                class="s_parallax_bg oe_img_bg"
+                style="background-image: url('/web/image/website.s_banner_connected_default_image'); background-position: 50% 75%;"
+                />
+        </span>
         <div
             class="o_we_bg_filter"
             style="background-image: radial-gradient(circle farthest-side at 25% 25%, rgba(222, 222, 222, 0) 0%, rgb(69, 69, 69) 100%);"

--- a/addons/website/views/snippets/s_banner_product.xml
+++ b/addons/website/views/snippets/s_banner_product.xml
@@ -5,8 +5,10 @@
     <section class="s_banner_product o_cc o_cc5 pt24 pb24 parallax"
             data-scroll-background-ratio="0.2"
             data-parallax-type="zoom_out">
-        <span class="s_parallax_bg oe_img_bg o_bg_img_center o_bg_img_origin_border_box"
-                style="background-image: url('/web/image/website.shop_category_1_16x9'); top: -20px; bottom: -20px; transform: scale(1.097);"/>
+        <span class="s_parallax_bg_wrap">
+            <span class="s_parallax_bg oe_img_bg o_bg_img_center o_bg_img_origin_border_box"
+                    style="background-image: url('/web/image/website.shop_category_1_16x9'); top: -20px; bottom: -20px; transform: scale(1.097);"/>
+        </span>
         <div class="o_we_bg_filter bg-black-15"/>
         <div class="container">
             <div class="row o_grid_mode" data-row-count="15">

--- a/addons/website/views/snippets/s_cover.xml
+++ b/addons/website/views/snippets/s_cover.xml
@@ -3,7 +3,9 @@
 
 <template id="s_cover" name="Cover">
     <section class="s_cover parallax s_parallax_is_fixed o_cc o_cc5 pt232 pb232" data-scroll-background-ratio="1">
-        <span class="s_parallax_bg oe_img_bg" style="background-image: url('/web/image/website.s_cover_default_image'); background-position: 50% 75%;"/>
+        <span class="s_parallax_bg_wrap">
+            <span class="s_parallax_bg oe_img_bg" style="background-image: url('/web/image/website.s_cover_default_image'); background-position: 50% 75%;"/>
+        </span>
         <div class="o_we_bg_filter bg-black-50"/>
         <div class="container s_allow_columns">
             <h1 class="display-3" style="text-align: center;">Your journey starts here</h1>

--- a/addons/website/views/snippets/s_floating_blocks.xml
+++ b/addons/website/views/snippets/s_floating_blocks.xml
@@ -35,7 +35,9 @@
                         class="s_floating_blocks_block s_col_no_resize position-sticky parallax py-5 py-lg-0 d-flex o_cc o_cc5"
                         data-scroll-background-ratio="-2"
                         >
-                        <span class="s_parallax_bg oe_img_bg o_bg_img_center" style="background-image: url('/web/image/website.s_floating_blocks_1'); background-position: top center"/>
+                        <span class="s_parallax_bg_wrap">
+                            <span class="s_parallax_bg oe_img_bg o_bg_img_center" style="background-image: url('/web/image/website.s_floating_blocks_1'); background-position: top center"/>
+                        </span>
                         <div class="o_we_bg_filter bg-black-25"/>
                         <div class="container-fluid align-self-start align-self-lg-center">
                             <div class="s_floating_blocks_block_grid oe_unremovable row mx-0 o_grid_mode" data-row-count="8">
@@ -57,7 +59,9 @@
                         class="s_floating_blocks_block s_col_no_resize position-sticky parallax py-5 py-lg-0 d-flex o_cc o_cc5"
                         data-scroll-background-ratio="-2"
                         >
-                        <span class="s_parallax_bg oe_img_bg" style="background-image: url('/web/image/website.s_floating_blocks_2'); background-position: 50% 50%;" />
+                        <span class="s_parallax_bg_wrap">
+                            <span class="s_parallax_bg oe_img_bg" style="background-image: url('/web/image/website.s_floating_blocks_2'); background-position: 50% 50%;" />
+                        </span>
                         <div class="container-fluid align-self-start align-self-lg-center">
                             <div class="s_floating_blocks_block_grid oe_unremovable row mx-0 o_grid_mode" data-row-count="8">
                                 <div class="o_grid_item g-height-4 g-col-lg-8 col-lg-8 order-lg-0" style="z-index: 1; grid-area: 1 / 1 / 5 / 9;">

--- a/addons/website/views/snippets/s_kickoff.xml
+++ b/addons/website/views/snippets/s_kickoff.xml
@@ -2,8 +2,10 @@
 <odoo>
 
 <template id="s_kickoff" name="Kickoff">
-    <section class="s_kickoff o_cc o_cc5 parallax s_parallax_is_fixed s_parallax_no_overflow_hidden pt232 pb88" data-scroll-background-ratio="1" data-oe-shape-data="{'shape': 'html_builder/Connections/06', 'colors': {'c5': 'o-color-4'}, 'flip': [], 'showOnMobile': false}">
-        <span class="s_parallax_bg oe_img_bg" style="background-image: url('/web/image/website.s_kickoff_default_image');"/>
+    <section class="s_kickoff o_cc o_cc5 parallax s_parallax_is_fixed pt232 pb88" data-scroll-background-ratio="1" data-oe-shape-data="{'shape': 'html_builder/Connections/06', 'colors': {'c5': 'o-color-4'}, 'flip': [], 'showOnMobile': false}">
+        <span class="s_parallax_bg_wrap">
+            <span class="s_parallax_bg oe_img_bg" style="background-image: url('/web/image/website.s_kickoff_default_image');"/>
+        </span>
         <div class="o_we_bg_filter bg-black-50"/>
         <div class="o_we_shape o_html_builder_Connections_06" style="background-image: url('/html_editor/shape/html_builder/Connections/06.svg?c5=o-color-4');"/>
         <div class="container">

--- a/addons/website/views/snippets/s_opening_hours.xml
+++ b/addons/website/views/snippets/s_opening_hours.xml
@@ -3,7 +3,9 @@
 
 <template id="s_opening_hours" name="Opening Hours">
     <section class="s_opening_hours parallax pt256" data-scroll-background-ratio="1.5">
-        <span class="s_parallax_bg oe_img_bg o_bg_img_center" style="background-image: url('/web/image/website.s_opening_hours_default_image'); background-position: 50% 75%;"/>
+        <span class="s_parallax_bg_wrap">
+            <span class="s_parallax_bg oe_img_bg o_bg_img_center" style="background-image: url('/web/image/website.s_opening_hours_default_image'); background-position: 50% 75%;"/>
+        </span>
         <div class="container-fluid">
             <div class="row o_grid_mode" data-row-count="7">
                 <!-- This next div is intended to correct a visual issue, specifically a vertical line anomaly next to the hours, that appears only in the modal preview.-->

--- a/addons/website/views/snippets/s_parallax.xml
+++ b/addons/website/views/snippets/s_parallax.xml
@@ -3,7 +3,9 @@
 
 <template id="s_parallax" name="Parallax">
     <section class="s_parallax parallax s_parallax_is_fixed bg-black-50 o_half_screen_height" data-scroll-background-ratio="1">
-        <span class="s_parallax_bg oe_img_bg" style="background-image: url('/web/image/website.s_parallax_default_image'); background-position: 50% 75%;"/>
+        <span class="s_parallax_bg_wrap">
+            <span class="s_parallax_bg oe_img_bg" style="background-image: url('/web/image/website.s_parallax_default_image'); background-position: 50% 75%;"/>
+        </span>
         <div class="o_we_bg_filter bg-black-50"/>
         <div class="oe_structure oe_empty"/>
     </section>

--- a/addons/website/views/snippets/s_pricelist_boxed.xml
+++ b/addons/website/views/snippets/s_pricelist_boxed.xml
@@ -2,8 +2,10 @@
 <odoo>
 
 <template id="s_pricelist_boxed" name="Pricelist Boxed">
-    <section class="s_pricelist_boxed pt72 pb72 o_colored_level parallax s_parallax_is_fixed s_parallax_no_overflow_hidden" data-scroll-background-ratio="1">
-        <span class="s_parallax_bg oe_img_bg o_bg_img_center" style="background-image: url('/web/image/website.s_pricelist_boxed_default_background');"/>
+    <section class="s_pricelist_boxed pt72 pb72 o_colored_level parallax s_parallax_is_fixed" data-scroll-background-ratio="1">
+        <span class="s_parallax_bg_wrap">
+            <span class="s_parallax_bg oe_img_bg o_bg_img_center" style="background-image: url('/web/image/website.s_pricelist_boxed_default_background');"/>
+        </span>
         <div class="container">
             <div class="row">
                 <div class="offset-lg-2 col-lg-8 rounded px-3 px-md-5 pt48 pb48 o_cc o_cc1" data-name="Menu">

--- a/addons/website_forum/views/forum_forum_templates_forum_all.xml
+++ b/addons/website_forum/views/forum_forum_templates_forum_all.xml
@@ -93,7 +93,7 @@
 <template id="forum_all_oe_structure_forum_all_top" inherit_id="website_forum.forum_all" name="Forum Navigation (oe_structure_forum_all_top)">
     <xpath expr="//*[hasclass('oe_structure')][@id='oe_structure_forum_all_top']" position="replace">
         <div class="oe_structure oe_empty" id="oe_structure_forum_all_top" t-ignore="True">
-            <section class="s_cover o_colored_level s_parallax_no_overflow_hidden pt96 pb48" data-scroll-background-ratio="0" data-snippet="s_cover" data-name="Cover">
+            <section class="s_cover o_colored_level pt96 pb48" data-snippet="s_cover" data-name="Cover">
                 <div class="s_allow_columns container">
                     <h1 class="display-3" style="text-align: center; font-weight: bold;">Community Forums</h1>
                     <p class="lead" style="text-align: center;">Tap into the collective knowledge of our community by asking your questions in our forums,<br/> where helpful members are ready to assist you.</p>

--- a/addons/website_forum/views/forum_forum_templates_layout.xml
+++ b/addons/website_forum/views/forum_forum_templates_layout.xml
@@ -358,7 +358,11 @@
     <xpath expr="//*[hasclass('oe_structure')][@id='oe_structure_website_forum_header_1']" position="replace">
         <div t-if="forum" class="oe_structure oe_empty" id="oe_structure_website_forum_header_1">
             <section t-if="editable or (is_public_user and not forum_welcome_message)" t-attf-class="s_cover parallax s_parallax_is_fixed bg-black-50 pt48 pb48 #{'css_non_editable_mode_hidden' if editable else 'forum_intro'}" data-scroll-background-ratio="1" data-snippet="s_cover">
-                <span t-if="forum.image_1920" class="s_parallax_bg oe_img_bg" t-attf-style="background-image: url('#{request.website.image_url(forum, 'image_1920')}'); background-position: center;"/>
+                <t t-if="forum.image_1920">
+                    <span class="s_parallax_bg_wrap">
+                        <span class="s_parallax_bg oe_img_bg" t-attf-style="background-image: url('#{request.website.image_url(forum, 'image_1920')}'); background-position: center;"/>
+                    </span>
+                </t>
                 <div t-if="forum.image_1920" class="o_we_bg_filter bg-black-50"/>
                 <div class="container s_allow_columns">
                     <div class="row" data-row-count="5">

--- a/addons/website_slides/data/slide_slide_demo.xml
+++ b/addons/website_slides/data/slide_slide_demo.xml
@@ -229,7 +229,9 @@
         <field name="channel_id" ref="website_slides.slide_channel_demo_1_gard1"/>
         <field name="html_content" type="html">
 <section class="s_cover parallax bg-black-50 pt16 pb16" data-scroll-background-ratio="0" style="background-image: none;" data-snippet="s_cover">
-    <span class="s_parallax_bg oe_img_bg" style="background-image: url('/website_slides/static/src/img/slide_demo_tree_img_1.jpg'); background-position: 50% 0;"></span>
+    <span class="s_parallax_bg_wrap">
+        <span class="s_parallax_bg oe_img_bg" style="background-image: url('/website_slides/static/src/img/slide_demo_tree_img_1.jpg'); background-position: 50% 0;"></span>
+    </span>
     <div class="o_we_bg_filter bg-black-50"/>
     <div class="container">
         <div class="row s_nb_column_fixed">
@@ -466,7 +468,9 @@
         <field name="channel_id" ref="website_slides.slide_channel_demo_2_gard2"/>
         <field name="html_content" type="html">
 <section class="s_cover parallax bg-black-50 pt16 pb16" data-scroll-background-ratio="0" style="background-image: none;" data-snippet="s_cover">
-    <span class="s_parallax_bg oe_img_bg" style="background-image: url('/website_slides/static/src/img/slide_demo_tree_img_3.jpg'); background-position: 50% 0;"></span>
+    <span class="s_parallax_bg_wrap">
+        <span class="s_parallax_bg oe_img_bg" style="background-image: url('/website_slides/static/src/img/slide_demo_tree_img_3.jpg'); background-position: 50% 0;"></span>
+    </span>
     <div class="o_we_bg_filter bg-black-50"/>
     <div class="container">
         <div class="row s_nb_column_fixed">
@@ -609,7 +613,9 @@
         <field name="channel_id" ref="website_slides.slide_channel_demo_4_furn1"/>
         <field name="html_content" type="html">
 <section class="s_cover parallax bg-black-50 pt16 pb16" data-scroll-background-ratio="0" style="background-image: none;" data-snippet="s_cover">
-    <span class="s_parallax_bg oe_img_bg" style="background-image: url('/website_slides/static/src/img/slide_demo_tree_img_3.jpg'); background-position: 50% 0;"></span>
+    <span class="s_parallax_bg_wrap">
+        <span class="s_parallax_bg oe_img_bg" style="background-image: url('/website_slides/static/src/img/slide_demo_tree_img_3.jpg'); background-position: 50% 0;"></span>
+    </span>
     <div class="o_we_bg_filter bg-black-50"/>
     <div class="container">
         <div class="row s_nb_column_fixed">


### PR DESCRIPTION
This commit refactors the Parallax effect to fix overflow-related
issues. Parallax backgrounds are now wrapped in an additional element
with "overflow: hidden", instead of applying the "overflow: hidden" rule
directly on the section. This prevents issues such as dropdowns or
animations being cut off when inside a block with a parallax background.

Steps to reproduce the issue:

- Drag and drop a "Cover" block.
- Drag and drop a "Search bar" inside the Cover block.
- Save the page.
- Type a letter in the "Search bar" so that the dropdown with search
results overflows the bottom of the Cover block.
- Bug: The dropdown is cut off, its bottom part is not visible.

task-4926420