### PR TITLE
[FIX] website: prevent error when submitting the 'Send Email' form

### DIFF
--- a/addons/website/controllers/form.py
+++ b/addons/website/controllers/form.py
@@ -84,15 +84,16 @@ class WebsiteForm(http.Controller):
                 # for the email queue to process
 
                 if model_name == 'mail.mail':
-                    form_has_email_cc = {'email_cc', 'email_bcc'} & kwargs.keys() or \
-                        'email_cc' in kwargs["website_form_signature"]
-                    # remove the email_cc information from the signature
-                    kwargs["website_form_signature"] = kwargs["website_form_signature"].split(':')[0]
-                    if kwargs.get("email_to"):
-                        value = kwargs['email_to'] + (':email_cc' if form_has_email_cc else '')
-                        hash_value = hmac(model_record.env, 'website_form_signature', value)
-                        if not consteq(kwargs["website_form_signature"], hash_value):
-                            raise AccessDenied('invalid website_form_signature')
+                    if kwargs.get("website_form_signature"):
+                        form_has_email_cc = {'email_cc', 'email_bcc'} & kwargs.keys() or \
+                            'email_cc' in kwargs["website_form_signature"]
+                        # remove the email_cc information from the signature
+                        kwargs["website_form_signature"] = kwargs["website_form_signature"].split(':')[0]
+                        if kwargs.get("email_to"):
+                            value = kwargs['email_to'] + (':email_cc' if form_has_email_cc else '')
+                            hash_value = hmac(model_record.env, 'website_form_signature', value)
+                            if not consteq(kwargs["website_form_signature"], hash_value):
+                                raise AccessDenied('invalid website_form_signature')
                     request.env[model_name].sudo().browse(id_record).send()
 
         # Some fields have additional SQL constraints that we can't check generically


### PR DESCRIPTION
Currently, an error occurs when submitting the 'Send Email' form.

**Steps to Reproduce:**

 - Install the `website` and `web_studio` modules.
 - Go to `website` > Click on `Edit` > `Drag and drop form`.
 - Click the `form` and in `Actions` select the `more models`, and 
   select `outgoing mails(mail.mail)` model and `save`.
 - Fill out the form and `Submit`.

**Error:**
`KeyError: 'website_form_signature'`

**Cause:**
This error occurs after [this commit](https://github.com/odoo/odoo/commit/70fa5af872524ea271113851c050297ef50efa45), when submitting the "Send Email" 
form from the website. If the form is saved without entering the 
recipient's email (email_to). As a result, the `email_to` field is not 
present in the form. The `website_form_signature` is added from [1], 
but due to the condition at [2], the code at [1] is not executed. And when 
it is accessed at [3], KeyError is raised.

[1]: https://github.com/odoo/odoo/blob/82639728f2bcb4e7786f120de2aeba3f5fbab209/addons/website/tools.py#L252

[2]: https://github.com/odoo/odoo/blob/82639728f2bcb4e7786f120de2aeba3f5fbab209/addons/website/tools.py#L236

[3]: https://github.com/odoo/odoo/blob/82639728f2bcb4e7786f120de2aeba3f5fbab209/addons/website/controllers/form.py#L88

**Fix:**
This commit ensures that 'website_form_signature' is used if it is 
available in kwargs.

sentry-6746753251

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr