### PR TITLE
[FIX] mail: `showLoadOlder` in chatter crashes on portal

### DIFF
--- a/addons/mail/static/src/core/common/thread.js
+++ b/addons/mail/static/src/core/common/thread.js
@@ -645,8 +645,8 @@ export class Thread extends Component {
             this.props.thread.isLoaded &&
             !this.props.thread.isTransient &&
             !this.props.thread.hasLoadingFailed &&
-            !this.messageHighlight.initiated &&
-            !this.messageHighlight.highlightedMessageId
+            !this.messageHighlight?.initiated &&
+            !this.messageHighlight?.highlightedMessageId
         );
     }
 

--- a/addons/test_mail_full/static/tests/tours/load_more_tour.js
+++ b/addons/test_mail_full/static/tests/tours/load_more_tour.js
@@ -1,0 +1,19 @@
+import { registry } from "@web/core/registry";
+import { contains } from "@web/../tests/utils";
+
+registry.category("web_tour.tours").add("load_more_tour", {
+    steps: () => [
+        {
+            trigger: "#chatterRoot:shadow .o-mail-Thread .o-mail-Message",
+            run: async function () {
+                await contains(".o-mail-Thread .o-mail-Message", {
+                    count: 30,
+                    target: document.querySelector("#chatterRoot").shadowRoot,
+                });
+            },
+        },
+        {
+            trigger: "#chatterRoot:shadow .o-mail-Thread button:contains(Load More):not(:visible)",
+        },
+    ],
+});

--- a/addons/test_mail_full/tests/test_ui.py
+++ b/addons/test_mail_full/tests/test_ui.py
@@ -21,3 +21,22 @@ class TestUIPortal(TestPortal):
             "star_message_tour",
             login=self.user_employee.login,
         )
+
+    def test_load_more(self):
+        self.env["mail.message"].create(
+            [
+                {
+                    "author_id": self.user_employee.partner_id.id,
+                    "body": f"Test Message {i + 1}",
+                    "model": self.record_portal._name,
+                    "res_id": self.record_portal.id,
+                    "subtype_id": self.ref("mail.mt_comment"),
+                }
+                for i in range(30)
+            ]
+        )
+        self.start_tour(
+            f"/my/test_portal_records/{self.record_portal.id}",
+            "load_more_tour",
+            login=self.user_employee.login,
+        )


### PR DESCRIPTION
PR #198829 introduces a new getter as `showLoadOlder`. `messageHighlight` feature is not available in portal chatter. This fix guards `messageHighlight` usages in this getter to avoid crashing in portal chatter.

Steps to reproduce:
- Go to a portal document with chatter
- Send 30 messages to make `loadOlder` true
- The chatter crashes when loading because `messageHighlight` is null
