### PR TITLE
[FIX] point_of_sale: Remove non-existing method

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/product_screen/order_summary/order_summary.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/order_summary/order_summary.js
@@ -204,8 +204,7 @@ export class OrderSummary extends Component {
         const decreaseQuantity = selectedLine.getQuantity() - newQuantity;
         selectedLine.setQuantity(newQuantity);
         if (newQuantity == 0) {
-            selectedLine.delete();
-            this.currentOrder._unlinkOrderline(selectedLine);
+            this.currentOrder.removeOrderline(selectedLine);
         }
         return decreaseQuantity;
     }

--- a/addons/point_of_sale/static/tests/generic_helpers/numpad_util.js
+++ b/addons/point_of_sale/static/tests/generic_helpers/numpad_util.js
@@ -1,6 +1,6 @@
 import { escapeRegExp } from "@web/core/utils/strings";
 
-const buttonTriger = (buttonValue) =>
+export const buttonTriger = (buttonValue) =>
     `div.numpad button:contains(/^${escapeRegExp(buttonValue)}$/)`; // regex to match the exact button value ( for ex: avoids matching "+10" instead of "1")
 
 export const click = (buttonValue) => ({

--- a/addons/point_of_sale/static/tests/pos/tours/product_screen_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/product_screen_tour.js
@@ -1,3 +1,5 @@
+/* global posmodel */
+
 import * as PaymentScreen from "@point_of_sale/../tests/pos/tours/utils/payment_screen_util";
 import * as Dialog from "@point_of_sale/../tests/generic_helpers/dialog_util";
 import * as PartnerList from "@point_of_sale/../tests/pos/tours/utils/partner_list_util";
@@ -826,5 +828,33 @@ registry.category("web_tour.tours").add("test_preset_timing_retail", {
             TicketScreen.nthRowContains(1, "Delivery", false),
             TicketScreen.nthRowContains(2, "002"),
             TicketScreen.nthRowContains(2, "Eat in", false),
+        ].flat(),
+});
+
+registry.category("web_tour.tours").add("test_delete_line", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            ProductScreen.clickDisplayedProduct("Desk Organizer"),
+            {
+                content: "replace disallowLineQuantityChange to be true",
+                trigger: "body",
+                run: () => {
+                    posmodel.disallowLineQuantityChange = () => true;
+                },
+            },
+            inLeftSide([
+                ...ProductScreen.selectedOrderlineHasDirect("Desk Organizer", "1"),
+                Numpad.click("⌫"),
+                {
+                    content: "Click 0",
+                    trigger: ".modal " + Numpad.buttonTriger("0"),
+                    run: "click",
+                },
+                ...Chrome.confirmPopup(),
+            ]),
+            ProductScreen.orderIsEmpty(),
+            Chrome.endTour(),
         ].flat(),
 });

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -2393,6 +2393,11 @@ class TestUi(TestPointOfSaleHttpCommon):
         self.main_pos_config.with_user(self.pos_user).open_ui()
         self.start_tour(f"/pos/ui?config_id={self.main_pos_config.id}", 'test_paid_order_with_archived_product_loads', login="pos_user")
 
+    def test_delete_line(self):
+        """ Test that deleting a line in the POS through the popup works correctly. """
+        self.main_pos_config.with_user(self.pos_user).open_ui()
+        self.start_pos_tour('test_delete_line')
+
 
 # This class just runs the same tests as above but with mobile emulation
 class MobileTestUi(TestUi):


### PR DESCRIPTION
Before this commit, we were calling _unlinkOrderline on the order when decreasing the quantity of an unsynced line to 0 from the decreaseQuantityPopup. This method does not exists anymore so we replace this call with a call to removeOrderline.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
