### PR TITLE
[REM] html_builder: remove website mocks from tests

### DIFF
--- a/addons/html_builder/static/tests/shadow_option.test.js
+++ b/addons/html_builder/static/tests/shadow_option.test.js
@@ -1,23 +1,9 @@
-import { expect, test, beforeEach } from "@odoo/hoot";
+import { expect, test } from "@odoo/hoot";
 import { queryAllTexts, queryAllValues, waitFor } from "@odoo/hoot-dom";
 import { xml } from "@odoo/owl";
-import { contains, mockService } from "@web/../tests/web_test_helpers";
+import { contains } from "@web/../tests/web_test_helpers";
 import { addBuilderOption, setupHTMLBuilder, addBuilderPlugin } from "./helpers";
 import { ShadowOptionPlugin } from "@html_builder/plugins/shadow_option_plugin";
-
-beforeEach(() => {
-    mockService("website", () => ({
-        currentWebsite: {
-            id: 1,
-            metadata: {
-                lang: "en_US",
-            },
-            default_lang_id: {
-                code: "en_US",
-            },
-        },
-    }));
-});
 
 test("edit box-shadow with ShadowOption", async () => {
     addBuilderOption({


### PR DESCRIPTION
Tests moved from website to html_builder were mocking website service as it was a required dependency. After the work of this [PR] it became okay to remove the mocks from the tests.

Tests should work normally without the need to have website service present.

[PR]: https://github.com/odoo/odoo/pull/217994
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
