### PR TITLE
[FIX] orm: exists subquery requires an alias

### DIFF
--- a/odoo/addons/base/tests/test_expression.py
+++ b/odoo/addons/base/tests/test_expression.py
@@ -2147,7 +2147,7 @@ class TestOne2many(TransactionCase):
                 SELECT "res_partner_bank"."partner_id" AS __inverse
                 FROM "res_partner_bank"
                 WHERE "res_partner_bank"."id" IN %s
-            ) WHERE __inverse = "res_partner"."id")
+            ) AS __sub WHERE __inverse = "res_partner"."id")
             ORDER BY "res_partner"."complete_name"asc,"res_partner"."id"desc
         ''']):
             self.Partner.search([('bank_ids', 'in', self.partner.bank_ids.ids)])
@@ -2159,7 +2159,7 @@ class TestOne2many(TransactionCase):
                 SELECT "res_partner_bank"."partner_id" AS __inverse
                 FROM "res_partner_bank"
                 WHERE "res_partner_bank"."sanitized_acc_number" LIKE %s
-            ) WHERE __inverse = "res_partner"."id")
+            ) AS __sub WHERE __inverse = "res_partner"."id")
             ORDER BY "res_partner"."complete_name"asc,"res_partner"."id"desc
         ''']):
             self.Partner.search([('bank_ids.sanitized_acc_number', 'like', '12')])
@@ -2176,10 +2176,10 @@ class TestOne2many(TransactionCase):
                         SELECT "res_partner_bank"."partner_id" AS __inverse
                         FROM "res_partner_bank"
                         WHERE "res_partner_bank"."sanitized_acc_number" LIKE %s
-                    ) WHERE __inverse = "res_partner"."id")
+                    ) AS __sub WHERE __inverse = "res_partner"."id")
                     AND "res_partner"."parent_id" IS NOT NULL
                 )
-            ) WHERE __inverse = "res_partner"."id")
+            ) AS __sub WHERE __inverse = "res_partner"."id")
             ORDER BY "res_partner"."complete_name"asc,"res_partner"."id"desc
         ''']):
             self.Partner.search([('child_ids.bank_ids.sanitized_acc_number', 'like', '12')])
@@ -2198,7 +2198,7 @@ class TestOne2many(TransactionCase):
                 SELECT "res_partner_bank"."partner_id" AS __inverse
                 FROM "res_partner_bank"
                 WHERE "res_partner_bank"."id" IN %s
-            ) WHERE __inverse = "res_partner"."id")
+            ) AS __sub WHERE __inverse = "res_partner"."id")
             ORDER BY "res_partner"."complete_name"asc,"res_partner"."id"desc
         ''']):
             self.Partner.search([('bank_ids', 'in', self.partner.bank_ids.ids)])
@@ -2210,7 +2210,7 @@ class TestOne2many(TransactionCase):
                 SELECT "res_partner_bank"."partner_id" AS __inverse
                 FROM "res_partner_bank"
                 WHERE "res_partner_bank"."sanitized_acc_number" LIKE %s
-            ) WHERE __inverse = "res_partner"."id")
+            ) AS __sub WHERE __inverse = "res_partner"."id")
             ORDER BY "res_partner"."complete_name"asc,"res_partner"."id"desc
         ''']):
             self.Partner.search([('bank_ids.sanitized_acc_number', 'like', '12')])
@@ -2222,12 +2222,12 @@ class TestOne2many(TransactionCase):
                 SELECT "res_partner_bank"."partner_id" AS __inverse
                 FROM "res_partner_bank"
                 WHERE "res_partner_bank"."sanitized_acc_number" LIKE %s
-            ) WHERE __inverse = "res_partner"."id")
+            ) AS __sub WHERE __inverse = "res_partner"."id")
             AND EXISTS (SELECT FROM (
                 SELECT "res_partner_bank"."partner_id" AS __inverse
                 FROM "res_partner_bank"
                 WHERE "res_partner_bank"."sanitized_acc_number" LIKE %s
-            ) WHERE __inverse = "res_partner"."id"))
+            ) AS __sub WHERE __inverse = "res_partner"."id"))
             ORDER BY "res_partner"."complete_name"asc,"res_partner"."id"desc
         ''']):
             self.Partner.search([
@@ -2247,10 +2247,10 @@ class TestOne2many(TransactionCase):
                         SELECT "res_partner_bank"."partner_id" AS __inverse
                         FROM "res_partner_bank"
                         WHERE "res_partner_bank"."sanitized_acc_number" LIKE %s
-                    ) WHERE __inverse = "res_partner"."id")
+                    ) AS __sub WHERE __inverse = "res_partner"."id")
                     AND "res_partner"."parent_id" IS NOT NULL
                 )
