### PR TITLE
[FIX] html_builder: fix padding handlers clickable area

### DIFF
--- a/addons/html_builder/static/src/core/builder_overlay/builder_overlay.scss
+++ b/addons/html_builder/static/src/core/builder_overlay/builder_overlay.scss
@@ -112,7 +112,7 @@ div[data-oe-local-overlay-id="builder-overlay-container"] {
                     &::before {
                         content: '';
                         position: absolute;
-                        inset: -$o-we-handles-btn-size;
+                        inset: $o-we-handles-btn-size * -0.5;
                         display: block;
                         border-radius: inherit;
                     }


### PR DESCRIPTION
Before this commit, the handlers for the padding option were
too big, which made it really hard to click on the text of the
"Contact Us" button (the focus would be on the handlers instead).

This commit reduces the size of the clickable area around the
handlers icons, enabling to edit the text of the "Contact Us"
button, while keeping the handlers large enough to be accessible.

task-4367641