### PR TITLE
[FIX] html_editor: user-selectable buttons in navbar

### DIFF
--- a/addons/html_editor/static/src/main/link/link.scss
+++ b/addons/html_editor/static/src/main/link/link.scss
@@ -6,9 +6,11 @@
 }
 
 .odoo-editor-editable {
-    .btn {
-        user-select: auto;
-        cursor: text;
+    &[contenteditable=true], [contenteditable=true] {
+        &.btn, .btn {
+            user-select: auto;
+            cursor: text;
+        }
     }
 
     [contenteditable=false] .btn {

--- a/addons/html_editor/static/tests/link/button.test.js
+++ b/addons/html_editor/static/tests/link/button.test.js
@@ -31,6 +31,15 @@ describe("button style", () => {
         const button = el.querySelector(".o_embedded_toolbar button");
         expect(button).toHaveStyle({ cursor: "pointer" });
     });
+    test("editable button is user-selectable", async () => {
+        await setupEditor('<p><a href="#" class="btn test-btn">button</a></p>');
+        expect(queryOne(".test-btn")).toHaveStyle({ userSelect: "auto" });
+    });
+    test("non-editable button should not be user-selectable", async () => {
+        const { el } = await setupEditor('<p><a href="#" class="btn test-btn">button</a></p>');
+        el.setAttribute("contenteditable", "false");
+        expect(queryOne(".test-btn")).toHaveStyle({ userSelect: "none" });
+    });
 });
 
 const allowCustomOpt = {


### PR DESCRIPTION
Steps:
- In the website builder, have a navbar with an empty space next to a non-editable button (e.g. the shopping cart or the search button).
- Click on the empty space next to the button.

As a result the whole content of the navbar gets selected (this might not be visible in Chrome), and the floating toolbar opens.

It is not clear why the resulting selection is produced (nor why it is not visible on Chrome), but it is not desirable to have the toolbar opened when clicking on the navbar. But making the non-editable buttons also not user-selectable seems to solve the issue.

task-4936596

