### PR TITLE
[FIX] payment_razorpay: error when using fpx in razorpay

### DIFF
--- a/addons/payment_razorpay/models/payment_transaction.py
+++ b/addons/payment_razorpay/models/payment_transaction.py
@@ -415,6 +415,10 @@ class PaymentTransaction(models.Model):
         if self.provider_code != 'razorpay':
             return super()._compare_notification_data(notification_data)
 
+        # Amount and currency are not sent in notification data for REDIRECT_PAYMENT_METHOD_CODES.
+        if self.payment_method_id.code in const.REDIRECT_PAYMENT_METHOD_CODES:
+            return
+
         amount = payment_utils.to_major_currency_units(
             notification_data.get('amount', 0), self.currency_id
         )


### PR DESCRIPTION
Steps to reproduce:
1. Create a company based in Malaysia.
2. Configure a Razorpay (Malaysia) account using valid credentials.
3. Enable the FPX payment method for Razorpay.
4. Create a Sales Order and attempt to pay using FPX.

Issue:
- An error occurs after the payment is completed.

Cause:
- After this PR: https://github.com/odoo/odoo/pull/163860, we are comparing currency and amount values. However, this information is not available in the data received via the `return_url`.

Fix:
- Do not compare amount and currency for REDIRECT_PAYMENT_METHOD_CODES.

opw-4922299

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
