### PR TITLE
[IMP] account: respect force_create for account.tax.group

### DIFF
--- a/addons/account/models/chart_template.py
+++ b/addons/account/models/chart_template.py
@@ -307,6 +307,11 @@ class AccountChartTemplate(models.AbstractModel):
         current_fiscal_positions =  self.env['account.fiscal.position'].with_context(active_test=False).search([
             *self.env['account.fiscal.position']._check_company_domain(company),
         ])
+
+        current_tax_groups = self.env['account.tax.group'].with_context(active_test=False).search([
+            *self.env['account.tax.group']._check_company_domain(company)
+        ])
+
         unique_tax_name_key = lambda t: (t.name, t.type_tax_use, t.tax_scope, t.company_id)
         unique_tax_name_keys = set(current_taxes.mapped(unique_tax_name_key))
         xmlid2tax = {
@@ -316,6 +321,10 @@ class AccountChartTemplate(models.AbstractModel):
         xmlid2fiscal_position= {
             xml_id.split('.')[1].split('_', maxsplit=1)[1]: self.env['account.fiscal.position'].browse(record)
             for record, xml_id in current_fiscal_positions.get_external_id().items() if xml_id.startswith('account.')
+        }
+        xmlid2tax_group = {
+            xml_id.split('.')[1].split('_', maxsplit=1)[1]: self.env['account.tax.group'].browse(res_id)
+            for res_id, xml_id in current_tax_groups.get_external_id().items() if xml_id.startswith('account.')
         }
         def tax_template_changed(tax, template):
             template_line_ids = [x for x in template.get('repartition_line_ids', []) if x[0] != Command.CLEAR]
@@ -354,6 +363,11 @@ class AccountChartTemplate(models.AbstractModel):
                                         new_ids.append(element)
                             if new_ids:
                                 values[f'{model}_ids'] = new_ids
+
+                elif model_name == 'account.tax.group':
+                    if xmlid not in xmlid2tax_group and not force_create:
+                        skip_update.add((model_name, xmlid))
+                        continue
 
                 elif model_name == 'account.tax':
                     # Only update the tags of existing taxes


### PR DESCRIPTION
**Description**
- The `force_create` attribute was added to `try_loading` in odoo/odoo@a3c57b4f0198236b04486d336d56b25de74677b8 allowing control over whether missing standard records should be created.
However, this wasn't respected for `account.tax.group`. As a result, tax groups could still be created even when `force_create=False`, leading to null values in accounts fields like `tax_payable_account_id` and `tax_receivable_account_id`.

**The issue which prompted this patch:**
- A recent patch in upgrade: odoo/upgrade@d2d16a2321abb525fe3fe2c403f89009f51c1394 This patch was made to update the `reconcile` and `non_trade` flags on standard accounts due to recent changes across localizations. During the upgrade, we overrode the `write` method of `account.tax.group` to conditionally update these flags. However, in a client’s database, `account.tax.group` records were missing for the `l10n_pk` module, while the standard account records were present. When `try_loading` was triggered at the end, it attempted to `create` the missing tax groups. But since the create method is called during creation and does not include the conditional update logic for `reconcile` and `non_trade` the upgrade failed with the same error that the original patch aimed to resolve.

- To avoid such errors and prevent tax groups from being created with null account fields when `force_create=False`, this patch ensures `force_create` is respected for `account.tax.group`.

**Steps to reproduce:**
- Create a `v17` DB and install `l10n_pk`
- Delete the standard tax groups
- Upgrade to `v18`

OPW-4915394

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
