### PR TITLE
[FIX] mail: fix failed nightly tests with multi-company avatar cards

### DIFF
--- a/addons/mail/tests/common.py
+++ b/addons/mail/tests/common.py
@@ -1988,6 +1988,7 @@ class MailCommon(MailCase):
         for data in users_data:
             if "hr.leave" not in self.env:
                 data.pop("leave_date_to", None)
+                data.pop("employee_ids", None)
         return list(users_data)
 
     def _filter_threads_fields(self, /, *threads_data):


### PR DESCRIPTION
The PR https://github.com/odoo/odoo/pull/212173 created issues in nightly builds due to their "single app installed" nature.

fixes runbot-229895
fixes runbot-229900

This PR solves this problem by popping the unnecessary keys depending on the module installed


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
