### PR TITLE
[FIX] project_todo: use user timezone for act states

### DIFF
--- a/addons/project_todo/models/res_users.py
+++ b/addons/project_todo/models/res_users.py
@@ -3,7 +3,7 @@
 
 import json
 
-from odoo import _, api, models, modules
+from odoo import _, api, fields, models, modules
 
 
 class Users(models.Model):
@@ -24,9 +24,9 @@ class Users(models.Model):
         # 2. creating groups for todo and task seperately
         query = """SELECT BOOL(t.project_id) as is_task, count(*), act.res_model, act.res_id,
                        CASE
-                           WHEN CURRENT_DATE - act.date_deadline::date = 0 THEN 'today'
-                           WHEN CURRENT_DATE - act.date_deadline::date > 0 THEN 'overdue'
-                           WHEN CURRENT_DATE - act.date_deadline::date < 0 THEN 'planned'
+                           WHEN %(date)s - act.date_deadline::date = 0 THEN 'today'
+                           WHEN %(date)s - act.date_deadline::date > 0 THEN 'overdue'
+                           WHEN %(date)s - act.date_deadline::date < 0 THEN 'planned'
                         END AS states
                      FROM mail_activity AS act
                      JOIN project_task AS t ON act.res_id = t.id
@@ -34,6 +34,7 @@ class Users(models.Model):
                  GROUP BY is_task, states, act.res_model, act.res_id
                 """
         self.env.cr.execute(query, {
+            'date': str(fields.Date.context_today(self)),
             'user_id': self.env.uid,
             'active': self._context.get('active_test', True),
         })


### PR DESCRIPTION
User timezone was not being used for activity states and thus the future, today, and late activities would be inaccurate. They were being computed with CURRENT_DATE through SQL which is based on the timezone that the SQL server is in. This would lead to there being a period of some hours based on the user timezone where the actual activities page that you click into and the systray showing different counts of activity states.

For example, on our Odoo production database, activities that SF office members create on projects that were for tomorrow would show today after 5pm and when clicking on the today activities there would be nothing until midnight.

Using the user timezone in order to compute what today is for them, then using this in the SQL query fixes this issue. This is the same behavior as the compute_state for the state field in mail.activity.

opw-4893182
