### PR TITLE
[FIX] account: add notify_progress to auto send CRON

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -5506,6 +5506,10 @@ class AccountMove(models.Model):
             [('sending_data', '!=', False)],
             limit=limit,
         )
+        total_to_process = self.env['account.move'].search_count(
+            [('sending_data', '!=', False)],
+        )
+
         need_retrigger = len(to_process) > job_count
         if not to_process:
             return
@@ -5522,6 +5526,8 @@ class AccountMove(models.Model):
             to_process,
             from_cron=True,
         )
+        self.env['ir.cron']._notify_progress(done=len(to_process),
+                                             remaining=total_to_process - len(to_process))
 
         for partner_id, partner_moves in moves_by_partner.items():
             partner = self.env['res.partner'].browse(partner_id)


### PR DESCRIPTION
The scheduled action for the automatic sending of invoices currently does not explictly use the `_notify_progress` method introduced since Odoo 18 to track the progress of CRON jobs.

This means that implicitly, by default the CRON will log `processed 0 records, 0 records remaining` at each run.

This can be confusing, as the automatic invoice sending CRON is batched, and might run multiple times in sucession, reporting each time that it processed 0 records (which might not be true).

## Proposed fix:
We correctly count the total account moves that need to be processed (using a `search_count`) and calculate the number of processed records and the remaining ones.

opw-4926541

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
