### PR TITLE
[IMP] mrp: bom/mo overview ux improvements

### DIFF
--- a/addons/mrp/__manifest__.py
+++ b/addons/mrp/__manifest__.py
@@ -66,6 +66,9 @@
         'web.assets_unit_tests': [
             'mrp/static/tests/**/*',
         ],
+        'web.report_assets_common': [
+            'mrp/static/src/scss/**/*',
+        ],
     },
     'author': 'Odoo S.A.',
     'license': 'LGPL-3',

--- a/addons/mrp/report/mrp_report_bom_structure.xml
+++ b/addons/mrp/report/mrp_report_bom_structure.xml
@@ -1,14 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <odoo>
     <template id="report_mrp_bom">
-        <div class="o_mrp_bom_report_page px-0 overflow-auto bg-view">
+        <div class="o_mrp_bom_report px-0 overflow-auto bg-view">
             <div t-if="data.get('lines')">
-                <div>
-                    <h1>BoM Overview</h1>
-                    <h3 t-out="data['name']"/>
-                    <hr t-if="data['bom_code']"/>
-                    <h6 t-if="data['bom_code']">Reference: <t t-out="data['bom_code']"/></h6>
-                </div>
                 <t t-set="currency" t-value="data['currency']"/>
                 <table class="o_mrp_bom_expandable table table-borderless">
                     <thead>
@@ -25,7 +19,11 @@
                     </thead>
                     <tbody>
                         <tr>
-                            <td name="td_mrp_bom" t-out="data['name']"/>
+                            <td name="td_mrp_bom">
+                                <div class="o_mrp_bom_report_name_cell">
+                                    <span t-out="data['name']"/>
+                                </div>
+                            </td>
                             <td class="text-end" t-out="data['quantity']" t-options='{"widget": "float", "decimal_precision": "Product Unit"}'/>
                             <td class="text-start" groups="uom.group_uom" t-out="data['uom_name']"/>
                             <td t-if="data['forecast_mode']" class="text-center">
@@ -47,9 +45,9 @@
                                 </span>
                             </td>
                             <td t-if="data['forecast_mode']">
-                                <span t-if="data['route_name'] and data['route_detail']" t-attf-class="{{'text-danger' if data.get('route_alert') else ''}}">
-                                    <t t-out="data['route_name']"/>:</span>
-                                <span t-out="data['route_detail']"/>
+                                <div t-if="data['route_name'] and data['route_detail']" t-attf-class="{{'text-danger' if data.get('route_alert') else ''}} o_mrp_bom_report_name_cell">
+                                    <t t-out="data['route_name']"/>: <t t-out="data['route_detail']"/>
+                                </div>
                             </td>
                             <td class="text-end"
                                 t-out="data['bom_cost']"
@@ -60,7 +58,9 @@
                     <tfoot t-if="data['quantity'] &gt; 0">
                         <tr>
                             <td name="td_mrp_bom_f" class="text-end" t-attf-colspan="2">
-                                <t t-if="data['byproducts']" t-out="data['name']"/>
+                                <div t-if="data['byproducts']" class="o_mrp_bom_report_byproduct_cell">
+                                    <span t-out="data['name']"/>
+                                </div>
                             </td>
                             <td t-if="(data['byproducts'] or data['product_uom_name'] != data['uom_name'])" groups="uom.group_uom" t-out="data['product_uom_name']"/>
                             <td name="free_to_use" t-if="data['forecast_mode']"/>
@@ -75,7 +75,11 @@
                         </tr>
                         <t t-if="data['byproducts']" t-foreach="data['byproducts']" t-as="byproduct">
                             <tr t-if="byproduct['quantity'] &gt; 0">
-                                <td name="td_mrp_bom_byproducts_f" class="text-end" colspan="2" t-out="byproduct['name']"/>
+                                <td name="td_mrp_bom_byproducts_f" class="text-end" colspan="2">
+                                    <div class="o_mrp_bom_report_byproduct_cell">
+                                        <span t-out="byproduct['name']"/>
+                                    </div>
+                                </td>
                                 <td class="text-start" groups="uom.group_uom" t-out="byproduct['product_uom_name']"/>
                                 <td name="free_to_use" t-if="data['forecast_mode']"/>
                                 <td name="status" t-if="data['forecast_mode']"/>
@@ -100,8 +104,9 @@
         <t t-foreach="data['lines']" t-as="l">
             <tr t-if="l['visible']">
                 <td name="td_mrp_code">
