### PR TITLE
[FIX] web: fix transparent background in calendar "more" popover

### DIFF
--- a/addons/web/static/src/views/calendar/calendar_renderer.scss
+++ b/addons/web/static/src/views/calendar/calendar_renderer.scss
@@ -174,6 +174,10 @@
                 max-height: 500px;
                 overflow: auto;
             }
+
+            &.o_calendar_disabled {
+                background-color: $gray-200;
+            }
         }
 
         .o_calendar_disabled {


### PR DESCRIPTION
This commit resolves a visual issue with the FullCalendar "more" popover, where its background could appear partially transparent—causing events behind it to show through and creating a poor user experience.

The problem was introduced with the update to FullCalendar v6.1.10, which applies cell-related classes (like o_calendar_disabled) to the popover. On non-working days, this class applies a semi-transparent grey background, affecting the popover's readability.

The fix ensures that the popover background remains opaque in this specific case, restoring proper visual separation from underlying content.

task-4916099
