### PR TITLE
[IMP] base: ir.attachment._check_access and _search

### DIFF
--- a/addons/account/tests/test_account_incoming_supplier_invoice.py
+++ b/addons/account/tests/test_account_incoming_supplier_invoice.py
@@ -221,8 +221,8 @@ class TestAccountInvoiceImportMixin:
         """
 
         with (
-            RecordCapturer(self.env['ir.attachment']) as attachment_capturer,
-            RecordCapturer(self.env['mail.message']) as message_capturer,
+            RecordCapturer(self.env['ir.attachment'].sudo()) as attachment_capturer,
+            RecordCapturer(self.env['mail.message'].sudo()) as message_capturer,
             RecordCapturer(self.env['account.move']) as move_capturer,
         ):
             journal = self.company_data['default_journal_purchase']

--- a/addons/account/tests/test_account_move_send.py
+++ b/addons/account/tests/test_account_move_send.py
@@ -983,7 +983,7 @@ class TestAccountMoveSend(TestAccountMoveSendCommon):
         # The PDF is generated and linked
         self.assertTrue(invoice.invoice_pdf_report_id)
         # Not a proforma
-        self.assertFalse(self.env['ir.attachment'].search([
+        self.assertFalse(self.env['ir.attachment'].sudo().search([
             ('name', '=', invoice._get_invoice_proforma_pdf_report_filename()),
         ]))
 
@@ -1004,7 +1004,7 @@ class TestAccountMoveSend(TestAccountMoveSendCommon):
 
         # The PDF is not generated but a proforma.
         self.assertFalse(invoice.invoice_pdf_report_id)
-        self.assertTrue(self.env['ir.attachment'].search([
+        self.assertTrue(self.env['ir.attachment'].sudo().search([
             ('name', '=', invoice._get_invoice_proforma_pdf_report_filename()),
         ]))
 

--- a/addons/api_doc/controllers/api_doc.py
+++ b/addons/api_doc/controllers/api_doc.py
@@ -100,11 +100,11 @@ class DocController(http.Controller):
         # installed.
         # TODO: gzip
         filename = f'odoo-doc-index-{db_registry_sequence}-{unique}.json'
-        index_attach = self.env['ir.attachment'].search([('name', '=', filename)], limit=1)
+        index_attach = self.env['ir.attachment'].sudo().search([('name', '=', filename)], limit=1)
         if not index_attach:
             # No cache, generate the index and save it.
             modules, models = self._doc_index()
-            index_attach = self.env['ir.attachment'].create({
+            index_attach = index_attach.create({
                 'name': filename,
                 'description': (
                     "Generated /doc/index.json document.\n\n"

--- a/addons/mail/models/ir_attachment.py
+++ b/addons/mail/models/ir_attachment.py
@@ -2,7 +2,7 @@
 
 import contextlib
 
-from odoo import _, models, SUPERUSER_ID
+from odoo import _, models
 from odoo.exceptions import AccessError, UserError
 from odoo.tools.misc import limited_field_access_token, verify_limited_field_access_token
 from odoo.addons.mail.tools.discuss import Store
@@ -24,15 +24,13 @@ class IrAttachment(models.Model):
             raise UserError(_("An access token must be provided for each attachment."))
 
         def is_owned(attachment, token):
-            if not attachment.with_user(SUPERUSER_ID).exists():
+            if not attachment.exists():
                 return False
-            try:
-                attachment.sudo(False).check("write")
+            if attachment.sudo(False).has_access("write"):
                 return True
-            except AccessError:
-                return token and verify_limited_field_access_token(
-                    attachment, "id", token, scope="attachment_ownership"
-                )
+            return token and verify_limited_field_access_token(
+                attachment, "id", token, scope="attachment_ownership"
+            )
 
         return all(is_owned(att, tok) for att, tok in zip(self, attachment_tokens, strict=True))
 

--- a/addons/mail/models/mail_mail.py
+++ b/addons/mail/models/mail_mail.py
@@ -116,16 +116,14 @@ class MailMail(models.Model):
         Compute the attachments we have access to,
         and the number of attachments we do not have access to.
         """
