### PR TITLE
[I18N] test_translation_import: skip modules with empty pot files

### DIFF
--- a/odoo/addons/test_translation_import/tests/test_export_wizard.py
+++ b/odoo/addons/test_translation_import/tests/test_export_wizard.py
@@ -16,6 +16,9 @@ class TestTranslationFlow(common.TransactionCase):
                 "modules": [(6, 0, [module.id])]
             })
             export.act_getfile()
+            if not export.data:
+                # export.data = False => no terms to translate
+                continue
             pot_file = base64.b64decode(export.data)
             common.save_test_file(
                 module.name, pot_file, prefix="i18n_", extension="pot",


### PR DESCRIPTION
The pot exporter was improved to not export empty pot files by returning a file with `data=False`, so that when users try to export a module without any terms to translate, no file is exported and a warning shows in the wizard/logger based on the data being `False`. At this time, the test to auto-export the pot file wasn't adapted to handle this false data, so we adapt now to make auto-exporting work again.

For additional context, see:
https://github.com/odoo/odoo/commit/5192edca2166aa2701aad46d3e6d839c7a7bb12f


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
