### PR TITLE
[FIX] industry: prevent upgrade if major changed

### DIFF
--- a/addons/base_import_module/views/base_import_module_view.xml
+++ b/addons/base_import_module/views/base_import_module_view.xml
@@ -11,6 +11,7 @@
                     <group invisible="state != 'init'">
                         <field name="module_file" string="Module file (.zip)" options="{'accepted_file_extensions': '.zip'}" invisible="context.get('data_module')"/>
                         <field name="force" groups="base.group_no_one"/>
+                        <field name="major_upgrade" groups="base.group_no_one"/>
                         <field name="with_demo" string="Load demo data"/>
                     </group>
                     <group invisible="state != 'done'">

--- a/addons/base_import_module/views/ir_module_views.xml
+++ b/addons/base_import_module/views/ir_module_views.xml
@@ -11,7 +11,7 @@
                 </xpath>
                 <xpath expr="//button[@name='button_immediate_install']" position="after">
                     <button type="object" class="btn btn-primary btn-sm" name="button_immediate_install_app" invisible="state != 'uninstalled' or module_type in ('official', False)" groups="base.group_system" context="{'module_name':name}">Activate</button>
-                    <button type="object" class="btn btn-primary btn-sm" name="button_immediate_install_app" invisible="state == 'uninstalled' or module_type in ('official', False)" groups="base.group_system" context="{'module_name':name}">Upgrade</button>
+                    <button type="object" class="btn btn-primary btn-sm" name="button_immediate_install_app" invisible="state == 'uninstalled' or module_type in ('official', False)" groups="base.group_system" context="{'module_name':name}">Reset</button>
                 </xpath>
                 <xpath expr="//button[@name='button_immediate_install']" position="attributes">
                     <attribute name="invisible">state != 'uninstalled' or (module_type and module_type != 'official')</attribute>
@@ -52,7 +52,7 @@
                 </xpath>
                 <xpath expr="//button[@name='button_immediate_install']" position="after">
                     <button type="object" class="btn btn-primary me-1" name="button_immediate_install_app" invisible="state != 'uninstalled' or module_type in ('official', False)" groups="base.group_system">Activate</button>
-                    <button type="object" class="btn btn-primary me-1" name="button_immediate_install_app" invisible="state == 'uninstalled' or module_type in ('official', False)" groups="base.group_system">Upgrade</button>
+                    <button type="object" class="btn btn-primary me-1" name="button_immediate_install_app" invisible="state == 'uninstalled' or module_type in ('official', False)" groups="base.group_system">Reset</button>
                 </xpath>
                 <xpath expr="//button[@name='button_immediate_install']" position="attributes">
                     <attribute name="invisible">to_buy or state != 'uninstalled' or (module_type and module_type != 'official')</attribute>


### PR DESCRIPTION
 Activated industry apps had an "Upgrade" button with was slightly misleading, since the button was actually reseting the module regardless if there is a new version or not.

 The "Upgrade" button has been named "Reset" for better clarity. Additionally in case of a major change in module version a warning will be raised to signal to users potential record breakage in case of upgrade.

- Created `is_major_version_different` in `ir.module.module` to check if the major version of the current module being installed has been changed.
- Changes in `button_immediate_install_app ` are for built-in industry apps.
- Changes in `import_module` are for zip installed apps.
- Lines flagged by ci/security should be safe because it only manifest files are read.

task-4752273

