### PR TITLE
[FIX] base: res.country _name_search change capitalize to title

### DIFF
--- a/doc/cla/individual/217690thompson.md
+++ b/doc/cla/individual/217690thompson.md
@@ -1,0 +1,11 @@
+United States, 2025-07-14
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Christian Thompson cjtkeeper@gmail.com https://github.com/217690thompson

--- a/odoo/addons/base/models/res_country.py
+++ b/odoo/addons/base/models/res_country.py
@@ -91,9 +91,9 @@ class Country(models.Model):
             ids = list(self._search([('code', 'ilike', name)] + domain, limit=limit, order=order))
         elif operator in ('=', '!=', 'in', 'not in'):
             if isinstance(name, str):
-                name = name.capitalize()
+                name = name.title()
             else:  # iterable
-                name = [n.capitalize() if n else n for n in name]
+                name = [n.title() if n else n for n in name]
 
         search_domain = [('name', operator, name)]
         if ids:


### PR DESCRIPTION
**Current behavior:**
When performing a domain search on a field related to
`res.country` and searching for a country with more than one
word (e.g. United States), no `res.country` match is found.

**Expected behavior:**
Searching the name of a country on a `res.country` related field
should match the specified country, regardless of the number
of words in the country's name.

**Steps to reproduce:**
1. Open the Contacts kanban view (res.partner)

2. Add a custom filter with the domain:
`[("country_id", "in", ["United States"])]`

3. The search does not match contacts with "United States" set
as the country.

**Cause of the issue:**
The `_name_search` function in `res.country` uses `capitalize()` to
format the country name, which will only capitalize the first letter
of the first word, instead of the first letter of each word.

**Fix:**
Use `title()` on the input value when we do the search,
which will transform the string into the correct format.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