-            ) WHERE __inverse = "res_partner"."id")
+            ) AS __sub WHERE __inverse = "res_partner"."id")
             ORDER BY "res_partner"."complete_name"asc,"res_partner"."id"desc
         ''']):
             self.Partner.search([('child_ids.bank_ids.sanitized_acc_number', 'like', '12')])
@@ -2275,11 +2275,11 @@ class TestOne2many(TransactionCase):
                             "res_partner_bank"."id" IN %s
                             AND "res_partner_bank"."sanitized_acc_number" LIKE %s
                         )
-                    ) WHERE __inverse = "res_partner"."id")
+                    ) AS __sub WHERE __inverse = "res_partner"."id")
                     AND ("res_partner"."name" NOT IN %s OR "res_partner"."name" IS NULL)
                     AND "res_partner"."parent_id" IS NOT NULL
                 )
-            ) WHERE __inverse = "res_partner"."id")
+            ) AS __sub WHERE __inverse = "res_partner"."id")
             ORDER BY "res_partner"."complete_name"asc,"res_partner"."id"desc
         ''']):
             self.Partner.search([('child_ids.bank_ids.id', 'in', self.partner.bank_ids.ids)])
@@ -2305,7 +2305,7 @@ class TestOne2many(TransactionCase):
                     AND "res_partner"."parent_id" IS NOT NULL
                     AND ("res_partner"."state_id" IS NOT NULL AND "res_partner__state_id__country_id"."code" LIKE %s)
                 )
-            ) WHERE __inverse = "res_partner"."id")
+            ) AS __sub WHERE __inverse = "res_partner"."id")
             ORDER BY "res_partner"."complete_name"asc,"res_partner"."id"desc
         ''']):
             self.Partner.search([('child_ids.state_id.country_id.code', 'like', 'US')])
@@ -2320,7 +2320,7 @@ class TestOne2many(TransactionCase):
                 SELECT "res_partner_bank"."partner_id" AS __inverse
                 FROM "res_partner_bank"
                 WHERE "res_partner_bank"."sanitized_acc_number" LIKE %s
-            ) WHERE __inverse = "res_partner"."id")
+            ) AS __sub WHERE __inverse = "res_partner"."id")
             ORDER BY "res_partner"."complete_name"asc,"res_partner"."id"desc
         ''']):
             self.Partner.search([('bank_ids', 'like', '12')])
@@ -2336,7 +2336,7 @@ class TestOne2many(TransactionCase):
             WHERE EXISTS (SELECT FROM (
                 SELECT "res_partner_bank"."partner_id" AS __inverse
                 FROM "res_partner_bank"
-            ) WHERE __inverse = "res_partner"."id")
+            ) AS __sub WHERE __inverse = "res_partner"."id")
             ORDER BY "res_partner"."id"
         ''']):
             self.Partner.search([('bank_ids', '!=', False)], order='id')
@@ -2347,7 +2347,7 @@ class TestOne2many(TransactionCase):
             WHERE NOT EXISTS (SELECT FROM (
                 SELECT "res_partner_bank"."partner_id" AS __inverse
                 FROM "res_partner_bank"
-            ) WHERE __inverse = "res_partner"."id")
+            ) AS __sub WHERE __inverse = "res_partner"."id")
             ORDER BY "res_partner"."id"
         ''']):
             self.Partner.search([('bank_ids', '=', False)], order='id')

