### PR TITLE
[IMP] orm: domain use 'any!' if in sudo

### DIFF
--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -679,7 +679,7 @@ class AccountMoveLine(models.Model):
                 operator = {'any': 'in', 'not any': 'not in'}[operator]
 
             if isinstance(value, (Query, SQL)):
-                query_value = value.select('id') if isinstance(value, Query) else value
+                query_value = value.select() if isinstance(value, Query) else value
                 value = [row[0] for row in self.env.execute_query(query_value)]
             else:  # isinstance(value, Domain) is True
                 # sudo reason: ignore ir.rules, `account_id` is with `bypass_search_access=True`

--- a/odoo/addons/base/tests/test_expression.py
+++ b/odoo/addons/base/tests/test_expression.py
@@ -1921,11 +1921,11 @@ class TestMany2one(TransactionCase):
         with self.assertQueries(['''
             SELECT "res_partner"."id"
             FROM "res_partner"
-            WHERE ("res_partner"."company_id" NOT IN (
+            WHERE ("res_partner"."company_id" IS NULL OR "res_partner"."company_id" NOT IN (
                 SELECT "res_company"."id"
                 FROM "res_company"
                 WHERE "res_company"."name" LIKE %s
-            ) OR "res_partner"."company_id" IS NULL)
+            ))
             ORDER BY "res_partner"."complete_name"asc,"res_partner"."id"desc
         ''']):
             self.Partner.search(['!', ('company_id.name', 'like', self.company.name)])
@@ -2130,11 +2130,11 @@ class TestMany2one(TransactionCase):
         with self.assertQueries(['''
             SELECT "res_partner"."id"
             FROM "res_partner"
-            WHERE ("res_partner"."company_id" NOT IN (
+            WHERE ("res_partner"."company_id" IS NULL OR "res_partner"."company_id" NOT IN (
                 SELECT "res_company"."id"
                 FROM "res_company"
                 WHERE "res_company"."name" LIKE %s
-            ) OR "res_partner"."company_id" IS NULL)
+            ))
             ORDER BY "res_partner"."complete_name"asc,"res_partner"."id"desc
         ''']):
             self.Partner.search([('company_id', 'not like', "blablabla")])

--- a/odoo/addons/base/tests/test_expression.py
+++ b/odoo/addons/base/tests/test_expression.py
@@ -1778,12 +1778,10 @@ class TestQueries(TransactionCase):
         with self.assertQueries(['''
             SELECT "res_partner"."id"
             FROM "res_partner"
+            LEFT JOIN "res_partner" AS "res_partner__commercial_partner_id"
+            ON ("res_partner"."commercial_partner_id" = "res_partner__commercial_partner_id"."id")
             WHERE "res_partner"."active" IS TRUE AND (
-            "res_partner"."commercial_partner_id" IN (
-                SELECT "res_partner"."id"
-                FROM "res_partner"
-                WHERE "res_partner"."name" IN %s
-            )
+            ("res_partner"."commercial_partner_id" IS NOT NULL AND "res_partner__commercial_partner_id"."name" IN %s)
             AND EXISTS(SELECT FROM (
                 SELECT "res_users"."partner_id" AS __inverse
                 FROM "res_users"
@@ -1871,11 +1869,9 @@ class TestMany2one(TransactionCase):
         with self.assertQueries(['''
             SELECT "res_partner"."id"
             FROM "res_partner"
-            WHERE "res_partner"."company_id" IN (
-                SELECT "res_company"."id"
-                FROM "res_company"
-                WHERE "res_company"."name" LIKE %s
-            )
+            LEFT JOIN "res_company" AS "res_partner__company_id"
+            ON ("res_partner"."company_id" = "res_partner__company_id"."id")
+            WHERE ("res_partner"."company_id" IS NOT NULL AND "res_partner__company_id"."name" LIKE %s)
             ORDER BY "res_partner"."complete_name"asc,"res_partner"."id"desc
         ''']):
             self.Partner.search([('company_id.name', 'like', self.company.name)])
@@ -1883,15 +1879,11 @@ class TestMany2one(TransactionCase):
         with self.assertQueries(['''
             SELECT "res_partner"."id"
             FROM "res_partner"
-            WHERE "res_partner"."company_id" IN (
-                SELECT "res_company"."id"
-                FROM "res_company"
-                WHERE "res_company"."partner_id" IN (
-                    SELECT "res_partner"."id"
-                    FROM "res_partner"
-                    WHERE "res_partner"."name" LIKE %s
-                )
-            )
+            LEFT JOIN "res_company" AS "res_partner__company_id"
+            ON ("res_partner"."company_id" = "res_partner__company_id"."id")
+            LEFT JOIN "res_partner" AS "res_partner__company_id__partner_id"
+            ON ("res_partner__company_id"."partner_id" = "res_partner__company_id__partner_id"."id")
+            WHERE ("res_partner"."company_id" IS NOT NULL AND "res_partner__company_id__partner_id"."name" LIKE %s)
             ORDER BY "res_partner"."complete_name"asc,"res_partner"."id"desc
         ''']):
             self.Partner.search([('company_id.partner_id.name', 'like', self.company.name)])
@@ -1899,15 +1891,14 @@ class TestMany2one(TransactionCase):
         with self.assertQueries(['''
             SELECT "res_partner"."id"
             FROM "res_partner"
-            WHERE ("res_partner"."company_id" IN (
-                SELECT "res_company"."id"
-                FROM "res_company"
-                WHERE "res_company"."name" LIKE %s
-            ) OR "res_partner"."country_id" IN (
-                SELECT "res_country"."id"
-                FROM "res_country"
-                WHERE "res_country"."code" LIKE %s
-            ))
+            LEFT JOIN "res_company" AS "res_partner__company_id"
+            ON ("res_partner"."company_id" = "res_partner__company_id"."id")
+            LEFT JOIN "res_country" AS "res_partner__country_id"
+            ON ("res_partner"."country_id" = "res_partner__country_id"."id")
+            WHERE (
+                ("res_partner"."company_id" IS NOT NULL AND "res_partner__company_id"."name" LIKE %s)
+                OR ("res_partner"."country_id" IS NOT NULL AND "res_partner__country_id"."code" LIKE %s)
+            )
             ORDER BY "res_partner"."complete_name"asc,"res_partner"."id"desc
         ''']):
             self.Partner.search([
@@ -2029,11 +2020,9 @@ class TestMany2one(TransactionCase):
             FROM "res_partner"
             LEFT JOIN "res_company" AS "res_partner__company_id" ON
                 ("res_partner"."company_id" = "res_partner__company_id"."id")
-            WHERE ("res_partner"."company_id" IS NOT NULL AND "res_partner__company_id"."partner_id" IN (
-                SELECT "res_partner"."id"
-                FROM "res_partner"
-                WHERE "res_partner"."name" LIKE %s
-            ))
+            LEFT JOIN "res_partner" AS "res_partner__company_id__partner_id" ON
+                ("res_partner__company_id"."partner_id" = "res_partner__company_id__partner_id"."id")
+            WHERE ("res_partner"."company_id" IS NOT NULL AND "res_partner__company_id__partner_id"."name" LIKE %s)
             ORDER BY "res_partner"."complete_name"asc,"res_partner"."id"desc
         ''']):
             self.Partner.search([('company_id.partner_id.name', 'like', self.company.name)])
