### PR TITLE
[FIX] pos_self_order: only display `tracking_number` for restaurant

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/receipt_header/receipt_header.xml
+++ b/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/receipt_header/receipt_header.xml
@@ -4,6 +4,9 @@
         <img t-attf-src="/web/image?model=res.company&amp;id={{order.company.id}}&amp;field=logo" alt="Logo" class="pos-receipt-logo"/>
         <br/>
         <div class="d-flex flex-column align-items-center">
+            <!-- TODO-manv: should we display the `big` tracking number only for self/kiosk receipts? (if it contains 'K' or 'S' prefix?) cause for
+            the moment it display a huge tracking number for all restaurant receipts if you have self order enabled   -->
+            <h1 class="tracking-number text-center" style="font-size: 100px" t-if="order.tracking_number and order.config.self_ordering_mode !== 'nothing'" t-esc="order.tracking_number" />
             <div class="pos-receipt-contact">
                 <!-- contact address -->
                 <div t-if="order.company?.name" t-esc="order.company.name" />
@@ -28,6 +31,9 @@
                     </span>
                     </t>
                 </div>
+            </div>
+            <div t-if="order.tracking_number and order.config.self_ordering_mode === 'nothing' and order.config.module_pos_restaurant">
+                <span class="tracking-number fs-1" t-esc="order.tracking_number" />
             </div>
         </div>
         <br />

--- a/addons/pos_restaurant/static/src/app/screens/receipt_screen/order_receipt/order_receipt.xml
+++ b/addons/pos_restaurant/static/src/app/screens/receipt_screen/order_receipt/order_receipt.xml
@@ -38,14 +38,6 @@
         <xpath expr="//div[hasclass('cashier')]" position="after">
             <t t-if="order.table_id" t-esc="tableName"/>
         </xpath>
-        <xpath expr="//div[hasclass('pos-receipt-contact')]" position="before">
-            <h1 class="tracking-number text-center" style="font-size: 100px" t-if="order.tracking_number and order.config.self_ordering_mode !== 'nothing'" t-esc="order.tracking_number" />
-        </xpath>
-        <xpath expr="//div[hasclass('pos-receipt-contact')]" position="after">
-            <div t-if="order.tracking_number and order.config.self_ordering_mode === 'nothing'">
-                <span class="tracking-number fs-1" t-esc="order.tracking_number" />
-            </div>
-        </xpath>
     </t>
 
 </templates>

--- a/addons/pos_self_order/static/tests/tours/self_order_combo_tour.js
+++ b/addons/pos_self_order/static/tests/tours/self_order_combo_tour.js
@@ -2,6 +2,7 @@ import { registry } from "@web/core/registry";
 import * as Utils from "@pos_self_order/../tests/tours/utils/common";
 import * as CartPage from "@pos_self_order/../tests/tours/utils/cart_page_util";
 import * as ProductPage from "@pos_self_order/../tests/tours/utils/product_page_util";
+import * as ConfirmationPage from "@pos_self_order/../tests/tours/utils/confirmation_page_util";
 
 registry.category("web_tour.tours").add("self_combo_selector", {
     steps: () => [
@@ -47,6 +48,8 @@ registry.category("web_tour.tours").add("self_combo_selector", {
             },
         ]),
         Utils.clickBtn("Pay"),
+        ConfirmationPage.orderNumberShown(),
+        ConfirmationPage.orderNumberIs("S", "1"),
         Utils.clickBtn("Ok"),
         Utils.checkIsNoBtn("Order Now"),
     ],

--- a/addons/pos_self_order/static/tests/tours/self_order_kiosk_tour.js
+++ b/addons/pos_self_order/static/tests/tours/self_order_kiosk_tour.js
@@ -17,6 +17,8 @@ registry.category("web_tour.tours").add("self_kiosk_each_table_takeaway_in", {
         Utils.clickBtn("Pay"),
         Numpad.click("3"),
         Utils.clickBtn("Pay"),
+        ConfirmationPage.orderNumberShown(),
+        ConfirmationPage.orderNumberIs("K", "3"),
         Utils.clickBtn("Close"),
         Utils.checkIsNoBtn("My Order"),
         Utils.clickBtn("Order Now"),

--- a/addons/pos_self_order/static/tests/tours/utils/confirmation_page_util.js
+++ b/addons/pos_self_order/static/tests/tours/utils/confirmation_page_util.js
@@ -11,3 +11,19 @@ export function orderNumberShown() {
         trigger: ".number",
     };
 }
+
+export function orderNumberIs(trackingPrefix, trackingNumber) {
+    return {
+        content: `Check that the order number start with '${trackingPrefix}', and end with number '${trackingNumber}'.`,
+        trigger: `span.number`,
+        run: function () {
+            const span = document.querySelector("span.number");
+            const text = span.textContent || "";
+            if (!text.startsWith(trackingPrefix) || !text.endsWith(trackingNumber)) {
+                throw new Error(
+                    `Order number '${text}' does not start with '${trackingPrefix}' and end with '${trackingNumber}'`
+                );
+            }
+        },
+    };
+}


### PR DESCRIPTION
- Fix issue where `tracking_number` was displayed for all config. We want to display this number only for `pos_restaurant` configurations.
- Fix issue where `tracking_number` was not displayed on kiosk order receipts.

task-id: 4922308



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
