### PR TITLE
[FIX] website, *: fix issues on website app as a no-rights internal user

### DIFF
--- a/addons/event/views/event_event_views.xml
+++ b/addons/event/views/event_event_views.xml
@@ -282,7 +282,16 @@
                 <group expand="0" string="Group By">
                     <filter string="Responsible" name="responsible" context="{'group_by': 'user_id'}"/>
                     <filter string="Template" name="event_type_id" context="{'group_by': 'event_type_id'}"/>
-                    <filter string="Stage" name="stage_id" context="{'group_by': 'stage_id'}"/>
+                    <!--
+                    TODO the "groups" attribute is not directly useful here: the
+                    whole event app is supposed to be hidden for those lambda
+                    non-"event users". However, this view is also used in the
+                    website builder, where we do want normal website users to
+                    access events views. This should be reviewed in master.
+                    This was mostly made to avoid runbot "errors".
+                    See WEBSITE_RECORDS_VIEWS_ACCESS_RIGHTS.
+                    -->
+                    <filter string="Stage" name="stage_id" context="{'group_by': 'stage_id'}" groups="event.group_event_registration_desk"/>
                     <filter string="Start Date" name="date_begin" domain="[]" context="{'group_by': 'date_begin'}"/>
                 </group>
             </search>

--- a/addons/website/models/website_page.py
+++ b/addons/website/models/website_page.py
@@ -96,6 +96,8 @@ class Page(models.Model):
         if self.env.user.has_group('website.group_website_designer'):
             for record in self:
                 record.can_publish = True
+        # FIXME this makes it so no-rights internal users *see* the publish
+        # button for website pages (although they cannot use it)
         else:
             super()._compute_can_publish()
 

--- a/addons/website/static/src/systray_items/edit_in_backend.js
+++ b/addons/website/static/src/systray_items/edit_in_backend.js
@@ -36,7 +36,19 @@ EditInBackendSystray.template = "website.EditInBackendSystray";
 
 export const systrayItem = {
     Component: EditInBackendSystray,
-    isDisplayed: env => env.services.website.currentWebsite && env.services.website.currentWebsite.metadata.editableInBackend,
+    isDisplayed: env => env.services.website.currentWebsite && env.services.website.currentWebsite.metadata.editableInBackend
+        // TODO the functional desire is to have read access on all "website"
+        // models for all internal users, but there are many fields preventing
+        // that... to review in master (should views just be smarter? should
+        // they be more basic in the website app?). This disables the form view
+        // access feature for some models that are known to lead to access
+        // rights lock. At least, list views are accessible at the moment.
+        // See WEBSITE_RECORDS_VIEWS_ACCESS_RIGHTS.
+        && (
+            !env.services.website.currentWebsite.metadata.mainObject
+            || !['event.event', 'hr.job'].includes(env.services.website.currentWebsite.metadata.mainObject.model)
+            || env.services.website.currentWebsite.metadata.canPublish
+        ),
 };
 
 registry.category("website_systray").add("EditInBackend", systrayItem, { sequence: 9 });

--- a/addons/website_event/views/website_pages_views.xml
+++ b/addons/website_event/views/website_pages_views.xml
@@ -47,6 +47,15 @@
             <attribute name="js_class">website_pages_kanban</attribute>
             <attribute name="type">object</attribute>
             <attribute name="action">open_website_url</attribute>
+            <!--
+            TODO a bit bad (why grouping by responsible user?) but we want
+            website views to be reachable by any internal user and those
+            apparently cannot access stage_id... maybe they should be able to?
+            This should be reviewed in master. This was mostly made to avoid
+            runbot "errors".
+            See WEBSITE_RECORDS_VIEWS_ACCESS_RIGHTS.
+            -->
+            <attribute name="default_group_by">user_id</attribute>
         </xpath>
         <xpath expr="//kanban" position="inside">
             <field name="website_url" invisible="1"/>

--- a/addons/website_hr_recruitment/views/website_pages_views.xml
+++ b/addons/website_hr_recruitment/views/website_pages_views.xml
@@ -25,6 +25,17 @@
 
             <field name="website_id" groups="website.group_multi_website"/>
         </xpath>
+
+        <!--
+        TODO a bit fragile and ugly (why would you add some "groups" for this
+        specific view only?). This is the functional desire to be able to access
+        this website view as a lambda internal user. This should be reviewed in
+        master. This was mostly made to avoid runbot "errors".
+        See WEBSITE_RECORDS_VIEWS_ACCESS_RIGHTS.
+        -->
+        <xpath expr="//field[@name='application_count']" position="attributes">
+            <attribute name="groups">hr_recruitment.group_hr_recruitment_interviewer,hr_recruitment.group_hr_recruitment_user</attribute>
+        </xpath>
     </field>
 </record>
 
@@ -50,6 +61,26 @@
             </div>
         </xpath>
         <xpath expr="//div[hasclass('o_link_trackers')]" position="replace"/>
+
+        <!--
+        TODO a bit fragile and ugly (why would you add some "groups" for this
+        specific view only?). This is the functional desire to be able to access
+        this website view as a lambda internal user. This should be reviewed in
+        master. This was mostly made to avoid runbot "errors".
+        See WEBSITE_RECORDS_VIEWS_ACCESS_RIGHTS.
+        -->
+        <xpath expr="//field[@name='application_count']" position="attributes">
+            <attribute name="groups">hr_recruitment.group_hr_recruitment_interviewer,hr_recruitment.group_hr_recruitment_user</attribute>
+        </xpath>
+        <xpath expr="//field[@name='new_application_count']" position="attributes">
+            <attribute name="groups">hr_recruitment.group_hr_recruitment_interviewer,hr_recruitment.group_hr_recruitment_user</attribute>
+        </xpath>
+        <xpath expr="//div[hasclass('col-7')]/button" position="attributes">
+            <attribute name="groups">hr_recruitment.group_hr_recruitment_interviewer,hr_recruitment.group_hr_recruitment_user</attribute>
+        </xpath>
+        <xpath expr="//ul[hasclass('o_job_activities')]/li[2]" position="attributes">
+            <attribute name="groups">hr_recruitment.group_hr_recruitment_interviewer,hr_recruitment.group_hr_recruitment_user</attribute>
+        </xpath>
     </field>
 </record>
 


### PR DESCRIPTION
*: event, website_event, website_hr_recruitment

The functional desire is to be able to access the website app as a basic
internal user and see records views that you can see.
In practice, there are quite a few technical issues preventing that (the
user easily gets hit with "you don't have the rights to access this"
because of internal fields of the main models and screens could maybe be
different or the framework should be a bit more smarter about this.

This commit adds bandaids on the problem to at least allow some access
without warning on some things (by hiding specific fields in the website
views, etc). The main reason for this commit is keeping the no-demo
runbot tests happy (especially in later versions where it became the
standard). In master, this should definitely be reviewed to work more
robustly and more well-thought from a functional point of view.

Some (all?) examples of issues solved: as an internal user without any
access rights (except being an internal user), try to:
- Access the kanban view of events in the website app
- Group the list view of events by "stage" in the website app
- Access the list view or kanban view of jobs in the website app
- Go on an event in the website app, try to access the form view with
  the related top-right button
- Go on a job page in the website app, try to access the form view with
  the related top-right button

Note: the publish button also kinda has the same problem for pages. This
will be fixed in a dedicated PR after this one.

runbot-161791