### PR TITLE
[FIX] point_of_sale: ensure consistent payment method display

### DIFF
--- a/addons/point_of_sale/report/pos_order_report.py
+++ b/addons/point_of_sale/report/pos_order_report.py
@@ -47,7 +47,7 @@ class PosOrderReport(models.Model):
             WITH payment_method_by_order_line AS (
                 SELECT
                     pol.id AS pos_order_line_id,
-                    (array_agg(pm.payment_method_id))[1] AS payment_method_id
+                    (array_agg(pm.payment_method_id ORDER BY pm.id ASC))[1] AS payment_method_id
                 FROM pos_order_line pol
                 LEFT JOIN pos_order po ON (po.id = pol.order_id)
                 LEFT JOIN pos_payment pm ON (pm.pos_order_id=po.id)


### PR DESCRIPTION
Previously, orders with multiple payment methods showed different methods in the search view and the report. This remains a technical limitation of multi-method payments, but the behavior is now consistent.

Steps to reproduce:
-------------------
* In PoS create and validate an order paid by cash AND card
* In the backend go to Reporting > Orders
* Select Group By : Payement Method
* Open the Report of your order

> Observation:
On the report, the method usually was the first one used but not in the search view

opw-4851249

