### PR TITLE
[FIX] mail: fix non-deterministic im status tests

### DIFF
--- a/addons/mail/static/tests/discuss/im_status.test.js
+++ b/addons/mail/static/tests/discuss/im_status.test.js
@@ -12,6 +12,7 @@ describe.current.tags("headless");
 test("update presence if IM status changes to offline while this device is online", async () => {
     mockService("bus_service", { send: (type) => asyncStep(type) });
     const pyEnv = await startServer();
+    pyEnv["res.partner"].write(serverState.partnerId, { im_status: "online" });
     await start();
     await waitForSteps(["update_presence"]);
     pyEnv["bus.bus"]._sendone(serverState.partnerId, "bus.bus/im_status_updated", {
@@ -26,6 +27,7 @@ test("update presence if IM status changes to away while this device is online",
     mockService("bus_service", { send: (type) => asyncStep(type) });
     localStorage.setItem("presence.lastPresence", Date.now());
     const pyEnv = await startServer();
+    pyEnv["res.partner"].write(serverState.partnerId, { im_status: "online" });
     await start();
     await waitForSteps(["update_presence"]);
     pyEnv["bus.bus"]._sendone(serverState.partnerId, "bus.bus/im_status_updated", {
@@ -40,6 +42,7 @@ test("do not update presence if IM status changes to away while this device is a
     mockService("bus_service", { send: (type) => asyncStep(type) });
     localStorage.setItem("presence.lastPresence", Date.now() - AWAY_DELAY);
     const pyEnv = await startServer();
+    pyEnv["res.partner"].write(serverState.partnerId, { im_status: "away" });
     await start();
     await waitForSteps(["update_presence"]);
     pyEnv["bus.bus"]._sendone(serverState.partnerId, "bus.bus/im_status_updated", {
@@ -54,6 +57,7 @@ test("do not update presence if other user's IM status changes to away", async (
     mockService("bus_service", { send: (type) => asyncStep(type) });
     localStorage.setItem("presence.lastPresence", Date.now());
     const pyEnv = await startServer();
+    pyEnv["res.partner"].write(serverState.partnerId, { im_status: "online" });
     await start();
     await waitForSteps(["update_presence"]);
     pyEnv["bus.bus"]._sendone(serverState.partnerId, "bus.bus/im_status_updated", {
@@ -73,6 +77,8 @@ test("update presence when user comes back from away", async () => {
         },
     });
     localStorage.setItem("presence.lastPresence", Date.now() - AWAY_DELAY);
+    const pyEnv = await startServer();
+    pyEnv["res.partner"].write(serverState.partnerId, { im_status: "away" });
     await start();
     await waitForSteps([AWAY_DELAY]);
     localStorage.setItem("presence.lastPresence", Date.now());
@@ -88,6 +94,8 @@ test("update presence when user status changes to away", async () => {
         },
     });
     localStorage.setItem("presence.lastPresence", Date.now());
+    const pyEnv = await startServer();
+    pyEnv["res.partner"].write(serverState.partnerId, { im_status: "online" });
     await start();
     await waitForSteps([0]);
     await advanceTime(AWAY_DELAY);


### PR DESCRIPTION
This commit fixes the im_status test suite which fails in a non-deterministic fashion. Initially, those tests wait for the first update of the presence (the one sent when the first connection to the websocket is established).

Presence is updated when:
- Self persona status is offline.
- Bus notification is received for self with different value than the one of this device (e.g. offline while away/online, away while online).
- The websocket connection is first established.

In those test, another subscription could happen according to the timing of the `/mail/data` RPC which returns the initial status of the user as offline.

This commit fixes this issue by setting an initial status on the current user.

fixes runbot-229757

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
