### PR TITLE
[FIX] gamification: prevent key error exception

### DIFF
--- a/addons/gamification/models/gamification_challenge.py
+++ b/addons/gamification/models/gamification_challenge.py
@@ -617,7 +617,9 @@ class Challenge(models.Model):
                 lines = challenge._get_serialized_challenge_lines(user, restrict_goals=subset_goals)
                 if not lines:
                     continue
-
+                # Avoid error if 'full_suffix' is missing in the line
+                for line in lines:
+                    line.setdefault('full_suffix', '')
                 body_html = challenge.report_template_id.with_user(user).with_context(challenge_lines=lines)._render_field('body_html', challenge.ids)[challenge.id]
 
                 # notify message only to users, do not post on the challenge


### PR DESCRIPTION
 [FIX] gamification: prevent key error exception

To reproduce:
=============
1. Navigate to Settings > Gamification Tools > Challenges.
2. Create a new challenge or open any existing active challenge.
3. Set the Display Mode to Individual Goals, and then click on Send Report.

Problem:
=========
Accessing line['full_suffix'] directly raised an exception
when the key was missing, causing the template rendering to fail.
https://github.com/odoo/odoo/blob/cd5f29b8b50ef4228be8f58a02bb328548208f77/addons/gamification/data/mail_template_data.xml#L175C1-L175C92

Solution:
=========
Use line.setdefault('full_suffix', '') to ensure the key exists with
a default empty string, preventing errors and allowing the template
to render smoothly.

opw-4909617.
