### PR TITLE
[FIX] pos_loyalty: max usage partner with points

### DIFF
--- a/addons/pos_loyalty/static/src/overrides/models/loyalty.js
+++ b/addons/pos_loyalty/static/src/overrides/models/loyalty.js
@@ -538,7 +538,7 @@ patch(Order.prototype, {
             for (let idx = 0; idx < Math.min(pointsAdded.length, oldChanges.length); idx++) {
                 Object.assign(oldChanges[idx], pointsAdded[idx]);
             }
-            if (pointsAdded.length < oldChanges.length) {
+            if (pointsAdded.length < oldChanges.length || !this._programIsApplicable(program)) {
                 const removedIds = oldChanges.map((pe) => pe.coupon_id);
                 this.couponPointChanges = Object.fromEntries(
                     Object.entries(this.couponPointChanges).filter(([k, pe]) => {

--- a/addons/pos_loyalty/static/tests/tours/PosLoyaltyLoyaltyProgramTour.js
+++ b/addons/pos_loyalty/static/tests/tours/PosLoyaltyLoyaltyProgramTour.js
@@ -364,3 +364,20 @@ registry.category("web_tour.tours").add("test_buy_x_get_y_reward_qty", {
             PosLoyalty.finalizeOrder("Cash", "32"),
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("test_max_usage_partner_with_point", {
+    steps: () =>
+        [
+            ProductScreen.confirmOpeningPopup(),
+            ProductScreen.clickPartnerButton(),
+            ProductScreen.clickCustomer("Test Partner 2"),
+            ProductScreen.addOrderline("Desk Organizer", "3"),
+            PosLoyalty.clickRewardButton(),
+            PosLoyalty.claimReward("100% on your order"),
+            PosLoyalty.finalizeOrder("Cash", "0"),
+            ProductScreen.clickPartnerButton(),
+            ProductScreen.clickCustomer("Test Partner"),
+            ProductScreen.addOrderline("Desk Organizer", "3"),
+            PosLoyalty.isRewardButtonHighlighted(false),
+        ].flat(),
+});


### PR DESCRIPTION
When an existing partner with points tries to claim a reward from a loyalty program that has reached its max usage in the current session, he was still able to claim the reward.

Steps to reproduce:
-------------------
* Create a loyalty program with max usage set to 1
* Create a partner and assign points to him
* Open PoS and select any partner and make an order
* Claim the reward from the loyalty program
* Select the partner that already has points
* Make an order and try to claim the reward again
> Observation: The reward can be claimed, even though the max usage
  is already reached.

Why the fix:
------------
When updating programs, we were not removing the couponPointChanges for programs that are not applicable anymore. We now make sure to delete them when the program is not applicable anymore.

opw-4805704