### PR TITLE
[FIX] website_sale: fix "real" delivery price computation

### DIFF
--- a/addons/website_sale/controllers/delivery.py
+++ b/addons/website_sale/controllers/delivery.py
@@ -72,6 +72,7 @@ class Delivery(WebsiteSale):
         return {
             'success': True,
             'is_free_delivery': not bool(order.amount_delivery),
+            'compute_price_after_delivery': order.carrier_id.invoice_policy == 'real',
             'amount_delivery': Monetary.value_to_html(
                 order.amount_delivery, {'display_currency': currency}
             ),
@@ -112,6 +113,7 @@ class Delivery(WebsiteSale):
                 rate['price'], {'display_currency': order.currency_id}
             )
             rate['is_free_delivery'] = not bool(rate['price'])
+            rate['compute_price_after_delivery'] = delivery_method.invoice_policy == 'real'
         else:
             rate['amount_delivery'] = Monetary.value_to_html(
                 0.0, {'display_currency': order.currency_id}

--- a/addons/website_sale/static/src/js/checkout.js
+++ b/addons/website_sale/static/src/js/checkout.js
@@ -315,13 +315,16 @@ publicWidget.registry.WebsiteSaleCheckout = publicWidget.Widget.extend({
     _updateAmountBadge(radio, rateData) {
         const deliveryPriceBadge = this._getDeliveryPriceBadge(radio);
         if (rateData.success) {
-             // If it's a free delivery (`free_over` field), show 'Free', not '$ 0'.
-             if (rateData.is_free_delivery) {
-                 deliveryPriceBadge.textContent = _t("Free");
-             } else {
-                 deliveryPriceBadge.innerHTML = rateData.amount_delivery;
-             }
-             this._toggleDeliveryMethodRadio(radio);
+            if (rateData.compute_price_after_delivery) {
+                // Inform the customer that the price will be computed after delivery.
+                deliveryPriceBadge.textContent = _t("Computed after delivery");
+            } else if (rateData.is_free_delivery) {
+                // If it's a free delivery (`free_over` field), show 'Free', not '$ 0'.
+                deliveryPriceBadge.textContent = _t("Free");
+            } else {
+                deliveryPriceBadge.innerHTML = rateData.amount_delivery;
+            }
+            this._toggleDeliveryMethodRadio(radio);
         } else {
             deliveryPriceBadge.textContent = rateData.error_message;
             this._toggleDeliveryMethodRadio(radio, true);


### PR DESCRIPTION
Issue:
If the delivery invoice policy was set to "real" (meaning that we'll invoice the
real delivery cost, after delivery), the delivery was shown as being free on
eCommerce (since we don't know the cost yet).

Fix:
Show a disclaimer indicating that the cost will be computed after delivery.

opw-4779059