### PR TITLE
[FIX] iot_drivers: escpos printer traceback on print

### DIFF
--- a/addons/iot_drivers/iot_handlers/drivers/printer_driver_L.py
+++ b/addons/iot_drivers/iot_handlers/drivers/printer_driver_L.py
@@ -45,7 +45,7 @@ class PrinterDriver(PrinterDriverBase):
         if device.get('usb_product'):
             def usb_matcher(usb_device):
                 return (
-                    usb_device.manufacturer.lower() == device['usb_manufacturer'] and
+                    usb_device.manufacturer and usb_device.manufacturer.lower() == device['usb_manufacturer'] and
                     usb_device.product == device['usb_product'] and
                     usb_device.serial_number == device['usb_serial_number']
                 )


### PR DESCRIPTION
On Linux with a USB connected ESC/POS receipt printer, a traceback can occur in the following conditions:

- The printer is successfully initialised as an ESCPOS printer by the `python-escpos` library at driver start
- Later, when trying to print, some other USB device causes a traceback in the `usb_matcher` method, preventing the print from taking place

The fix is to make the `usb_matcher` method more robust by checking the `manufacturer` property exists before using it.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
