### PR TITLE
[IMP] mail: open avatar card on participant name click in sidebar call view

### DIFF
--- a/addons/mail/static/src/discuss/call/web/discuss_sidebar_call_participants_patch.js
+++ b/addons/mail/static/src/discuss/call/web/discuss_sidebar_call_participants_patch.js
@@ -1,0 +1,25 @@
+import { DiscussSidebarCallParticipants } from "@mail/discuss/call/public_web/discuss_sidebar_call_participants";
+import { AvatarCardPopover } from "@mail/discuss/web/avatar_card/avatar_card_popover";
+
+import { usePopover } from "@web/core/popover/popover_hook";
+import { patch } from "@web/core/utils/patch";
+
+patch(DiscussSidebarCallParticipants.prototype, {
+    setup() {
+        super.setup();
+        this.avatarCard = usePopover(AvatarCardPopover, {
+            position: "right",
+        });
+    },
+    onClickParticipant(ev, session) {
+        if (!session.persona.main_user_id) {
+            return;
+        }
+        if (!this.avatarCard.isOpen) {
+            this.avatarCard.open(ev.currentTarget, {
+                id: session.persona.main_user_id.id,
+            });
+        }
+    },
+});
+Object.assign(DiscussSidebarCallParticipants.components, { AvatarCardPopover });

--- a/addons/mail/static/src/discuss/call/web/discuss_sidebar_call_participants_patch.scss
+++ b/addons/mail/static/src/discuss/call/web/discuss_sidebar_call_participants_patch.scss
@@ -1,0 +1,3 @@
+.o-mail-DiscussSidebarCallParticipants-participant.o-active:hover {
+    background-color: $gray-200;
+}

--- a/addons/mail/static/src/discuss/call/web/discuss_sidebar_call_participants_patch.xml
+++ b/addons/mail/static/src/discuss/call/web/discuss_sidebar_call_participants_patch.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+    <t t-inherit="mail.DiscussSidebarCallParticipants.participant" t-inherit-mode="extension">
+        <xpath expr="//div[hasclass('o-mail-DiscussSidebarCallParticipants-participant')]" position="attributes">
+            <attribute name="t-attf-class">{{ session.persona.main_user_id ? 'o-active cursor-pointer rounded-4' : '' }}</attribute>
+            <attribute name="t-on-click">(ev) => this.onClickParticipant(ev, session)</attribute>
+        </xpath>
+    </t>
+</templates>

--- a/addons/mail/static/tests/discuss/call/call.test.js
+++ b/addons/mail/static/tests/discuss/call/call.test.js
@@ -518,6 +518,16 @@ test("start call when accepting from push notification", async () => {
     await contains(`.o-discuss-CallParticipantCard[title='${serverState.partnerName}']`);
 });
 
+test("Clicking sidebar call participant opens avatar card", async () => {
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({ name: "General" });
+    await start();
+    await openDiscuss(channelId);
+    await click("[title='Start Call']");
+    await click(".o-mail-DiscussSidebarCallParticipants-participant", { text: "Mitchell Admin" });
+    await contains(".o_avatar_card .o_card_user_infos", { text: "Mitchell Admin" });
+});
+
 test("Use saved volume settings", async () => {
     const pyEnv = await startServer();
     const channelId = pyEnv["discuss.channel"].create({ name: "General" });


### PR DESCRIPTION
Purpose of this commit:
This commit allows users to click a participant’s name in the sidebar to quickly open their avatar card popover, improving accessibility.

![TestChannel-ezgif com-optimize](https://github.com/user-attachments/assets/eee6c50d-b96f-470f-aabe-ffeea6e0a331)



task-4860583
