### PR TITLE
[FIX] web_editor: fix parallax label on snippet previews

### DIFF
--- a/addons/web_editor/i18n/web_editor.pot
+++ b/addons/web_editor/i18n/web_editor.pot
@@ -2130,6 +2130,12 @@ msgstr ""
 
 #. module: web_editor
 #. odoo-javascript
+#: code:addons/web_editor/static/src/js/editor/add_snippet_dialog.js:0
+msgid "Parallax"
+msgstr ""
+
+#. module: web_editor
+#. odoo-javascript
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 msgid "Paste as URL"
 msgstr ""

--- a/addons/web_editor/static/src/js/editor/add_snippet_dialog.js
+++ b/addons/web_editor/static/src/js/editor/add_snippet_dialog.js
@@ -245,8 +245,22 @@ export class AddSnippetDialog extends Component {
                 // the tours here.
                 snippetPreviewWrapEl.dataset.snippetId = snippet.data.oeSnippetKey;
                 snippetPreviewWrapEl.dataset.snippetKey = snippet.key;
-                if (snippet.label) {
-                    snippetPreviewWrapEl.dataset.label = snippet.label;
+                // Check if any element in the snippet has the "parallax" class
+                // to show the "Parallax" label. This must be done this way
+                // because a theme or custom snippet may add or remove parallax
+                // elements. Note that if a label is already set, we do not
+                // change it.
+                // TODO In master, remove the "|| snippetLabel === 'Parallax'"
+                // part from the condition, as the label="Parallax" will be
+                // removed from the snippet definition.
+                let snippetLabel = snippet.label;
+                if (!snippetLabel || snippetLabel === "Parallax") {
+                    const hasParallax = snippet.baseBody.matches(".parallax")
+                        || !!snippet.baseBody.querySelector(".parallax");
+                    snippetLabel = hasParallax ? _t("Parallax") : "";
+                }
+                if (snippetLabel) {
+                    snippetPreviewWrapEl.dataset.label = snippetLabel;
                 }
                 snippetPreviewWrapEl.appendChild(clonedSnippetEl);
                 this.__onSnippetPreviewClick = this._onSnippetPreviewClick.bind(this);


### PR DESCRIPTION
Steps to reproduce the issues:

**Issue 1**
- Enter "Website" edit mode.
- Drag and drop a "Cover" snippet into the page.
- Save the snippet as a custom snippet.
- Click the "Custom" category.
- Bug: the "Parallax" label is not displayed on the snippet preview.

**Issue 2**
- Install the "Artists" theme.
- Enter "Website" edit mode.
- Click the "Intro" category.
- Bug: The "Parallax" label is displayed on the "Cover" snippet preview even though it doesn't have a parallax effect.

Commit [1] added a label on snippet previews to indicate if they are Carousel, Popup, Gallery, Tab, or Parallax. This label is linked directly to the snippet's original template. However, this does not work well for "Parallax" because it's an option that can be enabled or disabled. So it doesn't make sense to keep the label when the option is not active.

This commit fixes that by checking the snippet structure to see if it contains a parallax on its background.

[1]: https://github.com/odoo/odoo/commit/63cd0c6497c3c2e8482dc62b4359eb2431a75926

task-4926420