### PR TITLE
[FIX] im_livechat: dashboard not updating according to filters

### DIFF
--- a/addons/spreadsheet_dashboard_im_livechat/data/files/livechat_dashboard.json
+++ b/addons/spreadsheet_dashboard_im_livechat/data/files/livechat_dashboard.json
@@ -661,7 +661,11 @@
             "stacked": false,
             "fieldMatching": {
               "4db3e2d2-5471-44a4-80ca-7c2fa4f1a5ac": { "chain": "start_date", "type": "datetime" },
-              "5124b7b1-aa17-46cc-b574-2309708de75b": { "chain": "partner_id", "type": "many2one" }
+              "5124b7b1-aa17-46cc-b574-2309708de75b": { "chain": "partner_id", "type": "many2one" },
+              "5efd6191-32ae": { "chain": "country_id", "type": "many2one" },
+              "d8c5ec23-6206": { "chain": "lang_id", "type": "many2one" },
+              "5d0a8551-7ea8": { "chain": "livechat_channel_id", "type": "many2one" },
+              "ee4a297f-0cc3": { "chain": "session_expertise_ids", "type": "many2many" }
             }
           }
         },
@@ -869,7 +873,10 @@
             "fieldMatching": {
               "4db3e2d2-5471-44a4-80ca-7c2fa4f1a5ac": { "chain": "start_date", "type": "datetime" },
               "5124b7b1-aa17-46cc-b574-2309708de75b": { "chain": "partner_id", "type": "many2one" },
-              "ee4a297f-0cc3": { "chain": "session_expertise_ids", "type": "many2many" }
+              "ee4a297f-0cc3": { "chain": "session_expertise_ids", "type": "many2many" },
+              "5efd6191-32ae": { "chain": "country_id", "type": "many2one" },
+              "d8c5ec23-6206": { "chain": "lang_id", "type": "many2one" },
+              "5d0a8551-7ea8": { "chain": "livechat_channel_id", "type": "many2one" }
             }
           }
         },
@@ -909,7 +916,10 @@
             "fieldMatching": {
               "4db3e2d2-5471-44a4-80ca-7c2fa4f1a5ac": { "chain": "start_date", "type": "datetime" },
               "5124b7b1-aa17-46cc-b574-2309708de75b": { "chain": "partner_id", "type": "many2one" },
-              "ee4a297f-0cc3": { "chain": "session_expertise_ids", "type": "many2many" }
+              "ee4a297f-0cc3": { "chain": "session_expertise_ids", "type": "many2many" },
+              "5efd6191-32ae": { "chain": "country_id", "type": "many2one" },
+              "d8c5ec23-6206": { "chain": "lang_id", "type": "many2one" },
+              "5d0a8551-7ea8": { "chain": "livechat_channel_id", "type": "many2one" }
             }
           }
         },
@@ -949,7 +959,10 @@
             "fieldMatching": {
               "4db3e2d2-5471-44a4-80ca-7c2fa4f1a5ac": { "chain": "start_date", "type": "datetime" },
               "5124b7b1-aa17-46cc-b574-2309708de75b": { "chain": "partner_id", "type": "many2one" },
-              "ee4a297f-0cc3": { "chain": "session_expertise_ids", "type": "many2many" }
+              "ee4a297f-0cc3": { "chain": "session_expertise_ids", "type": "many2many" },
+              "5efd6191-32ae": { "chain": "country_id", "type": "many2one" },
+              "d8c5ec23-6206": { "chain": "lang_id", "type": "many2one" },
+              "5d0a8551-7ea8": { "chain": "livechat_channel_id", "type": "many2one" }
             }
           }
         }
@@ -1046,19 +1059,9 @@
     "2": { "fontSize": 16, "bold": true, "textColor": "#01666B" },
     "3": { "bold": true, "fontSize": 11, "textColor": "#434343" },
     "4": { "textColor": "#000000" },
-    "5": {
-      "bold": true,
-      "fillColor": "#FFFFFF",
-      "fontSize": 16,
-      "textColor": "#01666B"
-    },
+    "5": { "bold": true, "fillColor": "#FFFFFF", "fontSize": 16, "textColor": "#01666B" },
     "6": { "textColor": "#000000", "align": "right" },
