### PR TITLE
[IMP] iot_box_image: hide mouse cursor by default

### DIFF
--- a/addons/iot_box_image/configuration/packages.txt
+++ b/addons/iot_box_image/configuration/packages.txt
@@ -57,4 +57,5 @@ seatd
 swaybg
 vim
 wlr-randr
+wtype
 xdotool

--- a/addons/iot_box_image/overwrite_after_init/home/odoo/.config/labwc/autostart
+++ b/addons/iot_box_image/overwrite_after_init/home/odoo/.config/labwc/autostart
@@ -1,1 +1,2 @@
 swaybg -i ~/.config/labwc/iot-bg.png -m fit >/dev/null 2>&1 &
+wtype -M alt -M logo h -m alt -m logo

--- a/addons/iot_box_image/overwrite_after_init/home/odoo/.config/labwc/rc.xml
+++ b/addons/iot_box_image/overwrite_after_init/home/odoo/.config/labwc/rc.xml
@@ -1,1 +1,12 @@
+<?xml version="1.0"?>
+<labwc_config>
+
 <touch deviceName="" mapToOutput="HDMI-A-1" mouseEmulation="no"/>
+<keyboard>
+  <keybind key="A-W-h">
+    <action name="HideCursor" />
+    <action name="WarpCursor" x="-1" y="-1" />
+  </keybind>
+</keyboard>
+
+</labwc_config>


### PR DESCRIPTION
See this labwc PR: https://github.com/labwc/labwc/pull/2633

Now that the cursor hiding feature is available in the Raspberry Pi OS version of labwc (0.8.4), we can use it to hide the cursor on start-up. This means it is no longer visible on the Odoo splashscreen or on the customer display.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
