### PR TITLE
[FIX] l10n_ar: prevent crash when sanitizing invalid VAT values

### DIFF
--- a/addons/l10n_ar/models/res_partner.py
+++ b/addons/l10n_ar/models/res_partner.py
@@ -132,5 +132,5 @@ class ResPartner(models.Model):
             res = int(stdnum.ar.cuit.compact(self.vat))
         else:
             id_number = re.sub('[^0-9]', '', self.vat)
-            res = int(id_number)
+            res = id_number and int(id_number)
         return res

--- a/addons/l10n_ar/tests/test_manual.py
+++ b/addons/l10n_ar/tests/test_manual.py
@@ -3,6 +3,7 @@ from . import common
 from odoo import Command
 from odoo.tests import Form, tagged
 from odoo.tools.float_utils import float_split_str
+from odoo.exceptions import ValidationError
 
 
 @tagged('post_install_l10n', '-at_install', 'post_install')
@@ -348,3 +349,10 @@ class TestManual(common.TestAr):
         self.assertAlmostEqual(l10n_ar_values['price_unit'], 5470.0)
         self.assertAlmostEqual(l10n_ar_values['price_subtotal'], 124716.0)
         self.assertAlmostEqual(l10n_ar_values['price_net'], 5196.5)
+
+    def test_l10n_ar_vat_with_non_numeric_value(self):
+        with self.assertRaises(ValidationError) as e:
+            with Form(self.partner) as partner_form:
+                partner_form.l10n_latam_identification_type_id = self.env.ref("l10n_ar.it_dni")
+                partner_form.vat = "test"
+        self.assertIn('Only numbers allowed for "DNI"', str(e.exception))


### PR DESCRIPTION
The system crashes when trying to `sanitize invalid VAT` inputs for `Argentina
partners` due to the assumption that the identification number can always be
safely cast to int().

**Steps to reproduce:-**
- Initialize a database with `demo data`.
- Install the `l10n_ar` module and switch to the `AR Company`.
- Create a partner with:
             - Country: `Argentina`
             - Identification Method: `DNI`
             - Number: `test`
- Observe the error.

**Error:-**
`ValueError: invalid literal for int() with base 10: ''`

**Root cause:-**
- The method `_run_check_identification` is introduced after this [commit](https://github.com/odoo/odoo/pull/179078)
- in this method, when [1] is executed, then `get_id_number_sanitize` method
  is called.
- At [2], the error occurs because `_get_id_number_sanitize()` assumes the VAT
  is numeric after removing `non-digit characters`. If the VAT input is non-
  numeric (e.g., 'test'), it becomes an `empty string ''`, and converting that to
  int('') raises an error.

**Solution:-**
- Added a VAT validity check using `_check_vat_number()` at the start of
  `_get_id_number_sanitize()`. If the VAT is invalid, we return 0
  early to prevent `int()` conversion errors.
  
[1]: https://github.com/odoo/odoo/blob/2c019833bbc771866fb9a1c0021d87b8b07ed411/addons/l10n_ar/models/res_partner.py#L63

[2]: https://github.com/odoo/odoo/blob/2c019833bbc771866fb9a1c0021d87b8b07ed411/addons/l10n_ar/models/res_partner.py#L134-L135


**sentry-6743438515**