### PR TITLE
[IMP] website_slides: correct display of search bar results page

### DIFF
--- a/addons/website/static/src/snippets/s_searchbar/search_bar.js
+++ b/addons/website/static/src/snippets/s_searchbar/search_bar.js
@@ -45,6 +45,7 @@ export class SearchBar extends Interaction {
             "displayDescription": dataset.displayDescription,
             "displayExtraLink": dataset.displayExtraLink,
             "displayDetail": dataset.displayDetail,
+            "displayHtmlContent": dataset.displayHtmlContent,
             // Make it easy for customization to disable fuzzy matching on specific searchboxes
             "allowFuzzy": !dataset.noFuzzy,
         };

--- a/addons/website/views/website_templates.xml
+++ b/addons/website/views/website_templates.xml
@@ -2726,6 +2726,7 @@ Sitemap: <t t-out="url_root"/>sitemap.xml
         <attribute name="t-att-data-display-description">display_description or 'true'</attribute>
         <attribute name="t-att-data-display-extra-link">display_extra_link or 'true'</attribute>
         <attribute name="t-att-data-display-detail">display_detail or 'true'</attribute>
+        <attribute name="t-att-data-display-html-content">display_html_content or 'true'</attribute>
         <attribute name="t-att-data-order-by">order_by or 'name asc'</attribute>
     </xpath>
     <xpath expr="//div[@role='search']" position="attributes">

--- a/addons/website_slides/controllers/main.py
+++ b/addons/website_slides/controllers/main.py
@@ -389,6 +389,7 @@ class WebsiteSlides(WebsiteProfile):
             'displayDetail': False,
             'displayExtraDetail': False,
             'displayExtraLink': False,
+            'displayHtmlContent': True,
             'displayImage': False,
             'allowFuzzy': not post.get('noFuzzy'),
             'my': my,

--- a/addons/website_slides/models/slide_slide.py
+++ b/addons/website_slides/models/slide_slide.py
@@ -1282,6 +1282,7 @@ class SlideSlide(models.Model):
     @api.model
     def _search_get_detail(self, website, order, options):
         with_description = options['displayDescription']
