### PR TITLE
[FIX] account: exchange with same foreign currency not in partial

### DIFF
--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -2140,10 +2140,7 @@ class AccountMoveLine(models.Model):
                 and company_currency.compare_amounts(partial_credit_amount, partial_debit_amount_range[2]) <= 0
                 and company_currency.compare_amounts(partial_credit_amount, partial_debit_amount_range[0]) >= 0
             ):
-                if debit_fully_matched:
-                    partial_amount = remaining_debit_amount
-                else:
-                    partial_amount = -remaining_credit_amount
+                partial_amount = min(remaining_debit_amount, -remaining_credit_amount)
                 partial_debit_amount = partial_amount
                 partial_credit_amount = partial_amount
 

--- a/addons/account/tests/test_account_move_reconcile.py
+++ b/addons/account/tests/test_account_move_reconcile.py
@@ -2063,6 +2063,128 @@ class TestAccountMoveReconcile(AccountTestInvoicingCommon):
                     ]
                 self.assertRecordValues(partials.sorted('amount'), expected_partials)
 
+    def test_full_reconcile_foreign_currency_rounding_difference_credit_larger(self):
+        # Full reconciliation between 2 lines with same currency + same amount currency
+        # If the balance is different, an exchange move should be reconciled with the
+        # line having the largest absolute balance
+
+        foreign_currency = self.env['res.currency'].create({
+            'name': "Bread",
+            'symbol': '🍞',
+            'rounding': 0.01,
+            'rate_ids': [
+                Command.create({'name': '2019-06-01', 'rate': 0.648587}),
+            ],
+        })
+
+        rec_pay_account = self.company_data['default_account_receivable'].copy()
+        self.assertTrue(rec_pay_account.reconcile)
+
+        line_1 = self.create_line_for_reconciliation(-44.41, -28.8, foreign_currency, '2019-06-01', rec_pay_account)
+        line_2 = self.create_line_for_reconciliation(44.4, 28.8, foreign_currency, '2019-06-01', rec_pay_account)
+        amls = line_1 + line_2
+        amls.reconcile()
+
+        full_reconcile = amls.full_reconcile_id
+        self.assertTrue(full_reconcile)
+
+        partials = self._get_partials(amls)
+        exchange_move = partials.exchange_move_id
+
+        self.assertRecordValues(exchange_move.line_ids, [
+            {
+                'debit': 0.01,
+                'credit': 0.0,
+                'amount_currency': 0.0,
+                'currency_id': foreign_currency.id,
+                'account_id': line_1.account_id.id,
+            },
+            {
+                'debit': 0.0,
+                'credit': 0.01,
+                'amount_currency': 0.0,
+                'currency_id': foreign_currency.id,
+                'account_id': self.exch_income_account.id,
+            },
+        ])
+        self.assertRecordValues(partials.sorted('amount'), [
+            {
+                'amount': 0.01,
+                'debit_amount_currency': 0.0,
+                'credit_amount_currency': 0.0,
+                'debit_move_id': exchange_move.line_ids.sorted('balance')[1].id,
+                'credit_move_id': line_1.id,
+            },
+            {
+                'amount': 44.40,
+                'debit_amount_currency': 28.8,
+                'credit_amount_currency': 28.8,
+                'debit_move_id': line_2.id,
+                'credit_move_id': line_1.id,
+            },
+        ])
+
+    def test_full_reconcile_foreign_currency_rounding_difference_debit_larger(self):
+        # Full reconciliation between 2 lines with same currency + same amount currency
+        # If the balance is different, an exchange move should be reconciled with the
+        # line having the largest absolute balance
+
+        foreign_currency = self.env['res.currency'].create({
+            'name': "Bread",
+            'symbol': '🍞',
+            'rounding': 0.01,
+            'rate_ids': [
+                Command.create({'name': '2019-06-01', 'rate': 0.648587}),
+            ],
+        })
+
+        rec_pay_account = self.company_data['default_account_receivable'].copy()
+        self.assertTrue(rec_pay_account.reconcile)
+
+        line_1 = self.create_line_for_reconciliation(-44.4, -28.8, foreign_currency, '2019-06-01', rec_pay_account)
+        line_2 = self.create_line_for_reconciliation(44.41, 28.8, foreign_currency, '2019-06-01', rec_pay_account)
+        amls = line_1 + line_2
+        amls.reconcile()
+
+        full_reconcile = amls.full_reconcile_id
+        self.assertTrue(full_reconcile)
+
+        partials = self._get_partials(amls)
+        exchange_move = partials.exchange_move_id
+
+        self.assertRecordValues(exchange_move.line_ids, [
+            {
+                'debit': 0.0,
+                'credit': 0.01,
+                'amount_currency': 0.0,
+                'currency_id': foreign_currency.id,
+                'account_id': line_2.account_id.id,
+            },
+            {
+                'debit': 0.01,
+                'credit': 0.0,
+                'amount_currency': 0.0,
+                'currency_id': foreign_currency.id,
+                'account_id': self.exch_expense_account.id,
+            },
+        ])
+        self.assertRecordValues(partials.sorted('amount'), [
+            {
+                'amount': 0.01,
+                'debit_amount_currency': 0.0,
+                'credit_amount_currency': 0.0,
+                'debit_move_id': line_2.id,
+                'credit_move_id': exchange_move.line_ids.sorted('balance')[0].id,
+            },
+            {
+                'amount': 44.40,
+                'debit_amount_currency': 28.8,
+                'credit_amount_currency': 28.8,
+                'debit_move_id': line_2.id,
+                'credit_move_id': line_1.id,
+            },
+        ])
+
     def test_reconcile_special_mexican_workflow_1(self):
         comp_curr = self.company_data['currency']
         foreign_curr = self.env['res.currency'].create({


### PR DESCRIPTION
After https://github.com/odoo/odoo/pull/204746, in some situations we will default the amount of the partial on residual of debit aml even if this one is larger than the credit aml amount.
This lead to multiple exchange moves creation that are not properly linked to the reconciliation chain.

Steps to reproduce:
1/ Setup foreign currency with rate 0.648587 (ex 0.648587 USD = 1 AUD for AUD company)
2/ Create invoice with lines
36 USD (55.51 AUD)
-7.2 USD (-11.1 AUD)
=> Receivable will be 28.8 USD (44.41 AUD) because it's computed from sum of above lines
3/ Register a payment of 28.8 USD (44.4 AUD)
=> Two exchange moves will be created with 0.01 in credit, none of them is in a partial with the invoice or payment line

This PR makes sure that we take the smallest amount of residual if both credit and debit are considered as fully matched.

opw-4835254
