### PR TITLE
[FIX] survey: reject non-numerical values in numerical questions

### DIFF
--- a/addons/survey/models/survey_question.py
+++ b/addons/survey/models/survey_question.py
@@ -6,6 +6,7 @@ import contextlib
 import itertools
 import json
 import operator
+import re
 from textwrap import shorten
 
 from odoo import api, fields, models, tools, _
@@ -465,15 +466,13 @@ class SurveyQuestion(models.Model):
         return {}
 
     def _validate_numerical_box(self, answer):
-        try:
-            floatanswer = float(answer)
-        except ValueError:
+        if not re.match(r'^\d+(\.\d+)?$', answer):
             return {self.id: _('This is not a number')}
 
         if self.validation_required:
             # Answer is not in the right range
             with contextlib.suppress(Exception):
-                if not (self.validation_min_float_value <= floatanswer <= self.validation_max_float_value):
+                if not (self.validation_min_float_value <= float(answer) <= self.validation_max_float_value):
                     return {self.id: self.validation_error_msg  or _('The answer you entered is not valid.')}
         return {}
 

--- a/addons/survey/tests/test_survey.py
+++ b/addons/survey/tests/test_survey.py
@@ -191,6 +191,11 @@ class TestSurveyInternals(common.TestSurveyCommon, MailCase):
             {}
         )
 
+        self.assertEqual(
+            question.validate_question('2e1'),
+            {question.id: _('This is not a number')}
+        )
+
     @users('survey_manager')
     def test_answer_validation_char_box_email(self):
         question = self._add_question(self.page_0, 'Q0', 'char_box', validation_email=True)

--- a/addons/survey/views/survey_templates.xml
+++ b/addons/survey/views/survey_templates.xml
@@ -408,7 +408,7 @@
 
     <template id="question_numerical_box" name="Question: numerical box">
         <div class="o_survey_answer_wrapper p-1 rounded">
-            <input type="number" step="any" class="form-control o_survey_question_numerical_box bg-transparent rounded-0 p-0"
+            <input type="text" step="any" class="form-control o_survey_question_numerical_box bg-transparent rounded-0 p-0"
                 t-att-name="question.id" t-att-placeholder="question.question_placeholder"
                 t-att-value="answer_lines[0].value_numerical_box if answer_lines else None"
                 t-att-data-question-type="question.question_type"


### PR DESCRIPTION
_______________________________________
## Short functional explanation of the error
On a survey, when answering a question that requires only a numerical answer, there's a different behavior observed based on the navigator used:
1. On chrome, characters other than numerical characters are rejected, except 'e' (for scientific notation). This causes a problem if the answer simply consists of 'e' and not an actual scientific number.
2. On firefox, every character is accepted. This causes the answer to be set as "skipped" instead of registering a result.

## Reproduction Steps
1. Go to the survey module.
2. Click on new. Add a title, Click on the 'survey' radio button and add a question.
3. Set a title and the type of the question to Numerical value.
4. Click on share and copy the link obtained.
5. Open a new incognito window and paste the link in it.
6. Start the survey and, if you're on chrome, enter 'e'; if you're on firefox, enter anything except a normal number. Then, hit submit.
### Expected behavior
The answer shouldn't be submitted, and a red message saying "This is not a number" should appear.

### Unexpected behavior
The answer is accepted, and when reviewing your answers, you'll see that the question has been skipped.

## Origin of the issue
In the corresponding XML, the input type has been set to numerical. However, in that case, Chrome sets restrictions for writable characters but still accepts the 'e' character for scientific notations. However, if only the 'e' character is entered, when clicking on submit, nothing is sent as an answer.
On Firefox, the issue is similar: nothing is sent except if the answer is a well formatted number, but there are no restrictions on what users can enter.
As nothing is sent, the answer is considered as skipped. Note: if you setup the question as mandatory, only entering 'e' on Chrome or random characters on firefox will trigger the error message 'This question requires an answer.'

_________________________________________
opw-4883341

---


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
