### PR TITLE
[FIX] pos_mercado_pago: handle PROCESSING state

### DIFF
--- a/addons/pos_mercado_pago/static/src/app/payment_mercado_pago.js
+++ b/addons/pos_mercado_pago/static/src/app/payment_mercado_pago.js
@@ -145,7 +145,7 @@ export class PaymentMercadoPago extends PaymentInterface {
                 // that was actually canceled/finished by the user on the terminal.
                 // Then the strategy here is to ask Mercado Pago MAX_RETRY times the
                 // payment intent status, hoping going out of this status
-                if (["OPEN", "ON_TERMINAL"].includes(last_status_payment_intent.state)) {
+                if (["OPEN", "ON_TERMINAL", "PROCESSING"].includes(last_status_payment_intent.state)) {
                     return await new Promise((resolve) => {
                         let retry_cnt = 0;
                         const s = setInterval(async () => {


### PR DESCRIPTION
The Mercado Pago 'PROCESSING' payment status was not handled.

As a result, when receiving this status, the payment was treated as failed and the user saw an 'Unknown payment status' message.

This fix treats 'PROCESSING' as an in-progress state, just like 'OPEN' and 'ON_TERMINAL'. It triggers the same retry mechanism.

opw-4918455