### PR TITLE
[FIX] website: prevent error when multiple views has the same key

### DIFF
--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -1090,7 +1090,7 @@ class Website(models.Model):
                 order = View._order
             views = View.with_context(active_test=False).search(domain, order=order)
             if views:
-                view = views.filter_duplicate()
+                view = views.filter_duplicate()[:1]
             else:
                 # we handle the raise below
                 view = self.env.ref(view_id, raise_if_not_found=False)


### PR DESCRIPTION
Backport of https://github.com/odoo/odoo/commit/fb4e7151907b9f5b1c9d27a7a75c2431309d5e09

When multiple `ir.ui.view` records exist with the same key
(e.g., due to duplication), it can lead to a singleton error.

Steps to reproduce:
1. Install the website module
2. Go to Settings > Technical > User Interface > Views.
3. Find and duplicate the Home view for My Website (same key).
4. Open the website home page in Editor mode.

Error:
`ValueError - Expected singleton: ir.ui.view(2776, 2774)`

Cause:
In `viewref()`, it uses `filter_duplicate()` to filter for the
most suitable view, but it may return multiple views if more
than one match the criteria. - [1]

Ref:
At [2], system uses `limit=1` in `_view_obj()` to
ensure only one view is returned, even if duplicates
exist for the same key.

[1]: https://github.com/odoo/odoo/blob/edfa37271a0015a0d4acb17e6985a87e707e5f33/addons/website/models/website.py#L1228-L1230

[2]: https://github.com/odoo/odoo/blob/51fcbd211d2b1abf4b93becedbcbb9e03002cdd6/addons/web_editor/models/ir_ui_view.py#L326

Fix:
This commit ensures that the result is a record set with at
most one view and preventing singleton-related errors.

sentry-6223988092
