### PR TITLE
[FIX] l10n_fr_facturx_chorus_pro: remove `schemeName` in BIS3 XML

### DIFF
--- a/addons/l10n_fr_facturx_chorus_pro/models/account_edi_xml_ubl_bis3.py
+++ b/addons/l10n_fr_facturx_chorus_pro/models/account_edi_xml_ubl_bis3.py
@@ -1,7 +1,9 @@
 from odoo import models, _
+from odoo.addons.account_edi_ubl_cii.models.account_edi_common import EAS_MAPPING
 
 
 CHORUS_PRO_PEPPOL_ID = "0009:11000201100044"
+FR_SCHEME_IDS = {v: k for k, v in EAS_MAPPING['FR'].items()}
 
 
 class AccountEdiXmlUBLBIS3(models.AbstractModel):
@@ -35,12 +37,12 @@ class AccountEdiXmlUBLBIS3(models.AbstractModel):
                 if 'siret' in partner._fields and partner.siret and partner.country_code == 'FR':
                     vals['vals'][f'accounting_{role}_party_vals']['party_vals']['party_identification_vals'] = [{
                         'id': partner.siret,
-                        'id_attrs': {'schemeName': 1},
+                        'id_attrs': {'schemeID': FR_SCHEME_IDS['siret']},
                     }]
                 else:
                     vals['vals'][f'accounting_{role}_party_vals']['party_vals']['party_identification_vals'] = [{
                         'id': partner.vat,
-                        'id_attrs': {'schemeName': 2},
+                        'id_attrs': {'schemeID': FR_SCHEME_IDS['vat']},
                     }]
         return vals
 
@@ -95,8 +97,8 @@ class AccountEdiXmlUBLBIS3(models.AbstractModel):
                         if 'siret' in partner._fields and partner.siret and partner.country_code == 'FR'
                         else partner.vat
                     ),
-                    'schemeName': (
-                        '1' if 'siret' in partner._fields and partner.siret and partner.country_code == 'FR' else '2'
+                    'schemeID': (
+                        FR_SCHEME_IDS['siret'] if 'siret' in partner._fields and partner.siret and partner.country_code == 'FR' else FR_SCHEME_IDS['vat']
                     ),
                 }
             }

--- a/addons/l10n_fr_facturx_chorus_pro/tests/test_chorus_pro_xml.py
+++ b/addons/l10n_fr_facturx_chorus_pro/tests/test_chorus_pro_xml.py
@@ -50,11 +50,11 @@ class TestChorusProXml(AccountTestInvoicingCommon):
 
         supplier_identification_node = xml_etree.find("{*}AccountingSupplierParty/{*}Party/{*}PartyIdentification/{*}ID")
         self.assertEqual(supplier_identification_node.text, "02546465000024")
-        self.assertEqual(supplier_identification_node.attrib, {'schemeName': '1'})
+        self.assertEqual(supplier_identification_node.attrib, {'schemeID': '0009'})
 
         customer_identification_node = xml_etree.find("{*}AccountingCustomerParty/{*}Party/{*}PartyIdentification/{*}ID")
         self.assertEqual(customer_identification_node.text, "21440109300015")
-        self.assertEqual(customer_identification_node.attrib, {'schemeName': '1'})
+        self.assertEqual(customer_identification_node.attrib, {'schemeID': '0009'})
 
         self.assertEqual(xml_etree.findtext("{*}BuyerReference"), "buyer_ref_123")
         self.assertEqual(xml_etree.findtext("{*}OrderReference/{*}ID"), "order_ref_123")


### PR DESCRIPTION
### Issue:
BIS3 XML is not valid for Peppol

### Steps to reproduce:
- Install l10n_fr_facturx_chorus_pro and switch to french company
- Activate peppol
- Create a French customer
- Under Sales and Purchase tab, set SIRET to "11000201100044"
- Under Accounting tab, set the following:
	- Invoice sending = Peppol
	- Einvoice format = BIS Billing 3.0
	- peppol_eas = France SIRET
	- peppol endpoint = 11000201100044
- Use Invoice/Invoiced smart button, then select New to create an invoice for this french customer
- Add any non-zero invoice line, then confirm
- Send and print, send to peppol
- Download the XML. The /PartyIdentification/ID element will have the schemeName attribute set.

### Cause:
Previous [commit](https://github.com/odoo/odoo/commit/0f3a9dee5cf15fa978a1857c184413003147c4a6#diff-10c62c279423109c43458eab15a3177ff5592d6570451f890fead74389bc3740) added `schemeName`. But Peppol doesn't want any `schemeName`, see the [doc](https://docs.peppol.eu/poacc/billing/3.0/rules/ubl-tc434/UBL-DT-08/).

### Solution:
The correct attribute here seems to be `schemeID`. See an [example from the docs of Peppol](https://docs.peppol.eu/poacc/billing/3.0/bis/#_parties_2). Change `schemeName` to `schemeID`.

opw-4934436