### PR TITLE
[FIX] contacts: nightly test with single app

### DIFF
--- a/addons/contacts/tests/test_ui.py
+++ b/addons/contacts/tests/test_ui.py
@@ -41,6 +41,7 @@ class TestUi(odoo.tests.HttpCase):
         # call get view to warm the cache
         partner.get_view()
 
+        self.env.user.company_id.country_id = self.env.ref('base.us')
         self.env.user.company_id.country_id.vat_label = "TVA"
         view = partner.get_view()
 


### PR DESCRIPTION
**PROBLEM**
`test_vat_label_string` fail on nightly test

**CAUSE**
`self.env.user.company_id.country_id` is empty because:
- we don't load demo data by default starting from 18.3
- we installed only one app, so the module that sets the default company country (there must be one since runbot non-nightly tests passed) isn't installed.

**FIX**
set the country to US in the test, so we have a country to work with.

see https://runbot.odoo.com/odoo/error/229770