### PR TITLE
[FIX] web: correctly show selected transparent color inside picker

### DIFF
--- a/addons/web/static/src/core/color_picker/custom_color_picker/custom_color_picker.js
+++ b/addons/web/static/src/core/color_picker/custom_color_picker/custom_color_picker.js
@@ -41,7 +41,7 @@ export class CustomColorPicker extends Component {
         this.colorComponents = {};
         this.uniqueId = uniqueId("colorpicker");
         this.selectedHexValue = "";
-        if (!this.props.selectedColor || this.props.selectedColor === "#00000000") {
+        if (!this.props.selectedColor) {
             this.props.selectedColor = this.props.defaultColor;
         }
         this.debouncedOnChangeInputs = debounce(this.onChangeInputs.bind(this), 10, true);
@@ -222,6 +222,15 @@ export class CustomColorPicker extends Component {
      * @param {integer} l
      */
     _updateHsl(h, s, l) {
+        // Remove full darkness/brightness and non-saturation in case hue is changed
+        if (0.1 < Math.abs(h - this.colorComponents.hue)) {
+            if (l < 0.1 || 99.9 < l) {
+                l = 50;
+            }
+            if (s < 0.1) {
+                s = 100;
+            }
+        }
         // Remove full transparency in case some lightness is added
         let a = this.colorComponents.opacity;
         if (a < 0.1 && l > 0.1) {

--- a/addons/web/static/src/core/color_picker/custom_color_picker/custom_color_picker.js
+++ b/addons/web/static/src/core/color_picker/custom_color_picker/custom_color_picker.js
@@ -69,15 +69,15 @@ export class CustomColorPicker extends Component {
                 }
             }),
         ].map((w) => w.document);
-        this.throttleOnMouseMove = useThrottleForAnimation((ev) => {
-            this.onMouseMovePicker(ev);
-            this.onMouseMoveSlider(ev);
-            this.onMouseMoveOpacitySlider(ev);
+        this.throttleOnPointerMove = useThrottleForAnimation((ev) => {
+            this.onPointerMovePicker(ev);
+            this.onPointerMoveSlider(ev);
+            this.onPointerMoveOpacitySlider(ev);
         });
 
         for (const doc of documents) {
-            useExternalListener(doc, "mousemove", this.throttleOnMouseMove);
-            useExternalListener(doc, "mouseup", this.onMouseUp.bind(this));
+            useExternalListener(doc, "pointermove", this.throttleOnPointerMove);
+            useExternalListener(doc, "pointerup", this.onPointerUp.bind(this));
         }
         onMounted(async () => {
             const defaultCssColor = this.props.selectedColor
@@ -318,7 +318,7 @@ export class CustomColorPicker extends Component {
         }
         this.selectedHexValue = "";
     }
-    onMouseUp() {
+    onPointerUp() {
         if (this.pickerFlag || this.sliderFlag || this.opacitySliderFlag) {
             this._colorSelected();
         }
@@ -332,18 +332,18 @@ export class CustomColorPicker extends Component {
      * @private
      * @param {Event} ev
      */
-    onMouseDownPicker(ev) {
+    onPointerDownPicker(ev) {
         this.pickerFlag = true;
         ev.preventDefault();
-        this.onMouseMovePicker(ev);
+        this.onPointerMovePicker(ev);
     }
     /**
-     * Updates saturation and lightness values on mouse drag over picker.
+     * Updates saturation and lightness values on pointer drag over picker.
      *
      * @private
      * @param {Event} ev
      */
-    onMouseMovePicker(ev) {
+    onPointerMovePicker(ev) {
         if (!this.pickerFlag) {
             return;
         }
@@ -368,18 +368,18 @@ export class CustomColorPicker extends Component {
      * @private
      * @param {Event} ev
      */
-    onMouseDownSlider(ev) {
+    onPointerDownSlider(ev) {
         this.sliderFlag = true;
         ev.preventDefault();
-        this.onMouseMoveSlider(ev);
+        this.onPointerMoveSlider(ev);
     }
     /**
-     * Updates hue value on mouse drag over slider.
+     * Updates hue value on pointer drag over slider.
      *
      * @private
      * @param {Event} ev
      */
-    onMouseMoveSlider(ev) {
+    onPointerMoveSlider(ev) {
         if (!this.sliderFlag) {
             return;
         }
@@ -398,18 +398,18 @@ export class CustomColorPicker extends Component {
      * @private
      * @param {Event} ev
      */
-    onMouseDownOpacitySlider(ev) {
+    onPointerDownOpacitySlider(ev) {
         this.opacitySliderFlag = true;
         ev.preventDefault();
-        this.onMouseMoveOpacitySlider(ev);
+        this.onPointerMoveOpacitySlider(ev);
     }
     /**
-     * Updates opacity value on mouse drag over opacity slider.
+     * Updates opacity value on pointer drag over opacity slider.
      *
      * @private
      * @param {Event} ev
      */
-    onMouseMoveOpacitySlider(ev) {
+    onPointerMoveOpacitySlider(ev) {
         if (!this.opacitySliderFlag || this.props.noTransparency) {
             return;
         }

--- a/addons/web/static/src/core/color_picker/custom_color_picker/custom_color_picker.xml
+++ b/addons/web/static/src/core/color_picker/custom_color_picker/custom_color_picker.xml
@@ -4,13 +4,13 @@
 <t t-name="web.CustomColorPicker">
     <div class="o_colorpicker_widget" t-ref="el" t-on-click="onClick" t-on-keydown="onKeydown" >
         <div class="d-flex justify-content-between align-items-stretch mb-2">
-            <div t-ref="colorPickerArea" class="o_color_pick_area position-relative w-75" t-att-style="props.noTransparency ? 'width: 89%;' : None" t-on-mousedown="onMouseDownPicker">
+            <div t-ref="colorPickerArea" class="o_color_pick_area position-relative w-75" t-att-style="props.noTransparency ? 'width: 89%;' : None" t-on-pointerdown="onPointerDownPicker">
                 <div t-ref="colorPickerPointer" class="o_picker_pointer rounded-circle p-1 position-absolute" tabindex="-1"/>
             </div>
-            <div t-ref="colorSlider" class="o_color_slider position-relative" t-on-mousedown="onMouseDownSlider">
+            <div t-ref="colorSlider" class="o_color_slider position-relative" t-on-pointerdown="onPointerDownSlider">
                 <div t-ref="colorSliderPointer" class="o_slider_pointer" tabindex="-1"/>
             </div>
-            <div t-ref="opacitySlider" class="o_opacity_slider position-relative" t-if="!props.noTransparency" t-on-mousedown="onMouseDownOpacitySlider">
+            <div t-ref="opacitySlider" class="o_opacity_slider position-relative" t-if="!props.noTransparency" t-on-pointerdown="onPointerDownOpacitySlider">
                 <div t-ref="opacitySliderPointer" class="o_opacity_pointer" tabindex="-1"/>
             </div>
         </div>

--- a/addons/web/static/tests/core/color_picker.test.js
+++ b/addons/web/static/tests/core/color_picker.test.js
@@ -151,3 +151,10 @@ test("custom color picker sets default color as selected", async () => {
     });
     expect("input.o_hex_input").toHaveValue("#FF0000");
 });
+
+test("custom color picker change color on click in hue slider", async () => {
+    await mountWithCleanup(CustomColorPicker, { props: { selectedColor: "#FF0000" } });
+    expect("input.o_hex_input").toHaveValue("#FF0000");
+    await click(".o_color_slider");
+    expect("input.o_hex_input").not.toHaveValue("#FF0000");
+});


### PR DESCRIPTION
> click on header, "Header Position": "Over the Content", click on the color of the background, it is supposed to be transparent, but the picker shows solid red

The changes in 41fec6b94900fa85febbfb0fd748a44747182cc6 causes the picker to show incorrect information when the selected color at the creation of the picker is transparent

This commit changes the approach used to achieve the same goal (to get the color clicked on when clicking on the hue bar). Without faking a selected color when it is transparent

Steps to reproduce:
- Open website builder
- Click on the header, and set "Header Position" to "Over the Content"
- Click on "Background"
- Bug: the color shown as selected by the picker is red, not transparent

task-4367641
