### PR TITLE
[FIX] google_calendar: attendees switch owner

### DIFF
--- a/addons/google_calendar/models/calendar.py
+++ b/addons/google_calendar/models/calendar.py
@@ -375,3 +375,8 @@ class Meeting(models.Model):
         if self.user_id and self.user_id.sudo().google_calendar_token:
             return self.user_id
         return self.env.user
+
+    def _is_google_insertion_blocked(self, sender_user):
+        self.ensure_one()
+        has_different_owner = self.user_id and self.user_id != sender_user
+        return has_different_owner

--- a/addons/google_calendar/models/calendar_recurrence_rule.py
+++ b/addons/google_calendar/models/calendar_recurrence_rule.py
@@ -239,3 +239,9 @@ class RecurrenceRule(models.Model):
         if event:
             return event._get_event_user()
         return self.env.user
+
+    def _is_google_insertion_blocked(self, sender_user):
+        self.ensure_one()
+        has_base_event = self.base_event_id
+        has_different_owner = self.base_event_id.user_id and self.base_event_id.user_id != sender_user
+        return has_base_event and has_different_owner

--- a/addons/google_calendar/models/google_sync.py
+++ b/addons/google_calendar/models/google_sync.py
@@ -151,6 +151,8 @@ class GoogleSync(models.AbstractModel):
                 if record.google_id and record.need_sync:
                     record.with_user(record._get_event_user())._google_delete(google_service, record.google_id)
             for record in new_records:
+                if record._is_google_insertion_blocked(sender_user=self.env.user):
+                    continue
                 record.with_user(record._get_event_user())._google_insert(google_service, record._google_values())
             for record in updated_records:
                 record.with_user(record._get_event_user())._google_patch(google_service, record.google_id, record._google_values())
@@ -407,5 +409,14 @@ class GoogleSync(models.AbstractModel):
         It's possible that a user creates an event and sets another user as the organizer. Using self.env.user will
         cause some issues, and It might not be possible to use this user for sending the request, so this method gets
         the appropriate user accordingly.
+        """
+        raise NotImplementedError()
+
+    def _is_google_insertion_blocked(self, sender_user):
+        """
+        Returns True if the record insertion to Google should be blocked.
+        This is a necessary step for ensuring data match between Odoo and Google,
+        as it avoids that events have permanently the wrong organizer in Google
+        by not synchronizing records through owner and not through the attendees.
         """
         raise NotImplementedError()

--- a/addons/google_calendar/tests/test_sync_odoo2google.py
+++ b/addons/google_calendar/tests/test_sync_odoo2google.py
@@ -924,6 +924,60 @@ class TestSyncOdoo2Google(TestSyncGoogle):
         }, timeout=3)
 
     @patch_api
+    @patch.object(User, '_sync_request')
+    def test_skip_google_sync_for_non_synchronized_users_new_events(self, mock_sync_request):
+        """
+        Skip the synchro of new events by attendees when the organizer is not synchronized with Google.
+        Otherwise, the event ownership will be lost to the attendee and it could generate duplicates in
+        Odoo, as well cause problems in the future the synchronization of that event for the original owner.
+        """
+        with self.mock_datetime_and_now("2023-01-10"):
+            # Stop the synchronization for the organizer and leave the attendee synchronized.
+            # Then, create an event with the organizer and attendee. Assert that it was not inserted.
+            self.organizer_user.google_synchronization_stopped = True
+            self.attendee_user.google_synchronization_stopped = False
+            record = self.env['calendar.event'].with_user(self.organizer_user).create({
+                'name': "Event",
+                'start': datetime(2023, 1, 15, 8, 0),
+                'stop': datetime(2023, 1, 15, 18, 0),
+                'need_sync': True,
+                'partner_ids': [(4, self.organizer_user.partner_id.id), (4, self.attendee_user.partner_id.id)]
+            })
+            self.assertGoogleEventNotInserted()
+
+            # Define mock return values for the '_sync_request' method.
+            mock_sync_request.return_value = {
+                'events': GoogleEvent([]),
+                'default_reminders': (),
+                'full_sync': False,
+            }
+
+            # Synchronize the attendee, and ensure that the event was not inserted after it.
+            self.attendee_user.with_user(self.attendee_user).sudo()._sync_google_calendar(self.google_service)
+            self.assertGoogleAPINotCalled()
+
+            # Now, we synchronize the organizer and make sure the event got inserted by him.
+            self.organizer_user.with_user(self.organizer_user).restart_google_synchronization()
+            self.organizer_user.with_user(self.organizer_user).sudo()._sync_google_calendar(self.google_service)
+            self.assertGoogleEventInserted({
+                'id': False,
+                'start': {'dateTime': '2023-01-15T08:00:00+00:00', 'date': None},
+                'end': {'dateTime': '2023-01-15T18:00:00+00:00', 'date': None},
+                'summary': 'Event',
+                'description': '',
+                'location': '',
+                'guestsCanModify': True,
+                'transparency': 'opaque',
+                'reminders': {'overrides': [], 'useDefault': False},
+                'organizer': {'email': self.organizer_user.email, 'self': True},
+                'attendees': [
+                                {'email': self.attendee_user.email, 'responseStatus': 'needsAction'},
+                                {'email': self.organizer_user.email, 'responseStatus': 'accepted'}
+                            ],
+                'extendedProperties': {'shared': {'%s_odoo_id' % self.env.cr.dbname: record.id}},
+            })
+
+    @patch_api
     def test_event_duplication_allday_google_calendar(self):
         event = self.env['calendar.event'].with_user(self.organizer_user).create({
             'name': "Event",


### PR DESCRIPTION
Before this commit, when an user A is invited by an event of user B and none of these users are synchronized with Google, when the synchronization of user A starts or resumes, the event will be synchronized with the user A as organizer in Google. In the meanwhile, in Odoo, the event ownership will be shown as user B, mismatching the organizer field between the two ends. This is problematic because the ownership of the event will be forever wrong in Google.

After this commit, when user A starts or resumes its synchronization with Outlook, previous Odoo events which user A is attendee but not organizer won't be synchronized until the organizer synchronizes its calendar. This will keep the ownership of the event intact in Odoo, and when the organizer synchronizes its calendar with Google, it will be correctly synchronized in Google as well.

Recently, we had to revert this PR due to an emergency at odoo/odoo#215449. The issue got solved, so we're adding this fix back.

task-4269432