### PR TITLE
[FIX] hr_recruitment: prevent error when refusing the applicant

### DIFF
--- a/addons/hr_recruitment/tests/test_recruitment.py
+++ b/addons/hr_recruitment/tests/test_recruitment.py
@@ -3,7 +3,7 @@
 import base64
 
 from odoo.fields import Domain
-from odoo.tests import tagged, TransactionCase
+from odoo.tests import tagged, TransactionCase, Form
 
 
 @tagged('recruitment')
@@ -295,6 +295,17 @@ class TestRecruitment(TransactionCase):
 
         applicant.stage_id = stage_new
         self.assertEqual(job.no_of_recruitment, 1)
+
+    def test_open_refuse_applicant_wizard_without_partner_name(self):
+        """Test opening the refuse wizard when the applicant has no partner_name."""
+        applicant = self.env['hr.applicant'].create({
+            'partner_phone': '123',
+        })
+        wizard = Form(self.env['applicant.get.refuse.reason'].with_context(
+            default_applicant_ids=[applicant.id], active_test=False))
+
+        wizard_applicant = wizard.applicant_ids[0]
+        self.assertFalse(wizard_applicant.partner_name)
 
     def test_applicant_refuse_reason(self):
 

--- a/addons/hr_recruitment/wizard/applicant_refuse_reason.py
+++ b/addons/hr_recruitment/wizard/applicant_refuse_reason.py
@@ -51,7 +51,7 @@ class ApplicantGetRefuseReason(models.TransientModel):
             if applicants:
                 wizard.applicant_without_email = "%s\n%s" % (
                     _("You can't select Send email option.\nThe email will not be sent to the following applicant(s) as they don't have an email address:"),
-                    ", ".join([i.partner_name or i.display_name for i in applicants])
+                    ", ".join([i.partner_name or i.display_name or '' for i in applicants])
                 )
             else:
                 wizard.applicant_without_email = False


### PR DESCRIPTION
Currently, an error occurs when refusing an applicant.

Steps to Reproduce:

 - Install the `hr_recruitment` module.
 - Go to `Recruitment` > `Applications` > `All Applications`.
 - Click `New`, then click `Refuse`.

`TypeError: sequence item 0: expected str instance, bool found`

This error occurs when refusing an applicant who does not have an applicant name. It tries to access partner_name or display_name, but since it is False, the join raise the error[1].

This commit ensures that if the partner name is present, it is added; otherwise, an empty string is added.

[1]- https://github.com/odoo/odoo/blob/ca90fd17b2c50651d698e6e0e3065ba978b06d01/addons/hr_recruitment/wizard/applicant_refuse_reason.py#L52

sentry-6740479737


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
