### PR TITLE
[FIX] point_of_sale: prevent session missing error on opening control

### DIFF
--- a/addons/point_of_sale/static/src/app/components/popups/opening_control_popup/opening_control_popup.js
+++ b/addons/point_of_sale/static/src/app/components/popups/opening_control_popup/opening_control_popup.js
@@ -6,6 +6,7 @@ import { _t } from "@web/core/l10n/translation";
 import { Input } from "@point_of_sale/app/components/inputs/input/input";
 import { parseFloat } from "@web/views/fields/parsers";
 import { Dialog } from "@web/core/dialog/dialog";
+import { RPCError } from "@web/core/network/rpc";
 
 class CustomDialog extends Dialog {
     onEscape() {}
@@ -38,13 +39,25 @@ export class OpeningControlPopup extends Component {
     }
     confirm() {
         this.pos.session.state = "opened";
-        this.pos.data.call(
-            "pos.session",
-            "set_opening_control",
-            [this.pos.session.id, parseFloat(this.state.openingCash), this.state.notes],
-            {},
-            true
-        );
+        this.pos.data
+            .call(
+                "pos.session",
+                "set_opening_control",
+                [this.pos.session.id, parseFloat(this.state.openingCash), this.state.notes],
+                {},
+                true
+            )
+            .catch(async (error) => {
+                if (
+                    error instanceof RPCError &&
+                    error.data.name === "odoo.exceptions.MissingError" &&
+                    (await this.pos.isSessionDeleted())
+                ) {
+                    return window.location.reload();
+                }
+                throw error;
+            });
+
         this.props.close();
     }
     async openDetailsPopup() {

--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -2307,6 +2307,12 @@ export class PosStore extends WithLazyGetterTrap {
     weighProduct() {
         return makeAwaitable(this.env.services.dialog, ScaleScreen);
     }
+
+    async isSessionDeleted() {
+        return (
+            (await this.data.orm.searchCount("pos.session", [["id", "=", this.session.id]])) === 0
+        );
+    }
 }
 
 PosStore.prototype.electronic_payment_interfaces = {};


### PR DESCRIPTION
Steps to reproduce:
1. Open a POS session on two devices. Leave both on the opening control screen.
2. On Device 1:
  - Click Open the Register.
  - Then click Close the Register.
  - Click on Backend ( the session is deleted)
3. On Device 2:
  - Click Open the Register.
  - This will result in a MissingError.

After this commit, the case where the session has been deleted is handled, and the UI is refreshed to ensure the user can continue working without displaying the exception.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
