### PR TITLE
[FIX] crm, mail: display user-specific activity in "My Activities"

### DIFF
--- a/addons/crm/views/crm_lead_views.xml
+++ b/addons/crm/views/crm_lead_views.xml
@@ -1126,7 +1126,8 @@
             <field name="domain">[('activity_ids','!=',False)]</field>
             <field name="search_view_id" ref="crm.view_crm_case_my_activities_filter"/>
             <field name="context">{'default_type': 'opportunity',
-                    'search_default_assigned_to_me': 1}
+                    'search_default_assigned_to_me': 1,
+                    'my_activities_only': True}
             </field>
             <field name="help" type="html">
                 <p class="o_view_nocontent_smiling_face">


### PR DESCRIPTION
Steps to reproduce:
  1. Create or go to any Lead.
  2. Schedule an activity for yourself for today.
  3. Schedule another activity for another user tha's overdue.
  4. Go to the "My Activities" view.
  5. Observe that the activity for the other user is also present in the list with all my activities.

Issue:
The "My Activities" list view correctly filters records to show only leads/opportunities where the current user has an activity. However, the columns displaying the activity details (e.g., Summary, Responsible, Deadline) were showing the overall next upcoming activity on the record, regardless of the assignee. This was confusing, as a user would see an activity belonging to a colleague in their own activity list.

Solution:
The activity display fields in `mail.activity.mixin` are made context-aware.

1.  A context key `my_activities_only: True` is passed from the `crm_lead_action_my_activities` window action.

2.  In `mail.activity.mixin`, a helper method `_get_activities_to_display` is introduced to select activities based on this context key.

3.  The fields `activity_summary` and `activity_type_id` are converted from `related` to `compute` fields to enable contextual logic.

4.  All relevant compute methods (`_compute_activity_user_id`, `_compute_activity_date_deadline`, etc.) are updated to use the new helper. This ensures that when viewed in the "My Activities" context, the displayed details are from the current user's next activity.

This way we ensure that the "My Activities" view only shows activities that are relevant to the current user, and the details displayed are specific to their activities, avoiding confusion with activities assigned to other users.

opw-4900220