### PR TITLE
[FIX] point_of_sale: Ensure custom free text attribute appears on receipt

### DIFF
--- a/addons/point_of_sale/static/src/app/models/pos_order_line.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order_line.js
@@ -29,7 +29,9 @@ export class PosOrderline extends Base {
     }
 
     set_full_product_name() {
-        this.full_product_name = constructFullProductName(this);
+        this.full_product_name = !this.full_product_name?.length
+            ? constructFullProductName(this)
+            : this.full_product_name;
     }
 
     setOptions(options) {

--- a/addons/point_of_sale/static/src/app/models/product_product.js
+++ b/addons/point_of_sale/static/src/app/models/product_product.js
@@ -37,7 +37,8 @@ export class ProductProduct extends Base {
     async _onScaleNotAvailable() {}
 
     isConfigurable() {
-        return this.attribute_line_ids.map((a) => a.product_template_value_ids).flat().length > 1;
+        const values = this.attribute_line_ids.flatMap((a) => a.product_template_value_ids);
+        return values.length > 1 || values.some((v) => v.is_custom);
     }
 
     needToConfigure() {

--- a/addons/point_of_sale/static/src/utils.js
+++ b/addons/point_of_sale/static/src/utils.js
@@ -42,7 +42,7 @@ export function constructFullProductName(line) {
                         cus.custom_product_template_attribute_value_id?.id == parseInt(value.id)
                 );
                 if (customValue) {
-                    attributeString += `${value.attribute_id.name}: ${value.name}: ${customValue.custom_value}, `;
+                    attributeString += `${value.name}: ${customValue.custom_value}, `;
                 }
             } else {
                 attributeString += `${value.name}, `;

--- a/addons/point_of_sale/static/tests/tours/product_configurator_tour.js
+++ b/addons/point_of_sale/static/tests/tours/product_configurator_tour.js
@@ -39,7 +39,7 @@ registry.category("web_tour.tours").add("ProductConfiguratorTour", {
 
             // Check that the product has been added to the order with correct attributes and price
             ProductScreen.selectedOrderlineHas(
-                "Configurable Chair (Fabrics: Other: Custom Fabric, Metal, Red)",
+                "Configurable Chair (Other: Custom Fabric, Metal, Red)",
                 "1.0",
                 "11.0"
             ),
@@ -52,7 +52,7 @@ registry.category("web_tour.tours").add("ProductConfiguratorTour", {
             ProductConfigurator.fillCustomAttribute("Custom Fabric"),
             Dialog.confirm(),
             ProductScreen.selectedOrderlineHas(
-                "Configurable Chair (Fabrics: Other: Custom Fabric, Metal, Red)",
+                "Configurable Chair (Other: Custom Fabric, Metal, Red)",
                 "2.0",
                 "22.0"
             ),

--- a/addons/point_of_sale/static/tests/tours/receipt_screen_tour.js
+++ b/addons/point_of_sale/static/tests/tours/receipt_screen_tour.js
@@ -9,6 +9,7 @@ import * as Dialog from "@point_of_sale/../tests/tours/utils/dialog_util";
 import * as Numpad from "@point_of_sale/../tests/tours/utils/numpad_util";
 import { registry } from "@web/core/registry";
 import { inLeftSide } from "@point_of_sale/../tests/tours/utils/common";
+import * as ProductConfigurator from "@point_of_sale/../tests/tours/utils/product_configurator_util";
 
 registry.category("web_tour.tours").add("ReceiptScreenTour", {
     steps: () =>
@@ -194,5 +195,25 @@ registry.category("web_tour.tours").add("test_auto_validate_force_done", {
                 run: "click",
             },
             ReceiptScreen.receiptIsThere(),
+        ].flat(),
+});
+
+registry.category("web_tour.tours").add("test_free_text_custom_attribute_on_receipt", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            ProductScreen.clickDisplayedProduct("Configurable Chair"),
+            ProductConfigurator.pickRadio("Other"),
+            ProductConfigurator.fillCustomAttribute("Custom Fabric"),
+            Dialog.confirm(),
+            ProductScreen.clickPayButton(),
+            PaymentScreen.clickPaymentMethod("Bank"),
+            PaymentScreen.clickValidate(),
+            ReceiptScreen.receiptIsThere(),
+            Order.hasLine({
+                productName: "Configurable Chair (Other: Custom Fabric)",
+            }),
+            ReceiptScreen.clickNextOrder(),
         ].flat(),
 });

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -2116,6 +2116,13 @@ class TestUi(TestPointOfSaleHttpCommon):
         self.assertAlmostEqual(lines[3].balance, 352.59)
         self.assertAlmostEqual(lines[4].balance, 7771.01)
 
+    def test_free_text_custom_attribute_on_receipt(self):
+        """ Test that free text (custom) attribute values are correctly shown on the PoS receipt screen. """
+        configurable_product = self.env['product.product'].search([('name', '=', 'Configurable Chair'), ('available_in_pos', '=', 'True')], limit=1)
+        configurable_product.attribute_line_ids[:2].unlink()
+        self.main_pos_config.with_user(self.pos_admin).open_ui()
+        self.start_pos_tour('test_free_text_custom_attribute_on_receipt', login="pos_admin")
+
 # This class just runs the same tests as above but with mobile emulation
 class MobileTestUi(TestUi):
     browser_size = '375x667'


### PR DESCRIPTION
Before this commit
=======================
- Free text custom attributes were shown on the product screen but not on the receipt.
- The product configurator didn't open if the product had only one attribute and it was a free text type (custom attribute).

Example: Create a custom attribute with "free text" enabled and assign it to a
         product. When adding that product to the cart, the configurator should
         open—but it didn't.

After this commit:
====================
- Free text custom attributes are now shown on both the product screen and the receipt.
- The configurator now opens even if the product has only one free text attribute.

Task-4922193