### PR TITLE
[FIX] stock: fix SQL error due to incorrect param format

### DIFF
--- a/addons/stock/tests/test_quant.py
+++ b/addons/stock/tests/test_quant.py
@@ -217,7 +217,7 @@ class StockQuant(TransactionCase):
         with closing(self.registry.cursor()) as cr:
             cr.execute("SELECT id FROM stock_quant WHERE product_id=%s AND location_id=%s", (product.id, self.stock_location.id))
             quant_id = cr.fetchone()
-            cr.execute("SELECT 1 FROM stock_quant WHERE id=%s FOR UPDATE", quant_id)
+            cr.execute("SELECT 1 FROM stock_quant WHERE id=%s FOR UPDATE", [quant_id])
             self.env['stock.quant']._update_available_quantity(product, self.stock_location, 1.0)
 
         self.assertEqual(self.env['stock.quant']._get_available_quantity(product, self.stock_location, allow_negative=True), available_quantity + 1)


### PR DESCRIPTION
The raw SQL query on stock_quant using cr.execute() failed due to incorrect parameter binding — the placeholder %s was not properly substituted, resulting in a misleading error: column "s" does not exist. This happened because the parameter was passed as a scalar instead of a sequence.

This fix wraps the parameter in a list to ensure correct binding and prevent SQL syntax errors.

build_error-223115
