### PR TITLE
[FIX] website: prevent from editing logout button in dropdown

### DIFF
--- a/addons/website/static/src/builder/website.inside.scss
+++ b/addons/website/static/src/builder/website.inside.scss
@@ -1,0 +1,7 @@
+.editor_enable {
+    // Some dropdown links are not deactivated in edit, so we prevent clicks.
+    #o_logout,
+    .js_change_lang {
+        pointer-events: none;
+    }
+}


### PR DESCRIPTION
During website refactor [1], the CSS snippet that prevents editing the logout button was not migrated to the new asset, making the button editable.
This snippet was originally in `website.edit_mode.scss`.

Steps to reproduce:
- Enter edit mode
- Click on username in navbar (e.g. Mitchell Admin)
- Dropdown opens
- The "Logout" button is editable, which it shouldn't be.

[1]: https://github.com/odoo/odoo/commit/9fe45e2b7ddbbfd0445ffe25a859e67a316d02b2
