### PR TITLE
[FIX] stock: correct demo address from incoming return slips

### DIFF
--- a/addons/stock/report/report_return_slip.xml
+++ b/addons/stock/report/report_return_slip.xml
@@ -15,7 +15,7 @@
                                 Please put this document inside your return parcel.<br/>
                                 Your parcel must be sent to this address:
                             </p>
-                            <span t-field="o.location_id.warehouse_id.partner_id"
+                            <span t-field="(o if o.picking_type_code == 'incoming' else o.location_id.warehouse_id).partner_id"
                                 t-options='{"widget": "contact", "fields": ["address", "name"], "no_marker": True}'>Demo Address and Name</span>
                         </div>
                         <div class="col-4 text-center mt-4">


### PR DESCRIPTION
Issue
-----
Incoming return slips have a "Demo Address and Name" text instead of the correct destination address.
<img width="928" height="658" alt="image" src="https://github.com/user-attachments/assets/6ff0a5e7-f1ee-4faa-a22b-76ec8f2f7a28" />

Steps to reproduce
-----
- Create a receipt for a product
- Print its return slip

Cause
-----
By default, the address is taken from the pickings location_id -> warehouse_id -> partner_id. For incoming pickings, the warehouse is the vendor one, with no associated partner. In such cases, the partner can be found directly on the picking itself with the partner_id field.

Note
-----
To render t-fields, qweb first applies a `rsplit` before evaluating the expression, see
https://github.com/odoo/odoo/blob/cb1c761777e84d96f82c4f754586795509ce1b3d/odoo/addons/base/models/ir_qweb.py#L2015-L2016

With this in mind, using parentheses and moving `.partner_id` outside of them seems like the most readable way to go about it.

-----
Ticket:
opw-4660716