### PR TITLE
[FIX] stock: prevent error raise on MTO route delete

### DIFF
--- a/addons/stock/models/res_config_settings.py
+++ b/addons/stock/models/res_config_settings.py
@@ -56,12 +56,12 @@ class ResConfigSettings(models.TransientModel):
     replenish_on_order = fields.Boolean("Replenish on Order (MTO)", compute='_compute_replenish_on_order', inverse='_inverse_replenish_on_order')
 
     def _compute_replenish_on_order(self):
-        route = self.env.ref('stock.route_warehouse0_mto')
+        route = self.env.ref('stock.route_warehouse0_mto', raise_if_not_found=False)
         if route:
             self.replenish_on_order = route.active
 
     def _inverse_replenish_on_order(self):
-        route = self.env.ref('stock.route_warehouse0_mto')
+        route = self.env.ref('stock.route_warehouse0_mto', raise_if_not_found=False)
         if route:
             route.active = self.replenish_on_order
 


### PR DESCRIPTION
Problem:
When MTO route is deleted from routes, an error will be raised in the settings and it will be unaccessible.

Solution:
Set `raise_if_not_found` to false when accessing the MTO route in the compute/inverse.

Steps to reproduce:
1. Enable Multi-Step Routes and Replenish on Order (MTO) from settings
2. Go to Inventory > Configuration > Routes
3. Delete Replenish on Order (MTO) route
4. Go back to settings --> Settings will raise an error.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
