### PR TITLE
[IMP] api_doc: a few changes

### DIFF
--- a/addons/api_doc/__manifest__.py
+++ b/addons/api_doc/__manifest__.py
@@ -40,7 +40,18 @@ the methods over HTTP, with examples in various programming languages.
             'web/static/src/core/assets.js',
             'web/static/src/core/code_editor/**',
 
-            'api_doc/static/src/**/*',
+            # Bootstrap
+            ('include', 'web._assets_helpers'),
+            'web/static/src/scss/pre_variables.scss',
+            'web/static/lib/bootstrap/scss/_variables.scss',
+            'web/static/lib/bootstrap/scss/_variables-dark.scss',
+            'web/static/lib/bootstrap/scss/_maps.scss',
+            ('include', 'web._assets_bootstrap'),
+
+            # Static files
+            'api_doc/static/src/**/*.xml',
+            'api_doc/static/src/**/*.js',
+            'api_doc/static/src/doc_client.css',
         ],
     },
     'bootstrap': True,

--- a/addons/api_doc/static/src/components/doc_method.js
+++ b/addons/api_doc/static/src/components/doc_method.js
@@ -1,4 +1,4 @@
-import { Component, useState } from "@odoo/owl";
+import { Component, useState, markup } from "@odoo/owl";
 import { DocRequest } from "@api_doc/components/doc_request";
 import { DocTable, TABLE_TYPES } from "@api_doc/components/doc_table";
 import { getParameterDefaultValue } from "@api_doc/utils/doc_model_utils";
@@ -27,7 +27,7 @@ export class DocMethod extends Component {
                     value: "annotation" in options ? options.annotation : "-",
                 },
                 { type: TABLE_TYPES.Code, value: this.getDefaultValue(options) },
-                { type: TABLE_TYPES.Tooltip, value: options.doc || "" },
+                { type: TABLE_TYPES.Tooltip, value: markup(options.doc) || "" },
             ]),
         };
     }
