### PR TITLE
[FIX] mail: ensure channel marked as read on open after missed notif

### DIFF
--- a/addons/mail/tests/discuss/test_discuss_channel.py
+++ b/addons/mail/tests/discuss/test_discuss_channel.py
@@ -200,7 +200,7 @@ class TestChannelInternals(MailCommon):
         )
 
     @users('employee')
-    def test_set_last_seen_message_should_send_notification_only_once(self):
+    def test_set_last_seen_message_should_always_send_notification(self):
         chat = self.env['discuss.channel'].with_user(self.user_admin).channel_get((self.partner_employee | self.user_admin.partner_id).ids)
         msg_1 = self._add_messages(chat, 'Body1', author=self.user_employee.partner_id)
         member = chat.channel_member_ids.filtered(lambda m: m.partner_id == self.user_admin.partner_id)
@@ -247,10 +247,32 @@ class TestChannelInternals(MailCommon):
             ],
         ):
             chat._channel_seen(msg_1.id)
-        # There should be no channel member to be set as seen in the second time
-        # So no notification should be sent
+        # send the bus notification only to the current user if the
+        # seen message is older or same as the current one in the DB
         self._reset_bus()
-        with self.assertBus([], []):
+        with self.assertBus(
+            [(self.env.cr.dbname, "res.partner", self.user_admin.partner_id.id)],
+            [{
+                "type": "mail.record/insert",
+                "payload": {
+                    "ChannelMember": {
+                        "id": member.id,
+                        "persona": {
+                            "id": self.user_admin.partner_id.id,
+                            "type": "partner",
+                        },
+                        "lastSeenMessage": {"id": msg_1.id},
+                        "thread": {
+                            "id": chat.id,
+                            "message_unread_counter": 0,
+                            "message_unread_counter_bus_id": self.env['bus.bus'].sudo()._bus_last_id(),
+                            "model": "discuss.channel",
+                            "seen_message_id": msg_1.id
+                        }
+                    },
+                },
+            }],
+        ):
             chat._channel_seen(msg_1.id)
 
     def test_channel_message_post_should_not_allow_adding_wrong_parent(self):


### PR DESCRIPTION
Before this commit, if you opened an unread channel that the server already considered “read,” the channel would remain marked as unread in your browser. This typically happens when one browser instance misses the bus notification that cleared the unread status.

Steps to reproduce:
1. Open Discuss as the same user on two browsers (A and B)
2. Send a message to said user
3. Stop bus notifications on browser A
4. Read the message on browser B
5. Re-enable bus notification on browser A
6. Open the channel on browser A -> not being marked as read

This happens because the method `_set_last_seen_message` skips sending the notification when the message seen is older than the current `seen_message_id` (previously set by the other browser). This commit fixes the issue by setting the `allow_order` parameter in the rpc call.

task-4863058