-        IrAttachment = self.env['ir.attachment']
         for mail_sudo, mail in zip(self.sudo(), self):
-            mail.unrestricted_attachment_ids = IrAttachment._filter_attachment_access(mail_sudo.attachment_ids.ids)
+            mail.unrestricted_attachment_ids = mail_sudo.attachment_ids.sudo(False)._filter_attachment_access()
             mail.restricted_attachment_count = len(mail_sudo.attachment_ids) - len(mail.unrestricted_attachment_ids)
 
     def _inverse_unrestricted_attachment_ids(self):
         """We can only remove the attachments we have access to."""
-        IrAttachment = self.env['ir.attachment']
         for mail_sudo, mail in zip(self.sudo(), self):
-            restricted_attaments = mail_sudo.attachment_ids - IrAttachment._filter_attachment_access(mail_sudo.attachment_ids.ids)
+            restricted_attaments = mail_sudo.attachment_ids - mail_sudo.attachment_ids.sudo(False)._filter_attachment_access()
             mail_sudo.attachment_ids = restricted_attaments | mail.unrestricted_attachment_ids
 
     def _search_body_content(self, operator, value):

--- a/addons/mail/models/mail_mail.py
+++ b/addons/mail/models/mail_mail.py
@@ -117,13 +117,13 @@ class MailMail(models.Model):
         and the number of attachments we do not have access to.
         """
         for mail_sudo, mail in zip(self.sudo(), self):
-            mail.unrestricted_attachment_ids = mail_sudo.attachment_ids.sudo(False)._filter_attachment_access()
+            mail.unrestricted_attachment_ids = mail_sudo.attachment_ids.sudo(False)._filtered_access('read')
             mail.restricted_attachment_count = len(mail_sudo.attachment_ids) - len(mail.unrestricted_attachment_ids)
 
     def _inverse_unrestricted_attachment_ids(self):
         """We can only remove the attachments we have access to."""
         for mail_sudo, mail in zip(self.sudo(), self):
-            restricted_attaments = mail_sudo.attachment_ids - mail_sudo.attachment_ids.sudo(False)._filter_attachment_access()
+            restricted_attaments = mail_sudo.attachment_ids - mail_sudo.attachment_ids.sudo(False)._filtered_access('read')
             mail_sudo.attachment_ids = restricted_attaments | mail.unrestricted_attachment_ids
 
     def _search_body_content(self, operator, value):
@@ -147,7 +147,7 @@ class MailMail(models.Model):
             if values.get('attachment_ids'):
                 new_mails_w_attach += mail
         if new_mails_w_attach:
-            new_mails_w_attach.mapped('attachment_ids').check(mode='read')
+            new_mails_w_attach.attachment_ids.check_access('read')
 
         return new_mails
 
@@ -157,8 +157,7 @@ class MailMail(models.Model):
             vals['scheduled_date'] = parsed_datetime.replace(tzinfo=None) if parsed_datetime else False
         res = super(MailMail, self).write(vals)
         if vals.get('attachment_ids'):
-            for mail in self:
-                mail.attachment_ids.check(mode='read')
+            self.attachment_ids.check_access('read')
         return res
 
     def unlink(self):

--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -739,7 +739,7 @@ class MailMessage(models.Model):
         else:
             attachments_tocheck = messages.attachment_ids  # fallback on read if any unknown command
         if attachments_tocheck:
-            attachments_tocheck.check('read')
+            attachments_tocheck.check_access('read')
 
         for message, values, tracking_values_cmd in zip(messages, vals_list, tracking_values_list):
             if tracking_values_cmd:
@@ -778,8 +778,7 @@ class MailMessage(models.Model):
             self._invalidate_documents()
         res = super().write(vals)
         if vals.get('attachment_ids'):
-            for mail in self:
-                mail.attachment_ids.check(mode='read')
+            self.attachment_ids.check_access('read')
         if 'notification_ids' in vals or record_changed:
             self._invalidate_documents()
         return res

--- a/addons/project/tests/test_project_sharing_portal_access.py
+++ b/addons/project/tests/test_project_sharing_portal_access.py
@@ -112,7 +112,7 @@ class TestProjectSharingPortalAccess(TestProjectSharingCommon):
                 if field.type == 'html':
                     value = f'<p>{value}</p>'
                 return value
-            if field.relational:
+            if field.relational and field.comodel_name != 'ir.attachment':
                 value = task.env[field.comodel_name].search([], limit=1).id
                 if field.type != 'many2one':
                     value = [value]

--- a/addons/snailmail/models/snailmail_letter.py
+++ b/addons/snailmail/models/snailmail_letter.py
@@ -120,13 +120,13 @@ class SnailmailLetter(models.Model):
 
         self.env['mail.notification'].sudo().create(notification_vals)
 
-        letters.attachment_id.check('read')
+        letters.attachment_id.check_access('read')
         return letters
 
     def write(self, vals):
         res = super().write(vals)
         if 'attachment_id' in vals:
-            self.attachment_id.check('read')
+            self.attachment_id.check_access('read')
         return res
 
     def _fetch_attachment(self):

--- a/addons/test_mail/tests/test_mail_composer.py
+++ b/addons/test_mail/tests/test_mail_composer.py
@@ -585,6 +585,7 @@ class TestComposerForm(TestMailComposer):
                 form.template_id = template_no_subject
                 self.assertEqual(form.subject, template_complete.subject, "subject should be kept unchanged")
 
+
 @tagged('mail_composer')
 class TestComposerInternals(TestMailComposer):
 
@@ -601,7 +602,7 @@ class TestComposerInternals(TestMailComposer):
             'attachment_ids': False,
             'report_template_ids': False,
         })
-        attachs = self.env['ir.attachment'].search([('name', 'in', [a['name'] for a in attachment_data])])
+        attachs = self.env['ir.attachment'].sudo().search([('name', 'in', [a['name'] for a in attachment_data])])
         self.assertEqual(len(attachs), 3)
         extra_attach = self.env['ir.attachment'].create({
             'datas': base64.b64encode(b'ExtraData'),
@@ -1873,7 +1874,7 @@ class TestComposerResultsComment(TestMailComposer, CronMixinCase):
             'partner_to': '%s, {{ object.customer_id.id if object.customer_id else "" }}' % self.partner_admin.id,
             'report_template_ids': [(6, 0, (self.test_report + self.test_report_2).ids)],
         })
-        attachs = self.env['ir.attachment'].search([('name', 'in', [a['name'] for a in attachment_data])])
+        attachs = self.env['ir.attachment'].sudo().search([('name', 'in', [a['name'] for a in attachment_data])])
         self.assertEqual(len(attachs), 2)
 
         for batch_mode, scheduled_date, email_layout_xmlid, reply_to, use_lang in product(
@@ -2209,7 +2210,7 @@ class TestComposerResultsComment(TestMailComposer, CronMixinCase):
             'mail_server_id': False,  # let it find a server
             'partner_to': '%s, {{ object.customer_id.id if object.customer_id else "" }}' % self.partner_admin.id,
         })
-        attachs = self.env['ir.attachment'].search([('name', 'in', [a['name'] for a in attachment_data])])
+        attachs = self.env['ir.attachment'].sudo().search([('name', 'in', [a['name'] for a in attachment_data])])
         self.assertEqual(len(attachs), 2)
 
         for batch, companies, expected_companies, expected_alias_domains in [
@@ -2934,7 +2935,7 @@ class TestComposerResultsMass(TestMailComposer):
             'partner_to': '%s, {{ object.customer_id.id if object.customer_id else "" }}' % self.partner_admin.id,
             'report_template_ids': [(6, 0, self.test_report.ids)],
         })
-        attachs = self.env['ir.attachment'].search([('name', 'in', [a['name'] for a in attachment_data])])
+        attachs = self.env['ir.attachment'].sudo().search([('name', 'in', [a['name'] for a in attachment_data])])
         self.assertEqual(len(attachs), 2)
 
         # ensure initial data
@@ -3131,7 +3132,7 @@ class TestComposerResultsMass(TestMailComposer):
             'mail_server_id': False,  # let it find a server
             'partner_to': '%s, {{ object.customer_id.id if object.customer_id else "" }}' % self.partner_admin.id,
         })
-        attachs = self.env['ir.attachment'].search([('name', 'in', [a['name'] for a in attachment_data])])
+        attachs = self.env['ir.attachment'].sudo().search([('name', 'in', [a['name'] for a in attachment_data])])
         self.assertEqual(len(attachs), 2)
 
         for companies, expected_companies, expected_alias_domains in [

--- a/odoo/addons/base/models/ir_attachment.py
+++ b/odoo/addons/base/models/ir_attachment.py
@@ -10,15 +10,17 @@ import os
 import psycopg2
 import re
 import uuid
+import warnings
 import werkzeug
 
 from collections import defaultdict
+from collections.abc import Collection
 
 from odoo import api, fields, models, _
 from odoo.exceptions import AccessError, MissingError, ValidationError, UserError
 from odoo.fields import Domain
 from odoo.http import Stream, root, request
-from odoo.tools import config, consteq, human_size, image, split_every, str2bool
+from odoo.tools import config, consteq, human_size, image, split_every, str2bool, OrderedSet
 from odoo.tools.mimetypes import guess_mimetype, fix_filename_extension, _olecf_mimetypes
 from odoo.tools.misc import limited_field_access_token
 
@@ -440,87 +442,115 @@ class IrAttachment(models.Model):
     @api.model
     def check(self, mode, values=None):
         """ Restricts the access to an ir.attachment, according to referred mode """
+        warnings.warn("Since 19.0, use check_access", DeprecationWarning, stacklevel=2)
         # Always require an internal user (aka, employee) to access to a attachment
         if not (self.env.is_admin() or self.env.user._is_internal()):
             raise AccessError(_("Sorry, you are not allowed to access this document."))
-        # Filter returns the same instance if we have access to all documents
-        if self is not self._filter_attachment_access(mode, values):
+        self.check_access(mode)
+        if values and any(self._inaccessible_comodel_records({values.get('res_model'): [values.get('res_id')]}, mode)):
             raise AccessError(_("Sorry, you are not allowed to access this document."))
 
-    def _filter_attachment_access(self, mode='read', values=None):
-        """Filter the given attachment to return only the records the current user have access to.
-        Return ``self`` if the user has access to all records and values.
+    def _check_access(self, operation):
+        """Check access for attachments.
 
-        :return: <ir.attachment> the current user have access to
+        Rules:
+        - `public` is always accessible for reading.
+        - If we have `res_model and res_id`, the attachment is accessible if the
+          referenced model is accessible. Also, when `res_field != False` and
+          the user is not an administrator, we check the access on the field.
+        - If we don't have a referenced record, the attachment is accessible to
+          the administrator and the creator of the attachment.
         """
-        if self.env.su:
-            return self
-        Attachments = self.browse()
-        if not Attachments.has_access(mode):
-            return Attachments
-        if mode in ('create', 'unlink'):
+        res = super()._check_access(operation)
+        remaining = self
+        error_func = None
+        forbidden_ids = OrderedSet()
+        if res:
+            forbidden_recs, error_func = res
+            if forbidden_recs == self:
+                return self, error_func
+            remaining -= forbidden_recs
+            forbidden_ids.update(forbidden_ids._ids)
+        elif not self:
+            return None
+
+        if operation in ('create', 'unlink'):
             # check write operation instead of unlinking and creating for
             # related models and field access
-            mode = 'write'
-        att_accessible_ids = set()
-
-        # additional value to check
-        values = values or {}
-        additional_res = (values.get('res_model'), values.get('res_id'))
-        if not all(additional_res):
-            additional_res = None
+            operation = 'write'
 
         # collect the records to check (by model)
         model_ids = defaultdict(set)            # {model_name: set(ids)}
         att_model_ids = []                      # [(att_id, (res_model, res_id))]
-        if self:
-            # DLE P173: `test_01_portal_attachment`
-            self.env['ir.attachment'].flush_model(['res_model', 'res_id', 'create_uid', 'public', 'res_field'])
-            self.env.cr.execute('SELECT id, res_model, res_id, create_uid, public, res_field FROM ir_attachment WHERE id IN %s', [tuple(self.ids)])
-            for att_id, res_model, res_id, create_uid, public, res_field in self.env.cr.fetchall():
-                if public and mode == 'read':
-                    att_accessible_ids.add(att_id)
+        # DLE P173: `test_01_portal_attachment`
+        remaining.flush_recordset(['res_model', 'res_id', 'create_uid', 'public', 'res_field'])
+        self.env.cr.execute('SELECT id, res_model, res_id, create_uid, public, res_field FROM ir_attachment WHERE id IN %s', [tuple(remaining.ids)])
+        for att_id, res_model, res_id, create_uid, public, res_field in self.env.cr.fetchall():
+            if public and operation == 'read':
+                continue
+            if not self.env.is_system():
+                if not res_id and create_uid != self.env.uid:
+                    forbidden_ids.add(att_id)
                     continue
