### PR TITLE
[FIX] web, *: preserve spaces in many2x autocomplete results

### DIFF
--- a/addons/hr/static/src/views/fields/many2one_avatar_employee_field/kanban_many2one_avatar_employee_field.xml
+++ b/addons/hr/static/src/views/fields/many2one_avatar_employee_field/kanban_many2one_avatar_employee_field.xml
@@ -9,7 +9,7 @@
             <t t-set-slot="autoCompleteItem" t-slot-scope="autoCompleteItemScope">
                 <span class="o_avatar_many2x_autocomplete o_avatar d-flex align-items-center">
                     <img class="rounded me-1" t-attf-src="/web/image/{{relation}}/{{autoCompleteItemScope.record.id}}/avatar_128"/>
-                    <t t-out="autoCompleteItemScope.label"/>
+                    <span t-out="autoCompleteItemScope.label"/>
                 </span>
             </t>
         </KanbanMany2One>

--- a/addons/hr/static/src/views/fields/many2one_avatar_employee_field/many2one_avatar_employee_field.xml
+++ b/addons/hr/static/src/views/fields/many2one_avatar_employee_field/many2one_avatar_employee_field.xml
@@ -11,7 +11,7 @@
                 <t t-set-slot="autoCompleteItem" t-slot-scope="autoCompleteItemScope">
                     <div class="o_avatar_many2x_autocomplete d-flex align-items-center">
                         <AvatarEmployee resModel="relation" resId="autoCompleteItemScope.record.id" canOpenPopover="false"/>
-                        <t t-out="autoCompleteItemScope.label"/>
+                        <span t-out="autoCompleteItemScope.label"/>
                     </div>
                 </t>
             </Many2One>

--- a/addons/mail/static/src/views/web/fields/many2one_avatar_user_field/kanban_many2one_avatar_user_field.xml
+++ b/addons/mail/static/src/views/web/fields/many2one_avatar_user_field/kanban_many2one_avatar_user_field.xml
@@ -10,7 +10,7 @@
             <t t-set-slot="autoCompleteItem" t-slot-scope="autoCompleteItemScope">
                 <span class="o_avatar_many2x_autocomplete o_avatar d-flex align-items-center">
                     <img class="rounded me-1" t-attf-src="/web/image/{{relation}}/{{autoCompleteItemScope.record.id}}/avatar_128"/>
-                    <t t-out="autoCompleteItemScope.label"/>
+                    <span t-out="autoCompleteItemScope.label"/>
                 </span>
             </t>
         </KanbanMany2One>

--- a/addons/mail/static/src/views/web/fields/many2one_avatar_user_field/many2one_avatar_user_field.xml
+++ b/addons/mail/static/src/views/web/fields/many2one_avatar_user_field/many2one_avatar_user_field.xml
@@ -10,7 +10,7 @@
                 <t t-set-slot="autoCompleteItem" t-slot-scope="autoCompleteItemScope">
                     <div class="o_avatar_many2x_autocomplete d-flex align-items-center">
                         <Avatar resModel="relation" resId="autoCompleteItemScope.record.id" canOpenPopover="false"/>
-                        <t t-out="autoCompleteItemScope.label"/>
+                        <span t-out="autoCompleteItemScope.label"/>
                     </div>
                 </t>
             </Many2One>

--- a/addons/resource_mail/static/src/views/fields/many2one_avatar_resource/kanban_many2one_avatar_resource_field.xml
+++ b/addons/resource_mail/static/src/views/fields/many2one_avatar_resource/kanban_many2one_avatar_resource_field.xml
@@ -27,7 +27,7 @@
                     <t t-elif="autoCompleteItemScope.record.resource_type === 'user'">
                         <img class="rounded me-1" t-attf-src="/web/image/{{relation}}/{{autoCompleteItemScope.record.id}}/avatar_128"/>
                     </t>
-                    <t t-out="autoCompleteItemScope.label"/>
+                    <span t-out="autoCompleteItemScope.label"/>
                 </span>
             </t>
         </KanbanMany2One>

--- a/addons/resource_mail/static/src/views/fields/many2one_avatar_resource/many2one_avatar_resource_field.xml
+++ b/addons/resource_mail/static/src/views/fields/many2one_avatar_resource/many2one_avatar_resource_field.xml
@@ -28,7 +28,7 @@
                         <t t-elif="autoCompleteItemScope.record.resource_type === 'user'">
                             <img class="rounded me-1" t-attf-src="/web/image/{{relation}}/{{autoCompleteItemScope.record.id}}/avatar_128"/>
                         </t>
