### PR TITLE
[REF] web,mail: StaticList: remove `reload` option of addAndRemove

### DIFF
--- a/addons/mail/static/src/views/web/fields/many2many_tags_email/many2many_tags_email.js
+++ b/addons/mail/static/src/views/web/fields/many2many_tags_email/many2many_tags_email.js
@@ -37,12 +37,12 @@ export class FieldMany2ManyTagsEmail extends Many2ManyTagsField {
     static components = {
         ...FieldMany2ManyTagsEmail.components,
         TagsList: FieldMany2ManyTagsEmailTagsList,
-        Many2XAutocomplete: FieldMany2ManyTagsEmailMany2xAutocomplete
+        Many2XAutocomplete: FieldMany2ManyTagsEmailMany2xAutocomplete,
     };
     static props = {
         ...Many2ManyTagsField.props,
         context: { type: Object, optional: true },
-        canEditTags: { type: Boolean, optional: true }
+        canEditTags: { type: Boolean, optional: true },
     };
 
     setup() {
@@ -86,7 +86,8 @@ export class FieldMany2ManyTagsEmail extends Many2ManyTagsField {
      * @returns {Object}
      */
     getTagProps(record) {
-        return {...super.getTagProps(record),
+        return {
+            ...super.getTagProps(record),
             text:
                 record.data.name || record.data.email || record.data.display_name || _t("Unnamed"),
             onClick: (ev) => this.onTagClick(ev, record),
@@ -121,8 +122,10 @@ export class FieldMany2ManyTagsEmail extends Many2ManyTagsField {
     }
 
     async updateRecipient(newEmail, partnerId) {
-        await this.orm.write("res.partner", [partnerId], { email: newEmail });
-        return this.props.record.data[this.props.name].addAndRemove({ reload: true });
+        const list = this.props.record.data[this.props.name];
+        const partnerRecord = list.records.find((r) => r.resId === partnerId);
+        partnerRecord.canSaveOnUpdate = true;
+        return partnerRecord.update({ email: newEmail }, { save: true });
     }
 }
 
@@ -146,7 +149,7 @@ export const fieldMany2ManyTagsEmail = {
     },
     relatedFields: (fieldInfo) => [
         ...many2ManyTagsField.relatedFields(fieldInfo),
-        { name: "email", type: "char" },
+        { name: "email", type: "char", readonly: false },
         { name: "name", type: "char" },
     ],
     additionalClasses: ["o_field_many2many_tags"],

--- a/addons/mail/static/tests/web/fields/many2many_tags_email.test.js
+++ b/addons/mail/static/tests/web/fields/many2many_tags_email.test.js
@@ -40,7 +40,11 @@ test("fieldmany2many tags email (edition)", async () => {
     const messageId = pyEnv["mail.message"].create({ partner_ids: [partnerId_1] });
     onRpc("res.partner", "web_read", (params) => {
         expect(params.kwargs.specification).toInclude("email");
-        asyncStep(JSON.stringify(params.args[0]));
+        asyncStep(`web_read ${JSON.stringify(params.args[0])}`);
+    });
+    onRpc("res.partner", "web_save", (params) => {
+        expect(params.kwargs.specification).toInclude("email");
+        asyncStep(`web_save ${JSON.stringify(params.args[0])}`);
     });
     onRpc("res.partner", "get_formview_id", () => false);
     await start();
@@ -71,7 +75,7 @@ test("fieldmany2many tags email (edition)", async () => {
         "coucou@petite.perruche"
     );
     // should have read Partner_2 2 times: when opening the dropdown and when saving the new email.
-    await waitForSteps([`[${partnerId_2}]`, `[${partnerId_1},${partnerId_2}]`]);
+    await waitForSteps([`web_read [${partnerId_2}]`, `web_save [${partnerId_2}]`]);
 });
 
 test("fieldmany2many tags email popup close without filling", async () => {


### PR DESCRIPTION
This option was then propagated to `_applyChanges` to force the reload of records in the relation. There was a single usecase, in FieldMany2ManyTagsEmail, which was actually a workaround to reload a specific record of the relation. We refactored that usecase to use the Record datapoint to do the write, as it uses web_save, which writes and reads the record in a single RPC. We thus no longer reload the whole relation, but only the record that has been updated.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
