### PR TITLE
[REF] *: update arguments of write and default_get

### DIFF
--- a/addons/account/models/account_account.py
+++ b/addons/account/models/account_account.py
@@ -738,12 +738,12 @@ class AccountAccount(models.Model):
         data[self.env.company.id][self.id][index] = amount
 
     @api.model
-    def default_get(self, default_fields):
+    def default_get(self, fields):
         """If we're creating a new account through a many2one, there are chances that we typed the account code
         instead of its name. In that case, switch both fields values.
         """
         context = {}
-        if 'name' in default_fields or 'code' in default_fields:
+        if 'name' in fields or 'code' in fields:
             default_name = self.env.context.get('default_name')
             default_code = self.env.context.get('default_code')
             if default_name and not default_code:
@@ -753,9 +753,9 @@ class AccountAccount(models.Model):
                     default_name = False
                 context.update({'default_name': default_name, 'default_code': default_code})
 
-        defaults = super(AccountAccount, self.with_context(**context)).default_get(default_fields)
+        defaults = super(AccountAccount, self.with_context(**context)).default_get(fields)
 
-        if 'code_mapping_ids' in default_fields and 'code_mapping_ids' not in defaults:
+        if 'code_mapping_ids' in fields and 'code_mapping_ids' not in defaults:
             defaults['code_mapping_ids'] = [Command.create({'company_id': c.id}) for c in self.env.user.company_ids]
 
         return defaults

--- a/addons/account/models/account_bank_statement.py
+++ b/addons/account/models/account_bank_statement.py
@@ -261,11 +261,11 @@ class AccountBankStatement(models.Model):
     # -------------------------------------------------------------------------
 
     @api.model
-    def default_get(self, fields_list):
+    def default_get(self, fields):
         # EXTENDS base
-        defaults = super().default_get(fields_list)
+        defaults = super().default_get(fields)
 
-        if 'line_ids' not in fields_list:
+        if 'line_ids' not in fields:
             return defaults
 
         active_ids = self.env.context.get('active_ids', [])
@@ -345,11 +345,11 @@ class AccountBankStatement(models.Model):
             container['records'] = stmts = super().create(vals_list)
         return stmts
 
-    def write(self, values):
-        if len(self) != 1 and 'attachment_ids' in values:
-            values.pop('attachment_ids')
+    def write(self, vals):
+        if len(self) != 1 and 'attachment_ids' in vals:
+            vals.pop('attachment_ids')
 
         container = {'records': self}
-        with self._check_attachments(container, [values]):
-            result = super().write(values)
+        with self._check_attachments(container, [vals]):
+            result = super().write(vals)
         return result

--- a/addons/account/models/account_bank_statement_line.py
+++ b/addons/account/models/account_bank_statement_line.py
@@ -336,13 +336,14 @@ class AccountBankStatementLine(models.Model):
     # LOW-LEVEL METHODS
     # -------------------------------------------------------------------------
 
-    def default_get(self, fields_list):
+    @api.model
+    def default_get(self, fields):
         self_ctx = self.with_context(is_statement_line=True)
-        defaults = super(AccountBankStatementLine, self_ctx).default_get(fields_list)
-        if 'journal_id' in fields_list and not defaults.get('journal_id'):
+        defaults = super(AccountBankStatementLine, self_ctx).default_get(fields)
+        if 'journal_id' in fields and not defaults.get('journal_id'):
             defaults['journal_id'] = self_ctx.env['account.move']._search_default_journal().id
 
-        if 'date' in fields_list and not defaults.get('date') and 'journal_id' in defaults:
+        if 'date' in fields and not defaults.get('date') and 'journal_id' in defaults:
             # copy the date and statement from the latest transaction of the same journal to help the user
             # to enter the next transaction, they do not have to enter the date and the statement every time until the
             # statement is completed. It is only possible if we know the journal that is used, so it can only be done

--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -1471,8 +1471,9 @@ class AccountMoveLine(models.Model):
         )
         return super(AccountMoveLine, contextualized).search_fetch(domain, field_names, offset, limit, order)
 
-    def default_get(self, fields_list):
-        defaults = super().default_get(fields_list)
+    @api.model
+    def default_get(self, fields):
+        defaults = super().default_get(fields)
         quick_encode_suggestion = self.env.context.get('quick_encoding_vals')
         if quick_encode_suggestion and self.env.context.get('default_display_type') not in ('line_section', 'line_note'):
             defaults['account_id'] = quick_encode_suggestion['account_id']

--- a/addons/account/models/company.py
+++ b/addons/account/models/company.py
@@ -692,30 +692,30 @@ class ResCompany(models.Model):
         locks.sort()
         return locks
 
-    def write(self, values):
-        self._validate_locks(values)
+    def write(self, vals):
+        self._validate_locks(vals)
 
-        self.env['res.company'].invalidate_model(fnames=[f'user_{field}' for field in LOCK_DATE_FIELDS if field in values])
+        self.env['res.company'].invalidate_model(fnames=[f'user_{field}' for field in LOCK_DATE_FIELDS if field in vals])
 
         # Reflect the change on accounts
         for company in self:
-            if values.get('bank_account_code_prefix'):
-                new_bank_code = values.get('bank_account_code_prefix') or company.bank_account_code_prefix
+            if vals.get('bank_account_code_prefix'):
+                new_bank_code = vals.get('bank_account_code_prefix') or company.bank_account_code_prefix
                 company.reflect_code_prefix_change(company.bank_account_code_prefix, new_bank_code)
 
-            if values.get('cash_account_code_prefix'):
-                new_cash_code = values.get('cash_account_code_prefix') or company.cash_account_code_prefix
+            if vals.get('cash_account_code_prefix'):
+                new_cash_code = vals.get('cash_account_code_prefix') or company.cash_account_code_prefix
                 company.reflect_code_prefix_change(company.cash_account_code_prefix, new_cash_code)
 
-            #forbid the change of currency_id if there are already some accounting entries existing
-            if 'currency_id' in values and values['currency_id'] != company.currency_id.id:
+            # forbid the change of currency_id if there are already some accounting entries existing
+            if 'currency_id' in vals and vals['currency_id'] != company.currency_id.id:
                 if company.root_id._existing_accounting():
                     raise UserError(_('You cannot change the currency of the company since some journal items already exist'))
 
-        companies = super().write(values)
+        companies = super().write(vals)
 
         # We revoke all active exceptions affecting the changed lock dates and recreate them (with the updated lock dates)
-        changed_soft_lock_fields = [field for field in SOFT_LOCK_DATE_FIELDS if field in values]
+        changed_soft_lock_fields = [field for field in SOFT_LOCK_DATE_FIELDS if field in vals]
         for company in self:
             active_exceptions = self.env['account.lock_exception'].search(
                 self.env['account.lock_exception']._get_active_exceptions_domain(company, changed_soft_lock_fields),

--- a/addons/account/models/res_partner_bank.py
+++ b/addons/account/models/res_partner_bank.py
@@ -348,15 +348,16 @@ class ResPartnerBank(models.Model):
             account.partner_id._message_log(body=msg)
         return super().unlink()
 
-    def default_get(self, fields_list):
-        if 'acc_number' not in fields_list:
-            return super().default_get(fields_list)
+    @api.model
+    def default_get(self, fields):
+        if 'acc_number' not in fields:
+            return super().default_get(fields)
 
         # When create & edit, `name` could be used to pass (in the context) the
         # value input by the user. However, we want to set the default value of
         # `acc_number` variable instead.
         default_acc_number = self.env.context.get('default_acc_number', False) or self.env.context.get('default_name', False)
-        return super(ResPartnerBank, self.with_context(default_acc_number=default_acc_number)).default_get(fields_list)
+        return super(ResPartnerBank, self.with_context(default_acc_number=default_acc_number)).default_get(fields)
 
     @api.depends('allow_out_payment', 'acc_number', 'bank_id')
     @api.depends_context('display_account_trust')

--- a/addons/account/wizard/account_move_send_batch_wizard.py
+++ b/addons/account/wizard/account_move_send_batch_wizard.py
@@ -18,10 +18,10 @@ class AccountMoveSendBatchWizard(models.TransientModel):
     # -------------------------------------------------------------------------
 
     @api.model
-    def default_get(self, fields_list):
+    def default_get(self, fields):
         # EXTENDS 'base'
-        results = super().default_get(fields_list)
-        if 'move_ids' in fields_list and 'move_ids' not in results:
+        results = super().default_get(fields)
+        if 'move_ids' in fields and 'move_ids' not in results:
             move_ids = self.env.context.get('active_ids', [])
             results['move_ids'] = [Command.set(move_ids)]
         return results

--- a/addons/account/wizard/account_move_send_wizard.py
+++ b/addons/account/wizard/account_move_send_wizard.py
@@ -86,10 +86,10 @@ class AccountMoveSendWizard(models.TransientModel):
     # -------------------------------------------------------------------------
 
     @api.model
-    def default_get(self, fields_list):
+    def default_get(self, fields):
         # EXTENDS 'base'
-        results = super().default_get(fields_list)
-        if 'move_id' in fields_list and 'move_id' not in results:
+        results = super().default_get(fields)
+        if 'move_id' in fields and 'move_id' not in results:
             move_id = self.env.context.get('active_ids', [])[0]
             results['move_id'] = move_id
         return results

--- a/addons/account/wizard/account_payment_register.py
+++ b/addons/account/wizard/account_payment_register.py
@@ -913,11 +913,11 @@ class AccountPaymentRegister(models.TransientModel):
     # -------------------------------------------------------------------------
 
     @api.model
-    def default_get(self, fields_list):
+    def default_get(self, fields):
         # OVERRIDE
-        res = super().default_get(fields_list)
+        res = super().default_get(fields)
 
-        if 'line_ids' in fields_list and 'line_ids' not in res:
+        if 'line_ids' in fields and 'line_ids' not in res:
 
             # Retrieve moves to pay from the context.
 

--- a/addons/account/wizard/account_resequence.py
+++ b/addons/account/wizard/account_resequence.py
@@ -22,9 +22,9 @@ class AccountResequenceWizard(models.TransientModel):
     preview_moves = fields.Text(compute='_compute_preview_moves')
 
     @api.model
-    def default_get(self, fields_list):
-        values = super().default_get(fields_list)
-        if 'move_ids' not in fields_list:
+    def default_get(self, fields):
+        values = super().default_get(fields)
+        if 'move_ids' not in fields:
             return values
         active_move_ids = self.env['account.move']
         if self.env.context['active_model'] == 'account.move' and 'active_ids' in self.env.context:

--- a/addons/account/wizard/account_validate_account_move.py
+++ b/addons/account/wizard/account_validate_account_move.py
@@ -36,9 +36,10 @@ class ValidateAccountMove(models.TransientModel):
         for wizard in self:
             wizard.abnormal_amount_partner_ids = wizard.move_ids.filtered('abnormal_amount_warning').partner_id
 
-    def default_get(self, fields_list):
-        result = super().default_get(fields_list)
-        if 'move_ids' in fields_list and not result.get('move_ids'):
+    @api.model
+    def default_get(self, fields):
+        result = super().default_get(fields)
+        if 'move_ids' in fields and not result.get('move_ids'):
             if self.env.context.get('active_model') == 'account.move':
                 domain = [('id', 'in', self.env.context.get('active_ids', [])), ('state', '=', 'draft')]
             elif self.env.context.get('active_model') == 'account.journal':

--- a/addons/base_vat/models/res_partner.py
+++ b/addons/base_vat/models/res_partner.py
@@ -767,8 +767,8 @@ class ResPartner(models.Model):
             res.env.remove_to_compute(self._fields['vies_valid'], res)
         return res
 
-    def write(self, values):
-        res = super().write(values)
+    def write(self, vals):
+        res = super().write(vals)
         if self.env.context.get('import_file'):
             self.env.remove_to_compute(self._fields['vies_valid'], self)
         return res

--- a/addons/calendar/models/calendar_event.py
+++ b/addons/calendar/models/calendar_event.py
@@ -678,7 +678,8 @@ class CalendarEvent(models.Model):
 
         return events
 
-    def write(self, values):
+    def write(self, vals):
+        values = vals
         detached_events = self.env['calendar.event']
         recurrence_update_setting = values.pop('recurrence_update', None)
         update_recurrence = recurrence_update_setting in ('all_events', 'future_events') and len(self) == 1 and self.recurrence_id

--- a/addons/calendar/models/mail_activity.py
+++ b/addons/calendar/models/mail_activity.py
@@ -12,11 +12,11 @@ class MailActivity(models.Model):
 
     calendar_event_id = fields.Many2one('calendar.event', string="Calendar Meeting", index='btree_not_null', ondelete='cascade')
 
-    def write(self, values):
+    def write(self, vals):
         # synchronize calendar events
-        res = super().write(values)
+        res = super().write(vals)
         # protect against loops in case of ill-managed timezones
-        if 'date_deadline' in values and not self.env.context.get('calendar_event_meeting_update') and self.calendar_event_id:
+        if 'date_deadline' in vals and not self.env.context.get('calendar_event_meeting_update') and self.calendar_event_id:
             date_deadline = self[0].date_deadline  # updated, hence all same value
             # also protect against loops in case of ill-managed timezones
             events = self.calendar_event_id.with_context(mail_activity_meeting_update=True)

--- a/addons/event/models/event_event.py
+++ b/addons/event/models/event_event.py
@@ -12,7 +12,7 @@ from urllib.parse import urlparse
 from odoo import _, api, Command, fields, models, tools
 from odoo.addons.base.models.res_partner import _tz_get
 from odoo.exceptions import ValidationError
-from odoo.fields import Domain
+from odoo.fields import Datetime, Domain
 from odoo.tools import format_date, format_datetime, format_time, frozendict
 from odoo.tools.mail import is_html_empty, html_to_inner_content
 from odoo.tools.misc import formatLang
@@ -35,13 +35,13 @@ class EventEvent(models.Model):
     _order = 'date_begin, id'
 
     @api.model
-    def default_get(self, fields_list):
-        result = super().default_get(fields_list)
-        if 'date_begin' in fields_list and 'date_begin' not in result:
-            now = fields.Datetime.now()
+    def default_get(self, fields):
+        result = super().default_get(fields)
+        if 'date_begin' in fields and 'date_begin' not in result:
+            now = Datetime.now()
             # Round the datetime to the nearest half hour (e.g. 08:17 => 08:30 and 08:37 => 09:00)
             result['date_begin'] = now.replace(second=0, microsecond=0) + timedelta(minutes=-now.minute % 30)
-        if 'date_end' in fields_list and 'date_end' not in result and result.get('date_begin'):
+        if 'date_end' in fields and 'date_end' not in result and result.get('date_begin'):
             result['date_end'] = result['date_begin'] + timedelta(days=1)
         return result
 

--- a/addons/event/models/event_registration.py
+++ b/addons/event/models/event_registration.py
@@ -105,6 +105,7 @@ class EventRegistration(models.Model):
                 )
             ])
 