-    "7": {
-      "bold": true,
-      "fontSize": 11,
-      "align": "center",
-      "textColor": "#434343"
-    },
+    "7": { "bold": true, "fontSize": 11, "align": "center", "textColor": "#434343" },
     "8": { "textColor": "#434343" }
   },
   "formats": {
@@ -1070,12 +1073,8 @@
     "6": "0 \"min\"",
     "7": "0%"
   },
-  "borders": {
-    "1": {
-      "bottom": { "style": "thin", "color": "#CCCCCC" }
-    }
-  },
-  "revisionId": "cfb95d8c-0b4f-4637-8a6a-b71fa073f96f",
+  "borders": { "1": { "bottom": { "style": "thin", "color": "#CCCCCC" } } },
+  "revisionId": "3d6a9a87-82d5-4046-9946-0c9505fd822a",
   "uniqueFigureIds": true,
   "settings": {
     "locale": {
@@ -1093,42 +1092,29 @@
     "1": {
       "type": "ODOO",
       "fieldMatching": {
-        "4db3e2d2-5471-44a4-80ca-7c2fa4f1a5ac": { "chain": "start_date", "type": "datetime", "offset": 0 },
+        "4db3e2d2-5471-44a4-80ca-7c2fa4f1a5ac": {
+          "chain": "start_date",
+          "type": "datetime",
+          "offset": 0
+        },
         "5124b7b1-aa17-46cc-b574-2309708de75b": { "chain": "partner_id", "type": "many2one" },
-        "ee4a297f-0cc3": { "chain": "session_expertise_ids", "type": "many2many" }
+        "ee4a297f-0cc3": { "chain": "session_expertise_ids", "type": "many2many" },
+        "5efd6191-32ae": { "chain": "country_id", "type": "many2one" },
+        "d8c5ec23-6206": { "chain": "lang_id", "type": "many2one" },
+        "5d0a8551-7ea8": { "chain": "livechat_channel_id", "type": "many2one" }
       },
       "context": {},
       "domain": [],
       "id": "1",
       "measures": [
         { "id": "duration:avg", "fieldName": "duration", "aggregator": "avg" },
-        {
-          "id": "time_to_answer:avg",
-          "fieldName": "time_to_answer",
-          "aggregator": "avg"
-        },
+        { "id": "time_to_answer:avg", "fieldName": "time_to_answer", "aggregator": "avg" },
         { "id": "rating:avg", "fieldName": "rating", "aggregator": "avg" },
-        {
-          "id": "nbr_message:avg",
-          "fieldName": "nbr_message",
-          "aggregator": "avg"
-        },
+        { "id": "nbr_message:avg", "fieldName": "nbr_message", "aggregator": "avg" },
         { "id": "has_call:sum", "fieldName": "has_call", "aggregator": "sum" },
-        {
-          "id": "call_duration_hour:avg",
-          "fieldName": "call_duration_hour",
-          "aggregator": "avg"
-        },
-        {
-          "id": "handled_by_bot:sum",
-          "fieldName": "handled_by_bot",
-          "aggregator": "sum"
-        },
-        {
-          "id": "handled_by_agent:sum",
-          "fieldName": "handled_by_agent",
-          "aggregator": "sum"
-        }
+        { "id": "call_duration_hour:avg", "fieldName": "call_duration_hour", "aggregator": "avg" },
+        { "id": "handled_by_bot:sum", "fieldName": "handled_by_bot", "aggregator": "sum" },
+        { "id": "handled_by_agent:sum", "fieldName": "handled_by_agent", "aggregator": "sum" }
       ],
       "model": "im_livechat.report.channel",
       "name": "stats 2 - current",
@@ -1140,42 +1126,29 @@
     "2": {
       "type": "ODOO",
       "fieldMatching": {
-        "4db3e2d2-5471-44a4-80ca-7c2fa4f1a5ac": { "chain": "start_date", "type": "datetime", "offset": -1 },
+        "4db3e2d2-5471-44a4-80ca-7c2fa4f1a5ac": {
+          "chain": "start_date",
+          "type": "datetime",
+          "offset": -1
+        },
         "5124b7b1-aa17-46cc-b574-2309708de75b": { "chain": "partner_id", "type": "many2one" },
-        "ee4a297f-0cc3": { "chain": "session_expertise_ids", "type": "many2many" }
+        "ee4a297f-0cc3": { "chain": "session_expertise_ids", "type": "many2many" },
+        "5efd6191-32ae": { "chain": "country_id", "type": "many2one" },
+        "d8c5ec23-6206": { "chain": "lang_id", "type": "many2one" },
+        "5d0a8551-7ea8": { "chain": "livechat_channel_id", "type": "many2one" }
       },
       "context": {},
       "domain": [],
       "id": "2",
       "measures": [
         { "id": "duration:avg", "fieldName": "duration", "aggregator": "avg" },
-        {
-          "id": "time_to_answer:avg",
-          "fieldName": "time_to_answer",
-          "aggregator": "avg"
-        },
+        { "id": "time_to_answer:avg", "fieldName": "time_to_answer", "aggregator": "avg" },
         { "id": "rating:avg", "fieldName": "rating", "aggregator": "avg" },
-        {
-          "id": "nbr_message:avg",
-          "fieldName": "nbr_message",
-          "aggregator": "avg"
-        },
+        { "id": "nbr_message:avg", "fieldName": "nbr_message", "aggregator": "avg" },
         { "id": "has_call:sum", "fieldName": "has_call", "aggregator": "sum" },
-        {
-          "id": "call_duration_hour:avg",
-          "fieldName": "call_duration_hour",
-          "aggregator": "avg"
-        },
-        {
-          "id": "handled_by_agent:sum",
-          "fieldName": "handled_by_agent",
-          "aggregator": "sum"
-        },
-        {
-          "id": "handled_by_bot:sum",
-          "fieldName": "handled_by_bot",
-          "aggregator": "sum"
-        }
+        { "id": "call_duration_hour:avg", "fieldName": "call_duration_hour", "aggregator": "avg" },
+        { "id": "handled_by_agent:sum", "fieldName": "handled_by_agent", "aggregator": "sum" },
+        { "id": "handled_by_bot:sum", "fieldName": "handled_by_bot", "aggregator": "sum" }
       ],
       "model": "im_livechat.report.channel",
       "name": "stats 2 - previous",
@@ -1187,56 +1160,52 @@
     "3": {
       "type": "ODOO",
       "fieldMatching": {
-        "4db3e2d2-5471-44a4-80ca-7c2fa4f1a5ac": { "chain": "start_date", "type": "datetime", "offset": 0 },
+        "4db3e2d2-5471-44a4-80ca-7c2fa4f1a5ac": {
+          "chain": "start_date",
+          "type": "datetime",
+          "offset": 0
+        },
         "5124b7b1-aa17-46cc-b574-2309708de75b": { "chain": "partner_id", "type": "many2one" },
-        "ee4a297f-0cc3": { "chain": "session_expertise_ids", "type": "many2many" }
+        "ee4a297f-0cc3": { "chain": "session_expertise_ids", "type": "many2many" },
+        "5efd6191-32ae": { "chain": "country_id", "type": "many2one" },
+        "d8c5ec23-6206": { "chain": "lang_id", "type": "many2one" },
+        "5d0a8551-7ea8": { "chain": "livechat_channel_id", "type": "many2one" }
       },
       "context": { "im_livechat.hide_partner_company": true },
-      "domain": [
-        ["partner_id.chatbot_script_ids", "=", false]
-      ],
+      "domain": [["partner_id.chatbot_script_ids", "=", false]],
       "id": "3",
       "measures": [
         { "id": "__count", "fieldName": "__count", "aggregator": "sum" },
-        {
-          "id": "time_to_answer:avg",
-          "fieldName": "time_to_answer",
-          "aggregator": "avg"
-        },
+        { "id": "time_to_answer:avg", "fieldName": "time_to_answer", "aggregator": "avg" },
         { "id": "duration:avg", "fieldName": "duration", "aggregator": "avg" },
         { "id": "rating:avg", "fieldName": "rating", "aggregator": "avg" },
-        {
-          "id": "nbr_message:avg",
-          "fieldName": "nbr_message",
-          "aggregator": "avg"
-        }
+        { "id": "nbr_message:avg", "fieldName": "nbr_message", "aggregator": "avg" }
       ],
       "model": "im_livechat.report.channel",
       "name": "Livechat Support Statistics by Agent",
-      "sortedColumn": {
-        "domain": [],
-        "order": "desc",
-        "measure": "__count"
-      },
+      "sortedColumn": { "domain": [], "order": "desc", "measure": "__count" },
       "formulaId": "3",
       "columns": [],
-      "rows": [
-        { "fieldName": "partner_id", "order": "asc" }
-      ]
+      "rows": [{ "fieldName": "partner_id", "order": "asc" }]
     },
     "4": {
       "type": "ODOO",
       "fieldMatching": {
-        "4db3e2d2-5471-44a4-80ca-7c2fa4f1a5ac": { "chain": "start_date", "type": "datetime", "offset": 0 },
+        "4db3e2d2-5471-44a4-80ca-7c2fa4f1a5ac": {
+          "chain": "start_date",
+          "type": "datetime",
+          "offset": 0
+        },
         "5124b7b1-aa17-46cc-b574-2309708de75b": { "chain": "partner_id", "type": "many2one" },
-        "ee4a297f-0cc3": { "chain": "session_expertise_ids", "type": "many2many" }
+        "ee4a297f-0cc3": { "chain": "session_expertise_ids", "type": "many2many" },
+        "5efd6191-32ae": { "chain": "country_id", "type": "many2one" },
+        "d8c5ec23-6206": { "chain": "lang_id", "type": "many2one" },
+        "5d0a8551-7ea8": { "chain": "livechat_channel_id", "type": "many2one" }
       },
       "context": {},
       "domain": [],
       "id": "4",
-      "measures": [
-        { "id": "__count", "fieldName": "__count" }
-      ],
+      "measures": [{ "id": "__count", "fieldName": "__count" }],
       "model": "im_livechat.report.channel",
       "name": "sessions count - current",
       "sortedColumn": null,
@@ -1247,16 +1216,21 @@
     "5": {
       "type": "ODOO",
       "fieldMatching": {
-        "4db3e2d2-5471-44a4-80ca-7c2fa4f1a5ac": { "chain": "start_date", "type": "datetime", "offset": -1 },
+        "4db3e2d2-5471-44a4-80ca-7c2fa4f1a5ac": {
+          "chain": "start_date",
+          "type": "datetime",
+          "offset": -1
+        },
         "5124b7b1-aa17-46cc-b574-2309708de75b": { "chain": "partner_id", "type": "many2one" },
-        "ee4a297f-0cc3": { "chain": "session_expertise_ids", "type": "many2many" }
+        "ee4a297f-0cc3": { "chain": "session_expertise_ids", "type": "many2many" },
+        "5efd6191-32ae": { "chain": "country_id", "type": "many2one" },
+        "d8c5ec23-6206": { "chain": "lang_id", "type": "many2one" },
+        "5d0a8551-7ea8": { "chain": "livechat_channel_id", "type": "many2one" }
       },
       "context": {},
       "domain": [],
       "id": "5",
-      "measures": [
-        { "id": "__count", "fieldName": "__count" }
-      ],
+      "measures": [{ "id": "__count", "fieldName": "__count" }],
       "model": "im_livechat.report.channel",
       "name": "sessions count - previous",
       "sortedColumn": null,
@@ -1267,213 +1241,185 @@
     "6": {
       "type": "ODOO",
       "fieldMatching": {
-        "4db3e2d2-5471-44a4-80ca-7c2fa4f1a5ac": { "chain": "start_date", "type": "datetime", "offset": 0 },
+        "4db3e2d2-5471-44a4-80ca-7c2fa4f1a5ac": {
+          "chain": "start_date",
+          "type": "datetime",
+          "offset": 0
+        },
         "5124b7b1-aa17-46cc-b574-2309708de75b": { "chain": "partner_id", "type": "many2one" },
-        "ee4a297f-0cc3": { "chain": "session_expertise_ids", "type": "many2many" }
+        "ee4a297f-0cc3": { "chain": "session_expertise_ids", "type": "many2many" },
+        "5efd6191-32ae": { "chain": "country_id", "type": "many2one" },
+        "d8c5ec23-6206": { "chain": "lang_id", "type": "many2one" },
+        "5d0a8551-7ea8": { "chain": "livechat_channel_id", "type": "many2one" }
       },
       "context": { "im_livechat.hide_partner_company": true },
-      "domain": [
-        ["partner_id.chatbot_script_ids", "=", false]
-      ],
+      "domain": [["partner_id.chatbot_script_ids", "=", false]],
       "id": "6",
       "measures": [
         { "id": "has_call:sum", "fieldName": "has_call", "aggregator": "sum" },
-        {
-          "id": "call_duration_hour:avg",
-          "fieldName": "call_duration_hour",
-          "aggregator": "avg"
-        },
-        {
-          "id": "__count",
-          "fieldName": "__count",
-          "aggregator": "sum",
-          "isHidden": false
-        }
+        { "id": "call_duration_hour:avg", "fieldName": "call_duration_hour", "aggregator": "avg" },
+        { "id": "__count", "fieldName": "__count", "aggregator": "sum", "isHidden": false }
       ],
       "model": "im_livechat.report.channel",
       "name": "Livechat Call Statistics by Agent",
-      "sortedColumn": {
-        "domain": [],
-        "order": "desc",
-        "measure": "has_call:sum"
-      },
+      "sortedColumn": { "domain": [], "order": "desc", "measure": "has_call:sum" },
       "formulaId": "6",
       "columns": [],
-      "rows": [
-        { "fieldName": "partner_id", "order": "" }
-      ]
+      "rows": [{ "fieldName": "partner_id", "order": "" }]
     },
     "a96176e7-d33f": {
       "type": "ODOO",
       "fieldMatching": {
-        "4db3e2d2-5471-44a4-80ca-7c2fa4f1a5ac": { "chain": "start_date", "type": "datetime", "offset": 0 },
+        "4db3e2d2-5471-44a4-80ca-7c2fa4f1a5ac": {
+          "chain": "start_date",
+          "type": "datetime",
+          "offset": 0
+        },
         "5124b7b1-aa17-46cc-b574-2309708de75b": { "chain": "partner_id", "type": "many2one" },
-        "ee4a297f-0cc3": { "chain": "session_expertise_ids", "type": "many2many" }
+        "ee4a297f-0cc3": { "chain": "session_expertise_ids", "type": "many2many" },
+        "5efd6191-32ae": { "chain": "country_id", "type": "many2one" },
+        "d8c5ec23-6206": { "chain": "lang_id", "type": "many2one" },
+        "5d0a8551-7ea8": { "chain": "livechat_channel_id", "type": "many2one" }
       },
       "context": {},
       "domain": [],
       "id": "1",
-      "measures": [
-        { "id": "__count", "fieldName": "__count", "aggregator": "sum" }
-      ],
+      "measures": [{ "id": "__count", "fieldName": "__count", "aggregator": "sum" }],
       "model": "im_livechat.report.channel",
       "name": "current escalated/failure statistics",
       "sortedColumn": null,
       "formulaId": "7",
       "columns": [],
-      "rows": [
-        { "fieldName": "session_outcome" }
-      ]
+      "rows": [{ "fieldName": "session_outcome" }]
     },
     "a22ba739-5135": {
       "type": "ODOO",
       "fieldMatching": {
-        "4db3e2d2-5471-44a4-80ca-7c2fa4f1a5ac": { "chain": "start_date", "type": "datetime", "offset": 0 },
+        "4db3e2d2-5471-44a4-80ca-7c2fa4f1a5ac": {
+          "chain": "start_date",
+          "type": "datetime",
+          "offset": 0
+        },
         "5124b7b1-aa17-46cc-b574-2309708de75b": { "chain": "partner_id", "type": "many2one" },
-        "ee4a297f-0cc3": { "chain": "session_expertise_ids", "type": "many2many" }
+        "ee4a297f-0cc3": { "chain": "session_expertise_ids", "type": "many2many" },
+        "5efd6191-32ae": { "chain": "country_id", "type": "many2one" },
+        "d8c5ec23-6206": { "chain": "lang_id", "type": "many2one" },
+        "5d0a8551-7ea8": { "chain": "livechat_channel_id", "type": "many2one" }
       },
       "context": {},
       "domain": [],
       "id": "1",
-      "measures": [
-        { "id": "__count", "fieldName": "__count", "aggregator": "sum" }
-      ],
+      "measures": [{ "id": "__count", "fieldName": "__count", "aggregator": "sum" }],
       "model": "im_livechat.report.channel",
       "name": "previous escalated/failure statistics",
       "sortedColumn": null,
       "formulaId": "8",
       "columns": [],
-      "rows": [
-        { "fieldName": "session_outcome" }
-      ]
+      "rows": [{ "fieldName": "session_outcome" }]
     },
     "6670ff23-c9c4": {
       "type": "ODOO",
       "fieldMatching": {
-        "4db3e2d2-5471-44a4-80ca-7c2fa4f1a5ac": { "chain": "start_date", "type": "datetime", "offset": 0 },
+        "4db3e2d2-5471-44a4-80ca-7c2fa4f1a5ac": {
+          "chain": "start_date",
+          "type": "datetime",
+          "offset": 0
+        },
         "5124b7b1-aa17-46cc-b574-2309708de75b": { "chain": "partner_id", "type": "many2one" },
-        "ee4a297f-0cc3": { "chain": "session_expertise_ids", "type": "many2many" }
+        "ee4a297f-0cc3": { "chain": "session_expertise_ids", "type": "many2many" },
+        "5efd6191-32ae": { "chain": "country_id", "type": "many2one" },
+        "d8c5ec23-6206": { "chain": "lang_id", "type": "many2one" },
+        "5d0a8551-7ea8": { "chain": "livechat_channel_id", "type": "many2one" }
       },
       "context": {},
-      "domain": [
-        ["country_id", "!=", false]
-      ],
+      "domain": [["country_id", "!=", false]],
       "id": "1",
-      "measures": [
-        { "id": "__count", "fieldName": "__count", "aggregator": "sum" }
-      ],
+      "measures": [{ "id": "__count", "fieldName": "__count", "aggregator": "sum" }],
       "model": "im_livechat.report.channel",
       "name": "Top countries",
-      "sortedColumn": {
-        "domain": [],
-        "order": "desc",
-        "measure": "__count"
-      },
+      "sortedColumn": { "domain": [], "order": "desc", "measure": "__count" },
       "formulaId": "9",
       "columns": [],
-      "rows": [
-        { "fieldName": "country_id" }
-      ],
-      "collapsedDomains": {
-        "COL": [],
-        "ROW": []
-      }
+      "rows": [{ "fieldName": "country_id" }],
+      "collapsedDomains": { "COL": [], "ROW": [] }
     },
     "b3250c1f-c721": {
       "type": "ODOO",
       "fieldMatching": {
-        "4db3e2d2-5471-44a4-80ca-7c2fa4f1a5ac": { "chain": "start_date", "type": "datetime", "offset": 0 },
+        "4db3e2d2-5471-44a4-80ca-7c2fa4f1a5ac": {
+          "chain": "start_date",
+          "type": "datetime",
+          "offset": 0
+        },
         "5124b7b1-aa17-46cc-b574-2309708de75b": { "chain": "partner_id", "type": "many2one" },
-        "ee4a297f-0cc3": { "chain": "session_expertise_ids", "type": "many2many" }
+        "ee4a297f-0cc3": { "chain": "session_expertise_ids", "type": "many2many" },
+        "5efd6191-32ae": { "chain": "country_id", "type": "many2one" },
+        "d8c5ec23-6206": { "chain": "lang_id", "type": "many2one" },
+        "5d0a8551-7ea8": { "chain": "livechat_channel_id", "type": "many2one" }
       },
       "context": {},
-      "domain": [
-        ["lang_id", "!=", false]
-      ],
+      "domain": [["lang_id", "!=", false]],
       "id": "1",
-      "measures": [
-        { "id": "__count", "fieldName": "__count", "aggregator": "sum" }
-      ],
+      "measures": [{ "id": "__count", "fieldName": "__count", "aggregator": "sum" }],
       "model": "im_livechat.report.channel",
       "name": "Top Languages",
-      "sortedColumn": {
-        "domain": [],
-        "order": "desc",
-        "measure": "__count"
-      },
+      "sortedColumn": { "domain": [], "order": "desc", "measure": "__count" },
       "formulaId": "10",
       "columns": [],
-      "rows": [
-        { "fieldName": "lang_id" }
-      ],
-      "collapsedDomains": {
-        "COL": [],
-        "ROW": []
-      }
+      "rows": [{ "fieldName": "lang_id" }],
+      "collapsedDomains": { "COL": [], "ROW": [] }
     },
     "21eaa7c7-29bc": {
       "type": "ODOO",
       "fieldMatching": {
-        "4db3e2d2-5471-44a4-80ca-7c2fa4f1a5ac": { "chain": "start_date", "type": "datetime", "offset": 0 },
+        "4db3e2d2-5471-44a4-80ca-7c2fa4f1a5ac": {
+          "chain": "start_date",
+          "type": "datetime",
+          "offset": 0
+        },
         "5124b7b1-aa17-46cc-b574-2309708de75b": { "chain": "partner_id", "type": "many2one" },
-        "ee4a297f-0cc3": { "chain": "session_expertise_ids", "type": "many2many" }
+        "ee4a297f-0cc3": { "chain": "session_expertise_ids", "type": "many2many" },
+        "5efd6191-32ae": { "chain": "country_id", "type": "many2one" },
+        "d8c5ec23-6206": { "chain": "lang_id", "type": "many2one" },
+        "5d0a8551-7ea8": { "chain": "livechat_channel_id", "type": "many2one" }
       },
       "context": {},
-      "domain": [
-        ["session_expertise_ids", "!=", false]
-      ],
+      "domain": [["session_expertise_ids", "!=", false]],
       "id": "1",
-      "measures": [
-        { "id": "__count", "fieldName": "__count", "aggregator": "sum" }
-      ],
+      "measures": [{ "id": "__count", "fieldName": "__count", "aggregator": "sum" }],
       "model": "im_livechat.report.channel",
       "name": "Top Expertises",
-      "sortedColumn": {
-        "domain": [],
-        "order": "desc",
-        "measure": "__count"
-      },
+      "sortedColumn": { "domain": [], "order": "desc", "measure": "__count" },
       "formulaId": "11",
       "columns": [],
-      "rows": [
-        { "fieldName": "session_expertises" }
-      ],
-      "collapsedDomains": {
-        "COL": [],
-        "ROW": []
-      }
+      "rows": [{ "fieldName": "session_expertises" }],
+      "collapsedDomains": { "COL": [], "ROW": [] }
     },
     "d11c47b1-b913": {
       "type": "ODOO",
       "fieldMatching": {
-        "4db3e2d2-5471-44a4-80ca-7c2fa4f1a5ac": { "chain": "start_date", "type": "datetime", "offset": 0 },
+        "4db3e2d2-5471-44a4-80ca-7c2fa4f1a5ac": {
+          "chain": "start_date",
+          "type": "datetime",
+          "offset": 0
+        },
         "5124b7b1-aa17-46cc-b574-2309708de75b": { "chain": "partner_id", "type": "many2one" },
-        "ee4a297f-0cc3": { "chain": "session_expertise_ids", "type": "many2many" }
+        "ee4a297f-0cc3": { "chain": "session_expertise_ids", "type": "many2many" },
+        "5efd6191-32ae": { "chain": "country_id", "type": "many2one" },
+        "d8c5ec23-6206": { "chain": "lang_id", "type": "many2one" },
+        "5d0a8551-7ea8": { "chain": "livechat_channel_id", "type": "many2one" }
       },
       "context": {},
-      "domain": [
-        ["chatbot_answers_path_str", "!=", false]
-      ],
+      "domain": [["chatbot_answers_path_str", "!=", false]],
       "id": "1",
-      "measures": [
-        { "id": "__count", "fieldName": "__count", "aggregator": "sum" }
-      ],
+      "measures": [{ "id": "__count", "fieldName": "__count", "aggregator": "sum" }],
       "model": "im_livechat.report.channel",
       "name": "Top Chatbot Answers",
-      "sortedColumn": {
-        "domain": [],
-        "order": "desc",
-        "measure": "__count"
-      },
+      "sortedColumn": { "domain": [], "order": "desc", "measure": "__count" },
       "formulaId": "12",
       "columns": [],
-      "rows": [
-        { "fieldName": "chatbot_answers_path_str" }
-      ],
-      "collapsedDomains": {
-        "COL": [],
-        "ROW": []
-      }
+      "rows": [{ "fieldName": "chatbot_answers_path_str" }],
+      "collapsedDomains": { "COL": [], "ROW": [] }
     }
   },
   "pivotNextId": 13,
@@ -1506,7 +1452,7 @@
       "label": "Languages",
       "type": "relation",
       "modelName": "res.lang",
-      "domainOfAllowedValues": [],
+      "domainOfAllowedValues": [["active", "in", [true, false]]],
       "includeChildren": false
     },
     {


### PR DESCRIPTION
This commit fixes the "Live Chat" dashboard which does not update when changing some of its filters. It happens because the filters were not linked to the spreadsheet pivots/charts.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