-                if not self.env.is_system():
-                    if not res_id and create_uid != self.env.uid:
-                        continue
-                    if res_field:
+                if res_field:
+                    try:
                         field = self.env[res_model]._fields[res_field]
-                        if not self._has_field_access(field, mode):
-                            continue
-                if res_model and res_id:
-                    model_ids[res_model].add(res_id)
-                    att_model_ids.append((att_id, (res_model, res_id)))
-                else:
-                    att_accessible_ids.add(att_id)
-        if additional_res:
-            model_ids[additional_res[0]].add(additional_res[1])
+                    except KeyError:
+                        # field does not exist
+                        field = None
+                    if field is None or not self._has_field_access(field, operation):
+                        forbidden_ids.add(att_id)
+                        continue
+            if res_model and res_id:
+                model_ids[res_model].add(res_id)
+                att_model_ids.append((att_id, (res_model, res_id)))
+        forbidden_res_model_id = set(self._inaccessible_comodel_records(model_ids, operation))
+        forbidden_ids.update(att_id for att_id, res in att_model_ids if res in forbidden_res_model_id)
 
+        if forbidden_ids:
+            forbidden = self.browse(forbidden_ids)
+            if error_func is None:
+                def error_func():
+                    return AccessError(self.env._(
+                        "Sorry, you are not allowed to access this document. "
+                        "Please contact your system administrator.\n\n"
+                        "(Operation: %(operation)s)\n\n"
+                        "Records: %(records)s, User: %(user)s",
+                        operation=operation,
+                        records=forbidden[:6],
+                        user=self.env.uid,
+                    ))
+            return forbidden, error_func
+        return None
+
+    def _inaccessible_comodel_records(self, model_and_ids: dict[str, Collection[int]], operation: str):
         # check access rights on the records
