### PR TITLE
[FIX] html_builder: reduce the size of dropdown to not go out of screen

### DIFF
--- a/addons/html_builder/static/src/core/building_blocks/builder_select.js
+++ b/addons/html_builder/static/src/core/building_blocks/builder_select.js
@@ -48,13 +48,13 @@ export class BuilderSelect extends Component {
 
         this.dropdown = useDropdownState();
 
-        const buttonRef = useRef("button");
+        this.buttonRef = useRef("button");
         let currentLabel;
         const updateCurrentLabel = () => {
             if (!this.props.slots.fixedButton) {
                 const newHtml = currentLabel || _t("None");
-                if (buttonRef.el && buttonRef.el.innerHTML !== newHtml) {
-                    setElementContent(buttonRef.el, newHtml);
+                if (this.buttonRef.el && this.buttonRef.el.innerHTML !== newHtml) {
+                    setElementContent(this.buttonRef.el, newHtml);
                 }
             }
         };
@@ -70,5 +70,9 @@ export class BuilderSelect extends Component {
                 this.dropdown.close();
             },
         });
+    }
+
+    heightOfButton() {
+        return this.buttonRef.el.getBoundingClientRect().height;
     }
 }

--- a/addons/html_builder/static/src/core/building_blocks/builder_select.xml
+++ b/addons/html_builder/static/src/core/building_blocks/builder_select.xml
@@ -12,7 +12,7 @@
                     <t t-slot="fixedButton"/>
                 </button>
                 <t t-set-slot="content">
-                    <div t-att-class="props.dropdownContainerClass" data-prevent-closing-overlay="true" style="max-height: 50vh;">
+                    <div t-att-class="props.dropdownContainerClass" data-prevent-closing-overlay="true" t-att-style="'max-height: calc(50dvh - ' + heightOfButton() + 'px);'">
                         <t t-slot="default" />
                     </div>
                 </t>


### PR DESCRIPTION
> [ROMO] The dropdown to select the scroll effect for the header is partially hidden on top

The size of dropdown of builder select was reduce by cdc74d6e5c1dc2c8d84d028b7b7c0284118a9d66 to avoid going out of viewport but it was not enough

Steps to reproduce:
- Open website builder
- Find a `BuilderSelect` that is long enough (or reduce the window size)
- Open it when it is near the middle of the height of the view port
- Bug: the end is outside of the viewport

task-4367641
