### PR TITLE
fix invoice tax recalculation 

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -1234,7 +1234,7 @@ class AccountMove(models.Model):
                             handle_price_include=False,
                             extra_context={'_extra_grouping_key_': 'epd'},
                         ))
-                move.tax_totals = self.env['account.tax']._prepare_tax_totals(**kwargs)
+                move.tax_totals = self.env['account.tax']._prepare_tax_totals(**kwargs, move=move)
                 if move.invoice_cash_rounding_id:
                     rounding_amount = move.invoice_cash_rounding_id.compute_difference(move.currency_id, move.tax_totals['amount_total'])
                     totals = move.tax_totals


### PR DESCRIPTION
Problem:
The tax totals widget on invoices re-calculates amounts every time it is
displayed. It uses the invoice line's `price_unit` and the current
configuration of the associated tax.

This leads to incorrect totals if a tax's definition (e.g., the
"Included in Price" setting) is changed after the invoice line has
already been created or posted. The widget then shows amounts that do
not match the stored values on the invoice lines.

Solution:
This commit modifies the `_compute_tax_totals` method to ensure the tax
widget always reflects the stored data of the invoice.

Instead of re-calculating from `price_unit`, the computation is forced
to use the line's stored `price_subtotal` as the definitive untaxed
base amount

task-4590075