### PR TITLE
[FIX] auth_passkey: tour tests not working with HR module

### DIFF
--- a/addons/auth_passkey/static/tests/passkeys_delete.js
+++ b/addons/auth_passkey/static/tests/passkeys_delete.js
@@ -26,7 +26,6 @@ registry.category("web_tour.tours").add('passkeys_tour_delete', {
             },
         }, {
             content: "Open Passkey dropdown",
-            // It just happens to be invisible due to scroll bar, if it becomes visible in the future just remove the :not(:visible).
             trigger: '.o_dropdown_kanban .o-dropdown:not(:visible)',
             run: 'click',
         }, {
@@ -56,6 +55,10 @@ registry.category("web_tour.tours").add('passkeys_tour_delete', {
             content: "Open preferences / profile screen",
             trigger: '[data-menu=settings]',
             run: 'click',
+        }, {
+            // The HR module causes the switch to security tab to trigger on the old DOM, before the new one is loaded
+            content: "Make sure the Preferences tab is open",
+            trigger: 'label:contains("Email Signature")',
         }, {
             content: "Switch to security tab",
             trigger: 'a[role=tab]:contains("Account Security")',

--- a/addons/auth_passkey/static/tests/passkeys_registration.js
+++ b/addons/auth_passkey/static/tests/passkeys_registration.js
@@ -97,12 +97,22 @@ registry.category("web_tour.tours").add('passkeys_tour_registration', {
             trigger: '[data-menu=settings]',
             run: 'click',
         }, {
+            // The HR module causes the switch to security tab to trigger on the old DOM, before the new one is loaded
+            content: "Make sure the Preferences tab is open",
+            trigger: 'label:contains("Email Signature")',
+        }, {
             content: "Switch to security tab",
             trigger: 'a[role=tab]:contains("Account Security")',
             run: 'click',
         }, {
             content: "Ensure there is one passkey",
             trigger: 'button:contains("Add Passkey")',
+            run: () => {
+                let amount = document.querySelectorAll("div[name='auth_passkey_key_ids'] article").length;
+                if(amount != 1) {
+                    throw Error("Amount of Passkeys must be 1");
+                }
+            },
         },
     ]
 })


### PR DESCRIPTION
The HR module caused the tests to break due to the difference in the user preference screen. The user preference screen normally closes after creating a passkey but in the case where HR is installed then the user preferences DOM is still visible while it's reloading the page.

Quick bugfix for 18.0 only, the others will be fixed in the forward ports of https://github.com/odoo/odoo/pull/217583