### PR TITLE
[FIX] im_livechat: fix chatbot rating flow tour

### DIFF
--- a/addons/website_livechat/static/tests/tours/website_livechat_common.js
+++ b/addons/website_livechat/static/tests/tours/website_livechat_common.js
@@ -12,6 +12,10 @@ export const start = [
         run: "click",
     },
     {
+        trigger:
+            ".o-livechat-root:shadow .o-mail-ChatWindow:contains(El Deboulonnator) .o-mail-Thread[data-transient]",
+    },
+    {
         content: "Say hello!",
         trigger: ".o-livechat-root:shadow .o-mail-Composer-input",
         run: "edit Hello Sir!",
@@ -42,6 +46,10 @@ export const start = [
         async run() {
             await waitForStable(document.body, 1000);
         },
+    },
+    {
+        trigger:
+            ".o-livechat-root:shadow .o-mail-ChatWindow:contains(El Deboulonnator) .o-mail-Thread:not([data-transient])",
     },
 ];
 


### PR DESCRIPTION
Chatbot rating tours can sometimes fail. They all share the same steps: start a chat, close the chat, then rate the agent. Before closing the chat, the tours check that the message is present in the DOM, assuming it has been posted, then close the chat window.

However, this is not enough to guarantee the thread was properly created. Initially, a temporary thread is shown. When the user sends the first message, a temporary message is posted on that thread while the real thread is created asynchronously.

As a result, closing the chat after checking the message in the DOM doesn’t guarantee the window belongs to the persisted thread. If it doesn’t (due to slow network or high CPU load), the rating panel never shows because the real thread was never closed.

This commit fixes the issue by waiting for the persisted thread to be created before closing the chat.

fixes runbot-159683