### PR TITLE
[FIX] project: show subtasks when opened from subtask action

### DIFF
--- a/addons/project/static/src/views/project_task_model_mixin.js
+++ b/addons/project/static/src/views/project_task_model_mixin.js
@@ -3,8 +3,8 @@ import { Domain } from "@web/core/domain";
 
 export const ProjectTaskModelMixin = (T) => class ProjectTaskModelMixin extends T {
     _processSearchDomain(domain) {
-        const showTaskActions = !this.env.searchModel.globalContext.my_tasks;
-        const showSubtasks = !showTaskActions || JSON.parse(browser.localStorage.getItem("showSubtasks"));
+        const { my_tasks, subtask_action } = this.env.searchModel.globalContext;
+        const showSubtasks = my_tasks || subtask_action || JSON.parse(browser.localStorage.getItem("showSubtasks"));
         if (!showSubtasks) {
             return Domain.and([
                 domain,


### PR DESCRIPTION
Steps to reproduce:
----------------
   - Install the Project module.
   - Go to Project and create a project.
   - Create a task and a subtask.
   - Deactivate the subtasks topbar in the control panel.
   - Open the task's form view and click on the Subtasks action.
  
Issue:
-----------
   Currently, if the subtasks topbar is deactivated and the user clicks on the Subtasks action from the task form view, the subtasks do not appear.

Reason:
-------------
   We are only displaying subtasks if the subtasks topbar is active and when accessed 
  via the My Tasks menu.

Fix:
--------
   We fixed this by checking the subtask_action context in project_task_model_mixin.js. When the user opens subtasks through the subtask action, this context is set, allowing subtasks to be shown even if the topbar is deactivated.

 Effected Commit- https://github.com/odoo/odoo/pull/213096/commits/268ffa321e12466682b520740b576b71d36eabd5

