### PR TITLE
[IMP] im_livechat,*: Info panel improvements

### DIFF
--- a/addons/crm_livechat/models/discuss_channel.py
+++ b/addons/crm_livechat/models/discuss_channel.py
@@ -73,10 +73,13 @@ class DiscussChannel(models.Model):
 
     def _get_livechat_session_fields_to_store(self):
         fields_to_store = super()._get_livechat_session_fields_to_store()
+        if not self.env["crm.lead"].has_access("read"):
+            return fields_to_store
         fields_to_store.append(
             Store.Many(
                 "livechat_customer_partner_ids",
                 [Store.Many("opportunity_ids", ["id", "name"])],
+                only_data=True,
             ),
         )
         return fields_to_store

--- a/addons/crm_livechat/static/src/core/web/livechat_channel_info_list_patch.xml
+++ b/addons/crm_livechat/static/src/core/web/livechat_channel_info_list_patch.xml
@@ -2,12 +2,12 @@
 <templates xml:space="preserve">
     <t t-name="website_livechat.LivechatChannelInfoList" t-inherit="im_livechat.LivechatChannelInfoList" t-inherit-mode="extension">
         <xpath expr="//t[@t-name='extra_infos']" position="inside">
-            <t t-call="im_livechat.LivechatChannelInfoList.info_links">
+            <t t-if="props.thread.livechatVisitorMember?.persona?.opportunity_ids?.length" t-call="im_livechat.LivechatChannelInfoList.info_links">
                 <t t-set="title">Open leads</t>
                 <t t-set="templateParams"
                     t-value="{
                         title,
-                        'info_records': props.thread.livechatVisitorMember?.persona?.opportunity_ids,
+                        'info_records': props.thread.livechatVisitorMember.persona.opportunity_ids,
                         'model': 'crm.lead'
                     }"
                 />

--- a/addons/im_livechat/static/src/core/web/livechat_channel_info_list.xml
+++ b/addons/im_livechat/static/src/core/web/livechat_channel_info_list.xml
@@ -17,11 +17,15 @@
                     <t t-elif="props.thread.livechat_outcome === 'escalated'">Escalated</t>
                 </div>
             </div>
+            <div class="d-flex flex-column bg-inherit gap-1">
+                <h3 class="pt-3">Notes</h3>
+                <textarea class="form-control" rows="3" placeholder="Add your notes here..." t-model="props.thread.livechatNoteText" t-on-blur="onBlurNote"></textarea>
+            </div>
             <div t-if="expectAnswerSteps.length" class="d-flex flex-column bg-inherit gap-1">
                 <h3 class="pt-3">Chatbot answers</h3>
                 <t t-foreach="expectAnswerSteps" t-as="step" t-key="step.id">
-                    <div class="d-flex align-items-center gap-1 bg-light rounded-3">
-                        <i class="fa fa-comment me-1"/>
+                    <div class="d-flex align-items-center gap-1 bg-inherit rounded-3">
+                        <i class="fa fa-comment-o me-1"/>
                         <span class="text-truncate" t-esc="step.answer"/>
                     </div>
                 </t>
@@ -33,11 +37,7 @@
                 </div>
             </div>
             <t t-name="extra_infos"/>
-            <div class="d-flex flex-column bg-inherit gap-1">
-                <h3 class="pt-3">Notes</h3>
-                <textarea class="form-control" rows="3" placeholder="Add your notes here..." t-model="props.thread.livechatNoteText" t-on-blur="onBlurNote"></textarea>
-            </div>
-            <div class="d-flex flex-column bg-inherit gap-1">
+            <div t-if="props.thread.livechat_end_dt" class="d-flex flex-column bg-inherit gap-1">
                 <h3 class="pt-3">Send conversation</h3>
                 <TranscriptSender thread="props.thread"/>
             </div>
@@ -49,14 +49,15 @@
             <h3 class="pt-3" t-out="templateParams.title"/>
             <t t-foreach="templateParams.info_records" t-as="record" t-key="record.localId">
                 <a
-                    class="btn btn-sm btn-secondary d-flex align-items-center justify-content-center gap-1 rounded-3"
+                    class="btn btn-sm btn-secondary d-flex align-items-center justify-content-start gap-1 px-3 py-1 rounded-3"
                     t-att-href="record.href"
                     t-att-data-oe-id="record.id"
                     t-att-data-oe-model="templateParams.model"
                     contenteditable="false"
+                    target="_blank"
                 >
                     <i class="fa fa-external-link opacity-75"/>
-                    <span class="fw-bold" t-esc="record.name"/>
+                    <span class="ms-1 fw-bold" t-esc="record.name"/>
                 </a>
             </t>
         </div>

--- a/addons/im_livechat/static/src/core/web/thread_actions.js
+++ b/addons/im_livechat/static/src/core/web/thread_actions.js
@@ -13,7 +13,6 @@ threadActionsRegistry
         icon: "fa fa-fw fa-info",
         iconLarge: "fa fa-fw fa-lg fa-info",
         name: _t("Information"),
-        nameActive: _t("Close Information"),
         sequence: 10,
         sequenceGroup: 7,
         toggle: true,

