### PR TITLE
[FIX] website_sale{,_wishlist}: locate form relative to button when outside standard hierarchy

### DIFF
--- a/addons/website_sale/static/src/js/website_sale.js
+++ b/addons/website_sale/static/src/js/website_sale.js
@@ -6,6 +6,7 @@ import { Interaction } from "@web/public/interaction";
 import "@website/libs/zoomodoo/zoomodoo";
 import { ProductImageViewer } from "@website_sale/js/components/website_sale_image_viewer";
 import VariantMixin from "@website_sale/js/sale_variant_mixin";
+import wSaleUtils from '@website_sale/js/website_sale_utils';
 
 export const WebsiteSale = publicWidget.Widget.extend(VariantMixin, {
     selector: '.oe_website_sale',
@@ -314,7 +315,8 @@ export const WebsiteSale = publicWidget.Widget.extend(VariantMixin, {
     async _onClickAdd(ev) {
         ev.preventDefault();
         var def = () => {
-            this._updateRootProduct((ev.currentTarget).closest('form'));
+            const form = wSaleUtils.getClosestProductForm(ev.currentTarget);
+            this._updateRootProduct(form);
             const isBuyNow = ev.currentTarget.classList.contains('o_we_buy_now');
             const isConfigured = ev.currentTarget.parentElement.id === 'add_to_cart_wrap';
             const showQuantity = Boolean(ev.currentTarget.dataset.showQuantity);
@@ -408,7 +410,7 @@ export const WebsiteSale = publicWidget.Widget.extend(VariantMixin, {
      * @returns {void}
      */
     _onChangeAddQuantity: function (ev) {
-        const $parent = $(ev.currentTarget).closest('form');
+        const $parent = $(wSaleUtils.getClosestProductForm($(ev.currentTarget)[0]));
         if ($parent.length > 0) {
             this.triggerVariantChange($parent);
         }
@@ -570,7 +572,8 @@ export const WebsiteSale = publicWidget.Widget.extend(VariantMixin, {
             // Variants list view
             'input[type="radio"][name="product_id"]:checked',
         ].join(','))?.value);
-        const quantity = parseFloat(form.querySelector('input[name="add_qty"]')?.value);
+        const productEl = form.closest('.js_product') ?? form;
+        const quantity = parseFloat(productEl.querySelector('input[name="add_qty"]')?.value);
         const uomId = this._getUoMId(form);
         const isCombo = form.querySelector(
             'input[type="hidden"][name="product_type"]'

--- a/addons/website_sale/static/src/js/website_sale_utils.js
+++ b/addons/website_sale/static/src/js/website_sale_utils.js
@@ -47,6 +47,18 @@ function animateClone($cart, $elem, offsetTop, offsetLeft) {
 }
 
 /**
+ * Returns the closest product form to a given element if exists.
+ * Required for product pages with full-width or no images where the "Add to cart" button can be 
+ * outside of the form.
+ *
+ * @param { HTMLElement } element - Reference to an HTML element in the DOM.
+ * @returns { HTMLFormElement|undefined }
+ */
+function getClosestProductForm(element){
+    return element.closest('form') ?? element.closest('.js_product')?.querySelector('form');
+}
+
+/**
  * Updates both navbar cart
  * @param {Object} data
  */
@@ -104,6 +116,7 @@ function showWarning(message) {
 
 export default {
     animateClone: animateClone,
+    getClosestProductForm: getClosestProductForm,
     updateCartNavBar: updateCartNavBar,
     showWarning: showWarning,
 };

--- a/addons/website_sale_wishlist/static/src/js/website_sale_wishlist.js
+++ b/addons/website_sale_wishlist/static/src/js/website_sale_wishlist.js
@@ -1,7 +1,7 @@
 import { rpc, RPCError } from "@web/core/network/rpc";
 import publicWidget from "@web/legacy/js/public/public_widget";
 import VariantMixin from "@website_sale/js/sale_variant_mixin";
-import wSaleUtils from "@website_sale/js/website_sale_utils";
+import wSaleUtils from '@website_sale/js/website_sale_utils';
 
 // VariantMixin events are overridden on purpose here
 // to avoid registering them more than once since they are already registered
@@ -78,7 +78,7 @@ publicWidget.registry.ProductWishlist = publicWidget.Widget.extend(VariantMixin,
         if ($el.hasClass('o_add_wishlist_dyn')) {
             productID = parseInt($el.closest('.js_product').find('.product_id:checked').val());;
         }
-        var $form = $el.closest('form');
+        const $form = $(wSaleUtils.getClosestProductForm($el[0]));
         var templateId = $form.find('.product_template_id').val();
         // when adding from /shop instead of the product page, need another selector
         if (!templateId) {
@@ -86,7 +86,7 @@ publicWidget.registry.ProductWishlist = publicWidget.Widget.extend(VariantMixin,
         }
         $el.prop("disabled", true).addClass('disabled');
         var productReady = this.selectOrCreateProduct(
-            $el.closest('form'),
+            $form,
             productID,
             templateId,
         );
@@ -102,7 +102,7 @@ publicWidget.registry.ProductWishlist = publicWidget.Widget.extend(VariantMixin,
                     self.wishlistProductIDs.push(productId);
                     sessionStorage.setItem('website_sale_wishlist_product_ids', JSON.stringify(self.wishlistProductIDs));
                     self._updateWishlistView();
-                    wSaleUtils.animateClone($navButton, $el.closest('form'), 25, 40);
+                    wSaleUtils.animateClone($navButton, $form, 25, 40);
                     // It might happen that `onChangeVariant` is called at the same time as this function.
                     // In this case we need to set the button to disabled again.
                     // Do this only if the productID is still the same.


### PR DESCRIPTION
## Version
saas-18.4+

## Steps to reproduce
- Open the shop;
- Select any product;
- Open the Editor:
  - Select the product's main image;
  - Change the image width to either `100 percent` or `None`, then save;
- Click on `Add to cart`.

## Issue
Commit bbb2d98d9ab97ce729d59b9858b63daccf5434e2 introduced a UI update that reorganizes the layout of the product configurator, placing the `Add to cart` button next to the form rather than below it.

Although the button remains inside the form in the original template, using the Editor to adjust the layout can result in the button being saved outside the `<form>` element in the final DOM.

This breaks the logic that relies on `closest('form')` to locate the surrounding form, since the button is no longer a descendant of the form element.

## Solution
Find the first product form relative to the button, since it may be a sibling rather than an ancestor in the DOM.

opw-4942986

See also:

- https://github.com/odoo/enterprise/pull/90631