### PR TITLE
[FIX] mail: role mentions are lost when editing

### DIFF
--- a/addons/mail/static/src/core/common/message_model.js
+++ b/addons/mail/static/src/core/common/message_model.js
@@ -596,7 +596,7 @@ export class Message extends Record {
         };
     }
 
-    // Async enterEditMode that fetches mentioned channels from the message body.
+    // Async enterEditMode that fetches mentioned channels and roles from the message body.
     async enterEditModeAsync(thread) {
         this.enterEditMode(thread);
         const doc = createDocumentFragmentFromContent(this.body);
@@ -612,7 +612,11 @@ export class Message extends Record {
                 )
             )
         ).filter((channel) => channel?.exists());
+        const validRoles = Array.from(
+            doc.querySelectorAll(".o-discuss-mention[data-oe-model='res.role']")
+        ).map((el) => this.store["res.role"].get(el.dataset.oeId));
         this.composer.mentionedChannels = validChannels;
+        this.composer.mentionedRoles = validRoles;
     }
 
     /** @param {import("models").Thread} thread the thread where the message is being viewed when stopping edition */

--- a/addons/mail/static/tests/message/message.test.js
+++ b/addons/mail/static/tests/message/message.test.js
@@ -187,6 +187,24 @@ test("Editing message keeps the mentioned channels", async () => {
     await contains(".o-mail-Discuss-threadName", { value: "other" });
 });
 
+test("Editing message keeps the mentioned roles", async () => {
+    const pyEnv = await startServer();
+    pyEnv["res.role"].create([{ name: "admin" }]);
+    const channelId = pyEnv["discuss.channel"].create({ name: "general" });
+    await start();
+    await openDiscuss(channelId);
+    await insertText(".o-mail-Composer-input", "@");
+    await click(".o-mail-Composer-suggestion strong", { text: "admin" });
+    await press("Enter");
+    await contains(".o-discuss-mention", { text: "@admin" });
+    await click(".o-mail-Message [title='Edit']");
+    await contains(".o-mail-Message .o-mail-Composer-input", { value: "@admin" });
+    await insertText(".o-mail-Message .o-mail-Composer-input", "@admin edit", { replace: true });
+    await click(".o-mail-Message a", { text: "save" });
+    await contains(".o-mail-Message-content", { text: "@admin edit (edited)" });
+    await contains(".o-discuss-mention", { text: "@admin" });
+});
+
 test("Can edit message comment in chatter", async () => {
     const pyEnv = await startServer();
     const partnerId = pyEnv["res.partner"].create({ name: "TestPartner" });


### PR DESCRIPTION
**Current behavior before PR:**

 Editing a message with a role mention would cause the mention to be lost.

**Desired behavior after PR is merged:**

 Role mentions are now preserved when editing a message.

task-4702960



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
