### PR TITLE
[IMP] mail, website: improve the server action form view

### DIFF
--- a/addons/base_automation/tests/test_automation.py
+++ b/addons/base_automation/tests/test_automation.py
@@ -224,8 +224,8 @@ class TestAutomation(TransactionCaseWithUserDemo):
         automation1.active = False
         self.assertRecordValues(cron, [{
             'active': False,
-            'interval_type': 'minutes',
-            'interval_number': 240,  # same as 4 hours
+            'interval_type': 'hours',
+            'interval_number': 4,
         }])
 
         # Enable automation1 and automation2

--- a/addons/mail/static/src/views/web/fields/html_composer_message_field/html_composer_message_field.scss
+++ b/addons/mail/static/src/views/web/fields/html_composer_message_field/html_composer_message_field.scss
@@ -1,6 +1,6 @@
 .o_field_html_composer_message {
     .note-editable {
-        min-height: 180px !important;
+        min-height: 300px !important;
         padding-left: 0;
     }
 }

--- a/addons/mail/views/ir_actions_server_views.xml
+++ b/addons/mail/views/ir_actions_server_views.xml
@@ -10,7 +10,7 @@
                 <xpath expr="//form" position="inside">
                     <chatter/>
                 </xpath>
-                <xpath expr="//t[@name='action_content']" position="inside">
+                <xpath expr="//t[@name='action_content']//notebook" position="before">
                     <!-- Create next activity -->
                     <group invisible="state != 'next_activity'">
                         <group>

--- a/addons/web/static/src/webclient/actions/action_service.js
+++ b/addons/web/static/src/webclient/actions/action_service.js
@@ -1027,6 +1027,7 @@ export function makeActionManager(env, router = _router) {
             if (size) {
                 actionDialogProps.size = size;
             }
+            actionDialogProps.header = action.context.header ?? actionDialogProps.header;
             actionDialogProps.footer = action.context.footer ?? actionDialogProps.footer;
             const onClose = dialog?.onClose;
             delete dialog?.onClose;

--- a/addons/web/static/tests/webclient/actions/client_action.test.js
+++ b/addons/web/static/tests/webclient/actions/client_action.test.js
@@ -149,6 +149,20 @@ test("can display client actions in Dialog, then as main destroys Dialog", async
     expect(".modal .test_client_action").toHaveCount(0);
 });
 
