### PR TITLE
[FIX] pos_self_order: display `tracking_number` prefix

### DIFF
--- a/addons/point_of_sale/static/src/app/models/pos_order.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order.js
@@ -287,7 +287,7 @@ export class PosOrder extends Base {
             shippingDate: this.shipping_date && formatDate(DateTime.fromSQL(this.shipping_date)),
             headerData: {
                 ...headerData,
-                trackingNumber: this.tracking_number,
+                trackingNumber: this.config.module_pos_restaurant ? this.tracking_number : "",
             },
             screenName: "ReceiptScreen",
         };

--- a/addons/pos_self_order/static/src/app/models/pos_order.js
+++ b/addons/pos_self_order/static/src/app/models/pos_order.js
@@ -6,6 +6,11 @@ import { patch } from "@web/core/utils/patch";
 patch(PosOrder.prototype, {
     setup() {
         super.setup(...arguments);
+        if (this.pos_reference?.startsWith("Self-Order")) {
+            this.tracking_number = "S" + this.tracking_number;
+        } else if (this.pos_reference?.startsWith("Kiosk")) {
+            this.tracking_number = "K" + this.tracking_number;
+        }
 
         if (!this.uiState.lineChanges) {
             this.uiState = {

--- a/addons/pos_self_order/static/src/app/pages/confirmation_page/confirmation_page.js
+++ b/addons/pos_self_order/static/src/app/pages/confirmation_page/confirmation_page.js
@@ -76,7 +76,6 @@ export class ConfirmationPage extends Component {
         const order = this.selfOrder.models["pos.order"].find(
             (o) => o.access_token === this.props.orderAccessToken
         );
-        order.tracking_number = "S" + order.tracking_number;
         this.confirmedOrder = order;
 
         const paymentMethods = this.selfOrder.filterPaymentMethods(

--- a/addons/pos_self_order/static/src/app/self_order_service.js
+++ b/addons/pos_self_order/static/src/app/self_order_service.js
@@ -908,7 +908,7 @@ export class SelfOrder extends Reactive {
             company: this.company,
             cashier: _t("Self-Order"),
             header: this.config.receipt_header,
-            trackingNumber: order.trackingNumber,
+            trackingNumber: this.config.module_pos_restaurant ? order.tracking_number : "",
             bigTrackingNumber: true,
             pickingService: this.config.self_ordering_service_mode,
             tableTracker: order.table_stand_number,

--- a/addons/pos_self_order/static/src/overrides/models/pos_store.js
+++ b/addons/pos_self_order/static/src/overrides/models/pos_store.js
@@ -27,6 +27,8 @@ patch(PosOrder.prototype, {
         super.setup(...arguments);
         if (this.pos_reference?.startsWith("Self-Order")) {
             this.tracking_number = "S" + this.tracking_number;
+        } else if (this.pos_reference?.startsWith("Kiosk")) {
+            this.tracking_number = "K" + this.tracking_number;
         }
     },
 });

--- a/addons/pos_self_order/static/tests/tours/self_order_combo_tour.js
+++ b/addons/pos_self_order/static/tests/tours/self_order_combo_tour.js
@@ -2,6 +2,7 @@ import { registry } from "@web/core/registry";
 import * as Utils from "@pos_self_order/../tests/tours/utils/common";
 import * as CartPage from "@pos_self_order/../tests/tours/utils/cart_page_util";
 import * as ProductPage from "@pos_self_order/../tests/tours/utils/product_page_util";
+import * as ConfirmationPage from "@pos_self_order/../tests/tours/utils/confirmation_page_util";
 
 registry.category("web_tour.tours").add("self_combo_selector", {
     steps: () => [
@@ -47,6 +48,7 @@ registry.category("web_tour.tours").add("self_combo_selector", {
             },
         ]),
         Utils.clickBtn("Pay"),
+        ConfirmationPage.orderNumberIs("S", "1"),
         Utils.clickBtn("Ok"),
         Utils.checkIsNoBtn("Order Now"),
     ],

--- a/addons/pos_self_order/static/tests/tours/self_order_kiosk_tour.js
+++ b/addons/pos_self_order/static/tests/tours/self_order_kiosk_tour.js
@@ -39,6 +39,8 @@ registry.category("web_tour.tours").add("self_kiosk_each_table_takeaway_in", {
         Utils.clickBtn("Pay"),
         Numpad.click("3"),
         Utils.clickBtn("Pay"),
+        ConfirmationPage.orderNumberShown(),
+        ConfirmationPage.orderNumberIs("K", "1"),
         Utils.clickBtn("Close"),
         Utils.checkIsNoBtn("My Order"),
         ...clickOrderNowAndWaitLocation("Eat In"),

--- a/addons/pos_self_order/static/tests/tours/utils/confirmation_page_util.js
+++ b/addons/pos_self_order/static/tests/tours/utils/confirmation_page_util.js
@@ -11,3 +11,19 @@ export function orderNumberShown() {
         trigger: ".number",
     };
 }
+
+export function orderNumberIs(trackingPrefix, trackingNumber) {
+    return {
+        content: `Check that the order number start with '${trackingPrefix}', and end with number '${trackingNumber}'.`,
+        trigger: `span.number`,
+        run: function () {
+            const span = document.querySelector("span.number");
+            const text = span.textContent || "";
+            if (!text.startsWith(trackingPrefix) || !text.endsWith(trackingNumber)) {
+                throw new Error(
+                    `Order number '${text}' does not start with '${trackingPrefix}' and end with '${trackingNumber}'`
+                );
+            }
+        },
+    };
+}


### PR DESCRIPTION
- Add a prefix `S` or `K` (respectively for Self and Kiosk orders) to the `tracking_number` for the Self/kiosk orders.
- Display the `tracking_number` in the receipt header only if `pos_restaurant` is installed.
- This prefix will be displayed on the ticket screen, on the receipt, on the preparation display and on the preparation receipt for coherence and to facilitate tracking of orders. 

task-id: 4922308

enterprise PR: https://github.com/odoo/enterprise/pull/90042



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
