### PR TITLE
[FIX] account: fix _compute_date for receipts

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -802,10 +802,10 @@ class AccountMove(models.Model):
             move.payment_reference = move._get_invoice_computed_reference()
         self._inverse_payment_reference()
 
-    @api.depends('invoice_date', 'company_id')
+    @api.depends('invoice_date', 'company_id', 'move_type')
     def _compute_date(self):
         for move in self:
-            if not move.invoice_date or not move.is_invoice():
+            if not move.invoice_date or not move.is_invoice(include_receipts=True):
                 if not move.date:
                     move.date = fields.Date.context_today(self)
                 continue


### PR DESCRIPTION
* When invoice_date is set with create method for receipts, the date is not set correctly to invoice_date, but it's wrongly set to today.

* Missing dependency 'move_type' to compute method.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