+    @api.model
     def default_get(self, fields):
         ret_vals = super().default_get(fields)
         utm_mixin_fields = ("campaign_id", "medium_id", "source_id")

--- a/addons/gamification/models/gamification_challenge.py
+++ b/addons/gamification/models/gamification_challenge.py
@@ -63,9 +63,9 @@ class GamificationChallenge(models.Model):
     _order = 'end_date, start_date, name, id'
 
     @api.model
-    def default_get(self, fields_list):
-        res = super().default_get(fields_list)
-        if 'user_domain' in fields_list and 'user_domain' not in res:
+    def default_get(self, fields):
+        res = super().default_get(fields)
+        if 'user_domain' in fields and 'user_domain' not in res:
             user_group_id = self.env.ref('base.group_user')
             res['user_domain'] = f'["&", ("all_group_ids", "in", [{user_group_id.id}]), ("active", "=", True)]'
         return res

--- a/addons/gamification/models/res_users.py
+++ b/addons/gamification/models/res_users.py
@@ -84,17 +84,17 @@ class ResUsers(models.Model):
 
         return res
 
-    def write(self, values):
-        if 'karma' in values:
+    def write(self, vals):
+        if 'karma' in vals:
             self._add_karma_batch({
                 user: {
-                    'gain': int(values['karma']) - user.karma,
+                    'gain': int(vals['karma']) - user.karma,
                     'origin_ref': f'res.users,{self.env.uid}',
                 }
                 for user in self
-                if int(values['karma']) != user.karma
+                if int(vals['karma']) != user.karma
             })
-        return super().write(values)
+        return super().write(vals)
 
     def _add_karma(self, gain, source=None, reason=None):
         self.ensure_one()

--- a/addons/google_calendar/models/calendar.py
+++ b/addons/google_calendar/models/calendar.py
@@ -87,15 +87,15 @@ class CalendarEvent(models.Model):
         archive_values = super()._get_archive_values()
         return {**archive_values, 'need_sync': False}
 
-    def write(self, values):
-        recurrence_update_setting = values.get('recurrence_update')
+    def write(self, vals):
+        recurrence_update_setting = vals.get('recurrence_update')
         if recurrence_update_setting in ('all_events', 'future_events') and len(self) == 1:
-            values = dict(values, need_sync=False)
+            vals = dict(vals, need_sync=False)
         notify_context = self.env.context.get('dont_notify', False)
         if not notify_context and ([self.env.user.id != record.user_id.id for record in self]):
-            self._check_modify_event_permission(values)
-        res = super(CalendarEvent, self.with_context(dont_notify=notify_context)).write(values)
-        if recurrence_update_setting in ('all_events',) and len(self) == 1 and values.keys() & self._get_google_synced_fields():
+            self._check_modify_event_permission(vals)
+        res = super(CalendarEvent, self.with_context(dont_notify=notify_context)).write(vals)
+        if recurrence_update_setting == 'all_events' and len(self) == 1 and vals.keys() & self._get_google_synced_fields():
             self.recurrence_id.need_sync = True
         return res
 

--- a/addons/hr/models/hr_version.py
+++ b/addons/hr/models/hr_version.py
@@ -264,7 +264,8 @@ class HrVersion(models.Model):
         if self.employee_id.versions_count == len(self):
             raise ValidationError(_('An employee must always have at least one version.'))
 
-    def write(self, values):
+    def write(self, vals):
+        values = vals
         # Employee Versions Validation
         # ARPI TODO: what if mass edit ?
         if 'employee_id' in values:

--- a/addons/hr_attendance/models/hr_employee.py
+++ b/addons/hr_attendance/models/hr_employee.py
@@ -1,11 +1,9 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import pytz
 from dateutil.relativedelta import relativedelta
 
 from odoo import models, fields, api, exceptions, _
-from odoo.tools import float_round
 
 
 class HrEmployee(models.Model):
@@ -59,18 +57,18 @@ class HrEmployee(models.Model):
             officer_group.sudo().write({'user_ids': group_updates})
         return super().create(vals_list)
 
-    def write(self, values):
+    def write(self, vals):
         old_officers = self.env['res.users']
-        if 'attendance_manager_id' in values:
+        if 'attendance_manager_id' in vals:
             old_officers = self.attendance_manager_id
             # Officer was added
-            if values['attendance_manager_id']:
-                officer = self.env['res.users'].browse(values['attendance_manager_id'])
+            if vals['attendance_manager_id']:
+                officer = self.env['res.users'].browse(vals['attendance_manager_id'])
                 officers_group = self.env.ref('hr_attendance.group_hr_attendance_officer', raise_if_not_found=False)
                 if officers_group and not officer.has_group('hr_attendance.group_hr_attendance_officer'):
                     officer.sudo().write({'group_ids': [(4, officers_group.id)]})
 
-        res = super(HrEmployee, self).write(values)
+        res = super().write(vals)
         old_officers.sudo()._clean_attendance_officers()
 
         return res

--- a/addons/hr_expense/wizard/hr_expense_split.py
+++ b/addons/hr_expense/wizard/hr_expense_split.py
@@ -13,6 +13,7 @@ class HrExpenseSplit(models.TransientModel):
     _description = 'Expense Split'
     _check_company_auto = True
 
+    @api.model
     def default_get(self, fields):
         result = super().default_get(fields)
         if 'expense_id' in result:

--- a/addons/hr_holidays/models/hr_employee.py
+++ b/addons/hr_holidays/models/hr_employee.py
@@ -204,7 +204,8 @@ class HrEmployee(models.Model):
             approver_group.sudo().write({'user_ids': group_updates})
         return super().create(vals_list)
 
-    def write(self, values):
+    def write(self, vals):
+        values = vals
         # Prevent the resource calendar of leaves to be updated by a write to
         # employee. When this module is enabled the resource calendar of
         # leaves are determined by those of the contracts.

--- a/addons/hr_holidays/models/hr_leave_allocation.py
+++ b/addons/hr_holidays/models/hr_leave_allocation.py
@@ -751,7 +751,8 @@ class HrLeaveAllocation(models.Model):
                 allocation.action_approve()
         return allocations
 
-    def write(self, values):
+    def write(self, vals):
+        values = vals
         employee_id = values.get('employee_id', False)
         if values.get('state'):
             self._check_approval_update(values['state'])

--- a/addons/hr_holidays_attendance/models/hr_leave_allocation.py
+++ b/addons/hr_holidays_attendance/models/hr_leave_allocation.py
@@ -10,6 +10,7 @@ from odoo.fields import Domain
 class HrLeaveAllocation(models.Model):
     _inherit = 'hr.leave.allocation'
 
+    @api.model
     def default_get(self, fields):
         res = super().default_get(fields)
         if 'holiday_status_id' in fields and self.env.context.get('deduct_extra_hours'):

--- a/addons/hr_timesheet/models/hr_timesheet.py
+++ b/addons/hr_timesheet/models/hr_timesheet.py
@@ -36,9 +36,9 @@ class AccountAnalyticLine(models.Model):
         return mode([t.project_id.id for t in last_timesheets])
 
     @api.model
-    def default_get(self, field_list):
-        result = super().default_get(field_list)
-        if not self.env.context.get('default_employee_id') and 'employee_id' in field_list and result.get('user_id'):
+    def default_get(self, fields):
+        result = super().default_get(fields)
+        if not self.env.context.get('default_employee_id') and 'employee_id' in fields and result.get('user_id'):
             result['employee_id'] = self.env['hr.employee'].search([('user_id', '=', result['user_id']), ('company_id', '=', result.get('company_id', self.env.company.id))], limit=1).id
         if not self.env.context.get('default_project_id') and self.env.context.get('is_timesheet'):
             employee_id = result.get('employee_id', self.env.context.get('default_employee_id', False))
@@ -333,7 +333,8 @@ class AccountAnalyticLine(models.Model):
                 line._timesheet_postprocess(values)
         return lines
 
-    def write(self, values):
+    def write(self, vals):
+        values = vals
         self._check_can_write(values)
 
         task = self.env['project.task'].sudo().browse(values.get('task_id'))

--- a/addons/hr_timesheet/models/project_project.py
+++ b/addons/hr_timesheet/models/project_project.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 from collections import defaultdict
 
@@ -151,13 +150,13 @@ class ProjectProject(models.Model):
                 vals['account_id'] = analytic_account.id
         return super().create(vals_list)
 
-    def write(self, values):
+    def write(self, vals):
         # create the AA for project still allowing timesheet
-        if values.get('allow_timesheets') and not values.get('account_id'):
+        if vals.get('allow_timesheets') and not vals.get('account_id'):
             project_wo_account = self.filtered(lambda project: not project.account_id and not project.is_template)
             if project_wo_account:
                 project_wo_account._create_analytic_account()
-        return super().write(values)
+        return super().write(vals)
 
     @api.depends('is_internal_project', 'company_id')
     @api.depends_context('allowed_company_ids')

--- a/addons/iap/models/iap_account.py
+++ b/addons/iap/models/iap_account.py
@@ -57,11 +57,11 @@ class IapAccount(models.Model):
     def web_save(self, *args, **kwargs):
         return super(IapAccount, self.with_context(disable_iap_fetch=True)).web_save(*args, **kwargs)
 
-    def write(self, values):
-        res = super().write(values)
+    def write(self, vals):
+        res = super().write(vals)
         if (
             not self.env.context.get('disable_iap_update')
-            and any(warning_attribute in values for warning_attribute in ('warning_threshold', 'warning_user_ids'))
+            and any(warning_attribute in vals for warning_attribute in ('warning_threshold', 'warning_user_ids'))
         ):
             route = '/iap/1/update-warning-email-alerts'
             endpoint = iap_tools.iap_get_endpoint(self.env)

--- a/addons/l10n_fi_sale/models/sale.py
+++ b/addons/l10n_fi_sale/models/sale.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import re
 from odoo import api, models, _
 from odoo.exceptions import UserError
@@ -7,13 +6,13 @@ from odoo.exceptions import UserError
 class SaleOrder(models.Model):
     _inherit = "sale.order"
 
-    def write(self, values):
+    def write(self, vals):
         # We compute the l10n_fi/SaleOrder.reference from itself the same way
         # we compute the l10n_fi/AccountMove.invoice_payment_ref from its name.
-        reference = values.get('reference', False)
+        reference = vals.get('reference', False)
         if reference:
-            values['reference'] = self.compute_payment_reference_finnish(reference)
-        return super().write(values)
+            vals['reference'] = self.compute_payment_reference_finnish(reference)
+        return super().write(vals)
 
     @api.model
     def number2numeric(self, number):

--- a/addons/l10n_in/wizard/l10n_in_withhold_wizard.py
+++ b/addons/l10n_in/wizard/l10n_in_withhold_wizard.py
@@ -11,8 +11,8 @@ class L10n_InWithholdWizard(models.TransientModel):
     _check_company_auto = True
 
     @api.model
-    def default_get(self, fields_list):
-        result = super().default_get(fields_list)
+    def default_get(self, fields):
+        result = super().default_get(fields)
         active_model = self.env.context.get('active_model')
         active_ids = self.env.context.get('active_ids', [])
         if len(active_ids) > 1:

--- a/addons/l10n_latam_check/wizards/l10n_latam_payment_mass_transfer.py
+++ b/addons/l10n_latam_check/wizards/l10n_latam_payment_mass_transfer.py
@@ -46,9 +46,9 @@ class L10n_LatamPaymentMassTransfer(models.TransientModel):
         self.company_id = journal.company_id.id
 
     @api.model
-    def default_get(self, fields_list):
-        res = super().default_get(fields_list)
-        if 'check_ids' in fields_list and 'check_ids' not in res:
+    def default_get(self, fields):
+        res = super().default_get(fields)
+        if 'check_ids' in fields and 'check_ids' not in res:
             if self.env.context.get('active_model') != 'l10n_latam.check':
                 raise UserError(_("The register payment wizard should only be called on account.payment records."))
             checks = self.env['l10n_latam.check'].browse(self.env.context.get('active_ids', []))

