### PR TITLE
[IMP] snailmail: prevent select state which does not belong to country

### DIFF
--- a/addons/snailmail/wizard/snailmail_letter_missing_required_fields.py
+++ b/addons/snailmail/wizard/snailmail_letter_missing_required_fields.py
@@ -12,7 +12,7 @@ class SnailmailLetterMissingRequiredFields(models.TransientModel):
     street2 = fields.Char('Street2')
     zip = fields.Char('Zip')
     city = fields.Char('City')
-    state_id = fields.Many2one("res.country.state", string='State')
+    state_id = fields.Many2one("res.country.state", string='State', domain="[('country_id', '=?', country_id)]")
     country_id = fields.Many2one('res.country', string='Country')
 
     @api.model
@@ -30,6 +30,16 @@ class SnailmailLetterMissingRequiredFields(models.TransientModel):
                 'country_id': letter.country_id.id,
             })
         return defaults
+
+    @api.onchange('country_id')
+    def _onchange_country_id(self):
+        if self.country_id and self.country_id != self.state_id.country_id:
+            self.state_id = False
+
+    @api.onchange('state_id')
+    def _onchange_state(self):
+        if self.state_id.country_id and self.country_id != self.state_id.country_id:
+            self.country_id = self.state_id.country_id
 
     def update_address_cancel(self):
         self.letter_id.cancel()


### PR DESCRIPTION

* PROBLEM: at wizard to update some require fields for snailmail letter,
user can choose state which doesn't belong to the country selected

* Fix by adding domain in state_id field some onchange method to
fallback, just like in res_partner

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
