### PR TITLE
[REM] purchase_requisition: remove redundant view inheritance

### DIFF
--- a/addons/purchase_requisition/views/purchase_views.xml
+++ b/addons/purchase_requisition/views/purchase_views.xml
@@ -58,16 +58,6 @@
         </field>
     </record>
 
-    <record id="purchase_order_tree_inherit_purchase_requisition" model="ir.ui.view">
-        <field name="name">purchase.order.list.inherit.purchase.requisition</field>
-        <field name="model">purchase.order</field>
-        <field name="inherit_id" ref="purchase.purchase_order_tree"/>
-        <field name="arch" type="xml">
-            <field name="name" position="before">
-            </field>
-        </field>
-    </record>
-
     <record id="purchase_order_line_compare_tree" model="ir.ui.view">
         <field name="name">purchase.order.line.compare.list</field>
         <field name="model">purchase.order.line</field>


### PR DESCRIPTION
This commit removes the 'purchase_order_tree_inherit_purchase_requisition' view, 
which was inheriting the 'purchase.purchase_order_tree' view but did not introduce
any actual changes.

Originally, this view was used to inject the 'has_alternatives' field, but that logic has since 
been removed in this [PR](https://github.com/odoo/odoo/pull/211005).
As a result, the view inheritance became redundant and had no functional impact.

This commit removes the dead code to keep the codebase clean.