### PR TITLE
[IMP] *: forbid names reserved by RPC

### DIFF
--- a/addons/account/models/account_root.py
+++ b/addons/account/models/account_root.py
@@ -15,6 +15,7 @@ class AccountRoot(models.Model):
     name = fields.Char(compute='_compute_root')
     parent_id = fields.Many2one('account.root', compute='_compute_root')
 
+    @api.private
     def browse(self, ids=()):
         if isinstance(ids, str):
             ids = (ids,)

--- a/addons/product_expiry/models/stock_move.py
+++ b/addons/product_expiry/models/stock_move.py
@@ -16,10 +16,10 @@ class StockMove(models.Model):
         string='Use Expiration Date', related='product_id.use_expiration_date')
 
     @api.model
-    def action_generate_lot_line_vals(self, context, mode, first_lot, count, lot_text):
-        vals_list = super().action_generate_lot_line_vals(context, mode, first_lot, count, lot_text)
-        product = self.env['product.product'].browse(context.get('default_product_id'))
-        picking = self.env['stock.picking'].browse(context.get('default_picking_id'))
+    def action_generate_lot_line_vals(self, context_data, mode, first_lot, count, lot_text):
+        vals_list = super().action_generate_lot_line_vals(context_data, mode, first_lot, count, lot_text)
+        product = self.env['product.product'].browse(context_data.get('default_product_id'))
+        picking = self.env['stock.picking'].browse(context_data.get('default_picking_id'))
         if product.use_expiration_date:
             from_date = picking.scheduled_date or fields.Datetime.today()
             expiration_date = from_date + datetime.timedelta(days=product.expiration_time)

--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -1011,8 +1011,8 @@ Please change the quantity done or the rounding precision in your settings.""",
         return move_lines_vals
 
     @api.model
-    def action_generate_lot_line_vals(self, context, mode, first_lot, count, lot_text):
-        if not context.get('default_product_id'):
+    def action_generate_lot_line_vals(self, context_data, mode, first_lot, count, lot_text):
+        if not context_data.get('default_product_id'):
             raise UserError(_("No product found to generate Serials/Lots for."))
         assert mode in ('generate', 'import')
         default_vals = {}
@@ -1032,9 +1032,9 @@ Please change the quantity done or the rounding precision in your settings.""",
             if text.startswith(prefix):
                 return text[len(prefix):]
             return text
-        for key in context:
+        for key in context_data:
             if key.startswith('default_'):
-                default_vals[remove_prefix(key, 'default_')] = context[key]
+                default_vals[remove_prefix(key, 'default_')] = context_data[key]
 
         if default_vals['tracking'] == 'lot' and mode == 'generate':
             lot_qties = generate_lot_qty(default_vals['quantity'], count)

--- a/addons/web_editor/models/ir_qweb_fields.py
+++ b/addons/web_editor/models/ir_qweb_fields.py
@@ -282,10 +282,10 @@ class IrQwebFieldContact(models.AbstractModel):
             attrs['data-oe-contact-options'] = json.dumps(options)
         return attrs
 
-    # helper to call the rendering of contact field
     @api.model
-    def get_record_to_html(self, ids, options=None):
-        return self.value_to_html(self.env['res.partner'].search([('id', '=', ids[0])]), options=options)
+    def get_record_to_html(self, contact_ids, options=None):
+        """ Helper to call the rendering of contact field. """
+        return self.value_to_html(self.env['res.partner'].search([('id', '=', contact_ids[0])]), options=options)
 
 
 class IrQwebFieldDate(models.AbstractModel):

--- a/odoo/addons/test_lint/tests/__init__.py
+++ b/odoo/addons/test_lint/tests/__init__.py
@@ -9,6 +9,7 @@ from . import test_jstranslate
 from . import test_l10n
 from . import test_manifests
 from . import test_markers
+from . import test_naming
 from . import test_onchange_domains
 from . import test_orm_import
 from . import test_override_signatures

--- a/odoo/addons/test_lint/tests/test_naming.py
+++ b/odoo/addons/test_lint/tests/test_naming.py
@@ -1,0 +1,27 @@
+import inspect
+
+from odoo.modules.registry import Registry
+from odoo.tests.common import get_db_name, tagged
+
+from .lint_case import LintCase
+
+
+@tagged('-at_install', 'post_install')
+class TestNaming(LintCase):
+    failureException = TypeError
+
+    def test_parameter_rpc_compatible(self):
+        """Parameters "ids" and "context" are not allowed in public methods.
+        These conflict with standard parameters used in RPC calls.
+        """
+        INVALID_NAMES = {'ids', 'context'}
+        registry = Registry(get_db_name())
+
+        for model_name, model_cls in registry.items():
+            for method_name, method in inspect.getmembers(model_cls, inspect.isroutine):
+                if method_name.startswith('_') or getattr(method, '_api_private', False):
+                    continue
+
+                with self.subTest(model=model_name, method=method_name):
+                    signature = inspect.signature(method)
+                    self.assertFalse(INVALID_NAMES.intersection(signature.parameters), "Invalid parameter names found")


### PR DESCRIPTION
`ids` and `context` are reserved for RPC calls and cannot be used as paramter names for public functions.

odoo/enterprise#89953


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
