### PR TITLE
[FIX] website_sale: ensure public and portal users access shop

### DIFF
--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -1553,8 +1553,13 @@
     <template id="categories_recursive" name="Category list">
         <li class="nav-item mb-1" t-att-data-publish="c.has_published_products and 'on' or 'off'">
             <t t-call="website_sale.categorie_link"/>
-            <ul t-if="c.child_id" class="nav flex-column nav-hierarchy mt-1 ps-3">
-                <t t-foreach="c.child_id" t-as="c">
+            <!-- Dynamic category display based on search -->
+            <t t-set="children" t-value="not search and c.child_id or c.child_id.filtered(lambda c: c.id in search_categories_ids)"/>
+            <!-- Only show categories with published products to portal users preventing from access errors  -->
+            <t t-set="children" t-value="request.env.user._is_internal() and children or children.filtered('has_published_products')"/>
+
+            <ul t-if="children" class="nav flex-column nav-hierarchy mt-1 ps-3">
+                <t t-foreach="children" t-as="c">
                     <t t-if="not search or c.id in search_categories_ids">
                         <t t-call="website_sale.categories_recursive" />
                     </t>
@@ -1640,7 +1645,9 @@
     </template>
 
     <template id="option_collapse_categories_recursive" name="Collapse Category Recursive">
+        <!-- Dynamic category display based on search -->
         <t t-set="children" t-value="not search and c.child_id or c.child_id.filtered(lambda c: c.id in search_categories_ids)"/>
+        <!-- Only show categories with published products to portal users preventing from access errors  -->
         <t t-set="children" t-value="request.env.user._is_internal() and children or children.filtered('has_published_products')"/>
 
         <t t-if="children">


### PR DESCRIPTION
## Version
18.4+

## Steps to reproduce
- On the `/shop` page, in editor mode:
  - Select the product display block;
  - Enable `Categories` display and set it to `Sidebar`;
  - Disable the option `Collapse Category Recursive`;
- Open a new incognito window (or use a Portal user).
  - Try to access `/shop`.

## Issue
When the category display is set to `Sidebar` collapse and some categories have unpublished products, the `ir.rule` introduced in commit 120a7633505891ba3e02e879f0c1a8287a690456 prevents Public and Portal users from accessing the shop. This results in a 403 or 500 error due to inaccessible child categories being used in the recursive sidebar rendering.

## Cause
Commit 120a7633505891ba3e02e879f0c1a8287a690456 added a rule to hide empty categories from Public and Portal users by restricting access to categories where `has_published_products = True`. However, the sidebar template continues to loop over all `child_id`, including categories filtered out by access rules. Since Public and Portal users no longer have access to empty categories, this results in access errors during template rendering.

opw-4937000