### PR TITLE
[FIX] account_qr_code_emv: Restore EMV QR configuration fields placement

### DIFF
--- a/addons/account_qr_code_emv/views/res_bank_views.xml
+++ b/addons/account_qr_code_emv/views/res_bank_views.xml
@@ -6,14 +6,14 @@
         <field name="model">res.partner.bank</field>
         <field name="inherit_id" ref="base.view_partner_bank_form"/>
         <field name="arch" type="xml">
-            <sheet position="inside">
+            <xpath expr="//sheet/group[@name='note']" position="before">
                 <field name="display_qr_setting" invisible="1" />
                 <group string="EMV QR Configuration" invisible="not display_qr_setting">
                     <field name="proxy_type"/>
                     <field name="proxy_value"/>
                     <field name="include_reference"/>
                 </group>
-            </sheet>
+            </xpath>
         </field>
     </record>
 


### PR DESCRIPTION
Before this PR:
- The `EMV QR Configuration fields` were positioned below the `Notes` section (The `Notes` section was introduced in saas-18.2). In saas-18.1 `EMV QR Configuration fields` were directly below the `Account information` section.

After this PR:
- `EMV QR Configuration fields` are positioned below the `Account information` section and above the `Notes` section, restoring the layout from saas-18.1.

Task: 4936165


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
