### PR TITLE
[FIX] html_editor: uneditable tables can still be edited

### DIFF
--- a/addons/html_editor/static/src/main/table/table_ui_plugin.js
+++ b/addons/html_editor/static/src/main/table/table_ui_plugin.js
@@ -105,7 +105,7 @@ export class TableUIPlugin extends Plugin {
             target !== this.activeTd &&
             this.editable.contains(target)
         ) {
-            if (ev.target.isContentEditable) {
+            if (ev.target.isContentEditable && closestElement(target, "table").isContentEditable) {
                 this.setActiveTd(target);
             }
         } else if (this.activeTd) {

--- a/addons/html_editor/static/tests/overlay.test.js
+++ b/addons/html_editor/static/tests/overlay.test.js
@@ -157,6 +157,34 @@ test("Table menu should close on scroll", async () => {
     expect(".o-dropdown--menu").not.toHaveCount();
 });
 
+test.tags("desktop");
+test("Table menu should only show on contenteditable true tables", async () => {
+    await mountView({
+        type: "form",
+        resId: 2,
+        resModel: "test",
+        arch: `
+            <form>
+                <field name="name"/>
+                <field name="txt" widget="html"/>
+            </form>`,
+    });
+
+    // check that table menu is visible
+    await hover(".odoo-editor-editable td");
+    await waitFor(".o-we-table-menu[data-type='column']");
+    expect(".o-we-table-menu[data-type='column']").toBeVisible();
+
+    // hover away set the table as not editable
+    await hover(".o_control_panel");
+    queryOne("table").setAttribute("contenteditable", "false");
+
+    // chack that table menu is now not visible
+    await hover(".odoo-editor-editable td");
+    await waitForNone(".o-we-table-menu[data-type='column']");
+    expect(".o-we-table-menu[data-type='column']").not.toHaveCount();
+});
+
 test("Toolbar should keep stable while extending down the selection", async () => {
     const top = (el) => el.getBoundingClientRect().top;
     const left = (el) => el.getBoundingClientRect().left;


### PR DESCRIPTION
Before this commit tables that should not be editable were instead editable by using the table_menu overlay

Steps to reproduce
- go to shop
- add any item to cart
- go to checkout
- open editor => the checkout total table is editable using the table_menu overlay when it shouldn't

After this commit uneditable tables do not display the table_menu overlay
