### PR TITLE
[FIX] html_editor: remove text from selected cell

### DIFF
--- a/addons/html_editor/static/src/main/table/table_plugin.js
+++ b/addons/html_editor/static/src/main/table/table_plugin.js
@@ -961,7 +961,7 @@ export class TablePlugin extends Plugin {
                 this._isTripleClickInTable = true;
             }
         }
-        if (isPointerInsideCell) {
+        if (isPointerInsideCell && ev.detail === 1) {
             this.editable.addEventListener("mousemove", this.onMousemove);
             const currentSelection = this.dependencies.selection.getEditableSelection();
             // disable dragging on table

--- a/addons/html_editor/static/tests/table/selection.test.js
+++ b/addons/html_editor/static/tests/table/selection.test.js
@@ -1719,7 +1719,7 @@ describe("single cell selection", () => {
             el,
             `<table class="table table-bordered o_table o_selected_table">
                 <tbody>
-                    <tr><td class="o_selected_td">[]abc<br></td><td><br></td><td><br></td></tr>
+                    <tr><td class="o_selected_td">[abc]<br></td><td><br></td><td><br></td></tr>
                     <tr><td><br></td><td><br></td><td><br></td></tr>
                 </tbody>
             </table>`

--- a/addons/html_editor/static/tests/toolbar.test.js
+++ b/addons/html_editor/static/tests/toolbar.test.js
@@ -542,15 +542,18 @@ test("toolbar open on single selected cell in table", async () => {
     const mouseDownPositionY = targetTd.getBoundingClientRect().top + 10;
     const mouseMoveDiff = 40;
     manuallyDispatchProgrammaticEvent(targetTd, "mousedown", {
+        detail: 1,
         clientX: mouseDownPositionX,
         clientY: mouseDownPositionY,
     });
     // Simulate mousemove horizontally for 40px.
     manuallyDispatchProgrammaticEvent(targetTd, "mousemove", {
+        detail: 1,
         clientX: mouseDownPositionX + mouseMoveDiff,
         clientY: mouseDownPositionY,
     });
     manuallyDispatchProgrammaticEvent(targetTd, "mouseup", {
+        detail: 1,
         clientX: mouseDownPositionX + mouseMoveDiff,
         clientY: mouseDownPositionY,
     });
@@ -589,6 +592,7 @@ test("should select table single cell when entire content is selected via mouse 
     // Simulate mousedown at the top of the first paragraph.
     const rectStart = firstP.getBoundingClientRect();
     manuallyDispatchProgrammaticEvent(firstP, "mousedown", {
+        detail: 1,
         clientX: rectStart.left,
         clientY: rectStart.top,
     });
@@ -610,14 +614,17 @@ test("should select table single cell when entire content is selected via mouse 
 
     // Simulate mousemove and mouseup events to complete the selection.
     manuallyDispatchProgrammaticEvent(lastP, "mousemove", {
+        detail: 1,
         clientX: rect.right,
         clientY: rect.top,
     });
     manuallyDispatchProgrammaticEvent(lastP, "mousemove", {
+        detail: 1,
         clientX: rect.right + 5,
         clientY: rect.top,
     });
     manuallyDispatchProgrammaticEvent(lastP, "mouseup", {
+        detail: 1,
         clientX: rect.right + 5,
         clientY: rect.top,
     });


### PR DESCRIPTION
**Current behavior before PR:**

Steps to reproduce:

- Add a 3x3 table
- Type something any cell.
- Select that cell using triple mouse click.
- Press backspace, the text is not removed.

This issue occurs because, in the `onMousedown` method, the cursor is positioned at the beginning of the cell content. To delete the cell’s text, the text must be selected. Since the cursor remains at the start of the text, pressing Backspace does not remove any content.

**Desired behavior after PR:**

Now, cell text is getting removed when pressing backspace.

task-4941622




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
