### PR TITLE
[FIX] mail: allow filtering on template_category as user

### DIFF
--- a/addons/mail/models/mail_template.py
+++ b/addons/mail/models/mail_template.py
@@ -138,7 +138,7 @@ class MailTemplate(models.Model):
         value = [value] if isinstance(value, str) else value
         operator = 'in' if operator in ("in", "=") else 'not in'
 
-        templates_with_xmlid = self.env['ir.model.data']._search([
+        templates_with_xmlid = self.env['ir.model.data'].sudo()._search([
             ('model', '=', 'mail.template'),
             ('module', '!=', '__export__')
         ]).subselect('res_id')


### PR DESCRIPTION
Since commit 42be7cebc84ac4af36104b6d2eba9d3e5d115005, filtering mail templates on their category triggers a search on `ir.model.data` to avoid a memory error on a database having a lot of mail templates.

However, regular users don't have a read access to this model, so when a user tries to filter on the template category, they get an `AccessError`.

With this commit, we add a `sudo()` on the search on `ir.model.data`, so that this error doesn't occur any more.

To reproduce the issue on a runbot, follow these steps:
- connect as *demo* on a 18.0 database
- open a *Sale Order* or a *Purchase Order*, and click on *Send by email*
- in the modal dialog, click on the vertical three dots to select a template
- if *Search More...* is not available, save the template several times with different new names until *Search More...* appears on the list
- click on *Search More...*
- in the *Search...* field, click on one of the *Base Templates* or *Custom Templates* filters
- boom! `Access Error, You are not allowed to access 'Model Data' (ir.model.data) records.`