### PR TITLE
[FIX] l10n_sa_edi: handle invalid format in CCSID error response

### DIFF
--- a/addons/l10n_sa_edi/models/account_journal.py
+++ b/addons/l10n_sa_edi/models/account_journal.py
@@ -278,8 +278,11 @@ class AccountJournal(models.Model):
         """
         CCSID_data = self._l10n_sa_api_get_compliance_CSID(otp)
         if CCSID_data.get('errors') or CCSID_data.get('error'):
-            raise UserError(_("Could not obtain Compliance CSID: %s",
-                              CCSID_data['errors'][0]['message'] if CCSID_data.get('errors') else CCSID_data['error']))
+            if CCSID_data.get('errors'):
+                error_message = CCSID_data['errors'][0]['message'] if 'message' in CCSID_data['errors'][0] else CCSID_data['errors'][0]
+            else:
+                error_message = CCSID_data['error']
+            raise UserError(_("Could not obtain Compliance CSID: %s", error_message))
         self.sudo().write({
             'l10n_sa_compliance_csid_json': json.dumps(CCSID_data),
             'l10n_sa_production_csid_json': False,


### PR DESCRIPTION
Currently, an error occurs when re-onboarding a journal if the ZATCA CCSID API 
returns `errors` in a list format.

**Error:**
`TypeError: string indices must be integers, not 'str'`

**Root Cause:**
At [1], the code assumes that `CCSID_data['errors'][0]` is always a dictionary 
containing a `message` key. However, when the function at [2] returns the 
errors as a list of strings, it causes an invalid indexing operation.

[1]

https://github.com/odoo/odoo/blob/385627ff85779a80a5a27d889bc212095754f41a/addons/l10n_sa_edi/models/account_journal.py#L279-L282

[2]

https://github.com/odoo/odoo/blob/385627ff85779a80a5a27d889bc212095754f41a/addons/l10n_sa_edi/models/account_journal.py#L601-L604

This commit adds a safe check for the `message` key and handles both 
dictionary and list formats in the errors response.

sentry-6747269450