### PR TITLE
[FIX] bus: log unhandled errors/promises

### DIFF
--- a/addons/bus/static/src/workers/websocket_worker_utils.js
+++ b/addons/bus/static/src/workers/websocket_worker_utils.js
@@ -42,7 +42,7 @@ export class Deferred extends Promise {
 }
 
 export class Logger {
-    static LOG_TTL = 45 * 60 * 1000; // 45 minutes
+    static LOG_TTL = 24 * 60 * 60 * 1000; // 24 hours
     static gcInterval = null;
     static instances = [];
     _db;

--- a/addons/bus/websocket.py
+++ b/addons/bus/websocket.py
@@ -958,7 +958,7 @@ class WebsocketConnectionHandler:
     # Latest version of the websocket worker. This version should be incremented
     # every time `websocket_worker.js` is modified to force the browser to fetch
     # the new worker bundle.
-    _VERSION = "saas-18.3-4"
+    _VERSION = "saas-18.3-5"
 
     @classmethod
     def websocket_allowed(cls, request):


### PR DESCRIPTION
Bus behaviors are not easy to troubleshoot:
- Worker devtools not easily available.
- Errors are kept in the worker, never logged nor raised client side.
- Worker communicates with many tabs. To ease troubleshooting the bus, logs were introduced. It's much better because they can be downloaded from any tab, survive reloads...

However, unhandled errors/promises are not logged which is cumbersome. This commit adds unhandled errors/promises to the bus logging.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