@@ -2056,13 +2045,11 @@ class TestMany2one(TransactionCase):
         with self.assertQueries(['''
             SELECT "res_partner"."id"
             FROM "res_partner"
-            WHERE "res_partner"."company_id" IN (
-                SELECT "res_company"."id"
-                FROM "res_company"
-                LEFT JOIN "res_partner" AS "res_company__partner_id" ON
-                    ("res_company"."partner_id" = "res_company__partner_id"."id")
-                WHERE "res_company__partner_id"."name" LIKE %s
-            )
+            LEFT JOIN "res_company" AS "res_partner__company_id" ON
+                ("res_partner"."company_id" = "res_partner__company_id"."id")
+            LEFT JOIN "res_partner" AS "res_partner__company_id__partner_id" ON
+                ("res_partner__company_id"."partner_id" = "res_partner__company_id__partner_id"."id")
+            WHERE ("res_partner"."company_id" IS NOT NULL AND "res_partner__company_id__partner_id"."name" LIKE %s)
             ORDER BY "res_partner"."complete_name"asc,"res_partner"."id"desc
         ''']):
             self.Partner.search([('company_id.partner_id.name', 'like', self.company.name)])
@@ -2118,11 +2105,9 @@ class TestMany2one(TransactionCase):
         with self.assertQueries(['''
             SELECT "res_partner"."id"
             FROM "res_partner"
-            WHERE "res_partner"."company_id" IN (
-                SELECT "res_company"."id"
-                FROM "res_company"
-                WHERE "res_company"."name" LIKE %s
-            )
+            LEFT JOIN "res_company" AS "res_partner__company_id"
+            ON ("res_partner"."company_id" = "res_partner__company_id"."id")
+            WHERE ("res_partner"."company_id" IS NOT NULL AND "res_partner__company_id"."name" LIKE %s)
             ORDER BY "res_partner"."complete_name"asc,"res_partner"."id"desc
         ''']):
             self.Partner.search([('company_id', 'like', self.company.name)])

--- a/odoo/addons/base/tests/test_expression.py
+++ b/odoo/addons/base/tests/test_expression.py
@@ -1756,7 +1756,7 @@ class TestQueries(TransactionCase):
             LEFT JOIN "res_partner" AS "res_users__partner_id" ON
                 ("res_users"."partner_id" = "res_users__partner_id"."id")
             WHERE "res_users"."active" IS TRUE
