### PR TITLE
[FIX] point_of_sale: ignore canceled payment lines

### DIFF
--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -1458,7 +1458,8 @@ export class PosStore extends Reactive {
             const paymentLine = order.payment_ids.find(
                 (paymentLine) =>
                     paymentLine.payment_method_id.use_payment_terminal === terminalName &&
-                    !paymentLine.is_done()
+                    !paymentLine.is_done() &&
+                    paymentLine.get_payment_status() !== "retry"
             );
             if (paymentLine) {
                 return paymentLine;


### PR DESCRIPTION
If you made an order and tried to pay with a payment terminal (like Adyen) then canceled the payment on the terminal. Then leave the order and create a new order, add different products, and try to pay again, pay on the terminal, the payment will not be transmitted to the PoS and the order would still be waiting for payment.

Steps to reproduce:
------------------
* Create a pos payment method using adyen
* Open a PoS session
* Create an order with a product
* Pay with the adyen payment method
* Cancel the payment on the terminal
* Leave the order
* Create a new order with different products
* Try to pay with the adyen payment method
* Validate the payment on the terminal
> Observation: The payment will not be transmitted to the PoS and the
  order will still be waiting for payment.

Why the fix:
----------------
The issue occurs because the canceled payment line is still considered as a pending payment line. And when the payment will be receiven on the pos it would take the canceled payment line as the pending one.

opw-4805704