### PR TITLE
[FIX] website_sale_collect: fix availability for not in_store dm

### DIFF
--- a/addons/website_sale_collect/models/product_template.py
+++ b/addons/website_sale_collect/models/product_template.py
@@ -30,7 +30,9 @@ class ProductTemplate(models.Model):
             ])
             if available_delivery_methods_sudo:
                 res['delivery_stock_data'] = utils.format_product_stock_values(
-                    product_or_template.sudo(), wh_id=website.warehouse_id.id
+                    product_or_template.sudo(),
+                    wh_id=website.warehouse_id.id,
+                    include_out_of_stock=True,  # Allow out-of-stock orders for delivery.
                 )
             else:
                 res['delivery_stock_data'] = {}

--- a/addons/website_sale_collect/tests/__init__.py
+++ b/addons/website_sale_collect/tests/__init__.py
@@ -5,5 +5,6 @@ from . import test_click_and_collect_flow
 from . import test_in_store_delivery
 from . import test_payment_provider
 from . import test_payment_transaction
+from . import test_product_template
 from . import test_sale_order
 from . import test_website

--- a/addons/website_sale_collect/tests/test_product_template.py
+++ b/addons/website_sale_collect/tests/test_product_template.py
@@ -1,0 +1,21 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from datetime import datetime
+
+from odoo.tests import tagged
+
+from odoo.addons.website_sale.tests.common import MockRequest
+from odoo.addons.website_sale_collect.tests.common import ClickAndCollectCommon
+
+
+@tagged('post_install', '-at_install')
+class TestProductTemplate(ClickAndCollectCommon):
+
+    def test_out_of_stock_product_available_for_standard_delivery_when_allow_continue_selling(self):
+        product = self._create_product(allow_out_of_stock_order=True)
+        self.free_delivery.is_published = True
+        with MockRequest(self.env, website=self.website, sale_order_id=self.cart.id):
+            comb_info = self.env['product.template']._get_additionnal_combination_info(
+                product, quantity=1, date=datetime(2000, 1, 1), website=self.website
+            )
+        self.assertTrue(comb_info['delivery_stock_data']['in_stock'])

--- a/addons/website_sale_collect/utils.py
+++ b/addons/website_sale_collect/utils.py
@@ -1,21 +1,25 @@
 import math
 
 
-def format_product_stock_values(product, wh_id=None, free_qty=None):
+def format_product_stock_values(product, wh_id=None, free_qty=None, include_out_of_stock=False):
     """ Format product stock values for the location selector.
 
     :param product.product|product.template product: The product whose stock values to format.
     :param int wh_id: The warehouse whose stock to check for the given product.
     :param int free_qty: The free quantity of the product. If not given, calculated from the
                          warehouse.
+    :param bool include_out_of_stock: Whether the product should be considered in stock even if
+                                     there's no free qty but the product allows out-of-stock
+                                     orders.
     :return: The formatted product stock values.
     :rtype: dict
     """
     if product.is_product_variant:  # Only available for `product.product` records.
         if free_qty is None:
             free_qty = product.with_context(warehouse_id=wh_id).free_qty
+        in_stock = free_qty > 0 or include_out_of_stock and product.allow_out_of_stock_order
         return {
-            'in_stock': free_qty > 0,
+            'in_stock': in_stock,
             'show_quantity': product.show_availability and product.available_threshold >= free_qty,
             'quantity': free_qty,
         }


### PR DESCRIPTION
Steps to reproduce:
1) Configure a product and allow selling when out of stock
2) Publish any delivery method
3) Publish the Pickup in-store delivery method
4) Check the product page of the created product

Problem: It is shown that the product is not available for delivery even though we allow selling it when out of stock

This commit shows that a product is available for delivery (not for in_store one) if allow selling when out of stock is enabled.

opw-4792024