--- a/addons/loyalty/models/loyalty_program.py
+++ b/addons/loyalty/models/loyalty_program.py
@@ -14,14 +14,14 @@ class LoyaltyProgram(models.Model):
     _rec_name = 'name'
 
     @api.model
-    def default_get(self, fields_list):
-        defaults = super().default_get(fields_list)
+    def default_get(self, fields):
+        defaults = super().default_get(fields)
         program_type = defaults.get('program_type')
         if program_type:
             program_default_values = self._program_type_default_values()
             if program_type in program_default_values:
                 default_values = program_default_values[program_type]
-                defaults.update({k: v for k, v in default_values.items() if k in fields_list})
+                defaults.update({k: v for k, v in default_values.items() if k in fields})
         return defaults
 
     name = fields.Char(string="Program Name", translate=True, required=True)

--- a/addons/loyalty/models/loyalty_reward.py
+++ b/addons/loyalty/models/loyalty_reward.py
@@ -15,9 +15,9 @@ class LoyaltyReward(models.Model):
     _order = 'required_points asc'
 
     @api.model
-    def default_get(self, fields_list):
+    def default_get(self, fields):
         # Try to copy the values of the program types default's
-        result = super().default_get(fields_list)
+        result = super().default_get(fields)
         if 'program_type' in self.env.context:
             program_type = self.env.context['program_type']
             program_default_values = self.env['loyalty.program']._program_type_default_values()
@@ -25,7 +25,7 @@ class LoyaltyReward(models.Model):
                 len(program_default_values[program_type]['reward_ids']) == 2 and\
                 isinstance(program_default_values[program_type]['reward_ids'][1][2], dict):
                 result.update({
-                    k: v for k, v in program_default_values[program_type]['reward_ids'][1][2].items() if k in fields_list
+                    k: v for k, v in program_default_values[program_type]['reward_ids'][1][2].items() if k in fields
                 })
         return result
 

--- a/addons/loyalty/models/loyalty_rule.py
+++ b/addons/loyalty/models/loyalty_rule.py
@@ -12,9 +12,9 @@ class LoyaltyRule(models.Model):
     _description = "Loyalty Rule"
 
     @api.model
-    def default_get(self, fields_list):
+    def default_get(self, fields):
         # Try to copy the values of the program types default's
-        result = super().default_get(fields_list)
+        result = super().default_get(fields)
         if 'program_type' in self.env.context:
             program_type = self.env.context['program_type']
             program_default_values = self.env['loyalty.program']._program_type_default_values()
@@ -22,7 +22,7 @@ class LoyaltyRule(models.Model):
                 len(program_default_values[program_type]['rule_ids']) == 2 and\
                 isinstance(program_default_values[program_type]['rule_ids'][1][2], dict):
                 result.update({
-                    k: v for k, v in program_default_values[program_type]['rule_ids'][1][2].items() if k in fields_list
+                    k: v for k, v in program_default_values[program_type]['rule_ids'][1][2].items() if k in fields
                 })
         return result
 

--- a/addons/lunch/models/lunch_alert.py
+++ b/addons/lunch/models/lunch_alert.py
@@ -143,9 +143,9 @@ class LunchAlert(models.Model):
         alerts._sync_cron()
         return alerts
 
-    def write(self, values):
-        res = super().write(values)
-        if not CRON_DEPENDS.isdisjoint(values):
+    def write(self, vals):
+        res = super().write(vals)
+        if not CRON_DEPENDS.isdisjoint(vals):
             self._sync_cron()
         return res
 

--- a/addons/lunch/models/lunch_order.py
+++ b/addons/lunch/models/lunch_order.py
@@ -173,7 +173,8 @@ class LunchOrder(models.Model):
                 orders |= super().create(vals)
         return orders
 
-    def write(self, values):
+    def write(self, vals):
+        values = vals
         change_topping = 'topping_ids_1' in values or 'topping_ids_2' in values or 'topping_ids_3' in values
         merge_needed = 'note' in values or change_topping or 'state' in values
         default_location_id = self.env.user.last_lunch_location_id and self.env.user.last_lunch_location_id.id or False

--- a/addons/lunch/models/lunch_supplier.py
+++ b/addons/lunch/models/lunch_supplier.py
@@ -186,7 +186,8 @@ class LunchSupplier(models.Model):
         suppliers._sync_cron()
         return suppliers
 
-    def write(self, values):
+    def write(self, vals):
+        values = vals
         for topping in values.get('topping_ids_2', []):
             topping_values = topping[2] if len(topping) > 2 else False
             if topping_values:

--- a/addons/mail/models/fetchmail.py
+++ b/addons/mail/models/fetchmail.py
@@ -172,17 +172,17 @@ odoo_mailgate: "|/path/to/odoo-mailgate.py --host=localhost -u %(uid)d -p PASSWO
 
     @api.model_create_multi
     def create(self, vals_list):
-        res = super(FetchmailServer, self).create(vals_list)
+        res = super().create(vals_list)
         self._update_cron()
         return res
 
-    def write(self, values):
-        res = super(FetchmailServer, self).write(values)
+    def write(self, vals):
+        res = super().write(vals)
         self._update_cron()
         return res
 
     def unlink(self):
-        res = super(FetchmailServer, self).unlink()
+        res = super().unlink()
         self._update_cron()
         return res
 

--- a/addons/mail/models/mail_activity.py
+++ b/addons/mail/models/mail_activity.py
@@ -312,14 +312,14 @@ class MailActivity(models.Model):
             todo_activities.user_id._bus_send("mail.activity/updated", {"activity_created": True})
         return activities
 
-    def write(self, values):
-        if values.get('user_id'):
-            user_changes = self.filtered(lambda activity: activity.user_id.id != values.get('user_id'))
+    def write(self, vals):
+        if vals.get('user_id'):
+            user_changes = self.filtered(lambda activity: activity.user_id.id != vals.get('user_id'))
             pre_responsibles = user_changes.user_id
-        res = super(MailActivity, self).write(values)
+        res = super().write(vals)
 
-        if values.get('user_id'):
-            if values['user_id'] != self.env.uid:
+        if vals.get('user_id'):
+            if vals['user_id'] != self.env.uid:
                 if not self.env.context.get('mail_activity_quick_update', False):
                     user_changes.action_notify()
             for activity in user_changes:

--- a/addons/mail/models/mail_blacklist.py
+++ b/addons/mail/models/mail_blacklist.py
@@ -50,10 +50,10 @@ class MailBlacklist(models.Model):
         results = super().create(to_create)
         return self.env['mail.blacklist'].browse(bl_entries.values()) | results
 
-    def write(self, values):
-        if 'email' in values:
-            values['email'] = tools.email_normalize(values['email'])
-        return super().write(values)
+    def write(self, vals):
+        if 'email' in vals:
+            vals['email'] = tools.email_normalize(vals['email'])
+        return super().write(vals)
 
     def _search(self, domain, *args, **kwargs):
         """ Override _search in order to grep search on email field and make it

--- a/addons/mail/models/mail_presence.py
+++ b/addons/mail/models/mail_presence.py
@@ -46,9 +46,9 @@ class MailPresence(models.Model):
         presences._send_presence()
         return presences
 
-    def write(self, values):
+    def write(self, vals):
         status_by_presence = {presence: presence.status for presence in self}
-        result = super().write(values)
+        result = super().write(vals)
         updated = self.filtered(lambda p: status_by_presence[p] != p.status)
         updated._send_presence()
         return result

--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -365,18 +365,18 @@ class MailThread(models.AbstractModel):
                     self.env.cr.precommit.data.setdefault(f'mail.tracking.create.{self._name}.{thread.id}', changes)
         return threads
 
-    def write(self, values):
+    def write(self, vals):
         if self.env.context.get('tracking_disable'):
-            return super(MailThread, self).write(values)
+            return super().write(vals)
 
         if not self.env.context.get('mail_notrack'):
             self._track_prepare(self._fields)
 
         # Perform write
-        result = super(MailThread, self).write(values)
+        result = super().write(vals)
 
         # update followers
-        self._message_auto_subscribe(values)
+        self._message_auto_subscribe(vals)
 
         return result
 

--- a/addons/mail/wizard/mail_activity_schedule.py
+++ b/addons/mail/wizard/mail_activity_schedule.py
@@ -18,17 +18,17 @@ class MailActivitySchedule(models.TransientModel):
     _batch_size = 500
 
     @api.model
-    def default_get(self, fields_list):
-        res = super().default_get(fields_list)
+    def default_get(self, fields):
+        res = super().default_get(fields)
         context = self.env.context
         active_res_ids = parse_res_ids(context.get('active_ids'), self.env)
-        if 'res_ids' in fields_list:
+        if 'res_ids' in fields:
             if active_res_ids and len(active_res_ids) <= self._batch_size:
                 res['res_ids'] = f"{context['active_ids']}"
             elif not active_res_ids and context.get('active_id'):
                 res['res_ids'] = f"{[context['active_id']]}"
         res_model = context.get('active_model') or context.get('params', {}).get('active_model', False)
-        if 'res_model' in fields_list:
+        if 'res_model' in fields:
             res['res_model'] = res_model
         return res
 

--- a/addons/mail/wizard/mail_compose_message.py
+++ b/addons/mail/wizard/mail_compose_message.py
@@ -45,7 +45,7 @@ class MailComposeMessage(models.TransientModel):
     _batch_size = 50
 
     @api.model
-    def default_get(self, fields_list):
+    def default_get(self, fields):
         """ Handle composition mode and contextual computation, until moving
         to computed fields. Support active_model / active_id(s) as valid default
         values, as this comes from standard web client usage.
@@ -64,15 +64,15 @@ class MailComposeMessage(models.TransientModel):
         if 'default_res_id' in self.env.context:
             raise ValueError(_("Deprecated usage of 'default_res_id', should use 'default_res_ids'."))
 
-        result = super().default_get(fields_list)
+        result = super().default_get(fields)
 
         # when being in new mode, create_uid is not granted -> ACLs issue may arise
-        if 'create_uid' in fields_list and 'create_uid' not in result:
+        if 'create_uid' in fields and 'create_uid' not in result:
             result['create_uid'] = self.env.uid
 
         return {
             fname: result[fname]
-            for fname in result if fname in fields_list
+            for fname in result if fname in fields
         }
 
     # content

--- a/addons/mail_group/models/mail_group_moderation.py
+++ b/addons/mail_group/models/mail_group_moderation.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import fields, models, api, _
@@ -29,12 +28,12 @@ class MailGroupModeration(models.Model):
             if not email_normalized:
                 raise UserError(_('Invalid email address “%s”', values.get('email')))
             values['email'] = email_normalized
-        return super(MailGroupModeration, self).create(vals_list)
+        return super().create(vals_list)
 
-    def write(self, values):
-        if 'email' in values:
-            email_normalized = email_normalize(values['email'])
+    def write(self, vals):
+        if 'email' in vals:
+            email_normalized = email_normalize(vals['email'])
             if not email_normalized:
-                raise UserError(_('Invalid email address “%s”', values.get('email')))
-            values['email'] = email_normalized
-        return super(MailGroupModeration, self).write(values)
+                raise UserError(_('Invalid email address “%s”', vals.get('email')))
+            vals['email'] = email_normalized
+        return super().write(vals)

--- a/addons/mass_mailing/models/mailing.py
+++ b/addons/mass_mailing/models/mailing.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import base64
@@ -21,7 +20,7 @@ from PIL import Image, UnidentifiedImageError
 from odoo import api, fields, models, modules, tools, _
 from odoo.addons.base_import.models.base_import import ImportValidationError
 from odoo.exceptions import UserError, ValidationError
-from odoo.fields import Domain
+from odoo.fields import Datetime, Domain
 from odoo.tools.float_utils import float_round
 from odoo.tools.image import ImageProcess
 
@@ -49,20 +48,20 @@ class MailingMailing(models.Model):
     _systray_view = 'list'
 
     @api.model
-    def default_get(self, fields_list):
-        vals = super().default_get(fields_list)
+    def default_get(self, fields):
+        vals = super().default_get(fields)
 
         # field sent by the calendar view when clicking on a date block
         # we use it to setup the scheduled date of the created mailing.mailing
         default_calendar_date = self.env.context.get('default_calendar_date')
-        if default_calendar_date and ('schedule_type' in fields_list and 'schedule_date' in fields_list) \
-           and fields.Datetime.from_string(default_calendar_date) > fields.Datetime.now():
+        if default_calendar_date and ('schedule_type' in fields and 'schedule_date' in fields) \
+           and Datetime.to_datetime(default_calendar_date) > Datetime.now():
             vals.update({
                 'schedule_type': 'scheduled',
                 'schedule_date': default_calendar_date
             })
 
-        if 'contact_list_ids' in fields_list and not vals.get('contact_list_ids') and vals.get('mailing_model_id'):
+        if 'contact_list_ids' in fields and not vals.get('contact_list_ids') and vals.get('mailing_model_id'):
             if vals.get('mailing_model_id') == self.env['ir.model']._get_id('mailing.list'):
                 mailing_list = self.env['mailing.list'].search([], limit=2)
                 if len(mailing_list) == 1:
@@ -532,7 +531,8 @@ class MailingMailing(models.Model):
                 mailing.body_html = mailing._convert_inline_images_to_urls(mailing.body_html)
         return mailings
 
