### PR TITLE
[FIX] html_editor: restore focus to editable after selecting font size

### DIFF
--- a/addons/html_editor/static/src/core/selection_plugin.js
+++ b/addons/html_editor/static/src/core/selection_plugin.js
@@ -1047,16 +1047,23 @@ export class SelectionPlugin extends Plugin {
     }
 
     focusEditable() {
-        const { editableSelection, documentSelectionIsInEditable } = this.getSelectionData();
-        if (documentSelectionIsInEditable) {
+        if (this.editable.contains(this.document.activeElement)) {
+            // Editor has focus — nothing to do.
             return;
         }
+
+        const { editableSelection, documentSelectionIsInEditable } = this.getSelectionData();
+
         // Manualy focusing the editable is necessary to avoid some non-deterministic error in the HOOT unit tests.
         this.editable.focus({ preventScroll: true });
-        const { anchorNode, anchorOffset, focusNode, focusOffset } = editableSelection;
-        const selection = this.document.getSelection();
-        if (selection) {
-            selection.setBaseAndExtent(anchorNode, anchorOffset, focusNode, focusOffset);
+
+        if (!documentSelectionIsInEditable) {
+            // Selection is outside the editor — restore it.
+            const { anchorNode, anchorOffset, focusNode, focusOffset } = editableSelection;
+            const selection = this.document.getSelection();
+            if (selection) {
+                selection.setBaseAndExtent(anchorNode, anchorOffset, focusNode, focusOffset);
+            }
         }
     }
 }

--- a/addons/html_editor/static/src/main/font/font_plugin.js
+++ b/addons/html_editor/static/src/main/font/font_plugin.js
@@ -208,6 +208,7 @@ export class FontPlugin extends Plugin {
                         });
                         this.updateFontSizeSelectorParams();
                     },
+                    onBlur: () => this.dependencies.selection.focusEditable(),
                     document: this.document,
                 },
             },

--- a/addons/html_editor/static/src/main/font/font_size_selector.js
+++ b/addons/html_editor/static/src/main/font/font_size_selector.js
@@ -18,6 +18,7 @@ export class FontSizeSelector extends Component {
         getDisplay: Function,
         onFontSizeInput: Function,
         onSelected: Function,
+        onBlur: { type: Function, optional: true },
         document: { validate: (p) => p.nodeType === Node.DOCUMENT_NODE },
         ...toolbarButtonProps,
     };
@@ -107,7 +108,14 @@ export class FontSizeSelector extends Component {
             () => {
                 if (this.fontSizeInput) {
                     // Focus input on dropdown open, blur on close.
-                    this.dropdown.isOpen ? this.fontSizeInput.select() : this.fontSizeInput.blur();
+                    if (this.dropdown.isOpen) {
+                        this.fontSizeInput.select();
+                    } else if (
+                        this.iframeContentRef.el?.contains(this.props.document.activeElement)
+                    ) {
+                        this.fontSizeInput.blur();
+                        this.props.onBlur?.();
+                    }
                 }
             },
             () => [this.dropdown.isOpen]

--- a/addons/html_editor/static/tests/toolbar.test.js
+++ b/addons/html_editor/static/tests/toolbar.test.js
@@ -333,6 +333,18 @@ test("toolbar works: can select font size", async () => {
     expect(inputEl).toHaveValue(oSmallSize);
 });
 
+test("should focus the editable area after selecting a font size item", async () => {
+    const { editor, el } = await setupEditor("<p>[test]</p>");
+    await expectElementCount(".o-we-toolbar", 1);
+    const iframeEl = queryOne(".o-we-toolbar [name='font-size'] iframe");
+    const inputEl = iframeEl.contentWindow.document?.querySelector("input");
+    await click(inputEl);
+    await contains(".o_font_size_selector_menu .dropdown-item:contains('34')").click();
+    expect(getActiveElement()).toBe(editor.editable);
+    expect(getActiveElement()).not.toBe(inputEl);
+    expect(getContent(el)).toBe(`<p><span class="h1-fs">[test]</span></p>`);
+});
+
 test.tags("desktop");
 test("toolbar works: display correct font size on select all", async () => {
     const { el } = await setupEditor("<p>test</p>");


### PR DESCRIPTION
### Steps to reproduce:

- Go to the To-Do app and type something in the editor.
- Select the typed text.
- Click on the Font Size Input and choose a value from the dropdown (e.g.,80).
- Try typing again in the editable area.
- Selection is still visible, the focus is no longer in the editable area.

### Description of the issue/feature this PR addresses:

- `focusEditable()` skipped restoring focus if the selection was inside the editor, even when the editor itself wasn’t focused.
- When the font size input (inside an iframe) is focused, editable loses focus.
- Selecting a value from the dropdown blurs the iframe input, but focus is not returned to the editable area.
- As a result, the selection is still visible but the user cannot type.

### Desired behavior after PR is merged:

- Does nothing if the editor or its descendants have focus.
- Focuses the editor if needed.
- Restores selection only when it's outside the editor.
- When the iframe input is blurred, focus is returned to the editable area.

task-4932364

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
