### PR TITLE
[FIX] hw_drivers: use lock when printing on windows

### DIFF
--- a/addons/hw_drivers/iot_handlers/drivers/PrinterDriver_W.py
+++ b/addons/hw_drivers/iot_handlers/drivers/PrinterDriver_W.py
@@ -14,6 +14,7 @@ from odoo.addons.hw_drivers.event_manager import event_manager
 from odoo.addons.hw_drivers.main import iot_devices
 from odoo.addons.hw_drivers.tools import helpers
 from odoo.tools.mimetypes import guess_mimetype
+from odoo.addons.hw_drivers.iot_handlers.interfaces.PrinterInterface_W import win32print_lock
 
 _logger = logging.getLogger(__name__)
 
@@ -100,37 +101,39 @@ class PrinterDriver(Driver):
         event_manager.device_changed(self)
 
     def print_raw(self, data):
-        win32print.StartDocPrinter(self.printer_handle, 1, ('', None, "RAW"))
-        win32print.StartPagePrinter(self.printer_handle)
-        win32print.WritePrinter(self.printer_handle, data)
-        win32print.EndPagePrinter(self.printer_handle)
-        win32print.EndDocPrinter(self.printer_handle)
+        with win32print_lock:
+            win32print.StartDocPrinter(self.printer_handle, 1, ('', None, "RAW"))
+            win32print.StartPagePrinter(self.printer_handle)
+            win32print.WritePrinter(self.printer_handle, data)
+            win32print.EndPagePrinter(self.printer_handle)
+            win32print.EndDocPrinter(self.printer_handle)
 
     def print_report(self, data):
-        helpers.write_file('document.pdf', data, 'wb')
-        file_name = helpers.path_file('document.pdf')
-        printer = self.device_name
+        with win32print_lock:
+            helpers.write_file('document.pdf', data, 'wb')
+            file_name = helpers.path_file('document.pdf')
+            printer = self.device_name
 
-        args = [
-            "-dPrinted", "-dBATCH", "-dNOPAUSE", "-dNOPROMPT",
-            "-q",
-            "-sDEVICE#mswinpr2",
-            f'-sOutputFile#%printer%{printer}',
-            f'{file_name}'
-        ]
+            args = [
+                "-dPrinted", "-dBATCH", "-dNOPAUSE", "-dNOPROMPT",
+                "-q",
+                "-sDEVICE#mswinpr2",
+                f'-sOutputFile#%printer%{printer}',
+                f'{file_name}'
+            ]
 
-        _logger.debug("Printing report with ghostscript using %s", args)
-        stderr_buf = io.BytesIO()
-        stdout_buf = io.BytesIO()
-        stdout_log_level = logging.DEBUG
-        try:
-            ghostscript.Ghostscript(*args, stdout=stdout_buf, stderr=stderr_buf)
-        except Exception:
-            _logger.exception("Error while printing report, ghostscript args: %s, error buffer: %s", args, stderr_buf.getvalue())
-            stdout_log_level = logging.ERROR # some stdout value might contains relevant error information
-            raise
-        finally:
-            _logger.log(stdout_log_level, "Ghostscript stdout: %s", stdout_buf.getvalue())
+            _logger.debug("Printing report with ghostscript using %s", args)
+            stderr_buf = io.BytesIO()
+            stdout_buf = io.BytesIO()
+            stdout_log_level = logging.DEBUG
+            try:
+                ghostscript.Ghostscript(*args, stdout=stdout_buf, stderr=stderr_buf)
+            except Exception:
+                _logger.exception("Error while printing report, ghostscript args: %s, error buffer: %s", args, stderr_buf.getvalue())
+                stdout_log_level = logging.ERROR  # some stdout value might contains relevant error information
+                raise
+            finally:
+                _logger.log(stdout_log_level, "Ghostscript stdout: %s", stdout_buf.getvalue())
 
     def print_receipt(self, data):
         _logger.debug("print_receipt called for printer %s", self.device_name)

--- a/addons/hw_drivers/iot_handlers/interfaces/PrinterInterface_W.py
+++ b/addons/hw_drivers/iot_handlers/interfaces/PrinterInterface_W.py
@@ -2,11 +2,14 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import logging
+from threading import Lock
 import win32print
 
 from odoo.addons.hw_drivers.interface import Interface
 
 _logger = logging.getLogger(__name__)
+
+win32print_lock = Lock()  # Calling win32print in parallel can cause failed prints
 
 
 class PrinterInterface(Interface):
@@ -15,25 +18,26 @@ class PrinterInterface(Interface):
 
     def get_devices(self):
         printer_devices = {}
-        printers = win32print.EnumPrinters(win32print.PRINTER_ENUM_LOCAL)
+        with win32print_lock:
+            printers = win32print.EnumPrinters(win32print.PRINTER_ENUM_LOCAL)
 
-        for printer in printers:
-            identifier = printer[2]
-            handle_printer = win32print.OpenPrinter(identifier)
-            # The value "2" is the level of detail we want to get from the printer, see:
-            # https://learn.microsoft.com/en-us/windows/win32/printdocs/getprinter#parameters
-            printer_details = win32print.GetPrinter(handle_printer, 2)
-            printer_port = None
-            if printer_details:
-                # see: https://learn.microsoft.com/en-us/windows/win32/printdocs/printer-info-2#members
-                printer_port = printer_details.get('pPortName')
-            if printer_port is None:
-                _logger.warning('Printer "%s" has no port name. Used dummy port', identifier)
-                printer_port = 'IOT_DUMMY_PORT'
+            for printer in printers:
+                identifier = printer[2]
+                handle_printer = win32print.OpenPrinter(identifier)
+                # The value "2" is the level of detail we want to get from the printer, see:
+                # https://learn.microsoft.com/en-us/windows/win32/printdocs/getprinter#parameters
+                printer_details = win32print.GetPrinter(handle_printer, 2)
+                printer_port = None
+                if printer_details:
+                    # see: https://learn.microsoft.com/en-us/windows/win32/printdocs/printer-info-2#members
+                    printer_port = printer_details.get('pPortName')
+                if printer_port is None:
+                    _logger.warning('Printer "%s" has no port name. Used dummy port', identifier)
+                    printer_port = 'IOT_DUMMY_PORT'
 
-            printer_devices[identifier] = {
-                'identifier': identifier,
-                'printer_handle': handle_printer,
-                'port': printer_port,
-            }
+                printer_devices[identifier] = {
+                    'identifier': identifier,
+                    'printer_handle': handle_printer,
+                    'port': printer_port,
+                }
         return printer_devices


### PR DESCRIPTION
Before this commit, if multiple documents were sent to print at exactly the same time, some of them could end up erroring because the Windows printing API requires us to send one document at a time.

After this commit, we use a lock similar to the Linux driver, to ensure that only one document is sent to the printer at once.

opw-4829908

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
