### PR TITLE
[IMP] project, project_todo: remove server actions

### DIFF
--- a/addons/project/models/project_task.py
+++ b/addons/project/models/project_task.py
@@ -1658,15 +1658,6 @@ class ProjectTask(models.Model):
             res.update(super(ProjectTask, leftover)._notify_get_reply_to(default=default, author_id=author_id))
         return res
 
-    def _ensure_personal_stages(self):
-        user = self.env.user
-        ProjectTaskTypeSudo = self.env['project.task.type'].sudo()
-        # In the case no stages have been found, we create the default stages for the user
-        if not ProjectTaskTypeSudo.search_count([('user_id', '=', user.id)], limit=1):
-            ProjectTaskTypeSudo.with_context(lang=user.lang, default_project_id=False).create(
-                self.with_context(lang=user.lang)._get_default_personal_stage_create_vals(user.id)
-            )
-
     @api.model
     def message_new(self, msg_dict, custom_values=None):
         # remove default author when going through the mail gateway. Indeed we

--- a/addons/project/models/res_users.py
+++ b/addons/project/models/res_users.py
@@ -1,4 +1,4 @@
-from odoo import models, fields
+from odoo import api, fields, models
 
 
 class ResUsers(models.Model):
@@ -6,3 +6,22 @@ class ResUsers(models.Model):
 
     favorite_project_ids = fields.Many2many('project.project', 'project_favorite_user_rel', 'user_id', 'project_id',
                                             string='Favorite Projects', export_string_translation=False, copy=False)
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        res = super().create(vals_list)
+        self._onboard_users_into_project(res)
+        return res
+
+    def _onboard_users_into_project(self, users):
+        if (internal_users := users.filtered(lambda u: not u.share)):
+            ProjectTaskTypeSudo = self.env["project.task.type"].sudo()
+            create_vals = []
+            for user in internal_users:
+                vals = self.env["project.task"].with_context(lang=user.lang)._get_default_personal_stage_create_vals(user.id)
+                create_vals.extend(vals)
+
+            if create_vals:
+                ProjectTaskTypeSudo.with_context(default_project_id=False).create(create_vals)
+
+            return internal_users

--- a/addons/project/views/project_menus.xml
+++ b/addons/project/views/project_menus.xml
@@ -28,7 +28,7 @@
             <menuitem
                 name="My Tasks"
                 id="menu_project_management_my_tasks"
-                action="action_server_view_my_task"
+                action="action_view_my_task"
                 sequence="1"
             />
             <menuitem

--- a/addons/project/views/project_task_views.xml
+++ b/addons/project/views/project_task_views.xml
@@ -1116,16 +1116,6 @@
             <field name="view_id" ref="view_task_all_calendar"/>
         </record>
 
-        <record id="action_server_view_my_task" model="ir.actions.server">
-            <field name="name">menu view My Tasks</field>
-            <field name="model_id" ref="project.model_project_task"/>
-            <field name="state">code</field>
-            <field name="path">my-tasks</field>
-            <field name="code">
-                model._ensure_personal_stages(); action = env["ir.actions.actions"]._for_xml_id("project.action_view_my_task")
-            </field>
-        </record>
-
         <record id="action_server_convert_to_subtask" model="ir.actions.server">
             <field name="name">Convert to Task/Sub-Task</field>
             <field name="model_id" ref="project.model_project_task"/>

--- a/addons/project_todo/__init__.py
+++ b/addons/project_todo/__init__.py
@@ -1,2 +1,6 @@
 from . import models
 from . import wizard
+
+
+def _todo_post_init(env):
+    env["res.users"].search([("share", "=", False)])._generate_onboarding_todo()

--- a/addons/project_todo/__manifest__.py
+++ b/addons/project_todo/__manifest__.py
@@ -21,6 +21,7 @@
     ],
     'installable': True,
     'application': True,
