### PR TITLE
[FIX] account: Outgoing group payments memo

### DIFF
--- a/addons/account/tests/test_account_payment_register.py
+++ b/addons/account/tests/test_account_payment_register.py
@@ -358,7 +358,7 @@ class TestAccountPaymentRegister(AccountTestInvoicingCommon, PaymentCommon):
         })._create_payments()
 
         self.assertRecordValues(payments, [{
-            'memo': Like(f'BATCH/{self.current_year}/...'),
+            'memo': 'BILL/2017/01/0001, BILL/2017/01/0002',
             'payment_method_line_id': self.outbound_payment_method_line.id,
         }])
         self.assertRecordValues(payments.move_id.line_ids.sorted('balance'), [
@@ -401,7 +401,7 @@ class TestAccountPaymentRegister(AccountTestInvoicingCommon, PaymentCommon):
         })._create_payments()
 
         self.assertRecordValues(payments, [{
-            'memo': Like(f'BATCH/{self.current_year}/...'),
+            'memo': 'BILL/2017/01/0001, BILL/2017/01/0002',
             'payment_method_line_id': self.outbound_payment_method_line.id,
         }])
         self.assertRecordValues(payments.move_id.line_ids.sorted('balance'), [
@@ -557,7 +557,7 @@ class TestAccountPaymentRegister(AccountTestInvoicingCommon, PaymentCommon):
 
         self.assertRecordValues(payments, [
             {
-                'memo': Like(f'BATCH/{self.current_year}/...'),
+                'memo': 'BILL/2017/01/0001, BILL/2017/01/0002, RBILL/2017/01/0001',
                 'payment_method_line_id': self.outbound_payment_method_line.id,
             },
         ])
@@ -678,7 +678,7 @@ class TestAccountPaymentRegister(AccountTestInvoicingCommon, PaymentCommon):
 
         self.assertRecordValues(payments, [
             {
-                'memo': Like(f'BATCH/{self.current_year}/...'),
+                'memo': 'BILL/2017/01/0001, BILL/2017/01/0002',
                 'payment_method_line_id': self.outbound_payment_method_line.id,
             },
             {
@@ -1766,7 +1766,6 @@ class TestAccountPaymentRegister(AccountTestInvoicingCommon, PaymentCommon):
             'installments_mode': 'next',
             'installments_switch_amount': 1333.33,
             'currency_id': self.company.currency_id.id,  # Different currencies, so we get the company's one
-            'communication': Like(f'BATCH/{self.current_year}/...'),
         }])
 
         wizard = self.env['account.payment.register'].with_context(
@@ -1803,7 +1802,6 @@ class TestAccountPaymentRegister(AccountTestInvoicingCommon, PaymentCommon):
             'payment_difference': 0.5,
             'installments_mode': 'next',
             'installments_switch_amount': 357.83,  # 24.5 for in_invoice_epd_applied + 1000 / 3 (rate) for the second
-            'communication': Like(f'BATCH/{self.current_year}/...'),
         }])
 
         # Clicking on the button to full gets the amount from js, so we need to put it by hand here
@@ -1817,7 +1815,6 @@ class TestAccountPaymentRegister(AccountTestInvoicingCommon, PaymentCommon):
             'payment_difference': 0.5,
             'installments_mode': 'full',
             'installments_switch_amount': 57.83,  # The previous 'next' amount
-            'communication': Like(f'BATCH/{self.current_year}/...'),
         }])
 
     def test_payment_register_with_next_payment_date(self):

--- a/addons/account/wizard/account_payment_register.py
+++ b/addons/account/wizard/account_payment_register.py
@@ -180,6 +180,10 @@ class AccountPaymentRegister(models.TransientModel):
         if len(lines.move_id) == 1:
             move = lines.move_id
             label = move.payment_reference or move.ref or move.name
+        elif any(move.is_outbound() for move in lines.move_id):
+            # outgoing payments references should use moves references
+            labels = {move.payment_reference or move.ref or move.name for move in lines.move_id}
+            return ', '.join(sorted(filter(lambda l: l, labels)))
         else:
             label = self.company_id.get_next_batch_payment_communication()
         return label


### PR DESCRIPTION
The payment memo of grouped bills should always consist of the concatenation of individual payments memos.

This commit is a partial revert of the changes done in this PR https://github.com/odoo/odoo/pull/162762
The original task was intended to improve internal workflows and should not have impacted payment communications to suppliers.

task-4936572




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
