### PR TITLE
[FIX] website: restore parallax options in popup

### DIFF
--- a/addons/website/static/src/builder/plugins/options/parallax_option.js
+++ b/addons/website/static/src/builder/plugins/options/parallax_option.js
@@ -1,12 +1,5 @@
-import { BaseOptionComponent, useDomState } from "@html_builder/core/utils";
+import { BaseOptionComponent } from "@html_builder/core/utils";
 export class ParallaxOption extends BaseOptionComponent {
     static template = "website.ParallaxOption";
     static props = {};
-
-    setup() {
-        super.setup();
-        this.state = useDomState((el) => ({
-            InDialog: el.closest('.modal[role="dialog"]'),
-        }));
-    }
 }

--- a/addons/website/static/src/builder/plugins/options/parallax_option.xml
+++ b/addons/website/static/src/builder/plugins/options/parallax_option.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
 <t t-name="website.ParallaxOption">
-    <BuilderRow t-if="isActiveItem('toggle_bg_image_id') and !isActiveItem('toggle_bg_video_id') and !this.state.InDialog" label.translate="Scroll Effect" level="2" preview="false">
+    <BuilderRow t-if="isActiveItem('toggle_bg_image_id') and !isActiveItem('toggle_bg_video_id')" label.translate="Scroll Effect" level="2" preview="false">
         <BuilderSelect action="'setParallaxType'">
             <BuilderSelectItem actionValue="'none'">None</BuilderSelectItem>
             <BuilderSelectItem actionValue="'fixed'">Fixed</BuilderSelectItem>


### PR DESCRIPTION
In [1], we wrongly removed the parallax option for background image that are in a dialog. This lead to some problems (e.g. dropping a snippet with parallax enabled (s_cover) inside a popup doesn't let you remove it). This commit just revert the change concerning the apparition of the option depending on the context.

[1]: https://github.com/odoo/odoo/commit/598827afe40e64b27134cb2c9ddbb9421e8a5d82