-    def write(self, values):
+    def write(self, vals):
+        values = vals
         if values.get('body_arch'):
             values['body_arch'] = self._convert_inline_images_to_urls(values['body_arch'])
         if values.get('body_html'):

--- a/addons/mass_mailing/models/mailing_contact.py
+++ b/addons/mass_mailing/models/mailing_contact.py
@@ -17,12 +17,13 @@ class MailingContact(models.Model):
     _order = 'name ASC, id DESC'
     _mailing_enabled = True
 
-    def default_get(self, fields_list):
+    @api.model
+    def default_get(self, fields):
         """ When coming from a mailing list we may have a default_list_ids context
         key. We should use it to create subscription_ids default value that
         are displayed to the user as list_ids is not displayed on form view. """
-        res = super().default_get(fields_list)
-        if 'subscription_ids' in fields_list and not res.get('subscription_ids'):
+        res = super().default_get(fields)
+        if 'subscription_ids' in fields and not res.get('subscription_ids'):
             list_ids = self.env.context.get('default_list_ids')
             if 'default_list_ids' not in res and list_ids and isinstance(list_ids, (list, tuple)):
                 res['subscription_ids'] = [

--- a/addons/microsoft_calendar/models/calendar.py
+++ b/addons/microsoft_calendar/models/calendar.py
@@ -164,7 +164,8 @@ class CalendarEvent(models.Model):
         """
         raise UserError(_("Due to an Outlook Calendar limitation, recurrent events must be created directly in Outlook Calendar."))
 
-    def write(self, values):
+    def write(self, vals):
+        values = vals
         recurrence_update_setting = values.get('recurrence_update')
         notify_context = self.env.context.get('dont_notify', False)
 

--- a/addons/mrp/models/mrp_workorder.py
+++ b/addons/mrp/models/mrp_workorder.py
@@ -475,7 +475,8 @@ class MrpWorkorder(models.Model):
             if res is not True:
                 return res
 
-    def write(self, values):
+    def write(self, vals):
+        values = vals
         new_workcenter = False
         if 'qty_produced' in values:
             if any(w.state in ['done', 'cancel'] for w in self):

--- a/addons/mrp/models/product.py
+++ b/addons/mrp/models/product.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import collections
@@ -6,7 +5,6 @@ from datetime import timedelta
 import operator as py_operator
 from odoo import api, fields, models, _
 from odoo.exceptions import UserError
-from odoo.tools.float_utils import float_round, float_is_zero
 
 
 PY_OPERATORS = {
@@ -68,12 +66,12 @@ class ProductTemplate(models.Model):
             template.used_in_bom_count = self.env['mrp.bom'].search_count(
                 [('bom_line_ids.product_tmpl_id', 'in', template.ids)])
 
-    def write(self, values):
-        if 'active' in values:
-            self.filtered(lambda p: p.active != values['active']).with_context(active_test=False).bom_ids.write({
-                'active': values['active']
+    def write(self, vals):
+        if 'active' in vals:
+            self.filtered(lambda p: p.active != vals['active']).with_context(active_test=False).bom_ids.write({
+                'active': vals['active']
             })
-        return super().write(values)
+        return super().write(vals)
 
     def action_used_in_bom(self):
         self.ensure_one()
@@ -213,12 +211,12 @@ class ProductProduct(models.Model):
         ]).move_raw_ids.product_id.ids
         return [('id', operator, product_ids)]
 
-    def write(self, values):
-        if 'active' in values:
-            self.filtered(lambda p: p.active != values['active']).with_context(active_test=False).variant_bom_ids.write({
-                'active': values['active']
+    def write(self, vals):
+        if 'active' in vals:
+            self.filtered(lambda p: p.active != vals['active']).with_context(active_test=False).variant_bom_ids.write({
+                'active': vals['active']
             })
-        return super().write(values)
+        return super().write(vals)
 
     def get_components(self):
         """ Return the components list ids in case of kit product.

--- a/addons/mrp/models/stock_move.py
+++ b/addons/mrp/models/stock_move.py
@@ -200,8 +200,8 @@ class StockMove(models.Model):
                 raise ValidationError(_("Please enter a positive quantity."))
 
     @api.model
-    def default_get(self, fields_list):
-        defaults = super(StockMove, self).default_get(fields_list)
+    def default_get(self, fields):
+        defaults = super().default_get(fields)
         if self.env.context.get('default_raw_material_production_id') or self.env.context.get('default_production_id'):
             production_id = self.env['mrp.production'].browse(self.env.context.get('default_raw_material_production_id') or self.env.context.get('default_production_id'))
             if production_id.state not in ('draft', 'cancel'):

--- a/addons/mrp_account/wizard/mrp_wip_accounting.py
+++ b/addons/mrp_account/wizard/mrp_wip_accounting.py
@@ -40,18 +40,18 @@ class MrpAccountWipAccounting(models.TransientModel):
     _description = 'Wizard to post Manufacturing WIP account move'
 
     @api.model
-    def default_get(self, fields_list):
-        res = super().default_get(fields_list)
+    def default_get(self, fields):
+        res = super().default_get(fields)
         productions = self.env['mrp.production'].browse(self.env.context.get('active_ids'))
         # ignore selected MOs that aren't a WIP
         productions = productions.filtered(lambda mo: mo.state in ['progress', 'to_close', 'confirmed'])
-        if 'journal_id' in fields_list:
+        if 'journal_id' in fields:
             default = self.env['product.category']._fields['property_stock_journal'].get_company_dependent_fallback(self.env['product.category'])
             if default:
                 res['journal_id'] = default.id
-        if 'reference' in fields_list:
+        if 'reference' in fields:
             res['reference'] = _("Manufacturing WIP - %(orders_list)s", orders_list=productions.mapped('name') or _("Manual Entry"))
-        if 'mo_ids' in fields_list:
+        if 'mo_ids' in fields:
             res['mo_ids'] = [Command.set(productions.ids)]
         return res
 

--- a/addons/mrp_subcontracting/models/stock_location.py
+++ b/addons/mrp_subcontracting/models/stock_location.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import api, fields, models, _
@@ -30,10 +29,10 @@ class StockLocation(models.Model):
         new_subcontracting_locations._activate_subcontracting_location_rules()
         return res
 
-    def write(self, values):
-        res = super().write(values)
-        if 'is_subcontracting_location' in values:
-            if values['is_subcontracting_location']:
+    def write(self, vals):
+        res = super().write(vals)
+        if 'is_subcontracting_location' in vals:
+            if vals['is_subcontracting_location']:
                 self._activate_subcontracting_location_rules()
             else:
                 self._archive_subcontracting_location_rules()

--- a/addons/mrp_subcontracting/models/stock_move.py
+++ b/addons/mrp_subcontracting/models/stock_move.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from collections import defaultdict
@@ -130,18 +129,18 @@ class StockMove(models.Model):
             vals['location_id'] = move.picking_id.location_id.id
         return vals_list
 
-    def write(self, values):
+    def write(self, vals):
         """ If the initial demand is updated then also update the linked
         subcontract order to the new quantity.
         """
-        self._check_access_if_subcontractor(values)
-        if 'product_uom_qty' in values and self.env.context.get('cancel_backorder') is not False and not self.env.context.get('extra_move_mode'):
+        self._check_access_if_subcontractor(vals)
+        if 'product_uom_qty' in vals and self.env.context.get('cancel_backorder') is not False and not self.env.context.get('extra_move_mode'):
             self.filtered(
                 lambda m: m.is_subcontract and m.state not in ['draft', 'cancel', 'done']
-                and m.product_uom.compare(m.product_uom_qty, values['product_uom_qty']) != 0
-            )._update_subcontract_order_qty(values['product_uom_qty'])
-        res = super().write(values)
-        if 'date' in values:
+                and m.product_uom.compare(m.product_uom_qty, vals['product_uom_qty']) != 0
+            )._update_subcontract_order_qty(vals['product_uom_qty'])
+        res = super().write(vals)
+        if 'date' in vals:
             for move in self:
                 if move.state in ('done', 'cancel') or not move.is_subcontract:
                     continue

--- a/addons/partnership/models/res_partner.py
+++ b/addons/partnership/models/res_partner.py
@@ -9,16 +9,16 @@ class ResPartner(models.Model):
 
     grade_id = fields.Many2one('res.partner.grade', 'Partner Level', tracking=True)
 
-    def write(self, values):
-        if values.get('grade_id'):
-            grade = self.env['res.partner.grade'].browse(values['grade_id'])
+    def write(self, vals):
+        if vals.get('grade_id'):
+            grade = self.env['res.partner.grade'].browse(vals['grade_id'])
             if grade.default_pricelist_id:
-                pricelist = values.get('specific_property_product_pricelist') or values.get('property_product_pricelist')
+                pricelist = vals.get('specific_property_product_pricelist') or vals.get('property_product_pricelist')
                 if pricelist and pricelist != grade.default_pricelist_id.id:
                     raise UserError(self.env._(
                         "You are trying to assign two different pricelists (one directly and one from grade (%(grade_name)s)).",
                         grade_name=grade.name,
                     ))
                 else:
-                    values['specific_property_product_pricelist'] = grade.default_pricelist_id.id
-        return super().write(values)
+                    vals['specific_property_product_pricelist'] = grade.default_pricelist_id.id
+        return super().write(vals)

--- a/addons/payment/models/payment_provider.py
+++ b/addons/payment/models/payment_provider.py
@@ -319,21 +319,21 @@ class PaymentProvider(models.Model):
             self._toggle_post_processing_cron()
         return providers
 
-    def write(self, values):
+    def write(self, vals):
         # Handle provider state changes.
         deactivated_providers = self.env['payment.provider']
         activated_providers = self.env['payment.provider']
-        if 'state' in values:
+        if 'state' in vals:
             state_changed_providers = self.filtered(
-                lambda p: p.state not in ('disabled', values['state'])
+                lambda p: p.state not in ('disabled', vals['state'])
             )  # Don't handle providers being enabled or whose state is not updated.
             state_changed_providers._archive_linked_tokens()
-            if values['state'] == 'disabled':
+            if vals['state'] == 'disabled':
                 deactivated_providers = state_changed_providers
             else:  # 'enabled' or 'test'
                 activated_providers = self.filtered(lambda p: p.state == 'disabled')
 
-        result = super().write(values)
+        result = super().write(vals)
         self._check_required_if_provider()
 
         deactivated_providers._deactivate_unsupported_payment_methods()

--- a/addons/payment/models/payment_token.py
+++ b/addons/payment/models/payment_token.py
@@ -72,15 +72,15 @@ class PaymentToken(models.Model):
         """
         return dict()
 
-    def write(self, values):
+    def write(self, vals):
         """ Prevent unarchiving tokens and handle their archiving.
 
         :return: The result of the call to the parent method.
         :rtype: bool
         :raise UserError: If at least one token is being unarchived.
         """
-        if 'active' in values:
-            if values['active']:
+        if 'active' in vals:
+            if vals['active']:
                 if any(
                     not token.payment_method_id.active
                     or token.provider_id.state == 'disabled'
@@ -94,7 +94,7 @@ class PaymentToken(models.Model):
                 # Call the handlers in sudo mode because this method might have been called by RPC.
                 self.filtered('active').sudo()._handle_archiving()
 
-        return super().write(values)
+        return super().write(vals)
 
     @api.constrains('partner_id')
     def _check_partner_is_never_public(self):

--- a/addons/payment/wizards/payment_link_wizard.py
+++ b/addons/payment/wizards/payment_link_wizard.py
@@ -12,8 +12,8 @@ class PaymentLinkWizard(models.TransientModel):
     _description = "Generate Payment Link"
 
     @api.model
-    def default_get(self, fields_list):
-        res = super().default_get(fields_list)
+    def default_get(self, fields):
+        res = super().default_get(fields)
         res_id = self.env.context.get('active_id')
         res_model = self.env.context.get('active_model')
         if res_id and res_model:

--- a/addons/payment_adyen/models/payment_provider.py
+++ b/addons/payment_adyen/models/payment_provider.py
@@ -48,9 +48,9 @@ class PaymentProvider(models.Model):
             self._adyen_extract_prefix_from_api_url(values)
         return super().create(vals_list)
 
-    def write(self, values):
-        self._adyen_extract_prefix_from_api_url(values)
-        return super().write(values)
+    def write(self, vals):
+        self._adyen_extract_prefix_from_api_url(vals)
+        return super().write(vals)
 
     @api.model
     def _adyen_extract_prefix_from_api_url(self, values):

--- a/addons/phone_validation/models/phone_blacklist.py
+++ b/addons/phone_validation/models/phone_blacklist.py
@@ -58,14 +58,14 @@ class PhoneBlacklist(models.Model):
         numbers_to_id = {record.number: record.id for record in existing | created}
         return self.browse(numbers_to_id[number] for number in numbers_requested)
 
-    def write(self, values):
-        if 'number' in values:
+    def write(self, vals):
+        if 'number' in vals:
             try:
-                sanitized = self.env.user._phone_format(number=values['number'], raise_exception=True)
+                sanitized = self.env.user._phone_format(number=vals['number'], raise_exception=True)
             except UserError as err:
                 raise UserError(_("%(error)s Please correct the number and try again.", error=str(err))) from err
-            values['number'] = sanitized
-        return super().write(values)
+            vals['number'] = sanitized
+        return super().write(vals)
 
     def _search_number(self, operator, value):
         sanitize = self.env.user._phone_format

--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -1502,19 +1502,19 @@ class PosOrderLine(models.Model):
                 vals['name'] = self.env['ir.sequence'].next_by_code('pos.order.line')
         return super().create(vals_list)
 
-    def write(self, values):
-        if values.get('pack_lot_line_ids'):
-            for pl in values.get('pack_lot_ids'):
+    def write(self, vals):
+        if vals.get('pack_lot_line_ids'):
+            for pl in vals.get('pack_lot_ids'):
                 if pl[2].get('server_id'):
                     pl[2]['id'] = pl[2]['server_id']
                     del pl[2]['server_id']
-        if self.order_id.config_id.order_edit_tracking and values.get('qty') is not None and values.get('qty') < self.qty:
+        if self.order_id.config_id.order_edit_tracking and vals.get('qty') is not None and vals.get('qty') < self.qty:
             self.is_edited = True
             body = _("%(product_name)s: Ordered quantity: %(old_qty)s", product_name=self.full_product_name, old_qty=self.qty)
-            body += Markup("&rarr;") + str(values.get('qty'))
+            body += Markup("&rarr;") + str(vals.get('qty'))
             for line in self:
                 line.order_id.message_post(body=line.order_id._prepare_pos_log(body))
-        return super().write(values)
+        return super().write(vals)
 
     @api.model
     def get_existing_lots(self, company_id, config_id, product_id):

--- a/addons/portal_rating/models/rating_rating.py
+++ b/addons/portal_rating/models/rating_rating.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from odoo import api, fields, models, exceptions, _
 
 
@@ -22,9 +20,9 @@ class RatingRating(models.Model):
             ratings._check_synchronize_publisher_values()
         return ratings
 
-    def write(self, values):
-        self._synchronize_publisher_values(values)
-        return super().write(values)
+    def write(self, vals):
+        self._synchronize_publisher_values(vals)
+        return super().write(vals)
 
     def _check_synchronize_publisher_values(self):
         """ Either current user is a member of website restricted editor group

