### PR TITLE
[FIX] html_builder: fix the "Version Control" alert style

### DIFF
--- a/addons/html_builder/static/src/sidebar/option_container.scss
+++ b/addons/html_builder/static/src/sidebar/option_container.scss
@@ -36,6 +36,16 @@
             border-spacing: $o-hb-row-spacing $o-hb-row-spacing;
         }
     }
+
+    .o_we_version_control {
+        background-color: $o-we-color-info;
+
+        div.title {
+            margin-bottom: $o-we-sidebar-content-field-label-spacing;
+            text-transform: uppercase;
+            font-weight: bold;
+        }
+    }
 }
 
 .o_we_img_animate:hover img {

--- a/addons/html_builder/static/src/sidebar/option_container.xml
+++ b/addons/html_builder/static/src/sidebar/option_container.xml
@@ -66,12 +66,12 @@
             </div>
         </t>
         <t t-else="">
-            <div class="o_we_version_control alert alert-info d-flex flex-column p-3 pt-4 align-items-center text-center text-white">
-                <div>This block is outdated.</div>
+            <div class="o_we_version_control d-flex flex-column p-3 pt-4 align-items-center text-center text-white">
+                <div class="title">This block is outdated.</div>
                 <div>You might not be able to customize it anymore.</div>
-                <button type="button" class="btn o_we_bg_brand_primary py-2 my-4 border-0" t-on-click="() => this.replaceElementWithNewVersion()">REPLACE BY NEW VERSION</button>
+                <button type="button" class="btn btn-primary py-2 my-4 border-0" t-on-click="() => this.replaceElementWithNewVersion()">REPLACE BY NEW VERSION</button>
                 <div>You can still access the block options but it might be ineffective.</div>
-                <button type="button" class="btn o_we_bg_brand_primary py-2 my-4 border-0" t-on-click="() => this.accessOutdated()">ACCESS OPTIONS ANYWAY</button>
+                <button type="button" class="btn btn-primary py-2 my-4 border-0" t-on-click="() => this.accessOutdated()">ACCESS OPTIONS ANYWAY</button>
             </div>
         </t>        
     </div>

--- a/addons/website/static/tests/tours/snippet_version.js
+++ b/addons/website/static/tests/tours/snippet_version.js
@@ -45,7 +45,7 @@ registerWebsitePreviewTour("snippet_version_2", {
 },
 {
     trigger:
-        ".o_customize_tab .options-container[data-container-title='Test snip'] .o_we_version_control.alert",
+        ".o_customize_tab .options-container[data-container-title='Test snip'] .o_we_version_control",
 },
 {
     content: "Edit text_image",
@@ -54,7 +54,7 @@ registerWebsitePreviewTour("snippet_version_2", {
 },
 {
     trigger:
-        ".o_customize_tab .options-container[data-container-title='Text - Image'] .o_we_version_control.alert",
+        ".o_customize_tab .options-container[data-container-title='Text - Image'] .o_we_version_control",
 },
 {
     content: "Edit s_share",
@@ -63,7 +63,7 @@ registerWebsitePreviewTour("snippet_version_2", {
 },
 {
     trigger:
-        ".o_customize_tab .options-container[data-container-title='Block'] .o_we_version_control.alert",
+        ".o_customize_tab .options-container[data-container-title='Block'] .o_we_version_control",
 },
 {
     content: "s_share is outdated",


### PR DESCRIPTION
This commit fixes the style of the "Version Control" alert. Indeed, its background color is too light, making it difficult to read the white text on it, and the buttons do not have any color unless hovered, making the options hard to use.

This commit restores the style used before the refactoring.

task-4367641