### PR TITLE
[FIX] hw_drivers: don't update certificate if empty

### DIFF
--- a/addons/hw_drivers/tools/helpers.py
+++ b/addons/hw_drivers/tools/helpers.py
@@ -397,6 +397,10 @@ def load_certificate():
         _logger.error("An error received from odoo.com while trying to get the certificate: %s", certificate_error)
         return "ERR_IOT_HTTPS_LOAD_REQUEST_NO_RESULT"
 
+    if not result.get('x509_pem') or not result.get('private_key_pem'):
+        _logger.error("The certificate received from odoo.com is not valid.")
+        return "ERR_IOT_HTTPS_LOAD_REQUEST_NO_RESULT"
+
     update_conf({'subject': result['subject_cn']})
     if platform.system() == 'Linux':
         with writable():


### PR DESCRIPTION
We now ensure that the certificate data returned by odoo.com is not empty, to avoid nginx not restarting.

Task: 492610