### PR TITLE
[IMP] calendar,crm,fleet,hr,hr_attendance,hr_org_chart,*: remove href="#"

### DIFF
--- a/addons/calendar/static/src/views/attendee_calendar/common/attendee_calendar_common_popover.xml
+++ b/addons/calendar/static/src/views/attendee_calendar/common/attendee_calendar_common_popover.xml
@@ -9,18 +9,18 @@
         </xpath>
         <xpath expr="//div[hasclass('flex-grow-1')]" position="after">
             <t t-if="fieldInfo.options.shouldOpenRecord">
-                <a href="#" t-on-click="onClickOpenRecord">
+                <button class="btn btn-link p-0 fw-normal" t-on-click="onClickOpenRecord">
                     <t t-out="props.record.rawRecord.res_model_name"/>
-                </a>
+                </button>
         </t>
         </xpath>
     </t>
 
     <t t-name="calendar.AttendeeCalendarCommonPopover.footer" t-inherit="web.CalendarCommonPopover.footer" t-inherit-mode="primary">
         <xpath expr="//t[@t-if='isEventDeletable']" position="after">
-            <a t-if="isEventArchivable and isEventDetailsVisible" href="#" class="btn btn-secondary" t-on-click="onClickArchive">
+            <button t-if="isEventArchivable and isEventDetailsVisible" class="btn btn-secondary" t-on-click="onClickArchive">
                 <i class="fa fa-trash"/>
-            </a>
+            </button>
         </xpath>
         <xpath expr="//t[@t-if='isEventDeletable']" position="before">
             <t t-if="displayAttendeeAnswerChoice">

