### PR TITLE
[FIX] resource, hr_work_entry_contract_attendance : Fetch attendance for flexible since start_date not monday

### DIFF
--- a/addons/hr_holidays/tests/test_leave_requests.py
+++ b/addons/hr_holidays/tests/test_leave_requests.py
@@ -1248,8 +1248,8 @@ class TestLeaveRequests(TestHrHolidaysCommon):
             'request_date_to': '2024-01-27',
         })
         holiday_status = self.holidays_type_4.with_user(self.user_employee_id)
-        self._check_holidays_status(holiday_status, employee, 20.0, 0.0, 20.0, 16.0)
-        self.assertEqual(leave.duration_display, '4 days')
+        self._check_holidays_status(holiday_status, employee, 20.0, 0.0, 20.0, 15.0)
+        self.assertEqual(leave.duration_display, '5 days')
 
     def test_default_request_date_timezone(self):
         """

--- a/addons/resource/models/resource_calendar.py
+++ b/addons/resource/models/resource_calendar.py
@@ -391,21 +391,22 @@ class ResourceCalendar(models.Model):
                     max_hours_per_day = resource.calendar_id.hours_per_day
 
                     intervals = []
-                    current_monday = start_date - timedelta(days=start_date.weekday())
+                    current_start_day = start_date
 
-                    while current_monday <= end_date:
-                        current_sunday = current_monday + timedelta(days=6)
+                    while current_start_day <= end_date:
+                        current_end_of_week = current_start_day + timedelta(days=6)
 
-                        week_start = max(current_monday, start_date)
-                        week_end = min(current_sunday, end_date)
+                        week_start = max(current_start_day, start_date)
+                        week_end = min(current_end_of_week, end_date)
 
-                        if current_monday < start_date:
-                            prior_days = (start_date - current_monday).days
+                        if current_start_day < start_date:
+                            prior_days = (start_date - current_start_day).days
                             prior_hours = min(full_time_required_hours, max_hours_per_day * prior_days)
                         else:
                             prior_hours = 0
 
                         remaining_hours = max(0, full_time_required_hours - prior_hours)
+                        remaining_hours = min(remaining_hours, (end_dt - start_dt).total_seconds() / 3600)
 
                         current_day = week_start
                         while current_day <= week_end:
@@ -427,7 +428,7 @@ class ResourceCalendar(models.Model):
 
                             current_day += timedelta(days=1)
 
-                        current_monday += timedelta(days=7)
+                        current_start_day += timedelta(days=7)
 
                     result_per_resource_id[resource.id] = WorkIntervals(intervals)
                 elif resource in per_resource_result:


### PR DESCRIPTION
### Steps to reproduce:
	- Set Marc Demo's contract work entry source to attendances and working schedule to flexible hours.
	- Create a public holiday with generic time off work entry type.
	- Create one or multiple attendances for marc demo on the public holiday.
	- Regenerate work entries for marc demo for that day, the gaps in between the attendances created and the working hours will be filled with work entries with the right start/end time but duration will always be 8h.

### Cause:
This is happening because when getting the duration batch for the work entry we get the attendance intervals the employee should work in that period and if the employee is flexible we will get a fake attendance with the number of hours required per day ignoring if the period is just a small period of the day

### Fix:
We are checking now since the start date not monday so we don't set a fixed week start. We check if the period is less than the remaining hours we get it as it mostly means that it is less than one day

opw-4887933