### PR TITLE
[FIX] sale_project_stock: Added post_install to profitability tests

### DIFF
--- a/addons/sale_project_stock/tests/test_sale_project_stock_profitability.py
+++ b/addons/sale_project_stock/tests/test_sale_project_stock_profitability.py
@@ -2,8 +2,10 @@
 
 from odoo import Command, fields
 from odoo.addons.sale_project.tests.test_project_profitability import TestProjectProfitabilityCommon
+from odoo.tests.common import tagged
 
 
+@tagged("post_install", "-at_install")
 class TestSaleProjectStockProfitability(TestProjectProfitabilityCommon):
     @classmethod
     def setUpClass(cls):


### PR DESCRIPTION
One of the tests failed without demo data due to a lacking stock accounting account. Since the test requires the Chart of Accounts, it was moved to post-install.

runbot error: [163084](https://runbot.odoo.com/odoo/error/163084)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
