### PR TITLE
[FIX] pos_restaurant: fix error when opening table

### DIFF
--- a/addons/pos_restaurant/static/src/app/services/pos_store.js
+++ b/addons/pos_restaurant/static/src/app/services/pos_store.js
@@ -647,7 +647,7 @@ patch(PosStore.prototype, {
                 if (orders[0].getScreenData().name === "PaymentScreen") {
                     props.orderUuid = orders[0].uuid;
                 }
-                this.showScreen(orders[0].getScreenData().name, props);
+                this.showScreen(orders[0].getScreenData().name || "ProductScreen", props);
             } else {
                 this.addNewOrder({ table_id: table });
                 this.showScreen("ProductScreen");


### PR DESCRIPTION
Fix error appearing when trying to open a table in POS restaurant, with an empty screen name.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
