### PR TITLE
[FIX] web: avoid reloading the Kanban view when exiting

### DIFF
--- a/addons/web/static/src/views/kanban/kanban_controller.js
+++ b/addons/web/static/src/views/kanban/kanban_controller.js
@@ -268,10 +268,12 @@ export class KanbanController extends Component {
         } else if (onCreate && onCreate !== "quick_create") {
             const options = {
                 additionalContext: root.context,
-                onClose: async () => {
-                    await root.load();
-                    this.model.useSampleModel = false;
-                    this.render(true); // FIXME WOWL reactivity
+                onClose: async ({ noReload } = {}) => {
+                    if (!noReload) {
+                        await root.load();
+                        this.model.useSampleModel = false;
+                        this.render(true); // FIXME WOWL reactivity
+                    }
                 },
             };
             await this.actionService.doAction(onCreate, options);

--- a/addons/web/static/tests/views/kanban/kanban_view.test.js
+++ b/addons/web/static/tests/views/kanban/kanban_view.test.js
@@ -26,6 +26,7 @@ import {
     clickModalButton,
     contains,
     createKanbanRecord,
+    defineActions,
     defineModels,
     defineParams,
     discardKanbanRecord,
@@ -1614,6 +1615,86 @@ test("kanban with an action id as on_create attrs", async () => {
         "web_search_read",
         "doAction some.action",
         "web_search_read",
+    ]);
+});
+
+test("Open new card in form view, without reloading the kanban view", async () => {
+    defineActions([
+        {
+            id: 1,
+            res_model: "partner",
+            type: "ir.actions.act_window",
+            views: [[false, "kanban"]],
+        },
+        {
+            id: 2,
+            xml_id: "some.action",
+            res_model: "partner",
+            type: "ir.actions.act_window",
+            target: "new",
+            views: [["create_view_ref", "form"]],
+        },
+    ]);
+    Partner._views = {
+        kanban: `
+            <kanban on_create="some.action">
+                <templates>
+                    <t t-name="card">
+                        <field name="foo"/>
+                    </t>
+                </templates>
+            </kanban>`,
+        form: `
+            <form>
+                <field name="foo"/>
+            </form>`,
+        "form,create_view_ref": `
+            <form>
+                <field name="foo"/>
+                <footer>
+                    <button string="Create Card" name="open_new_card" type="object" class="btn-primary"/>
+                </footer>
+            </form>`,
+        search: `<search />`,
+    };
+    onRpc("/web/dataset/call_button/partner/open_new_card", () => {
+        const newId = MockServer.env["partner"].create({ foo: "new" });
+        return {
+            type: "ir.actions.act_window",
+            name: "Open Card",
+            target: "current",
+            res_model: "partner",
+            res_id: newId,
+            view_mode: "form",
+            views: [[false, "form"]],
+        };
+    });
+
+    stepAllNetworkCalls();
+
+    await mountWithCleanup(WebClient);
+    await getService("action").doAction(1);
+
+    expect(".o_kanban_record:not(.o_kanban_ghost)").toHaveCount(4);
+    await createKanbanRecord();
+    expect(`.modal`).toHaveCount(1);
+    await contains(`.modal-footer button.btn-primary`).click();
+    expect(`.modal`).toHaveCount(0);
+    expect(".o_form_view").toHaveCount(1);
+    // should not reload the first kanban view
+    expect.verifySteps([
+        "/web/webclient/translations",
+        "/web/webclient/load_menus",
+        "/web/action/load",
+        "get_views",
+        "web_search_read",
+        "/web/action/load",
+        "get_views",
+        "onchange",
+        "web_save",
+        "open_new_card",
+        "get_views",
+        "web_read",
     ]);
 });
 


### PR DESCRIPTION
- Open a Project;
- Create a new project;

Before this commit, the dialog that allows you to create a new project would sometimes stay open and could not be closed. This occurs because, since [1] and especially [2], we waited for the view to reload before closing the dialog. However, while the view was reloading, it was destroyed and replaced by the Kanban view of the tasks of the new project. This meant that the reload promise was never resolved. Consequently, the code that actually closes the dialog [3] was never reached, as `await onClose?.(closeParams)` was never resolved.

[1] https://github.com/odoo/odoo/pull/202512
[2] [d606be7](https://github.com/odoo/odoo/pull/202512/commits/d606be75c44fccf0b1ddf5216892f1d4b7162686)
[3] [d606be7#diff-552aefb62246b1f4fe6a2607ec8f0a01773e53de2d68293266b38bc99c5cb56dR318](https://github.com/odoo/odoo/pull/202512/commits/d606be75c44fccf0b1ddf5216892f1d4b7162686#diff-552aefb62246b1f4fe6a2607ec8f0a01773e53de2d68293266b38bc99c5cb56dR318)

opw-4880968