### PR TITLE
[FIX] account_edi_ubl_cii: fix mention of `account_accountant`

### DIFF
--- a/addons/account_edi_ubl_cii/tests/test_ubl_cii.py
+++ b/addons/account_edi_ubl_cii/tests/test_ubl_cii.py
@@ -294,7 +294,7 @@ class TestAccountEdiUblCii(AccountTestInvoicingCommon):
         self.assertEqual(end_date.text, '20241231')
 
     def test_export_import_billing_dates(self):
-        if self.env.ref('base.module_account_accountant').state != 'installed':
+        if self.env.ref('base.module_accountant').state != 'installed':
             self.skipTest("payment_custom module is not installed")
 
         invoice = self.env['account.move'].create({


### PR DESCRIPTION
This [commit](https://github.com/odoo/odoo/commit/266c6bd8f4d7c64d1f0e02207a3e1bed4f75397d) added a test to skip if the enterprise module `accountant` is not installed. It uses the old name o the module `account_accountant` because the forward port was not adapted.