-                    <span t-attf-style="margin-left: {{ str(l['level'] * 20) }}px"/>
-                    <span t-out="l['name']"/>
+                    <div t-attf-style="margin-left: {{ l['level'] * 20 }}px;" class="o_mrp_bom_report_name_cell">
+                        <span t-out="l['name']"/>
+                    </div>
                 </td>
                 <td class="text-end">
                     <t t-if="l['type'] == 'operation'" t-out="l['quantity']" t-options="{'widget': 'float_time', 'unit': 'minutes', 'show_seconds': True}"/>
@@ -128,9 +133,9 @@
                     </span>
                 </td>
                 <td t-if="data['forecast_mode']">
-                    <span t-if="l.get('route_name') and l.get('route_detail')" t-attf-class="{{'text-danger' if l.get('route_alert') else ''}}">
+                    <div t-if="l.get('route_name') and l.get('route_detail')" t-attf-class="{{'text-danger' if l.get('route_alert') else ''}} o_mrp_bom_report_name_cell">
                         <t t-out="l['route_name']"/>: <t t-out="l['route_detail']"/>
-                    </span>
+                    </div>
                 </td>
                 <td t-if="not l['uom'] and (l['type'] == 'byproduct' or l['type'] == 'subcontract')" groups="uom.group_uom"/>
                 <td t-attf-class="text-end {{ 'text-muted' if l['type'] == 'component' else '' }}" t-attf-colspan="{{ 1 if data['forecast_mode'] else 2 }}" t-out="l['bom_cost']" t-options='{"widget": "monetary", "display_currency": currency}'/>

--- a/addons/mrp/report/mrp_report_views_main.xml
+++ b/addons/mrp/report/mrp_report_views_main.xml
@@ -1,6 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <data>
+        <record id="paperformat_report_bom_overview" model="report.paperformat">
+            <field name="name">BOM Overview</field>
+            <field name="margin_top">12</field>
+            <field name="margin_bottom">12</field>
+            <field name="margin_left">10</field>
+            <field name="margin_right">10</field>
+        </record>
         <record id="action_report_production_order" model="ir.actions.report">
             <field name="name">Production Order</field>
             <field name="model">mrp.production</field>
@@ -17,6 +24,7 @@
             <field name="report_type">qweb-pdf</field>
             <field name="report_name">mrp.report_bom_structure</field>
             <field name="report_file">mrp.report_bom_structure</field>
+            <field name="paperformat_id" ref="mrp.paperformat_report_bom_overview"/>
             <field name="print_report_name">'Bom Overview - %s' % object.display_name</field>
             <field name="binding_model_id" ref="model_mrp_bom"/>
             <field name="binding_type">report</field>

