### PR TITLE
[IMP] base: avoid cron server reset_modules_state

### DIFF
--- a/odoo/addons/base/models/ir_cron.py
+++ b/odoo/addons/base/models/ir_cron.py
@@ -222,7 +222,10 @@ class IrCron(models.Model):
         if not jobs:
             raise BadModuleState()
 
-        oldest = min(job['nextcall'] for job in jobs)
+        # use the max(job['nextcall'], job['write_date']) to avoid the cron
+        # reset_module_state for an ongoing module installation process
+        # right after installing a module with an old 'nextcall' cron in data
+        oldest = min(max(job['nextcall'], job['write_date'] or job['nextcall']) for job in jobs)
         if datetime.now() - oldest < MAX_FAIL_TIME:
             raise BadModuleState()
 


### PR DESCRIPTION
Previously, the cron would automatically ``reset_modules_state`` if
(a) Any module was in a transient state
    ('to install' / 'to update' / 'to remove')
(b) And the earliest nextcall of all cron jobs was older than
    ``now() - MAX_FAIL_TIME``
However some module will create ir.cron jobs with nextcall older than ``now() - MAX_FAIL_TIME``, which can trigger unexpected ``reset_modules_state``. This may conflict with the ongoing installation process and cause ``SerializationFailure`` when it tries to update the ir_module_module.state.

Steps to Reproduce:
Starts with a fresh saas-18.4 database with minimum modules (`-i base`)
Install industry module 'automobile' from the Industry Apps
The installation will
1. install some modules
2. install account_reports
     create ir.cron ir_cron_generate_account_return whose nextcall is
    ``eval="(DateTime.now().replace(day=3)).strftime('%Y-%m-%d %H:%M:%S')"``
     IMPORTANT make sure your ``datetime.now().day > 3`` to promise (b)
     cr.commit()
4. install hr_homeworking_calendar
    [The cron ``reset_modules_state`` which UPDATE ir_module_module for hr_homeworking_calendar]
    UPDATE ir_module_module for hr_homeworking_calendar at the end of installation => ``SerializationFailure``

This commit improves (b) by considering the write_date as a best effort to avoid unexpected ``reset_modules_state``

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
