### PR TITLE
[IMP] web: ControlPanel's buttons responsiveness

### DIFF
--- a/addons/base_import/static/tests/import_action.test.js
+++ b/addons/base_import/static/tests/import_action.test.js
@@ -7,6 +7,7 @@ import {
     defineModels,
     fields,
     getService,
+    getMockEnv,
     mockService,
     models,
     mountWebClient,
@@ -614,7 +615,12 @@ describe("Import view", () => {
         );
 
         await contains(".o_import_data_content .o_select_menu").selectDropdownItem("Display name");
-        await contains(".o_control_panel_main_buttons button:nth-child(2)").click();
+        if (getMockEnv().isSmall) {
+            await contains(".o_control_panel_main_buttons button > .oi-ellipsis-v").click();
+            await contains(".o-dropdown--menu button:visible").click();
+        } else {
+            await contains(".o_control_panel_main_buttons button:nth-child(2)").click();
+        }
         expect.verifySteps([
             "/web/dataset/call_kw/base_import.import/execute_import",
             "1 records successfully imported",
@@ -651,7 +657,12 @@ describe("Import view", () => {
         await animationFrame();
         // For this test, we force the display of an error message if this field is set
         await contains(".o_import_data_content .o_select_menu").selectDropdownItem("Selection");
-        await contains(".o_control_panel_main_buttons button:nth-child(2)").click();
+        if (getMockEnv().isSmall) {
+            await contains(".o_control_panel_main_buttons button > .oi-ellipsis-v").click();
+            await contains(".o-dropdown--menu button:visible").click();
+        } else {
+            await contains(".o_control_panel_main_buttons button:nth-child(2)").click();
+        }
         expect(".o_import_data_content .alert-danger:first").toHaveText(
             "The file contains blocking errors (see below)",
             { message: "a message is shown if the import was blocked" }
@@ -709,7 +720,12 @@ describe("Import view", () => {
         await animationFrame();
         // For this test, we force the display of an error message if this field is set
         await contains(".o_import_data_content .o_select_menu").selectDropdownItem("Bar");
-        await contains(".o_control_panel_main_buttons button:nth-child(2)").click();
+        if (getMockEnv().isSmall) {
+            await contains(".o_control_panel_main_buttons button > .oi-ellipsis-v").click();
+            await contains(".o-dropdown--menu button:visible").click();
+        } else {
+            await contains(".o_control_panel_main_buttons button:nth-child(2)").click();
+        }
         expect(".o_import_data_content .alert-danger:first").toHaveText(
             "The file contains blocking errors (see below)",
             { message: "a message is shown if the import was blocked" }
@@ -774,7 +790,12 @@ describe("Import view", () => {
             message: "import is now successful",
         });
         await contains(".o_import_field_many2many select").select("import_skip_records");
-        await contains(".o_control_panel_main_buttons button:nth-child(2)").click();
+        if (getMockEnv().isSmall) {
+            await contains(".o_control_panel_main_buttons button > .oi-ellipsis-v").click();
+            await contains(".o-dropdown--menu button:visible").click();
+        } else {
+            await contains(".o_control_panel_main_buttons button:nth-child(2)").click();
+        }
         expect.verifySteps(["execute_import"]);
         expect(".o_import_data_content .alert-info:first").toHaveText("Everything seems valid.", {
             message: "import is still successful",
@@ -927,7 +948,12 @@ describe("Import view", () => {
         await setInputFiles([file]);
         await animationFrame();
         await contains("input#o_import_batch_limit").edit(1);
-        await contains(".o_control_panel_main_buttons button:nth-child(2)").click();
+        if (getMockEnv().isSmall) {
+            await contains(".o_control_panel_main_buttons button > .oi-ellipsis-v").click();
+            await contains(".o-dropdown--menu button:visible").click();
+        } else {
+            await contains(".o_control_panel_main_buttons button:nth-child(2)").click();
+        }
         // Since a animationFrame is added to each batch, we must wait twice before the end of the second batch
         await animationFrame();
         await animationFrame();
@@ -1215,7 +1241,12 @@ describe("Import view", () => {
         await animationFrame();
         // For this test, we force the display of an error message if this field is set
         await contains(".o_import_data_content .o_select_menu").selectDropdownItem("Many2Many");
-        await contains(".o_control_panel_main_buttons button:nth-child(2)").click();
+        if (getMockEnv().isSmall) {
+            await contains(".o_control_panel_main_buttons button > .oi-ellipsis-v").click();
+            await contains(".o-dropdown--menu button:visible").click();
+        } else {
+            await contains(".o_control_panel_main_buttons button:nth-child(2)").click();
+        }
 
         expect(".o_import_data_content .alert-danger:first").toHaveText(
             "The file contains blocking errors (see below)",
@@ -1272,9 +1303,12 @@ describe("Import view", () => {
         // Parse the file again with the updated date format to check that
         // the format is correctly formatted in the UI
         await contains(".o_import_formatting button").click();
-        await contains(
-            ".o_control_panel_main_buttons > div:visible > button:contains(Import):eq(0)"
-        ).click();
+        if (getMockEnv().isSmall) {
+            await contains(".o_control_panel_main_buttons button > .oi-ellipsis-v").click();
+            await contains(".o-dropdown--menu button:visible").click();
+        } else {
+            await contains(".o_control_panel_main_buttons button:contains(Import):eq(0)").click();
+        }
         expect.verifySteps(["parse_preview", "parse_preview", "execute_import"]);
         expect(".o_import_date_format").toHaveValue("YYYYMMDD", {
             message: "UI displays the human formatted date",

--- a/addons/web/static/src/core/bottom_sheet/bottom_sheet.scss
+++ b/addons/web/static/src/core/bottom_sheet/bottom_sheet.scss
@@ -269,6 +269,8 @@
     .dropdown-item, .dropdown-header {
         --dropdown-item-padding-y: #{map-get($spacers, 3)};
         --dropdown-item-padding-x: var(--BottomSheet-Entry-paddingX);
+        --dropdown-header-padding-y: var(--dropdown-item-padding-y);
+        --dropdown-header-padding-x: var(--dropdown-item-padding-x);
 
         font-size: $h5-font-size;
         font-weight: $o-font-weight-medium;

--- a/addons/web/static/src/search/control_panel/control_panel.js
+++ b/addons/web/static/src/search/control_panel/control_panel.js
@@ -201,32 +201,6 @@ export class ControlPanel extends Component {
             this.initialScrollTop = this.getScrollingElement().scrollTop;
         });
 
-        this.mainButtons = useRef("mainButtons");
-
-        useEffect(() => {
-            // on small screen, clean-up the dropdown elements
-            const dropdownButtons = this.mainButtons.el.querySelectorAll(
-                ".o_control_panel_collapsed_create.dropdown-menu button"
-            );
-            if (!dropdownButtons.length) {
-                this.mainButtons.el
-                    .querySelectorAll(
-                        ".o_control_panel_collapsed_create.dropdown-menu, .o_control_panel_collapsed_create.dropdown-toggle"
-                    )
-                    .forEach((el) => el.classList.add("d-none"));
-                this.mainButtons.el
-                    .querySelectorAll(".o_control_panel_collapsed_create.btn-group")
-                    .forEach((el) => el.classList.remove("btn-group"));
-                return;
-            }
-            for (const button of dropdownButtons) {
-                for (const cl of Array.from(button.classList)) {
-                    button.classList.toggle(cl, !cl.startsWith("btn-"));
-                }
-                button.classList.add("dropdown-item", "btn", "btn-link");
-            }
-        });
-
         useSortable({
             enable: true,
             ref: this.root,
@@ -613,5 +587,31 @@ export class ControlPanel extends Component {
         }
         this._sortEmbeddedActions(order);
         browser.localStorage.setItem(this.embeddedOrderKey, JSON.stringify(order));
+    }
+
+    dropdownifyButtons() {
+        const adaptiveMenu = document.querySelector(
+            ".o-control-panel-adaptive-dropdown.dropdown-menu"
+        );
+        const meaningfulElements = this.getBoxedElements(adaptiveMenu.children);
+        for (const el of meaningfulElements) {
+            el.classList.add("dropdown-item");
+            el.classList.remove("btn");
+        }
+    }
+
+    getBoxedElements(elements) {
+        const boxed = [];
+        for (const el of [...elements]) {
+            const elStyles = el.ownerDocument.defaultView.getComputedStyle(el);
+            if (elStyles.getPropertyValue("display") === "contents") {
+                boxed.push(...this.getBoxedElements(el.children));
+            } else if (elStyles.getPropertyValue("display") === "none") {
+                continue;
+            } else {
+                boxed.push(el);
+            }
+        }
+        return boxed;
     }
 }

--- a/addons/web/static/src/search/control_panel/control_panel.xml
+++ b/addons/web/static/src/search/control_panel/control_panel.xml
@@ -21,22 +21,20 @@
             </Transition>
             <div class="o_control_panel_main d-flex flex-wrap flex-lg-nowrap justify-content-between align-items-lg-start gap-2 gap-lg-3 flex-grow-1">
                 <div class="o_control_panel_breadcrumbs d-flex align-items-center gap-1 order-0 h-lg-100">
-                    <div class="o_control_panel_main_buttons d-flex gap-1 d-empty-none d-print-none" t-ref="mainButtons" t-on-keydown="onMainButtonsKeydown">
-                        <div t-if="env.isSmall" class="btn-group o_control_panel_collapsed_create">
-                            <t t-slot="control-panel-create-button"/>
-                            <button t-att-class="{invisible: display.disableDropdown}" type="button" class="btn btn-primary dropdown-toggle dropdown-toggle-split o_control_panel_collapsed_create" data-bs-toggle="dropdown" aria-expanded="false">
-                                 <span class="visually-hidden">Toggle Dropdown</span>
+                    <div class="o_control_panel_main_buttons d-flex gap-1 d-empty-none d-print-none" t-on-keydown="onMainButtonsKeydown">
+                        <t t-slot="control-panel-create-button"/>
+                        <t t-slot="layout-buttons"/>
+                        <t t-slot="control-panel-always-buttons"/>
+                        <Dropdown t-if="env.isSmall" menuClass="'o-control-panel-adaptive-dropdown'" onOpened.bind="dropdownifyButtons">
+                            <button class="btn btn-secondary o-control-panel-adaptive-dropdown" title="More">
+                                <i class="oi oi-fw oi-ellipsis-v" />
                             </button>
-                            <ul class="dropdown-menu o_control_panel_collapsed_create">
+                            <t t-set-slot="content">
+                                <t t-slot="control-panel-create-button"/>
                                 <t t-slot="layout-buttons"/>
                                 <t t-slot="control-panel-always-buttons"/>
-                            </ul>
-                        </div>
-                        <div t-else="" class="d-inline-flex gap-1">
-                            <t t-slot="control-panel-create-button"/>
-                            <t t-slot="layout-buttons"/>
-                            <t t-slot="control-panel-always-buttons"/>
-                        </div>
+                            </t>
+                        </Dropdown>
                     </div>
                     <t t-if="env.config.noBreadcrumbs">
                         <section class="o_control_panel_breadcrumbs_actions d-contents d-print-none">

--- a/addons/web/static/src/search/control_panel/control_panel_mobile.css
+++ b/addons/web/static/src/search/control_panel/control_panel_mobile.css
@@ -1,0 +1,22 @@
+@media (max-width: 767.98px) { /* breakpoint-md */
+    .o_control_panel_main_buttons {
+        /* hide the ellipsis dropdown by default */
+        > .o-control-panel-adaptive-dropdown {
+            display: none;
+        }
+
+        /* hide the visible elements beside the first one and the ellipsis dropdown */
+        > :nth-child(n + 2 of :not(.d-none, .o_hidden, .o-control-panel-adaptive-dropdown)) {
+            display: none !important;
+
+            ~ .o-control-panel-adaptive-dropdown {
+                display: inline-block;
+            }
+        }
+    }
+
+    /* hide the first element in the ellipsis dropdown menu */
+    .o-control-panel-adaptive-dropdown.dropdown-menu > :nth-child(1 of :not(.d-none, .o_hidden)) {
+        display: none !important;
+    }
+}

--- a/addons/web/static/src/webclient/webclient.scss
+++ b/addons/web/static/src/webclient/webclient.scss
@@ -143,8 +143,10 @@ kbd {
 .o_web_client.o_touch_device {
   .btn {
       &, .btn-sm {
+        &:where(:not(.dropdown-item)) {
           font-size: $font-size-base;
           padding: $o-touch-btn-padding;
+        }
       }
 
       &:has(.fa-fw:only-child, .oi-fw:only-child) {

--- a/addons/web/static/tests/views/list/list_view.test.js
+++ b/addons/web/static/tests/views/list/list_view.test.js
@@ -1117,8 +1117,8 @@ test(`list view: action button in controlPanel with display='always' on mobile`,
         queryAllTexts(`div.o_control_panel_breadcrumbs button, div.o_control_panel_actions button`)
     ).toEqual([
         "New",
-        "Toggle Dropdown", // mobile dropdown
         "display",
+        "", // mobile dropdown
         "", // default selection
     ]);
 
@@ -1137,8 +1137,8 @@ test(`list view: action button in controlPanel with display='always' on mobile`,
         queryAllTexts(`div.o_control_panel_breadcrumbs button, div.o_control_panel_actions button`)
     ).toEqual([
         "New",
-        "Toggle Dropdown", // mobile dropdown
         "display",
+        "", // mobile dropdown
         "",
     ]);
 });
@@ -1890,7 +1890,11 @@ test(`discard a new record in editable="top" list with less than 4 records`, asy
     expect(`.o_data_row`).toHaveCount(4);
     expect(`tbody tr:eq(0)`).toHaveClass("o_selected_row");
 
-    await contains(`.o_list_button_discard:not(.dropdown-item)`).click();
+    if (getMockEnv().isSmall) {
+        await contains(".o_control_panel_main_buttons button > .oi-ellipsis-v").click();
+    }
+
+    await contains(`.o_list_button_discard`).click();
     expect(`.o_data_row`).toHaveCount(3);
     expect(`tbody tr`).toHaveCount(4);
     expect(`tbody tr:eq(0)`).toHaveClass("o_data_row");


### PR DESCRIPTION
This commit updates the ControlPanel buttons' responsive handling by
only displaying the first button in small screen and fold the other ones
(if present) into an "ellipsis" dropdown button.

At the same time, it now uses the OWL Dropdown component instead of the
Bootstrap's one, which then uses the BottomSheet. Better usability and
less dependency on Bootstrap's Javascript at once.

task-4277543