### PR TITLE
[FIX] point_of_sale: price based on min qty on lot

### DIFF
--- a/addons/point_of_sale/static/tests/tours/OrderWithLots.tour.js
+++ b/addons/point_of_sale/static/tests/tours/OrderWithLots.tour.js
@@ -1,0 +1,28 @@
+/** @odoo-module */
+
+import * as ProductScreen from "@point_of_sale/../tests/tours/helpers/ProductScreenTourMethods";
+import { registry } from "@web/core/registry";
+
+registry.category("web_tour.tours").add("test_03_pos_with_lots", {
+    test: true,
+    url: "/pos/ui",
+    steps: () =>
+        [
+            ProductScreen.confirmOpeningPopup(),
+            ProductScreen.clickHomeCategory(),
+            ProductScreen.clickDisplayedProduct("Monitor Stand"),
+            ProductScreen.enterLotNumber("1"),
+            ProductScreen.selectedOrderlineHas("Monitor Stand", "1"),
+            ProductScreen.pressNumpad("2"),
+            ProductScreen.totalAmountIs("6.38"),
+            ProductScreen.clickDisplayedProduct("Monitor Stand"),
+            ProductScreen.enterLotNumber("2"),
+            ProductScreen.pressNumpad("3"),
+            ProductScreen.totalAmountIs("15.95"),
+            ProductScreen.selectPriceList("min_quantity ordering"),
+            ProductScreen.totalAmountIs("5.00"),
+            ProductScreen.pressNumpad("⌫"),
+            ProductScreen.totalAmountIs("6.38"),
+            ProductScreen.isShown(),
+        ].flat(),
+});

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -348,6 +348,11 @@ class TestPointOfSaleHttpCommon(AccountTestInvoicingHttpCommon):
                 'applied_on': '0_product_variant',
                 'min_quantity': 2,
                 'product_id': env.ref('point_of_sale.product_product_consumable').id,
+            }), (0, 0, {
+                'compute_price': 'fixed',
+                'fixed_price': 1,
+                'min_quantity': 5,
+                'product_tmpl_id': cls.monitor_stand.product_tmpl_id.id,
             })],
         })
 
@@ -585,6 +590,14 @@ class TestUi(TestPointOfSaleHttpCommon):
         n_paid = self.env['pos.order'].search_count([('state', '=', 'paid')])
         self.assertEqual(n_invoiced, 1, 'There should be 1 invoiced order.')
         self.assertEqual(n_paid, 2, 'There should be 2 paid order.')
+
+    def test_03_pos_with_lots(self):
+
+        # open a session, the /pos/ui controller will redirect to it
+        self.main_pos_config.with_user(self.pos_user).open_ui()
+
+        self.monitor_stand.tracking = 'lot'
+        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'test_03_pos_with_lots', login="pos_user")
 
     def test_04_product_configurator(self):
         # Making one attribute inactive to verify that it doesn't show


### PR DESCRIPTION
**PROBLEM**
Pricelist rules based on a minimum quantity does not work well with lot tracked product, when the quantity is splitted between multiples lots. For example, if you take 2 product from lot A, and 3 product from lot B, a rule defining the price for a minimum quantity of 5 will not trigger (it should).

**STEP TO REPRODUCE**
1. install pos
2. create a lot tracked product
3. create a pricelist rule for the product, with a price based on min qty
4. from the pos, order the min qty but split it accross multiple lots
5. price will not takethe rule into account

**CAUSE**
Order line of lot tracked products are never merged. The quantity used to compute if a pricelist trigger is the quantity of each line individually.

**FIX**
For lot tracked product, to determine the price of a line, we parse find all corresponding lines and add their quantities together. Then we update all of their prices. To know if we should take into account a line, we verify if they would have been merged, if their product wasn't lot tracked.

**REMARK**
Ideally, their would be a way to merged order line of lot tracked product, while being able to edit the quantity taken from each lot directly from the pos. From now, order line doesn't work well with multiple lots, and it would require unstable change on the db.

opw-4751920