--- a/addons/web/static/src/core/browser/router.js
+++ b/addons/web/static/src/core/browser/router.js
@@ -305,12 +305,13 @@ browser.addEventListener("click", (ev) => {
     if (ev.defaultPrevented || ev.target.closest("[contenteditable]")) {
         return;
     }
-    const href = ev.target.closest("a")?.getAttribute("href");
+    const a = ev.target.closest("a");
+    const href = a?.getAttribute("href");
     if (href && !href.startsWith("#")) {
         let url;
         try {
             // ev.target.href is the full url including current path
-            url = new URL(ev.target.closest("a").href);
+            url = new URL(a.href);
         } catch {
             return;
         }
@@ -318,7 +319,7 @@ browser.addEventListener("click", (ev) => {
             browser.location.host === url.host &&
             browser.location.pathname.startsWith("/odoo") &&
             (["/web", "/odoo"].includes(url.pathname) || url.pathname.startsWith("/odoo/")) &&
-            ev.target.target !== "_blank"
+            a.target !== "_blank"
         ) {
             ev.preventDefault();
             state = router.urlToState(url);

--- a/addons/website_livechat/static/src/web/livechat_channel_info_list_patch.xml
+++ b/addons/website_livechat/static/src/web/livechat_channel_info_list_patch.xml
@@ -5,17 +5,20 @@
             <t t-set="visitor" t-value="props.thread.livechat_visitor_id"/>
             <div t-if="visitor?.history" class="d-flex flex-column bg-inherit gap-1">
                 <h3 class="pt-3">Recent page views</h3>
-                <div class="mt-1">
-                    <span t-esc="visitor.history"/>
+                <div t-if="visitor.website_id">
+                    <i class="me-1 fa fa-globe" aria-label="Website"/>
+                    <span t-esc="visitor.website_id.name"/>
                 </div>
+                <span t-esc="visitor.history"/>
             </div>
-            <div t-if="recentConversations.length" class="d-flex flex-column bg-inherit gap-1">
+            <div t-if="!props.thread.livechat_end_dt and recentConversations.length" class="d-flex flex-column bg-inherit gap-1">
                 <h3 class="pt-3">Recent conversations</h3>
                 <div class="btn btn-group o-rounded-bubble d-flex flex-column w-100 p-0 m-0" style="gap: 1px;">
-                    <button
+                    <a
                         t-foreach="recentConversations" t-as="thread" t-key="thread.localId"
-                        class="btn btn-sm btn-secondary btn-group-item d-flex align-items-baseline justify-content-start gap-1 w-100 m-0 px-3 py-1"
-                        t-on-click="()=>thread.open()"
+                        class="btn btn-sm btn-secondary btn-group-item d-flex align-items-center justify-content-start gap-1 w-100 m-0 px-3 py-1"
+                        t-attf-href="/odoo/discuss?active_id={{thread.model}}_{{thread.id}}"
+                        target="_blank"
                         t-att-class="{
                             'o-rounded-top-bubble': thread_first,
                             'o-rounded-bottom-bubble': thread_last,
@@ -26,7 +29,7 @@
                         <i class="fa fa-external-link opacity-75"/>
                         <span class="ms-1 fw-bold" t-esc="thread.displayName"/>
                         <span t-if="thread.livechat_end_dt" class="o-xsmaller text-muted" t-out="CLOSED_ON_TEXT(thread)"/>
-                    </button>
+                    </a>
                 </div>
             </div>
         </xpath>

--- a/addons/website_livechat/static/src/web/thread_patch.xml
+++ b/addons/website_livechat/static/src/web/thread_patch.xml
@@ -14,10 +14,6 @@
                         <i class="me-1 fa fa-comment-o" aria-label="Lang"/>
                         <t t-esc="visitor.lang_id.name"/>
                     </span>
-                    <span t-if="visitor.website_id">
-                        <i class="me-1 fa fa-globe" aria-label="Website"/>
-                        <span t-esc="visitor.website_id.name"/>
-                    </span>
                 </div>
             </div>
         </xpath>

--- a/addons/website_livechat/static/tests/livechat_channel_info_list_patch.test.js
+++ b/addons/website_livechat/static/tests/livechat_channel_info_list_patch.test.js
@@ -31,5 +31,6 @@ test("shows recent page views", async () => {
     await start();
     await openDiscuss(channelId);
     await contains("h3", { text: "Recent page views" });
+    await contains("div > span", { text: "General website" });
     await contains("span", { text: "Home → Contact" });
 });

--- a/addons/website_livechat/static/tests/thread_patch.test.js
+++ b/addons/website_livechat/static/tests/thread_patch.test.js
@@ -54,7 +54,6 @@ test("Rendering of visitor banner", async () => {
         text: `Website Visitor #${visitorId}`,
     });
     await contains("span", { text: "English" });
-    await contains("span > span", { text: "General website" });
 });
 
 test("Livechat with non-logged visitor should show visitor banner", async () => {


### PR DESCRIPTION
1. Add website name to recent page views.
2. Improve chatbot answers display in dark mode.
3. Update recent conversations button alignment.
4. Do not display recent conversations when the chat is closed.
5. Move notes section next to the status section.
6. Open links in the info panel in a new tab.
7. Helpdesk tickets accessibility improvements.

Task-4929870
https://github.com/odoo/enterprise/pull/90350

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
