### PR TITLE
[FIX] html_editor: buttons in navbar are not wrapped by zwnbsp/feff properly

### DIFF
--- a/addons/html_editor/static/src/main/link/link_selection_odoo_plugin.js
+++ b/addons/html_editor/static/src/main/link/link_selection_odoo_plugin.js
@@ -9,7 +9,7 @@ export class OdooLinkSelectionPlugin extends Plugin {
                 [link, ...link.querySelectorAll("*")].some(
                     (el) => el.nodeName === "IMG" || isBlock(el)
                 ),
-            (link) => link.matches("nav a, a.nav-link"),
+            (link) => link.matches("a.nav-link"),
         ],
         ineligible_link_for_selection_indication_predicates: (link) => link.matches(".btn"),
     };

--- a/addons/html_editor/static/tests/link/isolated.test.js
+++ b/addons/html_editor/static/tests/link/isolated.test.js
@@ -327,13 +327,6 @@ test("should not zwnbsp-pad nav-link", async () => {
     });
 });
 
-test("should not zwnbsp-pad in nav", async () => {
-    await testEditor({
-        contentBefore: '<nav>a<a href="http://test.test/">[]b</a>c</nav>',
-        contentBeforeEdit: '<nav>a<a href="http://test.test/">[]b</a>c</nav>',
-    });
-});
-
 test("should not zwnbsp-pad link with block fontawesome", async () => {
     await testEditor({
         contentBefore:


### PR DESCRIPTION
reproduction:
1. Go to website, and edit the website
2. In the navigation bar, the `contact us` button cannot be fully edited, e.g. when editing the text inside the button, when delete all the text and then add new text, the button is removed

**Before this commit:**
Buttons in the navbar without the `nav-link` class were excluded from the `feff` padding. In saas-18.3, even without introducing the new website builder or using the html editor, the issue is still there. This suggests that the old `zwnbsp` padding mechanism also excluded these buttons in the navbar. However, since editing a button in the navbar follows the same flow as editing one in the main editing area, these buttons should be properly padded like normal buttons.

**After this commit:**
Buttons in the navbar without the `nav-link` class are now padded like normal buttons in the main editing area, to make sure the text inside the button can be fully edited.

task-4898446


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
