### PR TITLE
[FIX] point_of_sale: prevent 0 as login number in order references

### DIFF
--- a/addons/point_of_sale/static/src/app/models/pos_order.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order.js
@@ -375,27 +375,6 @@ export class PosOrder extends Base {
         return this.lines.length === 0;
     }
 
-    generate_unique_id() {
-        // Generates a public identification number for the order.
-        // The generated number must be unique and sequential. They are made 12 digit long
-        // to fit into EAN-13 barcodes, should it be needed
-
-        function zero_pad(num, size) {
-            var s = "" + num;
-            while (s.length < size) {
-                s = "0" + s;
-            }
-            return s;
-        }
-        return (
-            zero_pad(this.session.id, 5) +
-            "-" +
-            zero_pad(this.session.login_number, 3) +
-            "-" +
-            zero_pad(this.sequence_number, 4)
-        );
-    }
-
     updateSavedQuantity() {
         this.lines.forEach((line) => line.updateSavedQuantity());
     }

--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -254,7 +254,7 @@ export class PosStore extends Reactive {
     }
 
     async closingSessionNotification(data) {
-        if (data.login_number == this.session.login_number) {
+        if (data.login_number == odoo.login_number) {
             return;
         }
 
@@ -1038,7 +1038,7 @@ export class PosStore extends Reactive {
         return (
             zero_pad(this.session.id, 5) +
             "-" +
-            zero_pad(this.session.login_number, 3) +
+            zero_pad(parseInt(odoo.login_number), 3) +
             "-" +
             zero_pad(this.getNextSequenceNumber(), 4)
         );
@@ -1149,7 +1149,7 @@ export class PosStore extends Reactive {
     getSyncAllOrdersContext(orders, options = {}) {
         return {
             config_id: this.config.id,
-            login_number: this.session.login_number,
+            login_number: parseInt(odoo.login_number),
             ...(options.context || {}),
         };
     }


### PR DESCRIPTION
Before this commit, it was possible for the session to assign `0` as a login number. This resulted in order references containing `000` in the middle, leading to various issues. Additionally, other parts of the code that relied on the session's login number were also using an incorrect value.

This problem occurred because the `session.login_number` is not stable; it gets updated whenever the PoS session record itself is modified, potentially overriding a valid login number with `0`. The fix involves changing the code to use `odoo.login_number` instead, which provides a reliable and consistent login number.

To reproduce the issue:
1. Open one PoS session on two different devices.
2. Log in with an employee on the first device.
3. Log in with a different employee on the second device.
4. Create a new order on the first device. You would observe that the login number in the order reference is `0`.

opw-4861456

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
