### PR TITLE
[FIX] website_sale_collect: focus on checking the public access

### DIFF
--- a/addons/website_sale_collect/static/src/tests/tours/buy_with_click_and_collect.js
+++ b/addons/website_sale_collect/static/src/tests/tours/buy_with_click_and_collect.js
@@ -2,67 +2,19 @@ import {registry} from '@web/core/registry';
 import {clickOnElement} from '@website/js/tours/tour_utils';
 import * as tourUtils from '@website_sale/js/tours/tour_utils';
 
-registry.category('web_tour.tours').add('website_sale_collect_buy_product', {
+registry.category('web_tour.tours').add('website_sale_collect_widget', {
     url: '/shop',
     steps: () => [
         ...tourUtils.searchProduct("Test CAC Product", { select: true }),
         clickOnElement("Open Location selector", '.o_click_and_collect_availability'),
+        {
+            content: "Check the dialog is opened",
+            trigger: '.o_location_selector',
+        },
         clickOnElement("Choose location", '#submit_location_large'),
-        clickOnElement('Add to cart', '#add_to_cart'),
-        tourUtils.goToCart({quantity: 1}),
-        tourUtils.goToCheckout(),
         {
-            content: "Fill delivery address form",
-            trigger: 'select[name="country_id"]',
-            run: 'selectByLabel Belgium',
-        },
-        {
-            trigger: 'input[name="name"]',
-            run: 'edit Name',
-        },
-        {
-            trigger: 'input[name="phone"]',
-            run: 'edit 99999999',
-        },
-        {
-            trigger: 'input[name="email"]',
-            run: 'edit test@odoo.com',
-        },
-        {
-            trigger: 'input[name="street"]',
-            run: 'edit Test Street',
-        },
-        {
-            trigger: 'input[name="city"]',
-            run: 'edit Test City',
-        },
-        {
-            trigger: 'input[name="zip"]',
-            run: 'edit 10000',
-        },
-        {
-            content: "Click on next button",
-            trigger: '.oe_cart .btn:contains("Continue checkout")',
-            run: 'click',
-        },
-        {
-            content: "Ensure in store delivery method is selected.",
-            trigger: 'input[name="o_delivery_radio"][data-delivery-type="in_store"]:checked',
-        },
-        {
-            content: "Check the pickup address is set.",
-            trigger: 'b[name="o_pickup_location_name"]:contains("Shop 1")',
-        },
-        tourUtils.confirmOrder(),
-        {
-            content: "Select `Pay on site`  payment method",
-            trigger: 'input[name="o_payment_radio"][data-payment-method-code="pay_on_site"]',
-            run: 'click',
-        },
-        ...tourUtils.pay({ expectUnloadPage: true, waitFinalizeYourPayment: true }),
-        {
-            content: "Check payment status confirmation window",
-            trigger: '.oe_website_sale_tx_status[data-order-tracking-info]',
+            content: "Check pickup location is set",
+            trigger: '.o_click_and_collect_availability strong:contains("Shop 1")',
         },
     ],
 });

--- a/addons/website_sale_collect/tests/test_click_and_collect_flow.py
+++ b/addons/website_sale_collect/tests/test_click_and_collect_flow.py
@@ -9,7 +9,7 @@ from odoo.addons.website_sale_collect.tests.common import ClickAndCollectCommon
 @tagged('post_install', '-at_install')
 class TestClickAndCollectFlow(HttpCase, ClickAndCollectCommon):
 
-    def test_buy_with_click_and_collect_as_public_user(self):
+    def test_click_and_collect_widget_as_public_user(self):
         self.storable_product.name = "Test CAC Product"
         self.provider.write(
             {
@@ -25,4 +25,4 @@ class TestClickAndCollectFlow(HttpCase, ClickAndCollectCommon):
                 'partner_longitude': 2.0,
             }
         )
-        self.start_tour('/', 'website_sale_collect_buy_product')
+        self.start_tour('/', 'website_sale_collect_widget')


### PR DESCRIPTION
Tours are too fast for imitating the user actions that led to sometimes creating 2 orders in parallel instead of reusing the first created. The test was added for b395f984b13eb83310024b9fa94d7822211ef8c1 fix, so with this commit, we keep the test more specific to the fix and avoid inconsistent behavior.