### PR TITLE
[FIX] web: calendar: always display sidebar if multi_create enabled

### DIFF
--- a/addons/web/static/src/views/calendar/calendar_controller.js
+++ b/addons/web/static/src/views/calendar/calendar_controller.js
@@ -90,7 +90,8 @@ export class CalendarController extends Component {
                     : true,
             showSideBar:
                 !this.env.isSmall &&
-                Boolean(sessionShowSidebar != null ? JSON.parse(sessionShowSidebar) : true),
+                (this.model.hasMultiCreate ||
+                    Boolean(sessionShowSidebar != null ? JSON.parse(sessionShowSidebar) : true)),
             sidePanelMode: this.model.hasMultiCreate
                 ? SIDE_PANEL_MODES.add
                 : SIDE_PANEL_MODES.filter,

--- a/addons/web/static/tests/views/calendar/calendar_multi_create.test.js
+++ b/addons/web/static/tests/views/calendar/calendar_multi_create.test.js
@@ -780,3 +780,25 @@ test("multi_create: test required attribute in form", async () => {
     await animationFrame();
     expect.verifySteps(["Test required_2019-03-04", "Test required_2019-03-04"]);
 });
+
+test.tags("desktop");
+test("multi_create: display sidebar even if session_storage says no", async () => {
+    patchWithCleanup(sessionStorage, {
+        getItem(key) {
+            if (key === "calendar.showSideBar") {
+                expect.step("read calendar.showSideBar");
+                return false;
+            }
+        },
+    });
+
+    await mountView({
+        type: "calendar",
+        resModel: "event",
+        arch: `<calendar date_start="date_start" scales="month" multi_create_view="multi_create_form" aggregate="id:count"/>`,
+    });
+
+    expect(".o_calendar_sidebar").toHaveCount(1);
+    expect(".o_calendar_sidebar .btn-group .btn").toHaveCount(3);
+    expect.verifySteps(["read calendar.showSideBar"]);
+});


### PR DESCRIPTION
The sidebar can be toggled in calendar views where the multi create feature isn't enabled. The toggled status is then stored in the session_storage s.t. when coming back, it is restored.

In calendar views with the multi create feature, the sidebar can't be toggled: it is always displayed.

Before this commit, if the user first went to a "normal" calendar view, toggled off the sidepanel, and then went to a calendar view with multi_create, the sidepanel wasn't displayed (and there was no way for him to toggle it in that view).

This commit fixes the issue: when the multi_create feature is enabled, the sidepanel must always be displayed, no matter the state saved in the session_storage.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
