### PR TITLE
[FIX] survey: prevent error when refreshing live session after deleting question

### DIFF
--- a/addons/survey/controllers/survey_session_manage.py
+++ b/addons/survey/controllers/survey_session_manage.py
@@ -227,6 +227,8 @@ class UserInputSession(http.Controller):
           The number of answers to the current question. """
 
         question = survey.session_question_id
+        if not question:
+            return {}
         answers_validity = []
         if (any(answer.is_correct for answer in question.suggested_answer_ids)):
             answers_validity = [answer.is_correct for answer in question.suggested_answer_ids]

--- a/addons/survey/tests/test_survey_controller.py
+++ b/addons/survey/tests/test_survey_controller.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import Command
+from odoo import Command, fields
 from odoo.addons.survey.tests import common
 from odoo.tests.common import HttpCase
 
@@ -153,3 +153,19 @@ class TestSurveyController(common.TestSurveyCommon, HttpCase):
             "Question should appear when printing survey with using an answer_token")
         self.assertIn("Test Answer", str(response.content),
             "Answer should appear when printing survey with using an answer_token")
+
+    def test_live_session_without_question(self):
+        """Test that the live session ('Thank You' page) does not crash when no question is present."""
+        survey = self.env['survey.survey'].with_user(self.survey_manager).create({
+            'title': 'Live Session Survey',
+            'access_mode': 'token',
+            'users_login_required': False,
+            'session_question_start_time': fields.datetime(2023, 7, 7, 12, 0, 0),
+        })
+
+        self.authenticate(self.survey_manager.login, self.survey_manager.login)
+
+        # Call the url without any question
+        session_manage_url = f'/survey/session/manage/{survey.access_token}'
+        response = self.url_open(session_manage_url)
+        self.assertEqual(response.status_code, 200, "Should be able to open live session manage page")


### PR DESCRIPTION
Currently, an error occurs when refreshing a live session's `Thank You` page 
after deleting a survey question.

**Steps to reproduce:**

- Install the `survey` module.
- Create a `new survey`, `add a question` and click on `Create Live Session`.
- Complete the survey and leave it on the `Thank You` page.
- Switch back to the `first tab`, delete the question and `save` the survey.
- Return to the `Thank You` tab and `refresh` the page.

**Error:**
`IndexError: list index out of range`

**Root Cause:**
At [1], the controller assumes the question exists and tries to access 
`index [0]`, but when the question has been deleted, the recordset is 
empty, causing an `error`.

[1]
https://github.com/odoo/odoo/blob/ffd9c0f96bda1bad1ad2059d9be2fae54b60eace/addons/survey/controllers/survey_session_manage.py#L236

This commit prevents a crash when refreshing a live session if the question was 
deleted.

sentry-6736648824