### PR TITLE
[FIX] web: fix pivot view asking twice same groupby

### DIFF
--- a/addons/web/static/tests/views/pivot_view.test.js
+++ b/addons/web/static/tests/views/pivot_view.test.js
@@ -3637,22 +3637,22 @@ test("group by properties in pivot view", async () => {
     expect(columns[2]).toHaveText("bbb");
 });
 
-test("avoid duplicates in formatted_read_grouping_sets parameter 'groupby'", async () => {
+test("avoid duplicates grouping_sets in formatted_read_grouping_sets", async () => {
     onRpc("formatted_read_grouping_sets", ({ kwargs }) => {
-        expect.step(kwargs.grouping_sets[0]);
-        expect.step(kwargs.grouping_sets[1]);
+        expect(kwargs.grouping_sets).toEqual([[], ["bar"], ["bar", "date:month"], ["date:month"]]);
     });
     await mountView({
         type: "pivot",
         resModel: "partner",
         arch: `
 				<pivot sample="1">
-					<field name="date" type="row"/>
+					<field name="date" type="row" interval="month"/>
+					<field name="bar" type="row"/>
+					<field name="bar" type="col"/>
 					<field name="date" type="col" interval="month"/>
 				</pivot>
 			`,
     });
-    expect.verifySteps([[], ["date:month"]]);
 });
 
 test("Close header dropdown when a simple groupby is selected", async function (assert) {


### PR DESCRIPTION
In https://github.com/odoo/odoo/pull/194413, we introduced the new grouping set API. However due to a technical constraint (assertion in _read_grouping_sets 
), which prevents us from asking the same set of groupbys multiple times. But in the pivot view, nothing prevents people from using the same field for columns and rows at different levels of grouping.

The solution is to make the set of groupbys unique in the pivot model.

Error: 
AssertionError: _read_grouping_sets doesn't manage duplicate groupby specs: [('department_id',), ('department_id',)]
