### PR TITLE
[IMP] hr_expense: Remove expense outstanding account setting

### DIFF
--- a/addons/account/models/chart_template.py
+++ b/addons/account/models/chart_template.py
@@ -876,30 +876,33 @@ class AccountChartTemplate(models.AbstractModel):
 
         # No fields on company
         if not company.parent_id:
-            accounts_data_no_fields = {
-                'account_journal_payment_debit_account_id': {
-                    'name': _("Outstanding Receipts"),
-                    'prefix': bank_prefix,
-                    'code_digits': code_digits,
-                    'account_type': 'asset_current',
-                    'reconcile': True,
-                },
-                'account_journal_payment_credit_account_id': {
-                    'name': _("Outstanding Payments"),
-                    'prefix': bank_prefix,
-                    'code_digits': code_digits,
-                    'account_type': 'asset_current',
-                    'reconcile': True,
-                },
+            self._create_outstanding_accounts(company, bank_prefix, code_digits)
+
+    def _create_outstanding_accounts(self, company, bank_prefix, code_digits):
+        accounts_data_no_fields = {
+            'account_journal_payment_debit_account_id': {
+                'name': _("Outstanding Receipts"),
+                'prefix': bank_prefix,
+                'code_digits': code_digits,
+                'account_type': 'asset_current',
+                'reconcile': True,
+            },
+            'account_journal_payment_credit_account_id': {
+                'name': _("Outstanding Payments"),
+                'prefix': bank_prefix,
+                'code_digits': code_digits,
+                'account_type': 'asset_current',
+                'reconcile': True,
+            },
+        }
+        self.env['account.account']._load_records([
+            {
+                'xml_id': f"account.{company.id}_{xml_id}",
+                'values': values,
+                'noupdate': True,
             }
-            self.env['account.account']._load_records([
-                {
-                    'xml_id': f"account.{company.id}_{xml_id}",
-                    'values': values,
-                    'noupdate': True,
-                }
-                for xml_id, values in accounts_data_no_fields.items()
-            ])
+            for xml_id, values in accounts_data_no_fields.items()
+        ])
 
     @api.model
     def _instantiate_foreign_taxes(self, country, company):

--- a/addons/hr_expense/models/res_company.py
+++ b/addons/hr_expense/models/res_company.py
@@ -13,13 +13,6 @@ class ResCompany(models.Model):
         domain="[('type', '=', 'purchase')]",
         help="The company's default journal used when an employee expense is created.",
     )
-    expense_outstanding_account_id = fields.Many2one(
-        "account.account",
-        string="Outstanding Account",
-        check_company=True,
-        domain="[('account_type', '=', 'asset_current'), ('reconcile', '=', True)]",
-        help="The account used to record the outstanding amount of the company expenses.",
-    )
     company_expense_allowed_payment_method_line_ids = fields.Many2many(
         "account.payment.method.line",
         string="Payment methods available for expenses paid by company",

--- a/addons/hr_expense/models/res_config_settings.py
+++ b/addons/hr_expense/models/res_config_settings.py
@@ -23,13 +23,6 @@ class ResConfigSettings(models.TransientModel):
     module_hr_expense_stripe = fields.Boolean(string='Link your stripe issuing account to manage company credit cards for your employees through Odoo')
 
     expense_journal_id = fields.Many2one('account.journal', related='company_id.expense_journal_id', readonly=False, check_company=True, domain="[('type', '=', 'purchase')]")
-    expense_outstanding_account_id = fields.Many2one(
-        comodel_name='account.account',
-        related='company_id.expense_outstanding_account_id',
-        domain="[('account_type', '=', 'asset_current'), ('reconcile', '=', True)]",
-        readonly=False,
-        check_company=True,
-    )
     company_expense_allowed_payment_method_line_ids = fields.Many2many(
         comodel_name='account.payment.method.line',
         check_company=True,

--- a/addons/hr_expense/views/res_config_settings_views.xml
+++ b/addons/hr_expense/views/res_config_settings_views.xml
@@ -44,10 +44,6 @@
                                      string="Employee Expense Journal">
                                 <field name="expense_journal_id"/>
                             </setting>
-                            <setting company_dependent="1" help="Default outstanding account for expenses paid by company."
-                                     string="Expense Outstanding Account">
-                                <field name="expense_outstanding_account_id"/>
-                            </setting>
                             <setting company_dependent="1" string="Payment methods"
                                      help="Payment method allowed for expenses paid by company.">
                                 <field name="company_expense_allowed_payment_method_line_ids" widget="many2many_tags"


### PR DESCRIPTION
As default outstanding accounts were installed in COA in https://github.com/odoo/odoo/commit/8c60d34c63f88f59bdf45de5ce01d8d87d639fac for flows that require them.

As expense is one of them, we are removing the expense outstanding account setting and using the default outstanding account defined in COA(installing it if not found)

task-4930809

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
