### PR TITLE
[IMP] web: json2 remove args and kwargs entries

### DIFF
--- a/addons/web/controllers/json2.py
+++ b/addons/web/controllers/json2.py
@@ -116,9 +116,8 @@ class WebJson2Controller(http.Controller):
         model: str,
         method: str,
         ids: Sequence[int] = (),
-        args: Sequence[Any] = (),
-        kwargs: Mapping[str, Any] = frozendict(),
         context: Mapping[str, Any] = frozendict(),
+        **kwargs,
     ):
         if request.httprequest.method != 'POST':
             raise MethodNotAllowed()
@@ -140,11 +139,11 @@ class WebJson2Controller(http.Controller):
         records = Model.browse(ids)
         signature = inspect.signature(func)
         try:
-            signature.bind(records, *args, **kwargs)
+            signature.bind(records, **kwargs)
         except TypeError as exc:
             raise UnprocessableEntity(exc.args[0])
 
-        result = func(records, *args, **kwargs)
+        result = func(records, **kwargs)
         if isinstance(result, BaseModel):
             result = result.ids
 

--- a/odoo/addons/test_http/tests/test_webjson2.py
+++ b/odoo/addons/test_http/tests/test_webjson2.py
@@ -29,7 +29,7 @@ class TestHttpWebJson_2(TestHttpBase):
     def test_webjson2_multi_db_no_header(self):
         res = self.multidb_url_open(
             '/json/2/res.users/search',
-            data=r'{"kwargs": {"domain": []}}',
+            data=r'{"domain": []}',
             headers=CT_JSON | self.bearer_header,
             dblist=(get_db_name(), 'another-database'),
         )
@@ -40,7 +40,7 @@ class TestHttpWebJson_2(TestHttpBase):
     def test_webjson2_multi_db_bad_header(self):
         res = self.multidb_url_open(
             '/json/2/res.users/search',
-            data=r'{"kwargs": {"domain": []}}',
+            data=r'{"domain": []}',
             headers={**CT_JSON, **self.bearer_header,
                 'X-odoo-database': f'{get_db_name()}-idontexist',
             },
@@ -67,7 +67,7 @@ class TestHttpWebJson_2(TestHttpBase):
         res = self.db_url_open(
             # application/x-www-form-urlencoded
             '/json/2/res.users/search',
-            data={"kwargs": {"domain": []}},
+            data={"domain": []},
             headers=self.bearer_header,
         )
         self.assertEqual(res.text, Like("""
@@ -100,7 +100,7 @@ class TestHttpWebJson_2(TestHttpBase):
     def test_webjson2_missing_auth(self):
         res = self.db_url_open(
             '/json/2/res.users/search',
-            data=r'{"kwargs": {"domain": []}}',
+            data=r'{"domain": []}',
             headers=CT_JSON,
         )
         self.assertEqual(res.status_code, HTTPStatus.UNAUTHORIZED)
@@ -118,7 +118,7 @@ class TestHttpWebJson_2(TestHttpBase):
     def test_webjson2_good(self):
         res = self.db_url_open(
             '/json/2/res.users/search',
-            data=r'{"kwargs": {"domain": [["id","=",%d]]}}' % self.jackoneill.id,
+            data=r'{"domain": [["id","=",%d]]}' % self.jackoneill.id,
             headers=CT_JSON | self.bearer_header,
         )
         self.assertEqual(res.text, f"[{self.jackoneill.id}]")
@@ -128,7 +128,7 @@ class TestHttpWebJson_2(TestHttpBase):
     def test_webjson2_api_model(self):
         res = self.db_url_open(
             '/json/2/res.users/create',
-            data=r'{"ids": [0], "args": [{}]}',
+            data=r'{"ids": [0]}',
             headers=CT_JSON | self.bearer_header,
         )
         self.assertEqual(res.text, '''"cannot call res.users.create with ids"''')


### PR DESCRIPTION
Before this work, the scheme was:

    POST /json/2/res.partner/create
    Content-Type: application/json

    {
        "ids": []
        "context": {},
        "args": [
            {
                "name": "bob"
            }
        ],
        "kwargs": {}
    }

With this work it becomes:

    POST /json/2/res.partner/create
    Content-Type: application/json

    {
        "ids": []
        "context": {},
        "vals_list": [
            {
                "name": "bob"
            }
        ]
    }

We removed the `args` way of providing positional arguments, now all parameters need to be given as named argument.

All the `kwargs` now must be defined at the same level as `ids` and `context`. A linter is being added in Odoo to prevent public methods from using `ids` and `context` as parameter name to prevent conflicts at #218355.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
