### PR TITLE
[IMP] web: calendar: multi_create: use state to keep value already set

### DIFF
--- a/addons/web/static/src/model/record.js
+++ b/addons/web/static/src/model/record.js
@@ -13,6 +13,7 @@ class StandaloneRelationalModel extends RelationalModel {
             const config = this._getNextConfig(this.config, params);
             this.root = this._createRoot(config, data);
             this.config = config;
+            this.hooks.onRootLoaded(this.root);
             return Promise.resolve();
         }
         return super.load(params);

--- a/addons/web/static/src/views/calendar/calendar_controller.js
+++ b/addons/web/static/src/views/calendar/calendar_controller.js
@@ -112,7 +112,7 @@ export class CalendarController extends Component {
             resModel: this.props.resModel,
             domain: this.props.domain,
             fields: this.props.fields,
-            date: this.props.state?.date,
+            state: this.props.state,
         };
     }
 

--- a/addons/web/static/src/views/calendar/calendar_side_panel/calendar_side_panel.js
+++ b/addons/web/static/src/views/calendar/calendar_side_panel/calendar_side_panel.js
@@ -112,9 +112,12 @@ export class CalendarSidePanel extends Component {
                 onRootLoaded: this.onMultiCreateRootLoaded.bind(this),
             },
         };
+        if (this.props.model.data.multiCreate.values) {
+            this.multiCreateRecordProps.values = this.props.model.data.multiCreate.values;
+        }
     }
 
     onMultiCreateRootLoaded(record) {
-        this.props.model.data.multiCreateRecord = record;
+        this.props.model.data.multiCreate.record = record;
     }
 }

--- a/addons/web/static/src/views/calendar/calendar_side_panel/calendar_side_panel.xml
+++ b/addons/web/static/src/views/calendar/calendar_side_panel/calendar_side_panel.xml
@@ -14,14 +14,14 @@
                     <div t-if="state.isReady and props.mode === MODES.add" class="o_form_view o_xxs_form_view gap-2 mt-2">
                         <div t-if="props.model.showMultiCreateTimeRange" class="d-flex align-items-baseline gap-2">
                             <TimePicker
-                                value="this.props.model.data.multiCreateTimeRange.start"
+                                value="this.props.model.data.multiCreate.timeRange.start"
                                 onChange="(time) => this.props.setMultiCreateTimeRange({start: time})"
                                 onInvalid="() => this.props.setMultiCreateTimeRange({start: null})"
                                 showSeconds="false"
                             />
                             <i class="fa fa-arrow-right"/>
                             <TimePicker
-                                value="this.props.model.data.multiCreateTimeRange.end"
+                                value="this.props.model.data.multiCreate.timeRange.end"
                                 onChange="(time) => this.props.setMultiCreateTimeRange({end: time})"
                                 onInvalid="() => this.props.setMultiCreateTimeRange({end: null})"
                                 showSeconds="false"


### PR DESCRIPTION
This commit, adds into the state the value set into the form when we are in calendar multi_create view.

task-4918909

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
