### PR TITLE
[FIX] website: remove the "Countdown" end message preview on clone

### DIFF
--- a/addons/website/static/src/builder/plugins/options/countdown_option.xml
+++ b/addons/website/static/src/builder/plugins/options/countdown_option.xml
@@ -17,9 +17,7 @@
                        t-if="!this.isActiveItem('no_end_action_opt') and !this.isActiveItem('redirect_end_action_opt')"
                        action="'previewEndMessage'"
                        preview="false"
-                       icon="'fa-eye'"
-                       classActive="'text-primary'"
-        />
+                       icon="'fa-eye'"/>
     </BuilderRow>
     <BuilderRow t-if="this.isActiveItem('redirect_end_action_opt')"
                 label.translate="URL">

--- a/addons/website/static/src/builder/plugins/options/countdown_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/countdown_option_plugin.js
@@ -1,5 +1,6 @@
 import { BuilderAction } from "@html_builder/core/builder_action";
 import { before, SNIPPET_SPECIFIC_END } from "@html_builder/utils/option_sequence";
+import { getElementsWithOption } from "@html_builder/utils/utils";
 import { Plugin } from "@html_editor/plugin";
 import { withSequence } from "@html_editor/utils/resource";
 import { registry } from "@web/core/registry";
@@ -23,6 +24,12 @@ class CountdownOptionPlugin extends Plugin {
             SetEndActionAction,
             PreviewEndMessageAction,
             SetLayoutAction,
+        },
+        on_cloned_handlers: ({ cloneEl }) => {
+            const countdownEls = getElementsWithOption(cloneEl, ".s_countdown");
+            for (const countdownEl of countdownEls) {
+                countdownEl.classList.remove("s_countdown_enable_preview");
+            }
         },
     };
 }
@@ -135,11 +142,15 @@ export class SetEndActionAction extends BaseCountdownAction {
 
 export class PreviewEndMessageAction extends BaseCountdownAction {
     static id = "previewEndMessage";
+    static dependencies = ["builderOptions"];
     apply({ editingElement }) {
-        return this.toggleEndMessagePreview(editingElement, true);
+        this.toggleEndMessagePreview(editingElement, true);
     }
     clean({ editingElement }) {
-        return this.toggleEndMessagePreview(editingElement, false);
+        this.toggleEndMessagePreview(editingElement, false);
+        // Activate the countdown options, to not stay on the message preview
+        // ones if they were active.
+        this.dependencies.builderOptions.setNextTarget(editingElement);
     }
     isApplied(context) {
         return this.isEndMessagePreviewed(context);


### PR DESCRIPTION
This commit removes the end message preview of the "Countdown" snippet when cloning it or a snippet containing it. This makes it easier for the user to understand that he cloned the whole snippet and not just the text block.

This commit also explicitely activates the `s_countdown` element options when hiding the end message preview. Indeed, if the message block was selected, its options were still activated despite it being hidden.

This commit also removes the `text-primary` class from the show/hide message preview option when it is active, to make the eye more visible.

task-4367641
