### PR TITLE
[FIX] mail: `showLoadOlder` in chatter crashes on portal

### DIFF
--- a/addons/mail/static/src/core/common/thread.js
+++ b/addons/mail/static/src/core/common/thread.js
@@ -645,8 +645,8 @@ export class Thread extends Component {
             this.props.thread.isLoaded &&
             !this.props.thread.isTransient &&
             !this.props.thread.hasLoadingFailed &&
-            !this.messageHighlight.initiated &&
-            !this.messageHighlight.highlightedMessageId
+            !this.messageHighlight?.initiated &&
+            !this.messageHighlight?.highlightedMessageId
         );
     }
 


### PR DESCRIPTION
PR #216776 introduces a new getter as `showLoadOlder`. `messageHighlight` feature is not available in portal chatter. This fix guards `messageHighlight` usages in this getter to avoid crashing in portal chatter.

Steps to reproduce:
- Go to a portal document with chatter
- Send 30 messages to make `loadOlder` true
- The chatter crashes when loading because `messageHighlight` is null
