### PR TITLE
[FIX] pos_self_order: allow `consultation` mode to select preset

### DIFF
--- a/addons/pos_self_order/static/src/app/pages/landing_page/landing_page.js
+++ b/addons/pos_self_order/static/src/app/pages/landing_page/landing_page.js
@@ -107,11 +107,7 @@ export class LandingPage extends Component {
         ) {
             return;
         }
-        if (
-            this.selfOrder.hasPresets() &&
-            !this.selfOrder.currentOrder.preset_id &&
-            this.selfOrder.ordering
-        ) {
+        if (this.selfOrder.hasPresets() && !this.selfOrder.currentOrder.preset_id) {
             this.router.navigate("location");
         } else {
             this.router.navigate("product_list");

--- a/addons/pos_self_order/static/tests/tours/self_order_attribute_tour.js
+++ b/addons/pos_self_order/static/tests/tours/self_order_attribute_tour.js
@@ -2,6 +2,7 @@ import { registry } from "@web/core/registry";
 import * as Utils from "@pos_self_order/../tests/tours/utils/common";
 import * as CartPage from "@pos_self_order/../tests/tours/utils/cart_page_util";
 import * as ProductPage from "@pos_self_order/../tests/tours/utils/product_page_util";
+import * as LandingPage from "@pos_self_order/../tests/tours/utils/landing_page_util";
 
 registry.category("web_tour.tours").add("self_attribute_selector", {
     steps: () => [
@@ -80,6 +81,7 @@ registry.category("web_tour.tours").add("selfAlwaysAttributeVariants", {
 registry.category("web_tour.tours").add("self_order_product_info", {
     steps: () => [
         Utils.clickBtn("Order Now"),
+        LandingPage.selectLocation("Test-In"),
         {
             trigger: ".o_self_product_box:contains('Product Info Test') .product_info_icon",
             run: "click",

--- a/addons/pos_self_order/static/tests/tours/self_order_common_tour.js
+++ b/addons/pos_self_order/static/tests/tours/self_order_common_tour.js
@@ -15,6 +15,7 @@ registry.category("web_tour.tours").add("self_order_is_close", {
 registry.category("web_tour.tours").add("self_order_is_open_consultation", {
     steps: () => [
         Utils.clickBtn("Order Now"),
+        LandingPage.selectLocation("Test-In"),
         LandingPage.isOpened(),
         ProductPage.clickProduct("Coca-Cola"),
         Utils.checkIsNoBtn("Order"),
@@ -30,6 +31,7 @@ registry.category("web_tour.tours").add("self_order_pos_closed", {
         LandingPage.isClosed(),
         // Normal product
         Utils.clickBtn("Order Now"),
+        LandingPage.selectLocation("Test-In"),
         ProductPage.clickProduct("Coca-Cola"),
         Utils.checkIsNoBtn("Checkout"),
         // Product with attributes
@@ -73,6 +75,7 @@ registry.category("web_tour.tours").add("kiosk_order_pos_closed", {
     steps: () => [
         LandingPage.isClosed(),
         Utils.clickBtn("Order Now"),
+        LandingPage.selectLocation("Test-In"),
         ProductPage.clickCategory("Miscellaneous"),
 
         ProductPage.clickProduct("Coca-Cola"),


### PR DESCRIPTION
- We now display the `location` page (to select a preset) also when the self order is in `consultation` mode, so the user can see the price of the products with the selected preset selected (and its price lists).
- The user is still only allowed to consult the menu, and not order anything.

task-id: 4934256



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
