### PR TITLE
[FIX] html_builder: show already used custom colors in colorpicker

### DIFF
--- a/addons/html_builder/static/src/core/building_blocks/builder_colorpicker.js
+++ b/addons/html_builder/static/src/core/building_blocks/builder_colorpicker.js
@@ -10,6 +10,7 @@ import {
     useHasPreview,
 } from "../utils";
 import { isColorGradient } from "@web/core/utils/colors";
+import { getAllUsedColors } from "@html_builder/utils/utils_css";
 
 // TODO replace by useInputBuilderComponent after extract unit by AGAU
 export function useColorPickerBuilderComponent() {
@@ -110,7 +111,6 @@ export class BuilderColorPicker extends Component {
         defaultColor: { type: String, optional: true },
     };
     static defaultProps = {
-        getUsedCustomColors: () => [],
         enabledTabs: ["theme", "gradient", "custom"],
         defaultColor: "#FFFFFF00",
     };
@@ -132,7 +132,8 @@ export class BuilderColorPicker extends Component {
                 applyColor: onApply,
                 applyColorPreview: onPreview,
                 applyColorResetPreview: onPreviewRevert,
-                getUsedCustomColors: this.props.getUsedCustomColors,
+                getUsedCustomColors:
+                    this.props.getUsedCustomColors || this.getUsedCustomColors.bind(this),
                 colorPrefix: "color-prefix-",
                 showRgbaField: true,
                 noTransparency: this.props.noTransparency,
@@ -164,5 +165,9 @@ export class BuilderColorPicker extends Component {
             }
         }
         return "";
+    }
+
+    getUsedCustomColors() {
+        return getAllUsedColors(this.env.editor.editable);
     }
 }

--- a/addons/html_builder/static/src/core/color_plugin.js
+++ b/addons/html_builder/static/src/core/color_plugin.js
@@ -1,0 +1,8 @@
+import { ColorPlugin as EditorColorPlugin } from "@html_editor/main/font/color_plugin";
+import { getAllUsedColors } from "@html_builder/utils/utils_css";
+
+export class ColorPlugin extends EditorColorPlugin {
+    getUsedCustomColors(mode) {
+        return getAllUsedColors(this.editable);
+    }
+}

--- a/addons/html_builder/static/src/core/core_plugins.js
+++ b/addons/html_builder/static/src/core/core_plugins.js
@@ -1,3 +1,5 @@
+import { MAIN_PLUGINS as MAIN_EDITOR_PLUGINS } from "@html_editor/plugin_sets";
+import { removePlugins } from "@html_builder/utils/utils";
 import { AnchorPlugin } from "./anchor/anchor_plugin";
 import { BuilderActionsPlugin } from "./builder_actions_plugin";
 import { BuilderComponentPlugin } from "./builder_component_plugin";
@@ -5,6 +7,7 @@ import { BuilderOptionsPlugin } from "./builder_options_plugin";
 import { BuilderOverlayPlugin } from "./builder_overlay/builder_overlay_plugin";
 import { CachedModelPlugin } from "./cached_model_plugin";
 import { ClonePlugin } from "./clone_plugin";
+import { ColorPlugin } from "./color_plugin";
 import { CoreBuilderActionPlugin } from "./core_builder_action_plugin";
 import { CompositeActionPlugin } from "./composite_action_plugin";
 import { CustomizeTabPlugin } from "./customize_tab_plugin";
@@ -24,7 +27,24 @@ import { SetupEditorPlugin } from "./setup_editor_plugin";
 import { VersionControlPlugin } from "./version_control_plugin";
 import { VisibilityPlugin } from "./visibility_plugin";
 
