### PR TITLE
[IMP] html_editor, website: customize link popover

### DIFF
--- a/addons/html_editor/static/src/main/link/link_plugin.js
+++ b/addons/html_editor/static/src/main/link/link_plugin.js
@@ -875,6 +875,7 @@ export class LinkPlugin extends Plugin {
         }
         cursors.restore();
         this.linkInDocument = null;
+        this.dependencies.selection.focusEditable();
         this.dependencies.history.addStep();
     }
 

--- a/addons/html_editor/static/src/main/link/link_popover.js
+++ b/addons/html_editor/static/src/main/link/link_popover.js
@@ -230,7 +230,9 @@ export class LinkPopover extends Component {
         }
         this.updateDocumentState();
         this.editingWrapper = useRef("editing-wrapper");
-        this.inputRef = useRef(this.state.isImage ? "url" : "label");
+        this.inputRef = useRef(
+            this.state.isImage || (this.state.label && !this.state.url) ? "url" : "label"
+        );
         useEffect(
             (el) => {
                 if (el) {
@@ -329,6 +331,7 @@ export class LinkPopover extends Component {
             textContent + "/" === this.props.linkElement.getAttribute("href");
         this.state.label = labelEqualsUrl ? "" : textContent;
     }
+    // TODO: remove in master
     async onClickCopy(ev) {
         ev.preventDefault();
         await browser.navigator.clipboard.writeText(this.props.linkElement.href || "");
@@ -591,41 +594,39 @@ export class LinkPopover extends Component {
     }
 
     get classes() {
-        let classes = [...this.props.linkElement.classList]
-            .filter(
-                (value) =>
-                    !value.match(/^(btn.*|rounded-circle|flat|(text|bg)-(o-color-\d$|\d{3}$))$/)
-            )
-            .join(" ");
+        const classes = [...this.props.linkElement.classList].filter(
+            (value) => !value.match(/^(btn.*|rounded-circle|flat|(text|bg)-(o-color-\d$|\d{3}$))$/)
+        );
 
         let stylePrefix = "";
-        if (this.state.type === "custom") {
+        if (this.state.type) {
             if (this.state.buttonSize) {
-                classes += ` btn-${this.state.buttonSize}`;
+                classes.push(`btn-${this.state.buttonSize}`);
             }
+
             if (this.state.buttonShape) {
                 const buttonShape = this.state.buttonShape.split(" ");
                 if (["outline", "fill"].includes(buttonShape[0])) {
                     stylePrefix = `${buttonShape[0]}-`;
                 }
-                classes += ` ${buttonShape.slice(stylePrefix ? 1 : 0).join(" ")}`;
+                classes.push(buttonShape.slice(stylePrefix ? 1 : 0).join(" "));
             }
-        }
-        if (this.state.type) {
-            classes += ` btn btn-${stylePrefix}${this.state.type}`;
+
+            classes.push(`btn`, `btn-${stylePrefix}${this.state.type}`);
         }
 
         const textColor = this.customTextColorState.selectedColor;
         if (isCSSVariable(textColor)) {
-            classes += " text-" + textColor;
+            classes.push(`text-${textColor}`);
         }
 
         const fillColor = this.customFillColorState.selectedColor;
         if (isCSSVariable(fillColor)) {
-            classes += " bg-" + fillColor;
+            classes.push(`bg-${fillColor}`);
         }
 
-        return classes.trim();
+        // Ensure single space between classes
+        return classes.filter(Boolean).join(" ");
     }
 
     get customStyles() {

--- a/addons/html_editor/static/src/main/link/link_popover.scss
+++ b/addons/html_editor/static/src/main/link/link_popover.scss
@@ -27,6 +27,10 @@
         border-color: $input-focus-border-color !important;
         box-shadow: 0 0 0 $focus-ring-width rgba($input-focus-border-color, $focus-ring-opacity);
     }
+
+    .o_link_popover_container {
+        min-width: 300px;
+    }
 }
 
 .o_seo_option_child {

--- a/addons/html_editor/static/src/main/link/link_popover.xml
+++ b/addons/html_editor/static/src/main/link/link_popover.xml
@@ -1,9 +1,9 @@
 <templates id="template" xml:space="preserve">
 
     <t t-name="html_editor.linkPopover">
-        <div class="o-we-linkpopover d-flex bg-light overflow-auto shadow" t-on-keydown="onKeydown">
+        <div class="o-we-linkpopover d-flex bg-light overflow-auto shadow" t-on-keydown="onKeydown" role="dialog" aria-modal="true" aria-label="Link Popover">
             <div t-if="state.editing" class="container-fluid d-flex vertical-center p-2" t-ref="editing-wrapper">
-                <div t-if="state.isImage" class="col p-2" style="max-width: 250px;">
+                <div t-if="state.isImage" class="col p-2 o_link_popover_container">
                     <div class="input-group mb-1">
                         <input name="o_linkpopover_url_img" t-ref="url" class="o_we_href_input_link border-dark-subtle form-control form-control-sm" t-model="state.url" title="URL" placeholder="Type your URL"
                             t-on-keydown="onKeydownEnter"/>
@@ -44,7 +44,7 @@
                         </div>
                     </t>
                 <t t-else="">
-                    <div class="col p-2" style="max-width: 250px;">
+                    <div class="col p-2 o_link_popover_container">
                         <div class="input-group mb-2" t-att-class="{'d-none': !state.showLabel}">
                             <input t-ref="label"
                                 class="o_we_label_link border-dark-subtle form-control form-control-sm"
@@ -71,11 +71,17 @@
                             <select name="link_type" class="form-select form-select-sm border-dark-subtle w-100 mb-1" t-model="state.type" t-on-change="onChange">
                                 <t t-foreach="this.colorsData" t-as="colorData" t-key="colorData.type">
                                     <t t-if="props.allowCustomStyle or colorData.type !== 'custom'">
-                                        <option t-att-value="colorData.type" t-att-selected="state.type === colorData.type" t-attf-class="o_btn_preview">
-                                            <span t-esc="colorData.label"/>
-                                        </option>
+                                        <option t-att-value="colorData.type" t-att-selected="state.type === colorData.type" t-attf-class="o_btn_preview" t-out="colorData.label"/>
                                     </t>
                                 </t>
+                            </select>
+                        </div>
+                        <div t-if="state.type" class="input-group">
+                            <select name="link_style_size" class="form-select form-select-sm border-dark-subtle mb-1" t-model="state.buttonSize" t-on-change="onChange" aria-label="Select button size">
+                                <option t-foreach="this.buttonSizesData" t-as="buttonSizesData" t-key="buttonSizesData.size" t-att-value="buttonSizesData.size" t-att-selected="state.buttonSize === buttonSizesData.size" t-out="buttonSizesData.label"/>
+                            </select>
+                            <select name="link_style_shape" class="form-select form-select-sm link-style border-dark-subtle mb-1" t-model="state.buttonShape" t-on-change="onChange" aria-label="Select button shape">
+                                <option t-foreach="this.buttonShapeData" t-as="buttonShapeData" t-key="buttonShapeData.shape" t-att-value="buttonShapeData.shape" t-att-selected="state.buttonShape === buttonShapeData.shape" t-out="buttonShapeData.label"/>
                             </select>
                         </div>
 
@@ -108,26 +114,6 @@
                                         t-attf-style="background-color: {{this.props.formatColor(this.customBorderColorState.selectedColor)}}" />
                                 </div>
                             </div>
-                            <div class="input-group mb-1">
-                                <label>Size</label>
-                                <select name="link_style_size" class="form-select form-select-sm link-style" t-model="state.buttonSize" t-on-change="onChange">
-                                    <t t-foreach="this.buttonSizesData" t-as="buttonSizesData" t-key="buttonSizesData.size">
-                                        <option t-att-value="buttonSizesData.size" t-att-selected="state.buttonSize === buttonSizesData.size">
-                                            <span t-esc="buttonSizesData.label"/>
-                                        </option>
-                                    </t>
-                                </select>
-                            </div>
-                            <div class="input-group mb-1">
-                                <label>Shape</label>
-                                <select name="link_style_shape" class="form-select form-select-sm link-style" t-model="state.buttonShape" t-on-change="onChange">
-                                    <t t-foreach="this.buttonShapeData" t-as="buttonShapeData" t-key="buttonShapeData.shape">
-                                        <option t-att-value="buttonShapeData.shape" t-att-selected="state.buttonShape === buttonShapeData.shape">
-                                            <span t-out="buttonShapeData.label"/>
-                                        </option>
-                                    </t>
-                                </select>
-                            </div>
                         </t>
                         <t t-if="props.allowTargetBlank">
                             <t t-if="state.isDocument">
@@ -152,9 +138,14 @@
                                 <button class="o_we_apply_link btn btn-sm btn-primary" t-att-disabled="!state.url" t-on-click="onClickApply">Apply</button>
                                 <button class="o_we_discard_link btn btn-sm btn-secondary ms-1" t-on-click="props.onDiscard">Discard</button>
                             </div>
-                            <button class="btn btn-sm btn-secondary" title="Advanced mode" t-att-disabled="!state.url" t-on-click="toggleAdvancedOptions">
-                                <i class="fa fa-gear"/>
-                            </button>
+                            <div class="d-flex align-items-center gap-1">
+                                <a t-if="props.canRemove and state.url" href="#" class="o_we_remove_link text-dark" t-on-click.prevent="onClickRemove" title="Remove Link">
+                                    <i class="fa fa-chain-broken"></i>
+                                </a>
+                                <button class="btn btn-sm btn-secondary" title="Advanced mode" t-att-disabled="!state.url" t-on-click="toggleAdvancedOptions">
+                                    <i class="fa fa-gear"/>
+                                </button>
+                            </div>
                         </div>
                     </div>
                 </t>
@@ -173,24 +164,16 @@
                                 <a href="#" target="_blank" t-attf-href="{{state.url}}" class="o_we_url_link fw-bold flex-grow-1 text-truncate" style="max-width: 160px;" t-attf-title="{{state.urlTitle}}">
                                     <t t-esc="state.urlTitle"/>
                                 </a>
-                                <div class="flex-grow-1 d-flex justify-content-end gap-2">
-                                    <a href="#" class="o_we_replace_title_btn text-dark"
+                                <div class="flex-grow-1 d-flex justify-content-end align-items-center gap-1">
+                                    <a href="#" class="mx-1 o_we_replace_title_btn text-dark"
                                         t-if="!state.isImage and state.urlTitle and state.label === '' and !state.showReplaceTitleBanner"
                                         t-on-click="onClickReplaceTitle"
                                         title="Replace URL with its title"
                                     >
                                         <i class="fa fa-magic"></i>
                                     </a>
-                                    <a href="#" class="o_we_copy_link text-dark" t-on-click="onClickCopy" title="Copy Link">
-                                        <i class="fa fa-clipboard"></i>
-                                    </a>
                                     <t t-if="props.canEdit">
-                                        <a href="#" class="o_we_edit_link text-dark" t-on-click="onClickEdit" title="Edit Link">
-                                            <i class="fa fa-edit"></i>
-                                        </a>
-                                        <a href="#" t-if="props.canRemove" class="o_we_remove_link text-dark" t-on-click="onClickRemove" title="Remove Link">
-                                            <i class="fa fa-chain-broken"></i>
-                                        </a>
+                                        <a href="#" class="o_we_edit_link btn btn-sm btn-secondary" t-on-click="onClickEdit" title="Edit Link">Edit</a>
                                     </t>
                                 </div>
                             </div>

--- a/addons/html_editor/static/tests/_helpers/user_actions.js
+++ b/addons/html_editor/static/tests/_helpers/user_actions.js
@@ -1,6 +1,13 @@
 import { closestBlock, isBlock } from "@html_editor/utils/blocks";
 import { findInSelection } from "@html_editor/utils/selection";
-import { click, manuallyDispatchProgrammaticEvent, press, tick, waitFor } from "@odoo/hoot-dom";
+import {
+    animationFrame,
+    click,
+    manuallyDispatchProgrammaticEvent,
+    press,
+    tick,
+    waitFor,
+} from "@odoo/hoot-dom";
 import { setSelection } from "./selection";
 import { execCommand } from "./userCommands";
 import { isMobileOS } from "@web/core/browser/feature_detection";
@@ -245,6 +252,8 @@ export async function unlinkFromToolbar() {
 
 export async function unlinkFromPopover() {
     await waitFor(".o-we-linkpopover");
+    await click(".o_we_edit_link");
+    await animationFrame();
     await click(".o_we_remove_link");
 }
 

--- a/addons/html_editor/static/tests/link/button.test.js
+++ b/addons/html_editor/static/tests/link/button.test.js
@@ -138,6 +138,20 @@ describe("Custom button style", () => {
         expect(optionsvalues).toInclude("Button Secondary");
         expect(optionsvalues).not.toInclude("Custom");
     });
+    test("Editor allow button size style by default", async () => {
+        await setupEditor(
+            '<p><a href="https://test.com/" class="btn btn-primary">link[]Label</a></p>'
+        );
+        await waitFor(".o-we-linkpopover");
+        await click(".o_we_edit_link");
+        await animationFrame();
+        const optionsValues = [...queryOne('select[name="link_style_size"]').options].map(
+            (opt) => opt.label
+        );
+        expect(optionsValues).toInclude("Small");
+        expect(optionsValues).toInclude("Medium");
+        expect(optionsValues).toInclude("Large");
+    });
     test("Editor don't allow target blank style by default", async () => {
         await setupEditor('<p><a href="https://test.com/">link[]Label</a></p>');
         await waitFor(".o-we-linkpopover");

--- a/addons/website/static/src/builder/plugins/navbar_link_popover/navbar_link_popover.xml
+++ b/addons/website/static/src/builder/plugins/navbar_link_popover/navbar_link_popover.xml
@@ -8,10 +8,9 @@
         <xpath expr="//a[hasclass('o_we_url_link')]" position="attributes">
             <attribute name="class" add="me-3" separator=" "/>
         </xpath>
-        <xpath expr="//a[@title='Remove Link']" position="replace">
+        <xpath expr="//a[@title='Edit Link']" position="after">
             <button type="button"
                     class="js_edit_menu btn btn-sm btn-primary"
-                    style="padding: 0px 6px;"
                     t-on-click="onClickEditMenu" title="Edit Menu">
                 Edit Menu
             </button>

--- a/addons/website/static/src/js/editor/html_editor.js
+++ b/addons/website/static/src/js/editor/html_editor.js
@@ -65,7 +65,7 @@ patch(LinkPopover.prototype, {
         this.urlRef = useChildRef();
         useEffect(
             (el) => {
-                if (el) {
+                if (el && (this.state.isImage || (!this.state.url && this.state.label))) {
                     el.focus();
                 }
             },

--- a/addons/website/static/src/xml/html_editor.xml
+++ b/addons/website/static/src/xml/html_editor.xml
@@ -26,7 +26,7 @@
         input="urlRef"
         dropdown="true"
         autofocus="true"
-        placeholder.translate="Type your URL"
+        placeholder.translate="Enter URL, /page, or #anchor"
         inputClass="'o_we_href_input_link border-dark-subtle form-control form-control-sm'"
         t-on-keydown="onKeydownEnter"
         updateValue.bind="updateValue"

--- a/addons/website/static/tests/builder/linkpopover_website.test.js
+++ b/addons/website/static/tests/builder/linkpopover_website.test.js
@@ -241,3 +241,16 @@ test("link redirection should not be prefixed when the current page is not a web
     // the open method should not be called from onClickForcePreviewMode
     expect.verifySteps([]);
 });
+
+test("Focus should be on label when adding a new URL", async () => {
+    const { editor } = await setupEditor("<p>ab[]</p>");
+    await insertText(editor, "/link");
+    await animationFrame();
+    expect(".active .o-we-command-name").toHaveText("Link");
+    await click(".o-we-command-name:first");
+    await animationFrame();
+    expect(".o-we-linkpopover").toHaveCount(1);
+    expect(".o-we-linkpopover input.o_we_label_link").toBeFocused({
+        message: "should focus label input by default",
+    });
+});

--- a/addons/website/static/tests/tours/edit_link_popover.js
+++ b/addons/website/static/tests/tours/edit_link_popover.js
@@ -69,6 +69,7 @@ registerWebsitePreviewTour(
             content: "Popover should be shown for home",
             trigger: ".o-we-linkpopover .o_we_url_link:contains('Home')",
         },
+        clickEditLink,
         {
             content: "Click on Remove Link in Popover",
             trigger: ".o-we-linkpopover .o_we_remove_link",


### PR DESCRIPTION
The link popover previously had multiple buttons, making the link
editing experience less intuitive. This commit unifies actions into
a single wider popover and refactors some logic to improve consistency.

## UI/UX changes:
- Replaced three buttons (copy, edit, remove) with one "Edit" button,
  which opens the link editing view.
   | Before  | After |
   | ------------- | ------------- |
   | ![image](https://github.com/user-attachments/assets/04727aea-fc7b-410b-9159-1ac56e9b42a0)  |  ![image](https://github.com/user-attachments/assets/512628c7-b425-4831-a90e-caa6b1868c3d)  |

- Widened the popover for better readability.
- Removed the copy link feature.

<br/>

## Changes in link editing view:
- Moved the "remove link" button in this view.
  <kbd>![image](https://github.com/user-attachments/assets/4ad69aa4-4edb-4a25-a7b0-f84e76cbcbce)</kbd>

- Updated URL input placeholder to: "Enter URL, /page, or #anchor".
- Auto-focus the URL input when creating a link for selected text.
- Auto-focus the label input when creating new links or editing
  existing links.

task-[4862671](https://www.odoo.com/odoo/project/974/tasks/4862671)

Co-authored-by: adch-odoo \<adch@odoo.com\>

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr