### PR TITLE
[FIX] pos_{,restaurant}: visiblity of tax control button and it's dialog title

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/product_screen/control_buttons/control_buttons.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/control_buttons/control_buttons.js
@@ -54,7 +54,7 @@ export class ControlButtons extends Component {
 
         const selectedFiscalPosition = await makeAwaitable(this.dialog, SelectionPopup, {
             list: fiscalPosList,
-            title: _t("Please register the voucher number"),
+            title: _t("Choose the tax you want to apply"),
         });
 
         if (!selectedFiscalPosition) {

--- a/addons/point_of_sale/static/tests/tours/product_screen_tour.js
+++ b/addons/point_of_sale/static/tests/tours/product_screen_tour.js
@@ -202,6 +202,17 @@ registry.category("web_tour.tours").add("test_reuse_empty_floating_order", {
         ].flat(),
 });
 
+registry.category("web_tour.tours").add("test_tax_control_button_visiblity", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            ProductScreen.clickReview(),
+            ProductScreen.clickControlButtonMore(),
+            negateStep(...ProductScreen.checkFiscalPositionButton()),
+        ].flat(),
+});
+
 registry.category("web_tour.tours").add("FiscalPositionNoTax", {
     steps: () =>
         [

--- a/addons/point_of_sale/static/tests/tours/utils/product_screen_util.js
+++ b/addons/point_of_sale/static/tests/tours/utils/product_screen_util.js
@@ -407,6 +407,14 @@ export function checkFiscalPosition(name) {
         Dialog.cancel(),
     ];
 }
+export function checkFiscalPositionButton() {
+    return [
+        {
+            content: "click fiscal position button",
+            trigger: ".o_fiscal_position_button",
+        },
+    ];
+}
 export function closeWithCashAmount(val) {
     return [
         {

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -824,6 +824,13 @@ class TestUi(TestPointOfSaleHttpCommon):
         self.main_pos_config.with_user(self.pos_user).open_ui()
         self.start_pos_tour("test_serial_number_do_not_duplicate_after_refresh")
 
+    def test_tax_control_button_visiblity(self):
+        self.main_pos_config.write({
+            'tax_regime_selection': False,
+        })
+        self.main_pos_config.with_user(self.pos_user).open_ui()
+        self.start_pos_tour('test_tax_control_button_visiblity')
+
     def test_fiscal_position_no_tax(self):
         #create a tax of 15% with price included
         tax = self.env['account.tax'].create({

--- a/addons/pos_restaurant/static/src/app/control_buttons/control_buttons.xml
+++ b/addons/pos_restaurant/static/src/app/control_buttons/control_buttons.xml
@@ -43,7 +43,7 @@
             </button>
         </xpath>
         <xpath expr="//button[hasclass('o_fiscal_position_button')]" position="attributes">
-            <attribute name="t-if">!pos.config.takeaway</attribute>
+            <attribute name="t-if">pos.models['account.fiscal.position']?.length and !pos.config.takeaway</attribute>
         </xpath>
     </t>
 </templates>


### PR DESCRIPTION
Before this commit:
===================
- When only point_of_sale is installed, the tax control button is visible only
if `Flexible Tax` is enabled. But with pos_restaurant installed, the button
is always visible, even if Flexible Tax is disabled.
- Also, the tax selection dialog had an incorrect title: `Please register the
voucher number`.

After this commit:
==================
- In point of sale, the tax control button will be visible if `Flexible Tax`
is enabled, and in restaurant mode, the button will be visible if the
`Flexible Tax` or `Takeout/Delivery` is enabled.
- The tax selection dialog title has been updated to: `Choose the tax you want
to apply`.

Task: 4937977