### PR TITLE
[FIX] point_of_sale: Restrict cost and margin visibility

### DIFF
--- a/addons/point_of_sale/static/src/app/components/popups/product_info_popup/product_info_popup.js
+++ b/addons/point_of_sale/static/src/app/components/popups/product_info_popup/product_info_popup.js
@@ -16,10 +16,10 @@ export class ProductInfoPopup extends Component {
         this.props.close();
     }
     _hasMarginsCostsAccessRights() {
-        const isAccessibleToEveryUser = this.pos.config.is_margins_costs_accessible_to_every_user;
-        const isCashierManager = this.pos.getCashier()._role === "manager";
-        const isMinimalCashier = this.pos.getCashier()._role === "minimal";
-        return isAccessibleToEveryUser || isCashierManager || isMinimalCashier;
+        if (!this.pos.config.is_margins_costs_accessible_to_every_user) {
+            return false;
+        }
+        return ["manager", "cashier"].includes(this.pos.getCashier()._role);
     }
     editProduct() {
         this.pos.editProduct(this.props.productTemplate);

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -656,6 +656,9 @@ class TestUi(TestPointOfSaleHttpCommon):
         self.pos_admin.write({
             'group_ids': [Command.link(self.env.ref('base.group_system').id)],
         })
+        self.main_pos_config.write({
+            'is_margins_costs_accessible_to_every_user': True,
+        })
         self.assertFalse(self.product_a.is_storable)
         self.main_pos_config.with_user(self.pos_admin).open_ui()
         self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'CheckProductInformation', login="pos_admin")

--- a/addons/pos_hr/static/tests/tours/pos_hr_tour.js
+++ b/addons/pos_hr/static/tests/tours/pos_hr_tour.js
@@ -225,3 +225,32 @@ registry.category("web_tour.tours").add("test_cashier_changed_in_receipt", {
             ReceiptScreen.clickNextOrder(),
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("test_cost_and_margin_visibility", {
+    steps: () =>
+        [
+            Chrome.clickBtn("Open Register"),
+            PosHr.loginScreenIsShown(),
+            PosHr.clickLoginButton(),
+            SelectionPopup.has("Mitchell Admin", { run: "click" }),
+            Dialog.confirm("Open Register"),
+            ProductScreen.clickInfoProduct("product_a"),
+            {
+                trigger: ".section-financials :contains('Margin')",
+            },
+            Dialog.confirm("Close"),
+            PosHr.clickCashierName(),
+            SelectionPopup.has("Test Employee 3", { run: "click" }),
+            ProductScreen.clickInfoProduct("product_a"),
+            {
+                trigger: ".section-financials :contains('Margin')",
+            },
+            Dialog.confirm("Close"),
+            PosHr.clickCashierName(),
+            SelectionPopup.has("Test Employee 4", { run: "click" }),
+            ProductScreen.clickInfoProduct("product_a"),
+            Utils.negateStep({
+                trigger: ".section-financials :contains('Margin')",
+            }),
+        ].flat(),
+});

--- a/addons/pos_hr/tests/test_frontend.py
+++ b/addons/pos_hr/tests/test_frontend.py
@@ -51,8 +51,14 @@ class TestPosHrHttpCommon(TestPointOfSaleHttpCommon):
             "company_id": cls.env.company.id,
         })
 
+        cls.emp4 = cls.env['hr.employee'].create({
+            'name': 'Test Employee 4',
+            "company_id": cls.env.company.id,
+        })
+
         cls.main_pos_config.write({
-            'basic_employee_ids': [Command.link(cls.emp1.id), Command.link(cls.emp2.id), Command.link(cls.emp3.id)]
+            'basic_employee_ids': [Command.link(cls.emp1.id), Command.link(cls.emp2.id), Command.link(cls.emp3.id)],
+            'minimal_employee_ids': [Command.link(cls.emp4.id)],
         })
 
 
@@ -191,3 +197,16 @@ class TestUi(TestPosHrHttpCommon):
         })
         order_payment.with_context(**payment_context).check()
         self.start_pos_tour("test_minimal_employee_refund", login="pos_admin")
+
+    def test_cost_and_margin_visibility(self):
+        self.product_a.available_in_pos = True
+        self.main_pos_config.write({
+            'is_margins_costs_accessible_to_every_user': True,
+        })
+        self.main_pos_config.with_user(self.pos_admin).open_ui()
+
+        self.start_tour(
+            "/pos/ui?config_id=%d" % self.main_pos_config.id,
+            "test_cost_and_margin_visibility",
+            login="pos_admin",
+        )


### PR DESCRIPTION
Before this commit, the "Show margins & costs" setting did not correctly enforce visibility. When enabled, cost and margin information was displayed to all users, regardless of their cashier rights. Furthermore, even when this setting was disabled, this sensitive information was still visible to cashiers with advanced and minimal rights.

This commit modifies the behavior:
- If "Show margins & costs" is enabled, cost and margin details are visible in the PoS UI only for employees with 'basic' and 'advanced' cashier rights, and hidden from those with 'minimal' rights.
- If "Show margins & costs" is not checked, this information is hidden from all users in the PoS UI.

opw-4899231

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
