### PR TITLE
[FIX] website: add vertical position check for highlights line detection

### DIFF
--- a/addons/website/static/src/js/highlight_utils.js
+++ b/addons/website/static/src/js/highlight_utils.js
@@ -406,12 +406,19 @@ function rectToBatch(rects) {
     }
     const rectBatches = [];
     let lastX = rects[0].x - 1;
+    let lastY = rects[0].y;
+    let lastHeight = rects[0].height;
     let lineIndex2 = 0;
     for (const rect of rects) {
-        if (rect.x <= lastX) {
+        // 90% of the previous rectangle height is the tolerance value used
+        // to determine whether two rectangles belong to the same line based
+        // on their vertical position.
+        if (rect.x <= lastX || rect.y - lastY > lastHeight * 0.9) {
             lineIndex2++;
         }
         lastX = rect.x;
+        lastY = rect.y;
+        lastHeight = rect.height;
         rectBatches[lineIndex2] = rectBatches[lineIndex2] || [];
         rectBatches[lineIndex2].push(rect);
     }

--- a/addons/website/static/tests/tours/text_highlights.js
+++ b/addons/website/static/tests/tours/text_highlights.js
@@ -2,28 +2,66 @@ import {
     insertSnippet,
     registerWebsitePreviewTour,
     clickToolbarButton,
+    goBackToBlocks,
 } from '@website/js/tours/tour_utils';
 import { editorsWeakMap } from "@html_editor/../tests/tours/helpers/editor";
+
+function applyHighlight(target, targetName, highlight) {
+    return [
+        ...clickToolbarButton(targetName, target, "Apply highlight", true),
+        {
+            content: "Check that the highlights grid was displayed",
+            trigger: ".o_popover .o_text_highlight",
+        },
+        {
+            content: "Select the highlight effect",
+            trigger: `.o_popover span.o_text_highlight_${highlight}`,
+            run: "click",
+        },
+    ];
+}
+
+function countLines(el) {
+    const range = document.createRange();
+    range.selectNodeContents(el);
+    const rects = range.getClientRects();
+    const lines = new Set([...rects].map((r) => Math.round(r.top)));
+    return lines.size;
+}
 
 registerWebsitePreviewTour("text_highlights", {
     url: "/",
     edition: true,
 }, () => [
     ...insertSnippet({
+        id: "s_title",
+        name: "Title",
+        groupName: "Text",
+    }),
+    {
+        content: "Set a long page title",
+        trigger: ":iframe .s_title h2",
+        run: "editor This is an example of an unusually long title that exists purely to test multi-line wrapping",
+    },
+    ...applyHighlight(".s_title h2", "page title", "underline"),
+    {
+        content: "Check that the highlights was correctly applied",
+        trigger: ":iframe .s_title .o_text_highlight",
+        run() {
+            if (
+                this.anchor.querySelectorAll("svg").length !== countLines(this.anchor)
+            ) {
+                throw new Error("The highlight svgs are not correctly applied to text lines");
+            }
+        },
+    },
+    goBackToBlocks(),
+    ...insertSnippet({
         id: "s_cover",
         name: "Cover",
         groupName: "Intro",
     }),
-    ...clickToolbarButton("snippet title", ".s_cover h1", "Apply highlight", true),
-    {
-        content: "Check that the highlights grid was displayed",
-        trigger: ".o_popover .o_text_highlight",
-    },
-    {
-        content: "Select the highlight effect",
-        trigger: ".o_popover span.o_text_highlight_underline",
-        run: "click",
-    },
+    ...applyHighlight(".s_cover h1", "snippet title", "underline"),
     {
         content: "Check that the highlight was applied",
         trigger: ":iframe .s_cover h1 span.o_text_highlight_underline svg.o_text_highlight_svg",


### PR DESCRIPTION
Steps to reproduce:

1. Go to Website (Edit mode) and drop a title block.

2. Select the title, set a highlight effect, and save the page.

3. Load the page in a reduced viewport in a way that makes the
highlighted text split into multiple lines.

4. The highlight won't be applied correctly (only the last line will be
detected).

The current line detection mechanism relies on the horizontal comparison
of rects (see `rectToBatch()`), which returns wrong results when applied
to centered text content.

The goal of this commit is to add a y-coordinate (vertical) check to
detect new lines more reliably in `rectToBatch()`. This improves
robustness for multi-line selections with unusual layouts.

related to opw-4865891