--- a/addons/pos_self_order/models/product_product.py
+++ b/addons/pos_self_order/models/product_product.py
@@ -74,14 +74,14 @@ class ProductTemplate(models.Model):
         for product in self:
             product.self_order_visible = any(p_cat_id in categ_ids for p_cat_id in product.pos_categ_ids.ids)
 
-    def write(self, vals_list):
-        if 'available_in_pos' in vals_list:
-            if not vals_list['available_in_pos']:
-                vals_list['self_order_available'] = False
+    def write(self, vals):
+        if 'available_in_pos' in vals:
+            if not vals['available_in_pos']:
+                vals['self_order_available'] = False
 
-        res = super().write(vals_list)
+        res = super().write(vals)
 
-        if 'self_order_available' in vals_list:
+        if 'self_order_available' in vals:
             for record in self:
                 for product in record.product_variant_ids:
                     product._send_availability_status()
@@ -109,9 +109,9 @@ class ProductProduct(models.Model):
             if attributes_by_ptal_id.get(id) is not None
         ]
 
-    def write(self, vals_list):
-        res = super().write(vals_list)
-        if 'self_order_available' in vals_list:
+    def write(self, vals):
+        res = super().write(vals)
+        if 'self_order_available' in vals:
             for record in self:
                 record._send_availability_status()
         return res

--- a/addons/product/models/product_pricelist.py
+++ b/addons/product/models/product_pricelist.py
@@ -69,12 +69,12 @@ class ProductPricelist(models.Model):
             pricelist_name = pricelist.name and pricelist.name or _('New')
             pricelist.display_name = f'{pricelist_name} ({pricelist.currency_id.name})'
 
-    def write(self, values):
-        res = super().write(values)
+    def write(self, vals):
+        res = super().write(vals)
 
         # Make sure that there is no multi-company issue in the existing rules after the company
         # change.
-        if 'company_id' in values and len(self) == 1:
+        if 'company_id' in vals and len(self) == 1:
             self.item_ids._check_company()
 
         return res

--- a/addons/product/models/product_product.py
+++ b/addons/product/models/product_product.py
@@ -397,12 +397,12 @@ class ProductProduct(models.Model):
         self.env.registry.clear_cache()
         return products
 
-    def write(self, values):
-        res = super(ProductProduct, self).write(values)
-        if 'product_template_attribute_value_ids' in values:
+    def write(self, vals):
+        res = super().write(vals)
+        if 'product_template_attribute_value_ids' in vals:
             # `_get_variant_id_for_combination` depends on `product_template_attribute_value_ids`
             self.env.registry.clear_cache()
-        elif 'active' in values:
+        elif 'active' in vals:
             # `_get_first_possible_variant_id` depends on variants active state
             self.env.registry.clear_cache()
         return res

--- a/addons/product/models/product_template.py
+++ b/addons/product/models/product_template.py
@@ -22,9 +22,10 @@ class ProductTemplate(models.Model):
     _check_company_auto = True
     _check_company_domain = models.check_company_domain_parent_of
 
-    def default_get(self, fields_list):
-        res = super().default_get(fields_list)
-        if 'uom_id' in fields_list and not res.get('uom_id') or self.env.context.get('default_uom_id') is False:
+    @api.model
+    def default_get(self, fields):
+        res = super().default_get(fields)
+        if ('uom_id' in fields and not res.get('uom_id')) or self.env.context.get('default_uom_id') is False:
             res['uom_id'] = self._get_default_uom_id().id
         return res
 

--- a/addons/product/models/product_template_attribute_exclusion.py
+++ b/addons/product/models/product_template_attribute_exclusion.py
@@ -38,10 +38,10 @@ class ProductTemplateAttributeExclusion(models.Model):
         templates._create_variant_ids()
         return res
 
-    def write(self, values):
+    def write(self, vals):
         templates = self.env['product.template']
-        if 'product_tmpl_id' in values:
+        if 'product_tmpl_id' in vals:
             templates = self.product_tmpl_id
-        res = super().write(values)
+        res = super().write(vals)
         (templates | self.product_tmpl_id)._create_variant_ids()
         return res

--- a/addons/product/models/product_template_attribute_line.py
+++ b/addons/product/models/product_template_attribute_line.py
@@ -114,13 +114,14 @@ class ProductTemplateAttributeLine(models.Model):
             res._update_product_template_attribute_values()
         return res
 
-    def write(self, values):
+    def write(self, vals):
         """Override to:
         - Add constraints to prevent doing changes that are not supported such
             as modifying the template or the attribute of existing lines.
         - Clean up related values and related variants when archiving or when
             updating `value_ids`.
         """
+        values = vals
         if 'product_tmpl_id' in values:
             for ptal in self:
                 if ptal.product_tmpl_id.id != values['product_tmpl_id']:

--- a/addons/product/models/product_template_attribute_value.py
+++ b/addons/product/models/product_template_attribute_value.py
@@ -87,7 +87,8 @@ class ProductTemplateAttributeValue(models.Model):
             raise UserError(_("You cannot update related variants from the values. Please update related values from the variants."))
         return super().create(vals_list)
 
-    def write(self, values):
+    def write(self, vals):
+        values = vals
         if 'ptav_product_variant_ids' in values:
             # Force write on this relation from `product.product` to properly
             # trigger `_compute_combination_indices`.

--- a/addons/project/models/project_task.py
+++ b/addons/project/models/project_task.py
@@ -6,7 +6,7 @@ from collections import defaultdict
 from datetime import timedelta, datetime, time
 
 from odoo import api, fields, models, tools, SUPERUSER_ID, _
-from odoo.fields import Command, Domain
+from odoo.fields import Command, Date, Domain
 from odoo.addons.rating.models import rating_data
 from odoo.addons.web_editor.tools import handle_history_divergence
 from odoo.exceptions import UserError, ValidationError
@@ -969,18 +969,18 @@ class ProjectTask(models.Model):
         return key + (self.env.user._is_portal(),)
 
     @api.model
-    def default_get(self, default_fields):
-        vals = super().default_get(default_fields)
+    def default_get(self, fields):
+        vals = super().default_get(fields)
 
         if project_id := self.env.context.get('default_create_in_project_id'):
             vals['project_id'] = project_id
 
         # prevent creating new task in the waiting state
-        if 'state' in default_fields and vals.get('state') == '04_waiting_normal':
+        if 'state' in fields and vals.get('state') == '04_waiting_normal':
             vals['state'] = '01_in_progress'
 
-        if 'repeat_until' in default_fields:
-            vals['repeat_until'] = fields.Date.today() + timedelta(days=7)
+        if 'repeat_until' in fields:
+            vals['repeat_until'] = Date.today() + timedelta(days=7)
 
         if 'partner_id' in vals and not vals['partner_id']:
             # if the default_partner_id=False or no default_partner_id then we search the partner based on the project and parent
@@ -996,9 +996,9 @@ class ProjectTask(models.Model):
         project_id = vals.get('project_id', self.env.context.get('default_project_id'))
         if project_id:
             project = self.env['project.project'].browse(project_id)
-            if 'company_id' in default_fields and 'default_project_id' not in self.env.context:
+            if 'company_id' in fields and 'default_project_id' not in self.env.context:
                 vals['company_id'] = project.sudo().company_id.id
-        elif 'default_user_ids' not in self.env.context and 'user_ids' in default_fields:
+        elif 'default_user_ids' not in self.env.context and 'user_ids' in fields:
             user_ids = vals.get('user_ids', [])
             user_ids.append(Command.link(self.env.user.id))
             vals['user_ids'] = user_ids

--- a/addons/project/models/project_update.py
+++ b/addons/project/models/project_update.py
@@ -24,6 +24,7 @@ class ProjectUpdate(models.Model):
     _order = 'id desc'
     _inherit = ['mail.thread.cc', 'mail.activity.mixin']
 
+    @api.model
     def default_get(self, fields):
         result = super().default_get(fields)
         if 'project_id' in fields and not result.get('project_id'):

--- a/addons/purchase/models/purchase_order_line.py
+++ b/addons/purchase/models/purchase_order_line.py
@@ -214,7 +214,8 @@ class PurchaseOrderLine(models.Model):
                 line.order_id.message_post(body=msg)
         return lines
 
-    def write(self, values):
+    def write(self, vals):
+        values = vals
         if 'display_type' in values and self.filtered(lambda line: line.display_type != values.get('display_type')):
             raise UserError(_("You cannot change the type of a purchase order line. Instead you should delete the current line and create a new line of the proper type."))
 

--- a/addons/purchase_stock/models/purchase_order_line.py
+++ b/addons/purchase_stock/models/purchase_order_line.py
@@ -91,7 +91,8 @@ class PurchaseOrderLine(models.Model):
         lines.filtered(lambda l: l.order_id.state == 'purchase')._create_or_update_picking()
         return lines
 
-    def write(self, values):
+    def write(self, vals):
+        values = vals
         if values.get('date_planned'):
             new_date = fields.Datetime.to_datetime(values['date_planned'])
             self.filtered(lambda l: not l.display_type)._update_move_date_deadline(new_date)

--- a/addons/rating/models/rating.py
+++ b/addons/rating/models/rating.py
@@ -131,12 +131,12 @@ class RatingRating(models.Model):
                 values['rated_on'] = fields.Datetime.now()
         return super().create(vals_list)
 
-    def write(self, values):
-        if values.get('res_model_id') and values.get('res_id'):
-            values.update(self._find_parent_data(values))
-        if 'rating' in values or 'feedback' in values:
-            values['rated_on'] = fields.Datetime.now()
-        return super().write(values)
+    def write(self, vals):
+        if vals.get('res_model_id') and vals.get('res_id'):
+            vals.update(self._find_parent_data(vals))
+        if 'rating' in vals or 'feedback' in vals:
+            vals['rated_on'] = fields.Datetime.now()
+        return super().write(vals)
 
     def unlink(self):
         # OPW-2181568: Delete the chatter message too

--- a/addons/rating/models/rating_mixin.py
+++ b/addons/rating/models/rating_mixin.py
@@ -94,15 +94,15 @@ class RatingMixin(models.AbstractModel):
             grade_count = sum(grade_repartition.values())
             record.rating_percentage_satisfaction = grade_repartition['great'] * 100 / grade_count if grade_count else -1
 
-    def write(self, values):
+    def write(self, vals):
         """ If the rated ressource name is modified, we should update the rating res_name too.
             If the rated ressource parent is changed we should update the parent_res_id too"""
-        result = super().write(values)
+        result = super().write(vals)
         for record in self.sudo():  # ratings may be inaccessible
-            if record._rec_name in values:  # set the res_name of ratings to be recomputed
+            if record._rec_name in vals:  # set the res_name of ratings to be recomputed
                 res_name_field = self.env['rating.rating']._fields['res_name']
                 self.env.add_to_compute(res_name_field, record.rating_ids)
-            if record._rating_get_parent_field_name() in values:
+            if record._rating_get_parent_field_name() in vals:
                 record.rating_ids.write({'parent_res_id': record[record._rating_get_parent_field_name()].id})
 
         return result

--- a/addons/repair/models/repair.py
+++ b/addons/repair/models/repair.py
@@ -365,12 +365,12 @@ class RepairOrder(models.Model):
             }
 
     @api.model
-    def default_get(self, fields_list):
+    def default_get(self, fields):
         # Adds the picking_id if it comes from a return. Avoids having a default_picking_id pollute the context for further move creation.
