### PR TITLE
[REF] base: ir.attachment._check_access

### DIFF
--- a/addons/mail/models/ir_attachment.py
+++ b/addons/mail/models/ir_attachment.py
@@ -1,8 +1,9 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import contextlib
+import itertools
 
-from odoo import _, models, SUPERUSER_ID
+from odoo import _, models
 from odoo.exceptions import AccessError, UserError
 from odoo.tools.misc import limited_field_access_token, verify_limited_field_access_token
 from odoo.addons.mail.tools.discuss import Store
@@ -24,17 +25,15 @@ class IrAttachment(models.Model):
             raise UserError(_("An access token must be provided for each attachment."))
 
         def is_owned(attachment, token):
-            if not attachment.with_user(SUPERUSER_ID).exists():
+            if not attachment.exists():
                 return False
-            try:
-                attachment.sudo(False).check("write")
+            if attachment.sudo(False).has_access("write"):
                 return True
-            except AccessError:
-                return token and verify_limited_field_access_token(
-                    attachment, "id", token, scope="attachment_ownership"
-                )
+            return token and verify_limited_field_access_token(
+                attachment, "id", token, scope="attachment_ownership"
+            )
 
-        return all(is_owned(att, tok) for att, tok in zip(self, attachment_tokens, strict=True))
+        return all(itertools.starmap(is_owned, zip(self, attachment_tokens, strict=True)))
 
     def _post_add_create(self, **kwargs):
         """ Overrides behaviour when the attachment is created through the controller

--- a/addons/mail/models/mail_mail.py
+++ b/addons/mail/models/mail_mail.py
@@ -109,16 +109,14 @@ class MailMail(models.Model):
         Compute the attachments we have access to,
         and the number of attachments we do not have access to.
         """
-        IrAttachment = self.env['ir.attachment']
         for mail_sudo, mail in zip(self.sudo(), self):
-            mail.unrestricted_attachment_ids = IrAttachment._filter_attachment_access(mail_sudo.attachment_ids.ids)
+            mail.unrestricted_attachment_ids = mail_sudo.attachment_ids.sudo(False)._filter_attachment_access()
             mail.restricted_attachment_count = len(mail_sudo.attachment_ids) - len(mail.unrestricted_attachment_ids)
 
     def _inverse_unrestricted_attachment_ids(self):
         """We can only remove the attachments we have access to."""
-        IrAttachment = self.env['ir.attachment']
         for mail_sudo, mail in zip(self.sudo(), self):
-            restricted_attaments = mail_sudo.attachment_ids - IrAttachment._filter_attachment_access(mail_sudo.attachment_ids.ids)
+            restricted_attaments = mail_sudo.attachment_ids - mail_sudo.attachment_ids.sudo(False)._filter_attachment_access()
             mail_sudo.attachment_ids = restricted_attaments | mail.unrestricted_attachment_ids
 
     def _search_body_content(self, operator, value):

--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -686,7 +686,7 @@ class MailMessage(models.Model):
         else:
             attachments_tocheck = messages.attachment_ids  # fallback on read if any unknown command
         if attachments_tocheck:
-            attachments_tocheck.check('read')
+            attachments_tocheck.check_access('read')
 
         for message, values, tracking_values_cmd in zip(messages, vals_list, tracking_values_list):
             if tracking_values_cmd:
@@ -725,8 +725,7 @@ class MailMessage(models.Model):
             self._invalidate_documents()
         res = super().write(vals)
         if vals.get('attachment_ids'):
-            for mail in self:
-                mail.attachment_ids.check(mode='read')
+            self.attachment_ids.check_access('read')
         if 'notification_ids' in vals or record_changed:
             self._invalidate_documents()
         return res

--- a/addons/snailmail/models/snailmail_letter.py
+++ b/addons/snailmail/models/snailmail_letter.py
@@ -120,13 +120,13 @@ class SnailmailLetter(models.Model):
 
         self.env['mail.notification'].sudo().create(notification_vals)
 
-        letters.attachment_id.check('read')
+        letters.attachment_id.check_access('read')
         return letters
 
     def write(self, vals):
         res = super().write(vals)
         if 'attachment_id' in vals:
-            self.attachment_id.check('read')
+            self.attachment_id.check_access('read')
         return res
 
     def _fetch_attachment(self):

--- a/odoo/addons/base/tests/test_qweb.py
+++ b/odoo/addons/base/tests/test_qweb.py
@@ -1957,6 +1957,7 @@ class TestQwebPerformance(TransactionCaseWithUserDemo):
         doc = self.env['ir.attachment'].create({
             'name': 'test',
             'type': 'url',
+            'public': True,
         })
 
         expected = """


### PR DESCRIPTION
Refactor how permissions are checked for `ir.attachment`.
- Batch checking whether the user has permission on the linked models.
- Implement `_check_access` instead of having a custom function for checks.
- Use cached values when checking permissions.

odoo/enterprise#90196

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
