### PR TITLE
[FIX] point_of_sale: prevent redundant draft order creation

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.js
@@ -423,7 +423,7 @@ export class PaymentScreen extends Component {
                     switchScreen = this.currentOrder.uuid === this.pos.selectedOrderUuid;
                     nextPage = this.pos.defaultPage;
                     if (switchScreen) {
-                        this.selectNextOrder();
+                        this.pos.selectNextOrder();
                     }
                 }
             }
@@ -433,6 +433,7 @@ export class PaymentScreen extends Component {
             this.pos.navigate(nextPage.page, nextPage.params);
         }
     }
+    // TODO: deprecated. Remove it in master (saas-18.5).
     selectNextOrder() {
         if (this.currentOrder.originalSplittedOrder) {
             this.pos.selectedOrderUuid = this.currentOrder.uiState.splittedOrderUuid;

--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -1280,7 +1280,9 @@ export class PosStore extends WithLazyGetterTrap {
     }
     selectNextOrder() {
         const orders = this.models["pos.order"].filter((order) => !order.finalized);
-        if (orders.length > 0) {
+        if (this.selectedOrder.originalSplittedOrder) {
+            this.selectedOrderUuid = this.selectedOrder.uiState.splittedOrderUuid;
+        } else if (orders.length > 0) {
             this.selectedOrderUuid = orders[0].uuid;
         } else {
             return this.addNewOrder();

--- a/addons/point_of_sale/static/tests/pos/tours/product_screen_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/product_screen_tour.js
@@ -855,6 +855,20 @@ registry.category("web_tour.tours").add("test_preset_timing_retail", {
         ].flat(),
 });
 
+registry.category("web_tour.tours").add("test_draft_orders_creation_with_auto_receipt", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            ProductScreen.clickDisplayedProduct("Desk Organizer"),
+            ProductScreen.clickPayButton(),
+            PaymentScreen.clickPaymentMethod("Bank", true, { remaining: "0.00" }),
+            PaymentScreen.clickValidate(),
+            Dialog.discard(),
+            Chrome.ongoingOrdersCount(1),
+        ].flat(),
+});
+
 registry.category("web_tour.tours").add("test_delete_line", {
     steps: () =>
         [

--- a/addons/point_of_sale/static/tests/pos/tours/utils/chrome_util.js
+++ b/addons/point_of_sale/static/tests/pos/tours/utils/chrome_util.js
@@ -1,3 +1,5 @@
+/* global posmodel */
+
 import * as Dialog from "@point_of_sale/../tests/generic_helpers/dialog_util";
 import { negate } from "@point_of_sale/../tests/generic_helpers/utils";
 import { waitFor } from "@odoo/hoot-dom";
@@ -86,6 +88,23 @@ export function fillTextArea(target, value) {
 }
 export function createFloatingOrder() {
     return { trigger: ".pos-leftheader .list-plus-btn", run: "click" };
+}
+
+export function ongoingOrdersCount(expectedCount) {
+    return {
+        content: `Stored order count should be ${expectedCount}`,
+        trigger: "body",
+        run: () => {
+            const actualCount = posmodel.data.models["pos.order"].filter(
+                (o) => !o.finalized
+            ).length;
+            if (actualCount !== expectedCount) {
+                throw new Error(
+                    `Expected stored order count to be ${expectedCount}, but got ${actualCount}`
+                );
+            }
+        },
+    };
 }
 
 function _hasFloatingOrder(name, yes) {

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -2483,6 +2483,16 @@ class TestUi(TestPointOfSaleHttpCommon):
         self.main_pos_config.with_user(self.pos_user).open_ui()
         self.start_pos_tour('test_delete_line')
 
+    def test_draft_orders_creation_with_auto_receipt(self):
+        """Test only one draft order is created when auto receipt is enabled."""
+        self.main_pos_config.write({
+            "iface_print_auto": True,
+            "other_devices": True,
+            "epson_printer_ip": "127.0.0.1:8069/receipt_receiver",
+        })
+        self.main_pos_config.with_user(self.pos_user).open_ui()
+        self.start_pos_tour('test_draft_orders_creation_with_auto_receipt')
+
 
 # This class just runs the same tests as above but with mobile emulation
 class MobileTestUi(TestUi):


### PR DESCRIPTION
Steps to reproduce:
-------------------------
- Open a session with automatic receipt printing enabled.
- Pay an order when only one open order is present.

Issue:
-------
- Two new draft orders are created instead of one.

Cause:
---------
- `this.pos.defaultPage` is a getter that creates a new draft order if none exists. Later, `selectNextOrder()` was also triggering a new order creation when automatic receipt printing was enabled, causing the creation of two draft orders.

FIX:
-----
- Removed the redundant order creation logic from `selectNextOrder()`, as the new order is already created through the default page getter also moved that function logic to pos store.

Task: 4925669