### PR TITLE
[FIX] point_of_sale: fix multi-serial selection with 'Create New' disabled

### DIFF
--- a/addons/point_of_sale/static/src/app/store/select_lot_popup/select_lot_popup.js
+++ b/addons/point_of_sale/static/src/app/store/select_lot_popup/select_lot_popup.js
@@ -123,10 +123,17 @@ export class EditListPopup extends Component {
     }
     hasValidValue(itemId, text) {
         return (
-            !this.props.isLotNameUsed(text) &&
-            (this.props.customInput || this.props.options.includes(text)) &&
+            this.isValidValue(text) &&
             (!this.props.uniqueValues ||
                 !this.state.array.some((elem) => elem._id !== itemId && elem.text === text))
+        );
+    }
+    isValidValue(text) {
+        return (
+            !this.props.isLotNameUsed(text) &&
+            (this.props.customInput ||
+                this.props.options.includes(text) ||
+                this.props.array.some((i) => i.text === text))
         );
     }
     onInputChange(itemId, text) {
@@ -187,10 +194,7 @@ export class EditListPopup extends Component {
             this.state.array
                 .filter((item) => {
                     const itemValue = item.text.trim();
-                    const isValidValue =
-                        itemValue !== "" &&
-                        !this.props.isLotNameUsed(itemValue) &&
-                        (this.props.customInput || this.props.options.includes(itemValue));
+                    const isValidValue = itemValue !== "" && this.isValidValue(itemValue);
                     if (!isValidValue) {
                         return false;
                     }

--- a/addons/point_of_sale/static/tests/tours/ticket_screen_tour.js
+++ b/addons/point_of_sale/static/tests/tours/ticket_screen_tour.js
@@ -279,3 +279,23 @@ registry.category("web_tour.tours").add("LotTour", {
             }),
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("test_order_with_existing_serial", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            ProductScreen.clickDisplayedProduct("Serial Product"),
+            ProductScreen.enterLotNumber("SN1"),
+            ProductScreen.selectedOrderlineHas("Serial Product", "1.00"),
+            inLeftSide({
+                trigger: ".info-list:contains('SN SN1')",
+            }),
+            ProductScreen.clickDisplayedProduct("Serial Product"),
+            ProductScreen.enterLastLotNumber("SN2"),
+            ProductScreen.selectedOrderlineHas("Serial Product", "2.00"),
+            inLeftSide({
+                trigger: ".info-list:contains('SN SN2')",
+            }),
+        ].flat(),
+});

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -1632,6 +1632,26 @@ class TestUi(TestPointOfSaleHttpCommon):
         self.main_pos_config.with_user(self.pos_user).open_ui()
         self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'LotTour', login="pos_user")
 
+    def test_order_with_existing_serial(self):
+        product = self.env['product.product'].create({
+            'name': 'Serial Product',
+            'is_storable': True,
+            'tracking': 'serial',
+            'categ_id': self.env.ref('product.product_category_all').id,
+            'available_in_pos': True,
+        })
+        for sn in ["SN1", "SN2"]:
+            self.env['stock.quant'].create({
+                'product_id': product.id,
+                'inventory_quantity': 1,
+                'location_id': self.env.user._get_default_warehouse_id().lot_stock_id.id,
+                'lot_id': self.env['stock.lot'].create({'name': sn, 'product_id': product.id}).id,
+            }).sudo().action_apply_inventory()
+        self.env['stock.picking.type'].search([('name', '=', 'PoS Orders')]).use_create_lots = False
+
+        self.main_pos_config.with_user(self.pos_user).open_ui()
+        self.start_pos_tour("test_order_with_existing_serial")
+
     def test_product_search(self):
         """Verify that the product search works correctly"""
         self.env['product.product'].create([


### PR DESCRIPTION
**Steps to reproduce:**
- Install `point_of_sale`.
- Go to POS -> configuration -> settings
- Search 'Operation type' -> open picking type -> Disable `Create new`
- Create a storable product 'test' with serial tracking.
- Add on-hand quantity with serial numbers.
- In POS, select the product and choose one SN,
- Select it again and choose another SN.

**Observation:**
- The order line should have 2 quantities with a list of Serial numbers chosen by the user. For one quantity, it's working fine, but for multiple quantities, an issue occurs.

**Issue:**
- While confirming edit serial numbers popup for multiple quantities, it checks whether each selected SN is valid or not.
- The condition is that the entered SN is in the existing available SNs option. But the already chosen SN is not in the existing SN option,
- Also, creating a new SN is disabled, so it's considered an invalid input.
https://github.com/odoo/odoo/blob/876b7337eb689e0682ab48e9e833f9f0dc6bb8d2/addons/point_of_sale/static/src/app/store/select_lot_popup/select_lot_popup.js#L190-L193

**Solution:**
- Added a condition to allow SNs that are already selected (matched by name and ID) to be considered valid inputs.

opw-4865902

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
