### PR TITLE
[FIX] portal: identitycheck for internal users with passkey

### DIFF
--- a/addons/portal/static/src/js/portal_security.js
+++ b/addons/portal/static/src/js/portal_security.js
@@ -174,7 +174,7 @@ export async function handleCheckIdentity(wrapped, ormService, dialogService) {
                         return false;
                     }
                     let result;
-                    await ormService.write("res.users.identitycheck", [checkId], { password: inputEl.value });
+                    await ormService.write("res.users.identitycheck", [checkId], { password: inputEl.value, 'auth_method': 'password' });
                     try {
                         result = await ormService.call("res.users.identitycheck", "run_check", [checkId]);
                     } catch {


### PR DESCRIPTION
When an internal user has a passkey and attempts to pass the portal identitycheck, then the identitycheck's auth_method is set to webauthn which breaks the flow since portal's identitycheck only supports passwords.

This scenario is unlikely to occur but it does break the internal users' portal. This is a temporary solution because once I implement passkeys for portal users, I will allow portal users to use webauthn to verify their identity.
