### PR TITLE
[IMP] account_qr_code_emv, l10n_*: dynamic_selection on proxy type

### DIFF
--- a/addons/account_qr_code_emv/models/res_bank.py
+++ b/addons/account_qr_code_emv/models/res_bank.py
@@ -13,6 +13,7 @@ class ResPartnerBank(models.Model):
     display_qr_setting = fields.Boolean(compute='_compute_display_qr_setting')
     include_reference = fields.Boolean(string="Include Reference", help="Include the reference in the QR code.")
     proxy_type = fields.Selection([('none', 'None')], string="Proxy Type", default='none')
+    country_proxy_keys = fields.Char(compute='_compute_country_proxy_keys')
     proxy_value = fields.Char(string="Proxy Value")
 
     @api.model
@@ -25,6 +26,10 @@ class ResPartnerBank(models.Model):
     @api.model
     def _remove_accents(self, string):
         return remove_accents(string).replace('đ', 'd').replace('Đ', 'D')
+
+    @api.depends('country_code')
+    def _compute_country_proxy_keys(self):
+        self.country_proxy_keys = ""
 
     @api.depends('country_code')
     def _compute_display_qr_setting(self):

--- a/addons/account_qr_code_emv/views/res_bank_views.xml
+++ b/addons/account_qr_code_emv/views/res_bank_views.xml
@@ -9,7 +9,8 @@
             <sheet position="inside">
                 <field name="display_qr_setting" invisible="1" />
                 <group string="EMV QR Configuration" invisible="not display_qr_setting">
-                    <field name="proxy_type"/>
+                    <field name="country_proxy_keys" invisible="1"/>
+                    <field name="proxy_type" widget="dynamic_selection" options="{'available_field': 'country_proxy_keys'}"/>
                     <field name="proxy_value"/>
                     <field name="include_reference"/>
                 </group>

--- a/addons/l10n_br/models/res_partner_bank.py
+++ b/addons/l10n_br/models/res_partner_bank.py
@@ -61,6 +61,12 @@ class ResPartnerBank(models.Model):
                     )
                 )
 
+    @api.depends('country_code')
+    def _compute_country_proxy_keys(self):
+        bank_br = self.filtered(lambda b: b.country_code == 'BR')
+        bank_br.country_proxy_keys = 'email,mobile,br_cpf_cnpj,br_random'
+        super(ResPartnerBank, self - bank_br)._compute_country_proxy_keys()
+
     @api.depends("country_code")
     def _compute_display_qr_setting(self):
         """Override."""

--- a/addons/l10n_hk/models/res_bank.py
+++ b/addons/l10n_hk/models/res_bank.py
@@ -27,6 +27,12 @@ class ResPartnerBank(models.Model):
                 raise ValidationError(_("Invalid Email! Please enter a valid email address for account number %s.", bank.acc_number))
 
     @api.depends('country_code')
+    def _compute_country_proxy_keys(self):
+        bank_hk = self.filtered(lambda b: b.country_code == 'HK')
+        bank_hk.country_proxy_keys = 'id,mobile,email'
+        super(ResPartnerBank, self - bank_hk)._compute_country_proxy_keys()
+
+    @api.depends('country_code')
     def _compute_display_qr_setting(self):
         bank_hk = self.filtered(lambda b: b.country_code == 'HK')
         bank_hk.display_qr_setting = True

--- a/addons/l10n_sg/models/res_bank.py
+++ b/addons/l10n_sg/models/res_bank.py
@@ -17,6 +17,12 @@ class ResPartnerBank(models.Model):
                 raise ValidationError(_("The PayNow Type must be either Mobile or UEN to generate a PayNow QR code for account number %s.", bank.acc_number))
 
     @api.depends('country_code')
+    def _compute_country_proxy_keys(self):
+        bank_sg = self.filtered(lambda b: b.country_code == 'SG')
+        bank_sg.country_proxy_keys = 'mobile,uen'
+        super(ResPartnerBank, self - bank_sg)._compute_country_proxy_keys()
+
+    @api.depends('country_code')
     def _compute_display_qr_setting(self):
         bank_sg = self.filtered(lambda b: b.country_code == 'SG')
         bank_sg.display_qr_setting = True

--- a/addons/l10n_th/models/res_bank.py
+++ b/addons/l10n_th/models/res_bank.py
@@ -26,6 +26,12 @@ class ResPartnerBank(models.Model):
                 raise ValidationError(_("The Mobile Number must be in the format 0812345678 for account number %s.", bank.acc_number))
 
     @api.depends('country_code')
+    def _compute_country_proxy_keys(self):
+        bank_th = self.filtered(lambda b: b.country_code == 'TH')
+        bank_th.country_proxy_keys = 'ewallet_id,merchant_tax_id,mobile'
+        super(ResPartnerBank, self - bank_th)._compute_country_proxy_keys()
+
+    @api.depends('country_code')
     def _compute_display_qr_setting(self):
         bank_th = self.filtered(lambda b: b.country_code == 'TH')
         bank_th.display_qr_setting = True

--- a/addons/l10n_vn/models/res_bank.py
+++ b/addons/l10n_vn/models/res_bank.py
@@ -22,6 +22,12 @@ class ResPartnerBank(models.Model):
                 raise ValidationError(_("The QR Code Type must be either Merchant ID, ATM Card Number or Bank Account to generate a Vietnam Bank QR code for account number %s.", bank.acc_number))
 
     @api.depends('country_code')
+    def _compute_country_proxy_keys(self):
+        bank_vn = self.filtered(lambda b: b.country_code == 'VN')
+        bank_vn.country_proxy_keys = 'merchant_id,payment_service,atm_card,bank_acc'
+        super(ResPartnerBank, self - bank_vn)._compute_country_proxy_keys()
+
+    @api.depends('country_code')
     def _compute_display_qr_setting(self):
         bank_vn = self.filtered(lambda b: b.country_code == 'VN')
         bank_vn.display_qr_setting = True


### PR DESCRIPTION
`*` = [br, hk, sg, th, vn]

In this PR:
- Added a `dynamic_selection` widget to the `proxy_type` field in `res.partner.bank`
- The available options now change based on the `country` of the selected partner for these localizations 
  (l10n_br, l10n_hk, l10n_sg, l10n_th, l10n_vn).

Task-4941447
