### PR TITLE
[FIX] */tests: fix default hr.groups in demo data

### DIFF
--- a/addons/account/tests/common.py
+++ b/addons/account/tests/common.py
@@ -271,12 +271,10 @@ class AccountTestInvoicingCommon(ProductCommon):
                 ('name', 'in', (
                     # TODO: Progressively remove groups from this list, hopefully no groups share the same name.
                     # This is a consequence of moving groups from data to demo data: https://github.com/odoo/odoo/pull/198078
-                    'group_hr_manager', # hr
                     'group_mrp_manager', # mrp
                     'group_purchase_manager', # purchase
                     'group_stock_manager', # stock
                     # enterprise groups
-                    'group_hr_payroll_manager', # hr_payroll
                     'group_plm_manager', # mrp_plm
                 ))
             ]).mapped('res_id')

--- a/addons/account/tests/common.py
+++ b/addons/account/tests/common.py
@@ -275,6 +275,7 @@ class AccountTestInvoicingCommon(ProductCommon):
                     'group_purchase_manager', # purchase
                     'group_stock_manager', # stock
                     # enterprise groups
+                    'group_hr_payroll_manager', # hr_payroll
                     'group_plm_manager', # mrp_plm
                 ))
             ]).mapped('res_id')

--- a/addons/hr_expense/tests/common.py
+++ b/addons/hr_expense/tests/common.py
@@ -13,6 +13,7 @@ class TestExpenseCommon(AccountTestInvoicingCommon):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+        cls.env.user.group_ids += cls.env.ref('hr.group_hr_manager')
 
         cls.company_data_2 = cls.setup_other_company()
         cls.other_currency = cls.setup_other_currency('HRK')

--- a/addons/hr_expense/tests/common.py
+++ b/addons/hr_expense/tests/common.py
@@ -13,7 +13,6 @@ class TestExpenseCommon(AccountTestInvoicingCommon):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.env.user.group_ids += cls.env.ref('hr.group_hr_manager')
 
         cls.company_data_2 = cls.setup_other_company()
         cls.other_currency = cls.setup_other_currency('HRK')


### PR DESCRIPTION
Since no demo data was made the default of odoo and default groups were moved from module data to demo data, which caused a lot of tests to fail without demo data. The previous behaviour of
AccountTestInvoicingCommon was restored by re-adding all groups explicitly.

This commit cleans up the hr groups by adding groups in tests that need permission to the user.

task-4677643

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
