### PR TITLE
[FIX] sale_stock: create_a_product_delivery_from_locked_task:

### DIFF
--- a/addons/sale_stock/models/sale_order_line.py
+++ b/addons/sale_stock/models/sale_order_line.py
@@ -312,7 +312,7 @@ class SaleOrderLine(models.Model):
         procurements = []
         for line in self:
             line = line.with_company(line.company_id)
-            if line.state != 'sale' or line.order_id.locked or not line.product_id.type in ('consu', 'product'):
+            if line.state != 'sale' or not line.product_id.type in ('consu', 'product'):
                 continue
             qty = line._get_qty_procurement(previous_product_uom_qty)
             if float_compare(qty, line.product_uom_qty, precision_digits=precision) == 0:


### PR DESCRIPTION
When adding a product to a new task in Field Service with the "Lock Confirmed Sales" configuration, The sale order will note the product as delivered and will not create a delivery order.

** Cause of the issue **

When creating adding a product to a task we will set the fsm_quantity of product_product (in industry_fsm_sale°: https://github.com/odoo/enterprise/blob/8a11e0357a68f42435406f1775d3d0bbcd3b6315/industry_fsm_sale/models/product_product.py#L148 this will trigger the _inverse_fsm_quantity which will create a new SaleOderLine (where the delivery will be created): https://github.com/odoo/enterprise/blob/8a11e0357a68f42435406f1775d3d0bbcd3b6315/industry_fsm_sale/models/product_product.py#L95 During _action_launch_stock_rule, where the procurement (delivery) (it will at the same time erase the delivered status) should be created, there is this condition that will block all locked orders: https://github.com/odoo-dev/odoo/commit/17bece3e797913bcba8dd7e07fc8541c0a45e3f7#diff-c728b1f95e4d88de6354fa24c888c5a70e7c435f43002b7ee1c87238e6cab80eR311 because if this, the procurement will not be created and will still be anotated as delivered

** Fix **
Erase the condition to allow locked order to create the delivery.

opw-4800934