--- a/odoo/addons/test_orm/tests/test_search.py
+++ b/odoo/addons/test_orm/tests/test_search.py
@@ -201,7 +201,7 @@ class TestSubqueries(TransactionCase):
                     "test_orm_multi_line"."multi" IS NOT NULL
                     AND "test_orm_multi_line"."name" LIKE %s
                 )
-            ) WHERE __inverse = "test_orm_multi"."id")
+            ) AS __sub WHERE __inverse = "test_orm_multi"."id")
             AND EXISTS (SELECT FROM(
                 SELECT "test_orm_multi_line"."multi" AS __inverse
                 FROM "test_orm_multi_line"
@@ -209,7 +209,7 @@ class TestSubqueries(TransactionCase):
                     "test_orm_multi_line"."multi" IS NOT NULL
                     AND "test_orm_multi_line"."name" LIKE %s
                 )
-            ) WHERE __inverse = "test_orm_multi"."id")
+            ) AS __sub WHERE __inverse = "test_orm_multi"."id")
             )
             ORDER BY "test_orm_multi"."id"
         """]):
@@ -232,7 +232,7 @@ class TestSubqueries(TransactionCase):
                         OR "test_orm_multi_line"."name" LIKE %s
                     )
                 )
-            ) WHERE __inverse = "test_orm_multi"."id")
+            ) AS __sub WHERE __inverse = "test_orm_multi"."id")
             ORDER BY "test_orm_multi"."id"
         """]):
             self.env['test_orm.multi'].search([
@@ -252,7 +252,7 @@ class TestSubqueries(TransactionCase):
                     "test_orm_multi_line"."multi" IS NOT NULL
                     AND "test_orm_multi_line"."name" LIKE %s
                 )
-            ) WHERE __inverse = "test_orm_multi"."id")
+            ) AS __sub WHERE __inverse = "test_orm_multi"."id")
             AND EXISTS (SELECT FROM(
                 SELECT "test_orm_multi_line"."multi" AS __inverse
                 FROM "test_orm_multi_line"
@@ -263,7 +263,7 @@ class TestSubqueries(TransactionCase):
                         OR "test_orm_multi_line"."name" LIKE %s
                     )
                 )
-            ) WHERE __inverse = "test_orm_multi"."id")
+            ) AS __sub WHERE __inverse = "test_orm_multi"."id")
             )
             ORDER BY "test_orm_multi"."id"
         """]):
@@ -665,7 +665,7 @@ class TestSearchRelated(TransactionCase):
                     FROM "test_orm_related"
                     WHERE "test_orm_related"."id" IN %s
                     AND "test_orm_related"."foo_id" IS NOT NULL
-                ) WHERE __inverse = "test_orm_related_foo"."id")
+                ) AS __sub WHERE __inverse = "test_orm_related_foo"."id")
                 AND "test_orm_related_foo"."id" < %s
             )
             AND "test_orm_related"."id" < %s
@@ -684,7 +684,7 @@ class TestSearchRelated(TransactionCase):
                     FROM "test_orm_related"
                     WHERE ("test_orm_related"."foo_id" IS NOT NULL AND "test_orm_related"."name" IN %s)
                     AND "test_orm_related"."id" < %s
-                ) WHERE __inverse = "test_orm_related_foo"."id")
+                ) AS __sub WHERE __inverse = "test_orm_related_foo"."id")
                 AND "test_orm_related_foo"."id" < %s
             )
             AND "test_orm_related"."id" < %s
@@ -703,7 +703,7 @@ class TestSearchRelated(TransactionCase):
                     FROM "test_orm_related"
                     WHERE "test_orm_related"."id" IN %s
                     AND "test_orm_related"."foo_id" IS NOT NULL
-                ) WHERE __inverse = "test_orm_related__foo_id"."id")
+                ) AS __sub WHERE __inverse = "test_orm_related__foo_id"."id")
             )
             AND "test_orm_related"."id" < %s
             ORDER BY "test_orm_related"."id"
@@ -724,7 +724,7 @@ class TestSearchRelated(TransactionCase):
                         AND "test_orm_related"."name" IN %s
                     )
                     AND "test_orm_related"."id" < %s
-                ) WHERE __inverse = "test_orm_related__foo_id"."id")
+                ) AS __sub WHERE __inverse = "test_orm_related__foo_id"."id")
             )
             AND "test_orm_related"."id" < %s
             ORDER BY "test_orm_related"."id"
@@ -919,7 +919,7 @@ class TestSearchRelated(TransactionCase):
                     "test_orm_related"."foo_id" IS NOT NULL
                     AND "test_orm_related"."name" IN %s
                 ) AND "test_orm_related"."id" < %s
-            ) WHERE __inverse = "test_orm_related_foo"."id"
+            ) AS __sub WHERE __inverse = "test_orm_related_foo"."id"
             ) AND "test_orm_related_foo"."id" < %s
             ORDER BY "test_orm_related_foo"."id"
         """]):
