### PR TITLE
[FIX] base: avoid error if embedded action refers to uninstalled module

### DIFF
--- a/odoo/addons/base/models/ir_embedded_actions.py
+++ b/odoo/addons/base/models/ir_embedded_actions.py
@@ -75,7 +75,8 @@ class IrEmbeddedActions(models.Model):
             active_model_record = self.env[parent_res_model].search(domain_id, order='id')
             for record in records:
                 action_groups = record.groups_ids
-                if not action_groups or (action_groups & self.env.user.all_group_ids):
+                is_valid_method = not record.python_method or hasattr(self.env[parent_res_model], record.python_method)
+                if is_valid_method and (not action_groups or (action_groups & self.env.user.all_group_ids)):
                     domain_model = literal_eval(record.domain or '[]')
                     record.is_visible = (
                         record.parent_res_id in (False, self.env.context.get('active_id', False))


### PR DESCRIPTION
The system failed to evaluate the embedded action, which refers to the Uninstalled module.

**Steps to produce:-**
- Install `Project` and `Timesheets`.
- Go to Project and open any project.
- Click on the `embedded action` icon and select Timesheets.
- `Save` the view from the `embedded action's icon`.
- Now, `Uninstall Timesheets`.
- Now, go to that Project and try to open it.

**Error:-**
`KeyError: 'allow_timesheets'
ValueError: Invalid field in filter of project.project:
 [('allow_timesheets', '=', True)]`

**Solution:-**
- Added a safe check using `hasattr` to verify if the `python_method` defined on the embedded action actually exists on the specified model.
- Ensured that if the method is missing or invalid, the embedded action is marked as not visible instead of causing a crash.

**sentry-6738596751**

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
