### PR TITLE
[FIX] web: pivot: disable cell pointer when linking is disabled

### DIFF
--- a/addons/web/static/src/views/pivot/pivot_renderer.xml
+++ b/addons/web/static/src/views/pivot/pivot_renderer.xml
@@ -34,7 +34,7 @@
                             <t t-foreach="row.subGroupMeasurements" t-as="cell" t-key="'row_cell_' + cell_index">
                                 <td class="o_pivot_cell_value bg-100" t-att-class="{
                                         o_empty: cell.value === undefined,
-                                        'cursor-pointer': cell.value !== undefined,
+                                        'cursor-pointer': cell.value !== undefined and !model.metaData.disableLinking,
                                         'fw-bold': cell.isBold,
                                     }" t-custom-click.synthetic="(ev, isMiddleClick) => this.onOpenView(cell, isMiddleClick)"
                                     t-on-mouseover="onMouseEnter" t-on-mouseout="onMouseLeave">

--- a/addons/web/static/tests/views/pivot_view.test.js
+++ b/addons/web/static/tests/views/pivot_view.test.js
@@ -577,6 +577,7 @@ test('pivot view with disable_linking="True"', async () => {
 
     expect("table").not.toHaveClass("o_enable_linking");
     expect(".o_pivot_cell_value").toHaveCount(1);
+    expect(".o_pivot_cell_value").not.toHaveClass("cursor-pointer");
     await contains(".o_pivot_cell_value").click(); // should not trigger a do_action
 });
 


### PR DESCRIPTION
This commit removes the cursor-pointer class from pivot cell values when disable_linking is true. In this mode, clicking on a cell has no effect, so keeping the pointer cursor is misleading.

task-4936806
