### PR TITLE
[FIX] marketing_card: translate the timezone of date fields

### DIFF
--- a/addons/mail/models/models.py
+++ b/addons/mail/models/models.py
@@ -489,13 +489,20 @@ class BaseModel(models.AbstractModel):
         return ' '.join(str(value if value is not False and value is not None else '') for value in field_value)
 
     def _mail_get_timezone(self):
-        """To be override to get desired timezone of the model
+        """deprecated, override `_mail_get_timezone_with_default` instead."""
+        return self._mail_get_timezone_with_default()
 
+    def _mail_get_timezone_with_default(self, default_tz=True):
+        """To be overridden to get desired timezone of the model.
+
+        :param default_tz: the default timezone if none is found, or True to use the user's.
         :returns: selected timezone (e.g. 'UTC' or 'Asia/Kolkata')
         """
         if self:
             self.ensure_one()
-        tz = self.env.user.tz or 'UTC'
+        if default_tz is True:
+            default_tz = self.env.user.tz or 'UTC'
+        tz = default_tz
         for tz_field in ('date_tz', 'tz', 'timezone'):
             if tz_field in self:
                 tz = self[tz_field] or tz

--- a/addons/marketing_card/models/card_campaign.py
+++ b/addons/marketing_card/models/card_campaign.py
@@ -1,4 +1,6 @@
 import base64
+import pytz
+from datetime import date, datetime
 
 from odoo import _, api, fields, models, exceptions
 
@@ -394,4 +396,10 @@ class CardCampaign(models.Model):
                 except (AttributeError, KeyError):
                     # for generic image, or if field incorrect, return name of field
                     result[el] = self[path_field]
+                # force dates to their relevant timezone as that's what is usually wanted
+                if (
+                    isinstance(result[el], (date, datetime))
+                    and (tz := record._mail_get_timezone_with_default(default_tz=None))
+                ):
+                    result[el] = pytz.utc.localize(result[el]).astimezone(pytz.timezone(tz)).replace(tzinfo=None)
         return result

--- a/addons/marketing_card/tests/common.py
+++ b/addons/marketing_card/tests/common.py
@@ -1,5 +1,6 @@
 import base64
 from contextlib import contextmanager
+from freezegun import freeze_time
 from unittest.mock import patch
 
 from odoo.tests import BaseCase, TransactionCase
@@ -133,3 +134,9 @@ class MarketingCardCommon(TransactionCase, MockImageRender):
             'reward_target_url': f"{cls.env['card.campaign'].get_base_url()}/share-rewards/2039-sharer-badge/",
             'target_url': cls.env['card.campaign'].get_base_url(),
         })
+
+    @contextmanager
+    def mock_datetime_and_now(self, mock_dt):
+        with freeze_time(mock_dt), \
+                patch.object(self.env.cr, 'now', lambda: mock_dt):
+            yield

--- a/addons/marketing_card/tests/test_campaign.py
+++ b/addons/marketing_card/tests/test_campaign.py
@@ -1,4 +1,5 @@
 import base64
+from datetime import datetime
 from lxml import html
 from unittest.mock import patch
 
@@ -187,6 +188,40 @@ class TestMarketingCardRender(MarketingCardCommon):
             # match with card
             self.static_campaign.preview_record_ref = self.partners[0]
             self.assertEqual(self.static_campaign.res_model, 'res.partner')
+
+    @mock_image_render
+    def test_fetch_datetime(self):
+        """Fetching a datetime field should attempt to translate it in the relevant timezone."""
+        freeze_dt = datetime(2020, 5, 5, 12, 0, 0)
+        campaign = self.campaign.with_user(self.env.user)
+        campaign.write({
+            'content_header': False,
+            'content_header_dyn': True,
+            'content_header_path': 'write_date',
+        })
+        with self.mock_datetime_and_now(freeze_dt):
+            campaign.preview_record_ref.name = 'test_fetch_datetime'
+        timezones = [None, 'Europe/Brussels', 'Asia/Tokyo']
+        timezone_result_headers = []
+        for tz in timezones:
+            # force find different timezones to check the returned time
+            with patch(
+                    'odoo.addons.mail.models.models.BaseModel._mail_get_timezone_with_default',
+                    lambda model, default_tz: tz
+            ):
+                timezone_result_headers.append(
+                    campaign._get_card_element_values(campaign.preview_record_ref)['header']
+                )
+        utc_header, brussels_header, tokyo_header = timezone_result_headers
+        self.assertEqual(
+            utc_header, datetime(2020, 5, 5, 12, 0, 0)
+        )
+        self.assertEqual(
+            brussels_header, datetime(2020, 5, 5, 14, 0, 0)
+        )
+        self.assertEqual(
+            tokyo_header, datetime(2020, 5, 5, 21, 0, 0)
+        )
 
 
 @tagged('post_install', '-at_install')

--- a/addons/website_event_track/models/event_track.py
+++ b/addons/website_event_track/models/event_track.py
@@ -435,6 +435,12 @@ class Track(models.Model):
     # MESSAGING
     # ------------------------------------------------------------
 
+    def _mail_get_timezone_with_default(self, default_tz=True):
+        tz = None
+        if self:
+            tz = self.event_id._mail_get_timezone_with_default(default_tz=default_tz)
+        return tz or super()._mail_get_timezone_with_default(default_tz=default_tz)
+
     def _message_get_default_recipients(self):
         return {
             track.id: {


### PR DESCRIPTION
When possible we want to fetch a date field in its relevant timezone
not in UTC. As that is generally what you want people to share.

task-4936298