### PR TITLE
[FIX] im_livechat: provide fallback for "can_load_livechat"

### DIFF
--- a/addons/im_livechat/static/src/embed/common/livechat_service.js
+++ b/addons/im_livechat/static/src/embed/common/livechat_service.js
@@ -6,6 +6,7 @@ import { rpc } from "@web/core/network/rpc";
 import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 import { session } from "@web/session";
+import { canLoadLivechat } from "@im_livechat/embed/common/misc";
 
 export const RATING = Object.freeze({
     GOOD: 5,
@@ -147,7 +148,7 @@ export const livechatService = {
     dependencies: ["mail.store", "notification"],
     start(env, services) {
         const livechat = reactive(new LivechatService(env, services));
-        if (session.livechatData?.can_load_livechat) {
+        if (canLoadLivechat()) {
             livechat.initialize();
         }
         return livechat;

--- a/addons/im_livechat/static/src/embed/common/misc.js
+++ b/addons/im_livechat/static/src/embed/common/misc.js
@@ -1,6 +1,15 @@
+import { session } from "@web/session";
+
 export function isValidEmail(val) {
     // http://stackoverflow.com/questions/46155/validate-email-address-in-javascript
     const re =
         /^(([^<>()[\].,;:\s@"]+(\.[^<>()[\].,;:\s@"]+)*)|(".+"))@(([^<>()[\].,;:\s@"]+\.)+[^<>()[\].,;:\s@"]{2,})$/i;
     return re.test(val);
+}
+
+export function canLoadLivechat() {
+    const sessionData = session.livechatData ?? {};
+    return "can_load_livechat" in sessionData
+        ? sessionData.can_load_livechat
+        : sessionData.isAvailable;
 }

--- a/addons/im_livechat/static/src/embed/external/boot.js
+++ b/addons/im_livechat/static/src/embed/external/boot.js
@@ -1,4 +1,5 @@
 import { makeRoot, makeShadow } from "@im_livechat/embed/common/boot_helpers";
+import { canLoadLivechat } from "@im_livechat/embed/common/misc";
 
 import { mount, whenReady } from "@odoo/owl";
 
@@ -10,7 +11,7 @@ import { makeEnv, startServices } from "@web/env";
 import { session } from "@web/session";
 
 (async function boot() {
-    if (!session.livechatData.can_load_livechat) {
+    if (!canLoadLivechat()) {
         return;
     }
     session.origin = session.livechatData.serverUrl;

--- a/addons/im_livechat/static/src/embed/frontend/boot_service.js
+++ b/addons/im_livechat/static/src/embed/frontend/boot_service.js
@@ -1,11 +1,11 @@
 import { makeRoot, makeShadow } from "@im_livechat/embed/common/boot_helpers";
+import { canLoadLivechat } from "@im_livechat/embed/common/misc";
 import { LivechatRoot } from "@im_livechat/embed/frontend/livechat_root";
-import { _t } from "@web/core/l10n/translation";
 import { App } from "@odoo/owl";
+import { _t } from "@web/core/l10n/translation";
 
-import { getTemplate } from "@web/core/templates";
 import { registry } from "@web/core/registry";
-import { session } from "@web/session";
+import { getTemplate } from "@web/core/templates";
 
 export const livechatBootService = {
     dependencies: ["mail.store"],
@@ -18,7 +18,7 @@ export const livechatBootService = {
     },
 
     start(env) {
-        if (!session.livechatData?.can_load_livechat) {
+        if (!canLoadLivechat()) {
             return;
         }
         const target = this.getTarget();


### PR DESCRIPTION
In [1], the "can_load_livechat" key was added to determine if the live chat should be loaded on a page. However, templates might not have been updated. This commit provides a fallback to the old "isAvailable" value in this case.

[1]: https://github.com/odoo/odoo/pull/217695

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
