### PR TITLE
[FIX] website: theme background image not displayed

### DIFF
--- a/addons/website/static/src/builder/plugins/customize_website_plugin.js
+++ b/addons/website/static/src/builder/plugins/customize_website_plugin.js
@@ -475,8 +475,9 @@ export class CustomizeBodyBgTypeAction extends BuilderAction {
                 "body-image": "",
             });
         } else {
-            imageSrc = historyImageSrc || (await getAction("replaceBgImage").load({ el }));
-            if (imageSrc) {
+            const imageEl = historyImageSrc || (await getAction("replaceBgImage").load({ el }));
+            if (imageEl) {
+                imageSrc = imageEl.src;
                 await this.dependencies.customizeWebsite.customizeWebsiteVariables({
                     "body-image-type": `'${value}'`,
                     "body-image": `'${imageSrc}'`,

--- a/addons/website/static/src/scss/website.scss
+++ b/addons/website/static/src/scss/website.scss
@@ -169,7 +169,7 @@ $-seen-urls: ();
 }
 
 @mixin body-image-bg-style() {
-    background-image: url("/#{str-slice(o-website-value('body-image'), 2)}");
+    background-image: url("#{str-slice(o-website-value('body-image'), 1)}");
     background-position: center;
     background-attachment: fixed;
     @if o-website-value('body-image-type') == 'pattern' {


### PR DESCRIPTION
This commit fixes a bug in the new version of the editor where setting a background image in the website theme would do nothing.

Steps to reproduce
- open editor
- open theme tab
- set any image as background => nothing happens

After this commit the background image shows correctly.
