### PR TITLE
[IMP] point_of_sale: remove no subscription dialog

### DIFF
--- a/addons/point_of_sale/static/src/app/utils/printer/base_printer.js
+++ b/addons/point_of_sale/static/src/app/utils/printer/base_printer.js
@@ -70,32 +70,16 @@ export class BasePrinter {
      * if it failed to connect to the IoT box.
      */
     getActionError() {
-        if (window.isSecureContext) {
-            // We assume if we get a network error over HTTPS that it is a certificate issue.
-            return {
-                successful: false,
-                canRetry: false,
-                message: {
-                    title: _t("Connection to IoT Box failed"),
-                    body: _t(
-                        "Your database is not registered.\n" +
-                            "Buy a subscription, or register your subscription code, then retry.\n\n" +
-                            "You can still download the receipt and print it manually."
-                    ),
-                },
-            };
-        } else {
-            return {
-                successful: false,
-                canRetry: true,
-                message: {
-                    title: _t("Connection to IoT Box failed"),
-                    body: _t(
-                        "Please ensure the IoT box is turned on and connected to the network before retrying."
-                    ),
-                },
-            };
-        }
+        return {
+            successful: false,
+            canRetry: true,
+            message: {
+                title: _t("Connection to IoT Box failed"),
+                body: _t(
+                    "Please ensure the IoT box is turned on and connected to the network before retrying."
+                ),
+            },
+        };
     }
 
     /**


### PR DESCRIPTION
As we always provide a certificate for IoT Boxes, it made no sense to tell users that their subscription was not valid.

Task: 4942391
