### PR TITLE
[FIX] pos_loyalty: Correctly synchronize coupons between sessions

### DIFF
--- a/addons/pos_loyalty/static/src/overrides/models/pos_order_line.js
+++ b/addons/pos_loyalty/static/src/overrides/models/pos_order_line.js
@@ -46,6 +46,9 @@ patch(PosOrderline.prototype, {
         const json = super.serialize(...arguments);
         if (options.orm && json.coupon_id < 0) {
             json.coupon_id = undefined;
+            // It's necessary to do this before sending the data to the server for synchronization,
+            // so that the other sessions can compute the coupons themselves.
+            json.is_reward_line = false;
         }
         return json;
     },


### PR DESCRIPTION
Steps:
- Install `pos_restaurant_loyalty`
- Create a discount for example: if 2 coca -> 10%
- Open a restaurant session
- Open another restaurant session with the same user in incognito
- Add 2 coca + sushi in session 1 and press "Order"
- In session 2 products are automatically added, in live
- Try to validate the order from session 2
- Traceback

Traceback is due to the fact that, in order to synchronize, session 1 must send data to the server, which in turn sends further data to all sessions.

The problem is that as coupons are only created once the order has been validated, they are not yet “really created” on the customer side. To avoid sending “invalid” records, we remove them from the data via an override of the `serialize` method in `Base`.

But since python doesn't receive coupons, it can't send coupons to other sessions, so if we try to pay with the session that didn't initially get the discount, it will cause a traceback.

The solution is to remove `is_reward_line` as well. Because it already makes no sense to have a `PosOrderLine` which is a reward line without a coupon, and then because it will regenerate the discounts in the new session.

opw-4892767