-        res = super().default_get(fields_list)
-        if 'picking_id' not in res and 'picking_id' in fields_list and 'default_repair_picking_id' in self.env.context:
+        res = super().default_get(fields)
+        if 'picking_id' not in res and 'picking_id' in fields and 'default_repair_picking_id' in self.env.context:
             res['picking_id'] = self.env.context.get('default_repair_picking_id')
-        if 'lot_id' not in res and 'lot_id' in fields_list and 'default_repair_lot_id' in self.env.context:
+        if 'lot_id' not in res and 'lot_id' in fields and 'default_repair_lot_id' in self.env.context:
             res['lot_id'] = self.env.context.get('default_repair_lot_id')
         return res
 

--- a/addons/resource/models/resource_calendar_leaves.py
+++ b/addons/resource/models/resource_calendar_leaves.py
@@ -6,6 +6,7 @@ from pytz import timezone, utc
 
 from odoo import api, fields, models, _
 from odoo.exceptions import ValidationError
+from odoo.fields import Datetime
 
 
 class ResourceCalendarLeaves(models.Model):
@@ -13,11 +14,12 @@ class ResourceCalendarLeaves(models.Model):
     _description = "Resource Time Off Detail"
     _order = "date_from"
 
-    def default_get(self, fields_list):
-        res = super().default_get(fields_list)
-        if 'date_from' in fields_list and 'date_to' in fields_list and not res.get('date_from') and not res.get('date_to'):
+    @api.model
+    def default_get(self, fields):
+        res = super().default_get(fields)
+        if 'date_from' in fields and 'date_to' in fields and not res.get('date_from') and not res.get('date_to'):
             # Then we give the current day and we search the begin and end hours for this day in resource.calendar of the current company
-            today = fields.Datetime.now()
+            today = Datetime.now()
             calendar = self.env.company.resource_calendar_id
             if 'calendar_id' in res:
                 calendar = self.env['resource.calendar'].browse(res['calendar_id'])

--- a/addons/resource/models/resource_resource.py
+++ b/addons/resource/models/resource_resource.py
@@ -77,16 +77,16 @@ class ResourceResource(models.Model):
         vals_list = super().copy_data(default=default)
         return [dict(vals, name=self.env._("%s (copy)", resource.name)) for resource, vals in zip(self, vals_list)]
 
-    def write(self, values):
+    def write(self, vals):
         if self.env.context.get('check_idempotence') and len(self) == 1:
-            values = {
+            vals = {
                 fname: value
-                for fname, value in values.items()
+                for fname, value in vals.items()
                 if self._fields[fname].convert_to_write(self[fname], self) != value
             }
-        if not values:
+        if not vals:
             return True
-        return super().write(values)
+        return super().write(vals)
 
     @api.onchange('company_id')
     def _onchange_company_id(self):

--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -1184,7 +1184,8 @@ class SaleOrderLine(models.Model):
             if 'price_unit' in vals and 'technical_price_unit' not in vals:
                 vals['technical_price_unit'] = vals['price_unit']
 
-    def write(self, values):
+    def write(self, vals):
+        values = vals
         if 'display_type' in values and self.filtered(lambda line: line.display_type != values.get('display_type')):
             raise UserError(_("You cannot change the type of a sale order line. Instead you should delete the current line and create a new line of the proper type."))
 

--- a/addons/sale_management/models/sale_order_template_line.py
+++ b/addons/sale_management/models/sale_order_template_line.py
@@ -79,10 +79,10 @@ class SaleOrderTemplateLine(models.Model):
                 vals.update(product_id=False, product_uom_qty=0, product_uom_id=False)
         return super().create(vals_list)
 
-    def write(self, values):
-        if 'display_type' in values and self.filtered(lambda line: line.display_type != values.get('display_type')):
+    def write(self, vals):
+        if 'display_type' in vals and self.filtered(lambda line: line.display_type != vals.get('display_type')):
             raise UserError(_("You cannot change the type of a sale quote line. Instead you should delete the current line and create a new line of the proper type."))
-        return super().write(values)
+        return super().write(vals)
 
     #=== BUSINESS METHODS ===#
 

--- a/addons/sale_project/models/project_project.py
+++ b/addons/sale_project/models/project_project.py
@@ -47,8 +47,8 @@ class ProjectProject(models.Model):
     )
 
     @api.model
-    def default_get(self, fields_list):
-        defaults = super().default_get(fields_list)
+    def default_get(self, fields):
+        defaults = super().default_get(fields)
         if self.env.context.get('order_state') == 'sale':
             order_id = self.env.context.get('order_id')
             sale_line_id = self.env['sale.order.line'].search(

--- a/addons/sale_project/models/sale_order.py
+++ b/addons/sale_project/models/sale_order.py
@@ -13,9 +13,9 @@ class SaleOrder(models.Model):
     _inherit = 'sale.order'
 
     @api.model
-    def default_get(self, fields_list):
-        res = super().default_get(fields_list)
-        if 'origin' in fields_list and (task_id := self.env.context.get('create_for_task_id')):
+    def default_get(self, fields):
+        res = super().default_get(fields)
+        if 'origin' in fields and (task_id := self.env.context.get('create_for_task_id')):
             task = self.env['project.task'].browse(task_id)
             res['origin'] = self.env._('[Project] %(task_name)s', task_name=task.name)
         return res
@@ -308,9 +308,9 @@ class SaleOrder(models.Model):
                 task.sale_line_id = service_sol
         return created_records
 
-    def write(self, values):
-        res = super().write(values)
-        if 'state' in values and values['state'] == 'cancel':
+    def write(self, vals):
+        res = super().write(vals)
+        if 'state' in vals and vals['state'] == 'cancel':
             # Remove sale line field reference from all projects
             self.env['project.project'].sudo().search([('sale_line_id.order_id', 'in', self.ids)]).sale_line_id = False
         return res

--- a/addons/sale_project/models/sale_order_line.py
+++ b/addons/sale_project/models/sale_order_line.py
@@ -23,6 +23,7 @@ class SaleOrderLine(models.Model):
             ('company_id', 'in', [False, self.env.company.id]),
         ]
 
+    @api.model
     def default_get(self, fields):
         res = super().default_get(fields)
         if self.env.context.get('form_view_ref') == 'sale_project.sale_order_line_view_form_editable':
@@ -143,12 +144,12 @@ class SaleOrderLine(models.Model):
                     project.reinvoiced_sale_order_id = service_line.order_id
         return lines
 
-    def write(self, values):
-        result = super().write(values)
+    def write(self, vals):
+        result = super().write(vals)
         # changing the ordered quantity should change the allocated hours on the
         # task, whatever the SO state. It will be blocked by the super in case
         # of a locked sale order.
-        if 'product_uom_qty' in values and not self.env.context.get('no_update_allocated_hours', False):
+        if 'product_uom_qty' in vals and not self.env.context.get('no_update_allocated_hours', False):
             for line in self:
                 if line.task_id and line.product_id.type == 'service':
                     allocated_hours = line._convert_qty_company_hours(line.task_id.company_id or self.env.user.company_id)

--- a/addons/sale_purchase/models/sale_order_line.py
+++ b/addons/sale_purchase/models/sale_order_line.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from dateutil.relativedelta import relativedelta
@@ -49,24 +48,24 @@ class SaleOrderLine(models.Model):
         )._purchase_service_generation()
         return lines
 
-    def write(self, values):
+    def write(self, vals):
         increased_lines = None
         decreased_lines = None
         increased_values = {}
         decreased_values = {}
-        if 'product_uom_qty' in values:
+        if 'product_uom_qty' in vals:
             precision = self.env['decimal.precision'].precision_get('Product Unit')
-            increased_lines = self.sudo().filtered(lambda r: r.product_id.with_company(r._purchase_service_get_company()).service_to_purchase and r.purchase_line_count and float_compare(r.product_uom_qty, values['product_uom_qty'], precision_digits=precision) == -1)
-            decreased_lines = self.sudo().filtered(lambda r: r.product_id.with_company(r._purchase_service_get_company()).service_to_purchase and r.purchase_line_count and float_compare(r.product_uom_qty, values['product_uom_qty'], precision_digits=precision) == 1)
+            increased_lines = self.sudo().filtered(lambda r: r.product_id.with_company(r._purchase_service_get_company()).service_to_purchase and r.purchase_line_count and float_compare(r.product_uom_qty, vals['product_uom_qty'], precision_digits=precision) == -1)
+            decreased_lines = self.sudo().filtered(lambda r: r.product_id.with_company(r._purchase_service_get_company()).service_to_purchase and r.purchase_line_count and float_compare(r.product_uom_qty, vals['product_uom_qty'], precision_digits=precision) == 1)
             increased_values = {line.id: line.product_uom_qty for line in increased_lines}
             decreased_values = {line.id: line.product_uom_qty for line in decreased_lines}
 
-        result = super(SaleOrderLine, self).write(values)
+        result = super().write(vals)
 
         if increased_lines:
-            increased_lines._purchase_increase_ordered_qty(values['product_uom_qty'], increased_values)
+            increased_lines._purchase_increase_ordered_qty(vals['product_uom_qty'], increased_values)
         if decreased_lines:
-            decreased_lines._purchase_decrease_ordered_qty(values['product_uom_qty'], decreased_values)
+            decreased_lines._purchase_decrease_ordered_qty(vals['product_uom_qty'], decreased_values)
         return result
 
     # --------------------------

--- a/addons/sale_stock/models/sale_order.py
+++ b/addons/sale_stock/models/sale_order.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import json
@@ -149,7 +148,8 @@ class SaleOrder(models.Model):
         if any(c not in other_company_warehouses.company_id.ids for c in other_company):
             raise UserError(_("You must have a warehouse for line using a delivery in different company."))
 
-    def write(self, values):
+    def write(self, vals):
+        values = vals
         if values.get('order_line') and self.state == 'sale':
             for order in self:
                 pre_order_line_qty = {order_line: order_line.product_uom_qty for order_line in order.mapped('order_line') if not order_line.is_expense}

--- a/addons/sale_stock/models/sale_order_line.py
+++ b/addons/sale_stock/models/sale_order_line.py
@@ -212,17 +212,17 @@ class SaleOrderLine(models.Model):
 
     @api.model_create_multi
     def create(self, vals_list):
-        lines = super(SaleOrderLine, self).create(vals_list)
+        lines = super().create(vals_list)
         lines.filtered(lambda line: line.state == 'sale')._action_launch_stock_rule()
         return lines
 
-    def write(self, values):
+    def write(self, vals):
         lines = self.env['sale.order.line']
-        if 'product_uom_qty' in values:
+        if 'product_uom_qty' in vals:
             lines = self.filtered(lambda r: r.state == 'sale' and not r.is_expense)
 
         previous_product_uom_qty = {line.id: line.product_uom_qty for line in lines}
-        res = super(SaleOrderLine, self).write(values)
+        res = super().write(vals)
         if lines:
             lines._action_launch_stock_rule(previous_product_uom_qty=previous_product_uom_qty)
         return res

--- a/addons/sale_timesheet/models/project_project.py
+++ b/addons/sale_timesheet/models/project_project.py
@@ -180,9 +180,9 @@ class ProjectProject(models.Model):
             if project.sale_line_id.is_expense:
                 raise ValidationError(_("You cannot link a billable project to a sales order item that comes from an expense or a vendor bill."))
 
-    def write(self, values):
-        res = super().write(values)
-        if 'allow_billable' in values and not values.get('allow_billable'):
+    def write(self, vals):
+        res = super().write(vals)
+        if 'allow_billable' in vals and not vals.get('allow_billable'):
             self.task_ids._get_timesheet().write({
                 'so_line': False,
             })

--- a/addons/sale_timesheet/models/project_sale_line_employee_map.py
+++ b/addons/sale_timesheet/models/project_sale_line_employee_map.py
@@ -131,8 +131,8 @@ class ProjectSaleLineEmployeeMap(models.Model):
         maps._update_project_timesheet()
         return maps
 
-    def write(self, values):
-        res = super().write(values)
+    def write(self, vals):
+        res = super().write(vals)
         self._update_project_timesheet()
         return res
 

--- a/addons/sales_team/models/crm_team.py
+++ b/addons/sales_team/models/crm_team.py
@@ -207,13 +207,13 @@ class CrmTeam(models.Model):
         teams.filtered(lambda t: t.member_ids)._add_members_to_favorites()
         return teams
 
-    def write(self, values):
-        res = super(CrmTeam, self).write(values)
+    def write(self, vals):
+        res = super().write(vals)
         # manually launch company sanity check
-        if values.get('company_id'):
+        if vals.get('company_id'):
             self.crm_team_member_ids._check_company(fnames=['crm_team_id'])
 
-        if values.get('member_ids'):
+        if vals.get('member_ids'):
             self._add_members_to_favorites()
         return res
 

--- a/addons/sales_team/models/crm_team_member.py
+++ b/addons/sales_team/models/crm_team_member.py
@@ -160,7 +160,7 @@ class CrmTeamMember(models.Model):
             mail_create_nosubscribe=True
         )).create(vals_list)
 
-    def write(self, values):
+    def write(self, vals):
         """ Specific behavior about active. If you change user_id / team_id user
         get warnings in form view and a raise in constraint check. We support
         archive / activation of memberships that toggles other memberships. But
@@ -171,12 +171,12 @@ class CrmTeamMember(models.Model):
         modifying user_id or team_id is advanced and does not benefit from our
         support. """
         is_membership_multi = self.env['ir.config_parameter'].sudo().get_param('sales_team.membership_multi', False)
