### PR TITLE
[FIX] website: fix `s_intro_pill` layout

### DIFF
--- a/addons/website/views/snippets/s_intro_pill.xml
+++ b/addons/website/views/snippets/s_intro_pill.xml
@@ -9,8 +9,8 @@
                     <img class="img-fluid mx-auto" data-shape="html_builder/geometric_round/geo_round_pill" data-file-name="s_intro_pill_default_image.jpg"
                     data-format-mimetype="image/jpeg" src="/html_editor/image_shape/website.s_intro_pill_default_image/html_builder/geometric_round/geo_round_pill.svg" alt=""/>
                 </div>
-                <div class="o_grid_item g-height-11 g-col-lg-8 col-lg-8 order-lg-0" data-name="Box" style="order: 1; z-index: 3; grid-area: 1 / 3 / 12 / 11; --grid-item-padding-y: 120px;">
-                    <h1 class="display-3" style="text-align: center;">Experience the<br/>best quality services</h1>
+                <div class="o_grid_item g-height-11 g-col-lg-4 col-lg-4 order-lg-0" data-name="Box" style="order: 1; z-index: 3; grid-area: 1 / 5 / 12 / 9; --grid-item-padding-y: 120px;">
+                    <h1 class="display-3" style="text-align: center;">Discover our<br/>services</h1>
                     <p>
                         <br/>
                     </p>


### PR DESCRIPTION
This PR prevents the `s_intro_pill` text block from overflowing the images, which would lead the user to think the image cannot be reached and edited.

To prevent this, we reduce the size of the text block and the copy so it does not get too long.

task-4943061

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
