### PR TITLE
[FIX] sale: correct fixed taxes with early payment discount

### DIFF
--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -533,7 +533,7 @@ class SaleOrder(models.Model):
                     currency_id=currency,
                     sign=1,
                     special_type='early_payment',
-                    tax_ids=line.tax_id,
+                    tax_ids=line.tax_id.flatten_taxes_hierarchy().filtered(lambda tax: tax.amount_type != 'fixed'),
                 ))
                 epd_lines.append(self.env['account.tax']._prepare_base_line_for_taxes_computation(
                     record=self,


### PR DESCRIPTION
### Issue:
The fixed tax value is doubled in `sale` when an early payment discount is applied.

Steps to reproduce:
- Create a fixed tax of $20 for example
- Create a payment term with an early discount of 10% if paid before 10 days
- Select "Always (upon invoice)"
- In Sale create a new quotation with a line of $100 and the fixed tax
- Select the created payment term
- The tax value is doubled ($40)

### Cause:
To compute the payment terms `_add_base_lines_for_early_payment_discount` (added in this [commit](https://github.com/odoo/odoo/commit/781678fb07ab3dd4d132193a938bbb71e8395424))  is adding two lines:
- one with the negative amount of the payment term and the taxes
- one with the positive amount of the payment term 

The goal is to compute the taxes on the discounted untaxed amount of the line. The original line compute the taxes for the undiscounted amount. The first added line computes the taxes for the amount of the discount and is negative. When adding the two the result is the tax value computed from the discounted untaxed amount.

The issue is that a fixed will always have the same value, this means that the tax amount of the first added line will be positive and the same as the original line. When adding the two the amount is doubled.

### Solution:
We don't add taxes with fixed amount on the first add line.

opw-4868011