### PR TITLE
[FIX] website: indeterministic test

### DIFF
--- a/addons/website/static/tests/builder/operation.test.js
+++ b/addons/website/static/tests/builder/operation.test.js
@@ -112,7 +112,8 @@ describe("Block editable", () => {
         await contains(":iframe .test-options-target").click();
         await contains("[data-action-id='customAction']").click();
         expect(":iframe .o_loading_screen:not(.o_we_ui_loading)").toHaveCount(1);
-        await new Promise((resolve) => setTimeout(resolve, 600));
+        await advanceTime(50); // cancelTime=50 trigger by the preview
+        await advanceTime(500); // setTimeout in addLoadingElement
         expect(":iframe .o_loading_screen.o_we_ui_loading").toHaveCount(1);
 
         customActionDef.resolve();


### PR DESCRIPTION
In this commit, we're going to replace the use of setTimeout with advanceTime. No test should use setTimeout to wait for time, you should always use advanceTime. Using setTimout will slow down the test and cause some indeterminate bugs.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