--- a/addons/calendar/static/tests/attendee_calendar_views.test.js
+++ b/addons/calendar/static/tests/attendee_calendar_views.test.js
@@ -122,7 +122,7 @@ test("Linked record rendering", async () => {
     await changeScale("week");
     await clickEvent(eventId);
     expect(".fa-link").toHaveCount(1, { message: "A link icon should be present" });
-    expect("li a[href='#']").toHaveText(display_name);
+    expect("li button").toHaveText(display_name);
 });
 
 test("Default duration rendering", async () => {

--- a/addons/crm/views/utm_campaign_views.xml
+++ b/addons/crm/views/utm_campaign_views.xml
@@ -15,14 +15,14 @@
                 <t t-else="">
                     <t t-set="crm_lead_count_label">Opportunities</t>
                 </t>
-                <a t-if="record.crm_lead_count" href="#" t-att-title="crm_lead_count_label" role="button"
+                <button t-if="record.crm_lead_count" t-att-title="crm_lead_count_label" role="button"
                     groups="sales_team.group_sale_salesman" type="object" name="action_redirect_to_leads_opportunities"
-                    class="btn-outline-primary rounded-pill me-1 order-3">
+                    class="rounded-pill me-1 order-3 p-0">
                     <span class="badge">
                         <i class="fa fa-fw fa-star" t-att-aria-label="crm_lead_count_label" role="img"/>
                         <field name="crm_lead_count"/>
                     </span>
-                </a>
+                </button>
             </xpath>
         </field>
     </record>

--- a/addons/fleet/views/fleet_vehicle_views.xml
+++ b/addons/fleet/views/fleet_vehicle_views.xml
@@ -312,8 +312,8 @@
                             <field name="vehicle_properties" widget="properties"/>
                             <footer class="pt-0 mt-0" t-if="!selection_mode">
                                 <div class="d-flex fs-6">
-                                    <a t-if="record.contract_count.raw_value>0" type="object"
-                                        name="return_action_to_open" href="#" context='{"xml_id":"fleet_vehicle_log_contract_action"}'>
+                                    <button t-if="record.contract_count.raw_value>0" type="object"
+                                        name="return_action_to_open" context='{"xml_id":"fleet_vehicle_log_contract_action"}' class="btn btn-link fw-normal p-0">
                                         <field name="contract_count"/>
                                         Contract(s)
                                         <span t-if="record.contract_renewal_due_soon.raw_value and !record.contract_renewal_overdue.raw_value"
@@ -322,7 +322,7 @@
                                         <span t-if="record.contract_renewal_overdue.raw_value"
                                             class="fa fa-exclamation-triangle text-danger" role="img" aria-label="Attention: renewal overdue" title="Attention: renewal overdue">
                                         </span>
-                                    </a>
+                                    </button>
                                     <field name="activity_ids" widget="kanban_activity" class="ms-2"/>
                                 </div>
                             </footer>

--- a/addons/hr/static/src/components/employee_chat/employee_chat.xml
+++ b/addons/hr/static/src/components/employee_chat/employee_chat.xml
@@ -1,14 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
     <t t-name="hr.OpenChat">
-        <a t-if="props.record.data.user_id and props.record.resId"
+        <button t-if="props.record.data.user_id and props.record.resId"
             title="Chat"
             icon="fa-comments"
             t-on-click.prevent="() => openChat(props.record.resId)"
-            href="#"
-            class="ml8 o_employee_chat_btn"
-            role="button">
+            class="ml8 o_employee_chat_btn btn btn-link p-0">
             <i class="fa fa-comments align-middle fs-6"/>
-        </a>
+        </button>
     </t>
 </templates>

--- a/addons/hr/static/src/fields/hr_org_chart.xml
+++ b/addons/hr/static/src/fields/hr_org_chart.xml
@@ -72,9 +72,9 @@
     <t t-set="emp_count" t-value="0"/>
     <div t-if='managers.length &gt; 0' class="o_org_chart_group_up position-relative">
         <div t-if='managers_more' class="o_org_chart_more pe-3" t-attf-class="{{max_level !== null ? 'invisible' : ''}}">
-            <a href="#" t-att-data-employee-id="managers[0].id" class="o_employee_more_managers d-block bg-100 px-2" t-on-click.prevent="() => this._onEmployeeMoreManager(managers[0].id)">
+            <button t-att-data-employee-id="managers[0].id" class="o_employee_more_managers d-block bg-100 px-2 btn btn-link text-start w-100" t-on-click.prevent="() => this._onEmployeeMoreManager(managers[0].id)">
                 <i class="fa fa-angle-double-up" role="img" aria-label="More managers" title="More managers"/>
-            </a>
+            </button>
         </div>
 
         <t t-foreach="managers" t-as="employee" t-key="employee_index">
@@ -144,11 +144,11 @@
         <t t-if="(children.length + managers.length) &gt; 19">
             <div class="o_org_chart_entry o_org_chart_more d-flex overflow-visible">
                 <div class="o_media_left position-relative">
-                    <a href="#"
+                    <button
                         t-att-data-employee-id="self.id"
                         t-att-data-employee-name="self.name"
                         class="o_org_chart_show_more o_employee_sub_redirect btn btn-link ps-2"
-                        t-on-click.prevent="_onEmployeeSubRedirect">See All</a>
+                        t-on-click.prevent="_onEmployeeSubRedirect">See All</button>
                 </div>
             </div>
         </t>
@@ -162,7 +162,7 @@
             <div class="d-flex align-items-center">
                 <span class="o_media_object flex-shrink-0 rounded me-1" t-att-style='"background-image:url(\"/web/image/hr.employee.public/" + props.employee.id + "/avatar_1024/\")"'/>
                 <b class="flex-grow-1 fw-medium"><t t-esc="props.employee.name"/></b>
-                <a href="#" class="o_employee_redirect btn btn-link" t-att-data-employee-id="props.employee.id" t-on-click.prevent="() => this._onEmployeeRedirect(props.employee.id)"><i class="fa fa-user" role="img" aria-label='View employee' title="View employee"/></a>
+                <button class="o_employee_redirect btn btn-link" t-att-data-employee-id="props.employee.id" t-on-click.prevent="() => this._onEmployeeRedirect(props.employee.id)"><i class="fa fa-user" role="img" aria-label='View employee' title="View employee"/></button>
             </div>
         </h3>
         <div class="popover-body">
@@ -171,10 +171,10 @@
                     <tr>
                         <td class="text-end"><b t-esc="props.employee.direct_sub_count"/></td>
                         <td>
-                            <a href="#" class="o_employee_sub_redirect" data-type='direct'
+                            <button class="o_employee_sub_redirect btn btn-link p-0" data-type='direct'
                                     t-att-data-employee-name="props.employee.name" t-att-data-employee-id="props.employee.id"
                                     t-on-click.prevent="_onEmployeeSubRedirect">
-                                <b>Direct subordinates</b></a>
+                                <b>Direct subordinates</b></button>
                         </td>
                     </tr>
                     <tr>
@@ -182,19 +182,19 @@
                             <b t-esc="props.employee.indirect_sub_count - props.employee.direct_sub_count"/>
                         </td>
                         <td>
-                            <a href="#" class="o_employee_sub_redirect" data-type='indirect'
+                            <button class="o_employee_sub_redirect btn btn-link fw-normal p-0" data-type='indirect'
                                     t-att-data-employee-name="props.employee.name" t-att-data-employee-id="props.employee.id"
                                     t-on-click.prevent="_onEmployeeSubRedirect">
-                                Indirect subordinates</a>
+                                Indirect subordinates</button>
                         </td>
                     </tr>
                     <tr>
                         <td class="text-end"><b t-esc="props.employee.indirect_sub_count"/></td>
                         <td>
-                            <a href="#" class="o_employee_sub_redirect" data-type='total'
+                            <button class="o_employee_sub_redirect btn btn-link fw-normal p-0" data-type='total'
                                     t-att-data-employee-name="props.employee.name" t-att-data-employee-id="props.employee.id"
                                     t-on-click.prevent="_onEmployeeSubRedirect">
-                                Total</a>
+                                Total</button>
                         </td>
                     </tr>
                 </tbody>

--- a/addons/hr/static/tests/tours/hr_employee_subordinates.js
+++ b/addons/hr/static/tests/tours/hr_employee_subordinates.js
@@ -9,7 +9,7 @@ registry.category("web_tour.tours").add("indirect_subordinates_tour", {
         },
         {
             content: "Click Indirect Subordinates",
-            trigger: ".o_org_chart_popup a.o_employee_sub_redirect[data-type='indirect']",
+            trigger: ".o_org_chart_popup button.o_employee_sub_redirect[data-type='indirect']",
             run: "click",
         },
     ],

--- a/addons/hr_attendance/static/src/components/pin_code/pin_code.xml
+++ b/addons/hr_attendance/static/src/components/pin_code/pin_code.xml
@@ -24,9 +24,9 @@
                                 </div>
                                 <div class="row g-2">
                                     <div class="col-4" t-foreach="padButtons" t-as="btn" t-key="btn[0]">
-                                        <a href="#" t-on-click="() => this.onClickPadButton(btn[0])" t-attf-class="o_hr_attendance_PINbox_button btn {{btn[1]? btn[1] : 'btn-secondary'}} d-flex align-items-center justify-content-center py-2 py-xl-3 rounded-1">
+                                        <button t-on-click="() => this.onClickPadButton(btn[0])" t-attf-class="o_hr_attendance_PINbox_button btn {{btn[1]? btn[1] : 'btn-secondary'}} d-flex align-items-center justify-content-center py-2 py-xl-3 rounded-1 w-100">
                                             <t t-esc="btn[0]"/>
-                                        </a>
+                                        </button>
                                     </div>
                                 </div>
                             </div>

--- a/addons/hr_attendance/static/src/views/badge_scanner/badge_scanner.xml
+++ b/addons/hr_attendance/static/src/views/badge_scanner/badge_scanner.xml
@@ -4,9 +4,9 @@
         <div class="o_hr_barcode_bg o_home_menu_background">
             <div class="o_hr_barcode_main container d-flex flex-column h-100 h-sm-auto bg-view shadow">
                 <div class="d-flex align-items-center justify-content-between my-3">
-                    <a href="#" class="btn btn-light" t-on-click.prevent="() => this.onClickBack()">
+                    <button class="btn btn-light" t-on-click.prevent="() => this.onClickBack()">
                         <i class="oi oi-chevron-left fa-lg"></i>
-                    </a>
+                    </button>
                     <span class="fs-2 me-auto ms-2">Scan Badge</span>
                 </div>
                 <div class="flex-grow-1 d-flex flex-column justify-content-center align-items-center">

--- a/addons/hr_timesheet/views/project_task_portal_templates.xml
+++ b/addons/hr_timesheet/views/project_task_portal_templates.xml
@@ -7,7 +7,7 @@
         </xpath>
         <xpath expr="//div[@id='task-nav']" position="before">
             <div t-if="timesheets and allow_timesheets and show_portal_timesheets" class="d-grid flex-grow-1" id='nav-report'>
-                <a class="btn btn-light o_print_btn o_project_timesheet_print d-block" t-att-href="task.get_portal_url(report_type='pdf')" href="#" title="View Details" role="button" target="_blank"><i class="fa fa-print"/> View Details</a>
+                <a class="btn btn-light o_print_btn o_project_timesheet_print d-block" t-att-href="task.get_portal_url(report_type='pdf')" title="View Details" role="button" target="_blank"><i class="fa fa-print"/> View Details</a>
             </div>
         </xpath>
         <xpath expr="//li[@id='nav-header']" position="after">

--- a/addons/link_tracker/views/utm_campaign_views.xml
+++ b/addons/link_tracker/views/utm_campaign_views.xml
@@ -20,14 +20,14 @@
         <field name="inherit_id" ref="utm.utm_campaign_view_kanban"/>
         <field name="arch" type="xml">
             <xpath expr="//footer/div" position="inside">
-                <a t-if="record.click_count" href="#" title="Clicks" role="button"
+                <button t-if="record.click_count" title="Clicks" role="button"
                     type="action" name="%(link_tracker_action_campaign)d"
-                    class="btn-outline-primary rounded-pill me-1 order-4">
+                    class="rounded-pill me-1 order-4 p-0">
                     <span class="badge">
                         <i class="fa fa-fw fa-mouse-pointer" aria-label="Clicks" role="img"/>
                         <field name="click_count"/>
                     </span>
-                </a>
+                </button>
             </xpath>
         </field>
     </record>

--- a/addons/mail_group/views/portal_templates.xml
+++ b/addons/mail_group/views/portal_templates.xml
@@ -176,12 +176,12 @@
                         <t t-set="group_message_child_ids" t-value="message.group_message_child_ids.filtered(lambda m: m.moderation_status == 'accepted')"/>
                         <div class="o_mg_link_parent" t-if="group_message_child_ids and (not mode or mode == 'thread')">
                             <p class="mt8">
-                                <a href="#" class="o_mg_link_hide">
+                                <button class="o_mg_link_hide btn btn-link p-0">
                                     <i class="oi oi-chevron-right" role="img" aria-label="Hide replies" title="Hide replies"/> <t t-out="len(group_message_child_ids)"/> replies
-                                </a>
-                                <a href="#" class="o_mg_link_show d-none">
+                                </button>
+                                <button class="o_mg_link_show d-none btn btn-link p-0">
                                     <i class="oi oi-chevron-down" role="img" aria-label="Show replies" title="Show replies"/> <t t-out="len(group_message_child_ids)"/> replies
-                                </a>
+                                </button>
                             </p>
                             <div class="o_mg_link_content o_mg_replies ms-5 d-none">
                                 <t t-call="mail_group.messages_short"
@@ -214,12 +214,12 @@
         <div class="o_mg_link_parent">
             <t t-set="attachments" t-value="message.attachment_ids"/>
             <p t-if="attachments" class="mt8">
-                <a href="#" class="o_mg_link_hide">
+                <button class="o_mg_link_hide btn btn-link p-0">
                     <i class="oi oi-chevron-right" role="img" aria-label="Hide attachments" title="Hide attachments"/> <t t-out="len(attachments)"/> attachments
-                </a>
-                <a href="#" class="o_mg_link_show d-none">
+                </button>
+                <button class="o_mg_link_show d-none btn btn-link p-0">
                     <i class="oi oi-chevron-down" role="img" aria-label="Show attachments" title="Show attachments"/> <t t-out="len(attachments)"/> attachments
-                </a>
+                </button>
             </p>
             <div class="o_mg_link_content d-none row justify-content-center">
                 <div class="mx-4 my-3 text-center o_mg_attachment" t-foreach="attachments" t-as="attachment">


### PR DESCRIPTION
*hr_timesheet,link_tracker,mail_group

We use `href="#"` to activate <a> elements, but the default behavior of clicking this link is prevented. However, this creates an inconsistency for middle-click and Ctrl+Click, as these events are not prevented by default.

This commit removes `href="#"` and replaces it with the appropriate element or class to activate the <a> elements correctly.

Task-4380519

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
