### PR TITLE
[FIX] hw_drivers: longpolling was disabled by 'general' in devtools

### DIFF
--- a/addons/hw_drivers/tools/helpers.py
+++ b/addons/hw_drivers/tools/helpers.py
@@ -75,9 +75,10 @@ def toggleable(function):
 
     @wraps(function)
     def devtools_wrapper(*args, **kwargs):
-        if args and args[0].__class__.__name__ == 'DriverController' and get_conf('longpolling', section='devtools'):
-            _logger.warning("Refusing call to %s: longpolling is disabled by devtools", fname)
-            raise Locked("Longpolling disabled by devtools")  # raise to make the http request fail
+        if args and args[0].__class__.__name__ == 'DriverController':
+            if get_conf('longpolling', section='devtools'):
+                _logger.warning("Refusing call to %s: longpolling is disabled by devtools", fname)
+                raise Locked("Longpolling disabled by devtools")  # raise to make the http request fail
         elif function.__name__ == 'action':
             action = args[1].get('action', 'default')  # first argument is self (containing Driver instance), second is 'data'
             disabled_actions = (get_conf('actions', section='devtools') or '').split(',')


### PR DESCRIPTION
`devtools disable general` should not disable longpolling actions/events. We updated the `toggleable` wrapper to avoid this.
