### PR TITLE
[FIX] pos_loyalty: prevent error when archiving a program

### DIFF
--- a/addons/pos_loyalty/static/src/overrides/models/pos_order.js
+++ b/addons/pos_loyalty/static/src/overrides/models/pos_order.js
@@ -97,6 +97,11 @@ patch(PosOrder.prototype, {
     setupState(vals) {
         super.setupState(...arguments);
         this.uiState.disabledRewards = new Set(vals?.disabledRewards || []);
+        for (const [key, pe] of Object.entries(this.uiState.couponPointChanges)) {
+            if (!this.models["loyalty.program"].get(pe.program_id)) {
+                delete this.uiState.couponPointChanges[key];
+            }
+        }
     },
     serializeState() {
         const state = super.serializeState(...arguments);

--- a/addons/pos_loyalty/static/src/overrides/models/pos_store.js
+++ b/addons/pos_loyalty/static/src/overrides/models/pos_store.js
@@ -43,6 +43,13 @@ patch(PosStore.prototype, {
             [this.data.records["pos.order"]]
         );
     },
+    async afterProcessServerData() {
+        // Remove reward lines that have no reward anymore (could happen if the program got archived)
+        this.models["pos.order.line"]
+            .filter((order) => order.is_reward_line && !order.reward_id)
+            .map((line) => line.delete());
+        await super.afterProcessServerData(...arguments);
+    },
     async updateOrder(order) {
         // Read value to trigger effect
         order?.lines?.length;


### PR DESCRIPTION
Before this commit, archiving a loyalty program while it was actively applied to an order could lead to errors.

Specifically, if a PoS order had an active loyalty program applied, and that program was subsequently archived from the backend, reloading the PoS interface would cause issues or prevent proper functionality due to the program's sudden unavailability.

opw-4941044

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
