### PR TITLE
[FIX] website_sale: prevent dom duplication on variant tags

### DIFF
--- a/addons/website_sale/static/src/js/sale_variant_mixin.js
+++ b/addons/website_sale/static/src/js/sale_variant_mixin.js
@@ -578,9 +578,8 @@ var VariantMixin = {
             .trigger('change');
 
         $parent
-            .find('.o_product_tags')
-            .first()
-            .html(combination.product_tags);
+            .find('.o_product_tags:first')
+            .replaceWith(combination.product_tags);
 
         this.handleCustomValues($(ev.target));
     },


### PR DESCRIPTION
Steps:
- Open Odoo 18.
- Go to Website > Shop.
- Open any product with tags.
- Inspect the DOM.

Issue:
- The `.o_product_tags` div was duplicated.
- This resulted in a nested `.o_product_tags` block in the DOM.

Reason:
- The system was inserting the full HTML tags, including its wrapper, causing the nesting.

Solution:
- Now only the inside content of the tags is updated, not the whole wrapper.
- This keeps the structure clean and avoids duplication.

Result:
Now, there will be no duplication in the `.o_product_tags` block div section.

OPW:4863967

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
