### PR TITLE
[FIX] point_of_sale: Remove draft orders from the server if present

### DIFF
--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -552,7 +552,7 @@ export class PosStore extends Reactive {
                 delete this.toRefundLines[line.refunded_orderline_id];
             }
         }
-        if (this.isOpenOrderShareable() && removeFromServer) {
+        if ((this.isOpenOrderShareable() || this.config.id === order.pos.config.id) && removeFromServer) {
             if (this.ordersToUpdateSet.has(order)) {
                 this.ordersToUpdateSet.delete(order);
             }


### PR DESCRIPTION
**Steps to Reproduce:**

1. Ensure that a preparation display is configured for the given POS with all categories enabled.
2. Open that POS session.
3. Go to the Orders (ticket screen).
4. Create a new order from the ticket screen.
5. Add some products.
6. Return to the ticket screen and create another order.
7. Add payment and validate the second order.
8. Go back to the ticket screen and delete all orders.
9. Refresh the screen or try to close the session.

**Issue:**
After refreshing, the first (unvalidated) order reappears. Attempting to close the POS session fails because draft orders are still present in the database.


**Description of the Issue/Feature this PR Addresses:**
When a preparation display is configured for the current POS setup, and a user creates a draft order from the ticket or receipt screen, then creates and validates a second order without validating the first, the original order is saved as a draft in the database.

This draft cannot be deleted from the server, even if the user deletes it from the POS interface. Upon refreshing the POS, the draft reappears and prevents session closure due to its presence in the system.

This PR ensures that such draft orders are removed from the database as well, allowing them to be fully deleted both from the POS screen and the backend.


**Current Behavior Before PR:**
Draft orders saved on the server cannot be deleted from the POS interface, and block session closure.


**Desired Behavior After PR is Merged:**
Draft orders can be successfully deleted from both the POS interface and the server, allowing proper session closure.




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
