### PR TITLE
[FIX] point_of_sale: adapt order change receipt template

### DIFF
--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -1756,6 +1756,7 @@ export class PosStore extends WithLazyGetterTrap {
             config_name: order.config_id.name,
             time: DateTime.now().toFormat("HH:mm"),
             tracking_number: order.tracking_number,
+            preset_time: order.presetDateTime,
             preset_name: order.preset_id?.name || "",
             employee_name: order.employee_id?.name || order.user_id?.name,
             internal_note: this.getStrNotes(order.internal_note),

--- a/addons/point_of_sale/static/src/app/store/order_change_receipt_template.xml
+++ b/addons/point_of_sale/static/src/app/store/order_change_receipt_template.xml
@@ -12,7 +12,7 @@
                     <span><t t-esc="data.config_name"/> : <t t-esc="data.time"/></span><br/>
                     <span>By: <t t-esc="data.employee_name"/></span>
                 </div>
-                <span class="my-4" style="font-size: 120%;">
+                <span class="my-4" style="font-size: 150%;">
                     <span>Order <strong><t t-esc="data.pos_reference"/></strong></span>
                     <strong t-if="data.tracking_number" class="fw-light my-3">
                         # <t t-esc="data.tracking_number"/>
@@ -62,7 +62,7 @@
     </t>
 
     <t t-name="point_of_sale.OrderChangeReceiptLine">
-        <div t-attf-class="orderline #{line.isCombo ? 'ms-5 px-2' : 'mx-1'}" style="font-size: 120%;">
+        <div t-attf-class="orderline #{line.isCombo ? 'ms-5 px-2' : 'mx-1'}" style="font-size: 150%;">
             <div class="d-flex medium">
                 <span class="me-3" t-esc="line.quantity"/> <span class="product-name" t-esc="line.basic_name"/>
             </div>

--- a/addons/point_of_sale/static/src/css/pos_receipts.css
+++ b/addons/point_of_sale/static/src/css/pos_receipts.css
@@ -43,7 +43,7 @@
 
 .pos-receipt .pos-receipt-title {
     font-weight: bold;
-    font-size: 125%;
+    font-size: 200%;
     text-align: center;
 }
 

--- a/addons/point_of_sale/static/tests/unit/services/pos_service.test.js
+++ b/addons/point_of_sale/static/tests/unit/services/pos_service.test.js
@@ -210,6 +210,28 @@ describe("pos_store.js", () => {
         expect(openOrders.length).toBe(0);
     });
 
+    test("getOrderData", async () => {
+        const store = await setupPosEnv();
+        const order = await getFilledOrder(store);
+        const orderData = store.getOrderData(order);
+        expect(orderData).toEqual({
+            reprint: undefined,
+            pos_reference: "",
+            config_name: "Hoot",
+            time: "10:30",
+            tracking_number: "",
+            preset_time: false,
+            preset_name: "In",
+            employee_name: "Administrator",
+            internal_note: "",
+            general_customer_note: "",
+            changes: {
+                title: "",
+                data: [],
+            },
+        });
+    });
+
     test("productsToDisplay", async () => {
         const store = await setupPosEnv();
         store.selectedCategory = store.models["pos.category"].get(1);

--- a/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
@@ -439,12 +439,14 @@ registry.category("web_tour.tours").add("PreparationPrinterContent", {
                 trigger: "body",
                 run: async () => {
                     const receipts = await PreparationReceipt.generatePreparationReceipts();
-
                     if (!receipts[0].innerHTML.includes("Value 1")) {
                         throw new Error("Value 1 not found in printed receipt");
                     }
                     if (!receipts[0].innerHTML.includes("14:20")) {
                         throw new Error("14:20 not found in printed receipt");
+                    }
+                    if (!receipts[0].innerHTML.includes("Eat in")) {
+                        throw new Error("Eat in not found in printed receipt");
                     }
                     if (receipts[0].innerHTML.includes("DUPLICATA!")) {
                         throw new Error("DUPLICATA! should not be present in printed receipt");
@@ -472,6 +474,25 @@ registry.category("web_tour.tours").add("PreparationPrinterContent", {
                     }
                     if (receipts[1].innerHTML.includes("colorIndex")) {
                         throw new Error("colorIndex should not be displayed in printed receipt");
+                    }
+                },
+            },
+            Chrome.clickPlanButton(),
+            FloorScreen.clickTable("4"),
+            ProductScreen.clickDisplayedProduct("Water"),
+            ProductScreen.selectPreset("Eat in", "Takeaway"),
+            Chrome.selectPresetTimingSlotHour("12:00"),
+            Chrome.presetTimingSlotIs("12:00"),
+            {
+                content: "Check if order preparation order contains Takeaway and its timing slot",
+                trigger: "body",
+                run: async () => {
+                    const receipts = await PreparationReceipt.generatePreparationReceipts();
+                    if (!receipts[0].innerHTML.includes("Takeaway")) {
+                        throw new Error("Takeaway not found in printed receipt");
+                    }
+                    if (!receipts[0].innerHTML.includes("12:00")) {
+                        throw new Error("12:00 not found in printed receipt");
                     }
                 },
             },

--- a/addons/pos_restaurant/tests/test_frontend.py
+++ b/addons/pos_restaurant/tests/test_frontend.py
@@ -341,63 +341,89 @@ class TestFrontend(TestFrontendCommon):
         self.start_pos_tour('test_pos_restaurant_course')
 
     def test_preparation_printer_content(self):
-            self.env['pos.printer'].create({
-                'name': 'Printer',
-                'printer_type': 'epson_epos',
-                'epson_printer_ip': '0.0.0.0',
-                'product_categories_ids': [Command.set(self.env['pos.category'].search([]).ids)],
-            })
+        self.preset_eat_in = self.env['pos.preset'].create({
+            'name': 'Eat in',
+        })
+        self.preset_takeaway = self.env['pos.preset'].create({
+            'name': 'Takeaway',
+            'identification': 'name',
+        })
+        self.main_pos_config.write({
+            'use_presets': True,
+            'default_preset_id': self.preset_eat_in.id,
+            'available_preset_ids': [(6, 0, [self.preset_takeaway.id])],
+        })
+        resource_calendar = self.env['resource.calendar'].create({
+            'name': 'Takeaway',
+            'attendance_ids': [(0, 0, {
+                'name': 'Takeaway',
+                'dayofweek': str(day),
+                'hour_from': 0,
+                'hour_to': 24,
+                'day_period': 'morning',
+            }) for day in range(0, 7)],
+        })
+        self.preset_takeaway.write({
+            'use_timing': True,
+            'resource_calendar_id': resource_calendar
+        })
+        self.env['pos.printer'].create({
+            'name': 'Printer',
+            'printer_type': 'epson_epos',
+            'epson_printer_ip': '0.0.0.0',
+            'product_categories_ids': [Command.set(self.env['pos.category'].search([]).ids)],
+        })
 
-            self.main_pos_config.write({
-                'is_order_printer' : True,
-                'printer_ids': [Command.set(self.env['pos.printer'].search([]).ids)],
-            })
+        self.main_pos_config.write({
+            'is_order_printer': True,
+            'printer_ids': [Command.set(self.env['pos.printer'].search([]).ids)],
+        })
 
-            self.product_test = self.env['product.product'].create({
-                'name': 'Product Test',
-                'available_in_pos': True,
-                'list_price': 10,
-                'pos_categ_ids': [(6, 0, [self.env['pos.category'].search([], limit=1).id])],
-                'taxes_id': False,
-            })
+        self.product_test = self.env['product.product'].create({
+            'name': 'Product Test',
+            'available_in_pos': True,
+            'list_price': 10,
+            'pos_categ_ids': [(6, 0, [self.env['pos.category'].search([], limit=1).id])],
+            'taxes_id': False,
+        })
 
-            attribute = self.env['product.attribute'].create({
-                'name': 'Attribute 1',
-                'create_variant': 'no_variant',
-            })
-            attribute_value = self.env['product.attribute.value'].create({
-                'name': 'Value 1',
-                'attribute_id': attribute.id,
-            })
-            attribute_value_2 = self.env['product.attribute.value'].create({
-                'name': 'Value 2',
-                'attribute_id': attribute.id,
-            })
-            self.env['product.template.attribute.line'].create({
-                'product_tmpl_id': self.product_test.product_tmpl_id.id,
-                'attribute_id': attribute.id,
-                'value_ids': [(6, 0, [attribute_value.id, attribute_value_2.id])],
-            })
+        attribute = self.env['product.attribute'].create({
+            'name': 'Attribute 1',
+            'create_variant': 'no_variant',
+        })
+        attribute_value = self.env['product.attribute.value'].create({
+            'name': 'Value 1',
+            'attribute_id': attribute.id,
+        })
+        attribute_value_2 = self.env['product.attribute.value'].create({
+            'name': 'Value 2',
+            'attribute_id': attribute.id,
+        })
+        self.env['product.template.attribute.line'].create({
+            'product_tmpl_id': self.product_test.product_tmpl_id.id,
+            'attribute_id': attribute.id,
+            'value_ids': [(6, 0, [attribute_value.id, attribute_value_2.id])],
+        })
 
-            attribute_2 = self.env['product.attribute'].create({
-                'name': 'Attribute 1',
-                'create_variant': 'always',
-            })
-            attribute_2_value = self.env['product.attribute.value'].create({
-                'name': 'Value 1',
-                'attribute_id': attribute_2.id,
-            })
-            attribute_2_value_2 = self.env['product.attribute.value'].create({
-                'name': 'Value 2',
-                'attribute_id': attribute_2.id,
-            })
-            self.env['product.template.attribute.line'].create({
-                'product_tmpl_id': self.product_test.product_tmpl_id.id,
-                'attribute_id': attribute_2.id,
-                'value_ids': [(6, 0, [attribute_2_value.id, attribute_2_value_2.id])],
-            })
-            self.main_pos_config.with_user(self.pos_user).open_ui()
-            self.start_tour(f"/pos/ui?config_id={self.main_pos_config.id}", 'PreparationPrinterContent', login="pos_user")
+        attribute_2 = self.env['product.attribute'].create({
+            'name': 'Attribute 1',
+            'create_variant': 'always',
+        })
+        attribute_2_value = self.env['product.attribute.value'].create({
+            'name': 'Value 1',
+            'attribute_id': attribute_2.id,
+        })
+        attribute_2_value_2 = self.env['product.attribute.value'].create({
+            'name': 'Value 2',
+            'attribute_id': attribute_2.id,
+        })
+        self.env['product.template.attribute.line'].create({
+            'product_tmpl_id': self.product_test.product_tmpl_id.id,
+            'attribute_id': attribute_2.id,
+            'value_ids': [(6, 0, [attribute_2_value.id, attribute_2_value_2.id])],
+        })
+        self.main_pos_config.with_user(self.pos_user).open_ui()
+        self.start_tour(f"/pos/ui?config_id={self.main_pos_config.id}", 'PreparationPrinterContent', login="pos_user")
 
     def test_course_restaurant_preparation_tour(self):
         self.env['pos.printer'].create({


### PR DESCRIPTION
- Increase the size of the `order_reference`, `tracking_number`, order lines and title element on the order changes preparation receipts.
- Also ensure that the preparation receipt contains the `preset_time` information when a preset with `use_timing` is used for the order.

task-id: 4936935



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
