### PR TITLE
[FIX] mail: send message to customer from project

### DIFF
--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -1897,6 +1897,9 @@ class MailThread(models.AbstractModel):
         user_field = self._fields.get('user_id')
         if user_field and user_field.type == 'many2one' and user_field.comodel_name == 'res.users':
             for obj in self.sudo():  # SUPERUSER because of a read on res.users that would crash otherwise
+                if self._name == 'project.project':
+                    obj._message_add_suggested_recipient(result, partner=obj.partner_id, reason=self._fields['partner_id'].string)
+                    continue
                 if not obj.user_id or not obj.user_id.partner_id:
                     continue
                 obj._message_add_suggested_recipient(result, partner=obj.user_id.partner_id, reason=self._fields['user_id'].string)

--- a/addons/project/tests/test_project_flow.py
+++ b/addons/project/tests/test_project_flow.py
@@ -522,3 +522,12 @@ class TestProjectFlow(TestProjectCommon, MailCommon):
         # Tag name_search should not raise Error if project_id is False
         task.tag_ids.with_context(project_id=task.project_id.id).name_search(
             args=["!", ["id", "in", []]])
+
+    def test_project_message(self):
+        project = self.env['project.project'].create({
+            'name': 'Test Project',
+            'partner_id': self.partner_1.id,
+        })
+
+        result = project._message_get_suggested_recipients()
+        self.assertEqual(self.partner_1.id, result[project.id][0][0])


### PR DESCRIPTION
To reproduce:
=============
1- Go to project
2- Add a customer for that project
3- click on send message

Problem:
=========
When sending an email to the customer,
the method mailThread._message_get_suggested_recipients uses user_id to
determine the partner_id:
https://github.com/odoo/odoo/blob/7e19a3dc83f4410403499ed54dc58051de1127a0/addons/mail/models/mail_thread.py#L1897-L1897
However, in the project context, it's different — we should retrieve
the partner_id directly from the partner_id field.
We cannot rely on partner_id by default because, in some modules,
that field doesn't exist and the logic works with user_id instead.
Since this is very specific to the project module and we cannot
add customers as followers (as it would expose all tasks to them),
we will implement a workaround that applies only to projects.

Solution:
=========
- Workaround, if we are in project.project just get recepients from partner
directly.

opw-4889723