-        accessible_model_ids = set()
-        for res_model, res_ids in model_ids.items():
+        if self.env.su:
+            return
+        for res_model, res_ids in model_and_ids.items():
+            res_ids = OrderedSet(filter(None, res_ids))
+            if not res_model or not res_ids:
+                # nothing to check
+                continue
             # forbid access to attachments linked to removed models as we do not
             # know what persmissions should be checked
             if res_model not in self.env:
+                for res_id in res_ids:
+                    yield res_model, res_id
                 continue
             records = self.env[res_model].browse(res_ids)
             if res_model == 'res.users' and len(records) == 1 and self.env.uid == records.id:
                 # by default a user cannot write on itself, despite the list of writeable fields
                 # e.g. in the case of a user inserting an image into his image signature
                 # we need to bypass this check which would needlessly throw us away
-                accessible_model_ids.add((res_model, records.id))
                 continue
             try:
-                records = records._filtered_access(mode)
+                records = records._filtered_access(operation)
             except MissingError:
-                records = records.exists()._filtered_access(mode)
-            accessible_model_ids.update((res_model, id_) for id_ in records._ids)
-        att_accessible_ids.update(att_id for att_id, res in att_model_ids if res in accessible_model_ids)
-
-        if len(att_accessible_ids) == len(self) and (not additional_res or additional_res in accessible_model_ids):
-            # all is accessible
-            return self
-        return Attachments.browse(id_ for id_ in self._ids if id_ in att_accessible_ids)
+                records = records.exists()._filtered_access(operation)
+            res_ids.difference_update(records._ids)
+            for res_id in res_ids:
+                yield res_model, res_id
 
     @api.model
     def _search(self, domain, offset=0, limit=None, order=None, *, active_test=True, bypass_access=False):
