### PR TITLE
[FIX] web: `o_kanban_colorpicker` too big

### DIFF
--- a/addons/web/static/src/views/fields/kanban_color_picker/kanban_color_picker_field.scss
+++ b/addons/web/static/src/views/fields/kanban_color_picker/kanban_color_picker_field.scss
@@ -1,4 +1,8 @@
 .o_kanban_colorpicker {
+    [class*="col-"]:has(&) {
+        min-width: 150px;
+    }
+
     .o_field_kanban_color_picker:has(> &) {
         width: 100%;
     }


### PR DESCRIPTION
Since the BottomSheet PR some `o_kanban_colorpicker` are too big and the `DropDown` too tall. This commit fixes this by forcing the `o_kanban_colorpicker` to have a minimal size so the grid can have at least 4 colors per row.

Steps to reproduce:
* Open Odoo
* Go to the menu "Project Templates"
* Create a record if none present
* Select the kanban view
* Click on the DropDown button of the card => Bug

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
