### PR TITLE
[FIX] mail: click on correct message 'edit' action in test

### DIFF
--- a/addons/mail/static/tests/tours/discuss_channel_public_tour.js
+++ b/addons/mail/static/tests/tours/discuss_channel_public_tour.js
@@ -102,7 +102,7 @@ registry.category("web_tour.tours").add("discuss_channel_public_tour.js", {
         },
         {
             trigger: ".o-mail-Message[data-persistent]:contains(cheese)",
-            run: "hover && click .o-mail-Message [title='Add a Reaction']",
+            run: "hover && click .o-mail-Message:contains(cheese) [title='Add a Reaction']",
         },
         {
             trigger: ".o-EmojiPicker .o-Emoji:contains('🙂')",
@@ -133,7 +133,7 @@ registry.category("web_tour.tours").add("discuss_channel_public_tour.js", {
         {
             content: "Click on more menu",
             trigger: ".o-mail-Message[data-persistent]:contains(cheese)",
-            run: "hover && click .o-mail-Message [title='Expand']",
+            run: "hover && click .o-mail-Message:contains(cheese) [title='Expand']",
         },
         {
             content: "Click on edit",


### PR DESCRIPTION
Before this commit, "test_discuss_channel_public_page_as_internal" tour would fail non-deterministically at following step:

```
FAILED: [21/33] Tour discuss_channel_public_tour.js → Step Click on edit (trigger: .o-mail-Message-moreMenu [title='Edit'], .o-mail-Message [title='Edit']).
```

This happens because this tour is run twice, and in the 2nd run the selector to hover and click on 'Expand' is just targeting the 1st message. This works fine in the 1st run, but in the 2nd run this picks the message of previous test instead of the 2nd one.

A full run of tour posts a message "cheese" and edits its content to "vegetales", so targeting the message with content "cheese" ensures the right message is picked, which is what this commit does to fix the issue.

This commit also properly targets the right message for message reaction.

Fixes runbot-error-227756