### PR TITLE
[ADD] ir_action_report: allow get a render by api

### DIFF
--- a/odoo/addons/base/models/ir_actions_report.py
+++ b/odoo/addons/base/models/ir_actions_report.py
@@ -1122,6 +1122,9 @@ class IrActionsReport(models.Model):
             return None
         return render_func(report_ref, res_ids, data=data)
 
+    def render(self, report_ref, res_ids, data=None):
+        return self._render(report_ref=report_ref, res_ids=res_ids, data=data)
+
     def report_action(self, docids, data=None, config=True):
         """Return an action of type ir.actions.report.
 


### PR DESCRIPTION
Desired behavior after PR is merged:
Allow users to get a render report by API to integrate different services.
Ex:
Get an invoice report to send to different customer by any platform



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