-            AND ("res_users"."id" IN %s AND "res_users__partner_id"."id" IN %s)
+            AND ("res_users"."id" IN %s AND "res_users"."partner_id" IN %s)
             ORDER BY "res_users__partner_id"."name", "res_users"."login"
         ''']):
             Model.search([])

--- a/odoo/addons/test_orm/tests/test_domain.py
+++ b/odoo/addons/test_orm/tests/test_domain.py
@@ -906,37 +906,37 @@ class TestDomainOptimize(TransactionCase):
         ]:
             field_type = model._fields[field_name].type
             m2o = field_type == 'many2one'
-            left = left.optimize_full(model[field_name])
-            right = right.optimize_full(model[field_name])
+            left = left.optimize(model[field_name])
+            right = right.optimize(model[field_name])
 
             with self.subTest(field_type=field_type):
                 self.assertEqual(
-                    (Domain(field_name, 'any', left) | Domain(field_name, 'any', right)).optimize_full(model),
+                    (Domain(field_name, 'any', left) | Domain(field_name, 'any', right)).optimize(model),
                     Domain(field_name, 'any', left | right),
                 )
                 self.assertEqual(
-                    (Domain(field_name, 'any', left) & Domain(field_name, 'any', right)).optimize_full(model),
+                    (Domain(field_name, 'any', left) & Domain(field_name, 'any', right)).optimize(model),
                     Domain(field_name, 'any', left & right) if m2o
                     else Domain(field_name, 'any', left) & Domain(field_name, 'any', right),
                 )
                 query = model[field_name]._search([])
                 self.assertEqual(
-                    (Domain(field_name, 'any', left) | Domain(field_name, 'any', query) | Domain(field_name, 'any', right)).optimize_full(model),
+                    (Domain(field_name, 'any', left) | Domain(field_name, 'any', query) | Domain(field_name, 'any', right)).optimize(model),
                     Domain(field_name, 'any', left | right) | Domain(field_name, 'any!', query),
                     "Don't merge query with domains",
                 )
                 self.assertEqual(
-                    (Domain(field_name, 'not any', left) | Domain(field_name, 'not any', right)).optimize_full(model),
+                    (Domain(field_name, 'not any', left) | Domain(field_name, 'not any', right)).optimize(model),
                     Domain(field_name, 'not any', left & right) if m2o
                     else Domain(field_name, 'not any', left) | Domain(field_name, 'not any', right),
                 )
                 self.assertEqual(
-                    (Domain(field_name, 'not any', left) & Domain(field_name, 'not any', right)).optimize_full(model),
+                    (Domain(field_name, 'not any', left) & Domain(field_name, 'not any', right)).optimize(model),
                     Domain(field_name, 'not any', left | right),
                 )
 
                 self.assertEqual(
-                    (Domain(field_name, 'any', left) | Domain(field_name, 'not any', right)).optimize_full(model),
+                    (Domain(field_name, 'any', left) | Domain(field_name, 'not any', right)).optimize(model),
                     (Domain(field_name, 'any', left) | Domain(field_name, 'not any', right)),
                     "Do not merge any and not any",
                 )

--- a/odoo/addons/test_orm/tests/test_domain.py
+++ b/odoo/addons/test_orm/tests/test_domain.py
@@ -772,6 +772,22 @@ class TestDomainOptimize(TransactionCase):
             self.number_domain,
         )
 
+    def test_sudo_optimize(self):
+        model = self.env['test_orm.discussion'].with_user(self.env.ref('base.public_user'))
+        self.assertEqual(
+            Domain('moderator', 'any', Domain('login', 'like', 'one')).optimize_full(model),
+            Domain('moderator', 'any', Domain('login', 'like', 'one')),
+        )
+        self.assertEqual(
+            Domain('moderator', 'any', Domain('login', 'like', 'one')).optimize_full(model.sudo()),
+            Domain('moderator', 'any!', Domain('login', 'like', 'one')),
+        )
+        query = model.moderator._search(Domain.TRUE)
+        self.assertEqual(
+            Domain('moderator', 'any', query).optimize(model),
+            Domain('moderator', 'any!', query),
+        )
+
     def test_nary_build(self):
         self.assertEqual(
             ~(self.number_domain & self.number_domain),

--- a/odoo/addons/test_orm/tests/test_domain.py
+++ b/odoo/addons/test_orm/tests/test_domain.py
@@ -3,7 +3,7 @@ from freezegun import freeze_time
 from itertools import combinations
 
 from odoo.fields import Command, Domain
-from odoo.tests import TransactionCase
+from odoo.tests import TransactionCase, users
 from odoo.tools import SQL, OrderedSet
 
 from odoo.addons.base.tests.test_expression import TransactionExpressionCase
@@ -974,3 +974,29 @@ class TestDomainOptimize(TransactionCase):
         domain = Domain('foo', '=', 4) | Domain('foo', '=', 5)
         domain = domain.optimize_full(bar)
         self.assertEqual(domain, Domain('name', 'in', OrderedSet(['(4, 5)'])))
+
+    @users('admin')  # just so it's not SUPERUSER to be able to de-escalate su.
+    def test_bypass_comodel_id_lookup(self):
+        model = self.env['test_orm.mixed']
+        base_domain = Domain('currency_id.id', '=', 2)
+        self.assertEqual(  # without sudo
+            list(base_domain.optimize_full(model)),
+            [('currency_id', 'any', [('id', 'in', [2])])],
+        )
+        self.assertEqual(  # with sudo
+            list(base_domain.optimize_full(model.sudo())),
+            [('currency_id', 'in', [2])],
+        )
+
+        # check how False is managed
+        base_domain = Domain('currency_id.id', 'in', [2, False])
+        self.assertEqual(  # with sudo
+            list(base_domain.optimize_full(model.sudo())),
+            [('currency_id', 'in', [2])],
+        )
+
+        base_domain = Domain('currency_id.id', 'not in', [2])
+        self.assertEqual(  # with sudo
+            list(base_domain.optimize_full(model.sudo())),
+            [('currency_id', 'not in', [2, False])],
+        )

--- a/odoo/addons/test_orm/tests/test_search.py
+++ b/odoo/addons/test_orm/tests/test_search.py
@@ -11,13 +11,12 @@ class TestSubqueries(TransactionCase):
         with self.assertQueries(["""
             SELECT "test_orm_multi"."id"
             FROM "test_orm_multi"
-            WHERE "test_orm_multi"."partner" IN (
-                SELECT "res_partner"."id"
-                FROM "res_partner"
-                WHERE ("res_partner"."name" LIKE %s
-                   AND "res_partner"."phone" LIKE %s
-                )
-            )
+            LEFT JOIN "res_partner" AS "test_orm_multi__partner"
+            ON ("test_orm_multi"."partner" = "test_orm_multi__partner"."id")
+            WHERE ("test_orm_multi"."partner" IS NOT NULL AND (
+                "test_orm_multi__partner"."name" LIKE %s
+                AND "test_orm_multi__partner"."phone" LIKE %s
+            ))
             ORDER BY "test_orm_multi"."id"
         """]):
             self.env['test_orm.multi'].search([
@@ -29,13 +28,12 @@ class TestSubqueries(TransactionCase):
         with self.assertQueries(["""
             SELECT "test_orm_multi"."id"
             FROM "test_orm_multi"
-            WHERE "test_orm_multi"."partner" IN (
-                SELECT "res_partner"."id"
-                FROM "res_partner"
-                WHERE ("res_partner"."name" LIKE %s
-                    OR "res_partner"."phone" LIKE %s
-                )
-            )
+            LEFT JOIN "res_partner" AS "test_orm_multi__partner"
+            ON ("test_orm_multi"."partner" = "test_orm_multi__partner"."id")
+            WHERE ("test_orm_multi"."partner" IS NOT NULL AND (
+                "test_orm_multi__partner"."name" LIKE %s
+                OR "test_orm_multi__partner"."phone" LIKE %s
+            ))
             ORDER BY "test_orm_multi"."id"
         """]):
             self.env['test_orm.multi'].search([
@@ -106,15 +104,11 @@ class TestSubqueries(TransactionCase):
         with self.assertQueries(["""
             SELECT "test_orm_multi"."id"
             FROM "test_orm_multi"
-            LEFT JOIN "res_partner" AS "test_orm_multi__partner"
-                ON ("test_orm_multi"."partner" = "test_orm_multi__partner"."id")
-            WHERE (
-                "test_orm_multi"."partner" IS NULL OR
-                ((
-                    "test_orm_multi__partner"."name" LIKE %s
-                    OR "test_orm_multi__partner"."phone" LIKE %s
-                )) IS NOT TRUE
-            )
+            WHERE ("test_orm_multi"."partner" IS NULL OR "test_orm_multi"."partner" NOT IN (
+                SELECT "res_partner"."id"
+                FROM "res_partner"
+                WHERE ("res_partner"."name" LIKE %s OR "res_partner"."phone" LIKE %s)
+            ))
             ORDER BY "test_orm_multi"."id"
         """]):
             self.env['test_orm.multi'].search([
@@ -127,16 +121,15 @@ class TestSubqueries(TransactionCase):
         with self.assertQueries(["""
             SELECT "test_orm_multi"."id"
             FROM "test_orm_multi"
-            WHERE "test_orm_multi"."partner" IN (
-                SELECT "res_partner"."id"
-                FROM "res_partner"
-                WHERE (
-                    "res_partner"."email" LIKE %s
-                    AND ("res_partner"."name" LIKE %s
-                      OR "res_partner"."phone" LIKE %s
-                    )
+            LEFT JOIN "res_partner" AS "test_orm_multi__partner"
+            ON ("test_orm_multi"."partner" = "test_orm_multi__partner"."id")
+            WHERE ("test_orm_multi"."partner" IS NOT NULL AND (
+                "test_orm_multi__partner"."email" LIKE %s
+                AND (
+                    "test_orm_multi__partner"."name" LIKE %s
+                    OR "test_orm_multi__partner"."phone" LIKE %s
                 )
-            )
+            ))
             ORDER BY "test_orm_multi"."id"
         """]):
             self.env['test_orm.multi'].search([
@@ -150,23 +143,19 @@ class TestSubqueries(TransactionCase):
         with self.assertQueries(["""
             SELECT "test_orm_multi"."id"
             FROM "test_orm_multi"
+            LEFT JOIN "res_partner" AS "test_orm_multi__partner"
+            ON ("test_orm_multi"."partner" = "test_orm_multi__partner"."id")
             WHERE (
-                {many2one} IN (
-                    {subselect}
-                    WHERE (
-                        "res_partner"."email" LIKE %s
-                        OR "res_partner"."name" LIKE %s
-                    )
-                )
+                ({many2one} IS NOT NULL AND (
+                    "test_orm_multi__partner"."email" LIKE %s
+                    OR "test_orm_multi__partner"."name" LIKE %s
+                ))
                 AND ({many2one} IS NULL OR {many2one} NOT IN (
                     {subselect}
                     WHERE "res_partner"."website" LIKE %s
                 ))
                 AND (
-                    {many2one} IN (
-                        {subselect}
-                        WHERE "res_partner"."function" LIKE %s
-                    )
+                    ({many2one} IS NOT NULL AND "test_orm_multi__partner"."function" LIKE %s)
                     OR ({many2one} IS NULL OR {many2one} NOT IN (
                         {subselect}
                         WHERE "res_partner"."phone" LIKE %s
@@ -1005,11 +994,9 @@ class TestSearchRelated(TransactionCase):
         with self.assertQueries(["""
             SELECT "test_orm_related"."id"
             FROM "test_orm_related"
-            WHERE "test_orm_related"."foo_id" IN (
-                SELECT "test_orm_related_foo"."id"
-                FROM "test_orm_related_foo"
-                WHERE "test_orm_related_foo"."name" IN %s
-            )
+            LEFT JOIN "test_orm_related_foo" AS "test_orm_related__foo_id"
+            ON ("test_orm_related"."foo_id" = "test_orm_related__foo_id"."id")
+            WHERE ("test_orm_related"."foo_id" IS NOT NULL AND "test_orm_related__foo_id"."name" IN %s)
             ORDER BY "test_orm_related"."id"
         """]):
             model.search([('foo_name', '=', 'a')])
@@ -1031,14 +1018,12 @@ class TestSearchRelated(TransactionCase):
         with self.assertQueries(["""
             SELECT "test_orm_related"."id"
             FROM "test_orm_related"
-            WHERE (
-                "test_orm_related"."foo_id" IS NULL
-                OR "test_orm_related"."foo_id" IN (
-                    SELECT "test_orm_related_foo"."id"
-                    FROM "test_orm_related_foo"
-                    WHERE ("test_orm_related_foo"."name" IN %s OR "test_orm_related_foo"."name" IS NULL)
-                )
-            )
+            LEFT JOIN "test_orm_related_foo" AS "test_orm_related__foo_id"
+            ON ("test_orm_related"."foo_id" = "test_orm_related__foo_id"."id")
+            WHERE ("test_orm_related"."foo_id" IS NULL OR (
+                "test_orm_related"."foo_id" IS NOT NULL
+                AND ("test_orm_related__foo_id"."name" IN %s OR "test_orm_related__foo_id"."name" IS NULL)
+            ))
             ORDER BY "test_orm_related"."id"
         """]):
             model.search([('foo_name', '=', False)])
@@ -1046,11 +1031,9 @@ class TestSearchRelated(TransactionCase):
         with self.assertQueries(["""
             SELECT "test_orm_related"."id"
             FROM "test_orm_related"
-            WHERE "test_orm_related"."foo_id" IN (
-                SELECT "test_orm_related_foo"."id"
-                FROM "test_orm_related_foo"
-                WHERE "test_orm_related_foo"."name" NOT IN %s
-            )
+            LEFT JOIN "test_orm_related_foo" AS "test_orm_related__foo_id"
+            ON ("test_orm_related"."foo_id" = "test_orm_related__foo_id"."id")
+            WHERE ("test_orm_related"."foo_id" IS NOT NULL AND "test_orm_related__foo_id"."name" NOT IN %s)
             ORDER BY "test_orm_related"."id"
         """]):
             model.search([('foo_name', '!=', False)])
@@ -1058,11 +1041,9 @@ class TestSearchRelated(TransactionCase):
         with self.assertQueries(["""
             SELECT "test_orm_related"."id"
             FROM "test_orm_related"
-            WHERE "test_orm_related"."foo_id" IN (
-                SELECT "test_orm_related_foo"."id"
-                FROM "test_orm_related_foo"
-                WHERE "test_orm_related_foo"."name" IN %s
-            )
+            LEFT JOIN "test_orm_related_foo" AS "test_orm_related__foo_id"
+            ON ("test_orm_related"."foo_id" = "test_orm_related__foo_id"."id")
+            WHERE ("test_orm_related"."foo_id" IS NOT NULL AND "test_orm_related__foo_id"."name" IN %s)
             ORDER BY "test_orm_related"."id"
         """]):
             model.search([('foo_name', 'in', ['a', 'b'])])
@@ -1085,17 +1066,14 @@ class TestSearchRelated(TransactionCase):
         with self.assertQueries(["""
             SELECT "test_orm_related"."id"
             FROM "test_orm_related"
-            WHERE (
-                "test_orm_related"."foo_id" IS NULL
-                OR "test_orm_related"."foo_id" IN (
-                    SELECT "test_orm_related_foo"."id"
-                    FROM "test_orm_related_foo"
-                    WHERE (
-                        "test_orm_related_foo"."name" IN %s
-                        OR "test_orm_related_foo"."name" IS NULL
-                    )
+            LEFT JOIN "test_orm_related_foo" AS "test_orm_related__foo_id"
+            ON ("test_orm_related"."foo_id" = "test_orm_related__foo_id"."id")
+            WHERE ("test_orm_related"."foo_id" IS NULL OR (
+                "test_orm_related"."foo_id" IS NOT NULL AND (
+                    "test_orm_related__foo_id"."name" IN %s
+                    OR "test_orm_related__foo_id"."name" IS NULL
                 )
-            )
+            ))
             ORDER BY "test_orm_related"."id"
         """]):
             model.search([('foo_name', 'in', ['a', False])])
@@ -1103,10 +1081,11 @@ class TestSearchRelated(TransactionCase):
         with self.assertQueries(["""
             SELECT "test_orm_related"."id"
             FROM "test_orm_related"
-            WHERE "test_orm_related"."foo_id" IN (
-                SELECT "test_orm_related_foo"."id"
-                FROM "test_orm_related_foo"
-                WHERE "test_orm_related_foo"."name" NOT IN %s
+            LEFT JOIN "test_orm_related_foo" AS "test_orm_related__foo_id"
+            ON ("test_orm_related"."foo_id" = "test_orm_related__foo_id"."id")
+            WHERE (
+                "test_orm_related"."foo_id" IS NOT NULL
+                AND "test_orm_related__foo_id"."name" NOT IN %s
             )
             ORDER BY "test_orm_related"."id"
         """]):
@@ -1115,12 +1094,11 @@ class TestSearchRelated(TransactionCase):
         with self.assertQueries(["""
             SELECT "test_orm_related"."id"
             FROM "test_orm_related"
-            LEFT JOIN "test_orm_related_foo" AS "test_orm_related__foo_id"
-                ON ("test_orm_related"."foo_id" = "test_orm_related__foo_id"."id")
-            WHERE (
-                "test_orm_related"."foo_id" IS NULL
-                OR ("test_orm_related__foo_id"."name" IN %s) IS NOT TRUE
-            )
+            WHERE ("test_orm_related"."foo_id" IS NULL OR "test_orm_related"."foo_id" NOT IN (
+                SELECT "test_orm_related_foo"."id"
+                FROM "test_orm_related_foo"
+                WHERE "test_orm_related_foo"."name" IN %s
+            ))
             ORDER BY "test_orm_related"."id"
         """]):
             model.search([('foo_name_sudo', '!=', 'a')])
@@ -1143,20 +1121,19 @@ class TestSearchRelated(TransactionCase):
         with self.assertQueries(["""
             SELECT "test_orm_related"."id"
             FROM "test_orm_related"
+            LEFT JOIN "test_orm_related_foo" AS "test_orm_related__foo_id"
+            ON ("test_orm_related"."foo_id" = "test_orm_related__foo_id"."id")
+            LEFT JOIN "test_orm_related_bar" AS "test_orm_related__foo_id__bar_id"
+            ON ("test_orm_related__foo_id"."bar_id" = "test_orm_related__foo_id__bar_id"."id")
             WHERE (
                 "test_orm_related"."foo_id" IS NULL
-                OR "test_orm_related"."foo_id" IN (
-                    SELECT "test_orm_related_foo"."id"
-                    FROM "test_orm_related_foo"
-                    WHERE (
-                        "test_orm_related_foo"."bar_id" IS NULL
-                        OR "test_orm_related_foo"."bar_id" IN (
-                            SELECT "test_orm_related_bar"."id"
-                            FROM "test_orm_related_bar"
-                            WHERE ("test_orm_related_bar"."name" IN %s OR "test_orm_related_bar"."name" IS NULL)
-                        )
-                    )
-                )
+                OR ("test_orm_related"."foo_id" IS NOT NULL AND (
+                    "test_orm_related__foo_id"."bar_id" IS NULL
+                    OR ("test_orm_related__foo_id"."bar_id" IS NOT NULL AND (
+                        "test_orm_related__foo_id__bar_id"."name" IN %s
+                        OR "test_orm_related__foo_id__bar_id"."name" IS NULL
+                    ))
+                ))
             )
             ORDER BY "test_orm_related"."id"
         """]):
@@ -1165,15 +1142,14 @@ class TestSearchRelated(TransactionCase):
         with self.assertQueries(["""
             SELECT "test_orm_related"."id"
             FROM "test_orm_related"
-            WHERE "test_orm_related"."foo_id" IN (
-                SELECT "test_orm_related_foo"."id"
-                FROM "test_orm_related_foo"
-                WHERE "test_orm_related_foo"."bar_id" IN (
-                    SELECT "test_orm_related_bar"."id"
-                    FROM "test_orm_related_bar"
-                    WHERE "test_orm_related_bar"."name" NOT IN %s
-                )
-            )
+            LEFT JOIN "test_orm_related_foo" AS "test_orm_related__foo_id"
+            ON ("test_orm_related"."foo_id" = "test_orm_related__foo_id"."id")
+            LEFT JOIN "test_orm_related_bar" AS "test_orm_related__foo_id__bar_id"
+            ON ("test_orm_related__foo_id"."bar_id" = "test_orm_related__foo_id__bar_id"."id")
+            WHERE ("test_orm_related"."foo_id" IS NOT NULL AND (
+                "test_orm_related__foo_id"."bar_id" IS NOT NULL
+                AND "test_orm_related__foo_id__bar_id"."name" NOT IN %s
+            ))
             ORDER BY "test_orm_related"."id"
         """]):
             model.search([('foo_bar_name', '!=', False)])
@@ -1565,11 +1541,9 @@ class TestFlushSearch(TransactionCase):
         ''', '''
             SELECT "test_orm_city"."id"
             FROM "test_orm_city"
-            WHERE "test_orm_city"."country_id" IN (
-                SELECT "test_orm_country"."id"
-                FROM "test_orm_country"
-                WHERE "test_orm_country"."name" LIKE %s
-            )
+            LEFT JOIN "test_orm_country" AS "test_orm_city__country_id"
+            ON ("test_orm_city"."country_id" = "test_orm_city__country_id"."id")
+            WHERE ("test_orm_city"."country_id" IS NOT NULL AND "test_orm_city__country_id"."name" LIKE %s)
             ORDER BY "test_orm_city"."id"
         ''']):
             self.brussels.country_id = self.france