@@ -63,7 +63,6 @@ export class DocMethod extends Component {
 
         const request = {
             ids: [],
-            kwargs: {},
             context: {},
         };
 
@@ -73,7 +72,7 @@ export class DocMethod extends Component {
 
         for (const paramName in this.method.parameters) {
             const param = this.method.parameters[paramName];
-            request.kwargs[paramName] = getParameterDefaultValue(paramName, param);
+            request[paramName] = getParameterDefaultValue(paramName, param);
         }
 
         return request;

--- a/addons/api_doc/static/src/components/doc_method.xml
+++ b/addons/api_doc/static/src/components/doc_method.xml
@@ -4,45 +4,49 @@
 <t t-name="web.DocMethod">
     <article class="o-doc-method mb-2 rounded" t-att-class="props.class" t-att-id="this.method.name">
         <div
-            class="o-doc-method-header position-sticky flex w-100 align-items-center justify-content-between cursor-pointer rounded bg-1"
+            class="o-doc-method-header position-sticky d-flex flex-nowrap w-100 cursor-pointer rounded bg-1"
             t-on-click="() => this.state.open = !this.state.open"
             t-att-class="{ ['border-bottom']: this.state.open, o_collapsed: !this.state.open }"
             role="button"
         >
             <div class="icon-btn" role="button" t-att-class="{ o_collapsed: !this.state.open }">
-                <i class="fa fa-angle-right" aria-hidden="true"></i>
+                <i class="fa fa-angle-right ps-1 pt-1" aria-hidden="true"></i>
             </div>
             <h4 class="flex-grow ms-1" t-out="this.method.name"></h4>
-            <div class="ms-1 text-muted" t-out="this.method.module"></div>
+            <a
+                class="ms-2 fs-5"
+                t-att-href="'#' + method.name"
+                t-on-click.stop=""
+            >#</a>
+            <div class="text-muted align-self-center ms-auto" t-out="this.method.module"></div>
         </div>
 
         <div
             t-if="state.open"
-            class="o-doc-method-content p-3 bg-1 flex"
+            class="o-doc-method-content p-3 bg-1 d-flex flex-nowrap"
             t-att-class="{ 'flex-column': isVertical }"
         >
             <div t-att-class="{ 'w-100': isVertical, 'w-50 pe-2': !isVertical }">
                 <h4>Route</h4>
-                <pre t-out="this.method.url"/>
+                <pre t-out="this.method.url" class="mb-2"/>
 
                 <t t-if="doc">
                     <h4 class="mt-2">Description</h4>
                     <p class="doc_method_description mb-2" t-out="doc"></p>
                 </t>
-
-                <t t-if="method.signature">
-                    <h4 class="mt-2">Signature</h4>
-                    <pre t-out="method.signature"/>
-                </t>
-
                 <h4 class="mt-2">Parameters</h4>
                 <DocTable
                     t-if="parametersData.items.length > 0"
                     data="parametersData"
                 />
                 <div class="text-muted" t-else="">There's no parameters for this method</div>
+                <t t-if="(method.returnAnnotation || method.returnDoc)">
+                    <h4 class="mt-2">Return</h4>
+                    <pre t-if="method.returnAnnotation" t-out="method.returnAnnotation"/>
+                    <p class="doc_method_description mb-2" t-if="method.returnDoc" t-out="method.returnDoc"/>
+                </t>
             </div>
-            <div t-att-class="{ 'w-100 pt-2 mt-2 border-top': isVertical, 'w-50 ps-2 border-start': !isVertical }">
+            <div t-att-class="{ 'w-100 pt-2 mt-2 border-top': isVertical, 'w-50 ps-3 border-start': !isVertical }">
                 <DocRequest
                     url="method.url"
                     request="request"

--- a/addons/api_doc/static/src/components/doc_modal_api_key.xml
+++ b/addons/api_doc/static/src/components/doc_modal_api_key.xml
@@ -2,8 +2,8 @@
 <templates xml:space="preserve">
 
 <t t-name="web.DocApiKeyModal">
-    <div class="modal-bg flex justify-content-center align-items-center">
-        <div class="modal p-2 flex flex-column mb-1" t-ref="modalRef">
+    <div class="modal-bg d-flex flex-nowrap justify-content-center align-items-center">
+        <div class="modal p-3 d-flex flex-nowrap flex-column mb-2" style="height: 14rem; width: 25rem" t-ref="modalRef">
             <h2 class="mb-2">API key</h2>
 
             <p>To try the API, please insert your API key here</p>
@@ -13,7 +13,7 @@
                 autocorrect="off"
             />
 
-            <div class="flex flex-content-between mt-3">
+            <div class="d-flex flex-nowrap flex-content-between mt-2">
                 <button class="btn me-1" t-on-click="save">Save</button>
                 <button class="btn" t-on-click="cancel">Cancel</button>
             </div>

--- a/addons/api_doc/static/src/components/doc_modal_search.xml
+++ b/addons/api_doc/static/src/components/doc_modal_search.xml
@@ -2,10 +2,10 @@
 <templates xml:space="preserve">
 
 <t t-name="web.DocSearchModal">
-    <div class="modal-bg flex justify-content-center align-items-center">
-        <div class="modal p-2 flex flex-column mb-1" style="height: 40rem; width: 40rem" t-ref="modalRef">
+    <div class="modal-bg d-flex flex-nowrap justify-content-center align-items-center">
+        <div class="modal p-2 d-flex flew-nowrap flex-column mb-2" style="height: 40rem; width: 40rem" t-ref="modalRef">
             <input
-                class="mb-1"
+                class="mb-2"
                 type="text"
                 autocorrect="off"
                 placeholder="Find anything..."
@@ -13,39 +13,39 @@
                 t-ref="seachRef"
             />
 
-            <div class="flex gap-1 mb-1 align-items-center">
+            <div class="d-flex flex-nowrap mb-2 align-items-center">
                 <div
                     t-foreach="state.activeFilters"
                     t-as="filter"
                     t-key="filter"
-                    class="flex align-items-center cursor-pointer btn"
+                    class="d-flex flex-nowrap ms-2 align-items-center cursor-pointer btn o-doc-modal-checkbox"
                     t-on-click="() => this.onFilterClick(filter)"
                 >
-                    <input class="me-1" type="checkbox" t-att-id="filter" t-att-checked="state.activeFilters[filter]"/>
-                    <label class="text-ellipsis" t-att-for="filter" t-out="filter" t-on-click.prevent=""></label>
+                    <input class="me-2" type="checkbox" t-att-id="filter" t-att-checked="state.activeFilters[filter]"/>
+                    <label class="text-truncate" t-att-for="filter" t-out="filter" t-on-click.prevent=""></label>
                 </div>
-                <div class="text-muted me-1">
+                <div class="text-muted ms-2 me-2">
                     <t t-out="this.state.resultCount"/>
                     results
                 </div>
             </div>
 
-            <div class="flex flex-column w-100 overflow-auto flex-grow" t-ref="scrollRef" t-on-scroll="(ev) => this.onScroll(ev.target)">
+            <div class="d-flex flex-nowrap flex-column w-100 overflow-auto flex-grow" t-ref="scrollRef" t-on-scroll="(ev) => this.onScroll(ev.target)">
                 <div class="overflow-hidden" t-att-style="`min-height: ${this.state.scrollHeight}px`">
                     <div t-att-style="`transform: translateY(${this.state.scrollOffsetY}px)`">
                         <button
                             t-foreach="state.results"
                             t-as="result"
                             t-key="result_index + result.type + '/' + result.label + '/' + result.path"
-                            class="btn mb-1 text-start w-100 flex flex-row"
+                            class="btn mb-2 text-start w-100 d-flex flex-nowrap flex-row o-doc-modal-checkbox justify-content-between"
                             t-on-click="() => this.onSelect(result)"
                             t-att-style="`min-height: ${itemHeight}px; max-height: ${itemHeight}px; margin-bottom: ${itemMargin}px`"
                         >
-                            <div class="h-100 flex-grow">
-                                <h4 t-out="result.label" class="text-ellipsis"></h4>
-                                <div class="text-muted text-ellipsis" t-out="result.path"></div>
+                            <div class="h-100 flex-grow-1 me-2">
+                                <h5 t-out="result.label" class="text-truncate mb-0"></h5>
+                                <div class="text-muted text-truncate" t-out="result.path"></div>
                             </div>
-                            <span class="text-muted h-100" t-out="result.type"></span>
+                            <span class="text-muted h-100 align-self-center" t-out="result.type"></span>
                         </button>
                     </div>
                 </div>

--- a/addons/api_doc/static/src/components/doc_model.js
+++ b/addons/api_doc/static/src/components/doc_model.js
@@ -1,4 +1,4 @@
-import { Component, useState, useEffect, onPatched } from "@odoo/owl";
+import { Component, useState, useEffect, onPatched, markup } from "@odoo/owl";
 import { DocTable, TABLE_TYPES } from "@api_doc/components/doc_table";
 import { getCrudMethodsExamples } from "@api_doc/utils/doc_model_utils";
 import { DocMethod } from "@api_doc/components/doc_method";
@@ -6,9 +6,9 @@ import { DocLoadingIndicator } from "@api_doc/components/doc_loading_indicator";
 import { useDocUI } from "@api_doc/utils/doc_ui_store";
 
 const TYPE_COLORS = {
-    "text-green": ["integer", "char", "boolean", "selection", "float"],
-    "text-blue": ["html", "datetime", "date", "binary"],
-    "text-orange": ["many2one", "many2many", "one2many", "many2one_reference"],
+    "text-success": ["integer", "char", "boolean", "selection", "float"],
+    "text-info": ["html", "datetime", "date", "binary"],
+    "text-warning": ["many2one", "many2many", "one2many", "many2one_reference"],
 };
 
 function getTypeColor(type) {
@@ -177,15 +177,24 @@ export class DocModel extends Component {
 
         for (const methodName in model.methods) {
             const method = model.methods[methodName];
+
+            let returnDoc = "";
+            let returnAnnotation = "";
+            if (method.return) {
+                returnDoc = method.return.doc ? markup(method.return.doc) : "";
+                returnAnnotation = method.return.annotation;
+            }
+
             methods.push({
                 name: methodName,
                 module: method.module,
                 api: method.api,
                 doc: method.doc,
                 model: model.model,
-                signature: `def ${methodName}${method.signature}`,
                 parameters: method.parameters,
                 url: `/json/2/${model.model}/${methodName}`,
+                returnDoc: returnDoc,
+                returnAnnotation: returnAnnotation,
             });
         }
 
@@ -227,7 +236,7 @@ export class DocModel extends Component {
                     {
                         type: TABLE_TYPES.Code,
                         value: fieldData.required ? "required" : "optional",
-                        class: fieldData.required ? "text-red" : "text-muted",
+                        class: fieldData.required ? "text-danger" : "text-muted",
                     },
                     {
                         type: TABLE_TYPES.Tooltip,
@@ -236,10 +245,6 @@ export class DocModel extends Component {
                     {
                         type: TABLE_TYPES.Code,
                         value: fieldData.module || "",
-                    },
-                    {
-                        type: TABLE_TYPES.Id,
-                        value: fieldData.name,
                     },
                 ]
             });

--- a/addons/api_doc/static/src/components/doc_model.xml
+++ b/addons/api_doc/static/src/components/doc_model.xml
@@ -2,11 +2,11 @@
 <templates xml:space="preserve">
 
 <t t-name="web.DocModel">
-    <div t-if="!state.error" class="o-doc-model position-relative flex flex-basis flex-column p-3">
-        <h1 class="w-100 mb-1 mt-2" t-out="this.state.model?.name ?? ''"></h1>
+    <div t-if="!state.error" class="o-doc-model position-relative d-flex flex-nowrap flex-fill flex-column p-3">
+        <h2 class="w-100 mb-2 mt-2" t-out="this.state.model?.name ?? ''"></h2>
         <DocTable data="state.modelData"/>
 
-        <h2 class="mt-3 mb-1" id="fields">Fields</h2>
+        <h3 class="mt-3 mb-2" id="fields">Fields</h3>
         <DocLoadingIndicator
             isLoaded="this.state.model and this.state.model.fields != null and this.state.fields.data"
             class="'o-fade-in'"
@@ -14,7 +14,7 @@
             <DocTable data="this.state.fields.data" activeIndex="this.state.fields.activeIndex"/>
         </DocLoadingIndicator>
 
-        <h2 class="mt-3 mb-1" id="methods">Methods</h2>
+        <h3 class="mt-3 mb-2" id="methods">Methods</h3>
         <DocLoadingIndicator
             isLoaded="this.state.methods and this.state.methods.length > 0"
             class="'o-fade-in position-relative'"
@@ -31,16 +31,16 @@
         <div style="min-height: 30vh"/>
     </div>
 
-    <aside t-if="!ui.isSmall and !state.error" class="o-doc-model-aside overflow-auto position-sticky block flex-basis bg-default pt-2 pb-2 ps-3 pe-3 border-start">
+    <aside t-if="!ui.isSmall and !state.error" class="o-doc-model-aside overflow-auto position-sticky d-block flex-fill bg-default pt-2 pb-2 ps-3 pe-3 border-start">
         <div
-            class="flex w-100 cursor-pointer capitalize align-items-center"
+            class="d-flex flex-nowrap w-100 cursor-pointer text-capitalize align-items-center"
             t-on-click="() => this.state.showModulesFilter = !this.state.showModulesFilter"
             role="button"
         >
             <div class="icon-btn ps-1" role="button" t-att-class="{ o_collapsed: !state.showModulesFilter}">
                 <i class="fa fa-angle-right" aria-hidden="true"></i>
             </div>
-            <h2 class="ms-1">Modules</h2>
+            <h3 class="ms-2">Modules</h3>
         </div>
         <t t-if="this.state.showModulesFilter">
             <span>
@@ -55,15 +55,15 @@
                 t-foreach="state.modules"
                 t-as="module"
                 t-key="module"
-                class="flex align-items-center mb-1 cursor-pointer btn"
+                class="d-flex flex-nowrap align-items-center mb-2 cursor-pointer btn o-doc-module-checks"
                 t-on-click="() => this.setActiveModules([module], !this.state.activeModules[module])"
             >
                 <input class="me-1" type="checkbox" t-att-id="module" t-att-checked="state.activeModules[module]"/>
-                <label class="text-ellipsis" t-att-for="module" t-out="module" t-on-click.prevent=""></label>
+                <label class="text-truncate" t-att-for="module" t-out="module" t-on-click.prevent=""></label>
             </div>
         </t>
 
-        <h2>On This Page</h2>
+        <h3 class="mt-2">On This Page</h3>
         <a
             t-foreach="state.methods"
             t-as="method"
@@ -71,14 +71,14 @@
             t-out="method.name"
             t-if="isModuleActive(method.module)"
             t-att-href="'#' + method.name"
-            class="block w-100 text-ellipsis"
+            class="d-block w-100 text-truncate"
         >
         </a>
     </aside>
 
-    <div t-if="state.error" class="flex align-items-center justify-content-center w-100 h-100">
-        <div class="alert error mt-1 flex flex-column">
-            <h5 class="mb-2 flex align-items-center">
+    <div t-if="state.error" class="d-flex flex-nowrap align-items-center justify-content-center w-100 h-100">
+        <div class="alert error mt-1 d-flex flex-nowrap flex-column">
+            <h5 class="mb-2 d-flex flex-nowrap align-items-center">
                 <i class="pe-1 fa fa-exclamation-triangle" aria-hidden="true"></i>
                 <span>Error while loading model</span>
             </h5>

--- a/addons/api_doc/static/src/components/doc_request.xml
+++ b/addons/api_doc/static/src/components/doc_request.xml
@@ -3,9 +3,9 @@
 
 <t t-name="web.DocRequest">
     <div class="o_doc_request h-100">
-        <div class="flex justify-content-between align-items-center mb-1">
-            <h3>Request</h3>
-            <div class="flex">
+        <div class="d-flex flex-nowrap justify-content-between align-items-center mb-1">
+            <h4>Request</h4>
+            <div class="d-flex flex-nowrap">
                 <select class="me-1" t-on-change="event => this.selectLanguage(event.target.value)">
                     <option
                         t-foreach="LANGUAGES"
@@ -17,12 +17,12 @@
                     />
                 </select>
                 <button
-                    class="btn primary flex align-items-center"
+                    class="btn primary d-flex flex-nowrap align-items-center"
                     t-on-click="execute"
                     t-att-disabled="state.exampleLanguage !== 'json'"
                 >
                     <span>Run</span>
-                    <i class="fa fa-play ms-1" aria-hidden="true"></i>
+                    <i class="fa fa-play ms-2" aria-hidden="true"></i>
                 </button>
             </div>
         </div>
@@ -37,8 +37,8 @@
             showLineNumbers="false"
         />
 
-        <div class="mt-2 flex align-items-center mb-1">
-            <h3>Response</h3>
+        <div class="mt-2 d-flex flex-nowrap align-items-center mb-1">
+            <h4>Response</h4>
             <span t-if="hasResponse and !state.response.error" class="badge success ms-1">Success</span>
             <span t-if="hasResponse and state.response.error" class="badge error ms-1">Failed</span>
         </div>
@@ -53,8 +53,8 @@
                 theme="'monokai'"
                 showLineNumbers="false"
             />
-            <div t-else="" class="alert error mt-1flex flex-column">
-                <h5 class="mb-2 flex align-items-center">
+            <div t-else="" class="alert error mt-1 d-flex flex-nowrap flex-column">
+                <h5 class="mb-2 d-flex flex-nowrap align-items-center">
                     <i class="pe-1 fa fa-exclamation-triangle" aria-hidden="true"></i>
                     <span>Error <t t-out="state.response.status"/> while executing request</span>
                 </h5>

--- a/addons/api_doc/static/src/components/doc_sidebar.js
+++ b/addons/api_doc/static/src/components/doc_sidebar.js
@@ -21,6 +21,12 @@ export class DocSidebar extends Component {
             },
             () => [this.containerRef.el]
         );
+
+        for (const addon of this.filteredAddons) {
+            if (!(addon.name in this.state.collapseAddons)) {
+                this.state.collapseAddons[addon.name] = false;
+            }
+        }
     }
 
     onSearchInput(event) {
@@ -28,8 +34,18 @@ export class DocSidebar extends Component {
         this.containerRef.el.scrollTop = 0;
     }
 
-    toggleAddon(addonName) {
-        this.state.collapseAddons[addonName] = !this.isCollapsed(addonName);
+    _toggleAllAddons(isCollapsed) {
+        const allAddons = this.filteredAddons;
+        allAddons.forEach((a) => this.state.collapseAddons[a.name] = !isCollapsed);
+    }
+
+    toggleAddon(event, addonName) {
+        const isCollapsed = this.isCollapsed(addonName);
+        if (event.altKey && event.ctrlKey) {
+            this._toggleAllAddons(isCollapsed);
+        } else {
+            this.state.collapseAddons[addonName] = !isCollapsed;
+        }
     }
 
     isCollapsed(addonName) {

--- a/addons/api_doc/static/src/components/doc_sidebar.xml
+++ b/addons/api_doc/static/src/components/doc_sidebar.xml
@@ -2,34 +2,34 @@
 <templates xml:space="preserve">
 
 <t t-name="web.DocSidebar">
-    <div class="o-doc-sidebar position-sticky bg-1 border-end flex flex-column">
-        <div>
+    <div class="o-doc-sidebar pt-3 ps-3 position-sticky bg-1 border-end d-flex flex-nowrap flex-column">
+        <div class="pe-4 pb-4">
             <input t-on-input="onSearchInput" class="w-100" placeholder="Search for models..."/>
         </div>
-        <div class="o-doc-sidebar-content h-100 flex-basis flex flex-column gap-1" t-ref="containerRef">
+        <div class="o-doc-sidebar-content h-100 flex-fill d-flex flex-nowrap flex-column gap-1" t-ref="containerRef">
             <t t-foreach="filteredAddons" t-as="addon" t-key="addon.name">
                 <div
-                    class="position-sticky bg-1 top-0 flex w-100 cursor-pointer capitalize user-select-none"
-                    t-on-click="() => this.toggleAddon(addon.name)"
+                    class="position-sticky o-doc-sidebar-header top-0 d-flex flex-nowrap w-100 cursor-pointer text-capitalize user-select-none"
+                    t-on-click="(ev) => this.toggleAddon(ev, addon.name)"
                     role="button"
                 >
-                    <div class="icon-btn ps-1" role="button" t-att-class="{ o_collapsed: isCollapsed(addon.name)}">
+                    <div class="icon-btn ps-2 pt-2" role="button" t-att-class="{ o_collapsed: isCollapsed(addon.name)}">
                         <i class="fa fa-angle-right" aria-hidden="true"></i>
                     </div>
-                    <h3 class="ms-1" t-out="addon.name"></h3>
+                    <h4 class="ms-2" t-out="addon.name"></h4>
                 </div>
 
-                <div t-if="!isCollapsed(addon.name)" class="ms-1 ps-1 border-start">
+                <div t-if="!isCollapsed(addon.name)" class="ms-2 ps-2 border-start">
                     <t t-foreach="addon.models" t-as="model" t-key="model.model">
                         <a
-                            class="btn block bg-none user-select-none"
+                            class="btn d-block bg-none text-start"
                             href="#"
                             t-on-click="() => this.modelStore.setActiveModel({ model })"
                             t-att-class="{ o_active: isActiveItem(model) }"
                             role="button"
                         >
                             <div t-out="model.name"></div>
-                            <small class="block" t-out="model.model"></small>
+                            <small class="d-block" t-out="model.model"></small>
                         </a>
                     </t>
                 </div>

--- a/addons/api_doc/static/src/components/doc_table.xml
+++ b/addons/api_doc/static/src/components/doc_table.xml
@@ -37,16 +37,19 @@
                 >
                     <i
                         t-if="row.subData"
-                        class="fa fa-bars o-doc-sub-table-btn inline me-1 cursor-pointer"
+                        class="fa fa-bars o-doc-sub-table-btn d-inline me-1 cursor-pointer"
                         aria-hidden="true"
                         t-on-click="(ev) => this.showSubTable(ev, row.subData)"
                     />
 
                     <t t-if="row and row.type == 'tooltip'">
-                        <div t-if="row.value" class="tooltip w-100 h-100">
-                            <i class="fa fa-question-circle" aria-hidden="true"></i>
-                            <span class="tooltiptext" t-out="row.value"></span>
-                        </div>
+                        <i
+                            class="fa fa-question-circle"
+                            aria-hidden="true"
+                            t-if="row.value"
+                            t-on-mouseover="(ev) => this.showDynamicTooltip(ev, row.value)"
+                            t-on-mouseleave="() => this.hideDynamicTooltip()"
+                        ></i>
                     </t>
                     <t t-else="" t-tag="getTag(row)" t-att-class="getClass(row)" t-out="getValue(row)"/>
 
@@ -58,7 +61,7 @@
                     >
                         <t t-out="row.relation"/>
                         <i
-                            class="fa fa-external-link ps-1 inline"
+                            class="fa fa-external-link ps-1 d-inline"
                             aria-hidden="true"
                         ></i>
                     </a>
@@ -82,6 +85,13 @@
         t-ref="subTableRef"
     >
         <DocTable data="state.subTable"/>
+    </div>
+    <div
+        class="o-doc-dynamic-tooltip"
+        t-att-style="state.tooltipStyle"
+        t-ref="tooltipRef"
+    >
+        <t t-out="state.tooltipContent"/>
     </div>
 </t>
 

--- a/addons/api_doc/static/src/doc_client.css
+++ b/addons/api_doc/static/src/doc_client.css
@@ -52,6 +52,8 @@ body[theme="odoo-dark"] {
     --error:rgb(190, 49, 77);
     --error-background:rgb(45, 21, 27);
     --error-text:rgb(241, 229, 230);
+
+    --bs-border-color: var(--border);
 }
 
 *,
@@ -67,8 +69,8 @@ body[theme="odoo-dark"] {
 
 body {
     max-width: 100vw;
-    color: var(--text);
-    background: var(--background);
+    color: var(--text) !important;
+    background: var(--background) !important;
     overflow-y: scroll;
     scrollbar-color: var(--border) var(--background-2);
     scrollbar-width: thin;
@@ -80,7 +82,7 @@ header {
     height: var(--header-size);
     top: 0;
     z-index: 50;
-    border-bottom: 1px solid var(--border);
+    border-bottom: 1px solid var(--border) !important;
     padding: 0 1rem;
 
     h2 {
@@ -159,10 +161,10 @@ code {
 }
 
 pre {
-    margin-bottom: 0;
+    margin-bottom: 0 !important;
     padding: .15rem .3rem;
     background-color: var(--background-2);
-    border: 1px solid var(--border);
+    border: 1px solid var(--border) !important;
     color: var(--text);
     border-radius: 5px;
     overflow: auto;
@@ -225,46 +227,33 @@ pre {
 }
 
 .modal {
-    background: var(--background);
+    position: relative;
+    background-color: var(--background) !important;
     border-radius: 5px;
     box-shadow: 0px 5px 20px rgba(0, 0, 0, 0.3);
     max-width: 100vw;
     max-height: 100vh;
 }
 
-.tooltip {
-    position: relative;
-    display: inline-block;
-}
-
-.tooltip .tooltiptext {
-    position: absolute;
-    visibility: hidden;
-    bottom: 120%;
-    left: -50%;
-    width: auto;
+.o-doc-dynamic-tooltip {
+    position: fixed;
+    z-index: 1000;
     min-width: 10rem;
     max-width: 25rem;
-    z-index: 1;
     background-color: var(--background);
     color: var(--text);
     padding: .3rem .5rem;
     border-radius: 6px;
     text-align: center;
-    transition: opacity 0.25s;
-    opacity: 0;
     box-shadow: 0px 5px 20px rgba(0, 0, 0, 0.3);
-}
-
-.tooltip:hover .tooltiptext {
-    visibility: visible;
-    opacity: 1;
+    opacity: 0;
+    transition: opacity 0.2s ease-in-out;
 }
 
 .btn {
-    background: var(--btn);
+    background: var(--bs-btn-bg);
     padding: .5rem .75rem;
-    color: var(--text);
+    color: var(--text) !important;
     border-radius: 5px;
     cursor: pointer;
     text-decoration: none;
@@ -276,15 +265,15 @@ pre {
     }
 
     &:hover, &.active, &.o_active {
-        background: var(--btn-primary);
-        color: var(--text-active);
+        background: var(--btn-primary) !important;
+        color: var(--text-active) !important;
         box-shadow: 0px 0px 15px -5px var(--btn-primary);
         z-index: 1;
     }
 
     &.primary {
         background: var(--btn-primary);
-        color: var(--text-active);
+        color: var(--text-active) !important;
 
         i {
             color: var(--text-active);
@@ -442,6 +431,11 @@ pre {
         padding: 0 var(--sidebar-pe) 10rem 0;
         overflow-y: scroll;
     }
+
+    .o-doc-sidebar-header {
+        background-color: var(--background-1);
+        z-index: 10;
+    }
 }
 
 /* Model */
@@ -455,6 +449,18 @@ pre {
     max-width: 20rem;
     max-height: calc(100vh - var(--header-size));
     padding-bottom: 10rem;
+
+    a {
+        color: var(--text-primary);
+    }
+
+    .o-doc-module-checks {
+        background-color: var(--btn);
+    }
+}
+
+.o-doc-modal-checkbox {
+    background-color: var(--btn);
 }
 
 .o-doc-method {
@@ -515,300 +521,14 @@ pre {
     background: none;
 }
 
-.cursor-pointer {
-    cursor: pointer;
-}
-
-.capitalize {
-    text-transform: capitalize;
-}
-
 .text-muted {
-    color: var(--text);
+    color: var(--text) !important;
     opacity: 0.5;
     font-style: italic;
-}
-
-.text-ellipsis {
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-}
-
-.text-start {
-    text-align: start;
 }
 
 .text-vertical-center {
     vertical-align: middle;
 }
 
-.text-red {
-    color: var(--red);
-}
-
-.text-green {
-    color: var(--green);
-}
-
-.text-blue {
-    color: var(--blue);
-}
-
-.text-orange {
-    color: var(--orange);
-}
-
-.text-nowrap {
-    white-space: nowrap;
-}
-
-.fs-6 {
-    font-size: .8em;
-}
-
-.font-monospace {
-    font-family: monospace;
-}
-
-.rounded {
-    border-radius: 5px;
-}
-
-.border {
-    border: 1px solid var(--border);
-}
-.border-top {
-    border-top: 1px solid var(--border);
-}
-.border-bottom {
-    border-bottom: 1px solid var(--border);
-}
-.border-end {
-    border-right: 1px solid var(--border);
-}
-.border-start {
-    border-left: 1px solid var(--border);
-}
-
-.shadow {
-    box-shadow: 0 .5rem 1rem rgba(0, 0, 0, .15);
-}
-
-.position-relative {
-    position: relative;
-}
-
-.position-fixed {
-    position: fixed;
-}
-
-.position-absolute {
-    position: absolute;
-}
-
-.position-sticky {
-    position: sticky;
-    z-index: 1;
-}
-
-.overflow-auto {
-    overflow: auto;
-}
-
-.overflow-y-auto {
-    overflow-y: auto;
-}
-
-.overflow-hidden {
-    overflow: hidden;
-}
-
-.top-0 {
-    top: 0;
-}
-.top-1 {
-    top: var(--size-1);
-}
-.top-2 {
-    top: var(--size-2);
-}
-.top-3 {
-    top: var(--size-3);
-}
-
-.end-0 {
-    right: 0;
-}
-
-.block {
-    display: block;
-}
-
-.inline {
-    display: inline;
-}
-
-/* Flex */
-.flex {
-    display: flex;
-    flex-wrap: nowrap;
-}
-
-.flex-wrap {
-    flex-wrap: wrap;
-}
-
-.flex-column {
-    flex-direction: column;
-}
-
-.flex-basis {
-    flex: 1 1 auto;
-}
-
-.flex-grow {
-    flex-grow: 1;
-}
-
-.align-items-center {
-    align-items: center;
-}
-
-.justify-content-between {
-    justify-content: space-between;
-}
-
-.justify-content-center {
-    justify-content: center;
-}
-
-.gap-1 {
-    gap: var(--size-1);
-}
-
-/* Sizing */
-.h-100 {
-    height: 100%;
-}
-
-.w-100 {
-    width: 100%;
-}
-
-.w-50 {
-    width: 50%;
-}
-
-.min-w-50 {
-    min-width: 50%;
-}
-
-.m-1 {
-    margin: var(--size-1);
-}
-
-.m-2 {
-    margin: var(--size-2);
-}
-
-.me-1 {
-    margin-right: var(--size-1);
-}
-
-.me-2 {
-    margin-right: var(--size-2);
-}
-
-.ms-1 {
-    margin-left: var(--size-1);
-}
-
-.ms-2 {
-    margin-left: var(--size-2);
-}
-
-.mt-1 {
-    margin-top: var(--size-1);
-}
-
-.mt-2 {
-    margin-top: var(--size-2);
-}
-
-.mt-3 {
-    margin-top: var(--size-3);
-}
-
-.mt-4 {
-    margin-top: var(--size-4);
-}
-
-.mb-1 {
-    margin-bottom: var(--size-1);
-}
-
-.mb-2 {
-    margin-bottom: var(--size-2);
-}
-
-.mb-3 {
-    margin-bottom: var(--size-3);
-}
-
-.p-0 {
-    padding: 0;
-}
-
-.p-1 {
-    padding: var(--size-1);
-}
-
-.p-2 {
-    padding: var(--size-2);
-}
-
-.p-3 {
-    padding: var(--size-3);
-}
-
-.ps-1 {
-    padding-left: var(--size-1);
-}
-
-.ps-2 {
-    padding-left: var(--size-2);
-}
-
-.ps-3 {
-    padding-left: var(--size-3);
-}
-
-.pe-1 {
-    padding-right: var(--size-1);
-}
-
-.pe-2 {
-    padding-right: var(--size-2);
-}
-
-.pe-3 {
-    padding-right: var(--size-3);
-}
-
-.pt-1 {
-    padding-top: var(--size-1);
-}
-
-.pt-2 {
-    padding-top: var(--size-2);
-}
-
-.pt-3 {
-    padding-top: var(--size-3);
-}
-
-.user-select-none {
-    user-select: none;
-}
 /* #endregion*/

--- a/addons/api_doc/static/src/doc_client.xml
+++ b/addons/api_doc/static/src/doc_client.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0"?>
 <templates>
 <t t-name="api_doc.DocClient">
-    <header class="position-fixed bg-1 flex gap-1 align-items-center justify-content-between w-100">
-        <div class="flex">
+    <header class="position-fixed bg-1 d-flex flex-nowrap gap-1 align-items-center justify-content-between w-100">
+        <div class="d-flex flex-nowrap">
             <h2>Odoo Runtime Doc</h2>
         </div>
         <div>
@@ -11,7 +11,7 @@
                 placeholder="Find anything..."
             />
         </div>
-        <div class="flex gap-1">
+        <div class="d-flex flex-nowrap gap-1">
             <button class="btn" role="button" t-on-click="() => this.env.modelStore.showApiKeyModal = true">
                 <i class="fa fa-key" aria-hidden="true"></i>
             </button>
@@ -20,19 +20,19 @@
             </button>
         </div>
     </header>
-    <main class="position-relative flex">
+    <main class="position-relative d-flex flex-nowrap">
         <DocSidebar t-if="!ui.isSmall"/>
         <t t-if="modelStore.models.length > 0">
             <DocModel t-if="modelStore.activeModel"/>
         </t>
-        <div t-elif="!modelStore.error" class="h-100 w-100 flex align-items-center justify-content-center gap-1">
+        <div t-elif="!modelStore.error" class="h-100 w-100 d-flex flex-nowrap align-items-center justify-content-center gap-1">
             <i class="fa fa-spinner o-doc-spinner" aria-hidden="true"></i>
             <div>Loading Models</div>
         </div>
 
-        <div t-if="modelStore.error" class="flex align-items-center justify-content-center w-100 h-100">
-            <div class="alert error mt-1 flex flex-column">
-                <h5 class="mb-2 flex align-items-center">
+        <div t-if="modelStore.error" class="d-flex flex-nowrap align-items-center justify-content-center w-100 h-100">
+            <div class="alert error mt-1 d-flex flex-nowrap d-flex flex-nowrap-column">
+                <h5 class="mb-2 d-flex flex-nowrap align-items-center">
                     <i class="pe-1 fa fa-exclamation-triangle" aria-hidden="true"></i>
                     <span>Error while loading models</span>
                 </h5>

--- a/addons/api_doc/static/src/utils/doc_code_gen.js
+++ b/addons/api_doc/static/src/utils/doc_code_gen.js
@@ -12,7 +12,21 @@ function noQuotesStringify(obj) {
 
 export function createRequestCode({ language, url, requestObj }) {
     if (LANGUAGES[language] === LANGUAGES.json) {
-        return JSON.stringify(requestObj, null, 4);
+
+        // Display the domain inline
+        const replacer = (key, value) => {
+            if (key === "domain" && Array.isArray(value)) {
+                return { __inline_json__: JSON.stringify(value) };
+            }
+            return value;
+        };
+        let json = JSON.stringify(requestObj, replacer, 4);
+        json = json.replace(
+            /{\s*"__inline_json__":\s*"(.+?)"\s*}/g,
+            (match, p1) => JSON.parse(`"${p1}"`)
+        );
+        return json;
+
     } else if (LANGUAGES[language] === LANGUAGES.javascript) {
         const objStr = noQuotesStringify(requestObj).replace(/\n/gm, "\n    ");
 

--- a/addons/api_doc/static/src/utils/doc_model_utils.js
+++ b/addons/api_doc/static/src/utils/doc_model_utils.js
@@ -140,7 +140,7 @@ export function getParameterDefaultValue(name, parameter) {
         /\b(list|sequence|collection|tuple|range|set)\b/i.test(parameter.annotation)
     ) {
         return [];
-    } else if (/dict|kwargs/i.test(parameter.annotation)) {
+    } else if (/dict/i.test(parameter.annotation)) {
         return {};
     } else {
         return "";


### PR DESCRIPTION
The goal of this PR is to improve dev experience in /doc, align with Odoo's UI conventions, and reduce custom styling.

Here's what changed:
- swapped out method signature in DocMethod with return type to simplify method summaries.
- fixed a tooltip clipping issue caused by table overflow, tooltips now render above all elements and safely escape HTML.
- added a keymap (Ctrl+Alt click) to the sidebar collapse button to allow collapsing all sections at once.
- moved domain display inline in the request tab for consistency with standard Odoo patterns.
- replaced custom CSS with Bootstrap classes where possible and added Bootstrap assets to api_doc.
- added a button to set the method tag at the end of the url.

task-4934340