### PR TITLE
[FIX] stock: fix showing uom in generate serial wizard

### DIFF
--- a/addons/stock/static/src/widgets/generate_serial.js
+++ b/addons/stock/static/src/widgets/generate_serial.js
@@ -5,8 +5,9 @@ import { useService } from "@web/core/utils/hooks";
 import { registry } from "@web/core/registry";
 import { parseInteger  } from "@web/views/fields/parsers";
 import { getId } from "@web/model/relational_model/utils";
-import { Component, useRef, onMounted } from "@odoo/owl";
+import { Component, useRef, onMounted, onWillStart } from "@odoo/owl";
 import { standardWidgetProps } from "@web/views/widgets/standard_widget_props";
+import { user } from "@web/core/user";
 
 export class GenerateDialog extends Component {
     static template = "stock.generate_serial_dialog";
@@ -32,6 +33,9 @@ export class GenerateDialog extends Component {
         this.keepLines = useRef('keepLines');
         this.lots = useRef('lots');
         this.orm = useService("orm");
+        onWillStart(async () => {
+            this.displayUOM = await user.hasGroup("uom.group_uom");
+        });
         onMounted(() => {
             if (this.props.mode === 'generate') {
                 this.nextSerialCount.el.value = this.props.move.data.product_uom_qty || 2;

--- a/addons/stock/static/src/widgets/lots_dialog.xml
+++ b/addons/stock/static/src/widgets/lots_dialog.xml
@@ -44,7 +44,7 @@
                                 <div name="next_serial_count" class="o_field_widget o_field_integer">
                                     <input inputmode="numeric" t-ref="nextSerialCount" class="o_input" id="next_serial_count_0" type="text"/>
                                 </div>
-                                <span t-if="props.move.data.has_tracking === 'lot'" t-esc="props.move.data.product_uom.display_name"/>
+                                <span t-if="props.move.data.has_tracking === 'lot' &amp;&amp; displayUOM" t-esc="props.move.data.product_uom.display_name"/>
                             </div>
                         </div>
                         <div t-if="props.move.data.has_tracking === 'lot'" class="row mb-2">
@@ -55,7 +55,7 @@
                                 <div name="total_received" class="o_field_widget o_field_integer">
                                     <input inputmode="numeric" t-ref="totalReceived" class="o_input" id="total_received_0" type="text"/>
                                 </div>
-                                <span t-esc="props.move.data.product_uom.display_name"/>
+                                <span t-if="displayUOM" t-esc="props.move.data.product_uom.display_name"/>
                             </div>
                         </div>
                         <div class="row">


### PR DESCRIPTION
Previous to this commit, the generating serial wizard would try to load the product uom in case that the product was lot-tracked, even if the UoM group was not activated. This led to an error when opening the wizard without activating the group. This commit makes sure the group is activated before showing that field.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
