### PR TITLE
[FIX] point_of_sale: prevent update of product while product in cart

### DIFF
--- a/addons/point_of_sale/static/src/app/components/popups/product_info_popup/product_info_popup.xml
+++ b/addons/point_of_sale/static/src/app/components/popups/product_info_popup/product_info_popup.xml
@@ -118,7 +118,7 @@
             <t t-set-slot="footer">
                 <div class="d-flex flex-row gap-2 w-100">
                     <button class="btn btn-primary btn-lg lh-lg w-50" t-on-click="props.close">Close</button>
-                    <button t-if="allowProductEdition" class="btn btn-secondary btn-lg lh-lg w-50" t-on-click="editProduct">Edit</button>
+                    <button t-if="allowProductEdition" t-att-disabled="this.pos.orderContainsProduct(this.props.productTemplate)" class="btn btn-secondary btn-lg lh-lg w-50" t-on-click="editProduct">Edit</button>
                 </div>
             </t>
         </Dialog>

--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -2165,6 +2165,10 @@ export class PosStore extends WithLazyGetterTrap {
             }
         );
     }
+    orderContainsProduct(product) {
+        const lines = this.getOpenOrders().flatMap((o) => o.lines);
+        return lines.some((l) => l.product_id.product_tmpl_id.id === product.id);
+    }
     async loadSampleData() {
         const [isPosManager, isAdmin] = await Promise.all([
             user.hasGroup("point_of_sale.group_pos_manager"),

--- a/addons/point_of_sale/static/tests/generic_helpers/dialog_util.js
+++ b/addons/point_of_sale/static/tests/generic_helpers/dialog_util.js
@@ -48,3 +48,10 @@ export function bodyIs(body) {
         trigger: `.modal-body:contains(${body})`,
     };
 }
+
+export function footerBtnIsDisabled(buttonText) {
+    return {
+        content: `footer btn ${buttonText} should be disabled`,
+        trigger: `.modal .modal-footer button:contains(${buttonText})[disabled]`,
+    };
+}

--- a/addons/point_of_sale/static/tests/pos/tours/product_screen_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/product_screen_tour.js
@@ -723,28 +723,20 @@ registry.category("web_tour.tours").add("test_product_create_update_from_fronten
 
             // Click on the category button for "Chair test" to verify the product's addition.
             ProductScreen.clickSubcategory("Chair test"),
-            ProductScreen.clickDisplayedProduct("Test Frontend Product"),
-            inLeftSide([
-                ...ProductScreen.selectedOrderlineHasDirect("Test Frontend Product", "1", "20.0"),
-            ]),
 
-            // Open the product's information popup.
-            ProductScreen.clickInfoProduct(
-                "Test Frontend Product",
-                [
-                    Dialog.confirm("Edit", ".btn-secondary"),
-                    // Verify that the "Edit Product" dialog is displayed.
-                    Dialog.is({ title: "Edit Product" }),
+            ProductScreen.longPressProduct("Test Frontend Product"),
+            Dialog.confirm("Edit", ".btn-secondary"),
+            // Verify that the "Edit Product" dialog is displayed.
+            Dialog.is({ title: "Edit Product" }),
 
-                    // Edit the product with new details.
-                    ProductScreen.editProductFromFrontend(
-                        "Test Frontend Product Edited",
-                        "710535977348",
-                        "50.0"
-                    ),
-                    Dialog.confirm(),
-                ].flat()
+            // Edit the product with new details.
+            ProductScreen.editProductFromFrontend(
+                "Test Frontend Product Edited",
+                "710535977348",
+                "50.0"
             ),
+            Dialog.confirm(),
+
             ProductScreen.clickSubcategory("Chair test"),
             ProductScreen.clickDisplayedProduct("Test Frontend Product Edited"),
             inLeftSide([
@@ -754,6 +746,9 @@ registry.category("web_tour.tours").add("test_product_create_update_from_fronten
                     "50.0"
                 ),
             ]),
+            ProductScreen.longPressProduct("Test Frontend Product Edited"),
+            // Edit button should be disabled (cause we cannot edit a product which is in the cart)
+            Dialog.footerBtnIsDisabled("Edit"),
             Chrome.endTour(),
         ].flat(),
 });

--- a/addons/point_of_sale/static/tests/pos/tours/utils/product_screen_util.js
+++ b/addons/point_of_sale/static/tests/pos/tours/utils/product_screen_util.js
@@ -959,14 +959,13 @@ export function longPressProduct(productName) {
     return [
         {
             content: `Long pressing product "${productName}"...`,
-            trigger: `.product-name:contains("${productName}")`,
-            run: async () => {
-                const el = document.querySelector(".product-name");
+            trigger: `.product-list .product-name:contains("${productName}")`,
+            run: async (el) => {
                 const mouseDown = new MouseEvent("mousedown", { bubbles: true });
                 const mouseUp = new MouseEvent("mouseup", { bubbles: true });
-                el.dispatchEvent(mouseDown);
+                el.anchor.dispatchEvent(mouseDown);
                 await new Promise((resolve) => setTimeout(resolve, LONG_PRESS_DURATION + 50));
-                el.dispatchEvent(mouseUp);
+                el.anchor.dispatchEvent(mouseUp);
             },
         },
     ];

--- a/addons/point_of_sale/static/tests/unit/services/pos_service.test.js
+++ b/addons/point_of_sale/static/tests/unit/services/pos_service.test.js
@@ -145,6 +145,30 @@ describe("pos_store.js", () => {
         expect(orderChange.new.length).toBe(0);
         expect(orderChange.cancelled.length).toBe(0);
     });
+
+    test("orderContainsProduct", async () => {
+        const store = await setupPosEnv();
+        await getFilledOrder(store);
+        const product1 = store.models["product.template"].get(5);
+        const product2 = store.models["product.template"].get(6);
+        const product3 = store.models["product.template"].get(8);
+        expect(store.orderContainsProduct(product1)).toBe(true);
+        expect(store.orderContainsProduct(product2)).toBe(true);
+        expect(store.orderContainsProduct(product3)).toBe(false);
+        const order = await store.addNewOrder();
+        await store.addLineToOrder(
+            {
+                product_tmpl_id: product3,
+                qty: 1,
+            },
+            order
+        );
+
+        expect(store.orderContainsProduct(product1)).toBe(true);
+        expect(store.orderContainsProduct(product2)).toBe(true);
+        expect(store.orderContainsProduct(product3)).toBe(true);
+    });
+
     test("generateReceiptsDataToPrint", async () => {
         const store = await setupPosEnv();
         const pos_categories = store.models["pos.category"].getAll().map((c) => c.id);


### PR DESCRIPTION
- Prevent update of product via POS when the product is already in the current order (to avoid leading to inconcistent data on this product for the current order).

task-id: 4943650



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