--- a/addons/mrp/static/src/components/bom_overview/mrp_bom_overview.js
+++ b/addons/mrp/static/src/components/bom_overview/mrp_bom_overview.js
@@ -22,6 +22,7 @@ export class BomOverviewComponent extends Component {
         this.warehouses = [];
         this.showVariants = false;
         this.uomName = "";
+        this.foldableIds = new Set();
         this.unfoldedIds = new Set();
 
         this.state = useState({
@@ -45,8 +46,8 @@ export class BomOverviewComponent extends Component {
 
         useBus(
             this.env.overviewBus,
-            "toggle-fold-all",
-            () => (this.state.allFolded = !this.state.allFolded)
+            "toggle-fold-all-bom",
+            (ev) => this.state.allFolded = ev.detail.foldAll
         );
 
         onWillStart(async () => {
@@ -76,6 +77,13 @@ export class BomOverviewComponent extends Component {
         }
         this.state.precision = bomData["precision"];
         this.state.foldable = bomData["lines"]["foldable"];
+        this._collectFoldableIds(this.state.bomData);
+        if (this.state.bomData.byproducts?.length) {
+            this.foldableIds.add(`byproducts_${this.state.bomData.index}`);
+        }
+        if (this.state.bomData.components?.length) {
+            this.foldableIds.delete(`${this.state.bomData.type}_${this.state.bomData.index}`);
+        }
     }
 
     async getBomData() {
@@ -113,7 +121,16 @@ export class BomOverviewComponent extends Component {
     onChangeFolded(foldInfo) {
         const { ids, isFolded } = foldInfo;
         const operation = isFolded ? "delete" : "add";
-        ids.forEach(id => this.unfoldedIds[operation](id));
+        ids.forEach((id) => {
+            if (this.foldableIds.has(id)) {
+                this.unfoldedIds[operation](id);
+            }
+        });
+        if (this.unfoldedIds.size === 0) {
+            this.state.allFolded = true;
+        } else if (this.unfoldedIds.size === this.foldableIds.size) {
+            this.state.allFolded = false;
+        }
     }
 
     onChangeMode(mode) {
@@ -172,6 +189,16 @@ export class BomOverviewComponent extends Component {
             reportName += "&variant=" + this.state.currentVariantId;
         }
         return reportName;
+    }
+
+    _collectFoldableIds(data) {
+        if (data.components?.length) {
+            this.foldableIds.add(`${data.type}_${data.index}`);
+            data.components.forEach((component) => this._collectFoldableIds(component));
+        }
+        if (data.operations?.length) {
+            this.foldableIds.add(`operations_${data.index}`);
+        }
     }
 }
 

--- a/addons/mrp/static/src/components/bom_overview_components_block/mrp_bom_overview_components_block.js
+++ b/addons/mrp/static/src/components/bom_overview_components_block/mrp_bom_overview_components_block.js
@@ -34,7 +34,7 @@ export class BomOverviewComponentsBlock extends Component {
         }
 
         if (this.hasComponents) {
-            useBus(this.env.overviewBus, "toggle-fold-all", () => this._toggleFoldAll());
+            useBus(this.env.overviewBus, "toggle-fold-all-bom", (ev) => this._onFoldAll(ev.detail.foldAll));
         }
 
         onWillUpdateProps(newProps => {
@@ -61,12 +61,11 @@ export class BomOverviewComponentsBlock extends Component {
         this.props.changeFolded({ ids: [foldId], isFolded: newState });
     }
 
-    _toggleFoldAll() {
+    _onFoldAll(foldAll) {
         const allChildIds = this.childIds;
-
-        this.state.unfoldAll = !this.state.unfoldAll;
-        allChildIds.forEach(id => this.state[id] = !this.state.unfoldAll);
-        this.props.changeFolded({ ids: allChildIds, isFolded: !this.state.unfoldAll });
+        this.state.unfoldAll = !foldAll;
+        allChildIds.forEach(id => this.state[id] = foldAll);
+        this.props.changeFolded({ ids: allChildIds, isFolded: foldAll });
     }
 
     //---- Getters ----

--- a/addons/mrp/static/src/components/bom_overview_control_panel/mrp_bom_overview_control_panel.js
+++ b/addons/mrp/static/src/components/bom_overview_control_panel/mrp_bom_overview_control_panel.js
@@ -66,7 +66,8 @@ export class BomOverviewControlPanel extends Component {
     }
 
     clickTogglefold() {
-        this.env.overviewBus.trigger("toggle-fold-all");
+        this.props.allFolded = !this.props.allFolded;
+        this.env.overviewBus.trigger("toggle-fold-all-bom", { foldAll: this.props.allFolded });
     }
 
     getDomain() {

--- a/addons/mrp/static/src/components/bom_overview_extra_block/mrp_bom_overview_extra_block.js
+++ b/addons/mrp/static/src/components/bom_overview_extra_block/mrp_bom_overview_extra_block.js
@@ -30,7 +30,7 @@ export class BomOverviewExtraBlock extends Component {
             this.props.changeFolded({ ids: [this.identifier], isFolded: false });
         }
 
-        useBus(this.env.overviewBus, "toggle-fold-all", () => this._toggleFoldAll());
+        useBus(this.env.overviewBus, "toggle-fold-all-bom", (ev) => this._onFoldAll(ev.detail.foldAll));
 
         onWillUpdateProps(newProps => {
             if (this.props.data.product_id != newProps.data.product_id) {
@@ -52,9 +52,9 @@ export class BomOverviewExtraBlock extends Component {
         this.props.changeFolded({ ids: [this.identifier], isFolded: newState });
     }
 
-    _toggleFoldAll() {
-        this.state.isFolded = !this.state.isFolded;
-        this.props.changeFolded({ ids: [this.identifier], isFolded: this.state.isFolded });
+    _onFoldAll(foldAll) {
+        this.state.isFolded = foldAll;
+        this.props.changeFolded({ ids: [this.identifier], isFolded: foldAll });
     }
 
     //---- Getters ----

--- a/addons/mrp/static/src/components/mo_overview/mrp_mo_overview.js
+++ b/addons/mrp/static/src/components/mo_overview/mrp_mo_overview.js
@@ -1,3 +1,4 @@
+import { _t } from "@web/core/l10n/translation";
 import { useState, useSubEnv } from "@web/owl2/utils";
 import { Component, EventBus, onWillStart } from "@odoo/owl";
 import { registry } from "@web/core/registry";
@@ -23,12 +24,14 @@ export class MoOverview extends Component {
     setup() {
         this.actionService = useService("action");
         this.ormService = useService("orm");
+        this.foldableIds = new Set();
         this.unfoldedIds = new Set();
         this.context = {};
 
         this.state = useState({
             data: {},
             showOptions: this.getDefaultConfig(),
+            allFolded: true,
         });
 
         useSubEnv({ overviewBus: new EventBus() });
@@ -63,11 +66,18 @@ export class MoOverview extends Component {
         this.state.showOptions.uom = reportValues.context.show_uom;
         this.context = reportValues.context;
         // Main MO's operations & byproducts are always unfolded by default.
-        if (reportValues.data?.operations?.summary?.index) {
+        if (reportValues.data?.operations?.details?.length && reportValues.data.operations.summary?.index) {
             this.unfoldedIds.add(reportValues.data.operations.summary.index);
+            this.foldableIds.add(reportValues.data.operations.summary.index);
         }
-        if (reportValues.data?.byproducts?.summary?.index) {
+        if (reportValues.data?.byproducts?.details?.length && reportValues.data.byproducts.summary?.index) {
             this.unfoldedIds.add(reportValues.data.byproducts.summary.index);
+            this.foldableIds.add(reportValues.data.byproducts.summary.index);
+        }
+        for (const component of reportValues.data?.components) {
+            if (component.replenishments?.length && component.summary?.index) {
+                this.foldableIds.add(component.summary.index);
+            }
         }
     }
 
@@ -80,7 +90,16 @@ export class MoOverview extends Component {
     onChangeFolded(foldInfo) {
         const { indexes, isFolded } = foldInfo;
         const operation = isFolded ? "delete" : "add";
-        indexes.forEach(index => this.unfoldedIds[operation](index));
+        indexes.forEach((index) => {
+            if (this.foldableIds.has(index)) {
+                this.unfoldedIds[operation](index);
+            }
+        });
+        if (this.unfoldedIds.size === 0) {
+            this.state.allFolded = true;
+        } else if (this.unfoldedIds.size === this.foldableIds.size) {
+            this.state.allFolded = false;
+        }
     }
 
     async onPrint() {
@@ -92,8 +111,9 @@ export class MoOverview extends Component {
         });
     }
 
-    onUnfold() {
-        this.env.overviewBus.trigger("unfold-all")
+    clickTogglefold() {
+        this.state.allFolded = !this.state.allFolded;
+        this.env.overviewBus.trigger("toggle-fold-all-mo", { foldAll: this.state.allFolded });
     }
 
     //---- Helpers ----
@@ -171,6 +191,10 @@ export class MoOverview extends Component {
 
     get isProductionDone() {
         return this.state.data?.summary?.state === "done";
+    }
+
+    get foldButtonText() {
+        return this.state.allFolded ? _t("Unfold") : _t("Fold");
     }
 
     get hasOperations() {

--- a/addons/mrp/static/src/components/mo_overview/mrp_mo_overview.xml
+++ b/addons/mrp/static/src/components/mo_overview/mrp_mo_overview.xml
@@ -9,7 +9,7 @@
 
             <t t-set-slot="control-panel-buttons">
                 <button class="btn btn-primary" t-on-click="this.onPrint">Print</button>
-                <button class="btn btn-primary" t-on-click="this.onUnfold">Unfold</button>
+                <button class="btn btn-primary" t-on-click="this.clickTogglefold" t-out="foldButtonText"/>
             </t>
 
             <div class="overflow-auto border-bottom bg-view container-fluid">

--- a/addons/mrp/static/src/components/mo_overview_components_block/mrp_mo_overview_components_block.js
+++ b/addons/mrp/static/src/components/mo_overview_components_block/mrp_mo_overview_components_block.js
@@ -50,7 +50,7 @@ export class MoOverviewComponentsBlock extends Component {
             this.env.overviewBus.trigger("update-folded", { indexes: Object.keys(this.state.fold), isFolded: false });
         }
 
-        useBus(this.env.overviewBus, "unfold-all", () => this.unfoldAll());
+        useBus(this.env.overviewBus, "toggle-fold-all-mo", (ev) => this._onFoldAll(ev.detail.foldAll));
 
         onWillUpdateProps(newProps => {
             // Update the fold indexes so it matches the newly added lines.
@@ -73,11 +73,11 @@ export class MoOverviewComponentsBlock extends Component {
         this.env.overviewBus.trigger("update-folded", { indexes: [foldIndex], isFolded: newState });
     }
 
-    unfoldAll() {
-        this.state.unfoldAll = true;
+    _onFoldAll(foldAll) {
+        this.state.unfoldAll = !foldAll;
         const foldIndexes = Object.keys(this.state.fold);
-        foldIndexes.forEach(index => this.state.fold[index] = false);
-        this.env.overviewBus.trigger("update-folded", { indexes: foldIndexes, isFolded: false });
+        foldIndexes.forEach(index => this.state.fold[index] = foldAll);
+        this.env.overviewBus.trigger("update-folded", { indexes: foldIndexes, isFolded: foldAll });
     }
 
     //---- Helpers ----

--- a/addons/mrp/static/src/components/mo_overview_operations_block/mrp_mo_overview_operations_block.js
+++ b/addons/mrp/static/src/components/mo_overview_operations_block/mrp_mo_overview_operations_block.js
@@ -46,7 +46,7 @@ export class MoOverviewOperationsBlock extends Component {
             this.env.overviewBus.trigger("update-folded", { indexes: [this.index], isFolded: false });
         }
 
-        useBus(this.env.overviewBus, "unfold-all", () => this.unfold());
+        useBus(this.env.overviewBus, "toggle-fold-all-mo", (ev) => this._onFoldAll(ev.detail.foldAll));
     }
 
     //---- Handlers ----
@@ -56,9 +56,9 @@ export class MoOverviewOperationsBlock extends Component {
         this.env.overviewBus.trigger("update-folded", { indexes: [this.index], isFolded: this.state.isFolded });
     }
 
-    unfold() {
-        this.state.isFolded = false;
-        this.env.overviewBus.trigger("update-folded", { indexes: [this.index], isFolded: false });
+    _onFoldAll(foldAll) {
+        this.state.isFolded = foldAll;
+        this.env.overviewBus.trigger("update-folded", { indexes: [this.index], isFolded: foldAll });
     }
 
     //---- Helpers ----

--- a/addons/mrp/static/src/scss/mrp_report_bom_structure.scss
+++ b/addons/mrp/static/src/scss/mrp_report_bom_structure.scss
@@ -1,0 +1,16 @@
+.o_mrp_bom_report {
+    td {
+        font-size: 16px;
+    }
+    th {
+        font-size: 18px;
+    }
+
+    .o_mrp_bom_report_name_cell {
+        max-width: 280px;
+    }
+
+    .o_mrp_bom_report_byproduct_cell {
+        max-width: 450px;
+    }
+}


### PR DESCRIPTION
### improve layout of bom overview print
- Improved the structure of the `BOM Overview` print report by correcting
  the indentation of finish-product/by-product and route column,
  ensuring a cleaner and more consistent hierarchy display.
- `Removed unnecessary top white space` from `BoM Overview`, which results
  in a more compact and space-efficient printout.

### correct fold/unfold behavior in bom overview
- When click on `Unfold` button, the previously `unfolded Operations` get
  `folded`, and the `folded Products` get `unfolded` instead of unfolding all.
  Because In the `_toggleFoldAll` method, the `isFolded` state is toggled
  without checking `fold/unfold` action.
- This PR ensures consistent behavior by passing an explicit `isFolded`
  value in `_onToggleFoldAll` to ensure consistent fold/unfold behavior
  across all `BOM Overview` sections.

### add fold functionality in mo overview
- Currently, In the `MO Overview`, only the `unfold functionality` is
  available, and once a section was expanded, there was no option to
  fold it back. This limited the usability, especially when users wanted
  to reduce visual clutter or print a cleaner report with folded sections.
- This improvement introduces a fold functionality, similar to the `BoM Overview`,
  allowing users to collapse previously expanded sections in the `MO Overview`.
  These changes improve readability, enhance usability, and provide better
  control over the `MO Overview` layout, particularly for review and printing
  purposes.

These changes enhance readability and make the printed report more user-friendly.

Task ID: [4394139](https://www.odoo.com/odoo/project/966/tasks/4394139)
