### PR TITLE
[FIX] website_sale: enable Pay button when ticking TC checkbox in mobile

### DIFF
--- a/addons/website_sale/static/src/js/payment_button.js
+++ b/addons/website_sale/static/src/js/payment_button.js
@@ -23,12 +23,15 @@ paymentButton.include({
      * @return {boolean}
      */
     _isTCCheckboxReady() {
-        const checkbox = document.querySelector('#website_sale_tc_checkbox');
-        if (!checkbox) { // The checkbox is not present.
+        // Find the one T&C checkbox that is not hidden, either the desktop or the mobile one.
+        const checkboxes = document.querySelectorAll('#website_sale_tc_checkbox');
+        const visibleCheckbox = Array.from(checkboxes).find(el => el.offsetParent !== null);
+
+        if (!visibleCheckbox) { // The checkbox is not present.
             return true;  // Ignore the check.
         }
 
-        return checkbox.checked;
+        return visibleCheckbox.checked;
     },
 
 });


### PR DESCRIPTION
Commit 260f3fc4 introduced an off-canvas cart summary containing a second "Terms & Conditions" checkbox with the same `id` as the desktop one. When ticking the mobile checkbox, the PaymentButton widget always found the desktop checkbox, which comes first in the DOM, when it should find the one that is currently visible instead.

opw-4935641
