### PR TITLE
[FIX] purchase: use valid product type in test

### DIFF
--- a/addons/purchase/tests/test_purchase.py
+++ b/addons/purchase/tests/test_purchase.py
@@ -955,7 +955,7 @@ class TestPurchase(AccountTestInvoicingCommon):
     def test_purchase_order_uom(self):
         fuzzy_drink = self.env['product.product'].create({
             'name': 'Fuzzy Drink',
-            'is_storable': True,
+            'type': 'consu',
             'uom_id': self.env.ref('uom.product_uom_unit').id,
             'seller_ids': [Command.create({
                 'partner_id': self.partner_a.id,


### PR DESCRIPTION
`is_storable` is defined in `stock`. This test is located in `purchase`, that do not depend on `stock`. We use type='consu' instead. This change ensures that the product is created with the correct type.
build_error-229762