### PR TITLE
[FIX] website: consider multiple mega menus in the page

### DIFF
--- a/addons/website/static/src/interactions/dropdown/mega_menu_dropdown.edit.js
+++ b/addons/website/static/src/interactions/dropdown/mega_menu_dropdown.edit.js
@@ -6,28 +6,32 @@ const MegaMenuDropdownEdit = (I) => class extends I {
         ...this.dynamicContent,
         ".o_mega_menu_toggle": {
             ...this.dynamicContent[".o_mega_menu_toggle"],
-            "t-on-shown.bs.dropdown": () => {
-                // Focus the mega menu to show its options. Click is
-                // listened to in BuilderOptionsPlugin to call updateContainers.
-                this.waitForTimeout(() => {
-                        document
-                            .querySelector(".o_mega_menu")
-                            .dispatchEvent(new PointerEvent("click", { bubbles: true }));
-                });
+            "t-on-click": (ev) => {
+                const toggleEl = ev.currentTarget;
+                const megaMenuEl = toggleEl.parentElement.querySelector(".o_mega_menu"); 
+                // Activate the mega menu options when shown.
+                if (!megaMenuEl || !megaMenuEl.classList.contains("show")) {
+                    this.websiteEditService.callShared("builderOptions", "deactivateContainers");  
+                } else {
+                    this.websiteEditService.callShared("builderOptions", "updateContainers", megaMenuEl);
+                }
             },
         },
     };
 
     setup() {
         super.setup();
-        const hasMegaMenu = this.el.querySelector(".o_mega_menu_toggle");
-        if (hasMegaMenu) {
-            const bsDropdown = window.Dropdown.getOrCreateInstance(".o_mega_menu_toggle");
-            this.registerCleanup(() => {
+        this.websiteEditService = this.services.website_edit;
+
+        // Hide all the open mega menus when destroying the interaction.
+        this.registerCleanup(() => {
+            const megaMenuToggleEls = this.el.querySelectorAll(".o_mega_menu_toggle.show");
+            for (const megaMenuToggleEl of megaMenuToggleEls) {
+                const bsDropdown = window.Dropdown.getOrCreateInstance(megaMenuToggleEl);
                 bsDropdown.hide();
                 bsDropdown.dispose();
-            });
-        }
+            }
+        });
     }
 };
 


### PR DESCRIPTION
During the refactoring in [1], the `MegaMenuDropdownEdit` interaction was added in order to manage the mega menus behavior in edit mode. However, the code was made by considering that only one mega menu would be present in the navbar, which is not the case. Indeed, we can add as many mega menus as needed in the menu editor. Moreover, even with only one mega menu on the page, there are still two toggles, since there is the mobile navbar equivalent.

This commit therefore fixes the code to consider all mega menus and not just the first one.

This commit also improves the code activating the mega menu options when opening it. Indeed, it was simulating a click on the mega menu, relying on the fact that the `builderOptions` plugin will listen to it, but this solution is hackish. Instead, when clicking on a mega menu toggle, there is now an explicit call to that plugin shared functions:
- `updateContainers` when showing it, and
- `deactivateContainers` when hiding it.

[1]: 9fe45e2b7ddbbfd0445ffe25a859e67a316d02b2

task-4367641