@@ -602,13 +632,22 @@ class IrAttachment(models.Model):
         return self.browse(result)._as_query(order)
 
     def write(self, vals):
-        self.check('write', values=vals)
+        self.check_access('write')
+        if vals.get('res_model') or vals.get('res_id'):
+            model_and_ids = defaultdict(OrderedSet)
+            if 'res_model' in vals and 'res_id' in vals:
+                model_and_ids[vals['res_model']].add(vals['res_id'])
+            else:
+                for record in self:
+                    model_and_ids[vals.get('res_model', record.res_model)].add(vals.get('res_id', record.res_id))
+            if any(self._inaccessible_comodel_records(model_and_ids, 'write')):
+                raise AccessError(_("Sorry, you are not allowed to access this document."))
         # remove computed field depending of datas
         for field in ('file_size', 'checksum', 'store_fname'):
             vals.pop(field, False)
         if 'mimetype' in vals or 'datas' in vals or 'raw' in vals:
             vals = self._check_contents(vals)
-        res = super(IrAttachment, self).write(vals)
+        res = super().write(vals)
         if 'url' in vals or 'type' in vals:
             self._check_serving_attachments()
         return res
@@ -623,16 +662,12 @@ class IrAttachment(models.Model):
         return vals_list
 
     def unlink(self):
-        if not self:
-            return True
-        self.check('unlink')
-
         # First delete in the database, *then* in the filesystem if the
         # database allowed it. Helps avoid errors when concurrent transactions
         # are deleting the same file, and some of the transactions are
         # rolled back by PostgreSQL (due to concurrent updates detection).
-        to_delete = set(attach.store_fname for attach in self if attach.store_fname)
-        res = super(IrAttachment, self).unlink()
+        to_delete = OrderedSet(attach.store_fname for attach in self if attach.store_fname)
+        res = super().unlink()
         for file_path in to_delete:
             self._file_delete(file_path)
 
@@ -669,9 +704,11 @@ class IrAttachment(models.Model):
             record_tuple_set.add(record_tuple)
 
         # don't use possible contextual recordset for check, see commit for details
-        Attachments = self.browse()
+        model_and_ids = defaultdict(set)
         for res_model, res_id in record_tuple_set:
