### PR TITLE
[FIX] account: test_switch_company_currency failed

### DIFF
--- a/addons/account/tests/test_settings.py
+++ b/addons/account/tests/test_settings.py
@@ -83,7 +83,6 @@ class TestSettings(AccountTestInvoicingCommon):
         # Create an invoice for company B
         invoice = self.env['account.move'].create({
             'move_type': "in_invoice",
-            'extract_state': "waiting_extraction",
             'company_id': company_b.id,
             'journal_id': journal.id,
         })


### PR DESCRIPTION
Problem:
========
"extract_state" field is defined in enterprise,and the test was in
community. So it breaks community test suite in nightly runbot builds

Solution:
=========
remove "extract_state" field when creating invoice

Runbot error - 229764
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
