### PR TITLE
[IMP] payment: add post-processing action on transactions

### DIFF
--- a/addons/payment/models/payment_transaction.py
+++ b/addons/payment/models/payment_transaction.py
@@ -351,6 +351,18 @@ class PaymentTransaction(models.Model):
             },
         }
 
+    def action_post_process(self):
+        """Trigger the post-processing of the transactions.
+
+        :return: A client action to soft-reload the view.
+        :rtype: dict
+        """
+        self._post_process()
+        return {
+            'type': 'ir.actions.client',
+            'tag': 'soft_reload',
+        }
+
     # === BUSINESS METHODS - PRE-PROCESSING === #
 
     @api.model

--- a/addons/payment/views/payment_transaction_views.xml
+++ b/addons/payment/views/payment_transaction_views.xml
@@ -10,6 +10,14 @@
                     <button type="object" name="action_capture" invisible="state != 'authorized'" string="Capture Transaction" class="oe_highlight"/>
                     <button type="object" name="action_void" invisible="state != 'authorized'" string="Void Transaction"
                             confirm="Are you sure you want to void the authorized transaction? This action can't be undone."/>
+                    <button
+                        string="Post-process"
+                        help="Run the post-processing step for this transaction."
+                        type="object"
+                        name="action_post_process"
+                        invisible="is_post_processed"
+                        groups="base.group_no_one"
+                    />
                     <field name="state" widget="statusbar"/>
                 </header>
                 <sheet>


### PR DESCRIPTION
Before this commit:

If there was any transaction that was not post-processed, we couldn’t see what was wrong.

After this commit:

Now we have button in debug mode only for post-processing so we can see error on UI and find exact cause of issue in logger.

Reason:

If a payment is not post-processed, it can cause major issues. For example, a subscription may not detect that the payment was completed, so the next invoice date is not updated. As a result, the system may attempt to charge the customer again the next day using the token, even though the payment was already completed. This repeats until the
post-processing step is successfully executed or someone manually creates the invoice.

To fix this, we need to know what the problem is without having to dig through large logs (which regular users, especially on SaaS, often don’t have access to).

task-4936432