### PR TITLE
[FIX] l10n_my_edi: improve CountrySubentityCode computation for special cases

### DIFF
--- a/addons/l10n_my_edi/models/account_edi_xml_ubl_my.py
+++ b/addons/l10n_my_edi/models/account_edi_xml_ubl_my.py
@@ -193,14 +193,30 @@ class AccountEdiXmlUBLMyInvoisMY(models.AbstractModel):
         # The API expects the iso3166-2 code for the state, in the same way as it expects the iso3166 code for the countries.
         # In Odoo, we mostly use these (although there is no standard format) so we'll try to use what Odoo gives us.
         # For malaysia, the codes where updated, but we use a mapping to ensure that outdated data will still end up correct.
-        subentity_code = partner.state_id.code or ''
 
-        if partner.country_id.code == 'MY' and partner.state_id.code in MALAYSIAN_SUBDIVISION_CODES:
-            subentity_code = MALAYSIAN_SUBDIVISION_CODES[partner.state_id.code]
+        subentity_code = ''
 
-        # The API does not expect the country code inside the state code, only the number part.
-        if f'{partner.country_id.code}-' in subentity_code:
-            subentity_code = subentity_code.split('-')[1]
+        if partner.state_id:
+            if (
+                partner._l10n_my_edi_get_tin_for_myinvois() == 'EI00000000010'
+                and partner.l10n_my_identification_number == 'NA'
+            ):
+                # Special case for consolidated entities (e.g., general public).
+                # When TIN is 'EI00000000010' and Identification Number is 'NA', MyInvois requires
+                # the CountrySubentityCode to be fixed as '17' regardless of the actual state.
+                subentity_code = '17'
+            elif partner.country_id.code != 'MY':
+                # For non-Malaysian partners return the state name instead of state code
+                subentity_code = partner.state_id.name
+            else:
+                # Get the subentity code for the partner, based on its state.
+                subentity_code = partner.state_id.code
+                # Map outdated subdivision codes to their latest expected values
+                # to ensure compatibility with the current version.
+                subentity_code = MALAYSIAN_SUBDIVISION_CODES.get(subentity_code, subentity_code)
+
+            # Strip 'MY-' prefix if present as we only need number part
+            subentity_code = subentity_code.split('-')[1] if 'MY-' in subentity_code else subentity_code
 
         vals.update({
             'address_lines': [partner.street or '', partner.street2 or ''],


### PR DESCRIPTION
## Before this commit:
The `CountrySubentityCode` was computed by simply using the `state code` of the partner, without handling the following cases:

- Non-Malaysian Partners: For partners located outside Malaysia, the format requires the `state name` to be passed instead of the `state code`.

- Consolidation Entries: For consolidation invoices, a fixed value `17` should be passed as the `CountrySubentityCode`, regardless of the partner’s state.

## After this commit:
The computation of `CountrySubentityCode` has been updated to handle both cases correctly:

- For non-Malaysian partners, the `state name` is used.
- For consolidation entries, the fixed value `17` is used.
- For regular Malaysian partners, the `state code` continues to be used as before.

This ensures compliance with Malaysian e-Invoicing specifications and prevents errors.

> Task-4938198