### PR TITLE
[FIX] website_sale_wishlist: fix "save for later" button in cart

### DIFF
--- a/addons/website_sale_wishlist/static/src/interactions/add_product_to_wishlist_button.js
+++ b/addons/website_sale_wishlist/static/src/interactions/add_product_to_wishlist_button.js
@@ -5,32 +5,10 @@ import wSaleUtils from '@website_sale/js/website_sale_utils';
 import wishlistUtils from '@website_sale_wishlist/js/website_sale_wishlist_utils';
 
 export class AddProductToWishlistButton extends Interaction {
-    static selector = '.oe_website_sale';
+    static selector = '.o_add_wishlist, .o_add_wishlist_dyn';
     dynamicContent = {
-        '.o_add_wishlist, .o_add_wishlist_dyn': { 't-on-click': this.addProduct },
-        'input.product_id': { 't-on-change': this.onChangeVariant },
+        _root: { 't-on-click': this.addProduct },
     };
-
-    /**
-     * Get the products in the wishlist.
-     */
-    async willStart() {
-        const wishCount = parseInt(
-            document.querySelector('header#top .my_wish_quantity')?.textContent
-        );
-        if (wishlistUtils.getWishlistProductIds().length !== wishCount) {
-            wishlistUtils.setWishlistProductIds(
-                await this.waitFor(rpc('/shop/wishlist/get_product_ids'))
-            );
-        }
-    }
-
-    /**
-     * Update the wishlist navbar.
-     */
-    start() {
-        wishlistUtils.updateWishlistNavBar();
-    }
 
     /**
      * Add a product to the wishlist.
@@ -52,34 +30,13 @@ export class AddProductToWishlistButton extends Interaction {
         await this.waitFor(rpc('/shop/wishlist/add', { product_id: productId }));
         wishlistUtils.addWishlistProduct(productId);
         wishlistUtils.updateWishlistNavBar();
-        this._updateDisabled(el, true);
+        wishlistUtils.updateDisabled(el, true);
         await wSaleUtils.animateClone(
-            $(document.querySelector('header .o_wsale_my_wish')),
-            $(this.el.querySelector('#product_detail_main') ?? form),
+            $(document.querySelector('.o_wsale_my_wish')),
+            $(document.querySelector('#product_detail_main') ?? el.closest('.o_cart_product') ?? form),
             25,
             40,
         );
-    }
-
-    /**
-     * Enable/disable the "add to wishlist" button based on the selected variant.
-     *
-     * @param {Event} ev
-     */
-    onChangeVariant(ev) {
-        const input = ev.target;
-        const productId = input.value;
-        const button = input.closest('.js_product')?.querySelector('[data-action="o_wishlist"]');
-        if (button) {
-            const isDisabled = wishlistUtils.getWishlistProductIds().includes(parseInt(productId));
-            this._updateDisabled(button, isDisabled);
-            button.dataset.productProductId = productId;
-        }
-    }
-
-    _updateDisabled(el, isDisabled) {
-        el.disabled = isDisabled;
-        el.classList.toggle('disabled', isDisabled);
     }
 }
 

--- a/addons/website_sale_wishlist/static/src/interactions/product_detail.js
+++ b/addons/website_sale_wishlist/static/src/interactions/product_detail.js
@@ -1,0 +1,30 @@
+import { Interaction } from '@web/public/interaction';
+import { registry } from '@web/core/registry';
+import wishlistUtils from '@website_sale_wishlist/js/website_sale_wishlist_utils';
+
+export class ProductDetail extends Interaction {
+    static selector = '#product_detail';
+    dynamicContent = {
+        'input.product_id': { 't-on-change': this.onChangeVariant },
+    };
+
+    /**
+     * Enable/disable the "add to wishlist" button based on the selected variant.
+     *
+     * @param {Event} ev
+     */
+    onChangeVariant(ev) {
+        const input = ev.target;
+        const productId = input.value;
+        const button = input.closest('.js_product')?.querySelector('[data-action="o_wishlist"]');
+        if (button) {
+            const isDisabled = wishlistUtils.getWishlistProductIds().includes(parseInt(productId));
+            wishlistUtils.updateDisabled(button, isDisabled);
+            button.dataset.productProductId = productId;
+        }
+    }
+}
+
+registry
+    .category('public.interactions')
+    .add('website_sale_wishlist.product_detail', ProductDetail);

--- a/addons/website_sale_wishlist/static/src/interactions/wishlist_navbar.js
+++ b/addons/website_sale_wishlist/static/src/interactions/wishlist_navbar.js
@@ -1,0 +1,31 @@
+import { Interaction } from '@web/public/interaction';
+import { registry } from '@web/core/registry';
+import { rpc } from '@web/core/network/rpc';
+import wishlistUtils from '@website_sale_wishlist/js/website_sale_wishlist_utils';
+
+export class WishlistNavbar extends Interaction {
+    static selector = '.o_wsale_my_wish';
+
+    /**
+     * Refresh the products in the wishlist.
+     */
+    async willStart() {
+        const wishCount = parseInt(this.el.querySelector('.my_wish_quantity')?.textContent);
+        if (wishlistUtils.getWishlistProductIds().length !== wishCount) {
+            wishlistUtils.setWishlistProductIds(
+                await this.waitFor(rpc('/shop/wishlist/get_product_ids'))
+            );
+        }
+    }
+
+    /**
+     * Update the wishlist navbar.
+     */
+    start() {
+        wishlistUtils.updateWishlistNavBar();
+    }
+}
+
+registry
+    .category('public.interactions')
+    .add('website_sale_wishlist.wishlist_navbar', WishlistNavbar);

--- a/addons/website_sale_wishlist/static/src/js/website_sale_wishlist_utils.js
+++ b/addons/website_sale_wishlist/static/src/js/website_sale_wishlist_utils.js
@@ -56,10 +56,22 @@ function updateWishlistNavBar() {
     wishlistQuantity.classList.toggle('d-none', !wishlistProductIds.length);
 }
 
+/**
+ * Update the disabled/enabled state of an element.
+ *
+ * @param {Element} el The element to disable/enable.
+ * @param {boolean} isDisabled Whether the element should be disabled.
+ */
+function updateDisabled(el, isDisabled) {
+    el.disabled = isDisabled;
+    el.classList.toggle('disabled', isDisabled);
+}
+
 export default {
     getWishlistProductIds: getWishlistProductIds,
     setWishlistProductIds: setWishlistProductIds,
     addWishlistProduct: addWishlistProduct,
     removeWishlistProduct: removeWishlistProduct,
     updateWishlistNavBar: updateWishlistNavBar,
+    updateDisabled: updateDisabled,
 };


### PR DESCRIPTION
Whenever the cart changes, the cart lines are re-rendered. As a result, the
interaction handling the cart lines needs to be restarted at each re-render.
However, the "save for later" button is handled in a separate interaction,
which wasn't restarted at each re-render (because its selector was too broad).
Consequently, the "save for later" button only worked before the first
re-render.

This PR splits the interaction handling the "save for later" button to make sure
it's restarted whenever the cart lines are re-rendered. As an added benefit, the
scope of the new interactions is now more specific (which is a best practice).