-        if not is_membership_multi and values.get('active'):
+        if not is_membership_multi and vals.get('active'):
             self._synchronize_memberships([
                 dict(user_id=membership.user_id.id, crm_team_id=membership.crm_team_id.id)
                 for membership in self
             ])
-        return super(CrmTeamMember, self).write(values)
+        return super().write(vals)
 
     def _synchronize_memberships(self, user_team_ids):
         """ Synchronize memberships: archive other memberships.

--- a/addons/stock/models/stock_location.py
+++ b/addons/stock/models/stock_location.py
@@ -213,7 +213,8 @@ class StockLocation(models.Model):
         ]
         return [('id', 'not in', location_ids)]
 
-    def write(self, values):
+    def write(self, vals):
+        values = vals
         if 'company_id' in values:
             for location in self:
                 if location.company_id.id != values['company_id']:

--- a/addons/stock/models/stock_lot.py
+++ b/addons/stock/models/stock_lot.py
@@ -28,11 +28,11 @@ class StockLot(models.Model):
     _order = 'name, id'
 
     @api.model
-    def default_get(self, fields_list):
+    def default_get(self, fields):
         context = dict(self.env.context)
         # We always want the company_id to be computed, regardless of where it's been created.
         context.pop('default_company_id', False)
-        return super(StockLot, self.with_context(context)).default_get(fields_list)
+        return super(StockLot, self.with_context(context)).default_get(fields)
 
     def _read_group_location_id(self, locations, domain):
         partner_locations = locations.search([('usage', 'in', ('customer', 'supplier'))])

--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -677,12 +677,12 @@ Please change the quantity done or the rounding precision in your settings.""",
                 and (move.picking_type_id.use_existing_lots or move.state == 'done' or move.origin_returned_move_id.id)
 
     @api.model
-    def default_get(self, fields_list):
+    def default_get(self, fields):
         # We override the default_get to make stock moves created after the picking was confirmed
         # directly as available in immediate transfer mode. This allows to create extra move lines
         # in the fp view. In planned transfer, the stock move are marked as `additional` and will be
         # auto-confirmed.
-        defaults = super(StockMove, self).default_get(fields_list)
+        defaults = super().default_get(fields)
         if self.env.context.get('default_picking_id'):
             picking_id = self.env['stock.picking'].browse(self.env.context['default_picking_id'])
             if picking_id.state == 'done':

--- a/addons/stock/models/stock_rule.py
+++ b/addons/stock/models/stock_rule.py
@@ -33,9 +33,9 @@ class StockRule(models.Model):
     _check_company_auto = True
 
     @api.model
-    def default_get(self, fields_list):
-        res = super().default_get(fields_list)
-        if 'company_id' in fields_list and not res['company_id']:
+    def default_get(self, fields):
+        res = super().default_get(fields)
+        if 'company_id' in fields and not res['company_id']:
             res['company_id'] = self.env.company.id
         return res
 

--- a/addons/stock_account/wizard/stock_valuation_layer_revaluation.py
+++ b/addons/stock_account/wizard/stock_valuation_layer_revaluation.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from collections import defaultdict
@@ -13,8 +12,8 @@ class StockValuationLayerRevaluation(models.TransientModel):
     _check_company_auto = True
 
     @api.model
-    def default_get(self, default_fields):
-        res = super().default_get(default_fields)
+    def default_get(self, fields):
+        res = super().default_get(fields)
         context = self.env.context
         if context.get('active_model') == 'stock.lot':
             # coming from action button where lot is group_by in valuation layer list view.
@@ -43,14 +42,14 @@ class StockValuationLayerRevaluation(models.TransientModel):
             if product.lot_valuated:
                 res['lot_ids'] = [(6, 0, product.stock_valuation_layer_ids.filtered(lambda layer: layer.remaining_qty != 0).lot_id.ids)]
 
-        if 'product_id' in default_fields:
+        if 'product_id' in fields:
             if not product:
                 raise UserError(_("You cannot adjust valuation without a product"))
             if product.cost_method == 'standard':
                 raise UserError(_("You cannot revalue a product with a standard cost method."))
             if product.quantity_svl <= 0:
                 raise UserError(_("You cannot revalue a product with an empty or negative stock."))
-            if 'account_journal_id' not in res and 'account_journal_id' in default_fields and product.valuation == 'real_time':
+            if 'account_journal_id' not in res and 'account_journal_id' in fields and product.valuation == 'real_time':
                 accounts = product.product_tmpl_id.get_product_accounts()
                 res['account_journal_id'] = accounts['stock_journal'].id
         return res

--- a/addons/stock_picking_batch/wizard/stock_add_to_wave.py
+++ b/addons/stock_picking_batch/wizard/stock_add_to_wave.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import fields, models, api, _
@@ -10,8 +9,8 @@ class StockAddToWave(models.TransientModel):
     _description = 'Wave Transfer Lines'
 
     @api.model
-    def default_get(self, fields_list):
-        res = super().default_get(fields_list)
+    def default_get(self, fields):
+        res = super().default_get(fields)
         if self.env.context.get('active_model') == 'stock.move.line':
             lines = self.env['stock.move.line'].browse(self.env.context.get('active_ids'))
             res['line_ids'] = self.env.context.get('active_ids')

--- a/addons/survey/models/survey_question.py
+++ b/addons/survey/models/survey_question.py
@@ -48,13 +48,13 @@ class SurveyQuestion(models.Model):
     _order = 'sequence,id'
 
     @api.model
-    def default_get(self, fields_list):
-        res = super().default_get(fields_list)
+    def default_get(self, fields):
+        res = super().default_get(fields)
         if default_survey_id := self.env.context.get('default_survey_id'):
             survey = self.env['survey.survey'].browse(default_survey_id)
-            if 'is_time_limited' in fields_list and 'is_time_limited' not in res:
+            if 'is_time_limited' in fields and 'is_time_limited' not in res:
                 res['is_time_limited'] = survey.session_speed_rating
-            if 'time_limit' in fields_list and 'time_limit' not in res:
+            if 'time_limit' in fields and 'time_limit' not in res:
                 res['time_limit'] = survey.session_speed_rating_time_limit
         return res
 

--- a/addons/survey/models/survey_survey.py
+++ b/addons/survey/models/survey_survey.py
@@ -26,11 +26,11 @@ class SurveySurvey(models.Model):
         return str(uuid.uuid4())
 
     @api.model
-    def default_get(self, fields_list):
-        result = super().default_get(fields_list)
+    def default_get(self, fields):
+        result = super().default_get(fields)
         # allows to propagate the text one write in a many2one widget after
         # clicking on 'Create and Edit...' to the popup form.
-        if 'title' in fields_list and not result.get('title') and self.env.context.get('default_name'):
+        if 'title' in fields and not result.get('title') and self.env.context.get('default_name'):
             result['title'] = self.env.context.get('default_name')
         return result
 

--- a/addons/utm/models/utm_source.py
+++ b/addons/utm/models/utm_source.py
@@ -1,6 +1,4 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 
 from odoo import _, api, fields, models
 from odoo.exceptions import ValidationError
@@ -61,9 +59,9 @@ class UtmSourceMixin(models.AbstractModel):
     source_id = fields.Many2one('utm.source', string='Source', required=True, ondelete='restrict', copy=False)
 
     @api.model
-    def default_get(self, fields_list):
-        # Exclude 'name' from fields_list to avoid retrieving it from context.
-        return super().default_get([field for field in fields_list if field != "name"])
+    def default_get(self, fields):
+        # Exclude 'name' from fields to avoid retrieving it from context.
+        return super().default_get([field for field in fields if field != "name"])
 
     @api.model_create_multi
     def create(self, vals_list):
@@ -90,20 +88,20 @@ class UtmSourceMixin(models.AbstractModel):
 
         return super().create(vals_list)
 
-    def write(self, values):
-        if (values.get(self._rec_name) or values.get('name')) and len(self) > 1:
+    def write(self, vals):
+        if (vals.get(self._rec_name) or vals.get('name')) and len(self) > 1:
             raise ValueError(
                 _('You cannot update multiple records with the same name. The name should be unique!')
             )
 
-        if values.get(self._rec_name) and not values.get('name'):
-            values['name'] = self.env['utm.source']._generate_name(self, values[self._rec_name])
-        if values.get('name'):
-            values['name'] = self.env['utm.mixin'].with_context(
+        if vals.get(self._rec_name) and not vals.get('name'):
+            vals['name'] = self.env['utm.source']._generate_name(self, vals[self._rec_name])
+        if vals.get('name'):
+            vals['name'] = self.env['utm.mixin'].with_context(
                 utm_check_skip_record_ids=self.source_id.ids
-            )._get_unique_names("utm.source", [values['name']])[0]
+            )._get_unique_names("utm.source", [vals['name']])[0]
 
-        return super().write(values)
+        return super().write(vals)
 
     def copy_data(self, default=None):
         """Increment the counter when duplicating the source."""

--- a/addons/web/models/models.py
+++ b/addons/web/models/models.py
@@ -2158,10 +2158,10 @@ class ResCompany(models.Model):
             self._update_asset_style()
         return companies
 
-    def write(self, values):
-        res = super().write(values)
+    def write(self, vals):
+        res = super().write(vals)
         style_fields = {'external_report_layout_id', 'font', 'primary_color', 'secondary_color'}
-        if not style_fields.isdisjoint(values):
+        if not style_fields.isdisjoint(vals):
             self._update_asset_style()
         return res
 

--- a/addons/website/models/mixins.py
+++ b/addons/website/models/mixins.py
@@ -233,17 +233,17 @@ class WebsitePublishedMixin(models.AbstractModel):
 
     @api.model_create_multi
     def create(self, vals_list):
-        records = super(WebsitePublishedMixin, self).create(vals_list)
+        records = super().create(vals_list)
         if any(record.is_published and not record.can_publish for record in records):
             raise AccessError(self._get_can_publish_error_message())
 
         return records
 
-    def write(self, values):
-        if 'is_published' in values and any(not record.can_publish for record in self):
+    def write(self, vals):
+        if 'is_published' in vals and any(not record.can_publish for record in self):
             raise AccessError(self._get_can_publish_error_message())
 
-        return super(WebsitePublishedMixin, self).write(values)
+        return super().write(vals)
 
     def create_and_get_website_url(self, **kwargs):
         return self.create(kwargs).website_url

--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -330,9 +330,10 @@ class Website(models.Model):
 
         return websites
 
-    def write(self, values):
+    def write(self, vals):
         public_user_to_change_websites = self.env['website']
         original_company = self.company_id
+        values = vals
         self._handle_create_write(values)
 
         self.env.registry.clear_cache()

--- a/addons/website/models/website_menu.py
+++ b/addons/website/models/website_menu.py
@@ -113,10 +113,10 @@ class WebsiteMenu(models.Model):
         # Only one record per vals is returned but multiple could have been created
         return menus
 
-    def write(self, values):
+    def write(self, vals):
         self.env.registry.clear_cache('templates')
-        res = super().write(values)
-        if 'group_ids' in values and not self.env.context.get("adding_designer_group_to_menu"):
+        res = super().write(vals)
+        if 'group_ids' in vals and not self.env.context.get("adding_designer_group_to_menu"):
             self.filtered("group_ids").with_context(
                 adding_designer_group_to_menu=True
             ).group_ids += self.env.ref("website.group_website_designer")

--- a/addons/website_crm_partner_assign/models/res_partner.py
+++ b/addons/website_crm_partner_assign/models/res_partner.py
@@ -7,14 +7,14 @@ class ResPartner(models.Model):
     _inherit = "res.partner"
 
     @api.model
-    def default_get(self, fields_list):
-        default_vals = super().default_get(fields_list)
+    def default_get(self, fields):
+        default_vals = super().default_get(fields)
         if self.env.context.get('partner_set_default_grade_activation'):
             # sets the lowest grade and activation if no default values given, mainly useful while
             # creating assigned partner on the fly (to make it visible in same m2o again)
-            if 'grade_id' in fields_list and not default_vals.get('grade_id'):
+            if 'grade_id' in fields and not default_vals.get('grade_id'):
                 default_vals['grade_id'] = self.env['res.partner.grade'].search([], order='sequence', limit=1).id
-            if 'activation' in fields_list and not default_vals.get('activation'):
+            if 'activation' in fields and not default_vals.get('activation'):
                 default_vals['activation'] = self.env['res.partner.activation'].search([], order='sequence', limit=1).id
         return default_vals
 

--- a/addons/website_event/models/event_tag.py
+++ b/addons/website_event/models/event_tag.py
@@ -1,15 +1,15 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import models
+from odoo import api, models
 
 
 class EventTag(models.Model):
     _name = 'event.tag'
     _inherit = ['event.tag', 'website.published.multi.mixin']
 
-    def default_get(self, fields_list):
-        result = super().default_get(fields_list)
+    @api.model
+    def default_get(self, fields):
+        result = super().default_get(fields)
         if self.env.context.get('default_website_id'):
             result['website_id'] = self.env.context.get('default_website_id')
         return result

--- a/addons/website_forum/models/forum_post_vote.py
+++ b/addons/website_forum/models/forum_post_vote.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import api, fields, models, _
@@ -57,14 +56,14 @@ class ForumPostVote(models.Model):
             vote._vote_update_karma('0', vote.vote)
         return votes
 
