### PR TITLE
[FIX] im_livechat: compute chatbot step from sequence number

### DIFF
--- a/addons/im_livechat/controllers/chatbot.py
+++ b/addons/im_livechat/controllers/chatbot.py
@@ -81,6 +81,7 @@ class LivechatChatbotScriptController(http.Controller):
                 'isLast': next_step._is_last_step(discuss_channel),
                 'message': plaintext2html(next_step.message) if not is_html_empty(next_step.message) else False,
                 'type': next_step.step_type,
+                'sequence': next_step.sequence,
             }
         }
 

--- a/addons/im_livechat/static/src/embed/common/chatbot/chatbot_service.js
+++ b/addons/im_livechat/static/src/embed/common/chatbot/chatbot_service.js
@@ -412,7 +412,7 @@ export class ChatBotService {
     }
 
     get isRestoringSavedState() {
-        return this.savedState?._chatbotCurrentStep.id > this.currentStep?.id;
+        return this.savedState?._chatbotCurrentStep.sequence > this.currentStep?.sequence;
     }
 }
 

--- a/addons/im_livechat/static/src/embed/common/chatbot/chatbot_step_model.js
+++ b/addons/im_livechat/static/src/embed/common/chatbot/chatbot_step_model.js
@@ -29,6 +29,8 @@ import { assignDefined } from "@mail/utils/common/misc";
 export class ChatbotStep {
     /** @type {number} */
     id;
+    /** @type {number} */
+    sequence;
     /** @type {StepAnswer[]} */
     answers = [];
     /** @type {string} */
@@ -53,6 +55,7 @@ export class ChatbotStep {
             "hasAnswer",
             "type",
             "isEmailValid",
+            "sequence",
         ]);
         this.hasAnswer = data.hasAnswer ?? Boolean(data.selectedAnswerId);
     }

--- a/addons/website_livechat/static/tests/tours/website_livechat_chatbot_restore_state.js
+++ b/addons/website_livechat/static/tests/tours/website_livechat_chatbot_restore_state.js
@@ -1,0 +1,25 @@
+/** @odoo-module */
+
+import { registry } from "@web/core/registry";
+
+registry.category("web_tour.tours").add("website_livechat.chatbot_restore_state_tour", {
+    test: true,
+    url: "/contactus",
+    shadow_dom: ".o-livechat-root",
+    steps: () => [
+        {
+            trigger: ".o-livechat-LivechatButton",
+        },
+        {
+            trigger: ".o-mail-Message:contains(How can I help you?)",
+            run: () => {
+                const chatbotService = odoo.__WOWL_DEBUG__.root.env.services["im_livechat.chatbot"];
+                if (chatbotService.isRestoringSavedState) {
+                    throw new Error(
+                        "Chatbot should not be restoring state at this stage."
+                    );
+                }
+            },
+        },
+    ],
+});


### PR DESCRIPTION
before this commit, `isRestoringSavedState` was computed by comparing chatbotStep IDs instead of the sequence number. This is an unreliable method that could lead to unexpected restart of the chatbot flow if the user created their steps in a certain order then swapped that order around.
Besides, the field `sequence` is precisely meant to track this state. This commit adds `sequence` and computes the `isRestoringSavedState` based on that sequence.

opw-4858896
