### PR TITLE
[FIX] web: prevent flicker in export data dialog

### DIFF
--- a/addons/web/static/src/views/view_dialogs/export_data_dialog.js
+++ b/addons/web/static/src/views/view_dialogs/export_data_dialog.js
@@ -104,10 +104,10 @@ export class ExportDataDialog extends Component {
         this.expandedFields = {};
         this.availableFormats = [];
         this.templates = [];
+        this.isCompatible = false;
 
         this.state = useState({
             exportList: [],
-            isCompatible: false,
             isEditingTemplate: false,
             search: [],
             selectedFormat: 0,
@@ -216,11 +216,11 @@ export class ExportDataDialog extends Component {
      * Load fields to display and (re)set the list of available fields
      */
     async fetchFields() {
-        this.state.search = [];
         this.knownFields = {};
         this.expandedFields = {};
         await this.loadFields();
         await this.setDefaultExportList();
+        this.state.search = [];
         if (this.searchRef.el) {
             this.searchRef.el.value = "";
         }
@@ -272,7 +272,7 @@ export class ExportDataDialog extends Component {
         if (preventLoad) {
             return;
         }
-        const fields = await this.props.getExportedFields(this.state.isCompatible, parentParams);
+        const fields = await this.props.getExportedFields(this.isCompatible, parentParams);
         for (const field of fields) {
             field.parent = parentField;
             if (!this.knownFields[field.id]) {
@@ -351,7 +351,7 @@ export class ExportDataDialog extends Component {
         this.state.disabled = true;
         await this.props.download(
             this.state.exportList,
-            this.state.isCompatible,
+            this.isCompatible,
             this.availableFormats[this.state.selectedFormat].tag
         );
         this.state.disabled = false;
@@ -395,7 +395,7 @@ export class ExportDataDialog extends Component {
     }
 
     onToggleCompatibleExport(value) {
-        this.state.isCompatible = value;
+        this.isCompatible = value;
         this.fetchFields();
     }
 

--- a/addons/web/static/src/views/view_dialogs/export_data_dialog.xml
+++ b/addons/web/static/src/views/view_dialogs/export_data_dialog.xml
@@ -33,7 +33,7 @@
             <div class="row w-100">
                 <div class="o_left_panel col-12 col-md-6 h-100 d-flex flex-column flex-nowrap">
                     <div class="o_import_compat">
-                        <CheckBox className="'o_import_compat'" id="'o-update-data'" value="state.isCompatible" onChange.bind="onToggleCompatibleExport">
+                        <CheckBox className="'o_import_compat'" id="'o-update-data'" value="isCompatible" onChange.bind="onToggleCompatibleExport">
                             I want to update data (import-compatible export)
                         </CheckBox>
                     </div>
@@ -42,7 +42,7 @@
                     <div class="o_left_field_panel h-100 overflow-auto border">
                         <div class="o_field_tree_structure">
                             <t t-if="fieldsAvailable">
-                                <t t-foreach="rootFields" t-as="field" t-key="field.id + '_' + state.search.length + '_' + state.isCompatible">
+                                <t t-foreach="rootFields" t-as="field" t-key="field.id + '_' + state.search.length + '_' + isCompatible">
                                     <ExportDataItem
                                         exportList="state.exportList"
                                         field="field"


### PR DESCRIPTION
This commit resolves a flickering issue in the export data dialog, where toggling the compatibility checkbox would cause the list of available fields to reset momentarily before updating.

The issue was due to the isCompatible value being stored in component state, triggering an unnecessary re-render before the asynchronous field update completed. The fix involves removing isCompatible from the state and deferring the search state reset until after the field list has finished loading, preventing intermediate renders.

task-4936825
