### PR TITLE
[IMP] account,account_edi_ubl_cii: Export Invoices in all supported extensions in ZIP

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -5511,6 +5511,13 @@ class AccountMove(models.Model):
             'target': target,
         }
 
+    def action_move_download_all(self):
+        return {
+            'type': 'ir.actions.act_url',
+            'url': f'/account/download_move_attachments/{",".join(str(move_id) for move_id in self.ids)}',
+            'target': 'download',
+        }
+
     def action_print_pdf(self):
         self.ensure_one()
         invoice_template = self.env['account.move.send']._get_default_pdf_report_id(self)
@@ -6686,7 +6693,14 @@ class AccountMove(models.Model):
     def get_extra_print_items(self):
         """ Helper to dynamically add items in the 'Print' menu of list and form of account.move.
         """
-        # TO OVERRIDE
+        if posted_moves := self.filtered(lambda m: m.state == 'posted'):
+            return [
+                {
+                    'key': 'download_all',
+                    'description': _("Export ZIP"),
+                    **posted_moves.action_move_download_all(),
+                },
+            ]
         return []
 
     @staticmethod

--- a/addons/account/tests/test_download_docs.py
+++ b/addons/account/tests/test_download_docs.py
@@ -15,7 +15,8 @@ class TestDownloadDocs(AccountTestInvoicingHttpCommon):
         invoice_1 = cls.env['account.move'].create({
             'move_type': 'out_invoice',
             'partner_id': cls.partner_a.id,
-            'invoice_line_ids': [Command.create({'price_unit': 100})]
+            'invoice_line_ids': [Command.create({'price_unit': 100})],
+            'attachment_ids': [Command.create({'name': "Attachment", 'mimetype': 'application/pdf', 'res_model': 'account.move', 'datas': "test"})],
         })
         invoice_2 = cls.env['account.move'].create({
             'move_type': 'out_invoice',
@@ -85,3 +86,54 @@ class TestDownloadDocs(AccountTestInvoicingHttpCommon):
             self.assertEqual(len(file_names), 2)
             self.assertTrue(self.invoices[0].invoice_pdf_report_id.name in file_names)
             self.assertTrue(self.invoices[1].invoice_pdf_report_id.name in file_names)
+
+    def test_download_moves_attachments(self):
+        self.authenticate(self.env.user.login, self.env.user.login)
+        url = f'/account/download_move_attachments/{",".join(map(str, self.invoices.ids))}'
+        attachment_names = sorted([doc['filename'] for invoice in self.invoices for doc in invoice._get_invoice_legal_documents_all()])
+        res = self.url_open(url)
+        self.assertEqual(res.status_code, 200)
+        with ZipFile(BytesIO(res.content)) as zip_file:
+            file_names = sorted(zip_file.namelist())
+            self.assertEqual(file_names, attachment_names)
+
+    def test_download_moves_attachments_with_bills(self):
+        bill = self.init_invoice('in_invoice', products=self.product_a)
+        bill.message_main_attachment_id = self.env['ir.attachment'].create({'name': "Attachment", 'mimetype': 'application/pdf', 'res_model': 'account.move', 'datas': "test_bill"})
+        attachment_names = [bill.message_main_attachment_id.name]
+        self.authenticate(self.env.user.login, self.env.user.login)
+        url = f'/account/download_move_attachments/{bill.id}'
+        res = self.url_open(url)
+        self.assertEqual(res.status_code, 200)
+        with ZipFile(BytesIO(res.content)) as zip_file:
+            file_names = sorted(zip_file.namelist())
+            self.assertEqual(file_names, attachment_names)
+
+    def test_download_moves_attachments_with_duplicate_names(self):
+        bill_1 = self.init_invoice('in_invoice', products=self.product_a)
+        bill_2 = self.init_invoice('in_invoice', products=self.product_a)
+        bill_3 = self.init_invoice('in_invoice', products=self.product_a)
+        att_name = "Attachment"
+        bill_1.message_main_attachment_id = self.env['ir.attachment'].create({'name': att_name, 'mimetype': 'application/pdf', 'res_model': 'account.move', 'datas': "test_bill"})
+        bill_2.message_main_attachment_id = self.env['ir.attachment'].create({'name': att_name, 'mimetype': 'application/pdf', 'res_model': 'account.move', 'datas': "test_bill"})
+        bill_3.message_main_attachment_id = self.env['ir.attachment'].create({'name': f"{att_name} (1)", 'mimetype': 'application/pdf', 'res_model': 'account.move', 'datas': "test_bill"})
+        attachment_names = [att_name, f"{att_name} (1)", f"{att_name} (1) (1)"]
+        self.authenticate(self.env.user.login, self.env.user.login)
+
+        url = f'/account/download_move_attachments/{bill_1.id},{bill_2.id},{bill_3.id}'
+        res = self.url_open(url)
+        self.assertEqual(res.status_code, 200)
+        with ZipFile(BytesIO(res.content)) as zip_file:
+            file_names = sorted(zip_file.namelist())
+            self.assertEqual(file_names, attachment_names)
+
+        att_name = "Attachment.ext"
+        bill_1.message_main_attachment_id.name = att_name
+        bill_2.message_main_attachment_id.name = att_name
+        attachment_names = [f"{att_name.split('.')[0]} (1).{att_name.split('.')[1]}", att_name]
+
+        url = f'/account/download_move_attachments/{bill_1.id},{bill_2.id}'
+        res = self.url_open(url)
+        with ZipFile(BytesIO(res.content)) as zip_file:
+            file_names = sorted(zip_file.namelist())
+            self.assertEqual(file_names, attachment_names)

--- a/addons/account_edi_ubl_cii/tests/test_ubl_cii.py
+++ b/addons/account_edi_ubl_cii/tests/test_ubl_cii.py
@@ -488,15 +488,14 @@ class TestAccountEdiUblCii(AccountTestInvoicingCommon, HttpCase):
         ])
         invoices[:2].action_post()
         invoices[:2]._generate_and_send()
-        print_items = invoices.get_extra_print_items()
+        xml_print_url = next(item for item in invoices.get_extra_print_items() if item['key'] == 'download_ubl')['url']
         self.assertEqual(
-            print_items[0]['url'],
+            xml_print_url,
             f'/account/download_invoice_documents/{invoices[0].id},{invoices[1].id}/ubl?allow_fallback=true',
             'Only posted invoices should be called in the URL',
         )
-        url = print_items[0]['url']
         self.authenticate(self.env.user.login, self.env.user.login)
-        res = self.url_open(url)
+        res = self.url_open(xml_print_url)
         self.assertEqual(res.status_code, 200)
         with ZipFile(BytesIO(res.content)) as zip_file:
             self.assertEqual(


### PR DESCRIPTION
With PEPPOL, many clients use Odoo for invoicing while their accountant uses another tool. To easily send invoices to the accountant, it’s important to export invoices for both sales and purchase.

Adding a `Export ZIP` option to download invoices in all supported extensions (pdf, xml, ..etc) in the same zip.

task-4946367

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
