### PR TITLE
[FIX] *: f-strings inside _() calls

### DIFF
--- a/addons/mail/models/discuss/discuss_channel.py
+++ b/addons/mail/models/discuss/discuss_channel.py
@@ -1284,15 +1284,13 @@ class Channel(models.Model):
             )
         else:
             if members := self.channel_member_ids.filtered(lambda m: not m.is_self):
+                member_names = html_escape(format_list(self.env, [f"%(member_{member.id})s" for member in members])) % {
+                    f"member_{member.id}": member._get_html_link(for_persona=True)
+                    for member in members
+                }
                 msg = _(
                     "You are in a private conversation with %(member_names)s.",
-                    member_names=html_escape(
-                        format_list(self.env, [f"%(member_{member.id})s" for member in members])
-                    )
-                    % {
-                        f"member_{member.id}": member._get_html_link(for_persona=True)
-                        for member in members
-                    },
+                    member_names=member_names,
                 )
             else:
                 msg = _("You are alone in a private conversation.")
@@ -1326,13 +1324,13 @@ class Channel(models.Model):
                 list_params.append(_("more"))
             else:
                 list_params.append(_("you"))
+            member_names = html_escape(format_list(self.env, list_params)) % {
+                f"member_{member.id}": member._get_html_link(for_persona=True)
+                for member in members
+            }
             msg = _(
                 "Users in this channel: %(members)s.",
-                members=html_escape(format_list(self.env, list_params))
-                % {
-                    f"member_{member.id}": member._get_html_link(for_persona=True)
-                    for member in members
-                },
+                members=member_names,
             )
         else:
             msg = _("You are alone in this channel.")

--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -3112,7 +3112,7 @@ class _Relational(Field[M], typing.Generic[M]):
                 _logger.warning(env._(
                     "Couldn't generate a company-dependent domain for field %s. "
                     "The model doesn't have a 'company_id' or 'company_ids' field, and isn't company-dependent either.",
-                    f'{self.model_name}.{self.name}'
+                    self.model_name + '.' + self.name,
                 ))
                 return domain
             company_domain = env[self.comodel_name]._check_company_domain(companies=unquote(cids))


### PR DESCRIPTION
On Jammy, babel does *not* cope well with f-strings as values inside `_()` calls: it uses `eval` to try and figure them out, which attempts to execute the f-string, which fails because the evaluation context is empty.

This is likely fixed from Babel 2.11 onwards (python-babel/babel#915) but Jammy uses babel 2.8[^1].

https://runbot.odoo.com/odoo/runbot.build.error/97849

[^1]: This doesn't seem to trigger on Noble even though it uses 2.10, but locally it does trigger on 2.10.3 (installed via pip), so ubuntu might have backported the fix or something.
