### PR TITLE
[FIX] crm: fix membership description to use Levels instead of Grades

### DIFF
--- a/addons/crm/views/res_config_settings_views.xml
+++ b/addons/crm/views/res_config_settings_views.xml
@@ -31,7 +31,7 @@
                                 Install Extension
                             </a>
                         </setting>
-                        <setting id="partnership_settings" help="Manage members or partners. Members get grades and pricelists, partners allow lead assignment and commission plans.">
+                        <setting id="partnership_settings" help="Manage members or partners. Members get levels and pricelists, partners allow lead assignment and commission plans.">
                             <field name="module_partnership"/>
                         </setting>
                     </block>


### PR DESCRIPTION
This PR updates the description shown when the "Membership / Partnership" setting is enabled. The term Grades was previously used, but the actual model is named Level, so we have replaced Grades with Levels for consistency

Task-4945715