### PR TITLE
[IMP] sale_pdf_quote_builder: improve performance of available_product_document_ids

### DIFF
--- a/addons/sale_pdf_quote_builder/models/sale_order_line.py
+++ b/addons/sale_pdf_quote_builder/models/sale_order_line.py
@@ -1,5 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from collections import defaultdict
 from odoo import api, fields, models
 
 
@@ -34,14 +35,26 @@ class SaleOrderLine(models.Model):
 
     @api.depends('product_id', 'product_template_id')
     def _compute_available_product_document_ids(self):
-        for line in self:
-            line.available_product_document_ids = self.env['product.document'].search([
+        available_documents_ordered = self.env['product.document']._read_group(
+            [
+                ('attached_on_sale', '=', 'inside'),
                 '|',
-                    '&',
-                        ('res_model', '=', 'product.product'),
-                        ('res_id', '=', line.product_id.id),
-                    '&',
-                        ('res_model', '=', 'product.template'),
-                        ('res_id', '=', line.product_template_id.id),
-                ('attached_on_sale', '=', 'inside')
-            ], order='res_model, sequence').ids
+                '&',
+                ('res_model', '=', 'product.product'),
+                ('res_id', 'in', self.product_id.ids),
+                '&',
+                ('res_model', '=', 'product.template'),
+                ('res_id', 'in', self.product_template_id.ids),
+            ],
+            ['res_model', 'res_id', 'sequence'],
+            ['id:array_agg'],
+            order='res_model, sequence',
+        )
+        available_documents = defaultdict(list)
+        for res_model, res_id, _sequence, ids in available_documents_ordered:
+            available_documents[res_model, res_id].extend(ids)
+        for line in self:
+            line.available_product_document_ids = (
+                available_documents['product.product', line.product_id.id]
+                + available_documents['product.template', line.product_template_id.id]
+            )

--- a/addons/sale_pdf_quote_builder/tests/test_pdf_quote_builder.py
+++ b/addons/sale_pdf_quote_builder/tests/test_pdf_quote_builder.py
@@ -211,6 +211,58 @@ class TestPDFQuoteBuilder(BaseUsersCommon, SaleManagementCommon):
         msg = "There shouldn't be any selected product documents left."
         self.assertFalse(self.sale_order.order_line[0].product_document_ids, msg=msg)
 
+    def test_available_documents_order(self):
+        product_document = self.product_document.copy()
+        product_document.sequence = self.product_document.sequence - 1
+        docs = self.sale_order.order_line[0].available_product_document_ids
+        self.assertEqual(len(docs), 2, "There should be 2 available documents.")
+        self.assertEqual(docs[0], product_document, "The first available document should be the one with the lowest sequence.")
+        self.assertEqual(
+            docs[1], self.product_document, "The second available document should be the one with the highest sequence."
+        )
+
+    def test_available_documents_multiple_products(self):
+        product_doc_copy = self.product_document.copy()
+        product2 = self._create_product(name="Test Product 2")
+        product_template_document2 = self.product_document.copy(
+            {'res_model': 'product.template', 'res_id': product2.product_tmpl_id.id, 'sequence': 1}
+        )
+        product_document2 = self.product_document.copy({'res_model': 'product.product', 'res_id': product2.id, 'sequence': 99})
+        self.sale_order.write(
+            {
+                'order_line': [
+                    Command.create({'product_id': self.product.id}),
+                    Command.create({'product_id': product2.id}),
+                ]
+            }
+        )
+        self.assertEqual(
+            self.sale_order.order_line[0].available_product_document_ids,
+            self.product_document | product_doc_copy,
+        )
+        self.assertFalse(
+            self.sale_order.order_line[1].available_product_document_ids,
+            "The second order line should not have any available product documents.",
+        )
+        self.assertEqual(
+            self.sale_order.order_line[0].available_product_document_ids,
+            self.sale_order.order_line[2].available_product_document_ids,
+            "The first and third order lines should have the same available product documents.",
+        )
+        self.assertEqual(
+            self.sale_order.order_line[3].available_product_document_ids[0].res_model,
+            'product.product',
+            "Alphabetical order of res_model should be respected.",
+        )
+        self.assertEqual(
+            self.sale_order.order_line[3].available_product_document_ids[0],
+            product_document2,
+        )
+        self.assertEqual(
+            self.sale_order.order_line[3].available_product_document_ids[1],
+            product_template_document2,
+        )
+
     def test_quotation_document_upload_no_template(self):
         """Check that uploading quotation documents get assigned the active company."""
         if 'website' not in self.env:


### PR DESCRIPTION
Replace search in for loop with `_read_group` and a precomputed dictionary of available product documents

Description of the issue/feature this PR addresses:
Performance issue when opening SO with multiple lines (more than 100).


See Speedscope before
[speedscope_before.json](https://github.com/user-attachments/files/21251034/speedscope_before.json)
<img width="1920" height="659" alt="image" src="https://github.com/user-attachments/assets/e77bec12-e8cf-4cc9-b3d2-90ad59db6fa3" />

And after:
[speedscope_after.json](https://github.com/user-attachments/files/21251096/speedscope_after.json)

<img width="1911" height="404" alt="image" src="https://github.com/user-attachments/assets/e1663ec3-2918-451d-ae25-6103d8a75eff" />
We went from 252ms for the query only to 12.63ms.






---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
