### PR TITLE
[FIX] website_sale: sync review toggle button state after saving editor

### DIFF
--- a/addons/website_sale/static/src/js/website_sale.js
+++ b/addons/website_sale/static/src/js/website_sale.js
@@ -853,6 +853,9 @@ publicWidget.registry.websiteSaleProductPageReviews = publicWidget.Widget.extend
         await this._super(...arguments);
         this._updateChatterComposerPosition();
         extraMenuUpdateCallbacks.push(this._updateChatterComposerPosition.bind(this));
+        const reviewsContent = this.el.querySelector("#o_product_page_reviews_content");
+        const reviewsTitle = this.el.querySelector(".o_product_page_reviews_title");
+        reviewsTitle.classList.toggle("collapsed", !reviewsContent.classList.contains("show"));
     },
     /**
      * @override


### PR DESCRIPTION
Problem:
When the product review section is uncollapsed in the web editor and the page is saved, the content becomes collapsed again, but the toggle button incorrectly shows the uncollapsed ("-") state.

Cause:
The `collapsed` class is removed from `.o_product_page_reviews_title` when it is editable. On saving, it renders without the `collapsed` class, so the content appears collapsed while the toggle button remains in the incorrect state.

Solution:
Ensure the `collapsed` class is applied to
`.o_product_page_reviews_title` when the widget starts, keeping the button and content in sync.

Steps to reproduce:
- Enable product ratings
- Open the web editor
- Click "+" to uncollapse the review section
- Save -> The content is collapsed but the toggle button still shows "-"

opw-4843145

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
