### PR TITLE
[IMP] orm: many2one use EXISTS when possible

### DIFF
--- a/odoo/addons/base/tests/test_expression.py
+++ b/odoo/addons/base/tests/test_expression.py
@@ -1888,11 +1888,11 @@ class TestMany2one(TransactionCase):
         with self.assertQueries(['''
             SELECT "res_partner"."id"
             FROM "res_partner"
-            WHERE ("res_partner"."company_id" NOT IN (
+            WHERE ("res_partner"."company_id" IS NULL OR NOT EXISTS(SELECT FROM (
                 SELECT "res_company"."id"
                 FROM "res_company"
                 WHERE "res_company"."name" LIKE %s
-            ) OR "res_partner"."company_id" IS NULL)
+            ) AS __sub WHERE __sub.id = "res_partner"."company_id"))
             ORDER BY "res_partner"."complete_name"asc,"res_partner"."id"desc
         ''']):
             self.Partner.search(['!', ('company_id.name', 'like', self.company.name)])
@@ -2097,11 +2097,11 @@ class TestMany2one(TransactionCase):
         with self.assertQueries(['''
             SELECT "res_partner"."id"
             FROM "res_partner"
-            WHERE ("res_partner"."company_id" NOT IN (
+            WHERE ("res_partner"."company_id" IS NULL OR NOT EXISTS(SELECT FROM (
                 SELECT "res_company"."id"
                 FROM "res_company"
                 WHERE "res_company"."name" LIKE %s
-            ) OR "res_partner"."company_id" IS NULL)
+            ) AS __sub WHERE __sub.id = "res_partner"."company_id"))
             ORDER BY "res_partner"."complete_name"asc,"res_partner"."id"desc
         ''']):
             self.Partner.search([('company_id', 'not like', "blablabla")])


### PR DESCRIPTION
Exists clause is faster for non-existence checks. We can use it when the sub-query is a SELECT (as opposed to a list of values).

- If we bypass access (auto_join or "any!") and value is a Domain: use LEFT JOIN
- Otherwise:
  - If positive operator: use IN
  - If negative operator: use NOT EXISTS (or NOT IN)

Even for EXISTS, we keep the nullability condition as some indexes may use it and it may avoid running sub-queries when all values are NULL.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
