### PR TITLE
[FIX] spreadsheet: rename 'not_set' operator

### DIFF
--- a/addons/spreadsheet/static/src/@types/global_filter.d.ts
+++ b/addons/spreadsheet/static/src/@types/global_filter.d.ts
@@ -61,7 +61,7 @@ declare module "@spreadsheet" {
         | DateRangeValue;
 
     interface SetValue {
-        operator: "set" | "not_set";
+        operator: "set" | "not set";
     }
 
     interface RelationIdsValue {
@@ -70,7 +70,7 @@ declare module "@spreadsheet" {
     }
 
     interface RelationContainsValue {
-        operator: "ilike" | "not ilike" | "starts_with" | "ends_with";
+        operator: "ilike" | "not ilike" | "starts with";
         strings: string[];
     }
 
@@ -101,7 +101,7 @@ declare module "@spreadsheet" {
     }
 
     interface TextContainsValue {
-        operator: "ilike" | "not ilike" | "starts_with";
+        operator: "ilike" | "not ilike" | "starts with";
         text: string;
     }
 

--- a/addons/spreadsheet/static/src/global_filters/helpers.js
+++ b/addons/spreadsheet/static/src/global_filters/helpers.js
@@ -101,7 +101,7 @@ export function checkFilterDefaultValueIsValid(filter, defaultValue) {
 }
 
 const SET_OPERATORS_BEHAVIORS = {
-    operators: ["set", "not_set"],
+    operators: ["set", "not set"],
     validateValue: isSetValueValid,
     validateDefaultValue: isSetValueValid,
     getSearchBarFacetValues: (env, filter, filterValue) => [
@@ -147,7 +147,7 @@ const FILTERS_BEHAVIORS = {
             },
         },
         {
-            operators: ["starts_with"],
+            operators: ["starts with"],
             defaultValue: { strings: [] },
             validateValue: (filterValue) => isArrayOfStrings(filterValue.strings),
             validateDefaultValue: (filterValue) => isArrayOfStrings(filterValue.strings),
@@ -336,7 +336,7 @@ function isCurrentUserOrArrayOfIds(value) {
  * @returns {boolean}
  */
 function isSetValueValid(value) {
-    return value.operator === "set" || value.operator === "not_set";
+    return value.operator === "set" || value.operator === "not set";
 }
 
 /**
@@ -753,7 +753,7 @@ export function getDateDomain(from, to, field, fieldType) {
     return new Domain();
 }
 
-const TEXT_OPERATORS = ["ilike", "not ilike", "starts_with"];
+const TEXT_OPERATORS = ["ilike", "not ilike", "starts with"];
 
 export function getFilterTypeOperators(filterType) {
     if (filterType === "date") {
@@ -865,7 +865,7 @@ function getOperatorLabel(operator) {
         case "=":
         case "in":
         case "set":
-        case "not_set":
+        case "not set":
             return "";
         case "!=":
         case "not in":

--- a/addons/spreadsheet/static/src/o_spreadsheet/migration.js
+++ b/addons/spreadsheet/static/src/o_spreadsheet/migration.js
@@ -150,7 +150,7 @@ migrationStepRegistry.add("18.5.10", {
                     delete globalFilter.defaultValue; // [true, false] no longer supported
                 } else {
                     globalFilter.defaultValue = {
-                        operator: globalFilter.defaultValue[0] ? "set" : "not_set",
+                        operator: globalFilter.defaultValue[0] ? "set" : "not set",
                     };
                 }
             }

--- a/addons/spreadsheet/static/tests/global_filters/filter_search_dialog.test.js
+++ b/addons/spreadsheet/static/tests/global_filters/filter_search_dialog.test.js
@@ -259,10 +259,10 @@ test("Can change a boolean filter value", async function () {
     await mountFiltersSearchDialog(env, { model });
     await contains(".o-add-global-filter").click();
     await contains(".o-add-global-filter-label").click();
-    await contains(".modal select").select("not_set");
+    await contains(".modal select").select("not set");
     await contains(".btn-primary").click();
     expect(model.getters.getGlobalFilterValue("42")).toEqual(
-        { operator: "not_set" },
+        { operator: "not set" },
         {
             message: "value is set",
         }
@@ -340,19 +340,19 @@ test("clearing a filter value preserves the operator", async function () {
         defaultValue: { operator: "ilike", strings: ["foo"] },
     });
     await mountFiltersSearchDialog(env, { model });
-    await contains(".modal select").select("starts_with");
+    await contains(".modal select").select("starts with");
 
     // remove the only value
     await contains(".o-filters-search-dialog .o-filter-item .o_tag .o_delete").click();
     expect(".o-filters-search-dialog .o-filter-item .o_tag").toHaveCount(0);
-    expect(".modal select").toHaveValue("starts_with");
+    expect(".modal select").toHaveValue("starts with");
 
     // add a value back
     await contains(".o-filters-search-dialog .o-filter-item .o-autocomplete input").edit("foo");
     await contains(".o-filters-search-dialog .o-filter-item .o-autocomplete input").press("Enter");
     await contains(".btn-primary").click();
     expect(model.getters.getGlobalFilterValue("42")).toEqual({
-        operator: "starts_with",
+        operator: "starts with",
         strings: ["foo"],
     });
 });
@@ -399,4 +399,48 @@ test(`Relational global filter with "set" operator doesn't have a record selecto
     });
     await mountFiltersSearchDialog(env, { model });
     expect(".o-filter-value input").toHaveCount(0);
+});
+
+test("relational global filter operator options", async function () {
+    onRpc("ir.model", "has_searchable_parent_relation", () => ({ partner: true }));
+    const env = await makeMockEnv();
+    const model = new Model({}, { custom: { odooDataProvider: new OdooDataProvider(env) } });
+    await addGlobalFilter(model, {
+        id: "42",
+        type: "relation",
+        label: "Filter",
+        modelName: "partner",
+        defaultValue: { operator: "in", ids: [38] },
+    });
+    await mountFiltersSearchDialog(env, { model });
+    expect(queryAllTexts("option")).toEqual([
+        "is in",
+        "is not in",
+        "child of",
+        "contains",
+        "does not contain",
+        "is set",
+        "is not set",
+    ]);
+});
+
+test("text global filter operator options", async function () {
+    const env = await makeMockEnv();
+    const model = new Model({}, { custom: { odooDataProvider: new OdooDataProvider(env) } });
+    await addGlobalFilter(model, {
+        id: "42",
+        type: "text",
+        label: "Filter",
+        defaultValue: { operator: "in", strings: ["hello"] },
+    });
+    await mountFiltersSearchDialog(env, { model });
+    expect(queryAllTexts("option")).toEqual([
+        "contains",
+        "does not contain",
+        "is in",
+        "is not in",
+        "starts with",
+        "is set",
+        "is not set",
+    ]);
 });

--- a/addons/spreadsheet/static/tests/global_filters/global_filter_helper.test.js
+++ b/addons/spreadsheet/static/tests/global_filters/global_filter_helper.test.js
@@ -24,7 +24,7 @@ describe.current.tags("headless");
 const { DateTime } = luxon;
 
 const LAZY_TRANSLATED_SET = getOperatorLabel("set");
-const LAZY_TRANSLATED_NOT_SET = getOperatorLabel("not_set");
+const LAZY_TRANSLATED_NOT_SET = getOperatorLabel("not set");
 const LAZY_TRANSLATED_CONTAINS = getOperatorLabel("ilike");
 
 beforeEach(() => {
@@ -470,7 +470,7 @@ test("getFacetInfo for boolean values", async () => {
         operator: "",
         values: [LAZY_TRANSLATED_SET],
     });
-    expect(await getFacetInfo(env, filter, { operator: "not_set" })).toEqual({
+    expect(await getFacetInfo(env, filter, { operator: "not set" })).toEqual({
         title: "Boolean Filter",
         id: "1",
         separator: "or",

--- a/addons/spreadsheet/static/tests/global_filters/global_filters_model.test.js
+++ b/addons/spreadsheet/static/tests/global_filters/global_filters_model.test.js
@@ -2797,7 +2797,7 @@ test("Check boolean filter domain", async () => {
     expect(model.getters.getGlobalFilterDomain("42", fieldMatching).toString()).toEqual(
         `[("active", "!=", False)]`
     );
-    model.dispatch("SET_GLOBAL_FILTER_VALUE", { id: "42", value: { operator: "not_set" } });
+    model.dispatch("SET_GLOBAL_FILTER_VALUE", { id: "42", value: { operator: "not set" } });
     expect(model.getters.getGlobalFilterDomain("42", fieldMatching).toString()).toEqual(
         `[("active", "=", False)]`
     );
@@ -2900,7 +2900,7 @@ test("text global filter with starts_with operator", async () => {
         id: "42",
         label: "test",
         type: "text",
-        defaultValue: { operator: "starts_with", strings: ["hello", "world"] },
+        defaultValue: { operator: "starts with", strings: ["hello", "world"] },
     };
     await addGlobalFilter(model, filter);
     const fieldMatching = { chain: "product_id", type: "many2one" };

--- a/addons/spreadsheet/static/tests/migrations/migrations.test.js
+++ b/addons/spreadsheet/static/tests/migrations/migrations.test.js
@@ -686,7 +686,7 @@ test("global filter default value have operators", () => {
         ids: [2],
     });
     expect(migratedData.globalFilters[3].defaultValue).toEqual({ operator: "set" });
-    expect(migratedData.globalFilters[4].defaultValue).toEqual({ operator: "not_set" });
+    expect(migratedData.globalFilters[4].defaultValue).toEqual({ operator: "not set" });
     expect(migratedData.globalFilters[5].defaultValue).toBe(undefined);
 });
 


### PR DESCRIPTION
Steps to reproduce:
- open a dashboard with any relation filter having operators
- click on the search bar to open the filter dialog
- add a filter

=> the last select option is the technical value '"not_set"' instead of being a human friendly text.

The commit that introduced global filters operators (dddcd8919f0) was done at the same time as commit 7602ca0f61750 which changed "not_set" to "not set"

Task: 4937875

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
