### PR TITLE
[FIX] website: forget reload target after save

### DIFF
--- a/addons/html_builder/static/src/core/builder_options_plugin.js
+++ b/addons/html_builder/static/src/core/builder_options_plugin.js
@@ -44,6 +44,12 @@ export class BuilderOptionsPlugin extends Plugin {
             //     reasons.push(`I hate ${el.dataset.name}`);
             // }
         ],
+        start_edition_handlers: () => {
+            if (this.config.initialTarget) {
+                const el = this.editable.querySelector(this.config.initialTarget);
+                this.updateContainers(el);
+            }
+        },
     };
 
     setup() {
@@ -68,10 +74,6 @@ export class BuilderOptionsPlugin extends Plugin {
         this.editable.addEventListener("click", this.onClick, { capture: true });
 
         this.lastContainers = [];
-        if (this.config.initialTarget) {
-            const el = this.editable.querySelector(this.config.initialTarget);
-            this.updateContainers(el);
-        }
 
         // Selector of elements that should not update/have containers when they
         // are clicked.

--- a/addons/website/static/src/client_actions/website_preview/website_builder_action.js
+++ b/addons/website/static/src/client_actions/website_preview/website_builder_action.js
@@ -490,6 +490,8 @@ export class WebsiteBuilderClientAction extends Component {
     }
 
     async reloadIframeAndCloseEditor() {
+        this.initialTab = null;
+        this.target = null;
         const isEditing = false;
         this.state.isEditing = isEditing;
         this.addSystrayItems();


### PR DESCRIPTION
> [QSM] Cannot find the right steps to systematically reproduce it: sometimes, when I enter edit mode, the header is automatically selected if I clicked on it outside of edit mode first (instead of being in the "Add blocks" panel) -> Could you look at the code to see if the issue can be found there? Idea: could it be that some event handlers of the editor are not properly cleaned up when discarding?

Steps to reproduce:
- Open website builder
- Click on the header
- Change "Content Width" (or any other option that triggers a reload)
- Optionally do other changes anywhere that do not trigger reloads
- Click "Discard" (or "Save") to close the builder
- Click "Edit" to open it again
- Bug: The "Edit" tab is active, and the header selected again

With the initial website refactor, keeping the target after a reload was done by saving the target in the state of the component `WebsiteBuilderClientAction`, and using it during setup of editor (which is re-created after a reload). The stored value was not cleared when exiting the builder, so the last one stored got reused on the next normal opening

NOTE: In `builderOptions` plugin, this commit move the initialization of containers from the setup of the plugin to the resource `start_edition_handlers`. This is because `updateContainers` requires (in the general case) that the plugins `dragAndDrop` and `setup_editor_plugin` have been setup. (this is not achievable through `dependencies` because `dragAndDrop` already depends on `builderOptions`). This issue was not caught manually because the options concerned with `reloadTarget`:
- have `editableOnly: false`, which bypass the check for `o_editable` that is added in the setup of `setup_editor_plugin`
- target elements that have `.oe_unmovable`, which bypass the search made by `dragAndDrop` (which needs values from setup) These 2 conditions have no strong reasons to always be true, and were not in the test for simplicity (and because I did not know that constraint)

Website refactor: 9fe45e2b7ddbbfd0445ffe25a859e67a316d02b2
task-4367641
