### PR TITLE
[IMP] account: Export invoices/bills pdfs in zip

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -6565,8 +6565,14 @@ class AccountMove(models.Model):
     def get_extra_print_items(self):
         """ Helper to dynamically add items in the 'Print' menu of list and form of account.move.
         """
-        # TO OVERRIDE
+        if len(self) > 1:
+            return [{
+                'key': 'download_zip',
+                'description': _('Export ZIP'),
+                **self.action_invoice_download_pdf(),
+            }]
         return []
+
 
     @staticmethod
     def _can_commit():


### PR DESCRIPTION
With PEPPOL, many clients use Odoo for invoicing while their accountant uses another tool. To easily send invoices to the accountant, it’s important to export PDFs (one invoice per PDF) for both sales and purchase.

This commit adds a new printing option `Export ZIP` to invoices/bills that exports them, in .pdf format, into a zip file.

task-4946367

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