-            Attachments.check('create', values={'res_model':res_model, 'res_id':res_id})
+            model_and_ids[res_model].add(res_id)
+        if any(self._inaccessible_comodel_records(model_and_ids, 'write')):
+            raise AccessError(_("Sorry, you are not allowed to access this document."))
         records = super().create(vals_list)
         records._check_serving_attachments()
         return records
@@ -847,6 +884,6 @@ class IrAttachment(models.Model):
         if self.env.user._is_portal():
             # Check the read access on the record linked to the attachment
             # eg: Allow to download an attachment on a task from /my/tasks/task_id
-            self.check("read")
+            self.check_access('read')
             return True
         return super()._can_return_content(field_name, access_token)

--- a/odoo/addons/base/models/ir_attachment.py
+++ b/odoo/addons/base/models/ir_attachment.py
@@ -15,7 +15,7 @@ import werkzeug
 from collections import defaultdict
 
 from odoo import api, fields, models, _
-from odoo.exceptions import AccessError, ValidationError, UserError
+from odoo.exceptions import AccessError, MissingError, ValidationError, UserError
 from odoo.fields import Domain
 from odoo.http import Stream, root, request
 from odoo.tools import config, consteq, human_size, image, split_every, str2bool
@@ -440,72 +440,87 @@ class IrAttachment(models.Model):
     @api.model
     def check(self, mode, values=None):
         """ Restricts the access to an ir.attachment, according to referred mode """
-        if self.env.is_superuser():
-            return True
         # Always require an internal user (aka, employee) to access to a attachment
         if not (self.env.is_admin() or self.env.user._is_internal()):
             raise AccessError(_("Sorry, you are not allowed to access this document."))
+        # Filter returns the same instance if we have access to all documents
+        if self is not self._filter_attachment_access(mode, values):
+            raise AccessError(_("Sorry, you are not allowed to access this document."))
+
+    def _filter_attachment_access(self, mode='read', values=None):
+        """Filter the given attachment to return only the records the current user have access to.
+        Return ``self`` if the user has access to all records and values.
+
+        :return: <ir.attachment> the current user have access to
+        """
+        if self.env.su:
+            return self
+        Attachments = self.browse()
+        if not Attachments.has_access(mode):
+            return Attachments
+        if mode in ('create', 'unlink'):
+            # check write operation instead of unlinking and creating for
+            # related models and field access
+            mode = 'write'
+        att_accessible_ids = set()
+
+        # additional value to check
+        values = values or {}
+        additional_res = (values.get('res_model'), values.get('res_id'))
+        if not all(additional_res):
+            additional_res = None
+
         # collect the records to check (by model)
         model_ids = defaultdict(set)            # {model_name: set(ids)}
+        att_model_ids = []                      # [(att_id, (res_model, res_id))]
         if self:
             # DLE P173: `test_01_portal_attachment`
             self.env['ir.attachment'].flush_model(['res_model', 'res_id', 'create_uid', 'public', 'res_field'])
-            self.env.cr.execute('SELECT res_model, res_id, create_uid, public, res_field FROM ir_attachment WHERE id IN %s', [tuple(self.ids)])
-            for res_model, res_id, create_uid, public, res_field in self.env.cr.fetchall():
+            self.env.cr.execute('SELECT id, res_model, res_id, create_uid, public, res_field FROM ir_attachment WHERE id IN %s', [tuple(self.ids)])
+            for att_id, res_model, res_id, create_uid, public, res_field in self.env.cr.fetchall():
                 if public and mode == 'read':
+                    att_accessible_ids.add(att_id)
                     continue
                 if not self.env.is_system():
                     if not res_id and create_uid != self.env.uid:
-                        raise AccessError(_("Sorry, you are not allowed to access this document."))
+                        continue
                     if res_field:
                         field = self.env[res_model]._fields[res_field]
