### PR TITLE
[FIX] l10n_es_modelo130: inconsistent filter date

### DIFF
--- a/addons/l10n_es_modelo130/data/mod130.xml
+++ b/addons/l10n_es_modelo130/data/mod130.xml
@@ -5,7 +5,7 @@
             <field name="name">Tax Report(Mod 130)</field>
             <field name="sequence">130</field>
             <field name="filter_analytic" eval="False"/>
-            <field name="filter_date_range" eval="True"/>
+            <field name="filter_date_range" eval="False"/>
             <field name="filter_period_comparison" eval="False"/>
             <field name="filter_unfold_all" eval="True"/>
             <field name="filter_journals" eval="True"/>


### PR DESCRIPTION
Currently mod130 report is configured to compute from the beginning of
the fiscal period, however the date filter widget is in range mode.

This means that when a user open the report and select a date range, the
entries will not be just in the selected range but span from the
beginning of the fiscal year to the end of the range, creating
confusion.

We should disable filter date range, so the date widget allow to set an
end date to the current period

Enterprise PR: https://github.com/odoo/enterprise/pull/90044

opw-4933241