### PR TITLE
[FIX] mail,*: error when adding reaction on message

### DIFF
--- a/addons/im_livechat/tests/test_message.py
+++ b/addons/im_livechat/tests/test_message.py
@@ -197,6 +197,7 @@ class TestImLivechatMessage(ChatbotCase, MailCommon):
                 "mail.thread": self._filter_threads_fields(
                     {
                         "display_name": "test1 Ernest Employee",
+                        "has_mail_thread": True,
                         "id": channel_livechat_1.id,
                         "model": "discuss.channel",
                         "module_icon": "/mail/static/description/icon.png",
@@ -305,6 +306,7 @@ class TestImLivechatMessage(ChatbotCase, MailCommon):
                                 "mail.thread": self._filter_threads_fields(
                                     {
                                         "display_name": "Chell Gladys Ernest Employee",
+                                        "has_mail_thread": True,
                                         "id": channel.id,
                                         "model": "discuss.channel",
                                         "module_icon": "/mail/static/description/icon.png",

--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -1070,6 +1070,7 @@ class MailMessage(models.Model):
         record_fields = [
             # sudo: mail.thread - if mentionned in a non accessible thread, name is allowed
             Store.Attr("display_name", sudo=True),
+            Store.Attr("has_mail_thread", lambda record: isinstance(record, self.env.registry["mail.thread"])),
             Store.Attr(
                 "module_icon",
                 lambda record: modules.module.get_module_icon(self.env[record._name]._original_module),

--- a/addons/mail/static/src/core/common/message_model.js
+++ b/addons/mail/static/src/core/common/message_model.js
@@ -441,7 +441,12 @@ export class Message extends Record {
 
     /** @param {import("models").Thread} thread the thread where the message is shown */
     canAddReaction(thread) {
-        return Boolean(!this.is_transient && !this.isPending && this.thread?.can_react);
+        return Boolean(
+            !this.is_transient &&
+                !this.isPending &&
+                this.thread?.can_react &&
+                this.thread.has_mail_thread
+        );
     }
 
     /** @param {import("models").Thread} thread the thread where the message is shown */

--- a/addons/mail/static/src/core/common/thread_model.js
+++ b/addons/mail/static/src/core/common/thread_model.js
@@ -205,6 +205,8 @@ export class Thread extends Record {
             this.onPinStateUpdated();
         },
     });
+    /** @type {Boolean|undefined} */
+    has_mail_thread;
     mainAttachment = Record.one("ir.attachment");
     message_needaction_counter = 0;
     message_needaction_counter_bus_id = 0;

--- a/addons/mail/static/src/discuss/core/common/@types/models.d.ts
+++ b/addons/mail/static/src/discuss/core/common/@types/models.d.ts
@@ -37,6 +37,7 @@ declare module "models" {
         default_display_mode: "video_full_screen" | false | undefined,
         fetchChannelMembers(): Promise<void>,
         firstUnreadMessage: Message,
+        has_mail_thread: boolean | undefined,
         hasOtherMembersTyping: boolean,
         readonly hasMemberList: boolean,
         readonly hasSeenFeature: boolean,

--- a/addons/mail/static/tests/message/message.test.js
+++ b/addons/mail/static/tests/message/message.test.js
@@ -2079,3 +2079,42 @@ test("should delete link preview along with message", async () => {
     await click("button:contains('Confirm')");
     await contains(".o-mail-LinkPreviewCard", { count: 0 });
 });
+
+test("Prevent adding reactions on messages without a mail thread", async () => {
+    const pyEnv = await startServer();
+    const fakeId = pyEnv["res.fake"].create({ name: "Fake" });
+    const messageIds = pyEnv["mail.message"].create([
+        {
+            body: "Hello",
+            message_type: "user_notification",
+            model: "res.partner",
+            res_id: serverState.partnerId,
+        },
+        {
+            body: "Hello",
+            message_type: "user_notification",
+            model: "res.fake",
+            res_id: fakeId,
+        },
+    ]);
+    pyEnv["mail.notification"].create([
+        {
+            mail_message_id: messageIds[0],
+            notification_type: "inbox",
+            is_read: true,
+            res_partner_id: serverState.partnerId,
+        },
+        {
+            mail_message_id: messageIds[1],
+            notification_type: "inbox",
+            is_read: true,
+            res_partner_id: serverState.partnerId,
+        },
+    ]);
+    await start();
+    await openDiscuss("mail.box_history");
+    await contains(".o-mail-Message", { count: 2 });
+    await contains("[title='Add a Reaction']");
+    await contains(".o-mail-Message:eq(0) [title='Add a Reaction']");
+    await contains(".o-mail-Message:eq(1):not(:has([title='Add a Reaction']))");
+});

--- a/addons/mail/static/tests/mock_server/mock_models/mail_message.js
+++ b/addons/mail/static/tests/mock_server/mock_models/mail_message.js
@@ -124,6 +124,7 @@ export class MailMessage extends models.ServerModel {
             if (thread) {
                 const thread_data = {
                     display_name: thread.name ?? thread.display_name,
+                    has_mail_thread: this.env[message.model]._inherit?.includes("mail.thread"),
                     module_icon: "/base/static/description/icon.png",
                 };
                 if (for_current_user && add_followers) {

--- a/addons/mail/tests/discuss/test_discuss_channel.py
+++ b/addons/mail/tests/discuss/test_discuss_channel.py
@@ -124,6 +124,7 @@ class TestChannelInternals(MailCommon, HttpCase):
                                 "mail.thread": self._filter_threads_fields(
                                     {
                                         "display_name": "Channel",
+                                        "has_mail_thread": True,
                                         "id": channel.id,
                                         "model": "discuss.channel",
                                         "module_icon": "/mail/static/description/icon.png",

--- a/addons/portal/models/mail_message.py
+++ b/addons/portal/models/mail_message.py
@@ -135,7 +135,11 @@ class MailMessage(models.Model):
                         "name": message.author_id.name,
                         "type": "partner",
                     },
-                    "thread": {"model": values["model"], "id": values["res_id"]},
+                    "thread": {
+                       "has_mail_thread": isinstance(self.env[values["model"]], self.pool["mail.thread"]),
+                       "id": values["res_id"],
+                       "model": values["model"],
+                   },
                 }
             )
         return vals_list

--- a/addons/test_discuss_full/tests/test_performance.py
+++ b/addons/test_discuss_full/tests/test_performance.py
@@ -1748,6 +1748,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
 
     def _expected_result_for_thread(self, channel):
         common_data = {
+            "has_mail_thread": True,
             "id": channel.id,
             "model": "discuss.channel",
             "module_icon": "/mail/static/description/icon.png",

--- a/addons/test_mail/tests/test_performance.py
+++ b/addons/test_mail/tests/test_performance.py
@@ -1642,6 +1642,7 @@ class TestMessageToStorePerformance(BaseMailPerformance):
                             "mail.thread": self._filter_threads_fields(
                                 {
                                     "display_name": "Test",
+                                    "has_mail_thread": True,
                                     "id": record.id,
                                     "model": "mail.test.simple",
                                     "module_icon": "/base/static/description/icon.png",
@@ -1752,6 +1753,7 @@ class TestMessageToStorePerformance(BaseMailPerformance):
                             "mail.thread": self._filter_threads_fields(
                                 {
                                     "display_name": "Test",
+                                    "has_mail_thread": True,
                                     "id": record.id,
                                     "model": "mail.test.simple",
                                     "module_icon": "/base/static/description/icon.png",


### PR DESCRIPTION
*= im_livechat, portal, test_discuss_full

**Steps to reproduce:**

• Install the mail_group module
• Open Discuss
• Go to the History tab
• Add a reaction on a message that has model `mail.group`  
• Throws an error

The error occurs because the `mail.group` model does not implement the `_get_allowed_access_params()` method, which is invoked during the process here. Actually, the "add reaction" button should not be shown on messages whose model
does not inherit from mail.thread.
https://github.com/odoo/odoo/blob/d12c1e07727f9b04cd2be2e7dac1ec3af49cb637/addons/mail/models/mail_message.py#L579

Desired behavior after PR is merged:

This PR fixes the issue by hiding the "add reaction" button on messages with
models that don’t inherit from mail.thread, such as mail.group.

enterprise: https://github.com/odoo/enterprise/pull/111271
Task-5098050

[Reference](https://github.com/user-attachments/assets/aa2c4251-fd1f-4734-a62c-9fc80dd5f587)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