@@ -1585,11 +1559,9 @@ class TestFlushSearch(TransactionCase):
         ''', '''
             SELECT "test_orm_city"."id"
             FROM "test_orm_city"
-            WHERE "test_orm_city"."country_id" IN (
-                SELECT "test_orm_country"."id"
-                FROM "test_orm_country"
-                WHERE "test_orm_country"."name" LIKE %s
-            )
+            LEFT JOIN "test_orm_country" AS "test_orm_city__country_id"
+            ON ("test_orm_city"."country_id" = "test_orm_city__country_id"."id")
+            WHERE ("test_orm_city"."country_id" IS NOT NULL AND "test_orm_city__country_id"."name" LIKE %s)
             ORDER BY "test_orm_city"."id"
         ''']):
             self.belgium.name = "Belgique"

--- a/odoo/addons/test_orm/tests/test_search.py
+++ b/odoo/addons/test_orm/tests/test_search.py
@@ -48,13 +48,13 @@ class TestSubqueries(TransactionCase):
         with self.assertQueries(["""
             SELECT "test_orm_multi"."id"
             FROM "test_orm_multi"
-            WHERE ("test_orm_multi"."partner" NOT IN (
+            WHERE ("test_orm_multi"."partner" IS NULL OR "test_orm_multi"."partner" NOT IN (
                 SELECT "res_partner"."id"
                 FROM "res_partner"
                 WHERE ("res_partner"."name" LIKE %s
                     AND "res_partner"."phone" LIKE %s
                 )
-            ) OR "test_orm_multi"."partner" IS NULL)
+            ))
             ORDER BY "test_orm_multi"."id"
         """]):
             self.env['test_orm.multi'].search([
@@ -67,13 +67,13 @@ class TestSubqueries(TransactionCase):
         with self.assertQueries(["""
             SELECT "test_orm_multi"."id"
             FROM "test_orm_multi"
-            WHERE ("test_orm_multi"."partner" NOT IN (
+            WHERE ("test_orm_multi"."partner" IS NULL OR "test_orm_multi"."partner" NOT IN (
                 SELECT "res_partner"."id"
                 FROM "res_partner"
                 WHERE ("res_partner"."name" LIKE %s
                     OR "res_partner"."phone" LIKE %s
                 )
-            ) OR "test_orm_multi"."partner" IS NULL)
+            ))
             ORDER BY "test_orm_multi"."id"
         """]):
             self.env['test_orm.multi'].search([
@@ -158,19 +158,19 @@ class TestSubqueries(TransactionCase):
                         OR "res_partner"."name" LIKE %s
                     )
                 )
-                AND ({many2one} NOT IN (
+                AND ({many2one} IS NULL OR {many2one} NOT IN (
                     {subselect}
                     WHERE "res_partner"."website" LIKE %s
-                ) OR {many2one} IS NULL)
+                ))
                 AND (
                     {many2one} IN (
                         {subselect}
                         WHERE "res_partner"."function" LIKE %s
                     )
-                    OR ({many2one} NOT IN (
+                    OR ({many2one} IS NULL OR {many2one} NOT IN (
                         {subselect}
                         WHERE "res_partner"."phone" LIKE %s
-                    ) OR {many2one} IS NULL)
+                    ))
                 )
             )
             ORDER BY "test_orm_multi"."id"
@@ -1018,11 +1018,11 @@ class TestSearchRelated(TransactionCase):
             SELECT "test_orm_related"."id"
             FROM "test_orm_related"
             WHERE (
-                "test_orm_related"."foo_id" NOT IN (
+                "test_orm_related"."foo_id" IS NULL OR "test_orm_related"."foo_id" NOT IN (
                     SELECT "test_orm_related_foo"."id"
                     FROM "test_orm_related_foo"
                     WHERE "test_orm_related_foo"."name" IN %s
-                ) OR "test_orm_related"."foo_id" IS NULL
+                )
             )
             ORDER BY "test_orm_related"."id"
         """]):
@@ -1071,11 +1071,12 @@ class TestSearchRelated(TransactionCase):
             SELECT "test_orm_related"."id"
             FROM "test_orm_related"
             WHERE (
+                "test_orm_related"."foo_id" IS NULL OR
                 "test_orm_related"."foo_id" NOT IN (
                     SELECT "test_orm_related_foo"."id"
                     FROM "test_orm_related_foo"
                     WHERE "test_orm_related_foo"."name" IN %s
-                ) OR "test_orm_related"."foo_id" IS NULL
+                )
             )
             ORDER BY "test_orm_related"."id"
         """]):

--- a/odoo/orm/domains.py
+++ b/odoo/orm/domains.py
@@ -1738,6 +1738,43 @@ def _optimize_any_with_rights(condition, model):
     return condition
 
 
+@field_type_optimization(['many2one'], level=OptimizationLevel.FULL)
+def _optimize_m2o_bypass_comodel_id_lookup(condition, model):
+    """Avoid comodel's subquery, if it can be compared with the field directly"""
+    operator = condition.operator
+    if (
+        operator in ('any!', 'not any!')
+        and isinstance(subdomain := condition.value, DomainCondition)
+        and subdomain.field_expr == 'id'
+        and (suboperator := subdomain.operator) in ('in', 'not in', 'any!', 'not any!')
+    ):
+        # We are bypassing permissions, we can transform:
+        #  a ANY (id IN X)  =>  a IN (X - {False})
+        #  a ANY (id NOT IN X)  =>  a NOT IN (X | {False})
+        #  a ANY (id ANY X)  =>  a ANY X
+        #  a ANY (id NOT ANY X)  =>  a != False AND a NOT ANY X
+        #  a NOT ANY (id IN X)  =>  a NOT IN (X - {False})
+        #  a NOT ANY (id NOT IN X)  =>  a IN (X | {False})
+        #  a NOT ANY (id ANY X)  =>  a NOT ANY X
+        #  a NOT ANY (id NOT ANY X)  =>  a = False OR a ANY X
+        val = subdomain.value
+        match suboperator:
+            case 'in':
+                domain = DomainCondition(condition.field_expr, 'in', val - {False})
+            case 'not in':
+                domain = DomainCondition(condition.field_expr, 'not in', val | {False})
+            case 'any!':
+                domain = DomainCondition(condition.field_expr, 'any!', val)
+            case 'not any!':
+                domain = DomainCondition(condition.field_expr, '!=', False) \
+                    & DomainCondition(condition.field_expr, 'not any!', val)
+        if operator == 'not any!':
+            domain = ~domain
+        return domain
+
+    return condition
+
+
 # --------------------------------------------------
 # Optimizations: nary
 # --------------------------------------------------

--- a/odoo/orm/domains.py
+++ b/odoo/orm/domains.py
@@ -1731,6 +1731,13 @@ def _operator_parent_of_domain(comodel: BaseModel, parent):
     return parent_ids
 
 
+@operator_optimization(['any', 'not any'], level=OptimizationLevel.FULL)
+def _optimize_any_with_rights(condition, model):
+    if model.env.su or condition._field(model).bypass_search_access:
+        return DomainCondition(condition.field_expr, condition.operator + '!', condition.value)
+    return condition
+
+
 # --------------------------------------------------
 # Optimizations: nary
 # --------------------------------------------------

--- a/odoo/orm/fields_relational.py
+++ b/odoo/orm/fields_relational.py
@@ -479,7 +479,7 @@ class Many2one(_Relational):
                 subselect,
             )
             if can_be_null and operator in ('not any', 'not any!'):
-                sql = SQL("(%s OR %s IS NULL)", sql, sql_field)
+                sql = SQL("(%s IS NULL OR %s)", sql_field, sql)
             if self.company_dependent:
                 sql = self._condition_to_sql_company(sql, field_expr, operator, value, model, alias, query)
             return sql

--- a/odoo/orm/fields_relational.py
+++ b/odoo/orm/fields_relational.py
@@ -459,51 +459,62 @@ class Many2one(_Relational):
             # for other operators than 'any', just generate condition based on column type
             return super().condition_to_sql(field_expr, operator, value, model, alias, query)
 
-        fname = field_expr
         comodel = model.env[self.comodel_name]
-        sql_field = model._field_to_sql(alias, fname, query)
+        sql_field = model._field_to_sql(alias, field_expr, query)
         can_be_null = self not in model.env.registry.not_null_fields
+        bypass_access = operator in ('any!', 'not any!') or self.bypass_search_access
+        positive = operator in ('any', 'any!')
 
-        if not isinstance(value, Domain):
-            # value is SQL or Query
-            if isinstance(value, Query):
-                subselect = value.subselect()
-            elif isinstance(value, SQL):
-                subselect = SQL("(%s)", value)
-            else:
-                raise TypeError(f"condition_to_sql() 'any' operator accepts Domain, SQL or Query, got {value}")
-            sql = SQL(
-                "%s%s%s",
-                sql_field,
-                SQL(" IN ") if operator in ('any', 'any!') else SQL(" NOT IN "),
-                subselect,
+        # Decide whether to use a LEFT JOIN
+        left_join = bypass_access and isinstance(value, Domain)
+        if left_join and not positive:
+            # For 'not any!', we get a better query with a NOT IN when we have a
+            # lot of positive conditions which have a better chance to use
+            # indexes.
+            #   `field NOT IN (SELECT ... WHERE z = y)` better than
+            #   `LEFT JOIN ... ON field = id WHERE z <> y`
+            # There are some exceptions: we filter on 'id'.
+            left_join = sum(
+                (-1 if Domain.is_negative_operator(cond.operator) else 1)
+                for cond in value.iter_conditions()
+            ) < 0 or any(
+                cond.field_expr == 'id' and not Domain.is_negative_operator(cond.operator)
+                for cond in value.iter_conditions()
             )
-            if can_be_null and operator in ('not any', 'not any!'):
-                sql = SQL("(%s IS NULL OR %s)", sql_field, sql)
+
+        if left_join:
+            comodel, coalias = self.join(model, alias, query)
+            if not positive:
+                value = (~value).optimize_full(model)
+            sql = value._to_sql(comodel, coalias, query)
             if self.company_dependent:
                 sql = self._condition_to_sql_company(sql, field_expr, operator, value, model, alias, query)
+            if can_be_null:
+                if positive:
+                    sql = SQL("(%s IS NOT NULL AND %s)", sql_field, sql)
+                else:
+                    sql = SQL("(%s IS NULL OR %s)", sql_field, sql)
             return sql
 
-        # value is a Domain
-
-        if self.bypass_search_access or operator in ('any!', 'not any!'):
-            comodel, coalias = self.join(model, alias, query)
-
-            sql = value._to_sql(comodel, coalias, query)
-            if operator in ('any', 'any!'):
-                if can_be_null:
-                    return SQL("(%s IS NOT NULL AND %s)", sql_field, sql)
-                else:
-                    return sql
-            else:
-                if can_be_null:
-                    return SQL("(%s IS NULL OR (%s) IS NOT TRUE)", sql_field, sql)
-                else:
-                    return SQL("(%s) IS NOT TRUE", sql)
-
-        # execute search and generate condition with a SQL query
-        domain_query = comodel._search(value, active_test=False)
-        return self.condition_to_sql(fname, operator, domain_query, model, alias, query)
+        if isinstance(value, Domain):
+            value = comodel._search(value, active_test=False, bypass_access=bypass_access)
+        if isinstance(value, Query):
+            subselect = value.subselect()
+        elif isinstance(value, SQL):
+            subselect = SQL("(%s)", value)
+        else:
+            raise TypeError(f"condition_to_sql() 'any' operator accepts Domain, SQL or Query, got {value}")
+        sql = SQL(
+            "%s%s%s",
+            sql_field,
+            SQL(" IN ") if positive else SQL(" NOT IN "),
+            subselect,
+        )
+        if can_be_null and not positive:
+            sql = SQL("(%s IS NULL OR %s)", sql_field, sql)
+        if self.company_dependent:
+            sql = self._condition_to_sql_company(sql, field_expr, operator, value, model, alias, query)
+        return sql
 
     def join(self, model: BaseModel, alias: str, query: Query) -> tuple[BaseModel, str]:
         """ Add a LEFT JOIN to ``query`` by following field ``self``,


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
When performing optimizations on the Domains, transform "any" into "any!" when we are optimizing with a `model.env.su` or when the field has `auto_join=True`.
Sometimes LEFT JOIN in slower for "not any" queries, if we have more positive than negative conditions, use a NOT IN.

Current behavior before PR:
A lot of queries stay in the form "any".

Desired behavior after PR is merged:
"any!" domains are translated mostly using left joins for many2one fields.

odoo/enterprise#90270


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
