### PR TITLE
[IMP] iot_box_image: add iot_drivers to sparse checkout

### DIFF
--- a/addons/iot_box_image/build_image.sh
+++ b/addons/iot_box_image/build_image.sh
@@ -77,6 +77,7 @@ if [ ! -d $CLONE_DIR ]; then
     echo "addons/web
 addons/hw_*
 addons/iot_base
+addons/iot_drivers
 addons/iot_box_image/configuration
 addons/point_of_sale/tools/posbox/configuration
 odoo/


### PR DESCRIPTION
In order for the image (built in `saas-18.1`) to be ready for the replacement of `hw_drivers` and `hw_posbox_homepage` by `iot_drivers` in `saas-18.4`, we add it to git's sparse-checkout. This way, we ensure it is fetched by git when upgrading.

