### PR TITLE
[FIX] point_of_sale: redirect QR scan directly to ticket validation screen

### DIFF
--- a/addons/point_of_sale/controllers/main.py
+++ b/addons/point_of_sale/controllers/main.py
@@ -152,10 +152,8 @@ class PosController(PortalAccount):
         elif request.httprequest.method == 'GET':
             if kwargs.get('order_uuid'):
                 order = self.env['pos.order'].sudo().search([('uuid', '=', kwargs['order_uuid'])], limit=1)
-                form_values.update({
-                    'pos_reference': order.pos_reference if order.exists() else '',
-                    'date_order': order.date_order.strftime("%Y-%m-%d") if order.exists() else '',
-                })
+                if order:
+                    return request.redirect('/pos/ticket/validate?access_token=%s' % (order.access_token))
 
         return request.render("point_of_sale.ticket_request_with_code", {
             'errors': errors,

--- a/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/order_receipt.js
+++ b/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/order_receipt.js
@@ -35,7 +35,7 @@ export class OrderReceipt extends Component {
 
     get qrCode() {
         const baseUrl = this.order.config._base_url;
-        const url = `${baseUrl}/pos/ticket?order_uuid=${this.order.uuid}`;
+        const url = `${baseUrl}/pos/ticket/validate?access_token=${this.order.access_token}`;
         return generateQRCodeDataUrl(url);
     }
 


### PR DESCRIPTION
Before:
QR scan(self invoicing) redirected to /pos/ticket with pre-filled data but missing ticket code.

After:
Now directly redirects to the validation screen or invoice if customer is already registered.

taskID-4777138