### PR TITLE
[FIX] html_builder, html_editor: activate options when replacing a media

### DIFF
--- a/addons/html_builder/static/src/plugins/image/image_tool_option_plugin.js
+++ b/addons/html_builder/static/src/plugins/image/image_tool_option_plugin.js
@@ -213,24 +213,9 @@ export class ResetTransformImageAction extends BuilderAction {
 }
 export class ReplaceMediaAction extends BuilderAction {
     static id = "replaceMedia";
-    static dependencies = ["media", "history", "builderOptions"];
-    async load({ editingElement }) {
-        let image;
-        await this.dependencies.media.openMediaDialog({
-            node: editingElement,
-            save: (newImage) => {
-                image = newImage;
-            },
-        });
-        return image;
-    }
-    apply({ editingElement, loadResult: newImage }) {
-        if (!newImage) {
-            return;
-        }
-        editingElement.replaceWith(newImage);
-        this.dependencies.history.addStep();
-        this.dependencies["builderOptions"].updateContainers(newImage);
+    static dependencies = ["media_website"];
+    async apply({ editingElement: mediaEl }) {
+        await this.dependencies["media_website"].replaceMedia(mediaEl);
     }
 }
 export class SetLinkAction extends BuilderAction {

--- a/addons/html_editor/static/src/main/media/media_plugin.js
+++ b/addons/html_editor/static/src/main/media/media_plugin.js
@@ -157,8 +157,10 @@ export class MediaPlugin extends Plugin {
             } else {
                 node.replaceWith(element);
             }
+            this.dispatchTo("on_replaced_media_handlers", { newMediaEl: element });
         } else {
             this.dependencies.dom.insert(element);
+            this.dispatchTo("on_added_media_handlers", { newMediaEl: element });
         }
         // Collapse selection after the inserted/replaced element.
         const [anchorNode, anchorOffset] = rightPos(element);


### PR DESCRIPTION
When replacing a media by double-clicking on it, the new media options were not activated. When using the "replaceMedia" option, they were activated but the way it was done was not correct. Another issue also happens when replacing icons: if they were replaced by double-clicking, the tag name was preserved (so an `<i>` stayed an `<i>` and a `<span>` stayed as a `<span>`), but with the "replaceMedia" option, the tag was always becoming a `<span>` (because we were replacing the node with the media dialog result manually).

This commit fixes that by uniformizing the "replace a media" flow. More precisely, the `replaceMedia` shared function was added in the `media_website` plugin and it is used by both the double-click handler and the "replaceMedia" option. It simply uses the `openMediaDialog` shared function, where everything is correctly managed (so the icons now keep their tag).

In order to activate the replaced media options, a new resource `on_replaced_media_handlers` is now dispatched in `openMediaDialog`. The resource then simply asks to update the containers target with the replaced media. Another still unused `on_added_media_handlers` resource is also dispatched when a new media is added. It was simply done to have the access point/hook (as it was needed before the refactoring).

This commit also takes the opportunity to clean the `media_website` plugin code, by factorizing redundant code, removing unused variables, formatting lines and adding some doc.

For the reference, the commit adding the "Double-click to edit" tooltip was commit [1] and the refactoring is in commit [2].

[1]: ce533be3f71e08c06fbe0c1fdbbe9fe7f0545dc8
[2]: 9fe45e2b7ddbbfd0445ffe25a859e67a316d02b2

task-4367641