-    def write(self, values):
+    def write(self, vals):
         # can't modify owner of a vote
         if not self.env.is_admin():
-            values.pop('user_id', None)
+            vals.pop('user_id', None)
 
         for vote in self:
-            vote._check_general_rights(values)
-            vote_value = values.get('vote')
+            vote._check_general_rights(vals)
+            vote_value = vals.get('vote')
             if vote_value is not None:
                 upvote = vote.vote == '-1' if vote_value == '0' else vote_value == '1'
                 vote._check_karma_rights(upvote)
@@ -72,8 +71,7 @@ class ForumPostVote(models.Model):
                 # karma update
                 vote._vote_update_karma(vote.vote, vote_value)
 
-        res = super().write(values)
-        return res
+        return super().write(vals)
 
     def _check_general_rights(self, vals=None):
         if vals is None:

--- a/addons/website_sale/models/product_pricelist.py
+++ b/addons/website_sale/models/product_pricelist.py
@@ -69,8 +69,8 @@ class ProductPricelist(models.Model):
             self.env.registry.clear_cache()
         return pricelists
 
-    def write(self, data):
-        res = super().write(data)
+    def write(self, vals):
+        res = super().write(vals)
         self and self.env.registry.clear_cache()
         return res
 

--- a/addons/website_slides/models/slide_slide.py
+++ b/addons/website_slides/models/slide_slide.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import base64
@@ -591,7 +590,8 @@ class SlideSlide(models.Model):
                 slide.channel_id.channel_partner_ids._recompute_completion()
         return slides
 
-    def write(self, values):
+    def write(self, vals):
+        values = vals
         if values.get('is_category'):
             values['is_preview'] = True
             values['is_published'] = True

--- a/addons/website_slides/models/slide_slide_partner.py
+++ b/addons/website_slides/models/slide_slide_partner.py
@@ -34,13 +34,13 @@ class SlideSlidePartner(models.Model):
             completed._recompute_completion()
         return res
 
-    def write(self, values):
+    def write(self, vals):
         slides_completion_to_recompute = self.env['slide.slide.partner']
-        if 'completed' in values:
+        if 'completed' in vals:
             slides_completion_to_recompute = self.filtered(
-                lambda slide_partner: slide_partner.completed != values['completed'])
+                lambda slide_partner: slide_partner.completed != vals['completed'])
 
-        res = super().write(values)
+        res = super().write(vals)
 
         if slides_completion_to_recompute:
             slides_completion_to_recompute._recompute_completion()

--- a/addons/website_slides_survey/models/slide_slide.py
+++ b/addons/website_slides_survey/models/slide_slide.py
@@ -105,10 +105,10 @@ class SlideSlide(models.Model):
         slides_with_survey._ensure_challenge_category()
         return slides
 
-    def write(self, values):
+    def write(self, vals):
         old_surveys = self.mapped('survey_id')
-        result = super().write(values)
-        if 'survey_id' in values:
+        result = super().write(vals)
+        if 'survey_id' in vals:
             self._ensure_challenge_category(old_surveys=old_surveys - self.mapped('survey_id'))
         return result
 

--- a/odoo/addons/base/models/decimal_precision.py
+++ b/odoo/addons/base/models/decimal_precision.py
@@ -32,8 +32,8 @@ class DecimalPrecision(models.Model):
         self.env.registry.clear_cache()
         return res
 
-    def write(self, data):
-        res = super().write(data)
+    def write(self, vals):
+        res = super().write(vals)
         self.env.registry.clear_cache()
         return res
 

--- a/odoo/addons/base/models/ir_asset.py
+++ b/odoo/addons/base/models/ir_asset.py
@@ -67,10 +67,10 @@ class IrAsset(models.Model):
         self.env.registry.clear_cache('assets')
         return super().create(vals_list)
 
-    def write(self, values):
+    def write(self, vals):
         if self:
             self.env.registry.clear_cache('assets')
-        return super().write(values)
+        return super().write(vals)
 
     def unlink(self):
         self.env.registry.clear_cache('assets')

--- a/odoo/addons/base/models/ir_cron.py
+++ b/odoo/addons/base/models/ir_cron.py
@@ -112,12 +112,12 @@ class IrCron(models.Model):
         return super().create(vals_list)
 
     @api.model
-    def default_get(self, fields_list):
+    def default_get(self, fields):
         # only 'code' state is supported for cron job so set it as default
         model = self
         if not model.env.context.get('default_state'):
             model = model.with_context(default_state='code')
-        return super(IrCron, model).default_get(fields_list)
+        return super(IrCron, model).default_get(fields)
 
     def method_direct_trigger(self):
         """Run the CRON job in the current (HTTP) thread.

--- a/odoo/addons/base/models/ir_model.py
+++ b/odoo/addons/base/models/ir_model.py
@@ -2131,15 +2131,15 @@ class IrModelAccess(models.Model):
                     ima.get("perm_create"),
                     ima.get("perm_unlink")]):
                 _logger.warning("Rule %s has no group, this is a deprecated feature. Every access-granting rule should specify a group.", ima['name'])
-        return super(IrModelAccess, self).create(vals_list)
+        return super().create(vals_list)
 
-    def write(self, values):
+    def write(self, vals):
         self.call_cache_clearing_methods()
-        return super(IrModelAccess, self).write(values)
+        return super().write(vals)
 
     def unlink(self):
         self.call_cache_clearing_methods()
-        return super(IrModelAccess, self).unlink()
+        return super().unlink()
 
 
 class IrModelData(models.Model):
@@ -2251,10 +2251,10 @@ class IrModelData(models.Model):
             self.env.registry.clear_cache('groups')
         return res
 
-    def write(self, values):
+    def write(self, vals):
         self.env.registry.clear_cache()  # _xmlid_lookup
-        res = super().write(values)
-        if values.get('model') == 'res.groups':
+        res = super().write(vals)
+        if vals.get('model') == 'res.groups':
             self.env.registry.clear_cache('groups')
         return res
 
@@ -2263,7 +2263,7 @@ class IrModelData(models.Model):
         self.env.registry.clear_cache()  # _xmlid_lookup
         if self and any(data.model == 'res.groups' for data in self.exists()):
             self.env.registry.clear_cache('groups')
-        return super(IrModelData, self).unlink()
+        return super().unlink()
 
     def _lookup_xmlids(self, xml_ids, model):
         """ Look up the given XML ids of the given model. """

--- a/odoo/addons/base/models/ir_ui_menu.py
+++ b/odoo/addons/base/models/ir_ui_menu.py
@@ -154,13 +154,13 @@ class IrUiMenu(models.Model):
         for values in vals_list:
             if 'web_icon' in values:
                 values['web_icon_data'] = self._compute_web_icon_data(values.get('web_icon'))
-        return super(IrUiMenu, self).create(vals_list)
+        return super().create(vals_list)
 
-    def write(self, values):
+    def write(self, vals):
         self.env.registry.clear_cache()
-        if 'web_icon' in values:
-            values['web_icon_data'] = self._compute_web_icon_data(values.get('web_icon'))
-        return super(IrUiMenu, self).write(values)
+        if 'web_icon' in vals:
+            vals['web_icon_data'] = self._compute_web_icon_data(vals.get('web_icon'))
+        return super().write(vals)
 
     def _compute_web_icon_data(self, web_icon):
         """ Returns the image associated to ``web_icon``.

--- a/odoo/addons/base/models/res_partner.py
+++ b/odoo/addons/base/models/res_partner.py
@@ -196,14 +196,14 @@ class ResPartner(models.Model):
         return self.env['res.partner.category'].browse(self.env.context.get('category_id'))
 
     @api.model
-    def default_get(self, default_fields):
+    def default_get(self, fields):
         """Add the company of the parent as default if we are creating a child partner. """
-        values = super().default_get(default_fields)
-        if 'parent_id' in default_fields and values.get('parent_id'):
+        values = super().default_get(fields)
+        if 'parent_id' in fields and values.get('parent_id'):
             parent = self.browse(values.get('parent_id'))
             values['company_id'] = parent.company_id.id
         # protection for `default_type` values leaking from menu action context (e.g. for crm's email)
-        if 'type' in default_fields and values.get('type'):
+        if 'type' in fields and values.get('type'):
             if values['type'] not in self._fields['type'].get_values(self.env):
                 values['type'] = None
         return values

--- a/odoo/addons/base/models/res_users.py
+++ b/odoo/addons/base/models/res_users.py
@@ -587,36 +587,36 @@ class ResUsers(models.Model):
             self.env['res.users.settings'].sudo().create(setting_vals)
         return users
 
-    def write(self, values):
-        if values.get('active') and SUPERUSER_ID in self._ids:
+    def write(self, vals):
+        if vals.get('active') and SUPERUSER_ID in self._ids:
             raise UserError(_("You cannot activate the superuser."))
-        if values.get('active') == False and self.env.uid in self._ids:  # noqa: E712
+        if vals.get('active') == False and self.env.uid in self._ids:  # noqa: E712
             raise UserError(_("You cannot deactivate the user you're currently logged in as."))
 
-        if values.get('active'):
+        if vals.get('active'):
             # unarchive partners before unarchiving the users
             self.partner_id.action_unarchive()
         if self == self.env.user:
             writeable = self._self_accessible_fields()[1]
-            for key in list(values):
+            for key in list(vals):
                 if key not in writeable:
                     break
             else:
-                if 'company_id' in values:
-                    if values['company_id'] not in self.env.user.company_ids.ids:
-                        del values['company_id']
+                if 'company_id' in vals:
+                    if vals['company_id'] not in self.env.user.company_ids.ids:
+                        del vals['company_id']
                 # safe fields only, so we write as super-user to bypass access rights
                 self = self.sudo()
 
-        res = super().write(values)
+        res = super().write(vals)
 
-        if 'company_id' in values:
+        if 'company_id' in vals:
             for user in self:
                 # if partner is global we keep it that way
-                if user.partner_id.company_id and user.partner_id.company_id.id != values['company_id']:
+                if user.partner_id.company_id and user.partner_id.company_id.id != vals['company_id']:
                     user.partner_id.write({'company_id': user.company_id.id})
 
-        if 'company_id' in values or 'company_ids' in values:
+        if 'company_id' in vals or 'company_ids' in vals:
             # Reset lazy properties `company` & `companies` on all envs,
             # This is unlikely in a business code to change the company of a user and then do business stuff
             # but in case it happens this is handled.
@@ -625,7 +625,7 @@ class ResUsers(models.Model):
                 if env.user in self:
                     reset_cached_properties(env)
 
-        if 'group_ids' in values and self.ids:
+        if 'group_ids' in vals and self.ids:
             # clear caches linked to the users
             self.env['ir.model.access'].call_cache_clearing_methods()
 
@@ -633,7 +633,7 @@ class ResUsers(models.Model):
         # clear_cache/clear_caches methods pretty much just end up calling
         # Registry.clear_cache
         invalidation_fields = self._get_invalidation_fields()
-        if invalidation_fields & values.keys():
+        if invalidation_fields & vals.keys():
             self.env.registry.clear_cache()
 
         return res
@@ -1347,9 +1347,9 @@ class UsersMultiCompany(models.Model):
                     user.write({'group_ids': [Command.link(group_multi_company_id)]})
         return users
 
-    def write(self, values):
-        res = super().write(values)
-        if 'company_ids' not in values:
+    def write(self, vals):
+        res = super().write(vals)
+        if 'company_ids' not in vals:
             return res
         group_multi_company_id = self.env['ir.model.data']._xmlid_to_res_id(
             'base.group_multi_company', raise_if_not_found=False)

--- a/odoo/addons/test_lint/tests/test_override_signatures.py
+++ b/odoo/addons/test_lint/tests/test_override_signatures.py
@@ -27,8 +27,6 @@ MODULES_TO_IGNORE = {
     'pos_blackbox_be',  # TODO cannot update to sanitize without certification
 }
 METHODS_TO_IGNORE = {
-    # Not yet sanitized...
-    'write', 'default_get',
     # base
     'action_timer_stop',
     '_get_eval_context',

--- a/odoo/orm/models.py
+++ b/odoo/orm/models.py
@@ -1261,12 +1261,12 @@ class BaseModel(metaclass=MetaModel):
                 check(records)
 
     @api.model
-    def default_get(self, fields_list: Sequence[str]) -> ValuesType:
+    def default_get(self, fields: Sequence[str]) -> ValuesType:
         """Return default values for the fields in ``fields_list``. Default
         values are determined by the context, user defaults, user fallbacks
         and the model itself.
 
-        :param fields_list: names of field whose default is requested
+        :param fields: names of field whose default is requested
         :return: a dictionary mapping field names to their corresponding default values,
             if they have a default value.
 
@@ -1279,7 +1279,7 @@ class BaseModel(metaclass=MetaModel):
         parent_fields = defaultdict(list)
         ir_defaults = self.env['ir.default']._get_model_defaults(self._name)
 
-        for name in fields_list:
+        for name in fields:
             # 1. look up context
             key = 'default_' + name
             if key in self.env.context:


### PR DESCRIPTION
Aligning the arguments with the parent definition.

This is required to make RPC calls work with keyword arguments. Right now, sometimes you need to call `write(vals)` or `write(values)` depending on the model and on the installed modules.

- `write(self, vals)`
- `default_get(self, fields)` (api.model) parameter named aligned to
  other methods

odoo/enterprise#89944


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
