### PR TITLE
[FIX] l10n_vn_edi_viettel: no need buyer district, correct buyercity

### DIFF
--- a/addons/l10n_vn_edi_viettel/models/account_move.py
+++ b/addons/l10n_vn_edi_viettel/models/account_move.py
@@ -622,8 +622,7 @@ class AccountMove(models.Model):
             'buyerAddressLine': self.partner_id.street,
             'buyerPhoneNumber': commercial_partner_phone or '',
             'buyerEmail': self.commercial_partner_id.email or '',
-            'buyerDistrictName': self.partner_id.state_id.name,
-            'buyerCityName': self.partner_id.city,
+            'buyerCityName': self.partner_id.city or self.partner_id.state_id.name,
             'buyerCountryCode': self.partner_id.country_id.code,
             'buyerNotGetInvoice': 0,  # Set to 1 to no send the invoice to the buyer.
         }

--- a/addons/l10n_vn_edi_viettel/tests/test_edi.py
+++ b/addons/l10n_vn_edi_viettel/tests/test_edi.py
@@ -37,7 +37,7 @@ class TestVNEDI(AccountTestInvoicingCommon):
         cls.partner_a.write({
             'street': '121 Hang Bac Street',
             'state_id': cls.env.ref('base.state_vn_VN-HN').id,
-            'city': 'Hoan Kiem District',
+            'city': 'Hà Nội',
             'country_id': cls.env.ref('base.vn').id,
             'vat': '0100109106-505',
             'phone': '3825 7670',
@@ -114,8 +114,7 @@ class TestVNEDI(AccountTestInvoicingCommon):
                     'buyerAddressLine': '121 Hang Bac Street',
                     'buyerPhoneNumber': '38257670',
                     'buyerEmail': 'partner_a@gmail.com',
-                    'buyerDistrictName': 'Hà Nội',
-                    'buyerCityName': 'Hoan Kiem District',
+                    'buyerCityName': 'Hà Nội',
                     'buyerCountryCode': 'VN',
                     'buyerNotGetInvoice': 0,
                 },


### PR DESCRIPTION
* Problem: Since what has been described in https://github.com/odoo/odoo/pull/214134 and
https://thuvienphapluat.vn/chinh-sach-phap-luat-moi/vn/ho-tro-phap-luat/chinh-sach-moi/82581/tu-ngay-01-7-2025-ca-nuoc-se-khong-con-quan-huyen Vietnam no longer have district and city in city no more (Before in Vietnam we will have Thu Duc City belong to Ho Chi Minh State or Thuy Nguyen City belong to Hai Phong), Therefore we need to update Sinvoice data for this to.

* This commit remove BuyerDistrict parameter , beside using state in the district is totally wrong and for 'buyerCityName' accept city or state field because odoo user might leave the city empty and just input state

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
