### PR TITLE
[FIX] account: Creating an invoice with an empty item is possible

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -4900,6 +4900,8 @@ class AccountMove(models.Model):
                 validation_msgs.add(_('The entry %(name)s (id %(id)s) must be in draft.', name=move.name, id=move.id))
             if not move.line_ids.filtered(lambda line: line.display_type not in ('line_section', 'line_note')):
                 validation_msgs.add(_('You need to add a line before posting.'))
+            if not any(line.product_id for line in move.line_ids):
+                validation_msgs.add(_('You need at least one product in the line before posting.'))
             if not soft and move.auto_post != 'no' and move.date > fields.Date.context_today(self):
                 date_msg = move.date.strftime(get_lang(self.env).date_format)
                 validation_msgs.add(_("This move is configured to be auto-posted on %(date)s", date=date_msg))


### PR DESCRIPTION
Description of the issue/feature this PR addresses: Creating an invoice with an empty item is possible. Current behavior before PR:
Creating an invoice with an empty item is possible. Desired behavior after PR is merged:
A line with empty item identifier should not be possible.

opw-217383
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
