### PR TITLE
[FIX] core: bs 4.10 compatibility

### DIFF
--- a/odoo/_monkeypatches/bs4.py
+++ b/odoo/_monkeypatches/bs4.py
@@ -3,6 +3,7 @@ import warnings
 
 
 def patch_module():
-    # ofxparse use an html parser to parse ofx xml files and triggers a warning since bs4 4.11.0
-    # https://github.com/jseutter/ofxparse/issues/170
-    warnings.filterwarnings('ignore', category=bs4.XMLParsedAsHTMLWarning)
+    if hasattr(bs4, 'XMLParsedAsHTMLWarning'):
+        # ofxparse use an html parser to parse ofx xml files and triggers a
+        # warning since bs4 4.11.0 https://github.com/jseutter/ofxparse/issues/170
+        warnings.filterwarnings('ignore', category=bs4.XMLParsedAsHTMLWarning)

--- a/odoo/netsvc.py
+++ b/odoo/netsvc.py
@@ -199,10 +199,6 @@ def init_logger():
     warnings.simplefilter('default', category=DeprecationWarning)
     # https://github.com/urllib3/urllib3/issues/2680
     warnings.filterwarnings('ignore', r'^\'urllib3.contrib.pyopenssl\' module is deprecated.+', category=DeprecationWarning)
-    if bs4 := sys.modules.get('bs4'):
-        # avoid loading bs4 module during initialization; this filter is also
-        # monkeypatched if the import is done afterwards
-        warnings.filterwarnings('ignore', category=bs4.XMLParsedAsHTMLWarning)
     # ignore a bunch of warnings we can't really fix ourselves
     for module in [
         'babel.util', # deprecated parser module, no release yet


### PR DESCRIPTION
Ubuntu Jammy ships BeautifulSoup 4.10, which does not have the `XMLParsedAsHTMLWarning` symbol. Because the import guard was removed in #212408 any use of ofxparse or bs4 (directly) on jammy using distro packages will blow up.

https://runbot.odoo.com/odoo/error/226555
