### PR TITLE
[IMP] stock_delivery: standardize chosen pickings for logging labels

### DIFF
--- a/addons/stock_delivery/models/stock_picking.py
+++ b/addons/stock_delivery/models/stock_picking.py
@@ -253,3 +253,14 @@ class StockPicking(models.Model):
     def _should_generate_commercial_invoice(self):
         self.ensure_one()
         return self.picking_type_id.warehouse_id.partner_id.country_id != self.partner_id.country_id
+
+    def get_lognote_pickings(self):
+        """ Helper method for use in delivery_* modules. Intended to allow for consistent behavior
+        regarding which related picking records are given a shipping label across shipping connectors.
+        """
+        lognote_pickings = next_picking = self
+        while next_picking:
+            next_picking = next_picking._get_next_transfers()
+            if next_picking and next_picking.state not in ('done', 'cancel'):
+                lognote_pickings |= next_picking
+        return lognote_pickings


### PR DESCRIPTION
### Issue:
Currently, there is no shared behavior between shipping connectors and how they determine which `picking` records to log a generated shipping label to. This leads to situations where bugs are discovered and patched in different ways in different `delivery_*` modules, leading to inconsistent results. Some examples include odoo/enterprise#44887, odoo/enterprise#71441, and odoo/enterprise#84202.

While these patches fix their intended issue, other modules do not contain their fixes since the target was an individual connector. Additional, the patches either cause or ignore others issues, namely the following:

1. If you complete a sale order's delivery, add new products to the order, then validate the new delivery, the shipping note will be posted in all of the sale order's pickings.

2. If you confirm a sale order, then validate a portion of the quantity (creating a backorder), the shipping note for the first picking will be added to the backorder. Then, when you validate the backorder, the new chatter will also be added to the first picking.

### Solution:
The goal here is three-fold:

1. The provide a helper function that can be used across `delivery_*` modules, centralizing the logic to ensure that any additional changes or fixed issues can be applied to all affected modules.

2. Resolve the existing issues reported above.

3. After discussion with logitics and PO, decision was made to streamline the label propogation to only display on `picking` records that come after, not before, the currently validated one.

opw-4601697
