### PR TITLE
[IMP] point_of_sale: move cash rounding displayed value

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.xml
+++ b/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.xml
@@ -156,12 +156,13 @@
             <div class="paymentmethods gap-1 gap-lg-2" t-att-class="{ 'd-grid p-1 gap-1 overflow-y-auto rounded-3 bg-200': ui.isSmall, 'd-flex flex-column gap-lg-2': !ui.isSmall }">
                 <t t-foreach="payment_methods_from_config" t-as="paymentMethod" t-key="paymentMethod.id">
                     <div t-if="!(this.pos.cashier._role === 'minimal' and paymentMethod.type === 'pay_later')" class="button paymentmethod btn btn-secondary btn-lg lh-lg flex-fill"
-                        t-att-class="{'opacity-50': this.pos.paymentTerminalInProgress and paymentMethod.use_payment_terminal}"
+                        t-att-class="{'opacity-50': this.pos.paymentTerminalInProgress and paymentMethod.use_payment_terminal, 'd-flex justify-content-between align-items-center': true}"
                         t-on-click="() => this.addNewPaymentLine(paymentMethod)">
                         <div class="payment-method-display d-flex align-items-center gap-2 text-wrap text-start lh-sm">
                             <img class="payment-method-icon" t-att-src="paymentMethodImage(paymentMethod.id)" />
-                            <span class="payment-name" t-esc="pos.getPaymentMethodDisplayText(paymentMethod, currentOrder)" />
+                            <span class="payment-name" t-esc="paymentMethod.name" />
                         </div>
+                        <span class="text-muted" t-esc="pos.getPaymentMethodFmtAmount(paymentMethod, currentOrder)"/>
                     </div>
                 </t>
             </div>

--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -2534,18 +2534,17 @@ export class PosStore extends WithLazyGetterTrap {
         return this.sortByWordIndex(Array.from(new Set([...exactMatches, ...matches])), words);
     }
 
-    getPaymentMethodDisplayText(pm, order) {
+    getPaymentMethodFmtAmount(pm, order) {
         const { cash_rounding, only_round_cash_method } = this.config;
         const amount = order.getDefaultAmountDueToPayIn(pm);
-        const fmtAmount = this.env.utils.formatCurrency(amount, false);
+        const fmtAmount = this.env.utils.formatCurrency(amount, true);
         if (
-            !this.currency.isPositive(amount) ||
-            !cash_rounding ||
-            (only_round_cash_method && pm.type !== "cash")
+            this.currency.isPositive(amount) &&
+            cash_rounding &&
+            !only_round_cash_method &&
+            pm.type === "cash"
         ) {
-            return pm.name;
-        } else {
-            return `${pm.name} (${fmtAmount})`;
+            return fmtAmount;
         }
     }
     getDate(date) {


### PR DESCRIPTION
We moved the cash rounding value to the right, making it text muted to improve UI.