### PR TITLE
[FIX] account_edi_ubl_cii: export product barcode too

### DIFF
--- a/addons/account_edi_ubl_cii/data/ubl_20_templates.xml
+++ b/addons/account_edi_ubl_cii/data/ubl_20_templates.xml
@@ -333,6 +333,11 @@
                 <cac:SellersItemIdentification>
                     <cbc:ID t-out="item_vals.get('sellers_item_identification_vals', {}).get('id')"/>
                 </cac:SellersItemIdentification>
+                <cac:StandardItemIdentification>
+                    <t t-set="standard_item_identification_vals" t-value="item_vals.get('standard_item_identification_vals', {})"/>
+                    <cbc:ID t-att="standard_item_identification_vals.get('id_attrs')"
+                            t-out="standard_item_identification_vals.get('id')"/>
+                </cac:StandardItemIdentification>
                 <cac:CommodityClassification t-foreach="item_vals.get('commodity_classification_vals', [])" t-as="foreach_vals">
                     <cbc:ItemClassificationCode
                             t-att="foreach_vals.get('item_classification_attrs', {})"

--- a/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_20.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_20.py
@@ -295,6 +295,10 @@ class AccountEdiXmlUBL20(models.AbstractModel):
             'name': product.name or description,
             'sellers_item_identification_vals': {'id': product.code},
             'classified_tax_category_vals': tax_category_vals_list,
+            'standard_item_identification_vals': {
+                'id': product.barcode,
+                'id_attrs': {'schemeID': '0160'},  # GTIN
+            } if product.barcode else {},
         }
 
     def _get_document_allowance_charge_vals_list(self, invoice):

--- a/addons/account_edi_ubl_cii/tests/test_ubl_cii.py
+++ b/addons/account_edi_ubl_cii/tests/test_ubl_cii.py
@@ -38,7 +38,7 @@ class TestAccountEdiUblCii(AccountTestInvoicingCommon):
             .with_context(default_journal_id=journal.id) \
             ._create_document_from_attachment(attachment.id)
 
