### PR TITLE
[FIX] html_builder, *: remove implicit editableWindow and editableDocument

### DIFF
--- a/addons/html_builder/static/src/builder.js
+++ b/addons/html_builder/static/src/builder.js
@@ -20,12 +20,9 @@ import { InvisibleElementsPanel } from "@html_builder/sidebar/invisible_elements
 import { BlockTab } from "@html_builder/sidebar/block_tab";
 import { CustomizeTab } from "@html_builder/sidebar/customize_tab";
 import { useSnippets } from "@html_builder/snippets/snippet_service";
-import {
-    setBuilderCSSVariables,
-    setEditableDocument,
-    setEditableWindow,
-} from "@html_builder/utils/utils_css";
+import { setBuilderCSSVariables } from "@html_builder/utils/utils_css";
 import { withSequence } from "@html_editor/utils/resource";
+import { getHtmlStyle } from "@html_editor/utils/formatting";
 
 export class Builder extends Component {
     static template = "html_builder.Builder";
@@ -151,8 +148,6 @@ export class Builder extends Component {
             // editor.
             const iframeEl = await this.props.iframeLoaded;
             this.editableEl = iframeEl.contentDocument.body.querySelector("#wrapwrap");
-            setEditableWindow(iframeEl.contentWindow);
-            setEditableDocument(iframeEl.contentDocument);
 
             // Prevent image dragging in the website builder. Not via css because
             // if one of the image ancestor has a dragstart listener, the dragstart handler
@@ -188,7 +183,7 @@ export class Builder extends Component {
 
         onMounted(() => {
             this.editor.document.body.classList.add("editor_enable");
-            setBuilderCSSVariables();
+            setBuilderCSSVariables(getHtmlStyle(this.editor.document));
             // TODO: onload editor
             this.updateInvisibleEls();
         });

--- a/addons/html_builder/static/src/core/core_builder_action_plugin.js
+++ b/addons/html_builder/static/src/core/core_builder_action_plugin.js
@@ -1,4 +1,5 @@
 import { Plugin } from "@html_editor/plugin";
+import { getHtmlStyle } from "@html_editor/utils/formatting";
 import {
     CSS_SHORTHANDS,
     applyNeededCss,
@@ -38,13 +39,22 @@ function getStyleValue(el, styleName) {
     const computedStyle = window.getComputedStyle(el);
     const cssProps = CSS_SHORTHANDS[styleName] || [styleName];
     const cssValues = cssProps.map((cssProp) => computedStyle.getPropertyValue(cssProp).trim());
-    if (cssValues.length === 4 && areCssValuesEqual(cssValues[3], cssValues[1], styleName)) {
+    if (
+        cssValues.length === 4 &&
+        areCssValuesEqual(cssValues[3], cssValues[1], styleName, computedStyle)
+    ) {
         cssValues.pop();
     }
-    if (cssValues.length === 3 && areCssValuesEqual(cssValues[2], cssValues[0], styleName)) {
+    if (
+        cssValues.length === 3 &&
+        areCssValuesEqual(cssValues[2], cssValues[0], styleName, computedStyle)
+    ) {
         cssValues.pop();
     }
-    if (cssValues.length === 2 && areCssValuesEqual(cssValues[1], cssValues[0], styleName)) {
+    if (
+        cssValues.length === 2 &&
+        areCssValuesEqual(cssValues[1], cssValues[0], styleName, computedStyle)
+    ) {
         cssValues.pop();
     }
     return cssValues.join(" ");
@@ -165,7 +175,10 @@ class DataAttributeAction extends BuilderAction {
         if (!/(^color|Color)($|(?=[A-Z]))/.test(attributeName)) {
             return editingElement.dataset[attributeName];
         }
-        const color = normalizeColor(editingElement.dataset[attributeName]);
+        const color = normalizeColor(
+            editingElement.dataset[attributeName],
+            getHtmlStyle(this.document)
+        );
         return color;
     }
     isApplied({ editingElement, params: { mainParam: attributeName } = {}, value }) {

--- a/addons/html_builder/static/src/plugins/font/font_plugin.js
+++ b/addons/html_builder/static/src/plugins/font/font_plugin.js
@@ -1,9 +1,9 @@
 import { Plugin } from "@html_editor/plugin";
+import { getCSSVariableValue, getHtmlStyle } from "@html_editor/utils/formatting";
 import { registry } from "@web/core/registry";
 import { _t } from "@web/core/l10n/translation";
 import { Cache } from "@web/core/utils/cache";
 import { loadCSS } from "@web/core/assets";
-import { getCSSVariableValue } from "@html_builder/utils/utils_css";
 import { BuilderFontSizeSelector } from "./font_size_selector";
 
 export class BuilderFontPlugin extends Plugin {
@@ -53,7 +53,7 @@ export class BuilderFontPlugin extends Plugin {
         return this.fontsCache.read({});
     }
     async _fetchFonts() {
-        const style = window.getComputedStyle(this.document.documentElement);
+        const style = getHtmlStyle(this.document);
         const nbFonts = parseInt(getCSSVariableValue("number-of-fonts", style));
         // User fonts served by google server.
         const googleFontsProperty = getCSSVariableValue("google-fonts", style);

--- a/addons/html_builder/static/src/plugins/image/image_filter_option_plugin.js
+++ b/addons/html_builder/static/src/plugins/image/image_filter_option_plugin.js
@@ -2,6 +2,7 @@ import { BuilderAction } from "@html_builder/core/builder_action";
 import { normalizeColor } from "@html_builder/utils/utils_css";
 import { defaultImageFilterOptions } from "@html_editor/main/media/image_post_process_plugin";
 import { Plugin } from "@html_editor/plugin";
+import { getHtmlStyle } from "@html_editor/utils/formatting";
 import { registry } from "@web/core/registry";
 
 class ImageFilterOptionPlugin extends Plugin {
@@ -53,7 +54,9 @@ export class SetCustomFilterAction extends BuilderAction {
     async load({ editingElement: img, params: { mainParam: filterProperty }, value }) {
         const filterOptions = JSON.parse(img.dataset.filterOptions || "{}");
         filterOptions[filterProperty] =
-            filterProperty === "filterColor" ? normalizeColor(value) : value;
+            filterProperty === "filterColor"
+                ? normalizeColor(value, getHtmlStyle(this.document))
+                : value;
         return this.dependencies.imagePostProcess.processImage({
             img,
             newDataset: {

--- a/addons/html_builder/static/src/plugins/image/image_shape_option_plugin.js
+++ b/addons/html_builder/static/src/plugins/image/image_shape_option_plugin.js
@@ -1,8 +1,8 @@
 import { Plugin } from "@html_editor/plugin";
 import { registry } from "@web/core/registry";
 import { DEFAULT_PALETTE } from "@html_editor/utils/color";
+import { getCSSVariableValue, getHtmlStyle } from "@html_editor/utils/formatting";
 import { isCSSColor } from "@web/core/utils/colors";
-import { getCSSVariableValue } from "@html_builder/utils/utils_css";
 import { getShapeURL } from "@html_builder/plugins/image/image_helpers";
 import { activateCropper, createDataURL, loadImage } from "@html_editor/utils/image_processing";
 import { getValueFromVar } from "@html_builder/utils/utils";
@@ -323,7 +323,7 @@ export class ImageShapeOptionPlugin extends Plugin {
         if (!color || isCSSColor(color)) {
             return color;
         }
-        return getCSSVariableValue(color);
+        return getCSSVariableValue(color, getHtmlStyle(this.document));
     }
     isTransformableShape(shapeId) {
         if (!shapeId) {

--- a/addons/html_builder/static/src/sidebar/block_tab.js
+++ b/addons/html_builder/static/src/sidebar/block_tab.js
@@ -5,8 +5,8 @@ import { getScrollingElement } from "@web/core/utils/scrolling";
 import { _t } from "@web/core/l10n/translation";
 import { closest } from "@web/core/utils/ui";
 import { useDragAndDrop } from "@html_editor/utils/drag_and_drop";
+import { getCSSVariableValue } from "@html_editor/utils/formatting";
 import { useSnippets } from "@html_builder/snippets/snippet_service";
-import { getCSSVariableValue } from "@html_builder/utils/utils_css";
 import { scrollTo } from "@html_builder/utils/scrolling";
 import { Snippet } from "./snippet";
 import { CustomInnerSnippet } from "./custom_inner_snippet";
@@ -290,7 +290,12 @@ export class BlockTab extends Component {
                         if (match) {
                             colorCustomizedURL.searchParams.set(
                                 key,
-                                getCSSVariableValue(`o-color-${match[1]}`)
+                                getCSSVariableValue(
+                                    `o-color-${match[1]}`,
+                                    this.document.defaultView.getComputedStyle(
+                                        this.document.documentElement
+                                    )
+                                )
                             );
                         }
                     });

--- a/addons/html_editor/static/src/main/list/list_plugin.js
+++ b/addons/html_editor/static/src/main/list/list_plugin.js
@@ -26,7 +26,7 @@ import { _t } from "@web/core/l10n/translation";
 import { compareListTypes, createList, insertListAfter, isListItem } from "./utils";
 import { callbacksForCursorUpdate } from "@html_editor/utils/selection";
 import { withSequence } from "@html_editor/utils/resource";
-import { FONT_SIZE_CLASSES, getFontSizeOrClass } from "@html_editor/utils/formatting";
+import { FONT_SIZE_CLASSES, getFontSizeOrClass, getHtmlStyle } from "@html_editor/utils/formatting";
 import { getTextColorOrClass } from "@html_editor/utils/color";
 import { baseContainerGlobalSelector } from "@html_editor/utils/base_container";
 import { ListSelector } from "./list_selector";
@@ -1070,8 +1070,7 @@ export class ListPlugin extends Plugin {
         const largestMarkerPadding = Math.round(largestMarker) * (list.nodeName === "UL" ? 2 : 1);
 
         // bootstrap sets ul { padding-left: 2rem; }
-        const defaultPadding =
-            parseFloat(this.window.getComputedStyle(document.documentElement).fontSize) * 2;
+        const defaultPadding = parseFloat(getHtmlStyle(this.document).fontSize) * 2;
         // Align the whole list based on the item that requires the largest padding.
         // For smaller font sizes, doubling the width of the dot marker is still lower than the
         // default. The default is kept in that case.

--- a/addons/website/static/src/builder/plugins/background_option/background_image_option.js
+++ b/addons/website/static/src/builder/plugins/background_option/background_image_option.js
@@ -1,5 +1,6 @@
 import { BaseOptionComponent } from "@html_builder/core/utils";
 import { getBgImageURLFromEl, normalizeColor } from "@html_builder/utils/utils_css";
+import { getHtmlStyle } from "@html_editor/utils/formatting";
 
 export class BackgroundImageOption extends BaseOptionComponent {
     static template = "website.BackgroundImageOption";
@@ -48,6 +49,6 @@ export function getBackgroundImageColor(editingEl, colorName) {
         window.location.origin
     ).searchParams.get(colorName);
     if (backgroundImageColor) {
-        return normalizeColor(backgroundImageColor);
+        return normalizeColor(backgroundImageColor, getHtmlStyle(editingEl.ownerDocument));
     }
 }

--- a/addons/website/static/src/builder/plugins/background_option/background_shape_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/background_option/background_shape_option_plugin.js
@@ -10,6 +10,7 @@ import { getDefaultColors } from "./background_shape_option";
 import { withSequence } from "@html_editor/utils/resource";
 import { getBgImageURLFromURL } from "@html_editor/utils/image";
 import { BuilderAction } from "@html_builder/core/builder_action";
+import { getHtmlStyle } from "@html_editor/utils/formatting";
 
 export class BackgroundShapeOptionPlugin extends Plugin {
     static id = "backgroundShapeOption";
@@ -444,7 +445,7 @@ class BackgroundShapeColorAction extends BaseAnimationAction {
         const { shape, colors: customColors } = this.getShapeData(editingElement);
         const colors = Object.assign(getDefaultColors(editingElement), customColors);
         const color = shape && colors[colorName];
-        return (color && normalizeColor(color)) || "";
+        return (color && normalizeColor(color, getHtmlStyle(this.document))) || "";
     }
     apply({ editingElement, params: { mainParam: colorName }, value }) {
         this.applyShape(editingElement, () => {

--- a/addons/website/static/src/builder/plugins/customize_website_plugin.js
+++ b/addons/website/static/src/builder/plugins/customize_website_plugin.js
@@ -1,9 +1,6 @@
-import {
-    getCSSVariableValue,
-    isCSSVariable,
-    setBuilderCSSVariables,
-} from "@html_builder/utils/utils_css";
+import { isCSSVariable, setBuilderCSSVariables } from "@html_builder/utils/utils_css";
 import { Plugin } from "@html_editor/plugin";
+import { getCSSVariableValue, getHtmlStyle } from "@html_editor/utils/formatting";
 import { parseHTML } from "@html_editor/utils/html";
 import { ConfirmationDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
 import { _t } from "@web/core/l10n/translation";
@@ -52,7 +49,7 @@ export class CustomizeWebsitePlugin extends Plugin {
         color_combination_getters: withSequence(5, (el, actionParam) => {
             const combination = actionParam.combinationColor;
             if (combination) {
-                const style = this.window.getComputedStyle(this.document.documentElement);
+                const style = getHtmlStyle(this.document);
                 return `o_cc${getCSSVariableValue(combination, style)}`;
             }
         }),
@@ -86,7 +83,7 @@ export class CustomizeWebsitePlugin extends Plugin {
         this.pendingThemeRequests = pendingThemeRequests;
     }
     getWebsiteVariableValue(variable) {
-        const style = this.window.getComputedStyle(this.document.documentElement);
+        const style = getHtmlStyle(this.document);
         let finalValue = getCSSVariableValue(variable, style);
         /* TODO dedicated action ?
         if (!params.colorNames) {
@@ -428,7 +425,7 @@ export class CustomizeBodyBgTypeAction extends BuilderAction {
         if (bgImage === "none") {
             return "NONE";
         }
-        const style = this.window.getComputedStyle(this.document.documentElement);
+        const style = getHtmlStyle(this.document);
         return getCSSVariableValue("body-image-type", style);
     }
     async load({ editingElement: el, params, value, historyImageSrc }) {
@@ -742,7 +739,7 @@ export class CustomizeWebsiteColorAction extends BuilderAction {
         this.dependencies.customizeWebsite.withCustomHistory(this);
     }
     getValue({ params: { mainParam: color, colorType, gradientColor, combinationColor } }) {
-        const style = this.window.getComputedStyle(this.document.documentElement);
+        const style = getHtmlStyle(this.document);
         if (gradientColor) {
             const gradientValue =
                 this.dependencies.customizeWebsite.getWebsiteVariableValue(gradientColor);
@@ -796,7 +793,7 @@ export class CustomizeWebsiteColorAction extends BuilderAction {
                 { colorType, combinationColor, resetCcOnEmpty: true, nullValue }
             );
         }
-        setBuilderCSSVariables();
+        setBuilderCSSVariables(getHtmlStyle(this.document));
     }
 }
 
@@ -811,7 +808,7 @@ export class CustomizeButtonStyleAction extends BuilderAction {
         return this.getValue({ params }) === value;
     }
     getValue({ params: { mainParam: which } }) {
-        const style = this.window.getComputedStyle(this.document.documentElement);
+        const style = getHtmlStyle(this.document);
         const isOutline = getCSSVariableValue(`btn-${which}-outline`, style);
         const isFlat = getCSSVariableValue(`btn-${which}-flat`, style);
         return isFlat === "true" ? "flat" : isOutline === "true" ? "outline" : "fill";

--- a/addons/website/static/src/builder/plugins/font/font_plugin.js
+++ b/addons/website/static/src/builder/plugins/font/font_plugin.js
@@ -1,6 +1,6 @@
 import { registry } from "@web/core/registry";
-import { getCSSVariableValue } from "@html_builder/utils/utils_css";
 import { Plugin } from "@html_editor/plugin";
+import { getCSSVariableValue, getHtmlStyle } from "@html_editor/utils/formatting";
 import { showAddFontDialog } from "./add_font_dialog";
 
 // TODO Website-specific
@@ -70,7 +70,7 @@ class WebsiteFontPlugin extends Plugin {
         }
 
         // Adapt font variable indexes to the removal
-        const style = window.getComputedStyle(this.document.documentElement);
+        const style = getHtmlStyle(this.document);
         this.getResource("fontCssVariables").forEach((variable) => {
             const value = getCSSVariableValue(variable, style);
             if (value.substring(1, value.length - 1) === fontName) {

--- a/addons/website/static/src/builder/plugins/highlight/highlight_configurator.js
+++ b/addons/website/static/src/builder/plugins/highlight/highlight_configurator.js
@@ -2,6 +2,7 @@ import { Component, onWillStart, useState } from "@odoo/owl";
 import { ColorPicker } from "@web/core/color_picker/color_picker";
 import { HighlightPicker } from "./highlight_picker";
 import { normalizeColor } from "@html_builder/utils/utils_css";
+import { getHtmlStyle } from "@html_editor/utils/formatting";
 
 export const highlightIdToName = {
     underline: "Underline",
@@ -78,7 +79,7 @@ export class HighlightConfigurator extends Component {
                 applyColorPreview: (color) =>
                     this.props.previewHighlightStyle(
                         "--text-highlight-color",
-                        normalizeColor(color)
+                        normalizeColor(color, getHtmlStyle(document))
                     ),
                 applyColorResetPreview: this.props.revertHighlightStyle,
                 className: "d-contents",
@@ -95,7 +96,10 @@ export class HighlightConfigurator extends Component {
 
     selectHighlightColor(color) {
         this.props.componentStack.pop();
-        this.props.applyHighlightStyle("--text-highlight-color", normalizeColor(color));
+        this.props.applyHighlightStyle(
+            "--text-highlight-color",
+            normalizeColor(color, getHtmlStyle(document))
+        );
     }
 
     deleteHighlight() {

--- a/addons/website/static/src/builder/plugins/options/chart_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/chart_option_plugin.js
@@ -1,7 +1,7 @@
 import { BuilderAction } from "@html_builder/core/builder_action";
 import { ChartOption, DATASET_KEY_PREFIX } from "./chart_option";
-import { getCSSVariableValue } from "@html_builder/utils/utils_css";
 import { Plugin } from "@html_editor/plugin";
+import { getCSSVariableValue } from "@html_editor/utils/formatting";
 import { registry } from "@web/core/registry";
 import { isCSSColor } from "@web/core/utils/colors";
 

--- a/addons/website/static/src/builder/plugins/options/mega_menu_option.js
+++ b/addons/website/static/src/builder/plugins/options/mega_menu_option.js
@@ -1,5 +1,5 @@
 import { BaseOptionComponent, useDomState } from "@html_builder/core/utils";
-import { getCSSVariableValue } from "@html_builder/utils/utils_css";
+import { getCSSVariableValue, getHtmlStyle } from "@html_editor/utils/formatting";
 
 export class MegaMenuOption extends BaseOptionComponent {
     static template = "website.MegaMenuOption";
@@ -15,7 +15,10 @@ export class MegaMenuOption extends BaseOptionComponent {
     }
 
     hasHeaderTemplates(headerTemplates) {
-        const currentHeaderTemplate = getCSSVariableValue("header-template");
+        const currentHeaderTemplate = getCSSVariableValue(
+            "header-template",
+            getHtmlStyle(this.env.editor.document)
+        );
         return headerTemplates.includes(currentHeaderTemplate.slice(1, -1));
     }
 }

--- a/addons/website/static/src/builder/plugins/theme/theme_colors_option.js
+++ b/addons/website/static/src/builder/plugins/theme/theme_colors_option.js
@@ -1,6 +1,6 @@
 import { onMounted } from "@odoo/owl";
-import { getCSSVariableValue } from "@html_builder/utils/utils_css";
 import { BaseOptionComponent, useDomState } from "@html_builder/core/utils";
+import { getCSSVariableValue } from "@html_editor/utils/formatting";
 
 export class ThemeColorsOption extends BaseOptionComponent {
     static template = "website.ThemeColorsOption";

--- a/addons/website/static/src/builder/plugins/theme/theme_tab_plugin.js
+++ b/addons/website/static/src/builder/plugins/theme/theme_tab_plugin.js
@@ -1,8 +1,9 @@
 import { Plugin } from "@html_editor/plugin";
+import { getCSSVariableValue, getHtmlStyle } from "@html_editor/utils/formatting";
 import { withSequence } from "@html_editor/utils/resource";
 import { ThemeColorsOption } from "./theme_colors_option";
 import { ThemeAdvancedOption } from "./theme_advanced_option";
-import { getCSSVariableValue, setBuilderCSSVariables } from "@html_builder/utils/utils_css";
+import { setBuilderCSSVariables } from "@html_builder/utils/utils_css";
 import { ConfirmationDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
 import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
@@ -282,7 +283,7 @@ export class ChangeColorPaletteAction extends CustomizeWebsiteVariableAction {
             return;
         }
         await super.apply(context);
-        setBuilderCSSVariables();
+        setBuilderCSSVariables(getHtmlStyle(this.document));
     }
 }
 

--- a/addons/website/static/src/snippets/s_chart/chart.js
+++ b/addons/website/static/src/snippets/s_chart/chart.js
@@ -1,8 +1,8 @@
 import { Interaction } from "@web/public/interaction";
 import { registry } from "@web/core/registry";
 
+import { getCSSVariableValue } from "@html_editor/utils/formatting";
 import { loadBundle } from "@web/core/assets";
-import weUtils from "@web_editor/js/common/utils";
 
 export class Chart extends Interaction {
     static selector = ".s_chart";
@@ -122,7 +122,7 @@ export class Chart extends Interaction {
      * @param {string} color
      */
     convertToCSSColor(color) {
-        return color ? weUtils.getCSSVariableValue(color, this.style) || color : "transparent";
+        return color ? getCSSVariableValue(color, this.style) || color : "transparent";
     }
 }
 

--- a/addons/website/static/tests/tours/website_style_edition.js
+++ b/addons/website/static/tests/tours/website_style_edition.js
@@ -14,19 +14,19 @@ const TARGET_BODY_COLOR_V2 = 'rgb(255, 0, 255)';
 
 const checkFontSize = function () {
     const style = document.defaultView.getComputedStyle(this.anchor);
-    if (!areCssValuesEqual(style.fontSize, `${TARGET_FONT_SIZE}px`, "font-size")) {
+    if (!areCssValuesEqual(style.fontSize, `${TARGET_FONT_SIZE}px`, "font-size", style)) {
         console.error(`Expected the font-size to be equal to ${TARGET_FONT_SIZE}px but found ${style.fontSize} instead`);
     }
 };
 const checkBodyBgColor = function () {
     const style = document.defaultView.getComputedStyle(this.anchor);
-    if (!areCssValuesEqual(style.backgroundColor, `${TARGET_BODY_BG_COLOR}`, "background-color")) {
+    if (!areCssValuesEqual(style.backgroundColor, `${TARGET_BODY_BG_COLOR}`, "background-color", style)) {
         console.error(`Expected the background color to be equal to ${TARGET_BODY_BG_COLOR} but found ${style.backgroundColor} instead`);
     }
 };
 const checkBodyColor = function () {
     const style = document.defaultView.getComputedStyle(this.anchor);
-    if (!areCssValuesEqual(style.color, `${TARGET_BODY_COLOR}`, "color")) {
+    if (!areCssValuesEqual(style.color, `${TARGET_BODY_COLOR}`, "color", style)) {
         console.error(`Expected the color to be equal to ${TARGET_BODY_COLOR} but found ${style.color} instead`);
     }
 };


### PR DESCRIPTION
*: html_editor, website

The `editableWindow` and `editableDocument` global variables in
html_builder's utils_css file were leftovers from the previous codebase.
We would rather not cache them that way, as this prevents from having
different instances of the builder with different editable documents,
and it would also be easy to break it without noticing after an iframe
reload.
Utils that needed the editableDocument or window mostly needed the
iframe's computed style. Therefore, instead of relying on implicit
variables, `htmlStyle` is added as a mandatory parameter.

task-4367641