### PR TITLE
Fixes #217386: Creating customers with invalid contact fields was possible.

### DIFF
--- a/doc/cla/individual/hamzaahmedhussein.md
+++ b/doc/cla/individual/hamzaahmedhussein.md
@@ -1,0 +1,6 @@
+I hereby agree to the terms of the Odoo Individual Contributor License Agreement v1.0.
+I declare that I am authorized and able to make this agreement and sign this declaration.
+
+Signed,
+Hamza Ahmed
+hamzaahmedhussein1@gmail.com

--- a/odoo/addons/base/models/res_partner.py
+++ b/odoo/addons/base/models/res_partner.py
@@ -381,7 +381,6 @@ class ResPartner(models.Model):
 
     @api.constrains('phone', 'mobile', 'email', 'website')
     def _validate_contact_fields(self):
-        """Validate partner contact fields."""
         for partner in self:
             if partner.phone and not re.match(r'^[+\d][\d\s().-]{5,}$', partner.phone.strip()):
                 raise ValidationError(_(
@@ -397,25 +396,20 @@ class ResPartner(models.Model):
 
             if partner.email and not re.match(r'^[^@\s]+@[^@\s]+\.[^@\s]+$', partner.email.strip()):
                 raise ValidationError(_(
-                    "Invalid email format. Must contain '@' and domain. "
+                    "Invalid email format. Must contain '@' and a domain. "
                     "Example: valid@example.com"
                 ))
-
+            
             if partner.website:
                 ws = partner.website.strip()
-                if not re.match(r'^https?://\w+', ws):
+                pattern = r'^https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*)$'
+                if not re.match(pattern, ws):
                     raise ValidationError(_(
-                        "Website must start with http:// or https://. "
+                        "Invalid website format.\n"
+                        "Must start with http:// or https:// and contain a valid domain.\n"
                         "Example: https://www.example.com"
                     ))
-                domain = ws.split('//')[-1].split('/')[0]
-                if '.' not in domain:
-                    raise ValidationError(_(
-                        "Website must contain a domain extension. "
-                        "Example: https://www.example.com"
-                    ))
-
-
+            
 
     @api.depends('is_company', 'name', 'parent_id.name', 'type', 'company_name', 'commercial_company_name')
     def _compute_complete_name(self):

--- a/odoo/addons/base/tests/__init__.py
+++ b/odoo/addons/base/tests/__init__.py
@@ -77,3 +77,4 @@ from . import test_config_parameter
 from . import test_ir_module_category
 from . import test_configmanager
 from . import test_num2words_ar
+from . import test_partner_validation

--- a/odoo/addons/base/tests/test_partner_validation.py
+++ b/odoo/addons/base/tests/test_partner_validation.py
@@ -2,36 +2,109 @@ from odoo.tests.common import TransactionCase
 from odoo.exceptions import ValidationError
 
 class TestResPartnerValidation(TransactionCase):
-    """Validate contact fields (phone, email, website) formatting."""
+    """Test contact field validation in res.partner"""
+
+    def setUp(self):
+        super().setUp()
+        self.Partner = self.env['res.partner']
 
     def test_valid_contact_fields(self):
-        Partner = self.env['res.partner']
-        valid = Partner.create({
+        """Test creation with valid contact data"""
+        partner = self.Partner.create({
             'name': 'Valid Partner',
-            'phone': '+1234567890',
-            'mobile': '123-456-7890',
-            'email': 'test@example.com',
-            'website': 'https://valid.com',
+            'phone': '+1 (555) 123-4567',  
+            'mobile': '555.123.4567',       
+            'email': 'valid.email+test@sub.example.com',
+            'website': 'https://www.odoo-valid.com/path?query=1'
         })
-        self.assertTrue(valid.id > 0)
+        self.assertTrue(partner.id > 0)
 
-    def test_invalid_phone(self):
+    def test_phone_validation(self):
+        """Test phone/mobile validation scenarios"""
+        valid_numbers = [
+            '+1234567890',     
+            '123 456 7890',    
+            '(555)123-4567',   
+            '555.123.4567',   
+            '1234567890'       
+        ]
+        
+        for number in valid_numbers:
+            partner = self.Partner.create({
+                'name': f'Test {number}',
+                'phone': number
+            })
+            self.assertTrue(partner.id > 0)
+
+    def test_invalid_phone_format(self):
+        """Test invalid phone formats"""
+        invalid_numbers = [
+            'abc123',          
+            '+1 () 123',       
+            '123!456',          
+            '123 45',           
+            '-----'             
+        ]
+        
+        for number in invalid_numbers:
+            with self.assertRaises(ValidationError):
+                self.Partner.create({
+                    'name': f'Invalid {number}',
+                    'phone': number
+                })
+
+    def test_phone_minimum_digits(self):
+        """Test minimum digit requirement"""
         with self.assertRaises(ValidationError):
-            self.env['res.partner'].create({
-                'name': 'Invalid Phone',
-                'phone': 'abc'
+            self.Partner.create({
+                'name': 'Short Number',
+                'mobile': '12345'  
             })
 
-    def test_invalid_email(self):
-        with self.assertRaises(ValidationError):
-            self.env['res.partner'].create({
-                'name': 'Invalid Email',
-                'email': 'invalid@'
+    def test_email_validation(self):
+        """Test email validation"""
+        valid_emails = [
+            'simple@example.com',
+            'with+tag@example.com',
+            'with.dots@sub.example.com'
+        ]
+        
+        for email in valid_emails:
+            partner = self.Partner.create({
+                'name': f'Test {email}',
+                'email': email
             })
+            self.assertTrue(partner.id > 0)
 
-    def test_website_invalid_URL(self):
-        with self.assertRaises(ValidationError):
-            self.env['res.partner'].create({
-                'name': 'Invalid Website URL',
-                'website': 'http://localhost' 
-            })
+        invalid_emails = [
+            'missing@dot',
+            'invalid@',
+            '@missing.local',
+            'spaces in@email.com'
+        ]
+        
+        for email in invalid_emails:
+            with self.assertRaises(ValidationError):
+                self.Partner.create({
+                    'name': f'Invalid {email}',
+                    'email': email
+                })
+
+    def test_invalid_websites(self):
+        """Test that invalid websites are rejected"""
+        invalid_sites = [
+                   
+            'javascript:alert(1)', 
+            'http://',             
+            'example..com',        
+            'example.c',           
+            'example',             
+            'example.com/path with space'  
+        ]
+        
+        for site in invalid_sites:
+            with self.assertRaises(ValidationError):
+                self.Partner.create({
+                    'name': f'Invalid {site}',
+                    'website': site
+                })

--- a/odoo/addons/base/tests/test_partner_validation.py
+++ b/odoo/addons/base/tests/test_partner_validation.py
@@ -1,0 +1,44 @@
+from odoo.tests.common import TransactionCase
+from odoo.exceptions import ValidationError
+
+class TestResPartnerValidation(TransactionCase):
+    """Validate contact fields (phone, email, website) formatting."""
+
+    def test_valid_contact_fields(self):
+        Partner = self.env['res.partner']
+        valid = Partner.create({
+            'name': 'Valid Partner',
+            'phone': '+1234567890',
+            'mobile': '123-456-7890',
+            'email': 'test@example.com',
+            'website': 'https://valid.com',
+        })
+        self.assertTrue(valid.id > 0)
+
+    def test_invalid_phone(self):
+        with self.assertRaises(ValidationError):
+            self.env['res.partner'].create({
+                'name': 'Invalid Phone',
+                'phone': 'abc'
+            })
+
+    def test_invalid_email(self):
+        with self.assertRaises(ValidationError):
+            self.env['res.partner'].create({
+                'name': 'Invalid Email',
+                'email': 'invalid@'
+            })
+
+    def test_website_missing_protocol(self):
+        with self.assertRaises(ValidationError):
+            self.env['res.partner'].create({
+                'name': 'Invalid Website',
+                'website': 'invalid.com'
+            })
+
+    def test_website_invalid_tld(self):
+        with self.assertRaises(ValidationError):
+            self.env['res.partner'].create({
+                'name': 'Invalid Website TLD',
+                'website': 'http://localhost'
+            })

--- a/odoo/addons/base/tests/test_partner_validation.py
+++ b/odoo/addons/base/tests/test_partner_validation.py
@@ -29,16 +29,9 @@ class TestResPartnerValidation(TransactionCase):
                 'email': 'invalid@'
             })
 
-    def test_website_missing_protocol(self):
+    def test_website_invalid_URL(self):
         with self.assertRaises(ValidationError):
             self.env['res.partner'].create({
-                'name': 'Invalid Website',
-                'website': 'invalid.com'
-            })
-
-    def test_website_invalid_tld(self):
-        with self.assertRaises(ValidationError):
-            self.env['res.partner'].create({
-                'name': 'Invalid Website TLD',
-                'website': 'http://localhost'
+                'name': 'Invalid Website URL',
+                'website': 'http://localhost' 
             })


### PR DESCRIPTION
Purpose :
Prevent saving invalid contact data when creating or updating partners.

Fixes: #217386

Changes
1. Server-side validation in res.partner:

Phone/Mobile must match: ^[+\d][\d\s().-]{5,}$

Email must match: ^[^@\s]+@[^@\s]+\.[^@\s]+$

Website must:

Start with http:// or https://

Contain a valid domain and top-level domain (TLD)

2. Unit tests:

Added test_partner_validation.py

Validates:

Invalid/valid phone numbers

Invalid/valid email addresses

Invalid/valid website URLs

3. CLA:

Signed the Individual Contributor License Agreement

Added doc/cla/individual/hamzaahmedhussein.md

