### PR TITLE
[FIX] html_editor: background color opacity preview

### DIFF
--- a/addons/html_editor/static/src/main/font/color_selector.js
+++ b/addons/html_editor/static/src/main/font/color_selector.js
@@ -94,7 +94,7 @@ export class ColorSelector extends Component {
     }
 
     onColorPreview(ev) {
-        const color = ev.hex ? ev.hex : this.processColorFromEvent(ev);
+        const color = ev.cssColor ? ev.cssColor : this.processColorFromEvent(ev);
         this.props.applyColorPreview({ color: color || "", mode: this.mode });
     }
 

--- a/addons/html_editor/static/tests/color_selector.test.js
+++ b/addons/html_editor/static/tests/color_selector.test.js
@@ -9,6 +9,7 @@ import {
     edit,
     queryAllValues,
     queryAll,
+    manuallyDispatchProgrammaticEvent,
 } from "@odoo/hoot-dom";
 import { animationFrame } from "@odoo/hoot-mock";
 import { setupEditor } from "./_helpers/editor";
@@ -709,5 +710,29 @@ describe("color preview", () => {
             </table>
         `);
         await expectElementCount(".o-we-toolbar", 1);
+    });
+
+    test("should preview background color on moving opacity slider in custom tab", async () => {
+        await setupEditor(`<p>[test]</p>`);
+        await expectElementCount(".o-we-toolbar", 1);
+        await click(".o-select-color-background");
+        await animationFrame();
+        await click(".btn:contains('Custom')");
+        const newColor = "#FF0000";
+        await contains(".o_hex_input").edit(newColor);
+        const slider = document.querySelector(".o_opacity_slider");
+        const rect = slider.getBoundingClientRect();
+        const middleY = rect.top + rect.height / 2;
+        manuallyDispatchProgrammaticEvent(slider, "mousedown", {
+            clientX: rect.left,
+            clientY: middleY,
+        });
+        const fontEl = queryOne("font");
+        const bgColor = fontEl.style.backgroundColor;
+        expect(bgColor).toMatch(/^rgba\(255,\s*0,\s*0,\s*0\.\d+\)$/);
+        manuallyDispatchProgrammaticEvent(slider, "mouseup", {
+            clientX: rect.left,
+            clientY: middleY,
+        });
     });
 });


### PR DESCRIPTION
### Steps to reproduce:

- Type a command (e.g., /table) to insert a table.
- Select some cells and apply a background color using the toolbar.
- Click the Background Color button again in the toolbar.
- Go to the Custom tab in the color picker.
- Adjust the opacity using the slider.

### Description of the issue/feature this PR addresses:

- Adjusting the opacity slider had no effect on the background color preview.

### Desired behavior after PR is merged:

- The preview updates dynamically as the opacity slider is moved.

task-4942309

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
