### PR TITLE
[IMP] web: calendar: replace filter icon in side panel

### DIFF
--- a/addons/web/static/src/views/calendar/calendar_side_panel/calendar_side_panel.xml
+++ b/addons/web/static/src/views/calendar/calendar_side_panel/calendar_side_panel.xml
@@ -5,7 +5,7 @@
             <div class="o_calendar_sidebar">
                 <div t-if="props.model.hasMultiCreate" class="d-flex flex-column gap-1">
                     <div class="btn-group">
-                        <button class="btn btn-secondary" t-att-class="{'active': props.mode === MODES.filter}" data-tooltip="Filter"  t-on-click.stop="() => this.props.setMode(MODES.filter)"><i class="fa fa-filter"/></button>
+                        <button class="btn btn-secondary" t-att-class="{'active': props.mode === MODES.filter}" t-on-click.stop="() => this.props.setMode(MODES.filter)"><i class="fa fa-pencil"/></button>
                         <button class="btn btn-secondary" t-att-class="{'active': props.mode === MODES.add}" data-tooltip="New" t-on-click="() => this.props.setMode(MODES.add)"><i class="fa fa-plus"/></button>
                         <button class="btn btn-secondary" t-att-class="{'active': props.mode === MODES.delete}" data-tooltip="Clicking on a day or selecting an area will irrevocably delete its content" t-on-click="() => this.props.setMode(MODES.delete)">
                             <i class="fa fa-trash" t-att-class="{'text-danger': props.mode === MODES.delete}"/>

--- a/addons/web/static/tests/views/calendar/calendar_multi_create.test.js
+++ b/addons/web/static/tests/views/calendar/calendar_multi_create.test.js
@@ -118,10 +118,10 @@ class Event extends models.Model {
                 <!-- Popover -->
                 <field name="name"/>
                 <field name="type"/>
-                
+
                 <!-- Filter -->
                 <field name="user_id" write_model="filter.user" write_field="filter_user_id" filter_field="is_checked"/>
-            
+
                 <!-- For filter to work -->
                 <field name="date_start" invisible="1"/>
                 <field name="filter_user_id" invisible="1"/>
@@ -338,7 +338,7 @@ test("multi_create: basic creation (datetime field)", async () => {
                 <!-- Popover -->
                 <field name="name"/>
                 <field name="type"/>
-                
+
                 <!-- Filter -->
                 <field name="user_id" write_model="filter.user" write_field="filter_user_id" filter_field="is_checked"/>
             </calendar>
@@ -457,7 +457,7 @@ test("multi_create: input validation (datetime field)", async () => {
                 <!-- Popover -->
                 <field name="name"/>
                 <field name="type"/>
-                
+
                 <!-- Filter -->
                 <field name="user_id" write_model="filter.user" write_field="filter_user_id" filter_field="is_checked"/>
             </calendar>
@@ -517,9 +517,9 @@ test("multi_create: filter mode (normal calendar)", async () => {
         context: { default_name: "Sick" },
     });
 
-    await click(".o_calendar_sidebar .btn-group .btn[data-tooltip='Filter']");
+    await click(".o_calendar_sidebar .btn-group .btn .fa-pencil");
     await animationFrame();
-    expect(".o_calendar_sidebar .btn-group .btn.active").toHaveAttribute("data-tooltip", "Filter", {
+    expect(".o_calendar_sidebar .btn-group .btn.active .fa-pencil").toHaveCount(1, {
         message: "filter mode (normal) should be active",
     });
 
@@ -626,7 +626,7 @@ test("multi_create: test onChange on TimePicker with no blur (input text)", asyn
                 <!-- Popover -->
                 <field name="name"/>
                 <field name="type"/>
-                
+
                 <!-- Filter -->
                 <field name="user_id" write_model="filter.user" write_field="filter_user_id" filter_field="is_checked"/>
             </calendar>
@@ -673,7 +673,7 @@ test("multi_create: test popover in all mode", async () => {
     await animationFrame();
     expect(".o_popover").toHaveCount(1);
 
-    await click(".o_calendar_sidebar .btn-group .btn[data-tooltip='Filter']");
+    await click(".o_calendar_sidebar .btn-group .btn .fa-pencil");
     await animationFrame();
     expect(".o_popover").toHaveCount(0);
 


### PR DESCRIPTION
This commit replaces the filter icon in the calendar side panel with a pencil icon and removes the tooltip because it doesn't make much sense `¯\_(ツ)_/¯`.

task-4921675