### PR TITLE
[FIX] website: fix the "Form" snippet success message preview option

### DIFF
--- a/addons/website/static/src/builder/plugins/form/form_option.inside.scss
+++ b/addons/website/static/src/builder/plugins/form/form_option.inside.scss
@@ -1,12 +1,3 @@
-.o_builder_form_show_message {
-    &.d-none {
-        display: block !important;
-    }
-    &:not(.d-none) {
-        display: none !important;
-    }
-}
-
 .s_website_form {
     // Hidden field is only partially hidden in editor
     .s_website_form_field_hidden {
@@ -20,5 +11,14 @@
     }
     .s_website_form_label, .s_website_form_check_label {
         pointer-events: none;
+    }
+
+    .o_show_form_success_message {
+        &.d-none {
+            display: block !important;
+        }
+        &:not(.d-none) {
+            display: none !important;
+        }
     }
 }

--- a/addons/website/static/src/builder/plugins/form/form_option.xml
+++ b/addons/website/static/src/builder/plugins/form/form_option.xml
@@ -32,9 +32,11 @@
             <BuilderSelectItem actionValue="'redirect'" id="'show_redirect_opt'">Redirect</BuilderSelectItem>
             <BuilderSelectItem actionValue="'message'" id="'show_message_opt'">Show Message</BuilderSelectItem>
         </BuilderSelect>
-        <BuilderButton className="'fa fa-fw fa-eye align-self-end toggle-edit-message'" title.translate="Edit Message" id="'message_opt'"
-            t-if="isActiveItem('show_message_opt')" preview="false" action="'toggleEndMessage'"
-        />
+        <BuilderButton t-if="isActiveItem('show_message_opt')"
+                       title.translate="Edit Message"
+                       icon="'fa-eye'"
+                       preview="false"
+                       action="'toggleEndMessage'"/>
     </BuilderRow>
     <BuilderRow label.translate="URL">
         <WebsiteUrlPicker dataAttributeAction="'successPage'" default="'/contactus-thank-you'" id="'url_opt'" t-if="isActiveItem('show_redirect_opt')"/>

--- a/addons/website/static/tests/builder/website_builder/form_option.test.js
+++ b/addons/website/static/tests/builder/website_builder/form_option.test.js
@@ -1,7 +1,11 @@
 import { redo, undo } from "@html_editor/../tests/_helpers/user_actions";
 import { expect, test } from "@odoo/hoot";
 import { contains, defineModels, models, onRpc } from "@web/../tests/web_test_helpers";
-import { defineWebsiteModels, setupWebsiteBuilder } from "../website_helpers";
+import {
+    defineWebsiteModels,
+    setupWebsiteBuilder,
+    setupWebsiteBuilderWithSnippet,
+} from "../website_helpers";
 import { patch } from "@web/core/utils/patch";
 import { IrModel } from "@web/../tests/_framework/mock_server/mock_models/ir_model";
 import { _t } from "@web/core/l10n/translation";
@@ -145,4 +149,19 @@ test("empty placeholder selection input for selection field", async () => {
     await contains(".o_we_table_wrapper input[type='checkbox']").click();
     expect(":iframe select option").toHaveCount(4);
     expect(":iframe select option:eq(0)").toHaveText("");
+});
+
+test("Set 'Message' as form success action and show/hide the message preview", async () => {
+    await setupWebsiteBuilderWithSnippet("s_website_form");
+    await contains(":iframe section.s_website_form").click();
+    expect(".options-container[data-container-title='Form']").toHaveCount(1);
+
+    await contains(".options-container [data-label='On Success'] button").click();
+    await contains("div[data-action-id='onSuccess'][data-action-value='message']").click();
+    expect(":iframe .s_website_form_end_message.d-none").toHaveCount(1);
+
+    await contains(".options-container [data-action-id='toggleEndMessage']").click();
+    expect(":iframe .o_show_form_success_message").toHaveCount(2);
+    await contains(".options-container [data-action-id='toggleEndMessage']").click();
+    expect(":iframe .o_show_form_success_message").toHaveCount(0);
 });


### PR DESCRIPTION
This commit fixes the `toggleEndMessage` option, showing/hiding the success message preview.

Steps to reproduce:
- Drop a "Form" snippet and click on it.
- Set its "On Success" option to "Show Message".
- Click on the eye button to show the message preview. => Traceback

This happens because the `builderOptions` dependency was missing in the `ToggleEndMessageAction` class. Once that fixed, another issue was revealed:
- Click on the eye. => The button state does not match the fact that the preview is now toggled.

This happens because the added preview class is a system class, meaning that the mutations containing it are ignored. This caused the button action to not add a step in the history (since there is no mutation), preventing the `DOM_UPDATED` event to be triggered, which is the one triggering the update of the widgets.

This commit therefore makes this class observed (so not a system class anymore) and cleaned when needed, so in the `clean_for_save_handlers` and `on_cloned_handlers` resources. This class was also renamed to be more relevant.

The CSS was also changed to scope this class rules in the "Form" snippet ones, to be applicable only in that snippet. A bit of cleaning was also done. Notably, the `updateContainers` calls to activate the newly added fields were replaced by `setNextTarget`, following what was done in commit [1]. This allows to properly update the containers and to stay consistent on undo/redo.

[1]: 203a7af2c2b27c02be7b201f5c707f46caa34573

task-4367641
