### PR TITLE
[FIX] html_builder, website: copied web images get saved as attachments

### DIFF
--- a/addons/html_builder/static/src/builder.js
+++ b/addons/html_builder/static/src/builder.js
@@ -133,6 +133,7 @@ export class Builder extends Component {
                 updateInvisibleElementsPanel: () => this.updateInvisibleEls(),
                 allowCustomStyle: true,
                 allowTargetBlank: true,
+                dropImageAsAttachment: true,
                 getAnimateTextConfig: () => ({ editor: this.editor, editorBus: this.editorBus }),
             },
             this.env.services


### PR DESCRIPTION
Before this commit copying an image from the web and pasting it into a text snippet in the website editor would cause
the image to be saved as base64 instead of being properly converted into an attachment.

Steps to reproduce
- open editor
- add a text snippet
- go to Google images, find an image and copy it (copy the image itself, not the link)
- paste the image in the text snippet
- save and quit the editor
=> the image is saved as a base64 img

After the change images get properly saved as attachments.
