### PR TITLE
[FIX] payment: Show post-processing error in UI

### DIFF
--- a/addons/payment/models/payment_transaction.py
+++ b/addons/payment/models/payment_transaction.py
@@ -100,6 +100,7 @@ class PaymentTransaction(models.Model):
     # Fields used for user redirection & payment post-processing
     is_post_processed = fields.Boolean(
         string="Is Post-processed", help="Has the payment been post-processed")
+    error_on_post_process = Fields.Text(string="Error on Post-process")
     tokenize = fields.Boolean(
         string="Create Token",
         help="Whether a payment token should be created when post-processing the transaction")
@@ -930,6 +931,9 @@ class PaymentTransaction(models.Model):
                     tx.reference, e
                 )
                 self.env.cr.rollback()
+                #Don't add in domain of txs_to_post_process because this is bug and we need fix it.
+                tx.error_on_post_process = str(e)
+
 
     def _post_process(self):
         """ Post-process the transactions.

--- a/addons/payment/views/payment_transaction_views.xml
+++ b/addons/payment/views/payment_transaction_views.xml
@@ -60,6 +60,9 @@
                     <group string="Message" invisible="not state_message">
                         <field colspan="2" name="state_message" nolabel="1"/>
                     </group>
+                    <group string="Error on Post-processed" invisible="not error_on_post_process" groups="base.group_no_one">
+                        <field colspan="2" name="error_on_post_process" nolabel="1"/>
+                    </group>
                 </sheet>
             </form>
         </field>


### PR DESCRIPTION
Before this commit:
If there was any transaction that was not post-processed, we couldn’t see what was wrong.

After this commit:
The UI now displays post-processing errors (in debug mode only).

Reason:
If a payment is not post-processed, it can cause major issues. For example, a subscription may not detect that the payment was completed, so the next invoice date is not updated. As a result, the system may attempt to charge the customer again the next day using the token, even though the payment was already completed. This repeats until the post-processing step is successfully executed or someone manually creates the invoice.

To fix this, we need to know what the problem is—without having to dig through large logs (which regular users, especially on SaaS, often don’t have access to)

Task 4936432

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
