### PR TITLE
[IMP] *: calendar view: multi creation/deletion

### DIFF
--- a/addons/hr_timesheet/static/src/views/timesheet_calendar/timesheet_calendar_model.js
+++ b/addons/hr_timesheet/static/src/views/timesheet_calendar/timesheet_calendar_model.js
@@ -8,7 +8,7 @@ export class TimesheetCalendarModel extends TimesheetCalendarMyTimesheetsModel {
         this.notification = services.notification;
     }
 
-    multiCreateRecords(dates) {
+    multiCreateRecords(multiCreateData, dates) {
         const [section] = this.filterSections;
         if (section.filters.filter((filter) => filter.active).length === 0) {
             this.notification.add(_t("Choose an employee to create their timesheet."), {
@@ -16,6 +16,6 @@ export class TimesheetCalendarModel extends TimesheetCalendarMyTimesheetsModel {
             });
             return;
         }
-        super.multiCreateRecords(dates);
+        super.multiCreateRecords(multiCreateData, dates);
     }
 }

--- a/addons/hr_timesheet/static/src/views/timesheet_calendar_my_timesheets/timesheet_calendar_my_timesheets_model.js
+++ b/addons/hr_timesheet/static/src/views/timesheet_calendar_my_timesheets/timesheet_calendar_my_timesheets_model.js
@@ -1,9 +1,12 @@
 import { CalendarModel } from "@web/views/calendar/calendar_model";
 
 export class TimesheetCalendarMyTimesheetsModel extends CalendarModel {
-    multiCreateRecords(dates) {
+    /**
+     * @override
+     */
+    async multiCreateRecords(multiCreateData, dates) {
         this.meta.context = this.meta.context || {};
         this.meta.context.timesheet_calendar = true;
-        super.multiCreateRecords(dates);
+        super.multiCreateRecords(multiCreateData, dates);
     }
 }

--- a/addons/web/static/src/views/calendar/calendar_controller.xml
+++ b/addons/web/static/src/views/calendar/calendar_controller.xml
@@ -54,14 +54,15 @@
                                 <t t-esc="dayHeader" />
                             </t>
                         </h5>
+                        <MultiSelectionButtons reactive="this.multiSelectionButtonsReactive" />
                     </div>
-                    <div t-if="hasSideBar and !model.hasMultiCreate and !env.isSmall" class="o_sidebar_toggler d-flex d-print-none align-items-center border-bottom pe-3">
+                    <div t-if="hasSideBar and !env.isSmall" class="o_sidebar_toggler d-flex d-print-none align-items-center border-bottom pe-3">
                         <button class="btn btn-light oi oi-panel-right collapsed ms-2 lh-base" t-on-click="toggleSideBar"/>
                     </div>
                     <MobileFilterPanel t-if="env.isSmall and hasSideBar" t-props="mobileFilterPanelProps" />
                     <div class="o_calendar_wrapper d-flex overflow-hidden">
                         <t t-if="showCalendar" t-component="props.Renderer" t-props="rendererProps"/>
-                        <CalendarSidePanel t-if="(hasSideBar or model.hasMultiCreate) and showSideBar" t-props="sidePanelProps"/>
+                        <CalendarSidePanel t-if="hasSideBar and showSideBar" t-props="sidePanelProps"/>
                     </div>
                 </div>
             </Layout>

--- a/addons/web/static/src/views/calendar/calendar_renderer.js
+++ b/addons/web/static/src/views/calendar/calendar_renderer.js
@@ -20,9 +20,9 @@ export class CalendarRenderer extends Component {
         editRecord: Function,
         deleteRecord: Function,
         setDate: Function,
-        sidePanelMode: String,
-        multiCreateRecords: Function,
-        multiDeleteRecords: Function,
+        callbackRecorder: Object,
+        onSquareSelection: Function,
+        cleanSquareSelection: Function,
     };
     get concreteRenderer() {
         return this.constructor.components[this.props.model.scale];

--- a/addons/web/static/src/views/calendar/calendar_side_panel/calendar_side_panel.xml
+++ b/addons/web/static/src/views/calendar/calendar_side_panel/calendar_side_panel.xml
@@ -3,36 +3,7 @@
     <t t-name="web.CalendarSidePanel">
         <div class="o_calendar_sidebar_container d-print-none position-relative w-100 w-md-auto bg-view overflow-x-hidden overflow-y-auto">
             <div class="o_calendar_sidebar">
-                <div t-if="props.model.hasMultiCreate" class="d-flex flex-column gap-1">
-                    <div class="btn-group">
-                        <button class="btn btn-secondary" t-att-class="{'active': props.mode === MODES.filter}" data-tooltip="Filter"  t-on-click.stop="() => this.props.setMode(MODES.filter)"><i class="fa fa-filter"/></button>
-                        <button class="btn btn-secondary" t-att-class="{'active': props.mode === MODES.add}" data-tooltip="New" t-on-click="() => this.props.setMode(MODES.add)"><i class="fa fa-plus"/></button>
-                        <button class="btn btn-secondary" t-att-class="{'active': props.mode === MODES.delete}" data-tooltip="Clicking on a day or selecting an area will irrevocably delete its content" t-on-click="() => this.props.setMode(MODES.delete)">
-                            <i class="fa fa-trash" t-att-class="{'text-danger': props.mode === MODES.delete}"/>
-                        </button>
-                    </div>
-                    <div t-if="state.isReady and props.mode === MODES.add" class="o_form_view o_xxs_form_view gap-2 mt-2">
-                        <div t-if="props.model.showMultiCreateTimeRange" class="d-flex align-items-baseline gap-2">
-                            <TimePicker
-                                value="this.props.model.data.multiCreate.timeRange.start"
-                                onChange="(time) => this.props.setMultiCreateTimeRange({start: time})"
-                                onInvalid="() => this.props.setMultiCreateTimeRange({start: null})"
-                                showSeconds="false"
-                            />
-                            <i class="fa fa-arrow-right"/>
-                            <TimePicker
-                                value="this.props.model.data.multiCreate.timeRange.end"
-                                onChange="(time) => this.props.setMultiCreateTimeRange({end: time})"
-                                onInvalid="() => this.props.setMultiCreateTimeRange({end: null})"
-                                showSeconds="false"
-                            />
-                        </div>
-                        <Record t-props="multiCreateRecordProps" t-slot-scope="data">
-                            <FormRenderer record="data.record" archInfo="multiCreateArchInfo" class="'p-0'"/>
-                        </Record>
-                    </div>
-                </div>
-                <DatePicker t-if="props.mode === MODES.filter and showDatePicker" t-props="datePickerProps" />
+                <DatePicker t-if="showDatePicker" t-props="datePickerProps" />
                 <t t-foreach="props.model.filterSections" t-as="section" t-key="section.fieldName">
                     <FilterSection model="props.model" section="section"/>
                 </t>

--- a/addons/web/static/src/views/view_components/multi_create_popover.js
+++ b/addons/web/static/src/views/view_components/multi_create_popover.js
@@ -1,0 +1,78 @@
+import { Component } from "@odoo/owl";
+import { _t } from "@web/core/l10n/translation";
+import { TimePicker } from "@web/core/time_picker/time_picker";
+import { useService } from "@web/core/utils/hooks";
+import { Record } from "@web/model/record";
+import { useCallbackRecorder } from "@web/search/action_hook";
+import { FormRenderer } from "@web/views/form/form_renderer";
+
+export class MultiCreatePopover extends Component {
+    static template = "web.MultiCreatePopover";
+    static components = {
+        FormRenderer,
+        Record,
+        TimePicker,
+    };
+    static props = {
+        close: Function,
+        multiCreateArchInfo: Object,
+        multiCreateRecordProps: Object,
+        onAdd: Function,
+        callbackRecorder: Object,
+        timeRange: { type: [Object, { value: null }] },
+    };
+
+    setup() {
+        this.notification = useService("notification");
+
+        this.multiCreateData = {
+            timeRange: this.props.timeRange && { ...this.props.timeRange },
+        };
+        this.multiCreateArchInfo = this.props.multiCreateArchInfo;
+        this.multiCreateRecordProps = {
+            ...this.props.multiCreateRecordProps,
+            hooks: {
+                onRootLoaded: (record) => {
+                    this.multiCreateData.record = record;
+                },
+            },
+        };
+
+        useCallbackRecorder(this.props.callbackRecorder, () => this.multiCreateData);
+    }
+
+    setMultiCreateTimeRange(timeRange) {
+        Object.assign(this.multiCreateData.timeRange, timeRange);
+    }
+
+    async onAdd() {
+        const isValid = await this.multiCreateData.record.checkValidity({
+            displayNotification: true,
+        });
+        if (!isValid) {
+            return;
+        }
+        if (this.multiCreateData.timeRange) {
+            const { start, end } = this.multiCreateData.timeRange;
+            if (!start || !end) {
+                this.notification.add(_t("Invalid time range"), {
+                    title: "User Error",
+                    type: "warning",
+                });
+                return;
+            }
+            if (
+                luxon.DateTime.fromObject(start.toObject()) >
+                luxon.DateTime.fromObject(end.toObject())
+            ) {
+                this.notification.add(_t("Start time should be before end time"), {
+                    title: "User Error",
+                    type: "warning",
+                });
+                return;
+            }
+        }
+        this.props.onAdd(this.multiCreateData);
+        this.props.close();
+    }
+}

--- a/addons/web/static/src/views/view_components/multi_create_popover.xml
+++ b/addons/web/static/src/views/view_components/multi_create_popover.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+
+    <t t-name="web.MultiCreatePopover">
+        <div class="o_multi_create_popover">
+            <div class="popover-body o_form_view">
+                <div t-if="this.multiCreateData.timeRange" class="d-flex align-items-baseline gap-2">
+                    <TimePicker
+                        value="this.multiCreateData.timeRange.start"
+                        onChange="(time) => this.setMultiCreateTimeRange({start: time})"
+                        onInvalid="() => this.setMultiCreateTimeRange({start: null})"
+                        showSeconds="false"
+                    />
+                    <i class="fa fa-arrow-right"/>
+                    <TimePicker
+                        value="this.multiCreateData.timeRange.end"
+                        onChange="(time) => this.setMultiCreateTimeRange({end: time})"
+                        onInvalid="() => this.setMultiCreateTimeRange({end: null})"
+                        showSeconds="false"
+                    />
+                </div>
+                <Record t-props="multiCreateRecordProps" t-slot-scope="data">
+                    <FormRenderer record="data.record" archInfo="multiCreateArchInfo" class="'p-0'"/>
+                </Record>
+            </div>
+            <div class="popover-footer p-3 pt-0 d-flex gap-1">
+                <button class="btn btn-sm btn-primary" t-on-click="() => this.onAdd()">Add</button>
+                <button class="btn btn-sm btn-secondary" t-on-click="() => this.props.close()">Discard</button>
+            </div>
+        </div>
+    </t>
+
+</templates>

--- a/addons/web/static/src/views/view_components/multi_selection_buttons.js
+++ b/addons/web/static/src/views/view_components/multi_selection_buttons.js
@@ -1,0 +1,206 @@
+import { Component, onWillRender, reactive, toRaw, useEffect, useRef, useState } from "@odoo/owl";
+import { browser } from "@web/core/browser/browser";
+import { useHotkey } from "@web/core/hotkeys/hotkey_hook";
+import { Time } from "@web/core/l10n/time";
+import { usePopover } from "@web/core/popover/popover_hook";
+import { useService } from "@web/core/utils/hooks";
+import { parseXML } from "@web/core/utils/xml";
+import { extractFieldsFromArchInfo } from "@web/model/relational_model/utils";
+import { CallbackRecorder, useSetupAction } from "@web/search/action_hook";
+import { FormArchParser } from "@web/views/form/form_arch_parser";
+import { MultiCreatePopover } from "./multi_create_popover";
+
+export class MultiSelectionButtons extends Component {
+    static template = "web.MultiSelectionButtons";
+    static props = { reactive: Object };
+
+    setup() {
+        this.viewService = useService("view");
+        this.state = useState({ isReady: false });
+        onWillRender(() => {
+            if (this.props.reactive.visible && !this.state.isReady) {
+                this.loadMultiCreateView().then(() => {
+                    this.state.isReady = true;
+                });
+            }
+        });
+
+        this.multiCreateValues = this.props.reactive.multiCreateValues;
+        this.callbackRecorder = new CallbackRecorder();
+        useSetupAction({
+            getLocalState: () => {
+                const multiCreateData = this.getMultiCreateDataFromPopover();
+                if (multiCreateData) {
+                    this.storeMultiCreateData(multiCreateData);
+                }
+                return { multiCreateValues: this.multiCreateValues };
+            },
+        });
+
+        this.multiCreatePopover = usePopover(MultiCreatePopover, {
+            onClose: () => {
+                const multiCreateData = this.getMultiCreateDataFromPopover();
+                if (multiCreateData) {
+                    this.storeMultiCreateData(multiCreateData);
+                }
+            },
+        });
+        this.addButtonRef = useRef("addButton");
+
+        const rootRef = useRef("root");
+        useEffect(
+            (el) => {
+                if (!el) {
+                    return;
+                }
+                // @ts-ignore
+                const { width: parentWidth } = el.parentElement.getBoundingClientRect();
+                const { width } = el.getBoundingClientRect();
+                const left = Math.floor((parentWidth - width) / 2);
+                el.style.setProperty("left", `${left}px`);
+            },
+            () => [rootRef.el]
+        );
+
+        useHotkey("escape", () => {
+            if (this.props.reactive.visible) {
+                this.props.reactive.onCancel();
+            }
+        });
+    }
+
+    getMultiCreateDataFromPopover() {
+        const fn = this.callbackRecorder.callbacks[0];
+        return fn?.() || null;
+    }
+
+    storeMultiCreateData(multiCreateData) {
+        this.storeTimeRange(multiCreateData.timeRange);
+        this.multiCreateValues = this.computeValues(multiCreateData.record);
+    }
+
+    async loadMultiCreateView() {
+        // todo: accept variable context,... ?
+        const { context, resModel, multiCreateView } = this.props.reactive;
+        const { fields, relatedModels, views } = await this.viewService.loadViews({
+            context: { ...context, form_view_ref: multiCreateView },
+            resModel,
+            views: [[false, "form"]],
+        });
+        const parser = new FormArchParser();
+        const arch = views.form.arch;
+        this.multiCreateArchInfo = parser.parse(parseXML(arch), relatedModels, resModel);
+        const { activeFields } = extractFieldsFromArchInfo(this.multiCreateArchInfo, fields);
+        this.multiCreateRecordProps = { resModel, fields, activeFields, context };
+    }
+
+    getMultiCreatePopoverProps() {
+        return {
+            timeRange: this.props.reactive.showMultiCreateTimeRange ? this.getTimeRange() : null,
+            multiCreateArchInfo: { ...this.multiCreateArchInfo },
+            multiCreateRecordProps: {
+                ...this.multiCreateRecordProps,
+                values: this.multiCreateValues,
+            },
+            onAdd: (multiCreateData) => {
+                this.storeMultiCreateData(multiCreateData);
+                this.props.reactive.onAdd(multiCreateData);
+            },
+            callbackRecorder: this.callbackRecorder,
+        };
+    }
+
+    getTimeRange() {
+        return {
+            start: new Time(this.getItemFromStorage("timeRange_start", { hour: 12, minute: 0 })),
+            end: new Time(this.getItemFromStorage("timeRange_end", { hour: 13, minute: 0 })),
+        };
+    }
+
+    generateLocalStorageKey(key) {
+        const { resModel } = this.props.reactive;
+        return `multiCreate_${key}_${resModel}`;
+    }
+
+    getItemFromStorage(key, defaultValue) {
+        const item = browser.localStorage.getItem(this.generateLocalStorageKey(key));
+        try {
+            return item ? JSON.parse(item) : defaultValue;
+        } catch {
+            return defaultValue;
+        }
+    }
+
+    setItemInStorage(key, value) {
+        browser.localStorage.setItem(this.generateLocalStorageKey(key), JSON.stringify(value));
+    }
+
+    storeTimeRange(timeRange) {
+        if (timeRange?.start) {
+            this.setItemInStorage("timeRange_start", timeRange.start);
+        }
+        if (timeRange?.end) {
+            this.setItemInStorage("timeRange_end", timeRange.end);
+        }
+    }
+
+    computeValues(record) {
+        const multiCreateFormRecord = toRaw(record);
+        const values = Object.assign({}, multiCreateFormRecord.data);
+        for (const [fieldName, data] of Object.entries(multiCreateFormRecord.data)) {
+            if (["one2many", "many2many"].includes(multiCreateFormRecord.fields[fieldName].type)) {
+                values[fieldName] = data.records.map((record) =>
+                    Object.assign({ id: record.resId }, record.data)
+                );
+            }
+        }
+        return values;
+    }
+
+    onAdd() {
+        if (this.multiCreatePopover.isOpen) {
+            return;
+        }
+        this.multiCreatePopover.open(this.addButtonRef.el, this.getMultiCreatePopoverProps());
+    }
+}
+
+/**
+ * @param {Object} params
+ * @param {Function} params.onAdd
+ * @param {Function} params.onCancel
+ * @param {Function} params.onDelete
+ * @param {number} params.nbSelected
+ * @param {string} params.multiCreateView
+ * @param {string} params.resModel
+ * @param {Object} [params.multiCreateValues]
+ * @param {boolean} [params.showMultiCreateTimeRange=false]
+ * @param {boolean} [params.visible=false]
+ * @param {Object} [params.context={}]
+ * @returns {Object}
+ */
+export function useMultiSelectionButtons({
+    onAdd,
+    onCancel,
+    onDelete,
+    nbSelected,
+    multiCreateView,
+    resModel,
+    multiCreateValues,
+    showMultiCreateTimeRange,
+    visible,
+    context,
+}) {
+    return reactive({
+        onCancel,
+        onAdd,
+        onDelete,
+        nbSelected,
+        multiCreateView,
+        resModel,
+        multiCreateValues,
+        visible: Boolean(visible),
+        showMultiCreateTimeRange: Boolean(showMultiCreateTimeRange),
+        context: context || {},
+    });
+}

--- a/addons/web/static/src/views/view_components/multi_selection_buttons.xml
+++ b/addons/web/static/src/views/view_components/multi_selection_buttons.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+
+    <t t-name="web.MultiSelectionButtons">
+        <div t-if="this.props.reactive.visible and this.state.isReady" class="o_multi_selection_buttons position-absolute btn-group gap-1" t-ref="root">
+            <div class="o_selection_box list-group flex-row w-auto" role="alert">
+                <span class="list-group-item active d-flex align-items-center pe-0 py-0 rounded-1 gap-1 flex-grow-1">
+                    <b t-esc="this.props.reactive.nbSelected"/> selected
+                    <button data-tooltip="Unselect All" class="o_unselect_all btn btn-link ms-auto border-0" t-on-click="() => this.props.reactive.onCancel()">
+                        <i class="oi oi-close"/>
+                    </button>
+                </span>
+            </div>
+            <button class="btn btn-secondary" data-tooltip="Add" t-on-click="() => this.onAdd()" t-ref="addButton">
+                Add
+            </button>
+            <button class="btn btn-secondary" data-tooltip="Delete" t-on-click="() => this.props.reactive.onDelete()">
+                <i class="fa fa-trash text-danger"/>
+            </button>
+        </div>
+    </t>
+
+</templates>

--- a/addons/web/static/tests/views/calendar/calendar_common_renderer.test.js
+++ b/addons/web/static/tests/views/calendar/calendar_common_renderer.test.js
@@ -11,14 +11,16 @@ import {
 } from "./calendar_test_helpers";
 
 import { CalendarCommonRenderer } from "@web/views/calendar/calendar_common/calendar_common_renderer";
-import { SIDE_PANEL_MODES } from "@web/views/calendar/calendar_side_panel/calendar_side_panel";
+import { CallbackRecorder } from "@web/search/action_hook";
 
 const FAKE_PROPS = {
     model: FAKE_MODEL,
     createRecord() {},
     deleteRecord() {},
     editRecord() {},
-    sidePanelMode: SIDE_PANEL_MODES.filter,
+    callbackRecorder: new CallbackRecorder(),
+    onSquareSelection() {},
+    cleanSquareSelection() {},
 };
 
 async function start(props = {}, target) {


### PR DESCRIPTION
We change the multi creation/deletion feature of the calendar view in order to make it more similar to the record selection feature in a list view: first we select cells/records, then we act on those cells/records.
This means that we have have reworded the side panel of the calendar view. The +/delete tabs have been removed. They are replaced by three buttons that appear when a block of cells has been selected:
- a button that displays the number of selected records (those in the cells selected) and allowing to cancel the selection
- a button "Add" that allows to create records in batch via a popover that displays the values (and time range if applicable) to use when creating the records.
- a button "Delete" that allows to delete the selected records.

The basic components used by the feature are generic so that the feature can be made available elsewhere (e.g. in the gantt view).

Task ID: 4938831