### PR TITLE
[FIX] account: update partner banking information on payments when bank account is added

### DIFF
--- a/addons/account/models/account_payment.py
+++ b/addons/account/models/account_payment.py
@@ -512,7 +512,7 @@ class AccountPayment(models.Model):
             else:
                 payment.amount_signed = payment.amount
 
-    @api.depends('partner_id', 'company_id', 'payment_type')
+    @api.depends('partner_id', 'company_id', 'payment_type', 'partner_id', 'partner_id.bank_ids')
     def _compute_available_partner_bank_ids(self):
         for pay in self:
             if pay.payment_type == 'inbound':

--- a/addons/account/tests/test_account_payment.py
+++ b/addons/account/tests/test_account_payment.py
@@ -859,3 +859,35 @@ class TestAccountPayment(AccountTestInvoicingCommon, MailCommon):
             'amount_signed': -100,
             'amount_company_currency_signed': -50,
         }])
+
+    def test_partner_bank_onchange_triggered_by_bank_creation(self):
+        """Ensure payment.partner_bank_id is updated when a new bank account is added to the partner."""
+
+        partner = self.env['res.partner'].create({'name': 'Bank Partner'})
+        payments = self.env['account.payment']
+        for _ in range(2):
+            payments += self.env['account.payment'].create({
+                'amount': 50.0,
+                'payment_type': 'outbound',
+                'partner_type': 'supplier',
+                'partner_id': partner.id,
+                'destination_account_id': partner.property_account_payable_id.id,
+                'currency_id': self.other_currency.id,
+                'partner_bank_id': False,
+            })
+
+        payments.action_post()
+        batch_payment_action = payments.create_batch_payment()
+        batch_payment_id = self.env['account.batch.payment'].browse(batch_payment_action.get('res_id'))
+
+        bank = self.env['res.partner.bank'].create({
+            'partner_id': partner.id,
+            'acc_number': 'BE123',
+            'acc_holder_name': 'Bank Test',
+            'allow_out_payment': True,
+            'acc_type': 'bank',
+        })
+
+        for payment in batch_payment_id.payment_ids:
+            self.assertEqual(payment.partner_bank_id.acc_number, bank.acc_number)
+            self.assertEqual(payment.partner_bank_id.acc_holder_name, bank.acc_holder_name)


### PR DESCRIPTION
**Issue**
When a payment is created for a partner who has no bank account at that moment, the payment’s partner bank fields (account holder name, account number) remain empty in the database. Later adding a bank account to the partner does not update these fields on existing payments. As a result, printing batch payments after adding the bank account still shows empty or placeholder bank information instead of the correct details.

**Steps to Reproduce**
1. Navigate to Accounting > Vendors > Bills.
2. Create two vendor bills for a partner without a bank account.
3. Select both bills and create payments.
4. Create and validate a batch payment for those payments.
5. Print the batch payment — bank details will be empty as expected.
6. Add a bank account to the partner.
7. Print the batch payment again — bank details remain empty and do not reflect the newly added bank info.

**Root Cause**
The payment’s partner bank fields are computed only at payment creation and not updated when the partner’s bank accounts change later. This causes outdated or missing bank info on payments if the bank is added after payment creation.

**Fix**
Modify the `_compute_partner_bank_id` computed field to depend not only on payment-related fields but also on `partner_id` and `partner_id.bank_ids`. This ensures that when a new bank account is added to the partner, the payment’s partner bank is automatically recomputed and updated with the latest bank information.

Opw-4915059
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
