### PR TITLE
[FIX] website{, _livechat}: traceback when linking visitor to livechats

### DIFF
--- a/addons/website_livechat/models/website_visitor.py
+++ b/addons/website_livechat/models/website_visitor.py
@@ -109,9 +109,10 @@ class WebsiteVisitor(models.Model):
         if upsert == 'inserted':
             visitor_sudo = self.sudo().browse(visitor_id)
             if guest := self.env["mail.guest"]._get_guest_from_context():
-                guest_livechats = guest.channel_ids.filtered(lambda c: c.channel_type == "livechat")
-                guest_livechats.channel_ids.livechat_visitor_id = visitor_sudo.id
-                guest_livechats.channel_ids.anonymous_name = (
+                # sudo: mail.guest - guest can access their own channels and link them to newly created visitor.
+                guest_livechats = guest.sudo().channel_ids.filtered(lambda c: c.channel_type == "livechat")
+                guest_livechats.livechat_visitor_id = visitor_sudo.id
+                guest_livechats.anonymous_name = (
                     "Visitor #%d (%s)" % (visitor_sudo.id, visitor_sudo.country_id.name)
                     if visitor_sudo.country_id
                     else f"Visitor #{visitor_sudo.id}"


### PR DESCRIPTION
When a new website.visitor is created while a guest is set in the context, 
livechat channels of the related guest need to be updated to link the 
newly created visitor.

Before this PR, 
the update caused an access error because the public user does not 
have permission to update channel records.

Steps to reproduce:
- Go to a tracked page (e.g., /contactus) and start a livechat as a guest, 
then end it.
- Log in as a user, go to a tracked page, start a livechat, then end it.
- Log out and go to a tracked page -> an access error occurs.

This PR uses sudo to allow updating channels, as guests can access 
their own channels.

task-[4891195](https://www.odoo.com/odoo/project/1519/tasks/4891195)