### PR TITLE
[FIX] point_of_sale: handle closing session notification

### DIFF
--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -96,7 +96,7 @@ class PosSession(models.Model):
     def write(self, vals):
         if vals.get('state') == 'closed':
             for record in self:
-                record.config_id._notify(('CLOSING_SESSION', {'login_number': self.env.context.get('login_number', False)}))
+                record.config_id._notify(('CLOSING_SESSION', {'login_number': self.env.context.get('login_number', False), 'session_id': self.id}))
         return super().write(vals)
 
     @api.model

--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -272,7 +272,7 @@ export class PosStore extends WithLazyGetterTrap {
 
     async closingSessionNotification(data) {
         if (
-            parseInt(data.login_number) == this.session.login_number ||
+            parseInt(data.login_number) === this.session.login_number ||
             this.session.id !== parseInt(data.session_id)
         ) {
             return;


### PR DESCRIPTION
Previously, the “closing session” notification was not correctly handled in the frontend.

Steps to reproduce:
- Open a POS session on two devices
- On Device 1:  Close the Register.
- On Device 2:  Nothing happens. A dialog titled “Closing session” should appear, but it does not.

After this commit, the notification includes the correct parameters, allowing the frontend to handle the “closing session” event properly.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
