### PR TITLE
[FIX] website: prevent removal of scroll top button

### DIFF
--- a/addons/website/static/src/builder/plugins/options/footer_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/footer_option_plugin.js
@@ -69,6 +69,7 @@ class FooterOptionPlugin extends Plugin {
             WebsiteConfigFooterAction,
         },
         on_prepare_drag_handlers: this.prepareDrag.bind(this),
+        unremovable_node_predicates: (node) => node.id === "o_footer_scrolltop",
     };
 
     prepareDrag() {


### PR DESCRIPTION
> [VBAL] Footer: it is possible to manually delete the content of the of "scroll top" button, and there is no functional way to bring it back: https://drive.google.com/file/d/1IaEESlpSkfYRrc4b4wVjV2efS2-CHuGo/view?usp=drive_link.

Steps to reproduce:
- Open website builder
- Click on the footer
- Enable "Scroll Top Button"
- Click on the button and delete its content
- On the link tool that appears, click "Remove Link"
- Bug: It is not possible to add it back

With the website builder refactor, the removal of this button from within the document was not prevented

NOTE: the supported way to remove the button is to disable it from the side bar by toggling "Scroll Top Button"

Website refactor: 9fe45e2b7ddbbfd0445ffe25a859e67a316d02b2
task-4367641
