### PR TITLE
[FIX] sale_project,sale_pdf_quote_builder: fix wrong dependency

### DIFF
--- a/addons/sale_pdf_quote_builder/views/sale_order_views.xml
+++ b/addons/sale_pdf_quote_builder/views/sale_order_views.xml
@@ -19,7 +19,7 @@
                 <page
                     name="pdf_quote_builder"
                     string="Quote Builder"
-                    invisible="not (partner_id and is_pdf_quote_builder_available)"
+                    invisible="not (partner_id and is_pdf_quote_builder_available) or context.get('hide_pdf_quote_builder')"
                 >
                     <!-- Needed by customContentKanbanLikeWidget to save selected documents. -->
                     <field name="quotation_document_ids" invisible="1"/>

--- a/addons/sale_project/static/src/components/so_line_create_button/so_line_create_button.js
+++ b/addons/sale_project/static/src/components/so_line_create_button/so_line_create_button.js
@@ -26,6 +26,7 @@ export class SoLineCreateButton extends Component {
                 form_view_ref: context.so_form_view_ref,
                 default_company_id: context.default_company_id || user.activeCompany.id,
                 default_user_id: user.userId,
+                hide_pdf_quote_builder: true,
             },
             onRecordSaved: async (rec) => {
                 const service_line_id = await rec.model.orm.call(

--- a/addons/sale_project/views/sale_order_views.xml
+++ b/addons/sale_project/views/sale_order_views.xml
@@ -85,7 +85,6 @@
                     <button string="Discard" special="cancel" class="btn btn-secondary"/>
                 </footer>
             </sheet>
-            <page name="pdf_quote_builder" position="replace"/>
         </field>
     </record>
 


### PR DESCRIPTION
* Steps to reproduce:
1. Install sale_project in a new database
2. Uninstall and reinstall sale_pdf_quote_builder (using test_module_operations)

* Traceback: Element '<page name="pdf_quote_builder">' cannot be located in parent view

* Issue: sale_project looks for pdf_quote_builder in the view_order_form. That element is introduced by pdf_quote_builder in sale_order_form_inherit_sale_pdf_quote_builder but there is no dependency between the two (sale_pdf_quote_builder is just auto_install on sale_management which is a dependency of sale_project). So if sale_pdf_quote_builder is uninstalled sale_project is not touched, and the view is broken.

* Fix: We replace the use of the xpath in the form view of our widget (sale_project) by a context key to hide the pdf quote builder conditionally.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
