### PR TITLE
[FIX] html_builder: accept negative value in shadow option

### DIFF
--- a/addons/html_builder/static/src/plugins/shadow_option_plugin.js
+++ b/addons/html_builder/static/src/plugins/shadow_option_plugin.js
@@ -49,7 +49,7 @@ function parseShadow(value) {
         return {};
     }
     const regex =
-        /(?<color>(rgb(a)?\([^)]*\))|(var\([^)]+\)))\s+(?<offsetX>\d+px)\s+(?<offsetY>\d+px)\s+(?<blur>\d+px)\s+(?<spread>\d+px)(\s+)?(?<mode>\w+)?/;
+        /(?<color>(rgb(a)?\([^)]*\))|(var\([^)]+\)))\s+(?<offsetX>-?\d+px)\s+(?<offsetY>-?\d+px)\s+(?<blur>-?\d+px)\s+(?<spread>-?\d+px)(?:\s+(?<mode>\w+))?/;
     return value.match(regex).groups;
 }
 


### PR DESCRIPTION
Since website refactor [1], negative values for the shadow option were not properly handled, leading to a traceback.

This commit updates `parseShadow` regex to correctly accept all negative shadow values.
These negative values are crucial for precise shadow styling, enabling effects like inner shadows or shadows that extend inward or upward.

Steps to reproduce:
- Edit website
- Click on header
- Modify shadow offset to a negative value
- A traceback occurs

[1]: https://github.com/odoo/odoo/commit/9fe45e2b7ddbbfd0445ffe25a859e67a316d02b2
