### PR TITLE
[REF] web, web_tour: onStep and onError macro returns object

### DIFF
--- a/addons/web/static/src/core/macro.js
+++ b/addons/web/static/src/core/macro.js
@@ -134,14 +134,15 @@ export class Macro {
             return;
         }
         try {
-            const currentStep = this.steps[this.currentIndex];
+            const step = this.steps[this.currentIndex];
             const executeStep = async () => {
-                const trigger = await waitForTrigger(currentStep.trigger);
-                await this.onStep(currentStep, trigger, this.currentIndex);
-                return await performAction(trigger, currentStep.action);
+                const trigger = await waitForTrigger(step.trigger);
+                const result = await performAction(trigger, step.action);
+                await this.onStep({ step, trigger, index: this.currentIndex });
+                return result;
             };
             const launchTimer = async () => {
-                const timeout_delay = currentStep.timeout || this.timeout || 10000;
+                const timeout_delay = step.timeout || this.timeout || 10000;
                 await delay(timeout_delay);
                 throw new MacroError(
                     "Timeout",
@@ -169,7 +170,8 @@ export class Macro {
         }
         this.isComplete = true;
         if (error) {
-            this.onError(error, this.steps[this.currentIndex], this.currentIndex);
+            const step = this.steps[this.currentIndex];
+            this.onError({ error, step, index: this.currentIndex });
         } else if (this.currentIndex === this.steps.length) {
             this.onComplete();
         }

--- a/addons/web_tour/static/src/tour_service/tour_automatic.js
+++ b/addons/web_tour/static/src/tour_service/tour_automatic.js
@@ -122,7 +122,7 @@ export class TourAutomatic {
         this.macro = new Macro({
             name: this.name,
             steps: macroSteps,
-            onError: (error) => {
+            onError: ({ error }) => {
                 if (error.type === "Timeout") {
                     this.throwError(...this.currentStep.describeWhyIFailed, error.message);
                 } else {

--- a/addons/web_tour/static/tests/check_undeterminisms.test.js
+++ b/addons/web_tour/static/tests/check_undeterminisms.test.js
@@ -85,7 +85,7 @@ afterEach(() => {
 });
 
 test("element is no longer visible", async () => {
-    macro.onStep = (step, el, index) => {
+    macro.onStep = ({ index }) => {
         if (index == 2) {
             setTimeout(() => {
                 queryFirst(".container").classList.add("d-none");
@@ -104,7 +104,7 @@ ${expectedError}`,
 });
 
 test("change text", async () => {
-    macro.onStep = (step, el, index) => {
+    macro.onStep = ({ index }) => {
         if (index == 2) {
             setTimeout(() => {
                 queryFirst(".button1").textContent = "Text has changed :)";
@@ -131,7 +131,7 @@ Initial element has changed:
 });
 
 test("change attributes", async () => {
-    macro.onStep = (step, el, index) => {
+    macro.onStep = ({ index }) => {
         if (index == 2) {
             setTimeout(() => {
                 const button1 = queryFirst(".button1");
@@ -168,7 +168,7 @@ ${expectedError}`,
 });
 
 test("add child node", async () => {
-    macro.onStep = (step, el, index) => {
+    macro.onStep = ({ index }) => {
         if (index == 4) {
             setTimeout(() => {
                 const addElement = document.createElement("div");
@@ -205,7 +205,7 @@ ${expectedError}`,
 });
 
 test.skip("snapshot is the same but has mutated", async () => {
-    macro.onStep = async (step, el, index) => {
+    macro.onStep = async ({ index }) => {
         if (index === 2) {
             setTimeout(() => {
                 const button1 = queryFirst(".button1");


### PR DESCRIPTION
In this commit, we're changing the structure of the onStep and onError callback functions in macro.js to make them easier to use. Previously, when using onStep and onError, it was difficult to understand what was being returned in the callback and required declaring variables that might not be used. Now, it's easier to destructure the returned object.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
