### PR TITLE
[IMP] html_editor,*: rename some resource predicates to match convention

### DIFF
--- a/addons/html_editor/static/src/core/format_plugin.js
+++ b/addons/html_editor/static/src/core/format_plugin.js
@@ -301,7 +301,9 @@ export class FormatPlugin extends Plugin {
             // with a class that is not indicated as splittable.
             const isClassListSplittable = (classList) =>
                 [...classList].every((className) =>
-                    this.getResource("format_splittable_class").some((cb) => cb(className))
+                    this.getResource("format_splittable_class_predicates").some((cb) =>
+                        cb(className)
+                    )
                 );
 
             while (

--- a/addons/html_editor/static/src/main/font/font_plugin.js
+++ b/addons/html_editor/static/src/main/font/font_plugin.js
@@ -290,7 +290,7 @@ export class FontPlugin extends Plugin {
         /** Processors */
         clipboard_content_processors: this.processContentForClipboard.bind(this),
 
-        format_splittable_class: (className) => FONT_SIZE_CLASSES.includes(className),
+        format_splittable_class_predicates: (className) => FONT_SIZE_CLASSES.includes(className),
     };
 
     setup() {

--- a/addons/html_editor/static/src/main/table/table_plugin.js
+++ b/addons/html_editor/static/src/main/table/table_plugin.js
@@ -121,7 +121,7 @@ export class TablePlugin extends Plugin {
         fully_selected_node_predicates: (node) => !!closestElement(node, ".o_selected_td"),
         targeted_nodes_processors: this.adjustTargetedNodes.bind(this),
         move_node_whitelist_selectors: "table",
-        collapsed_selection_toolbar_predicate: (selectionData) =>
+        collapsed_selection_toolbar_predicates: (selectionData) =>
             !!closestElement(selectionData.editableSelection.anchorNode, "td.o_selected_td"),
     };
 

--- a/addons/html_editor/static/src/main/toolbar/toolbar_plugin.js
+++ b/addons/html_editor/static/src/main/toolbar/toolbar_plugin.js
@@ -357,7 +357,7 @@ export class ToolbarPlugin extends Plugin {
         }
         const isCollapsed = selectionData.editableSelection.isCollapsed;
         if (isCollapsed) {
-            return this.getResource("collapsed_selection_toolbar_predicate").some((fn) =>
+            return this.getResource("collapsed_selection_toolbar_predicates").some((fn) =>
                 fn(selectionData)
             );
         }

--- a/addons/website/static/src/builder/plugins/highlight/highlight_plugin.js
+++ b/addons/website/static/src/builder/plugins/highlight/highlight_plugin.js
@@ -63,9 +63,9 @@ export class HighlightPlugin extends Plugin {
                 }
             }
         },
-        format_splittable_class: (className) => className.startsWith("o_text_highlight"),
+        format_splittable_class_predicates: (className) => className.startsWith("o_text_highlight"),
         selectionchange_handlers: this.updateSelectedHighlight.bind(this),
-        collapsed_selection_toolbar_predicate: (selectionData) =>
+        collapsed_selection_toolbar_predicates: (selectionData) =>
             !!closestElement(selectionData.editableSelection.anchorNode, ".o_text_highlight"),
         remove_format_handlers: () => {
             const highlightedNodes = this.getSelectedHighlightNodes();


### PR DESCRIPTION
*: website

This commit changes the name of
- `format_splittable_class` to `format_splittable_class_predicates`
- `collapsed_selection_toolbar_predicate` to `collapsed_selection_toolbar_predicates` to match the naming convention for resources

Introduction of the naming convention: fe809b8bf8adbf39289317654c8afad8283bcf9f

task-4367641

