### PR TITLE
[FIX] account: regenerate invoice PDF if payments are more recent than the cached PDF

### DIFF
--- a/addons/account/wizard/account_move_send.py
+++ b/addons/account/wizard/account_move_send.py
@@ -793,6 +793,15 @@ class AccountMoveSend(models.TransientModel):
                 },
             }
 
+        for move in self.move_ids:
+            payments = move._get_reconciled_payments()
+            latest_payment = max((p.create_date for p in payments), default=None)
+            pdf_created = move.invoice_pdf_report_id.create_date if move.invoice_pdf_report_id else None
+
+            if latest_payment and (not pdf_created or latest_payment >= pdf_created):
+                move.invoice_pdf_report_file = False
+                move.invoice_pdf_report_id = False
+
         return self._process_send_and_print(
             self.move_ids.sudo(),
             wizard=self,


### PR DESCRIPTION
**Issue**
Once an invoice PDF is generated, it is cached and reused on subsequent actions. If a new payment is registered after the PDF is created, the cached version is still used, meaning the updated payment status is not reflected in the document.

**Steps to Reproduce**
1. Create and post an invoice for $1000
2. Register a payment of $100
3. Click Send & Print -> PDF is generated (shows $100 paid)
4. Register another payment of $100
5. Click Send & Print again
6. The same (old) PDF is returned, not showing the new payment

**Root Cause**
Odoo avoids regenerating the PDF if a cached version exists:

https://github.com/odoo/odoo/blob/7df78a28dd7c05b1ea246e9f0735d8da0cb5486e/addons/account/wizard/account_move_send.py#L372-L377

https://github.com/odoo/odoo/blob/7df78a28dd7c05b1ea246e9f0735d8da0cb5486e/addons/account/wizard/account_move_send.py#L389-L395

As a result, changes like new payments are ignored once the PDF has been generated.

**Fix**
Before triggering PDF generation, the system now checks if any payments exist that were created after the PDF's `create_date`. If so, the cached PDF (`invoice_pdf_report_file` and `invoice_pdf_report_id`) is cleared, forcing regeneration.

This ensures that the latest financial state of the invoice is always accurately reflected in the document.

Opw-4818721
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
