### PR TITLE
[FIX] mail: connection alert test

### DIFF
--- a/addons/mail/static/tests/discuss_app/bus_connection_alert.test.js
+++ b/addons/mail/static/tests/discuss_app/bus_connection_alert.test.js
@@ -3,12 +3,26 @@ import { WEBSOCKET_CLOSE_CODES } from "@bus/workers/websocket_worker";
 import { defineMailModels, openDiscuss, start } from "@mail/../tests/mail_test_helpers";
 import { describe, expect, test } from "@odoo/hoot";
 import { animationFrame, runAllTimers, waitFor, waitForNone } from "@odoo/hoot-dom";
+
+import { browser } from "@web/core/browser/browser";
 import { asyncStep, MockServer, waitForSteps } from "@web/../tests/web_test_helpers";
 
 defineMailModels();
 describe.current.tags("desktop");
 
 test("show warning when bus connection encounters issues", async () => {
+    // The bus service listens to online/offline events. Prevent them to make the
+    // test deterministic.
+    for (const event of ["online", "offline"]) {
+        browser.addEventListener(
+            event,
+            (ev) => {
+                ev.preventDefault();
+                ev.stopImmediatePropagation();
+            },
+            { capture: true }
+        );
+    }
     addBusServiceListeners(
         ["connect", () => asyncStep("connect")],
         ["reconnect", () => asyncStep("reconnect")],


### PR DESCRIPTION
Before this commit, the `show warning when bus connection encounters issues` test was sometime failing. [1] attempted to fix this issue and seems to have greatly reduced its frequence. However, the bus monitoring service still listens to the "offline" event. As a result, the test can still fails according to the runbot network condition.

This commit fixes the issue by preventing the "online"/"offline" events during this test.

fixes runbot-226443

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