+        with_html_content = options.get('displayHtmlContent')
         search_fields = ['name']
         fetch_fields = ['id', 'name']
         mapping = {
@@ -1294,6 +1295,10 @@ class SlideSlide(models.Model):
             search_fields.append('description')
             fetch_fields.append('description')
             mapping['description'] = {'name': 'description', 'type': 'text', 'html': True, 'match': True}
+        if with_html_content:
+            search_fields.append('html_content')
+            fetch_fields.append('html_content')
+            mapping['html_content'] = {'name': 'html_content', 'type': 'text', 'html': True, 'match': True}
         return {
             'model': 'slide.slide',
             'base_domain': [website.website_domain()],

--- a/addons/website_slides/static/src/website_builder/slides_searchbar_option_plugin.js
+++ b/addons/website_slides/static/src/website_builder/slides_searchbar_option_plugin.js
@@ -25,6 +25,11 @@ class SlidesSearchbarOptionPlugin extends Plugin {
                 dependency: "search_slides_opt",
             },
             {
+                label: _t("HTML Content"),
+                dataAttribute: "displayHtmlContent",
+                dependency: "search_slides_opt",
+            },
+            {
                 label: _t("Publication Date"),
                 dataAttribute: "displayDetail",
                 dependency: "search_slides_opt",

--- a/addons/website_slides/views/website_slides_templates_course.xml
+++ b/addons/website_slides/views/website_slides_templates_course.xml
@@ -49,7 +49,7 @@
                         <t t-set="action" t-valuef="/slides"/>
                         <t t-set="display_description" t-valuef="true"/>
                         <t t-set="display_detail" t-valuef="false"/>
-                        <t t-set="placeholder">Search courses</t>
+                        <t t-set="placeholder">Search courses or contents</t>
                         <t t-set="search" t-value="search_term"/>
                     </t>
                 </div>
@@ -96,7 +96,7 @@
                                     <t t-set="action" t-value="'/slides/%s' % slug(channel)"/>
                                     <t t-set="display_description" t-valuef="true"/>
                                     <t t-set="display_detail" t-valuef="false"/>
-                                    <t t-set="placeholder">Search courses</t>
+                                    <t t-set="placeholder">Search courses or contents</t>
                                     <t t-set="search" t-value="search_term"/>
                                 </t>
                             </div>

--- a/addons/website_slides/views/website_slides_templates_homepage.xml
+++ b/addons/website_slides/views/website_slides_templates_homepage.xml
@@ -151,7 +151,7 @@
 <template id="courses_search_bar">
     <div class="container o_wslides_home_nav">
         <!-- Navbar dynamically composed using displayed channel tag groups. -->
-        <nav class="navbar navbar-expand-md navbar-light shadow-sm px-2 mb-4">
+        <nav class="navbar navbar-expand-md navbar-light shadow-sm px-2 mb-4 rounded px-3">
             <a class="fw-bold" href="/slides">Online Courses</a>
             <!-- Clear filtering (mobile)-->
             <div class="text-nowrap ms-auto d-md-none" t-if="search_slide_category or search_tags">
@@ -207,7 +207,7 @@
                 </div>
                 <!-- Search box (desktop) -->
                 <t t-call="website.website_search_box_input">
-                    <t t-set="_form_classes" t-valuef="o_wslides_nav_navbar_right d-none d-md-flex"/>
+                    <t t-set="_form_classes" t-valuef="o_wslides_nav_navbar_right"/>
                     <t t-set="search_type" t-valuef="slides"/>
                     <!-- No action: remain on same URL -->
                     <t t-set="display_description" t-valuef="true"/>

--- a/addons/website_slides/views/website_slides_templates_homepage.xml
+++ b/addons/website_slides/views/website_slides_templates_homepage.xml
@@ -166,7 +166,7 @@
                 <!-- No action: remain on same URL -->
                 <t t-set="display_description" t-valuef="true"/>
                 <t t-set="display_detail" t-valuef="false"/>
-                <t t-set="placeholder">Search courses</t>
+                <t t-set="placeholder">Search courses or contents</t>
                 <t t-set="search" t-value="original_search or search_term"/>
                 <input type="hidden" name="my" t-attf-value="#{1 if search_my else 0}"/>
                 <input t-if="search_slide_category" type="hidden" name="slide_category" t-att-value="search_slide_category" />
@@ -212,7 +212,7 @@
                     <!-- No action: remain on same URL -->
                     <t t-set="display_description" t-valuef="true"/>
                     <t t-set="display_detail" t-valuef="false"/>
-                    <t t-set="placeholder">Search courses</t>
+                    <t t-set="placeholder">Search courses or contents</t>
                     <t t-set="search" t-value="original_search or search_term"/>
                     <input type="hidden" name="my" t-attf-value="#{1 if search_my else 0}"/>
                     <input t-if="search_slide_category" type="hidden" name="slide_category" t-att-value="search_slide_category" />
@@ -253,25 +253,42 @@
 <template id="courses_search_results">
     <div class="container o_wslides_home_main pb-5">
         <t t-call="website_slides.courses_search_tags"/>
-        <div t-if="not channels and not search_term and not search_slide_category and not search_my and not search_tags">
+        <div t-if="not channels and not search_term and not search_slide_category and not search_my and not search_tags and not grouped_slides_by_category">
             <p class="h2">No Course created yet.</p>
             <p groups="website_slides.group_website_slides_officer">Click on "New" in the top-right corner to write your first course.</p>
         </div>
-        <div t-elif="search_term and not channels" class="alert alert-info mb-5">
-            No course was found matching your search <code><t t-out="search_term"/></code>.
-        </div>
-        <div t-elif="not channels" class="alert alert-info mb-5">
-            No course was found matching your search.
+        <div t-elif="not search_count" class="alert alert-info mb-5">
+            No course or other content was found matching your search <code><t t-esc="search_term"/></code>.
         </div>
         <t t-else="">
             <div t-if="original_search" class="alert alert-warning mb-5">
                 No results found for '<span t-out="original_search"/>'. Showing results for '<span t-out="search_term"/>'.
             </div>
             <div class="row mx-n2">
-                <t t-foreach="channels" t-as="channel">
-                    <div class="col-12 col-sm-6 col-md-4 col-lg-3 px-2 d-flex">
-                        <t t-call="website_slides.course_card"/>
+                <t t-if="channels">
+                    <t t-if="search">
+                        <div class="d-flex align-items-center justify-content-between border-bottom pb-2 mb-3">
+                            <h3 class="m-0">Course</h3>
+                        </div>
+                    </t>
+                    <t t-foreach="channels" t-as="channel">
+                        <div class="col-12 col-sm-6 col-md-4 col-lg-3 px-2 d-flex">
+                            <t t-call="website_slides.course_card"/>
+                        </div>
+                    </t>
+                </t>
+                <t t-foreach="grouped_slides_by_category.items()" t-as="categorized_slide">
+                    <t t-set="category" t-value="categorized_slide[0]"/>
+                    <t t-set="slide_categories" t-value="categorized_slide[1]"/>
+                    <div class="d-flex align-items-center justify-content-between border-bottom pb-2 mb-3">
+                        <h3 class="m-0" t-out="category"/>
                     </div>
+                    <t t-foreach="slide_categories" t-as="slide">
+                        <div class="col-12 col-sm-6 col-md-4 col-lg-3 px-2 mb-3 d-flex">
+                            <t t-set="channel" t-value="slide.channel_id"/>
+                            <t t-call="website_slides.lesson_card"/>
+                        </div>
+                    </t>
                 </t>
             </div>
         </t>


### PR DESCRIPTION
**Current**
When you search for a group of words in the search bar, it displays both courses
and content related to these words. However, if you press "Enter" or click on
the magnifying glass, only the courses are shown.

**Implementation/Correction**
Consistency about this has been added. We can also see all types of results
sorted by document type to facilitate user navigation, made possible by the
controller, sending results for subsidiary contents.

task-4858135