### PR TITLE
[IMP] hw_drivers: devtools disable longpolling

### DIFF
--- a/addons/hw_drivers/controllers/driver.py
+++ b/addons/hw_drivers/controllers/driver.py
@@ -22,6 +22,7 @@ _logger = logging.getLogger(__name__)
 
 
 class DriverController(http.Controller):
+    @helpers.toggleable
     @http.route('/hw_drivers/action', type='jsonrpc', auth='none', cors='*', csrf=False, save_session=False)
     def action(self, session_id, device_identifier, data):
         """
@@ -55,6 +56,7 @@ class DriverController(http.Controller):
         """
         helpers.get_certificate_status()
 
+    @helpers.toggleable
     @http.route('/hw_drivers/event', type='jsonrpc', auth='none', cors='*', csrf=False, save_session=False)
     def event(self, listener):
         """

--- a/addons/hw_drivers/tools/helpers.py
+++ b/addons/hw_drivers/tools/helpers.py
@@ -25,6 +25,7 @@ import urllib3.util
 from threading import Thread, Lock
 import time
 import zipfile
+from werkzeug.exceptions import Locked
 
 from odoo import http, release, service
 from odoo.tools.func import lazy_property
@@ -74,15 +75,18 @@ def toggleable(function):
 
     @wraps(function)
     def devtools_wrapper(*args, **kwargs):
-        if function.__name__ == 'action':
+        if args and args[0].__class__.__name__ == 'DriverController' and get_conf('longpolling', section='devtools'):
+            _logger.warning("Refusing call to %s: longpolling is disabled by devtools", fname)
+            raise Locked("Longpolling disabled by devtools")  # raise to make the http request fail
+        elif function.__name__ == 'action':
             action = args[1].get('action', 'default')  # first argument is self (containing Driver instance), second is 'data'
             disabled_actions = (get_conf('actions', section='devtools') or '').split(',')
             if action in disabled_actions or '*' in disabled_actions:
                 _logger.warning("Ignoring call to %s: '%s' action is disabled by devtools", fname, action)
-                return
+                return None
         elif get_conf('general', section='devtools'):
             _logger.warning(f"Ignoring call to {fname}: method is disabled by devtools")
-            return
+            return None
 
         return function(*args, **kwargs)
     return devtools_wrapper

--- a/addons/iot_box_image/overwrite_before_init/etc/init_image.sh
+++ b/addons/iot_box_image/overwrite_before_init/etc/init_image.sh
@@ -113,14 +113,14 @@ devtools() {
   case \"\$1\" in
     enable|disable)
       case \"\$2\" in
-        general|actions)
+        general|actions|longpolling)
           write_mode
           if ! grep -q '^\[devtools\]' /home/pi/odoo.conf; then
             sudo -u odoo bash -c \"printf '\n[devtools]\n' >> /home/pi/odoo.conf\"
           fi
           if [ \"\$1\" == \"disable\" ]; then
             value=\"\${3:-*}\" # Default to '*' if no action name is provided
-            devtools enable \"\$2\" # Remove action/general from conf to avoid duplicate keys
+            devtools enable \"\$2\" # Remove action/general/longpolling from conf to avoid duplicate keys
             write_mode
             sudo sed -i \"/^\[devtools\]/a\\\\\$2 = \$value\" /home/pi/odoo.conf
           elif [ \"\$1\" == \"enable\" ]; then


### PR DESCRIPTION
In order to ease development/debugging lonpolling=>websocket fallback we added the possibility to disable longpolling calls in order to force the communication via websocket.

Task: 4929877