### PR TITLE
[FIX] point_of_sale: correct archived combinations calculation

### DIFF
--- a/addons/point_of_sale/models/product_template.py
+++ b/addons/point_of_sale/models/product_template.py
@@ -239,6 +239,8 @@ class ProductTemplate(models.Model):
                 taxes_by_company[tax.company_id.id].add(tax.id)
 
         different_currency = config_id.currency_id != self.env.company.currency_id
+
+        self._add_archived_combinations(products)
         for product in products:
             if different_currency:
                 product['list_price'] = self.env.company.currency_id._convert(product['list_price'], config_id.currency_id, self.env.company, fields.Date.today())
@@ -249,9 +251,18 @@ class ProductTemplate(models.Model):
             if len(taxes_by_company) > 1 and len(product['taxes_id']) > 1:
                 product['taxes_id'] = filter_taxes_on_company(product['taxes_id'], taxes_by_company)
 
-            product['_archived_combinations'] = []
-            for product_product in self.env['product.product'].with_context(active_test=False).search([('product_tmpl_id', '=', product['id']), ('active', '=', False)]):
-                product['_archived_combinations'].append(product_product.product_template_attribute_value_ids.ids)
+    def _add_archived_combinations(self, products):
+        """ Add archived combinations to the product template data. """
+        product_data = {product['id']: product for product in products}
+        for product_tmpl in self.browse(product_data.keys()):
+            product = product_data[product_tmpl.id]
+            attribute_exclusions = product_tmpl._get_attribute_exclusions()
+            product['_archived_combinations'] = attribute_exclusions['archived_combinations']
+            excluded = {}
+            for ptav_id, ptav_ids in attribute_exclusions['exclusions'].items():
+                for ptav_id2 in set(ptav_ids) - excluded.keys():
+                    excluded[ptav_id] = ptav_id2
+            product['_archived_combinations'].extend(excluded.items())
 
     @api.ondelete(at_uninstall=False)
     def _unlink_except_open_session(self):

--- a/addons/point_of_sale/tests/test_pos_basic_config.py
+++ b/addons/point_of_sale/tests/test_pos_basic_config.py
@@ -1335,3 +1335,74 @@ class TestPoSBasicConfig(TestPoSCommon):
         self.assertEqual(order.picking_count, 1, 'Order should have one picking')
         self.assertEqual(len(order.payment_ids), 1, 'Order should have one payment')
         self.assertEqual(self.env['account.move'].search_count([('pos_order_ids', 'in', order.ids)]), 1, 'Order should have one invoice')
+
+    def test_pos_archived_combination(self):
+        product = self.env['product.template'].create({
+            'name': 'Product Test',
+            'available_in_pos': True,
+            'list_price': 10,
+            'taxes_id': False,
+        })
+
+        attribute_1, attribute_2, attribute_3 = self.env['product.attribute'].create([{
+            'name': 'Attribute 1',
+            'create_variant': 'always',
+            'value_ids': [(0, 0, {
+                'name': 'Value 1',
+            }), (0, 0, {
+                'name': 'Value 2',
+            })],
+        }, {
+            'name': 'Attribute 2',
+            'create_variant': 'always',
+            'value_ids': [(0, 0, {
+                'name': 'Value 1',
+            }), (0, 0, {
+                'name': 'Value 2',
+            })],
+        }, {
+            'name': 'Attribute 3',
+            'create_variant': 'always',
+            'value_ids': [(0, 0, {
+                'name': 'Value 1',
+            }), (0, 0, {
+                'name': 'Value 2',
+            })],
+        }])
+
+        _, _, ptal = self.env['product.template.attribute.line'].create([{
+            'product_tmpl_id': product.id,
+            'attribute_id': attribute_1.id,
+            'value_ids': [(6, 0, attribute_1.value_ids.ids)],
+            'sequence': 3,
+        }, {
+            'product_tmpl_id': product.id,
+            'attribute_id': attribute_2.id,
+            'value_ids': [(6, 0, attribute_2.value_ids.ids)],
+            'sequence': 2,
+        }, {
+            'product_tmpl_id': product.id,
+            'attribute_id': attribute_3.id,
+            'value_ids': [(6, 0, attribute_3.value_ids.ids)],
+            'sequence': 1,
+        }])
+
+        product.write({
+            'attribute_line_ids': [(2, ptal.id)],
+        })
+
+        self.open_new_session()
+        response = self.pos_session.load_data([])
+        product_data = next((item for item in response['product.template'] if item['id'] == product.id), None)
+
+        self.assertEqual(len(product_data['_archived_combinations']), 0, "There should be no archived combinations for the product")
+
+        first_variant = product.product_variant_ids[0]
+        first_variant.write({'active': False})
+
+        response = self.pos_session.load_data([])
+        product_data = next((item for item in response['product.template'] if item['id'] == product.id), None)
+
+        self.assertEqual(len(product_data['_archived_combinations']), 1, "There should be one archived combination for the product")
+        self.assertEqual(len(product_data['_archived_combinations'][0]), 2, "Archived combination should have two values")
+        self.assertTrue(all(value in product_data['_archived_combinations'][0] for value in first_variant.product_template_attribute_value_ids.ids), "Archived combination should match the first variant's attribute values")

--- a/addons/pos_self_order/models/product_product.py
+++ b/addons/pos_self_order/models/product_product.py
@@ -49,10 +49,8 @@ class ProductTemplate(models.Model):
         return super()._post_read_pos_self_data(data)
 
     def _process_pos_self_ui_products(self, products):
+        self._add_archived_combinations(products)
         for product in products:
-            product['_archived_combinations'] = []
-            for product_product in self.env['product.product'].with_context(active_test=False).search([('product_tmpl_id', '=', product['id']), ('active', '=', False)]):
-                product['_archived_combinations'].append(product_product.product_template_attribute_value_ids.ids)
             product['image_128'] = bool(product['image_128'])
 
     @api.model


### PR DESCRIPTION
Before this commit, removing an attribute line from a product would inadvertently prevent the sale of any combination in the PoS interface.

opw-4947529

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
