### PR TITLE
[FIX] sale_stock: cancel a return for exchange

### DIFF
--- a/addons/sale_stock/wizard/stock_return_picking.py
+++ b/addons/sale_stock/wizard/stock_return_picking.py
@@ -7,6 +7,7 @@ class ReturnPicking(models.TransientModel):
     _inherit = 'stock.return.picking'
 
     def _get_proc_values(self, line):
-        vals = super()._get_proc_values(line)
-        vals['sale_line_id'] = line.move_id.sale_line_id.id
-        return vals
+        sol = line.move_id.sale_line_id
+        if sol:
+            return sol._prepare_procurement_values(group_id=self.picking_id.group_id)
+        return super()._get_proc_values(line)


### PR DESCRIPTION
When dealing with a "return for exchange" case, some SM won't be merged

To reproduce the issue:
1. Confirm a SO with a product
2. Process the delivery
3. Return > Return for exchange
4. Process the receipt
5. Set the SOL qty to 0

Error: a receipt is created. The second delivery should actually be
canceled

This happens because the SM from step 5 is not merged into the SM of
the second delivery. When editing a SOL qty, a procurement is ran
and its values are based on the SOL:
https://github.com/odoo/odoo/blob/66c5d10833af8946ab5d3f887086f9ba08d36ab3/addons/sale_stock/models/sale_order_line.py#L228-L230
https://github.com/odoo/odoo/blob/66c5d10833af8946ab5d3f887086f9ba08d36ab3/addons/sale_stock/models/sale_order_line.py#L378
Where we define a specific `date_deadline`
https://github.com/odoo/odoo/blob/66c5d10833af8946ab5d3f887086f9ba08d36ab3/addons/sale_stock/models/sale_order_line.py#L260

However, when we return for exchange, we also run a procurement, but
its values are defined differently:
https://github.com/odoo/odoo/blob/30e60b55736cfd5f3116ebbc680b49d9113ca419/addons/stock/wizard/stock_picking_return.py#L238
And nothing defines `date_dealine`

Since the values of both SM are not the same, they won't be merged, cf
https://github.com/odoo/odoo/blob/9f8c364f056c8937409f8ed91b8d1fa436c2d7c0/addons/stock/models/stock_move.py#L1119
Hence the creation of the receipt picking

OPW-4688679