### PR TITLE
[FIX] website_sale: fix cart actions with full-width product images

### DIFF
--- a/addons/website_sale/static/src/js/website_sale.js
+++ b/addons/website_sale/static/src/js/website_sale.js
@@ -314,7 +314,7 @@ export const WebsiteSale = publicWidget.Widget.extend(VariantMixin, {
     async _onClickAdd(ev) {
         ev.preventDefault();
         var def = () => {
-            this._updateRootProduct((ev.currentTarget).closest('form'));
+            this._updateRootProduct(document.querySelector('form#product_details_form'));
             const isBuyNow = ev.currentTarget.classList.contains('o_we_buy_now');
             const isConfigured = ev.currentTarget.parentElement.id === 'add_to_cart_wrap';
             const showQuantity = Boolean(ev.currentTarget.dataset.showQuantity);
@@ -570,7 +570,7 @@ export const WebsiteSale = publicWidget.Widget.extend(VariantMixin, {
             // Variants list view
             'input[type="radio"][name="product_id"]:checked',
         ].join(','))?.value);
-        const quantity = parseFloat(form.querySelector('input[name="add_qty"]')?.value);
+        const quantity = parseFloat(document.querySelector('input[name="add_qty"]')?.value);
         const uomId = this._getUoMId(form);
         const isCombo = form.querySelector(
             'input[type="hidden"][name="product_type"]'

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -1978,7 +1978,7 @@
                                             t-value="product_variant.all_product_tag_ids"
                                         />
                                     </t>
-                                    <form t-if="product._is_add_to_cart_possible()">
+                                    <form t-if="product._is_add_to_cart_possible()" id="product_details_form">
                                         <input
                                             type="hidden"
                                             name="csrf_token"
@@ -2127,7 +2127,7 @@
                                     />
                                 </div>
                                 <div
-                                    t-if="is_fullwidth_content"
+                                    t-if="is_fullwidth_content and product._is_add_to_cart_possible()"
                                     t-attf-class="col-lg-4 offset-lg-1"
                                 >
                                     <div class="o_wsale_product_sticky_col position-sticky">


### PR DESCRIPTION
Recent design changes from this PR: https://github.com/odoo/odoo/pull/201019 caused the `Add to Cart`, `Buy Now` buttons, and quantity selector to be moved outside the main `<form>` element on the product page — specifically when the product image is full width or has zero size.

Steps to reproduce:
- Install eCommerce
- Edit a product page and set the product image to full width or zero width
- Try to add the product to the cart or use Buy Now

Issue:
- Clicking `Add to Cart` or `Buy Now` throws a traceback
- The product cannot be ordered when using full-width images

Root cause:
- The buttons and quantity selector are no longer inside the expected `<form>`, so the selector used in the JS widget fails to find the right form data.

Fix:
- Update the selector to correctly target the intended `<form>` so the widget can fetch the correct product details when a button is clicked.

opw-4934557
Affected version: saas~18.4

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
