### PR TITLE
[IMP] account : add default tax of account in bank statement line

### DIFF
--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -923,6 +923,10 @@ class AccountMoveLine(models.Model):
             filtered_supplier_taxes_id = self.product_id.supplier_taxes_id.filtered_domain(company_domain)
             tax_ids = filtered_supplier_taxes_id or self.account_id.tax_ids.filtered(lambda tax: tax.type_tax_use == 'purchase')
 
+        # add default taxes of account if we set account on bsl by 'Set Account' or we use reco model
+        elif self.env.context.get('account_default_taxes'):
+            tax_ids = self.account_id.tax_ids
+
         else:
             tax_ids = False if self.env.context.get('skip_computed_taxes') or self.move_id.is_entry() else self.account_id.tax_ids
 


### PR DESCRIPTION

In this PR:
- When setting the account from the bank reconciliation widget (using 'Set Account'), the default tax set on that account will now be automatically applied to the bank statement line.

task-4930945
