### PR TITLE
[FIX] l10n_in_withholding: missing index on o2m FK

### DIFF
--- a/addons/l10n_in_withholding/models/account_move.py
+++ b/addons/l10n_in_withholding/models/account_move.py
@@ -23,6 +23,7 @@ class AccountMove(models.Model):
         comodel_name='account.payment',
         string="Indian TDS Ref Payment",
         readonly=True,
+        index='btree_not_null',
         copy=False,
         help="Reference Payment for withholding entry",
     )


### PR DESCRIPTION
FK columns in large tables like `account.move` need to be indexed if an opposite one-to-many relationship is defined, otherwise reading that o2m requires a full Seq Scan of the table.

Introduced via #183335