+const mainEditorPluginsToRemove = [
+    "PowerButtonsPlugin",
+    "DoubleClickImagePreviewPlugin",
+    "SeparatorPlugin",
+    "StarPlugin",
+    "BannerPlugin",
+    "MoveNodePlugin",
+    // Replaced plugins:
+    "ColorPlugin",
+];
+
+export const MAIN_PLUGINS = [
+    ...removePlugins(MAIN_EDITOR_PLUGINS, mainEditorPluginsToRemove),
+    ColorPlugin,
+];
+
 export const CORE_PLUGINS = [
+    ...MAIN_PLUGINS,
     BuilderOptionsPlugin,
     BuilderActionsPlugin,
     BuilderComponentPlugin,

--- a/addons/html_builder/static/src/plugins/shadow_option_plugin.js
+++ b/addons/html_builder/static/src/plugins/shadow_option_plugin.js
@@ -1,6 +1,7 @@
 import { BuilderAction } from "@html_builder/core/builder_action";
 import { Plugin } from "@html_editor/plugin";
 import { registry } from "@web/core/registry";
+import { parseBoxShadow } from "@html_builder/utils/utils_css";
 
 const shadowClass = "shadow";
 
@@ -48,9 +49,7 @@ function parseShadow(value) {
     if (!value || value === "none") {
         return {};
     }
-    const regex =
-        /(?<color>(rgb(a)?\([^)]*\))|(var\([^)]+\)))\s+(?<offsetX>-?\d+px)\s+(?<offsetY>-?\d+px)\s+(?<blur>-?\d+px)\s+(?<spread>-?\d+px)(?:\s+(?<mode>\w+))?/;
-    return value.match(regex).groups;
+    return parseBoxShadow(value);
 }
 
 export function shadowToString(shadow) {

--- a/addons/html_builder/static/tests/helpers.js
+++ b/addons/html_builder/static/tests/helpers.js
@@ -2,10 +2,8 @@ import { Builder } from "@html_builder/builder";
 import { CORE_PLUGINS } from "@html_builder/core/core_plugins";
 import { Img } from "@html_builder/core/img";
 import { SetupEditorPlugin } from "@html_builder/core/setup_editor_plugin";
-import { removePlugins } from "@html_builder/utils/utils";
 import { LocalOverlayContainer } from "@html_editor/local_overlay_container";
 import { Plugin } from "@html_editor/plugin";
-import { MAIN_PLUGINS } from "@html_editor/plugin_sets";
 import { withSequence } from "@html_editor/utils/resource";
 import { defineMailModels } from "@mail/../tests/mail_test_helpers";
 import { after } from "@odoo/hoot";
@@ -158,18 +156,7 @@ export async function setupHTMLBuilder(content = "", { snippetContent, dropzoneS
         render_public_asset: () => getSnippetView(snippets),
     });
 
-    const mainPlugins = removePlugins(
-        [...MAIN_PLUGINS],
-        [
-            "PowerButtonsPlugin",
-            "DoubleClickImagePreviewPlugin",
-            "SeparatorPlugin",
-            "StarPlugin",
-            "BannerPlugin",
-            "MoveNodePlugin",
-        ]
-    );
-    const Plugins = [...mainPlugins, ...CORE_PLUGINS];
+    const Plugins = [...CORE_PLUGINS];
 
     if (dropzoneSelectors) {
         const pluginId = uniqueId("test-dropzone-selector");

--- a/addons/html_editor/static/src/main/media/media_dialog/image_selector.js
+++ b/addons/html_editor/static/src/main/media/media_dialog/image_selector.js
@@ -460,7 +460,7 @@ export class ImageSelector extends FileSelector {
         const mediaUrl = imgEl.src;
         try {
             const response = await fetch(mediaUrl);
-            if (response.headers.get("content-type") === "image/svg+xml") {
+            if (response.headers.get("content-type").startsWith("image/svg+xml")) {
                 let svg = await response.text();
                 const dynamicColors = {};
                 const combinedColorsRegex = new RegExp(

--- a/addons/website/static/src/builder/website_builder.js
+++ b/addons/website/static/src/builder/website_builder.js
@@ -1,13 +1,12 @@
 import { Builder } from "@html_builder/builder";
 import { BuilderOptionsPlugin } from "@html_builder/core/builder_options_plugin_translate";
-import { CORE_PLUGINS as CORE_BUILDER_PLUGINS } from "@html_builder/core/core_plugins";
+import { CORE_PLUGINS, MAIN_PLUGINS } from "@html_builder/core/core_plugins";
 import { DisableSnippetsPlugin } from "@html_builder/core/disable_snippets_plugin_translation";
 import { OperationPlugin } from "@html_builder/core/operation_plugin";
 import { SavePlugin } from "@html_builder/core/save_plugin";
 import { SetupEditorPlugin } from "@html_builder/core/setup_editor_plugin";
 import { VisibilityPlugin } from "@html_builder/core/visibility_plugin";
 import { removePlugins } from "@html_builder/utils/utils";
-import { MAIN_PLUGINS as MAIN_EDITOR_PLUGINS } from "@html_editor/plugin_sets";
 import { closestElement } from "@html_editor/utils/dom_traversal";
 import { Component } from "@odoo/owl";
 import { registry } from "@web/core/registry";
@@ -46,13 +45,8 @@ export class WebsiteBuilder extends Component {
         const websitePlugins = this.props.translation
             ? TRANSLATION_PLUGINS
             : registry.category("website-plugins").getAll();
-        const mainEditorPluginsToRemove = [
-            "PowerButtonsPlugin",
-            "DoubleClickImagePreviewPlugin",
-            "SeparatorPlugin",
-            "StarPlugin",
-            "BannerPlugin",
-            "MoveNodePlugin",
+        const builderPluginsToRemove = [
+            // Currently empty.
         ];
         const pluginsBlockedInTranslationMode = [
             "PowerboxPlugin",
@@ -61,11 +55,13 @@ export class WebsiteBuilder extends Component {
             "ImagePlugin",
         ];
         const pluginsToRemove = this.props.translation
-            ? [...mainEditorPluginsToRemove, ...pluginsBlockedInTranslationMode]
-            : mainEditorPluginsToRemove;
-        const mainEditorPlugins = removePlugins([...MAIN_EDITOR_PLUGINS], pluginsToRemove);
-        const coreBuilderPlugins = this.props.translation ? [] : CORE_BUILDER_PLUGINS;
-        const Plugins = [...mainEditorPlugins, ...coreBuilderPlugins, ...(websitePlugins || [])];
+            ? [...builderPluginsToRemove, ...pluginsBlockedInTranslationMode]
+            : builderPluginsToRemove;
+        const coreBuilderPlugins = removePlugins(
+            this.props.translation ? MAIN_PLUGINS : CORE_PLUGINS,
+            pluginsToRemove
+        );
+        const Plugins = [...coreBuilderPlugins, ...(websitePlugins || [])];
         builderProps.Plugins = Plugins;
         builderProps.onEditorLoad = (editor) => {
             this.editor = editor;


### PR DESCRIPTION
Since the introduction of `html_builder`, the colorpicker does not give access to already used custom colors.

This commit obtains all used colors by default for builder colorpickers.

task-4367641
