### PR TITLE
[IMP] iot_box_image: update packages for forward compatibility

### DIFF
--- a/addons/iot_box_image/overwrite_before_init/etc/init_image.sh
+++ b/addons/iot_box_image/overwrite_before_init/etc/init_image.sh
@@ -182,7 +182,10 @@ PKGS_TO_INSTALL="
     nginx-full \
     printer-driver-all \
     python3 \
+    python3-aioice \
     python3-cups \
+    python3-crc32c \
+    python3-cryptography \
     python3-babel \
     python3-dateutil \
     python3-dbus \
@@ -198,12 +201,15 @@ PKGS_TO_INSTALL="
     python3-mako \
     python3-mock \
     python3-netifaces \
+    python3-openssl \
     python3-passlib \
     python3-pil \
     python3-pip \
     python3-psutil \
     python3-psycopg2 \
     python3-pydot \
+    python3-pyee \
+    python3-pylibsrtp \
     python3-pyudev \
     python3-qrcode \
     python3-reportlab \
@@ -261,9 +267,7 @@ PIP_TO_INSTALL="
     PyPDF2==1.26.0 \
     Werkzeug==2.0.2 \
     urllib3==1.26.5 \
-    pyOpenssl==22.0.0 \
     python-escpos==3.1 \
-    cryptography==36.0.2 \
     screeninfo==0.8.1 \
     zeep==4.2.1 \
     num2words==0.5.13 \


### PR DESCRIPTION
This commit contains two changes:
- Install `cryptography` and `pyopenssl` using `apt` instead of `pip`
  - This means the correct versions are used for compatibility with other `python3-*` apt packages.
- Install additional libraries for compatibility with WebRTC (19.0)

task-4894918

To be merged after: https://github.com/odoo/odoo/pull/218871

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
