### PR TITLE
[FIX] tools: add quarter to possible timedelta

### DIFF
--- a/odoo/tools/date_utils.py
+++ b/odoo/tools/date_utils.py
@@ -86,7 +86,7 @@ def get_fiscal_year(date: D, day: int = 31, month: int = 12) -> Tuple[D, D]:
     return date_from, date_to
 
 
-def get_timedelta(qty: int, granularity: Literal['hour', 'day', 'week', 'month', 'year']):
+def get_timedelta(qty: int, granularity: Literal['hour', 'day', 'week', 'month', 'quarter', 'year']):
     """ Helper to get a `relativedelta` object for the given quantity and interval unit.
     """
     switch = {
@@ -94,6 +94,7 @@ def get_timedelta(qty: int, granularity: Literal['hour', 'day', 'week', 'month',
         'day': relativedelta(days=qty),
         'week': relativedelta(weeks=qty),
         'month': relativedelta(months=qty),
+        'quarter': relativedelta(months=3 * qty),
         'year': relativedelta(years=qty),
     }
     return switch[granularity]


### PR DESCRIPTION
**Issue:**
In the gantt views, quarter filtering is treated in the same way as the month filtering after
some refactoring. Its scale was removed as well. When using `gantt_scale` to view project tasks,
the time range was not displayed properly in the interface (no quarter grouping).

**Fix:**
Added 'quarter' to the possible timedelta to keep `delta = get_timedelta(1, scale)`. We could
also add a simpler check for 'quarter' scale and cast it in month quantity, but it seems worse.

opw-4916133

related : https://github.com/odoo/enterprise/commit/1abfc20baae80a3e7e250019b09a7070e831eeac
related : https://github.com/odoo/enterprise/commit/067c2b43ec3329d1ef59e0e8f6030f0ec5e43829

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
