### PR TITLE
[FIX] web_editor: avoid duplicate protocol in background video URL

### DIFF
--- a/addons/web_editor/static/src/components/media_dialog/video_selector.js
+++ b/addons/web_editor/static/src/components/media_dialog/video_selector.js
@@ -104,7 +104,9 @@ export class VideoSelector extends Component {
             if (this.props.media) {
                 const src = this.props.media.dataset.oeExpression || this.props.media.dataset.src || (this.props.media.tagName === 'IFRAME' && this.props.media.getAttribute('src')) || '';
                 if (src) {
-                    this.state.urlInput = "https:" + src;
+                    if (!src.startsWith("http:") && !src.startsWith("https:")) {
+                        this.state.urlInput = "https:" + src;
+                    }
                     await this.updateVideo();
 
                     this.state.options = this.state.options.map((option) => {


### PR DESCRIPTION
Problem:
After https://github.com/odoo/odoo/pull/175663/commits/75c2343ed3a41f32964fc91a007c6b11b5a75d9f, if a background video is added and then replaced, the resulting video URL contains a duplicated protocol in video selector.

Cause:
For background videos, the URL is retrieved from `iframe.src`, which already includes the protocol. The current logic unconditionally prefixes the URL with a protocol, leading to duplication.

Solution:
Check whether the URL already contains a protocol before prefixing it.

Steps to reproduce:
- Add a block
- Add a background video
- Open the video selector to replace the background video -> The resulting URL has the protocol duplicated

opw-4931945

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
