### PR TITLE
[FIX] stock_account: ignore float errors in avg_cost

### DIFF
--- a/addons/stock_account/models/product.py
+++ b/addons/stock_account/models/product.py
@@ -132,7 +132,9 @@ class ProductProduct(models.Model):
         for group in groups:
             product = self.browse(group['product_id'][0])
             value_svl = company_id.currency_id.round(group['value'])
-            avg_cost = value_svl / group['quantity'] if group['quantity'] else 0
+            avg_cost = 0
+            if not float_is_zero(group['quantity'], precision_rounding=product.uom_id.rounding):
+                avg_cost = value_svl / group['quantity']
             product.value_svl = value_svl
             product.quantity_svl = group['quantity']
             product.avg_cost = avg_cost


### PR DESCRIPTION
## Before this commit:
Opening the stock report displays gigantic unit cost in some cases, when the sum of the valuation's quantity is near zero but not exactly, due to float arithmetics.
For example, if the total quantity is 1e-15 and the total value is $0.01, the average cost will display $10000000000000 instead of $0.

## After this commit:
Use `float_is_zero` to correctly detect zero-ish quantity.

opw-4869588