### PR TITLE
[FIX] account: delay invoice email after payment creation

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -4626,7 +4626,7 @@ class AccountMove(models.Model):
             **kwargs,
         }
 
-    def _generate_pdf_and_send_invoice(self, template, force_synchronous=True, allow_fallback_pdf=True, bypass_download=False, **kwargs):
+    def _generate_pdf_and_send_invoice(self, template, force_synchronous=True, force_process_later=False, allow_fallback_pdf=True, bypass_download=False, **kwargs):
         """ Generate the pdf for the current invoices and send them by mail using the send & print wizard.
         :param force_synchronous:   Flag indicating if the method should be done synchronously.
         :param allow_fallback_pdf:  In case of error when generating the documents for invoices, generate a
@@ -4635,7 +4635,7 @@ class AccountMove(models.Model):
         """
         composer_vals = self._get_pdf_and_send_invoice_vals(template, **kwargs)
         composer = self.env['account.move.send'].create(composer_vals)
-        return composer.action_send_and_print(force_synchronous=force_synchronous, allow_fallback_pdf=allow_fallback_pdf, bypass_download=bypass_download)
+        return composer.action_send_and_print(force_synchronous=force_synchronous, force_process_later=force_process_later, allow_fallback_pdf=allow_fallback_pdf, bypass_download=bypass_download)
 
     def _get_invoice_legal_documents(self):
         """ Return existing attachments or a temporary Pro Forma pdf. """

--- a/addons/account/wizard/account_move_send.py
+++ b/addons/account/wizard/account_move_send.py
@@ -763,7 +763,7 @@ class AccountMoveSend(models.TransientModel):
 
         return {'type': 'ir.actions.act_window_close'}
 
-    def action_send_and_print(self, force_synchronous=False, allow_fallback_pdf=False, **kwargs):
+    def action_send_and_print(self, force_synchronous=False, force_process_later=False, allow_fallback_pdf=False, **kwargs):
         """ Create the documents and send them to the end customers.
         If we are sending multiple invoices and not downloading them we will process the moves asynchronously.
         :param force_synchronous:   Flag indicating if the method should be done synchronously.
@@ -776,7 +776,7 @@ class AccountMoveSend(models.TransientModel):
             raise UserError(_('Please select a mail template to send multiple invoices.'))
 
         force_synchronous = force_synchronous or self.checkbox_download
-        process_later = self.mode == 'invoice_multi' and not force_synchronous
+        process_later = force_process_later or (self.mode == 'invoice_multi' and not force_synchronous)
         if process_later:
             # Set sending information on moves
             for move in self.move_ids:

--- a/addons/sale/models/payment_transaction.py
+++ b/addons/sale/models/payment_transaction.py
@@ -132,9 +132,9 @@ class PaymentTransaction(models.Model):
                 send_invoice_cron._trigger()
             else:
                 # Must be called after the super() call to make sure the invoice are correctly posted.
-                self._send_invoice()
+                self._send_invoice(force_process_later=True)
 
-    def _send_invoice(self):
+    def _send_invoice(self, force_process_later=False):
         template_id = int(self.env['ir.config_parameter'].sudo().get_param(
             'sale.default_invoice_email_template',
             default=0
@@ -153,7 +153,7 @@ class PaymentTransaction(models.Model):
                 lambda i: not i.is_move_sent and i.state == 'posted' and i._is_ready_to_be_sent()
             )
             invoice_to_send.is_move_sent = True # Mark invoice as sent
-            invoice_to_send.with_user(SUPERUSER_ID)._generate_pdf_and_send_invoice(template)
+            invoice_to_send.with_user(SUPERUSER_ID)._generate_pdf_and_send_invoice(template, force_process_later=force_process_later)
 
     def _cron_send_invoice(self):
         """


### PR DESCRIPTION
**Before this commit:**
When creating an invoice payment with the "automatic invoice" option enabled in Sales settings and using a saved payment token, the email sent to the customer is triggered before the transaction is processed and before the invoice payment status is updated to "In Payment."
This results in the email incorrectly asking the customer to remit payment, even though the payment is already being processed.

**Steps to Reproduce:**
1. Enable "Automatic Invoicing" from Sales settings.
2. Enable and publish any payment provider (e.g., Demo) in test mode.
3. Create an invoice and generate a payment link.
   Open the link in a new incognito tab and pay using any dummy card number (ensure the "Save my payment details" checkbox is checked). This saves the payment token for the partner.
4. Create a new invoice with the same partner, then register payment.
   Select the payment method and the previously saved token, then confirm.
5. Observe that the payment status is "In Payment," but the email sent to the customer incorrectly asks them to remit payment.

**Fix:**
This change ensures that the email is delayed until the payment transaction is fully processed and the invoice payment status is updated.
This prevents sending incorrect payment reminders to customers during the payment process.

opw-4850293

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
