### PR TITLE
[IMP] l10n_in_pos: add HSN code to POS reversal journal items for IN companies

### DIFF
--- a/addons/l10n_in_pos/models/pos_order.py
+++ b/addons/l10n_in_pos/models/pos_order.py
@@ -18,3 +18,11 @@ class PosOrder(models.Model):
                 l10n_in_gst_treatment = partner.vat and 'regular' or 'consumer'
             vals['l10n_in_gst_treatment'] = l10n_in_gst_treatment
         return vals
+
+    def _prepare_product_aml_dict(self, base_line_vals, update_base_line_vals, rate, sign):
+        res = super()._prepare_product_aml_dict(base_line_vals, update_base_line_vals, rate, sign)
+        if self.company_id.account_fiscal_country_id.code == 'IN':
+            res.update({
+                'l10n_in_hsn_code': base_line_vals['l10n_in_hsn_code'],
+            })
+        return res

--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -772,6 +772,24 @@ class PosOrder(models.Model):
             vals.update({'narration': self.floating_order_name})
         return vals
 
+    def _prepare_product_aml_dict(self, base_line_vals, update_base_line_vals, rate, sign):
+        amount_currency = update_base_line_vals['amount_currency']
+        balance = self.company_id.currency_id.round(amount_currency * rate)
+        order_line = base_line_vals['record']
+        return {
+            'name': order_line.full_product_name,
+            'product_id': order_line.product_id.id,
+            'quantity': order_line.qty * sign,
+            'account_id': base_line_vals['account_id'].id,
+            'partner_id': base_line_vals['partner_id'].id,
+            'currency_id': base_line_vals['currency_id'].id,
+            'tax_ids': [(6, 0, base_line_vals['tax_ids'].ids)],
+            'tax_tag_ids': update_base_line_vals['tax_tag_ids'],
+            'amount_currency': amount_currency,
+            'balance': balance,
+            'tax_tag_invert': not base_line_vals['is_refund'],
+        }
+
     def _prepare_aml_values_list_per_nature(self):
         self.ensure_one()
         AccountTax = self.env['account.tax']
@@ -803,24 +821,10 @@ class PosOrder(models.Model):
 
         # Create the aml values for order lines.
         for base_line_vals, update_base_line_vals in tax_results['base_lines_to_update']:
-            order_line = base_line_vals['record']
-            amount_currency = update_base_line_vals['amount_currency']
-            balance = company_currency.round(amount_currency * rate)
-            aml_vals_list_per_nature['product'].append({
-                'name': order_line.full_product_name,
-                'product_id': order_line.product_id.id,
-                'quantity': order_line.qty * sign,
-                'account_id': base_line_vals['account_id'].id,
-                'partner_id': base_line_vals['partner_id'].id,
-                'currency_id': base_line_vals['currency_id'].id,
-                'tax_ids': [(6, 0, base_line_vals['tax_ids'].ids)],
-                'tax_tag_ids': update_base_line_vals['tax_tag_ids'],
-                'amount_currency': amount_currency,
-                'balance': balance,
-                'tax_tag_invert': not base_line_vals['is_refund'],
-            })
-            total_amount_currency += amount_currency
-            total_balance += balance
+            product_dict = self._prepare_product_aml_dict(base_line_vals, update_base_line_vals, rate, sign)
+            aml_vals_list_per_nature['product'].append(product_dict)
+            total_amount_currency += product_dict['amount_currency']
+            total_balance += product_dict['balance']
 
         # Cash rounding.
         cash_rounding = self.config_id.rounding_method


### PR DESCRIPTION
This commit ensures that the `l10n_in_hsn_code` is also included in the accounting move lines are generated for reversal entries of POS orders when the The company’s fiscal country is India.

Key changes:

* Introduced the method `_prepare_product_aml_dict` in `point_of_sale` to centralize journal line creation logic.
* Overridden the method in `l10n_in_pos` to append the `l10n_in_hsn_code` from the base values for Indian companies.
* Ensured this applies consistently for both regular and reversal entries.

This enhancement is essential for maintaining accurate HSN-wise reporting in GSTR filings, even when entries are reversed after session closure.

OPW: 4931360
