### PR TITLE
[FIX] html_builder: fix display for sub-options

### DIFF
--- a/addons/html_builder/static/src/core/building_blocks/basic_many2many.scss
+++ b/addons/html_builder/static/src/core/building_blocks/basic_many2many.scss
@@ -1,0 +1,3 @@
+.o-hb-m2m-table:not(:empty) {
+    margin-bottom: $o-hb-row-spacing;
+}

--- a/addons/html_builder/static/src/core/building_blocks/basic_many2many.xml
+++ b/addons/html_builder/static/src/core/building_blocks/basic_many2many.xml
@@ -2,8 +2,8 @@
 <templates xml:space="preserve">
 
 <t t-name="html_builder.BasicMany2Many">
-    <div class="d-flex flex-column gap-1">
-        <table>
+    <div class="d-flex flex-column">
+        <table class="o-hb-m2m-table">
             <tr t-foreach="props.selection" t-as="entry" t-key="entry.id">
                 <td>
                     <input type="text" class="o-hb-input-base" disabled="" t-att-data-name="entry.display_name" t-att-value="entry.display_name"/>

--- a/addons/html_builder/static/src/core/building_blocks/builder_row.scss
+++ b/addons/html_builder/static/src/core/building_blocks/builder_row.scss
@@ -1,4 +1,16 @@
+@mixin sublevel-line($_level-left: 0) {
+    position: absolute;
+    border: $o-we-border-width solid var(--o-hb-row-sublevel-color, #{mix($o-we-bg-lighter, $o-we-fg-light)});
+    border-width: 0 0 $o-we-border-width $o-we-border-width;
+    height: 100%;
+    pointer-events: none;
+    transform: translate($_level-left - $o-we-border-width, ($o-hb-row-min-height * -0.5) - $o-we-border-width);
+    content: "";
+}
+
 .hb-row {
+    $_z-index: 4;
+
     .popover & {
         --o-hb-row-bg-color: var(--o-hb-row-bg-color-popover, --popover-bg);
         --o-hb-row-active-bg-color: var(--o-hb-row-active-bg-color-popover, #{mix($o-we-color-accent, $o-we-fg-lighter, 20%)});
@@ -27,7 +39,7 @@
     .hb-row-label {
         min-width: 0;
         flex: 0 0 44%;
-        z-index: 4;
+        z-index: $_z-index;
         position: relative;
         background-color: var(--o-hb-row-bg-color, #{$o-we-bg-lighter});
         padding: $o-hb-row-spacing 0 $o-hb-row-spacing $o-hb-row-padding-left;
@@ -41,13 +53,13 @@
         width: 56%;
         align-items: center;
         gap: var(--hb-row-content-gap);
-        z-index: 4; // Make sure outlines / shadows are not trimmed.
+        z-index: $_z-index; // Make sure outlines / shadows are not trimmed.
     }
 
     .o_hb_collapse_toggler {
         position: absolute;
         padding-left: $o-hb-row-spacing;
-        z-index: 5;
+        z-index: $_z-index + 1;
         font-size: 0.8em;
         color: inherit;
 
@@ -88,23 +100,18 @@
 
     // ==== Sublevels
     &.hb-row-sublevel:after {
-        position: absolute;
-        border: $o-we-border-width solid var(--o-hb-row-sublevel-color, #{mix($o-we-bg-lighter, $o-we-fg-light)});
-        border-width: 0 0 $o-we-border-width $o-we-border-width;
-        height: 100%;
-        transform: translate(-$o-we-border-width, ($o-hb-row-min-height * -0.5) - $o-we-border-width);
-        pointer-events: none;
-        content: "";
+        @include sublevel-line;
     }
 
     // Sublevel specific rules
     @for $_level from 1 through 3 {
-        &.hb-row-sublevel-#{$_level} {
-            $_level-padding: $o-hb-row-padding-left + ($o-hb-row-indent-left * $_level);
-            $_level-width: $o-hb-row-spacing + $o-we-border-width;
+        $_level-padding: $o-hb-row-padding-left + ($o-hb-row-indent-left * $_level);
+        $_level-width: $o-hb-row-spacing + $o-we-border-width;
+        $_level-left: $_level-padding - $_level-width - $o-we-border-width;
 
+        &.hb-row-sublevel-#{$_level} {
             .hb-row-label, &:after {
-                z-index: 4 - $_level;
+                z-index: $_z-index - $_level;
             }
 
             .hb-row-label {
@@ -113,8 +120,13 @@
 
             &:after {
                 width: $_level-width;
-                left: $_level-padding - $_level-width - $o-we-border-width;
+                left: $_level-left;
             }
+        }
+
+        &[data-label=" "]:not(.hb-row-sublevel):has(+ .hb-row-sublevel-#{$_level}):after {
+            @include sublevel-line($_level-left);
+            z-index: $_z-index - $_level;
         }
     }
 }

--- a/addons/html_builder/static/src/core/building_blocks/builder_row.xml
+++ b/addons/html_builder/static/src/core/building_blocks/builder_row.xml
@@ -28,7 +28,7 @@
             <t t-if="props.label">
                 <div
                     class="hb-row-label d-flex align-items-center"
-                    t-att-class="{'hb-row-label-actionable': props.slots.collapse}"
+                    t-att-class="{'hb-row-label-actionable': props.slots.collapse, 'bg-transparent': !props.label.trim()}"
                     t-att-data-tooltip="state.tooltip"
                     t-on-click="toggleCollapseContent"
                     >


### PR DESCRIPTION
The sub-options for the conditional visiblity were not displayed properly which could make it hard to understand them. There was gap between inputs that were linked ("visibile for" and "choose a record") and no gap between inputs that were not. The line of the left of the options was also misguiding the user who would associate the inputs to the wrong category (UTM Campaign, UTM Medium, ...).

This commit remove the gaps between the options but make the display more readable by having the line on the left of the sub-categories continuous.