### PR TITLE
[FIX] stock: avoid quant dupplication due to quant cache with packages

### DIFF
--- a/addons/stock/models/stock_move_line.py
+++ b/addons/stock/models/stock_move_line.py
@@ -686,7 +686,7 @@ class StockMoveLine(models.Model):
             available_qty, in_date = ml._synchronize_quant(-ml.quantity_product_uom, ml.location_id)
             ml._synchronize_quant(ml.quantity_product_uom, ml.location_dest_id, package=ml.result_package_id, in_date=in_date)
             if available_qty < 0:
-                ml._free_reservation(
+                ml.with_context(quants_cache=None)._free_reservation(
                     ml.product_id, ml.location_id,
                     abs(available_qty), lot_id=ml.lot_id, package_id=ml.package_id,
                     owner_id=ml.owner_id, ml_ids_to_ignore=ml_ids_to_ignore)

--- a/addons/stock/tests/test_quant.py
+++ b/addons/stock/tests/test_quant.py
@@ -1573,3 +1573,67 @@ class StockQuantRemovalStrategy(TransactionCase):
             ('package_id', '=', package.id),
             ('location_id', '=', self.stock_location.id),
         ]))
+
+    def test_quant_cache_for_packages(self):
+        """
+        Create and assign a delivery for different packages.
+        Create an internal transfer to move on of the package in a sublocation.
+        Check that the delivery is still reserved in the proper locations.
+        """
+        products = self.env['product.product'].create([
+            {'name': 'Good product', 'is_storable': True},
+            {'name': 'Great product', 'is_storable': True},
+            {'name': 'Super product', 'is_storable': True},
+        ])
+        products.categ_id.removal_strategy_id = self.env['product.removal']
+        packages = self.env['stock.quant.package'].create([
+            {'name': 'Pack 001'},
+            {'name': 'Pack 002'},
+        ])
+        warehouse = self.env['stock.warehouse'].search([('company_id', '=', self.env.company.id)])
+        # Pack the first 2 prodcuts in Pack 001 and the last in Pack 002
+        self.env['stock.quant']._update_available_quantity(products[0], warehouse.lot_stock_id, 1.0, package_id=packages[0])
+        self.env['stock.quant']._update_available_quantity(products[1], warehouse.lot_stock_id, 1.0, package_id=packages[0])
+        self.env['stock.quant']._update_available_quantity(products[2], warehouse.lot_stock_id, 1.0, package_id=packages[1])
+        sublocation = self.env['stock.location'].create({
+            'name': 'sublocation',
+            'location_id': warehouse.lot_stock_id.id,
+        })
+        delivery, internal_transfer = self.env['stock.picking'].create([
+            {
+                'name': 'Delivery',
+                'location_id': warehouse.lot_stock_id.id,
+                'location_dest_id': self.ref('stock.stock_location_customers'),
+                'picking_type_id': warehouse.out_type_id.id,
+                'move_ids': [
+                    Command.create({
+                        'name': f'move {product.name}',
+                        'location_id': warehouse.lot_stock_id.id,
+                        'location_dest_id': self.ref('stock.stock_location_customers'),
+                        'product_id': product.id,
+                        'product_uom_qty': 1,
+                    }) for product in products
+                ]
+            },
+            {
+                'name': 'Internal transfer',
+                'location_id': warehouse.lot_stock_id.id,
+                'location_dest_id': sublocation.id,
+                'picking_type_id': warehouse.int_type_id.id,
+            },
+        ])
+        delivery.action_confirm()
+        # Make an internal transfer to move Pack 001 in a sublocation
+        warehouse.int_type_id.show_entire_packs = True
+        with Form(internal_transfer) as picking_form:
+            with picking_form.package_level_ids.new() as package_level:
+                package_level.package_id = packages[0]
+        internal_transfer.action_confirm()
+        internal_transfer.package_level_ids.is_done = True
+        internal_transfer.button_validate()
+        quants = self.env['stock.quant'].search([('product_id', 'in', products.ids)])
+        self.assertRecordValues(quants, [
+            {'product_id': products[2].id, 'location_id':  warehouse.lot_stock_id.id, 'package_id': packages[1].id, 'quantity': 1.0, 'reserved_quantity': 1.0},
+            {'product_id': products[0].id, 'location_id':  sublocation.id, 'package_id': packages[0].id, 'quantity': 1.0, 'reserved_quantity': 1.0},
+            {'product_id': products[1].id, 'location_id':  sublocation.id, 'package_id': packages[0].id, 'quantity': 1.0, 'reserved_quantity': 1.0},
+        ])


### PR DESCRIPTION
### Steps to reproduce:

- In the settings enable "packages" and Multi-Step Routes
- Create a 3 storable products: P1, P2, P3
- Put on hand quantities for each of them:
    - 1 x P1 in PACK001 in stock
    - 1 x P2 in PACK001 in stock
    - 1 x P3 in PACK002 in stock
- Create and confirm a delivery with 3 moves:
    - 1 x P1
    - 1 x P2
    - 1 x P3
- Go to Inventory > Configuration > Warehouse Management > Operation type
- Modify internal transfers to "Move entire packages"
- Create and confirm and internal transfer for PACK001 from stock to the sublocation stock/shelf1
- Mark the package as done and validate the transfer
#### > You end up with 2 quants for PACK002 in stock

### Cause of the issue:

When validating the internal transfer for PACK001, we launch an `_action_done` on the moves lines of the internal transfer. In particular, during this action done, a `quant_cache` will be set for to fetch and use the quants for P1 and P2:
https://github.com/odoo/odoo/blob/cb1c761777e84d96f82c4f754586795509ce1b3d/addons/stock/models/stock_move_line.py#L679-L681 https://github.com/odoo/odoo/blob/cb1c761777e84d96f82c4f754586795509ce1b3d/addons/stock/models/stock_quant.py#L933-L949 This cache is correctly use in order to update our move lines during the `synchronize_quant` that will follow:
https://github.com/odoo/odoo/blob/cb1c761777e84d96f82c4f754586795509ce1b3d/addons/stock/models/stock_move_line.py#L684-L692 However, they are not in the `_free_reservation` because this call will reassign the move line and then `_check_entire_pack` for the entire picking:
https://github.com/odoo/odoo/blob/cb1c761777e84d96f82c4f754586795509ce1b3d/addons/stock/models/stock_move.py#L1980-L1981 In particular, it will update the reservation for the move related to P3. But, since the `quant_cache` is taken from the context and did not change it can not find the quants related to P3 and a new quant will be created in addition to the already existing one: https://github.com/odoo/odoo/blob/82639728f2bcb4e7786f120de2aeba3f5fbab209/addons/stock/models/stock_quant.py#L1055 https://github.com/odoo/odoo/blob/82639728f2bcb4e7786f120de2aeba3f5fbab209/addons/stock/models/stock_quant.py#L1101

opw-4922032
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
