### PR TITLE
[FIX] base: View validation is not performed for dependent views

### DIFF
--- a/addons/web/tests/test_js.py
+++ b/addons/web/tests/test_js.py
@@ -165,7 +165,7 @@ class WebSuite(QunitCommon, HOOTCommon):
     def _check_forbidden_statements(self, bundle):
         # As we currently are not in a request context, we cannot render `web.layout`.
         # We then re-define it as a minimal proxy template.
-        self.env.ref('web.layout').write({'arch_db': '<t t-name="web.layout"><head><meta charset="utf-8"/><t t-esc="head"/></head></t>'})
+        self.env.ref('web.layout').write({'arch_db': '<t t-name="web.layout"><html><head><meta charset="utf-8"/><link/><script id="web.layout.odooscript"/><meta/><t t-esc="head"/></head><body><t t-out="0"/></body></html></t>'})
 
         assets = self.env['ir.qweb']._get_asset_content(bundle)[0]
         if len(assets) == 0:
@@ -184,7 +184,7 @@ class WebSuite(QunitCommon, HOOTCommon):
         # ! DEPRECATED
         # As we currently aren't in a request context, we can't render `web.layout`.
         # redefinied it as a minimal proxy template.
-        self.env.ref('web.layout').write({'arch_db': '<t t-name="web.layout"><head><meta charset="utf-8"/><t t-esc="head"/></head></t>'})
+        self.env.ref('web.layout').write({'arch_db': '<t t-name="web.layout"><html><head><meta charset="utf-8"/><link/><script id="web.layout.odooscript"/><meta/><t t-esc="head"/></head><body><t t-out="0"/></body></html></t>'})
 
         assets = self.env['ir.qweb']._get_asset_content(suite)[0]
         if len(assets) == 0:

--- a/addons/website/tests/test_views.py
+++ b/addons/website/tests/test_views.py
@@ -961,7 +961,7 @@ class TestCowViewSaving(TestViewSavingCommon, HttpCase):
         self.assertEqual(specific_view_arch, '<p>COMPARE EDITED</p>', "When a module updates an inherited view (on a generic tree), it should also update the copies of that view (COW).")
 
         # Test fields that should not be COW'd
-        random_views = View.search([('key', '!=', None)], limit=2)
+        random_views = self.env.ref('website.s_accordion_image') + self.env.ref('website.s_accordion')
         View._load_records([dict(xml_id='_website_sale_comparison.product_add_to_compare', values={
             'website_id': None,
             'inherit_id': random_views[0].id,


### PR DESCRIPTION
The error is triggered when using the view, not when editing it. This can prevent the user from correcting their error because the interface is broken.

```
# P: primary, E: extension
#
#         P1
#       /    \
#     E1      E2
#    /  \    /  \
#   E3  E4  P2  E5
#
# If we update the E4, we should check the P1 and P2 views
```