### PR TITLE
Saas 18.3 keep relative url in link tools blse

### DIFF
--- a/addons/html_editor/static/tests/delete/backward.test.js
+++ b/addons/html_editor/static/tests/delete/backward.test.js
@@ -497,7 +497,7 @@ describe("Selection collapsed", () => {
         });
         test("should delete only the button", async () => {
             await testEditor({
-                contentBefore: `<p>a<a class="btn" href="#">[]</a></p>`,
+                contentBefore: `<p>a<a class="btn" href="http://test.test/">[]</a></p>`,
                 stepFunction: deleteBackward,
                 contentAfter: `<p>a[]</p>`,
             });

--- a/addons/html_editor/static/tests/delete/forward.test.js
+++ b/addons/html_editor/static/tests/delete/forward.test.js
@@ -348,7 +348,7 @@ describe("Selection collapsed", () => {
 
         test("should delete only the button", async () => {
             await testEditor({
-                contentBefore: `<p><a class="btn" href="#">[]</a>a</p>`,
+                contentBefore: `<p><a class="btn" href="http://test.test/">[]</a>a</p>`,
                 stepFunction: deleteForward,
                 contentAfter: `<p>[]a</p>`,
             });

--- a/addons/html_editor/static/tests/html_field.test.js
+++ b/addons/html_editor/static/tests/html_field.test.js
@@ -928,7 +928,7 @@ test("link preview in Link Popover", async () => {
     Partner._records = [
         {
             id: 1,
-            txt: "<p class='test_target'>abc<a href='/test'>This website</a></p>",
+            txt: "<p class='test_target'>abc<a href='http://test.test'>This website</a></p>",
         },
     ];
     await mountView({

--- a/addons/html_editor/static/tests/image.test.js
+++ b/addons/html_editor/static/tests/image.test.js
@@ -333,7 +333,9 @@ test("Image transformation disappears on backspace/delete", async () => {
     `);
     click("img.test-image");
     await expectElementCount(".o-we-toolbar", 1);
-    await contains(".o-we-toolbar div[name='image_modifiers'] button[name='image_transform']").click();
+    await contains(
+        ".o-we-toolbar div[name='image_modifiers'] button[name='image_transform']"
+    ).click();
     await expectElementCount(".transfo-container", 1);
     press("backspace");
     await expectElementCount(".transfo-container", 0);
@@ -341,12 +343,13 @@ test("Image transformation disappears on backspace/delete", async () => {
     click("img.test-image");
     await waitFor(".o-we-toolbar");
     await expectElementCount(".o-we-toolbar", 1);
-    await contains(".o-we-toolbar div[name='image_modifiers'] button[name='image_transform']").click();
+    await contains(
+        ".o-we-toolbar div[name='image_modifiers'] button[name='image_transform']"
+    ).click();
     await expectElementCount(".transfo-container", 1);
     press("delete");
     await expectElementCount(".transfo-container", 0);
 });
-
 
 test("Image transformation disappears on character key press", async () => {
     const { editor } = await setupEditor(`
@@ -354,7 +357,9 @@ test("Image transformation disappears on character key press", async () => {
     `);
     click("img.test-image");
     await expectElementCount(".o-we-toolbar", 1);
-    await contains(".o-we-toolbar div[name='image_modifiers'] button[name='image_transform']").click();
+    await contains(
+        ".o-we-toolbar div[name='image_modifiers'] button[name='image_transform']"
+    ).click();
     await expectElementCount(".transfo-container", 1);
     insertText(editor, "a");
     await expectElementCount(".transfo-container", 0);
@@ -531,7 +536,7 @@ test("can undo adding link to image", async () => {
 
 test("can remove the link of an image", async () => {
     await setupEditor(`
-        <a href="#"><img src="${base64Img}"></a>
+        <a href="http://test.test/"><img src="${base64Img}"></a>
     `);
     const img = queryOne("img");
     await click("img");
@@ -545,7 +550,7 @@ test("can remove the link of an image", async () => {
 
 test("can undo link removing of an image", async () => {
     const { editor } = await setupEditor(`
-        <a href="#"><img src="${base64Img}"></a>
+        <a href="http://test.test/"><img src="${base64Img}"></a>
     `);
     const img = queryOne("img");
     await click("img");

--- a/addons/html_editor/static/tests/insert/paragraph_break.test.js
+++ b/addons/html_editor/static/tests/insert/paragraph_break.test.js
@@ -476,73 +476,75 @@ describe("Selection collapsed", () => {
         // see `anchor.nodeName === "A" && brEls.includes(anchor.firstChild)` in line_break_plugin.js
         test("should insert line breaks outside the edges of an anchor in unbreakable", async () => {
             await testEditor({
-                contentBefore: `<div class="oe_unbreakable">ab<a href="#">[]cd</a></div>`,
+                contentBefore: `<div class="oe_unbreakable">ab<a href="http://test.test/">[]cd</a></div>`,
                 stepFunction: splitBlockA,
-                contentAfter: `<div class="oe_unbreakable">ab<br><a href="#">[]cd</a></div>`,
+                contentAfter: `<div class="oe_unbreakable">ab<br><a href="http://test.test/">[]cd</a></div>`,
             });
             await testEditor({
-                contentBefore: `<div class="oe_unbreakable"><a href="#">a[]b</a></div>`,
+                contentBefore: `<div class="oe_unbreakable"><a href="http://test.test/">a[]b</a></div>`,
                 stepFunction: splitBlockA,
-                contentAfter: `<div class="oe_unbreakable"><a href="#">a<br>[]b</a></div>`,
+                contentAfter: `<div class="oe_unbreakable"><a href="http://test.test/">a<br>[]b</a></div>`,
             });
             await testEditor({
-                contentBefore: `<div class="oe_unbreakable"><a href="#">ab[]</a></div>`,
+                contentBefore: `<div class="oe_unbreakable"><a href="http://test.test/">ab[]</a></div>`,
                 stepFunction: splitBlockA,
-                contentAfter: `<div class="oe_unbreakable"><a href="#">ab</a><br><br>[]</div>`,
+                contentAfter: `<div class="oe_unbreakable"><a href="http://test.test/">ab</a><br><br>[]</div>`,
             });
             await testEditor({
-                contentBefore: `<div class="oe_unbreakable"><a href="#">ab[]</a>cd</div>`,
+                contentBefore: `<div class="oe_unbreakable"><a href="http://test.test/">ab[]</a>cd</div>`,
                 stepFunction: splitBlockA,
-                contentAfter: `<div class="oe_unbreakable"><a href="#">ab</a><br>[]cd</div>`,
+                contentAfter: `<div class="oe_unbreakable"><a href="http://test.test/">ab</a><br>[]cd</div>`,
             });
             await testEditor({
-                contentBefore: `<div class="oe_unbreakable"><a href="#" style="display: block;">ab[]</a></div>`,
+                contentBefore: `<div class="oe_unbreakable"><a href="http://test.test/" style="display: block;">ab[]</a></div>`,
                 stepFunction: splitBlockA,
-                contentAfter: `<div class="oe_unbreakable"><a href="#" style="display: block;">ab</a>[]<br></div>`,
+                contentAfter: `<div class="oe_unbreakable"><a href="http://test.test/" style="display: block;">ab</a>[]<br></div>`,
             });
         });
 
         test("should insert a paragraph break outside the starting edge of an anchor at start of block", async () => {
             await testEditor({
-                contentBefore: '<p><a href="#">[]ab</a></p>',
+                contentBefore: '<p><a href="http://test.test/">[]ab</a></p>',
                 stepFunction: splitBlockA,
                 contentAfterEdit:
-                    '<p><br></p><p>\ufeff<a href="#" class="o_link_in_selection">\ufeff[]ab\ufeff</a>\ufeff</p>',
-                contentAfter: '<p><br></p><p><a href="#">[]ab</a></p>',
+                    '<p><br></p><p>\ufeff<a href="http://test.test/" class="o_link_in_selection">\ufeff[]ab\ufeff</a>\ufeff</p>',
+                contentAfter: '<p><br></p><p><a href="http://test.test/">[]ab</a></p>',
             });
         });
         test("should insert a paragraph break outside the starting edge of an anchor after some text", async () => {
             await testEditor({
-                contentBefore: '<p>ab<a href="#">[]cd</a></p>',
+                contentBefore: '<p>ab<a href="http://test.test/">[]cd</a></p>',
                 stepFunction: splitBlockA,
                 contentAfterEdit:
-                    '<p>ab</p><p>\ufeff<a href="#" class="o_link_in_selection">\ufeff[]cd\ufeff</a>\ufeff</p>',
-                contentAfter: '<p>ab</p><p><a href="#">[]cd</a></p>',
+                    '<p>ab</p><p>\ufeff<a href="http://test.test/" class="o_link_in_selection">\ufeff[]cd\ufeff</a>\ufeff</p>',
+                contentAfter: '<p>ab</p><p><a href="http://test.test/">[]cd</a></p>',
             });
         });
         test("should insert a paragraph break in the middle of an anchor", async () => {
             await testEditor({
-                contentBefore: '<p><a href="#">a[]b</a></p>',
+                contentBefore: '<p><a href="http://test.test/">a[]b</a></p>',
                 stepFunction: splitBlockA,
                 contentAfterEdit:
-                    '<p>\ufeff<a href="#">\ufeffa\ufeff</a>\ufeff</p><p>\ufeff<a href="#" class="o_link_in_selection">\ufeff[]b\ufeff</a>\ufeff</p>',
-                contentAfter: '<p><a href="#">a</a></p><p><a href="#">[]b</a></p>',
+                    '<p>\ufeff<a href="http://test.test/">\ufeffa\ufeff</a>\ufeff</p><p>\ufeff<a href="http://test.test/" class="o_link_in_selection">\ufeff[]b\ufeff</a>\ufeff</p>',
+                contentAfter:
+                    '<p><a href="http://test.test/">a</a></p><p><a href="http://test.test/">[]b</a></p>',
             });
         });
         test("should insert a paragraph break outside the ending edge of an anchor", async () => {
             await testEditor({
-                contentBefore: '<p><a href="#">ab[]</a></p>',
+                contentBefore: '<p><a href="http://test.test/">ab[]</a></p>',
                 stepFunction: splitBlockA,
-                contentAfterEdit: `<p>\ufeff<a href="#">\ufeffab\ufeff</a>\ufeff</p><p o-we-hint-text='Type "/" for commands' class="o-we-hint">[]<br></p>`,
-                contentAfter: `<p><a href="#">ab</a></p><p>[]<br></p>`,
+                contentAfterEdit: `<p>\ufeff<a href="http://test.test/">\ufeffab\ufeff</a>\ufeff</p><p o-we-hint-text='Type "/" for commands' class="o-we-hint">[]<br></p>`,
+                contentAfter: `<p><a href="http://test.test/">ab</a></p><p>[]<br></p>`,
             });
         });
         test("should insert a paragraph break outside the ending edge of an anchor (2)", async () => {
             await testEditor({
-                contentBefore: '<p><a href="#">ab[]</a>cd</p>',
+                contentBefore: '<p><a href="http://test.test/">ab[]</a>cd</p>',
                 stepFunction: splitBlockA,
-                contentAfterEdit: '<p>\ufeff<a href="#">\ufeffab\ufeff</a>\ufeff</p><p>[]cd</p>',
-                contentAfter: '<p><a href="#">ab</a></p><p>[]cd</p>',
+                contentAfterEdit:
+                    '<p>\ufeff<a href="http://test.test/">\ufeffab\ufeff</a>\ufeff</p><p>[]cd</p>',
+                contentAfter: '<p><a href="http://test.test/">ab</a></p><p>[]cd</p>',
             });
         });
     });

--- a/addons/html_editor/static/tests/keyboard/arrow.test.js
+++ b/addons/html_editor/static/tests/keyboard/arrow.test.js
@@ -298,11 +298,11 @@ describe("Around links", () => {
 
     test("should move out of a link (ArrowRight)", async () => {
         await testEditor({
-            contentBefore: '<p>ab<a href="#">cd[]</a>ef</p>',
+            contentBefore: '<p>ab<a href="http://test.test/">cd[]</a>ef</p>',
             contentBeforeEdit:
                 "<p>ab" +
                 "\ufeff" + // before zwnbsp
-                '<a href="#" class="o_link_in_selection">' +
+                '<a href="http://test.test/" class="o_link_in_selection">' +
                 "\ufeff" + // start zwnbsp
                 "cd[]" + // content
                 "\ufeff" + // end zwnbsp
@@ -313,24 +313,24 @@ describe("Around links", () => {
             contentAfterEdit:
                 "<p>ab" +
                 "\ufeff" + // before zwnbsp
-                '<a href="#">' +
+                '<a href="http://test.test/">' +
                 "\ufeff" + // start zwnbsp
                 "cd" + // content
                 "\ufeff" + // end zwnbsp
                 "</a>" +
                 "\ufeff" + // after zwnbsp
                 "[]ef</p>",
-            contentAfter: '<p>ab<a href="#">cd</a>[]ef</p>',
+            contentAfter: '<p>ab<a href="http://test.test/">cd</a>[]ef</p>',
         });
     });
 
     test("should move out of a link (ArrowLeft)", async () => {
         await testEditor({
-            contentBefore: '<p>ab<a href="#">[]cd</a>ef</p>',
+            contentBefore: '<p>ab<a href="http://test.test/">[]cd</a>ef</p>',
             contentBeforeEdit:
                 "<p>ab" +
                 "\ufeff" + // before zwnbsp
-                '<a href="#" class="o_link_in_selection">' +
+                '<a href="http://test.test/" class="o_link_in_selection">' +
                 "\ufeff" + // start zwnbsp
                 "[]cd" + // content
                 "\ufeff" + // end zwnbsp
@@ -341,14 +341,14 @@ describe("Around links", () => {
             contentAfterEdit:
                 "<p>ab[]" +
                 "\ufeff" + // before zwnbsp
-                '<a href="#">' +
+                '<a href="http://test.test/">' +
                 "\ufeff" + // start zwnbsp
                 "cd" + // content
                 "\ufeff" + // end zwnbsp
                 "</a>" +
                 "\ufeff" + // after zwnbsp
                 "ef</p>",
-            contentAfter: '<p>ab[]<a href="#">cd</a>ef</p>',
+            contentAfter: '<p>ab[]<a href="http://test.test/">cd</a>ef</p>',
         });
     });
 });

--- a/addons/html_editor/static/tests/link/button.test.js
+++ b/addons/html_editor/static/tests/link/button.test.js
@@ -33,16 +33,22 @@ describe("button style", () => {
 
 describe("button edit", () => {
     test("button link should be editable with double click select", async () => {
-        const { el, editor } = await setupEditor('<p>this is a <a href="#">link</a></p>');
+        const { el, editor } = await setupEditor(
+            '<p>this is a <a href="http://test.test/">link</a></p>'
+        );
         await waitForNone(".o-we-linkpopover");
         const button = el.querySelector("a");
         // simulate double click selection
         await simulateDoubleClickSelect(button);
         expect(getContent(el)).toBe(
-            '<p>this is a \ufeff<a href="#" class="o_link_in_selection">[\ufefflink]\ufeff</a>\ufeff</p>'
+            '<p>this is a \ufeff<a href="http://test.test/" class="o_link_in_selection">[\ufefflink]\ufeff</a>\ufeff</p>'
         );
-        expect(cleanLinkArtifacts(getContent(el))).toBe('<p>this is a <a href="#">[link]</a></p>');
+        expect(cleanLinkArtifacts(getContent(el))).toBe(
+            '<p>this is a <a href="http://test.test/">[link]</a></p>'
+        );
         await insertText(editor, "X");
-        expect(cleanLinkArtifacts(getContent(el))).toBe('<p>this is a <a href="#">X[]</a></p>');
+        expect(cleanLinkArtifacts(getContent(el))).toBe(
+            '<p>this is a <a href="http://test.test/">X[]</a></p>'
+        );
     });
 });

--- a/addons/html_editor/static/tests/link/existing.test.js
+++ b/addons/html_editor/static/tests/link/existing.test.js
@@ -8,85 +8,85 @@ import { contains } from "@web/../tests/_framework/dom_test_helpers";
 
 test("should parse correctly a span inside a Link", async () => {
     await testEditor({
-        contentBefore: '<p>a<a href="exist"><span class="a">b[]</span></a>c</p>',
-        contentAfter: '<p>a<a href="exist"><span class="a">b[]</span></a>c</p>',
+        contentBefore: '<p>a<a href="http://test.test/"><span class="a">b[]</span></a>c</p>',
+        contentAfter: '<p>a<a href="http://test.test/"><span class="a">b[]</span></a>c</p>',
     });
 });
 
 test("should parse correctly an empty span inside a Link", async () => {
     await testEditor({
-        contentBefore: '<p>a<a href="exist">b[]<span class="a"></span></a>c</p>',
-        contentAfter: '<p>a<a href="exist">b[]<span class="a"></span></a>c</p>',
+        contentBefore: '<p>a<a href="http://test.test/">b[]<span class="a"></span></a>c</p>',
+        contentAfter: '<p>a<a href="http://test.test/">b[]<span class="a"></span></a>c</p>',
     });
 });
 
 test("should parse correctly a span inside a Link 2", async () => {
     await testEditor({
-        contentBefore: '<p>a<a href="exist"><span class="a">b[]</span>c</a>d</p>',
-        contentAfter: '<p>a<a href="exist"><span class="a">b[]</span>c</a>d</p>',
+        contentBefore: '<p>a<a href="http://test.test/"><span class="a">b[]</span>c</a>d</p>',
+        contentAfter: '<p>a<a href="http://test.test/"><span class="a">b[]</span>c</a>d</p>',
     });
 });
 
 test("should parse correctly an empty span inside a Link then add a char", async () => {
     await testEditor({
-        contentBefore: '<p>a<a href="exist">b[]<span class="a"></span></a>c</p>',
+        contentBefore: '<p>a<a href="http://test.test/">b[]<span class="a"></span></a>c</p>',
         stepFunction: async (editor) => {
             await insertText(editor, "c");
         },
-        contentAfter: '<p>a<a href="exist">bc[]<span class="a"></span></a>c</p>',
+        contentAfter: '<p>a<a href="http://test.test/">bc[]<span class="a"></span></a>c</p>',
     });
 });
 
 test("should parse correctly a span inside a Link then add a char", async () => {
     await testEditor({
-        contentBefore: '<p>a<a href="exist"><span class="a">b[]</span></a>d</p>',
+        contentBefore: '<p>a<a href="http://test.test/"><span class="a">b[]</span></a>d</p>',
         stepFunction: async (editor) => {
             await insertText(editor, "c");
         },
-        // JW cAfter: '<p>a<span><a href="exist">b</a>c[]</span>d</p>',
-        contentAfter: '<p>a<a href="exist"><span class="a">bc[]</span></a>d</p>',
+        // JW cAfter: '<p>a<span><a href="http://test.test/">b</a>c[]</span>d</p>',
+        contentAfter: '<p>a<a href="http://test.test/"><span class="a">bc[]</span></a>d</p>',
     });
 });
 
 test("should parse correctly a span inside a Link then add a char 2", async () => {
     await testEditor({
-        contentBefore: '<p>a<a href="exist"><span class="a">b[]</span>d</a>e</p>',
+        contentBefore: '<p>a<a href="http://test.test/"><span class="a">b[]</span>d</a>e</p>',
         stepFunction: async (editor) => {
             await insertText(editor, "c");
         },
-        contentAfter: '<p>a<a href="exist"><span class="a">bc[]</span>d</a>e</p>',
+        contentAfter: '<p>a<a href="http://test.test/"><span class="a">bc[]</span>d</a>e</p>',
     });
 });
 
 test("should parse correctly a span inside a Link then add a char 3", async () => {
     await testEditor({
-        contentBefore: '<p>a<a href="exist"><span class="a">b</span>c[]</a>e</p>',
+        contentBefore: '<p>a<a href="http://test.test/"><span class="a">b</span>c[]</a>e</p>',
         stepFunction: async (editor) => {
             await insertText(editor, "d");
         },
-        // JW cAfter: '<p>a<a href="exist"><span class="a">b</span>c</a>d[]e</p>',
-        contentAfter: '<p>a<a href="exist"><span class="a">b</span>cd[]</a>e</p>',
+        // JW cAfter: '<p>a<a href="http://test.test/"><span class="a">b</span>c</a>d[]e</p>',
+        contentAfter: '<p>a<a href="http://test.test/"><span class="a">b</span>cd[]</a>e</p>',
     });
 });
 
 test("should add a character after the link", async () => {
     await testEditor({
-        contentBefore: '<p>a<a href="exist">b[]</a>d</p>',
+        contentBefore: '<p>a<a href="http://test.test/">b[]</a>d</p>',
         stepFunction: async (editor) => {
             await insertText(editor, "c");
         },
-        // JW cAfter: '<p>a<a href="exist">b</a>c[]d</p>',
-        contentAfter: '<p>a<a href="exist">bc[]</a>d</p>',
+        // JW cAfter: '<p>a<a href="http://test.test/">b</a>c[]d</p>',
+        contentAfter: '<p>a<a href="http://test.test/">bc[]</a>d</p>',
     });
 });
 
 test("should add two character after the link", async () => {
     await testEditor({
-        contentBefore: '<p>a<a href="exist">b[]</a>e</p>',
+        contentBefore: '<p>a<a href="http://test.test/">b[]</a>e</p>',
         stepFunction: async (editor) => {
             await insertText(editor, "cd");
         },
-        contentAfter: '<p>a<a href="exist">bcd[]</a>e</p>',
+        contentAfter: '<p>a<a href="http://test.test/">bcd[]</a>e</p>',
     });
 });
 
@@ -102,28 +102,28 @@ test("should add a character after the link if range just after link", async () 
 
 test("should add a character in the link after a br tag", async () => {
     await testEditor({
-        contentBefore: '<p>a<a href="exist">b<br>[]</a>d</p>',
+        contentBefore: '<p>a<a href="http://test.test/">b<br>[]</a>d</p>',
         stepFunction: async (editor) => {
             await insertText(editor, "c");
         },
-        contentAfter: '<p>a<a href="exist">b<br>c[]</a>d</p>',
+        contentAfter: '<p>a<a href="http://test.test/">b<br>c[]</a>d</p>',
     });
 });
 
 test("should remove an empty link on save", async () => {
     await testEditor({
-        contentBefore: '<p>a<a href="exist">b[]</a>c</p>',
+        contentBefore: '<p>a<a href="http://test.test/">b[]</a>c</p>',
         contentBeforeEdit:
-            '<p>a\ufeff<a href="exist" class="o_link_in_selection">\ufeffb[]\ufeff</a>\ufeffc</p>',
+            '<p>a\ufeff<a href="http://test.test/" class="o_link_in_selection">\ufeffb[]\ufeff</a>\ufeffc</p>',
         stepFunction: deleteBackward,
         contentAfterEdit:
-            '<p>a\ufeff<a href="exist" class="o_link_in_selection">\ufeff[]\ufeff</a>\ufeffc</p>',
+            '<p>a\ufeff<a href="http://test.test/" class="o_link_in_selection">\ufeff[]\ufeff</a>\ufeffc</p>',
         contentAfter: "<p>a[]c</p>",
     });
     await testEditor({
-        contentBefore: '<p>a<a href="exist"></a>b</p>',
-        contentBeforeEdit: '<p>a\ufeff<a href="exist">\ufeff</a>\ufeffb</p>',
-        contentAfterEdit: '<p>a\ufeff<a href="exist">\ufeff</a>\ufeffb</p>',
+        contentBefore: '<p>a<a href="http://test.test/"></a>b</p>',
+        contentBeforeEdit: '<p>a\ufeff<a href="http://test.test/">\ufeff</a>\ufeffb</p>',
+        contentAfterEdit: '<p>a\ufeff<a href="http://test.test/">\ufeff</a>\ufeffb</p>',
         contentAfter: "<p>ab</p>",
     });
 });

--- a/addons/html_editor/static/tests/link/isolated.test.js
+++ b/addons/html_editor/static/tests/link/isolated.test.js
@@ -41,46 +41,46 @@ test("should pad a link with ZWNBSPs and add visual indication (2)", async () =>
 
 test("should keep link padded with ZWNBSPs after a delete", async () => {
     await testEditor({
-        contentBefore: '<p>a<a href="#/">b[]</a>c</p>',
+        contentBefore: '<p>a<a href="http://test.test/">b[]</a>c</p>',
         stepFunction: deleteBackward,
         contentAfterEdit:
-            '<p>a\ufeff<a href="#/" class="o_link_in_selection">\ufeff[]\ufeff</a>\ufeffc</p>',
+            '<p>a\ufeff<a href="http://test.test/" class="o_link_in_selection">\ufeff[]\ufeff</a>\ufeffc</p>',
         contentAfter: "<p>a[]c</p>",
     });
 });
 
 test("should keep isolated link after a delete and typing", async () => {
     await testEditor({
-        contentBefore: '<p>a<a href="#/">b[]</a>c</p>',
+        contentBefore: '<p>a<a href="http://test.test/">b[]</a>c</p>',
         stepFunction: async (editor) => {
             deleteBackward(editor);
             await insertText(editor, "a");
             await insertText(editor, "b");
             await insertText(editor, "c");
         },
-        contentAfter: '<p>a<a href="#/">abc[]</a>c</p>',
+        contentAfter: '<p>a<a href="http://test.test/">abc[]</a>c</p>',
     });
 });
 
 test("should delete the content from the link when popover is active", async () => {
-    const { editor, el } = await setupEditor('<p><a href="#/">abc[]abc</a></p>');
+    const { editor, el } = await setupEditor('<p><a href="http://test.test/">abc[]abc</a></p>');
     await expectElementCount(".o-we-linkpopover", 1);
     deleteBackward(editor);
     deleteBackward(editor);
     deleteBackward(editor);
     const content = getContent(el);
     expect(content).toBe(
-        '<p>\ufeff<a href="#/" class="o_link_in_selection">\ufeff[]abc\ufeff</a>\ufeff</p>'
+        '<p>\ufeff<a href="http://test.test/" class="o_link_in_selection">\ufeff[]abc\ufeff</a>\ufeff</p>'
     );
-    expect(cleanLinkArtifacts(content)).toBe('<p><a href="#/">[]abc</a></p>');
+    expect(cleanLinkArtifacts(content)).toBe('<p><a href="http://test.test/">[]abc</a></p>');
 });
 
 describe.tags("desktop");
 describe("should position the cursor outside the link", () => {
     test("clicking at the start of the link", async () => {
-        const { el } = await setupEditor('<p><a href="#/">te[]st</a></p>');
+        const { el } = await setupEditor('<p><a href="http://test.test/">te[]st</a></p>');
         expect(getContent(el)).toBe(
-            '<p>\ufeff<a href="#/" class="o_link_in_selection">\ufeffte[]st\ufeff</a>\ufeff</p>'
+            '<p>\ufeff<a href="http://test.test/" class="o_link_in_selection">\ufeffte[]st\ufeff</a>\ufeff</p>'
         );
 
         const aElement = queryOne("p a");
@@ -88,31 +88,39 @@ describe("should position the cursor outside the link", () => {
         // Simulate the selection with mousedown
         setSelection({ anchorNode: aElement.childNodes[0], anchorOffset: 0 });
         expect(getContent(el)).toBe(
-            '<p>\ufeff<a href="#/" class="o_link_in_selection">[]\ufefftest\ufeff</a>\ufeff</p>'
+            '<p>\ufeff<a href="http://test.test/" class="o_link_in_selection">[]\ufefftest\ufeff</a>\ufeff</p>'
         );
         await animationFrame(); // selection change
         await pointerUp(el);
-        expect(getContent(el)).toBe('<p>[]\ufeff<a href="#/">\ufefftest\ufeff</a>\ufeff</p>');
+        expect(getContent(el)).toBe(
+            '<p>[]\ufeff<a href="http://test.test/">\ufefftest\ufeff</a>\ufeff</p>'
+        );
     });
 
     test("clicking at the start of the link when format is applied on link", async () => {
         const { el } = await setupEditor('<p><strong><a href="#/">test</a></strong></p>');
-        expect(getContent(el)).toBe('<p><strong>\ufeff<a href="#/">\ufefftest\ufeff</a>\ufeff</strong></p>');
+        expect(getContent(el)).toBe(
+            '<p><strong>\ufeff<a href="#/">\ufefftest\ufeff</a>\ufeff</strong></p>'
+        );
 
         const aElement = queryOne("p a");
         await pointerDown(el);
         // Simulate the selection with mousedown
         setSelection({ anchorNode: aElement.childNodes[0], anchorOffset: 0 });
-        expect(getContent(el)).toBe('<p><strong>\ufeff<a href="#/">[]\ufefftest\ufeff</a>\ufeff</strong></p>');
+        expect(getContent(el)).toBe(
+            '<p><strong>\ufeff<a href="#/">[]\ufefftest\ufeff</a>\ufeff</strong></p>'
+        );
         await animationFrame(); // selection change
         await pointerUp(el);
-        expect(getContent(el)).toBe('<p><strong>[]\ufeff<a href="#/">\ufefftest\ufeff</a>\ufeff</strong></p>');
+        expect(getContent(el)).toBe(
+            '<p><strong>[]\ufeff<a href="#/">\ufefftest\ufeff</a>\ufeff</strong></p>'
+        );
     });
 
     test("clicking at the end of the link", async () => {
-        const { el } = await setupEditor('<p><a href="#/">te[]st</a></p>');
+        const { el } = await setupEditor('<p><a href="http://test.test/">te[]st</a></p>');
         expect(getContent(el)).toBe(
-            '<p>\ufeff<a href="#/" class="o_link_in_selection">\ufeffte[]st\ufeff</a>\ufeff</p>'
+            '<p>\ufeff<a href="http://test.test/" class="o_link_in_selection">\ufeffte[]st\ufeff</a>\ufeff</p>'
         );
 
         const aElement = queryOne("p a");
@@ -123,17 +131,19 @@ describe("should position the cursor outside the link", () => {
             anchorOffset: nodeSize(aElement.childNodes[2]),
         });
         expect(getContent(el)).toBe(
-            '<p>\ufeff<a href="#/" class="o_link_in_selection">\ufefftest\ufeff[]</a>\ufeff</p>'
+            '<p>\ufeff<a href="http://test.test/" class="o_link_in_selection">\ufefftest\ufeff[]</a>\ufeff</p>'
         );
         await animationFrame(); // selectionChange
         await pointerUp(el);
-        expect(getContent(el)).toBe('<p>\ufeff<a href="#/">\ufefftest\ufeff</a>\ufeff[]</p>');
+        expect(getContent(el)).toBe(
+            '<p>\ufeff<a href="http://test.test/">\ufefftest\ufeff</a>\ufeff[]</p>'
+        );
     });
 
     test("clicking before the link's text content", async () => {
-        const { el, editor } = await setupEditor('<p><a href="#/">te[]st</a></p>');
+        const { el, editor } = await setupEditor('<p><a href="http://test.test/">te[]st</a></p>');
         expect(getContent(el)).toBe(
-            '<p>\ufeff<a href="#/" class="o_link_in_selection">\ufeffte[]st\ufeff</a>\ufeff</p>'
+            '<p>\ufeff<a href="http://test.test/" class="o_link_in_selection">\ufeffte[]st\ufeff</a>\ufeff</p>'
         );
 
         const aElement = queryOne("p a");
@@ -141,30 +151,34 @@ describe("should position the cursor outside the link", () => {
         // Simulate the selection with mousedown
         setSelection({ anchorNode: aElement.childNodes[1], anchorOffset: 0 });
         expect(getContent(el)).toBe(
-            '<p>\ufeff<a href="#/" class="o_link_in_selection">\ufeff[]test\ufeff</a>\ufeff</p>'
+            '<p>\ufeff<a href="http://test.test/" class="o_link_in_selection">\ufeff[]test\ufeff</a>\ufeff</p>'
         );
         await animationFrame(); // selection change
         await pointerUp(el);
-        expect(getContent(el)).toBe('<p>[]\ufeff<a href="#/">\ufefftest\ufeff</a>\ufeff</p>');
+        expect(getContent(el)).toBe(
+            '<p>[]\ufeff<a href="http://test.test/">\ufefftest\ufeff</a>\ufeff</p>'
+        );
 
         await insertText(editor, "link");
-        expect(getContent(el)).toBe('<p>link[]\ufeff<a href="#/">\ufefftest\ufeff</a>\ufeff</p>');
+        expect(getContent(el)).toBe(
+            '<p>link[]\ufeff<a href="http://test.test/">\ufefftest\ufeff</a>\ufeff</p>'
+        );
 
         setSelection({ anchorNode: aElement.childNodes[1], anchorOffset: 0 });
         await animationFrame(); // selectionChange
         expect(getContent(el)).toBe(
-            '<p>link\ufeff<a href="#/" class="o_link_in_selection">\ufeff[]test\ufeff</a>\ufeff</p>'
+            '<p>link\ufeff<a href="http://test.test/" class="o_link_in_selection">\ufeff[]test\ufeff</a>\ufeff</p>'
         );
         await insertText(editor, "content");
         expect(getContent(el)).toBe(
-            '<p>link\ufeff<a href="#/" class="o_link_in_selection">\ufeffcontent[]test\ufeff</a>\ufeff</p>'
+            '<p>link\ufeff<a href="http://test.test/" class="o_link_in_selection">\ufeffcontent[]test\ufeff</a>\ufeff</p>'
         );
     });
 
     test(" clicking after the link's text content", async () => {
-        const { el, editor } = await setupEditor('<p><a href="#/">t[]est</a></p>');
+        const { el, editor } = await setupEditor('<p><a href="http://test.test/">t[]est</a></p>');
         expect(getContent(el)).toBe(
-            '<p>\ufeff<a href="#/" class="o_link_in_selection">\ufefft[]est\ufeff</a>\ufeff</p>'
+            '<p>\ufeff<a href="http://test.test/" class="o_link_in_selection">\ufefft[]est\ufeff</a>\ufeff</p>'
         );
 
         const aElement = queryOne("p a");
@@ -175,14 +189,18 @@ describe("should position the cursor outside the link", () => {
             anchorOffset: nodeSize(aElement.childNodes[1]),
         });
         expect(getContent(el)).toBe(
-            '<p>\ufeff<a href="#/" class="o_link_in_selection">\ufefftest[]\ufeff</a>\ufeff</p>'
+            '<p>\ufeff<a href="http://test.test/" class="o_link_in_selection">\ufefftest[]\ufeff</a>\ufeff</p>'
         );
         await animationFrame(); // selection change
         await pointerUp(el);
-        expect(getContent(el)).toBe('<p>\ufeff<a href="#/">\ufefftest\ufeff</a>\ufeff[]</p>');
+        expect(getContent(el)).toBe(
+            '<p>\ufeff<a href="http://test.test/">\ufefftest\ufeff</a>\ufeff[]</p>'
+        );
 
         await insertText(editor, "link");
-        expect(getContent(el)).toBe('<p>\ufeff<a href="#/">\ufefftest\ufeff</a>\ufefflink[]</p>');
+        expect(getContent(el)).toBe(
+            '<p>\ufeff<a href="http://test.test/">\ufefftest\ufeff</a>\ufefflink[]</p>'
+        );
 
         setSelection({
             anchorNode: aElement.childNodes[1],
@@ -190,11 +208,11 @@ describe("should position the cursor outside the link", () => {
         });
         await animationFrame(); // selectionChange
         expect(getContent(el)).toBe(
-            '<p>\ufeff<a href="#/" class="o_link_in_selection">\ufefftest[]\ufeff</a>\ufefflink</p>'
+            '<p>\ufeff<a href="http://test.test/" class="o_link_in_selection">\ufefftest[]\ufeff</a>\ufefflink</p>'
         );
         await insertText(editor, "content");
         expect(getContent(el)).toBe(
-            '<p>\ufeff<a href="#/" class="o_link_in_selection">\ufefftestcontent[]\ufeff</a>\ufefflink</p>'
+            '<p>\ufeff<a href="http://test.test/" class="o_link_in_selection">\ufefftestcontent[]\ufeff</a>\ufefflink</p>'
         );
     });
 });
@@ -224,9 +242,9 @@ describe("should zwnbsp-pad simple text link", () => {
     });
     test("should zwnbsp-pad simple text link (2)", async () => {
         await testEditor({
-            contentBefore: '<p>a<a href="#/">[]bc</a>d</p>',
+            contentBefore: '<p>a<a href="http://test.test/">[]bc</a>d</p>',
             contentBeforeEdit:
-                '<p>a\ufeff<a href="#/" class="o_link_in_selection">\ufeff[]bc\ufeff</a>\ufeffd</p>',
+                '<p>a\ufeff<a href="http://test.test/" class="o_link_in_selection">\ufeff[]bc\ufeff</a>\ufeffd</p>',
             stepFunction: async (editor) => {
                 removeZwnbsp(editor);
                 const a = editor.editable.querySelector("a");
@@ -237,14 +255,14 @@ describe("should zwnbsp-pad simple text link", () => {
                 dispatchNormalize(editor);
             },
             contentAfterEdit:
-                '<p>a\ufeff<a href="#/" class="o_link_in_selection">\ufeff[]bc\ufeff</a>\ufeffd</p>',
+                '<p>a\ufeff<a href="http://test.test/" class="o_link_in_selection">\ufeff[]bc\ufeff</a>\ufeffd</p>',
         });
     });
     test("should zwnbsp-pad simple text link (3)", async () => {
         await testEditor({
-            contentBefore: '<p>a<a href="#/">b[]</a>d</p>',
+            contentBefore: '<p>a<a href="http://test.test/">b[]</a>d</p>',
             contentBeforeEdit:
-                '<p>a\ufeff<a href="#/" class="o_link_in_selection">\ufeffb[]\ufeff</a>\ufeffd</p>',
+                '<p>a\ufeff<a href="http://test.test/" class="o_link_in_selection">\ufeffb[]\ufeff</a>\ufeffd</p>',
             stepFunction: async (editor) => {
                 const a = editor.editable.querySelector("a");
                 // Insert an extra character as a text node so we can set
@@ -259,14 +277,14 @@ describe("should zwnbsp-pad simple text link", () => {
                 dispatchNormalize(editor);
             },
             contentAfterEdit:
-                '<p>a\ufeff<a href="#/" class="o_link_in_selection">\ufeffb[]c\ufeff</a>\ufeffd</p>',
+                '<p>a\ufeff<a href="http://test.test/" class="o_link_in_selection">\ufeffb[]c\ufeff</a>\ufeffd</p>',
         });
     });
     test("should zwnbsp-pad simple text link (4)", async () => {
         await testEditor({
-            contentBefore: '<p>a<a href="#/">bc[]</a>d</p>',
+            contentBefore: '<p>a<a href="http://test.test/">bc[]</a>d</p>',
             contentBeforeEdit:
-                '<p>a\ufeff<a href="#/" class="o_link_in_selection">\ufeffbc[]\ufeff</a>\ufeffd</p>',
+                '<p>a\ufeff<a href="http://test.test/" class="o_link_in_selection">\ufeffbc[]\ufeff</a>\ufeffd</p>',
             stepFunction: async (editor) => {
                 removeZwnbsp(editor);
                 const a = editor.editable.querySelector("a");
@@ -277,7 +295,7 @@ describe("should zwnbsp-pad simple text link", () => {
                 dispatchNormalize(editor);
             },
             contentAfterEdit:
-                '<p>a\ufeff<a href="#/" class="o_link_in_selection">\ufeffbc[]\ufeff</a>\ufeffd</p>',
+                '<p>a\ufeff<a href="http://test.test/" class="o_link_in_selection">\ufeffbc[]\ufeff</a>\ufeffd</p>',
         });
     });
     test("should zwnbsp-pad simple text link (5)", async () => {
@@ -300,31 +318,32 @@ describe("should zwnbsp-pad simple text link", () => {
 
 test("should not zwnbsp-pad nav-link", async () => {
     await testEditor({
-        contentBefore: '<p>a<a href="#/" class="nav-link">[]b</a>c</p>',
-        contentBeforeEdit: '<p>a<a href="#/" class="nav-link">[]b</a>c</p>',
+        contentBefore: '<p>a<a href="http://test.test/" class="nav-link">[]b</a>c</p>',
+        contentBeforeEdit: '<p>a<a href="http://test.test/" class="nav-link">[]b</a>c</p>',
     });
 });
 
 test("should not zwnbsp-pad in nav", async () => {
     await testEditor({
-        contentBefore: '<nav>a<a href="#/">[]b</a>c</nav>',
-        contentBeforeEdit: '<nav>a<a href="#/">[]b</a>c</nav>',
+        contentBefore: '<nav>a<a href="http://test.test/">[]b</a>c</nav>',
+        contentBeforeEdit: '<nav>a<a href="http://test.test/">[]b</a>c</nav>',
     });
 });
 
 test("should not zwnbsp-pad link with block fontawesome", async () => {
     await testEditor({
         contentBefore:
-            '<p>a<a href="#/">[]<i style="display: flex;" class="fa fa-star"></i></a>b</p>',
+            '<p>a<a href="http://test.test/">[]<i style="display: flex;" class="fa fa-star"></i></a>b</p>',
         contentBeforeEdit:
-            '<p>a<a href="#/">\ufeff[]<i style="display: flex;" class="fa fa-star" contenteditable="false">\u200b</i>\ufeff</a>b</p>',
+            '<p>a<a href="http://test.test/">\ufeff[]<i style="display: flex;" class="fa fa-star" contenteditable="false">\u200b</i>\ufeff</a>b</p>',
     });
 });
 
 test("should not zwnbsp-pad link with image", async () => {
     await testEditor({
-        contentBefore: '<p>a<a href="#/">[]<img style="display: inline;"></a>b</p>',
-        contentBeforeEdit: '<p>a<a href="#/">[]<img style="display: inline;"></a>b</p>',
+        contentBefore: '<p>a<a href="http://test.test/">[]<img style="display: inline;"></a>b</p>',
+        contentBeforeEdit:
+            '<p>a<a href="http://test.test/">[]<img style="display: inline;"></a>b</p>',
     });
 });
 
@@ -370,7 +389,8 @@ test("should zwnbps-pad links with .btn class", async () => {
 
 test("should not add visual indication to a button", async () => {
     await testEditor({
-        contentBefore: '<p><a href="#" class="btn">[]content</a></p>',
-        contentBeforeEdit: '<p>\ufeff<a href="#" class="btn">\ufeff[]content\ufeff</a>\ufeff</p>',
+        contentBefore: '<p><a href="http://test.test/" class="btn">[]content</a></p>',
+        contentBeforeEdit:
+            '<p>\ufeff<a href="http://test.test/" class="btn">\ufeff[]content\ufeff</a>\ufeff</p>',
     });
 });

--- a/addons/html_editor/static/tests/link/popover.test.js
+++ b/addons/html_editor/static/tests/link/popover.test.js
@@ -196,6 +196,18 @@ describe("popover should edit,copy,remove the link", () => {
             '<p>this is a <a href="http://test.com/">http://test.com/[]</a></p>'
         );
     });
+    test("relative URLs should be kept relative URLs", async () => {
+        onRpc("/html_editor/link_preview_internal", () => ({}));
+        onRpc("/contactus", () => ({}));
+        const { el } = await setupEditor('<p>this is a <a href="/contactus">li[]nk</a></p>');
+        await waitFor(".o-we-linkpopover");
+        await click(".o_we_edit_link");
+        await waitFor(".o_we_apply_link");
+        await click(".o_we_apply_link");
+        expect(cleanLinkArtifacts(getContent(el))).toBe(
+            '<p>this is a <a href="/contactus">li[]nk</a></p>'
+        );
+    });
     test("after clicking on copy button, the url should be copied to clipboard", async () => {
         await setupEditor('<p>this is a <a href="http://test.com/">li[]nk</a></p>');
         await waitFor(".o-we-linkpopover");

--- a/addons/html_editor/static/tests/link/popover.test.js
+++ b/addons/html_editor/static/tests/link/popover.test.js
@@ -36,7 +36,9 @@ describe("should open a popover", () => {
         await expectElementCount(".o-we-linkpopover", 0);
     });
     test("should open a popover when the selection is inside a link and stay open if selection move in the same link", async () => {
-        const { el } = await setupEditor('<p>this []is a <a href="exist">l<b>in</b>k</a></p>');
+        const { el } = await setupEditor(
+            '<p>this []is a <a href="http://test.test/">l<b>in</b>k</a></p>'
+        );
         await expectElementCount(".o-we-linkpopover", 0);
         // selection inside a link
         const aNode = queryOne("a");
@@ -49,7 +51,7 @@ describe("should open a popover", () => {
         await expectElementCount(".o-we-linkpopover", 1);
         // FEFF is taken into account in the index
         expect(cleanLinkArtifacts(getContent(el))).toBe(
-            '<p>this is a <a href="exist">l<b>in</b>[]k</a></p>'
+            '<p>this is a <a href="http://test.test/">l<b>in</b>[]k</a></p>'
         );
         // Another selection in the same link
         setSelection({
@@ -61,7 +63,7 @@ describe("should open a popover", () => {
         await animationFrame();
         await expectElementCount(".o-we-linkpopover", 1);
         expect(cleanLinkArtifacts(getContent(el))).toBe(
-            '<p>this is a <a href="exist">[]l<b>in</b>k</a></p>'
+            '<p>this is a <a href="http://test.test/">[]l<b>in</b>k</a></p>'
         );
     });
     test("link popover should have input field for href when the link doesn't have href", async () => {
@@ -71,7 +73,7 @@ describe("should open a popover", () => {
         expect(".o_we_href_input_link").toHaveValue("");
     });
     test("link popover should have buttons for link operation when the link has href", async () => {
-        await setupEditor('<p>this is a <a href="test.com">li[]nk</a></p>');
+        await setupEditor('<p>this is a <a href="http://test.test/">li[]nk</a></p>');
         await expectElementCount(".o-we-linkpopover", 1);
         expect(".o_we_copy_link").toHaveCount(1);
         expect(".o_we_edit_link").toHaveCount(1);
@@ -329,8 +331,12 @@ describe("Link creation", () => {
             await animationFrame();
             await click(".o-we-command-name:first");
 
-            await contains(".o-we-linkpopover input.o_we_href_input_link").fill("#");
-            expect(cleanLinkArtifacts(getContent(el))).toBe('<p><a href="#">#[]</a></p>');
+            await contains(".o-we-linkpopover input.o_we_href_input_link").fill(
+                "http://test.test/"
+            );
+            expect(cleanLinkArtifacts(getContent(el))).toBe(
+                '<p><a href="http://test.test/">http://test.test/[]</a></p>'
+            );
         });
         test("Should be able to insert button on empty p", async () => {
             const { editor, el } = await setupEditor("<p>[]</p>");
@@ -338,9 +344,11 @@ describe("Link creation", () => {
             await animationFrame();
             await click(".o-we-command-name:first");
 
-            await contains(".o-we-linkpopover input.o_we_href_input_link").fill("#");
+            await contains(".o-we-linkpopover input.o_we_href_input_link").fill(
+                "http://test.test/"
+            );
             expect(cleanLinkArtifacts(getContent(el))).toBe(
-                '<p><a href="#" class="btn btn-fill-primary">#[]</a></p>'
+                '<p><a href="http://test.test/" class="btn btn-fill-primary">http://test.test/[]</a></p>'
             );
         });
         test("Should keep http protocol on valid http url", async () => {
@@ -362,9 +370,11 @@ describe("Link creation", () => {
             await animationFrame();
             await click(".o-we-command-name:first");
             await contains(".o-we-linkpopover input.o_we_label_link").fill("link");
-            await contains(".o-we-linkpopover input.o_we_href_input_link").fill("#");
+            await contains(".o-we-linkpopover input.o_we_href_input_link").fill(
+                "http://test.test/"
+            );
             expect(cleanLinkArtifacts(getContent(el))).toBe(
-                '<p>a <a href="#">link[]</a>&nbsp;&nbsp;b</p>'
+                '<p>a <a href="http://test.test/">link[]</a>&nbsp;&nbsp;b</p>'
             );
         });
         test("should insert a link then create a new <p>", async () => {
@@ -373,11 +383,13 @@ describe("Link creation", () => {
             await animationFrame();
             await click(".o-we-command-name:first");
             await contains(".o-we-linkpopover input.o_we_label_link").fill("link");
-            await contains(".o-we-linkpopover input.o_we_href_input_link").fill("#");
+            await contains(".o-we-linkpopover input.o_we_href_input_link").fill(
+                "http://test.test/"
+            );
             // press("Enter");
             splitBlock(editor);
             expect(cleanLinkArtifacts(getContent(el))).toBe(
-                `<p>ab<a href="#">link</a></p><p o-we-hint-text='Type "/" for commands' class="o-we-hint">[]<br></p>`
+                `<p>ab<a href="http://test.test/">link</a></p><p o-we-hint-text='Type "/" for commands' class="o-we-hint">[]<br></p>`
             );
         });
         test("should insert a link then create a new <p>, and another character", async () => {
@@ -386,12 +398,14 @@ describe("Link creation", () => {
             await animationFrame();
             await click(".o-we-command-name:first");
             await contains(".o-we-linkpopover input.o_we_label_link").fill("link");
-            await contains(".o-we-linkpopover input.o_we_href_input_link").fill("#");
+            await contains(".o-we-linkpopover input.o_we_href_input_link").fill(
+                "http://test.test/"
+            );
             // press("Enter");
             splitBlock(editor);
             await insertText(editor, "D");
             expect(cleanLinkArtifacts(getContent(el))).toBe(
-                '<p>a<a href="#">link</a></p><p>D[]b</p>'
+                '<p>a<a href="http://test.test/">link</a></p><p>D[]b</p>'
             );
         });
         test("should insert a link then insert a <br>", async () => {
@@ -400,10 +414,14 @@ describe("Link creation", () => {
             await animationFrame();
             await click(".o-we-command-name:first");
             await contains(".o-we-linkpopover input.o_we_label_link").fill("link");
-            await contains(".o-we-linkpopover input.o_we_href_input_link").fill("#");
+            await contains(".o-we-linkpopover input.o_we_href_input_link").fill(
+                "http://test.test/"
+            );
             // press("Enter");
             insertLineBreak(editor);
-            expect(cleanLinkArtifacts(getContent(el))).toBe('<p>a<a href="#">link</a><br>[]b</p>');
+            expect(cleanLinkArtifacts(getContent(el))).toBe(
+                '<p>a<a href="http://test.test/">link</a><br>[]b</p>'
+            );
         });
         test("should insert a link then insert a <br> and another character", async () => {
             const { editor, el } = await setupEditor("<p>a[]b</p>");
@@ -411,11 +429,15 @@ describe("Link creation", () => {
             await animationFrame();
             await click(".o-we-command-name:first");
             await contains(".o-we-linkpopover input.o_we_label_link").fill("link");
-            await contains(".o-we-linkpopover input.o_we_href_input_link").fill("#");
+            await contains(".o-we-linkpopover input.o_we_href_input_link").fill(
+                "http://test.test/"
+            );
             // press("Enter");
             insertLineBreak(editor);
             await insertText(editor, "D");
-            expect(cleanLinkArtifacts(getContent(el))).toBe('<p>a<a href="#">link</a><br>D[]b</p>');
+            expect(cleanLinkArtifacts(getContent(el))).toBe(
+                '<p>a<a href="http://test.test/">link</a><br>D[]b</p>'
+            );
         });
     });
     describe("Creation by toolbar", () => {
@@ -424,9 +446,11 @@ describe("Link creation", () => {
             await waitFor(".o-we-toolbar");
             await click(".o-we-toolbar .fa-link");
             await contains(".o-we-linkpopover input.o_we_href_input_link", { timeout: 1500 }).edit(
-                "#"
+                "http://test.test/"
             );
-            expect(cleanLinkArtifacts(getContent(el))).toBe('<p><a href="#">Hello[]</a></p>');
+            expect(cleanLinkArtifacts(getContent(el))).toBe(
+                '<p><a href="http://test.test/">Hello[]</a></p>'
+            );
         });
         test("should convert valid url to https link", async () => {
             const { el } = await setupEditor("<p>[Hello]</p>");
@@ -456,9 +480,11 @@ describe("Link creation", () => {
             );
             await waitFor(".o-we-toolbar");
             click(".o-we-toolbar .fa-link");
-            await contains(".o-we-linkpopover input.o_we_href_input_link").edit("#");
+            await contains(".o-we-linkpopover input.o_we_href_input_link").edit(
+                "http://test.test/"
+            );
             expect(cleanLinkArtifacts(getContent(el))).toBe(
-                '<p>Hello this is <a href="#">a <b>new</b> <u>link</u> keeping style[]</a>!</p>'
+                '<p>Hello this is <a href="http://test.test/">a <b>new</b> <u>link</u> keeping style[]</a>!</p>'
             );
         });
         test("should convert all selected text to link and keep style except bgclor", async () => {
@@ -467,9 +493,11 @@ describe("Link creation", () => {
             );
             await waitFor(".o-we-toolbar");
             click(".o-we-toolbar .fa-link");
-            await contains(".o-we-linkpopover input.o_we_href_input_link").edit("#");
+            await contains(".o-we-linkpopover input.o_we_href_input_link").edit(
+                "http://test.test/"
+            );
             expect(cleanLinkArtifacts(getContent(el))).toBe(
-                '<p>Hello this is <a href="#">a <b>new</b> <u>link</u> keeping style[]</a>!</p>'
+                '<p>Hello this is <a href="http://test.test/">a <b>new</b> <u>link</u> keeping style[]</a>!</p>'
             );
         });
         test("should convert all selected text to link and keep style except color (2)", async () => {
@@ -478,9 +506,11 @@ describe("Link creation", () => {
             );
             await waitFor(".o-we-toolbar");
             click(".o-we-toolbar .fa-link");
-            await contains(".o-we-linkpopover input.o_we_href_input_link").edit("#");
+            await contains(".o-we-linkpopover input.o_we_href_input_link").edit(
+                "http://test.test/"
+            );
             expect(cleanLinkArtifacts(getContent(el))).toBe(
-                '<p>Hello this is a <b>ne</b><a href="#"><b>w</b> <u>link</u> keep[]</a><span style="color:red">ing</span> style!</p>'
+                '<p>Hello this is a <b>ne</b><a href="http://test.test/"><b>w</b> <u>link</u> keep[]</a><span style="color:red">ing</span> style!</p>'
             );
         });
         test("should set the link on two existing characters", async () => {
@@ -491,9 +521,11 @@ describe("Link creation", () => {
             expect('.o-we-toolbar button[name="link"]').not.toHaveAttribute("disabled");
             await click(".o-we-toolbar .fa-link");
             await contains(".o-we-linkpopover input.o_we_href_input_link", { timeout: 1500 }).edit(
-                "#"
+                "http://test.test/"
             );
-            expect(cleanLinkArtifacts(getContent(el))).toBe('<p>H<a href="#">el[]</a>lo</p>');
+            expect(cleanLinkArtifacts(getContent(el))).toBe(
+                '<p>H<a href="http://test.test/">el[]</a>lo</p>'
+            );
         });
         test("should not allow to create a link if selection span multiple block", async () => {
             const { el } = await setupEditor("<p>H[ello</p><p>wor]ld</p>");
@@ -547,9 +579,11 @@ describe("Link creation", () => {
             await waitFor(".o-we-toolbar");
             await click(".o-we-toolbar .fa-link");
             await contains(".o-we-linkpopover input.o_we_href_input_link", { timeout: 1500 }).edit(
-                "#"
+                "http://test.test/"
             );
-            expect(cleanLinkArtifacts(getContent(el))).toBe('<p>aaa<a href="#">ab[]</a>cdef</p>');
+            expect(cleanLinkArtifacts(getContent(el))).toBe(
+                '<p>aaa<a href="http://test.test/">ab[]</a>cdef</p>'
+            );
         });
         test("should remove link when click away without inputting url", async () => {
             const { el } = await setupEditor("<p>H[el]lo</p>");
@@ -604,9 +638,11 @@ describe("Link creation", () => {
             // not validated link shouldn't affect the DOM yet
             expect(cleanLinkArtifacts(getContent(el))).toBe("<p>[Hello]</p>");
             await contains(".o-we-linkpopover input.o_we_href_input_link", { timeout: 1500 }).edit(
-                "#"
+                "http://test.test/"
             );
-            expect(cleanLinkArtifacts(getContent(el))).toBe('<p><a href="#">Hello[]</a></p>');
+            expect(cleanLinkArtifacts(getContent(el))).toBe(
+                '<p><a href="http://test.test/">Hello[]</a></p>'
+            );
 
             undo(editor);
             expect(cleanLinkArtifacts(getContent(el))).toBe("<p>[Hello]</p>");
@@ -617,9 +653,11 @@ describe("Link creation", () => {
             await click(".o-we-toolbar .fa-link");
             // not validated link shouldn't affect the DOM yet
             expect(cleanLinkArtifacts(getContent(el))).toBe("<p><b>[Hello]</b></p>");
-            await contains(".o-we-linkpopover input.o_we_href_input_link").edit("#");
+            await contains(".o-we-linkpopover input.o_we_href_input_link").edit(
+                "http://test.test/"
+            );
             expect(cleanLinkArtifacts(getContent(el))).toBe(
-                '<p><b><a href="#">Hello[]</a></b></p>'
+                '<p><b><a href="http://test.test/">Hello[]</a></b></p>'
             );
             undo(editor);
             expect(cleanLinkArtifacts(getContent(el))).toBe("<p><b>[Hello]</b></p>");
@@ -960,7 +998,8 @@ describe("link preview", () => {
     });
     test("test external metadata cached correctly", async () => {
         const title = "Open Source ERP and CRM | Odoo";
-        const description = "From ERP to CRM, eCommerce and CMS. Download Odoo or use it in the cloud. Grow Your Business.";
+        const description =
+            "From ERP to CRM, eCommerce and CMS. Download Odoo or use it in the cloud. Grow Your Business.";
         onRpc("/html_editor/link_preview_external", () => {
             expect.step("/html_editor/link_preview_external");
             return {
@@ -1040,73 +1079,79 @@ describe("links with inline image", () => {
         const { el } = await setupEditor(`<p>ab[cd<img src="${base64Img}">ef]g</p>`);
         await waitFor(".o-we-toolbar");
         await click(".o-we-toolbar .fa-link");
-        await contains(".o-we-linkpopover input.o_we_href_input_link", { timeout: 1500 }).edit("#");
+        await contains(".o-we-linkpopover input.o_we_href_input_link", { timeout: 1500 }).edit(
+            "http://test.test/"
+        );
         expect(cleanLinkArtifacts(getContent(el))).toBe(
-            `<p>ab<a href="#">cd<img src="${base64Img}">ef[]</a>g</p>`
+            `<p>ab<a href="http://test.test/">cd<img src="${base64Img}">ef[]</a>g</p>`
         );
     });
     test("can undo add link to inline image + text", async () => {
         const { editor, el } = await setupEditor(`<p>ab[cd<img src="${base64Img}">ef]g</p>`);
         await waitFor(".o-we-toolbar");
         await click(".o-we-toolbar .fa-link");
-        await contains(".o-we-linkpopover input.o_we_href_input_link", { timeout: 1500 }).edit("#");
+        await contains(".o-we-linkpopover input.o_we_href_input_link", { timeout: 1500 }).edit(
+            "http://test.test/"
+        );
         expect(cleanLinkArtifacts(getContent(el))).toBe(
-            `<p>ab<a href="#">cd<img src="${base64Img}">ef[]</a>g</p>`
+            `<p>ab<a href="http://test.test/">cd<img src="${base64Img}">ef[]</a>g</p>`
         );
         undo(editor);
         await animationFrame();
         expect(cleanLinkArtifacts(getContent(el))).toBe(`<p>ab[cd<img src="${base64Img}">ef]g</p>`);
     });
     test("can remove link from an inline image", async () => {
-        const { el } = await setupEditor(`<p>ab<a href="#">cd<img src="${base64Img}">ef</a>g</p>`);
+        const { el } = await setupEditor(
+            `<p>ab<a href="http://test.test/">cd<img src="${base64Img}">ef</a>g</p>`
+        );
         await click("img");
         await waitFor(".o-we-toolbar");
         expect("button[name='unlink']").toHaveCount(1);
         await click("button[name='unlink']");
         await animationFrame();
         expect(cleanLinkArtifacts(getContent(el))).toBe(
-            `<p>ab<a href="#">cd[</a><img src="${base64Img}"><a href="#">]ef</a>g</p>`
+            `<p>ab<a href="http://test.test/">cd[</a><img src="${base64Img}"><a href="http://test.test/">]ef</a>g</p>`
         );
         await expectElementCount(".o-we-linkpopover", 0);
     });
     test("can remove link from a selection of an inline image + text", async () => {
         const { el } = await setupEditor(
-            `<p>ab<a href="#">c[d<img src="${base64Img}">e]f</a>g</p>`
+            `<p>ab<a href="http://test.test/">c[d<img src="${base64Img}">e]f</a>g</p>`
         );
         await waitFor(".o-we-toolbar");
         await click(".o-we-toolbar .fa-unlink");
         expect(cleanLinkArtifacts(getContent(el))).toBe(
-            `<p>ab<a href="#">c</a>[d<img src="${base64Img}">e]<a href="#">f</a>g</p>`
+            `<p>ab<a href="http://test.test/">c</a>[d<img src="${base64Img}">e]<a href="http://test.test/">f</a>g</p>`
         );
     });
     test("can remove link from a selection (ltr) with multiple inline images", async () => {
         const { el } = await setupEditor(
-            `<p>ab<a href="#">c[d<img src="${base64Img}">e<img src="${base64Img}">f]g</a>h</p>`
+            `<p>ab<a href="http://test.test/">c[d<img src="${base64Img}">e<img src="${base64Img}">f]g</a>h</p>`
         );
         await waitFor(".o-we-toolbar");
         await click(".o-we-toolbar .fa-unlink");
         expect(cleanLinkArtifacts(getContent(el))).toBe(
-            `<p>ab<a href="#">c</a>[d<img src="${base64Img}">e<img src="${base64Img}">f]<a href="#">g</a>h</p>`
+            `<p>ab<a href="http://test.test/">c</a>[d<img src="${base64Img}">e<img src="${base64Img}">f]<a href="http://test.test/">g</a>h</p>`
         );
     });
     test("can remove link from a selection (rtl) with multiple inline images", async () => {
         const { el } = await setupEditor(
-            `<p>ab<a href="#">c]d<img src="${base64Img}">e<img src="${base64Img}">f[g</a>h</p>`
+            `<p>ab<a href="http://test.test/">c]d<img src="${base64Img}">e<img src="${base64Img}">f[g</a>h</p>`
         );
         await waitFor(".o-we-toolbar");
         await click(".o-we-toolbar .fa-unlink");
         expect(cleanLinkArtifacts(getContent(el))).toBe(
-            `<p>ab<a href="#">c</a>]d<img src="${base64Img}">e<img src="${base64Img}">f[<a href="#">g</a>h</p>`
+            `<p>ab<a href="http://test.test/">c</a>]d<img src="${base64Img}">e<img src="${base64Img}">f[<a href="http://test.test/">g</a>h</p>`
         );
     });
     test("can remove link from a selection (ltr) with multiple inline images acrossing different links", async () => {
         const { el } = await setupEditor(
-            `<p>ab<a href="#">c[d<img src="${base64Img}">e</a>xx<a href="#">f<img src="${base64Img}">g]h</a>i</p>`
+            `<p>ab<a href="http://test.test/">c[d<img src="${base64Img}">e</a>xx<a href="http://test.test/">f<img src="${base64Img}">g]h</a>i</p>`
         );
         await waitFor(".o-we-toolbar");
         await click(".o-we-toolbar .fa-unlink");
         expect(cleanLinkArtifacts(getContent(el))).toBe(
-            `<p>ab<a href="#">c</a>[d<img src="${base64Img}">exxf<img src="${base64Img}">g]<a href="#">h</a>i</p>`
+            `<p>ab<a href="http://test.test/">c</a>[d<img src="${base64Img}">exxf<img src="${base64Img}">g]<a href="http://test.test/">h</a>i</p>`
         );
     });
     test("can remove link from a selection (rtl) with multiple inline images acrossing different links", async () => {
@@ -1119,8 +1164,10 @@ describe("links with inline image", () => {
             `<p>ab<a href="#">c</a>]d<img src="${base64Img}">exxf<img src="${base64Img}">g[<a href="#">h</a>i</p>`
         );
     });
-    test("link elelment should be removed and popover should close when image is deleted from a image link ", async () => {
-        const { el } = await setupEditor(`<p>ab<a href="#"><img src="${base64Img}">[]</a>c</p>`);
+    test("link element should be removed and popover should close when image is deleted from a image link", async () => {
+        const { el } = await setupEditor(
+            `<p>ab<a href="http://test.test/"><img src="${base64Img}"></a>c[]</p>`
+        );
         await click("img");
         await waitFor(".o-we-toolbar");
         await waitFor(".o-we-linkpopover");
@@ -1250,7 +1297,7 @@ describe("apply button should be disabled when the URL is empty", () => {
         expect(".o_we_apply_link").toHaveAttribute("disabled");
     });
     test("when URL on link is empty, the apply link button should be disabled (3)", async () => {
-        await setupEditor('<p>this is a <a href="exiting">li[]nk</a></p>');
+        await setupEditor('<p>this is a <a href="http://test.test/">li[]nk</a></p>');
         await waitFor(".o-we-linkpopover");
         await click(".o_we_edit_link");
         await contains(".o-we-linkpopover input.o_we_href_input_link").edit("");

--- a/addons/html_editor/static/tests/link/remove.test.js
+++ b/addons/html_editor/static/tests/link/remove.test.js
@@ -6,28 +6,28 @@ import { getContent, setSelection } from "../_helpers/selection";
 describe("range collapsed, remove by popover unlink button", () => {
     test("should remove the link if collapsed range at the end of a link", async () => {
         await testEditor({
-            contentBefore: '<p>a<a href="exist">bcd[]</a>e</p>',
+            contentBefore: '<p>a<a href="http://test.test/">bcd[]</a>e</p>',
             stepFunction: unlinkFromPopover,
             contentAfter: "<p>abcd[]e</p>",
         });
         // With fontawesome at the start of the link.
         await testEditor({
             contentBefore:
-                '<p>a<a href="exist"><span class="fa fa-music" contenteditable="false">\u200B</span>bcd[]</a>e</p>',
+                '<p>a<a href="http://test.test/"><span class="fa fa-music" contenteditable="false">\u200B</span>bcd[]</a>e</p>',
             stepFunction: unlinkFromPopover,
             contentAfter: '<p>a<span class="fa fa-music"></span>bcd[]e</p>',
         });
         // With fontawesome at the middle of the link.
         await testEditor({
             contentBefore:
-                '<p>a<a href="exist">bc<span class="fa fa-music" contenteditable="false">\u200B</span>d[]</a>e</p>',
+                '<p>a<a href="http://test.test/">bc<span class="fa fa-music" contenteditable="false">\u200B</span>d[]</a>e</p>',
             stepFunction: unlinkFromPopover,
             contentAfter: '<p>abc<span class="fa fa-music"></span>d[]e</p>',
         });
         // With fontawesome at the end of the link.
         await testEditor({
             contentBefore:
-                '<p>a<a href="exist">bcd[]<span class="fa fa-music" contenteditable="false">\u200B</span></a>e</p>',
+                '<p>a<a href="http://test.test/">bcd[]<span class="fa fa-music" contenteditable="false">\u200B</span></a>e</p>',
             stepFunction: unlinkFromPopover,
             contentAfter: '<p>abcd[]<span class="fa fa-music"></span>e</p>',
         });
@@ -35,28 +35,28 @@ describe("range collapsed, remove by popover unlink button", () => {
 
     test("should remove the link if collapsed range in the middle a link", async () => {
         await testEditor({
-            contentBefore: '<p>a<a href="exist">b[]cd</a>e</p>',
+            contentBefore: '<p>a<a href="http://test.test/">b[]cd</a>e</p>',
             stepFunction: unlinkFromPopover,
             contentAfter: "<p>ab[]cde</p>",
         });
         // With fontawesome at the start of the link.
         await testEditor({
             contentBefore:
-                '<p>a<a href="exist"><span class="fa fa-music" contenteditable="false">\u200B</span>b[]cd</a>e</p>',
+                '<p>a<a href="http://test.test/"><span class="fa fa-music" contenteditable="false">\u200B</span>b[]cd</a>e</p>',
             stepFunction: unlinkFromPopover,
             contentAfter: '<p>a<span class="fa fa-music"></span>b[]cde</p>',
         });
         // With fontawesome at the middle of the link.
         await testEditor({
             contentBefore:
-                '<p>a<a href="exist">b[]c<span class="fa fa-music" contenteditable="false">\u200B</span>d</a>e</p>',
+                '<p>a<a href="http://test.test/">b[]c<span class="fa fa-music" contenteditable="false">\u200B</span>d</a>e</p>',
             stepFunction: unlinkFromPopover,
             contentAfter: '<p>ab[]c<span class="fa fa-music"></span>de</p>',
         });
         // With fontawesome at the end of the link.
         await testEditor({
             contentBefore:
-                '<p>a<a href="exist">b[]cd<span class="fa fa-music" contenteditable="false">\u200B</span></a>e</p>',
+                '<p>a<a href="http://test.test/">b[]cd<span class="fa fa-music" contenteditable="false">\u200B</span></a>e</p>',
             stepFunction: unlinkFromPopover,
             contentAfter: '<p>ab[]cd<span class="fa fa-music"></span>e</p>',
         });
@@ -64,28 +64,28 @@ describe("range collapsed, remove by popover unlink button", () => {
 
     test("should remove the link if collapsed range at the start of a link", async () => {
         await testEditor({
-            contentBefore: '<p>a<a href="exist">[]bcd</a>e</p>',
+            contentBefore: '<p>a<a href="http://test.test/">[]bcd</a>e</p>',
             stepFunction: unlinkFromPopover,
             contentAfter: "<p>a[]bcde</p>",
         });
         // With fontawesome at the start of the link.
         await testEditor({
             contentBefore:
-                '<p>a<a href="exist"><span class="fa fa-music" contenteditable="false">\u200B</span>[]bcd</a>e</p>',
+                '<p>a<a href="http://test.test/"><span class="fa fa-music" contenteditable="false">\u200B</span>[]bcd</a>e</p>',
             stepFunction: unlinkFromPopover,
             contentAfter: '<p>a<span class="fa fa-music"></span>[]bcde</p>',
         });
         // With fontawesome at the middle of the link.
         await testEditor({
             contentBefore:
-                '<p>a<a href="exist">[]bc<span class="fa fa-music" contenteditable="false">\u200B</span>d</a>e</p>',
+                '<p>a<a href="http://test.test/">[]bc<span class="fa fa-music" contenteditable="false">\u200B</span>d</a>e</p>',
             stepFunction: unlinkFromPopover,
             contentAfter: '<p>a[]bc<span class="fa fa-music"></span>de</p>',
         });
         // With fontawesome at the end of the link.
         await testEditor({
             contentBefore:
-                '<p>a<a href="exist">[]bcd<span class="fa fa-music" contenteditable="false">\u200B</span></a>e</p>',
+                '<p>a<a href="http://test.test/">[]bcd<span class="fa fa-music" contenteditable="false">\u200B</span></a>e</p>',
             stepFunction: unlinkFromPopover,
             contentAfter: '<p>a[]bcd<span class="fa fa-music"></span>e</p>',
         });
@@ -94,33 +94,34 @@ describe("range collapsed, remove by popover unlink button", () => {
     test("should remove only the current link if collapsed range in the middle of a link", async () => {
         await testEditor({
             contentBefore:
-                '<p><a href="exist">a</a>b<a href="exist">c[]d</a>e<a href="exist">f</a></p>',
+                '<p><a href="http://test.test/">a</a>b<a href="http://test.test/">c[]d</a>e<a href="http://test.test/">f</a></p>',
             stepFunction: unlinkFromPopover,
-            contentAfter: '<p><a href="exist">a</a>bc[]de<a href="exist">f</a></p>',
+            contentAfter:
+                '<p><a href="http://test.test/">a</a>bc[]de<a href="http://test.test/">f</a></p>',
         });
         // With fontawesome at the start of the link.
         await testEditor({
             contentBefore:
-                '<p><a href="exist">a</a>b<a href="exist"><span class="fa fa-music" contenteditable="false">\u200B</span>c[]d</a>e<a href="exist">f</a></p>',
+                '<p><a href="http://test.test/">a</a>b<a href="http://test.test/"><span class="fa fa-music" contenteditable="false">\u200B</span>c[]d</a>e<a href="http://test.test/">f</a></p>',
             stepFunction: unlinkFromPopover,
             contentAfter:
-                '<p><a href="exist">a</a>b<span class="fa fa-music"></span>c[]de<a href="exist">f</a></p>',
+                '<p><a href="http://test.test/">a</a>b<span class="fa fa-music"></span>c[]de<a href="http://test.test/">f</a></p>',
         });
         // With fontawesome at the middle of the link.
         await testEditor({
             contentBefore:
-                '<p><a href="exist">a</a>b<a href="exist">c<span class="fa fa-music" contenteditable="false">\u200B</span>d[]e</a>f<a href="exist">g</a></p>',
+                '<p><a href="http://test.test/">a</a>b<a href="http://test.test/">c<span class="fa fa-music" contenteditable="false">\u200B</span>d[]e</a>f<a href="http://test.test/">g</a></p>',
             stepFunction: unlinkFromPopover,
             contentAfter:
-                '<p><a href="exist">a</a>bc<span class="fa fa-music"></span>d[]ef<a href="exist">g</a></p>',
+                '<p><a href="http://test.test/">a</a>bc<span class="fa fa-music"></span>d[]ef<a href="http://test.test/">g</a></p>',
         });
         // With fontawesome at the end of the link.
         await testEditor({
             contentBefore:
-                '<p><a href="exist">a</a>b<a href="exist">c[]d<span class="fa fa-music" contenteditable="false">\u200B</span></a>e<a href="exist">f</a></p>',
+                '<p><a href="http://test.test/">a</a>b<a href="http://test.test/">c[]d<span class="fa fa-music" contenteditable="false">\u200B</span></a>e<a href="http://test.test/">f</a></p>',
             stepFunction: unlinkFromPopover,
             contentAfter:
-                '<p><a href="exist">a</a>bc[]d<span class="fa fa-music"></span>e<a href="exist">f</a></p>',
+                '<p><a href="http://test.test/">a</a>bc[]d<span class="fa fa-music"></span>e<a href="http://test.test/">f</a></p>',
         });
     });
 });
@@ -297,7 +298,7 @@ describe("range not collapsed", () => {
     });
     test("should be able to remove link if selection has FEFF character (2)", async () => {
         const { el } = await setupEditor(
-            '<p><a href="google.com" class="btn btn-primary">[]test</a></p>'
+            '<p><a href="http://test.test/" class="btn btn-primary">[]test</a></p>'
         );
         const link = el.querySelector("a");
         const firstFeffChar = link.firstChild;

--- a/addons/html_editor/static/tests/paste.test.js
+++ b/addons/html_editor/static/tests/paste.test.js
@@ -2624,7 +2624,8 @@ describe("link", () => {
 
         test("should replace link for new content when pasting in an empty link (collapsed)", async () => {
             await testEditor({
-                contentBefore: '<p><a href="#" oe-zws-empty-inline="">[]\u200B</a></p>',
+                contentBefore:
+                    '<p><a href="http://test.test/" oe-zws-empty-inline="">[]\u200B</a></p>',
                 stepFunction: async (editor) => {
                     pasteText(editor, "abc");
                 },
@@ -2633,7 +2634,8 @@ describe("link", () => {
         });
         test("should replace link for new content when pasting in an empty link (collapsed)(2)", async () => {
             await testEditor({
-                contentBefore: '<p>xy<a href="#" oe-zws-empty-inline="">\u200B[]</a>z</p>',
+                contentBefore:
+                    '<p>xy<a href="http://test.test/" oe-zws-empty-inline="">\u200B[]</a>z</p>',
                 stepFunction: async (editor) => {
                     pasteText(editor, "abc");
                 },
@@ -2643,7 +2645,7 @@ describe("link", () => {
 
         test("should replace link for new content (url) when pasting in an empty link (collapsed)", async () => {
             const { el, editor } = await setupEditor(
-                `<p>xy<a href="#" oe-zws-empty-inline="">\u200B[]</a>z</p>`
+                `<p>xy<a href="http://test.test/" oe-zws-empty-inline="">\u200B[]</a>z</p>`
             );
             pasteText(editor, "http://odoo.com");
             await animationFrame();
@@ -2654,9 +2656,11 @@ describe("link", () => {
         });
 
         test("should replace link for new content (imgUrl) when pasting in an empty link (collapsed) (1)", async () => {
-            const { el, editor } = await setupEditor(`<p>xy<a href="#">[]</a>z</p>`);
+            const { el, editor } = await setupEditor(
+                `<p>xy<a href="http://test.test/">[]</a>z</p>`
+            );
             expect(getContent(el)).toBe(
-                `<p>xy\ufeff<a href="#" class="o_link_in_selection">\ufeff[]</a>\ufeffz</p>`
+                `<p>xy\ufeff<a href="http://test.test/" class="o_link_in_selection">\ufeff[]</a>\ufeffz</p>`
             );
             pasteText(editor, imgUrl);
             await animationFrame();
@@ -2669,7 +2673,7 @@ describe("link", () => {
 
         test("should replace link for new content (url) when pasting in an empty link (collapsed) (2)", async () => {
             const { el, editor } = await setupEditor(
-                `<p>xy<a href="#" oe-zws-empty-inline="">\u200B[]</a>z</p>`
+                `<p>xy<a href="http://test.test/" oe-zws-empty-inline="">\u200B[]</a>z</p>`
             );
             pasteText(editor, imgUrl);
             await animationFrame();
@@ -2687,14 +2691,14 @@ describe("link", () => {
 
         test("should paste and transform plain text content over an empty link (collapsed)", async () => {
             await testEditor({
-                contentBefore: '<p><a href="#">[]\u200B</a></p>',
+                contentBefore: '<p><a href="http://test.test/">[]\u200B</a></p>',
                 stepFunction: async (editor) => {
                     pasteText(editor, "abc www.odoo.com xyz");
                 },
                 contentAfter: '<p>abc <a href="http://www.odoo.com">www.odoo.com</a> xyz[]</p>',
             });
             await testEditor({
-                contentBefore: '<p><a href="#">[]\u200B</a></p>',
+                contentBefore: '<p><a href="http://test.test/">[]\u200B</a></p>',
                 stepFunction: async (editor) => {
                     pasteText(editor, "odoo.com\ngoogle.com");
                 },
@@ -2706,7 +2710,7 @@ describe("link", () => {
 
         test("should paste html content over an empty link (collapsed)", async () => {
             await testEditor({
-                contentBefore: '<p><a href="#">[]\u200B</a></p>',
+                contentBefore: '<p><a href="http://test.test/">[]\u200B</a></p>',
                 stepFunction: async (editor) => {
                     pasteHtml(
                         editor,
@@ -2719,7 +2723,7 @@ describe("link", () => {
         });
         test("should paste html content over an empty link (collapsed) (2)", async () => {
             await testEditor({
-                contentBefore: '<p><a href="#">[]\u200B</a></p>',
+                contentBefore: '<p><a href="http://test.test/">[]\u200B</a></p>',
                 stepFunction: async (editor) => {
                     pasteHtml(
                         editor,
@@ -2795,11 +2799,11 @@ describe("link", () => {
 
         test("should paste plain text inside non empty link (collapsed)", async () => {
             await testEditor({
-                contentBefore: '<p><a href="#">a[]b</a></p>',
+                contentBefore: '<p><a href="http://test.test/">a[]b</a></p>',
                 stepFunction: async (editor) => {
                     pasteHtml(editor, "<span>123</span>");
                 },
-                contentAfter: '<p><a href="#">a123[]b</a></p>',
+                contentAfter: '<p><a href="http://test.test/">a123[]b</a></p>',
             });
         });
 

--- a/addons/html_editor/static/tests/toolbar.test.js
+++ b/addons/html_editor/static/tests/toolbar.test.js
@@ -928,7 +928,7 @@ test("toolbar should close on open link popover", async () => {
 
 test.tags("desktop");
 test("toolbar should close on edit link from preview", async () => {
-    await setupEditor(`<p><a href="#">[a]</a></p>`);
+    await setupEditor(`<p><a href="http://test.test/">[a]</a></p>`);
     await expectElementCount(".o-we-toolbar", 1);
     await click(".o-we-toolbar .fa-link");
     await waitFor(".o-we-linkpopover");

--- a/addons/website/static/tests/builder/website_builder/menu_data.test.js
+++ b/addons/website/static/tests/builder/website_builder/menu_data.test.js
@@ -1,0 +1,261 @@
+import { describe, expect, test, beforeEach } from "@odoo/hoot";
+import { waitFor, waitForNone, click, queryOne } from "@odoo/hoot-dom";
+import { defineWebsiteModels, setupWebsiteBuilder } from "../website_helpers";
+import { setupEditor } from "@html_editor/../tests/_helpers/editor";
+import { setSelection } from "@html_editor/../tests/_helpers/selection";
+import { expectElementCount } from "@html_editor/../tests/_helpers/ui_expectations";
+import { patchWithCleanup, mockService, onRpc } from "@web/../tests/web_test_helpers";
+import { MAIN_PLUGINS } from "@html_editor/plugin_sets";
+import { MenuDataPlugin } from "@website/builder/plugins/menu_data_plugin";
+import { MenuDialog } from "@website/components/dialog/edit_menu";
+import { SavePlugin } from "@html_builder/core/save_plugin";
+import { insertText } from "@html_editor/../tests/_helpers/user_actions";
+
+defineWebsiteModels();
+
+beforeEach(() => {
+    onRpc("/web/exists", () => ({}));
+    onRpc("/html_editor/link_preview_internal", () => ({}));
+});
+
+describe("NavbarLinkPopover", () => {
+    test("should open a navbar popover when the selection is inside a top menu link and close outside of a top menu link", async () => {
+        const { el } = await setupEditor(
+            `<ul class="top_menu">
+                <li>
+                    <a class="nav-link" href="exists">
+                        <span>Top Menu Item</span>
+                    </a>
+                </li>
+            </ul>
+            <p>Outside</p>`,
+            {
+                config: { Plugins: [...MAIN_PLUGINS, MenuDataPlugin, SavePlugin] },
+            }
+        );
+        await expectElementCount(".o-we-linkpopover", 0);
+        // selection inside a top menu link
+        setSelection({ anchorNode: el.querySelector(".nav-link > span"), anchorOffset: 0 });
+        await waitFor(".o-we-linkpopover");
+        // remove link button replaced with sitemap button
+        expect(".o-we-linkpopover:has(i.fa-chain-broken)").toHaveCount(0);
+        expect(".o-we-linkpopover:has(i.fa-sitemap)").toHaveCount(1);
+        // selection outside a top menu link
+        setSelection({ anchorNode: el.querySelector("p"), anchorOffset: 0 });
+        await expectElementCount(".o-we-linkpopover", 0);
+    });
+
+    test("should open a navbar popover when the selection is inside a top menu link and stay open if selection move in the same link", async () => {
+        const { el } = await setupEditor(
+            `<ul class="top_menu">
+                <li>
+                    <a class="nav-link" href="exists">
+                        <span>Top Menu Item</span>
+                    </a>
+                </li>
+            </ul>`,
+            {
+                config: { Plugins: [...MAIN_PLUGINS, MenuDataPlugin, SavePlugin] },
+            }
+        );
+        expect(".o-we-linkpopover:has(i.fa-sitemap)").toHaveCount(0);
+        // open navbar link popover
+        setSelection({ anchorNode: el.querySelector(".nav-link > span"), anchorOffset: 0 });
+        await waitFor(".o-we-linkpopover");
+        expect(".o-we-linkpopover:has(i.fa-sitemap)").toHaveCount(1);
+        // selection in the same link
+        setSelection({ anchorNode: el.querySelector(".nav-link > span"), anchorOffset: 1 });
+        await waitFor(".o-we-linkpopover");
+        expect(".o-we-linkpopover:has(i.fa-sitemap)").toHaveCount(1);
+    });
+
+    test("should open a navbar popover when the selection is inside a top menu dropdown link", async () => {
+        const { el } = await setupEditor(
+            `<ul class="top_menu">
+                <li>
+                    <a class="nav-link" href="exists">
+                        <span>Top Menu Item</span>
+                    </a>
+                </li>
+                <div class="dropdown">
+                    <a class="dropdown-toggle" data-bs-toggle="dropdown"></a>
+                    <div class="dropdown-menu">
+                        <li>
+                            <a class="dropdown-item" href="exists">
+                                <span>Dropdown Menu Item</span>
+                            </a>
+                        </li>
+                    </div>
+                </div>
+            </ul>`,
+            {
+                config: { Plugins: [...MAIN_PLUGINS, MenuDataPlugin, SavePlugin] },
+            }
+        );
+        expect(".o-we-linkpopover:has(i.fa-sitemap)").toHaveCount(0);
+        // selection in dropdown menu
+        setSelection({ anchorNode: el.querySelector(".dropdown-item > span"), anchorOffset: 0 });
+        await waitFor(".o-we-linkpopover");
+        expect(".o-we-linkpopover:has(i.fa-sitemap)").toHaveCount(1);
+    });
+});
+
+describe("MenuDialog", () => {
+    test("after clicking on edit link button, a MenuDialog should appear", async () => {
+        const { el } = await setupEditor(
+            `<ul class="top_menu">
+                <li>
+                    <a class="nav-link" href="exists">
+                        <span data-oe-id="5">Top Menu Item</span>
+                    </a>
+                </li>
+            </ul>`,
+            {
+                config: { Plugins: [...MAIN_PLUGINS, MenuDataPlugin, SavePlugin] },
+            }
+        );
+        patchWithCleanup(MenuDialog.prototype, {
+            setup() {
+                super.setup();
+                this.website.pageDocument = el.ownerDocument;
+            },
+        });
+        expect(".o-we-linkpopover:has(i.fa-sitemap)").toHaveCount(0);
+        // open navbar link popover
+        setSelection({ anchorNode: el.querySelector(".nav-link > span"), anchorOffset: 0 });
+        await waitFor(".o-we-linkpopover");
+        expect(".o-we-linkpopover:has(i.fa-sitemap)").toHaveCount(1);
+        // click the link edit button
+        await click(".o_we_edit_link");
+        // check that MenuDialog is open and that name and url have been passed correctly
+        await waitFor(".o_website_dialog");
+        expect("input.form-control:not(#url_input)").toHaveValue("Top Menu Item");
+        expect("#url_input").toHaveValue("exists");
+    });
+});
+
+describe("EditMenuDialog", () => {
+    const sampleMenuData = {
+        fields: {
+            id: 4,
+            name: "Top Menu",
+            url: "#",
+            new_window: false,
+            is_mega_menu: false,
+            sequence: 0,
+            parent_id: false,
+        },
+        children: [
+            {
+                fields: {
+                    id: 5,
+                    name: "Top Menu Item",
+                    url: "#",
+                    new_window: false,
+                    is_mega_menu: false,
+                    sequence: 10,
+                    parent_id: 4,
+                },
+                children: [],
+                is_homepage: true,
+            },
+        ],
+        is_homepage: false,
+    };
+    beforeEach(() => {
+        mockService("website", {
+            get currentWebsite() {
+                return {
+                    id: 1,
+                    default_lang_id: {
+                        code: "en_US",
+                    },
+                    metadata: {
+                        lang: "en_EN",
+                    },
+                };
+            },
+        });
+    });
+
+    test("after clicking on edit menu button, an EditMenuDialog should appear", async () => {
+        const { el } = await setupEditor(
+            `<ul class="top_menu">
+                <li>
+                    <a class="nav-link" href="exists">
+                        <span>Top Menu Item</span>
+                    </a>
+                </li>
+            </ul>`,
+            {
+                config: { Plugins: [...MAIN_PLUGINS, MenuDataPlugin, SavePlugin] },
+            }
+        );
+
+        onRpc(({ model, method, args }) => {
+            expect(model).toBe("website.menu");
+            expect(method).toBe("get_tree");
+            expect(args[0]).toBe(1);
+            return sampleMenuData;
+        });
+
+        expect(".o-we-linkpopover:has(i.fa-sitemap)").toHaveCount(0);
+        // open navbar link popover
+        setSelection({ anchorNode: el.querySelector(".nav-link > span"), anchorOffset: 0 });
+        await waitFor(".o-we-linkpopover");
+        expect(".o-we-linkpopover:has(i.fa-sitemap)").toHaveCount(1);
+        // click on edit menu button
+        await click(".js_edit_menu");
+        // check that EditMenuDialog is open with correct values
+        await waitFor(".o_website_dialog");
+        expect(".oe_menu_editor").toHaveCount(1);
+        expect(".js_menu_label").toHaveText("Top Menu Item");
+    });
+
+    test("clicking save in the EditMenuDialog should not clear the editor changes", async () => {
+        const { getEditor } = await setupWebsiteBuilder(
+            // Using tel: as link to avoid having to mock fetching metadata for link preview
+            // This does not influence the test in any way
+            `<ul class="top_menu">
+                <li>
+                    <a class="nav-link" href="tel: 123" contenteditable="true">
+                        <span>Top Menu Item</span>
+                    </a>
+                </li>
+            </ul>
+            <section>
+                <p>TEXT</p>
+            </section>`,
+            {
+                openEditor: true,
+            }
+        );
+
+        onRpc(({ method, model, args }) => {
+            if (method === "save" && model === "ir.ui.view") {
+                expect(args[1]).toInclude("EDITED TEXT");
+                expect.step("editor_has_saved");
+            }
+            return sampleMenuData;
+        });
+
+        const editor = getEditor();
+
+        // add some text
+        var p = queryOne(":iframe section > p");
+        setSelection({ anchorNode: p, anchorOffset: 0 });
+        await insertText(editor, "EDITED ");
+        expect(p).toHaveInnerHTML("EDITED TEXT");
+
+        // open navbar link popover
+        setSelection({ anchorNode: queryOne(":iframe .nav-link > span"), anchorOffset: 0 });
+
+        // open menu editor and save
+        await waitFor(".o-we-linkpopover");
+        await click(queryOne("i.fa-sitemap"));
+        await waitFor("footer.modal-footer");
+        await click(queryOne("button.btn-primary"));
+        await waitForNone(".modal");
+        expect.verifySteps(["editor_has_saved"]);
+    });
+});

--- a/addons/website/static/tests/website_html_editor.test.js
+++ b/addons/website/static/tests/website_html_editor.test.js
@@ -35,6 +35,8 @@ test("autocomplete should shown and able to edit the link", async () => {
             ],
         };
     });
+    onRpc("/contactus", () => ({}));
+    onRpc("/html_editor/link_preview_internal", () => ({}));
 
     const { el } = await setupEditor('<p>this is a <a href="http://test.com/">li[]nk</a></p>');
 


### PR DESCRIPTION
This PR is Backport of  https://github.com/odoo/odoo/pull/216832

> [BSO] Drop block with button link > edit link: it shows the full URL (including protocol etc) for local URLs

Steps to reproduce:

- Open website builder
- Click on a link with a relative URL (there is /contactus in footer)
- Bug: the url shown is an absolute url (https://.../contactus)
- Click "Edit Link" (one of the icons)
- Click "Apply"
- Bug: the url in the dom has changed (it saved the absolute url)

The link popover used HTMLAnchorElement.href to get the url. This getter returns an absolute url even if the href attribute is a relative url.

task-4367641

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
