### PR TITLE
[FIX] mail: sidebar channel name bold when unread

### DIFF
--- a/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.js
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.js
@@ -134,7 +134,7 @@ export class DiscussSidebarChannel extends Component {
             "o-unread fw-bolder":
                 this.thread.selfMember?.message_unread_counter > 0 && !this.thread.selfMember?.mute_until_dt,
             "text-muted":
-                this.thread.selfMember?.message_unread_counter !== 0 || this.thread.selfMember?.mute_until_dt,
+                this.thread.selfMember?.message_unread_counter == 0 || this.thread.selfMember?.mute_until_dt,
         };
     }
 


### PR DESCRIPTION
Before this commit, the channel name in the sidebar would be bold when read and muted when unread which is the opposite of the intended behavior.

This happens because in https://github.com/odoo/odoo/pull/217629 the condition to make the name bold or muted got extracted into a component method with the incorrect opposite condition for muted.

This commit fixes the issue by changing the condition to the correct opposite.

task-4938469
