### PR TITLE
[FIX] account_edi_ubl_cii: make 'cash_rounding_base_lines' optional

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_20.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_20.py
@@ -1354,7 +1354,7 @@ class AccountEdiXmlUBL20(models.AbstractModel):
         # (For the 'biggest_tax' strategy the amounts are directly included in the tax amounts.)
         for currency_suffix in ['', '_currency']:
             vals[f'cash_rounding_base_amount{currency_suffix}'] = 0.0
-            for base_line in vals['cash_rounding_base_lines']:
+            for base_line in vals.setdefault('cash_rounding_base_lines', []):
                 tax_details = base_line['tax_details']
                 vals[f'cash_rounding_base_amount{currency_suffix}'] += tax_details[f'total_excluded{currency_suffix}']
 


### PR DESCRIPTION
Recently in commit b033a87bbf38ed12364ebf2e3ce0cefb2670470f the UBL generation was improved to handle cash rounding better.

I.e. a new key 'cash_rounding_base_lines' was introduced to the `vals` used in the generation.

This commit makes it optional to avoid tracebacks in case it is forgotten to be added.

task-None