### PR TITLE
[FIX] website: fix animated text with highlight effects

### DIFF
--- a/addons/website/static/src/js/editor/snippets.editor.js
+++ b/addons/website/static/src/js/editor/snippets.editor.js
@@ -509,9 +509,24 @@ export class WebsiteSnippetsMenu extends weSnippetEditor.SnippetsMenu {
             selectedTextEl.classList.add(...optionClassList);
             let $snippet = null;
             try {
+                const extendRange = (element) => {
+                    const elementRange = document.createRange();
+                    elementRange.selectNodeContents(element);
+                    // Don't reduce the range if it already contains the
+                    // targeted element.
+                    if (
+                        range.compareBoundaryPoints(Range.START_TO_START, elementRange) > 0 ||
+                        range.compareBoundaryPoints(Range.END_TO_END, elementRange) < 0
+                    ) {
+                        range.setStartBefore(element);
+                        range.setEndAfter(element);
+                    }
+                };
                 const commonAncestor = range.commonAncestorContainer;
                 const ancestorElement =
                     commonAncestor.nodeType === 1 ? commonAncestor : commonAncestor.parentElement;
+                const highlightParentEl =
+                    ancestorElement.parentElement.closest(".o_text_highlight");
                 const backgroundColorParentEl = ancestorElement.closest(
                     'font[style*="background-color"], font[style*="background-image"], font[class^="bg-"]'
                 );
@@ -519,8 +534,10 @@ export class WebsiteSnippetsMenu extends weSnippetEditor.SnippetsMenu {
                     // As long as we handle the same text content, we extend the
                     // existing range to the `<font/>` boundaries to keep the
                     // background color applied correctly.
-                    range.setStartBefore(backgroundColorParentEl);
-                    range.setEndAfter(backgroundColorParentEl);
+                    extendRange(backgroundColorParentEl);
+                }
+                if (highlightParentEl?.textContent.includes(commonAncestor.textContent)) {
+                    extendRange(highlightParentEl);
                 }
                 range.surroundContents(selectedTextEl);
                 $snippet = $(selectedTextEl);


### PR DESCRIPTION
Steps to reproduce:

1. Go to Website (Edit mode) and drop a title block.

2. Select the title and set a highlight effect, then a text animation on
it, and save the page.

3. Load the page in a reduced viewport in a way that makes the
highlighted text split into multiple lines.

4. The animation won't work.

The issue is caused mainly by the highlights being automatically split
(and also the animation wrapper inside) when there is no available space
for the text content, which destroys the "animation" interaction
targeted element without retargeting the new wrappers.

The goal of this commit is to fix this behavior by forcing the animation
to target the whole highlight when a part of its content is animated.

opw-4865891