### PR TITLE
[FIX] html_editor: fix recognition of SVG mimetype

### DIFF
--- a/addons/html_editor/static/src/main/media/media_dialog/image_selector.js
+++ b/addons/html_editor/static/src/main/media/media_dialog/image_selector.js
@@ -407,7 +407,7 @@ export class ImageSelector extends FileSelector {
         const mediaUrl = imgEl.src;
         try {
             const response = await fetch(mediaUrl);
-            if (response.headers.get("content-type") === "image/svg+xml") {
+            if (response.headers.get("content-type").startsWith("image/svg+xml")) {
                 let svg = await response.text();
                 const dynamicColors = {};
                 const combinedColorsRegex = new RegExp(


### PR DESCRIPTION
When illustrations mimetypes changed from simple `image/svg+xml` to `image/svg+xml; charset=utf-8`, `html_editor` was not used for website pages yet - and it therefore missed the fix in [1]. Because of this, when an illustration is selected, it is detected as an uploaded image, and the dynamic colors are not available.

This commit adapts the mimetype detection.

[1]: https://github.com/odoo/odoo/commit/af11070a6d4eeb69ee49c28435341a220eb64203
