### PR TITLE
Update account_move_views.xml

### DIFF
--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -703,10 +703,15 @@
                 <form string="Account Entry" js_class="account_move_form">
                     <header>
                         <!-- Post -->
-                        <button name="action_post" string="Post" class="oe_highlight"
-                                type="object" groups="account.group_account_invoice" data-hotkey="q"
-                                context="{'validate_analytic': True, 'disable_abnormal_invoice_detection': False}"
-                                invisible="hide_post_button or move_type != 'entry'"/>
+                        <sheet>
+    <field name="hide_post_button" invisible="1"/>
+                            
+    <button name="action_post" string="Confirm" class="oe_highlight"
+            type="object" groups="account.group_account_invoice" data-hotkey="q"
+            context="{'validate_analytic': True}"
+            invisible="hide_post_button or move_type == 'entry' or display_inactive_currency_warning"/>
+</sheet>
+
                         <button name="action_post" string="Confirm" class="oe_highlight"
                                 type="object" groups="account.group_account_invoice" data-hotkey="q"
                                 context="{'validate_analytic': True, 'disable_abnormal_invoice_detection': False}"

--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -703,15 +703,13 @@
                 <form string="Account Entry" js_class="account_move_form">
                     <header>
                         <!-- Post -->
-                        <sheet>
-    <field name="hide_post_button" invisible="1"/>
-                            
-    <button name="action_post" string="Confirm" class="oe_highlight"
-            type="object" groups="account.group_account_invoice" data-hotkey="q"
-            context="{'validate_analytic': True}"
-            invisible="hide_post_button or move_type == 'entry' or display_inactive_currency_warning"/>
-</sheet>
-
+                         <button name="action_post" string="Confirm" class="oe_highlight"
+                                type="object" groups="account.group_account_invoice" data-hotkey="q"
+                                context="{'validate_analytic': True}"
+                                invisible="hide_post_button or move_type == 'entry' or display_inactive_currency_warning"/>
+                        
+                    <!-- Send (only invoices) -->
+                        <field name="hide_post_button" invisible="1"/>
                         <button name="action_post" string="Confirm" class="oe_highlight"
                                 type="object" groups="account.group_account_invoice" data-hotkey="q"
                                 context="{'validate_analytic': True, 'disable_abnormal_invoice_detection': False}"


### PR DESCRIPTION
[FIX] account: ensure `hide_post_button` is declared in form view

The `hide_post_button` field is used in the `invisible` condition of the "Post" (`action_post`) button on `account.move` form views. However, it was not explicitly declared in the view, which caused the button to be always visible even when it should be hidden.

This commit adds the missing field to the form view (invisible), so the `invisible` condition is properly evaluated by the client UI.

This fixes a UI inconsistency where the Post button appears for posted or auto-scheduled entries, despite backend logic preventing their posting.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:





