### PR TITLE
[FIX] mail: press Enter on composer when send button active in tour

### DIFF
--- a/addons/mail/static/tests/tours/discuss_channel_public_tour.js
+++ b/addons/mail/static/tests/tours/discuss_channel_public_tour.js
@@ -92,7 +92,7 @@ registry.category("web_tour.tours").add("discuss_channel_public_tour.js", {
         { trigger: ".o-mail-Composer-input", run: "click" }, // focus
         {
             content: "Send message",
-            trigger: ".o-mail-Composer-input",
+            trigger: ".o-mail-Composer:has(button[title='Send']:enabled) .o-mail-Composer-input",
             run: "press Enter",
         },
         {


### PR DESCRIPTION
Before this commit, tour "test_mail_group_public_page_as_portal" failed non-deterministically at the following step:

```
FAILED: [14/37] Tour discuss_channel_public_tour.js → Step Check message is shown (trigger: .o-mail-Message-body:contains("cheese")).
```

When looking at screenshot from runbot, it shows that the message is indeed not on UI, but the composer still contains "cheese" in input, which means the message hasn't been effectively posted.

This can happen when the press Enter is made before the composer is not in a state to send the message. In practice the conditions should be met: have some text in composer and some attachments have been attached and fully uploaded. However test it running steps fast and it can trigger the "press Enter" sooner than it's actually made available.

This commit fixes the issue by pressing Enter when the "send" button is enabled, which is the right time when press Enter is also available to use.

Fixes runbot-error-229828