### PR TITLE
[FIX] mail: fix next activity type filtering with keep_done=True

### DIFF
--- a/addons/mail/models/mail_activity_mixin.py
+++ b/addons/mail/models/mail_activity_mixin.py
@@ -67,7 +67,9 @@ class MailActivityMixin(models.AbstractModel):
         groups="base.group_user")
     activity_type_id = fields.Many2one(
         'mail.activity.type', 'Next Activity Type',
-        related='activity_ids.activity_type_id', readonly=False,
+        compute='_compute_activity_type_id',
+        store=False,
+        readonly=False,
         search='_search_activity_type_id',
         groups="base.group_user")
     activity_type_icon = fields.Char('Activity Type Icon', related='activity_ids.icon')
@@ -131,6 +133,16 @@ class MailActivityMixin(models.AbstractModel):
                 record.activity_state = 'planned'
             else:
                 record.activity_state = False
+
+    @api.depends('activity_ids.state', 'activity_ids.date_deadline', 'activity_ids.activity_type_id')
+    def _compute_activity_type_id(self):
+        for record in self:
+            activities = record.activity_ids.filtered(lambda a: a.state != 'done')
+            if activities:
+                first = min(activities, key=lambda a: a.date_deadline or fields.Date.max)
+                record.activity_type_id = first.activity_type_id
+            else:
+                record.activity_type_id = False
 
     def _search_activity_state(self, operator, value):
         all_states = {'overdue', 'today', 'planned', False}


### PR DESCRIPTION
Prior to this fix, when filtering on the `Next Activity Type` (e.g., “To-do”) in any model using `mail.activity.mixin`, records with  **done** activities were incorrectly included in the results — **if the corresponding activity type had keep_done=True**.

This regression was observed after upgrading to saas-18.1. It stems from the fact that the `activity_type_id` field was implemented as a related field across a one2many (`activity_ids.activity_type_id`). This led Odoo to use `_search_related`, which does not re-evaluate `active_test` during nested search queries.

1. Go to CRM -> Configuration -> Activity Types
2. Select an activity type (for example To-Do) and Set `keep_done = True` on the “To-do” activity type.
3. Go to CRM Pipeline or any App with a chatter , do an activity to-do and make it as done
3. In the search view, filter by `Next Activity Type = To-do`.  The record appears, even though the only “To-do” activity is done.

This is not the expected behavior — `Next Activity Type` should refer only to open (active) activities, regardless of chatter visibility settings (`keep_done`).

- Replace `activity_type_id` as a `related` field with a `computed` one.
- Ensure the compute method picks the first *not-done* activity by deadline.
- Update the `_search_activity_type_id` method to match only records with active activities of the given type.

This approach avoids low-level issues with `_search_related`, and properly respects the semantic meaning of "next" activity.

Task: 4843918