### PR TITLE
[FIX] l10n_fr_invoice_addr: prevent error when try to remove field

### DIFF
--- a/addons/l10n_fr_invoice_addr/models/account_move.py
+++ b/addons/l10n_fr_invoice_addr/models/account_move.py
@@ -13,8 +13,9 @@ class AccountMove(models.Model):
         arch, view = super()._get_view(view_id, view_type, **options)
         company = self.env.company
         if view_type == 'form' and company.country_code in company._get_france_country_codes():
-            shipping_field = arch.xpath("//field[@name='partner_shipping_id']")[0]
-            shipping_field.attrib.pop("groups", None)
+            shipping_fields = arch.xpath("//field[@name='partner_shipping_id']")
+            if shipping_fields:
+                shipping_fields[0].attrib.pop("groups", None)
         return arch, view
 
     @api.depends('company_id.country_code')


### PR DESCRIPTION
The system will crash with an error when we try to remove the field 'Delivery Address' from the invoice view while in 'fr company'.

**Steps to Produce:-**
- Install `l10n_fr` and `web_studio` with demo data.
- Switch to `FR Company`.
- Go to `Invoicing > Customers > Invoices`.
- Open any invoice > Toggle studio > Click on `Delivery Address` > and then click on `REMOVE FROM VIEW`.
- Observe the error.

**Error:-** `IndexError: list index out of range`

**Root Cause:-**
- At [1], the `_get_view` method unconditionally expects the `partner_shipping_id` field to be present in the invoice form view.
- It performs an `xpath` search for the field and immediately attempts to access the first element of the result list.

**Solution:-**
- Now, if the `partner_shipping_id` field exists in the view, then the logic proceeds as before. If it's not found, the code block is simply skipped.

[1]:
https://github.com/odoo/odoo/blob/044833804c9e10048ec10d7e982c98c4f33f4cf4/addons/l10n_fr_invoice_addr/models/account_move.py#L16

**sentry-6746543069**

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
