### PR TITLE
[FIX] website: re-initialize progress bar interval

### DIFF
--- a/addons/website/static/src/components/website_loader/website_loader.js
+++ b/addons/website/static/src/components/website_loader/website_loader.js
@@ -158,9 +158,6 @@ export class WebsiteLoader extends Component {
      * Initializes the progress bar.
      */
     initProgressBar() {
-        if (this.updateProgressInterval) {
-            return;
-        }
         // The progress speed decreases as it approaches its limit. This way,
         // users have the feeling that the website creation progressing is fast
         // and we prevent them from leaving the page too early (because they


### PR DESCRIPTION
__Current behavior before commit:__
When switching a theme, the website loader is displayed with a progress bar. When the operation is finished, the loader is hidden and the progress bar interval is cleared.

However, the variable holding the interval ID is not being reset. If the user switch theme a second time, the `initProgressBar` method doesn't start a new interval because its initial guard finds the old interval ID and exit prematurely.

This resulted in the progress bar appearing to be stuck.

__Description of the fix:__
This commit fixes the issue by removing the initial guard of the `initProgressBar` method.

__Steps to reproduce:__
1. Open the Website builder
2. Click on the "Theme" tab
3. Click on "Switch Theme"
4. Choose a Theme
5. The loader is progressing
6. Do every steps again
7. The loader is stuck at the beginning
