### PR TITLE
[FIX] im_livechat: chat bot step sequence tour

### DIFF
--- a/addons/im_livechat/static/tests/tours/im_livechat_chatbot_steps_sequence_tour.js
+++ b/addons/im_livechat/static/tests/tours/im_livechat_chatbot_steps_sequence_tour.js
@@ -29,7 +29,7 @@ function createChatbotSteps(...stepMessages) {
                 },
                 {
                     trigger: ".modal textarea#message_0",
-                    run: () => waitFor(".modal textarea#message_0:value()"),
+                    run: () => waitFor(".modal textarea#message_0:empty"),
                 },
             ])
             .flat(),


### PR DESCRIPTION
This commit fixes the `im_livechat_chatbot_steps_sequence_tour`. When creating the chat bot steps, we wait for the textarea to be cleared between each step. However, the selector is wrong: `value()` matches everything, regardless of the content. This commit fixes the issue by using `:empty` instead.

follow-up of https://github.com/odoo/odoo/pull/217760.
fixes runbot-229755.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
