### PR TITLE
[FIX] website_sale: prevent duplicate category list display on shop page

### DIFF
--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -627,8 +627,7 @@
                         </div>
                     </div>
                 </div>
-                <div t-if="opt_wsale_categories"
-                     class="accordion-item">
+                <div t-if="opt_wsale_categories" class="accordion-item d-lg-none">
                     <h2 id="o_wsale_offcanvas_categories_header" class="accordion-header mb-0">
                         <button class="o_wsale_offcanvas_title accordion-button rounded-0 collapsed"
                                 type="button"


### PR DESCRIPTION
Steps to reproduce:
1. Go to the shop page.
2. Open the editor and configure Categories to display on the left, and Attributes at the top.
3. Save the changes and click the offcanvas toggle button next to the layout buttons.

Issue:
- The category list appears twice: once on the left side and again in the offcanvas dropdown. This is redundant and affects the user experience.

Cause:
- The category list in the offcanvas menu isn’t restricted to mobile view, so it also displays on larger screens where it’s already visible in the sidebar.

Fix:
- Add the 'd-lg-none' class to hide the category list in the offcanvas menu on large devices.

opw-4830180

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
