### PR TITLE
[FIX] hr_homeworking: recompute current location name

### DIFF
--- a/addons/hr_homeworking/models/hr_employee.py
+++ b/addons/hr_homeworking/models/hr_employee.py
@@ -44,7 +44,7 @@ class HrEmployeeBase(models.AbstractModel):
             res['views']['list']['arch'] = res['views']['list']['arch'].replace('name_work_location_display', dayfield)
         return res
 
-    @api.depends('exceptional_location_id')
+    @api.depends('exceptional_location_id', *DAYS)
     def _compute_name_work_location_display(self):
         dayfield = self._get_current_day_location_field()
         unspecified = _('Unspecified')

--- a/addons/hr_homeworking/tests/__init__.py
+++ b/addons/hr_homeworking/tests/__init__.py
@@ -1,1 +1,2 @@
 from . import test_hr_employee_location
+from . import test_hr_employee

--- a/addons/hr_homeworking/tests/test_hr_employee.py
+++ b/addons/hr_homeworking/tests/test_hr_employee.py
@@ -1,0 +1,48 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from freezegun import freeze_time
+
+from odoo.tests import common
+
+
+class TestHrHomeworkingCommon(common.TransactionCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        main_partner_id = cls.env.ref('base.main_partner')
+
+        cls.work_office_1, cls.work_office_2, cls.work_home = cls.env['hr.work.location'].create([
+            {
+                'name': "Office 1",
+                'location_type': "office",
+                'address_id': main_partner_id.id,
+            }, {
+                'name': "Office 2",
+                'location_type': "office",
+                'address_id': main_partner_id.id,
+            }, {
+                'name': "Home",
+                'location_type': "home",
+                'address_id': main_partner_id.id,
+            },
+        ])
+
+        cls.employee_1 = cls.env['hr.employee'].create([{
+            'name': 'Employee Test',
+            'monday_location_id': cls.work_home.id,
+            'tuesday_location_id': cls.work_office_1.id,
+            'wednesday_location_id': cls.work_home.id,
+            'thursday_location_id': cls.work_office_2.id,
+            'friday_location_id': cls.work_office_2.id,
+            'work_location_id': cls.work_office_2.id,
+        }])
+
+    @freeze_time("2025-07-09")
+    def test_change_current_work_location(self):
+        "2025-07-09 ==> Wednesday"
+        self.assertEqual(self.employee_1.name_work_location_display, "Home")
+        self.assertEqual(self.employee_1.hr_icon_display, "presence_home")
+        self.employee_1.wednesday_location_id = self.work_office_1.id
+        self.assertEqual(self.employee_1.name_work_location_display, "Office 1")
+        self.assertEqual(self.employee_1.hr_icon_display, "presence_office")


### PR DESCRIPTION
Step to reproduce:
------------------
    * Go on Employees
    * Click on one Employee
    * Change a today worklocation "office" (don't save, you need to have the little cloud)
    * Hover over hr presence icon

This title will be "unspecified" and not "office".

Reason:
--------
name_work_location_display is computed but doesn't depends of daily worklocation field (monday_worklocation, tuesday...)

Solution:
---------
Depends of these daily worklocation field

task-4948488

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
