### PR TITLE
[FIX] pos_self_order: avoid error when printing self ticket

### DIFF
--- a/addons/l10n_ar_pos/models/pos_config.py
+++ b/addons/l10n_ar_pos/models/pos_config.py
@@ -13,6 +13,6 @@ class PosConfig(models.Model):
     @api.model
     def _load_pos_data_read(self, records, config):
         read_records = super()._load_pos_data_read(records, config)
-        if self.env.company.country_id.code == 'AR':
+        if read_records and self.env.company.country_id.code == 'AR':
             read_records[0]['_consumidor_final_anonimo_id'] = self.env.ref('l10n_ar.par_cfa').id
         return read_records

--- a/addons/l10n_be_pos_sale/models/pos_config.py
+++ b/addons/l10n_be_pos_sale/models/pos_config.py
@@ -7,7 +7,7 @@ class PosConfig(models.Model):
     @api.model
     def _load_pos_data_read(self, records, config):
         read_records = super()._load_pos_data_read(records, config)
-        if self.env.company.country_code == 'BE':
+        if read_records and self.env.company.country_code == 'BE':
             intracom_fpos = self.env["account.chart.template"].with_company(self.company_id.root_id).sudo().ref("fiscal_position_template_3", False)
             if intracom_fpos:
                 read_records[0]['_intracom_tax_ids'] = intracom_fpos.tax_ids.ids

--- a/addons/l10n_es_edi_tbai_pos/models/pos_config.py
+++ b/addons/l10n_es_edi_tbai_pos/models/pos_config.py
@@ -8,7 +8,7 @@ class PosConfig(models.Model):
     def _load_pos_data_read(self, records, config):
         data = super()._load_pos_data_read(records, config)
 
-        if self.env.company.country_id.code == 'ES':
+        if data and self.env.company.country_id.code == 'ES':
             tbai_refund_reason_field = self.env['ir.model.fields']._get('account.move', 'l10n_es_tbai_refund_reason')
             data[0]['_tbai_refund_reasons'] = [
                 {'value': refund_reason.value, 'name': refund_reason.name}

--- a/addons/l10n_pe_pos/models/pos_config.py
+++ b/addons/l10n_pe_pos/models/pos_config.py
@@ -13,6 +13,6 @@ class PosConfig(models.Model):
     @api.model
     def _load_pos_data_read(self, records, config):
         read_records = super()._load_pos_data_read(records, config)
-        if self.env.company.country_id.code == "PE":
+        if read_records and self.env.company.country_id.code == "PE":
             read_records[0]['_consumidor_final_anonimo_id'] = self.env.ref('l10n_pe_pos.partner_pe_cf').id
         return read_records

--- a/addons/point_of_sale/models/pos_config.py
+++ b/addons/point_of_sale/models/pos_config.py
@@ -207,7 +207,7 @@ class PosConfig(models.Model):
         static_records = {}
 
         for model, ids in records.items():
-            records = self.env[model].browse(ids)
+            records = self.env[model].browse(ids).exists()
             static_records[model] = self.env[model]._load_pos_data_read(records, self)
 
         self._notify('SYNCHRONISATION', {
@@ -250,8 +250,10 @@ class PosConfig(models.Model):
     @api.model
     def _load_pos_data_read(self, records, config):
         read_records = super()._load_pos_data_read(records, config)
-        record = read_records[0]
+        if not read_records:
+            return read_records
 
+        record = read_records[0]
         record['_server_version'] = exp_version()
         record['_base_url'] = self.get_base_url()
         record['_data_server_date'] = self.env.context.get('pos_last_server_date') or self.env.cr.now()

--- a/addons/pos_self_order/models/pos_config.py
+++ b/addons/pos_self_order/models/pos_config.py
@@ -292,6 +292,8 @@ class PosConfig(models.Model):
     @api.model
     def _load_pos_self_data_read(self, records, config):
         read_records = super()._load_pos_data_read(records, config)
+        if not read_records:
+            return read_records
         record = read_records[0]
         record['_self_ordering_image_home_ids'] = config.self_ordering_image_home_ids.ids
         record['_self_ordering_image_background_ids'] = config.self_ordering_image_background_ids.ids

--- a/addons/pos_self_order/models/pos_session.py
+++ b/addons/pos_self_order/models/pos_session.py
@@ -19,6 +19,9 @@ class PosSession(models.Model):
 
     def _load_pos_data_read(self, records, config):
         read_records = super()._load_pos_data_read(records, config)
+        if not read_records:
+            return read_records
+
         record = read_records[0]
         record['_self_ordering'] = (
             self.env["pos.config"]


### PR DESCRIPTION
Previously, when a self-order ticket was printed in a POS restaurant configuration, an error "list index out of range" occurred because there was an empty pos_session array returned by the method "pos.order.get_order_to_print".

Steps to reproduce:
1. Configure and open a POS restaurant session
2. Enable self-ordering and online payment
3. Create and pay an order using the self-service interface
4. The ticket is printed in the restaurant session, but an error is displayed

This commit ensures we check for the existence of required records before assigning data to avoid this error

Enterprise PR: https://github.com/odoo/enterprise/pull/90081

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
