### PR TITLE
[FIX] html_editor: fix nondeterminism of tests showing link popover

### DIFF
--- a/addons/html_editor/static/src/main/link/link_popover.js
+++ b/addons/html_editor/static/src/main/link/link_popover.js
@@ -1,5 +1,5 @@
 import { _t } from "@web/core/l10n/translation";
-import { Component, useState, onMounted, useRef, useEffect, useExternalListener } from "@odoo/owl";
+import { Component, useState, useRef, useEffect, useExternalListener } from "@odoo/owl";
 import { useService } from "@web/core/utils/hooks";
 import { browser } from "@web/core/browser/browser";
 import { cleanZWChars, deduceURLfromText } from "./utils";
@@ -171,11 +171,9 @@ export class LinkPopover extends Component {
             },
             () => [this.inputRef.el]
         );
-        onMounted(() => {
-            if (!this.state.editing) {
-                this.loadAsyncLinkPreview();
-            }
-        });
+        if (!this.state.editing) {
+            this.loadAsyncLinkPreview();
+        }
         const onPointerDown = (ev) => {
             if (!this.state.url) {
                 this.props.onDiscard();


### PR DESCRIPTION
In 3145a4ffe2e64737297aab90f382fad9f1a29491, tests were adapted to use absolute urls if they failed because they tried to fetch metadata for relative url.

Some tests open the link popover near the end, thus passed sometimes (when the test ended before the fetch error). These tests were also adapted in 06263227eb59ce0e0be2416d794ce50f907e1413. But the indeterminism that lead them to pass was not fixed (because of uncertainty about the correct appraoch)

The tests failed sometimes because the metadata fetch is triggered in the `onMounted` of the link popover, which does not happen if the component is cancelled before it is rendered

task-4367641
