### PR TITLE
[FIX] web: settings data shouldn't be cache

### DIFF
--- a/addons/web/static/src/webclient/settings_form_view/settings_form_view.js
+++ b/addons/web/static/src/webclient/settings_form_view/settings_form_view.js
@@ -36,6 +36,8 @@ class SettingRecord extends formView.Model.Record {
 }
 
 class SettingModel extends formView.Model {
+    static withCache = false;
+
     setup(params) {
         super.setup(...arguments);
         this._headerFields = params.headerFields;


### PR DESCRIPTION
Since [1], the data for the views has been cached, including the `on_change` of the settings. The data of the settings shouldn't be cached.

task-id: 4942256

[1] https://github.com/odoo/odoo/commit/e5cee98d6ebbf318386ec4002007fbecc0fb3937
