### PR TITLE
[FIX] website: serialize colors of header as rgba

### DIFF
--- a/addons/website/static/src/builder/plugins/options/website_page_config_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/website_page_config_option_plugin.js
@@ -1,7 +1,7 @@
 import { after } from "@html_builder/utils/option_sequence";
 import { Plugin } from "@html_editor/plugin";
 import { registry } from "@web/core/registry";
-import { rgbToHex } from "@web/core/utils/colors";
+import { rgbaToHex } from "@web/core/utils/colors";
 import { withSequence } from "@html_editor/utils/resource";
 import { FOOTER_COPYRIGHT } from "./footer_option_plugin";
 import { HEADER_SCROLL_EFFECT } from "./header_option_plugin";
@@ -64,7 +64,7 @@ class WebsitePageConfigOptionPlugin extends Plugin {
     getColorValue(attribute, classPrefix) {
         const headerEl = this.document.querySelector("#wrapwrap > header");
         const matchingClass = [...headerEl.classList].find((cls) => cls.startsWith(classPrefix));
-        return matchingClass || rgbToHex(headerEl.style.getPropertyValue(attribute));
+        return matchingClass || rgbaToHex(headerEl.style.getPropertyValue(attribute));
     }
 
     setDirty() {


### PR DESCRIPTION
> [QSM] Try to set up a "Over the content" header with a semi-transparent color => You can't

During the initial website refactor, the alpha of colors of header was not saved, but multiplied in the value.

Steps to reproduce:
- Open website builder
- Set "Header Position" to "Over the Content"
- On the header change the color of "Background" to a color with alpha
- Save
- Bug: the background of header is opaque

Website refactor: 9fe45e2b7ddbbfd0445ffe25a859e67a316d02b2
task-4367641
