### PR TITLE
[FIX] website: recalculate navbar link items on website variables custo

### DIFF
--- a/addons/website/static/src/builder/plugins/theme/theme_tab.xml
+++ b/addons/website/static/src/builder/plugins/theme/theme_tab.xml
@@ -28,7 +28,7 @@
             <BuilderButton action="'addLanguage'">Add a Language</BuilderButton>
         </BuilderRow>
         <BuilderRow label.translate="Page Layout">
-            <BuilderSelect action="'customizeWebsiteVariable'" actionParam="'layout'">
+            <BuilderSelect action="'customizePageLayout'" actionParam="'layout'">
                 <BuilderSelectItem actionValue="'full'" id="'layout_full_opt'">Full</BuilderSelectItem>
                 <BuilderSelectItem actionValue="'boxed'">Boxed</BuilderSelectItem>
                 <BuilderSelectItem actionValue="'framed'">Framed</BuilderSelectItem>

--- a/addons/website/static/src/builder/plugins/theme/theme_tab_plugin.js
+++ b/addons/website/static/src/builder/plugins/theme/theme_tab_plugin.js
@@ -45,6 +45,7 @@ export class ThemeTabPlugin extends Plugin {
             ChangeColorPaletteAction,
             EditCustomCodeAction,
             ConfigureApiKeyAction,
+            CustomizePageLayout,
         },
         theme_options: [
             withSequence(
@@ -298,6 +299,17 @@ export class ConfigureApiKeyAction extends BuilderAction {
     static dependencies = ["googleMapsOption"];
     apply() {
         this.dependencies.googleMapsOption.configureGMapsAPI("", true);
+    }
+}
+
+export class CustomizePageLayout extends CustomizeWebsiteVariableAction {
+    static id = "customizePageLayout";
+
+    async apply(...args) {
+        await super.apply(...args);
+        // since we do not reload on website variables customization we need to
+        // trigger resize to have navbar layout recomputed when we modify page layout
+        this.window.dispatchEvent(new Event("resize"));
     }
 }
 


### PR DESCRIPTION
The issue happens when the navbar contains many items and the website page layout is customized to a smaller size, causing the navbar to overflow.
Steps to reproduce:
- Open website and start editing
- Click on the navbar and change content width to "Full"
- Go to the theme tab and change the "Page Layout" option from "Full" to "Boxed"

=> We have an overflow.
This commit follows the [html_builder refactoring]. 
Related to task-4367641

[html_builder refactoring]: https://github.com/odoo/odoo/commit/9fe45e2b7ddb