### PR TITLE
[FIX] point_of_sale: properly unlink lots from pos_order_line

### DIFF
--- a/addons/point_of_sale/static/src/app/models/pos_order_line.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order_line.js
@@ -152,9 +152,7 @@ export class PosOrderline extends Base {
         }
 
         // Remove those that needed to be removed.
-        for (const lotLine of lotLinesToRemove) {
-            this.pack_lot_ids = this.pack_lot_ids.filter((pll) => pll.id !== lotLine.id);
-        }
+        this.update({ pack_lot_ids: [["unlink", ...lotLinesToRemove]] });
 
         for (const newLotLine of newPackLotLines) {
             this.models["pos.pack.operation.lot"].create({

--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -836,9 +836,6 @@ export class PosStore extends Reactive {
 
             if (!pack_lot_ids) {
                 return;
-            } else {
-                const packLotLine = pack_lot_ids.newPackLotLines;
-                values.pack_lot_ids = packLotLine.map((lot) => ["create", lot]);
             }
         }
 
@@ -906,7 +903,7 @@ export class PosStore extends Reactive {
             this.selectOrderLine(order, order.get_last_orderline());
         }
 
-        if (product.tracking === "serial") {
+        if (product.isTracked()) {
             this.selectedOrder.get_selected_orderline().setPackLotLines({
                 modifiedPackLotLines: pack_lot_ids.modifiedPackLotLines ?? [],
                 newPackLotLines: pack_lot_ids.newPackLotLines ?? [],

--- a/addons/point_of_sale/static/tests/tours/ticket_screen_tour.js
+++ b/addons/point_of_sale/static/tests/tours/ticket_screen_tour.js
@@ -9,6 +9,7 @@ import * as Chrome from "@point_of_sale/../tests/tours/utils/chrome_util";
 import * as Dialog from "@point_of_sale/../tests/tours/utils/dialog_util";
 import { inLeftSide } from "@point_of_sale/../tests/tours/utils/common";
 import { registry } from "@web/core/registry";
+import * as Utils from "@point_of_sale/../tests/tours/utils/common";
 
 registry.category("web_tour.tours").add("TicketScreenTour", {
     steps: () =>
@@ -300,6 +301,30 @@ registry.category("web_tour.tours").add("test_order_with_existing_serial", {
             ProductScreen.selectedOrderlineHas("Serial Product", "2.00"),
             inLeftSide({
                 trigger: ".info-list:contains('SN SN2')",
+            }),
+        ].flat(),
+});
+
+registry.category("web_tour.tours").add("test_serial_number_do_not_duplicate_after_refresh", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            ProductScreen.clickDisplayedProduct("Product A"),
+            ProductScreen.enterLotNumber("1"),
+            ProductScreen.selectedOrderlineHas("Product A", "1.00"),
+            Utils.refresh(),
+            inLeftSide({
+                content: `check serial number`,
+                trigger: `.info-list`,
+                run: () => {
+                    const serialNumberCount = document.querySelectorAll(
+                        "ul.info-list li:not(:first-child)"
+                    ).length;
+                    if (serialNumberCount !== 1) {
+                        throw new Error(`Expected 1 serial number, got ${serialNumberCount}`);
+                    }
+                },
             }),
         ].flat(),
 });

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -813,6 +813,17 @@ class TestUi(TestPointOfSaleHttpCommon):
         self.main_pos_config.with_user(self.pos_user).open_ui()
         self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'CustomerNoteIsPresentAfterRefresh', login="pos_user")
 
+    def test_serial_number_do_not_duplicate_after_refresh(self):
+        self.product1 = self.env['product.product'].create({
+            'name': 'Product A',
+            'is_storable': True,
+            'tracking': 'serial',
+            'categ_id': self.env.ref('product.product_category_all').id,
+            'available_in_pos': True,
+        })
+        self.main_pos_config.with_user(self.pos_user).open_ui()
+        self.start_pos_tour("test_serial_number_do_not_duplicate_after_refresh")
+
     def test_fiscal_position_no_tax(self):
         #create a tax of 15% with price included
         tax = self.env['account.tax'].create({


### PR DESCRIPTION
**Step to reproduce:**
- start pos
- add product tracked with serial number
- refresh the page

**Observation:**
- serial number is attached twice in same orderline

**Issue:**
currently, when dealing with tracked product, we add the lots in values

       values.pack_lot_ids = packLotLine.map((lot) => ["create", lot])

these values are used to create pos_order_line.
Now, in case of product tracked by 'serial' , we again call `setPackLotLines`

https://github.com/odoo/odoo/blob/b3b0a0959ae12f53f702c359c1205d89a8e92ffb/addons/point_of_sale/static/src/app/store/pos_store.js#L897-L901

there, we remove the initially added lot and again add the same lot, (with new id).
but the old one is not properly unlinked from indexed db.
```
    for (const lotLine of lotLinesToRemove) {
        this.pack_lot_ids = this.pack_lot_ids.filter((pll) => pll.id !== lotLine.id);
    }
```
hence on refresh, same lot (with different id) is attached to orderline.

**Fix:**
this pr tries to fix the issue at both places, we will add the lot only once
and also unlink the lot properly.

Note: issue only in 18.0, in higher version, SN vanishes after refresh

opw-4897882

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
