### PR TITLE
[FIX] mail: allow activity creation on archive

### DIFF
--- a/addons/mail/models/mail_activity_mixin.py
+++ b/addons/mail/models/mail_activity_mixin.py
@@ -290,14 +290,13 @@ class MailActivityMixin(models.AbstractModel):
         activities. Otherwise they stay in the systray and concerning archived
         records it makes no sense. """
         records = self.filtered(self._active_name)
-        res = super(MailActivityMixin, records).action_archive()
         if records:
-            # use a sudo to bypass every access rights; all activities should be removed
+            # use a sudo to bypass every access rights; all activities existing before archival should be removed
             self.env['mail.activity'].sudo().search([
                 ('res_model', '=', self._name),
                 ('res_id', 'in', records.ids)
             ]).unlink()
-        return res
+        return super(MailActivityMixin, records).action_archive()
 
     def activity_send_mail(self, template_id):
         """ Automatically send an email based on the given mail.template, given


### PR DESCRIPTION
**Issue**
Activities created by an automation triggered when archiving a record are deleted. It can be useful to be able to generate an activity when a record such as a Lead is archived.

**Cause**
Commit d220bb4c872d3660d15373d15565c846e3a35d9f introduced a change in behavior: activities linked to a mail activity mixin record are deleted after the record has been archived. `on_archive` automations will create the activity when writing on the active field of the record, which now happens before the activities linked to the record are unlinked.

**Steps to reproduce**
1. Create an automation rule for a model using the mail activity mixin (e.g. Contact), set the trigger "On archive" and "Create an activity" as an action.
2. Archive the record and notice no activity appears in the chatter.

opw-4936246
