### PR TITLE
[FIX] l10n_din5008_stock: remove vat from address

### DIFF
--- a/addons/l10n_din5008_stock/report/din5008_stock_picking_layout.xml
+++ b/addons/l10n_din5008_stock/report/din5008_stock_picking_layout.xml
@@ -12,10 +12,6 @@
                         <t t-else="">
                             <address class="mb-0" t-field="o.partner_id" t-options='{"widget": "contact", "fields": ["address", "name", "phone"], "no_marker": True}'/>
                         </t>
-                        <div t-if="not (o.picking_type_id.code == 'outgoing' and main_address.id != o.partner_id.commercial_partner_id.id)" id="partner_vat_address_same_as_shipping">
-                            <t t-if="o.company_id.account_fiscal_country_id.vat_label" t-out="o.company_id.account_fiscal_country_id.vat_label" id="inv_tax_id_label"/>
-                            <t t-else="">Tax ID</t>: <span t-field="o.partner_id.vat"/>
-                        </div>
                     </t>
                 </t>
             </xpath>


### PR DESCRIPTION
When printing the delivery slip of a dropship operation using the DIN 5008 layout, the customer's address is correctly displayed, but the VAT of the vendor is shown beneath it.  This is misleading. Actually we do not need vat at all.

**Step to reproduce:**
- Install `l10n_din5008_stock` and `sale_management`
- Go to setting 
    -> configure document layout -> set `DIN 5008` as layout 
    -> enable `dropshipping`
- Create a product, enable Purchase, and select Dropship route.
- Assign Azure Interior as the vendor in purchase tab.
- Create a SO with that product and Deco Addict as customer, confirm it
- Click on purchase smart button, confirm it,  click on dropship smart button
- print delivery slip Observation: Below the customer's address, the vendor's VAT is printed.

**Issue:**
- issue lies in this condition 
- `not (o.picking_type_id.code == 'outgoing' and main_address.id != o.partner_id.commercial_partner_id.id)`
- as `o.picking_type_id.code` is `dropship`
- here, condition evaluates to true, which incorrectly assumes the customer and vendor is same, and prints partner i.e vendor's VAT

**Fix:**
- no need to display vat,so we remove it

<img width="1519" height="244" alt="image" src="https://github.com/user-attachments/assets/d8630fa5-c568-4208-a97e-7e4ceb371109" />


**Before**

<img width="803" height="366" alt="image" src="https://github.com/user-attachments/assets/e2148bb0-7413-4efe-b312-ba7a577e0b62" />

**After**

<img width="615" height="244" alt="image" src="https://github.com/user-attachments/assets/526cfae3-4d8b-4755-b59c-54dfce79526c" />


opw-4929680


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
