### PR TITLE
[FIX] website_sale: fix crash on creating ribbons

### DIFF
--- a/addons/website_sale/__manifest__.py
+++ b/addons/website_sale/__manifest__.py
@@ -180,6 +180,7 @@
         ],
         'web.assets_unit_tests': [
             'website_sale/static/tests/interactions/**/*',
+            'website_sale/static/tests/builder/**/*',
         ],
         'web.assets_unit_tests_setup': [
             'website_sale/static/src/interactions/**/*',

--- a/addons/website_sale/static/src/website_builder/products_item_option.xml
+++ b/addons/website_sale/static/src/website_builder/products_item_option.xml
@@ -9,7 +9,7 @@
                             <tr>
                                 <t t-foreach="[...Array(this.maxWidth).keys()]" t-as="j" t-key="j">
                                     <td t-on-mouseover="()=>this._onTableCellMouseOver(i, j)" t-on-click="()=>this._onTableCellMouseClick(i, j)">
-                                        <BuilderButton preview="false" actionValue="[i, j]" />
+                                        <BuilderButton preview="false" actionValue="[i, j]" className="'border-0'" />
                                     </td>
                                 </t>
                             </tr>
@@ -43,7 +43,7 @@
                 </t>
             </BuilderSelect>
             <BuilderButton title.translate="Edit" className="'fa fa-edit'" t-if="!this.isActiveItem('no_ribbon_opt')" t-on-click="()=>state.ribbonEditMode = !state.ribbonEditMode"/>
-            <BuilderButton action="'createRibbon'" preview="false" title.translate="Create" className="'fa fa-plus text-success'" style="'background-color: transparent !important;'" t-if="!state.ribbonEditMode" t-on-click="()=>state.ribbonEditMode = true" />
+            <BuilderButton action="'createRibbon'" preview="false" title.translate="Create" className="'fa fa-plus text-success border-0'" style="'background-color: transparent !important;'" t-if="!state.ribbonEditMode" t-on-click="()=>state.ribbonEditMode = true" />
         </BuilderRow>
 
         <t t-if="state.ribbonEditMode">
@@ -52,10 +52,10 @@
                     <BuilderTextInput actionParam="'name'" />
                 </BuilderRow>
                 <BuilderRow label.translate="Background" level="1">
-                    <BuilderColorPicker actionParam="'bg_color'" />
+                    <BuilderColorPicker actionParam="'bg_color'" enabledTabs="['solid', 'custom']" />
                 </BuilderRow>
                 <BuilderRow label.translate="Text" level="1">
-                    <BuilderColorPicker actionParam="'text_color'" />
+                    <BuilderColorPicker actionParam="'text_color'" enabledTabs="['solid', 'custom']" />
                 </BuilderRow>
                 <BuilderRow label.translate="Position" level="1">
                     <BuilderSelect actionParam="'position'">

--- a/addons/website_sale/static/src/website_builder/products_item_option_plugin.js
+++ b/addons/website_sale/static/src/website_builder/products_item_option_plugin.js
@@ -18,12 +18,11 @@ class ProductsItemOptionPlugin extends Plugin {
         "setRibbonObject",
         "addRibbon",
         "getRibbons",
-        "_deleteRibbon",
-        "_setRibbon"
+        "deleteRibbon",
+        "setRibbon",
     ];
     itemSize = reactive({ x: 1, y: 1 });
     count = reactive({ value: 0 });
-
 
     resources = {
         builder_options: [
@@ -103,7 +102,7 @@ class ProductsItemOptionPlugin extends Plugin {
         );
     }
 
-    _setRibbon(editingElement, ribbon, save = true) {
+    setRibbon(editingElement, ribbon, save = true) {
         const ribbonId = ribbon.id;
         const editableBody = editingElement.ownerDocument.body;
         editingElement.dataset.ribbonId = ribbonId;
@@ -252,7 +251,7 @@ class ProductsItemOptionPlugin extends Plugin {
      * Deletes a ribbon.
      *
      */
-    _deleteRibbon(editingElement) {
+    deleteRibbon(editingElement) {
         const ribbonId = parseInt(editingElement.dataset.ribbonId);
         if (this.ribbonsObject[ribbonId]) {
             this.deletedRibbonClasses += `${
@@ -313,13 +312,13 @@ class ProductsItemOptionPlugin extends Plugin {
     getRibbons() {
         return this.ribbons;
     }
-
 }
 
 export class SetItemSizeAction extends BuilderAction {
     static id = "setItemSize";
     static dependencies = ["productsItemOptionPlugin"];
     setup() {
+        this.productItemPlugin = this.dependencies.productsItemOptionPlugin;
         this.reload = {};
     }
     isApplied({ editingElement, value: [i, j] }) {
@@ -327,7 +326,7 @@ export class SetItemSizeAction extends BuilderAction {
             parseInt(editingElement.dataset.rowspan || 1) - 1 === i &&
             parseInt(editingElement.dataset.colspan || 1) - 1 === j
         ) {
-            this.dependencies.productsItemOptionPlugin.setItemSize(j + 1, i + 1);
+            this.productItemPlugin.setItemSize(j + 1, i + 1);
             return true;
         }
         return false;
@@ -336,13 +335,15 @@ export class SetItemSizeAction extends BuilderAction {
         const x = j + 1;
         const y = i + 1;
 
-        this.dependencies.productsItemOptionPlugin.setProductTemplateID(parseInt(
-            editingElement
-                .querySelector('[data-oe-model="product.template"]')
-                .getAttribute("data-oe-id")
-        ));
+        this.productItemPlugin.setProductTemplateID(
+            parseInt(
+                editingElement
+                    .querySelector('[data-oe-model="product.template"]')
+                    .getAttribute("data-oe-id")
+            )
+        );
         return rpc("/shop/config/product", {
-            product_id: this.dependencies.productsItemOptionPlugin.getProductTemplateID(),
+            product_id: this.productItemPlugin.getProductTemplateID(),
             x: x,
             y: y,
         });
@@ -352,16 +353,19 @@ export class ChangeSequenceAction extends BuilderAction {
     static id = "changeSequence";
     static dependencies = ["productsItemOptionPlugin"];
     setup() {
+        this.productItemPlugin = this.dependencies.productsItemOptionPlugin;
         this.reload = {};
     }
     apply({ editingElement, value }) {
-        this.dependencies.productsItemOptionPlugin.setProductTemplateID(parseInt(
-            editingElement
-                .querySelector('[data-oe-model="product.template"]')
-                .getAttribute("data-oe-id")
-        ));
+        this.productItemPlugin.setProductTemplateID(
+            parseInt(
+                editingElement
+                    .querySelector('[data-oe-model="product.template"]')
+                    .getAttribute("data-oe-id")
+            )
+        );
         return rpc("/shop/config/product", {
-            product_id: this.dependencies.productsItemOptionPlugin.getProductTemplateID(),
+            product_id: this.productItemPlugin.getProductTemplateID(),
             sequence: value,
         });
     }
@@ -369,22 +373,27 @@ export class ChangeSequenceAction extends BuilderAction {
 export class SetRibbonAction extends BuilderAction {
     static id = "setRibbon";
     static dependencies = ["productsItemOptionPlugin"];
+    setup() {
+        this.productItemPlugin = this.dependencies.productsItemOptionPlugin;
+    }
     isApplied({ editingElement, value }) {
         return (parseInt(editingElement.dataset.ribbonId) || "") === value;
     }
     apply({ isPreviewing, editingElement, value }) {
-        this.dependencies.productsItemOptionPlugin.setProductTemplateID(parseInt(
-            editingElement
-                .querySelector('[data-oe-model="product.template"]')
-                .getAttribute("data-oe-id")
-        ));
+        this.productItemPlugin.setProductTemplateID(
+            parseInt(
+                editingElement
+                    .querySelector('[data-oe-model="product.template"]')
+                    .getAttribute("data-oe-id")
+            )
+        );
         const ribbonId = value;
-        this.dependencies.productsItemOptionPlugin.addProductTemplatesRibbons({
-            templateId: this.dependencies.productsItemOptionPlugin.getProductTemplateID(),
+        this.productItemPlugin.addProductTemplatesRibbons({
+            templateId: this.productItemPlugin.getProductTemplateID(),
             ribbonId: ribbonId,
         });
 
-        const ribbon = this.dependencies.productsItemOptionPlugin.getRibbonsObject()[ribbonId] || {
+        const ribbon = this.productItemPlugin.getRibbonsObject()[ribbonId] || {
             id: "",
             name: "",
             bg_color: "",
@@ -392,21 +401,26 @@ export class SetRibbonAction extends BuilderAction {
             position: "left",
         };
 
-        return this.dependencies.productsItemOptionPlugin._setRibbon(editingElement, ribbon, !isPreviewing);
+        return this.productItemPlugin.setRibbon(editingElement, ribbon, !isPreviewing);
     }
 }
 export class CreateRibbonAction extends BuilderAction {
     static id = "createRibbon";
     static dependencies = ["productsItemOptionPlugin"];
+    setup() {
+        this.productItemPlugin = this.dependencies.productsItemOptionPlugin;
+    }
     apply({ editingElement }) {
-        this.dependencies.productsItemOptionPlugin.setProductTemplateID(parseInt(
-            editingElement
-                .querySelector('[data-oe-model="product.template"]')
-                .getAttribute("data-oe-id")
-        ));
+        this.productItemPlugin.setProductTemplateID(
+            parseInt(
+                editingElement
+                    .querySelector('[data-oe-model="product.template"]')
+                    .getAttribute("data-oe-id")
+            )
+        );
         const ribbonId = Date.now();
-        this.dependencies.productsItemOptionPlugin.addProductTemplatesRibbons({
-            templateId: this.dependencies.productsItemOptionPlugin.getProductTemplateID(),
+        this.productItemPlugin.addProductTemplatesRibbons({
+            templateId: this.productItemPlugin.getProductTemplateID(),
             ribbonId: ribbonId,
         });
         const ribbon = reactive({
@@ -416,16 +430,16 @@ export class CreateRibbonAction extends BuilderAction {
             text_color: "purple",
             position: "left",
         });
-        this.dependencies.productsItemOptionPlugin.addRibbon(ribbon);
-        this.dependencies.productsItemOptionPlugin.setRibbonObject(ribbonId, ribbon);
-        return this.dependencies.productsItemOptionPlugin._setRibbon(editingElement, ribbon);
+        this.productItemPlugin.addRibbon(ribbon);
+        this.productItemPlugin.setRibbonObject(ribbonId, ribbon);
+        return this.productItemPlugin.setRibbon(editingElement, ribbon);
     }
 }
 export class ModifyRibbonAction extends BuilderAction {
     static id = "modifyRibbon";
     static dependencies = ["productsItemOptionPlugin"];
     setup() {
-        this.piop = this.dependencies.productsItemOptionPlugin
+        this.productItemPlugin = this.dependencies.productsItemOptionPlugin;
     }
     getValue({ editingElement, params }) {
         const field = params.mainParam;
@@ -434,7 +448,7 @@ export class ModifyRibbonAction extends BuilderAction {
             return;
         }
 
-        return this.dependencies.productsItemOptionPlugin.getRibbonsObject()[ribbonId][field];
+        return this.productItemPlugin.getRibbonsObject()[ribbonId][field];
     }
     isApplied({ editingElement, params, value }) {
         const field = params.mainParam;
@@ -442,28 +456,31 @@ export class ModifyRibbonAction extends BuilderAction {
         if (!ribbonId) {
             return;
         }
-        if (!this.dependencies.productsItemOptionPlugin.getRibbonsObject()[ribbonId]) {
-            ribbonId = Object.keys(this.dependencies.productsItemOptionPlugin.getRibbonsObject()).find(
-                (key) => this.dependencies.productsItemOptionPlugin.getRibbonsObject()[key].id === ribbonId
+        if (!this.productItemPlugin.getRibbonsObject()[ribbonId]) {
+            ribbonId = Object.keys(this.productItemPlugin.getRibbonsObject()).find(
+                (key) => this.productItemPlugin.getRibbonsObject()[key].id === ribbonId
             );
             editingElement.dataset.ribbonId = ribbonId;
         }
-        return this.dependencies.productsItemOptionPlugin.getRibbonsObject()[ribbonId][field] === value;
+        return this.productItemPlugin.getRibbonsObject()[ribbonId][field] === value;
     }
     apply({ isPreviewing, editingElement, params, value }) {
         const setting = params.mainParam;
         const ribbonId = parseInt(editingElement.dataset.ribbonId);
-        this.dependencies.productsItemOptionPlugin.getRibbonsObject()[ribbonId][setting] = value;
+        this.productItemPlugin.getRibbonsObject()[ribbonId][setting] = value;
 
-        const ribbon = this.dependencies.productsItemOptionPlugin.getRibbons().find((ribbon) => ribbon.id == ribbonId);
+        const ribbon = this.productItemPlugin.getRibbons().find((ribbon) => ribbon.id == ribbonId);
         ribbon[setting] = value;
 
-        return this.plugin._setRibbon(editingElement, ribbon, !isPreviewing);
+        return this.productItemPlugin.setRibbon(editingElement, ribbon, !isPreviewing);
     }
 }
 export class DeleteRibbonAction extends BuilderAction {
     static id = "deleteRibbon";
     static dependencies = ["productsItemOptionPlugin"];
+    setup() {
+        this.productItemPlugin = this.dependencies.productsItemOptionPlugin;
+    }
     async apply({ editingElement }) {
         const save = await new Promise((resolve) => {
             this.services.dialog.add(ConfirmationDialog, {
@@ -475,7 +492,7 @@ export class DeleteRibbonAction extends BuilderAction {
         if (!save) {
             return;
         }
-        return this.dependencies.productsItemOptionPlugin._deleteRibbon(editingElement);
+        return this.productItemPlugin.deleteRibbon(editingElement);
     }
 }
 

--- a/addons/website_sale/static/src/website_builder/products_item_option_plugin.js
+++ b/addons/website_sale/static/src/website_builder/products_item_option_plugin.js
@@ -397,7 +397,7 @@ export class SetRibbonAction extends BuilderAction {
 }
 export class CreateRibbonAction extends BuilderAction {
     static id = "createRibbon";
-    dependencies = ["productsItemOptionPlugin"]
+    static dependencies = ["productsItemOptionPlugin"];
     apply({ editingElement }) {
         this.dependencies.productsItemOptionPlugin.setProductTemplateID(parseInt(
             editingElement

--- a/addons/website_sale/static/tests/builder/products_item_option.test.js
+++ b/addons/website_sale/static/tests/builder/products_item_option.test.js
@@ -1,0 +1,55 @@
+import { expect, test } from "@odoo/hoot";
+import { contains, defineModels, models, onRpc } from "@web/../tests/web_test_helpers";
+import {
+    defineWebsiteModels,
+    setupWebsiteBuilder,
+} from "@website/../tests/builder/website_helpers";
+
+class productRibbon extends models.Model {
+    _name = "product.ribbon";
+}
+
+defineWebsiteModels();
+defineModels([productRibbon]);
+
+test("add a new ribbon", async () => {
+    onRpc("product.ribbon", "create", () => [1]);
+    onRpc("product.template", "write", () => ({}));
+    await setupWebsiteBuilder(
+        `<div id="o_wsale_container" data-ppg="20" data-ppr="4" data-default-sort="website_sequence asc">
+        <div id="products_grid">
+            <section id="o_wsale_products_grid" class="o_wsale_products_grid_table grid o_wsale_products_grid_table_md" style="--o-wsale-ppr: 4; --o-wsale-ppg: 20" data-name="Grid">
+                <div class="oe_product" style="--o-wsale-products-grid-product-col-height: 1;" data-name="Product">
+                <div class="o_wsale_product_grid_wrapper o_wsale_product_grid_wrapper_1_1">
+                <form class="oe_product_cart" data-publish="off">
+                    <div class="oe_product_image">
+                        <a class="oe_product_image_link d-block position-relative" contenteditable="false" href="/shop/event-registration-4">
+                            <span class="oe_product_image_img_wrapper d-flex h-100 justify-content-center align-items-center position-absolute"><img src="/web/image/product.template/4/image_512/product?unique=5c2586b" class="img img-fluid h-100 w-100 position-absolute"></span>
+                            <span class="o_ribbon o_not_editable d-none" style=""></span>
+                        </a>
+                    </div>
+                    <div class="o_wsale_product_information">
+                            <div class="o_wsale_product_information_text">
+                                <h6 class="o_wsale_products_item_title">
+                                    <a data-oe-model="product.template" data-oe-id="4" data-oe-field="name" data-oe-type="char" data-oe-expression="product.name">
+                                        Test product
+                                    </a>
+                                </h6>
+                            </div>
+                        <div class="o_wsale_product_sub">
+                            <div class="product_price">
+                                <span class="oe_currency_value">1.00</span>
+                            </div>
+                        </div>
+                    </div>
+                </form>
+                </div>
+                </div>
+            </section>
+        </div>
+        </div>`
+    );
+    await contains(":iframe .oe_product").click();
+    await contains("button[data-action-id='createRibbon']").click();
+    expect(":iframe .oe_product .o_ribbon").toHaveText("Ribbon Name");
+});


### PR DESCRIPTION
To reproduce the issue introduced in this [commit],
- Open website, having eCommerce installed and at least one product set
- Go to /shop and start editing
- Click on a product
- Ribbon option: Click on create a new ribbon

=> We receive a traceback because "dependencies" aren't set as static.
In the 2nd commit, linted the code for readability.
3rd commit sets ribbon text and background color pickers to have 
only 2 enabled colors, and removes borders from the product option


[commit]: https://github.com/odoo/odoo/commit/b4b215325db61fbbe9793545293c8b6fbc99f310