-    def test_import_product(self):
+    def test_export_import_product(self):
         products = self.env['product.product'].create([{
             'name': 'XYZ',
             'default_code': '1234',
@@ -95,45 +95,59 @@ class TestAccountEdiUblCii(AccountTestInvoicingCommon):
         company.email = 'company@site.ext'
         company.phone = '+33499999999'
         company.zip = '78440'
-
-        company.partner_id.ubl_cii_format = 'facturx'
         company.partner_id.bank_ids = [Command.create({
             'acc_number': '999999',
             'partner_id': company.partner_id.id,
             'acc_holder_name': 'The Chosen One'
         })]
 
-        invoice = self.env['account.move'].create({
-            'company_id': company.id,
-            'partner_id': company.partner_id.id,
-            'move_type': 'out_invoice',
-            'journal_id': self.company_data_2['default_journal_sale'].id,
-            'invoice_line_ids': [Command.create(vals) for vals in line_vals],
-        })
-        invoice.action_post()
+        for ubl_cii_format in ['facturx', 'ubl_bis3']:
+            with self.subTest(sub_test_name=f"format: {ubl_cii_format}"):
+                company.partner_id.ubl_cii_format = ubl_cii_format
 
-        template = self.env.ref('account.email_template_edi_invoice', raise_if_not_found=False)
-        print_wiz = self.env['account.move.send'].create({
-            'move_ids': invoice.ids,
-            'mail_template_id': template.id
-        })
-        print_wiz.checkbox_download = False
-        print_wiz.checkbox_send_mail = False
-        print_wiz.checkbox_send_by_post = False
-        print_wiz.checkbox_ubl_cii_xml = True
-        print_wiz.action_send_and_print()
+                invoice = self.env['account.move'].create({
+                    'company_id': company.id,
+                    'partner_id': company.partner_id.id,
+                    'move_type': 'out_invoice',
+                    'journal_id': self.company_data_2['default_journal_sale'].id,
+                    'invoice_line_ids': [Command.create(vals) for vals in line_vals],
+                })
+                invoice.action_post()
 
-        facturx_attachment = invoice.ubl_cii_xml_id
-        xml_tree = etree.fromstring(facturx_attachment.raw)
+                template = self.env.ref('account.email_template_edi_invoice', raise_if_not_found=False)
+                print_wiz = self.env['account.move.send'].create({
+                    'move_ids': invoice.ids,
+                    'mail_template_id': template.id
+                   })
+                print_wiz.checkbox_download = False
+                print_wiz.checkbox_send_mail = False
+                print_wiz.checkbox_send_by_post = False
+                print_wiz.checkbox_ubl_cii_xml = True
+                print_wiz.action_send_and_print()
 
-        # Testing the case where a product on the invoice has a UoM with a different category than the one in the DB
-        wrong_uom_line = xml_tree.findall('./{*}SupplyChainTradeTransaction/{*}IncludedSupplyChainTradeLineItem')[1]
-        wrong_uom_line.find('./{*}SpecifiedLineTradeDelivery/{*}BilledQuantity').attrib['unitCode'] = 'HUR'
+                attachment = invoice.ubl_cii_xml_id
+                xml_tree = etree.fromstring(attachment.raw)
 
-        facturx_attachment.raw = etree.tostring(xml_tree)
-        new_invoice = invoice.journal_id._create_document_from_attachment(facturx_attachment.ids)
+                if ubl_cii_format == 'facturx':
+                    # Testing the case where a product on the invoice has a UoM with a different category than the one in the DB
+                    wrong_uom_line = xml_tree.findall('./{*}SupplyChainTradeTransaction/{*}IncludedSupplyChainTradeLineItem')[1]
+                    wrong_uom_line.find('./{*}SpecifiedLineTradeDelivery/{*}BilledQuantity').attrib['unitCode'] = 'HUR'
+                    last_line_product = xml_tree.find('./{*}SupplyChainTradeTransaction/{*}IncludedSupplyChainTradeLineItem[8]/{*}SpecifiedTradeProduct')
+                    self.assertEqual(last_line_product.find('./{*}GlobalID').text, '00002')
+                    self.assertEqual(last_line_product.find('./{*}SellerAssignedID').text, '1111')
+                    self.assertEqual(last_line_product.find('./{*}Name').text, '[1111] YYY')
+                elif ubl_cii_format == 'ubl_bis3':
+                    last_line_product = xml_tree.find('./{*}InvoiceLine[8]/{*}Item')
+                    barcode_node = last_line_product.find('./{*}StandardItemIdentification/{*}ID')
+                    self.assertEqual(barcode_node.text, '00002')
+                    self.assertEqual(barcode_node.attrib['schemeID'], '0160')
+                    self.assertEqual(last_line_product.find('./{*}SellersItemIdentification/{*}ID').text, '1111')
+                    self.assertEqual(last_line_product.find('./{*}Name').text, 'YYY')
 
-        self.assertRecordValues(new_invoice.invoice_line_ids, line_vals)
+                attachment.raw = etree.tostring(xml_tree)
+                new_invoice = invoice.journal_id._create_document_from_attachment(attachment.ids)
+
+                self.assertRecordValues(new_invoice.invoice_line_ids, line_vals)
 
     def test_import_tax_prediction(self):
         """ We are going to create 2 tax and import the e-invoice twice.


### PR DESCRIPTION
[FIX] account_edi_ubl_cii: export product barcode too

Currently we use the `Item/StandardItemIdentification` as the barcode
when importing a product.
But we do not export the same information.

In 18.0+ the `Item/StandardItemIdentification` was added to the UBL XML
(for exporting) in commit 72e312815f372de88388c47c612bb5f44b4d8b4e.
But there it is only used in `l10n_co_dian`.

After this commit we export and fill the tag "by default".

task-4941855