### PR TITLE
[FIX] pos_sale: read the updated order lines when settling

### DIFF
--- a/addons/pos_sale/static/src/overrides/models/pos_store.js
+++ b/addons/pos_sale/static/src/overrides/models/pos_store.js
@@ -69,7 +69,7 @@ patch(PosStore.prototype, {
     },
     async _getSaleOrder(id) {
         const sale_order = (await this.data.read("sale.order", [id]))[0];
-        const orderlines = this.models["sale.order.line"].readMany(sale_order.raw.order_line);
+        const orderlines = await this.data.read("sale.order.line", sale_order.raw.order_line);
         sale_order.order_line = orderlines;
         return sale_order;
     },

--- a/addons/pos_sale/static/tests/tours/pos_sale_tour.js
+++ b/addons/pos_sale/static/tests/tours/pos_sale_tour.js
@@ -449,3 +449,23 @@ registry.category("web_tour.tours").add("test_down_payment_displayed", {
             }),
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("test_quantity_updated_settle", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            PosSale.settleNthOrder(1),
+            ProductScreen.clickNumpad("2"),
+            ProductScreen.clickPayButton(),
+            PaymentScreen.clickPaymentMethod("Bank"),
+            PaymentScreen.clickValidate(),
+            ReceiptScreen.clickNextOrder(),
+            PosSale.settleNthOrder(1),
+            Order.hasLine({
+                productName: "Product A",
+                quantity: "3.0",
+                price: "34.50",
+            }),
+        ].flat(),
+});

--- a/addons/pos_sale/tests/test_pos_sale_flow.py
+++ b/addons/pos_sale/tests/test_pos_sale_flow.py
@@ -1437,3 +1437,23 @@ class TestPoSSale(TestPointOfSaleHttpCommon):
 
         self.assertEqual(pos_order.lines[0].qty, 12.0, "quantity should be 12.0")
         self.assertEqual(pos_order.lines[0].price_unit, 0.83, "price of product should be 0.83")
+
+    def test_quantity_updated_settle(self):
+        """
+        Tests that the quantity is updated when partially settling an order, so that the
+        settle displays the right amount that still needs to be settled.
+        """
+        product_a = self.env['product.product'].create({
+            'name': 'Product A',
+            'lst_price': 10.0,
+        })
+        self.env['sale.order'].create({
+            'partner_id': self.env['res.partner'].create({'name': 'Test Partner'}).id,
+            'order_line': [(0, 0, {
+                'product_id': product_a.id,
+                'product_uom_qty': 5,
+                'price_unit': product_a.lst_price,
+            })]
+        })
+        self.main_pos_config.open_ui()
+        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'test_quantity_updated_settle', login="accountman")


### PR DESCRIPTION
Steps to reproduce
------------------
1. Create a Sales Order, add a product with QTY = X
2. Open PoS
3. Load this same Sales order (by clicking "Settle the order"-> QTX is
   X as expected
4. Return to Sales order (in the sales app)
5. Edit QTY from X to Y and save
6. Go back to PoS
7. Delete the laoded Sales Order and load it again
   -> Notice that QTY is still X and not the updated Y!!

Other Flow in frontend
----------------------
1. Create a Sales Order, add a product with QTY = X
2. Open PoS
3. Load this same Sales order (by clicking "Settle the order"-> QTY
   is X as expected
4. Change the quantity manually, to pay for X - 1
5. Validate and pay for the order
6. Load the same Sales order again with "Settle the order"
   -> The quantity is still X and the price is the unit price times X!!

Why the issue
-------------
When settling the order, we get its value using _getSaleOrder
which basically reads it from the cache. So it will read the old
order lines having the old qty, and not the updated one.

The fix
-------
Instead of reading the lines from the cache, we read them direcly from
the backend, to accomodate for cases where the data might have been
changed on another device or has not been updated in the cache.

opw-4819708
opw-4913397

Co-authored-by: Arthur Nanson <artn@odoo.com>