+test("dialog no header", async () => {
+    await mountWithCleanup(WebClient);
+    await getService("action").doAction({
+        name: "Dialog Test",
+        target: "new",
+        tag: "__test__client__action__",
+        type: "ir.actions.client",
+        context: { header: false },
+    });
+
+    expect(".modal .test_client_action").toHaveCount(1);
+    expect(".modal-title").toHaveCount(0);
+});
+
 test("soft_reload will refresh data", async () => {
     onRpc("web_search_read", () => {
         expect.step("web_search_read");

--- a/addons/website/views/ir_actions_server_views.xml
+++ b/addons/website/views/ir_actions_server_views.xml
@@ -8,15 +8,16 @@
             <field name="inherit_id" ref="base.view_server_action_form"/>
             <field name="arch" type="xml">
                 <data>
-                    <xpath expr="//notebook" position="inside">
-                        <page string="Website" groups="base.group_no_one" invisible="state != 'code' or context.get('is_modal')">
-                            <group>
-                                <field name="website_published"/>
-                                <field name="xml_id" invisible="1"/>
-                                <field name="website_path" invisible="not website_published"/>
-                                <field name="website_url" widget="url" readonly="1" invisible="not website_published"/>
-                            </group>
-                        </page>
+                    <xpath expr="//page[@name='usage']" position="inside">
+                        <group invisible="state != 'code' or context.get('is_modal')">
+                            <field name="website_published" string="Use in website"/>
+                            <field name="xml_id" invisible="1"/>
+                            <field name="website_path" invisible="not website_published"/>
+                            <field name="website_url" widget="url" readonly="1" invisible="not website_published"/>
+                        </group>
+                    </xpath>
+                    <xpath expr="//page[@name='usage']" position="attributes">
+                        <attribute name="invisible" add="state != 'code' or context.get('is_modal')" separator="and"/>
                     </xpath>
                 </data>
             </field>

--- a/odoo/addons/base/views/ir_actions_views.xml
+++ b/odoo/addons/base/views/ir_actions_views.xml
@@ -548,6 +548,7 @@ env['res.partner'].create({'name': partner_name})
                                     'sms': 'fa-mobile',
                                     'webhook': 'fa-paper-plane',
                                     'whatsapp': 'fa-whatsapp',
+                                    'ai': 'fa-magic',
                                 }[record.state.raw_value] || 'fa-circle-thin'"
                             />
                             <i class="fa fa-warning text-warning px-2 m-0" invisible="not warning" t-att-title="record.warning.raw_value"/>

--- a/odoo/addons/base/views/ir_actions_views.xml
+++ b/odoo/addons/base/views/ir_actions_views.xml
@@ -460,6 +460,9 @@
                                     <field name="webhook_sample_payload" string="Sample Payload" nolabel="1" colspan="2" readonly="1" widget="code" options="{'mode': 'javascript'}" />
                                 </group>
                             </group>
+                            <group>
+                                <field name="usage"/>
+                            </group>
                             <t invisible="state != 'multi'">
                                 <field name="child_ids" widget="many2many" mode="kanban" context="{
                                     'is_modal': 1,
@@ -469,11 +472,11 @@
                                     If several actions return an action, only the last one will be executed.
                                 </p>
                             </t>
-                            <notebook invisible="state != 'code'">
-                                <page string="Code">
+                            <notebook>
+                                <page string="Code" invisible="state != 'code'">
                                     <field name="code" invisible="state != 'code'" widget="code" options="{'mode': 'python'}" placeholder="Enter Python code here. Help about Python expression is available in the help tab of this document."/>
                                 </page>
-                                <page string="Help">
+                                <page string="Help" invisible="state != 'code'" name="ir_actions_server_code_help">
                                     <p>The following variables can be used:</p>
                                     <ul>
                                         <li><code>env</code>: environment on which the action is triggered</li>
@@ -502,6 +505,7 @@ env['res.partner'].create({'name': partner_name})
     </pre>
                                     </div>
                                 </page>
+                                <page string="Usage" name="usage" invisible="1"/>
                             </notebook>
                         </t>
                     </sheet>

--- a/odoo/tools/mail.py
+++ b/odoo/tools/mail.py
@@ -493,7 +493,8 @@ def is_html_empty(html_content: str | markupsafe.Markup | Literal[False] | None)
         return True
     icon_re = r'<\s*(i|span)\b(\s+[A-Za-z_-][A-Za-z0-9-_]*(\s*=\s*[\'"][^"\']*[\'"])?)*\s*\bclass\s*=\s*["\'][^"\']*\b(fa|fab|fad|far|oi)\b'
     tag_re = r'<\s*\/?(?:p|div|section|span|br|b|i|font)\b(?:(\s+[A-Za-z_-][A-Za-z0-9-_]*(\s*=\s*[\'"][^"\']*[\'"]))*)(?:\s*>|\s*\/\s*>)'
-    return not bool(re.sub(tag_re, '', html_content).strip()) and not re.search(icon_re, html_content)
+    text_content = htmllib.unescape(re.sub(tag_re, '', html_content))
+    return not bool(text_content.strip()) and not re.search(icon_re, html_content)
 
 
 def html_keep_url(text):

--- a/odoo/tools/mail.py
+++ b/odoo/tools/mail.py
@@ -77,7 +77,7 @@ safe_attrs = defs.safe_attrs | frozenset(
      'data-class', 'data-mimetype', 'data-original-src', 'data-original-id', 'data-gl-filter', 'data-quality', 'data-resize-width',
      'data-shape', 'data-shape-colors', 'data-file-name', 'data-original-mimetype',
      'data-attachment-id', 'data-format-mimetype',
-     'data-ai-field',
+     'data-ai-field', 'data-ai-record-id',
      'data-heading-link-id',
      'data-mimetype-before-conversion',
      ])


### PR DESCRIPTION
Purpose
=======
The server action will be changed by the AI module, and so some changes
are required in the overwrite of the form view.

We need `data-ai-record-id` in safe attributes, now that we dropped qweb in favor of a custom rendering.

Create a method `_run` for the server actions to be able to control the evaluation context from the caller.

Add an option to be able to remove the header from the modal (like it already exist for the footer).

Make `is_html_empty` decoding the HTML, in case some blank characters are encoded (it happen often because of some plugin of the web editor).

Task-4915266