### PR TITLE
[IMP] mail: search messages with access using SQL

### DIFF
--- a/addons/event/models/event_event.py
+++ b/addons/event/models/event_event.py
@@ -667,7 +667,7 @@ class EventEvent(models.Model):
             # allow the registration desk users to post messages on Event
             # can not be done with "_mail_post_access" otherwise public user will be
             # able to post on published Event (see website_event)
-            return dict.fromkeys(self, 'read')
+            return [(Domain.TRUE, 'read')]
         return super()._mail_get_operation_for_mail_message_operation(message_operation)
 
     def _set_tz_context(self):

--- a/addons/mail/controllers/thread.py
+++ b/addons/mail/controllers/thread.py
@@ -39,8 +39,10 @@ class ThreadController(http.Controller):
         behavior is to rely on _mail_post_access but it might be customized.
         See '_mail_get_operation_for_mail_message_operation'. """
         thread_su = request.env[thread_model].sudo().browse(int(thread_id))
-        access_mode = thread_su._mail_get_operation_for_mail_message_operation('create')[thread_su]
-        if not access_mode:
+        for document_domain, access_mode in thread_su._mail_get_operation_for_mail_message_operation('create'):
+            if thread_su.filtered_domain(document_domain):
+                break
+        else:
             return request.env[thread_model]  # match _get_thread_with_access void result
         return cls._get_thread_with_access(thread_model, thread_id, mode=access_mode, **kwargs)
 

--- a/addons/mail/models/models.py
+++ b/addons/mail/models/models.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from collections import defaultdict
@@ -8,6 +7,7 @@ from markupsafe import Markup
 
 from odoo import api, exceptions, models, tools, _
 from odoo.addons.mail.tools.alias_error import AliasError
+from odoo.fields import Domain
 from odoo.tools import parse_contact_from_email
 from odoo.tools.mail import email_normalize, email_split_and_format
 
@@ -54,6 +54,7 @@ class Base(models.AbstractModel):
     # CHECK ACCESS
     # ------------------------------------------------------------
 
+    @api.model
     def _mail_get_operation_for_mail_message_operation(self, message_operation):
         """ Give document permission based on mail.message check permission.
         This is used when no other checks already granted permission (e.g.
@@ -71,19 +72,7 @@ class Base(models.AbstractModel):
             check_access = mail_post_access
         else:
             check_access = 'write'
-        return dict.fromkeys(self, check_access)
-
-    def _mail_group_by_operation_for_mail_message_operation(self, message_operation):
-        """ Globally reverse result of '_mail_get_operation_for_mail_message_operation'
-        aka return documents for a given access to check on them. """
-        document_operations = self._mail_get_operation_for_mail_message_operation(message_operation)
-        operation_documents = defaultdict(lambda: self.env[self._name])
-        for record, record_operation in document_operations.items():
-            operation_documents[record_operation] += record
-        # force prefetch in a post-loop as recordset concatenation may lose it
-        for operation, records in operation_documents.items():
-            records = records.with_prefetch(self.ids)
-        return operation_documents
+        return ((Domain.TRUE, check_access),)
 
     # ------------------------------------------------------------
     # FIELDS HELPERS

--- a/addons/product_email_template/tests/test_account_move.py
+++ b/addons/product_email_template/tests/test_account_move.py
@@ -43,11 +43,7 @@ class TestAccountMove(AccountTestInvoicingCommon):
         """
         Test scenario of a product ordered through the portal.
         """
-        id_max = self.env['mail.message'].search([], order='id desc', limit=1)
-        if id_max:
-            id_max = id_max[0].id
-        else:
-            id_max = 0
+        id_max = self.env['mail.message'].sudo().search([], order='id desc', limit=1).id or 0
         invoice = self.env['account.move'].create({
             'move_type': 'out_invoice',
             'partner_id': self.customer.id,

--- a/addons/test_discuss_full/tests/test_performance.py
+++ b/addons/test_discuss_full/tests/test_performance.py
@@ -50,10 +50,11 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
     #   2: _init_messaging (discuss)
     #       - fetch discuss_channel_member (is_self)
     #       - _compute_message_unread
-    #   3: _init_messaging (mail)
+    #   4: _init_messaging (mail)
     #       - search bus_bus (_bus_last_id)
     #       - _get_needaction_count (inbox counter)
     #       - search mail_message (starred counter)
+    #           - _check_access
     #   23: _process_request_for_all (discuss):
     #       - search discuss_channel (channels_domain)
     #       22: channel add:
@@ -81,7 +82,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
     #           - _compute_message_needaction
     #           - search discuss_channel_res_groups_rel (group_ids)
     #           - fetch res_groups (group_public_id)
-    _query_count_init_messaging = 35
+    _query_count_init_messaging = 36
     # Queries for _query_count_discuss_channels (in order):
     #   1: insert res_device_log
     #   3: _search_is_member (for current user, first occurence _get_channels_as_member)

--- a/addons/test_mail/models/mail_test_access.py
+++ b/addons/test_mail/models/mail_test_access.py
@@ -1,4 +1,5 @@
 from odoo import fields, models, tools
+from odoo.fields import Domain
 
 
 class MailTestAccess(models.Model):
@@ -55,13 +56,15 @@ class MailTestAccessCusto(models.Model):
     def _mail_get_operation_for_mail_message_operation(self, message_operation):
         # customize message creation: only unlocked, except admins
         if message_operation == "create":
-            return dict.fromkeys(self.filtered(lambda r: not r.is_locked), 'read')
+            return (
+                (Domain('is_locked', '=', False), 'read'),
+            )
         # customize read: read access on unlocked, write access on locked
         elif message_operation == "read":
-            return {
-                record: 'write' if record.is_locked else 'read'
-                for record in self
-            }
+            return (
+                (Domain('is_locked', '=', True), 'write'),
+                (Domain.TRUE, 'read'),
+            )
         return super()._mail_get_operation_for_mail_message_operation(message_operation)
 
 

--- a/addons/website_forum/models/forum_post.py
+++ b/addons/website_forum/models/forum_post.py
@@ -729,11 +729,10 @@ class ForumPost(models.Model):
     # ----------------------------------------------------------------------
 
     def _mail_get_operation_for_mail_message_operation(self, message_operation):
+        operations = super()._mail_get_operation_for_mail_message_operation(message_operation)
         if message_operation in ('write', 'unlink'):
-            filtered_self = self.filtered(lambda post: post.can_edit)
-        else:
-            filtered_self = self
-        return super(ForumPost, filtered_self)._mail_get_operation_for_mail_message_operation(message_operation)
+            operations = [(Domain('can_edit', '=', True) & domain, op) for domain, op in operations]
+        return operations
 
     def _notify_get_recipients_groups(self, message, model_description, msg_vals=False):
         groups = super()._notify_get_recipients_groups(


### PR DESCRIPTION
When searching for messages, perform the access checks in SQL.
We can translate rules that have restriction on `model` values directly into a Domain.

We keep the fallback to search without access rights and filter afterwards for other cases. We will always limit the number of returned results from the query to avoid checking the whole table.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
