### PR TITLE
[FIX] website: exclude cover properties from the o_dirty system

### DIFF
--- a/addons/website/static/src/components/wysiwyg_adapter/wysiwyg_adapter.js
+++ b/addons/website/static/src/components/wysiwyg_adapter/wysiwyg_adapter.js
@@ -172,6 +172,11 @@ export class WysiwygAdapterComponent extends ComponentAdapter {
         if (this.props.editableElements) {
             return this.props.editableElements();
         }
+        for (const coverPartEl of $wrapwrap[0].querySelectorAll(".o_record_cover_component")) {
+            // Exclude cover properties from the o_dirty system, they are
+            // handled by _saveCoverProperties.
+            coverPartEl.dataset.oeReadonly = 1;
+        }
         return $wrapwrap.find('[data-oe-model]')
             .not('.o_not_editable')
             .filter(function () {


### PR DESCRIPTION
Since summernote was replaced by the editor, the record cover template becomes `o_dirty` and therefore gets saved when a cover image is changed.

This commit solves this by marking the record cover components readonly inside the DOM.

Steps to reproduce:
- install website_blog
- set a blog cover image or specify its filter
- save

=> The `record_cover` template was saved with the modifications, thus combining `t-att-style` and `style` attributes.

task-jke