@@ -935,7 +935,7 @@ class TestSearchRelated(TransactionCase):
                     "test_orm_related"."foo_id" IS NOT NULL
                     AND "test_orm_related"."name" IN %s
                 )
-            ) WHERE __inverse = "test_orm_related_foo"."id"
+            ) AS __sub WHERE __inverse = "test_orm_related_foo"."id"
             ) AND "test_orm_related_foo"."id" < %s
             ORDER BY "test_orm_related_foo"."id"
         """]):
@@ -1411,7 +1411,7 @@ class TestSearchAny(TransactionCase):
                     "test_orm_related"."foo_id" IS NOT NULL
                     AND "test_orm_related"."name" IN %s
                 ) AND "test_orm_related"."id" < %s
-            ) WHERE __inverse = "test_orm_related_foo"."id"
+            ) AS __sub WHERE __inverse = "test_orm_related_foo"."id"
             ) AND "test_orm_related_foo"."id" < %s
             ORDER BY "test_orm_related_foo"."id"
         """]):
@@ -1432,7 +1432,7 @@ class TestSearchAny(TransactionCase):
                         AND "test_orm_related_foo"."id" < %s
                     )
                 ) AND "test_orm_related"."id" < %s
-            ) WHERE __inverse = "test_orm_related_foo"."id"
+            ) AS __sub WHERE __inverse = "test_orm_related_foo"."id"
             ) AND "test_orm_related_foo"."id" < %s
             ORDER BY "test_orm_related_foo"."id"
         """]):
@@ -1448,7 +1448,7 @@ class TestSearchAny(TransactionCase):
                     "test_orm_related"."foo_id" IS NOT NULL
                     AND "test_orm_related"."name" IN %s
                 )
-            ) WHERE __inverse = "test_orm_related_foo"."id"
+            ) AS __sub WHERE __inverse = "test_orm_related_foo"."id"
             ) AND "test_orm_related_foo"."id" < %s
             ORDER BY "test_orm_related_foo"."id"
         """]):
@@ -1469,7 +1469,7 @@ class TestSearchAny(TransactionCase):
                         AND "test_orm_related_foo"."id" < %s
                     )
                 )
-            ) WHERE __inverse = "test_orm_related_foo"."id"
+            ) AS __sub WHERE __inverse = "test_orm_related_foo"."id"
             ) AND "test_orm_related_foo"."id" < %s
             ORDER BY "test_orm_related_foo"."id"
         """]):

--- a/odoo/orm/fields_relational.py
+++ b/odoo/orm/fields_relational.py
@@ -1163,7 +1163,7 @@ class One2many(_RelationalMulti):
             SQL("%s AS __inverse", comodel._field_to_sql(coquery.table, inverse_field.name, coquery))
         )
         return SQL(
-            "%sEXISTS(SELECT FROM %s WHERE __inverse = %s)",
+            "%sEXISTS(SELECT FROM %s AS __sub WHERE __inverse = %s)",
             SQL() if exists else SQL("NOT "),
             subselect,
             SQL.identifier(alias, 'id'),


### PR DESCRIPTION
`SELECT FROM (...) WHERE` is not accepted in postgres <16. We need to add an alias for the subquery.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
