### PR TITLE
[IMP] im_livechat: add live chat channels configuration menu

### DIFF
--- a/addons/im_livechat/__manifest__.py
+++ b/addons/im_livechat/__manifest__.py
@@ -32,6 +32,7 @@ Help your customers with this chat, and analyse their feedback.
         "views/im_livechat_channel_views.xml",
         "views/im_livechat_channel_templates.xml",
         "views/im_livechat_chatbot_templates.xml",
+        "views/im_livechat_channel_config_views.xml",
         "views/im_livechat_expertise_views.xml",
         "views/im_livechat_channel_member_history_views.xml",
         "views/res_users_views.xml",

--- a/addons/im_livechat/views/im_livechat_channel_config_views.xml
+++ b/addons/im_livechat/views/im_livechat_channel_config_views.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0"?>
+<odoo>
+    <data>
+        <record id="im_livechat_channel_config_view_kanban" model="ir.ui.view">
+            <field name="name">im_livechat.channel.kanban</field>
+            <field name="model">im_livechat.channel</field>
+            <field name="inherit_id" ref="im_livechat.im_livechat_channel_view_kanban"/>
+            <field name="mode">primary</field>
+            <field name="arch" type="xml">
+                <xpath expr="//kanban" position="attributes">
+                    <attribute name="action"/>
+                </xpath>
+                <xpath expr="//t[@t-name='menu']" position="replace"/>
+            </field>
+        </record>
+
+        <record id="im_livechat_channel_config_action" model="ir.actions.act_window">
+            <field name="name">Live Chat Channels</field>
+            <field name="res_model">im_livechat.channel</field>
+            <field name="view_mode">list,kanban,form</field>
+            <field name="view_id" ref="im_livechat_channel_config_view_kanban"/>
+            <field name="help" type="html">
+              <p class="o_view_nocontent_smiling_face">
+                Define a new website live chat channel
+              </p><p>
+                You can create channels for each website on which you want
+                to integrate the website live chat widget, allowing your website
+                visitors to talk in real time with your operators.
+              </p>
+            </field>
+        </record>
+
+        <record id="im_livechat_channel_config_action_list" model="ir.actions.act_window.view">
+            <field name="sequence">1</field>
+            <field name="view_mode">list</field>
+            <field name="view_id" ref="im_livechat_channel_view_list"/>
+            <field name="act_window_id" ref="im_livechat_channel_config_action"/>
+        </record>
+
+        <record id="im_livechat_channel_config_action_kanban" model="ir.actions.act_window.view">
+            <field name="sequence">2</field>
+            <field name="view_mode">kanban</field>
+            <field name="view_id" ref="im_livechat_channel_config_view_kanban"/>
+            <field name="act_window_id" ref="im_livechat_channel_config_action"/>
+        </record>
+
+        <menuitem
+            id="livechat_channels_config"
+            name="Live Chat Channels"
+            parent="livechat_config"
+            action="im_livechat_channel_config_action"
+            groups="im_livechat_group_manager"
+            sequence="10"
+        />
+    </data>
+</odoo>

--- a/addons/im_livechat/views/im_livechat_channel_views.xml
+++ b/addons/im_livechat/views/im_livechat_channel_views.xml
@@ -18,11 +18,24 @@
             </field>
         </record>
 
+        <record id="im_livechat_channel_view_list" model="ir.ui.view">
+            <field name="name">im_livechat.channel.list</field>
+            <field name="model">im_livechat.channel</field>
+            <field name="arch" type="xml">
+                <list string="Live Chat Channels" sample="1">
+                    <field name="name" string="Name"/>
+                    <field name="user_ids" string="Operators" widget="many2many_avatar_user"/>
+                    <field name="nbr_channel" string="Sessions"/>
+                    <field name="rating_percentage_satisfaction" string="Rating (%)"/>
+                </list>
+            </field>
+        </record>
+
         <record id="im_livechat_channel_view_kanban" model="ir.ui.view">
             <field name="name">im_livechat.channel.kanban</field>
             <field name="model">im_livechat.channel</field>
             <field name="arch" type="xml">
-                <kanban js_class="im_livechat.livechat_channel_kanban" action="im_livechat.discuss_channel_action_from_livechat_channel" type="action">
+                <kanban sample="1" js_class="im_livechat.livechat_channel_kanban" action="im_livechat.discuss_channel_action_from_livechat_channel" type="action">
                     <field name="are_you_inside"/>
                     <field name="rating_count"/>
                     <templates>
@@ -234,7 +247,8 @@
             <field name="model">im_livechat.channel</field>
             <field name="arch" type="xml">
                 <search string="LiveChat Channel Search">
-                    <field name="name" string="Channel"/>
+                    <field name="name" string="Channel Name"/>
+                    <field name="user_ids" string="Operators"/>
                 </search>
             </field>
         </record>


### PR DESCRIPTION
**Description of the issue this PR addresses:**
Add Live Chat Channels Configuration Menu

**Desired behaviour after PR is merged:**
- Admin users can now access channels configuration
through the dedicated 'Live Chat Channels' menu.
- Visible only to users with 'Live Chat > Admin' access rights
- Displays a list view with columns: Name, Operators, Sessions, and Rating
- Adds a  kanban view.
- Adds a custom search view with quick items: Name and Operators
- Enables sample data and action helper

task-[4916202](https://www.odoo.com/odoo/project/1519/tasks/4916202)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
