### PR TITLE
[IMP] account_peppol: Add a demo EAS for Peppol

### DIFF
--- a/addons/account_edi_ubl_cii/models/res_partner.py
+++ b/addons/account_edi_ubl_cii/models/res_partner.py
@@ -129,6 +129,7 @@ class ResPartner(models.Model):
             ('EM', "Electronic mail"),
         ]
     )
+    available_peppol_eas = fields.Json(compute='_compute_available_peppol_eas')
 
     @api.constrains('peppol_endpoint')
     def _check_peppol_fields(self):
@@ -244,6 +245,12 @@ class ResPartner(models.Model):
                                 new_eas = eas
                                 break
                     partner.peppol_eas = new_eas
+
+    @api.depends_context('company')
+    @api.depends('company_id')
+    def _compute_available_peppol_eas(self):
+        # TO OVERRIDE
+        self.available_peppol_eas = list(dict(self._fields['peppol_eas'].selection))
 
     def _build_error_peppol_endpoint(self, eas, endpoint):
         """ This function contains all the rules regarding the peppol_endpoint."""

--- a/addons/account_edi_ubl_cii/views/res_partner_views.xml
+++ b/addons/account_edi_ubl_cii/views/res_partner_views.xml
@@ -7,9 +7,12 @@
             <xpath expr="//group[@id='invoice_send_settings']" position="inside">
                 <label for="peppol_eas" string="Peppol Address" invisible="1"/> <!-- TODO remove in master -->
                 <div id="peppol_address" class="row" invisible="1"/> <!-- TODO remove in master -->
+                <field name="available_peppol_eas" invisible="1"/>
                 <field name="peppol_eas"
                        placeholder="Peppol ID"
                        nolabel="1"
+                       widget="filterable_selection"
+                       options="{'whitelist_fname': 'available_peppol_eas'}"
                        class="o_field_peppol_eas_selection"/>
                 <field name="peppol_endpoint" nolabel="1" placeholder="Your endpoint"/>
             </xpath>

--- a/addons/account_peppol/models/account_edi_proxy_user.py
+++ b/addons/account_peppol/models/account_edi_proxy_user.py
@@ -167,6 +167,7 @@ class AccountEdiProxyClientUser(models.Model):
             }
         }
         for edi_user in self:
+            edi_user = edi_user.with_company(edi_user.company_id)
             params['domain']['receiver_identifier'] = edi_user.edi_identification
             try:
                 # request all messages that haven't been acknowledged
@@ -228,6 +229,7 @@ class AccountEdiProxyClientUser(models.Model):
         job_count = self._context.get('peppol_crons_job_count') or BATCH_SIZE
         need_retrigger = False
         for edi_user in self:
+            edi_user = edi_user.with_company(edi_user.company_id)
             edi_user_moves = self.env['account.move'].search(
                 [
                     ('peppol_move_state', '=', 'processing'),
@@ -277,6 +279,7 @@ class AccountEdiProxyClientUser(models.Model):
 
     def _peppol_get_participant_status(self):
         for edi_user in self:
+            edi_user = edi_user.with_company(edi_user.company_id)
             try:
                 proxy_user = edi_user._call_peppol_proxy("/api/peppol/2/participant_status")
             except AccountEdiProxyError as e:

--- a/addons/account_peppol/models/res_company.py
+++ b/addons/account_peppol/models/res_company.py
@@ -283,4 +283,5 @@ class ResCompany(models.Model):
         config_param = self.env['ir.config_parameter'].sudo().get_param('account_peppol.edi.mode')
         # by design, we can only have zero or one proxy user per company with type Peppol
         peppol_user = self.sudo().account_edi_proxy_client_ids.filtered(lambda u: u.proxy_type == 'peppol')
-        return peppol_user.edi_mode or config_param or 'prod'
+        demo_if_demo_identifier = 'demo' if self.peppol_eas == 'odemo' else False
+        return demo_if_demo_identifier or peppol_user.edi_mode or config_param or 'prod'

--- a/addons/account_peppol/models/res_partner.py
+++ b/addons/account_peppol/models/res_partner.py
@@ -23,6 +23,7 @@ class ResPartner(models.Model):
     invoice_sending_method = fields.Selection(
         selection_add=[('peppol', 'by Peppol')],
     )
+    peppol_eas = fields.Selection(selection_add=[('odemo', 'Odoo Demo ID')])  # Not a real EAS, used for demonstration.
     available_peppol_sending_methods = fields.Json(compute='_compute_available_peppol_sending_methods')
     available_peppol_edi_formats = fields.Json(compute='_compute_available_peppol_edi_formats')
     peppol_verification_state = fields.Selection(
@@ -56,6 +57,14 @@ class ResPartner(models.Model):
                 partner.available_peppol_edi_formats = self._get_peppol_formats()
             else:
                 partner.available_peppol_edi_formats = list(dict(self._fields['invoice_edi_format'].selection))
+
+    def _compute_available_peppol_eas(self):
+        # EXTENDS 'account_edi_ubl_cii'
+        super()._compute_available_peppol_eas()
+        eas_codes = set(self.available_peppol_eas)
+        if self.env.company._get_peppol_edi_mode() != 'demo' and 'odemo' in eas_codes:
+            eas_codes.remove('odemo')
+            self.available_peppol_eas = list(eas_codes)
 
     # -------------------------------------------------------------------------
     # HELPERS

--- a/addons/account_peppol/static/src/components/res_config_settings_buttons/res_config_settings_buttons.js
+++ b/addons/account_peppol/static/src/components/res_config_settings_buttons/res_config_settings_buttons.js
@@ -38,7 +38,8 @@ class PeppolSettingsButtons extends Component {
     }
 
     get ediMode() {
-        return this.props.record.data.edi_mode || this.props.record.data.account_peppol_edi_mode;
+        const demo_if_demo_identifier = this.props.record.data.peppol_eas === 'odemo' ? "demo": false
+        return demo_if_demo_identifier || this.props.record.data.edi_mode || this.props.record.data.account_peppol_edi_mode;
     }
 
     get modeConstraint() {

--- a/addons/account_peppol/wizard/peppol_registration.py
+++ b/addons/account_peppol/wizard/peppol_registration.py
@@ -136,12 +136,8 @@ class PeppolRegistration(models.TransientModel):
 
     @api.depends('edi_user_id')
     def _compute_edi_mode(self):
-        edi_mode = self.env['ir.config_parameter'].sudo().get_param('account_peppol.edi.mode')
         for wizard in self:
-            if wizard.edi_user_id:
-                wizard.edi_mode = wizard.edi_user_id.edi_mode
-            else:
-                wizard.edi_mode = edi_mode or 'prod'
+            wizard.edi_mode = wizard.company_id._get_peppol_edi_mode()
 
     def _inverse_edi_mode(self):
         for wizard in self:


### PR DESCRIPTION
When the company is registered with this particular EAS, Odoo will act as if it was in demo mode.
No call to the real Peppol Network is performed, everything is mocked locally. This allows to do the trainings on /trial databases, and get the lastests improvements.

Also fixing some crons that needed to be run with the right company.

task-no (FP/WTA request)
