### PR TITLE
[IMP] website_sale: align pills attribute design

### DIFF
--- a/addons/website_sale/static/src/js/website_sale.js
+++ b/addons/website_sale/static/src/js/website_sale.js
@@ -26,7 +26,6 @@ export const WebsiteSale = publicWidget.Widget.extend(VariantMixin, {
         'click .o_wsale_filmstrip_wrapper' : '_onClickHandler',
         'submit': '_onClickConfirmOrder',
         'input .o_wsale_attribute_search_bar': '_searchAttributeValues',
-        'click .o_wsale_variant_pills_shop': '_onClickPillsAttribute',
         'click .o_wsale_view_more_btn': '_onToggleViewMoreLabel',
     }),
 
@@ -372,19 +371,6 @@ export const WebsiteSale = publicWidget.Widget.extend(VariantMixin, {
             const labelText = item.querySelector('.form-check-label').textContent.toLowerCase();
             item.style.display = labelText.includes(searchValue) ? '' : 'none'
         });
-    },
-    /**
-     * Highlight selected pill
-     *
-     * @private
-     * @param {MouseEvent} ev
-     */
-    _onClickPillsAttribute(ev) {
-        if (ev.target.tagName === "LABEL" || ev.target.tagName === "INPUT") {
-            return;
-        }
-        const checkbox = ev.target.closest('.o_wsale_variant_pills_shop').querySelector("input");
-        checkbox.click();
     },
     /**
      * Toggle the button text between "View More" and "View Less"

--- a/addons/website_sale/static/src/scss/website_sale.scss
+++ b/addons/website_sale/static/src/scss/website_sale.scss
@@ -1683,28 +1683,3 @@ a.no-decoration {
 body.modal-open:has(.js_sale.o_wsale_product_page) {
     overflow: hidden;
 }
-
-.o_wsale_variant_pills_shop {
-    padding: $spacer/2 $spacer;
-    border: none;
-    cursor: pointer;
-
-    &.btn.active {
-        background-color: map-get($theme-colors, 'primary');
-    }
-    &:not(.active) {
-        color: map-get($grays, '600');
-        background-color: map-get($grays, '200');
-    }
-    &:hover{
-        background-color: map-get($theme-colors, 'primary');
-        color: white;
-    }
-
-    input {
-        -moz-appearance: none;
-        -webkit-appearance: none;
-        appearance: none;
-        opacity: 0;
-    }
-}

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -1071,23 +1071,20 @@
 
     <template id="website_sale.filter_pills_attributes" name="Pills attributes in Filter">
         <t t-foreach="a.value_ids" t-as="v">
-            <div
-                t-attf-class="o_wsale_variant_pills_shop form-check btn btn-primary mb-1 {{'active' if v.id in attrib_set else ''}}"
-            >
-                <input
-                    type="checkbox"
-                    name="attribute_value"
-                    class="form-check-input"
-                    t-att-id="'%s-%s' % (a.id,v.id)"
-                    t-att-value="'%s-%s' % (a.id,v.id)"
-                    t-att-checked="v.id in attrib_set"
-                />
-                <label
-                    class="form-check-label fw-normal"
-                    t-att-for="'%s-%s' % (a.id,v.id)"
-                    t-field="v.name"
-                />
-            </div>
+            <input
+                type="checkbox"
+                name="attribute_value"
+                class="btn-check"
+                t-att-id="'%s-%s' % (a.id,v.id)"
+                t-att-value="'%s-%s' % (a.id,v.id)"
+                t-att-checked="v.id in attrib_set"
+                autocomplete="off"
+            />
+            <label
+                t-attf-class="btn border {{'active bg-primary-subtle border-primary text-primary-emphasis' if v.id in attrib_set else ''}}"
+                t-att-for="'%s-%s' % (a.id,v.id)"
+                t-field="v.name"
+            />
         </t>
     </template>
 
@@ -1160,7 +1157,7 @@
                                 </div>
                                 <div
                                     t-elif="a.display_type == 'pills'"
-                                    t-attf-class="btn-group-toggle {{'my-2' if isMobile else 'mb-3'}}"
+                                    t-attf-class="d-flex flex-wrap gap-2 {{'my-2' if isMobile else 'mb-3'}}"
                                     data-bs-toggle="buttons"
                                 >
                                     <t t-call="website_sale.filter_pills_attributes"/>


### PR DESCRIPTION
This PR aligns the design of the display type pills attribute on the `/shop` page to match the one used on the `/product` page.

| Master | This PR |
|--------|--------|
| <img width="275" height="223" alt="image" src="https://github.com/user-attachments/assets/f1e77a80-7f61-4daa-9d07-af85aca2d679" /> | <img width="259" height="215" alt="image" src="https://github.com/user-attachments/assets/9efac09a-66b5-4597-80b8-929362b0cd9f" /> | 

Prior to this PR, two different designs were used across these two pages, which was not consistent and required custom CSS to handle the different states of the buttons.

To fix this, we cleared up the custom CSS and handle the design with utility classes, as done on `/product`. We also take this opportunity to clear up legacy `.btn-group-toggle` class which was previously allowing to style checkboxes as button in an older version of bootstrap, which is now done by applying utility classes on both input and label.

task-4896925
part of task-4252024

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
