### PR TITLE
[FIX] pos_loyalty: fix partner name in tests

### DIFF
--- a/addons/pos_loyalty/static/tests/tours/pos_loyalty_loyalty_program_tour.js
+++ b/addons/pos_loyalty/static/tests/tours/pos_loyalty_loyalty_program_tour.js
@@ -319,7 +319,7 @@ registry.category("web_tour.tours").add("PosLoyaltyMultipleOrders", {
             // Order1: Add a product and leave the order in draft.
             ProductScreen.addOrderline("Whiteboard Pen", "2"),
             ProductScreen.clickPartnerButton(),
-            ProductScreen.clickCustomer("Test Partner"),
+            ProductScreen.clickCustomer("Partner Test 1"),
             ProductScreen.clickPayButton(),
             PaymentScreen.clickPaymentMethod("Cash"),
 

--- a/addons/pos_loyalty/tests/test_frontend.py
+++ b/addons/pos_loyalty/tests/test_frontend.py
@@ -870,7 +870,7 @@ class TestUi(TestPointOfSaleHttpCommon):
             })],
         })
 
-        partner = self.env['res.partner'].create({'name': 'Test Partner'})
+        partner = self.env['res.partner'].create({'name': 'Partner Test 1'})
         card = self.env['loyalty.card'].create({
             'partner_id': partner.id,
             'program_id': loyalty_program.id,


### PR DESCRIPTION
steps to reproduce :
1. on multi enterprise
2. run the test `test_loyalty_program_different_orders`

change partner name and in the test and the tour to match the demo data

build_error-223079