### PR TITLE
[FIX] l10n_be_hr_contract_salary: ensure plan_to_change_car is set to False after signing a contract.

### DIFF
--- a/addons/fleet/models/fleet_vehicle.py
+++ b/addons/fleet/models/fleet_vehicle.py
@@ -387,12 +387,12 @@ class FleetVehicle(models.Model):
             self.search([
                 ('driver_id', 'in', to_update_drivers_cars),
                 ('vehicle_type', '=', 'car'),
-            ]).plan_to_change_car = True
+            ]).plan_to_change_car = False
         if to_update_drivers_bikes:
             self.search([
                 ('driver_id', 'in', to_update_drivers_bikes),
                 ('vehicle_type', '=', 'bike'),
-            ]).plan_to_change_bike = True
+            ]).plan_to_change_bike = False
         return vehicles
 
     def write(self, vals):


### PR DESCRIPTION
Issue: When a contract was signed and a future driver was assigned to a vehicle, the car still remained marked as available.
Fix: Once the first signature is completed and the future driver is assigned, the vehicle is correctly marked with plan_to_change_car = False (same for the bike).
Related task: 4926335.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
