### PR TITLE
[FIX] website_livechat: website visit time in the agent's timezone

### DIFF
--- a/addons/website_livechat/static/src/web/persona_model_patch.js
+++ b/addons/website_livechat/static/src/web/persona_model_patch.js
@@ -1,0 +1,18 @@
+import { Persona } from "@mail/core/common/persona_model";
+
+import { patch } from "@web/core/utils/patch";
+import { deserializeDateTime } from "@web/core/l10n/dates";
+
+const { DateTime } = luxon;
+
+patch(Persona.prototype, {
+    get historyLocalized() {
+        const history = [];
+        for (const h of this.history_data ?? []) {
+            const [label, date] = h;
+            const time = deserializeDateTime(date).toLocaleString(DateTime.TIME_24_SIMPLE);
+            history.push(`${label} (${time})`);
+        }
+        return history.join(" → ");
+    },
+});

--- a/addons/website_livechat/static/src/web/thread_patch.xml
+++ b/addons/website_livechat/static/src/web/thread_patch.xml
@@ -23,7 +23,7 @@
                     </div>
                     <div class="mt-1">
                         <i class="me-1 fa fa-history" aria-label="History"/>
-                        <span t-esc="visitor.history"/>
+                        <span t-esc="visitor.historyLocalized or visitor.history"/>
                     </div>
                 </div>
             </div>

--- a/addons/website_livechat/static/tests/mock_server/mock_models/discuss_channel.js
+++ b/addons/website_livechat/static/tests/mock_server/mock_models/discuss_channel.js
@@ -1,6 +1,14 @@
 import { livechatModels } from "@im_livechat/../tests/livechat_test_helpers";
 import { fields } from "@web/../tests/web_test_helpers";
 
+function historyDataToString(history) {
+    const formatDateTime = (dateTime) => {
+        const match = dateTime.match(/.* ([0-9]{2}:[0-9]{2}:)/);
+        return match ? match[1].slice(0, -1) : "";
+    };
+    return history.map((h) => `${h[0]} (${formatDateTime(h[1])})`).join(" → ");
+}
+
 export class DiscussChannel extends livechatModels.DiscussChannel {
     livechat_visitor_id = fields.Many2one({ relation: "website.visitor", string: "Visitor" }); // FIXME: somehow not fetched properly
 
@@ -28,10 +36,13 @@ export class DiscussChannel extends livechatModels.DiscussChannel {
                 const [visitor] = WebsiteVisitor.browse(channel.livechat_visitor_id);
                 const [partner] = ResPartner.browse(visitor.partner_id);
                 const [country] = ResCountry.browse(visitor.country_id);
+                const visitorHistoryData = JSON.parse(visitor.history_data || "[]");
+
                 channelInfo.visitor = {
                     country: country ? { id: country.id, code: country.code } : false,
                     name: partner?.name || partner?.display_name || visitor.display_name || `Visitor #${visitor.id}`,
-                    history: visitor.history, // TODO should be computed
+                    history: historyDataToString(visitorHistoryData),
+                    history_data: visitorHistoryData,
                     id: visitor.id,
                     is_connected: visitor.is_connected,
                     lang_name: visitor.lang_id ? ResLang.read(visitor.lang_id)[0].name : false,

--- a/addons/website_livechat/static/tests/mock_server/mock_models/website_visitor.js
+++ b/addons/website_livechat/static/tests/mock_server/mock_models/website_visitor.js
@@ -6,7 +6,7 @@ export class WebsiteVisitor extends models.ServerModel {
     _name = "website.visitor";
 
     country_id = fields.Many2one({ relation: "res.country", string: "Country" }); // FIXME: somehow not fetched properly
-    history = fields.Char();
+    history_data = fields.Char();
     lang_id = fields.Many2one({ relation: "res.lang", string: "Language" }); // FIXME: somehow not fetched properly
     name = fields.Char({ string: "Name" }); // FIXME: somehow not fetched
     partner_id = fields.Many2one({ relation: "res.partner", string: "Contact" }); // FIXME: somehow not fetched properly

--- a/addons/website_livechat/tests/test_livechat_basic_flow.py
+++ b/addons/website_livechat/tests/test_livechat_basic_flow.py
@@ -40,9 +40,30 @@ class TestLivechatBasicFlowHttpCase(HttpCaseWithUserDemo, TestLivechatCommon):
             self.env.ref('website.contactus_page').name,
             self.env.ref('website.homepage_page').name,
         )
+        handmade_history_data = [
+            (
+                self.env.ref("website.homepage_page").name,
+                (self.base_datetime - datetime.timedelta(minutes=20)).strftime(
+                    "%Y-%m-%d %H:%M:%S"
+                ),
+            ),
+            (
+                self.env.ref("website.contactus_page").name,
+                (self.base_datetime - datetime.timedelta(minutes=10)).strftime(
+                    "%Y-%m-%d %H:%M:%S"
+                ),
+            ),
+            (
+                self.env.ref("website.homepage_page").name,
+                self.base_datetime.strftime("%Y-%m-%d %H:%M:%S"),
+            ),
+        ]
+
         history = self.env['discuss.channel']._get_visitor_history(self.visitor)
+        history_data = self.env['discuss.channel']._get_visitor_history_data(self.visitor)
 
         self.assertEqual(history, handmade_history)
+        self.assertEqual(history_data, handmade_history_data)
 
     def test_livechat_username(self):
         # Open a new live chat


### PR DESCRIPTION
Before this PR, when browsing a website livechat in the discuss app, the banner containing the 3 last pages browsed by the user showed the utc time instead of the time in the timezone of the agent.

Now, the livechat agent is seeing the visit timings in his timezone.

To achieve this, we now construct the visit string in the frontend and receive the page and datetime (utc) info from the backend

task-4937769

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
