### PR TITLE
[ADD] web: fixed issue regarding inconsistent breadcrumbs.

### DIFF
--- a/addons/web/static/src/webclient/actions/action_service.js
+++ b/addons/web/static/src/webclient/actions/action_service.js
@@ -813,6 +813,14 @@ export function makeActionManager(env, router = _router) {
         if (action.target !== "new" && "newStack" in options) {
             controllerStack = options.newStack;
         }
+        // If the action that triggered _updateUI is an embedded action, we want to 
+        // replace the last element of controllerStack before adding the new controller
+        // but only if the last element is the parent action of this current action.
+        const actionContext = action.context;
+        const prevAction = controllerStack.at(-1)?.action;
+        if (actionContext && prevAction && actionContext.from_embedded_action && actionContext.parent_action_id === prevAction.id) {
+            options.stackPosition = "replaceCurrentAction";
+        }
         const index = _computeStackIndex(options);
         const nextStack = [...controllerStack.slice(0, index), controller];
         // Compute breadcrumbs


### PR DESCRIPTION
When using embedded action buttons (in this case in the project app), clicking on a embedded action button besides the default 'task' button and refreshing the page results in erroneous breadcrumbs. Specifically, the breadcrumbs will include a random task that was not clicked on. This is caused by an additional action being registered to the action list for the embedded action button while we are still on the same project. Instead, with the implemented fix, the current action will be replaced by the new embedded action instead of the new action being added to the action list without replacement. With this fix, refreshing the page after clicking an embedded button will not cause errors in the breadcrumbs.

However, there are side effects caused by this change. Before the fix, clicking on an embedded action button other than the default 'task' button would create a breadcrumb to go back to the 'task' action. With the fix, this is no longer the case: a breadcrumb is no longer created when clicking on an embedded action. This should not be a big issue as the user will still be on the same page anyways and can easily nagivate back to the 'task' page with the embedded action.

To reproduce the error on a blank DB:
1) Download and open the project app
2) Open any project
3) View embedded action buttons by clicking on the button to the left of view selection
4) Enable the 'sale orders' button and click on it 
5) Notice the breadcrumbs
6) Refresh the page
7) Notice the erroneous breadcrumbs

opw-4889557
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