-                        if not self._has_field_access(field, 'read'):
-                            raise AccessError(_("Sorry, you are not allowed to access this document."))
-                if not (res_model and res_id):
-                    continue
-                model_ids[res_model].add(res_id)
-        if values and values.get('res_model') and values.get('res_id'):
-            model_ids[values['res_model']].add(values['res_id'])
+                        if not self._has_field_access(field, mode):
+                            continue
+                if res_model and res_id:
+                    model_ids[res_model].add(res_id)
+                    att_model_ids.append((att_id, (res_model, res_id)))
+                else:
+                    att_accessible_ids.add(att_id)
+        if additional_res:
+            model_ids[additional_res[0]].add(additional_res[1])
 
         # check access rights on the records
+        accessible_model_ids = set()
         for res_model, res_ids in model_ids.items():
-            # ignore attachments that are not attached to a resource anymore
-            # when checking access rights (resource was deleted but attachment
-            # was not)
+            # forbid access to attachments linked to removed models as we do not
+            # know what persmissions should be checked
             if res_model not in self.env:
                 continue
-            if res_model == 'res.users' and len(res_ids) == 1 and self.env.uid == list(res_ids)[0]:
+            records = self.env[res_model].browse(res_ids)
+            if res_model == 'res.users' and len(records) == 1 and self.env.uid == records.id:
                 # by default a user cannot write on itself, despite the list of writeable fields
                 # e.g. in the case of a user inserting an image into his image signature
                 # we need to bypass this check which would needlessly throw us away
+                accessible_model_ids.add((res_model, records.id))
                 continue
-            records = self.env[res_model].browse(res_ids).exists()
-            # For related models, check if we can write to the model, as unlinking
-            # and creating attachments can be seen as an update to the model
-            access_mode = 'write' if mode in ('create', 'unlink') else mode
-            records.check_access(access_mode)
-
-    @api.model
-    def _filter_attachment_access(self, attachment_ids):
-        """Filter the given attachment to return only the records the current user have access to.
-
-        :param attachment_ids: List of attachment ids we want to filter
-        :return: <ir.attachment> the current user have access to
-        """
-        ret_attachments = self.env['ir.attachment']
-        attachments = self.browse(attachment_ids)
-        if not attachments.has_access('read'):
-            return ret_attachments
-
-        for attachment in attachments.sudo():
-            # Use SUDO here to not raise an error during the prefetch
-            # And then drop SUDO right to check if we can access it
             try:
-                attachment.sudo(False).check('read')
-                ret_attachments |= attachment
-            except AccessError:
-                continue
-        return ret_attachments
+                records = records._filtered_access(mode)
+            except MissingError:
+                records = records.exists()._filtered_access(mode)
+            accessible_model_ids.update((res_model, id_) for id_ in records._ids)
+        att_accessible_ids.update(att_id for att_id, res in att_model_ids if res in accessible_model_ids)
+
+        if len(att_accessible_ids) == len(self) and (not additional_res or additional_res in accessible_model_ids):
+            # all is accessible
+            return self
+        return Attachments.browse(id_ for id_ in self._ids if id_ in att_accessible_ids)
 
     @api.model
     def _search(self, domain, offset=0, limit=None, order=None, *, active_test=True, bypass_access=False):

--- a/odoo/addons/base/tests/test_qweb.py
+++ b/odoo/addons/base/tests/test_qweb.py
@@ -2184,6 +2184,7 @@ class TestQwebPerformance(TransactionCaseWithUserDemo):
         doc = self.env['ir.attachment'].create({
             'name': 'test',
             'type': 'url',
+            'public': True,
         })
 
         expected = """


### PR DESCRIPTION
Refactor how permissions are checked for `ir.attachment`.

- Batch checking whether the user has permission on the linked models.
- Implement `_check_access` instead of having a custom function for checks.
- Use cached values when checking permissions.
- Move attachments on activities in sudo to avoid additional permission checks.
- Implement `_search` by performing checks directly in the domain instead of fetching all and filtering. See commit message for details.

odoo/enterprise#90240

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