+    'post_init_hook': '_todo_post_init',
     'assets': {
         'web.assets_backend': [
             'project_todo/static/src/components/**/*',

--- a/addons/project_todo/models/project_task.py
+++ b/addons/project_todo/models/project_task.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import api, models, Command
+from odoo import api, models
 from odoo.tools import html2plaintext
 
 
@@ -20,30 +20,6 @@ class ProjectTask(models.Model):
                 else:
                     vals['name'] = self.env._('Untitled to-do')
         return super().create(vals_list)
-
-    def _ensure_onboarding_todo(self):
-        if not self.env.user.has_group('project_todo.group_onboarding_todo'):
-            self._generate_onboarding_todo(self.env.user)
-            onboarding_group = self.env.ref('project_todo.group_onboarding_todo').sudo()
-            onboarding_group.write({'user_ids': [Command.link(self.env.user.id)]})
-
-    def _generate_onboarding_todo(self, user):
-        user.ensure_one()
-        self_lang = self.with_context(lang=user.lang or self.env.user.lang)
-        body = self_lang.env['ir.qweb']._render(
-            'project_todo.todo_user_onboarding',
-            {'object': user},
-            minimal_qcontext=True,
-            raise_if_not_found=False
-        )
-        if not body:
-            return
-        title = self_lang.env._('Welcome %s!', user.name)
-        self.env['project.task'].create([{
-            'user_ids': user.ids,
-            'description': body,
-            'name': title,
-        }])
 
     def action_convert_to_task(self):
         self.ensure_one()

--- a/addons/project_todo/security/project_todo_security.xml
+++ b/addons/project_todo/security/project_todo_security.xml
@@ -1,10 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
 
-    <record id="group_onboarding_todo" model="res.groups">
-        <field name="name">Onboarding todo already generated for those users</field>
-    </record>
-
 <data noupdate="1">
 
     <record model="ir.rule" id="task_edition_rule_internal">

--- a/addons/project_todo/tests/__init__.py
+++ b/addons/project_todo/tests/__init__.py
@@ -2,5 +2,6 @@
 
 from . import test_access_rights
 from . import test_mail_activity_todo_create
+from . import test_todo_onboarding_for_users
 from . import test_todo_ui
 from . import test_todo_quick_create

--- a/addons/project_todo/tests/test_todo_onboarding_for_users.py
+++ b/addons/project_todo/tests/test_todo_onboarding_for_users.py
@@ -1,0 +1,33 @@
+from odoo.tests.common import TransactionCase, new_test_user
+
+
+class TestTodoOnboardingUsers(TransactionCase):
+    """Test personal stages onboarding and onboarding task creation for project_todo."""
+
+    def test_onboarding_stages_and_task_created_for_new_users(self):
+        """Personal stages and onboarding task should be created for internal users upon creation."""
+        ProjectTaskSudo = self.env["project.task"].sudo()
+
+        internal_user = new_test_user(
+            self.env,
+            login="internal_user",
+            groups="base.group_user",
+        )
+        onboarding_tasks = ProjectTaskSudo.search([('user_ids', 'in', internal_user.ids)])
+
+        self.assertEqual(len(onboarding_tasks), 1, "Exactly 1 onboarding task should be created for internal users upon creation.")
+        portal_user = new_test_user(
+            self.env,
+            login="portal_user",
+            groups="base.group_portal",
+        )
+        onboarding_tasks = ProjectTaskSudo.search([('user_ids', 'in', portal_user.ids)])
+        self.assertEqual(len(onboarding_tasks), 0, "Portal users should not receive onboarding tasks upon creation.")
+
+        public_user = new_test_user(
+            self.env,
+            login="public_user",
+            groups="base.group_public",
+        )
+        onboarding_tasks = ProjectTaskSudo.search([('user_ids', 'in', public_user.ids)])
+        self.assertEqual(len(onboarding_tasks), 0, "Public users should not receive onboarding tasks upon creation.")

--- a/addons/project_todo/views/project_task_views.xml
+++ b/addons/project_todo/views/project_task_views.xml
@@ -274,6 +274,7 @@
     <record id="project_task_action_todo" model="ir.actions.act_window">
         <field name="name">To-dos</field>
         <field name="res_model">project.task</field>
+        <field name="path">to-do</field>
         <field name="domain">[('user_ids', 'in', [uid]), ('project_id', '=', False), ('parent_id', '=', False)]</field>
         <field name="view_mode">kanban,form,list,calendar,activity</field>
         <field name="search_view_id" ref="project_task_view_todo_search"/>
@@ -321,17 +322,6 @@
         <field name="view_mode">activity</field>
         <field name="view_id" ref="project_task_view_todo_activity"/>
         <field name="act_window_id" ref="project_task_action_todo"/>
-    </record>
-
-    <!-- Todo pre-loading action -->
-    <record id="project_task_preload_action_todo" model="ir.actions.server">
-        <field name="name">menu load To-dos</field>
-        <field name="path">to-do</field>
-        <field name="model_id" ref="project.model_project_task"/>
-        <field name="state">code</field>
-        <field name="code">
-            model._ensure_onboarding_todo(); action = env["ir.actions.actions"]._for_xml_id("project_todo.project_task_action_todo")
-        </field>
     </record>
 
     <!-- Conversion actions-->

--- a/addons/project_todo/views/project_todo_menus.xml
+++ b/addons/project_todo/views/project_todo_menus.xml
@@ -3,7 +3,7 @@
     <menuitem
         id="menu_todo_todos"
         name="To-do"
-        action="project_todo.project_task_preload_action_todo"
+        action="project_todo.project_task_action_todo"
         web_icon="project_todo,static/description/icon.png">
     </menuitem>
 </odoo>


### PR DESCRIPTION
In this PR for Project and To-Do to support offline mode

- The server action is removed and replaced with a direct window action.
- When a new internal user is created , the personal stages and onboarding
 todos are now created automatically.
- post-init hook ensures the onboarding is set up for all existing internal
users during module installation.
- Tests covering all the scenarios
- Making sure by removing stages and onboarding task at start to
make sure we pass tests.

task-4920346