-                        <t t-out="autoCompleteItemScope.label"/>
+                        <span t-out="autoCompleteItemScope.label"/>
                     </span>
                 </t>
             </Many2One>

--- a/addons/web/static/src/views/fields/many2many_tags/many2many_tags_field.xml
+++ b/addons/web/static/src/views/fields/many2many_tags/many2many_tags_field.xml
@@ -27,7 +27,7 @@
                 >
                     <t t-set-slot="autoCompleteItem" t-slot-scope="autoCompleteItemScope">
                         <span t-att-class="{ 'fw-bold': isSelected(autoCompleteItemScope.record) }">
-                            <t t-out="autoCompleteItemScope.label"/>
+                            <span t-out="autoCompleteItemScope.label"/>
                         </span>
                     </t>
                 </Many2XAutocomplete>

--- a/addons/web/static/src/views/fields/many2many_tags_avatar/many2many_tags_avatar_field.xml
+++ b/addons/web/static/src/views/fields/many2many_tags_avatar/many2many_tags_avatar_field.xml
@@ -35,7 +35,7 @@
             <img t-if="autoCompleteItemScope.value" class="rounded me-1"
                 t-attf-src="/web/image/{{relation}}/{{autoCompleteItemScope.value}}/avatar_128"/>
             <span t-att-class="{ 'fw-bold': isSelected(autoCompleteItemScope.record) }" t-out="autoCompleteItemScope.label">
-                <t t-out="autoCompleteItemScope.label"/>
+                <span t-out="autoCompleteItemScope.label"/>
             </span>
         </span>
     </t>

--- a/addons/web/static/src/views/fields/many2one_avatar/kanban_many2one_avatar_field.xml
+++ b/addons/web/static/src/views/fields/many2one_avatar/kanban_many2one_avatar_field.xml
@@ -12,7 +12,7 @@
             <t t-set-slot="autoCompleteItem" t-slot-scope="autoCompleteItemScope">
                 <span class="o_avatar_many2x_autocomplete o_avatar d-flex align-items-center">
                     <img class="rounded me-1" t-attf-src="/web/image/{{relation}}/{{autoCompleteItemScope.record.id}}/avatar_128"/>
-                    <t t-out="autoCompleteItemScope.label"/>
+                    <span t-out="autoCompleteItemScope.label"/>
                 </span>
             </t>
         </KanbanMany2One>

--- a/addons/web/static/src/views/fields/many2one_avatar/many2one_avatar_field.xml
+++ b/addons/web/static/src/views/fields/many2one_avatar/many2one_avatar_field.xml
@@ -17,7 +17,7 @@
                 <t t-set-slot="autoCompleteItem" t-slot-scope="autoCompleteItemScope">
                     <span class="o_avatar_many2x_autocomplete o_avatar d-flex align-items-center">
                         <img class="rounded me-1" t-attf-src="/web/image/{{relation}}/{{autoCompleteItemScope.record.id}}/avatar_128"/>
-                        <t t-out="autoCompleteItemScope.label"/>
+                        <span t-out="autoCompleteItemScope.label"/>
                     </span>
                 </t>
             </Many2One>

--- a/addons/web/static/tests/views/fields/many2many_field.test.js
+++ b/addons/web/static/tests/views/fields/many2many_field.test.js
@@ -1948,18 +1948,21 @@ test("highlight search in many2many", async () => {
     await runAllTimers();
     expect(`.o-autocomplete.dropdown li a > span`).toHaveCount(2);
     expect(`.o-autocomplete.dropdown li:eq(0) a > span`).toHaveInnerHTML(`
+    <span>
         first
         <span class="text-primary fw-bold">
             rec
         </span>
         ord
-    `);
+    </span>`);
     expect(`.o-autocomplete.dropdown li:eq(1) a > span`).toHaveInnerHTML(`
+    <span>
         second
         <span class="text-primary fw-bold">
             rec
         </span>
         ord
+    </span>
     `);
 });
 


### PR DESCRIPTION
This commit fixes an issue in many2x autocomplete fields where typing a complete word followed by a space would result in that space being removed, causing the next word to stick to the previous one.

The problem stemmed from how highlighted search results wrap the matched text in a \<span\>, which inadvertently isolates adjacent spaces. Combined with the display: flex styling of parent elements, these isolated spaces were visually trimmed.

To resolve this, each autocomplete result item is now entirely wrapped in a \<span\>, preventing space trimming and ensuring proper word separation during input.

task-4898120
