### PR TITLE
[FIX] base:  refresh company cache on archive/unarchive company

### DIFF
--- a/odoo/addons/base/models/res_company.py
+++ b/odoo/addons/base/models/res_company.py
@@ -340,6 +340,15 @@ class ResCompany(models.Model):
         return res
 
     def write(self, values):
+        if 'parent_id' in values:
+            raise UserError(_("The company hierarchy cannot be changed."))
+
+        if values.get('currency_id'):
+            currency = self.env['res.currency'].browse(values['currency_id'])
+            if not currency.active:
+                currency.write({'active': True})
+
+        res = super().write(values)
         invalidation_fields = self.cache_invalidation_fields()
         asset_invalidation_fields = {'font', 'primary_color', 'secondary_color', 'external_report_layout_id'}
 
@@ -355,16 +364,6 @@ class ResCompany(models.Model):
             # this is used in the content of an asset (see asset_styles_company_report)
             # and thus needs to invalidate the assets cache when this is changed
             self.env.registry.clear_cache('assets')  # not 100% it is useful a test is missing if it is the case
-
-        if 'parent_id' in values:
-            raise UserError(_("The company hierarchy cannot be changed."))
-
-        if values.get('currency_id'):
-            currency = self.env['res.currency'].browse(values['currency_id'])
-            if not currency.active:
-                currency.write({'active': True})
-
-        res = super().write(values)
 
         # Archiving a company should also archive all of its branches
         if values.get('active') is False:


### PR DESCRIPTION
Currently below error occurs while archive/unarchive company:
- Company list is not being updated.
- In `hr_timesheet` KeyError will be encountered on unarchiving a company.
- In `l10n_it_pos` module an AccessError will be encountered on unarchiving a company.

**Root Cause:**
Since https://github.com/odoo/odoo/commit/22e9d822e8cab08114c006eb8c4054c4de0c40f2, the `session_info` method relies on `user_companies` at [1], which fetches only
active company IDs via `_get_company_ids()`. However, `_get_company_ids` uses caching as
shown at [2]. When a company is archived or unarchived, 'write' method is called. Now, here
the cache is invalidated before writing to the company as shown at [3]. Due to which
'_get_company_ids' method doesn't receive the updated list of companies, causing this issue.

**Solution:**
This commit prevents error by ensuring companies are stored before invalidating
the cache.

[1]- https://github.com/odoo/odoo/blob/d3482e32f7dbe273125de84f1bbc434ac3c9ffc3/addons/web/models/ir_http.py#L146

[2]-
https://github.com/odoo/odoo/blob/7db62d6d65bd57f6ed43ce52a820cf03df19efdd/odoo/addons/base/models/res_users.py#L927-L931

[3]-
https://github.com/odoo/odoo/blob/3173a5f993a3ffa3d3a14d29713142e5b6b314d9/odoo/addons/base/models/res_company.py#L343-L367

Sentry-6251348500